### PR TITLE
defer: add S17-supply/migrate.t to too_difficult.txt

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -90,6 +90,7 @@
 - [ ] roast/S17-supply/max.t
 - [ ] roast/S17-supply/merge.t
 - [ ] roast/S17-supply/migrate.t
+  - Blocker: `Supply.migrate` is not implemented. Needs a derived live Supply that taps a stream of inner Supplies, dynamically untaps the previous inner tap whenever a new inner Supply arrives, forwards inner emits downstream, handles inner-done by waiting for next inner, and throws `X::Supply::Migrate::Needs` when an emit arrives while the previous inner is still active. This requires extending the `supplier_id` event registry with a new "migrate" tap state machine and typed exception emission. Added to `too_difficult.txt`.
 - [ ] roast/S17-supply/minmax.t
 - [ ] roast/S17-supply/min.t
 - [ ] roast/S17-supply/on-demand.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -5,4 +5,5 @@ roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
+roast/S17-supply/migrate.t
 roast/S32-array/perl.t


### PR DESCRIPTION
## Summary
- `Supply.migrate` is not implemented; the test needs a switching live-Supply combinator and `X::Supply::Migrate::Needs` typed exception emission.
- Defer the test by adding it to `too_difficult.txt` and recording the blocker in `TODO_roast/S17.md`.

## Test plan
- [x] `raku roast/S17-supply/migrate.t` passes (confirms it is a real spec test, not a raku bug).
- [x] `LC_ALL=C sort -c too_difficult.txt` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)