### PR TITLE
fix: support custom trait_mod:<is> on class/role declarations

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -597,6 +597,7 @@ roast/S14-roles/rw.t
 roast/S14-roles/stubs.t
 roast/S14-roles/submethods-6e.t
 roast/S14-roles/typecheck.t
+roast/S14-traits/package.t
 roast/S14-traits/variables.t
 roast/S15-literals/identifiers.t
 roast/S15-literals/numbers.t

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -3,7 +3,7 @@ use super::super::helpers::{skip_balanced_parens, ws, ws1};
 use super::super::parse_result::{PError, PResult, opt_char, parse_char, take_while1};
 use super::super::primary::regex::scan_to_delim;
 
-use crate::ast::{Expr, ParamDef, Stmt};
+use crate::ast::{CallArg, Expr, ParamDef, Stmt};
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::Value;
@@ -759,6 +759,7 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     let mut parents = Vec::new();
     let mut does_parents = Vec::new();
     let mut is_repr: Option<String> = None;
+    let mut custom_class_traits: Vec<(String, Option<Expr>)> = Vec::new();
     let mut r = rest;
     loop {
         if let Some(r2) = keyword("is", r) {
@@ -774,8 +775,14 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             };
             if parent == "hidden" {
                 is_hidden = true;
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
             } else if parent == "rw" {
                 class_is_rw = true;
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
             } else if parent == "repr" {
                 // Extract repr value from `is repr('CUnion')` etc.
                 if let Some(inner) = r2.strip_prefix('(') {
@@ -804,6 +811,24 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                 r = r2;
                 continue;
             }
+            // Lowercase non-builtin trait — treat as custom trait_mod:<is>.
+            // Optionally parse a parenthesized argument expression.
+            let (r2, _) = ws(r2)?;
+            let (r2, arg_expr) = if let Some(inner) = r2.strip_prefix('(') {
+                let after = skip_balanced_parens(r2);
+                let body_len = r2.len() - after.len() - 2;
+                let body = &inner[..body_len];
+                let trimmed = body.trim();
+                if trimmed.is_empty() {
+                    (after, None)
+                } else {
+                    let (_leftover, e) = expression(trimmed)?;
+                    (after, Some(e))
+                }
+            } else {
+                (r2, None)
+            };
+            custom_class_traits.push((parent, arg_expr));
             let (r2, _) = ws(r2)?;
             r = r2;
             continue;
@@ -899,10 +924,24 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
     }
-    if stmts.is_empty() {
+    let trait_calls: Vec<Stmt> = custom_class_traits
+        .into_iter()
+        .map(|(tname, arg)| Stmt::Call {
+            name: Symbol::intern("trait_mod:<is>"),
+            args: vec![
+                CallArg::Positional(Expr::BareWord(name.clone())),
+                CallArg::Named {
+                    name: tname,
+                    value: arg,
+                },
+            ],
+        })
+        .collect();
+    if stmts.is_empty() && trait_calls.is_empty() {
         return Ok((rest, class_stmt));
     }
     stmts.push(class_stmt);
+    stmts.extend(trait_calls);
     Ok((rest, Stmt::Block(stmts)))
 }
 
@@ -1173,6 +1212,7 @@ pub(super) fn role_decl(input: &str) -> PResult<'_, Stmt> {
     let mut role_is_rw = false;
     let mut is_export = false;
     let mut export_tags: Vec<String> = Vec::new();
+    let mut custom_role_traits: Vec<(String, Option<Expr>)> = Vec::new();
 
     // Optional parent/trait clauses in any order.
     loop {
@@ -1195,7 +1235,23 @@ pub(super) fn role_decl(input: &str) -> PResult<'_, Stmt> {
         if let Some(r) = keyword("is", rest) {
             let (r, _) = ws1(r)?;
             let (r, trait_name) = ident(r)?;
-            let r = skip_balanced_parens(r);
+            // Try to parse an optional parenthesized argument expression.
+            let (r, arg_expr) = if let Some(inner) = r.strip_prefix('(') {
+                let after = skip_balanced_parens(r);
+                let body_len = r.len() - after.len() - 2;
+                let body = &inner[..body_len];
+                let trimmed = body.trim();
+                if trimmed.is_empty() {
+                    (after, None)
+                } else {
+                    match expression(trimmed) {
+                        Ok((_leftover, e)) => (after, Some(e)),
+                        Err(_) => (after, None),
+                    }
+                }
+            } else {
+                (r, None)
+            };
             let (r, _) = ws(r)?;
             if trait_name == "hidden" {
                 is_hidden_role = true;
@@ -1219,10 +1275,17 @@ pub(super) fn role_decl(input: &str) -> PResult<'_, Stmt> {
                     | "nodal"
                     | "pure"
             ) {
-                // Known lowercase trait keywords are skipped;
-                // everything else (including lowercase class/role names like irA)
-                // is treated as a parent.
-                parent_roles.push(trait_name);
+                // Uppercase identifiers are treated as parent roles/classes.
+                // Lowercase non-builtin trait names go through trait_mod:<is>.
+                if trait_name
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_uppercase())
+                {
+                    parent_roles.push(trait_name);
+                } else {
+                    custom_role_traits.push((trait_name, arg_expr));
+                }
             }
             rest = r;
             continue;
@@ -1272,19 +1335,33 @@ pub(super) fn role_decl(input: &str) -> PResult<'_, Stmt> {
     }
     super::simple::register_user_type(&name);
 
-    Ok((
-        rest,
-        Stmt::RoleDecl {
-            name: Symbol::intern(&name),
-            type_params,
-            type_param_defs,
-            is_export,
-            export_tags,
-            body,
-            is_rw: role_is_rw,
-            language_version: super::simple::current_language_version(),
-        },
-    ))
+    let role_stmt = Stmt::RoleDecl {
+        name: Symbol::intern(&name),
+        type_params,
+        type_param_defs,
+        is_export,
+        export_tags,
+        body,
+        is_rw: role_is_rw,
+        language_version: super::simple::current_language_version(),
+    };
+    if custom_role_traits.is_empty() {
+        return Ok((rest, role_stmt));
+    }
+    let mut stmts = vec![role_stmt];
+    for (tname, arg) in custom_role_traits {
+        stmts.push(Stmt::Call {
+            name: Symbol::intern("trait_mod:<is>"),
+            args: vec![
+                CallArg::Positional(Expr::BareWord(name.clone())),
+                CallArg::Named {
+                    name: tname,
+                    value: arg,
+                },
+            ],
+        });
+    }
+    Ok((rest, Stmt::Block(stmts)))
 }
 
 /// Parse `does` declaration.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -168,8 +168,20 @@ impl Interpreter {
                 })
                 .collect();
             ranked.sort_by(|a, b| {
-                // Higher rank first, then lower distance
-                b.1.0.cmp(&a.1.0).then(a.1.1.cmp(&b.1.1))
+                // Compare primary specificity (literal/where/subset/typed/subsig/named
+                // counts) first, then prefer smaller type-hierarchy distance, then
+                // fall back to required-named/trait counts as a final tiebreak so
+                // type narrowness wins over required-vs-optional.
+                let ar = &a.1.0;
+                let br = &b.1.0;
+                let a_primary = (ar.0, ar.1, ar.2, ar.3, ar.4, ar.5);
+                let b_primary = (br.0, br.1, br.2, br.3, br.4, br.5);
+                let a_tail = (ar.6, ar.7);
+                let b_tail = (br.6, br.7);
+                b_primary
+                    .cmp(&a_primary)
+                    .then(a.1.1.cmp(&b.1.1))
+                    .then(b_tail.cmp(&a_tail))
             });
             let sorted_matches: Vec<FunctionDef> =
                 ranked.iter().map(|(i, _)| matches[*i].clone()).collect();
@@ -284,7 +296,36 @@ impl Interpreter {
     fn candidate_type_distance(&self, args: &[Value], def: &FunctionDef) -> usize {
         let mut total = 0usize;
         let params: Vec<&ParamDef> = Self::dispatch_visible_params(def).collect();
+        // Index named args by name from Value::Pair entries.
+        let mut named_args: std::collections::HashMap<String, &Value> =
+            std::collections::HashMap::new();
+        for v in args.iter() {
+            if let Value::Pair(name, boxed) = v {
+                named_args.insert(name.clone(), boxed.as_ref());
+            }
+        }
+        // Compare named params against named arg type distance.
+        for pd in params.iter() {
+            if !pd.named {
+                continue;
+            }
+            let Some(constraint) = &pd.type_constraint else {
+                total += 1000;
+                continue;
+            };
+            // Look up arg by parameter sigilless name.
+            let lookup = pd.name.trim_start_matches(['$', '@', '%', '&']);
+            if let Some(arg) = named_args.get(lookup) {
+                let base = Self::constraint_base_name(constraint);
+                total += self.type_hierarchy_distance_with_var_type(base, arg, None);
+            } else if pd.required {
+                total += 1000;
+            }
+        }
         for (i, pd) in params.iter().enumerate() {
+            if pd.named {
+                continue;
+            }
             if let Some(constraint) = &pd.type_constraint {
                 let base = Self::constraint_base_name(constraint);
                 if i < args.len() {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -195,6 +195,17 @@ impl Interpreter {
         if let Value::CustomType { how, .. } | Value::CustomTypeInstance { how, .. } = target {
             return Ok(*how.clone());
         }
+        // Check for class HOW overrides set by `Type.HOW does Role`.
+        let override_key = match target {
+            Value::Package(name) => Some(name.resolve()),
+            Value::Instance { class_name, .. } => Some(class_name.resolve()),
+            _ => None,
+        };
+        if let Some(key) = override_key
+            && let Some(overridden) = self.class_how_overrides.get(&key)
+        {
+            return Ok(overridden.clone());
+        }
         // Return CurriedRoleHOW for parameterized roles
         if let Value::ParametricRole {
             base_name,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -883,6 +883,10 @@ pub struct Interpreter {
     /// Rebless mapping: instance_id -> new HOW value.
     /// Used by Metamodel::Primitives.rebless to track reblessed objects.
     pub(crate) rebless_map: HashMap<u64, Value>,
+    /// Override map for class HOW values: type_name -> modified HOW value.
+    /// Populated when `Type.HOW does Role` mutates the HOW so that
+    /// subsequent `Type.HOW` lookups return the modified meta-object.
+    pub(crate) class_how_overrides: HashMap<String, Value>,
     /// Value set by `make()` inside grammar action methods.
     /// Persists across env save/restore in method dispatch.
     pub(crate) action_made: Option<Value>,
@@ -2699,6 +2703,7 @@ impl Interpreter {
             squish_iterator_meta: HashMap::new(),
             custom_type_data: HashMap::new(),
             rebless_map: HashMap::new(),
+            class_how_overrides: HashMap::new(),
             action_made: None,
             pending_regex_error: None,
             precomp_enabled: true,
@@ -4193,6 +4198,7 @@ impl Interpreter {
             squish_iterator_meta: HashMap::new(),
             custom_type_data: self.custom_type_data.clone(),
             rebless_map: self.rebless_map.clone(),
+            class_how_overrides: self.class_how_overrides.clone(),
             action_made: None,
             pending_regex_error: None,
             precomp_enabled: self.precomp_enabled,

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -150,16 +150,46 @@ impl Interpreter {
         right: Value,
     ) -> Result<Value, RuntimeError> {
         if let Some((role_name, args)) = self.extract_role_application(&right) {
+            let how_target = Self::class_how_target_name(&left);
             let result = self.compose_role_on_value(left.clone(), &role_name, &args)?;
             // Call BUILD submethods from the composed role
             let result = self.call_role_build_submethods(result, &role_name)?;
             if let Some(target_name) = Self::var_target_name_from_value(&left) {
                 self.set_var_meta_value(&target_name, result.clone());
             }
+            // If `Type.HOW does Role` was used, persist the modified HOW so
+            // subsequent `Type.HOW` calls return the role-augmented metaclass.
+            if let Some(type_name) = how_target {
+                self.class_how_overrides.insert(type_name, result.clone());
+            }
             return Ok(result);
         }
         let role_name = right.to_string_value();
         Ok(Value::Bool(left.does_check(&role_name)))
+    }
+
+    /// If `value` is a metaclass HOW instance (e.g. ClassHOW), return the
+    /// owning type name from its `name` attribute.
+    fn class_how_target_name(value: &Value) -> Option<String> {
+        let inner = match value {
+            Value::Mixin(inner, _) => inner.as_ref(),
+            other => other,
+        };
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = inner
+        {
+            let cn = class_name.resolve();
+            if cn.starts_with("Perl6::Metamodel::")
+                && cn.ends_with("HOW")
+                && let Some(Value::Str(name)) = attributes.get("name")
+            {
+                return Some(name.to_string());
+            }
+        }
+        None
     }
 
     /// Apply multiple roles at once: `$obj does (RoleA, RoleB)`


### PR DESCRIPTION
## Summary
- Parse `is <lowercase>(...)` on class/role declarations and dispatch to user-defined `multi trait_mod:<is>` candidates via synthesized post-decl calls.
- Persist `Type.HOW does Role[...]` mutations in a class HOW override map so subsequent `Type.HOW` lookups return the augmented metaclass.
- Rank multi candidates by named-parameter type-hierarchy distance before required-named/trait counts so `Str:D :$x` beats `Any :$x!` on a string arg.

Adds `roast/S14-traits/package.t` to the whitelist (4/4 passing).

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S14-traits/package.t` (4/4)
- [x] `make test` (3802 tests pass)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>