### PR TITLE
fix: support is/does/hides on unit class and strip :: from parent names

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -474,6 +474,7 @@ roast/S09-subscript/multidim-assignment.t
 roast/S09-typed-arrays/native-decl.t
 roast/S10-packages/export.t
 roast/S10-packages/joined-namespaces.t
+roast/S10-packages/nested-use.t
 roast/S10-packages/precompilation.t
 roast/S10-packages/require-and-use.t
 roast/S10-packages/use-with-class.t

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1496,22 +1496,70 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("unit", input).ok_or_else(|| PError::expected("unit statement"))?;
     let (rest, _) = ws1(rest)?;
     // unit class Name;
+    // unit class Name is Parent does Role;
     if let Some(r) = keyword("class", rest) {
         let (r, _) = ws1(r)?;
         let (r, name) = qualified_ident(r)?;
         let (r, _) = ws(r)?;
+        // Parse `is Parent` and `does Role` clauses before the semicolon
+        let mut parents = Vec::new();
+        let mut does_parents = Vec::new();
+        let mut class_is_rw = false;
+        let mut is_hidden = false;
+        let mut hidden_parents = Vec::new();
+        let mut r = r;
+        loop {
+            if let Some(r2) = keyword("is", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, parent) = if let Some(stripped) = r2.strip_prefix("::") {
+                    let (r3, ident_part) = qualified_ident(stripped)?;
+                    (r3, format!("::{}", ident_part))
+                } else {
+                    qualified_ident(r2)?
+                };
+                if parent == "rw" {
+                    class_is_rw = true;
+                } else if parent == "hidden" {
+                    is_hidden = true;
+                } else {
+                    parents.push(parent);
+                }
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            }
+            if let Some(r2) = keyword("does", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, role_name) = qualified_ident(r2)?;
+                parents.push(role_name.clone());
+                does_parents.push(role_name);
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            }
+            if let Some(r2) = keyword("hides", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, parent) = qualified_ident(r2)?;
+                parents.push(parent.clone());
+                hidden_parents.push(parent);
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            }
+            break;
+        }
         let (r, _) = opt_char(r, ';');
         return Ok((
             r,
             Stmt::ClassDecl {
                 name: Symbol::intern(&name),
                 name_expr: None,
-                parents: Vec::new(),
-                class_is_rw: false,
-                is_hidden: false,
+                parents,
+                class_is_rw,
+                is_hidden,
                 is_lexical: false,
-                hidden_parents: Vec::new(),
-                does_parents: Vec::new(),
+                hidden_parents,
+                does_parents,
                 repr: None,
                 body: Vec::new(),
                 language_version: super::simple::current_language_version(),

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -39,7 +39,7 @@ const CACHE_MAGIC: &[u8; 4] = b"MTSU";
 /// bumped whenever the AST enum layout changes (adding/removing/reordering variants).
 fn interpreter_version() -> String {
     // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change
-    const CACHE_FORMAT_VERSION: u32 = 4;
+    const CACHE_FORMAT_VERSION: u32 = 5;
     format!("{}+cf{}", env!("CARGO_PKG_VERSION"), CACHE_FORMAT_VERSION)
 }
 

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -575,6 +575,15 @@ impl Interpreter {
             hidden_parents,
             does_parents,
         } = modifiers;
+        // Normalize parent names: strip leading `::` (indirect name lookup syntax).
+        // `is ::Foo` means the same as `is Foo` in Raku.
+        let strip_colons = |s: &str| s.strip_prefix("::").unwrap_or(s).to_string();
+        let parents: Vec<String> = parents.iter().map(|p| strip_colons(p)).collect();
+        let parents = parents.as_slice();
+        let does_parents: Vec<String> = does_parents.iter().map(|p| strip_colons(p)).collect();
+        let does_parents = does_parents.as_slice();
+        let hidden_parents: Vec<String> = hidden_parents.iter().map(|p| strip_colons(p)).collect();
+        let hidden_parents = hidden_parents.as_slice();
         let prev_class = self.classes.get(name).cloned();
         let prev_hidden = self.hidden_classes.contains(name);
         let prev_hidden_defer = self.hidden_defer_parents.get(name).cloned();


### PR DESCRIPTION
## Summary
- Fix `unit class` parser to handle `is Parent`, `does Role`, and `hides Parent` clauses. Previously `unit class Foo is ::Bar;` would leave `is ::Bar;` as a separate statement, which conflicted with Test module's `is` function.
- Normalize parent names by stripping leading `::` prefix in `register_class_decl`, so `is ::Foo` resolves to class `Foo` correctly.
- Bump precomp cache format version to invalidate stale caches that were parsed before this fix.
- Add `roast/S10-packages/nested-use.t` to whitelist (all 9 subtests pass).

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S10-packages/nested-use.t` passes all 9 subtests
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `make test` shows no new regressions
- [x] `make roast` shows no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)