### PR TITLE
test: expand Test::Util make-temp-file/make-temp-dir tests

### DIFF
--- a/t/test-util-make-temp-dir.t
+++ b/t/test-util-make-temp-dir.t
@@ -1,0 +1,36 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+plan 6;
+
+# Available as exported function
+ok &make-temp-dir.defined, 'make-temp-dir is available as an exported function';
+
+# No args: returns IO::Path, directory exists
+{
+    my $d = make-temp-dir();
+    isa-ok $d, IO::Path, 'no args: returns IO::Path';
+    ok $d.d, 'no args: directory exists';
+}
+
+# Can create files inside the temp dir
+{
+    my $d = make-temp-dir();
+    my $f = $d.child("test.txt");
+    $f.spurt("inside");
+    is $f.slurp, "inside", 'can create and read files inside temp dir';
+}
+
+# Paths are unique
+{
+    my $a = make-temp-dir();
+    my $b = make-temp-dir();
+    isnt $a.Str, $b.Str, 'two calls return different paths';
+}
+
+# With chmod argument
+{
+    my $d = make-temp-dir(0o755);
+    ok $d.d, ':chmod: directory exists';
+}


### PR DESCRIPTION
## Summary
- Split Test::Util tests into separate files per function
- Expand `make-temp-file` tests from 1 to 12: no args, `:content`, `:content("")`, `:chmod`, `:content + :chmod`, path uniqueness
- Add `make-temp-dir` tests (6): no args, directory existence, file creation inside dir, path uniqueness, chmod argument
- `make-temp-path` is deferred — requires capture flattening (`|c`) to be implemented

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/test-util-make-temp-file.t` — 12 tests pass
- [x] `prove -e 'target/debug/mutsu' t/test-util-make-temp-dir.t` — 6 tests pass
- [x] `make test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)