### PR TITLE
chore: defer roast/S17-supply/categorize.t

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -6,5 +6,6 @@ roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
+roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t


### PR DESCRIPTION
## Summary
- Adds roast/S17-supply/categorize.t to too_difficult.txt
- The test requires a Supply/Supplier/Tap/Scheduler implementation that mutsu does not have. Even the leading dies-ok checks rely on Supply being a class with a categorize method.

## Test plan
- [x] LC_ALL=C sort -c too_difficult.txt