### PR TITLE
feat: implement Supply.on-demand, Supplier class, and fix s.identifier parsing

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -171,6 +171,7 @@ roast/S17-procasync/many-processes-no-close-stdin.t
 roast/S17-procasync/no-runaway-file-limit.t
 roast/S17-promise/stress.t
 roast/S17-supply/do.t
+roast/S17-supply/on-demand.t
 roast/S17-supply/repeated.t
 roast/S17-supply/watch-path.t
 roast/S19-command-line-options/03-dash-p.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -214,6 +214,7 @@ pub struct Interpreter {
     loaded_modules: HashSet<String>,
     state_vars: HashMap<String, Value>,
     let_saves: Vec<(String, Value)>,
+    pub(super) supply_emit_buffer: Vec<Vec<Value>>,
 }
 
 pub(crate) struct SubtestContext {
@@ -266,11 +267,24 @@ impl Interpreter {
                 parents: Vec::new(),
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["emit", "tap", "repeated", "do"]
+                native_methods: ["emit", "tap", "repeated", "do", "Supply"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
                 mro: vec!["Supply".to_string()],
+            },
+        );
+        classes.insert(
+            "Supplier".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: ["emit", "done", "Supply"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                mro: vec!["Supplier".to_string()],
             },
         );
         classes.insert(
@@ -523,6 +537,7 @@ impl Interpreter {
             loaded_modules: HashSet::new(),
             state_vars: HashMap::new(),
             let_saves: Vec::new(),
+            supply_emit_buffer: Vec::new(),
         };
         interpreter.init_io_environment();
         interpreter.init_order_enum();


### PR DESCRIPTION
## Summary
- Implement `Supply.on-demand` class method with on-demand callback support
- Add `Supplier` class with `.emit()`, `.done()`, `.Supply` methods
- Add `supply_emit_buffer` mechanism for collecting emitted values during tapping
- Update `tap-ok` test helper to handle `:!live` named arg and on-demand supplies
- Fix `s.identifier` being incorrectly parsed as substitution operator (block `s.` when followed by 2+ char identifier)
- Fix `scan_to_delim` to skip `.` when part of `..` range operator

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-supply/on-demand.t` passes (7/7 tests)
- [x] `prove -e 'target/debug/mutsu' roast/S05-metasyntax/delimiters.t` passes (no regression)
- [x] `make test` passes
- [x] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)