### PR TITLE
fix: implement Semaphore.acquire/release with a counting registry

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -12,6 +12,16 @@
 - [ ] roast/S17-lowlevel/cas.t
 - [ ] roast/S17-lowlevel/lock.t
 - [ ] roast/S17-lowlevel/semaphore.t
+  - Semaphore.acquire/release native methods are now implemented (counting
+    semaphore via shared registry), but the test exercises bare
+    acquire/release around `$r += $i` across 4000 Promise.start threads.
+    Mutsu's cross-thread shared scalar mechanism only re-reads from
+    `shared_vars` for explicit `Lock.protect` blocks; bare critical sections
+    leave the local env stale, so the accumulator races. Fixing this requires
+    either making thread-cloned `$`-sigil reads always go through
+    `shared_vars`, or building a critical-section abstraction around
+    Semaphore.acquire/release that re-syncs and writes back captured
+    variables (analogous to `call_protect_block`). Deferred.
 - [x] roast/S17-lowlevel/thread-start-join-stress.t
   - 1/1 pass.
 - [ ] roast/S17-lowlevel/thread.t

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2195,6 +2195,26 @@ impl Interpreter {
                         return self.construct_proxy_subclass(class_key, &args);
                     }
                 }
+                // Semaphore takes a positional permits argument; build the
+                // instance directly using the semaphore registry.
+                if class_key == "Semaphore" {
+                    let permits = args
+                        .first()
+                        .map(|v| match v {
+                            Value::Int(i) => *i,
+                            Value::Num(f) => *f as i64,
+                            other => other.to_string_value().parse::<i64>().unwrap_or(1),
+                        })
+                        .unwrap_or(1)
+                        .max(0);
+                    let mut attrs = HashMap::new();
+                    attrs.insert("permits".to_string(), Value::Int(permits));
+                    attrs.insert(
+                        "semaphore-id".to_string(),
+                        Value::Int(super::native_methods::next_semaphore_id(permits) as i64),
+                    );
+                    return Ok(Value::make_instance(*class_name, attrs));
+                }
                 // Check for user-defined .new method first
                 if self.has_user_method(class_key, "new") {
                     let empty_attrs = HashMap::new();
@@ -2884,8 +2904,8 @@ impl Interpreter {
                         let mut attrs = HashMap::new();
                         attrs.insert("permits".to_string(), Value::Int(permits));
                         attrs.insert(
-                            "lock-id".to_string(),
-                            Value::Int(super::native_methods::next_lock_id() as i64),
+                            "semaphore-id".to_string(),
+                            Value::Int(super::native_methods::next_semaphore_id(permits) as i64),
                         );
                         Ok(Value::make_instance(name, attrs))
                     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1472,6 +1472,24 @@ impl Interpreter {
             },
         );
         classes.insert(
+            "Semaphore".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: ["acquire", "try_acquire", "release"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                mro: vec!["Semaphore".to_string()],
+                attribute_types: HashMap::new(),
+                attribute_smileys: HashMap::new(),
+                wildcard_handles: Vec::new(),
+                alias_attributes: HashSet::new(),
+                class_level_attrs: HashMap::new(),
+            },
+        );
+        classes.insert(
             "IO::Path".to_string(),
             ClassDef {
                 parents: Vec::new(),

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -81,6 +81,45 @@ impl Interpreter {
         }
     }
 
+    pub(in crate::runtime) fn native_semaphore(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        _args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let sem_id = match attributes.get("semaphore-id") {
+            Some(Value::Int(id)) if *id > 0 => *id as u64,
+            _ => {
+                return Err(RuntimeError::new(format!(
+                    "Semaphore.{} called on invalid Semaphore",
+                    method
+                )));
+            }
+        };
+        let rt = semaphore_runtime_by_id(sem_id)
+            .ok_or_else(|| RuntimeError::new("Semaphore state not found"))?;
+        match method {
+            "acquire" => {
+                semaphore_acquire(&rt)?;
+                Ok(Value::Nil)
+            }
+            "try_acquire" => {
+                let ok = semaphore_try_acquire(&rt)?;
+                Ok(Value::Bool(ok))
+            }
+            "release" => {
+                semaphore_release(&rt)?;
+                Ok(Value::Nil)
+            }
+            "WHAT" => Ok(Value::Package(Symbol::intern("Semaphore"))),
+            "Str" | "gist" => Ok(Value::str_from("Semaphore")),
+            _ => Err(RuntimeError::new(format!(
+                "No native method '{}' on Semaphore",
+                method
+            ))),
+        }
+    }
+
     pub(in crate::runtime) fn native_condition_variable(
         &mut self,
         attributes: &HashMap<String, Value>,

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -33,6 +33,7 @@ pub(in crate::runtime) use state::{
     update_async_connection,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
+pub(in crate::runtime) use state_lock::next_semaphore_id;
 pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
@@ -297,6 +298,7 @@ impl Interpreter {
                 | "Lock"
                 | "Lock::Async"
                 | "Lock::ConditionVariable"
+                | "Semaphore"
                 | "Distro"
                 | "Kernel"
                 | "Perl"
@@ -369,6 +371,7 @@ impl Interpreter {
             }
             "IO::Pipe" => self.native_io_pipe(attributes, method, &args),
             "Lock" | "Lock::Async" => self.native_lock(attributes, method, args),
+            "Semaphore" => self.native_semaphore(attributes, method, args),
             "Lock::ConditionVariable" => self.native_condition_variable(attributes, method, args),
             "Distro" => self.native_distro(attributes, method),
             "Kernel" => self.native_kernel(attributes, method, args),

--- a/src/runtime/native_methods/state_lock.rs
+++ b/src/runtime/native_methods/state_lock.rs
@@ -134,3 +134,78 @@ pub(super) fn next_condition_id() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     COUNTER.fetch_add(1, Ordering::Relaxed)
 }
+
+// --- Counting semaphore registry ---
+
+#[derive(Debug)]
+pub(crate) struct SemaphoreRuntime {
+    pub(super) state: std::sync::Mutex<i64>,
+    pub(super) cv: std::sync::Condvar,
+}
+
+type SemaphoreMap = std::sync::RwLock<HashMap<u64, Arc<SemaphoreRuntime>>>;
+
+fn semaphore_map() -> &'static SemaphoreMap {
+    static MAP: OnceLock<SemaphoreMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+pub(in crate::runtime) fn next_semaphore_id(permits: i64) -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut map) = semaphore_map().write() {
+        map.entry(id).or_insert_with(|| {
+            Arc::new(SemaphoreRuntime {
+                state: std::sync::Mutex::new(permits),
+                cv: std::sync::Condvar::new(),
+            })
+        });
+    }
+    id
+}
+
+pub(crate) fn semaphore_runtime_by_id(id: u64) -> Option<Arc<SemaphoreRuntime>> {
+    semaphore_map()
+        .read()
+        .ok()
+        .and_then(|map| map.get(&id).cloned())
+}
+
+pub(crate) fn semaphore_acquire(rt: &SemaphoreRuntime) -> Result<(), RuntimeError> {
+    let mut state = rt
+        .state
+        .lock()
+        .map_err(|_| RuntimeError::new("Semaphore state poisoned"))?;
+    while *state <= 0 {
+        state = rt
+            .cv
+            .wait(state)
+            .map_err(|_| RuntimeError::new("Semaphore wait failed"))?;
+    }
+    *state -= 1;
+    Ok(())
+}
+
+pub(crate) fn semaphore_try_acquire(rt: &SemaphoreRuntime) -> Result<bool, RuntimeError> {
+    let mut state = rt
+        .state
+        .lock()
+        .map_err(|_| RuntimeError::new("Semaphore state poisoned"))?;
+    if *state > 0 {
+        *state -= 1;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+pub(crate) fn semaphore_release(rt: &SemaphoreRuntime) -> Result<(), RuntimeError> {
+    let mut state = rt
+        .state
+        .lock()
+        .map_err(|_| RuntimeError::new("Semaphore state poisoned"))?;
+    *state += 1;
+    drop(state);
+    rt.cv.notify_one();
+    Ok(())
+}

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,1 +1,2 @@
 roast/S03-sequence/misc.t
+roast/S17-lowlevel/semaphore.t


### PR DESCRIPTION
## Summary
- Adds a global counting-semaphore registry (`SemaphoreRuntime`) so `Semaphore` instances created from different threads share state.
- Routes `Semaphore` through `call_native_instance_method` and registers `acquire` / `try_acquire` / `release` as native methods.
- Makes `Semaphore.new($permits)` go through the built-in package constructor instead of the auto-class default constructor that only accepts named args.

## Notes
roast/S17-lowlevel/semaphore.t still fails: the test uses bare `\$s.acquire; \$r += \$i; \$s.release` across 4000 Promise.start threads, and mutsu only refreshes thread-local scalars from `shared_vars` inside `Lock.protect` blocks. Documented in `TODO_roast/S17.md` and added to `too_difficult.txt`.

## Test plan
- [x] cargo build
- [x] cargo clippy -- -D warnings
- [x] cargo fmt
- [ ] make test (CI)
- [ ] make roast (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)