### PR TITLE
feat: add MUTSULIB env var, --help option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ This repo is a Rust implementation of a minimal Raku (Perl 6) compatible interpr
 - Run a single roast test: `cargo build && prove -e 'target/debug/mutsu' roast/<path>.t`
 - Pre-commit hooks (lefthook): `cargo clippy -- -D warnings` and `cargo fmt` run automatically on commit.
 - Temporary test scripts: write to `tmp/` (gitignored) using the Write tool (not cat/heredoc). Build first, then run with `./target/debug/mutsu ./tmp/<file>`.
+- Module search paths: use `-I <path>` to add a module search path, or set the `MUTSULIB` environment variable (colon-separated paths). `-I` paths take priority over `MUTSULIB` paths.
+  - Example: `cargo run -- -I lib script.raku`
+  - Example: `MUTSULIB=/path/to/lib1:/path/to/lib2 cargo run -- script.raku`
+- Help: `cargo run -- --help`
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` flag that prints usage information for all CLI options
- Add `MUTSULIB` environment variable support (colon-separated module search paths, similar to `PERL5LIB`)
- `-I` paths take priority over `MUTSULIB` paths
- Document both features in CLAUDE.md

## Test plan
- [x] `./target/debug/mutsu --help` prints usage
- [x] `./target/debug/mutsu -h` prints usage
- [x] `MUTSULIB=roast/packages/Test-Helpers/lib ./target/debug/mutsu -e 'use Test::Util; say "ok"'` loads module successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)