### PR TITLE
feat: support is-path Test::Util function via module loading

### DIFF
--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -136,13 +136,25 @@ const TEST_EXPORTS: &[&str] = &[
 ];
 
 /// Functions exported by `use Test::Util`.
+/// These must match the `is export` subs in roast/packages/Test-Helpers/lib/Test/Util.rakumod.
 const TEST_UTIL_EXPORTS: &[&str] = &[
+    "group-of",
+    "is-path",
+    "is-deeply-junction",
+    "test-iter-opt",
+    "is-eqv",
     "is_run",
     "get_out",
+    "doesn't-hang",
     "warns-like",
     "doesn't-warn",
-    "is-eqv",
-    "group-of",
+    "make-temp-path",
+    "make-temp-file",
+    "make-temp-dir",
+    "no-fatal-throws-like",
+    "run-with-tty",
+    "throws-like-any",
+    "make-test-dist",
 ];
 
 use super::{

--- a/src/runtime/seq_helpers.rs
+++ b/src/runtime/seq_helpers.rs
@@ -252,6 +252,23 @@ impl Interpreter {
             }
             (Value::Int(a), Value::Str(b)) => b.trim().parse::<f64>() == Ok(*a as f64),
             (Value::Nil, Value::Str(s)) => s.is_empty(),
+            // IO::Path ~~ IO::Path: compare by path string value
+            (
+                Value::Instance {
+                    class_name: cn_a,
+                    attributes: attrs_a,
+                    ..
+                },
+                Value::Instance {
+                    class_name: cn_b,
+                    attributes: attrs_b,
+                    ..
+                },
+            ) if cn_a == "IO::Path" && cn_b == "IO::Path" => {
+                let path_a = attrs_a.get("path").map(|v| v.to_string_value());
+                let path_b = attrs_b.get("path").map(|v| v.to_string_value());
+                path_a == path_b
+            }
             // Instance identity: two instances match iff they have the same id
             (Value::Instance { id: id_a, .. }, Value::Instance { id: id_b, .. }) => id_a == id_b,
             // When RHS is a Bool, result is that Bool

--- a/t/test-util-is-path.t
+++ b/t/test-util-is-path.t
@@ -1,0 +1,17 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+plan 4;
+
+# Basic: same path
+is-path "/tmp".IO, "/tmp".IO, "identical paths match";
+
+# Path with .. that resolves to the same location
+is-path "/tmp/../tmp".IO, "/tmp".IO, "path with .. resolves to same";
+
+# Path with trailing slash vs without
+is-path "/tmp/".IO, "/tmp".IO, "trailing slash resolves to same";
+
+# Relative path that resolves to cwd
+is-path ".".IO, $*CWD.IO, "dot resolves to cwd";


### PR DESCRIPTION
## Summary
- Add all 17 exported function names from `Test::Util.rakumod` to `TEST_UTIL_EXPORTS` (previously only 6 were listed), so the parser recognizes them as function calls with correct argument parsing
- Fix `IO::Path ~~ IO::Path` smartmatch to compare by path string value instead of instance identity, matching Raku semantics
- Add `t/test-util-is-path.t` exercising `is-path` loaded from the real `Test::Util.rakumod`

The `is-path` function runs as Raku code from the module — no Rust reimplementation needed.

## Test plan
- [x] `t/test-util-is-path.t` passes (4 tests)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)