### PR TITLE
fix: handle Bool negation and partially address type system issues

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -249,6 +249,7 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
 
 pub(crate) fn arith_negate(val: Value) -> Result<Value, RuntimeError> {
     match val {
+        Value::Bool(b) => Ok(Value::Int(if b { -1 } else { 0 })),
         Value::Int(i) => Ok(Value::Int(-i)),
         Value::Num(f) => Ok(Value::Num(-f)),
         Value::Rat(n, d) => Ok(Value::Rat(-n, d)),


### PR DESCRIPTION
## Summary
- Fix Bool negation: `-True` now evaluates to `-1` and `-False` to `0` (Bool is a subtype of Int in Raku)
- Partially addresses #93

Note: The Nil.WHAT issue from #93 is deferred because mutsu uses `Value::Nil` to represent both Raku's `Nil` and uninitialized `Any` type objects. Fixing this properly requires distinguishing these two concepts, which is a larger refactor.

The Array/Hash Cool hierarchy item from #93 was verified to be correct - Array and Hash DO inherit from Cool in Raku (`Array.^mro` shows `(Array) (List) (Cool) (Any) (Mu)`).

## Test plan
- [x] `make test` passes (only pre-existing socket.t network failure)
- [x] `-True` evaluates to `-1`, `-False` evaluates to `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)