### PR TITLE
fix: make EvalAstExpr fallback actually evaluate via interpreter

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -998,6 +998,7 @@ impl VM {
             }
             OpCode::EvalAstExpr(stmt_idx) => {
                 self.exec_eval_ast_expr_op(code, *stmt_idx)?;
+                *ip += 1;
             }
             OpCode::IndirectTypeLookup => {
                 self.exec_indirect_type_lookup_op();

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -389,11 +389,10 @@ impl VM {
         code: &CompiledCode,
         stmt_idx: u32,
     ) -> Result<(), RuntimeError> {
-        let stmt = &code.stmt_pool[stmt_idx as usize];
-        Err(RuntimeError::new(format!(
-            "Unsupported expression in compiled code: {:?}",
-            stmt
-        )))
+        let stmt = code.stmt_pool[stmt_idx as usize].clone();
+        let result = self.interpreter.eval_block_value(&[stmt])?;
+        self.stack.push(result);
+        Ok(())
     }
 
     pub(super) fn exec_indirect_type_lookup_op(&mut self) {


### PR DESCRIPTION
## Summary
- The compiler emits `OpCode::EvalAstExpr` for unsupported prefix/binary operators, but the VM handler always returned an error instead of evaluating the AST
- Now delegates to the interpreter's `eval_block_value()` and pushes the result onto the stack
- Adds the missing `ip += 1` after execution so the VM advances past the instruction

## Test plan
- [x] `make test` passes (only pre-existing `t/socket.t` failure)
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)