### PR TITLE
feat: implement Supply.batch with :elems/:seconds for live supplies

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -54,6 +54,8 @@
 - [ ] roast/S17-supply/act.t
 - [ ] roast/S17-supply/basic.t
 - [ ] roast/S17-supply/batch.t
+  - 5/9 pass: batch :elems tests pass. 4/9 fail: batch :seconds tests fail due to closure lexical
+    scoping bug (closures passed as named params see callee's same-named param value).
 - [ ] roast/S17-supply/categorize.t
 - [ ] roast/S17-supply/Channel.t
 - [ ] roast/S17-supply/classify.t

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -36,14 +36,14 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, flush_supplier_line_taps, get_classify_state,
-    get_classify_sub_supplier_ids, get_start_output_supplier_ids, register_supplier_classify_tap,
-    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_lines_tap,
-    register_supplier_produce_tap, register_supplier_quit_callback, register_supplier_start_tap,
-    register_supplier_tap, register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    supplier_emit_callbacks, supplier_produce_update_acc, supplier_tap_count,
-    supplier_unique_get_seen, supplier_unique_mark_seen, take_supplier_done_callbacks,
-    take_supplier_quit_callbacks, update_classify_state,
+    SupplierEmitAction, flush_supplier_batch_taps, flush_supplier_line_taps, get_classify_state,
+    get_classify_sub_supplier_ids, get_start_output_supplier_ids, register_supplier_batch_tap,
+    register_supplier_classify_tap, register_supplier_done_callback, register_supplier_elems_tap,
+    register_supplier_lines_tap, register_supplier_produce_tap, register_supplier_quit_callback,
+    register_supplier_start_tap, register_supplier_tap, register_supplier_tap_with_head_limit,
+    register_supplier_unique_tap, supplier_emit_callbacks, supplier_produce_update_acc,
+    supplier_tap_count, supplier_unique_get_seen, supplier_unique_mark_seen,
+    take_supplier_done_callbacks, take_supplier_quit_callbacks, update_classify_state,
 };
 
 use super::*;

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -83,6 +83,20 @@ impl Interpreter {
                 } => {
                     self.run_start_call_in_thread(callable, val, output_supplier_id);
                 }
+                SupplierEmitAction::BatchEmit {
+                    downstream_supplier_id,
+                    batch,
+                } => {
+                    let batch_value = Value::array(batch);
+                    supplier_emit(downstream_supplier_id, batch_value.clone());
+                    let ds_actions = supplier_emit_callbacks(downstream_supplier_id, &batch_value);
+                    for ds_action in ds_actions {
+                        if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = ds_action {
+                            Self::sleep_for_supply_delay(delay_seconds);
+                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                        }
+                    }
+                }
             }
         }
         Ok(())

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -45,6 +45,8 @@ struct SupplierTapSubscription {
     produce_state: Option<ProduceState>,
     /// Start transform state: callable and output supplier_id
     start_state: Option<StartState>,
+    /// Batch state: buffer values and emit as batched lists
+    batch_state: Option<BatchState>,
 }
 
 #[derive(Clone)]
@@ -59,6 +61,20 @@ struct StartState {
     callable: Value,
     /// The output supplier_id where wrapped Supply values are emitted
     output_supplier_id: u64,
+}
+
+#[derive(Clone)]
+struct BatchState {
+    /// Maximum number of elements per batch (from :elems)
+    elems: Option<usize>,
+    /// Time window in seconds (from :seconds)
+    seconds: Option<f64>,
+    /// Buffer of values accumulated so far
+    buffer: Vec<Value>,
+    /// The downstream supplier_id to emit batched lists into
+    downstream_supplier_id: u64,
+    /// Timestamp of last flush (for timer-based batching)
+    last_flush: std::time::Instant,
 }
 
 #[derive(Clone, Default)]
@@ -93,6 +109,7 @@ pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, de
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -120,6 +137,7 @@ pub(in crate::runtime) fn register_supplier_tap_with_head_limit(
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -147,6 +165,7 @@ pub(in crate::runtime) fn register_supplier_lines_tap(
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -180,6 +199,7 @@ pub(in crate::runtime) fn register_supplier_elems_tap(
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -219,6 +239,11 @@ pub(in crate::runtime) enum SupplierEmitAction {
         callable: Value,
         value: Value,
         output_supplier_id: u64,
+    },
+    /// Batch emit: a full batch is ready to be emitted to the downstream supplier
+    BatchEmit {
+        downstream_supplier_id: u64,
+        batch: Vec<Value>,
     },
 }
 
@@ -305,6 +330,33 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                         Value::Int(elems.emitted_count),
                         tap.delay_seconds,
                     ));
+                }
+            } else if let Some(ref mut bs) = tap.batch_state {
+                // Check if we should flush the existing buffer based on time
+                if let Some(seconds) = bs.seconds
+                    && bs.last_flush.elapsed().as_secs_f64() >= seconds
+                    && !bs.buffer.is_empty()
+                {
+                    let batch = std::mem::take(&mut bs.buffer);
+                    let dsid = bs.downstream_supplier_id;
+                    bs.last_flush = std::time::Instant::now();
+                    actions.push(SupplierEmitAction::BatchEmit {
+                        downstream_supplier_id: dsid,
+                        batch,
+                    });
+                }
+                bs.buffer.push(emitted_value.clone());
+                // Check if we should flush based on elems count
+                if let Some(elems) = bs.elems
+                    && bs.buffer.len() >= elems
+                {
+                    let batch = std::mem::take(&mut bs.buffer);
+                    let dsid = bs.downstream_supplier_id;
+                    bs.last_flush = std::time::Instant::now();
+                    actions.push(SupplierEmitAction::BatchEmit {
+                        downstream_supplier_id: dsid,
+                        batch,
+                    });
                 }
             } else if let Some(ref ps) = tap.produce_state {
                 actions.push(SupplierEmitAction::ProduceCall {
@@ -403,6 +455,7 @@ pub(in crate::runtime) fn register_supplier_unique_tap(
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -433,6 +486,7 @@ pub(in crate::runtime) fn register_supplier_produce_tap(
                     accumulator: None,
                 }),
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -465,6 +519,7 @@ pub(in crate::runtime) fn register_supplier_start_tap(
                     callable,
                     output_supplier_id,
                 }),
+                batch_state: None,
             });
     }
 }
@@ -537,6 +592,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                 head_count: 0,
                 produce_state: None,
                 start_state: None,
+                batch_state: None,
             });
     }
 }
@@ -657,4 +713,59 @@ pub(in crate::runtime) fn register_supplier_quit_callback(supplier_id: u64, quit
             .quit_callbacks
             .push(quit_cb);
     }
+}
+
+/// Register a batch tap on a supplier. Values are buffered and emitted as
+/// batched lists to the downstream supplier when `:elems` count is reached.
+pub(in crate::runtime) fn register_supplier_batch_tap(
+    supplier_id: u64,
+    downstream_supplier_id: u64,
+    elems: Option<usize>,
+    seconds: Option<f64>,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .taps
+            .push(SupplierTapSubscription {
+                callback: Value::Nil,
+                line_mode: false,
+                line_chomp: true,
+                line_buffer: String::new(),
+                delay_seconds: 0.0,
+                unique_filter: None,
+                classify_state: None,
+                elems_trace: None,
+                head_limit: None,
+                head_count: 0,
+                produce_state: None,
+                start_state: None,
+                batch_state: Some(BatchState {
+                    elems,
+                    seconds,
+                    buffer: Vec::new(),
+                    downstream_supplier_id,
+                    last_flush: std::time::Instant::now(),
+                }),
+            });
+    }
+}
+
+/// Flush any remaining values in batch tap buffers when the supplier is done.
+/// Returns (downstream_supplier_id, batched_values) pairs.
+pub(in crate::runtime) fn flush_supplier_batch_taps(supplier_id: u64) -> Vec<(u64, Vec<Value>)> {
+    let mut result = Vec::new();
+    if let Ok(mut map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get_mut(&supplier_id)
+    {
+        for tap in subs.taps.iter_mut() {
+            if let Some(ref mut bs) = tap.batch_state
+                && !bs.buffer.is_empty()
+            {
+                let batch = std::mem::take(&mut bs.buffer);
+                result.push((bs.downstream_supplier_id, batch));
+            }
+        }
+    }
+    result
 }

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -872,18 +872,43 @@ impl Interpreter {
                 Ok(self.make_supply_from_values(produced, attributes))
             }
             "batch" => {
-                let source_values = self.supply_get_values(attributes)?;
-                let mut batch_size: Option<usize> = None;
+                let mut batch_elems: Option<usize> = None;
+                let mut batch_seconds: Option<f64> = None;
                 for arg in &args {
                     if let Value::Pair(key, value) = arg {
-                        if key == "elems" {
-                            batch_size = Some(value.to_f64() as usize);
+                        match key.as_str() {
+                            "elems" => batch_elems = Some(value.to_f64() as usize),
+                            "seconds" => batch_seconds = Some(value.to_f64()),
+                            _ => {}
                         }
                     } else {
-                        batch_size = Some(arg.to_f64() as usize);
+                        batch_elems = Some(arg.to_f64() as usize);
                     }
                 }
-                let size = batch_size.unwrap_or(source_values.len().max(1));
+
+                // For supplier-backed (live) supplies, set up a batch tap chain
+                if let Some(Value::Int(source_supplier_id)) = attributes.get("supplier_id") {
+                    let source_sid = *source_supplier_id as u64;
+                    let downstream_sid = next_supplier_id();
+
+                    register_supplier_batch_tap(
+                        source_sid,
+                        downstream_sid,
+                        batch_elems,
+                        batch_seconds,
+                    );
+
+                    let mut new_attrs = HashMap::new();
+                    new_attrs.insert("values".to_string(), Value::array(Vec::new()));
+                    new_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+                    new_attrs.insert("supplier_id".to_string(), Value::Int(downstream_sid as i64));
+                    new_attrs.insert("live".to_string(), Value::Bool(false));
+                    return Ok(Value::make_instance(Symbol::intern("Supply"), new_attrs));
+                }
+
+                // Non-live supply: batch eagerly
+                let source_values = self.supply_get_values(attributes)?;
+                let size = batch_elems.unwrap_or(source_values.len().max(1));
                 let mut batched = Vec::new();
                 for chunk in source_values.chunks(size) {
                     batched.push(Value::array(chunk.to_vec()));
@@ -1225,6 +1250,23 @@ impl Interpreter {
                             } => {
                                 self.run_start_call_in_thread(callable, val, output_supplier_id);
                             }
+                            SupplierEmitAction::BatchEmit {
+                                downstream_supplier_id,
+                                batch,
+                            } => {
+                                let batch_value = Value::array(batch);
+                                supplier_emit(downstream_supplier_id, batch_value.clone());
+                                let ds_actions =
+                                    supplier_emit_callbacks(downstream_supplier_id, &batch_value);
+                                for ds_action in ds_actions {
+                                    if let SupplierEmitAction::Call(tap, emitted, delay_seconds) =
+                                        ds_action
+                                    {
+                                        Self::sleep_for_supply_delay(delay_seconds);
+                                        let _ = self.call_sub_value(tap, vec![emitted], true);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1233,6 +1275,23 @@ impl Interpreter {
             "done" => {
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_done(supplier_id);
+                    // Flush batch buffers before done
+                    for (dsid, batch) in flush_supplier_batch_taps(supplier_id) {
+                        let batch_value = Value::array(batch);
+                        supplier_emit(dsid, batch_value.clone());
+                        let ds_actions = supplier_emit_callbacks(dsid, &batch_value);
+                        for ds_action in ds_actions {
+                            if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = ds_action
+                            {
+                                Self::sleep_for_supply_delay(delay_seconds);
+                                let _ = self.call_sub_value(tap, vec![emitted], true);
+                            }
+                        }
+                        supplier_done(dsid);
+                        for done_cb in take_supplier_done_callbacks(dsid) {
+                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                        }
+                    }
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
                         let _ = self.call_sub_value(tap, vec![emitted], true);
                     }
@@ -1381,6 +1440,23 @@ impl Interpreter {
                             } => {
                                 self.run_start_call_in_thread(callable, val, output_supplier_id);
                             }
+                            SupplierEmitAction::BatchEmit {
+                                downstream_supplier_id,
+                                batch,
+                            } => {
+                                let batch_value = Value::array(batch);
+                                supplier_emit(downstream_supplier_id, batch_value.clone());
+                                let ds_actions =
+                                    supplier_emit_callbacks(downstream_supplier_id, &batch_value);
+                                for ds_action in ds_actions {
+                                    if let SupplierEmitAction::Call(tap, emitted, delay_seconds) =
+                                        ds_action
+                                    {
+                                        Self::sleep_for_supply_delay(delay_seconds);
+                                        self.call_sub_value(tap, vec![emitted], true)?;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1393,6 +1469,24 @@ impl Interpreter {
                 }
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
+                    // Flush batch buffers before done
+                    for (dsid, batch) in flush_supplier_batch_taps(sid) {
+                        let batch_value = Value::array(batch);
+                        supplier_emit(dsid, batch_value.clone());
+                        let ds_actions = supplier_emit_callbacks(dsid, &batch_value);
+                        for ds_action in ds_actions {
+                            if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = ds_action
+                            {
+                                Self::sleep_for_supply_delay(delay_seconds);
+                                self.call_sub_value(tap, vec![emitted], true)?;
+                            }
+                        }
+                        // Propagate done to downstream batch suppliers
+                        supplier_done(dsid);
+                        for done_cb in take_supplier_done_callbacks(dsid) {
+                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                        }
+                    }
                     // Propagate done to classify sub-suppliers
                     let classify_subs = get_classify_sub_supplier_ids(sid);
                     for sub_sid in classify_subs {


### PR DESCRIPTION
## Summary
- Implement `batch(:elems)` and `batch(:seconds)` for Supplier-backed (live) supplies
- Add `BatchState` to supplier tap subscriptions for value buffering
- Time-based batching checks elapsed time on each new emit and flushes when the window expires
- Remaining batch buffer is flushed on supplier done
- Handle `BatchEmit` action in all supplier emit dispatch paths

Previously `batch` only worked eagerly on non-live supplies. Now it creates a downstream supplier chain that buffers values and emits batched arrays.

5/9 subtests in `roast/S17-supply/batch.t` now pass. The 4 time-based tests fail due to a pre-existing closure lexical scoping bug (closures passed as named params see the callee's same-named parameter instead of their captured outer variable).

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `make test` passes
- [x] `make roast` passes (no regressions)
- [x] `timeout 120 target/debug/mutsu roast/S17-supply/batch.t` completes (no timeout)

Generated with [Claude Code](https://claude.com/claude-code)