### PR TITLE
fix: propagate writes through := bindings so bound vars see updates

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -243,6 +243,7 @@ roast/S04-blocks-and-statements/let.t
 roast/S04-blocks-and-statements/pointy-rw.t
 roast/S04-blocks-and-statements/pointy.t
 roast/S04-declarations/implicit-parameter.t
+roast/S04-declarations/multiple.t
 roast/S04-declarations/smiley.t
 roast/S04-exception-handlers/top-level.t
 roast/S04-exceptions/control_across_runloop.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -56,6 +56,7 @@ pub(super) struct VmCallFrame {
     pub saved_readonly: HashSet<String>,
     pub saved_env_dirty: bool,
     pub saved_locals_dirty: bool,
+    pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 
 pub(crate) struct VM {
@@ -95,8 +96,10 @@ pub(crate) struct VM {
     /// When true, the next SetLocal is from a `my` VarDecl (not a plain assignment).
     /// Used to allow overwriting immutable Blob containers in loop redeclarations.
     vardecl_context: bool,
-    // TODO: local slot aliases for `:=` binding - needs careful implementation
-    // to avoid S12-class/mro-6e.t regression
+    /// Local-slot binding pairs created by `:=` VarDecl in the current scope.
+    /// Each entry is (source_slot, target_slot): writing to source_slot should
+    /// propagate the value to target_slot.
+    local_bind_pairs: Vec<(usize, usize)>,
     /// Cache for on-the-fly compiled functions, keyed by fingerprint.
     /// Prevents re-compilation which would break state variables.
     otf_compile_cache: HashMap<u64, CompiledFunction>,
@@ -262,6 +265,7 @@ impl VM {
             constant_context: false,
             explicit_initializer_context: false,
             vardecl_context: false,
+            local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),
             state_scope_id: None,
             fn_resolve_cache: HashMap::new(),

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -24,6 +24,7 @@ impl VM {
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
             saved_locals_dirty: self.locals_dirty,
+            saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
         };
         self.env_dirty = false;
         self.locals_dirty = false;
@@ -38,6 +39,7 @@ impl VM {
             .pop()
             .expect("pop_call_frame: no frame to pop");
         self.locals = std::mem::take(&mut frame.saved_locals);
+        self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         self.interpreter
             .restore_readonly_vars(std::mem::take(&mut frame.saved_readonly));
         self.env_dirty = frame.saved_env_dirty;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2246,6 +2246,23 @@ impl VM {
             // from firing).
             self.interpreter
                 .set_shared_var(name, self.locals[idx].clone());
+            // Propagate value to variables bound to this one via `:=` binding.
+            // When `my $y := $x`, alias `y -> x` is stored. If `$x` is updated,
+            // find any local slots whose alias points to `x` and update them too.
+            {
+                let new_val = self.locals[idx].clone();
+                for (target_idx, target_name) in code.locals.iter().enumerate() {
+                    if target_idx == idx {
+                        continue;
+                    }
+                    let alias_key = format!("__mutsu_sigilless_alias::{}", target_name);
+                    if let Some(Value::Str(alias_source)) = self.interpreter.env().get(&alias_key)
+                        && alias_source.as_ref() == name
+                    {
+                        self.locals[target_idx] = new_val.clone();
+                    }
+                }
+            }
             // Track topic mutations for map rw writeback
             if name == "_" {
                 self.interpreter.env_mut().insert(
@@ -2603,6 +2620,21 @@ impl VM {
                     None
                 }
             });
+        }
+        // Reverse propagation: when writing to a variable that is the source
+        // of another variable's `:=` binding, update the bound variable's
+        // local slot too.  For example, `my $y := $x; my $x = 3;` must
+        // update $y's slot so it reads 3.
+        for (target_idx, target_name) in code.locals.iter().enumerate() {
+            if target_idx == idx {
+                continue;
+            }
+            let target_alias_key = format!("__mutsu_sigilless_alias::{}", target_name);
+            if let Some(Value::Str(alias_source)) = self.interpreter.env().get(&target_alias_key)
+                && alias_source.as_ref() == name
+            {
+                self.locals[target_idx] = val.clone();
+            }
         }
         if let Some(attr) = name.strip_prefix('.') {
             self.interpreter

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2247,19 +2247,13 @@ impl VM {
             self.interpreter
                 .set_shared_var(name, self.locals[idx].clone());
             // Propagate value to variables bound to this one via `:=` binding.
-            // When `my $y := $x`, alias `y -> x` is stored. If `$x` is updated,
-            // find any local slots whose alias points to `x` and update them too.
+            // Uses local_bind_pairs recorded at binding time to avoid
+            // cross-scope name collisions.
             {
                 let new_val = self.locals[idx].clone();
-                for (target_idx, target_name) in code.locals.iter().enumerate() {
-                    if target_idx == idx {
-                        continue;
-                    }
-                    let alias_key = format!("__mutsu_sigilless_alias::{}", target_name);
-                    if let Some(Value::Str(alias_source)) = self.interpreter.env().get(&alias_key)
-                        && alias_source.as_ref() == name
-                    {
-                        self.locals[target_idx] = new_val.clone();
+                for &(source, target) in &self.local_bind_pairs {
+                    if source == idx {
+                        self.locals[target] = new_val.clone();
                     }
                 }
             }
@@ -2498,16 +2492,21 @@ impl VM {
         }
         if let Some(source_name) = bind_source {
             let resolved_source = self.resolve_sigilless_alias_source_name(&source_name);
-            // TODO: compile to bytecode - implement local slot aliasing for `:=` binding
-            // so that `my $y := $x; my $x = 3; say $y` correctly prints 3.
-            // The write propagation approach needs careful handling to avoid
-            // breaking S12-class/mro-6e.t's role concretization tests.
             self.interpreter
                 .env_mut()
-                .insert(alias_key.clone(), Value::str(resolved_source));
+                .insert(alias_key.clone(), Value::str(resolved_source.clone()));
             self.interpreter
                 .env_mut()
                 .insert(readonly_key, Value::Bool(false));
+            // Record local-slot binding pair for write propagation.
+            // Only record if the source is also a local in the same code unit,
+            // so cross-scope name collisions do not cause spurious propagation.
+            if is_vardecl
+                && let Some(source_idx) = code.locals.iter().position(|n| n == &resolved_source)
+                && source_idx != idx
+            {
+                self.local_bind_pairs.push((source_idx, idx));
+            }
         }
         // If the current value is a Proxy, invoke STORE instead of overwriting
         if let Value::Proxy { storer, .. } = &self.locals[idx]
@@ -2625,15 +2624,11 @@ impl VM {
         // of another variable's `:=` binding, update the bound variable's
         // local slot too.  For example, `my $y := $x; my $x = 3;` must
         // update $y's slot so it reads 3.
-        for (target_idx, target_name) in code.locals.iter().enumerate() {
-            if target_idx == idx {
-                continue;
-            }
-            let target_alias_key = format!("__mutsu_sigilless_alias::{}", target_name);
-            if let Some(Value::Str(alias_source)) = self.interpreter.env().get(&target_alias_key)
-                && alias_source.as_ref() == name
-            {
-                self.locals[target_idx] = val.clone();
+        // Uses local_bind_pairs recorded at binding time to avoid
+        // cross-scope name collisions.
+        for &(source, target) in &self.local_bind_pairs {
+            if source == idx {
+                self.locals[target] = val.clone();
             }
         }
         if let Some(attr) = name.strip_prefix('.') {


### PR DESCRIPTION
## Summary
- When `my $y := $x` creates a binding and `$x` is later assigned (e.g. via redeclaration `my $x = 3`), `$y` now correctly reflects the new value
- Added reverse propagation in `SetLocal` (both fast and slow paths): after writing to a variable, scan for any other local whose sigilless alias points to it and update that slot too
- Passes all 8 subtests in `roast/S04-declarations/multiple.t` and adds it to the whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-declarations/multiple.t` passes
- [x] `prove -e 'target/debug/mutsu' roast/S12-class/mro-6e.t` still passes (no regression)
- [x] `make test` passes
- [x] `make roast` passes with no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)