### PR TITLE
fix: support IO handles opened in promise threads and IO::Pipe.get

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -690,6 +690,7 @@ roast/S16-io/bare-say.t
 roast/S16-io/basic-open.t
 roast/S16-io/bom.t
 roast/S16-io/cwd.t
+roast/S16-io/handles-between-threads.t
 roast/S16-io/home.t
 roast/S16-io/newline.t
 roast/S16-io/note.t

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -31,6 +31,23 @@ pub(super) fn finalized_proc_map() -> &'static FinalizedProcMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
+/// Per-pipe buffered-read state for IO::Pipe instances returned by
+/// `shell(..., :out)` / `run(..., :out)`. Keyed by the `pipe-id` attribute
+/// on the IO::Pipe instance so that repeated method calls on the same
+/// logical pipe share cursor state even after the instance value is cloned.
+pub(crate) struct IoPipeState {
+    pub(crate) content: String,
+    pub(crate) cursor: usize,
+    pub(crate) closed: bool,
+}
+
+type IoPipeStateMap = std::sync::Mutex<HashMap<i64, IoPipeState>>;
+
+pub(crate) fn io_pipe_state_map() -> &'static IoPipeStateMap {
+    static MAP: OnceLock<IoPipeStateMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
 /// Options extracted from named arguments for run/shell.
 struct ProcOptions {
     cwd: Option<String>,
@@ -48,10 +65,32 @@ impl Interpreter {
         let promise = SharedPromise::new_with_class(class_name);
         let ret = Value::Promise(promise.clone());
         let thread_interp = self.clone_for_thread();
+        let parent_handles_snapshot: std::collections::HashSet<usize> =
+            self.handles.keys().copied().collect();
 
         std::thread::spawn(move || {
             let vm = crate::vm::VM::new(thread_interp);
             let (mut thread_interp, result) = vm.call_value(block, vec![]);
+            // Transfer any handles opened by this thread back to the awaiter.
+            let mut new_handles: Vec<(usize, IoHandleState)> = Vec::new();
+            let new_ids: Vec<usize> = thread_interp
+                .handles
+                .keys()
+                .copied()
+                .filter(|id| !parent_handles_snapshot.contains(id))
+                .collect();
+            for id in new_ids {
+                if let Some(state) = thread_interp.handles.remove(&id) {
+                    new_handles.push((id, state));
+                }
+            }
+            let next_id = thread_interp.next_handle_id;
+            if !new_handles.is_empty() {
+                promise.set_thread_payload(Box::new(ThreadPromisePayload {
+                    new_handles,
+                    next_handle_id: next_id,
+                }));
+            }
             match result {
                 Ok(result) => {
                     let output = std::mem::take(&mut thread_interp.output);
@@ -542,10 +581,26 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Proc"), attrs)
     }
 
-    /// Create an IO::Pipe instance wrapping captured content.
+    /// Create an IO::Pipe instance wrapping captured content. Allocates
+    /// a persistent cursor id so repeated `.get` calls on the same pipe
+    /// advance through the buffered content.
     pub(super) fn make_io_pipe(content: String) -> Value {
+        use std::sync::atomic::{AtomicI64, Ordering};
+        static NEXT_PIPE_ID: AtomicI64 = AtomicI64::new(1);
+        let id = NEXT_PIPE_ID.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut map) = io_pipe_state_map().lock() {
+            map.insert(
+                id,
+                IoPipeState {
+                    content: content.clone(),
+                    cursor: 0,
+                    closed: false,
+                },
+            );
+        }
         let mut attrs = HashMap::new();
         attrs.insert("content".to_string(), Value::str(content));
+        attrs.insert("pipe-id".to_string(), Value::Int(id));
         Value::make_instance(Symbol::intern("IO::Pipe"), attrs)
     }
 
@@ -1208,6 +1263,20 @@ impl Interpreter {
                     let (result, output, stderr) = shared.wait();
                     self.emit_output(&output);
                     self.stderr_output.push_str(&stderr);
+                    if let Some(payload) = shared.take_thread_payload()
+                        && let Ok(payload) = payload.downcast::<ThreadPromisePayload>()
+                    {
+                        let ThreadPromisePayload {
+                            new_handles,
+                            next_handle_id,
+                        } = *payload;
+                        for (id, state) in new_handles {
+                            self.handles.entry(id).or_insert(state);
+                        }
+                        if next_handle_id > self.next_handle_id {
+                            self.next_handle_id = next_handle_id;
+                        }
+                    }
                     if shared.status() == "Broken" {
                         self.sync_shared_vars_to_env();
                         let msg = result.to_string_value();

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -317,6 +317,24 @@ impl Interpreter {
     }
 
     pub(crate) fn is_native_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        // IO::Pipe has native methods handled by native_io_pipe
+        if class_name == "IO::Pipe"
+            && matches!(
+                method_name,
+                "slurp"
+                    | "Str"
+                    | "gist"
+                    | "encoding"
+                    | "close"
+                    | "split"
+                    | "print"
+                    | "get"
+                    | "lines"
+                    | "eof"
+            )
+        {
+            return true;
+        }
         // IO::Special has native methods handled by native_io_special
         if class_name == "IO::Special"
             && matches!(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -458,8 +458,16 @@ impl SocketListener {
     }
 }
 
+/// Opaque payload attached to a `SharedPromise` so that a worker thread
+/// can hand newly-opened IO handles back to the awaiting interpreter.
 #[derive(Debug)]
-struct IoHandleState {
+pub(crate) struct ThreadPromisePayload {
+    pub(crate) new_handles: Vec<(usize, IoHandleState)>,
+    pub(crate) next_handle_id: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct IoHandleState {
     target: IoHandleTarget,
     mode: IoHandleMode,
     path: Option<String>,

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2263,6 +2263,73 @@ impl Interpreter {
                 _ => {}
             }
         }
+        // Look up persistent per-pipe cursor state (if any). Repeated calls
+        // on the same logical IO::Pipe share this so `.get` / `.lines` can
+        // advance through buffered content line by line.
+        let pipe_id = attributes.get("pipe-id").and_then(|v| {
+            if let Value::Int(i) = v {
+                Some(*i)
+            } else {
+                None
+            }
+        });
+        if let Some(id) = pipe_id {
+            match method {
+                "get" => {
+                    if let Ok(mut map) = super::builtins_system::io_pipe_state_map().lock()
+                        && let Some(state) = map.get_mut(&id)
+                    {
+                        if state.closed {
+                            return Err(RuntimeError::io_closed("get"));
+                        }
+                        if state.cursor >= state.content.len() {
+                            return Ok(Value::Nil);
+                        }
+                        let rest = &state.content[state.cursor..];
+                        let (line, advance) = if let Some(pos) = rest.find('\n') {
+                            let line = rest[..pos].trim_end_matches('\r').to_string();
+                            (line, pos + 1)
+                        } else {
+                            (rest.to_string(), rest.len())
+                        };
+                        state.cursor += advance;
+                        return Ok(Value::str(line));
+                    }
+                    return Ok(Value::Nil);
+                }
+                "lines" => {
+                    if let Ok(mut map) = super::builtins_system::io_pipe_state_map().lock()
+                        && let Some(state) = map.get_mut(&id)
+                    {
+                        if state.closed {
+                            return Err(RuntimeError::io_closed("lines"));
+                        }
+                        let rest = state.content[state.cursor..].to_string();
+                        state.cursor = state.content.len();
+                        let trimmed = rest.strip_suffix('\n').unwrap_or(&rest);
+                        let lines: Vec<Value> = if trimmed.is_empty() {
+                            Vec::new()
+                        } else {
+                            trimmed
+                                .split('\n')
+                                .map(|s| Value::str(s.trim_end_matches('\r').to_string()))
+                                .collect()
+                        };
+                        return Ok(Value::array(lines));
+                    }
+                    return Ok(Value::array(vec![]));
+                }
+                "eof" => {
+                    if let Ok(map) = super::builtins_system::io_pipe_state_map().lock()
+                        && let Some(state) = map.get(&id)
+                    {
+                        return Ok(Value::Bool(state.cursor >= state.content.len()));
+                    }
+                    return Ok(Value::Bool(true));
+                }
+                _ => {}
+            }
+        }
         let content = attributes
             .get("content")
             .map(|v| v.to_string_value())
@@ -2271,6 +2338,12 @@ impl Interpreter {
             "slurp" | "Str" | "gist" => Ok(Value::str(content)),
             "encoding" => Ok(Value::str("utf8".to_string())),
             "close" => {
+                if let Some(id) = pipe_id
+                    && let Ok(mut map) = super::builtins_system::io_pipe_state_map().lock()
+                    && let Some(state) = map.get_mut(&id)
+                {
+                    state.closed = true;
+                }
                 // TODO: should return the parent Proc object for identity
                 Ok(Value::Bool(true))
             }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -838,13 +838,28 @@ impl Clone for LazyThunkData {
 
 // --- SharedPromise: thread-safe promise state ---
 
-#[derive(Debug)]
 struct PromiseState {
     status: String, // "Planned", "Kept", "Broken"
     result: Value,
     output: String, // captured stdout from thread
     stderr_output: String,
     class_name: Symbol, // "Promise" or subclass name
+    /// Opaque payload transferred from the worker thread to the awaiting
+    /// thread. Used e.g. to hand off newly-opened IO handle state that
+    /// lives inside the per-thread Interpreter.
+    thread_payload: Option<Box<dyn std::any::Any + Send>>,
+}
+
+impl std::fmt::Debug for PromiseState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PromiseState")
+            .field("status", &self.status)
+            .field("result", &self.result)
+            .field("output", &self.output)
+            .field("stderr_output", &self.stderr_output)
+            .field("class_name", &self.class_name)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -871,6 +886,7 @@ impl SharedPromise {
                     output: String::new(),
                     stderr_output: String::new(),
                     class_name,
+                    thread_payload: None,
                 }),
                 Condvar::new(),
             )),
@@ -887,6 +903,7 @@ impl SharedPromise {
                     output: String::new(),
                     stderr_output: String::new(),
                     class_name: Symbol::intern("Promise"),
+                    thread_payload: None,
                 }),
                 Condvar::new(),
             )),
@@ -900,6 +917,21 @@ impl SharedPromise {
 
     pub(crate) fn id(&self) -> usize {
         Arc::as_ptr(&self.inner) as usize
+    }
+
+    /// Store an opaque payload to be handed off to whoever awaits the
+    /// promise. Must be called before `keep`/`break_with` so the awaiter
+    /// can observe it via `take_thread_payload`.
+    pub(crate) fn set_thread_payload(&self, payload: Box<dyn std::any::Any + Send>) {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.thread_payload = Some(payload);
+    }
+
+    pub(crate) fn take_thread_payload(&self) -> Option<Box<dyn std::any::Any + Send>> {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.thread_payload.take()
     }
 
     pub(crate) fn keep(&self, result: Value, output: String, stderr: String) {


### PR DESCRIPTION
## Summary
- Transfer newly-opened IO handles from Promise worker threads back to the awaiting interpreter via an opaque `SharedPromise` thread payload, so `await start { open(...) }` produces a usable handle in the main thread.
- Give `IO::Pipe` a persistent per-pipe cursor (global state map keyed by a `pipe-id` attribute) and implement `.get`, `.lines`, `.eof`, and cursor-aware `.close`. Register these in `is_native_method`.
- Whitelist `roast/S16-io/handles-between-threads.t` (all 8 subtests now pass).

## Test plan
- [x] `target/debug/mutsu roast/S16-io/handles-between-threads.t` — 1..8 all ok
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)