### PR TITLE
fix: support Supply.words on live Supplier-backed supplies

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -759,6 +759,7 @@ roast/S17-supply/supplier-preserving.t
 roast/S17-supply/tail.t
 roast/S17-supply/unique.t
 roast/S17-supply/watch-path.t
+roast/S17-supply/words.t
 roast/S19-command-line-options/02-dash-n.t
 roast/S19-command-line-options/03-dash-p.t
 roast/S19-command-line/arguments.t

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -17,7 +17,8 @@ mod system;
 
 // Re-export pub(crate) items accessed from outside `runtime` module
 pub(crate) use state::{
-    AsyncSocketConnState, SupplyEvent, split_supply_chunks_into_lines, take_supply_channel,
+    AsyncSocketConnState, SupplyEvent, split_supply_chunks_into_lines,
+    split_supply_chunks_into_words, take_supply_channel,
 };
 pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id, release_lock};
 
@@ -36,12 +37,13 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, flush_supplier_batch_taps, flush_supplier_line_taps, get_classify_state,
-    get_classify_sub_supplier_ids, get_start_output_supplier_ids, register_supplier_batch_tap,
-    register_supplier_classify_tap, register_supplier_done_callback, register_supplier_elems_tap,
-    register_supplier_lines_tap, register_supplier_produce_tap, register_supplier_quit_callback,
-    register_supplier_start_tap, register_supplier_tap, register_supplier_tap_with_head_limit,
-    register_supplier_unique_tap, supplier_emit_callbacks, supplier_produce_update_acc,
+    SupplierEmitAction, flush_supplier_batch_taps, flush_supplier_line_taps,
+    flush_supplier_words_taps, get_classify_state, get_classify_sub_supplier_ids,
+    get_start_output_supplier_ids, register_supplier_batch_tap, register_supplier_classify_tap,
+    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_lines_tap,
+    register_supplier_produce_tap, register_supplier_quit_callback, register_supplier_start_tap,
+    register_supplier_tap, register_supplier_tap_with_head_limit, register_supplier_unique_tap,
+    register_supplier_words_tap, supplier_emit_callbacks, supplier_produce_update_acc,
     supplier_tap_count, supplier_unique_get_seen, supplier_unique_mark_seen,
     take_supplier_done_callbacks, take_supplier_quit_callbacks, update_classify_state,
 };

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -107,6 +107,9 @@ impl Interpreter {
         for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
             let _ = self.call_sub_value(tap, vec![emitted], true);
         }
+        for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
+            let _ = self.call_sub_value(tap, vec![emitted], true);
+        }
         for done_cb in take_supplier_done_callbacks(supplier_id) {
             let _ = self.call_sub_value(done_cb, Vec::new(), true);
         }
@@ -115,6 +118,9 @@ impl Interpreter {
     fn async_supplier_quit_value(&mut self, supplier_id: u64, reason: Value) {
         supplier_quit(supplier_id, reason.clone());
         for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
+            let _ = self.call_sub_value(tap, vec![emitted], true);
+        }
+        for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
             let _ = self.call_sub_value(tap, vec![emitted], true);
         }
         for quit_cb in take_supplier_quit_callbacks(supplier_id) {

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -163,6 +163,38 @@ pub(crate) fn split_supply_chunks_into_lines(chunks: &[Value], chomp: bool) -> V
         .collect()
 }
 
+/// Split supply chunks into words, buffering across chunk boundaries.
+pub(crate) fn split_supply_chunks_into_words(chunks: &[Value]) -> Vec<Value> {
+    let mut words = Vec::new();
+    let mut buffer = String::new();
+    for chunk in chunks {
+        buffer.push_str(&chunk.to_string_value());
+        loop {
+            let trimmed = buffer.trim_start();
+            if trimmed.is_empty() {
+                buffer.clear();
+                break;
+            }
+            if let Some(ws_pos) = trimmed.find(char::is_whitespace) {
+                let word = trimmed[..ws_pos].to_string();
+                let consumed = buffer.len() - trimmed.len() + ws_pos;
+                buffer = buffer[consumed..].to_string();
+                words.push(Value::str(word));
+            } else {
+                let leading_ws = buffer.len() - trimmed.len();
+                buffer = buffer[leading_ws..].to_string();
+                break;
+            }
+        }
+    }
+    // Flush any remaining buffered word
+    let remaining = buffer.trim();
+    if !remaining.is_empty() {
+        words.push(Value::str(remaining.to_string()));
+    }
+    words
+}
+
 pub(super) fn take_complete_lines_from_buffer(
     buffer: &mut String,
     chomp: bool,

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -47,6 +47,10 @@ struct SupplierTapSubscription {
     start_state: Option<StartState>,
     /// Batch state: buffer values and emit as batched lists
     batch_state: Option<BatchState>,
+    /// Words mode: split incoming text into words across chunk boundaries
+    words_mode: bool,
+    /// Buffer for partial words across chunk boundaries
+    words_buffer: String,
 }
 
 #[derive(Clone)]
@@ -110,6 +114,8 @@ pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, de
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -138,6 +144,8 @@ pub(in crate::runtime) fn register_supplier_tap_with_head_limit(
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -166,6 +174,37 @@ pub(in crate::runtime) fn register_supplier_lines_tap(
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
+            });
+    }
+}
+
+pub(in crate::runtime) fn register_supplier_words_tap(
+    supplier_id: u64,
+    tap: Value,
+    delay_seconds: f64,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .taps
+            .push(SupplierTapSubscription {
+                callback: tap,
+                line_mode: false,
+                line_chomp: true,
+                line_buffer: String::new(),
+                delay_seconds,
+                unique_filter: None,
+                classify_state: None,
+                elems_trace: None,
+                head_limit: None,
+                head_count: 0,
+                produce_state: None,
+                start_state: None,
+                batch_state: None,
+                words_mode: true,
+                words_buffer: String::new(),
             });
     }
 }
@@ -200,6 +239,8 @@ pub(in crate::runtime) fn register_supplier_elems_tap(
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -272,6 +313,31 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                         Value::str(line),
                         tap.delay_seconds,
                     ));
+                }
+            } else if tap.words_mode {
+                tap.words_buffer.push_str(&emitted_value.to_string_value());
+                // Extract complete words (followed by whitespace) from the buffer
+                loop {
+                    let trimmed = tap.words_buffer.trim_start();
+                    if trimmed.is_empty() {
+                        tap.words_buffer.clear();
+                        break;
+                    }
+                    if let Some(ws_pos) = trimmed.find(char::is_whitespace) {
+                        let word = trimmed[..ws_pos].to_string();
+                        let consumed = tap.words_buffer.len() - trimmed.len() + ws_pos;
+                        tap.words_buffer = tap.words_buffer[consumed..].to_string();
+                        actions.push(SupplierEmitAction::Call(
+                            tap.callback.clone(),
+                            Value::str(word),
+                            tap.delay_seconds,
+                        ));
+                    } else {
+                        // No whitespace after word -- may be partial, keep in buffer
+                        let leading_ws = tap.words_buffer.len() - trimmed.len();
+                        tap.words_buffer = tap.words_buffer[leading_ws..].to_string();
+                        break;
+                    }
                 }
             } else if let Some(ref mut uf) = tap.unique_filter {
                 // Expire old seen values if :expires is set
@@ -456,6 +522,8 @@ pub(in crate::runtime) fn register_supplier_unique_tap(
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -487,6 +555,8 @@ pub(in crate::runtime) fn register_supplier_produce_tap(
                 }),
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -520,6 +590,8 @@ pub(in crate::runtime) fn register_supplier_start_tap(
                     output_supplier_id,
                 }),
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -593,6 +665,8 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                 produce_state: None,
                 start_state: None,
                 batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }
@@ -673,6 +747,24 @@ pub(in crate::runtime) fn flush_supplier_line_taps(supplier_id: u64) -> Vec<(Val
     callbacks
 }
 
+pub(in crate::runtime) fn flush_supplier_words_taps(supplier_id: u64) -> Vec<(Value, Value)> {
+    let mut callbacks = Vec::new();
+    if let Ok(mut map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get_mut(&supplier_id)
+    {
+        for tap in &mut subs.taps {
+            if tap.words_mode {
+                let remaining = tap.words_buffer.trim();
+                if !remaining.is_empty() {
+                    callbacks.push((tap.callback.clone(), Value::str(remaining.to_string())));
+                }
+                tap.words_buffer.clear();
+            }
+        }
+    }
+    callbacks
+}
+
 pub(in crate::runtime) fn take_supplier_done_callbacks(supplier_id: u64) -> Vec<Value> {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         if let Some(subs) = map.get_mut(&supplier_id) {
@@ -747,6 +839,8 @@ pub(in crate::runtime) fn register_supplier_batch_tap(
                     downstream_supplier_id,
                     last_flush: std::time::Instant::now(),
                 }),
+                words_mode: false,
+                words_buffer: String::new(),
             });
     }
 }

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -388,6 +388,7 @@ impl Interpreter {
                     let has_unique =
                         matches!(attributes.get("unique_filter"), Some(Value::Bool(true)));
                     let is_lines = matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
+                    let is_words = matches!(attributes.get("is_words"), Some(Value::Bool(true)));
                     let is_elems =
                         matches!(attributes.get("elems_filter"), Some(Value::Bool(true)));
                     if !Self::supply_has_active_callback(&tap_cb) {
@@ -401,6 +402,12 @@ impl Interpreter {
                             *supplier_id as u64,
                             tap_cb.clone(),
                             chomp,
+                            delay_seconds,
+                        );
+                    } else if is_words {
+                        register_supplier_words_tap(
+                            *supplier_id as u64,
+                            tap_cb.clone(),
                             delay_seconds,
                         );
                     } else if has_unique {
@@ -951,41 +958,57 @@ impl Interpreter {
                 Ok(self.make_supply_from_values(combed, attributes))
             }
             "words" => {
-                let source_values = self.supply_get_values(attributes)?;
+                let source_values = match attributes.get("values") {
+                    Some(Value::Array(items, ..)) => items.to_vec(),
+                    _ => Vec::new(),
+                };
                 let mut words = Vec::new();
                 let mut buffer = String::new();
                 for val in source_values {
                     let s = val.to_string_value();
                     buffer.push_str(&s);
-                    // Extract complete words from the buffer, keeping any
-                    // trailing partial word (text not followed by whitespace)
-                    // in the buffer for the next iteration.
                     loop {
                         let trimmed = buffer.trim_start();
                         if trimmed.is_empty() {
                             buffer.clear();
                             break;
                         }
-                        // Find end of word
                         if let Some(ws_pos) = trimmed.find(char::is_whitespace) {
                             let word = &trimmed[..ws_pos];
                             words.push(Value::str(word.to_string()));
                             let consumed = buffer.len() - trimmed.len() + ws_pos;
                             buffer = buffer[consumed..].to_string();
                         } else {
-                            // No whitespace found after word - it may be partial
                             let leading_ws = buffer.len() - trimmed.len();
                             buffer = buffer[leading_ws..].to_string();
                             break;
                         }
                     }
                 }
-                // Flush any remaining buffered word
                 let remaining = buffer.trim();
                 if !remaining.is_empty() {
                     words.push(Value::str(remaining.to_string()));
                 }
-                Ok(self.make_supply_from_values(words, attributes))
+                let new_id = next_supply_id();
+                let mut new_attrs = HashMap::new();
+                new_attrs.insert("values".to_string(), Value::array(words));
+                new_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+                new_attrs.insert("supply_id".to_string(), Value::Int(new_id as i64));
+                new_attrs.insert("is_words".to_string(), Value::Bool(true));
+                new_attrs.insert("live".to_string(), Value::Bool(false));
+                if let Some(parent_id) = attributes.get("supply_id") {
+                    new_attrs.insert("parent_supply_id".to_string(), parent_id.clone());
+                }
+                if let Some(supplier_id) = attributes.get("supplier_id") {
+                    new_attrs.insert("supplier_id".to_string(), supplier_id.clone());
+                }
+                if let Some(done) = attributes.get("supplier_done") {
+                    new_attrs.insert("supplier_done".to_string(), done.clone());
+                }
+                if let Some(reason) = attributes.get("quit_reason") {
+                    new_attrs.insert("quit_reason".to_string(), reason.clone());
+                }
+                Ok(Value::make_instance(Symbol::intern("Supply"), new_attrs))
             }
             "snip" => {
                 let source_values = self.supply_get_values(attributes)?;
@@ -1295,6 +1318,9 @@ impl Interpreter {
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
                         let _ = self.call_sub_value(tap, vec![emitted], true);
                     }
+                    for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
+                        let _ = self.call_sub_value(tap, vec![emitted], true);
+                    }
                     for done_cb in take_supplier_done_callbacks(supplier_id) {
                         let _ = self.call_sub_value(done_cb, Vec::new(), true);
                     }
@@ -1316,6 +1342,9 @@ impl Interpreter {
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_quit(supplier_id, reason.clone());
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
+                        self.call_sub_value(tap, vec![emitted], true)?;
+                    }
+                    for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
                     let (_, _, quit_reason) = supplier_snapshot(supplier_id);
@@ -1498,6 +1527,9 @@ impl Interpreter {
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
+                    for (tap, emitted) in flush_supplier_words_taps(sid) {
+                        self.call_sub_value(tap, vec![emitted], true)?;
+                    }
                     for done_cb in take_supplier_done_callbacks(sid) {
                         self.call_sub_value(done_cb, Vec::new(), true)?;
                     }
@@ -1524,6 +1556,9 @@ impl Interpreter {
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
+                        self.call_sub_value(tap, vec![emitted], true)?;
+                    }
+                    for (tap, emitted) in flush_supplier_words_taps(sid) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
                     for quit_cb in take_supplier_quit_callbacks(sid) {
@@ -1578,6 +1613,7 @@ impl Interpreter {
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let has_unique = matches!(attrs.get("unique_filter"), Some(Value::Bool(true)));
                     let is_lines = matches!(attrs.get("is_lines"), Some(Value::Bool(true)));
+                    let is_words = matches!(attrs.get("is_words"), Some(Value::Bool(true)));
                     let is_elems = matches!(attrs.get("elems_filter"), Some(Value::Bool(true)));
                     if !Self::supply_has_active_callback(&tap_cb) {
                         // done/quit-only taps do not register a value callback
@@ -1587,6 +1623,12 @@ impl Interpreter {
                             *supplier_id as u64,
                             tap_cb.clone(),
                             chomp,
+                            delay_seconds,
+                        );
+                    } else if is_words {
+                        register_supplier_words_tap(
+                            *supplier_id as u64,
+                            tap_cb.clone(),
                             delay_seconds,
                         );
                     } else if has_unique {

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use crate::runtime::native_methods::split_supply_chunks_into_words;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -272,6 +273,8 @@ impl Interpreter {
                 {
                     let is_lines = class_name == "Supply"
                         && matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
+                    let is_words = class_name == "Supply"
+                        && matches!(attributes.get("is_words"), Some(Value::Bool(true)));
                     if is_lines {
                         let chomp = attributes
                             .get("line_chomp")
@@ -280,6 +283,8 @@ impl Interpreter {
                         crate::runtime::native_methods::split_supply_chunks_into_lines(
                             &emitted, chomp,
                         )
+                    } else if is_words {
+                        split_supply_chunks_into_words(&emitted)
                     } else {
                         emitted
                     }


### PR DESCRIPTION
## Summary
- Add `words_mode` support to `SupplierTapSubscription` for splitting emitted text into words across chunk boundaries on live supplies
- Add `is_words` flag to derived Supply objects so the tap method registers a words-specific tap
- Add `split_supply_chunks_into_words` helper for the native `tap-ok` implementation
- Flush partial word buffers on supplier done/quit
- Add `roast/S17-supply/words.t` to the whitelist (all 5 subtests pass)

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S17-supply/words.t` passes all 5 subtests
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [ ] `make test` passes (CI will verify)
- [ ] `make roast` passes (CI will verify)

Generated with [Claude Code](https://claude.com/claude-code)