### PR TITLE
fix: implement Buf/Blob write-num32 and write-num64

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -139,6 +139,7 @@ roast/S03-binding/ro.t
 roast/S03-buf/read-int.t
 roast/S03-buf/read-num.t
 roast/S03-buf/read-write-bits.t
+roast/S03-buf/write-num.t
 roast/S03-feeds/basic.t
 roast/S03-junctions/associative.t
 roast/S03-junctions/autothreading.t

--- a/src/runtime/buf_write_num.rs
+++ b/src/runtime/buf_write_num.rs
@@ -1,0 +1,96 @@
+// Helpers for Buf/Blob.write-num32 and .write-num64.
+//
+// Spec: https://docs.raku.org/type/Buf
+//   method write-num32(::T:U: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
+//   method write-num32(Buf:D: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
+
+use crate::value::{RuntimeError, Value};
+
+/// Returns Some(size_in_bytes) if the method is a write-num method.
+pub(crate) fn write_num_size(method: &str) -> Option<usize> {
+    match method {
+        "write-num32" => Some(4),
+        "write-num64" => Some(8),
+        _ => None,
+    }
+}
+
+/// Decode an Endian enum / int into the canonical 0=Native / 1=LE / 2=BE.
+pub(crate) fn decode_endian(value: &Value) -> i64 {
+    match value {
+        Value::Enum { value, .. } => value.as_i64(),
+        Value::Int(i) => *i,
+        _ => 0,
+    }
+}
+
+/// Convert an arbitrary numeric Value into f64. Used for write-num input.
+pub(crate) fn to_f64_value(value: &Value) -> f64 {
+    match value {
+        Value::Num(f) => *f,
+        Value::Int(i) => *i as f64,
+        Value::Rat(n, d) | Value::FatRat(n, d) => {
+            if *d == 0 {
+                0.0
+            } else {
+                *n as f64 / *d as f64
+            }
+        }
+        Value::BigInt(bi) => num_traits::ToPrimitive::to_f64(bi.as_ref()).unwrap_or(0.0),
+        Value::Bool(b) => i64::from(*b) as f64,
+        Value::Str(s) => s.parse::<f64>().unwrap_or(0.0),
+        _ => 0.0,
+    }
+}
+
+/// Apply a write-num write to a byte slice (resizing if needed).
+pub(crate) fn apply_write_num(
+    bytes: &mut Vec<u8>,
+    method: &str,
+    offset: i64,
+    value: &Value,
+    endian_val: i64,
+) -> Result<(), RuntimeError> {
+    let size = write_num_size(method).expect("not a write-num method");
+    if offset < 0 {
+        return Err(RuntimeError::new(format!(
+            "Cannot write to a negative offset for {}: {}",
+            method, offset
+        )));
+    }
+    let off = offset as usize;
+    let needed = off
+        .checked_add(size)
+        .ok_or_else(|| RuntimeError::new(format!("write-num offset {} too large", offset)))?;
+    if bytes.len() < needed {
+        bytes.resize(needed, 0u8);
+    }
+    let v = to_f64_value(value);
+    if size == 4 {
+        let v32 = v as f32;
+        let encoded = match endian_val {
+            1 => v32.to_le_bytes(),
+            2 => v32.to_be_bytes(),
+            _ => v32.to_ne_bytes(),
+        };
+        bytes[off..off + 4].copy_from_slice(&encoded);
+    } else {
+        let encoded = match endian_val {
+            1 => v.to_le_bytes(),
+            2 => v.to_be_bytes(),
+            _ => v.to_ne_bytes(),
+        };
+        bytes[off..off + 8].copy_from_slice(&encoded);
+    }
+    Ok(())
+}
+
+/// Build a fresh Buf instance value from a byte vector.
+pub(crate) fn make_buf_value(class_name: &str, bytes: Vec<u8>) -> Value {
+    use crate::symbol::Symbol;
+    use std::collections::HashMap;
+    let items: Vec<Value> = bytes.into_iter().map(|b| Value::Int(b as i64)).collect();
+    let mut attrs = HashMap::new();
+    attrs.insert("bytes".to_string(), Value::array(items));
+    Value::make_instance(Symbol::intern(class_name), attrs)
+}

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -136,6 +136,97 @@ impl Interpreter {
             return Ok(Value::array(Vec::new()));
         }
 
+        // Buf/Blob write-num32 / write-num64 — non-mut entry point.
+        // Handles both type object (e.g. `buf8.write-num32(0, 42e0)`) and
+        // instance form (e.g. `(my $b := buf8.new).write-num32(0, 42e0)`).
+        // For instances we mutate the underlying instance id so that any
+        // bindings observing the same instance see the change.
+        if super::buf_write_num::write_num_size(method).is_some() {
+            let (is_inst, cn_opt, base_bytes, class_sym_opt, id_opt, attrs_opt) = match &target {
+                Value::Package(name) => {
+                    let cn = name.resolve();
+                    if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                        (false, Some(cn), Vec::new(), None, None, None)
+                    } else {
+                        (false, None, Vec::new(), None, None, None)
+                    }
+                }
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    id,
+                } => {
+                    let cn = class_name.resolve();
+                    if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                        let mut v: Vec<u8> = Vec::new();
+                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                            v.reserve(items.len());
+                            for it in items.iter() {
+                                v.push(match it {
+                                    Value::Int(i) => (*i).clamp(0, 255) as u8,
+                                    Value::Num(f) => (*f as i64).clamp(0, 255) as u8,
+                                    _ => 0,
+                                });
+                            }
+                        }
+                        (
+                            true,
+                            Some(cn),
+                            v,
+                            Some(*class_name),
+                            Some(*id),
+                            Some(attributes.as_ref().clone()),
+                        )
+                    } else {
+                        (false, None, Vec::new(), None, None, None)
+                    }
+                }
+                _ => (false, None, Vec::new(), None, None, None),
+            };
+            if let Some(cn) = cn_opt {
+                if is_inst && (cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob")) {
+                    return Err(RuntimeError::new(format!(
+                        "Cannot modify immutable {} with {}",
+                        cn, method
+                    )));
+                }
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(RuntimeError::new(format!(
+                        "{} expects 2 or 3 arguments, got {}",
+                        method,
+                        args.len()
+                    )));
+                }
+                let offset_i64 = match &args[0] {
+                    Value::Int(i) => *i,
+                    Value::Num(f) => *f as i64,
+                    _ => 0,
+                };
+                let endian_val = if args.len() == 3 {
+                    super::buf_write_num::decode_endian(&args[2])
+                } else {
+                    0
+                };
+                let mut bytes = base_bytes;
+                super::buf_write_num::apply_write_num(
+                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                )?;
+                if is_inst {
+                    let class_sym = class_sym_opt.unwrap();
+                    let id = id_opt.unwrap();
+                    let mut updated_attrs = attrs_opt.unwrap();
+                    updated_attrs.insert(
+                        "bytes".to_string(),
+                        Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
+                    );
+                    self.overwrite_instance_bindings_by_identity(&cn, id, updated_attrs.clone());
+                    return Ok(Value::make_instance_with_id(class_sym, updated_attrs, id));
+                }
+                let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
+                return Ok(super::buf_write_num::make_buf_value(&normalized, bytes));
+            }
+        }
+
         // IterationBuffer dispatch
         if matches!(&target, Value::Instance { class_name, .. } if class_name == "IterationBuffer")
             && matches!(

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1572,6 +1572,105 @@ impl Interpreter {
             }
         }
 
+        // Buf/Blob write-num32 / write-num64 — mutate an existing instance.
+        if super::buf_write_num::write_num_size(method).is_some()
+            && let Value::Instance {
+                class_name,
+                attributes,
+                id,
+            } = &target
+            && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
+        {
+            let cn = class_name.resolve();
+            if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
+                return Err(RuntimeError::new(format!(
+                    "Cannot modify immutable {} with {}",
+                    cn, method
+                )));
+            }
+            if args.len() < 2 || args.len() > 3 {
+                return Err(RuntimeError::new(format!(
+                    "{} expects 2 or 3 arguments, got {}",
+                    method,
+                    args.len()
+                )));
+            }
+            let offset_val = &args[0];
+            let value_val = &args[1];
+            let endian_val = if args.len() == 3 {
+                super::buf_write_num::decode_endian(&args[2])
+            } else {
+                0
+            };
+            let offset_i64 = match offset_val {
+                Value::Int(i) => *i,
+                Value::Num(f) => *f as i64,
+                _ => 0,
+            };
+            let mut bytes = {
+                let mut v: Vec<u8> = Vec::new();
+                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                    v.reserve(items.len());
+                    for it in items.iter() {
+                        v.push(match it {
+                            Value::Int(i) => (*i).clamp(0, 255) as u8,
+                            Value::Num(f) => (*f as i64).clamp(0, 255) as u8,
+                            _ => 0,
+                        });
+                    }
+                }
+                v
+            };
+            super::buf_write_num::apply_write_num(
+                &mut bytes, method, offset_i64, value_val, endian_val,
+            )?;
+            let mut updated_attrs = attributes.as_ref().clone();
+            updated_attrs.insert(
+                "bytes".to_string(),
+                Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
+            );
+            self.overwrite_instance_bindings_by_identity(
+                &class_name.resolve(),
+                *id,
+                updated_attrs.clone(),
+            );
+            let updated = Value::make_instance_with_id(*class_name, updated_attrs, *id);
+            self.env.insert(target_var.to_string(), updated.clone());
+            return Ok(updated);
+        }
+
+        // Buf/Blob write-num on type object: returns a fresh buf.
+        if super::buf_write_num::write_num_size(method).is_some()
+            && let Value::Package(name) = &target
+        {
+            let cn = name.resolve();
+            if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(RuntimeError::new(format!(
+                        "{} expects 2 or 3 arguments, got {}",
+                        method,
+                        args.len()
+                    )));
+                }
+                let offset_i64 = match &args[0] {
+                    Value::Int(i) => *i,
+                    Value::Num(f) => *f as i64,
+                    _ => 0,
+                };
+                let endian_val = if args.len() == 3 {
+                    super::buf_write_num::decode_endian(&args[2])
+                } else {
+                    0
+                };
+                let mut bytes: Vec<u8> = Vec::new();
+                super::buf_write_num::apply_write_num(
+                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                )?;
+                let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
+                return Ok(super::buf_write_num::make_buf_value(&normalized, bytes));
+            }
+        }
+
         // Buf/Blob mutating methods: append, push, prepend, unshift, reallocate
         if matches!(
             method,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -96,6 +96,7 @@ type ProtectBlockCacheEntry = (
 type ProtectBlockCache = HashMap<u64, ProtectBlockCacheEntry>;
 
 mod accessors;
+mod buf_write_num;
 mod builtins;
 mod builtins_atomic;
 mod builtins_coerce;


### PR DESCRIPTION
## Summary
- Implement `write-num32` and `write-num64` methods for `Buf`/`Blob`, supporting both the type-object form (`buf8.write-num32(0, 42e0)`) and the instance form, with NativeEndian/LittleEndian/BigEndian.
- Add a dedicated `runtime::buf_write_num` helper module for float encoding and byte-vector growth.
- Mutating callers (`$buf.write-num32(...)`) go through the mut path and propagate the grown byte vector to any existing bindings via `overwrite_instance_bindings_by_identity`.
- Add `roast/S03-buf/write-num.t` (all 82 subtests) to the whitelist.

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S03-buf/write-num.t` — all 82 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] CI `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)