### PR TITLE
fix: propagate imported operator sub metadata to parser

### DIFF
--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -983,8 +983,15 @@ pub(crate) fn is_imported_function(name: &str) -> bool {
 /// For `Test`, uses a hardcoded list (Test functions are implemented natively in Rust).
 /// For all other modules, dynamically scans the module file to extract `is export` subs.
 pub(in crate::parser) fn register_module_exports(module: &str) {
-    let exports: Vec<String> = if module == "Test" {
-        TEST_EXPORTS.iter().map(|s| (*s).to_string()).collect()
+    let exports: Vec<InlineModuleExport> = if module == "Test" {
+        TEST_EXPORTS
+            .iter()
+            .map(|s| InlineModuleExport {
+                name: (*s).to_string(),
+                precedence: None,
+                associativity: None,
+            })
+            .collect()
     } else {
         // Check for infinite recursion
         let already_loading = LOADING_MODULES.with(|m| m.borrow().contains(module));
@@ -1003,15 +1010,37 @@ pub(in crate::parser) fn register_module_exports(module: &str) {
     if exports.is_empty() {
         return;
     }
+    for export in &exports {
+        // Register operator subs into user_subs so that the parser's
+        // prefix/infix/postfix/circumfix matchers pick them up.
+        if is_operator_sub_name(&export.name) {
+            register_user_sub(&export.name);
+            register_user_callable_term_symbol(&export.name);
+            if let Some(prec) = export.precedence {
+                register_op_precedence(&export.name, prec);
+            }
+            if let Some(assoc) = export.associativity.as_deref() {
+                register_user_infix_assoc(&export.name, assoc);
+            }
+        }
+    }
     SCOPES.with(|s| {
         let mut scopes = s.borrow_mut();
         let current = scopes
             .last_mut()
             .expect("scope stack should never be empty");
-        for name in &exports {
-            current.imported_functions.insert(name.clone());
+        for export in &exports {
+            current.imported_functions.insert(export.name.clone());
         }
     });
+}
+
+fn is_operator_sub_name(name: &str) -> bool {
+    name.starts_with("infix:<")
+        || name.starts_with("prefix:<")
+        || name.starts_with("postfix:<")
+        || name.starts_with("circumfix:<")
+        || name.starts_with("postcircumfix:<")
 }
 
 /// Record exported subs from an inline `module Name { ... }` block.
@@ -1074,7 +1103,7 @@ pub(in crate::parser) fn import_inline_module_exports(module: &str) {
 }
 
 /// Find a module file and extract its exported function names.
-fn find_and_extract_exports(module: &str) -> Vec<String> {
+fn find_and_extract_exports(module: &str) -> Vec<InlineModuleExport> {
     let path = find_module_file(module);
     match path {
         Some(p) => {
@@ -1133,7 +1162,7 @@ fn find_module_file(module: &str) -> Option<String> {
 
 /// Parse module source and extract names of `is export` sub/proto declarations.
 /// Saves and restores the parser's scope state to avoid clobbering the caller's scopes.
-fn extract_exported_names(source: &str) -> Vec<String> {
+fn extract_exported_names(source: &str) -> Vec<InlineModuleExport> {
     // Save current scopes — parse_program_partial calls reset_user_subs which clears them
     let saved_scopes = SCOPES.with(|s| s.borrow().clone());
     // Save the language version — parsing the module may change it via `use v6.*`
@@ -1144,13 +1173,15 @@ fn extract_exported_names(source: &str) -> Vec<String> {
         *s.borrow_mut() = saved_scopes;
     });
     set_current_language_version(&saved_language_version);
-    let mut names = HashSet::new();
+    let mut exports: HashMap<String, InlineModuleExport> = HashMap::new();
     for stmt in &stmts {
         match stmt {
             Stmt::SubDecl {
                 name,
                 is_export,
                 export_tags,
+                associativity,
+                precedence_trait,
                 ..
             } if *is_export => {
                 // Only include subs that are in the DEFAULT or MANDATORY export tags.
@@ -1160,7 +1191,22 @@ fn extract_exported_names(source: &str) -> Vec<String> {
                     .iter()
                     .any(|t| t == "DEFAULT" || t == "MANDATORY")
                 {
-                    names.insert(name.resolve());
+                    let precedence = precedence_trait.as_ref().and_then(|(trait_name, ref_op)| {
+                        resolve_op_precedence(ref_op).map(|ref_level| match trait_name.as_str() {
+                            "tighter" => ref_level + 5,
+                            "looser" => ref_level - 5,
+                            _ => ref_level,
+                        })
+                    });
+                    let resolved = name.resolve();
+                    exports.insert(
+                        resolved.clone(),
+                        InlineModuleExport {
+                            name: resolved,
+                            precedence,
+                            associativity: associativity.clone(),
+                        },
+                    );
                 }
             }
             Stmt::ProtoDecl {
@@ -1168,7 +1214,14 @@ fn extract_exported_names(source: &str) -> Vec<String> {
             } if *is_export => {
                 // ProtoDecl doesn't carry export_tags; proto declarations with
                 // `is export` default to DEFAULT so always include them.
-                names.insert(name.resolve());
+                let resolved = name.resolve();
+                exports
+                    .entry(resolved.clone())
+                    .or_insert(InlineModuleExport {
+                        name: resolved,
+                        precedence: None,
+                        associativity: None,
+                    });
             }
             _ => {}
         }
@@ -1176,12 +1229,16 @@ fn extract_exported_names(source: &str) -> Vec<String> {
     // Fallback scan for modules that use syntax not yet fully covered by parse_program_partial.
     // This keeps imported exported-callables discoverable for statement-call parsing.
     for name in extract_exported_names_fallback(source) {
-        names.insert(name);
+        exports.entry(name.clone()).or_insert(InlineModuleExport {
+            name,
+            precedence: None,
+            associativity: None,
+        });
     }
 
-    let mut names: Vec<String> = names.into_iter().collect();
-    names.sort();
-    names
+    let mut result: Vec<InlineModuleExport> = exports.into_values().collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    result
 }
 
 fn extract_exported_names_fallback(source: &str) -> Vec<String> {
@@ -1350,7 +1407,8 @@ sub get_out(Str $code, :@compiler-args) is export { }
 proto doesn't-hang(|) is export {*}
 sub helper() { }
 "#;
-        let names = extract_exported_names(source);
+        let exports = extract_exported_names(source);
+        let names: Vec<String> = exports.iter().map(|e| e.name.clone()).collect();
         assert!(names.contains(&"is_run".to_string()));
         assert!(names.contains(&"get_out".to_string()));
         assert!(names.contains(&"doesn't-hang".to_string()));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -698,6 +698,11 @@ pub struct Interpreter {
     /// Functions declared with `our` scope that should persist across block boundaries.
     our_scoped_functions: HashMap<Symbol, FunctionDef>,
     operator_assoc: HashMap<String, String>,
+    /// Operator sub names (infix:<..>, prefix:<..>, etc.) that have been
+    /// imported into the current lexical scope via `use Module`. Used to
+    /// preseed the parser when EVAL is called so that imported operators
+    /// remain visible, but non-exported operators from loaded modules do not.
+    pub(crate) imported_operator_names: HashSet<String>,
     proto_functions: HashMap<Symbol, FunctionDef>,
     token_defs: HashMap<Symbol, Vec<FunctionDef>>,
     lib_paths: Vec<String>,
@@ -2457,6 +2462,7 @@ impl Interpreter {
             functions: HashMap::new(),
             our_scoped_functions: HashMap::new(),
             operator_assoc: HashMap::new(),
+            imported_operator_names: HashSet::new(),
             proto_functions: HashMap::new(),
             token_defs: HashMap::new(),
             lib_paths: Vec::new(),
@@ -4095,6 +4101,7 @@ impl Interpreter {
             functions: self.functions.clone(),
             our_scoped_functions: self.our_scoped_functions.clone(),
             operator_assoc: self.operator_assoc.clone(),
+            imported_operator_names: self.imported_operator_names.clone(),
             proto_functions: self.proto_functions.clone(),
             token_defs: self.token_defs.clone(),
             lib_paths: self.lib_paths.clone(),

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -977,6 +977,39 @@ impl Interpreter {
 
     /// Parse a module source file, using the precompilation cache when available.
     /// Returns (stmts, was_precompiled).
+    /// Extract operator sub names (infix:<..>, prefix:<..>, etc.) that a
+    /// module exports with `is export` (DEFAULT or MANDATORY tag). Used by
+    /// `load_module` to populate `imported_operator_names` so EVAL can see
+    /// operators from imported modules without seeing non-exported subs.
+    fn extract_module_exported_operator_names(source: &str) -> Vec<String> {
+        let (stmts, _) = crate::parser::parse_program_partial(source);
+        let mut out = Vec::new();
+        for stmt in &stmts {
+            if let crate::ast::Stmt::SubDecl {
+                name,
+                is_export,
+                export_tags,
+                ..
+            } = stmt
+                && *is_export
+                && export_tags
+                    .iter()
+                    .any(|t| t == "DEFAULT" || t == "MANDATORY")
+            {
+                let n = name.resolve();
+                if n.starts_with("infix:<")
+                    || n.starts_with("prefix:<")
+                    || n.starts_with("postfix:<")
+                    || n.starts_with("circumfix:<")
+                    || n.starts_with("postcircumfix:<")
+                {
+                    out.push(n);
+                }
+            }
+        }
+        out
+    }
+
     pub(super) fn parse_module_source(
         &mut self,
         module: &str,
@@ -1023,6 +1056,12 @@ impl Interpreter {
         let source_path = self
             .resolve_module_path(module)
             .ok_or_else(|| RuntimeError::new(format!("Module not found: {}", module)))?;
+        // Track operator subs exported by this module so EVAL can see them.
+        if let Ok(source) = fs::read_to_string(&source_path) {
+            for name in Self::extract_module_exported_operator_names(&source) {
+                self.imported_operator_names.insert(name);
+            }
+        }
         // Save and restore the language version around module loading.
         // Each module may set its own `use v6.*` which should not leak
         // into the caller's language version.

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -492,25 +492,33 @@ impl Interpreter {
     /// to recognize their delimiter syntax. Other operator categories (prefix, postfix,
     /// infix, term) work through runtime dispatch without parser pre-registration.
     pub(crate) fn collect_operator_sub_names(&self) -> Vec<String> {
-        let mut names = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Include circumfix/postcircumfix operators defined in any loaded
+        // module so EVAL parser can still recognize their delimiter syntax.
         for key in self.functions.keys() {
             let key_s = key.resolve();
-            // Strip package prefix if present (e.g. "GLOBAL::circumfix:<⌊ ⌋>")
             let name = if let Some(pos) = key_s.rfind("::") {
                 &key_s[pos + 2..]
             } else {
                 key_s.as_str()
             };
             if name.starts_with("circumfix:") || name.starts_with("postcircumfix:") {
-                names.push(name.to_string());
+                seen.insert(name.to_string());
             }
         }
-        // Also check env for operator subs stored as variables
         for key in self.env.keys() {
             if key.starts_with("circumfix:") || key.starts_with("postcircumfix:") {
-                names.push(key.clone());
+                seen.insert(key.clone());
             }
         }
+        // Also include operators imported via `use Module` at runtime. This
+        // captures prefix/infix/postfix operators declared with `is export`
+        // in loaded modules, without exposing non-exported subs.
+        for name in &self.imported_operator_names {
+            seen.insert(name.clone());
+        }
+        let mut names: Vec<String> = seen.into_iter().collect();
+        names.sort();
         names
     }
 


### PR DESCRIPTION
## Summary
- Register operator subs (`prefix:<..>`, `infix:<..>`, `postfix:<..>`, circumfix, postcircumfix) imported via `use Module` into the parser's `user_subs`, including their precedence trait and associativity
- Track exported operator names on the runtime `Interpreter` so `EVAL` sees imported operators without exposing non-exported subs from any loaded module
- Raises roast/S06-operator-overloading/imported-subs.t from 5 to 16 / 20 passing subtests (remaining 4 need parse-time X::Syntax::Confused + lexical hiding across scopes)

## Test plan
- [x] `make test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt`
- [ ] CI runs `make test` and `make roast`