### PR TITLE
Add rules to use Read/Grep/Glob tools instead of Bash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Flow: `call_method_with_values()` tries `native_method_*arg()` first; if `None`,
 - Push to remote after completing work.
 - Write all documents, code comments, and commit messages in English.
 - Do not use `echo`, `cat`, `printf`, or heredoc via Bash to create files. Always use the Write tool.
+- Do not use `cat`, `head`, `tail`, or `sed` via Bash to read files. Always use the Read tool.
+- Do not use `grep`, `rg`, or `find` via Bash to search files. Always use the Grep and Glob tools.
 
 ## Reference implementation
 


### PR DESCRIPTION
## Summary
- Forbid `cat`, `head`, `tail`, `sed` for reading files — use the Read tool instead
- Forbid `grep`, `rg`, `find` for searching files — use the Grep and Glob tools instead
- These Bash commands trigger permission prompts that block agent execution; the dedicated tools work without interruption
- `awk` is intentionally allowed since it handles line-based processing that has no tool equivalent

## Test plan
- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)