### PR TITLE
fix: add CallFrame attrs, @_ in methods, and package-qualified calls

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -1,7 +1,8 @@
 # S06 - multi, parameters, routine, signature, traits
 
 - [ ] roast/S06-advanced/caller.t
-- [ ] roast/S06-advanced/callframe.t
+  - Not in spectest.data (fails on raku too). 4/22 pass (tests 1,2,6,9). Test uses deprecated `caller()` function and `@_` in methods. Test 3 has wrong hardcoded line number (23 vs actual 17). Tests 4-19 require `caller()` type filtering and `:skip` which are not implemented.
+- [x] roast/S06-advanced/callframe.t
 - [ ] roast/S06-advanced/callsame.t
 - [ ] roast/S06-advanced/dispatching.t
   - 4/8 subtests pass (subtests 1, 4-skip, 5-skip, 7-skip, 8 pass). Subtests 2-3 fail: callwith/callsame wrapper dispatch not fully working. Subtest 6 fails: nextsame dispatch chain broken when multi method calls another method.

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -2,7 +2,7 @@ use super::super::expr::expression;
 use super::super::helpers::{ws, ws1};
 use super::super::parse_result::{PError, PResult, parse_char};
 
-use crate::ast::{Expr, ParamDef, Stmt};
+use crate::ast::{Expr, ParamDef, Stmt, collect_placeholders_shallow};
 use crate::symbol::Symbol;
 use crate::value::Value;
 use std::collections::HashMap;
@@ -1627,6 +1627,18 @@ fn method_decl_body_with_my(
     let (rest, traits) = parse_sub_traits(rest)?;
     let return_type = traits.return_type.or(param_return_type);
     let (rest, body) = block(rest)?;
+    // When no explicit signature is given, collect placeholder variables
+    // (@_, $^a, $^b, etc.) from the body as implicit parameters.
+    let (params, param_defs) = if params.is_empty() && param_defs.is_empty() {
+        let placeholders = collect_placeholders_shallow(&body);
+        if placeholders.is_empty() {
+            (params, param_defs)
+        } else {
+            (placeholders, Vec::new())
+        }
+    } else {
+        (params, param_defs)
+    };
     Ok((
         rest,
         Stmt::MethodDecl {

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -494,6 +494,18 @@ impl Interpreter {
         if let Some(callable) = self.env.get(&env_name).cloned() {
             return self.eval_call_on_value(callable, args);
         }
+        // Try stripping package prefix (e.g., "Main::foo" -> "foo")
+        // when the function is in the current or GLOBAL package.
+        if let Some(pos) = full_name.rfind("::") {
+            let short_name = &full_name[pos + 2..];
+            if let Some(def) = self.resolve_function_with_alias(short_name, &args) {
+                return self.call_function_def(&def, &args);
+            }
+            let env_short = format!("&{}", short_name);
+            if let Some(callable) = self.env.get(&env_short).cloned() {
+                return self.eval_call_on_value(callable, args);
+            }
+        }
         Err(RuntimeError::new(format!(
             "X::Undeclared::Symbols: Unknown function: {}",
             full_name

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -628,6 +628,12 @@ impl Interpreter {
             return self.call_method_with_values(target, "comb", method_args);
         }
 
+        // Try stripping package prefix (e.g., "Main::foo" -> "foo")
+        if let Some(pos) = name.rfind("::") {
+            let short_name = &name[pos + 2..];
+            return self.call_function(short_name, args.to_vec());
+        }
+
         Err(RuntimeError::new(format!(
             "X::Undeclared::Symbols: Unknown function: {}",
             name

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1425,8 +1425,44 @@ impl Interpreter {
                     } else {
                         method_name.resolve()
                     };
-                    let effective_param_defs =
+                    let mut effective_param_defs =
                         Self::effective_method_param_defs(param_defs, is_hidden);
+                    // Auto-detect @_ usage in methods without explicit signatures
+                    if param_defs.is_empty() {
+                        let (use_positional, _) = Self::auto_signature_uses(method_body);
+                        if use_positional && !effective_param_defs.iter().any(|pd| pd.name == "@_")
+                        {
+                            // Insert @_ slurpy before the named %_ slurpy (if any)
+                            let insert_pos = effective_param_defs
+                                .iter()
+                                .position(|pd| pd.name.starts_with('%') && pd.slurpy)
+                                .unwrap_or(effective_param_defs.len());
+                            effective_param_defs.insert(
+                                insert_pos,
+                                ParamDef {
+                                    name: "@_".to_string(),
+                                    default: None,
+                                    multi_invocant: true,
+                                    required: false,
+                                    named: false,
+                                    slurpy: true,
+                                    double_slurpy: false,
+                                    onearg: false,
+                                    sigilless: false,
+                                    type_constraint: None,
+                                    literal_value: None,
+                                    sub_signature: None,
+                                    where_constraint: None,
+                                    traits: Vec::new(),
+                                    optional_marker: false,
+                                    outer_sub_signature: None,
+                                    code_signature: None,
+                                    is_invocant: false,
+                                    shape_constraints: None,
+                                },
+                            );
+                        }
+                    }
                     let effective_params: Vec<String> = effective_param_defs
                         .iter()
                         .map(|p| p.name.clone())
@@ -1890,7 +1926,43 @@ impl Interpreter {
                     } else {
                         method_name.resolve()
                     };
-                    let effective_param_defs = Self::effective_method_param_defs(param_defs, false);
+                    let mut effective_param_defs =
+                        Self::effective_method_param_defs(param_defs, false);
+                    // Auto-detect @_ usage in methods without explicit signatures
+                    if param_defs.is_empty() {
+                        let (use_positional, _) = Self::auto_signature_uses(method_body);
+                        if use_positional && !effective_param_defs.iter().any(|pd| pd.name == "@_")
+                        {
+                            let insert_pos = effective_param_defs
+                                .iter()
+                                .position(|pd| pd.name.starts_with('%') && pd.slurpy)
+                                .unwrap_or(effective_param_defs.len());
+                            effective_param_defs.insert(
+                                insert_pos,
+                                ParamDef {
+                                    name: "@_".to_string(),
+                                    default: None,
+                                    multi_invocant: true,
+                                    required: false,
+                                    named: false,
+                                    slurpy: true,
+                                    double_slurpy: false,
+                                    onearg: false,
+                                    sigilless: false,
+                                    type_constraint: None,
+                                    literal_value: None,
+                                    sub_signature: None,
+                                    where_constraint: None,
+                                    traits: Vec::new(),
+                                    optional_marker: false,
+                                    outer_sub_signature: None,
+                                    code_signature: None,
+                                    is_invocant: false,
+                                    shape_constraints: None,
+                                },
+                            );
+                        }
+                    }
                     let effective_params: Vec<String> = effective_param_defs
                         .iter()
                         .map(|p| p.name.clone())

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -781,6 +781,7 @@ impl Interpreter {
             let mut attrs = HashMap::new();
             attrs.insert("line".to_string(), Value::Int(line));
             attrs.insert("file".to_string(), Value::str(file));
+            Self::insert_callframe_code_attrs(&mut attrs, &code);
             attrs.insert("code".to_string(), code);
             attrs.insert("my".to_string(), my_hash);
             attrs.insert("inline".to_string(), Value::Bool(false));
@@ -800,12 +801,34 @@ impl Interpreter {
         let mut attrs = HashMap::new();
         attrs.insert("line".to_string(), Value::Int(entry.line));
         attrs.insert("file".to_string(), Value::str(entry.file.clone()));
+        Self::insert_callframe_code_attrs(&mut attrs, &code);
         attrs.insert("code".to_string(), code);
         attrs.insert("my".to_string(), my_hash);
         attrs.insert("inline".to_string(), Value::Bool(false));
         attrs.insert("__depth".to_string(), Value::Int(depth as i64));
         attrs.insert("annotations".to_string(), self.build_annotations(&attrs));
         Some(Value::make_instance(Symbol::intern("CallFrame"), attrs))
+    }
+
+    /// Extract subname, package, subtype, and sub attributes from a code value
+    /// and insert them into the CallFrame attributes map.
+    fn insert_callframe_code_attrs(attrs: &mut HashMap<String, Value>, code: &Value) {
+        match code {
+            Value::Sub(sd) => {
+                let name = sd.name.resolve();
+                attrs.insert("subname".to_string(), Value::str(name.to_string()));
+                let pkg = sd.package.resolve();
+                attrs.insert("package".to_string(), Value::str(pkg.to_string()));
+                attrs.insert("subtype".to_string(), Value::str("SubRoutine".to_string()));
+                attrs.insert("sub".to_string(), code.clone());
+            }
+            _ => {
+                attrs.insert("subname".to_string(), Value::str(String::new()));
+                attrs.insert("package".to_string(), Value::str(String::new()));
+                attrs.insert("subtype".to_string(), Value::str(String::new()));
+                attrs.insert("sub".to_string(), Value::Nil);
+            }
+        }
     }
 
     fn current_routine_sub_value(&self) -> Value {


### PR DESCRIPTION
## Summary
- Add `subname`, `package`, `subtype`, and `sub` attributes to CallFrame instances built by `callframe()`/`caller()`, extracted from the code value's SubData
- Support `@_` placeholder variables in method bodies by auto-detecting `@_` usage and adding a slurpy `@_` parameter (matching existing behavior for subs)
- Support package-qualified function calls (e.g., `&Main::foo()`) by falling back to stripping the package prefix when the fully-qualified name is not found
- Mark `callframe.t` as passing in `TODO_roast/S06.md` and document `caller.t` blockers

These improvements fix test 1 (caller.subname) in `roast/S06-advanced/caller.t` and enable tests 4-19 to run (previously crashed at `@_` in methods). The `caller.t` test cannot be fully whitelisted because it is not in `spectest.data` and fails on `raku` itself.

## Test plan
- [x] `make test` passes (470 files, 3794 tests)
- [x] `make roast` passes (no new failures, only pre-existing timeouts)
- [x] `roast/S06-advanced/callframe.t` still passes (22/22)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)