### PR TITLE
Add bare say/print/put compile errors, fix Z precedence, pass bare-say.t (192 tests)

### DIFF
--- a/TODO_roast/S16.md
+++ b/TODO_roast/S16.md
@@ -13,7 +13,8 @@
 - [ ] roast/S16-filehandles/mode.t
 - [ ] roast/S16-filehandles/open.t
 - [ ] roast/S16-filehandles/unlink.t
-- [ ] roast/S16-io/bare-say.t
+- [x] roast/S16-io/bare-say.t
+  - 16/16 pass.
 - [ ] roast/S16-io/basic-open.t
 - [ ] roast/S16-io/bom.t
 - [ ] roast/S16-io/comb.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -146,6 +146,7 @@ roast/S15-normalization/nfkd-9.t
 roast/S15-normalization/nfkd-sanity.t
 roast/S16-filehandles/misc.t
 roast/S16-filehandles/unlink.t
+roast/S16-io/bare-say.t
 roast/S16-io/cwd.t
 roast/S16-unfiled/getpeername.t
 roast/S17-channel/subscription-drain-in-react.t

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -118,6 +118,12 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
             }
         }
         Err(e) => {
+            if e.is_fatal() {
+                // Fatal parse errors (e.g. bare say/print/put) pass through directly
+                let mut err = RuntimeError::new(format!("{}", e));
+                err.code = Some(RuntimeErrorCode::ParseGeneric);
+                return Err(err);
+            }
             if let Some(consumed) = e.consumed_from(source.len()) {
                 let tail = &source[consumed..];
                 let near_offset = consumed + leading_ws_bytes(tail);

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -266,6 +266,7 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "use-ok"
             | "EVAL"
             | "tap-ok"
+            | "flat"
     )
 }
 

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -20,7 +20,7 @@ impl Interpreter {
         // Primary method dispatch by name
         match method {
             "say" if args.is_empty() => {
-                self.output.push_str(&target.to_string_value());
+                self.output.push_str(&crate::runtime::gist_value(&target));
                 self.output.push('\n');
                 return Ok(Value::Nil);
             }
@@ -635,6 +635,14 @@ impl Interpreter {
                     items.sort_by(|a, b| compare_values(a, b).cmp(&0));
                 }
                 Ok(Value::Array(items))
+            }
+            Value::Hash(map) => {
+                // Convert hash to list of pairs, then sort
+                let items: Vec<Value> = map
+                    .into_iter()
+                    .map(|(k, v)| Value::Pair(k, Box::new(v)))
+                    .collect();
+                self.dispatch_sort(Value::Array(items), args)
             }
             other => Ok(other),
         }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -175,7 +175,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
             .map(|(k, v)| format!("{}\t{}", k, gist_value(v)))
             .collect::<Vec<_>>()
             .join("\n"),
-        Value::Pair(k, v) => format!("{}\t{}", k, gist_value(v)),
+        Value::Pair(k, v) => format!("{} => {}", k, gist_value(v)),
         Value::Version { .. } => format!("v{}", value.to_string_value()),
         Value::Nil => "Nil".to_string(),
         _ => value.to_string_value(),


### PR DESCRIPTION
## Summary
- Detect bare `say`/`print`/`put` (no arguments, no parens) as compile errors (X::Comp), matching Raku behavior
- Detect `say for`/`print for`/`put for` patterns as X::Obsolete errors
- Add fatal parse error mechanism so these errors propagate through the statement parser without being swallowed
- Fix Z/X meta-operators to consume comma-separated lists on the right side (correct list infix precedence)
- Add `flat` as an expression listop for proper parsing of `flat <a b c> Z 1,2,3`
- Fix `Pair.gist` to use `" => "` format instead of tab separator
- Fix `.say` method to use gist output (matching Raku behavior)

## Test plan
- [x] All 16 subtests in `roast/S16-io/bare-say.t` pass
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)