### PR TITLE
feat: implement MY:: pseudo-stash expression

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -180,6 +180,7 @@ pub(crate) enum Expr {
         package: Box<Expr>,
         name: String,
     },
+    PseudoStash(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -57,6 +57,10 @@ impl Compiler {
                     self.code.emit(OpCode::GetBareWord(name_idx));
                 }
             }
+            Expr::PseudoStash(name) => {
+                let name_idx = self.code.add_constant(Value::Str(name.clone()));
+                self.code.emit(OpCode::GetPseudoStash(name_idx));
+            }
             Expr::Unary { op, expr } => match op {
                 TokenKind::Minus => {
                     self.compile_expr(expr);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -19,6 +19,7 @@ pub(crate) enum OpCode {
     GetArrayVar(u32),
     GetHashVar(u32),
     GetBareWord(u32),
+    GetPseudoStash(u32),
 
     // -- Arithmetic --
     Add,

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -746,6 +746,16 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 full_name.push_str("::");
                 full_name.push_str(part);
                 r = rest2;
+            } else if super::var::is_pseudo_package(&full_name)
+                && (after.starts_with('.')
+                    || after.is_empty()
+                    || after.starts_with(';')
+                    || after.starts_with(')')
+                    || after.starts_with(',')
+                    || after.starts_with(' '))
+            {
+                // MY::, OUR::, etc. followed by method call or end-of-expression → PseudoStash
+                return Ok((after, Expr::PseudoStash(full_name)));
             } else {
                 return Err(PError::expected_at("identifier after '::'", after));
             }

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -201,7 +201,7 @@ pub(super) fn hash_var(input: &str) -> PResult<'_, Expr> {
 }
 
 /// Check if an identifier is a known pseudo-package name.
-fn is_pseudo_package(name: &str) -> bool {
+pub(crate) fn is_pseudo_package(name: &str) -> bool {
     matches!(
         name,
         "SETTING" | "CALLER" | "OUTER" | "CORE" | "GLOBAL" | "MY" | "OUR" | "DYNAMIC" | "UNIT"

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -217,6 +217,10 @@ impl VM {
                 self.exec_get_bare_word_op(code, *name_idx, compiled_fns)?;
                 *ip += 1;
             }
+            OpCode::GetPseudoStash(name_idx) => {
+                self.exec_get_pseudo_stash_op(code, *name_idx);
+                *ip += 1;
+            }
             OpCode::SetGlobal(name_idx) => {
                 let name = match &code.constants[*name_idx as usize] {
                     Value::Str(s) => s.clone(),

--- a/t/pseudo-stash.t
+++ b/t/pseudo-stash.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 5;
+
+# MY::.keys returns a list that includes declared variables
+my $x = 42;
+my @result = MY::.keys;
+ok @result.elems > 0, 'MY::.keys returns non-empty list';
+ok @result.grep(* eq '$x').elems > 0, 'MY::.keys includes $x';
+
+# MY:: can be used with .grep and .sort
+my $foo = 1;
+my $bar = 2;
+my @vars = MY::.keys.grep(*.starts-with('$')).sort;
+ok @vars.grep(* eq '$bar').elems > 0, 'MY::.keys.grep finds $bar';
+ok @vars.grep(* eq '$foo').elems > 0, 'MY::.keys.grep finds $foo';
+
+# MY::.elems returns a positive number
+ok MY::.elems > 0, 'MY::.elems returns positive count';


### PR DESCRIPTION
## Summary

- Add `MY::` pseudo-stash expression that evaluates to a Hash of all symbols in the current lexical scope
- `MY::.keys`, `.elems`, `.grep`, `.sort` and other Hash methods work naturally
- Parser recognizes `MY::` (and other pseudo-packages) followed by `.` or end-of-expression
- New AST node `PseudoStash`, opcode `GetPseudoStash`, and VM handler that collects locals + env with proper sigil prefixes

## Test plan

- [x] `t/pseudo-stash.t` — 5 tests covering `.keys`, `.grep`, `.sort`, `.elems`
- [x] `make test` passes (no new failures)
- [x] `make roast` passes (no regressions)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)