### PR TITLE
fix: enforce Raku minimal-whitespace parser rules

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -31,6 +31,7 @@ roast/S01-perl-5-integration/subs.t
 roast/S02-lexical-conventions/bom.t
 roast/S02-lexical-conventions/comments.t
 roast/S02-lexical-conventions/finish-pod.t
+roast/S02-lexical-conventions/minimal-whitespace.t
 roast/S02-lexical-conventions/one-pass-parsing.t
 roast/S02-lexical-conventions/pod-in-multi-line-exprs.t
 roast/S02-lexical-conventions/sub-block-parsing.t

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1281,6 +1281,35 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
         // Also handles: .^method (meta-method)
         // Also handles call-on: .(args)
         if rest.starts_with('.') && !rest.starts_with("..") {
+            // Whitespace immediately after dot has special rules:
+            // - If the target is a numeric literal, `<digit>. <non-digit>` is
+            //   a decimal-point error: "Decimal point must be followed by digit".
+            // - Otherwise `. ++` / `. --` is the obsolete Perl 5 postfix form.
+            let after_dot_raw = &rest[1..];
+            if after_dot_raw.starts_with(' ') || after_dot_raw.starts_with('\t') {
+                if matches!(
+                    expr,
+                    Expr::Literal(
+                        crate::value::Value::Int(_)
+                            | crate::value::Value::Num(_)
+                            | crate::value::Value::Rat(..)
+                            | crate::value::Value::Complex(..),
+                    )
+                ) {
+                    return Err(PError::fatal(
+                        "X::Syntax::Number::IllegalDecimal: Decimal point must be followed by digit"
+                            .to_string(),
+                    ));
+                }
+                let trimmed = after_dot_raw.trim_start_matches([' ', '\t']);
+                if trimmed.starts_with("++") || trimmed.starts_with("--") {
+                    return Err(PError::fatal(
+                        "X::Obsolete: Unsupported use of . postfix operator; \
+                         in Raku please use .++ or .-- without whitespace"
+                            .to_string(),
+                    ));
+                }
+            }
             expr = auto_invoke_bareword_method_target(expr);
             let r = &rest[1..];
             // Consume unspace after dot: `.\ method` or `.\ (args)`

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -277,6 +277,21 @@ pub(super) fn reduction_op(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
+    // Listop-style reduction (`[+] @a`) requires whitespace between `]`
+    // and the operand for symbolic operators. `[+]@a` would be two terms
+    // in a row. Alphabetic operators like `[min]` are ambiguous with array
+    // literals like `[Exception]` and are not enforced here.
+    if is_symbol_op
+        && !(r.starts_with(' ')
+            || r.starts_with('\t')
+            || r.starts_with('\n')
+            || r.starts_with('\r')
+            || r.starts_with('#'))
+    {
+        return Err(PError::fatal(
+            "X::Syntax::Confused: Two terms in a row".to_string(),
+        ));
+    }
     let (r, _) = ws(r)?;
     // Parse comma-separated list as the operand
     let (r, first) = parse_reduction_operand(r)?;


### PR DESCRIPTION
## Summary
- Reject `<digit>. <anything>` as `X::Syntax::Number::IllegalDecimal` (Decimal point must be followed by digit)
- Reject `expr. ++` / `expr. --` with `X::Obsolete` (Perl 5 postfix form)
- Reject listop-style reduction without whitespace (`[+]@a`) with `X::Syntax::Confused` "Two terms in a row", only for symbolic operators (keeps `[Exception]` as array literal working)

Passes all 18 subtests of `roast/S02-lexical-conventions/minimal-whitespace.t` and adds it to the roast whitelist.

## Test plan
- [x] `make test`
- [x] `make roast`
- [x] `prove -e target/debug/mutsu roast/S02-lexical-conventions/minimal-whitespace.t`

Generated with Claude Code