### PR TITLE
fix: raise X::Import::NoSuchTag for bad tags on unit modules

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -489,6 +489,7 @@ roast/S11-modules/export.t
 roast/S11-modules/gh2979.t
 roast/S11-modules/import-tag.t
 roast/S11-modules/import.t
+roast/S11-modules/importing.t
 roast/S11-modules/lexical.t
 roast/S11-modules/module-file.t
 roast/S11-modules/module.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -778,6 +778,15 @@ pub struct Interpreter {
     exported_subs: HashMap<String, HashMap<String, HashSet<String>>>,
     /// Exported variable/constant symbols by package and export tag.
     exported_vars: HashMap<String, HashMap<String, HashSet<String>>>,
+    /// Mirrored export tables for modules declared with `unit module X`
+    /// when the actual runtime package registration used "GLOBAL".
+    /// Populated during `load_module` so that `import_module` can perform
+    /// tag validation and raise `X::Import::NoSuchTag` for bad tags.
+    unit_module_exported_subs: HashMap<String, HashMap<String, HashSet<String>>>,
+    /// Stack of unit-module names currently being loaded; used by
+    /// `register_exported_sub` to mirror GLOBAL registrations into
+    /// `unit_module_exported_subs`.
+    unit_module_loading_stack: Vec<String>,
     /// When true, `is export` trait is ignored (used by `need` to load without importing).
     pub(crate) suppress_exports: bool,
     /// When true, rw routine calls should not auto-FETCH Proxy return values.
@@ -2671,6 +2680,8 @@ impl Interpreter {
             module_load_stack: Vec::new(),
             exported_subs: HashMap::new(),
             exported_vars: HashMap::new(),
+            unit_module_exported_subs: HashMap::new(),
+            unit_module_loading_stack: Vec::new(),
             suppress_exports: false,
             in_lvalue_assignment: false,
             hash_autovivify: false,
@@ -3191,6 +3202,20 @@ impl Interpreter {
                     .or_insert_with(|| def);
             }
         }
+        // Mirror this export into the unit-module export table so that
+        // `import_module` can validate tags for `unit module X` files whose
+        // runtime package registration used "GLOBAL".
+        if let Some(unit_mod) = self.unit_module_loading_stack.last().cloned() {
+            let mirror = self
+                .unit_module_exported_subs
+                .entry(unit_mod)
+                .or_default()
+                .entry(name.clone())
+                .or_default();
+            for tag in &tags {
+                mirror.insert(tag.clone());
+            }
+        }
         let entry = self
             .exported_subs
             .entry(package)
@@ -3236,7 +3261,18 @@ impl Interpreter {
 
         let subs = self.exported_subs.get(module).cloned().unwrap_or_default();
         let vars = self.exported_vars.get(module).cloned().unwrap_or_default();
-        if subs.is_empty() && vars.is_empty() {
+        // For `unit module Foo`, sub registration at runtime may have used
+        // the default "GLOBAL" package (because the interpreter's runtime
+        // `current_package` is not switched by the compile-time unit
+        // declaration). When a module declared the `unit_module` marker,
+        // its exports are tracked separately so we can still validate tags
+        // and report X::Import::NoSuchTag correctly.
+        let unit_global_subs: HashMap<String, HashSet<String>> = self
+            .unit_module_exported_subs
+            .get(module)
+            .cloned()
+            .unwrap_or_default();
+        if subs.is_empty() && vars.is_empty() && unit_global_subs.is_empty() {
             return Err(RuntimeError::new(format!(
                 "No exports found for module: {}",
                 module
@@ -3256,6 +3292,11 @@ impl Interpreter {
                 }
             }
             for symbol_tags in vars.values() {
+                for tag in symbol_tags {
+                    known_tags.insert(tag.clone());
+                }
+            }
+            for symbol_tags in unit_global_subs.values() {
                 for tag in symbol_tags {
                     known_tags.insert(tag.clone());
                 }
@@ -4166,6 +4207,8 @@ impl Interpreter {
             module_load_stack: Vec::new(),
             exported_subs: self.exported_subs.clone(),
             exported_vars: self.exported_vars.clone(),
+            unit_module_exported_subs: self.unit_module_exported_subs.clone(),
+            unit_module_loading_stack: Vec::new(),
             suppress_exports: false,
             in_lvalue_assignment: false,
             hash_autovivify: false,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1052,6 +1052,23 @@ impl Interpreter {
         Ok((stmts, precomp_eligible))
     }
 
+    /// Return the name of a top-level `unit module/package/class` statement
+    /// in `stmts`, if any. Used by `load_module` to track which unit module
+    /// is currently loading so exports can be mirrored under the module name.
+    fn detect_unit_package_name(stmts: &[crate::ast::Stmt]) -> Option<String> {
+        for s in stmts {
+            if let crate::ast::Stmt::Package {
+                name,
+                is_unit: true,
+                ..
+            } = s
+            {
+                return Some(name.resolve().to_string());
+            }
+        }
+        None
+    }
+
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
         let source_path = self
             .resolve_module_path(module)
@@ -1075,7 +1092,20 @@ impl Interpreter {
             // instead of `Export_PackA::foo`).
             let saved_package = self.current_package.clone();
             self.current_package = "GLOBAL".to_string();
+            // If the module file is a `unit module X` (or unit package/class),
+            // record X so that `register_exported_sub` can mirror exports into
+            // `unit_module_exported_subs` for tag validation.
+            let unit_name = Self::detect_unit_package_name(&stmts);
+            let pushed_unit = if let Some(name) = unit_name {
+                self.unit_module_loading_stack.push(name);
+                true
+            } else {
+                false
+            };
             let result = self.run_block(&stmts);
+            if pushed_unit {
+                self.unit_module_loading_stack.pop();
+            }
             self.current_package = saved_package;
             result?;
         }


### PR DESCRIPTION
## Summary
- Raise `X::Import::NoSuchTag` when `use Foo :BadTag` targets a `unit module` file. Previously the tag check was skipped because runtime sub registrations land under `GLOBAL` (the compile-time unit-module package switch is not mirrored into the interpreter's runtime `current_package`), so `exported_subs[\"Foo\"]` was empty and `import_module` early-returned with a swallowed "No exports found" error.
- Track a parallel `unit_module_exported_subs` table populated during `load_module` via a loading-stack of unit-module names. `register_exported_sub` mirrors each export into this table, and `import_module` consults it for tag validation.
- Whitelists `roast/S11-modules/importing.t` (18/18 passing).

## Test plan
- [x] `target/debug/mutsu roast/S11-modules/importing.t` → 18/18 pass
- [x] `make test`
- [x] `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)