### PR TITLE
feat: implement Proc::Async .start stderr, .kill, .write, .close-stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ name = "mutsu"
 version = "0.1.0"
 dependencies = [
  "emojis",
+ "libc",
  "num-bigint",
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ unicode-segmentation = "1.12.0"
 unicode-normalization = "0.1"
 rustyline = "15"
 emojis = "0.7"
+libc = "0.2"
 
 [profile.release]
 debug = true

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -716,6 +716,13 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             Value::Array(items) => Some(Ok(Value::array(tree_recursive(items)))),
             _ => Some(Ok(target.clone())),
         },
+        "encode" => {
+            let s = target.to_string_value();
+            let bytes: Vec<Value> = s.as_bytes().iter().map(|&b| Value::Int(b as i64)).collect();
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("bytes".to_string(), Value::array(bytes));
+            Some(Ok(Value::make_instance("Buf".to_string(), attrs)))
+        }
         "sink" => Some(Ok(Value::Nil)),
         "item" => Some(Ok(target.clone())),
         "race" | "hyper" => {

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -482,6 +482,16 @@ impl Interpreter {
                         }
                         return Err(err);
                     }
+                    // Replay deferred Proc::Async taps
+                    if let Value::Instance {
+                        ref class_name,
+                        ref attributes,
+                        ..
+                    } = result
+                        && class_name == "Proc"
+                    {
+                        self.replay_proc_taps(attributes);
+                    }
                     results.push(result);
                 }
                 // Backward compat: Instance-based Promise

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -309,11 +309,35 @@ impl Interpreter {
                 parents: Vec::new(),
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["start", "command", "started", "stdout", "stderr"]
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
+                native_methods: [
+                    "start",
+                    "command",
+                    "started",
+                    "stdout",
+                    "stderr",
+                    "kill",
+                    "write",
+                    "close-stdin",
+                ]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
                 mro: vec!["Proc::Async".to_string()],
+            },
+        );
+        classes.insert(
+            "Proc".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: [
+                    "exitcode", "signal", "command", "pid", "Numeric", "Int", "Bool", "Str", "gist",
+                ]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+                mro: vec!["Proc".to_string()],
             },
         );
         classes.insert(

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -296,6 +296,14 @@ impl Value {
                 .get("str")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Proc" => attributes
+                .get("exitcode")
+                .map(|v: &Value| v.to_string_value())
+                .unwrap_or_else(|| format!("{}()", class_name)),
             Value::Instance { class_name, .. } => format!("{}()", class_name),
             Value::Junction { kind, values } => {
                 let kind_str = match kind {

--- a/t/proc-async.t
+++ b/t/proc-async.t
@@ -1,9 +1,61 @@
 use Test;
-plan 4;
+plan 11;
 
+# Basic construction and start
 my $p = Proc::Async.new("echo", "hi");
 is elems($p.command), 2, 'command stored';
 ok !$p.started, 'not started';
 my $promise = $p.start;
 ok $p.started, 'started';
 is $promise.result, 0, 'start returns exit code';
+
+# stdout tap receives output with newlines preserved
+{
+    my $p2 = Proc::Async.new("echo", "hello world");
+    my $out = '';
+    $p2.stdout.tap: { $out ~= $^a };
+    my $pr = $p2.start;
+    await $pr;
+    is $out, "hello world\n", 'stdout tap preserves newlines';
+}
+
+# stderr tap receives error output
+{
+    my $p3 = Proc::Async.new("sh", "-c", "echo error-msg >&2");
+    my $err = '';
+    $p3.stderr.tap: { $err ~= $^a };
+    my $pr = $p3.start;
+    await $pr;
+    is $err, "error-msg\n", 'stderr tap receives error output';
+}
+
+# .kill terminates a long-running process
+{
+    my $p4 = Proc::Async.new("sleep", "60");
+    my $pr = $p4.start;
+    $p4.kill;
+    my $result = $pr.result;
+    ok $result.exitcode != 0 || $result.signal != 0, '.kill terminates process';
+}
+
+# Proc instance from result
+{
+    my $p5 = Proc::Async.new("echo", "test");
+    my $pr = $p5.start;
+    my $proc = $pr.result;
+    is $proc.exitcode, 0, 'Proc.exitcode is 0';
+    is $proc.signal, 0, 'Proc.signal is 0';
+    ok $proc.command ~~ Array, 'Proc.command is an Array';
+}
+
+# .write sends data to stdin
+{
+    my $p6 = Proc::Async.new(:w, "cat");
+    my $out = '';
+    $p6.stdout.tap: { $out ~= $^a };
+    my $pr = $p6.start;
+    await $p6.write("hello from stdin".encode);
+    $p6.close-stdin;
+    await $pr;
+    is $out, "hello from stdin", '.write sends data to stdin';
+}


### PR DESCRIPTION
## Summary

- Fix `.start` to spawn separate threads for stdout and stderr reading, preserving newlines in output
- Store child PID in attrs for `.kill` support; implement `.kill` using `libc::kill` with SIGHUP
- Add `.write` method via global `PROC_STDIN_MAP` registry for cross-thread stdin access
- Add `.close-stdin` method to close the child's stdin pipe
- Return `Proc` instance from Promise (with exitcode, signal, command, pid) instead of plain Int
- Add `Str.encode` method returning Buf instance
- Add global supply taps registry for cross-thread tap sharing
- Implement deferred tap replay pattern: collect stdout/stderr in threads, replay through taps on main thread when await/result is called
- Expand `t/proc-async.t` from 4 to 11 tests

## Test plan

- [x] `cargo build` succeeds
- [x] `timeout 10 target/debug/mutsu t/proc-async.t` — all 11 tests pass
- [x] `make test` — no new regressions (socket.t pre-existing)
- [x] `make roast` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)