### PR TITLE
fix: pass export tags through for Test::* module imports

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -991,6 +991,7 @@ roast/S32-str/pos.t
 roast/S32-str/rindex.t
 roast/S32-str/samecase.t
 roast/S32-str/samemark.t
+roast/S32-str/space-chars.t
 roast/S32-str/split-simple.t
 roast/S32-str/split.t
 roast/S32-str/sprintf-b.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1798,12 +1798,15 @@ impl Compiler {
             Stmt::Use { module, arg, .. } if module == "Test::More" => {
                 self.compile_test_more_use(arg);
             }
-            Stmt::Use { module, .. } if module == "Test" || module.starts_with("Test::") => {
+            Stmt::Use { module, tags, .. } if module == "Test" || module.starts_with("Test::") => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
-                self.code.emit(OpCode::UseModule {
-                    name_idx,
-                    tags_idx: None,
-                });
+                let tags_idx = if tags.is_empty() {
+                    None
+                } else {
+                    let entries = tags.iter().cloned().map(Value::str).collect::<Vec<Value>>();
+                    Some(self.code.add_constant(Value::array(entries)))
+                };
+                self.code.emit(OpCode::UseModule { name_idx, tags_idx });
             }
             Stmt::Use { module, tags, .. } => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));


### PR DESCRIPTION
## Summary
- The compiler special-cased `use Test` / `use Test::*` and dropped any requested export tags, so tagged imports like `use Test::Misc :int2hexstr` resolved nothing.
- Forward the parsed tags to `UseModule` like the generic `use` branch does.
- Adds `roast/S32-str/space-chars.t` to the whitelist (30/30 subtests passing).

## Test plan
- [x] `prove -e target/debug/mutsu roast/S32-str/space-chars.t`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make test`

Generated with Claude Code