### PR TITLE
feat: implement pseudo-package support and indirect package lookup

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -27,6 +27,7 @@ roast/S02-magicals/PERL.t
 roast/S02-magicals/pid.t
 roast/S02-magicals/USER.t
 roast/S02-names/bare-sigil.t
+roast/S02-names/SETTING-6e.t
 roast/S02-one-pass-parsing/less-than.t
 roast/S02-one-pass-parsing/misc.t
 roast/S02-types/built-in.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -175,6 +175,10 @@ pub(crate) enum Expr {
         label: Option<String>,
     },
     IndirectTypeLookup(Box<Expr>),
+    IndirectCodeLookup {
+        package: Box<Expr>,
+        name: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -559,6 +563,7 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             }
         }
         Expr::CodeVar(_) => {}
+        Expr::IndirectCodeLookup { package, .. } => collect_ph_expr(package, out),
         Expr::Reduction { expr, .. } => collect_ph_expr(expr, out),
         Expr::HyperOp { left, right, .. } | Expr::MetaOp { left, right, .. } => {
             collect_ph_expr(left, out);

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -777,6 +777,11 @@ impl Compiler {
                 self.compile_expr(inner);
                 self.code.emit(OpCode::IndirectTypeLookup);
             }
+            Expr::IndirectCodeLookup { package, name } => {
+                self.compile_expr(package);
+                let name_idx = self.code.add_constant(Value::Str(name.clone()));
+                self.code.emit(OpCode::IndirectCodeLookup(name_idx));
+            }
             Expr::ControlFlow { kind, label } => match kind {
                 crate::ast::ControlFlowKind::Last => {
                     self.code.emit(OpCode::Last(label.clone()));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -434,6 +434,9 @@ pub(crate) enum OpCode {
     /// Indirect type lookup: pop string from stack, resolve to Package value.
     IndirectTypeLookup,
 
+    /// Indirect code lookup: pop package string from stack, resolve &name in that package context.
+    IndirectCodeLookup(u32),
+
     /// Save current variable value for `let` scope management.
     /// Pops the array index (if index_mode is true) from the stack.
     LetSave {

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -249,6 +249,7 @@ fn postfix_expr(input: &str) -> PResult<'_, Expr> {
                 &expr,
                 Expr::Var(_)
                     | Expr::CodeVar(_)
+                    | Expr::IndirectCodeLookup { .. }
                     | Expr::MethodCall { .. }
                     | Expr::AnonSub(_)
                     | Expr::AnonSubParams { .. }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -189,6 +189,9 @@ impl Interpreter {
             // Concurrency (single-threaded simulation)
             "start" => self.builtin_start(args),
             "await" => self.builtin_await(&args),
+            // Boolean coercion functions
+            "not" => Ok(Value::Bool(!args.first().unwrap_or(&Value::Nil).truthy())),
+            "so" => Ok(Value::Bool(args.first().unwrap_or(&Value::Nil).truthy())),
             // Fallback
             _ => self.call_function_fallback(name, &args),
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1003,6 +1003,10 @@ impl VM {
                 self.exec_indirect_type_lookup_op();
                 *ip += 1;
             }
+            OpCode::IndirectCodeLookup(name_idx) => {
+                self.exec_indirect_code_lookup_op(code, *name_idx);
+                *ip += 1;
+            }
             OpCode::StateVarInit(slot, key_idx) => {
                 self.exec_state_var_init_op(code, *slot, *key_idx);
                 *ip += 1;

--- a/src/vm/vm_call_ops.rs
+++ b/src/vm/vm_call_ops.rs
@@ -161,9 +161,9 @@ impl VM {
         }
         let start = self.stack.len() - arity;
         let args: Vec<Value> = self.stack.drain(start..).collect();
-        let key = format!("&{}", name);
-        let result = if self.interpreter.env().contains_key(&key) {
-            let target = self.interpreter.resolve_code_var(&name);
+        // resolve_code_var handles pseudo-package stripping internally
+        let target = self.interpreter.resolve_code_var(&name);
+        let result = if !matches!(target, Value::Nil) {
             self.interpreter.eval_call_on_value(target, args)?
         } else if let Some(native_result) = Self::try_native_function(&name, &args) {
             native_result?


### PR DESCRIPTION
## Summary
- Add parser support for package-qualified code references (`&SETTING::OUTER::...::name`) and indirect package lookups (`&::($expr)::name`, `&CALLER::($expr)::name`)
- Add `IndirectCodeLookup` AST variant, opcode, and VM execution
- Extend `resolve_code_var()` to strip pseudo-package prefixes (SETTING, OUTER, CALLER, CORE, GLOBAL, etc.) and resolve to builtins when qualified names bypass user-defined overrides
- Add `not()` and `so()` as callable functions (previously only 0-arg methods)

## Test plan
- [x] `roast/S02-names/SETTING-6e.t` passes all 6 subtests (added to whitelist)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)