### PR TITLE
refactor: dynamically extract module exports at parse time

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,6 +10,8 @@ pub(crate) fn is_imported_function(name: &str) -> bool {
     stmt::simple::is_imported_function(name)
 }
 
+pub use stmt::simple::{clear_parser_lib_paths, set_parser_lib_paths, set_parser_program_path};
+
 use crate::ast::Stmt;
 use crate::value::RuntimeError;
 use crate::value::RuntimeErrorCode;

--- a/src/parser/stmt/decl.rs
+++ b/src/parser/stmt/decl.rs
@@ -66,6 +66,12 @@ pub(super) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
     };
     let (rest, _) = ws(rest)?;
     let (rest, _) = opt_char(rest, ';');
+    // Handle `use lib "path"` or `use lib $*PROGRAM.parent(N).add("path")` at parse time
+    if module == "lib"
+        && let Some(ref expr) = arg
+    {
+        super::simple::try_add_parse_time_lib_path(expr);
+    }
     // Register exported function names so they are recognized as calls without parens.
     super::simple::register_module_exports(&module);
     Ok((rest, Stmt::Use { module, arg }))

--- a/t/doesnt-warn.t
+++ b/t/doesnt-warn.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 

--- a/t/get-out.t
+++ b/t/get-out.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 

--- a/t/group-of.t
+++ b/t/group-of.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 

--- a/t/is-eqv.t
+++ b/t/is-eqv.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 

--- a/t/is-run.t
+++ b/t/is-run.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 

--- a/t/warns-like.t
+++ b/t/warns-like.t
@@ -1,3 +1,4 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `TEST_UTIL_EXPORTS` with dynamic module file scanning at parse time
- When `use SomeModule` is parsed, the parser searches lib_paths for the `.rakumod` file and extracts `is export` sub/proto names via partial parsing
- `TEST_EXPORTS` for `use Test` remains hardcoded (Test functions are implemented natively in Rust)
- Handle `use lib` string literals and `$*PROGRAM.parent(N).add("path")` patterns at parse time for module resolution
- Add `use lib` directives to test files that depend on Test::Util

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (1458 tests, only pre-existing socket.t failure)
- [x] `make roast` passes (92434 tests, only pre-existing getpeername.t failure)
- [x] Custom module with `is export` subs works via `-I`
- [x] `is-path`, `is-eqv`, `warns-like`, `group-of` test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)