### PR TITLE
fix: implement Mu.WALK and diamond role attribute composition

### DIFF
--- a/TODO_roast/S14.md
+++ b/TODO_roast/S14.md
@@ -1,7 +1,7 @@
 # S14 - roles
 
 - [ ] roast/S14-roles/anonymous.t
-- [ ] roast/S14-roles/attributes-6e.t
+- [x] roast/S14-roles/attributes-6e.t
 - [ ] roast/S14-roles/basic.t
   - 22/53 pass (55 reached). Good role basics. Failures: role type object .defined (5), .^does after composition (9-10), mixin method access (13-14, 16-17), but operator (15, 22), type constraint enforcement (24-25, 28, 31-32), non-existent role errors (33-38), gist (41), qualified method call (47-48), private methods (48), .^ver/.^auth (52-53). Difficulty: Medium-High
 - [x] roast/S14-roles/bool.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -585,6 +585,7 @@ roast/S13-overloading/operators.t
 roast/S13-syntax/aliasing.t
 roast/S13-type-casting/methods.t
 roast/S14-roles/anonymous.t
+roast/S14-roles/attributes-6e.t
 roast/S14-roles/bool.t
 roast/S14-roles/composition.t
 roast/S14-roles/conflicts.t

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -22,6 +22,14 @@ impl Interpreter {
             err.return_value = Some(target);
             return Err(err);
         }
+        // .WALK(name, :roles) — walk class+role chain calling the named
+        // submethod once per "own" definition. Returns a no-arg Sub that,
+        // when invoked, yields the list of results.
+        if method == "WALK"
+            && let Some(value) = self.try_walk_method(&target, &args)?
+        {
+            return Ok(value);
+        }
         // Unhandled Failure explosion
         if let Value::Instance { class_name, .. } = &target
             && class_name.resolve() == "Failure"

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -1,0 +1,252 @@
+//! Implementation of `Mu.WALK(method-name, :roles, :super, :submethod, :name, :omit)`.
+//!
+//! WALK walks the receiver's class hierarchy (and optionally its composed roles)
+//! looking up *own* candidates of the named method on each level. It returns a
+//! callable: invoking it with `()` produces a list of the results of calling
+//! each found method on the original invocant.
+//!
+//! Reference: <https://docs.raku.org/type/Any#method_WALK>
+//!
+//! Supported options for now:
+//! - `:name<methodname>` — the method name (also accepted as the first
+//!   positional argument)
+//! - `:roles` — also include each composed role in BFS order
+//! - `:super` — include parent classes (default)
+//! - `:method` / `:submethod` — currently both are looked up via the same
+//!   per-class method table; this is enough for what roast tests exercise.
+//!
+//! The implementation pre-evaluates each method call eagerly when WALK is
+//! invoked, then returns a no-arg `Sub` whose body returns the resulting
+//! list literal. This keeps the result trivially callable as `WALK(...)()`
+//! without needing a bespoke runtime callable kind.
+
+use super::*;
+use crate::ast::{Expr, Stmt};
+use crate::env::Env;
+use crate::symbol::Symbol;
+use crate::value::Value;
+use std::collections::HashSet;
+
+impl Interpreter {
+    pub(crate) fn try_walk_method(
+        &mut self,
+        target: &Value,
+        args: &[Value],
+    ) -> Result<Option<Value>, RuntimeError> {
+        // Only handle WALK on instances or type objects backed by a class def.
+        let receiver_class_name = match target {
+            Value::Instance { class_name, .. } => class_name.resolve(),
+            Value::Package(name) => name.resolve(),
+            _ => return Ok(None),
+        };
+        if !self.classes.contains_key(&receiver_class_name) {
+            return Ok(None);
+        }
+
+        // Parse arguments.
+        let mut method_name: Option<String> = None;
+        let mut want_roles = false;
+        let mut want_super = true; // default: walk class MRO
+        for arg in args {
+            match arg {
+                Value::Pair(k, v) => match k.as_str() {
+                    "name" => method_name = Some(v.to_string_value()),
+                    "roles" => want_roles = v.truthy(),
+                    "super" => want_super = v.truthy(),
+                    "method" | "submethod" | "omit" => { /* accepted; default behaviour */ }
+                    _ => {}
+                },
+                Value::ValuePair(k, v) => {
+                    let key = k.to_string_value();
+                    match key.as_str() {
+                        "name" => method_name = Some(v.to_string_value()),
+                        "roles" => want_roles = v.truthy(),
+                        "super" => want_super = v.truthy(),
+                        "method" | "submethod" | "omit" => {}
+                        _ => {}
+                    }
+                }
+                other => {
+                    if method_name.is_none() {
+                        method_name = Some(other.to_string_value());
+                    }
+                }
+            }
+        }
+        let Some(method_name) = method_name else {
+            return Ok(None);
+        };
+
+        // Build the walk order: BFS over class MRO, optionally including
+        // composed roles via `class_composed_roles` and `role_parents`.
+        let walk_targets = self.build_walk_targets(&receiver_class_name, want_super, want_roles);
+
+        // For each (kind, owner-name), look up an "own" MethodDef for the
+        // named method and invoke it on the original invocant.
+        let mut results: Vec<Value> = Vec::new();
+        for (kind, owner) in &walk_targets {
+            if let Some(method_def) =
+                self.lookup_own_walk_method(kind, owner, &receiver_class_name, &method_name)
+            {
+                let attributes = match target {
+                    Value::Instance { attributes, .. } => (**attributes).clone(),
+                    _ => std::collections::HashMap::new(),
+                };
+                let result = self.run_instance_method_resolved(
+                    &receiver_class_name,
+                    owner,
+                    method_def,
+                    attributes,
+                    Vec::new(),
+                    Some(target.clone()),
+                )?;
+                results.push(result.0);
+            }
+        }
+
+        // Wrap the precomputed results in a no-arg Sub whose body is the
+        // list literal `(v1, v2, ..., vN)`.
+        let body_exprs: Vec<Expr> = results.into_iter().map(Expr::Literal).collect();
+        let body = vec![Stmt::Expr(Expr::ArrayLiteral(body_exprs))];
+        let sub = Value::make_sub(
+            Symbol::intern(""),
+            Symbol::intern("WALK"),
+            Vec::new(),
+            Vec::new(),
+            body,
+            false,
+            Env::new(),
+        );
+        Ok(Some(sub))
+    }
+
+    fn build_walk_targets(
+        &self,
+        class_name: &str,
+        want_super: bool,
+        want_roles: bool,
+    ) -> Vec<(WalkKind, String)> {
+        let mut out: Vec<(WalkKind, String)> = Vec::new();
+        let mut visited_classes: HashSet<String> = HashSet::new();
+        let mut visited_roles: HashSet<String> = HashSet::new();
+
+        // Walk classes in MRO order. For each class, add the class itself
+        // and (if `:roles`) BFS over its composed roles.
+        let mro = self
+            .class_mro_readonly(class_name)
+            .unwrap_or_else(|| vec![class_name.to_string()]);
+        let class_chain: Vec<String> = if want_super {
+            mro
+        } else {
+            vec![class_name.to_string()]
+        };
+
+        for cn in &class_chain {
+            if cn == "Mu" || cn == "Any" || cn == "Cool" {
+                continue;
+            }
+            if visited_classes.insert(cn.clone()) {
+                out.push((WalkKind::Class, cn.clone()));
+            }
+            if !want_roles {
+                continue;
+            }
+            // BFS over composed roles for this class.
+            let initial: Vec<String> = self
+                .class_composed_roles
+                .get(cn)
+                .cloned()
+                .unwrap_or_default();
+            let mut queue: std::collections::VecDeque<String> = initial.into_iter().collect();
+            while let Some(role_name) = queue.pop_front() {
+                let base = role_name
+                    .split_once('[')
+                    .map(|(b, _)| b.to_string())
+                    .unwrap_or(role_name.clone());
+                if !visited_roles.insert(base.clone()) {
+                    continue;
+                }
+                out.push((WalkKind::Role, base.clone()));
+                if let Some(parents) = self.role_parents.get(&base) {
+                    for p in parents {
+                        let p_base = p
+                            .split_once('[')
+                            .map(|(b, _)| b.to_string())
+                            .unwrap_or(p.clone());
+                        if !visited_roles.contains(&p_base) {
+                            queue.push_back(p_base);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Read-only variant of class_mro for use from non-mut helpers.
+    fn class_mro_readonly(&self, class_name: &str) -> Option<Vec<String>> {
+        let class_def = self.classes.get(class_name)?;
+        if !class_def.mro.is_empty() {
+            return Some(class_def.mro.clone());
+        }
+        Some(vec![class_name.to_string()])
+    }
+
+    /// Look up the "own" MethodDef for `method_name` on the given class or role.
+    /// "Own" means defined directly on that level (not inherited from a parent).
+    fn lookup_own_walk_method(
+        &self,
+        kind: &WalkKind,
+        owner: &str,
+        receiver_class: &str,
+        method_name: &str,
+    ) -> Option<MethodDef> {
+        match kind {
+            WalkKind::Class => {
+                // For the receiver's own class, "own" is any candidate stored
+                // on the class with role_origin == None.
+                let class_def = self.classes.get(owner)?;
+                let overloads = class_def.methods.get(method_name)?;
+                if owner == receiver_class {
+                    overloads
+                        .iter()
+                        .find(|m| m.role_origin.is_none() && !m.is_private)
+                        .cloned()
+                } else {
+                    overloads
+                        .iter()
+                        .find(|m| m.role_origin.is_none() && !m.is_private && !m.is_my)
+                        .cloned()
+                }
+            }
+            WalkKind::Role => {
+                // Submethods on roles are not composed into the consuming
+                // class's method table, so look them up on the role's own
+                // method table first.
+                if let Some(role_def) = self.roles.get(owner)
+                    && let Some(overloads) = role_def.methods.get(method_name)
+                    && let Some(m) = overloads.iter().find(|m| !m.is_private)
+                {
+                    return Some(m.clone());
+                }
+                // Fall back to a method composed into the receiver's class
+                // table whose role origin matches this role.
+                let class_def = self.classes.get(receiver_class)?;
+                let overloads = class_def.methods.get(method_name)?;
+                overloads
+                    .iter()
+                    .find(|m| {
+                        let from_role = m.original_role.as_deref().or(m.role_origin.as_deref());
+                        from_role == Some(owner) && !m.is_private
+                    })
+                    .cloned()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WalkKind {
+    Class,
+    Role,
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -154,6 +154,7 @@ mod methods_supply_dispatch;
 mod methods_temporal;
 mod methods_trans;
 mod methods_type_coerce;
+mod methods_walk;
 mod native_io;
 mod native_io_special;
 pub(crate) mod native_methods;
@@ -269,6 +270,11 @@ pub(crate) struct RoleDef {
     /// Attribute conflicts detected during role-to-role composition.
     /// Each entry is (attr_name, declaring_role, conflicting_role).
     pub(crate) attribute_conflicts: Vec<(String, String, String)>,
+    /// Attribute names declared directly in this role's body (not inherited
+    /// via `does`). Used to disambiguate diamond composition (where the same
+    /// attribute reaches via two paths from a shared ancestor) from a real
+    /// attribute conflict.
+    pub(crate) own_attribute_names: HashSet<String>,
     /// Body statements deferred until composition time (for parameterized roles).
     /// These are non-method/non-attribute statements that may reference type parameters
     /// and must be re-executed for each class composition with concrete type bindings.
@@ -2512,6 +2518,7 @@ impl Interpreter {
                         wildcard_handles: Vec::new(),
                         role_id: 0,
                         attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
                         deferred_body_stmts: Vec::new(),
                     },
                 );
@@ -2527,6 +2534,7 @@ impl Interpreter {
                         wildcard_handles: Vec::new(),
                         role_id: 0,
                         attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
                         deferred_body_stmts: Vec::new(),
                     },
                 );
@@ -2542,6 +2550,7 @@ impl Interpreter {
                         wildcard_handles: Vec::new(),
                         role_id: 0,
                         attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
                         deferred_body_stmts: Vec::new(),
                     },
                 );
@@ -2557,6 +2566,7 @@ impl Interpreter {
                         wildcard_handles: Vec::new(),
                         role_id: 0,
                         attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
                         deferred_body_stmts: Vec::new(),
                     },
                 );
@@ -2598,6 +2608,7 @@ impl Interpreter {
                             wildcard_handles: Vec::new(),
                             role_id: 0,
                             attribute_conflicts: Vec::new(),
+                            own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
                         },
                     );

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -38,6 +38,7 @@ fn builtin_role_def() -> RoleDef {
         wildcard_handles: Vec::new(),
         role_id: 0,
         attribute_conflicts: Vec::new(),
+        own_attribute_names: HashSet::new(),
         deferred_body_stmts: Vec::new(),
     }
 }
@@ -2186,6 +2187,7 @@ impl Interpreter {
             wildcard_handles: Vec::new(),
             role_id: super::next_role_id(),
             attribute_conflicts: Vec::new(),
+            own_attribute_names: HashSet::new(),
             deferred_body_stmts: Vec::new(),
         };
         let is_parametric = !type_params.is_empty();
@@ -2227,6 +2229,7 @@ impl Interpreter {
                     is_type: _,
                 } => {
                     let attr_name_str = attr_name.resolve();
+                    role_def.own_attribute_names.insert(attr_name_str.clone());
                     // Check if this attribute already exists from a composed role
                     if let Some(existing) = role_def
                         .attributes
@@ -2353,12 +2356,18 @@ impl Interpreter {
                     };
                     for attr in &role.attributes {
                         if role_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
-                            // Attribute conflict: declared in both current role and parent role
-                            role_def.attribute_conflicts.push((
-                                attr.0.clone(),
-                                name.to_string(),
-                                base_role_name.to_string(),
-                            ));
+                            // Already present. Only a real conflict if both
+                            // sides declared it directly (vs. inherited from
+                            // a shared ancestor in a diamond). Skip otherwise.
+                            let parent_owns = role.own_attribute_names.contains(&attr.0);
+                            let current_owns = role_def.own_attribute_names.contains(&attr.0);
+                            if parent_owns && current_owns {
+                                role_def.attribute_conflicts.push((
+                                    attr.0.clone(),
+                                    name.to_string(),
+                                    base_role_name.to_string(),
+                                ));
+                            }
                         } else {
                             role_def.attributes.push(attr.clone());
                         }


### PR DESCRIPTION
## Summary
- Implements `Mu.WALK(method-name, :roles)` by walking the class MRO and BFS-ordered composed-role chain, pre-evaluating the named submethod on each level and returning a no-arg `Sub` that yields the resulting list.
- Fixes diamond role composition: `role R3 does R1 does R2` where both R1 and R2 inherit an attribute from a common ancestor R0 no longer raises a spurious conflict. `RoleDef` now tracks `own_attribute_names` so a conflict is reported only when both sides declared the attribute directly.
- Together these unblock `roast/S14-roles/attributes-6e.t`, which is added to the whitelist.

## Test plan
- [x] `prove -e ./target/debug/mutsu roast/S14-roles/attributes-6e.t`
- [x] `cargo test` (441 passed)
- [x] `prove -e ./target/debug/mutsu t/` (471 files, 3802 tests, all pass)
- [x] `prove -e ./target/debug/mutsu $(grep S14 roast-whitelist.txt)` (no S14 regressions)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`