### PR TITLE
fix: support named pair destructuring in signature bind

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -417,6 +417,7 @@ roast/S06-other/main-eval.t
 roast/S06-other/main-semicolon.t
 roast/S06-other/main-usage.t
 roast/S06-other/misc.t
+roast/S06-other/pairs-as-lvalues.t
 roast/S06-parameters/smiley.t
 roast/S06-routine-modifiers/lvalue-subroutines.t
 roast/S06-routine-modifiers/native-lvalue-subroutines.t

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -73,7 +73,17 @@ fn is_literal_expr(expr: &Expr) -> bool {
 /// Returns None if the expression is not a Signature literal.
 /// Returns Some(Vec<String>) where each string is either a variable name (e.g., "f")
 /// or empty string for anonymous params.
-fn extract_signature_param_names(expr: &Expr) -> Option<Vec<String>> {
+#[derive(Debug, Clone)]
+struct SigParamInfo {
+    /// Sigiled variable name (e.g. "$t", "@a") or empty if anonymous.
+    sigiled_name: String,
+    /// True if this is a named parameter.
+    is_named: bool,
+    /// Named keys (e.g. ["type"]) for named parameters; empty otherwise.
+    named_keys: Vec<String>,
+}
+
+fn extract_signature_param_infos(expr: &Expr) -> Option<Vec<SigParamInfo>> {
     let Expr::Literal(Value::Instance {
         class_name,
         attributes,
@@ -89,24 +99,72 @@ fn extract_signature_param_names(expr: &Expr) -> Option<Vec<String>> {
     let Value::Array(param_list, ..) = params else {
         return None;
     };
-    let mut names = Vec::new();
+    let mut infos = Vec::new();
     for param in param_list.iter() {
         let Value::Instance { attributes, .. } = param else {
-            names.push(String::new());
+            infos.push(SigParamInfo {
+                sigiled_name: String::new(),
+                is_named: false,
+                named_keys: Vec::new(),
+            });
             continue;
         };
-        if let Some(Value::Str(name)) = attributes.get("name") {
-            if name.is_empty() {
-                names.push(String::new());
-            } else {
-                // name has the sigil included, e.g. "$f" -> we need "f" for Stmt::Assign
-                names.push(name.to_string());
+        let sigiled_name = match attributes.get("name") {
+            Some(Value::Str(name)) => name.to_string(),
+            _ => String::new(),
+        };
+        let is_named = matches!(attributes.get("named"), Some(Value::Bool(true)));
+        let named_keys = match attributes.get("named_names") {
+            Some(Value::Array(arr, ..)) => arr
+                .iter()
+                .filter_map(|v| match v {
+                    Value::Str(s) => Some(s.to_string()),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+        infos.push(SigParamInfo {
+            sigiled_name,
+            is_named,
+            named_keys,
+        });
+    }
+    Some(infos)
+}
+
+/// If `rhs` is a static expression we can statically index by named key,
+/// extract a map from key → value-expression. Used to desugar
+/// `:(:type($t)) := (type => "foo")` into `$t := "foo"`.
+fn extract_static_named_map(rhs: &Expr) -> Option<std::collections::HashMap<String, Expr>> {
+    use std::collections::HashMap;
+    let items: &[Expr] = match rhs {
+        Expr::CaptureLiteral(items) => items,
+        Expr::ArrayLiteral(items) => items,
+        _ => return None,
+    };
+    let mut map = HashMap::new();
+    for item in items {
+        match item {
+            Expr::Binary {
+                left,
+                op: crate::token_kind::TokenKind::FatArrow,
+                right,
+            } => {
+                let key = match left.as_ref() {
+                    Expr::Literal(Value::Str(s)) => s.to_string(),
+                    Expr::BareWord(s) => s.clone(),
+                    _ => return None,
+                };
+                map.insert(key, (**right).clone());
             }
-        } else {
-            names.push(String::new());
+            Expr::Literal(Value::Pair(k, v)) => {
+                map.insert(k.to_string(), Expr::Literal((**v).clone()));
+            }
+            _ => return None,
         }
     }
-    Some(names)
+    Some(map)
 }
 
 fn is_pure_value_expr(expr: &Expr) -> bool {
@@ -952,9 +1010,9 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     if !matches!(expr, Expr::AssignExpr { .. })
         && (rest.starts_with(":=") || rest.starts_with("::="))
     {
-        // Signature binding: `:($f, $o, $) := @a`
-        // Extract variable names from the Signature literal and generate assignments.
-        if let Some(param_names) = extract_signature_param_names(&expr) {
+        // Signature binding: `:($f, $o, $) := @a` or `:(:type($t)) := (...)`
+        // Extract variable info from the Signature literal and generate assignments.
+        if let Some(param_infos) = extract_signature_param_infos(&expr) {
             let r = if let Some(stripped) = rest.strip_prefix("::=") {
                 stripped
             } else {
@@ -969,46 +1027,88 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 remaining_len: err.remaining_len.or(Some(r.len())),
                 exception: None,
             })?;
-            // Generate: $tmp = rhs; $f := $tmp[0]; $o := $tmp[1]; ...
+            // Try static lookup for named params: if rhs is a CaptureLiteral
+            // or comma-list of FatArrow pairs, we can bind each named param
+            // directly to its source expression (preserving identity).
+            let static_named = extract_static_named_map(&rhs);
+            let has_named = param_infos.iter().any(|p| p.is_named);
+            let mut stmts = Vec::new();
+            // Declare and assign the temp variable (used for positional params
+            // and for named params when no static map is available).
             let tmp_name = format!(
                 "__sig_bind_tmp_{}",
                 TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
             );
-            let mut stmts = Vec::new();
-            // Declare and assign the temp variable
-            stmts.push(Stmt::VarDecl {
-                name: tmp_name.clone(),
-                expr: rhs,
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: Vec::new(),
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            });
-            // For each named param, bind to the corresponding index
-            for (i, sigiled_name) in param_names.iter().enumerate() {
-                if sigiled_name.is_empty() {
-                    // Anonymous param ($) — skip binding
+            let need_tmp =
+                param_infos.iter().any(|p| !p.is_named) || (has_named && static_named.is_none());
+            if need_tmp {
+                stmts.push(Stmt::VarDecl {
+                    name: tmp_name.clone(),
+                    expr: rhs.clone(),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                });
+            } else {
+                // Still evaluate rhs for side effects.
+                stmts.push(Stmt::Expr(rhs.clone()));
+            }
+            let mut pos_index: usize = 0;
+            for info in param_infos.iter() {
+                if info.sigiled_name.is_empty() {
+                    if !info.is_named {
+                        pos_index += 1;
+                    }
                     continue;
                 }
-                let index_expr = Expr::Index {
-                    target: Box::new(Expr::Var(tmp_name.clone())),
-                    index: Box::new(Expr::Literal(Value::Int(i as i64))),
-                    is_positional: true,
-                };
-                // For Stmt::Assign, scalar vars ($x) use name "x" (no sigil),
-                // but array (@a) and hash (%h) vars keep the sigil.
-                let assign_name = if let Some(stripped) = sigiled_name.strip_prefix('$') {
+                let assign_name = if let Some(stripped) = info.sigiled_name.strip_prefix('$') {
                     stripped.to_string()
                 } else {
-                    sigiled_name.clone()
+                    info.sigiled_name.clone()
+                };
+                let value_expr = if info.is_named {
+                    // Find a key match in static_named, or fall back to .hash<key>
+                    let key = info
+                        .named_keys
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| assign_name.clone());
+                    if let Some(map) = static_named.as_ref() {
+                        match map.get(&key) {
+                            Some(e) => e.clone(),
+                            None => Expr::Literal(Value::Nil),
+                        }
+                    } else {
+                        // Runtime: $tmp.hash{key}
+                        Expr::Index {
+                            target: Box::new(Expr::MethodCall {
+                                target: Box::new(Expr::Var(tmp_name.clone())),
+                                name: Symbol::intern("hash"),
+                                args: Vec::new(),
+                                modifier: None,
+                                quoted: false,
+                            }),
+                            index: Box::new(Expr::Literal(Value::str(key))),
+                            is_positional: false,
+                        }
+                    }
+                } else {
+                    let i = pos_index;
+                    pos_index += 1;
+                    Expr::Index {
+                        target: Box::new(Expr::Var(tmp_name.clone())),
+                        index: Box::new(Expr::Literal(Value::Int(i as i64))),
+                        is_positional: true,
+                    }
                 };
                 stmts.push(Stmt::Assign {
                     name: assign_name,
-                    expr: index_expr,
+                    expr: value_expr,
                     op: crate::ast::AssignOp::Bind,
                 });
             }


### PR DESCRIPTION
## Summary
- Extend signature-bind desugar to handle named params (`:type($t)`) by binding to matching keys in the RHS.
- When RHS is a static `CaptureLiteral` or comma-list of `key => value` pairs, bind directly to value expressions (preserves `=:=` identity). Otherwise fall back to `.hash<key>` lookup.
- Whitelists `roast/S06-other/pairs-as-lvalues.t` (all 5 subtests pass).

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S06-other/pairs-as-lvalues.t` — 5/5 pass
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test`