### PR TITLE
fix: pass roast/S32-io/io-spec-qnx.t (canonpath :parent, is-absolute)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -873,6 +873,7 @@ roast/S32-io/io-path-subclasses.t
 roast/S32-io/io-path-symlink.t
 roast/S32-io/io-path-unix.t
 roast/S32-io/io-path-win.t
+roast/S32-io/io-spec-qnx.t
 roast/S32-io/io-special.t
 roast/S32-io/mkdir_rmdir.t
 roast/S32-io/move.t

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -368,16 +368,50 @@ impl Interpreter {
                 let is_win32 = cn == "IO::Spec::Win32";
                 match method {
                     "canonpath" => {
+                        // Separate positional and named args (e.g. `:parent`).
+                        let mut positional: Vec<&Value> = Vec::new();
+                        let mut parent = false;
+                        for a in &args {
+                            if let Value::Pair(k, v) = a {
+                                if k == "parent" {
+                                    parent = v.truthy();
+                                }
+                            } else {
+                                positional.push(a);
+                            }
+                        }
+                        let first = positional.first().copied();
+                        // Undefined invocant (Any / Nil / type object) -> ''
+                        let is_undef =
+                            matches!(first, None | Some(Value::Nil) | Some(Value::Package(_)));
+                        if is_undef {
+                            return Ok(Value::str_from(""));
+                        }
+                        let path = first.map(|v| v.to_string_value()).unwrap_or_default();
+                        let cleaned = if is_win32 {
+                            Self::cleanup_io_path_lexical_win32(&path)
+                        } else {
+                            Self::canonpath_unix(&path, parent)
+                        };
+                        return Ok(Value::str(cleaned));
+                    }
+                    "is-absolute" => {
                         let path = args
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
-                        let cleaned = if is_win32 {
-                            Self::cleanup_io_path_lexical_win32(&path)
+                        let abs = if is_win32 {
+                            // Drive-letter, UNC, or leading slash/backslash.
+                            let bytes = path.as_bytes();
+                            (bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic())
+                                || path.starts_with('/')
+                                || path.starts_with('\\')
                         } else {
-                            Self::cleanup_io_path_lexical(&path)
+                            // Unix: starts with '/'. Use chars().next() so that a
+                            // leading '/' followed by combining marks still counts.
+                            path.starts_with('/')
                         };
-                        return Ok(Value::str(cleaned));
+                        return Ok(Value::Bool(abs));
                     }
                     "dir-sep" => {
                         return Ok(Value::str_from(if is_win32 { "\\" } else { "/" }));

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1158,6 +1158,76 @@ impl Interpreter {
         basename.chars().filter(|&c| c == '.').count() as i64
     }
 
+    /// Strict Unix `IO::Spec::Unix.canonpath` implementation used by
+    /// `IO::Spec::Unix` / `IO::Spec::QNX` etc. When `parent` is true, `..`
+    /// segments are resolved lexically. Returns `''` for empty input.
+    /// Preserves a leading `//` (POSIX implementation-defined) but collapses
+    /// three or more leading slashes to a single `/`.
+    pub fn canonpath_unix(path: &str, parent: bool) -> String {
+        if path.is_empty() {
+            return String::new();
+        }
+        let bytes = path.as_bytes();
+        let mut leading = 0usize;
+        while leading < bytes.len() && bytes[leading] == b'/' {
+            leading += 1;
+        }
+        let prefix = if leading == 0 {
+            ""
+        } else if leading == 2 {
+            "//"
+        } else {
+            "/"
+        };
+        let is_absolute = leading > 0;
+        let rest = &path[leading..];
+        let segments: Vec<&str> = rest
+            .split('/')
+            .filter(|s| !s.is_empty() && *s != ".")
+            .collect();
+        // For "//"-prefixed paths, do not collapse leading `..` — POSIX leaves
+        // `//` implementation-defined and Rakudo's IO::Spec::Unix preserves it.
+        let collapse_leading_dotdot = is_absolute && prefix == "/";
+        let mut stack: Vec<&str> = Vec::new();
+        if parent {
+            for seg in segments {
+                if seg == ".." {
+                    if let Some(top) = stack.last() {
+                        if *top == ".." {
+                            stack.push(seg);
+                        } else {
+                            stack.pop();
+                        }
+                    } else if collapse_leading_dotdot {
+                        // can't go above root, drop
+                    } else {
+                        stack.push(seg);
+                    }
+                } else {
+                    stack.push(seg);
+                }
+            }
+        } else {
+            for seg in segments {
+                if seg == ".." && collapse_leading_dotdot && stack.is_empty() {
+                    continue;
+                }
+                stack.push(seg);
+            }
+        }
+        let joined = stack.join("/");
+        let mut out = String::new();
+        out.push_str(prefix);
+        if !joined.is_empty() {
+            out.push_str(&joined);
+        }
+        if out.is_empty() {
+            // Non-empty input that reduced to nothing (e.g. "foo/.." with :parent)
+            return ".".to_string();
+        }
+        out
+    }
+
     pub fn cleanup_io_path_lexical(path: &str) -> String {
         if path.is_empty() {
             return ".".to_string();


### PR DESCRIPTION
## Summary
- Add a strict Unix `canonpath` implementation for `IO::Spec::{Unix,QNX,Cygwin}` supporting the `:parent` adverb (lexical resolution of `..`).
- Preserve a leading `//` (POSIX implementation-defined) and collapse 3+ leading slashes to a single `/`.
- Return `''` for an undefined or empty invocant (e.g. `Any`).
- Implement `IO::Spec::*.is-absolute` for Unix and Win32 backends.
- Whitelist `roast/S32-io/io-spec-qnx.t` (29/29 passing).

## Test plan
- [x] `prove -e ./target/debug/mutsu roast/S32-io/io-spec-qnx.t` -> all 29 pass
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test`