### PR TITLE
fix: make Supply.wait block until live supplier is done

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -770,6 +770,7 @@ roast/S17-supply/start.t
 roast/S17-supply/supplier-preserving.t
 roast/S17-supply/tail.t
 roast/S17-supply/unique.t
+roast/S17-supply/wait.t
 roast/S17-supply/watch-path.t
 roast/S17-supply/words.t
 roast/S19-command-line-options/02-dash-n.t

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1144,9 +1144,37 @@ impl Interpreter {
                 Ok(self.make_supply_from_values(results, attributes))
             }
             "wait" => {
-                // Supply.wait: collect all values and return a Seq
+                // Supply.wait: block until the underlying live supplier is done
+                // (or quit), then return the last emitted value. For non-live
+                // supplies this returns immediately with the last value.
+                if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
+                    use crate::value::SharedPromise;
+                    let promise = SharedPromise::new_with_class(Symbol::intern("Promise"));
+                    supplier_register_promise(supplier_id, promise.clone());
+                    let (result, output, stderr) = promise.wait();
+                    self.emit_output(&output);
+                    self.stderr_output.push_str(&stderr);
+                    self.sync_shared_vars_to_env();
+                    // Drain shared thread output buffers so output produced by
+                    // any background `start { }` thread that emitted into this
+                    // supplier reaches the main TAP stream in chronological
+                    // order.
+                    if let Some(ref shared) = self.shared_thread_output {
+                        let drained = std::mem::take(&mut *shared.lock().unwrap());
+                        if !drained.is_empty() {
+                            self.emit_output(&drained);
+                        }
+                    }
+                    if let Some(ref shared) = self.shared_thread_stderr {
+                        let drained = std::mem::take(&mut *shared.lock().unwrap());
+                        if !drained.is_empty() {
+                            self.stderr_output.push_str(&drained);
+                        }
+                    }
+                    return Ok(result);
+                }
                 let source_values = self.supply_get_values(attributes)?;
-                Ok(Value::Seq(std::sync::Arc::new(source_values)))
+                Ok(source_values.last().cloned().unwrap_or(Value::Nil))
             }
             "Channel" => {
                 // Supply.Channel: create a Channel, send all supply values into it, close it


### PR DESCRIPTION
## Summary
- Make `Supply.wait` block on live (Supplier-backed) supplies until the underlying supplier signals done/quit, instead of returning a snapshot of currently-emitted values.
- After waking, sync shared variables and drain shared thread output/stderr so output produced inside a background `start { }` thread (including TAP lines) appears in the main TAP stream in chronological order.
- Whitelist `roast/S17-supply/wait.t` (5/5 subtests passing).

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-supply/wait.t` -> All tests successful (5/5).
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt`.
- [x] `make test` (pre-existing flakes in `t/lock.t` only; pass on rerun).

Generated with [Claude Code](https://claude.com/claude-code)