### PR TITLE
Support &infix:<OP> operator references

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -43,6 +43,7 @@ roast/S03-operators/gcd.t
 roast/S03-operators/infixed-function.t
 roast/S03-operators/lcm.t
 roast/S03-operators/list-quote-junction.t
+roast/S03-operators/names.t
 roast/S03-operators/not.t
 roast/S03-operators/so.t
 roast/S03-operators/spaceship-and-containers.t

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -370,6 +370,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && let Some(&c) = input.as_bytes().get(1)
         && (c == b'$'
             || c == b'@'
+            || c == b'&'
             || c == b'('
             || c == b'"'
             || c == b'\''


### PR DESCRIPTION
## Summary
- Extend code_var parser to handle `&infix:<+>`, `&prefix:<->`, `&postfix:<++>` operator references
- Add `&` to allowed chars after `~` prefix operator for stringification of code vars
- Passes roast/S03-operators/names.t (7/7 tests)

## Test plan
- [x] `roast/S03-operators/names.t` passes (7/7)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)