### PR TITLE
Fix listop parsing (shift, push, etc.) without parentheses

### DIFF
--- a/scripts/compare-ast.sh
+++ b/scripts/compare-ast.sh
@@ -26,13 +26,11 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # Determine if input is a file or inline code
 if [ -f "$INPUT" ]; then
     RAKU_ARGS=("--target=parse" "$INPUT")
-    MUTSU_ARGS_RD=("--dump-ast" "--parser=rd" "$INPUT")
-    MUTSU_ARGS_NOM=("--dump-ast" "--parser=nom" "$INPUT")
+    MUTSU_ARGS_NEW=("--dump-ast" "--parser=nom" "$INPUT")
     echo "=== Input: $INPUT ==="
 else
     RAKU_ARGS=("--target=parse" "-e" "$INPUT")
-    MUTSU_ARGS_RD=("--dump-ast" "--parser=rd" "-e" "$INPUT")
-    MUTSU_ARGS_NOM=("--dump-ast" "--parser=nom" "-e" "$INPUT")
+    MUTSU_ARGS_NEW=("--dump-ast" "--parser=nom" "-e" "$INPUT")
     echo "=== Input: '$INPUT' ==="
 fi
 
@@ -49,20 +47,9 @@ fi
 
 echo ""
 
-# 2. mutsu --parser=rd --dump-ast
-echo "--- mutsu --parser=rd --dump-ast ---"
-if "$MUTSU" "${MUTSU_ARGS_RD[@]}" > "$TMPDIR/rd.txt" 2>&1; then
-    cat "$TMPDIR/rd.txt"
-else
-    echo "(rd parse failed)"
-    cat "$TMPDIR/rd.txt"
-fi
-
-echo ""
-
-# 3. mutsu --parser=nom --dump-ast
+# 2. mutsu --parser=nom --dump-ast
 echo "--- mutsu --parser=nom --dump-ast ---"
-if "$MUTSU" "${MUTSU_ARGS_NOM[@]}" > "$TMPDIR/nom.txt" 2>&1; then
+if "$MUTSU" "${MUTSU_ARGS_NEW[@]}" > "$TMPDIR/nom.txt" 2>&1; then
     cat "$TMPDIR/nom.txt"
 else
     echo "(nom parse failed)"
@@ -71,9 +58,9 @@ fi
 
 echo ""
 
-# 4. Diff between rd and nom
+# 3. Diff between rd and nom
 echo "--- diff: rd vs nom ---"
-if diff -u "$TMPDIR/rd.txt" "$TMPDIR/nom.txt" > "$TMPDIR/diff.txt" 2>&1; then
+if diff -u "$TMPDIR/raku.txt" "$TMPDIR/nom.txt" > "$TMPDIR/diff.txt" 2>&1; then
     echo "(identical)"
 else
     cat "$TMPDIR/diff.txt"


### PR DESCRIPTION
Add support for listop functions (shift, unshift, push, pop, grep, map, etc.)
that can take arguments without parentheses. Previously, expressions like
"x" ~ shift @a were incorrectly parsed, with shift becoming a BareWord
instead of a function call.

Changes:
- Add is_listop() to identify functions that support listop syntax
- Add is_stmt_modifier_ahead() to avoid consuming statement modifiers as arguments
- Add parse_listop_arg() to parse a single listop argument
- Update identifier_or_call() to handle listop syntax

This fixes parsing of roast/S04-statement-modifiers/until.t (4/5 tests pass).
The remaining failure is due to a separate issue with comma-separated
expressions followed by statement modifiers.
