### PR TITLE
feat: implement is-eqv Test::Util function

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -325,6 +325,7 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "throws-like"
             | "warns-like"
             | "doesn't-warn"
+            | "is-eqv"
             | "pass"
             | "flunk"
             | "skip"

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -612,6 +612,7 @@ pub(super) const KNOWN_CALLS: &[&str] = &[
     "throws-like",
     "warns-like",
     "doesn't-warn",
+    "is-eqv",
     "fails-like",
     "force_todo",
     "force-todo",

--- a/t/is-eqv.t
+++ b/t/is-eqv.t
@@ -1,0 +1,28 @@
+use Test;
+use Test::Util;
+
+plan 8;
+
+# Integer equality
+is-eqv 42, 42, 'integers are eqv';
+
+# String equality
+is-eqv "hello", "hello", 'strings are eqv';
+
+# Bool equality
+is-eqv True, True, 'booleans are eqv';
+
+# Nil equality
+is-eqv Nil, Nil, 'Nil is eqv to Nil';
+
+# Array/List equality
+is-eqv (1, 2, 3), (1, 2, 3), 'lists are eqv';
+
+# Nested structure
+is-eqv (1, (2, 3)), (1, (2, 3)), 'nested lists are eqv';
+
+# Hash equality
+is-eqv {a => 1, b => 2}, {a => 1, b => 2}, 'hashes are eqv';
+
+# Rat equality
+is-eqv 1/3, 1/3, 'rats are eqv';


### PR DESCRIPTION
## Summary
- Implement `is-eqv` Test::Util function using the `eqv` operator
- On failure, display expected/got values using `.raku` representation
- Add `t/is-eqv.t` with 8 tests (int, str, bool, Nil, list, nested list, hash, rat)

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/is-eqv.t` — 8/8 pass
- [x] `make test` passes
- [x] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)