### PR TITLE
fix: bridge live Supply emits into Channel via Supply.Channel

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -739,6 +739,7 @@ roast/S17-scheduler/at.t
 roast/S17-scheduler/every.t
 roast/S17-scheduler/in.t
 roast/S17-scheduler/times.t
+roast/S17-supply/Channel.t
 roast/S17-supply/Promise.t
 roast/S17-supply/Seq.t
 roast/S17-supply/act.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -992,6 +992,7 @@ roast/S32-str/length.t
 roast/S32-str/lines.t
 roast/S32-str/numeric.t
 roast/S32-str/ords.t
+roast/S32-str/parse-base.t
 roast/S32-str/pos.t
 roast/S32-str/rindex.t
 roast/S32-str/samecase.t

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1382,17 +1382,11 @@ pub(crate) fn native_method_1arg(
         }
         "parse-base" => {
             let radix = match arg {
-                Value::Int(n) => *n as u32,
+                Value::Int(n) => *n,
                 _ => return None,
             };
             let s = target.to_string_value();
-            match i64::from_str_radix(&s, radix) {
-                Ok(n) => Some(Ok(Value::Int(n))),
-                Err(_) => Some(Err(RuntimeError::new(format!(
-                    "Cannot parse '{}' as base {}",
-                    s, radix
-                )))),
-            }
+            Some(crate::builtins::parse_base::parse_base(&s, radix))
         }
         "base" => match target {
             Value::Int(i) => {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod collation;
 mod functions;
 pub(crate) mod methods_0arg;
 mod methods_narg;
+pub(crate) mod parse_base;
 pub(crate) mod primality;
 pub(crate) mod rng;
 pub(crate) mod split;

--- a/src/builtins/parse_base.rs
+++ b/src/builtins/parse_base.rs
@@ -1,0 +1,166 @@
+//! Implementation of the `parse-base` builtin (sub and method form).
+//!
+//! Parses a string in the given numeric base (2..36), supporting:
+//! - Optional leading sign: `+`, `-`, or U+2212 (MINUS SIGN)
+//! - Integer or fractional values (with `.` separator)
+//! - ASCII digits/letters and Unicode decimal digits (Nd category)
+//!
+//! Errors thrown:
+//! - `X::Syntax::Number::RadixOutOfRange` when radix is not in 2..36
+//! - `X::Str::Numeric` for malformed input (with `source`, `pos`, `reason`)
+
+#![allow(clippy::result_large_err)]
+
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value, make_big_rat};
+use num_bigint::BigInt;
+use num_traits::{One, Zero};
+use std::collections::HashMap;
+
+fn radix_out_of_range(radix: i64) -> RuntimeError {
+    let msg = format!(
+        "Radix must be in range 2..36, not {} (use :{}[...] notation for radices outside this range)",
+        radix, radix
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("radix".to_string(), Value::Int(radix));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Number::RadixOutOfRange"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+fn str_numeric_error(source: &str, pos: usize, radix: i64) -> RuntimeError {
+    let reason = format!("malformed base-{} number", radix);
+    let msg = format!("Cannot convert string to number: {}", reason);
+    let mut attrs = HashMap::new();
+    attrs.insert("source".to_string(), Value::str(source.to_string()));
+    attrs.insert("pos".to_string(), Value::Int(pos as i64));
+    attrs.insert("reason".to_string(), Value::str(reason.clone()));
+    attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+/// Convert a single character to its digit value in the given radix.
+/// Returns Some(value) if the character is a valid digit, None otherwise.
+fn char_digit_value(ch: char, radix: u32) -> Option<u32> {
+    // ASCII fast path: 0-9, A-Z, a-z
+    let v = if ch.is_ascii_digit() {
+        (ch as u32) - ('0' as u32)
+    } else if ch.is_ascii_uppercase() {
+        (ch as u32) - ('A' as u32) + 10
+    } else if ch.is_ascii_lowercase() {
+        (ch as u32) - ('a' as u32) + 10
+    } else if let Some(d) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
+        // Unicode Nd character
+        d
+    } else {
+        return None;
+    };
+    if v < radix { Some(v) } else { None }
+}
+
+/// Parse a string in the given base. The `source` parameter is used for error
+/// reporting and should be the original string before any sign stripping.
+pub(crate) fn parse_base(s: &str, radix: i64) -> Result<Value, RuntimeError> {
+    if !(2..=36).contains(&radix) {
+        return Err(radix_out_of_range(radix));
+    }
+    let radix_u = radix as u32;
+    let source = s;
+
+    // Iterate by characters, tracking position in CHAR units (not bytes).
+    let chars: Vec<char> = s.chars().collect();
+    let mut idx = 0usize;
+    let mut negative = false;
+
+    // Optional sign
+    if idx < chars.len() {
+        match chars[idx] {
+            '+' => idx += 1,
+            '-' | '\u{2212}' => {
+                negative = true;
+                idx += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if idx >= chars.len() {
+        return Err(str_numeric_error(source, idx, radix));
+    }
+
+    let radix_big = BigInt::from(radix_u);
+
+    // Integer part
+    let int_start = idx;
+    let mut int_val: BigInt = BigInt::zero();
+    let mut int_digits = 0usize;
+    while idx < chars.len() && chars[idx] != '.' {
+        match char_digit_value(chars[idx], radix_u) {
+            Some(d) => {
+                int_val = &int_val * &radix_big + BigInt::from(d);
+                int_digits += 1;
+                idx += 1;
+            }
+            None => {
+                return Err(str_numeric_error(source, idx, radix));
+            }
+        }
+    }
+
+    let mut has_frac = false;
+    let mut frac_num: BigInt = BigInt::zero();
+    let mut frac_den: BigInt = BigInt::one();
+
+    if idx < chars.len() && chars[idx] == '.' {
+        has_frac = true;
+        idx += 1;
+        let frac_start = idx;
+        while idx < chars.len() {
+            match char_digit_value(chars[idx], radix_u) {
+                Some(d) => {
+                    frac_num = &frac_num * &radix_big + BigInt::from(d);
+                    frac_den *= &radix_big;
+                    idx += 1;
+                }
+                None => {
+                    return Err(str_numeric_error(source, idx, radix));
+                }
+            }
+        }
+        if idx == frac_start {
+            // Trailing dot with no fractional digits — treat as malformed
+            return Err(str_numeric_error(source, idx, radix));
+        }
+    }
+
+    if int_digits == 0 && !has_frac {
+        return Err(str_numeric_error(source, int_start, radix));
+    }
+
+    if has_frac {
+        // Combine: int_val + frac_num/frac_den
+        let combined_num = &int_val * &frac_den + &frac_num;
+        let combined_num = if negative {
+            -combined_num
+        } else {
+            combined_num
+        };
+        Ok(make_big_rat(combined_num, frac_den))
+    } else {
+        let val = if negative { -int_val } else { int_val };
+        // Try to represent as Int (i64) if it fits, otherwise BigInt
+        use num_traits::ToPrimitive;
+        if let Some(n) = val.to_i64() {
+            Ok(Value::Int(n))
+        } else {
+            Ok(Value::BigInt(std::sync::Arc::new(val)))
+        }
+    }
+}

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -613,6 +613,18 @@ impl Interpreter {
                 }
             }
             "split" => self.handle_split_function(args),
+            "parse-base" => {
+                let s = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let radix = match args.get(1) {
+                    Some(Value::Int(n)) => *n,
+                    Some(Value::Str(s)) => s.parse::<i64>().unwrap_or(10),
+                    _ => 10,
+                };
+                crate::builtins::parse_base::parse_base(&s, radix)
+            }
             // File I/O
             "slurp" => self.builtin_slurp(&args),
             "spurt" => self.builtin_spurt(&args),
@@ -846,6 +858,7 @@ impl Interpreter {
                 | "unimatch"
                 | "uniparse"
                 | "parse-names"
+                | "parse-base"
                 | "symlink"
                 | "link"
                 | "spurt"

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -1177,6 +1177,7 @@ impl Interpreter {
                 "encode",
                 "uniparse",
                 "parse-names",
+                "parse-base",
                 "IO",
                 "Numeric",
                 "Int",

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    fn as_exception_value(value: Value) -> Value {
+    pub(crate) fn as_exception_value(value: Value) -> Value {
         match value {
             Value::Instance { class_name, .. }
                 if class_name.resolve().contains("Exception")

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -38,16 +38,17 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, flush_supplier_batch_taps, flush_supplier_line_taps,
-    flush_supplier_words_taps, get_classify_state, get_classify_sub_supplier_ids,
-    get_start_output_supplier_ids, last_supplier_tap_id, register_supplier_batch_tap,
-    register_supplier_classify_tap, register_supplier_done_callback, register_supplier_elems_tap,
-    register_supplier_flat_tap, register_supplier_lines_tap, register_supplier_produce_tap,
-    register_supplier_quit_callback, register_supplier_start_tap, register_supplier_tap,
-    register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    register_supplier_words_tap, supplier_emit_callbacks, supplier_produce_update_acc,
-    supplier_tap_count, supplier_unique_get_seen, supplier_unique_mark_seen,
-    take_supplier_done_callbacks, take_supplier_quit_callbacks, update_classify_state,
+    SupplierEmitAction, close_supplier_channel_taps, flush_supplier_batch_taps,
+    flush_supplier_line_taps, flush_supplier_words_taps, get_classify_state,
+    get_classify_sub_supplier_ids, get_start_output_supplier_ids, last_supplier_tap_id,
+    register_supplier_batch_tap, register_supplier_channel_tap, register_supplier_classify_tap,
+    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_flat_tap,
+    register_supplier_lines_tap, register_supplier_produce_tap, register_supplier_quit_callback,
+    register_supplier_start_tap, register_supplier_tap, register_supplier_tap_with_head_limit,
+    register_supplier_unique_tap, register_supplier_words_tap, supplier_emit_callbacks,
+    supplier_produce_update_acc, supplier_tap_count, supplier_unique_get_seen,
+    supplier_unique_mark_seen, take_supplier_done_callbacks, take_supplier_quit_callbacks,
+    update_classify_state,
 };
 
 use super::*;

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -53,6 +53,10 @@ struct SupplierTapSubscription {
     words_buffer: String,
     /// Flat transform: re-emit flattened sub-elements to this downstream supplier
     flat_downstream: Option<u64>,
+    /// Channel sink: when set, emitted values are pushed directly into this
+    /// SharedChannel instead of being delivered to a callback. Used by
+    /// `Supply.Channel` to bridge a live supplier into a Channel.
+    channel_sink: Option<crate::value::SharedChannel>,
     /// Stable identifier so taps can be closed individually.
     tap_id: u64,
     /// When set, this tap is closed and should no longer receive emits.
@@ -133,6 +137,60 @@ pub(in crate::runtime) fn last_supplier_tap_id(supplier_id: u64) -> Option<u64> 
     }
 }
 
+/// Register a channel sink tap on a supplier. Each emitted value is pushed
+/// into the channel; on done/quit the channel is closed (or failed).
+pub(in crate::runtime) fn register_supplier_channel_tap(
+    supplier_id: u64,
+    channel: crate::value::SharedChannel,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .taps
+            .push(SupplierTapSubscription {
+                callback: Value::Nil,
+                line_mode: false,
+                line_chomp: true,
+                line_buffer: String::new(),
+                delay_seconds: 0.0,
+                unique_filter: None,
+                classify_state: None,
+                elems_trace: None,
+                head_limit: None,
+                head_count: 0,
+                produce_state: None,
+                start_state: None,
+                batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
+                flat_downstream: None,
+                channel_sink: Some(channel),
+                tap_id: next_tap_id(),
+                closed: false,
+            });
+    }
+}
+
+/// Close (or fail) all channel-sink taps registered on the given supplier.
+/// If `failure` is Some, the channel is failed with that value, otherwise
+/// it is closed cleanly.
+pub(in crate::runtime) fn close_supplier_channel_taps(supplier_id: u64, failure: Option<Value>) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get_mut(&supplier_id)
+    {
+        for tap in subs.taps.iter_mut() {
+            if let Some(ch) = tap.channel_sink.take() {
+                if let Some(ref err) = failure {
+                    ch.fail(err.clone());
+                } else {
+                    ch.close();
+                }
+                tap.closed = true;
+            }
+        }
+    }
+}
+
 pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, delay_seconds: f64) {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         map.entry(supplier_id)
@@ -155,6 +213,7 @@ pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, de
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -188,6 +247,7 @@ pub(in crate::runtime) fn register_supplier_tap_with_head_limit(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -221,6 +281,7 @@ pub(in crate::runtime) fn register_supplier_lines_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -253,6 +314,7 @@ pub(in crate::runtime) fn register_supplier_words_tap(
                 words_mode: true,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -292,6 +354,7 @@ pub(in crate::runtime) fn register_supplier_elems_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -362,6 +425,10 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
             if let Some(limit) = tap.head_limit
                 && tap.head_count >= limit
             {
+                continue;
+            }
+            if let Some(ref ch) = tap.channel_sink {
+                ch.send(emitted_value.clone());
                 continue;
             }
             if tap.line_mode {
@@ -598,6 +665,7 @@ pub(in crate::runtime) fn register_supplier_unique_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -634,6 +702,7 @@ pub(in crate::runtime) fn register_supplier_produce_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -672,6 +741,7 @@ pub(in crate::runtime) fn register_supplier_start_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -750,6 +820,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -927,6 +998,7 @@ pub(in crate::runtime) fn register_supplier_batch_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -961,6 +1033,7 @@ pub(in crate::runtime) fn register_supplier_flat_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: Some(downstream_supplier_id),
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1218,13 +1218,28 @@ impl Interpreter {
                 Ok(source_values.last().cloned().unwrap_or(Value::Nil))
             }
             "Channel" => {
-                // Supply.Channel: create a Channel, send all supply values into it, close it
+                // Supply.Channel: create a Channel that receives all values
+                // emitted by the underlying supplier. Existing snapshot values
+                // are pushed first, then a live tap forwards future emits.
+                // The channel is closed when the supplier is done, or failed
+                // when the supplier quits.
                 let source_values = self.supply_get_values(attributes)?;
                 let ch = SharedChannel::new();
                 for v in source_values {
                     ch.send(v);
                 }
-                ch.close();
+                if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
+                    let (_, done, quit_reason) = supplier_snapshot(supplier_id);
+                    if let Some(reason) = quit_reason {
+                        ch.fail(reason);
+                    } else if done {
+                        ch.close();
+                    } else {
+                        register_supplier_channel_tap(supplier_id, ch.clone());
+                    }
+                } else {
+                    ch.close();
+                }
                 Ok(Value::Channel(ch))
             }
             "Supply" | "supply" => {
@@ -1388,6 +1403,7 @@ impl Interpreter {
             "done" => {
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_done(supplier_id);
+                    close_supplier_channel_taps(supplier_id, None);
                     // Flush batch buffers before done
                     for (dsid, batch) in flush_supplier_batch_taps(supplier_id) {
                         let batch_value = Value::array(batch);
@@ -1431,6 +1447,7 @@ impl Interpreter {
                     .unwrap_or_else(|| Value::str_from("Died"));
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_quit(supplier_id, reason.clone());
+                    close_supplier_channel_taps(supplier_id, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
@@ -1609,6 +1626,7 @@ impl Interpreter {
                 }
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
+                    close_supplier_channel_taps(sid, None);
                     // Flush batch buffers before done
                     for (dsid, batch) in flush_supplier_batch_taps(sid) {
                         let batch_value = Value::array(batch);
@@ -1666,6 +1684,7 @@ impl Interpreter {
                 }
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
+                    close_supplier_channel_taps(sid, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -251,6 +251,24 @@ impl VM {
 
         let raw_items = if let Value::LazyList(ref ll) = iterable {
             self.force_lazy_list_vm(ll)?
+        } else if let Value::Channel(ref ch) = iterable {
+            // Drain the channel synchronously, blocking on receive until the
+            // channel is closed. Propagate any failure as an exception so the
+            // surrounding `start { }` / `try` can observe it.
+            let mut items = Vec::new();
+            loop {
+                match ch.receive_result() {
+                    Ok(Value::Nil) => break,
+                    Ok(v) => items.push(v),
+                    Err(cause) => {
+                        let ex = crate::runtime::Interpreter::as_exception_value(cause);
+                        let mut err = RuntimeError::new(ex.to_string_value());
+                        err.exception = Some(Box::new(ex));
+                        return Err(err);
+                    }
+                }
+            }
+            items
         } else {
             runtime::value_to_list(&iterable)
         };


### PR DESCRIPTION
## Summary
- Make `Supply.Channel` register a live channel-sink tap on the underlying Supplier so subsequent `emit`/`done`/`quit` reach the Channel (cleanly close on done, fail on quit).
- Teach the VM for-loop opcode to drain `Value::Channel` via blocking `receive_result`, propagating channel failures as exceptions.
- Whitelists roast/S17-supply/Channel.t (all 14 subtests now pass).

## Test plan
- [x] timeout 60 target/debug/mutsu roast/S17-supply/Channel.t -> 14/14 pass
- [x] make test
- [x] cargo clippy -- -D warnings
- [x] cargo fmt