### PR TITLE
Set up CI with make test/roast and enforce PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,43 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          submodules: true
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-registry-
+          components: clippy, rustfmt
 
-      - name: Cache cargo target
-        uses: actions/cache@v3
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          path: target
-          key: cargo-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      - name: Install prove
+        run: sudo apt-get update && sudo apt-get install -y perl
 
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Run cargo tests
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Unit tests
         run: cargo test
 
-      - name: Run TAP conversion tests
-        run: |
-          cargo run -- t/conversion-functions.t
-          cargo run -- t/os-functions.t
-          cargo run -- t/numeric-functions.t
+      - name: Build
+        run: cargo build
+
+      - name: TAP tests (make test)
+        run: make test
+
+      - name: Roast tests (make roast)
+        run: make roast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,14 @@ Flow: `call_method_with_values()` tries `native_method_*arg()` first; if `None`,
 - Prefer ASCII in source files unless a specific Unicode feature is required.
 - Do not rewrite or reformat unrelated code.
 - Do not use stubs, hardcoded outputs, or early returns to make tests pass.
-- Commit directly to the main branch. Do not use feature branches.
-- Push to remote after completing work.
+- Do NOT commit directly to the main branch. Always create a feature branch and open a pull request.
+- PR workflow:
+  1. Create a feature branch from main: `git checkout -b <branch-name>`
+  2. Commit changes to the feature branch.
+  3. Push and open a PR with `gh pr create`.
+  4. Enable auto-merge: `gh pr merge --auto --squash <pr-number>`.
+  5. CI (GitHub Actions) runs `make test` and `make roast`. The PR merges automatically when CI passes.
+- If CI fails, fix the issue on the same branch, push again, and wait for CI to pass.
 - Write all documents, code comments, and commit messages in English.
 - Do not use `echo`, `cat`, `printf`, or heredoc via Bash to create files. Always use the Write tool.
 - Do not use `cat`, `head`, `tail`, or `sed` via Bash to read files. Always use the Read tool.


### PR DESCRIPTION
## Summary
- Rewrite CI workflow to run full test suite (`make test` + `make roast`) with submodule checkout
- Update CLAUDE.md to enforce PR-based workflow instead of direct main commits
- Enable auto-merge and delete-branch-on-merge in repo settings

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] `make test` and `make roast` pass in CI

Generated with [Claude Code](https://claude.com/claude-code)
