### PR TITLE
fix: pass roast/S32-temporal/juliandate.t

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -334,7 +334,7 @@
 - [ ] roast/S32-temporal/DateTime-Instant-Duration.t
 - [ ] roast/S32-temporal/DateTime.t
 - [ ] roast/S32-temporal/greg-jd-frac-seconds.t
-- [ ] roast/S32-temporal/juliandate.t
+- [x] roast/S32-temporal/juliandate.t
 - [ ] roast/S32-temporal/local.t
 - [ ] roast/S32-temporal/time.t
 - [ ] roast/S32-trig/atan2.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1024,6 +1024,7 @@ roast/S32-temporal/DateTime.t
 roast/S32-temporal/baum-gregorian-data.t
 roast/S32-temporal/calendar.t
 roast/S32-temporal/greg-jd-frac-seconds.t
+roast/S32-temporal/juliandate.t
 roast/S32-trig/atan2.t
 roast/S32-trig/cos.t
 roast/S32-trig/cosec.t

--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -535,9 +535,52 @@ pub fn modified_julian_date(
     dc + day_fraction
 }
 
-/// Day fraction for DateTime.
-pub fn day_fraction(hour: i64, minute: i64, second: f64) -> f64 {
-    (hour as f64 * 3600.0 + minute as f64 * 60.0 + second) / 86400.0
+/// Number of seconds in the given UTC date. Normally 86400, but 86401 on a
+/// day where a positive leap second was inserted (the leap second is the
+/// final 23:59:60 of that UTC day).
+pub fn seconds_in_day(year: i64, month: i64, day: i64) -> i64 {
+    // POSIX timestamp for 00:00:00 of the day AFTER (year, month, day).
+    let next_day_posix = (civil_to_epoch_days(year, month, day) + 1) * 86_400;
+    for &(threshold, _) in LEAP_SECONDS {
+        if threshold == next_day_posix {
+            return 86_401;
+        }
+    }
+    86_400
+}
+
+/// Day fraction returned as (numerator, denominator) so callers can build a
+/// Rat exactly as Rakudo does. Handles leap-second days where the divisor is
+/// 86401 instead of 86400.
+pub fn day_fraction_rational(
+    year: i64,
+    month: i64,
+    day: i64,
+    hour: i64,
+    minute: i64,
+    second: f64,
+) -> (i64, i64) {
+    let denom = seconds_in_day(year, month, day);
+    // Convert second to a rational with up to 6 decimal places (Raku stores
+    // fractional seconds as a Rat). For most cases second is an integer here
+    // when called from is-deeply tests, so we keep it simple.
+    // Use a 1/1_000_000 scale: numerator = (h*3600 + m*60)*1_000_000 + sec*1_000_000
+    let scale: i64 = 1_000_000;
+    let sec_scaled = (second * scale as f64).round() as i64;
+    let num_scaled = (hour * 3600 + minute * 60) * scale + sec_scaled;
+    let denom_scaled = denom * scale;
+    let g = gcd_i64(num_scaled.unsigned_abs() as i64, denom_scaled);
+    (num_scaled / g, denom_scaled / g)
+}
+
+fn gcd_i64(a: i64, b: i64) -> i64 {
+    let (mut a, mut b) = (a, b);
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    if a == 0 { 1 } else { a }
 }
 
 /// Leap seconds table: (posix_timestamp_of_insertion, cumulative_leap_seconds).

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -221,7 +221,10 @@ pub fn datetime_method_0arg(
         "modified-julian-date" => Some(Ok(Value::Num(modified_julian_date(
             year, month, day, hour, minute, second,
         )))),
-        "day-fraction" => Some(Ok(Value::Num(day_fraction(hour, minute, second)))),
+        "day-fraction" => {
+            let (n, d) = day_fraction_rational(year, month, day, hour, minute, second);
+            Some(Ok(crate::value::make_rat(n, d)))
+        }
         "Instant" => {
             let posix = datetime_to_posix(year, month, day, hour, minute, second, timezone);
             let tai = posix_to_instant(posix);

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -808,7 +808,7 @@ fn parse_dot_assign<'a>(input: &'a str, expr: Expr) -> PResult<'a, Expr> {
         return Ok((r_final, result));
     }
     // Parse regular method name
-    let (r, method_name) = take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
+    let (r, method_name) = crate::parser::primary::var::parse_ident_with_hyphens(r)?;
     let (r, _) = ws(r)?;
     let (r_final, args) = if r.starts_with('(') {
         let (r2, _) = parse_char(r, '(')?;
@@ -1564,9 +1564,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             // Parse method name
             // Allow whitespace between dot and method name: `$x . abs` or `$x. abs`
             let r = ws(r).map_or(r, |(r_ws, _)| r_ws);
-            if let Ok((r, parsed_name)) =
-                take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')
-            {
+            if let Ok((r, parsed_name)) = crate::parser::primary::var::parse_ident_with_hyphens(r) {
                 let mut method_name = parsed_name.to_string();
                 let mut trailing_postfix: Option<TokenKind> = None;
                 if !r.starts_with('(') {
@@ -1583,9 +1581,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     let mut qualified = method_name;
                     let mut r = r;
                     while let Some(after_colons) = r.strip_prefix("::") {
-                        if let Ok((r2, part)) = take_while1(after_colons, |c: char| {
-                            c.is_alphanumeric() || c == '_' || c == '-'
-                        }) {
+                        if let Ok((r2, part)) =
+                            crate::parser::primary::var::parse_ident_with_hyphens(after_colons)
+                        {
                             qualified.push_str("::");
                             qualified.push_str(part);
                             r = r2;

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -363,7 +363,7 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
 /// Parse identifier allowing kebab-case hyphens and apostrophes (e.g., `my-var`, `same'proto`).
 /// A hyphen/apostrophe is only part of the name if followed by an alphabetic char or `_`,
 /// so `$pd--` parses as `$pd` + postfix `--`.
-pub(super) fn parse_ident_with_hyphens<'a>(input: &'a str) -> PResult<'a, &'a str> {
+pub(crate) fn parse_ident_with_hyphens<'a>(input: &'a str) -> PResult<'a, &'a str> {
     let first = input
         .chars()
         .next()

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1067,7 +1067,16 @@ impl Interpreter {
                             "DateTime.new cannot mix positional and component named arguments",
                         ));
                     }
-                    if let Some(v) = positional.first() {
+                    if positional.len() >= 6 {
+                        // DateTime.new($y, $mo, $d, $h, $mi, $s, :$timezone = 0)
+                        year = to_int(positional[0]);
+                        month = to_int(positional[1]);
+                        day = to_int(positional[2]);
+                        hour = to_int(positional[3]);
+                        minute = to_int(positional[4]);
+                        second = to_float_value(positional[5]).unwrap_or(0.0);
+                        has_named = true;
+                    } else if let Some(v) = positional.first() {
                         match v {
                             Value::Str(s) => {
                                 let (y, mo, d, h, mi, sec, tz) =


### PR DESCRIPTION
## Summary
- Parse method names as proper Raku identifiers (so `$f.chars-2` is `$f.chars - 2`, not a method called `chars-2`).
- Support `DateTime.new($y, $mo, $d, $h, $mi, $s)` positional form.
- `day-fraction` now returns a `Rat`, with leap-second days using denominator 86401 so `is-deeply` against `43200/86401` works.

## Test plan
- [x] roast/S32-temporal/juliandate.t passes 128/128
- [x] make test (only pre-existing flaky t/lock.t race)
- [x] cargo clippy -- -D warnings