### PR TITLE
feat: support anonymous enums and prefix +/- on hash variables

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -56,7 +56,7 @@
   - 9/28 pass (1, 4, 7, 10, 13, 15, 17, 25-26). Basic `.new` works. Failures: parent attribute access (2-3, 5-6, 8-9, 11-12, 18-19), missing class error (14, 16), Mu.new multi (20), alternate constructors (21-22), nextwith (23-24), MI attribute init (27-28). Difficulty: Medium-High
 - [ ] roast/S12-construction/roles-6e.t
 - [ ] roast/S12-construction/TWEAK.t
-- [ ] roast/S12-enums/anonymous.t
+- [x] roast/S12-enums/anonymous.t
 - [ ] roast/S12-enums/as-role.t
   - 6/9 pass. Tests 1, 5, 9 fail: enum member accessor methods (`.No`, `.Yes`, `.Dunno`) on objects with applied enum role. Requires `does`/`but` operators with enum parameters and enum-as-role composition. Difficulty: High
 - [ ] roast/S12-enums/basic.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -102,6 +102,7 @@ roast/S12-class/declaration-order.t
 roast/S12-class/literal.t
 roast/S12-class/type-object.t
 roast/S12-construction/autopairs.t
+roast/S12-enums/anonymous.t
 roast/S12-methods/typed-attributes.t
 roast/S12-traits/precomp.t
 roast/S14-roles/bool.t

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -696,6 +696,10 @@ impl Compiler {
                     let name_idx = self.code.add_constant(Value::Str(name.clone()));
                     self.code.emit(OpCode::GetBareWord(name_idx));
                 }
+                Stmt::EnumDecl { name, .. } if name.is_empty() => {
+                    // Anonymous enum: RegisterEnum pushes the Map result
+                    self.compile_stmt(stmt);
+                }
                 _ => {
                     self.compile_stmt(stmt);
                     self.code.emit(OpCode::LoadNil);

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -338,6 +338,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && let Some(c) = input[1..].chars().next()
         && (c == '$'
             || c == '@'
+            || c == '%'
             || c == '('
             || c == '"'
             || c == '\''
@@ -357,6 +358,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && let Some(&c) = input.as_bytes().get(1)
         && (c == b'$'
             || c == b'@'
+            || c == b'%'
             || c == b'('
             || c == b'"'
             || c == b'\''

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -304,9 +304,16 @@ fn postfix_expr(input: &str) -> PResult<'_, Expr> {
             };
             let key = &r[..end];
             if key.is_empty()
-                || !key
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+                || !key.chars().all(|c| {
+                    c.is_alphanumeric()
+                        || c == '_'
+                        || c == '-'
+                        || c == '!'
+                        || c == '.'
+                        || c == '?'
+                        || c == '+'
+                        || c == '/'
+                })
             {
                 return Err(PError::expected_at("angle index key", r));
             }

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -600,6 +600,18 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 return Ok((r, Expr::DoStmt(Box::new(stmt))));
             }
         }
+        "enum" => {
+            // enum in expression context: enum < ... > or enum :: < ... >
+            if let Ok((r, stmt)) = super::super::stmt::decl::enum_decl(input) {
+                return Ok((r, Expr::DoStmt(Box::new(stmt))));
+            }
+        }
+        "anon" => {
+            // anon enum < ... > in expression context
+            if let Ok((r, stmt)) = super::super::stmt::decl::anon_enum_decl(input) {
+                return Ok((r, Expr::DoStmt(Box::new(stmt))));
+            }
+        }
         "sub" => {
             let (r, _) = ws(rest)?;
             if r.starts_with('{') {

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -2,7 +2,7 @@ mod args;
 pub(super) mod assign;
 pub(super) mod class;
 mod control;
-mod decl;
+pub(crate) mod decl;
 pub(super) mod modifier;
 pub(super) mod simple;
 mod sub;
@@ -286,6 +286,7 @@ const STMT_PARSERS: &[StmtParser] = &[
     class::role_decl,
     class::grammar_decl,
     decl::subset_decl,
+    decl::anon_enum_decl,
     decl::enum_decl,
     decl::has_decl,
     class::does_decl,

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -192,7 +192,7 @@ impl Value {
             }
             "Seq" | "List" => matches!(self, Value::Array(_) | Value::LazyList(_) | Value::Slip(_)),
             "Positional" => matches!(self, Value::Array(_) | Value::LazyList(_)),
-            "Associative" => matches!(self, Value::Hash(_)),
+            "Map" | "Associative" => matches!(self, Value::Hash(_)),
             "Iterable" => matches!(self, Value::Array(_) | Value::LazyList(_) | Value::Hash(_)),
             _ => false,
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -233,7 +233,11 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::EnumDecl { name, variants } = stmt {
-            self.interpreter.register_enum_decl(name, variants)?;
+            let result = self.interpreter.register_enum_decl(name, variants)?;
+            // For anonymous enums, push the Map result onto the stack
+            if name.is_empty() {
+                self.stack.push(result);
+            }
             self.sync_locals_from_env(code);
             Ok(())
         } else {

--- a/t/anon-enum.t
+++ b/t/anon-enum.t
@@ -1,0 +1,27 @@
+use Test;
+plan 10;
+
+# Anonymous enum with < >
+my $e = enum < foo bar baz >;
+is $e.keys.elems, 3, 'anonymous enum has 3 keys';
+is $e<foo>, 0, 'anonymous enum first value is 0';
+is $e<bar>, 1, 'anonymous enum second value is 1';
+is $e<baz>, 2, 'anonymous enum third value is 2';
+isa-ok $e, Map, 'anonymous enum isa Map';
+
+# Anonymous enum with ::
+my %e2 = enum :: < x y z >;
+is +%e2<y>, 1, 'enum :: form works';
+
+# anon keyword
+anon enum < alpha >;
+is +alpha, 0, 'anon enum keyword works';
+
+# Single value
+my %e3 = enum <single>;
+is %e3.keys.elems, 1, 'single-value enum has 1 key';
+is %e3<single>, 0, 'single-value enum value is 0';
+
+# Prefix +/- on hash variables
+my %h = "a" => 42;
+is +%h<a>, 42, 'prefix + on hash angle bracket access';


### PR DESCRIPTION
## Summary
- Implement anonymous enum parsing and evaluation (`enum < foo bar >`, `enum :: < foo bar >`, `anon enum < foo >`)
- Anonymous enums return Map (Hash) values with key=>index pairs
- Fix prefix `+` and `-` operators to work on `%hash` variables
- Allow special characters (`!`, `.`, `?`, `+`, `/`) in angle bracket hash key access
- Add `Map` as parent type of `Hash` in type hierarchy

## Test plan
- [x] `roast/S12-enums/anonymous.t` passes (10/10 tests)
- [x] `t/anon-enum.t` local test added and passing
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)