### PR TITLE
feat: pass roast/S06-traits/as.t — coercion types

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -95,6 +95,7 @@ roast/S06-other/main-eval.t
 roast/S06-signature/closure-over-parameters.t
 roast/S06-signature/passing-hashes.t
 roast/S06-signature/scalar-type.t
+roast/S06-traits/as.t
 roast/S06-traits/is-readonly.t
 roast/S06-traits/native-is-copy.t
 roast/S07-hyperrace/stress.t


### PR DESCRIPTION
## Summary
- Parse coercion type syntax in signatures: `Int() $x` and `Int(Rat) $x`
- Implement coercion at argument binding time for Int, Num, Str, Rat, Bool target types
- Handle coercion types in `type_matches_value` for multi-dispatch matching

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-traits/as.t` passes (5/5)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)