### PR TITLE
defer: S02-types/multi_dimensional_array.t (raku blocker)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -217,6 +217,7 @@
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/multi_dimensional_array.t
   - 0/? pass. Parse error at line 15
+  - Deferred: raku itself fails with "Jagged array shapes not yet implemented" at line 35, so the test cannot pass even on Rakudo. Added to too_difficult.txt.
 - [ ] roast/S02-types/mu.t
   - 0/? pass. Parse error at line 9
 - [x] roast/S02-types/nan.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,4 +1,5 @@
 roast/S02-types/generics.t
+roast/S02-types/multi_dimensional_array.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-mass/recursive.t


### PR DESCRIPTION
## Summary
- Raku itself fails roast/S02-types/multi_dimensional_array.t with "Jagged array shapes not yet implemented" at line 35, so the test cannot pass even on Rakudo.
- Add the file to too_difficult.txt and note the blocker in TODO_roast/S02.md.

## Test plan
- [x] Confirmed raku fails: ran ``raku roast/S02-types/multi_dimensional_array.t`` and it dies at line 35.