### PR TITLE
fix: pass roast/S11-modules/nested.t (nested module namespaces)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -491,6 +491,7 @@ roast/S11-modules/lexical.t
 roast/S11-modules/module-file.t
 roast/S11-modules/module.t
 roast/S11-modules/need.t
+roast/S11-modules/nested.t
 roast/S11-modules/rakulib.t
 roast/S11-modules/re-export.t
 roast/S11-modules/require.t

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -39,6 +39,11 @@ pub(crate) struct Compiler {
     local_types: HashMap<String, String>,
     compiled_functions: HashMap<String, CompiledFunction>,
     current_package: String,
+    /// True when compiling inside a `unit module`/`unit class`/`unit role`
+    /// body. Used to pre-qualify class/role declarations with the package
+    /// prefix at compile time, since the runtime does not get a
+    /// PackageScope opcode for unit declarations.
+    pub(crate) in_unit_package: bool,
     /// The enclosing package name before closure mangling. Used for `$?PACKAGE`
     /// so that methods inside a class report the class name, not the internal
     /// closure package name.
@@ -67,6 +72,7 @@ impl Compiler {
             local_types: HashMap::new(),
             compiled_functions: HashMap::new(),
             current_package: "GLOBAL".to_string(),
+            in_unit_package: false,
             enclosing_package: None,
             tmp_counter: 0,
             dynamic_scope_all: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2,6 +2,89 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Compiler {
+    /// Pre-qualify a class/role declaration's name with the compiler's
+    /// `current_package` when compiling inside a `unit module`/`unit class`/
+    /// `unit role` body. Bare names (no `::`) are rewritten to
+    /// `Pkg::Name`. Names that already contain `::` or are top-level
+    /// (current_package == "GLOBAL") are returned unchanged.
+    fn qualify_decl_name(&self, stmt: &Stmt) -> Stmt {
+        if !self.in_unit_package
+            || self.current_package == "GLOBAL"
+            || self.current_package.contains("::&")
+        {
+            return stmt.clone();
+        }
+        let bare = match stmt {
+            Stmt::ClassDecl { name, .. } | Stmt::RoleDecl { name, .. } => name.resolve(),
+            _ => return stmt.clone(),
+        };
+        if bare.contains("::") {
+            return stmt.clone();
+        }
+        let qualified = format!("{}::{}", self.current_package, bare);
+        let qualified_sym = Symbol::intern(&qualified);
+        let pkg = self.current_package.clone();
+        let qualify_parent = |p: &String| -> String {
+            if p.contains("::") || p.is_empty() {
+                p.clone()
+            } else {
+                format!("{}::{}", pkg, p)
+            }
+        };
+        match stmt {
+            Stmt::ClassDecl {
+                name_expr,
+                parents,
+                class_is_rw,
+                is_hidden,
+                is_lexical,
+                hidden_parents,
+                does_parents,
+                repr,
+                body,
+                language_version,
+                ..
+            } => {
+                let new_parents: Vec<String> = parents.iter().map(&qualify_parent).collect();
+                let new_does: Vec<String> = does_parents.iter().map(&qualify_parent).collect();
+                let new_hidden: Vec<String> = hidden_parents.iter().map(&qualify_parent).collect();
+                Stmt::ClassDecl {
+                    name: qualified_sym,
+                    name_expr: name_expr.clone(),
+                    parents: new_parents,
+                    class_is_rw: *class_is_rw,
+                    is_hidden: *is_hidden,
+                    is_lexical: *is_lexical,
+                    hidden_parents: new_hidden,
+                    does_parents: new_does,
+                    repr: repr.clone(),
+                    body: body.clone(),
+                    language_version: language_version.clone(),
+                }
+            }
+            Stmt::RoleDecl {
+                type_params,
+                type_param_defs,
+                is_export,
+                export_tags,
+                body,
+                is_rw,
+                language_version,
+                ..
+            } => Stmt::RoleDecl {
+                name: qualified_sym,
+                type_params: type_params.clone(),
+                type_param_defs: type_param_defs.clone(),
+                is_export: *is_export,
+                export_tags: export_tags.clone(),
+                body: body.clone(),
+                is_rw: *is_rw,
+                language_version: language_version.clone(),
+            },
+            _ => stmt.clone(),
+        }
+    }
+
     fn regex_match_returns_multiple(expr: &Expr) -> bool {
         let Expr::Binary { op, right, .. } = expr else {
             return false;
@@ -1404,6 +1487,7 @@ impl Compiler {
                 if *is_unit {
                     // unit module/package — set package for the rest of the scope
                     self.current_package = qualified_name.clone();
+                    self.in_unit_package = true;
                     // Register the package name so it's accessible as a value
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
                     self.code.emit(OpCode::RegisterPackage { name_idx });
@@ -1423,11 +1507,17 @@ impl Compiler {
                         body_end: 0,
                     });
                     let saved_package = self.current_package.clone();
+                    let saved_in_unit = self.in_unit_package;
                     self.current_package = qualified_name;
+                    // Inside a non-unit `module Foo { ... }` block, runtime
+                    // PackageScope handles the package context, so we must
+                    // not pre-qualify nested class/role decls here.
+                    self.in_unit_package = false;
                     for s in body {
                         self.compile_stmt(s);
                     }
                     self.current_package = saved_package;
+                    self.in_unit_package = saved_in_unit;
                     self.code.patch_body_end(pkg_idx);
                 }
             }
@@ -1748,7 +1838,12 @@ impl Compiler {
                 self.code.emit(OpCode::RegisterEnum(idx));
             }
             Stmt::ClassDecl { .. } => {
-                let idx = self.code.add_stmt(stmt.clone());
+                // Pre-qualify the class name when compiling inside a
+                // `unit module`/`unit class` body so that the runtime
+                // registers it under the correct nested package
+                // (e.g. `class D` inside `unit module A::B` → `A::B::D`).
+                let stmt = self.qualify_decl_name(stmt);
+                let idx = self.code.add_stmt(stmt);
                 self.code.emit(OpCode::RegisterClass(idx));
             }
             Stmt::AugmentClass { .. } => {
@@ -1756,7 +1851,8 @@ impl Compiler {
                 self.code.emit(OpCode::AugmentClass(idx));
             }
             Stmt::RoleDecl { .. } => {
-                let idx = self.code.add_stmt(stmt.clone());
+                let stmt = self.qualify_decl_name(stmt);
+                let idx = self.code.add_stmt(stmt);
                 self.code.emit(OpCode::RegisterRole(idx));
             }
             Stmt::SubsetDecl { .. } => {

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1566,6 +1566,26 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             },
         ));
     }
+    // unit role Name;  — declare a role at the file scope.
+    if let Some(r) = keyword("role", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, name) = qualified_ident(r)?;
+        let (r, _) = ws(r)?;
+        let (r, _) = opt_char(r, ';');
+        return Ok((
+            r,
+            Stmt::RoleDecl {
+                name: Symbol::intern(&name),
+                type_params: Vec::new(),
+                type_param_defs: Vec::new(),
+                is_export: false,
+                export_tags: Vec::new(),
+                body: Vec::new(),
+                is_rw: false,
+                language_version: super::simple::current_language_version(),
+            },
+        ));
+    }
     let rest = keyword("module", rest).ok_or_else(|| PError::expected("'module' after 'unit'"))?;
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -558,6 +558,27 @@ impl Interpreter {
         if let Some(Value::Package(pkg)) = self.env.get(lookup) {
             return format!("{}{}", pkg.resolve(), suffix);
         }
+        // Fallback: when a compile-time pre-qualified name like `M::C1` cannot
+        // be resolved (e.g. because `C1` lives outside module `M`), try the
+        // bare suffix (`C1`).  This handles cross-package parents in classes
+        // declared inside a `unit module`/`unit class` body.
+        if lookup.contains("::") {
+            let bare = lookup.rsplit_once("::").map(|(_, b)| b).unwrap_or(lookup);
+            if !self.classes.contains_key(lookup)
+                && !self.roles.contains_key(lookup)
+                && (self.classes.contains_key(bare) || self.roles.contains_key(bare))
+            {
+                return format!("{}{}", bare, suffix);
+            }
+            if let Value::Package(pkg) = self.resolve_indirect_type_name(bare) {
+                let resolved = pkg.resolve();
+                if self.classes.contains_key(resolved.as_str())
+                    || self.roles.contains_key(resolved.as_str())
+                {
+                    return format!("{}{}", resolved, suffix);
+                }
+            }
+        }
         name.to_string()
     }
 
@@ -2158,6 +2179,23 @@ impl Interpreter {
             }
         }
 
+        // If this is a stub declaration (body is `...`, `!!!`, or `???`)
+        // and a real (non-stub) role already exists under this name, treat
+        // the stub as a forward declaration / no-op — don't register a new
+        // stub candidate that would shadow the real one.
+        let is_stub_body = body.iter().any(|s| {
+            matches!(s, Stmt::Expr(Expr::Call { name, .. })
+                if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn")
+        });
+        if is_stub_body
+            && type_params.is_empty()
+            && self
+                .roles
+                .get(name)
+                .is_some_and(|existing| !existing.is_stub_role)
+        {
+            return Ok(());
+        }
         // Clean up stale punned class entry for this role name.
         self.classes.remove(name);
         self.hidden_classes.remove(name);

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1010,6 +1010,23 @@ impl VM {
                     Value::Package(Symbol::intern(&qualified_name)),
                 );
             }
+            // When a class is declared with an already-qualified name
+            // (e.g. the compiler pre-qualified `class C1` inside
+            // `unit module M` to `M::C1`), also register the short name
+            // `C1` in the env so that subsequent code inside the same
+            // module can refer to it bare. Skip this when the parent
+            // package is a class (where suppress_name semantics apply).
+            if qualified_name.contains("::") && !parent_is_class {
+                let short = qualified_name
+                    .rsplit_once("::")
+                    .map(|(_, s)| s.to_string())
+                    .unwrap_or_else(|| qualified_name.clone());
+                if !short.is_empty() && short != qualified_name {
+                    let env = self.interpreter.env_mut();
+                    env.entry(short)
+                        .or_insert_with(|| Value::Package(Symbol::intern(&qualified_name)));
+                }
+            }
             // When `my class` is used, register the class name as lexically scoped
             // so it gets suppressed when the enclosing block scope exits.
             if *is_lexical {
@@ -1095,9 +1112,19 @@ impl VM {
                 *is_rw,
             )?;
             if *is_export && !self.interpreter.suppress_exports {
+                // The compiler may have pre-qualified the role name
+                // (e.g. `R1` → `GH2613::R1`) when compiling under a
+                // `unit module`. Exports use the short bare name and
+                // the originating package, so split the qualified name.
+                let (export_pkg, export_short) =
+                    if let Some((pkg, short)) = name_str.rsplit_once("::") {
+                        (pkg.to_string(), short.to_string())
+                    } else {
+                        (current_package.clone(), name_str.clone())
+                    };
                 self.interpreter.register_exported_var(
-                    current_package.clone(),
-                    name_str.clone(),
+                    export_pkg,
+                    export_short,
                     export_tags.clone(),
                 );
             }
@@ -1115,9 +1142,27 @@ impl VM {
                 Value::Package(Symbol::intern(&qualified_name)),
             );
             if qualified_name != name_str && !name_str.contains("::") {
-                self.interpreter
-                    .env_mut()
-                    .insert(name_str, Value::Package(Symbol::intern(&qualified_name)));
+                self.interpreter.env_mut().insert(
+                    name_str.clone(),
+                    Value::Package(Symbol::intern(&qualified_name)),
+                );
+            }
+            // When a role is declared with an already-qualified name
+            // (e.g. the compiler pre-qualified `role R1` inside
+            // `unit module GH2613` to `GH2613::R1`), also register the
+            // short name `R1` in the env so subsequent code in the same
+            // module can refer to it bare.
+            if qualified_name.contains("::") && qualified_name == name_str {
+                let short = qualified_name
+                    .rsplit_once("::")
+                    .map(|(_, s)| s.to_string())
+                    .unwrap_or_else(|| qualified_name.clone());
+                if !short.is_empty() && short != qualified_name {
+                    self.interpreter
+                        .env_mut()
+                        .entry(short)
+                        .or_insert_with(|| Value::Package(Symbol::intern(&qualified_name)));
+                }
             }
             self.env_dirty = true;
             // Execute deferred non-declaration body statements now that the role


### PR DESCRIPTION
## Summary
- Compile-time class/role declarations inside `unit module`/`unit class` bodies are pre-qualified with the enclosing package so nested namespaces like `A::B::D` and `A::B::B` resolve correctly at runtime.
- Added parser support for `unit role Name;` (empty forward declaration) and a stub skip for `role Name {...}` when a non-stub role already exists.
- Fall back to the bare suffix in `resolve_declared_type_name` so cross-package parents still work after pre-qualification.
- Whitelisted `roast/S11-modules/nested.t`.

## Test plan
- [x] `prove -e target/debug/mutsu roast/S11-modules/nested.t` passes 11/11
- [x] `make test` passes (local flaky t/lock.t unrelated)
- [x] `make roast` passes (all whitelisted tests)
- [x] Previously sensitive tests still pass: `S11-modules/export.t`, `S14-roles/typecheck.t`, `S06-currying/named.t`, `S06-multi/compile-time.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)