### PR TITLE
Use glob pattern for temp-test.* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,7 @@ hooks
 io-handle-testfile
 objects
 refs
-temp-test.24180.901
-temp-test.3948737.283
+temp-test.*
 tempfile-copy-mtgt
 tempfile-copy-stgt
 tempfile-move1


### PR DESCRIPTION
## Summary
- Replace individual `temp-test.24180.901` and `temp-test.3948737.283` entries with a single `temp-test.*` wildcard pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)