### PR TITLE
Implement start/await and do-for collection

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -159,6 +159,7 @@ roast/S16-unfiled/getpeername.t
 roast/S17-channel/subscription-drain-in-react.t
 roast/S17-procasync/many-processes-no-close-stdin.t
 roast/S17-procasync/no-runaway-file-limit.t
+roast/S17-promise/stress.t
 roast/S17-supply/repeated.t
 roast/S17-supply/watch-path.t
 roast/S19-command-line-options/03-dash-p.t

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -278,6 +278,7 @@ pub(crate) enum OpCode {
         body_end: u32,
         label: Option<String>,
         arity: u32,
+        collect: bool,
     },
     /// C-style loop: [cond opcodes][body opcodes][step opcodes].
     /// Layout after CStyleLoop: cond at [ip+1..cond_end), body at [cond_end..step_start),

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -289,6 +289,7 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "is_run"
             | "run"
             | "shell"
+            | "await"
     )
 }
 

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -181,6 +181,9 @@ impl Interpreter {
             "sleep" => self.builtin_sleep(&args),
             "sleep-timer" => self.builtin_sleep_timer(&args),
             "sleep-till" => self.builtin_sleep_till(&args),
+            // Concurrency (single-threaded simulation)
+            "start" => self.builtin_start(args),
+            "await" => self.builtin_await(&args),
             // Fallback
             _ => self.call_function_fallback(name, &args),
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1755,6 +1755,7 @@ impl VM {
                 body_end,
                 label,
                 arity,
+                collect,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -1762,6 +1763,7 @@ impl VM {
                     body_end: *body_end,
                     label: label.clone(),
                     arity: *arity,
+                    collect: *collect,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/t/start-await.t
+++ b/t/start-await.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 6;
+
+# Basic start/await
+{
+    my $p = start { 42 };
+    is await($p), 42, 'start/await returns block result';
+}
+
+# start with computation
+{
+    my $p = start { 10 + 20 };
+    is await($p), 30, 'start/await with computation';
+}
+
+# Multiple starts with await
+{
+    my @promises = do for ^3 { start { 100 } };
+    is @promises.elems, 3, 'do for with start creates array of promises';
+    my @results = await @promises;
+    is @results.elems, 3, 'await array returns correct number of results';
+    is @results[0], 100, 'await array first element correct';
+}
+
+# do for collects values
+{
+    my @vals = do for ^4 { $_ * 2 };
+    is @vals.join(','), '0,2,4,6', 'do for collects iteration results';
+}


### PR DESCRIPTION
## Summary
- Add `start { ... }` builtin: executes block synchronously, wraps result in a Kept Promise
- Add `await` builtin: extracts results from Promise instances (single or array)
- Implement `do for` expression collection via `collect` flag on ForLoop opcode
- Passes roast/S17-promise/stress.t

## Test plan
- [x] `t/start-await.t` passes (6 tests)
- [x] `roast/S17-promise/stress.t` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)