### PR TITLE
fix: validate Pod =table paragraph blocks for mixed column separators

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -796,7 +796,6 @@ roast/S26-documentation/03-abbreviated.t
 roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
-roast/S26-documentation/07b-tables.t
 roast/S26-documentation/07c-tables.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -796,6 +796,7 @@ roast/S26-documentation/03-abbreviated.t
 roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
+roast/S26-documentation/07b-tables.t
 roast/S26-documentation/07c-tables.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -182,12 +182,14 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
     if keyword == "begin" {
         // =begin IDENTIFIER ... =end IDENTIFIER
         // Match the identifier and ignore nested matching begin/end blocks.
+        // TODO: validate =begin table content (empty tables, consecutive row
+        // separators, mixed column separators) once BEGIN block timing is fixed
+        // so that tests generating tables at runtime don't regress.
         let begin_line_end = rest.find('\n').unwrap_or(rest.len());
         let begin_line = &rest[..begin_line_end];
         let target = begin_line.split_whitespace().next().unwrap_or("");
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();
         let mut depth = 1usize;
-        let mut content_lines: Vec<&str> = Vec::new();
 
         while !remaining.is_empty() {
             let line_end = remaining.find('\n').unwrap_or(remaining.len());
@@ -200,17 +202,11 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
                 } else if directive == "end" && directive_target == target {
                     depth -= 1;
                     if depth == 0 {
-                        if target == "table" {
-                            validate_pod_table(&content_lines)?;
-                        }
                         return Ok((next, ""));
                     }
                 }
             }
 
-            if depth == 1 {
-                content_lines.push(line);
-            }
             remaining = next;
         }
 

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -187,6 +187,7 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         let target = begin_line.split_whitespace().next().unwrap_or("");
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();
         let mut depth = 1usize;
+        let mut content_lines: Vec<&str> = Vec::new();
 
         while !remaining.is_empty() {
             let line_end = remaining.find('\n').unwrap_or(remaining.len());
@@ -199,19 +200,27 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
                 } else if directive == "end" && directive_target == target {
                     depth -= 1;
                     if depth == 0 {
+                        if target == "table" {
+                            validate_pod_table(&content_lines)?;
+                        }
                         return Ok((next, ""));
                     }
                 }
             }
 
+            if depth == 1 {
+                content_lines.push(line);
+            }
             remaining = next;
         }
 
         Ok(("", ""))
     } else {
         // =for, =head1, =item, =comment, etc. — skip to end of paragraph (blank line)
+        let is_table = keyword == "table";
         let end = rest.find('\n').unwrap_or(rest.len());
         let mut rest = &rest[end..];
+        let mut content_lines: Vec<&str> = Vec::new();
         loop {
             if rest.is_empty() {
                 break;
@@ -226,16 +235,77 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
             if rest.is_empty() || rest.starts_with('\n') || rest.starts_with('=') {
                 break;
             }
-            // Skip continuation line
+            // Collect and skip continuation line
             if let Some(nl) = rest.find('\n') {
+                content_lines.push(&rest[..nl]);
                 rest = &rest[nl..];
             } else {
+                content_lines.push(rest);
                 rest = "";
                 break;
             }
         }
+        if is_table {
+            validate_pod_table(&content_lines)?;
+        }
         Ok((rest, ""))
     }
+}
+
+/// Validate Pod table content lines.
+/// Checks for: empty tables, consecutive row separators, mixed column separator types.
+fn validate_pod_table(lines: &[&str]) -> PResult<'static, ()> {
+    // Filter out blank lines
+    let data_lines: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    if data_lines.is_empty() {
+        return Err(PError::expected("Pod table has no data"));
+    }
+
+    // Check for consecutive row separators and mixed column separator types
+    let mut prev_was_separator = false;
+    let mut has_visible_sep = false;
+    let mut has_ws_sep = false;
+
+    for line in &data_lines {
+        let trimmed = line.trim();
+        // A row separator is a line of only `=`, `-`, `_`, `+`, `|`, or whitespace
+        // that contains at least one separator character
+        let is_sep = !trimmed.is_empty()
+            && trimmed
+                .chars()
+                .all(|c| c == '=' || c == '-' || c == '_' || c == '+' || c == ' ');
+
+        if is_sep {
+            if prev_was_separator {
+                return Err(PError::expected(
+                    "Pod table has multiple interior row separator lines",
+                ));
+            }
+            prev_was_separator = true;
+        } else {
+            prev_was_separator = false;
+            // Check column separator type: visible (`|`) vs whitespace-only
+            if trimmed.contains('|') {
+                has_visible_sep = true;
+            } else if trimmed.contains("  ") {
+                // Two or more consecutive spaces indicate whitespace column separator
+                has_ws_sep = true;
+            }
+        }
+    }
+
+    if has_visible_sep && has_ws_sep {
+        return Err(PError::expected(
+            "Pod table has a mixture of visible and invisible column-separator types",
+        ));
+    }
+
+    Ok(("", ()))
 }
 
 fn parse_pod_directive_line(line: &str) -> Option<(&str, &str)> {


### PR DESCRIPTION
## Summary
- Add Pod table validation in the parser's `pod_block()` function for the `=table` paragraph form
- Validates three error conditions per the Raku Pod spec: empty tables, consecutive row separators, and mixed visible/invisible column separator types
- Improves `roast/S26-documentation/07b-tables.t` from 2/4 to 3/4 passing subtests
- The `=begin table` block form is not yet validated (deferred with TODO comment) because mutsu's BEGIN block timing doesn't match Raku's, which would regress `roast/S26-documentation/12-non-breaking-space.t`

## Test plan
- [x] 3/4 subtests pass in `roast/S26-documentation/07b-tables.t` (tests 2, 3, 4; test 1 blocked on BEGIN timing)
- [x] All existing S26-documentation whitelist tests still pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `prove -e './target/debug/mutsu' t/` (471 test files) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)