### PR TITLE
fix: parse BEGIN as PhaserExpr in expression context

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -264,6 +264,7 @@ roast/S04-phasers/keep-undo.t
 roast/S04-phasers/multiple.t
 roast/S04-phasers/next.t
 roast/S04-phasers/pre-post.t
+roast/S04-phasers/rvalue.t
 roast/S04-statement-modifiers/for.t
 roast/S04-statement-modifiers/given.t
 roast/S04-statement-modifiers/if.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -622,8 +622,9 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
             ));
         }
     }
-    // INIT/CHECK/END/ENTER/LEAVE as expression prefix phasers
+    // BEGIN/INIT/CHECK/END/ENTER/LEAVE as expression prefix phasers
     for (kw, kw_len, phaser_kind) in [
+        ("BEGIN", 5, crate::ast::PhaserKind::Begin),
         ("INIT", 4, crate::ast::PhaserKind::Init),
         ("CHECK", 5, crate::ast::PhaserKind::Check),
         ("ENTER", 5, crate::ast::PhaserKind::Enter),

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -297,7 +297,7 @@ fn lift_phasers_from_expr(
     if matches!(
         expr,
         Expr::PhaserExpr {
-            kind: PhaserKind::Check | PhaserKind::Init,
+            kind: PhaserKind::Begin | PhaserKind::Check | PhaserKind::Init,
             ..
         }
     ) {
@@ -322,6 +322,10 @@ fn lift_phasers_from_expr(
                 op: AssignOp::Assign,
             };
             match kind {
+                PhaserKind::Begin => {
+                    begin.push(var_decl);
+                    begin.push(assign);
+                }
                 PhaserKind::Check => {
                     check.push(var_decl);
                     check.push(assign);
@@ -448,7 +452,7 @@ fn lift_phasers_from_expr(
             }
         }
         Expr::PhaserExpr { body, .. } => {
-            // BEGIN PhaserExpr — don't extract, just recurse
+            // Non-BEGIN/CHECK/INIT PhaserExpr (e.g. END) — don't extract, just recurse
             lift_phasers_from_closure_stmts(body, begin, check, init);
         }
         Expr::DoStmt(inner_stmt) => {


### PR DESCRIPTION
## Summary
- Fixed BEGIN `{ ... }` in expression context (e.g. inside closure rvalues) being parsed as a function call instead of a `PhaserExpr`
- Added BEGIN to the parser's phaser expression keyword list alongside INIT/CHECK/ENTER/LEAVE/END
- Added BEGIN to the phaser extraction logic so `PhaserExpr { kind: Begin }` inside closures is properly lifted to the enclosing scope
- This ensures the correct B-C-I execution order for phasers used as rvalues inside closures

## Test plan
- [x] All 16 subtests in `roast/S04-phasers/rvalue.t` pass
- [x] Added `roast/S04-phasers/rvalue.t` to roast-whitelist.txt
- [x] `make test` passes (only pre-existing flaky t/lock.t failure)
- [x] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)