### PR TITLE
feat: implement capture slip (|c) for function call argument forwarding

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -192,7 +192,12 @@ pub(crate) enum ControlFlowKind {
 #[derive(Debug, Clone)]
 pub(crate) enum CallArg {
     Positional(Expr),
-    Named { name: String, value: Option<Expr> },
+    Named {
+        name: String,
+        value: Option<Expr>,
+    },
+    /// Capture slip: `|c` — flatten a capture variable into the argument list
+    Slip(Expr),
 }
 
 #[derive(Debug, Clone)]

--- a/src/compiler/helpers.rs
+++ b/src/compiler/helpers.rs
@@ -70,6 +70,7 @@ impl Compiler {
                     name: name.clone(),
                     value: value.clone(),
                 },
+                CallArg::Slip(expr) => CallArg::Slip(expr.clone()),
             })
             .collect()
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -171,6 +171,12 @@ pub(crate) enum OpCode {
         name_idx: u32,
         arity: u32,
     },
+    /// Expression-level function call with capture slip: pop 1 slip + `regular_arity` args,
+    /// flatten the slip into the argument list, call name, push result.
+    CallFuncSlip {
+        name_idx: u32,
+        regular_arity: u32,
+    },
     /// Method call: pop `arity` args + target, call method, push result.
     CallMethod {
         name_idx: u32,
@@ -193,6 +199,13 @@ pub(crate) enum OpCode {
     ExecCallPairs {
         name_idx: u32,
         arity: u32,
+    },
+    /// Call with capture slip: `regular_arity` normal args + 1 slip arg on stack.
+    /// The slip arg (top of stack) is an Array whose elements are flattened into
+    /// the argument list before the call.
+    ExecCallSlip {
+        name_idx: u32,
+        regular_arity: u32,
     },
     BlockScope {
         enter_end: u32,

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -92,10 +92,11 @@ pub(super) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    // |@array or |%hash or |$scalar — slip/flatten prefix
+    // |@array or |%hash or |$scalar or |ident — slip/flatten prefix
     if input.starts_with('|')
+        && !input.starts_with("||")
         && let Some(&c) = input.as_bytes().get(1)
-        && (c == b'@' || c == b'%' || c == b'$')
+        && (c == b'@' || c == b'%' || c == b'$' || c.is_ascii_alphabetic() || c == b'_')
     {
         let rest = &input[1..];
         let (rest, expr) = postfix_expr(rest)?;

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -120,6 +120,15 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
 
 /// Parse a single call argument (named or positional).
 pub(super) fn parse_single_call_arg(input: &str) -> PResult<'_, CallArg> {
+    // Capture slip: |var — flatten a capture into the argument list
+    if input.starts_with('|') && !input.starts_with("||") {
+        let after_pipe = &input[1..];
+        // Must be followed by an identifier (sigilless capture variable)
+        if let Ok((r, name)) = ident(after_pipe) {
+            return Ok((r, CallArg::Slip(Expr::BareWord(name))));
+        }
+    }
+
     // Colon pair: :name(expr) or :name or :!name or :name[...]
     if input.starts_with(':') && !input.starts_with("::") {
         let r = &input[1..];

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -386,7 +386,19 @@ impl Interpreter {
         for pd in param_defs {
             if pd.slurpy {
                 let is_hash_slurpy = pd.name.starts_with('%');
-                if is_hash_slurpy {
+                if pd.sigilless {
+                    // |c — capture parameter: collect ALL remaining args
+                    // (positional + named Pairs) into an array, stored as
+                    // sigilless variable (no sigil prefix)
+                    let mut items = Vec::new();
+                    while positional_idx < args.len() {
+                        items.push(args[positional_idx].clone());
+                        positional_idx += 1;
+                    }
+                    if !pd.name.is_empty() {
+                        self.env.insert(pd.name.clone(), Value::array(items));
+                    }
+                } else if is_hash_slurpy {
                     // *%hash — collect Pair arguments into a hash
                     let mut hash_items = std::collections::HashMap::new();
                     for arg in args.iter() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -651,6 +651,13 @@ impl VM {
                 self.exec_call_func_op(code, *name_idx, *arity, compiled_fns)?;
                 *ip += 1;
             }
+            OpCode::CallFuncSlip {
+                name_idx,
+                regular_arity,
+            } => {
+                self.exec_call_func_slip_op(code, *name_idx, *regular_arity, compiled_fns)?;
+                *ip += 1;
+            }
             OpCode::CallMethod {
                 name_idx,
                 arity,
@@ -688,6 +695,13 @@ impl VM {
             }
             OpCode::ExecCallPairs { name_idx, arity } => {
                 self.exec_exec_call_pairs_op(code, *name_idx, *arity)?;
+                *ip += 1;
+            }
+            OpCode::ExecCallSlip {
+                name_idx,
+                regular_arity,
+            } => {
+                self.exec_exec_call_slip_op(code, *name_idx, *regular_arity)?;
                 *ip += 1;
             }
 

--- a/t/capture-slip.t
+++ b/t/capture-slip.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 8;
+
+# Basic capture forwarding with parenthesized call
+{
+    sub inner($x) { $x * 2 }
+    sub outer(|c) { inner(|c) }
+    is outer(21), 42, "capture forwarding with parens works";
+}
+
+# Non-parenthesized capture forwarding (listop style)
+{
+    sub target($x) { $x + 10 }
+    sub wrapper(|c) { target |c }
+    is wrapper(5), 15, "capture forwarding without parens works";
+}
+
+# Named argument forwarding
+{
+    sub greet(:$name, :$greeting = "Hello") { "$greeting, $name!" }
+    sub wrap-greet(|c) { greet(|c) }
+    is wrap-greet(:name("World")), "Hello, World!", "named arg forwarding works";
+    is wrap-greet(:name("Alice"), :greeting("Hi")), "Hi, Alice!", "multiple named args forwarded";
+}
+
+# Mixed positional and named forwarding
+{
+    sub mixed($x, :$y = 0) { $x + $y }
+    sub wrap-mixed(|c) { mixed(|c) }
+    is wrap-mixed(10), 10, "positional only through capture";
+    is wrap-mixed(10, :y(5)), 15, "positional + named through capture";
+}
+
+# Multi-arg forwarding
+{
+    sub add($a, $b) { $a + $b }
+    sub wrap-add(|c) { add(|c) }
+    is wrap-add(3, 4), 7, "multi-arg capture forwarding";
+}
+
+# Capture with statement-level call (ExecCallSlip)
+{
+    sub printer($x) { $x.Str }
+    sub wrap-printer(|c) { printer |c }
+    is wrap-printer(42), "42", "statement-level capture slip works";
+}

--- a/t/test-util-make-temp-path.t
+++ b/t/test-util-make-temp-path.t
@@ -1,0 +1,42 @@
+use Test;
+use lib $?FILE.IO.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 10;
+
+# Basic: returns IO::Path
+{
+    my $path = make-temp-path();
+    ok $path ~~ IO::Path, "make-temp-path returns an IO::Path";
+    ok $path.Str.chars > 0, "path string is non-empty";
+}
+
+# With :content — file is created with content
+{
+    my $path = make-temp-path(:content("hello world"));
+    ok $path ~~ IO::Path, "with :content returns IO::Path";
+    ok $path.e, "file exists when :content given";
+    is $path.slurp, "hello world", "file has correct content";
+}
+
+# With :content("") — empty content
+{
+    my $path = make-temp-path(:content(""));
+    ok $path.e, "file exists when :content is empty string";
+    is $path.slurp, "", "file content is empty string";
+}
+
+# Uniqueness — each call returns a different path
+{
+    my $p1 = make-temp-path();
+    my $p2 = make-temp-path();
+    ok $p1.Str ne $p2.Str, "successive calls return different paths";
+}
+
+# make-temp-path is an alias for make-temp-file
+{
+    my $f = make-temp-file(:content("via alias"));
+    my $p = make-temp-path(:content("via path"));
+    ok $f ~~ IO::Path, "make-temp-file still works alongside make-temp-path";
+    ok $p ~~ IO::Path, "make-temp-path works alongside make-temp-file";
+}


### PR DESCRIPTION
## Summary
- Implement Raku capture parameter forwarding (`|c` in signatures and call sites)
- Parser: handle `|ident` as slip prefix for sigilless capture variables
- Compiler: detect capture slip patterns and emit `CallFuncSlip`/`ExecCallSlip` opcodes
- VM: implement handlers that flatten captured arrays back into argument lists
- Runtime: fix sigilless slurpy param binding to collect all args with bare name storage
- This enables `make-temp-path` in Test::Util (which delegates to `make-temp-file` via `|c`)

## Test plan
- [x] `t/capture-slip.t` — 8 tests for basic/named/mixed/multi-arg capture forwarding
- [x] `t/test-util-make-temp-path.t` — 10 tests for make-temp-path functionality
- [x] `make test` passes (122 files, 1399 tests)
- [x] `make roast` passes (229 files, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)