### PR TITLE
fix: drop Empty hash entries in deepmap

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -134,6 +134,7 @@
 - [ ] roast/S32-list/create.t
 - [ ] roast/S32-list/cross.t
 - [ ] roast/S32-list/deepmap.t
+    - 13/14 pass (test 13 fails: typed array constraint not tracked on Value::Array, returns Array instead of List; also fails on Rakudo - rakudo/rakudo#5778)
 - [ ] roast/S32-list/duckmap.t
 - [ ] roast/S32-list/end.t
   - 7/14 pass (1-6, 13). `.end` works for basic array operations (assign, pop, shift, unshift, push). Failures: sub form `end(@array)` (7-12), `end()` without args error (14). Difficulty: Low-Medium

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2438,6 +2438,11 @@ impl Interpreter {
                 let mut result = std::collections::HashMap::new();
                 for (k, v) in map.iter() {
                     match self.deepmap_iterate_inner(block, v, true) {
+                        Ok(Value::Slip(items)) if items.is_empty() => {
+                            // Empty slip means the block returned Empty;
+                            // drop the key from the result hash.
+                            continue;
+                        }
                         Ok(val) => {
                             result.insert(k.clone(), val);
                         }


### PR DESCRIPTION
## Summary
- When `deepmap` processes a Hash and the block returns Empty (an empty Slip), the key is now dropped from the result hash instead of being included with the Empty value
- This fixes test 14 in `roast/S32-list/deepmap.t` (13/14 subtests now pass)
- Test 13 requires typed array constraint tracking on `Value::Array`, which also fails on Rakudo (rakudo/rakudo#5778)
- Updated `TODO_roast/S32.md` with status notes

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-list/deepmap.t` shows 13/14 passing (test 13 also fails on Rakudo)
- [x] `make test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)