### PR TITLE
fix: implement parse-base sub form, pass roast/S32-str/parse-base.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -992,6 +992,7 @@ roast/S32-str/length.t
 roast/S32-str/lines.t
 roast/S32-str/numeric.t
 roast/S32-str/ords.t
+roast/S32-str/parse-base.t
 roast/S32-str/pos.t
 roast/S32-str/rindex.t
 roast/S32-str/samecase.t

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1382,17 +1382,11 @@ pub(crate) fn native_method_1arg(
         }
         "parse-base" => {
             let radix = match arg {
-                Value::Int(n) => *n as u32,
+                Value::Int(n) => *n,
                 _ => return None,
             };
             let s = target.to_string_value();
-            match i64::from_str_radix(&s, radix) {
-                Ok(n) => Some(Ok(Value::Int(n))),
-                Err(_) => Some(Err(RuntimeError::new(format!(
-                    "Cannot parse '{}' as base {}",
-                    s, radix
-                )))),
-            }
+            Some(crate::builtins::parse_base::parse_base(&s, radix))
         }
         "base" => match target {
             Value::Int(i) => {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod collation;
 mod functions;
 pub(crate) mod methods_0arg;
 mod methods_narg;
+pub(crate) mod parse_base;
 pub(crate) mod primality;
 pub(crate) mod rng;
 pub(crate) mod split;

--- a/src/builtins/parse_base.rs
+++ b/src/builtins/parse_base.rs
@@ -1,0 +1,166 @@
+//! Implementation of the `parse-base` builtin (sub and method form).
+//!
+//! Parses a string in the given numeric base (2..36), supporting:
+//! - Optional leading sign: `+`, `-`, or U+2212 (MINUS SIGN)
+//! - Integer or fractional values (with `.` separator)
+//! - ASCII digits/letters and Unicode decimal digits (Nd category)
+//!
+//! Errors thrown:
+//! - `X::Syntax::Number::RadixOutOfRange` when radix is not in 2..36
+//! - `X::Str::Numeric` for malformed input (with `source`, `pos`, `reason`)
+
+#![allow(clippy::result_large_err)]
+
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value, make_big_rat};
+use num_bigint::BigInt;
+use num_traits::{One, Zero};
+use std::collections::HashMap;
+
+fn radix_out_of_range(radix: i64) -> RuntimeError {
+    let msg = format!(
+        "Radix must be in range 2..36, not {} (use :{}[...] notation for radices outside this range)",
+        radix, radix
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("radix".to_string(), Value::Int(radix));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Number::RadixOutOfRange"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+fn str_numeric_error(source: &str, pos: usize, radix: i64) -> RuntimeError {
+    let reason = format!("malformed base-{} number", radix);
+    let msg = format!("Cannot convert string to number: {}", reason);
+    let mut attrs = HashMap::new();
+    attrs.insert("source".to_string(), Value::str(source.to_string()));
+    attrs.insert("pos".to_string(), Value::Int(pos as i64));
+    attrs.insert("reason".to_string(), Value::str(reason.clone()));
+    attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+/// Convert a single character to its digit value in the given radix.
+/// Returns Some(value) if the character is a valid digit, None otherwise.
+fn char_digit_value(ch: char, radix: u32) -> Option<u32> {
+    // ASCII fast path: 0-9, A-Z, a-z
+    let v = if ch.is_ascii_digit() {
+        (ch as u32) - ('0' as u32)
+    } else if ch.is_ascii_uppercase() {
+        (ch as u32) - ('A' as u32) + 10
+    } else if ch.is_ascii_lowercase() {
+        (ch as u32) - ('a' as u32) + 10
+    } else if let Some(d) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
+        // Unicode Nd character
+        d
+    } else {
+        return None;
+    };
+    if v < radix { Some(v) } else { None }
+}
+
+/// Parse a string in the given base. The `source` parameter is used for error
+/// reporting and should be the original string before any sign stripping.
+pub(crate) fn parse_base(s: &str, radix: i64) -> Result<Value, RuntimeError> {
+    if !(2..=36).contains(&radix) {
+        return Err(radix_out_of_range(radix));
+    }
+    let radix_u = radix as u32;
+    let source = s;
+
+    // Iterate by characters, tracking position in CHAR units (not bytes).
+    let chars: Vec<char> = s.chars().collect();
+    let mut idx = 0usize;
+    let mut negative = false;
+
+    // Optional sign
+    if idx < chars.len() {
+        match chars[idx] {
+            '+' => idx += 1,
+            '-' | '\u{2212}' => {
+                negative = true;
+                idx += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if idx >= chars.len() {
+        return Err(str_numeric_error(source, idx, radix));
+    }
+
+    let radix_big = BigInt::from(radix_u);
+
+    // Integer part
+    let int_start = idx;
+    let mut int_val: BigInt = BigInt::zero();
+    let mut int_digits = 0usize;
+    while idx < chars.len() && chars[idx] != '.' {
+        match char_digit_value(chars[idx], radix_u) {
+            Some(d) => {
+                int_val = &int_val * &radix_big + BigInt::from(d);
+                int_digits += 1;
+                idx += 1;
+            }
+            None => {
+                return Err(str_numeric_error(source, idx, radix));
+            }
+        }
+    }
+
+    let mut has_frac = false;
+    let mut frac_num: BigInt = BigInt::zero();
+    let mut frac_den: BigInt = BigInt::one();
+
+    if idx < chars.len() && chars[idx] == '.' {
+        has_frac = true;
+        idx += 1;
+        let frac_start = idx;
+        while idx < chars.len() {
+            match char_digit_value(chars[idx], radix_u) {
+                Some(d) => {
+                    frac_num = &frac_num * &radix_big + BigInt::from(d);
+                    frac_den *= &radix_big;
+                    idx += 1;
+                }
+                None => {
+                    return Err(str_numeric_error(source, idx, radix));
+                }
+            }
+        }
+        if idx == frac_start {
+            // Trailing dot with no fractional digits — treat as malformed
+            return Err(str_numeric_error(source, idx, radix));
+        }
+    }
+
+    if int_digits == 0 && !has_frac {
+        return Err(str_numeric_error(source, int_start, radix));
+    }
+
+    if has_frac {
+        // Combine: int_val + frac_num/frac_den
+        let combined_num = &int_val * &frac_den + &frac_num;
+        let combined_num = if negative {
+            -combined_num
+        } else {
+            combined_num
+        };
+        Ok(make_big_rat(combined_num, frac_den))
+    } else {
+        let val = if negative { -int_val } else { int_val };
+        // Try to represent as Int (i64) if it fits, otherwise BigInt
+        use num_traits::ToPrimitive;
+        if let Some(n) = val.to_i64() {
+            Ok(Value::Int(n))
+        } else {
+            Ok(Value::BigInt(std::sync::Arc::new(val)))
+        }
+    }
+}

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -613,6 +613,18 @@ impl Interpreter {
                 }
             }
             "split" => self.handle_split_function(args),
+            "parse-base" => {
+                let s = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let radix = match args.get(1) {
+                    Some(Value::Int(n)) => *n,
+                    Some(Value::Str(s)) => s.parse::<i64>().unwrap_or(10),
+                    _ => 10,
+                };
+                crate::builtins::parse_base::parse_base(&s, radix)
+            }
             // File I/O
             "slurp" => self.builtin_slurp(&args),
             "spurt" => self.builtin_spurt(&args),
@@ -846,6 +858,7 @@ impl Interpreter {
                 | "unimatch"
                 | "uniparse"
                 | "parse-names"
+                | "parse-base"
                 | "symlink"
                 | "link"
                 | "spurt"

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -1177,6 +1177,7 @@ impl Interpreter {
                 "encode",
                 "uniparse",
                 "parse-names",
+                "parse-base",
                 "IO",
                 "Numeric",
                 "Int",


### PR DESCRIPTION
## Summary
- Adds a free `parse-base` builtin and unifies the method form to share a single implementation supporting signs (incl. U+2212), Unicode decimal digits, integer/fractional parts, big rationals, and proper `X::Str::Numeric` / `X::Syntax::Number::RadixOutOfRange` errors.
- Exposes `parse-base` through `Str.^lookup` so the routine form iteration in the spec test works.
- Whitelists `roast/S32-str/parse-base.t` (110/110 subtests).

## Test plan
- [x] `prove -e target/debug/mutsu roast/S32-str/parse-base.t` → 110/110 pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt`
- [x] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)