### PR TITLE
fix: implement getc builtin and pass roast/S16-io/getc.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -692,6 +692,7 @@ roast/S16-io/bare-say.t
 roast/S16-io/basic-open.t
 roast/S16-io/bom.t
 roast/S16-io/cwd.t
+roast/S16-io/getc.t
 roast/S16-io/handles-between-threads.t
 roast/S16-io/home.t
 roast/S16-io/newline.t

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -186,7 +186,7 @@ impl Compiler {
     pub(super) fn xx_lhs_needs_reeval(expr: &Expr) -> bool {
         matches!(
             expr,
-            Expr::Call { name, .. } if name == "rand" || name == "pick" || name == "roll" || name == "start"
+            Expr::Call { name, .. } if name == "rand" || name == "pick" || name == "roll" || name == "start" || name == "getc" || name == "get"
         ) || matches!(
             expr,
             Expr::MethodCall { name, target, .. }
@@ -196,6 +196,8 @@ impl Compiler {
                     || name == "take"
                     || name == "readchars"
                     || name == "receive"
+                    || name == "getc"
+                    || name == "get"
                     || (name == "new" && matches!(target.as_ref(), Expr::BareWord(n) if n == "Promise"))
                     || Self::xx_lhs_needs_reeval(target)
         ) || matches!(

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -684,6 +684,7 @@ impl Interpreter {
             }
             "prompt" => self.builtin_prompt(&args),
             "get" => self.builtin_get(&args),
+            "getc" => self.builtin_getc(&args),
             "lines" => self.builtin_lines(&args),
             "words" => self.builtin_words(&args),
             // System

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -930,6 +930,21 @@ impl Interpreter {
         Ok(Value::Nil)
     }
 
+    pub(super) fn builtin_getc(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        let handle = args
+            .first()
+            .cloned()
+            .or_else(|| self.default_input_handle());
+        if let Some(handle) = handle {
+            let s = self.read_chars_from_handle_value(&handle, Some(1))?;
+            if s.is_empty() {
+                return Ok(Value::Nil);
+            }
+            return Ok(Value::str(s));
+        }
+        Ok(Value::Nil)
+    }
+
     pub(super) fn builtin_lines(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if let Some(first) = args.first()
             && Self::handle_id_from_value(first).is_none()

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1807,15 +1807,19 @@ impl Interpreter {
                     // For single-byte encodings, read 1 byte and decode
                     let bytes = self.read_bytes_from_handle_value(&target_val, 1)?;
                     if bytes.is_empty() {
-                        Ok(Value::str(String::new()))
+                        Ok(Value::Nil)
                     } else {
                         let decoded = self.decode_with_encoding(&bytes, &encoding)?;
                         Ok(Value::str(decoded))
                     }
                 } else {
-                    // UTF-8: may need multiple bytes for one character
-                    let bytes = self.read_bytes_from_handle_value(&target_val, 1)?;
-                    Ok(Value::str(String::from_utf8_lossy(&bytes).to_string()))
+                    // UTF-8: read one character, possibly multi-byte.
+                    let s = self.read_chars_from_handle_value(&target_val, Some(1))?;
+                    if s.is_empty() {
+                        Ok(Value::Nil)
+                    } else {
+                        Ok(Value::str(s))
+                    }
                 }
             }
             "readchars" => {


### PR DESCRIPTION
## Summary
- Add `getc` as a listop builtin that reads one character from a handle (file or default input).
- Fix `IO::Handle.getc` to read a full UTF-8 character (previously dropped multibyte sequences after 1 byte) and return `Nil` at EOF.
- Add `getc`/`get` to `xx_lhs_needs_reeval` so `.getc xx 4` re-evaluates per repetition as Raku requires.
- Whitelist `roast/S16-io/getc.t` (all 3 subtests pass).

## Test plan
- [x] `prove -e target/debug/mutsu roast/S16-io/getc.t` (3/3 ok)
- [x] `make test`
- [x] `cargo clippy -- -D warnings` / `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)