### PR TITLE
fix: pass all 9 subtests in roast/S02-types/baggy.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -100,6 +100,7 @@ roast/S02-types/array_extending.t
 roast/S02-types/array_ref.t
 roast/S02-types/assigning-refs.t
 roast/S02-types/bag-iterator.t
+roast/S02-types/baggy.t
 roast/S02-types/bool.t
 roast/S02-types/bool.t
 roast/S02-types/built-in.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -166,6 +166,13 @@ fn invert_value(target: &Value) -> Option<Value> {
                 result.push(make_inverted_pair(weight_val, Value::str(k.clone())));
             }
         }
+        // Instance types that compose Baggy: delegate to internal bag data
+        Value::Instance { attributes, .. } => {
+            if let Some(bag_data) = attributes.get("__baggy_data__") {
+                return invert_value(bag_data);
+            }
+            return None;
+        }
         Value::Pair(key, value) => {
             extend_inverted_pairs(&mut result, Value::str(key.clone()), value);
         }
@@ -308,6 +315,15 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 // Instance types should fall through to accessor dispatch,
                 // not be coerced via .hash builtin
                 None
+            }
+            // Type objects for setty/baggy types: .hash returns empty hash
+            Value::Package(name)
+                if matches!(
+                    name.resolve().as_str(),
+                    "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
+                ) =>
+            {
+                Some(Ok(Value::hash(std::collections::HashMap::new())))
             }
             _ => {
                 let items = crate::runtime::utils::value_to_list(target);

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1642,8 +1642,13 @@ pub(crate) fn native_method_1arg(
             if matches!(arg, Value::Sub(_) | Value::WeakSub(_)) {
                 return None;
             }
-            // For Bag, use weighted picking without expanding to a flat list
+            // For Bag/BagHash, use weighted picking without expanding to a flat list
             if let Value::Bag(bag, _) = target {
+                if let Value::Num(f) = arg
+                    && f.is_nan()
+                {
+                    return Some(Err(RuntimeError::new("Cannot convert NaN to Int")));
+                }
                 let total_items: i128 = bag.values().map(|c| *c as i128).sum();
                 let count: i128 = match arg {
                     Value::Whatever => total_items,
@@ -1747,6 +1752,12 @@ pub(crate) fn native_method_1arg(
                 return Some(Ok(Value::LazyList(Arc::new(
                     crate::value::LazyList::new_cached(cached),
                 ))));
+            }
+            // NaN check for general .pick path
+            if let Value::Num(f) = arg
+                && f.is_nan()
+            {
+                return Some(Err(RuntimeError::new("Cannot convert NaN to Int")));
             }
             let mut items = runtime::value_to_list(target);
             Some(Ok(match arg {
@@ -1870,6 +1881,10 @@ pub(crate) fn native_method_1arg(
             Value::Set(_, false) => Some(Err(RuntimeError::immutable("Set", method))),
             Value::Set(_, true) => Some(Err(RuntimeError::immutable("SetHash", method))),
             Value::Mix(_, false) => Some(Err(RuntimeError::immutable("Mix", method))),
+            // NaN check for grab/grabpairs on mutable types
+            Value::Bag(_, true) | Value::Mix(_, true) if matches!(arg, Value::Num(f) if f.is_nan()) => {
+                Some(Err(RuntimeError::new("Cannot convert NaN to Int")))
+            }
             _ => None,
         },
         "roll" => {

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -80,6 +80,12 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_set(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // Check for lazy inputs
+        for arg in args {
+            if Self::is_lazy_for_coerce(arg) {
+                return Err(RuntimeError::cannot_lazy_what("set"));
+            }
+        }
         let mut elems = HashSet::new();
         let mut original_keys = HashMap::new();
         let mut has_typed_keys = false;
@@ -131,6 +137,12 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_bag(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // Check for lazy inputs
+        for arg in args {
+            if Self::is_lazy_for_coerce(arg) {
+                return Err(RuntimeError::cannot_lazy_what("bag"));
+            }
+        }
         // The `bag` function counts occurrences of each element.
         // Unlike .Bag coercion, `bag` does NOT decompose pairs into key=>count.
         // Each element (including pairs) is treated as an opaque value to count.
@@ -200,6 +212,12 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_mix(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // Check for lazy inputs
+        for arg in args {
+            if Self::is_lazy_for_coerce(arg) {
+                return Err(RuntimeError::cannot_lazy_what("mix"));
+            }
+        }
         let mut weights: HashMap<String, f64> = HashMap::new();
         let mut original_keys: HashMap<String, Value> = HashMap::new();
         let mut has_typed_keys = false;

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -51,6 +51,11 @@ impl Interpreter {
                     elems.insert(k.to_string_value());
                 }
             }
+            // Instance types composing Baggy: delegate to internal bag data
+            Value::Instance { ref attributes, .. } if attributes.contains_key("__baggy_data__") => {
+                let bag_data = attributes.get("__baggy_data__").unwrap().clone();
+                return self.dispatch_to_set(bag_data);
+            }
             other if other.is_range() => {
                 for item in Self::value_to_list(&other) {
                     elems.insert(item.to_string_value());
@@ -83,7 +88,7 @@ impl Interpreter {
         match v {
             Value::Num(n) => n.is_infinite(),
             Value::Rat(_, d) | Value::FatRat(_, d) => *d == 0,
-            Value::HyperWhatever => true,
+            Value::Whatever | Value::HyperWhatever => true,
             _ => false,
         }
     }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2033,6 +2033,13 @@ impl Interpreter {
 
         // BagHash.grab / BagHash.grabpairs: remove random elements, mutating the Bag
         if matches!(&target, Value::Bag(_, true)) && matches!(method, "grab" | "grabpairs") {
+            // NaN check for grab/grabpairs count
+            if !args.is_empty()
+                && let Value::Num(f) = &args[0]
+                && f.is_nan()
+            {
+                return Err(RuntimeError::new("Cannot convert NaN to Int"));
+            }
             let bag = match &target {
                 Value::Bag(b, _) => b.counts.clone(),
                 _ => unreachable!(),

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1589,6 +1589,12 @@ impl Interpreter {
                     return Ok(Value::ValuePair(Box::new(key), Box::new(value)));
                 }
                 "Set" | "SetHash" => {
+                    // Check for lazy inputs
+                    for a in &args {
+                        if Self::is_lazy_for_coerce(a) {
+                            return Err(RuntimeError::cannot_lazy_what(base_class_name));
+                        }
+                    }
                     // Set/SetHash.new treats each element as an opaque value
                     // (does NOT decompose Pairs like the .Set/.SetHash coercion does).
                     // Single arg: if QuantHash, treat as single element; otherwise iterate.
@@ -2196,6 +2202,12 @@ impl Interpreter {
                                 .iter()
                                 .any(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)));
                             if has_positional {
+                                // Check if this class composes Baggy/Setty role;
+                                // if so, redirect to Bag-like construction
+                                let cn = class_name.resolve();
+                                if self.class_does_baggy_or_setty(&cn) {
+                                    return self.construct_baggy_instance(&cn, &args);
+                                }
                                 return Err(RuntimeError::new(format!(
                                     "Default constructor for '{}' only takes named arguments",
                                     class_name.resolve()
@@ -2294,6 +2306,12 @@ impl Interpreter {
                 // Mu.new only accepts named arguments. If positional args
                 // were passed and this is not a subclass that accepts them, reject.
                 if !positional_ctor_args.is_empty() {
+                    // Check if this class composes Baggy/Setty role;
+                    // if so, redirect to Bag-like construction
+                    let cn = class_name.resolve();
+                    if self.class_does_baggy_or_setty(&cn) {
+                        return self.construct_baggy_instance(&cn, &args);
+                    }
                     let accepts_positional = class_mro
                         .iter()
                         .any(|n| n == "Array" || n == "Int" || n == "Num" || n == "Hash");
@@ -3213,5 +3231,69 @@ impl Interpreter {
         attrs.insert("tertiary".to_string(), Value::Int(tertiary));
         attrs.insert("quaternary".to_string(), Value::Int(quaternary));
         Value::make_instance(Symbol::intern("Collation"), attrs)
+    }
+
+    /// Check if a class composes the Baggy or Setty role (directly or transitively).
+    fn class_does_baggy_or_setty(&self, class_name: &str) -> bool {
+        // Check the class definition's parents and MRO for Baggy/Setty
+        if let Some(class_def) = self.classes.get(class_name) {
+            if class_def
+                .parents
+                .iter()
+                .any(|p| p == "Baggy" || p == "Setty" || p == "QuantHash")
+            {
+                return true;
+            }
+            if class_def
+                .mro
+                .iter()
+                .any(|p| p == "Baggy" || p == "Setty" || p == "QuantHash")
+            {
+                return true;
+            }
+        }
+        // Also check composed roles
+        if let Some(roles) = self.class_composed_roles.get(class_name)
+            && roles
+                .iter()
+                .any(|r| r == "Baggy" || r == "Setty" || r == "QuantHash")
+        {
+            return true;
+        }
+        false
+    }
+
+    /// Construct an instance for a class that does Baggy.
+    /// Positional args are counted like a Bag, and the result is stored as
+    /// an Instance with internal Bag-like storage.
+    fn construct_baggy_instance(
+        &mut self,
+        class_name: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        // Flatten positional args into a list of elements to count
+        let mut items = Vec::new();
+        for arg in args {
+            match arg {
+                Value::Array(elems, _) => {
+                    items.extend(elems.iter().cloned());
+                }
+                other => items.push(other.clone()),
+            }
+        }
+        // Count occurrences (like Bag.new)
+        let mut counts: HashMap<String, i64> = HashMap::new();
+        for item in &items {
+            let key = item.to_string_value();
+            *counts.entry(key).or_insert(0) += 1;
+        }
+        // Build an Instance with bag-like attributes
+        let mut attrs = HashMap::new();
+        // Store the bag data as a Bag value in a special attribute
+        attrs.insert(
+            "__baggy_data__".to_string(),
+            Value::bag_typed(counts.clone(), HashMap::new()),
+        );
+        Ok(Value::make_instance(Symbol::intern(class_name), attrs))
     }
 }


### PR DESCRIPTION
## Summary

- Support classes composing Baggy role (`my class Foo does Baggy {}`) with Bag-like construction and method delegation
- Fix `.hash` on setty/baggy type objects (e.g. `Mix.hash` returns `{}`)
- Add NaN rejection for `.pick` and `.grab` on Bag/BagHash types
- Add `X::Cannot::Lazy` checks for `set`, `bag`, `mix` builtins and `SetHash.new` with lazy iterables
- Recognize `Whatever` as infinite endpoint for lazy range detection
- Add `roast/S02-types/baggy.t` to whitelist

## Test plan

- [x] `prove -e 'target/debug/mutsu' roast/S02-types/baggy.t` passes all 9 subtests
- [ ] `make test` passes (CI)
- [ ] `make roast` passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)