### PR TITLE
refactor: Arc-wrap Array, Hash, Set, Bag, Mix, Slip, Junction, and Instance.attributes in Value

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -91,7 +91,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 .split_whitespace()
                 .map(|p| Value::Str(p.to_string()))
                 .collect();
-            Some(Ok(Value::Array(parts)))
+            Some(Ok(Value::array(parts)))
         }
         "chars" => Some(Ok(Value::Int(
             arg.to_string_value().graphemes(true).count() as i64,
@@ -269,18 +269,18 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
         },
         "reverse" => Some(Ok(match arg {
             Value::Array(items) => {
-                let mut reversed = items.clone();
+                let mut reversed = (**items).clone();
                 reversed.reverse();
-                Value::Array(reversed)
+                Value::array(reversed)
             }
             Value::Str(s) => Value::Str(s.chars().rev().collect()),
             _ => Value::Nil,
         })),
         "sort" => Some(Ok(match arg {
             Value::Array(items) => {
-                let mut sorted = items.clone();
+                let mut sorted = (**items).clone();
                 sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                Value::Array(sorted)
+                Value::array(sorted)
             }
             _ => Value::Nil,
         })),
@@ -289,7 +289,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             fn flat_val(v: &Value, out: &mut Vec<Value>) {
                 match v {
                     Value::Array(items) => {
-                        for item in items {
+                        for item in items.iter() {
                             flat_val(item, out);
                         }
                     }
@@ -304,7 +304,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 }
             }
             flat_val(arg, &mut flat);
-            Some(Ok(Value::Array(flat)))
+            Some(Ok(Value::array(flat)))
         }
         "first" => Some(Ok(match arg {
             Value::Array(items) => items.first().cloned().unwrap_or(Value::Nil),
@@ -335,7 +335,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
         "ords" => {
             let s = arg.to_string_value();
             let codes: Vec<Value> = s.chars().map(|ch| Value::Int(ch as u32 as i64)).collect();
-            Some(Ok(Value::Array(codes)))
+            Some(Ok(Value::array(codes)))
         }
         "gist" => Some(Ok(Value::Str(arg.to_string_value()))),
         _ => None,
@@ -568,7 +568,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             for arg in args {
                 match arg {
                     Value::Array(items) => {
-                        for item in items {
+                        for item in items.iter() {
                             push_chr(&mut result, item);
                         }
                     }
@@ -582,7 +582,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             fn flat_val_deep(v: &Value, out: &mut Vec<Value>) {
                 match v {
                     Value::Array(items) => {
-                        for item in items {
+                        for item in items.iter() {
                             flat_val_deep(item, out);
                         }
                     }
@@ -599,7 +599,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             for arg in args {
                 flat_val_deep(arg, &mut result);
             }
-            Some(Ok(Value::Array(result)))
+            Some(Ok(Value::array(result)))
         }
         _ => None,
     }

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -22,10 +22,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             _ => Some(Ok(Value::Bool(false))),
         },
         "nude" => match target {
-            Value::Rat(n, d) => Some(Ok(Value::Array(vec![Value::Int(*n), Value::Int(*d)]))),
-            Value::FatRat(n, d) => Some(Ok(Value::Array(vec![Value::Int(*n), Value::Int(*d)]))),
-            Value::Int(i) => Some(Ok(Value::Array(vec![Value::Int(*i), Value::Int(1)]))),
-            _ => Some(Ok(Value::Array(vec![Value::Int(0), Value::Int(1)]))),
+            Value::Rat(n, d) => Some(Ok(Value::array(vec![Value::Int(*n), Value::Int(*d)]))),
+            Value::FatRat(n, d) => Some(Ok(Value::array(vec![Value::Int(*n), Value::Int(*d)]))),
+            Value::Int(i) => Some(Ok(Value::array(vec![Value::Int(*i), Value::Int(1)]))),
+            _ => Some(Ok(Value::array(vec![Value::Int(0), Value::Int(1)]))),
         },
         "is-prime" => match target {
             Value::Int(n) => {
@@ -69,25 +69,25 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             _ => Some(Ok(Value::Complex(0.0, 0.0))),
         },
         "reals" => match target {
-            Value::Complex(r, i) => Some(Ok(Value::Array(vec![Value::Num(*r), Value::Num(*i)]))),
+            Value::Complex(r, i) => Some(Ok(Value::array(vec![Value::Num(*r), Value::Num(*i)]))),
             _ => None,
         },
         "polar" => match target {
             Value::Complex(r, i) => {
                 let mag = (r * r + i * i).sqrt();
                 let angle = i.atan2(*r);
-                Some(Ok(Value::Array(vec![Value::Num(mag), Value::Num(angle)])))
+                Some(Ok(Value::array(vec![Value::Num(mag), Value::Num(angle)])))
             }
             Value::Int(i) => {
                 let f = *i as f64;
                 let mag = f.abs();
                 let angle = if f < 0.0 { std::f64::consts::PI } else { 0.0 };
-                Some(Ok(Value::Array(vec![Value::Num(mag), Value::Num(angle)])))
+                Some(Ok(Value::array(vec![Value::Num(mag), Value::Num(angle)])))
             }
             Value::Num(f) => {
                 let mag = f.abs();
                 let angle = if *f < 0.0 { std::f64::consts::PI } else { 0.0 };
-                Some(Ok(Value::Array(vec![Value::Num(mag), Value::Num(angle)])))
+                Some(Ok(Value::array(vec![Value::Num(mag), Value::Num(angle)])))
             }
             _ => None,
         },
@@ -123,40 +123,40 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "Slip" => match target {
             Value::Array(items) => Some(Ok(Value::Slip(items.clone()))),
             Value::Slip(_) => Some(Ok(target.clone())),
-            _ => Some(Ok(Value::Slip(vec![target.clone()]))),
+            _ => Some(Ok(Value::slip(vec![target.clone()]))),
         },
         "list" | "Array" => match target {
             Value::Range(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
                     Some(Ok(target.clone()))
                 } else {
-                    Some(Ok(Value::Array((*a..=*b).map(Value::Int).collect())))
+                    Some(Ok(Value::array((*a..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExcl(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
                     Some(Ok(target.clone()))
                 } else {
-                    Some(Ok(Value::Array((*a..*b).map(Value::Int).collect())))
+                    Some(Ok(Value::array((*a..*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclStart(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
                     Some(Ok(target.clone()))
                 } else {
-                    Some(Ok(Value::Array((a + 1..=*b).map(Value::Int).collect())))
+                    Some(Ok(Value::array((a + 1..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclBoth(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
                     Some(Ok(target.clone()))
                 } else {
-                    Some(Ok(Value::Array((a + 1..*b).map(Value::Int).collect())))
+                    Some(Ok(Value::array((a + 1..*b).map(Value::Int).collect())))
                 }
             }
             Value::GenericRange { .. } => Some(Ok(target.clone())),
             Value::Array(_) => Some(Ok(target.clone())),
-            _ => Some(Ok(Value::Array(vec![target.clone()]))),
+            _ => Some(Ok(Value::array(vec![target.clone()]))),
         },
         "Range" => match target {
             Value::Array(items) => Some(Ok(Value::RangeExcl(0, items.len() as i64))),

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -7,15 +7,15 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "keys" => match target {
             Value::Hash(map) => {
                 let keys: Vec<Value> = map.keys().map(|k| Value::Str(k.clone())).collect();
-                Some(Ok(Value::Array(keys)))
+                Some(Ok(Value::array(keys)))
             }
-            Value::Set(s) => Some(Ok(Value::Array(
+            Value::Set(s) => Some(Ok(Value::array(
                 s.iter().map(|k| Value::Str(k.clone())).collect(),
             ))),
-            Value::Bag(b) => Some(Ok(Value::Array(
+            Value::Bag(b) => Some(Ok(Value::array(
                 b.keys().map(|k| Value::Str(k.clone())).collect(),
             ))),
-            Value::Mix(m) => Some(Ok(Value::Array(
+            Value::Mix(m) => Some(Ok(Value::array(
                 m.keys().map(|k| Value::Str(k.clone())).collect(),
             ))),
             _ => None,
@@ -23,15 +23,15 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "values" => match target {
             Value::Hash(map) => {
                 let values: Vec<Value> = map.values().cloned().collect();
-                Some(Ok(Value::Array(values)))
+                Some(Ok(Value::array(values)))
             }
-            Value::Set(s) => Some(Ok(Value::Array(
+            Value::Set(s) => Some(Ok(Value::array(
                 s.iter().map(|_| Value::Bool(true)).collect(),
             ))),
-            Value::Bag(b) => Some(Ok(Value::Array(
+            Value::Bag(b) => Some(Ok(Value::array(
                 b.values().map(|v| Value::Int(*v)).collect(),
             ))),
-            Value::Mix(m) => Some(Ok(Value::Array(
+            Value::Mix(m) => Some(Ok(Value::array(
                 m.values().map(|v| Value::Num(*v)).collect(),
             ))),
             _ => None,
@@ -39,60 +39,60 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "kv" => match target {
             Value::Hash(items) => {
                 let mut kv = Vec::new();
-                for (k, v) in items {
+                for (k, v) in items.iter() {
                     kv.push(Value::Str(k.clone()));
                     kv.push(v.clone());
                 }
-                Some(Ok(Value::Array(kv)))
+                Some(Ok(Value::array(kv)))
             }
             Value::Set(s) => {
                 let mut kv = Vec::new();
-                for k in s {
+                for k in s.iter() {
                     kv.push(Value::Str(k.clone()));
                     kv.push(Value::Bool(true));
                 }
-                Some(Ok(Value::Array(kv)))
+                Some(Ok(Value::array(kv)))
             }
             Value::Bag(b) => {
                 let mut kv = Vec::new();
-                for (k, v) in b {
+                for (k, v) in b.iter() {
                     kv.push(Value::Str(k.clone()));
                     kv.push(Value::Int(*v));
                 }
-                Some(Ok(Value::Array(kv)))
+                Some(Ok(Value::array(kv)))
             }
             Value::Mix(m) => {
                 let mut kv = Vec::new();
-                for (k, v) in m {
+                for (k, v) in m.iter() {
                     kv.push(Value::Str(k.clone()));
                     kv.push(Value::Num(*v));
                 }
-                Some(Ok(Value::Array(kv)))
+                Some(Ok(Value::array(kv)))
             }
-            Value::Enum { key, value, .. } => Some(Ok(Value::Array(vec![
+            Value::Enum { key, value, .. } => Some(Ok(Value::array(vec![
                 Value::Str(key.clone()),
                 Value::Int(*value),
             ]))),
             _ => None,
         },
         "pairs" => match target {
-            Value::Hash(items) => Some(Ok(Value::Array(
+            Value::Hash(items) => Some(Ok(Value::array(
                 items
                     .iter()
                     .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
                     .collect(),
             ))),
-            Value::Set(s) => Some(Ok(Value::Array(
+            Value::Set(s) => Some(Ok(Value::array(
                 s.iter()
                     .map(|k| Value::Pair(k.clone(), Box::new(Value::Bool(true))))
                     .collect(),
             ))),
-            Value::Bag(b) => Some(Ok(Value::Array(
+            Value::Bag(b) => Some(Ok(Value::array(
                 b.iter()
                     .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Int(*v))))
                     .collect(),
             ))),
-            Value::Mix(m) => Some(Ok(Value::Array(
+            Value::Mix(m) => Some(Ok(Value::array(
                 m.iter()
                     .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Num(*v))))
                     .collect(),
@@ -100,7 +100,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             _ => None,
         },
         "antipairs" => match target {
-            Value::Hash(items) => Some(Ok(Value::Array(
+            Value::Hash(items) => Some(Ok(Value::array(
                 items
                     .iter()
                     .map(|(k, v)| Value::Pair(v.to_string_value(), Box::new(Value::Str(k.clone()))))
@@ -111,10 +111,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "invert" => match target {
             Value::Hash(items) => {
                 let mut result = Vec::new();
-                for (k, v) in items {
+                for (k, v) in items.iter() {
                     match v {
                         Value::Array(arr) => {
-                            for item in arr {
+                            for item in arr.iter() {
                                 result.push(Value::Pair(
                                     item.to_string_value(),
                                     Box::new(Value::Str(k.clone())),
@@ -129,7 +129,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         }
                     }
                 }
-                Some(Ok(Value::Array(result)))
+                Some(Ok(Value::array(result)))
             }
             _ => None,
         },
@@ -182,14 +182,14 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Array(items) => {
                 let mut result = Vec::new();
                 let mut last: Option<String> = None;
-                for item in items {
+                for item in items.iter() {
                     let s = item.to_string_value();
                     if last.as_ref() != Some(&s) {
                         last = Some(s);
                         result.push(item.clone());
                     }
                 }
-                Some(Ok(Value::Array(result)))
+                Some(Ok(Value::array(result)))
             }
             _ => None,
         },

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -192,7 +192,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         "ords" => {
             let s = target.to_string_value();
             let ords: Vec<Value> = s.chars().map(|c| Value::Int(c as u32 as i64)).collect();
-            Some(Ok(Value::Array(ords)))
+            Some(Ok(Value::array(ords)))
         }
         "chr" => {
             let code = match target {
@@ -304,29 +304,29 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         "flat" => match target {
             Value::Array(items) => {
                 let mut result = Vec::new();
-                for item in items {
+                for item in items.iter() {
                     match item {
                         Value::Array(inner) => result.extend(inner.iter().cloned()),
                         other => result.push(other.clone()),
                     }
                 }
-                Some(Ok(Value::Array(result)))
+                Some(Ok(Value::array(result)))
             }
             _ => None,
         },
         "sort" => match target {
             Value::Array(items) => {
-                let mut sorted = items.clone();
+                let mut sorted = (**items).clone();
                 sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                Some(Ok(Value::Array(sorted)))
+                Some(Ok(Value::array(sorted)))
             }
             _ => None,
         },
         "reverse" => match target {
             Value::Array(items) => {
-                let mut reversed = items.clone();
+                let mut reversed = (**items).clone();
                 reversed.reverse();
-                Some(Ok(Value::Array(reversed)))
+                Some(Ok(Value::array(reversed)))
             }
             Value::Str(s) => Some(Ok(Value::Str(s.chars().rev().collect()))),
             _ => None,
@@ -335,14 +335,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             Value::Array(items) => {
                 let mut seen = Vec::new();
                 let mut result = Vec::new();
-                for item in items {
+                for item in items.iter() {
                     let key = item.to_string_value();
                     if !seen.contains(&key) {
                         seen.push(key);
                         result.push(item.clone());
                     }
                 }
-                Some(Ok(Value::Array(result)))
+                Some(Ok(Value::array(result)))
             }
             _ => None,
         },
@@ -400,7 +400,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 .split_whitespace()
                 .map(|w| Value::Str(w.to_string()))
                 .collect();
-            Some(Ok(Value::Array(words)))
+            Some(Ok(Value::array(words)))
         }
         "codes" => {
             let s = target.to_string_value();
@@ -409,7 +409,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         "lines" => {
             let s = target.to_string_value();
             let lines: Vec<Value> = s.lines().map(|l| Value::Str(l.to_string())).collect();
-            Some(Ok(Value::Array(lines)))
+            Some(Ok(Value::array(lines)))
         }
         "trim" => Some(Ok(Value::Str(target.to_string_value().trim().to_string()))),
         "trim-leading" => Some(Ok(Value::Str(
@@ -442,7 +442,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         "comb" => {
             let s = target.to_string_value();
             let parts: Vec<Value> = s.chars().map(|c| Value::Str(c.to_string())).collect();
-            Some(Ok(Value::Array(parts)))
+            Some(Ok(Value::array(parts)))
         }
         "join" => match target {
             Value::Array(items) => {
@@ -671,7 +671,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             _ => Some(Ok(make_rat(0, 1))),
         },
         "tree" => match target {
-            Value::Array(items) => Some(Ok(Value::Array(tree_recursive(items)))),
+            Value::Array(items) => Some(Ok(Value::array(tree_recursive(items)))),
             _ => Some(Ok(target.clone())),
         },
         "sink" => Some(Ok(Value::Nil)),
@@ -679,7 +679,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         "race" | "hyper" => {
             // Single-threaded: just materialize into an array
             let items = runtime::value_to_list(target);
-            Some(Ok(Value::Array(items)))
+            Some(Ok(Value::array(items)))
         }
         "NFC" | "NFD" | "NFKC" | "NFKD" => {
             use unicode_normalization::UnicodeNormalization;
@@ -691,7 +691,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 _ => s.nfkd().collect(),
             };
             let codepoints: Vec<Value> = normalized.chars().map(|c| Value::Int(c as i64)).collect();
-            Some(Ok(Value::Array(codepoints)))
+            Some(Ok(Value::array(codepoints)))
         }
         _ => None,
     }
@@ -702,7 +702,7 @@ fn tree_recursive(items: &[Value]) -> Vec<Value> {
     items
         .iter()
         .map(|v| match v {
-            Value::Array(inner) => Value::Array(tree_recursive(inner)),
+            Value::Array(inner) => Value::array(tree_recursive(inner)),
             other => other.clone(),
         })
         .collect()

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -79,7 +79,7 @@ pub(crate) fn native_method_1arg(
             let s = target.to_string_value();
             let sep = arg.to_string_value();
             let parts: Vec<Value> = s.split(&sep).map(|p| Value::Str(p.to_string())).collect();
-            Some(Ok(Value::Array(parts)))
+            Some(Ok(Value::array(parts)))
         }
         "join" => match target {
             Value::Array(items) => {
@@ -99,7 +99,7 @@ pub(crate) fn native_method_1arg(
                     Value::Int(i) => *i as usize,
                     _ => return None,
                 };
-                Some(Ok(Value::Array(items[..n.min(items.len())].to_vec())))
+                Some(Ok(Value::array(items[..n.min(items.len())].to_vec())))
             }
             Value::Range(a, b) => {
                 let n = match arg {
@@ -107,7 +107,7 @@ pub(crate) fn native_method_1arg(
                     _ => return None,
                 };
                 let items: Vec<Value> = (*a..=*b).take(n).map(Value::Int).collect();
-                Some(Ok(Value::Array(items)))
+                Some(Ok(Value::array(items)))
             }
             _ => {
                 let n = match arg {
@@ -115,7 +115,7 @@ pub(crate) fn native_method_1arg(
                     _ => return None,
                 };
                 let items = runtime::value_to_list(target);
-                Some(Ok(Value::Array(items[..n.min(items.len())].to_vec())))
+                Some(Ok(Value::array(items[..n.min(items.len())].to_vec())))
             }
         },
         "tail" => match target {
@@ -125,7 +125,7 @@ pub(crate) fn native_method_1arg(
                     _ => return None,
                 };
                 let start = items.len().saturating_sub(n);
-                Some(Ok(Value::Array(items[start..].to_vec())))
+                Some(Ok(Value::array(items[start..].to_vec())))
             }
             _ => {
                 let n = match arg {
@@ -134,7 +134,7 @@ pub(crate) fn native_method_1arg(
                 };
                 let items = runtime::value_to_list(target);
                 let start = items.len().saturating_sub(n);
-                Some(Ok(Value::Array(items[start..].to_vec())))
+                Some(Ok(Value::array(items[start..].to_vec())))
             }
         },
         "rindex" => {
@@ -268,12 +268,12 @@ pub(crate) fn native_method_1arg(
                             % (i + 1);
                         items.swap(i, j);
                     }
-                    Value::Array(items)
+                    Value::array(items)
                 }
                 Value::Int(n) => {
                     let count = (*n).max(0) as usize;
                     if count == 0 || items.is_empty() {
-                        Value::Array(Vec::new())
+                        Value::array(Vec::new())
                     } else {
                         let mut result = Vec::with_capacity(count.min(items.len()));
                         for _ in 0..count.min(items.len()) {
@@ -282,7 +282,7 @@ pub(crate) fn native_method_1arg(
                                 % items.len();
                             result.push(items.swap_remove(idx));
                         }
-                        Value::Array(result)
+                        Value::array(result)
                     }
                 }
                 _ => return None,
@@ -296,7 +296,7 @@ pub(crate) fn native_method_1arg(
             };
             let items = runtime::value_to_list(target);
             if items.is_empty() || count == 0 {
-                return Some(Ok(Value::Array(Vec::new())));
+                return Some(Ok(Value::array(Vec::new())));
             }
             let mut result = Vec::with_capacity(count);
             for _ in 0..count {
@@ -306,7 +306,7 @@ pub(crate) fn native_method_1arg(
                 }
                 result.push(items[idx].clone());
             }
-            Some(Ok(Value::Array(result)))
+            Some(Ok(Value::array(result)))
         }
         "log" => {
             let base_val = match arg {

--- a/src/compiler/helpers.rs
+++ b/src/compiler/helpers.rs
@@ -380,7 +380,7 @@ impl Compiler {
         self.code.patch_jump(jump_else);
 
         if else_branch.is_empty() {
-            let empty_idx = self.code.add_constant(Value::Slip(vec![]));
+            let empty_idx = self.code.add_constant(Value::slip(vec![]));
             self.code.emit(OpCode::LoadConst(empty_idx));
         } else if else_branch.len() == 1 {
             if let Stmt::If {

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -137,7 +137,7 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     if input.starts_with('\u{2205}') {
         return Ok((
             &input['\u{2205}'.len_utf8()..],
-            Expr::Literal(Value::Set(std::collections::HashSet::new())),
+            Expr::Literal(Value::set(std::collections::HashSet::new())),
         ));
     }
     if let Ok(r) = try_kw("Inf", Value::Num(f64::INFINITY)) {

--- a/src/parser/stmt/decl.rs
+++ b/src/parser/stmt/decl.rs
@@ -314,7 +314,7 @@ pub(super) fn my_decl(input: &str) -> PResult<'_, Stmt> {
 
     let (rest, _) = opt_char(rest, ';');
     let expr = if is_array {
-        Expr::Literal(Value::Array(Vec::new()))
+        Expr::Literal(Value::array(Vec::new()))
     } else if is_hash {
         Expr::Hash(Vec::new())
     } else {

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -127,7 +127,7 @@ impl Interpreter {
             "join" => self.builtin_join(&args),
             "item" => Ok(args.first().cloned().unwrap_or(Value::Nil)),
             "list" => self.builtin_list(&args),
-            "lol" => Ok(Value::Array(args.clone())),
+            "lol" => Ok(Value::array(args.clone())),
             "flat" => self.builtin_flat(&args),
             "slip" => self.builtin_slip(&args),
             "reverse" => self.builtin_reverse(&args),

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -75,7 +75,7 @@ impl Interpreter {
             })?;
             entries.push(Value::Str(entry.path().to_string_lossy().to_string()));
         }
-        Ok(Value::Array(entries))
+        Ok(Value::array(entries))
     }
 
     pub(super) fn builtin_copy(&self, args: &[Value]) -> Result<Value, RuntimeError> {
@@ -366,9 +366,9 @@ impl Interpreter {
                 }
                 lines.push(Value::Str(line));
             }
-            return Ok(Value::Array(lines));
+            return Ok(Value::array(lines));
         }
-        Ok(Value::Array(Vec::new()))
+        Ok(Value::array(Vec::new()))
     }
 
     pub(super) fn builtin_words(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
@@ -390,8 +390,8 @@ impl Interpreter {
                     words.push(Value::Str(token.to_string()));
                 }
             }
-            return Ok(Value::Array(words));
+            return Ok(Value::array(words));
         }
-        Ok(Value::Array(Vec::new()))
+        Ok(Value::array(Vec::new()))
     }
 }

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -45,9 +45,9 @@ impl Interpreter {
                 .chars()
                 .map(|ch| Value::Int(ch as u32 as i64))
                 .collect();
-            return Ok(Value::Array(codes));
+            return Ok(Value::array(codes));
         }
-        Ok(Value::Array(Vec::new()))
+        Ok(Value::array(Vec::new()))
     }
 
     pub(super) fn builtin_flip(&self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -85,14 +85,14 @@ impl Interpreter {
         };
         for value in args.iter().skip(skip) {
             if let Value::Hash(map) = value {
-                for (key, inner) in map {
+                for (key, inner) in map.iter() {
                     match key.as_str() {
                         "cwd" => {
                             opts.cwd = Some(inner.to_string_value());
                         }
                         "env" => {
                             if let Value::Hash(env_map) = inner {
-                                for (ek, ev) in env_map {
+                                for (ek, ev) in env_map.iter() {
                                     opts.env.insert(ek.clone(), ev.to_string_value());
                                 }
                             }
@@ -159,7 +159,7 @@ impl Interpreter {
         let rest_args = &positional[1..];
 
         // Build the command tuple for .command attribute
-        let command_val = Value::Array(positional.iter().map(|s| Value::Str(s.clone())).collect());
+        let command_val = Value::array(positional.iter().map(|s| Value::Str(s.clone())).collect());
 
         let mut cmd = Command::new(program);
         cmd.args(rest_args);
@@ -453,7 +453,7 @@ impl Interpreter {
                     results.push(result);
                 }
                 Value::Array(elems) => {
-                    for elem in elems {
+                    for elem in elems.iter() {
                         match elem {
                             Value::Promise(shared) => {
                                 let (result, output, stderr) = shared.wait();
@@ -480,7 +480,7 @@ impl Interpreter {
         if results.len() == 1 {
             Ok(results.into_iter().next().unwrap())
         } else {
-            Ok(Value::Array(results))
+            Ok(Value::array(results))
         }
     }
 }

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -305,7 +305,7 @@ impl Interpreter {
             "signature".to_string(),
             Value::make_instance("Blob".to_string(), {
                 let mut a = HashMap::new();
-                a.insert("values".to_string(), Value::Array(vec![Value::Int(0)]));
+                a.insert("values".to_string(), Value::array(vec![Value::Int(0)]));
                 a
             }),
         );
@@ -315,7 +315,7 @@ impl Interpreter {
         );
         attrs.insert(
             "DISTROnames".to_string(),
-            Value::Array(vec![
+            Value::array(vec![
                 Value::Str("macos".to_string()),
                 Value::Str("linux".to_string()),
                 Value::Str("freebsd".to_string()),

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -34,64 +34,64 @@ impl Interpreter {
             match method {
                 "push" => {
                     let mut items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
                     items.extend(args);
-                    let result = Value::Array(items.clone());
-                    self.env.insert(key, Value::Array(items));
+                    let result = Value::array(items.clone());
+                    self.env.insert(key, Value::array(items));
                     return Ok(result);
                 }
                 "append" => {
                     let mut items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
                     for arg in args {
                         match arg {
-                            Value::Array(vals) => items.extend(vals),
+                            Value::Array(vals) => items.extend(vals.iter().cloned()),
                             other => items.push(other),
                         }
                     }
-                    self.env.insert(key, Value::Array(items));
+                    self.env.insert(key, Value::array(items));
                     return Ok(Value::Nil);
                 }
                 "unshift" | "prepend" => {
                     let items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
                     let mut pref = args;
                     pref.extend(items);
-                    self.env.insert(key, Value::Array(pref));
+                    self.env.insert(key, Value::array(pref));
                     return Ok(Value::Nil);
                 }
                 "pop" => {
                     let mut items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
                     let out = items.pop().unwrap_or(Value::Nil);
-                    self.env.insert(key, Value::Array(items));
+                    self.env.insert(key, Value::array(items));
                     return Ok(out);
                 }
                 "shift" => {
                     let mut items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
@@ -100,14 +100,14 @@ impl Interpreter {
                     } else {
                         items.remove(0)
                     };
-                    self.env.insert(key, Value::Array(items));
+                    self.env.insert(key, Value::array(items));
                     return Ok(out);
                 }
                 "splice" => {
                     let mut items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
@@ -138,14 +138,14 @@ impl Interpreter {
                             other => items.insert(start, other.clone()),
                         }
                     }
-                    self.env.insert(key, Value::Array(items));
-                    return Ok(Value::Array(removed));
+                    self.env.insert(key, Value::array(items));
+                    return Ok(Value::array(removed));
                 }
                 "squish" => {
                     let items = match self.env.get(&key) {
-                        Some(Value::Array(existing)) => existing.clone(),
+                        Some(Value::Array(existing)) => existing.to_vec(),
                         _ => match target {
-                            Value::Array(v) => v,
+                            Value::Array(v) => v.to_vec(),
                             _ => Vec::new(),
                         },
                     };
@@ -158,8 +158,8 @@ impl Interpreter {
                             squished.push(item);
                         }
                     }
-                    self.env.insert(key, Value::Array(squished.clone()));
-                    return Ok(Value::Array(squished));
+                    self.env.insert(key, Value::array(squished.clone()));
+                    return Ok(Value::array(squished));
                 }
                 _ => {}
             }
@@ -180,7 +180,7 @@ impl Interpreter {
                 // Try mutable dispatch first; if no mutable handler, fall back to immutable
                 match self.call_native_instance_method_mut(
                     &class_name,
-                    attributes.clone(),
+                    (*attributes).clone(),
                     method,
                     args.clone(),
                 ) {
@@ -203,7 +203,7 @@ impl Interpreter {
             }
             if self.has_user_method(&class_name, method) {
                 let (result, updated) =
-                    self.run_instance_method(&class_name, attributes, method, args)?;
+                    self.run_instance_method(&class_name, (*attributes).clone(), method, args)?;
                 self.env.insert(
                     target_var.to_string(),
                     Value::make_instance(class_name, updated),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10,6 +10,7 @@ use std::os::unix::fs::{self as unix_fs, PermissionsExt};
 use std::os::windows::fs as windows_fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -245,7 +246,7 @@ impl Interpreter {
     pub fn new() -> Self {
         let mut env = HashMap::new();
         env.insert("*PID".to_string(), Value::Int(std::process::id() as i64));
-        env.insert("@*ARGS".to_string(), Value::Array(Vec::new()));
+        env.insert("@*ARGS".to_string(), Value::array(Vec::new()));
         let mut classes = HashMap::new();
         classes.insert(
             "Promise".to_string(),
@@ -568,7 +569,7 @@ impl Interpreter {
     }
 
     pub fn set_args(&mut self, args: Vec<Value>) {
-        self.env.insert("@*ARGS".to_string(), Value::Array(args));
+        self.env.insert("@*ARGS".to_string(), Value::array(args));
     }
 
     pub fn add_lib_path(&mut self, path: String) {

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -168,7 +168,7 @@ impl Interpreter {
                     .lines()
                     .map(|line| Value::Str(line.to_string()))
                     .collect();
-                Ok(Value::Array(parts))
+                Ok(Value::array(parts))
             }
             "words" => {
                 let content = fs::read_to_string(&path_buf)
@@ -177,7 +177,7 @@ impl Interpreter {
                     .split_whitespace()
                     .map(|token| Value::Str(token.to_string()))
                     .collect();
-                Ok(Value::Array(parts))
+                Ok(Value::array(parts))
             }
             "slurp" => {
                 let content = fs::read_to_string(&path_buf).map_err(|err| {
@@ -261,7 +261,7 @@ impl Interpreter {
                     })?;
                     entries.push(Value::Str(entry.path().to_string_lossy().to_string()));
                 }
-                Ok(Value::Array(entries))
+                Ok(Value::array(entries))
             }
             "spurt" => {
                 let content = args
@@ -318,7 +318,7 @@ impl Interpreter {
                     }
                     lines.push(Value::Str(line));
                 }
-                Ok(Value::Array(lines))
+                Ok(Value::array(lines))
             }
             "words" => {
                 let mut words = Vec::new();
@@ -331,7 +331,7 @@ impl Interpreter {
                         words.push(Value::Str(token.to_string()));
                     }
                 }
-                Ok(Value::Array(words))
+                Ok(Value::array(words))
             }
             "read" => {
                 let count = args
@@ -474,7 +474,7 @@ impl Interpreter {
                     let byte_vals: Vec<Value> =
                         chunk.iter().map(|b| Value::Int(*b as i64)).collect();
                     let mut buf_attrs = HashMap::new();
-                    buf_attrs.insert("bytes".to_string(), Value::Array(byte_vals));
+                    buf_attrs.insert("bytes".to_string(), Value::array(byte_vals));
                     values.push(Value::make_instance("Buf".to_string(), buf_attrs));
                 }
                 if bytes.len() < size {
@@ -509,7 +509,7 @@ impl Interpreter {
 
         let mut supply_attrs = HashMap::new();
         supply_attrs.insert("live".to_string(), Value::Bool(false));
-        supply_attrs.insert("values".to_string(), Value::Array(values));
+        supply_attrs.insert("values".to_string(), Value::array(values));
         Ok(Value::make_instance("Supply".to_string(), supply_attrs))
     }
 

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -219,7 +219,7 @@ impl Interpreter {
 
     pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         match val {
-            Value::Array(items) => items.clone(),
+            Value::Array(items) => items.to_vec(),
             Value::Hash(items) => items
                 .iter()
                 .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
@@ -252,7 +252,7 @@ impl Interpreter {
                 .iter()
                 .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Num(*v))))
                 .collect(),
-            Value::Slip(items) => items.clone(),
+            Value::Slip(items) => items.to_vec(),
             Value::Nil => vec![],
             other => vec![other.clone()],
         }
@@ -271,7 +271,7 @@ impl Interpreter {
         let right_len = right_list.len();
 
         if left_len == 0 && right_len == 0 {
-            return Ok(Value::Array(Vec::new()));
+            return Ok(Value::array(Vec::new()));
         }
 
         let result_len = if !dwim_left && !dwim_right {
@@ -304,7 +304,7 @@ impl Interpreter {
             };
             results.push(Self::apply_reduction_op(op, l, r)?);
         }
-        Ok(Value::Array(results))
+        Ok(Value::array(results))
     }
 
     pub(crate) fn compare(

--- a/src/runtime/regex.rs
+++ b/src/runtime/regex.rs
@@ -503,7 +503,7 @@ impl Interpreter {
             .iter()
             .map(|s| Value::Str(s.clone()))
             .collect();
-        env.insert("/".to_string(), Value::Array(match_list));
+        env.insert("/".to_string(), Value::array(match_list));
         // Set named captures
         for (k, v) in &caps.named {
             env.insert(format!("<{}>", k), Value::Str(v.clone()));

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -178,7 +178,7 @@ impl Interpreter {
             for (key, val) in &enum_variants {
                 map.insert(key.clone(), Value::Int(*val));
             }
-            Ok(Value::Hash(map))
+            Ok(Value::hash(map))
         } else {
             Ok(Value::Nil)
         }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -144,8 +144,8 @@ impl Interpreter {
 
     pub(super) fn make_supply_instance(&self) -> Value {
         let mut attrs = HashMap::new();
-        attrs.insert("values".to_string(), Value::Array(Vec::new()));
-        attrs.insert("taps".to_string(), Value::Array(Vec::new()));
+        attrs.insert("values".to_string(), Value::array(Vec::new()));
+        attrs.insert("taps".to_string(), Value::array(Vec::new()));
         Value::make_instance("Supply".to_string(), attrs)
     }
 
@@ -365,7 +365,7 @@ impl Interpreter {
                             .cloned()
                             .unwrap_or(Value::Nil);
                         match val {
-                            Value::Slip(elems) => result.extend(elems),
+                            Value::Slip(elems) => result.extend(elems.iter().cloned()),
                             v => result.push(v),
                         }
                     }
@@ -401,9 +401,9 @@ impl Interpreter {
                     }
                 }
             }
-            return Ok(Value::Array(result));
+            return Ok(Value::array(result));
         }
-        Ok(Value::Array(list_items))
+        Ok(Value::array(list_items))
     }
 
     pub(super) fn eval_grep_over_items(
@@ -494,8 +494,8 @@ impl Interpreter {
                     }
                 }
             }
-            return Ok(Value::Array(result));
+            return Ok(Value::array(result));
         }
-        Ok(Value::Array(list_items))
+        Ok(Value::array(list_items))
     }
 }

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -162,9 +162,9 @@ impl Interpreter {
                 .env
                 .get("@*ARGS")
                 .cloned()
-                .unwrap_or(Value::Array(Vec::new()));
+                .unwrap_or_else(|| Value::array(Vec::new()));
             let args_list = if let Value::Array(items) = args_val {
-                items
+                items.to_vec()
             } else {
                 Vec::new()
             };

--- a/src/runtime/seq_helpers.rs
+++ b/src/runtime/seq_helpers.rs
@@ -116,7 +116,7 @@ impl Interpreter {
                 if lmap.len() != rmap.len() {
                     return false;
                 }
-                for (k, lv) in lmap {
+                for (k, lv) in lmap.iter() {
                     match rmap.get(k) {
                         Some(rv) => {
                             if !self.smart_match(lv, rv) {

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -9,7 +9,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let seeds_raw = Self::value_to_list(&left);
         if seeds_raw.is_empty() {
-            return Ok(Value::Array(vec![]));
+            return Ok(Value::array(vec![]));
         }
 
         // Separate seed values from generator closure
@@ -190,7 +190,7 @@ impl Interpreter {
                     result.push(s.clone());
                 }
                 result.extend(extra_rhs);
-                return Ok(Value::Array(result));
+                return Ok(Value::array(result));
             }
         }
 
@@ -222,7 +222,7 @@ impl Interpreter {
                         result.push(s.clone());
                     }
                     result.extend(extra_rhs);
-                    return Ok(Value::Array(result));
+                    return Ok(Value::array(result));
                 }
             } else {
                 // Alternating (negative ratio): check |value| against |endpoint|
@@ -251,7 +251,7 @@ impl Interpreter {
                             result.push(s.clone());
                         }
                         result.extend(extra_rhs);
-                        return Ok(Value::Array(result));
+                        return Ok(Value::array(result));
                     }
                 }
             }
@@ -304,7 +304,7 @@ impl Interpreter {
                         let end = if exclusive { i } else { i + 1 };
                         let mut result: Vec<Value> = seeds[..end].to_vec();
                         result.extend(extra_rhs);
-                        return Ok(Value::Array(result));
+                        return Ok(Value::array(result));
                     }
                 }
             }
@@ -315,7 +315,7 @@ impl Interpreter {
                         let end = if exclusive { i } else { i + 1 };
                         let mut result: Vec<Value> = seeds[..end].to_vec();
                         result.extend(extra_rhs);
-                        return Ok(Value::Array(result));
+                        return Ok(Value::array(result));
                     }
                 }
             }
@@ -337,11 +337,11 @@ impl Interpreter {
                     }
                     let mut result: Vec<Value> = seeds[..end].to_vec();
                     result.extend(extra_rhs);
-                    return Ok(Value::Array(result));
+                    return Ok(Value::array(result));
                 } else {
                     let mut result = seeds.clone();
                     result.extend(extra_rhs);
-                    return Ok(Value::Array(result));
+                    return Ok(Value::array(result));
                 }
             }
             // For geometric/alternating: also check if the endpoint matches earlier seeds
@@ -351,11 +351,11 @@ impl Interpreter {
                         if exclusive {
                             let mut result: Vec<Value> = seeds[..i].to_vec();
                             result.extend(extra_rhs);
-                            return Ok(Value::Array(result));
+                            return Ok(Value::array(result));
                         } else {
                             let mut result: Vec<Value> = seeds[..=i].to_vec();
                             result.extend(extra_rhs);
-                            return Ok(Value::Array(result));
+                            return Ok(Value::array(result));
                         }
                     }
                 }
@@ -448,7 +448,7 @@ impl Interpreter {
 
             if endpoint_kind.is_none() {
                 match next {
-                    Value::Slip(items) => result.extend(items),
+                    Value::Slip(items) => result.extend(items.iter().cloned()),
                     other => result.push(other),
                 }
                 continue;
@@ -599,6 +599,6 @@ impl Interpreter {
         }
 
         result.extend(extra_rhs);
-        Ok(Value::Array(result))
+        Ok(Value::array(result))
     }
 }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -60,14 +60,16 @@ impl Interpreter {
                 body.to_vec(),
                 self.env.clone(),
             );
-            let mut attrs = attributes.clone();
-            if let Some(Value::Array(items)) = attrs.get_mut("taps") {
-                items.push(tap_sub.clone());
+            let mut attrs = (*attributes).clone();
+            if let Some(Value::Array(items)) = attrs.get("taps") {
+                let mut new_items = items.to_vec();
+                new_items.push(tap_sub.clone());
+                attrs.insert("taps".to_string(), Value::array(new_items));
             } else {
-                attrs.insert("taps".to_string(), Value::Array(vec![tap_sub.clone()]));
+                attrs.insert("taps".to_string(), Value::array(vec![tap_sub.clone()]));
             }
             if let Some(Value::Array(values)) = attrs.get("values") {
-                for v in values {
+                for v in values.iter() {
                     let _ = self.call_sub_value(tap_sub.clone(), vec![v.clone()], true);
                 }
             }

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -45,7 +45,7 @@ impl Interpreter {
                 info.insert("package".to_string(), Value::Str(package.clone()));
                 info.insert("name".to_string(), Value::Str(name.clone()));
                 info.insert("depth".to_string(), Value::Int(depth as i64));
-                Value::Hash(info)
+                Value::hash(info)
             })
     }
 
@@ -97,10 +97,10 @@ impl Interpreter {
         let mut info = HashMap::new();
         info.insert("name".to_string(), Value::Str(name.clone()));
         info.insert("addr".to_string(), Value::Str(addresses[0].clone()));
-        info.insert("aliases".to_string(), Value::Array(Vec::new()));
+        info.insert("aliases".to_string(), Value::array(Vec::new()));
         let addrs_values = addresses.into_iter().map(Value::Str).collect();
-        info.insert("addrs".to_string(), Value::Array(addrs_values));
-        Value::Hash(info)
+        info.insert("addrs".to_string(), Value::array(addrs_values));
+        Value::hash(info)
     }
 
     pub(super) fn get_login_name() -> Option<String> {

--- a/src/runtime/test_functions.rs
+++ b/src/runtime/test_functions.rs
@@ -507,7 +507,7 @@ impl Interpreter {
         let mut expected_status: Option<i64> = None;
         let mut run_args: Option<Vec<Value>> = None;
         if let Value::Hash(expected_hash) = &expectations {
-            for (name, value) in expected_hash {
+            for (name, value) in expected_hash.iter() {
                 match name.as_str() {
                     "out" => expected_out = Some(value.clone()),
                     "err" => expected_err = Some(value.clone()),
@@ -521,7 +521,7 @@ impl Interpreter {
             }
         }
         if let Some(Value::Array(items)) = Self::named_value(args, "args") {
-            run_args = Some(items);
+            run_args = Some(items.to_vec());
         }
         let mut nested = Interpreter::new();
         if let Some(Value::Int(pid)) = self.env.get("*PID") {
@@ -710,7 +710,7 @@ impl Interpreter {
             if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
                 let emitter = Value::make_instance("Supplier".to_string(), {
                     let mut a = HashMap::new();
-                    a.insert("emitted".to_string(), Value::Array(Vec::new()));
+                    a.insert("emitted".to_string(), Value::array(Vec::new()));
                     a.insert("done".to_string(), Value::Bool(false));
                     a
                 });
@@ -722,7 +722,7 @@ impl Interpreter {
                     .get("values")
                     .and_then(|v| {
                         if let Value::Array(a) = v {
-                            Some(a.clone())
+                            Some(a.to_vec())
                         } else {
                             None
                         }
@@ -732,7 +732,7 @@ impl Interpreter {
                     .get("do_callbacks")
                     .and_then(|v| {
                         if let Value::Array(a) = v {
-                            Some(a.clone())
+                            Some(a.to_vec())
                         } else {
                             None
                         }
@@ -757,7 +757,7 @@ impl Interpreter {
         let expected_expanded = match &expected {
             Value::Array(items) => {
                 let mut expanded = Vec::new();
-                for item in items {
+                for item in items.iter() {
                     match item {
                         Value::Range(..)
                         | Value::RangeExcl(..)
@@ -767,16 +767,16 @@ impl Interpreter {
                             expanded.extend(Self::value_to_list(item));
                         }
                         Value::Array(sub) => {
-                            expanded.extend(sub.clone());
+                            expanded.extend(sub.iter().cloned());
                         }
                         _ => expanded.push(item.clone()),
                     }
                 }
-                Value::Array(expanded)
+                Value::array(expanded)
             }
             other => other.clone(),
         };
-        let collected_val = Value::Array(tap_values);
+        let collected_val = Value::array(tap_values);
         let ok = collected_val == expected_expanded;
         self.test_ok(ok, &desc, false)?;
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -294,7 +294,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         // Always set @_ for legacy Perl-style argument access
         self.env
-            .insert("@_".to_string(), Value::Array(args.to_vec()));
+            .insert("@_".to_string(), Value::array(args.to_vec()));
         if param_defs.is_empty() {
             // Legacy path: just bind by position
             for (i, param) in params.iter().enumerate() {
@@ -317,7 +317,7 @@ impl Interpreter {
                         }
                     }
                     if !pd.name.is_empty() {
-                        self.env.insert(pd.name.clone(), Value::Hash(hash_items));
+                        self.env.insert(pd.name.clone(), Value::hash(hash_items));
                     }
                 } else {
                     let mut items = Vec::new();
@@ -339,7 +339,7 @@ impl Interpreter {
                         } else {
                             format!("@{}", pd.name)
                         };
-                        self.env.insert(key, Value::Array(items));
+                        self.env.insert(key, Value::array(items));
                     }
                 }
             } else if pd.named {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -67,11 +67,11 @@ impl VM {
     pub(super) fn exec_make_slip_op(&mut self) {
         let val = self.stack.pop().unwrap();
         let items = match val {
-            Value::Array(items) => items,
-            Value::Slip(items) => items,
+            Value::Array(items) => (*items).clone(),
+            Value::Slip(items) => (*items).clone(),
             other => vec![other],
         };
-        self.stack.push(Value::Slip(items));
+        self.stack.push(Value::slip(items));
     }
 
     pub(super) fn exec_not_op(&mut self) {
@@ -203,7 +203,7 @@ impl VM {
             _ => 0,
         };
         let items: Vec<Value> = std::iter::repeat_n(left, n).collect();
-        self.stack.push(Value::Array(items));
+        self.stack.push(Value::array(items));
     }
 
     pub(super) fn exec_function_compose_op(&mut self) {

--- a/src/vm/vm_call_ops.rs
+++ b/src/vm/vm_call_ops.rs
@@ -62,14 +62,14 @@ impl VM {
             Some("+") => {
                 // .+method: must succeed, wraps result in a list
                 let val = call_result?;
-                self.stack.push(Value::Array(vec![val]));
+                self.stack.push(Value::array(vec![val]));
                 self.sync_locals_from_env(code);
             }
             Some("*") => {
                 // .*method: wraps in list if found, empty list if not
                 match call_result {
-                    Ok(val) => self.stack.push(Value::Array(vec![val])),
-                    Err(_) => self.stack.push(Value::Array(vec![])),
+                    Ok(val) => self.stack.push(Value::array(vec![val])),
+                    Err(_) => self.stack.push(Value::array(vec![])),
                 }
             }
             _ => {
@@ -113,12 +113,12 @@ impl VM {
             }
             Some("+") => {
                 let val = call_result?;
-                self.stack.push(Value::Array(vec![val]));
+                self.stack.push(Value::array(vec![val]));
                 self.sync_locals_from_env(code);
             }
             Some("*") => match call_result {
-                Ok(val) => self.stack.push(Value::Array(vec![val])),
-                Err(_) => self.stack.push(Value::Array(vec![])),
+                Ok(val) => self.stack.push(Value::array(vec![val])),
+                Err(_) => self.stack.push(Value::array(vec![])),
             },
             _ => {
                 self.stack.push(call_result?);
@@ -204,7 +204,7 @@ impl VM {
                 };
             results.push(call_result);
         }
-        self.stack.push(Value::Array(results));
+        self.stack.push(Value::array(results));
         Ok(())
     }
 

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -86,7 +86,7 @@ impl VM {
         let chunked_items: Vec<Value> = if arity > 1 {
             items
                 .chunks(arity)
-                .map(|chunk| Value::Array(chunk.to_vec()))
+                .map(|chunk| Value::array(chunk.to_vec()))
                 .collect()
         } else {
             items
@@ -157,7 +157,7 @@ impl VM {
             }
         }
         if let Some(coll) = collected {
-            self.stack.push(Value::Array(coll));
+            self.stack.push(Value::array(coll));
         }
         *ip = loop_end;
         Ok(())

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -8,11 +8,11 @@ impl VM {
         let mut elems = Vec::with_capacity(raw.len());
         for val in raw {
             match val {
-                Value::Slip(items) => elems.extend(items),
+                Value::Slip(items) => elems.extend(items.iter().cloned()),
                 other => elems.push(other),
             }
         }
-        self.stack.push(Value::Array(elems));
+        self.stack.push(Value::array(elems));
     }
 
     pub(super) fn exec_make_hash_op(&mut self, n: u32) {
@@ -25,7 +25,7 @@ impl VM {
             let val = pair[1].clone();
             map.insert(key, val);
         }
-        self.stack.push(Value::Hash(map));
+        self.stack.push(Value::hash(map));
     }
 
     pub(super) fn exec_say_op(&mut self, n: u32) -> Result<(), RuntimeError> {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -159,23 +159,19 @@ impl VM {
     ) -> Result<Value, RuntimeError> {
         if let Value::Junction { kind, values } = left {
             let results: Result<Vec<Value>, RuntimeError> = values
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|v| self.eval_binary_with_junctions(v, right.clone(), f))
                 .collect();
-            return Ok(Value::Junction {
-                kind,
-                values: results?,
-            });
+            return Ok(Value::junction(kind, results?));
         }
         if let Value::Junction { kind, values } = right {
             let results: Result<Vec<Value>, RuntimeError> = values
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|v| self.eval_binary_with_junctions(left.clone(), v, f))
                 .collect();
-            return Ok(Value::Junction {
-                kind,
-                values: results?,
-            });
+            return Ok(Value::junction(kind, results?));
         }
         f(self, left, right)
     }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -465,12 +465,12 @@ impl VM {
                 Ok(()) => break,
                 Err(e) if e.is_redo && Self::label_matches(&e.label, &label) => continue,
                 Err(e) if e.is_next && Self::label_matches(&e.label, &label) => {
-                    self.stack.push(Value::Array(vec![]));
+                    self.stack.push(Value::array(vec![]));
                     break;
                 }
                 Err(e) if e.is_last && Self::label_matches(&e.label, &label) => {
                     self.stack
-                        .push(e.return_value.unwrap_or(Value::Array(vec![])));
+                        .push(e.return_value.unwrap_or(Value::array(vec![])));
                     break;
                 }
                 Err(e) => return Err(e),

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -169,7 +169,7 @@ impl VM {
                 if op.is_empty() || op == "," {
                     for l in &left_list {
                         for r in &right_list {
-                            results.push(Value::Array(vec![l.clone(), r.clone()]));
+                            results.push(Value::array(vec![l.clone(), r.clone()]));
                         }
                     }
                 } else {
@@ -179,7 +179,7 @@ impl VM {
                         }
                     }
                 }
-                Value::Array(results)
+                Value::array(results)
             }
             "Z" => {
                 let left_list = runtime::value_to_list(&left);
@@ -188,7 +188,7 @@ impl VM {
                 let mut results = Vec::new();
                 if op.is_empty() || op == "," {
                     for i in 0..len {
-                        results.push(Value::Array(vec![
+                        results.push(Value::array(vec![
                             left_list[i].clone(),
                             right_list[i].clone(),
                         ]));
@@ -207,7 +207,7 @@ impl VM {
                         )?);
                     }
                 }
-                Value::Array(results)
+                Value::array(results)
             }
             _ => {
                 return Err(RuntimeError::new(format!(


### PR DESCRIPTION
## Summary
- Arc-wrap all heap-allocated Value variants (Array, Hash, Set, Bag, Mix, Slip, Junction.values, Instance.attributes) for O(1) cloning
- Add convenience constructors: `Value::array()`, `Value::hash()`, `Value::set()`, `Value::bag()`, `Value::mix()`, `Value::slip()`, `Value::junction()`
- Use `Arc::make_mut()` for copy-on-write at mutation sites

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (1371 tests)
- [x] `make roast` passes (92276 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)