### PR TITLE
fix: allow prefix ~ operator on hash variables

### DIFF
--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -370,6 +370,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && let Some(&c) = input.as_bytes().get(1)
         && (c == b'$'
             || c == b'@'
+            || c == b'%'
             || c == b'&'
             || c == b'('
             || c == b'"'

--- a/t/prefix-tilde-hash.t
+++ b/t/prefix-tilde-hash.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 3;
+
+my %h = a => 1, b => 2;
+ok (~%h).chars > 0, 'prefix ~ on hash produces string';
+
+my %h2 = x => 10;
+is ~%h2, "x\t10", 'prefix ~ on single-pair hash';
+
+# prefix ~ on hash method call
+my %h3 = a => 1, b => 2;
+ok (~%h3.sort).chars > 0, 'prefix ~ on hash method call';


### PR DESCRIPTION
## Summary
- Add `%` to the list of allowed characters after prefix `~` operator
- Enables syntax like `~%hash` and `~%hash.sort` which previously caused parse errors

## Test plan
- [x] New local test `t/prefix-tilde-hash.t` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)