### PR TITLE
defer: add S05-mass/recursive.t to too_difficult.txt

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -35,6 +35,16 @@
 - [x] roast/S05-mass/properties-script.t
   - 360/360 pass.
 - [ ] roast/S05-mass/recursive.t
+  - Blocker: needs semantic distinction between `|` (LTM) and `||` (ordered
+    alternation). mutsu currently collapses both to a single `Alternation`
+    variant and picks longest-match via LIFO stack ordering, so `<?> || x <&r>`
+    prefers the longer `x <&r>` branch instead of committing to the zero-width
+    first alternative. Fixing requires a new `OrderedAlternation` atom plumbed
+    through regex_parse, regex_match_atom, regex_match_atom_simple,
+    regex_match_capture, regex_helpers, and methods_grammar.
+  - Additional blocker: tests 17-20 use a left-recursive regex
+    `regex r2 { <?> | <&r2> x }` which causes a stack overflow. Requires
+    left-recursion detection/seeding in the backtracking engine.
 - [ ] roast/S05-mass/rx.t
 - [ ] roast/S05-mass/stdrules.t
 - [ ] roast/S05-match/arrayhash.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,6 +1,7 @@
 roast/S02-types/generics.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
+roast/S05-mass/recursive.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
 roast/S32-array/perl.t


### PR DESCRIPTION
## Summary
- Adds roast/S05-mass/recursive.t to too_difficult.txt with documented blockers.
- Notes the two blockers in TODO_roast/S05.md: (1) mutsu currently collapses `|` (LTM) and `||` (ordered alternation) into a single Alternation variant and picks the longest match via LIFO stack ordering, so `<?> || x <&r>` prefers the longer `x <&r>` alternative instead of the zero-width first branch (fails tests 6-8); (2) tests 17-20 use a left-recursive regex (`regex r2 { <?> | <&r2> x }`) which overflows the stack in the backtracking engine.

## Test plan
- [x] raku roast/S05-mass/recursive.t passes on rakudo (expected behavior confirmed)
- [x] too_difficult.txt remains sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)