### PR TITLE
fix: pass roast/S17-supply/interval.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -752,6 +752,7 @@ roast/S17-supply/from-list.t
 roast/S17-supply/grab.t
 roast/S17-supply/grep.t
 roast/S17-supply/head.t
+roast/S17-supply/interval.t
 roast/S17-supply/lines.t
 roast/S17-supply/list.t
 roast/S17-supply/map.t

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -412,6 +412,14 @@ impl Interpreter {
                     let _ = self.call_sub_value(cb, Vec::new(), true);
                 }
                 if !counter_values.is_empty() {
+                    // Push counter values into the active supply emit buffer
+                    // so tap-ok (with :virtual-time scheduler-driven supplies)
+                    // can collect them.
+                    if let Some(buf) = self.supply_emit_buffer.last_mut() {
+                        for v in &counter_values {
+                            buf.push(Value::Int(*v));
+                        }
+                    }
                     return Ok(Value::array(
                         counter_values.into_iter().map(Value::Int).collect(),
                     ));

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2127,7 +2127,7 @@ impl Value {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Instant" => {
+            } if class_name == "Instant" || class_name == "Duration" => {
                 attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0)
             }
             // Match coerces to Numeric via its matched string


### PR DESCRIPTION
## Summary
- Fix `Duration.to_f64()` to extract the `value` attribute so `progress-by(Duration.new(4.5))` advances FakeScheduler virtual time correctly.
- Have `FakeScheduler.progress-by` push counter-mode emissions into the active `supply_emit_buffer`, so `tap-ok` with `:virtual-time` scheduler-driven `Supply.interval` can collect emitted values.
- Add `roast/S17-supply/interval.t` to the whitelist.

## Test plan
- [x] `prove -e target/debug/mutsu roast/S17-supply/interval.t`
- [x] `make test` (only pre-existing flaky t/lock.t failure)
- [x] `cargo clippy -- -D warnings`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>