### PR TITLE
fix: support nested index ++/-- and fix try with binding

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -460,6 +460,7 @@ roast/S07-hyperrace/stress.t
 roast/S07-iterationbuffer/iterationbuffer.t
 roast/S07-iterators/range-iterator.t
 roast/S07-slip/slip.t
+roast/S09-autovivification/autoincrement.t
 roast/S09-multidim/assign.t
 roast/S09-multidim/decl.t
 roast/S09-multidim/indexing.t

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -19,13 +19,9 @@ impl Compiler {
                 let name_idx = self.code.add_constant(Value::str(name));
                 self.code.emit(OpCode::PostIncrementIndex(name_idx));
             } else {
-                // Arbitrary expression target: assign to temp, increment via temp
-                let temp_name = format!("__mutsu_tmp_inc_{}", self.code.constants.len());
-                let temp_name_idx = self.code.add_constant(Value::str(temp_name.clone()));
-                self.compile_expr(target);
-                self.code.emit(OpCode::SetGlobal(temp_name_idx));
-                self.compile_expr(index);
-                self.code.emit(OpCode::PostIncrementIndex(temp_name_idx));
+                // Nested index (e.g. $foo[0][0]++): read old value, increment,
+                // write back via IndexAssign, and return old value.
+                self.compile_nested_postfix_incdec(expr, true);
             }
         } else if let Expr::MethodCall {
             target,
@@ -98,12 +94,9 @@ impl Compiler {
                 let name_idx = self.code.add_constant(Value::str(name));
                 self.code.emit(OpCode::PostDecrementIndex(name_idx));
             } else {
-                let temp_name = format!("__mutsu_tmp_dec_{}", self.code.constants.len());
-                let temp_name_idx = self.code.add_constant(Value::str(temp_name.clone()));
-                self.compile_expr(target);
-                self.code.emit(OpCode::SetGlobal(temp_name_idx));
-                self.compile_expr(index);
-                self.code.emit(OpCode::PostDecrementIndex(temp_name_idx));
+                // Nested index (e.g. $foo[0][0]--): read old value, decrement,
+                // write back via IndexAssign, and return old value.
+                self.compile_nested_postfix_incdec(expr, false);
             }
         } else if let Expr::MethodCall {
             target,
@@ -157,6 +150,102 @@ impl Compiler {
                 name: Symbol::intern("__mutsu_incdec_nomatch"),
                 args: vec![Expr::Literal(Value::str_from("postfix:<-->"))],
             });
+        }
+    }
+
+    /// Compile postfix ++/-- on a nested index expression (e.g. `$foo[0][0]++`).
+    /// `expr` is the full Index expression (the operand of PostfixOp).
+    /// `increment` is true for ++, false for --.
+    ///
+    /// Strategy:
+    /// 1. Read old value into tmp_val
+    /// 2. PostIncrement/PostDecrement on tmp_val (returns old value, stores new)
+    /// 3. Save old value to tmp_old
+    /// 4. Write back tmp_val (which now has new value) via IndexAssign
+    /// 5. Return tmp_old (the old value before increment)
+    fn compile_nested_postfix_incdec(&mut self, expr: &Expr, increment: bool) {
+        if let Expr::Index { target, index } = expr {
+            let tmp_val = format!("__mutsu_nested_incdec_val_{}", self.code.constants.len());
+            let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
+            let tmp_old = format!("__mutsu_nested_incdec_old_{}", self.code.constants.len());
+            let tmp_old_idx = self.code.add_constant(Value::str(tmp_old.clone()));
+
+            // 1. Read current value and store in tmp_val
+            self.compile_expr(expr);
+            self.code.emit(OpCode::SetGlobal(tmp_val_idx));
+            self.code.emit(OpCode::Pop);
+
+            // 2. PostIncrement/PostDecrement on tmp_val:
+            //    - pushes old value on stack
+            //    - sets tmp_val = old +/- 1
+            if increment {
+                self.code.emit(OpCode::PostIncrement(tmp_val_idx));
+            } else {
+                self.code.emit(OpCode::PostDecrement(tmp_val_idx));
+            }
+            // Stack now has old value; tmp_val has new value
+            self.code.emit(OpCode::SetGlobal(tmp_old_idx));
+            self.code.emit(OpCode::Pop);
+
+            // 3. Write back the new value (tmp_val) via IndexAssign
+            let assign_expr = Expr::IndexAssign {
+                target: target.clone(),
+                index: index.clone(),
+                value: Box::new(Expr::Var(tmp_val)),
+            };
+            self.compile_expr(&assign_expr);
+            self.code.emit(OpCode::Pop);
+
+            // 4. Push the old value as the result of the post-increment expression
+            self.code.emit(OpCode::GetGlobal(tmp_old_idx));
+        }
+    }
+
+    /// Compile prefix ++/-- on a nested index expression (e.g. `++$foo[0][0]`).
+    /// `expr` is the full Index expression (the operand of UnaryOp).
+    /// `increment` is true for ++, false for --.
+    ///
+    /// Strategy:
+    /// 1. Read old value into tmp_val
+    /// 2. PreIncrement/PreDecrement on tmp_val (returns new value, stores new)
+    /// 3. Write back tmp_val via IndexAssign
+    /// 4. Return the new value
+    pub(super) fn compile_nested_prefix_incdec(&mut self, expr: &Expr, increment: bool) {
+        if let Expr::Index { target, index } = expr {
+            let tmp_val = format!("__mutsu_nested_preincdec_val_{}", self.code.constants.len());
+            let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
+
+            // 1. Read current value and store in tmp_val
+            self.compile_expr(expr);
+            self.code.emit(OpCode::SetGlobal(tmp_val_idx));
+            self.code.emit(OpCode::Pop);
+
+            // 2. PreIncrement/PreDecrement on tmp_val:
+            //    - modifies tmp_val in place
+            //    - pushes new value on stack
+            if increment {
+                self.code.emit(OpCode::PreIncrement(tmp_val_idx));
+            } else {
+                self.code.emit(OpCode::PreDecrement(tmp_val_idx));
+            }
+            // Stack now has new value; tmp_val also has new value
+            // Save new value, we'll push it back at the end
+            let tmp_new = format!("__mutsu_nested_preincdec_new_{}", self.code.constants.len());
+            let tmp_new_idx = self.code.add_constant(Value::str(tmp_new.clone()));
+            self.code.emit(OpCode::SetGlobal(tmp_new_idx));
+            self.code.emit(OpCode::Pop);
+
+            // 3. Write back the new value via IndexAssign
+            let assign_expr = Expr::IndexAssign {
+                target: target.clone(),
+                index: index.clone(),
+                value: Box::new(Expr::Var(tmp_val)),
+            };
+            self.compile_expr(&assign_expr);
+            self.code.emit(OpCode::Pop);
+
+            // 4. Push the new value as the result
+            self.code.emit(OpCode::GetGlobal(tmp_new_idx));
         }
     }
 }

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -47,12 +47,8 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name));
                         self.code.emit(OpCode::PreIncrementIndex(name_idx));
                     } else {
-                        let temp_name = format!("__mutsu_tmp_preinc_{}", self.code.constants.len());
-                        let temp_name_idx = self.code.add_constant(Value::str(temp_name.clone()));
-                        self.compile_expr(target);
-                        self.code.emit(OpCode::SetGlobal(temp_name_idx));
-                        self.compile_expr(index);
-                        self.code.emit(OpCode::PreIncrementIndex(temp_name_idx));
+                        // Nested index (e.g. ++$foo[0][0])
+                        self.compile_nested_prefix_incdec(expr, true);
                     }
                 } else {
                     self.compile_expr(&Expr::Call {
@@ -76,12 +72,8 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name));
                         self.code.emit(OpCode::PreDecrementIndex(name_idx));
                     } else {
-                        let temp_name = format!("__mutsu_tmp_predec_{}", self.code.constants.len());
-                        let temp_name_idx = self.code.add_constant(Value::str(temp_name.clone()));
-                        self.compile_expr(target);
-                        self.code.emit(OpCode::SetGlobal(temp_name_idx));
-                        self.compile_expr(index);
-                        self.code.emit(OpCode::PreDecrementIndex(temp_name_idx));
+                        // Nested index (e.g. --$foo[0][0])
+                        self.compile_nested_prefix_incdec(expr, false);
                     }
                 } else {
                     self.compile_expr(&Expr::Call {

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -697,6 +697,24 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
 }
 
 /// Check if the input starts with a term keyword (like `i`, `e`, `pi`, etc.)
+/// Check if input looks like it contains a binding operator `:=` or `::=`
+/// before a statement terminator. Used to decide whether `try STMT` should
+/// attempt parsing as an assignment/binding statement.
+fn looks_like_binding(input: &str) -> bool {
+    // Scan for `:=` before `;`, `}`, or end of input
+    let search_len = input.len().min(200);
+    let search = &input[..search_len];
+    for (i, c) in search.char_indices() {
+        if c == ';' || c == '}' {
+            return false;
+        }
+        if c == ':' && search[i + 1..].starts_with('=') {
+            return true;
+        }
+    }
+    false
+}
+
 /// that can appear as a listop argument without parentheses.
 fn starts_with_term_keyword(input: &str) -> bool {
     let first = input.chars().next().unwrap_or('\0');
@@ -1301,7 +1319,21 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 let (r, body) = parse_block_body(r)?;
                 return Ok((r, Expr::Try { body, catch: None }));
             }
-            // try EXPR — wrap the following expression in try.
+            // try STMT — wrap the following statement in try.
+            // Check if it's a binding statement ($a := expr) which the
+            // expression parser can't handle. Only try assign_stmt when
+            // the input looks like a binding (contains := before ;).
+            if looks_like_binding(r)
+                && let Ok((r, stmt)) = super::super::stmt::assign_stmt(r)
+            {
+                return Ok((
+                    r,
+                    Expr::Try {
+                        body: vec![stmt],
+                        catch: None,
+                    },
+                ));
+            }
             // Statement modifiers (for, if, etc.) bind outside try,
             // so we parse an expression, not a full statement.
             let (r, expr) = expression(r)?;

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1892,7 +1892,7 @@ pub(super) fn lift_meta_ops_in_list(items: Vec<Expr>) -> Vec<Expr> {
     items
 }
 
-pub(super) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
+pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
     let sigil = input.as_bytes().first().copied().unwrap_or(0);
     let is_sigiled = sigil == b'$' || sigil == b'@' || sigil == b'%' || sigil == b'&';
 

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -23,7 +23,8 @@ use super::helpers::{
 
 // Re-export submodule items used across submodules
 use args::{parse_stmt_call_args, parse_stmt_call_args_no_paren};
-use assign::{assign_stmt, parse_assign_expr_or_comma, parse_comma_or_expr, try_parse_assign_expr};
+pub(in crate::parser) use assign::assign_stmt;
+use assign::{parse_assign_expr_or_comma, parse_comma_or_expr, try_parse_assign_expr};
 use class::class_decl_body;
 use modifier::{is_stmt_modifier_keyword, parse_statement_modifier};
 use sub::{

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1969,7 +1969,7 @@ impl VM {
             }
         }
 
-        // Hash-in-Hash auto-vivification (original behavior)
+        // Hash-based nested assignment (Hash-in-Hash or Hash-containing-Array)
         // Drop the locals copy first so the Arc refcount is 1.
         // This avoids unnecessary cloning in Arc::make_mut which would
         // change the pointer and break .WHICH identity stability.
@@ -1978,11 +1978,25 @@ impl VM {
         }
         if let Some(Value::Hash(outer_hash)) = self.interpreter.env_mut().get_mut(&var_name) {
             let oh = Arc::make_mut(outer_hash);
-            let inner_hash = oh
+            let inner_val = oh
                 .entry(inner_key)
                 .or_insert_with(|| Value::hash(std::collections::HashMap::new()));
-            if let Value::Hash(ref mut h) = *inner_hash {
-                Arc::make_mut(h).insert(outer_key, val.clone());
+            match inner_val {
+                Value::Array(arr, _) => {
+                    // Hash-containing-Array: $hash<key>[idx] = val
+                    if let Ok(i) = outer_key.parse::<usize>() {
+                        let a = Arc::make_mut(arr);
+                        if i >= a.len() {
+                            a.resize(i + 1, Value::Nil);
+                        }
+                        a[i] = val.clone();
+                    }
+                }
+                Value::Hash(h) => {
+                    // Hash-in-Hash: $hash<key1><key2> = val
+                    Arc::make_mut(h).insert(outer_key, val.clone());
+                }
+                _ => {}
             }
         }
         if let Some(updated) = self.get_env_with_main_alias(&var_name) {


### PR DESCRIPTION
## Summary
- Handle postfix/prefix `++`/`--` on nested index expressions (e.g., `$foo[0][0]++`, `$foo<a>[0]++`, `%foo<a>[0]++`) by reading the current value, incrementing in a temp variable, and writing back via `IndexAssign`
- Fix `IndexAssignExprNested` to handle Hash-containing-Array nested assignment (`$hash<key>[idx] = val`)
- Fix `try` statement prefix to handle binding operator (`:=`) which was previously lost

## Test plan
- [x] All 7 subtests in `roast/S09-autovivification/autoincrement.t` pass
- [x] `t/bareword-assign-expr.t` still passes (no regression from try parser change)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)