### PR TITLE
refactor: Arc-wrap Sub values and use Weak for &?BLOCK to enable GC

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -1,0 +1,216 @@
+# Memory Management & GC Design
+
+## Goal
+
+mutsu aims to support long-running programs (daemons, servers). The current
+"clone everything, free at exit" strategy causes unbounded memory growth in
+such scenarios. This document describes an incremental plan to fix that.
+
+## Current state
+
+- `Value` derives `Clone`. Every operation (variable access, function call,
+  closure capture, array/hash copy) performs a deep clone.
+- `Value` is required to be `Send + Sync` (compile-time assertion in
+  `value/mod.rs`) for thread support (Promise, Channel, `clone_for_thread`).
+  This rules out `Rc<RefCell<>>`.
+- `Interpreter.env` is `HashMap<String, Value>`. Closure creation clones the
+  entire env (~21 `.env.clone()` call sites, plus ~123 `env.insert()` sites).
+- Circular references exist via `&?BLOCK` (a Sub whose `env` contains itself).
+- `Arc` is already used for `LazyList`, `SharedPromise`, `SharedChannel`.
+
+### Problems for long-running programs
+
+| Problem | Mechanism |
+|---------|-----------|
+| Circular references never freed | `&?BLOCK` creates Sub.env -> Sub cycle |
+| Closure env accumulates | Every function call clones the full env |
+| END phasers capture full env | `push_end_phaser` clones `self.env` |
+| Large collection cloning | Array/Hash deeply cloned on every pass |
+| state vars persist forever | `state_vars: HashMap<String, Value>` |
+
+## Design
+
+### Phase 1: Arc-wrap heap-allocated Value internals
+
+Replace deep clones with shared references for heap-allocated data. Cloning an
+`Arc` is just an atomic increment instead of a deep copy.
+
+#### Changes to Value
+
+```rust
+#[derive(Debug, Clone)]
+pub enum Value {
+    // Scalar types: unchanged (Copy-like cost)
+    Int(i64),
+    Num(f64),
+    Bool(bool),
+    Nil,
+    HyperWhatever,
+    Rat(i64, i64),
+    FatRat(i64, i64),
+    Complex(f64, f64),
+    Range(i64, i64),
+    RangeExcl(i64, i64),
+    RangeExclStart(i64, i64),
+    RangeExclBoth(i64, i64),
+
+    // Heap types: wrap in Arc
+    Str(Arc<String>),              // was: String
+    BigInt(Arc<NumBigInt>),        // was: NumBigInt
+    Array(Arc<Vec<Value>>),        // was: Vec<Value>
+    Hash(Arc<HashMap<String, Value>>),  // was: HashMap
+    Set(Arc<HashSet<String>>),     // was: HashSet
+    Bag(Arc<HashMap<String, i64>>),
+    Mix(Arc<HashMap<String, f64>>),
+
+    GenericRange {
+        start: Arc<Value>,         // was: Box<Value>
+        end: Arc<Value>,
+    },
+    Pair(String, Arc<Value>),      // was: Box<Value>
+    Mixin(Arc<Value>, Arc<HashMap<String, Value>>),
+
+    Sub {
+        package: Arc<String>,
+        name: Arc<String>,
+        params: Arc<Vec<String>>,
+        body: Arc<Vec<Stmt>>,
+        env: Arc<HashMap<String, Value>>,  // KEY CHANGE
+        id: u64,
+    },
+    Instance {
+        class_name: String,
+        attributes: Arc<HashMap<String, Value>>,  // was: HashMap
+        id: u64,
+    },
+    Junction {
+        kind: JunctionKind,
+        values: Arc<Vec<Value>>,
+    },
+    Slip(Arc<Vec<Value>>),
+    // ... remaining variants already use Arc
+}
+```
+
+#### Key principles
+
+- **Read path unchanged**: Pattern matching on `Arc<T>` works via auto-deref.
+  `match &*arc_vec { ... }` or `arc_str.as_str()`.
+- **Write path uses `Arc::make_mut`**: When mutation is needed (push to array,
+  insert to hash), `Arc::make_mut()` provides clone-on-write semantics. If
+  there is only one reference, it mutates in place; otherwise it clones.
+- **Value::clone() becomes cheap**: Cloning a Value with Arc internals only
+  increments reference counts, no deep copy.
+- **Send + Sync preserved**: `Arc<T>` is Send + Sync when T is Send + Sync.
+
+#### Migration strategy
+
+This is a large mechanical refactor. Approach:
+
+1. Change the `Value` enum definition.
+2. Fix all construction sites (wrap in `Arc::new()`).
+3. Fix all pattern match sites (add derefs where needed).
+4. Fix all mutation sites (use `Arc::make_mut()`).
+5. Run `cargo build` and fix remaining errors iteratively.
+
+The `env: Arc<HashMap<String, Value>>` change has the biggest impact:
+- `self.env.clone()` in `call_sub_value`, `push_end_phaser`, etc. becomes
+  an Arc clone (O(1) instead of O(n)).
+- `self.env.insert(k, v)` requires `Arc::make_mut(&mut self.env).insert(k, v)`.
+  When env has refcount 1 (common case), this is a no-op wrapper.
+
+### Phase 2: Weak references for &?BLOCK
+
+The `&?BLOCK` variable creates a cycle: a Sub's env contains a reference to
+itself. With Phase 1's `Arc`, this cycle prevents deallocation.
+
+#### Solution: dedicated Weak variant
+
+```rust
+pub enum Value {
+    // ... existing variants ...
+
+    /// A weak reference to a Value (used for &?BLOCK self-references).
+    /// Upgrade to the strong value when accessed; returns Nil if expired.
+    WeakSub(Weak<SubData>),
+}
+```
+
+Where `SubData` is extracted from the Sub variant:
+
+```rust
+pub(crate) struct SubData {
+    pub package: Arc<String>,
+    pub name: Arc<String>,
+    pub params: Arc<Vec<String>>,
+    pub body: Arc<Vec<Stmt>>,
+    pub env: Arc<HashMap<String, Value>>,
+    pub id: u64,
+}
+
+pub enum Value {
+    Sub(Arc<SubData>),
+    WeakSub(Weak<SubData>),
+    // ...
+}
+```
+
+#### Changes to &?BLOCK insertion
+
+In `resolution.rs` and `builtins.rs`, where `&?BLOCK` is inserted:
+
+```rust
+// Before (Phase 1):
+let block_self = Value::Sub(Arc::new(SubData { ... env: new_env.clone(), ... }));
+Arc::make_mut(&mut new_env).insert("&?BLOCK".to_string(), block_self);
+
+// After (Phase 2):
+let sub_data = Arc::new(SubData { ... env: new_env.clone(), ... });
+let weak_ref = Value::WeakSub(Arc::downgrade(&sub_data));
+Arc::make_mut(&mut new_env).insert("&?BLOCK".to_string(), weak_ref);
+let block_self = Value::Sub(sub_data);
+```
+
+#### Changes to &?BLOCK access
+
+When `&?BLOCK` is accessed (variable lookup), upgrade the weak reference:
+
+```rust
+// In env lookup:
+match value {
+    Value::WeakSub(weak) => {
+        match weak.upgrade() {
+            Some(strong) => Value::Sub(strong),
+            None => Value::Nil,  // already freed
+        }
+    }
+    other => other.clone(),
+}
+```
+
+### Phase 3 (future): Cycle collector
+
+For user-created cycles (`$a[0] = @a`, mutual object references), a proper
+cycle collector will be needed. This is deferred until the need arises.
+
+Options:
+- **Backup mark-and-sweep**: Periodically scan all live Values from roots
+  (Interpreter.env, stack, locals) and free unreachable Arc values.
+- **Python-style cycle detector**: Track container objects (Array, Hash,
+  Instance, Sub) in a generation list; periodically scan for reference cycles.
+- **Epoch-based collection**: Use a GC epoch counter; values created before
+  a certain epoch that are unreachable get collected.
+
+## Impact on existing tests
+
+All existing tests should pass unchanged. The refactor is purely internal:
+- Value semantics are preserved (clone-on-write matches deep-clone behavior).
+- Thread safety is preserved (Arc is Send + Sync).
+- Performance should improve (fewer deep clones).
+
+## Implementation order
+
+1. Phase 1a: Arc-wrap `Sub.env` (biggest win, most `.env.clone()` call sites).
+2. Phase 1b: Arc-wrap `Array`, `Hash`, `Str`, other heap types.
+3. Phase 2: Extract `SubData`, add `WeakSub`, fix `&?BLOCK` cycle.
+4. Run full test suite (`make test && make roast`) at each step.

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -203,7 +203,7 @@ impl Interpreter {
         self.env.insert("$*CWD".to_string(), cwd_val.clone());
         self.env.insert("*CWD".to_string(), cwd_val);
         let result = if let Some(body) = args.get(1) {
-            if matches!(body, Value::Sub { .. }) {
+            if matches!(body, Value::Sub(_)) {
                 self.call_sub_value(body.clone(), vec![], false)
             } else {
                 Ok(body.clone())

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,7 +18,6 @@ use crate::opcode::{CompiledCode, OpCode};
 use crate::parse_dispatch;
 use crate::value::{
     JunctionKind, LazyList, RuntimeError, SharedChannel, SharedPromise, Value, make_rat,
-    next_instance_id,
 };
 use num_traits::Signed;
 

--- a/src/runtime/seq_helpers.rs
+++ b/src/runtime/seq_helpers.rs
@@ -9,9 +9,9 @@ impl Interpreter {
             // When RHS is a callable (Sub), invoke it with LHS as argument and
             // return truthiness of the result.  If the sub accepts no parameters,
             // call it with no arguments (simple closure truth).
-            (_, Value::Sub { params, .. }) => {
+            (_, Value::Sub(data)) => {
                 let func = right.clone();
-                let args = if params.is_empty() {
+                let args = if data.params.is_empty() {
                     vec![]
                 } else {
                     vec![left.clone()]

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -53,14 +53,13 @@ impl Interpreter {
         } = supply_val
             && class_name == "Supply"
         {
-            let tap_sub = Value::Sub {
-                package: self.current_package.clone(),
-                name: String::new(),
-                params: param.iter().cloned().collect(),
-                body: body.to_vec(),
-                env: self.env.clone(),
-                id: next_instance_id(),
-            };
+            let tap_sub = Value::make_sub(
+                self.current_package.clone(),
+                String::new(),
+                param.iter().cloned().collect(),
+                body.to_vec(),
+                self.env.clone(),
+            );
             let mut attrs = attributes.clone();
             if let Some(Value::Array(items)) = attrs.get_mut("taps") {
                 items.push(tap_sub.clone());

--- a/src/runtime/test_functions.rs
+++ b/src/runtime/test_functions.rs
@@ -330,7 +330,7 @@ impl Interpreter {
         let desc = Self::positional_string(args, 1);
         let todo = Self::named_bool(args, "todo");
         let ok = match &block {
-            Value::Sub { body, .. } => self.eval_block_value(body).is_ok(),
+            Value::Sub(data) => self.eval_block_value(&data.body).is_ok(),
             _ => true,
         };
         self.test_ok(ok, &desc, todo)?;
@@ -342,7 +342,7 @@ impl Interpreter {
         let desc = Self::positional_string(args, 1);
         let todo = Self::named_bool(args, "todo");
         let ok = match &block {
-            Value::Sub { body, .. } => self.eval_block_value(body).is_err(),
+            Value::Sub(data) => self.eval_block_value(&data.body).is_err(),
             _ => false,
         };
         self.test_ok(ok, &desc, todo)?;
@@ -454,7 +454,7 @@ impl Interpreter {
             Self::positional_value_required(args, 1, "throws-like expects type")?.to_string_value();
         let desc = Self::positional_string(args, 2);
         let result = match &code_val {
-            Value::Sub { body, .. } => self.eval_block_value(body),
+            Value::Sub(data) => self.eval_block_value(&data.body),
             Value::Str(code) => {
                 let mut nested = Interpreter::new();
                 if let Some(Value::Int(pid)) = self.env.get("*PID") {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -223,7 +223,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Bag(_) => "Bag",
         Value::Mix(_) => "Mix",
         Value::Nil => "Any",
-        Value::Sub { .. } => "Sub",
+        Value::Sub(_) | Value::WeakSub(_) => "Sub",
         Value::Routine { .. } => "Routine",
         Value::Package(_) => "Package",
         Value::CompUnitDepSpec { .. } => "Any",

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -259,7 +259,11 @@ impl Value {
             }
             Value::Package(s) => format!("({})", s),
             Value::Routine { package, name } => format!("{}::{}", package, name),
-            Value::Sub { name, .. } => name.clone(),
+            Value::Sub(data) => data.name.clone(),
+            Value::WeakSub(weak) => match weak.upgrade() {
+                Some(data) => data.name.clone(),
+                None => String::new(),
+            },
             Value::Instance {
                 class_name,
                 attributes,

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -34,7 +34,7 @@ impl Value {
             | (Value::Enum { .. }, Value::Enum { .. })
             | (Value::Regex(_), Value::Regex(_))
             | (Value::Routine { .. }, Value::Routine { .. })
-            | (Value::Sub { .. }, Value::Sub { .. })
+            | (Value::Sub(_), Value::Sub(_))
             | (Value::Instance { .. }, Value::Instance { .. })
             | (Value::Range(_, _), Value::Range(_, _))
             | (Value::RangeExcl(_, _), Value::RangeExcl(_, _))
@@ -79,7 +79,7 @@ impl Value {
             Value::CompUnitDepSpec { .. } => true,
             Value::Package(_) => false,
             Value::Routine { .. } => true,
-            Value::Sub { .. } => true,
+            Value::Sub(_) | Value::WeakSub(_) => true,
             Value::Instance {
                 class_name,
                 attributes,
@@ -143,7 +143,7 @@ impl Value {
             Value::Instance { class_name, .. } => class_name.as_str(),
             Value::Package(name) => name.as_str(),
             Value::Enum { enum_type, .. } => enum_type.as_str(),
-            Value::Sub { .. } | Value::Routine { .. } => "Sub",
+            Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } => "Sub",
             Value::Regex(_) => "Regex",
             Value::Junction { .. } => "Junction",
             Value::Version { .. } => "Version",
@@ -194,7 +194,10 @@ impl Value {
             "Int" => matches!(self, Value::Bool(_)),
             "Stringy" => matches!(self, Value::Str(_)),
             "Block" | "Routine" | "Code" | "Callable" => {
-                matches!(self, Value::Sub { .. } | Value::Routine { .. })
+                matches!(
+                    self,
+                    Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
+                )
             }
             "Seq" | "List" => matches!(self, Value::Array(_) | Value::LazyList(_) | Value::Slip(_)),
             "Positional" => matches!(self, Value::Array(_) | Value::LazyList(_)),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,7 +5,7 @@ use crate::ast::Stmt;
 use crate::interpreter::Interpreter;
 use crate::opcode::{CompiledCode, CompiledFunction, OpCode};
 use crate::runtime;
-use crate::value::{JunctionKind, LazyList, RuntimeError, Value, make_rat, next_instance_id};
+use crate::value::{JunctionKind, LazyList, RuntimeError, Value, make_rat};
 use num_traits::{Signed, Zero};
 
 mod vm_arith_ops;

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -213,25 +213,26 @@ impl VM {
         static COMPOSE_ID: std::sync::atomic::AtomicU64 =
             std::sync::atomic::AtomicU64::new(1_000_000);
         let id = COMPOSE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let composed = Value::Sub {
-            package: String::new(),
-            name: "<composed>".to_string(),
-            params: vec!["x".to_string()],
-            body: vec![Stmt::Expr(Expr::Call {
+        let env = {
+            let mut env = std::collections::HashMap::new();
+            env.insert("__compose_left__".to_string(), left);
+            env.insert("__compose_right__".to_string(), right);
+            env
+        };
+        let composed = Value::make_sub_with_id(
+            String::new(),
+            "<composed>".to_string(),
+            vec!["x".to_string()],
+            vec![Stmt::Expr(Expr::Call {
                 name: "__compose_left__".to_string(),
                 args: vec![Expr::Call {
                     name: "__compose_right__".to_string(),
                     args: vec![Expr::Var("x".to_string())],
                 }],
             })],
-            env: {
-                let mut env = std::collections::HashMap::new();
-                env.insert("__compose_left__".to_string(), left);
-                env.insert("__compose_right__".to_string(), right);
-                env
-            },
+            env,
             id,
-        };
+        );
         self.stack.push(composed);
     }
 

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -327,7 +327,7 @@ impl VM {
 
     pub(super) fn exec_block_magic_op(&mut self) -> Result<(), RuntimeError> {
         if let Some(val) = self.interpreter.block_stack_top().cloned() {
-            if matches!(val, Value::Sub { .. }) {
+            if matches!(val, Value::Sub(_)) {
                 self.stack.push(val);
             } else {
                 return Err(RuntimeError::new("X::Undeclared::Symbols"));

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -28,14 +28,13 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::Block(body) = stmt {
-            let val = Value::Sub {
-                package: self.interpreter.current_package().to_string(),
-                name: String::new(),
-                params: vec![],
-                body: body.clone(),
-                env: self.interpreter.env().clone(),
-                id: next_instance_id(),
-            };
+            let val = Value::make_sub(
+                self.interpreter.current_package().to_string(),
+                String::new(),
+                vec![],
+                body.clone(),
+                self.interpreter.env().clone(),
+            );
             self.stack.push(val);
             Ok(())
         } else {
@@ -50,14 +49,13 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::SubDecl { params, body, .. } = stmt {
-            let val = Value::Sub {
-                package: self.interpreter.current_package().to_string(),
-                name: String::new(),
-                params: params.clone(),
-                body: body.clone(),
-                env: self.interpreter.env().clone(),
-                id: next_instance_id(),
-            };
+            let val = Value::make_sub(
+                self.interpreter.current_package().to_string(),
+                String::new(),
+                params.clone(),
+                body.clone(),
+                self.interpreter.env().clone(),
+            );
             self.stack.push(val);
             Ok(())
         } else {
@@ -72,14 +70,13 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::SubDecl { params, body, .. } = stmt {
-            let val = Value::Sub {
-                package: self.interpreter.current_package().to_string(),
-                name: String::new(),
-                params: params.clone(),
-                body: body.clone(),
-                env: self.interpreter.env().clone(),
-                id: next_instance_id(),
-            };
+            let val = Value::make_sub(
+                self.interpreter.current_package().to_string(),
+                String::new(),
+                params.clone(),
+                body.clone(),
+                self.interpreter.env().clone(),
+            );
             self.stack.push(val);
             Ok(())
         } else {
@@ -94,14 +91,13 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::Block(body) = stmt {
-            let val = Value::Sub {
-                package: self.interpreter.current_package().to_string(),
-                name: String::new(),
-                params: vec![],
-                body: body.clone(),
-                env: self.interpreter.env().clone(),
-                id: next_instance_id(),
-            };
+            let val = Value::make_sub(
+                self.interpreter.current_package().to_string(),
+                String::new(),
+                vec![],
+                body.clone(),
+                self.interpreter.env().clone(),
+            );
             self.stack.push(val);
             Ok(())
         } else {

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -194,24 +194,16 @@ impl VM {
                 Value::Array(result)
             }
             // WhateverCode index: @a[*-1] → evaluate the lambda with array length
-            (
-                Value::Array(ref items),
-                Value::Sub {
-                    ref params,
-                    ref body,
-                    ref env,
-                    ..
-                },
-            ) => {
+            (Value::Array(ref items), Value::Sub(ref data)) => {
                 let len = items.len() as i64;
-                let param = params.first().map(|s| s.as_str()).unwrap_or("_");
-                let mut sub_env = env.clone();
+                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
+                let mut sub_env = data.env.clone();
                 sub_env.insert(param.to_string(), Value::Int(len));
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
                     .interpreter
-                    .eval_block_value(body)
+                    .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
                 *self.interpreter.env_mut() = saved_env;
                 match idx {


### PR DESCRIPTION
## Summary

- Extract `SubData` struct from `Value::Sub` fields; change `Sub` to `Sub(Arc<SubData>)` for O(1) closure cloning
- Add `WeakSub(Weak<SubData>)` variant to break `&?BLOCK` circular references
- Add `Value::make_sub()` / `make_sub_with_id()` helpers
- Transparently upgrade `WeakSub` to `Sub` on variable access and calls
- Add `docs/gc.md` with memory management design (Phase 1–3 plan)

This is the first step toward supporting long-running programs (daemons). The main circular reference pattern (`&?BLOCK`) is now broken with `Weak`, and closure environments are shared via `Arc` instead of deep-cloned.

## Test plan

- [x] `make test` — 1365 tests pass
- [x] `make roast` — 92,276 tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)