### PR TITLE
feat: support top-level CATCH, when *, and Match object with from/to

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -59,6 +59,7 @@ roast/S03-smartmatch/any-sub.t
 roast/S03-smartmatch/range-range.t
 roast/S03-smartmatch/regex-hash.t
 roast/S03-smartmatch/scalar-hash.t
+roast/S04-exception-handlers/top-level.t
 roast/S04-exceptions/control_across_runloop.t
 roast/S04-statement-modifiers/until.t
 roast/S04-statement-modifiers/values_in_bool_context.t
@@ -197,6 +198,7 @@ roast/S32-str/append.t
 roast/S32-str/bool.t
 roast/S32-str/chop.t
 roast/S32-str/lc.t
+roast/S32-str/pos.t
 roast/S32-str/length.t
 roast/S32-str/tclc.t
 roast/S32-str/tc.t

--- a/src/runtime/seq_helpers.rs
+++ b/src/runtime/seq_helpers.rs
@@ -32,11 +32,12 @@ impl Interpreter {
             (_, Value::Regex(pat)) => {
                 let text = left.to_string_value();
                 if let Some(captures) = self.regex_match_with_captures(pat, &text) {
-                    // Set $/ to the matched substring
+                    // Set $/ to a Match object with from/to/str
                     if let Some((start, end)) = self.regex_find_first(pat, &text) {
                         let chars: Vec<char> = text.chars().collect();
                         let matched: String = chars[start..end].iter().collect();
-                        self.env.insert("/".to_string(), Value::Str(matched));
+                        let match_obj = Value::make_match_object(matched, start as i64, end as i64);
+                        self.env.insert("/".to_string(), match_obj);
                     }
                     for (k, v) in captures {
                         self.env.insert(format!("<{}>", k), Value::Str(v));

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -253,6 +253,14 @@ impl Value {
                 .get("WHICH")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Match" => attributes
+                .get("str")
+                .map(|v: &Value| v.to_string_value())
+                .unwrap_or_default(),
             Value::Instance { class_name, .. } => format!("{}()", class_name),
             Value::Junction { kind, values } => {
                 let kind_str = match kind {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -291,6 +291,15 @@ impl Value {
         }
     }
 
+    /// Create a Match object instance with from, to, and str attributes.
+    pub(crate) fn make_match_object(matched: String, from: i64, to: i64) -> Self {
+        let mut attrs = HashMap::new();
+        attrs.insert("str".to_string(), Value::Str(matched));
+        attrs.insert("from".to_string(), Value::Int(from));
+        attrs.insert("to".to_string(), Value::Int(to));
+        Value::make_instance("Match".to_string(), attrs)
+    }
+
     pub(crate) fn version_strip_trailing_zeros(parts: &[VersionPart]) -> Vec<VersionPart> {
         let mut v: Vec<VersionPart> = parts.to_vec();
         while matches!(v.last(), Some(VersionPart::Num(0))) {

--- a/t/top-level-catch.t
+++ b/t/top-level-catch.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 3;
+
+# Top-level CATCH block
+{
+    sub foo { die "boom" };
+    try {
+        foo;
+        CATCH {
+            when * {
+                pass 'when * catches exception in try';
+            }
+        }
+    }
+}
+
+# when * in given
+{
+    given 42 {
+        when * {
+            pass 'when * matches in given';
+        }
+    }
+}
+
+# Match .to and .from
+{
+    "hello world" ~~ /world/;
+    is $/.to, 11, 'Match.to returns end position';
+}


### PR DESCRIPTION
## Summary
- Wrap top-level program body in implicit try when CATCH block is present
- Handle `when *` (Whatever) as always-matching in when blocks
- Catch succeed signals from `when` inside CATCH blocks
- Store `$/` as Match instance with from/to/str attributes, enabling `$/.to`, `$/.from`, `$/.Str` methods
- Match instances stringify to matched text and delegate unknown string methods to their string representation
- Add roast/S04-exception-handlers/top-level.t and roast/S32-str/pos.t to whitelist

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S04-exception-handlers/top-level.t` passes
- [x] `prove -e './target/debug/mutsu' roast/S32-str/pos.t` passes
- [x] `prove -e './target/debug/mutsu' roast/S32-str/trim.t` passes (no regression)
- [x] `make test` passes (except pre-existing socket test)
- [x] `make roast` passes (except pre-existing getpeername test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)