### PR TITLE
Add -I flag, run/shell :err/:out capture, IO::Pipe, pass rt126904.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -84,6 +84,7 @@ roast/S06-signature/scalar-type.t
 roast/S06-traits/is-readonly.t
 roast/S06-traits/native-is-copy.t
 roast/S07-hyperrace/stress.t
+roast/S11-compunit/rt126904.t
 roast/S11-modules/versioning.t
 roast/S12-class/literal.t
 roast/S12-construction/autopairs.t

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,10 @@ fn main() {
 
     let mut dump_ast = false;
     let mut repl_flag = false;
+    let mut lib_paths: Vec<String> = Vec::new();
     let mut filtered_args: Vec<String> = Vec::new();
-    for arg in &args[1..] {
+    let mut iter = args[1..].iter();
+    while let Some(arg) = iter.next() {
         if arg == "--dump-ast" {
             dump_ast = true;
         } else if arg == "--repl" {
@@ -40,6 +42,15 @@ fn main() {
         } else if arg.starts_with("--parser=") {
             eprintln!("--parser option is no longer supported");
             std::process::exit(1);
+        } else if arg == "-I" {
+            if let Some(path) = iter.next() {
+                lib_paths.push(path.clone());
+            } else {
+                eprintln!("Usage: {} -I <path>", args[0]);
+                std::process::exit(1);
+            }
+        } else if let Some(path_suffix) = arg.strip_prefix("-I") {
+            lib_paths.push(path_suffix.to_string());
         } else {
             filtered_args.push(arg.clone());
         }
@@ -83,6 +94,9 @@ fn main() {
     }
 
     let mut interpreter = Interpreter::new();
+    for path in lib_paths {
+        interpreter.add_lib_path(path);
+    }
     interpreter.set_program_path(&program_name);
     match interpreter.run(&input) {
         Ok(output) => print!("{}", output),

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -230,8 +230,6 @@ pub(super) fn is_listop(name: &str) -> bool {
             | "sum"
             | "pick"
             | "roll"
-            | "run"
-            | "shell"
             | "make-temp-dir"
             | "make-temp-file"
     ) || is_expr_listop(name)
@@ -272,6 +270,8 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "tap-ok"
             | "flat"
             | "is_run"
+            | "run"
+            | "shell"
     )
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -371,6 +371,19 @@ impl Interpreter {
             },
         );
         classes.insert(
+            "IO::Pipe".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: ["slurp", "Str", "gist"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                mro: vec!["IO::Pipe".to_string()],
+            },
+        );
+        classes.insert(
             "IO::Socket::INET".to_string(),
             ClassDef {
                 parents: Vec::new(),
@@ -477,7 +490,7 @@ impl Interpreter {
         self.env.insert("@*ARGS".to_string(), Value::Array(args));
     }
 
-    pub(crate) fn add_lib_path(&mut self, path: String) {
+    pub fn add_lib_path(&mut self, path: String) {
         if !path.is_empty() {
             self.lib_paths.push(path);
         }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -425,4 +425,22 @@ impl Interpreter {
             ))),
         }
     }
+
+    pub(super) fn native_io_pipe(
+        &self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+    ) -> Result<Value, RuntimeError> {
+        let content = attributes
+            .get("content")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        match method {
+            "slurp" | "Str" | "gist" => Ok(Value::Str(content)),
+            _ => Err(RuntimeError::new(format!(
+                "No native method '{}' on IO::Pipe",
+                method
+            ))),
+        }
+    }
 }

--- a/src/runtime/native_methods.rs
+++ b/src/runtime/native_methods.rs
@@ -34,6 +34,7 @@ impl Interpreter {
             "IO::Path" => self.native_io_path(attributes, method, args),
             "IO::Handle" => self.native_io_handle(attributes, method, args),
             "IO::Socket::INET" => self.native_socket_inet(attributes, method, args),
+            "IO::Pipe" => self.native_io_pipe(attributes, method),
             "Distro" => self.native_distro(attributes, method),
             "Perl" => Ok(self.native_perl(attributes, method)),
             "Promise" => self.native_promise(attributes, method, args),

--- a/t/run-capture.t
+++ b/t/run-capture.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 6;
+
+# run with :err captures stderr
+my $p1 = run("echo", "hello", :err);
+isa-ok $p1, Proc, 'run returns a Proc';
+is $p1.err.slurp, '', 'stderr is empty for echo';
+
+# run with :out captures stdout
+my $p2 = run("echo", "hello", :out);
+is $p2.out.slurp, "hello\n", 'stdout captured with :out';
+
+# run with :err captures stderr content
+my $p3 = run("sh", "-c", "echo errmsg >&2", :err);
+is $p3.err.slurp, "errmsg\n", 'stderr content captured';
+
+# run without :err/:out still works
+my $p4 = run("echo", "test");
+isa-ok $p4, Proc, 'run without capture returns Proc';
+is $p4.exitcode, 0, 'exitcode is 0 for successful command';


### PR DESCRIPTION
## Summary
- Add `-I` command line flag for specifying library search paths
- Support `:err` and `:out` named parameters in `run()` and `shell()` to capture stderr/stdout via piped IO
- Add `IO::Pipe` instance type with `slurp` method for reading captured output
- Move `run`/`shell` from single-arg listop to expr_listop so all comma-separated arguments are parsed correctly (e.g. `run "echo", "hello", :err`)
- Pass `roast/S11-compunit/rt126904.t`

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S11-compunit/rt126904.t` passes
- [x] `make test` passes (only pre-existing socket.t failure)
- [x] `make roast` passes (only pre-existing getpeername.t failure)
- [x] `cargo clippy -- -D warnings` clean
- [x] New test `t/run-capture.t` covers :err, :out, and basic run behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)