### PR TITLE
Add .comb(Regex), Unicode-aware character classes, combined classes

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -21,7 +21,7 @@
 - [ ] roast/S05-grammar/ws.t
 - [ ] roast/S05-interpolation/lexicals.t
 - [ ] roast/S05-interpolation/regex-in-variable.t
-- [ ] roast/S05-mass/charsets.t
+- [x] roast/S05-mass/charsets.t
 - [x] roast/S05-mass/named-chars.t
   - 431/431 pass.
 - [x] roast/S05-mass/properties-block.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -68,6 +68,7 @@ roast/S04-statements/next.t
 roast/S04-statements/unless.t
 roast/S04-statements/until.t
 roast/S05-grammar/namespace-6e.t
+roast/S05-mass/charsets.t
 roast/S05-mass/named-chars.t
 roast/S05-mass/properties-block.t
 roast/S05-mass/properties-contributory.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -383,6 +383,17 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             let parts: Vec<Value> = s.chars().map(|c| Value::Str(c.to_string())).collect();
             Some(Ok(Value::Array(parts)))
         }
+        "join" => match target {
+            Value::Array(items) => {
+                let joined = items
+                    .iter()
+                    .map(|v| v.to_string_value())
+                    .collect::<Vec<_>>()
+                    .join("");
+                Some(Ok(Value::Str(joined)))
+            }
+            _ => Some(Ok(Value::Str(target.to_string_value()))),
+        },
         "gist" | "raku" | "perl" => match target {
             Value::Bool(b) => {
                 if method == "gist" {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -119,6 +119,24 @@ impl Interpreter {
                 }
                 return Ok(Value::Nil);
             }
+            "comb" if args.len() == 1 => {
+                let text = target.to_string_value();
+                let pattern = match &args[0] {
+                    Value::Regex(pat) => pat.clone(),
+                    Value::Str(s) => s.clone(),
+                    _ => args[0].to_string_value(),
+                };
+                let matches = self.regex_find_all(&pattern, &text);
+                let chars: Vec<char> = text.chars().collect();
+                let result: Vec<Value> = matches
+                    .iter()
+                    .map(|(start, end)| {
+                        let s: String = chars[*start..*end].iter().collect();
+                        Value::Str(s)
+                    })
+                    .collect();
+                return Ok(Value::Array(result));
+            }
             "IO" if args.is_empty() => {
                 return Ok(self.make_io_path_instance(&target.to_string_value()));
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -140,8 +140,19 @@ enum RegexAtom {
     Group(RegexPattern),
     Alternation(Vec<RegexPattern>),
     ZeroWidth,
-    UnicodeProp { name: String, negated: bool },
-    UnicodePropAssert { name: String, negated: bool }, // zero-width assertion
+    UnicodeProp {
+        name: String,
+        negated: bool,
+    },
+    UnicodePropAssert {
+        name: String,
+        negated: bool,
+    }, // zero-width assertion
+    /// Combined character class: <+ xdigit - lower>, matches positive AND NOT negative
+    CompositeClass {
+        positive: Vec<ClassItem>,
+        negative: Vec<ClassItem>,
+    },
 }
 
 #[derive(Clone)]
@@ -165,6 +176,8 @@ enum ClassItem {
     Digit,
     Word,
     Space,
+    NamedBuiltin(String),
+    UnicodePropItem { name: String, negated: bool },
 }
 
 pub struct Interpreter {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -296,7 +296,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         } => {
             // String ranges: expand as character sequences
             if let (Value::Str(a), Value::Str(b)) = (start.as_ref(), end.as_ref()) {
-                if a.len() == 1 && b.len() == 1 {
+                if a.chars().count() == 1 && b.chars().count() == 1 {
                     let s = a.chars().next().unwrap() as u32;
                     let e = b.chars().next().unwrap() as u32;
                     let s = if *excl_start { s + 1 } else { s };


### PR DESCRIPTION
## Summary
- Implement `.comb(Regex)` method for finding all non-overlapping regex matches in strings
- Make named character classes (`<alpha>`, `<upper>`, `<lower>`, `<alnum>`, `<space>`) Unicode-aware instead of ASCII-only
- Add missing named classes: `<ident>`, `<blank>`, `<cntrl>`, `<punct>`
- Add composite character class support: `<+ xdigit - lower>`, `<+ :HexDigit - :Upper>`
- Add 0-arity `.join()` method (defaults to empty separator)
- Fix variadic `flat()` to expand Range values
- Fix single-char string range detection for multi-byte UTF-8 chars (e.g. `chr(0)..chr(0xFF)`)

## Test plan
- [x] `roast/S05-mass/charsets.t` passes all 17/17 tests (added to whitelist)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)