### PR TITLE
chore: switch submodule URLs from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "old-design-docs"]
 	path = old-design-docs
-	url = git@github.com:Raku/old-design-docs.git
+	url = https://github.com/Raku/old-design-docs.git
 [submodule "roast"]
 	path = roast
-	url = git@github.com:Raku/roast.git
+	url = https://github.com/Raku/roast.git
 [submodule "raku-doc"]
 	path = raku-doc
-	url = git@github.com:Raku/doc.git
+	url = https://github.com/Raku/doc.git


### PR DESCRIPTION
## Summary
- Switch all submodule URLs in `.gitmodules` from SSH (`git@github.com:`) to HTTPS (`https://github.com/`)
- Allows cloning and fetching submodules without SSH key configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)