### PR TITLE
fix: implement lastcall to trim dispatch candidates

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -565,6 +565,7 @@ roast/S12-methods/fallback.t
 roast/S12-methods/how.t
 roast/S12-methods/indirect_notation.t
 roast/S12-methods/instance.t
+roast/S12-methods/lastcall.t
 roast/S12-methods/lvalue.t
 roast/S12-methods/method-vs-sub.t
 roast/S12-methods/parallel-dispatch.t

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -245,6 +245,7 @@ impl Interpreter {
             // Multi dispatch control flow
             "callsame" => self.builtin_callsame(),
             "nextsame" => self.builtin_nextsame(),
+            "lastcall" => self.builtin_lastcall(),
             "callwith" => self.builtin_callwith(&args),
             "nextwith" => self.builtin_nextwith(&args),
             "samewith" => self.builtin_samewith(&args),

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -18,6 +18,29 @@ impl Interpreter {
         }
     }
 
+    /// Trim the candidate list so that the current call is the final candidate.
+    /// After lastcall, callsame/nextsame from the same dispatch context return Nil.
+    pub(super) fn builtin_lastcall(&mut self) -> Result<Value, RuntimeError> {
+        // Clear remaining candidates of the topmost dispatch frame.
+        // Try wrap dispatch stack first.
+        if let Some(frame) = self.wrap_dispatch_stack.last_mut() {
+            frame.remaining.clear();
+            return Ok(Value::Bool(true));
+        }
+        // Try method dispatch stack.
+        if let Some(frame) = self.method_dispatch_stack.last_mut() {
+            frame.remaining.clear();
+            return Ok(Value::Bool(true));
+        }
+        // Try multi dispatch stack.
+        if let Some(top) = self.multi_dispatch_stack.last_mut() {
+            top.1.clear();
+            return Ok(Value::Bool(true));
+        }
+        // Outside a dispatch context: no-op (return False).
+        Ok(Value::Bool(false))
+    }
+
     /// Call next method/multi candidate with the original args; returns the result.
     pub(super) fn builtin_callsame(&mut self) -> Result<Value, RuntimeError> {
         self.dispatch_next_candidate("callsame", None, false)
@@ -110,6 +133,12 @@ impl Interpreter {
             let (receiver_class, invocant, call_args, owner_class, method_def) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
+                    if tail_call {
+                        return Err(RuntimeError {
+                            return_value: Some(Value::Nil),
+                            ..RuntimeError::new("")
+                        });
+                    }
                     return Ok(Value::Nil);
                 };
                 frame.remaining.remove(0);
@@ -203,6 +232,12 @@ impl Interpreter {
             }
             let Some(idx) = matched_idx else {
                 // No candidate matches — return Nil (nowhere to defer to)
+                if tail_call {
+                    return Err(RuntimeError {
+                        return_value: Some(Value::Nil),
+                        ..RuntimeError::new("")
+                    });
+                }
                 return Ok(Value::Nil);
             };
             let next_def = candidates[idx].clone();

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -167,6 +167,7 @@ impl VM {
             || name == "callwith"
             || name == "nextwith"
             || name == "nextcallee"
+            || name == "lastcall"
         {
             let result = self.interpreter.call_function(name, Vec::new())?;
             self.env_dirty = true;


### PR DESCRIPTION
## Summary
- Add `lastcall` builtin that clears the remaining candidate list of the topmost dispatch frame (wrap / method / multi).
- Make `nextsame`/`nextwith` tail-call even when no further candidate exists, so methods return Nil after lastcall instead of falling through.
- Whitelist `roast/S12-methods/lastcall.t` (now passing 7/7).

## Test plan
- [x] `prove -e target/debug/mutsu roast/S12-methods/lastcall.t`
- [x] `cargo clippy -- -D warnings`
- [x] `make test`

Generated with Claude Code