### PR TITLE
Add --allowedTools to fix-roast.sh

### DIFF
--- a/scripts/fix-roast.sh
+++ b/scripts/fix-roast.sh
@@ -21,6 +21,11 @@ while true; do
   git checkout -b "$BRANCH"
 
   claude -p \
+    --allowedTools \
+      "Bash(cargo *)" "Bash(make *)" "Bash(prove *)" \
+      "Bash(git *)" "Bash(gh *)" \
+      "Bash(raku *)" "Bash(./target/debug/mutsu *)" "Bash(timeout *)" \
+      "Read" "Edit" "Write" "Glob" "Grep" "Task" \
     "Fix the failing roast test: $TEST_FILE
 
 Steps:


### PR DESCRIPTION
## Summary
- Add `--allowedTools` flag to `claude -p` invocation
- Restrict Bash to specific command patterns: `cargo`, `make`, `prove`, `git`, `gh`, `raku`, `./target/debug/mutsu`, `timeout`
- Allow file tools (Read, Edit, Write, Glob, Grep, Task) without restriction

## Test plan
- [ ] Verify the allowed tool patterns cover all commands claude needs during a fix cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)