### PR TITLE
fix: distinguish positional vs associative indexing

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -103,6 +103,7 @@ roast/S02-types/bag-iterator.t
 roast/S02-types/bool.t
 roast/S02-types/bool.t
 roast/S02-types/built-in.t
+roast/S02-types/catch_type_cast_mismatch.t
 roast/S02-types/compact.t
 roast/S02-types/fatrat.t
 roast/S02-types/hash_ref.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -251,6 +251,9 @@ pub(crate) enum Expr {
     Index {
         target: Box<Expr>,
         index: Box<Expr>,
+        /// true when this index was written with `[...]` (positional subscript);
+        /// false when written with `{...}` or `<...>` (associative subscript).
+        is_positional: bool,
     },
     /// Multi-dimensional indexing with semicolons: @a[$x;$y;$z]
     MultiDimIndex {
@@ -999,7 +1002,7 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
                 collect_ph_expr(a, out);
             }
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             collect_ph_expr(target, out);
             collect_ph_expr(index, out);
         }
@@ -1289,7 +1292,7 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
                 collect_ph_expr_shallow(a, out);
             }
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             collect_ph_expr_shallow(target, out);
             collect_ph_expr_shallow(index, out);
         }

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -206,14 +206,21 @@ impl Compiler {
                 self.compile_expr_hyper_method_dynamic(target, name_expr, args, modifier);
             }
             // Indexing
-            Expr::Index { target, index } => {
-                self.compile_expr_index(target, index);
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+                ..
+            } => {
+                self.compile_expr_index(target, index, *is_positional);
             }
             // Multi-dimensional indexing: @a[$x;$y;$z]
             Expr::MultiDimIndex { target, dimensions } => {
                 self.compile_expr(target);
                 self.compile_expr(&Expr::ArrayLiteral(dimensions.clone()));
-                self.code.emit(OpCode::Index);
+                self.code.emit(OpCode::Index {
+                    is_positional: false,
+                });
             }
             // Hash hyperslice: %hash{**}:adverb
             Expr::HyperSlice { target, adverb } => {

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -44,7 +44,9 @@ impl Compiler {
                     self.code.emit(OpCode::GetGlobal(tmp_idx));
                     let idx = self.code.add_constant(Value::Int(i as i64));
                     self.code.emit(OpCode::LoadConst(idx));
-                    self.code.emit(OpCode::Index);
+                    self.code.emit(OpCode::Index {
+                        is_positional: true,
+                    });
                     let name_idx = self.code.add_constant(Value::str(var_name.clone()));
                     self.code.emit(OpCode::AssignExpr(name_idx));
                 }
@@ -57,6 +59,7 @@ impl Compiler {
             && let Expr::Index {
                 target: index_target,
                 index: index_key,
+                ..
             } = &args[0]
             && let Some(var_name) = Self::postfix_index_name(index_target)
         {
@@ -181,7 +184,7 @@ impl Compiler {
             } else if matches!(&args[0], Expr::Index { target, .. } if matches!(**target, Expr::HashVar(_) | Expr::ArrayVar(_) | Expr::Var(_)))
             {
                 // undefine %hash<key> or undefine @arr[idx] -> target[index] = Nil
-                if let Expr::Index { target, index } = &args[0] {
+                if let Expr::Index { target, index, .. } = &args[0] {
                     let assign_expr = Expr::IndexAssign {
                         target: target.clone(),
                         index: index.clone(),
@@ -287,7 +290,7 @@ impl Compiler {
             // For array element CAS: cas(@arr[idx], $expected, $new)
             // Emit __mutsu_cas_array_elem("@arr_name", idx, expected, new)
             // Single-dim array element CAS: cas(@arr[idx], $expected, $new)
-            if let Expr::Index { target, index } = &args[0]
+            if let Expr::Index { target, index, .. } = &args[0]
                 && let Some(arr_name) = match target.as_ref() {
                     Expr::ArrayVar(n) => Some(format!("@{}", n)),
                     Expr::Var(n) if n.starts_with('@') => Some(n.clone()),
@@ -342,7 +345,7 @@ impl Compiler {
                         expr: args[2].clone(),
                         op: AssignOp::Assign,
                     }),
-                    Expr::Index { target, index } => Some(Stmt::Expr(Expr::IndexAssign {
+                    Expr::Index { target, index, .. } => Some(Stmt::Expr(Expr::IndexAssign {
                         target: target.clone(),
                         index: index.clone(),
                         value: Box::new(args[2].clone()),

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -173,7 +173,9 @@ impl Compiler {
             Expr::ZenSlice(inner) => {
                 self.compile_expr(inner);
             }
-            Expr::Index { target: t, index } => {
+            Expr::Index {
+                target: t, index, ..
+            } => {
                 self.compile_expr(t);
                 self.compile_expr(index);
             }
@@ -190,6 +192,7 @@ impl Compiler {
             && let Expr::Index {
                 target: delete_target,
                 index: delete_index,
+                ..
             } = target
         {
             if let Some(var_name) = Self::postfix_index_name(delete_target) {
@@ -267,8 +270,8 @@ impl Compiler {
         }
     }
 
-    /// Compile Index expression (target[index]).
-    pub(super) fn compile_expr_index(&mut self, target: &Expr, index: &Expr) {
+    /// Compile Index expression (target[index] or target{index}).
+    pub(super) fn compile_expr_index(&mut self, target: &Expr, index: &Expr, is_positional: bool) {
         // Special case: %*ENV<key> compiles to GetEnvIndex
         if let Expr::HashVar(name) = target {
             if name == "*ENV" {
@@ -278,17 +281,17 @@ impl Compiler {
                 } else {
                     self.compile_expr(target);
                     self.compile_expr(index);
-                    self.code.emit(OpCode::Index);
+                    self.code.emit(OpCode::Index { is_positional });
                 }
             } else {
                 self.compile_expr(target);
                 self.compile_expr(index);
-                self.code.emit(OpCode::Index);
+                self.code.emit(OpCode::Index { is_positional });
             }
         } else {
             self.compile_expr(target);
             self.compile_expr(index);
-            self.code.emit(OpCode::Index);
+            self.code.emit(OpCode::Index { is_positional });
         }
     }
 

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -35,7 +35,7 @@ impl Compiler {
             Expr::ArrayVar(name) => Some(format!("@{}", name)),
             Expr::HashVar(name) => Some(format!("%{}", name)),
             Expr::CodeVar(name) => Some(format!("&{}", name)),
-            Expr::Index { target, index }
+            Expr::Index { target, index, .. }
                 if matches!(target.as_ref(), Expr::PseudoStash(_))
                     && matches!(index.as_ref(), Expr::Literal(Value::Str(_))) =>
             {

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -7,6 +7,7 @@ impl Compiler {
         if let Expr::Index {
             target: index_target,
             index,
+            ..
         } = target
             && let Some(source_name) = Self::index_assign_target_name(index_target)
         {
@@ -98,6 +99,7 @@ impl Compiler {
         if let Expr::Index {
             target: idx_target,
             index: idx_key,
+            ..
         } = target
         {
             let var_name = Self::postfix_index_name(idx_target).unwrap_or_default();
@@ -176,6 +178,7 @@ impl Compiler {
             && let Expr::Index {
                 target: delete_target,
                 index: delete_index,
+                ..
             } = target
         {
             if let Some(var_name) = Self::postfix_index_name(delete_target) {

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -13,7 +13,7 @@ impl Compiler {
             self.code.emit(OpCode::Pop);
             let name_idx = self.code.add_constant(Value::str(var_name));
             self.code.emit(OpCode::PostIncrement(name_idx));
-        } else if let Expr::Index { target, index } = expr {
+        } else if let Expr::Index { target, index, .. } = expr {
             if let Some(name) = Self::postfix_index_name(target) {
                 self.compile_expr(index);
                 let name_idx = self.code.add_constant(Value::str(name));
@@ -88,7 +88,7 @@ impl Compiler {
             self.code.emit(OpCode::Pop);
             let name_idx = self.code.add_constant(Value::str(var_name));
             self.code.emit(OpCode::PostDecrement(name_idx));
-        } else if let Expr::Index { target, index } = expr {
+        } else if let Expr::Index { target, index, .. } = expr {
             if let Some(name) = Self::postfix_index_name(target) {
                 self.compile_expr(index);
                 let name_idx = self.code.add_constant(Value::str(name));

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -164,7 +164,7 @@ impl Compiler {
     /// 4. Write back tmp_val (which now has new value) via IndexAssign
     /// 5. Return tmp_old (the old value before increment)
     fn compile_nested_postfix_incdec(&mut self, expr: &Expr, increment: bool) {
-        if let Expr::Index { target, index } = expr {
+        if let Expr::Index { target, index, .. } = expr {
             let tmp_val = format!("__mutsu_nested_incdec_val_{}", self.code.constants.len());
             let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
             let tmp_old = format!("__mutsu_nested_incdec_old_{}", self.code.constants.len());
@@ -211,7 +211,7 @@ impl Compiler {
     /// 3. Write back tmp_val via IndexAssign
     /// 4. Return the new value
     pub(super) fn compile_nested_prefix_incdec(&mut self, expr: &Expr, increment: bool) {
-        if let Expr::Index { target, index } = expr {
+        if let Expr::Index { target, index, .. } = expr {
             let tmp_val = format!("__mutsu_nested_preincdec_val_{}", self.code.constants.len());
             let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
 

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -41,7 +41,7 @@ impl Compiler {
                     self.code.emit(OpCode::Pop);
                     let name_idx = self.code.add_constant(Value::str(var_name));
                     self.code.emit(OpCode::PreIncrement(name_idx));
-                } else if let Expr::Index { target, index } = expr {
+                } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {
                         self.compile_expr(index);
                         let name_idx = self.code.add_constant(Value::str(name));
@@ -66,7 +66,7 @@ impl Compiler {
                     self.code.emit(OpCode::Pop);
                     let name_idx = self.code.add_constant(Value::str(var_name));
                     self.code.emit(OpCode::PreDecrement(name_idx));
-                } else if let Expr::Index { target, index } = expr {
+                } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {
                         self.compile_expr(index);
                         let name_idx = self.code.add_constant(Value::str(name));

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -128,6 +128,7 @@ impl Compiler {
         if let Expr::Index {
             target: inner_target,
             index: inner_index,
+            ..
         } = target
             && let Some(name) = Self::index_assign_target_name(inner_target)
         {

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -217,7 +217,7 @@ impl Compiler {
             | Expr::HyperMethodCallDynamic { target, args, .. } => {
                 Self::expr_has_placeholder(target) || args.iter().any(Self::expr_has_placeholder)
             }
-            Expr::Index { target, index } | Expr::IndexAssign { target, index, .. } => {
+            Expr::Index { target, index, .. } | Expr::IndexAssign { target, index, .. } => {
                 Self::expr_has_placeholder(target) || Self::expr_has_placeholder(index)
             }
             Expr::CallOn { target, args } => {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -309,6 +309,7 @@ impl Compiler {
                             op: crate::token_kind::TokenKind::DotDot,
                             right: Box::new(Expr::Whatever),
                         }),
+                        is_positional: true,
                     };
                     let capture_expr = Expr::CaptureLiteral(vec![Expr::Unary {
                         op: crate::token_kind::TokenKind::Pipe,
@@ -322,6 +323,7 @@ impl Compiler {
                         Expr::Index {
                             target: Box::new(Expr::Var(target_name.clone())),
                             index: Box::new(Expr::Literal(Value::Int(positional_index as i64))),
+                            is_positional: false,
                         },
                     ));
                     positional_index += 1;
@@ -338,6 +340,7 @@ impl Compiler {
                 Expr::Index {
                     target: Box::new(Expr::Var("_".to_string())),
                     index: Box::new(Expr::Literal(Value::Int(i as i64))),
+                    is_positional: false,
                 },
             );
             if p == "_" {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -381,7 +381,11 @@ pub(crate) enum OpCode {
     MakeLambda(u32, Option<u32>, bool),
     MakeBlockClosure(u32, Option<u32>),
     // -- Indexing --
-    Index,
+    /// `is_positional` is true when the subscript was `[...]` (positional),
+    /// false when `{...}` or `<...>` (associative).
+    Index {
+        is_positional: bool,
+    },
     DeleteIndexNamed(u32),
     DeleteIndexExpr,
     /// Multi-dimensional indexing: @a[$x;$y;$z]

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -317,7 +317,7 @@ fn contains_xx_with_bare_whatever(expr: &Expr) -> bool {
             contains_xx_with_bare_whatever(target)
                 || args.iter().any(contains_xx_with_bare_whatever)
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             contains_xx_with_bare_whatever(target) || contains_xx_with_bare_whatever(index)
         }
         Expr::Call { args, .. } => args.iter().any(contains_xx_with_bare_whatever),
@@ -434,9 +434,15 @@ fn wrap_composition_operands(expr: Expr) -> Expr {
             target: Box::new(wrap_composition_operands(*target)),
             args: args.into_iter().map(wrap_composition_operands).collect(),
         },
-        Expr::Index { target, index } => Expr::Index {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => Expr::Index {
             target: Box::new(wrap_composition_operands(*target)),
             index: Box::new(wrap_composition_operands(*index)),
+            is_positional,
         },
         other => other,
     }
@@ -812,9 +818,15 @@ fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
                 .map(|a| replace_whatever_numbered(a, counter))
                 .collect(),
         },
-        Expr::Index { target, index } => Expr::Index {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => Expr::Index {
             target: Box::new(replace_whatever_numbered(target, counter)),
             index: index.clone(),
+            is_positional: *is_positional,
         },
         Expr::InfixFunc {
             name,
@@ -885,9 +897,15 @@ fn rename_var(expr: &Expr, old_name: &str, new_name: &str) -> Expr {
                 .map(|a| rename_var(a, old_name, new_name))
                 .collect(),
         },
-        Expr::Index { target, index } => Expr::Index {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => Expr::Index {
             target: Box::new(rename_var(target, old_name, new_name)),
             index: Box::new(rename_var(index, old_name, new_name)),
+            is_positional: *is_positional,
         },
         _ => expr.clone(),
     }
@@ -1003,7 +1021,9 @@ fn expr_contains_topic(expr: &Expr) -> bool {
         Expr::CallOn { target, args } => {
             expr_contains_topic(target) || args.iter().any(expr_contains_topic)
         }
-        Expr::Index { target, index } => expr_contains_topic(target) || expr_contains_topic(index),
+        Expr::Index { target, index, .. } => {
+            expr_contains_topic(target) || expr_contains_topic(index)
+        }
         Expr::InfixFunc { left, right, .. } => {
             expr_contains_topic(left) || right.iter().any(expr_contains_topic)
         }
@@ -1063,9 +1083,15 @@ fn replace_whatever_single(expr: &Expr) -> Expr {
             target: Box::new(replace_whatever_single(target)),
             args: args.iter().map(replace_whatever_single).collect(),
         },
-        Expr::Index { target, index } => Expr::Index {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => Expr::Index {
             target: Box::new(replace_whatever_single(target)),
             index: index.clone(),
+            is_positional: *is_positional,
         },
         Expr::InfixFunc {
             name,
@@ -1524,7 +1550,7 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::Index { target, index }
+            Expr::Index { target, index, .. }
                 if matches!(target.as_ref(), Expr::PseudoStash(s) if s.as_str() == "DYNAMIC::")
                 && matches!(index.as_ref(), Expr::Literal(Value::Str(s)) if s.as_str() == "$*x80")
         ));

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -284,7 +284,7 @@ fn subscript_adverb_expr_with_cond(expr: Expr, adverb: &'static str, cond: Optio
             args,
         };
     }
-    let Expr::Index { target, index } = expr else {
+    let Expr::Index { target, index, .. } = expr else {
         return expr;
     };
     let var_name = match target.as_ref() {
@@ -726,6 +726,7 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
         Expr::Index {
             target: idx_target,
             index,
+            ..
         } => {
             use std::sync::atomic::Ordering;
             let tmp_idx = format!(
@@ -736,6 +737,7 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
             let lhs_expr = Expr::Index {
                 target: idx_target.clone(),
                 index: Box::new(tmp_idx_expr.clone()),
+                is_positional: false,
             };
             let assigned_value = method_call_fn(lhs_expr);
             Expr::DoBlock {
@@ -1315,6 +1317,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 expr = Expr::Index {
                     target: Box::new(expr),
                     index: Box::new(index),
+                    is_positional: true,
                 };
                 rest = r_inner;
                 continue;
@@ -1328,6 +1331,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 expr = Expr::Index {
                     target: Box::new(expr),
                     index: Box::new(index),
+                    is_positional: false,
                 };
                 rest = r;
                 continue;
@@ -1360,6 +1364,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         expr = Expr::Index {
                             target: Box::new(expr),
                             index: Box::new(index_expr),
+                            is_positional: false,
                         };
                         rest = r2;
                         continue;
@@ -1871,6 +1876,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             expr = Expr::Index {
                 target: Box::new(who),
                 index: Box::new(key_expr),
+                is_positional: false,
             };
             rest = r;
             continue;
@@ -1950,6 +1956,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     expr = Expr::Index {
                         target: Box::new(expr),
                         index: Box::new(index),
+                        is_positional: true,
                     };
                 }
                 ParsedBracketIndex::MultiDim(dimensions) => {
@@ -2009,6 +2016,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 Expr::Index {
                     target: Box::new(expr),
                     index: Box::new(index_expr),
+                    is_positional: false,
                 }
             };
             if is_zen_angle && r.starts_with(":v") && !is_ident_char(r.as_bytes().get(2).copied()) {
@@ -2054,6 +2062,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 expr = Expr::Index {
                     target: Box::new(expr),
                     index: Box::new(index_expr),
+                    is_positional: false,
                 };
                 rest = r;
                 continue;
@@ -2198,6 +2207,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     expr = Expr::Index {
                         target: Box::new(expr),
                         index: Box::new(Expr::Whatever),
+                        is_positional: false,
                     };
                     rest = r;
                     continue;
@@ -2228,6 +2238,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     let indexed = Expr::Index {
                         target: Box::new(expr.clone()),
                         index: Box::new(index.clone()),
+                        is_positional: false,
                     };
                     if let Some((r_after, exists_expr)) = try_parse_exists_adverb(r_adv, indexed) {
                         expr = exists_expr;
@@ -2239,6 +2250,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         let indexed_expr = Expr::Index {
                             target: Box::new(expr.clone()),
                             index: Box::new(index.clone()),
+                            is_positional: false,
                         };
                         if let Some((r_after, mut exists_expr)) =
                             try_parse_exists_adverb(r_after_delete, indexed_expr.clone())
@@ -2284,6 +2296,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     expr = Expr::Index {
                         target: Box::new(expr),
                         index: Box::new(index),
+                        is_positional: false,
                     };
                 }
             }

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -446,7 +446,7 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                 expr: Box::new(rhs),
             },
         )),
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             if let Expr::Call { name, args } = target.as_ref()
                 && name == "__mutsu_subscript_adverb"
                 && args.len() >= 3
@@ -561,7 +561,7 @@ fn assign_to_target_expr(target: Expr, value: Expr) -> Expr {
             name: format!("%{}", name),
             expr: Box::new(value),
         },
-        Expr::Index { target, index } => Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Expr::IndexAssign {
             target,
             index,
             value: Box::new(value),
@@ -651,10 +651,16 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
             name: format!("%{}", name.clone()),
             expr: Box::new(compound_assigned_value_expr(Expr::HashVar(name), op, value)),
         },
-        Expr::Index { target, index } => {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => {
             let lhs_expr = Expr::Index {
                 target: target.clone(),
                 index: index.clone(),
+                is_positional,
             };
             Expr::IndexAssign {
                 target,
@@ -704,6 +710,7 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
                 Expr::Index {
                     target,
                     index: Box::new(index),
+                    is_positional: true,
                 },
                 op_name,
                 value,
@@ -739,7 +746,7 @@ fn list_lvalue_assign_expr(items: Vec<Expr>, rhs: Expr) -> Option<Expr> {
             name: format!("%{}", name),
             expr: Box::new(rhs),
         }),
-        Expr::Index { target, index } => Some(Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Some(Expr::IndexAssign {
             target,
             index,
             value: Box::new(rhs),
@@ -1651,7 +1658,7 @@ fn build_pipe_feed_expr(source: Expr, sink: Expr) -> Expr {
             name: format!("&{}", name),
             expr: Box::new(source),
         },
-        Expr::Index { target, index } => Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Expr::IndexAssign {
             target,
             index,
             value: Box::new(source),
@@ -1707,10 +1714,16 @@ fn build_append_feed_expr(source: Expr, sink: Expr) -> Expr {
                 args: vec![Expr::HashVar(name), source],
             }),
         },
-        Expr::Index { target, index } => {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => {
             let current = Expr::Index {
                 target: target.clone(),
                 index: index.clone(),
+                is_positional,
             };
             Expr::IndexAssign {
                 target,

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -332,6 +332,7 @@ pub(super) fn class_literal(input: &str) -> PResult<'_, Expr> {
                 Expr::Index {
                     target: Box::new(Expr::PseudoStash("::".to_string())),
                     index: Box::new(Expr::Literal(Value::str(symbol.to_string()))),
+                    is_positional: false,
                 },
             ));
         }
@@ -346,6 +347,7 @@ pub(super) fn class_literal(input: &str) -> PResult<'_, Expr> {
             Expr::Index {
                 target: Box::new(Expr::PseudoStash("::".to_string())),
                 index: Box::new(key_expr),
+                is_positional: false,
             },
         ));
     }
@@ -1862,6 +1864,7 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     Expr::Index {
                         target: Box::new(Expr::PseudoStash(stash_name)),
                         index: Box::new(key_expr),
+                        is_positional: false,
                     },
                 ));
             }
@@ -1877,6 +1880,7 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         Expr::Index {
                             target: Box::new(Expr::PseudoStash(stash_name)),
                             index: Box::new(Expr::Literal(Value::str(symbol.to_string()))),
+                            is_positional: false,
                         },
                     ));
                 }

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -429,7 +429,7 @@ mod tests {
         let (rest, expr) = primary(".<path>").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 assert!(matches!(*target, Expr::Var(ref n) if n.as_str() == "_"));
                 assert!(matches!(*index, Expr::Literal(Value::Str(ref s)) if s.as_str() == "path"));
             }
@@ -442,7 +442,7 @@ mod tests {
         let (rest, expr) = primary(".{'path'}").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 assert!(matches!(*target, Expr::Var(ref n) if n.as_str() == "_"));
                 assert!(matches!(*index, Expr::Literal(Value::Str(ref s)) if s.as_str() == "path"));
             }
@@ -690,7 +690,7 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::Index { target, index }
+            Expr::Index { target, index, .. }
                 if matches!(target.as_ref(), Expr::PseudoStash(s) if s.as_str() == "::")
                 && matches!(index.as_ref(), Expr::Literal(Value::Str(s)) if s.as_str() == "$x")
         ));
@@ -702,7 +702,7 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::Index { target, index }
+            Expr::Index { target, index, .. }
                 if matches!(target.as_ref(), Expr::PseudoStash(s) if s.as_str() == "::")
                 && matches!(index.as_ref(), Expr::Literal(Value::Str(s)) if s.as_str() == "$x")
         ));
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::Index { target, index }
+            Expr::Index { target, index, .. }
                 if matches!(target.as_ref(), Expr::PseudoStash(s) if s.as_str() == "::")
                 && matches!(index.as_ref(), Expr::Literal(Value::Str(s)) if s.as_str() == "bear")
         ));

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -1747,6 +1747,7 @@ pub(super) fn topic_method_call(input: &str) -> PResult<'_, Expr> {
                     Expr::Index {
                         target: Box::new(Expr::Var("_".to_string())),
                         index: Box::new(index_expr),
+                        is_positional: false,
                     },
                 ));
             }
@@ -1763,6 +1764,7 @@ pub(super) fn topic_method_call(input: &str) -> PResult<'_, Expr> {
             Expr::Index {
                 target: Box::new(Expr::Var("_".to_string())),
                 index: Box::new(index),
+                is_positional: true,
             },
         ));
     }
@@ -1777,6 +1779,7 @@ pub(super) fn topic_method_call(input: &str) -> PResult<'_, Expr> {
             Expr::Index {
                 target: Box::new(Expr::Var("_".to_string())),
                 index: Box::new(index),
+                is_positional: false,
             },
         ));
     }

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -1578,6 +1578,7 @@ pub(super) fn try_interpolate_var<'a>(
                 Expr::Index {
                     target: Box::new(target),
                     index: Box::new(index),
+                    is_positional: false,
                 },
                 &after_dlt[end + 2..],
             );
@@ -1592,6 +1593,7 @@ pub(super) fn try_interpolate_var<'a>(
                 Expr::Index {
                     target: Box::new(target),
                     index: Box::new(index),
+                    is_positional: false,
                 },
                 &after_guillemet[end + '\u{00BB}'.len_utf8()..],
             );
@@ -1616,6 +1618,7 @@ pub(super) fn try_interpolate_var<'a>(
                 Expr::Index {
                     target: Box::new(target),
                     index: Box::new(index),
+                    is_positional: false,
                 },
                 &after_lt[end + 1..],
             );
@@ -1640,6 +1643,7 @@ pub(super) fn try_interpolate_var<'a>(
                 Expr::Index {
                     target: Box::new(target),
                     index: Box::new(index),
+                    is_positional: true,
                 },
                 &after_bracket[end + 1..],
             );
@@ -1669,6 +1673,7 @@ pub(super) fn try_interpolate_var<'a>(
                         Expr::Index {
                             target: Box::new(target),
                             index: Box::new(expr),
+                            is_positional: false,
                         },
                         &after_brace[end + 1..],
                     );
@@ -1705,6 +1710,7 @@ pub(super) fn try_interpolate_var<'a>(
             let expr = Expr::Index {
                 target: Box::new(var_expr),
                 index: Box::new(index),
+                is_positional: false,
             };
             let var_rest = &after_lt[end + 1..];
             let (expr, var_rest) = try_parse_interp_method_call(var_rest, expr);
@@ -1726,6 +1732,7 @@ pub(super) fn try_interpolate_var<'a>(
             let expr = Expr::Index {
                 target: Box::new(Expr::Var("/".to_string())),
                 index: Box::new(Expr::Literal(Value::Int(index_val))),
+                is_positional: true,
             };
             let (expr, var_rest) = try_parse_interp_method_call(&var_rest[end..], expr);
             parts.push(expr);

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -235,6 +235,7 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
             Expr::Index {
                 target: Box::new(Expr::PseudoStash("::".to_string())),
                 index: Box::new(key_expr),
+                is_positional: false,
             },
         ));
     }
@@ -248,6 +249,7 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
                 Expr::Index {
                     target: Box::new(Expr::PseudoStash("::".to_string())),
                     index: Box::new(Expr::Literal(Value::str(symbol.to_string()))),
+                    is_positional: false,
                 },
             ));
         }

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -630,7 +630,7 @@ fn subscript_adverb_lvalue_assign_expr(lhs: Expr, rhs: Expr) -> Option<Expr> {
             }
             None
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             let (base_target, base_index, mode) = subscript_parts(target.as_ref())?;
             if mode != "kv" && mode != "not-kv" {
                 return None;
@@ -679,7 +679,7 @@ fn list_lvalue_assign_expr(items: Vec<Expr>, rhs: Expr) -> Option<Expr> {
             name: format!("%{}", name),
             expr: Box::new(rhs),
         }),
-        Expr::Index { target, index } => Some(Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Some(Expr::IndexAssign {
             target,
             index,
             value: Box::new(rhs),
@@ -740,6 +740,7 @@ where
     let lhs_expr = Expr::Index {
         target: Box::new(target.clone()),
         index: Box::new(tmp_idx_expr.clone()),
+        is_positional: false,
     };
     let assigned_value = build_assigned_value(lhs_expr);
     Expr::DoBlock {
@@ -801,7 +802,7 @@ pub(crate) fn build_compound_assign_expr(
             name: format!("%{}", name),
             expr: Box::new(compound_assigned_value_expr(Expr::HashVar(name), op, rhs)),
         },
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
                 compound_assigned_value_expr(lhs_expr, op, rhs)
             }));
@@ -935,7 +936,7 @@ fn build_custom_compound_assign_expr(
                 modifier: None,
             }),
         },
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
                 Expr::InfixFunc {
                     name: op_name,
@@ -984,10 +985,16 @@ fn build_meta_assign_expr(lhs: Expr, meta: String, op: String, rhs: Expr) -> Res
                 right: Box::new(rhs),
             }),
         },
-        Expr::Index { target, index } => {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } => {
             let lhs_expr = Expr::Index {
                 target: target.clone(),
                 index: index.clone(),
+                is_positional,
             };
             Expr::IndexAssign {
                 target,
@@ -1166,7 +1173,7 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
                 name: format!("%{}", name),
                 expr: Box::new(rhs),
             },
-            Expr::Index { target, index } => Expr::IndexAssign {
+            Expr::Index { target, index, .. } => Expr::IndexAssign {
                 target,
                 index,
                 value: Box::new(rhs),
@@ -1239,7 +1246,7 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
             name: format!("%{}", name),
             expr: Box::new(rhs),
         },
-        Expr::Index { target, index } => Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Expr::IndexAssign {
             target,
             index,
             value: Box::new(rhs),

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -175,7 +175,7 @@ fn expr_uses_attr_twigil(expr: &Expr) -> bool {
                 || expr_uses_attr_twigil(then_expr)
                 || expr_uses_attr_twigil(else_expr)
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             expr_uses_attr_twigil(target) || expr_uses_attr_twigil(index)
         }
         Expr::IndexAssign {

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -2005,6 +2005,7 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                         let idx_expr = Expr::Index {
                             target: Box::new(Expr::Var(pname.clone())),
                             index: Box::new(Expr::Literal(Value::Int(positional_index as i64))),
+                            is_positional: true,
                         };
                         positional_index += 1;
                         idx_expr

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -358,11 +358,13 @@ fn parse_destructuring_with_rhs(
                     op: TokenKind::DotDot,
                     right: Box::new(Expr::Whatever),
                 }),
+                is_positional: true,
             }
         } else {
             Expr::Index {
                 target: Box::new(Expr::ArrayVar(array_bare.clone())),
                 index: Box::new(Expr::Literal(Value::Int(i as i64))),
+                is_positional: true,
             }
         };
         let effective_tc = dvar
@@ -441,6 +443,7 @@ fn parse_named_destructuring(
             expr: Expr::Index {
                 target: Box::new(Expr::HashVar(hash_bare.clone())),
                 index: Box::new(Expr::Literal(Value::str(bare_name.to_string()))),
+                is_positional: false,
             },
             type_constraint: type_constraint.clone(),
             is_state,

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -216,6 +216,7 @@ fn single_target_list_lvalue_stmt(lhs: Expr, rhs: Expr) -> Option<Stmt> {
     let extracted_rhs = Expr::Index {
         target: Box::new(rhs.clone()),
         index: Box::new(Expr::Literal(Value::Int(pos as i64))),
+        is_positional: true,
     };
     Some(match target {
         Expr::Var(name) => Stmt::Assign {
@@ -254,7 +255,7 @@ fn single_target_list_lvalue_stmt(lhs: Expr, rhs: Expr) -> Option<Stmt> {
             expr: extracted_rhs,
             op: AssignOp::Assign,
         },
-        Expr::Index { target, index } => Stmt::Expr(Expr::IndexAssign {
+        Expr::Index { target, index, .. } => Stmt::Expr(Expr::IndexAssign {
             target,
             index,
             value: Box::new(extracted_rhs),
@@ -455,7 +456,12 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 };
                 return parse_statement_modifier(r, stmt);
             }
-            Expr::Index { target, index } => {
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+                ..
+            } => {
                 let tmp_idx = format!(
                     "__mutsu_idx_{}",
                     TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -464,6 +470,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 let lhs_expr = Expr::Index {
                     target: target.clone(),
                     index: Box::new(tmp_idx_expr.clone()),
+                    is_positional,
                 };
                 let assigned_value = make_rhs(lhs_expr);
                 let stmt = Stmt::Expr(Expr::DoBlock {
@@ -548,7 +555,12 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 };
                 return parse_statement_modifier(r, stmt);
             }
-            Expr::Index { target, index } => {
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+                ..
+            } => {
                 let tmp_idx = format!(
                     "__mutsu_idx_{}",
                     TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -557,6 +569,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 let lhs_expr = Expr::Index {
                     target: target.clone(),
                     index: Box::new(tmp_idx_expr.clone()),
+                    is_positional,
                 };
                 let assigned_value = make_rhs(lhs_expr);
                 let stmt = Stmt::Expr(Expr::DoBlock {
@@ -627,7 +640,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             });
             return parse_statement_modifier(rest, stmt);
         }
-        if let Expr::Index { target, index } = expr {
+        if let Expr::Index { target, index, .. } = expr {
             if let Expr::Call { name, args } = target.as_ref()
                 && name == "__mutsu_subscript_adverb"
                 && args.len() >= 3
@@ -649,7 +662,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             return parse_statement_modifier(rest, stmt);
         }
     }
-    if let Expr::Index { target, index } = expr.clone()
+    if let Expr::Index { target, index, .. } = expr.clone()
         && let Some(rest) = parse_hyper_assign_op(rest)
     {
         let (rest, _) = ws(rest)?;
@@ -685,7 +698,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             args: vec![value, source_meta],
         };
         match expr {
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 let stmt = Stmt::Expr(Expr::IndexAssign {
                     target,
                     index,
@@ -984,6 +997,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 let index_expr = Expr::Index {
                     target: Box::new(Expr::Var(tmp_name.clone())),
                     index: Box::new(Expr::Literal(Value::Int(i as i64))),
+                    is_positional: true,
                 };
                 // For Stmt::Assign, scalar vars ($x) use name "x" (no sigil),
                 // but array (@a) and hash (%h) vars keep the sigil.
@@ -1102,7 +1116,13 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
-        if let Expr::Index { target, index } = &expr {
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } = &expr
+        {
             let tmp_idx = format!(
                 "__mutsu_idx_{}",
                 TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -1111,6 +1131,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             let lhs_expr = Expr::Index {
                 target: target.clone(),
                 index: Box::new(tmp_idx_expr.clone()),
+                is_positional: *is_positional,
             };
             let assigned_value = if matches!(op, super::assign::CompoundAssignOp::DefinedOr) {
                 Expr::Ternary {

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -358,7 +358,7 @@ fn expr_contains_whatever(expr: &Expr) -> bool {
         Expr::CallOn { target, args } => {
             expr_contains_whatever(target) || args.iter().any(expr_contains_whatever)
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             expr_contains_whatever(target) || expr_contains_whatever(index)
         }
         Expr::MultiDimIndex { target, dimensions } => {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1454,9 +1454,15 @@ impl Interpreter {
                     .map(Self::rewrite_proto_dispatch_expr)
                     .collect(),
             ),
-            Expr::Index { target, index } => Expr::Index {
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+                ..
+            } => Expr::Index {
                 target: Box::new(Self::rewrite_proto_dispatch_expr(target)),
                 index: Box::new(Self::rewrite_proto_dispatch_expr(index)),
+                is_positional: *is_positional,
             },
             Expr::IndexAssign {
                 target,

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -110,7 +110,7 @@ impl Interpreter {
                         || expr_contains_last(then_expr)
                         || expr_contains_last(else_expr)
                 }
-                Expr::Index { target, index } => {
+                Expr::Index { target, index, .. } => {
                     expr_contains_last(target) || expr_contains_last(index)
                 }
                 Expr::Exists { target, arg, .. } => {

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -352,7 +352,7 @@ impl Interpreter {
                         scan_expr(a, positional, named);
                     }
                 }
-                Expr::Index { target, index } => {
+                Expr::Index { target, index, .. } => {
                     scan_expr(target, positional, named);
                     scan_expr(index, positional, named);
                 }

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -385,7 +385,7 @@ fn lift_phasers_from_expr(
                 lift_phasers_from_expr(a, begin, check, init);
             }
         }
-        Expr::Index { target, index } => {
+        Expr::Index { target, index, .. } => {
             lift_phasers_from_expr(target, begin, check, init);
             lift_phasers_from_expr(index, begin, check, init);
         }

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -428,7 +428,7 @@ impl Interpreter {
                 self.validate_private_access_in_expr(caller_class, then_expr)?;
                 self.validate_private_access_in_expr(caller_class, else_expr)?;
             }
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 self.validate_private_access_in_expr(caller_class, target)?;
                 self.validate_private_access_in_expr(caller_class, index)?;
             }
@@ -625,7 +625,7 @@ impl Interpreter {
                 self.check_private_calls_exist_expr(class_name, class_def, then_expr)?;
                 self.check_private_calls_exist_expr(class_name, class_def, else_expr)?;
             }
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 self.check_private_calls_exist_expr(class_name, class_def, target)?;
                 self.check_private_calls_exist_expr(class_name, class_def, index)?;
             }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2899,7 +2899,7 @@ impl Interpreter {
                 Self::validate_attr_in_expr(class_own_attrs, then_expr)?;
                 Self::validate_attr_in_expr(class_own_attrs, else_expr)?;
             }
-            Expr::Index { target, index } => {
+            Expr::Index { target, index, .. } => {
                 Self::validate_attr_in_expr(class_own_attrs, target)?;
                 Self::validate_attr_in_expr(class_own_attrs, index)?;
             }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1871,8 +1871,8 @@ impl VM {
             }
 
             // -- Indexing --
-            OpCode::Index => {
-                self.exec_index_op()?;
+            OpCode::Index { is_positional } => {
+                self.exec_index_op_with_positional(*is_positional)?;
                 *ip += 1;
             }
             OpCode::DeleteIndexNamed(name_idx) => {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -36,7 +36,15 @@ impl VM {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Backward-compatible wrapper: defaults to associative indexing.
     pub(super) fn exec_index_op(&mut self) -> Result<(), RuntimeError> {
+        self.exec_index_op_with_positional(false)
+    }
+
+    pub(super) fn exec_index_op_with_positional(
+        &mut self,
+        is_positional: bool,
+    ) -> Result<(), RuntimeError> {
         let index = self.stack.pop().unwrap();
         let mut target = self.stack.pop().unwrap();
         if let Value::Junction { kind, values } = &target {
@@ -44,7 +52,7 @@ impl VM {
             for value in values.iter() {
                 self.stack.push(value.clone());
                 self.stack.push(index.clone());
-                self.exec_index_op()?;
+                self.exec_index_op_with_positional(is_positional)?;
                 results.push(self.stack.pop().unwrap_or(Value::Nil));
             }
             self.stack.push(Value::junction(kind.clone(), results));
@@ -55,7 +63,7 @@ impl VM {
             for value in values.iter() {
                 self.stack.push(target.clone());
                 self.stack.push(value.clone());
-                self.exec_index_op()?;
+                self.exec_index_op_with_positional(is_positional)?;
                 results.push(self.stack.pop().unwrap_or(Value::Nil));
             }
             self.stack.push(Value::junction(kind.clone(), results));
@@ -68,7 +76,7 @@ impl VM {
             // This supports chained autovivification (e.g. %h<a><b><c>).
             self.stack.push(resolved);
             self.stack.push(index);
-            return self.exec_index_op();
+            return self.exec_index_op_with_positional(is_positional);
         }
         // If target is a Failure, propagate it (// will catch it as undefined)
         if matches!(&target, Value::Instance { class_name, .. } if class_name == "Failure") {
@@ -339,6 +347,22 @@ impl VM {
                     Some(i) if i >= 0 => items.get(i as usize).cloned().unwrap_or(Value::Nil),
                     Some(i) if i < 0 => Self::make_out_of_range_failure(i),
                     _ => Value::Nil,
+                }
+            }
+            // Positional indexing on Hash: Hash is not Positional, so treat as
+            // single-item list. $hash[0] returns the hash itself, $hash[n>0] returns Nil.
+            (hash @ Value::Hash(_), Value::Int(i)) if is_positional => {
+                if i == 0 {
+                    hash
+                } else {
+                    Value::Nil
+                }
+            }
+            (hash @ Value::Hash(_), Value::Num(n)) if is_positional => {
+                if n == 0.0 {
+                    hash
+                } else {
+                    Value::Nil
                 }
             }
             (Value::Hash(items), Value::Whatever) => {
@@ -1103,8 +1127,10 @@ impl VM {
                     Value::Nil
                 }
             }
-            // Array + Str: coerce numeric string to Int for positional indexing
-            (Value::Array(items, is_arr), Value::Str(ref s)) => {
+            // Array + Str: when positional, coerce numeric string to Int for
+            // positional indexing; when associative, always fail (Array does not
+            // support associative indexing).
+            (Value::Array(items, is_arr), Value::Str(ref s)) if is_positional => {
                 if let Ok(i) = s.trim().parse::<i64>() {
                     if i < 0 {
                         Self::make_out_of_range_failure(i)
@@ -1116,6 +1142,11 @@ impl VM {
                 } else {
                     Self::make_assoc_indexing_failure("Array")
                 }
+            }
+            (Value::Array(..), Value::Str(_)) => {
+                return Err(RuntimeError::new(
+                    "Type Array does not support associative indexing.".to_string(),
+                ));
             }
             // Associative indexing on non-hash types returns a Failure
             (ref target, Value::Str(_))

--- a/t/list-functions.t
+++ b/t/list-functions.t
@@ -1,8 +1,8 @@
 use Test;
 plan 4;
 
-is classify(-> $x { $x % 2 }, 1, 2, 3, 4)[0].elems, 2, "classify evens";
-is classify(-> $x { $x % 2 }, 1, 2, 3, 4)[1].elems, 2, "classify odds";
+is classify(-> $x { $x % 2 }, 1, 2, 3, 4){0}.elems, 2, "classify evens";
+is classify(-> $x { $x % 2 }, 1, 2, 3, 4){1}.elems, 2, "classify odds";
 
 is categorize(-> $x { $x % 2 == 0 ?? ("even") !! ("odd") }, 1, 2, 3, 4)["even"].elems, 2, "categorize evens";
 is categorize(-> $x { $x % 2 == 0 ?? ("even") !! ("odd") }, 1, 2, 3, 4)["odd"].elems, 2, "categorize odds";


### PR DESCRIPTION
## Summary
- Add `is_positional` flag to `Expr::Index` and `OpCode::Index` to differentiate `[...]` (positional) from `{...}`/`<...>` (associative) subscripts
- Hash positional indexing (`$hash[0]`) now correctly returns the hash itself (non-Positional single-item semantics), matching Raku behavior
- Array associative indexing (`@arr<key>`) now throws "Type Array does not support associative indexing" instead of silently coercing numeric strings
- Updates `t/list-functions.t` to use correct associative subscript syntax on Hash results
- Adds `roast/S02-types/catch_type_cast_mismatch.t` (11 subtests) to whitelist

## Test plan
- [x] All 11 subtests in `roast/S02-types/catch_type_cast_mismatch.t` pass
- [x] `make test` passes (all 469 test files)
- [x] `make roast` passes (all 1050 whitelisted files)
- [x] `cargo clippy -- -D warnings` passes
- [x] No regressions in `roast/S02-types/array_ref.t` nested array assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)