### PR TITLE
refactor: use lexical scope stack for imported function names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,3 +322,4 @@ Each slang has its own grammar rules (e.g., `+` means repetition in Regex slang 
 - Write feature tests using prove (`t/*.t`).
 - Use Rust unit tests (`#[test]`) for internal components like parser and runtime helpers.
 - Every feature addition must include tests.
+- When implementing a temporary workaround or shortcut instead of the correct solution, always leave a `// TODO:` comment explaining what the correct approach would be and why the current implementation is insufficient. This ensures technical debt is visible and trackable.


### PR DESCRIPTION
## Summary
- Replace flat `HashSet` for imported functions with a `Vec<HashSet>` scope stack
- Each `{ }` block pushes/pops a lexical scope for imports
- `use` statements register exports into the current innermost scope
- Lookups search from innermost to outermost scope, matching Raku's lexical scoping semantics
- Added `push_import_scope()` / `pop_import_scope()` calls in `block()`, `block_or_hash_expr()`, and `parse_block_body()`
- Added TODO comment convention to CLAUDE.md
- Left a TODO on `USER_DECLARED_SUBS` which still uses a flat set

## Test plan
- [x] New unit tests `import_scope_is_lexical` and `import_scope_inherits_from_parent` verify scoping behavior
- [x] All unit tests pass (`cargo test` — 73 tests)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)