### PR TITLE
fix: correct smartmatch results for junctions, m//, and s///

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -221,6 +221,7 @@ roast/S03-sequence/exhaustive.t
 roast/S03-sequence/limit-arity-2-or-more.t
 roast/S03-sequence/misc.t
 roast/S03-sequence/nonnumeric.t
+roast/S03-smartmatch/00-sanity.t
 roast/S03-smartmatch/any-any.t
 roast/S03-smartmatch/any-bool.t
 roast/S03-smartmatch/any-callable.t

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -241,11 +241,13 @@ impl Compiler {
                     Expr::Var(name) => Some(name.clone()),
                     _ => None,
                 };
+                let rhs_is_match_regex = matches!(right, Expr::MatchRegex(_));
                 self.compile_expr(left);
                 let sm_idx = self.code.emit(OpCode::SmartMatchExpr {
                     rhs_end: 0,
                     negate: matches!(op, TokenKind::BangTilde),
                     lhs_var,
+                    rhs_is_match_regex,
                 });
                 // When RHS is m/regex/, unwrap to the regex value since
                 // SmartMatchExpr already handles the matching against LHS

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -403,6 +403,8 @@ impl Compiler {
             rhs_end: 0,
             negate: false,
             lhs_var,
+            // m// standalone (not in ~~ context) behaves like m// for result purposes
+            rhs_is_match_regex: true,
         });
         // RHS: load the regex constant
         let idx = self.code.add_constant(v.clone());

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -127,6 +127,9 @@ pub(crate) enum OpCode {
         negate: bool,
         /// Variable name for LHS (to write back after s/// substitution)
         lhs_var: Option<String>,
+        /// True when RHS was originally `m//` (MatchRegex), which affects
+        /// failure return value: `m//` failure returns False, bare `//` returns Nil.
+        rhs_is_match_regex: bool,
     },
     /// Scalarize a multi-match regex result: Nil -> 0, Positional -> elems, Match -> 1.
     ScalarizeRegexMatchResult,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -68,6 +68,9 @@ pub(crate) struct VM {
     /// The smartmatch handler uses this to return the transliterate result
     /// as a StrDistance-like value instead of performing eq comparison.
     transliterate_in_smartmatch: bool,
+    /// Set by substitution op when executed inside smartmatch RHS.
+    /// The smartmatch handler returns `$/` (Match) on success or False on failure.
+    substitution_in_smartmatch: bool,
     /// Tracks the last value passed to SetTopic, used as the REPL display value.
     last_topic_value: Option<Value>,
     /// Container name from when/default body (for Scalar container binding)
@@ -253,6 +256,7 @@ impl VM {
             locals: Vec::new(),
             in_smartmatch_rhs: false,
             transliterate_in_smartmatch: false,
+            substitution_in_smartmatch: false,
             last_topic_value: None,
             container_ref_var: None,
             container_ref_reversed: false,
@@ -1238,8 +1242,17 @@ impl VM {
                 rhs_end,
                 negate,
                 lhs_var,
+                rhs_is_match_regex,
             } => {
-                self.exec_smart_match_expr_op(code, ip, *rhs_end, *negate, lhs_var, compiled_fns)?;
+                self.exec_smart_match_expr_op(
+                    code,
+                    ip,
+                    *rhs_end,
+                    *negate,
+                    lhs_var,
+                    *rhs_is_match_regex,
+                    compiled_fns,
+                )?;
             }
             OpCode::ScalarizeRegexMatchResult => {
                 self.exec_scalarize_regex_match_result_op()?;

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -990,6 +990,7 @@ impl VM {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn exec_smart_match_expr_op(
         &mut self,
         code: &CompiledCode,
@@ -997,6 +998,7 @@ impl VM {
         rhs_end: u32,
         negate: bool,
         lhs_var: &Option<String>,
+        rhs_is_match_regex: bool,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let left = self.stack.pop().unwrap();
@@ -1017,10 +1019,13 @@ impl VM {
         let saved_in_smartmatch_rhs = self.in_smartmatch_rhs;
         self.in_smartmatch_rhs = true;
         self.transliterate_in_smartmatch = false;
+        self.substitution_in_smartmatch = false;
         let rhs_run = self.run_range(code, rhs_start, rhs_end, compiled_fns);
         self.in_smartmatch_rhs = saved_in_smartmatch_rhs;
         let was_transliterate = self.transliterate_in_smartmatch;
+        let was_substitution = self.substitution_in_smartmatch;
         self.transliterate_in_smartmatch = false;
+        self.substitution_in_smartmatch = false;
         rhs_run?;
         let right = self.stack.pop().unwrap_or(Value::Nil);
         if let Some(var_name) = lhs_var {
@@ -1048,11 +1053,19 @@ impl VM {
             } else {
                 right
             }
+        } else if was_substitution {
+            // s/// returns Match on success, False on failure.
+            // For !~~, negate the boolean result.
+            if negate {
+                Value::Bool(!right.truthy())
+            } else {
+                right
+            }
         } else if negate {
             // Smartmatch must NOT force lazy values (lazy ~~ anything → False)
-            self.eval_smartmatch_with_junctions(left, right, true)?
+            self.eval_smartmatch_with_junctions_ex(left, right, true, rhs_is_match_regex)?
         } else {
-            self.eval_smartmatch_with_junctions(left, right, false)?
+            self.eval_smartmatch_with_junctions_ex(left, right, false, rhs_is_match_regex)?
         };
         self.stack.push(out);
         self.env_dirty = true;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -322,15 +322,30 @@ impl VM {
     /// For `!~~` (negate=true), we compute `~~` first and then negate the
     /// collapsed result.  Raku defines `$x !~~ $y` as `not ($x ~~ $y)`,
     /// where `not` collapses junctions before negating.
+    #[allow(dead_code)]
     pub(super) fn eval_smartmatch_with_junctions(
         &mut self,
         left: Value,
         right: Value,
         negate: bool,
     ) -> Result<Value, RuntimeError> {
+        self.eval_smartmatch_with_junctions_ex(left, right, negate, false)
+    }
+
+    /// Extended smartmatch with junction threading.
+    /// `rhs_is_match_regex` indicates the RHS was originally `m//`, which
+    /// changes the failure return from Nil to False.
+    pub(super) fn eval_smartmatch_with_junctions_ex(
+        &mut self,
+        left: Value,
+        right: Value,
+        negate: bool,
+        rhs_is_match_regex: bool,
+    ) -> Result<Value, RuntimeError> {
         // For !~~, compute ~~ first, then negate the collapsed boolean.
         if negate {
-            let match_result = self.eval_smartmatch_with_junctions(left, right, false)?;
+            let match_result =
+                self.eval_smartmatch_with_junctions_ex(left, right, false, rhs_is_match_regex)?;
             let bool_val = match_result.truthy();
             return Ok(Value::Bool(!bool_val));
         }
@@ -340,8 +355,17 @@ impl VM {
         if matches!(&right, Value::Package(name) if matches!(name.resolve().as_str(), "Junction" | "Mu"))
             && matches!(&left, Value::Junction { .. })
         {
-            return self.smart_match_op(left, right);
+            return self.smart_match_op(left, right, rhs_is_match_regex);
         }
+        // Helper: check if a value is a regex (for junction collapse decisions)
+        let is_regex_value = |v: &Value| {
+            matches!(
+                v,
+                Value::Regex(_)
+                    | Value::RegexWithAdverbs { .. }
+                    | Value::Routine { is_regex: true, .. }
+            )
+        };
         if let (
             Value::Junction {
                 kind: left_kind,
@@ -357,33 +381,67 @@ impl VM {
             let results: Result<Vec<Value>, RuntimeError> = right_values
                 .iter()
                 .cloned()
-                .map(|v| self.eval_smartmatch_with_junctions(left.clone(), v, false))
+                .map(|v| {
+                    self.eval_smartmatch_with_junctions_ex(
+                        left.clone(),
+                        v,
+                        false,
+                        rhs_is_match_regex,
+                    )
+                })
                 .collect();
-            return Ok(Value::junction(right_kind.clone(), results?));
+            // Smartmatch collapses junctions to Bool
+            let junction = Value::junction(right_kind.clone(), results?);
+            return Ok(Value::Bool(junction.truthy()));
         }
         if let Value::Junction { kind, values } = left {
+            // When RHS is a non-junction regex and LHS is a junction,
+            // return the Junction of Match/Nil results without collapsing.
+            // For all other cases, collapse to Bool.
+            let keep_junction = is_regex_value(&right);
             let results: Result<Vec<Value>, RuntimeError> = values
                 .iter()
                 .cloned()
-                .map(|v| self.eval_smartmatch_with_junctions(v, right.clone(), false))
+                .map(|v| {
+                    self.eval_smartmatch_with_junctions_ex(
+                        v,
+                        right.clone(),
+                        false,
+                        rhs_is_match_regex,
+                    )
+                })
                 .collect();
-            return Ok(Value::junction(kind, results?));
+            let junction = Value::junction(kind, results?);
+            if keep_junction {
+                return Ok(junction);
+            }
+            return Ok(Value::Bool(junction.truthy()));
         }
         if let Value::Junction { kind, values } = right {
             let results: Result<Vec<Value>, RuntimeError> = values
                 .iter()
                 .cloned()
-                .map(|v| self.eval_smartmatch_with_junctions(left.clone(), v, false))
+                .map(|v| {
+                    self.eval_smartmatch_with_junctions_ex(
+                        left.clone(),
+                        v,
+                        false,
+                        rhs_is_match_regex,
+                    )
+                })
                 .collect();
-            return Ok(Value::junction(kind, results?));
+            // Smartmatch collapses junctions to Bool
+            let junction = Value::junction(kind, results?);
+            return Ok(Value::Bool(junction.truthy()));
         }
-        self.smart_match_op(left, right)
+        self.smart_match_op(left, right, rhs_is_match_regex)
     }
 
     pub(super) fn smart_match_op(
         &mut self,
         left: Value,
         right: Value,
+        rhs_is_match_regex: bool,
     ) -> Result<Value, RuntimeError> {
         // When RHS is Whatever, autoprime: return a WhateverCode that takes
         // one argument and smartmatches LHS against it.
@@ -443,7 +501,13 @@ impl VM {
             } else if matched {
                 // For regex smartmatch, return the Match object (from $/) or Nil
                 Ok(slash)
+            } else if rhs_is_match_regex && matches!(&slash, Value::Nil) {
+                // Failed m// (non-global) returns False, not Nil.
+                // But m:g// returns an empty list from $/, so we check that
+                // $/ is Nil before returning False.
+                Ok(Value::Bool(false))
             } else {
+                // Failed bare // returns Nil; m:g// returns $/ (empty list)
                 Ok(slash)
             }
         } else {

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -310,6 +310,23 @@ impl VM {
         )
     }
 
+    /// Create a Match object for a substitution match.
+    fn make_subst_match(text: &str, start: usize, end: usize) -> Value {
+        let chars: Vec<char> = text.chars().collect();
+        let matched: String = chars[start..end].iter().collect();
+        Value::make_match_object_full(
+            matched,
+            start as i64,
+            end as i64,
+            &[],
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+            &[],
+            &[],
+            Some(text),
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn exec_subst_op(
@@ -363,9 +380,19 @@ impl VM {
                     self.interpreter
                         .env_mut()
                         .insert("__mutsu_rw_map_topic__".to_string(), result);
-                    self.stack.push(Value::Bool(true));
+                    // Create Match object and set $/
+                    let match_obj = Self::make_subst_match(&text, start, end);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), match_obj.clone());
+                    self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+                    self.stack.push(match_obj);
                 } else {
-                    self.stack.push(Value::Nil);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), Value::Nil);
+                    self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+                    self.stack.push(Value::Bool(false));
                 }
             } else {
                 let found = self
@@ -393,9 +420,19 @@ impl VM {
                     self.interpreter
                         .env_mut()
                         .insert("__mutsu_rw_map_topic__".to_string(), result);
-                    self.stack.push(Value::Bool(true));
+                    // Create Match object and set $/
+                    let match_obj = Self::make_subst_match(&text, start, end);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), match_obj.clone());
+                    self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+                    self.stack.push(match_obj);
                 } else {
-                    self.stack.push(Value::Nil);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), Value::Nil);
+                    self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+                    self.stack.push(Value::Bool(false));
                 }
             }
             return Ok(());
@@ -442,7 +479,11 @@ impl VM {
             (selected, captures)
         };
         if ranges.is_empty() {
-            self.stack.push(Value::Nil);
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), Value::Nil);
+            self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+            self.stack.push(Value::Bool(false));
             return Ok(());
         }
 
@@ -480,8 +521,14 @@ impl VM {
         self.interpreter
             .env_mut()
             .insert("__mutsu_rw_map_topic__".to_string(), result);
-        // Push Bool::True so `$x ~~ s///` returns True on match
-        self.stack.push(Value::Bool(true));
+        // Create Match object from first match range and set $/
+        let (first_start, first_end) = ranges[0];
+        let match_obj = Self::make_subst_match(&text, first_start, first_end);
+        self.interpreter
+            .env_mut()
+            .insert("/".to_string(), match_obj.clone());
+        self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+        self.stack.push(match_obj);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- **Junction smartmatch collapse**: `any(1,2) ~~ 1` now correctly returns `Bool::True` instead of a Junction. Junction ~~ regex still preserves the Junction of Match/Nil results per Raku spec.
- **Failed m// returns False**: `"abc" ~~ m/\d+/` now returns `Bool::False` instead of `Nil` (bare `//` failures still return `Nil`).
- **s/// returns Match on success**: `$s ~~ s/\.+/_/` now returns the Match object and properly sets `$/`. Failed s/// returns `Bool::False`.
- Adds `roast/S03-smartmatch/00-sanity.t` (21 subtests) to the whitelist.

## Test plan
- [x] All 21 subtests in `roast/S03-smartmatch/00-sanity.t` pass
- [x] `make test` passes (471 tests, 3802 subtests)
- [x] `make roast` passes (1059 files, 176621 subtests)
- [x] No regressions in junction, regex, or substitution tests

Generated with [Claude Code](https://claude.com/claude-code)