### PR TITLE
feat: support return with statement modifiers

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -82,6 +82,7 @@ roast/S05-metasyntax/null.t
 roast/S05-transliteration/79778.t
 roast/S06-multi/compile-time.t
 roast/S06-other/main-eval.t
+roast/S06-signature/closure-over-parameters.t
 roast/S06-signature/passing-hashes.t
 roast/S06-signature/scalar-type.t
 roast/S06-traits/is-readonly.t

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -154,9 +154,8 @@ pub(super) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
         return Ok((rest, Stmt::Return(Expr::Literal(Value::Nil))));
     }
     let (rest, expr) = expression(rest)?;
-    let (rest, _) = ws(rest)?;
-    let (rest, _) = opt_char(rest, ';');
-    Ok((rest, Stmt::Return(expr)))
+    let stmt = Stmt::Return(expr);
+    parse_statement_modifier(rest, stmt)
 }
 
 /// Parse `last` / `next` / `redo`.

--- a/t/return-modifier.t
+++ b/t/return-modifier.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 4;
+
+# return with if modifier
+sub check-positive($n) { return "yes" if $n > 0; "no" }
+is check-positive(5), "yes", 'return with if modifier (true)';
+is check-positive(-1), "no", 'return with if modifier (false)';
+
+# return with unless modifier
+sub check-nonzero($n) { return "zero" unless $n; "nonzero" }
+is check-nonzero(0), "zero", 'return with unless modifier (true)';
+is check-nonzero(3), "nonzero", 'return with unless modifier (false)';


### PR DESCRIPTION
## Summary
- Add statement modifier support (if/unless/for/etc.) to return statements
- Enables syntax like `return $x if $cond;`
- Add `roast/S06-signature/closure-over-parameters.t` to whitelist (4 new passing tests)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-signature/closure-over-parameters.t` passes
- [x] New local test `t/return-modifier.t` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)