### PR TITLE
refactor: unify USER_DECLARED_SUBS into lexical scope stack

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -277,7 +277,7 @@ pub(super) fn block_or_hash_expr(input: &str) -> PResult<'_, Expr> {
     }
 
     // Otherwise parse as a block (anonymous sub)
-    crate::parser::stmt::simple::push_import_scope();
+    crate::parser::stmt::simple::push_scope();
     let result = (|| -> PResult<'_, Expr> {
         let (r, stmts) = super::super::stmt::stmt_list_pub(r)?;
         let (r, _) = ws_inner(r);
@@ -287,7 +287,7 @@ pub(super) fn block_or_hash_expr(input: &str) -> PResult<'_, Expr> {
         let r = &r[1..];
         Ok((r, make_anon_sub(stmts)))
     })();
-    crate::parser::stmt::simple::pop_import_scope();
+    crate::parser::stmt::simple::pop_scope();
     result
 }
 
@@ -302,14 +302,14 @@ pub(super) fn ws_inner(input: &str) -> (&str, ()) {
 /// Parse a block body: { stmts }
 pub(super) fn parse_block_body(input: &str) -> PResult<'_, Vec<crate::ast::Stmt>> {
     let (r, _) = parse_char(input, '{')?;
-    crate::parser::stmt::simple::push_import_scope();
+    crate::parser::stmt::simple::push_scope();
     let result = (|| -> PResult<'_, Vec<crate::ast::Stmt>> {
         let (r, stmts) = super::super::stmt::stmt_list_pub(r)?;
         let (r, _) = ws_inner(r);
         let (r, _) = parse_char(r, '}')?;
         Ok((r, stmts))
     })();
-    crate::parser::stmt::simple::pop_import_scope();
+    crate::parser::stmt::simple::pop_scope();
     result
 }
 

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -182,9 +182,9 @@ fn var_name(input: &str) -> PResult<'_, String> {
 /// only affects that block and its children.
 fn block(input: &str) -> PResult<'_, Vec<Stmt>> {
     let (input, _) = parse_char(input, '{')?;
-    simple::push_import_scope();
+    simple::push_scope();
     let result = block_inner(input);
-    simple::pop_import_scope();
+    simple::pop_scope();
     result
 }
 
@@ -711,11 +711,11 @@ mod tests {
         // At top scope, "ok" is not imported
         assert!(!simple::is_imported_function("ok"));
         // Push a child scope and import Test
-        simple::push_import_scope();
+        simple::push_scope();
         simple::register_module_exports("Test");
         assert!(simple::is_imported_function("ok"));
         // Pop the child scope — "ok" should no longer be visible
-        simple::pop_import_scope();
+        simple::pop_scope();
         assert!(
             !simple::is_imported_function("ok"),
             "imported function should not be visible after scope pop"
@@ -729,14 +729,46 @@ mod tests {
         simple::register_module_exports("Test");
         assert!(simple::is_imported_function("ok"));
         // Push a child scope — parent imports should still be visible
-        simple::push_import_scope();
+        simple::push_scope();
         assert!(
             simple::is_imported_function("ok"),
             "parent scope imports should be visible in child"
         );
-        simple::pop_import_scope();
+        simple::pop_scope();
         // Still visible in parent
         assert!(simple::is_imported_function("ok"));
+        simple::reset_user_subs();
+    }
+
+    #[test]
+    fn user_sub_scope_is_lexical() {
+        simple::reset_user_subs();
+        assert!(!simple::is_user_declared_sub("my-func"));
+        // Declare a sub in a child scope
+        simple::push_scope();
+        simple::register_user_sub("my-func");
+        assert!(simple::is_user_declared_sub("my-func"));
+        // Pop — sub should no longer be visible
+        simple::pop_scope();
+        assert!(
+            !simple::is_user_declared_sub("my-func"),
+            "user sub should not be visible after scope pop"
+        );
+    }
+
+    #[test]
+    fn user_sub_scope_inherits_from_parent() {
+        simple::reset_user_subs();
+        simple::register_user_sub("outer-func");
+        assert!(simple::is_user_declared_sub("outer-func"));
+        // Child scope should see parent's subs
+        simple::push_scope();
+        assert!(
+            simple::is_user_declared_sub("outer-func"),
+            "parent sub should be visible in child scope"
+        );
+        simple::pop_scope();
+        assert!(simple::is_user_declared_sub("outer-func"));
         simple::reset_user_subs();
     }
 }


### PR DESCRIPTION
## Summary
- Merge `USER_DECLARED_SUBS` (flat `HashSet`) and `IMPORTED_SCOPES` into a single `LexicalScope` struct with both `user_subs` and `imported_functions` fields
- Both user sub declarations and module imports now properly follow lexical scoping via the unified scope stack
- Renamed `push_import_scope`/`pop_import_scope` to `push_scope`/`pop_scope` since they now manage all lexical state

## Test plan
- [x] New unit tests `user_sub_scope_is_lexical` and `user_sub_scope_inherits_from_parent`
- [x] All unit tests pass (`cargo test` — 75 tests)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)