### PR TITLE
feat: support parenthesized assignment as lvalue

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -45,6 +45,7 @@ roast/S03-operators/lcm.t
 roast/S03-operators/list-quote-junction.t
 roast/S03-operators/names.t
 roast/S03-operators/not.t
+roast/S03-operators/scalar-assign.t
 roast/S03-operators/so.t
 roast/S03-operators/spaceship-and-containers.t
 roast/S03-operators/subscript-vs-lt.t
@@ -198,8 +199,8 @@ roast/S32-str/append.t
 roast/S32-str/bool.t
 roast/S32-str/chop.t
 roast/S32-str/lc.t
-roast/S32-str/pos.t
 roast/S32-str/length.t
+roast/S32-str/pos.t
 roast/S32-str/tclc.t
 roast/S32-str/tc.t
 roast/S32-str/trim.t

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -11,7 +11,7 @@ use crate::token_kind::TokenKind;
 use super::{ident, parse_statement_modifier, var_name};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CompoundAssignOp {
+pub(crate) enum CompoundAssignOp {
     DefinedOr,
     LogicalOr,
     LogicalAnd,
@@ -54,7 +54,7 @@ impl CompoundAssignOp {
         }
     }
 
-    pub(super) fn token_kind(self) -> TokenKind {
+    pub(crate) fn token_kind(self) -> TokenKind {
         match self {
             CompoundAssignOp::DefinedOr => TokenKind::SlashSlash,
             CompoundAssignOp::LogicalOr => TokenKind::OrOr,
@@ -97,7 +97,7 @@ pub(super) const COMPOUND_ASSIGN_OPS: &[CompoundAssignOp] = &[
     CompoundAssignOp::Max, // max= (word boundary checked in parse_compound_assign_op)
 ];
 
-pub(super) fn parse_compound_assign_op(input: &str) -> Option<(&str, CompoundAssignOp)> {
+pub(crate) fn parse_compound_assign_op(input: &str) -> Option<(&str, CompoundAssignOp)> {
     for op in COMPOUND_ASSIGN_OPS {
         if let Some(stripped) = input.strip_prefix(op.symbol()) {
             return Some((stripped, *op));

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -1,5 +1,5 @@
 mod args;
-mod assign;
+pub(super) mod assign;
 pub(super) mod class;
 mod control;
 mod decl;


### PR DESCRIPTION
## Summary
- Support parenthesized assignment expressions as lvalues: `($x = $y) = 5` and `($x += 2) *= 3`
- Extended parser to handle compound assignment operators inside parentheses
- Passes roast/S03-operators/scalar-assign.t (all 4 subtests)

## Test plan
- [x] `cargo build` succeeds
- [x] `timeout 30 target/debug/mutsu roast/S03-operators/scalar-assign.t` passes all 4 tests
- [x] `make test` passes (only pre-existing socket test failure)
- [x] `make roast` passes (only pre-existing getpeername failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)