### PR TITLE
feat: implement doesn't-warn Test::Util function

### DIFF
--- a/src/compiler/helpers.rs
+++ b/src/compiler/helpers.rs
@@ -37,6 +37,7 @@ impl Compiler {
                 | "eval-dies-ok"
                 | "throws-like"
                 | "warns-like"
+                | "doesn't-warn"
                 | "force_todo"
                 | "force-todo"
                 | "is_run"
@@ -46,7 +47,7 @@ impl Compiler {
     pub(super) fn rewrite_stmt_call_args(name: &str, args: &[CallArg]) -> Vec<CallArg> {
         let rewrites_needed = matches!(
             name,
-            "lives-ok" | "dies-ok" | "throws-like" | "warns-like" | "is_run"
+            "lives-ok" | "dies-ok" | "throws-like" | "warns-like" | "doesn't-warn" | "is_run"
         );
         if !rewrites_needed {
             return args.to_vec();
@@ -55,19 +56,20 @@ impl Compiler {
         args.iter()
             .map(|arg| match arg {
                 CallArg::Positional(expr) => {
-                    let rewritten =
-                        if matches!(name, "lives-ok" | "dies-ok" | "throws-like" | "warns-like")
-                            && positional_index == 0
-                        {
-                            match expr {
-                                Expr::Block(body) => make_anon_sub(body.clone()),
-                                _ => expr.clone(),
-                            }
-                        } else if name == "is_run" && positional_index == 1 {
-                            Self::rewrite_hash_block_values(expr)
-                        } else {
-                            expr.clone()
-                        };
+                    let rewritten = if matches!(
+                        name,
+                        "lives-ok" | "dies-ok" | "throws-like" | "warns-like" | "doesn't-warn"
+                    ) && positional_index == 0
+                    {
+                        match expr {
+                            Expr::Block(body) => make_anon_sub(body.clone()),
+                            _ => expr.clone(),
+                        }
+                    } else if name == "is_run" && positional_index == 1 {
+                        Self::rewrite_hash_block_values(expr)
+                    } else {
+                        expr.clone()
+                    };
                     positional_index += 1;
                     CallArg::Positional(rewritten)
                 }

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -324,6 +324,7 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "eval-dies-ok"
             | "throws-like"
             | "warns-like"
+            | "doesn't-warn"
             | "pass"
             | "flunk"
             | "skip"

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -611,6 +611,7 @@ pub(super) const KNOWN_CALLS: &[&str] = &[
     "is_run",
     "throws-like",
     "warns-like",
+    "doesn't-warn",
     "fails-like",
     "force_todo",
     "force-todo",

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -199,6 +199,7 @@ pub struct Interpreter {
     env: HashMap<String, Value>,
     output: String,
     stderr_output: String,
+    warn_output: String,
     test_state: Option<TestState>,
     halted: bool,
     exit_code: i64,
@@ -524,6 +525,7 @@ impl Interpreter {
             env,
             output: String::new(),
             stderr_output: String::new(),
+            warn_output: String::new(),
             test_state: None,
             halted: false,
             exit_code: 0,
@@ -617,6 +619,7 @@ impl Interpreter {
     pub(crate) fn write_warn_to_stderr(&mut self, message: &str) {
         let msg = format!("{}\n", message);
         self.stderr_output.push_str(&msg);
+        self.warn_output.push_str(&msg);
         eprint!("{}", msg);
     }
 
@@ -651,6 +654,7 @@ impl Interpreter {
             env: self.env.clone(),
             output: String::new(),
             stderr_output: String::new(),
+            warn_output: String::new(),
             test_state: None,
             halted: false,
             exit_code: 0,

--- a/t/doesnt-warn.t
+++ b/t/doesnt-warn.t
@@ -1,0 +1,16 @@
+use Test;
+use Test::Util;
+
+plan 4;
+
+# Code without warnings passes
+doesn't-warn 'say 42', 'say does not warn';
+
+# Simple expression without warnings
+doesn't-warn '1 + 2', 'arithmetic does not warn';
+
+# Multiple statements without warnings
+doesn't-warn 'my $x = 1; my $y = 2; $x + $y', 'multiple stmts no warn';
+
+# Note goes to stderr but is not a warning
+doesn't-warn 'note "info"', 'note is not a warn';


### PR DESCRIPTION
## Summary
- Add `warn_output` field to Interpreter to distinguish `warn` from `note` (both write to stderr but only `warn` is a warning)
- Implement `doesn't-warn` Test::Util function
- Fix `warns-like` to use `warn_output` instead of `stderr_output`

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/doesnt-warn.t` — 4/4 pass
- [x] `prove -e 'target/debug/mutsu' t/warns-like.t` — 5/5 pass (no regression)
- [x] `make test` passes
- [x] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)