### PR TITLE
fix: pass all 36 subtests in roast S02-types/instants-and-durations.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -112,6 +112,7 @@ roast/S02-types/fatrat.t
 roast/S02-types/hash_ref.t
 roast/S02-types/hyperwhatever.t
 roast/S02-types/infinity.t
+roast/S02-types/instants-and-durations.t
 roast/S02-types/int-uint.t
 roast/S02-types/is-type.t
 roast/S02-types/lazy-lists.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -413,6 +413,27 @@ pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError
         let (y, m, d) = temporal::epoch_days_to_civil(new_days);
         return Ok(temporal::make_date(y, m, d));
     }
+    // Instant + Instant is illegal
+    if instance_instant_value(&left).is_some() && instance_instant_value(&right).is_some() {
+        return Err(RuntimeError::new(
+            "Cannot add two Instants together".to_string(),
+        ));
+    }
+    // Instant + Duration => Instant
+    if let Some(tai) = instance_instant_value(&left)
+        && let Some(dur) = instance_duration_value(&right)
+    {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("value".to_string(), Value::Num(tai + dur));
+        return Ok(Value::make_instance(Symbol::intern("Instant"), attrs));
+    }
+    if let Some(tai) = instance_instant_value(&right)
+        && let Some(dur) = instance_duration_value(&left)
+    {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("value".to_string(), Value::Num(tai + dur));
+        return Ok(Value::make_instance(Symbol::intern("Instant"), attrs));
+    }
     // Instant + Numeric => Instant (add to TAI value)
     if let Some(tai) = instance_instant_value(&left)
         && right.is_numeric()
@@ -540,6 +561,14 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
     ) {
         // Instant - Instant returns a Duration
         return make_duration(a - b);
+    }
+    // Instant - Duration => Instant
+    if let Some(a) = instance_instant_value(&left)
+        && let Some(dur) = instance_duration_value(&right)
+    {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("value".to_string(), Value::Num(a - dur));
+        return Value::make_instance(Symbol::intern("Instant"), attrs);
     }
     if let Some(a) = instance_instant_value(&left)
         && right.is_numeric()

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -782,6 +782,12 @@ fn format_temporal_num(f: f64) -> String {
             "-Inf".to_string()
         };
     }
+    // For values outside the safe i64 Rat range, emit scientific notation
+    // so that Str -> Num literal round-trips through the parser instead of
+    // overflowing the Rat literal parser.
+    if f.is_finite() && f.abs() >= 1e18 {
+        return format!("{:e}", f);
+    }
     let s = format!("{}", f);
     if s.contains('.') {
         s

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1912,7 +1912,7 @@ impl Interpreter {
                     return Ok(Value::make_instance(Symbol::intern("Match"), attrs));
                 }
                 // Types that cannot be instantiated with .new
-                "HyperWhatever" | "Whatever" => {
+                "HyperWhatever" | "Whatever" | "Instant" => {
                     return Err(RuntimeError::new(format!(
                         "X::Cannot::New: Cannot create new object of type {}",
                         class_name

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -110,7 +110,7 @@ impl Interpreter {
         if constraint == "Real"
             && matches!(
                 value_type,
-                "Int" | "Num" | "Rat" | "FatRat" | "Bool" | "UInt"
+                "Int" | "Num" | "Rat" | "FatRat" | "Bool" | "UInt" | "Duration"
             )
         {
             return true;


### PR DESCRIPTION
## Summary
- Instant.new throws X::Cannot::New; Instant + Instant is rejected.
- Instant + Duration / Duration + Instant / Instant - Duration return Instant.
- Duration matches the Real role.
- Temporal .raku uses scientific notation for values outside the safe i64 Rat range so .raku.EVAL round-trips.

## Test plan
- [x] roast/S02-types/instants-and-durations.t passes all 36 subtests
- [x] make test
- [x] cargo clippy -- -D warnings && cargo fmt