### PR TITLE
[codex] fix: preserve native array declarations

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -468,6 +468,7 @@ roast/S09-multidim/indexing.t
 roast/S09-multidim/methods.t
 roast/S09-multidim/subs.t
 roast/S09-subscript/multidim-assignment.t
+roast/S09-typed-arrays/native-decl.t
 roast/S10-packages/export.t
 roast/S10-packages/joined-namespaces.t
 roast/S10-packages/precompilation.t

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -806,8 +806,10 @@ impl Interpreter {
                 .map(crate::builtins::methods_0arg::raku_repr::raku_value)
                 .collect::<Vec<_>>()
                 .join(", ");
-            let type_name = &info.value_type;
-            return Ok(Value::str(format!("Array[{}].new({})", type_name, inner)));
+            let type_name = info
+                .declared_type
+                .unwrap_or_else(|| format!("Array[{}]", info.value_type));
+            return Ok(Value::str(format!("{type_name}.new({inner})")));
         }
 
         // ACCEPTS for allomorphic types with Instance arguments

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -633,7 +633,11 @@ impl Interpreter {
                                     let info = crate::runtime::ContainerTypeInfo {
                                         value_type: constraint.clone(),
                                         key_type: None,
-                                        declared_type: Some(class_name.resolve()),
+                                        declared_type: Some(if base_class_name == "array" {
+                                            format!("array[{constraint}]")
+                                        } else {
+                                            class_name.resolve()
+                                        }),
                                     };
                                     self.register_container_type_metadata(&result, info);
                                 }
@@ -647,7 +651,11 @@ impl Interpreter {
                             let info = crate::runtime::ContainerTypeInfo {
                                 value_type: constraint.clone(),
                                 key_type: None,
-                                declared_type: Some(class_name.resolve()),
+                                declared_type: Some(if base_class_name == "array" {
+                                    format!("array[{constraint}]")
+                                } else {
+                                    class_name.resolve()
+                                }),
                             };
                             self.register_container_type_metadata(&shaped, info);
                         }
@@ -705,7 +713,11 @@ impl Interpreter {
                         let info = crate::runtime::ContainerTypeInfo {
                             value_type: constraint.clone(),
                             key_type: None,
-                            declared_type: Some(class_name.resolve()),
+                            declared_type: Some(if base_class_name == "array" {
+                                format!("array[{constraint}]")
+                            } else {
+                                class_name.resolve()
+                            }),
                         };
                         self.register_container_type_metadata(&result, info);
                     }
@@ -2004,7 +2016,11 @@ impl Interpreter {
                             crate::runtime::ContainerTypeInfo {
                                 value_type,
                                 key_type: None,
-                                declared_type: Some(class_name.resolve()),
+                                declared_type: Some(if base_class_name == "array" {
+                                    format!("array[{}]", type_args[0])
+                                } else {
+                                    class_name.resolve()
+                                }),
                             },
                         );
                         return Ok(result);
@@ -2030,7 +2046,11 @@ impl Interpreter {
                         crate::runtime::ContainerTypeInfo {
                             value_type,
                             key_type: None,
-                            declared_type: Some(class_name.resolve()),
+                            declared_type: Some(if base_class_name == "array" {
+                                format!("array[{}]", type_args[0])
+                            } else {
+                                class_name.resolve()
+                            }),
                         },
                     );
                     return Ok(result);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3672,6 +3672,7 @@ impl Interpreter {
     }
 
     fn parse_container_constraint(name: &str, raw: &str) -> ContainerTypeInfo {
+        let raw = raw.trim();
         // Note: For %-sigil variables, Hash[X] means "elements are Hash[X]",
         // NOT "elements are X". We do NOT unwrap Hash[...] here.
         // The only special case for % is the `TypeName{KeyType}` syntax
@@ -3692,7 +3693,13 @@ impl Interpreter {
         ContainerTypeInfo {
             value_type: raw.to_string(),
             key_type: None,
-            declared_type: None,
+            declared_type: if name.starts_with('@')
+                && crate::runtime::native_types::is_native_array_element_type(raw)
+            {
+                Some(format!("array[{raw}]"))
+            } else {
+                None
+            },
         }
     }
 

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -14,6 +14,11 @@ pub(crate) fn is_native_int_type(name: &str) -> bool {
     NATIVE_INT_TYPES.contains(&name)
 }
 
+/// Returns true if `name` is a native array element type.
+pub(crate) fn is_native_array_element_type(name: &str) -> bool {
+    is_native_int_type(name) || matches!(name, "num" | "num32" | "num64" | "str")
+}
+
 /// Returns (min, max) bounds for a native integer type as BigInt values.
 /// `byte` is an alias for `uint8`.
 /// `int` is an alias for `int64`, `uint` is an alias for `uint64`.

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -303,6 +303,21 @@ impl Interpreter {
         }
         if let Some((base, inner)) = Self::parse_generic_constraint(constraint) {
             match base {
+                "array" => {
+                    if let Value::Array(..) = value
+                        && let Some(metadata) = self.container_type_metadata(value)
+                        && metadata
+                            .declared_type
+                            .as_deref()
+                            .is_some_and(|declared| declared.starts_with("array["))
+                    {
+                        return self.type_matches_value(
+                            inner,
+                            &Value::Package(Symbol::intern(&metadata.value_type)),
+                        );
+                    }
+                    return false;
+                }
                 "Array" | "List" | "Positional" => {
                     if let Value::Array(items, ..) = value {
                         return items.iter().all(|v| self.type_matches_value(inner, v));

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2667,13 +2667,19 @@ impl VM {
             && let Some(value_type) = self.interpreter.var_type_constraint(name)
         {
             let info = crate::runtime::ContainerTypeInfo {
+                declared_type: if name.starts_with('@')
+                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
+                {
+                    Some(format!("array[{value_type}]"))
+                } else {
+                    None
+                },
                 value_type,
                 key_type: if name.starts_with('%') {
                     self.interpreter.var_hash_key_constraint(name)
                 } else {
                     None
                 },
-                declared_type: None,
             };
             self.interpreter
                 .register_container_type_metadata(&val, info);
@@ -2915,13 +2921,19 @@ impl VM {
             && let Some(value_type) = self.interpreter.var_type_constraint(name)
         {
             let info = crate::runtime::ContainerTypeInfo {
+                declared_type: if name.starts_with('@')
+                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
+                {
+                    Some(format!("array[{value_type}]"))
+                } else {
+                    None
+                },
                 value_type,
                 key_type: if name.starts_with('%') {
                     self.interpreter.var_hash_key_constraint(name)
                 } else {
                     None
                 },
-                declared_type: None,
             };
             self.interpreter
                 .register_container_type_metadata(&val, info);

--- a/t/native-array-decl.t
+++ b/t/native-array-decl.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 8;
+
+{
+    my int @a;
+    ok @a ~~ array[int], 'my int @a smartmatches native array[int]';
+    is @a.WHAT, '(array[int])', 'my int @a WHAT keeps native array type';
+    is @a.raku, 'array[int].new()', 'my int @a raku keeps native array type';
+}
+
+{
+    my @a of num;
+    ok @a ~~ array[num], 'my @a of num smartmatches native array[num]';
+    is @a.WHAT, '(array[num])', 'my @a of num WHAT keeps native array type';
+}
+
+{
+    my @a := array[str].new('a', 'b');
+    ok @a ~~ array[str], 'array[str].new smartmatches native array[str]';
+    is @a.WHAT, '(array[str])', 'array[str].new WHAT keeps native array type';
+    is @a.raku, "array[str].new(\"a\", \"b\")", 'array[str].new raku keeps native array type';
+}


### PR DESCRIPTION
Codex auto-fix for roast/S09-typed-arrays/native-decl.t