### PR TITLE
fix: improve Array .raku/.perl for constrained, lazy, and circular arrays

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -420,8 +420,12 @@ pub(super) fn dispatch(
                 Some(Ok(Value::Str(s.clone())))
             }
         }
-        Value::Array(_, _) if method == "raku" || method == "perl" => {
-            Some(Ok(Value::str(raku_value(target))))
+        Value::Array(_, kind) if method == "raku" || method == "perl" => {
+            if *kind == crate::value::ArrayKind::Lazy {
+                Some(Ok(Value::str_from("[...]")))
+            } else {
+                Some(Ok(Value::str(raku_value(target))))
+            }
         }
         Value::Seq(_) if method == "raku" || method == "perl" => {
             Some(Ok(Value::str(raku_value(target))))

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -259,24 +259,46 @@ pub fn raku_value(v: &Value) -> String {
     // that we're currently rendering. If we encounter the same pointer
     // again, emit a placeholder instead of recursing infinitely.
     thread_local! {
-        static SEEN_PTRS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
+        static SEEN_PTRS: std::cell::RefCell<Vec<(usize, String)>> = const { std::cell::RefCell::new(Vec::new()) };
+        static ARRAY_CYCLE_FOUND: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     }
     match v {
         Value::Array(items, kind) => {
-            let ptr = Arc::as_ptr(items) as usize;
-            let is_cycle = SEEN_PTRS.with(|seen| seen.borrow().contains(&ptr));
-            if is_cycle {
-                return raku_array_wrap("...", *kind);
+            // Lazy arrays should not be materialized
+            if *kind == crate::value::ArrayKind::Lazy {
+                return "[...]".to_string();
             }
-            SEEN_PTRS.with(|seen| seen.borrow_mut().push(ptr));
+            let ptr = Arc::as_ptr(items) as usize;
+            let var_name = format!("@Array_{}", ptr);
+            // Check for cycle
+            let cycle_var = SEEN_PTRS.with(|seen| {
+                seen.borrow()
+                    .iter()
+                    .find(|(p, _)| *p == ptr)
+                    .map(|(_, name)| name.clone())
+            });
+            if let Some(name) = cycle_var {
+                ARRAY_CYCLE_FOUND.with(|f| f.set(true));
+                return name;
+            }
+            let is_top = SEEN_PTRS.with(|seen| seen.borrow().is_empty());
+            SEEN_PTRS.with(|seen| seen.borrow_mut().push((ptr, var_name.clone())));
+            if is_top {
+                ARRAY_CYCLE_FOUND.with(|f| f.set(false));
+            }
             let result = raku_value_array(items, *kind, v);
+            let had_cycle = ARRAY_CYCLE_FOUND.with(|f| f.get());
             SEEN_PTRS.with(|seen| {
                 let mut s = seen.borrow_mut();
-                if let Some(pos) = s.iter().rposition(|p| *p == ptr) {
+                if let Some(pos) = s.iter().rposition(|(p, _)| *p == ptr) {
                     s.remove(pos);
                 }
             });
-            result
+            if is_top && had_cycle {
+                format!("((my {}) = {})", var_name, result)
+            } else {
+                result
+            }
         }
         Value::Seq(items) => {
             let inner = items.iter().map(raku_value).collect::<Vec<_>>().join(", ");

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -792,6 +792,23 @@ impl Interpreter {
             };
             return Ok(Value::str(result));
         }
+        // .raku/.perl on constrained regular Array (e.g. Array[Int])
+        if matches!(method, "raku" | "perl")
+            && args.is_empty()
+            && matches!(&target, Value::Array(_, kind) if *kind != crate::value::ArrayKind::Shaped)
+            && let Some(info) = self.container_type_metadata(&target)
+            && info.value_type != "Any"
+            && info.value_type != "Mu"
+            && let Value::Array(items, _) = &target
+        {
+            let inner = items
+                .iter()
+                .map(crate::builtins::methods_0arg::raku_repr::raku_value)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let type_name = &info.value_type;
+            return Ok(Value::str(format!("Array[{}].new({})", type_name, inner)));
+        }
 
         // ACCEPTS for allomorphic types with Instance arguments
         // This handles custom classes with .Numeric/.Str methods that the

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1003,6 +1003,25 @@ impl VM {
         } else {
             None
         };
+        // Capture old array Arc pointer for circular reference fixup.
+        let old_array_arc = if name.starts_with('@') {
+            let current = self.get_env_with_main_alias(&name).or_else(|| {
+                code.locals.iter().position(|n| n == &name).and_then(|idx| {
+                    if idx < self.locals.len() {
+                        Some(self.locals[idx].clone())
+                    } else {
+                        None
+                    }
+                })
+            });
+            if let Some(Value::Array(arc, _)) = current {
+                Some(Arc::as_ptr(&arc) as usize)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let mut val = if name.starts_with('%') {
             let hash_val = runtime::coerce_to_hash(raw_val);
             // Resolve hash sentinel entries (bound variable refs) when assigning
@@ -1204,6 +1223,25 @@ impl VM {
             {
                 let has_old_ref = stack_arc.values().any(|v| {
                     if let Value::Hash(inner_arc) = v {
+                        Arc::as_ptr(inner_arc) as usize == old_ptr
+                    } else {
+                        false
+                    }
+                });
+                if has_old_ref {
+                    *stack_top = val.clone();
+                }
+            }
+        }
+        // Circular array reference fixup
+        if name.starts_with('@') {
+            Self::fixup_circular_array_refs(&mut val, &old_array_arc);
+            if let Some(old_ptr) = old_array_arc
+                && let Some(stack_top) = self.stack.last_mut()
+                && let Value::Array(stack_arc, _) = stack_top
+            {
+                let has_old_ref = stack_arc.iter().any(|v| {
+                    if let Value::Array(inner_arc, _) = v {
                         Arc::as_ptr(inner_arc) as usize == old_ptr
                     } else {
                         false

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -72,14 +72,13 @@ impl VM {
             && self.interpreter.container_type_metadata(target).is_some();
         // Native typed array (e.g. array[int]): bypass builtins for .raku/.perl
         // so the runtime can produce the correct type prefix (e.g. "array[int].new(...)")
-        let bypass_typed_array_raku =
-            matches!(target, Value::Array(_, crate::value::ArrayKind::Shaped))
-                && args.is_empty()
-                && matches!(method_sym.resolve().as_ref(), "raku" | "perl")
-                && self
-                    .interpreter
-                    .container_type_metadata(target)
-                    .is_some_and(|info| info.value_type != "Any" && info.value_type != "Mu");
+        let bypass_typed_array_raku = matches!(target, Value::Array(..))
+            && args.is_empty()
+            && matches!(method_sym.resolve().as_ref(), "raku" | "perl")
+            && self
+                .interpreter
+                .container_type_metadata(target)
+                .is_some_and(|info| info.value_type != "Any" && info.value_type != "Mu");
         // Unconstrained Hash .keyof must also bypass builtins (returns Str(Any))
         let bypass_hash_keyof = matches!(target, Value::Hash(_))
             && args.is_empty()

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -248,6 +248,45 @@ impl VM {
         }
     }
 
+    /// Fix up circular references in array assignment.
+    /// When `@a = 42, @a`, the RHS contains a reference to the old array.
+    /// Replace that reference with the new array to create a circular structure.
+    pub(super) fn fixup_circular_array_refs(new_val: &mut Value, old_ptr: &Option<usize>) {
+        let Some(old_ptr) = old_ptr else { return };
+        if let Value::Array(new_arc, kind) = new_val {
+            let has_old_ref = new_arc.iter().any(|v| match v {
+                Value::Array(inner_arc, _) => Arc::as_ptr(inner_arc) as usize == *old_ptr,
+                _ => false,
+            });
+            if !has_old_ref {
+                return;
+            }
+            // Build a new items list, replacing old-array references with Nil placeholders
+            let mut new_items: Vec<Value> = Vec::with_capacity(new_arc.len());
+            let mut circular_indices = Vec::new();
+            for (i, v) in new_arc.iter().enumerate() {
+                if let Value::Array(inner_arc, _) = v
+                    && Arc::as_ptr(inner_arc) as usize == *old_ptr
+                {
+                    circular_indices.push(i);
+                    new_items.push(Value::Nil); // placeholder
+                } else {
+                    new_items.push(v.clone());
+                }
+            }
+            let result_arc = Arc::new(new_items);
+            let items_ptr = Arc::as_ptr(&result_arc) as *mut Vec<Value>;
+            for idx in &circular_indices {
+                // SAFETY: We just created result_arc and hold the only reference,
+                // so no other thread can access it.
+                unsafe {
+                    (&mut *items_ptr)[*idx] = Value::Array(result_arc.clone(), *kind);
+                }
+            }
+            *new_arc = result_arc;
+        }
+    }
+
     fn coerce_hash_var_value(&mut self, name: &str, value: Value) -> Result<Value, RuntimeError> {
         if let Some(constraint) = self.interpreter.var_type_constraint_fast(name).cloned()
             && let Some(trait_name) = Self::quant_hash_trait_from_constraint(&constraint)
@@ -2229,6 +2268,16 @@ impl VM {
         } else {
             None
         };
+        // Capture the old array Arc before assignment for circular reference fixup.
+        let old_array_arc = if name.starts_with('@') {
+            if let Value::Array(arc, _) = &self.locals[idx] {
+                Some(Arc::as_ptr(arc) as usize)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let mut val = if name.starts_with('%') {
             if has_explicit_initializer
                 && !is_constant
@@ -2496,6 +2545,13 @@ impl VM {
         // a true circular reference (matching Raku container semantics).
         if name.starts_with('%') && !is_bind && !is_constant {
             Self::fixup_circular_hash_refs(&mut self.locals[idx], &old_hash_arc);
+        }
+        // Circular array reference fixup: when assigning to an array variable,
+        // if any elements in the new array reference the old array (captured on the
+        // RHS before assignment), replace them with the new array's Arc to create
+        // a true circular reference (matching Raku container semantics).
+        if name.starts_with('@') && !is_bind && !is_constant {
+            Self::fixup_circular_array_refs(&mut self.locals[idx], &old_array_arc);
         }
         // Use the potentially fixed-up value for env/shared_vars.
         let val = self.locals[idx].clone();


### PR DESCRIPTION
## Summary
- Constrained arrays (`my Int @a = 1,2`) now produce `Array[Int].new(1, 2)` for `.raku` output
- Lazy arrays (`1..*` assigned to `@`) produce `[...]` instead of materializing all elements
- Circular array references (`@a = 42, @a`) are properly created via Arc pointer fixup and `.raku` produces Raku-compatible `((my @Array_...) = [...])` format
- Bypass native method fastpath for `.raku`/`.perl` on all constrained arrays, not just shaped arrays

Passes 8/9 subtests in `roast/S32-array/perl.t`. The remaining subtest (test 8: cross-container circular references between array and hash) requires Raku's container binding semantics where hash values hold references to array containers rather than value copies.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] `make test` passes (469 files, 3791 tests)
- [x] `make roast` passes
- [x] `roast/S32-array/perl.t` passes 8/9 subtests

Generated with [Claude Code](https://claude.com/claude-code)