### PR TITLE
feat: implement group-of Test::Util function

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -326,6 +326,7 @@ pub(super) fn is_expr_listop(name: &str) -> bool {
             | "warns-like"
             | "doesn't-warn"
             | "is-eqv"
+            | "group-of"
             | "pass"
             | "flunk"
             | "skip"

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -613,6 +613,7 @@ pub(super) const KNOWN_CALLS: &[&str] = &[
     "warns-like",
     "doesn't-warn",
     "is-eqv",
+    "group-of",
     "fails-like",
     "force_todo",
     "force-todo",

--- a/t/group-of.t
+++ b/t/group-of.t
@@ -1,0 +1,35 @@
+use Test;
+use Test::Util;
+
+plan 5;
+
+# Basic group-of with passing tests
+group-of 2 => 'basic group' => {
+    ok True, 'first test';
+    ok True, 'second test';
+}
+
+# group-of with is checks
+group-of 3 => 'is checks' => {
+    is 1 + 1, 2, 'addition';
+    is "hello".chars, 5, 'string length';
+    is (1, 2, 3).elems, 3, 'list length';
+}
+
+# group-of with a single test
+group-of 1 => 'single test' => {
+    ok 42 > 0, 'positive number';
+}
+
+# group-of with mixed test functions
+group-of 2 => 'mixed tests' => {
+    ok True, 'truthy value';
+    is 'hello', 'hello', 'string equality';
+}
+
+# Nested group-of (group-of inside group-of)
+group-of 1 => 'outer group' => {
+    group-of 1 => 'inner group' => {
+        ok True, 'nested test';
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `group-of` from `Test::Util` — a convenience wrapper around `subtest` that takes `$plan => $desc => { tests }` as a nested Pair argument
- Registers `group-of` in parser and test function dispatch
- Adds `t/group-of.t` with 5 tests (basic, is checks, single test, mixed, nested)

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/group-of.t` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)