### PR TITLE
defer: S11-modules/versioning.t (Raku language version pragmas)

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -2,6 +2,7 @@ roast/S02-types/generics.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-mass/recursive.t
+roast/S11-modules/versioning.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
 roast/S32-array/perl.t


### PR DESCRIPTION
## Summary
- Add roast/S11-modules/versioning.t to too_difficult.txt.

This test exercises Raku language version pragmas (use v6.c, use v6.d, use v6.e.PREVIEW) combined with version-specific core revisions, the CORE-SETTING-REV constant, BEGIN \$*RAKU.version, and version-specific module loading (Module_6c/d/e). Passing it requires implementing the full Raku language-version dispatch system, which is well beyond the scope of a single fix. Currently 0/9 subtests pass in mutsu.

## Test plan
- [x] raku roast/S11-modules/versioning.t passes 9/9
- [x] mutsu fails all 9 subtests with current architecture