### PR TITLE
feat: pass roast/S17-promise/in.t with cross-thread shared arrays

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -174,6 +174,7 @@ roast/S16-unfiled/getpeername.t
 roast/S17-channel/subscription-drain-in-react.t
 roast/S17-procasync/many-processes-no-close-stdin.t
 roast/S17-procasync/no-runaway-file-limit.t
+roast/S17-promise/in.t
 roast/S17-promise/lock-async-stress2.t
 roast/S17-promise/stress.t
 roast/S17-supply/do.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -170,6 +170,18 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
+    // now — returns current time as Instant (term)
+    if input.starts_with("now")
+        && !input[3..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')
+    {
+        return Ok((
+            &input[3..],
+            Expr::Call {
+                name: "now".to_string(),
+                args: vec![],
+            },
+        ));
+    }
     if let Ok(r) = try_kw("pi", Value::Num(std::f64::consts::PI)) {
         return Ok(r);
     }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -376,9 +376,10 @@ impl Interpreter {
         Ok(Value::Int(-1))
     }
 
-    pub(super) fn builtin_sleep(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_sleep(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let duration = Self::duration_from_seconds(Self::seconds_from_value(args.first().cloned()));
         thread::sleep(duration);
+        self.sync_shared_vars_to_env();
         Ok(Value::Nil)
     }
 
@@ -477,6 +478,9 @@ impl Interpreter {
                 _ => results.push(arg.clone()),
             }
         }
+        // Sync shared variables back from child threads
+        self.sync_shared_vars_to_env();
+
         if results.len() == 1 {
             Ok(results.into_iter().next().unwrap())
         } else {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -43,11 +43,13 @@ impl Interpreter {
             }
             "in" => {
                 if matches!(&target, Value::Package(name) if name == "Promise") {
-                    let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0);
+                    let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0).max(0.0);
                     let promise = SharedPromise::new();
                     let ret = Value::Promise(promise.clone());
                     std::thread::spawn(move || {
-                        std::thread::sleep(Duration::from_secs_f64(secs));
+                        if secs > 0.0 {
+                            std::thread::sleep(Duration::from_secs_f64(secs));
+                        }
                         promise.keep(Value::Bool(true), String::new(), String::new());
                     });
                     return Ok(ret);


### PR DESCRIPTION
## Summary
- Add `now` as a parser term (like `rand`) so it returns current time instead of being treated as a bareword
- Fix `Promise.in` with negative duration (clamp to 0.0 to avoid panic)
- Implement `shared_vars` mechanism (`Arc<Mutex<HashMap>>`) for cross-thread array sharing so that `push` from spawned threads is visible to the parent after `await`
- Sync shared variables back to env after `await` and `sleep`

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-promise/in.t` passes all 4 subtests
- [x] `make test` passes (only known socket.t failure)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)