### PR TITLE
fix: add .of attribute to Scalar .VAR objects

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -946,6 +946,7 @@ roast/S32-num/stress.t
 roast/S32-num/stringify.t
 roast/S32-num/unpolar.t
 roast/S32-scalar/defined.t
+roast/S32-scalar/perl.t
 roast/S32-str/Collation.t
 roast/S32-str/append.t
 roast/S32-str/bool.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1456,6 +1456,13 @@ impl Interpreter {
                 Value::Package(Symbol::intern("Any"))
             };
             attributes.insert("default".to_string(), default_val);
+            // Add .of: type constraint of the variable (Mu for unconstrained)
+            let of_val = if let Some(tc) = self.var_type_constraint(target_var) {
+                Value::Package(Symbol::intern(&tc))
+            } else {
+                Value::Package(Symbol::intern("Mu"))
+            };
+            attributes.insert("of".to_string(), of_val);
             let meta = Value::make_instance(Symbol::intern(class_name), attributes);
             self.set_var_meta_value(target_var, meta.clone());
             return Ok(meta);


### PR DESCRIPTION
## Summary
- Add `of` attribute to Scalar `.VAR` objects, returning the type constraint (`Mu` for unconstrained, declared type for typed variables like `my Int $a`)
- This fixes `$a.VAR.of =:= Mu` which is tested in `roast/S32-scalar/perl.t`
- Add `roast/S32-scalar/perl.t` to the whitelist (all 7 subtests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-scalar/perl.t` passes
- [x] `make roast` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)