### PR TITLE
Implement method-level `handles` trait for delegation

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -560,6 +560,7 @@ roast/S12-methods/chaining.t
 roast/S12-methods/class-and-instance.t
 roast/S12-methods/default-trait.t
 roast/S12-methods/defer-call.t
+roast/S12-methods/delegation.t
 roast/S12-methods/fallback.t
 roast/S12-methods/how.t
 roast/S12-methods/indirect_notation.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -684,6 +684,11 @@ pub(crate) enum Stmt {
         is_default_candidate: bool,
         /// `is DEPRECATED` message (None = not deprecated)
         deprecated_message: Option<String>,
+        /// `handles` specifications on this method: when set, this method acts
+        /// as a delegator source. For each spec, a forwarder method is
+        /// synthesized at class-registration time that calls
+        /// `self.<this-method>.<exposed>(|args)`.
+        handles: Vec<HandleSpec>,
     },
     RoleDecl {
         name: Symbol,

--- a/src/parser/stmt/decl/handles.rs
+++ b/src/parser/stmt/decl/handles.rs
@@ -50,7 +50,7 @@ fn parse_single_handle_spec<'a>(input: &'a str, specs: &mut Vec<HandleSpec>) -> 
 }
 
 /// Parse handle specifications after the `handles` keyword.
-pub(super) fn parse_handle_specs<'a>(
+pub(in crate::parser) fn parse_handle_specs<'a>(
     input: &'a str,
     specs: &mut Vec<HandleSpec>,
     rest_out: &mut &'a str,

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -13,6 +13,7 @@ mod use_decl;
 // Re-export public items that were previously accessible from the flat `decl` module.
 pub(in crate::parser::stmt) use constant_subset::{constant_decl, subset_decl};
 pub(crate) use enum_decl::{anon_enum_decl, enum_decl};
+pub(in crate::parser::stmt) use handles::parse_handle_specs;
 pub(in crate::parser::stmt) use has_decl::has_decl;
 pub(in crate::parser::stmt) use helpers::parse_array_shape_suffix;
 pub(in crate::parser::stmt) use my_decl::{my_decl, my_decl_expr};

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1011,6 +1011,9 @@ pub(crate) struct SubTraits {
     /// trait_name is one of "tighter", "looser", "equiv".
     /// reference_operator is the operator symbol or full name (e.g. "*", "+", "infix:<+>", "prefix:<foo>").
     pub precedence_trait: Option<(String, String)>,
+    /// `handles` specifications on a method declaration, e.g.
+    /// `method Str() handles 'uc' { ... }`.
+    pub handles: Vec<crate::ast::HandleSpec>,
 }
 
 /// Parse sub/method traits like `is test-assertion`, `is export`, `returns Str`, `of Num`, etc.
@@ -1026,6 +1029,7 @@ pub(super) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
     let mut custom_traits: Vec<String> = Vec::new();
     let mut seen_traits: Vec<String> = Vec::new();
     let mut precedence_trait: Option<(String, String)> = None;
+    let mut handles: Vec<crate::ast::HandleSpec> = Vec::new();
     loop {
         let (r, _) = ws(input)?;
         if r.starts_with('{') || r.is_empty() {
@@ -1041,8 +1045,16 @@ pub(super) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
                     associativity,
                     custom_traits: custom_traits.clone(),
                     precedence_trait: precedence_trait.clone(),
+                    handles: handles.clone(),
                 },
             ));
+        }
+        if let Some(r_after) = keyword("handles", r) {
+            let (r_after, _) = ws1(r_after)?;
+            let mut rest_out = r_after;
+            super::decl::parse_handle_specs(r_after, &mut handles, &mut rest_out)?;
+            input = rest_out;
+            continue;
         }
         if let Some(r) = keyword("is", r) {
             let (r, _) = ws(r)?;
@@ -1180,6 +1192,7 @@ pub(super) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
                 associativity,
                 custom_traits: custom_traits.clone(),
                 precedence_trait: precedence_trait.clone(),
+                handles: handles.clone(),
             },
         ));
     }

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -1663,6 +1663,7 @@ fn method_decl_body_with_my(
                     t.strip_prefix("DEPRECATED:").map(|msg| msg.to_string())
                 }
             }),
+            handles: traits.handles.clone(),
         },
     ))
 }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -787,12 +787,34 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
-        // Fast path: delegation methods forward the call to the delegate object
         if let Some((ref attr_var_name, ref target_method)) = method_def.delegation {
+            // Clear skip_pseudo_method_native: the outer call set it for the
+            // delegator's own method name, but we're about to forward to a
+            // different name on a (possibly different) target, so the flag
+            // must not leak into the delegate dispatch.
+            let saved_skip_pseudo = self.skip_pseudo_method_native.take();
+            // Method-based delegation: attr_var_name starts with `&`, meaning
+            // the delegate is obtained by invoking the named method on self.
+            let delegate = if let Some(source_method) = attr_var_name.strip_prefix('&') {
+                let invocant_val = if let Some(ref inv) = invocant {
+                    inv.clone()
+                } else if attributes.is_empty() {
+                    Value::Package(Symbol::intern(receiver_class_name))
+                } else {
+                    Value::make_instance(Symbol::intern(receiver_class_name), attributes.clone())
+                };
+                self.call_method_with_values(invocant_val, source_method, Vec::new())?
+            } else {
+                let attr_key = attr_var_name
+                    .trim_start_matches('.')
+                    .trim_start_matches('!');
+                attributes.get(attr_key).cloned().unwrap_or(Value::Nil)
+            };
+            let is_method_based = attr_var_name.starts_with('&');
             let attr_key = attr_var_name
+                .trim_start_matches('&')
                 .trim_start_matches('.')
                 .trim_start_matches('!');
-            let delegate = attributes.get(attr_key).cloned().unwrap_or(Value::Nil);
             if delegate == Value::Nil {
                 return Err(RuntimeError::new(format!(
                     "No such method '{}' for invocant of type '{}'",
@@ -808,9 +830,11 @@ impl Interpreter {
                 _ => None,
             };
             let result = self.call_method_with_values(delegate, target_method, args)?;
+            // Restore the saved skip_pseudo flag so the outer caller is unaffected.
+            self.skip_pseudo_method_native = saved_skip_pseudo;
             // For Instance delegates, check if the delegate was mutated and update
             // the frontend's attribute with the updated delegate.
-            if let (Some(did), Some(dcn)) = (delegate_id, delegate_class) {
+            if !is_method_based && let (Some(did), Some(dcn)) = (delegate_id, delegate_class) {
                 // Look for the updated delegate in env bindings
                 let mut updated_delegate = None;
                 for val in self.env.values() {

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1196,7 +1196,9 @@ impl Interpreter {
             return Err(super::methods_signature::make_multi_no_match_error(method));
         };
         // Delegation methods: forward assignment to the delegate
-        if let Some((attr_var_name, target_method)) = &method_def.delegation {
+        if let Some((attr_var_name, target_method)) = &method_def.delegation
+            && !attr_var_name.starts_with('&')
+        {
             let attr_key = attr_var_name
                 .trim_start_matches('.')
                 .trim_start_matches('!');
@@ -1286,7 +1288,9 @@ impl Interpreter {
         }
 
         // Check if this is a delegation method — forward assignment to delegate
-        if let Some((ref attr_var_name, ref target_method)) = method_def.delegation {
+        if let Some((ref attr_var_name, ref target_method)) = method_def.delegation
+            && !attr_var_name.starts_with('&')
+        {
             let attr_key = attr_var_name
                 .trim_start_matches('.')
                 .trim_start_matches('!');
@@ -2697,11 +2701,24 @@ impl Interpreter {
             if let Some(method_def) = self.resolve_method(&class_name.resolve(), method, &args)
                 && method_def.delegation.is_some()
             {
+                // Clear skip_pseudo_method_native so the inner delegate dispatch
+                // does not inherit the outer call's bypass flag (which was set
+                // for the delegator's own method name).
+                let saved_skip_pseudo = self.skip_pseudo_method_native.take();
                 let (attr_var_name, target_method) = method_def.delegation.as_ref().unwrap();
+                let is_method_based = attr_var_name.starts_with('&');
                 let attr_key = attr_var_name
+                    .trim_start_matches('&')
                     .trim_start_matches('.')
                     .trim_start_matches('!');
-                let delegate = attributes.get(attr_key).cloned().unwrap_or(Value::Nil);
+                let delegate = if is_method_based {
+                    let source_method = attr_var_name.trim_start_matches('&').to_string();
+                    let invocant_val =
+                        Value::make_instance_with_id(class_name, (*attributes).clone(), target_id);
+                    self.call_method_with_values(invocant_val, &source_method, Vec::new())?
+                } else {
+                    attributes.get(attr_key).cloned().unwrap_or(Value::Nil)
+                };
                 if delegate == Value::Nil {
                     return Err(RuntimeError::new(format!(
                         "No such method '{}' for invocant of type '{}'",
@@ -2722,18 +2739,22 @@ impl Interpreter {
                 // Read back the potentially-updated delegate
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
-                // Write the updated delegate back into the frontend's attributes
-                let mut updated = (*attributes).clone();
-                updated.insert(attr_key.to_string(), updated_delegate);
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    updated.clone(),
-                );
-                self.env.insert(
-                    target_var.to_string(),
-                    Value::make_instance_with_id(class_name, updated, target_id),
-                );
+                if !is_method_based {
+                    // Write the updated delegate back into the frontend's attributes
+                    let mut updated = (*attributes).clone();
+                    updated.insert(attr_key.to_string(), updated_delegate);
+                    self.overwrite_instance_bindings_by_identity(
+                        &class_name.resolve(),
+                        target_id,
+                        updated.clone(),
+                    );
+                    self.env.insert(
+                        target_var.to_string(),
+                        Value::make_instance_with_id(class_name, updated, target_id),
+                    );
+                }
+                // Restore skip_pseudo for the outer caller.
+                self.skip_pseudo_method_native = saved_skip_pseudo;
                 return Ok(result);
             }
 

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -182,6 +182,27 @@ impl Interpreter {
                 && matches!(target, Value::Package(class_name) if self.has_class_level_attr(&class_name.resolve(), method) && !self.has_public_accessor(&class_name.resolve(), method)))
             || (!is_pseudo_method
                 && matches!(target, Value::Instance { class_name, .. } if self.has_class_level_attr(&class_name.resolve(), method) && !self.has_public_accessor(&class_name.resolve(), method)))
+            || (!is_pseudo_method && self.mixin_role_has_method(target, method))
+    }
+
+    /// Check if a Mixin's role mixins define the given method.
+    /// Used so that role-method dispatch on punned role instances takes
+    /// precedence over the built-in Cool fallbacks (e.g. `.uc`).
+    pub(crate) fn mixin_role_has_method(&self, target: &Value, method: &str) -> bool {
+        let Value::Mixin(_, mixins) = target else {
+            return false;
+        };
+        for key in mixins.keys() {
+            let Some(role_name) = key.strip_prefix("__mutsu_role__") else {
+                continue;
+            };
+            if let Some(role) = self.roles.get(role_name)
+                && role.methods.contains_key(method)
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// Dispatch .raku/.perl on constrained Hash.

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1402,6 +1402,7 @@ impl Interpreter {
                     return_type,
                     is_default_candidate,
                     deprecated_message,
+                    handles: method_handles,
                 } => {
                     self.validate_private_access_in_stmts(name, method_body)?;
                     Self::validate_attr_declared_in_class(&class_own_attrs, method_body)?;
@@ -1554,6 +1555,47 @@ impl Interpreter {
                             class_def
                                 .methods
                                 .insert(resolved_method_name.clone(), vec![def]);
+                        }
+                    }
+                    // `handles` on a method: synthesize forwarder methods that
+                    // delegate to the return value of this method. E.g.
+                    //   method Str() handles 'uc' { 'x' }
+                    // registers a `uc` method that calls `self.Str.uc(|@_)`.
+                    if !method_handles.is_empty() {
+                        // Encode "method-based delegation" by prefixing the
+                        // source method name with `&`; the delegation dispatch
+                        // sites recognize this prefix and invoke the named
+                        // method on self to obtain the delegate.
+                        let source_attr_marker = format!("&{}", resolved_method_name);
+                        for spec in method_handles {
+                            match spec {
+                                HandleSpec::Name(target) => {
+                                    class_def
+                                        .methods
+                                        .entry(target.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Rename { exposed, target } => {
+                                    class_def
+                                        .methods
+                                        .entry(exposed.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Wildcard => {
+                                    class_def.wildcard_handles.push(source_attr_marker.clone());
+                                }
+                                HandleSpec::Regex(pattern) => {
+                                    class_def
+                                        .wildcard_handles
+                                        .push(format!("{}:regex:{}", source_attr_marker, pattern));
+                                }
+                                HandleSpec::Type(_) => {
+                                    // Method-based delegation via a type name
+                                    // is not yet supported; fall through.
+                                }
+                            }
                         }
                     }
                     // `our method` also registers as a package-scoped sub
@@ -2461,6 +2503,7 @@ impl Interpreter {
                     return_type,
                     is_default_candidate,
                     deprecated_message: _,
+                    handles: method_handles,
                 } => {
                     // Validate that $!attr references in the method body are declared
                     // in this role (same check as for class methods).
@@ -2554,11 +2597,44 @@ impl Interpreter {
                         if *multi {
                             role_def
                                 .methods
-                                .entry(resolved_method_name)
+                                .entry(resolved_method_name.clone())
                                 .or_default()
                                 .push(def);
                         } else {
-                            role_def.methods.insert(resolved_method_name, vec![def]);
+                            role_def
+                                .methods
+                                .insert(resolved_method_name.clone(), vec![def]);
+                        }
+                    }
+                    // `handles` on a role method: synthesize forwarder methods.
+                    if !is_role_private && !method_handles.is_empty() {
+                        let source_attr_marker = format!("&{}", resolved_method_name);
+                        for spec in method_handles {
+                            match spec {
+                                HandleSpec::Name(target) => {
+                                    role_def
+                                        .methods
+                                        .entry(target.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Rename { exposed, target } => {
+                                    role_def
+                                        .methods
+                                        .entry(exposed.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Wildcard => {
+                                    role_def.wildcard_handles.push(source_attr_marker.clone());
+                                }
+                                HandleSpec::Regex(pattern) => {
+                                    role_def
+                                        .wildcard_handles
+                                        .push(format!("{}:regex:{}", source_attr_marker, pattern));
+                                }
+                                HandleSpec::Type(_) => {}
+                            }
                         }
                     }
                 }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -135,6 +135,9 @@ impl Interpreter {
                 let Some((attr_var_name, target_method)) = &method_def.delegation else {
                     continue;
                 };
+                if attr_var_name.starts_with('&') {
+                    continue;
+                }
                 if target_method == method_name {
                     let attr_name = attr_var_name.trim_start_matches(['.', '!']);
                     return Some(format!("__mutsu_attr__{attr_name}"));

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -85,6 +85,10 @@ impl VM {
             && method_sym == "keyof"
             && !bypass_constrained_hash;
         // Proxy containers must auto-FETCH before dispatching methods (except meta-methods)
+        // Mixin with a role-defined method: bypass native so role-method
+        // dispatch (including `handles` delegation forwarders) takes precedence
+        // over the built-in Cool fallbacks like `.uc`/`.lc`/`.gist`.
+        let bypass_mixin_role_method = self.interpreter.mixin_role_has_method(target, &method_name);
         let bypass_proxy = matches!(target, Value::Proxy { .. })
             && !matches!(
                 method_sym.resolve().as_ref(),
@@ -102,6 +106,7 @@ impl VM {
             || bypass_constrained_hash
             || bypass_hash_keyof
             || bypass_typed_array_raku
+            || bypass_mixin_role_method
         {
             return None;
         }


### PR DESCRIPTION
## Summary

- Implements `method Foo() handles 'bar' { ... }` for both classes and roles so the delegator method's return value receives forwarded calls.
- Adds `HandleSpec` to `Stmt::MethodDecl`, parses `handles` after method signatures, and synthesizes forwarder `MethodDef`s at registration time, reusing the existing attribute-based delegation machinery via a `&source_method` marker prefix.
- Adds a VM native-fastpath bypass for Mixin targets when a composed role defines the method, so role-method delegation (e.g. `.uc`) is not shadowed by Cool stringification fallbacks.

Passes all 9 subtests of `roast/S12-methods/delegation.t`; test is added to `roast-whitelist.txt`.

## Test plan

- [x] `cargo build && prove -e target/debug/mutsu roast/S12-methods/delegation.t`
- [x] `cargo fmt && cargo clippy -- -D warnings`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)