### PR TITLE
fix: parse Pod =defn blocks (S26-documentation/14-defn.t)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -818,6 +818,7 @@ roast/S26-documentation/06-lists.t
 roast/S26-documentation/07c-tables.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t
+roast/S26-documentation/14-defn.t
 roast/S26-documentation/block-leading-user-format.t
 roast/S26-documentation/module-comment.t
 roast/S26-documentation/multiline-leading.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -739,6 +739,7 @@ roast/S17-scheduler/at.t
 roast/S17-scheduler/every.t
 roast/S17-scheduler/in.t
 roast/S17-scheduler/times.t
+roast/S17-supply/Channel.t
 roast/S17-supply/Promise.t
 roast/S17-supply/Seq.t
 roast/S17-supply/act.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -322,6 +322,7 @@ roast/S05-grammar/namespace.t
 roast/S05-grammar/parse_and_parsefile-6e.t
 roast/S05-grammar/protoregex.t
 roast/S05-grammar/protos.t
+roast/S05-grammar/signatures.t
 roast/S05-grammar/ws.t
 roast/S05-interpolation/lexicals.t
 roast/S05-interpolation/regex-in-variable.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -992,6 +992,7 @@ roast/S32-str/length.t
 roast/S32-str/lines.t
 roast/S32-str/numeric.t
 roast/S32-str/ords.t
+roast/S32-str/parse-base.t
 roast/S32-str/pos.t
 roast/S32-str/rindex.t
 roast/S32-str/samecase.t

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1382,17 +1382,11 @@ pub(crate) fn native_method_1arg(
         }
         "parse-base" => {
             let radix = match arg {
-                Value::Int(n) => *n as u32,
+                Value::Int(n) => *n,
                 _ => return None,
             };
             let s = target.to_string_value();
-            match i64::from_str_radix(&s, radix) {
-                Ok(n) => Some(Ok(Value::Int(n))),
-                Err(_) => Some(Err(RuntimeError::new(format!(
-                    "Cannot parse '{}' as base {}",
-                    s, radix
-                )))),
-            }
+            Some(crate::builtins::parse_base::parse_base(&s, radix))
         }
         "base" => match target {
             Value::Int(i) => {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod collation;
 mod functions;
 pub(crate) mod methods_0arg;
 mod methods_narg;
+pub(crate) mod parse_base;
 pub(crate) mod primality;
 pub(crate) mod rng;
 pub(crate) mod split;

--- a/src/builtins/parse_base.rs
+++ b/src/builtins/parse_base.rs
@@ -1,0 +1,166 @@
+//! Implementation of the `parse-base` builtin (sub and method form).
+//!
+//! Parses a string in the given numeric base (2..36), supporting:
+//! - Optional leading sign: `+`, `-`, or U+2212 (MINUS SIGN)
+//! - Integer or fractional values (with `.` separator)
+//! - ASCII digits/letters and Unicode decimal digits (Nd category)
+//!
+//! Errors thrown:
+//! - `X::Syntax::Number::RadixOutOfRange` when radix is not in 2..36
+//! - `X::Str::Numeric` for malformed input (with `source`, `pos`, `reason`)
+
+#![allow(clippy::result_large_err)]
+
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value, make_big_rat};
+use num_bigint::BigInt;
+use num_traits::{One, Zero};
+use std::collections::HashMap;
+
+fn radix_out_of_range(radix: i64) -> RuntimeError {
+    let msg = format!(
+        "Radix must be in range 2..36, not {} (use :{}[...] notation for radices outside this range)",
+        radix, radix
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("radix".to_string(), Value::Int(radix));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Number::RadixOutOfRange"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+fn str_numeric_error(source: &str, pos: usize, radix: i64) -> RuntimeError {
+    let reason = format!("malformed base-{} number", radix);
+    let msg = format!("Cannot convert string to number: {}", reason);
+    let mut attrs = HashMap::new();
+    attrs.insert("source".to_string(), Value::str(source.to_string()));
+    attrs.insert("pos".to_string(), Value::Int(pos as i64));
+    attrs.insert("reason".to_string(), Value::str(reason.clone()));
+    attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+/// Convert a single character to its digit value in the given radix.
+/// Returns Some(value) if the character is a valid digit, None otherwise.
+fn char_digit_value(ch: char, radix: u32) -> Option<u32> {
+    // ASCII fast path: 0-9, A-Z, a-z
+    let v = if ch.is_ascii_digit() {
+        (ch as u32) - ('0' as u32)
+    } else if ch.is_ascii_uppercase() {
+        (ch as u32) - ('A' as u32) + 10
+    } else if ch.is_ascii_lowercase() {
+        (ch as u32) - ('a' as u32) + 10
+    } else if let Some(d) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
+        // Unicode Nd character
+        d
+    } else {
+        return None;
+    };
+    if v < radix { Some(v) } else { None }
+}
+
+/// Parse a string in the given base. The `source` parameter is used for error
+/// reporting and should be the original string before any sign stripping.
+pub(crate) fn parse_base(s: &str, radix: i64) -> Result<Value, RuntimeError> {
+    if !(2..=36).contains(&radix) {
+        return Err(radix_out_of_range(radix));
+    }
+    let radix_u = radix as u32;
+    let source = s;
+
+    // Iterate by characters, tracking position in CHAR units (not bytes).
+    let chars: Vec<char> = s.chars().collect();
+    let mut idx = 0usize;
+    let mut negative = false;
+
+    // Optional sign
+    if idx < chars.len() {
+        match chars[idx] {
+            '+' => idx += 1,
+            '-' | '\u{2212}' => {
+                negative = true;
+                idx += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if idx >= chars.len() {
+        return Err(str_numeric_error(source, idx, radix));
+    }
+
+    let radix_big = BigInt::from(radix_u);
+
+    // Integer part
+    let int_start = idx;
+    let mut int_val: BigInt = BigInt::zero();
+    let mut int_digits = 0usize;
+    while idx < chars.len() && chars[idx] != '.' {
+        match char_digit_value(chars[idx], radix_u) {
+            Some(d) => {
+                int_val = &int_val * &radix_big + BigInt::from(d);
+                int_digits += 1;
+                idx += 1;
+            }
+            None => {
+                return Err(str_numeric_error(source, idx, radix));
+            }
+        }
+    }
+
+    let mut has_frac = false;
+    let mut frac_num: BigInt = BigInt::zero();
+    let mut frac_den: BigInt = BigInt::one();
+
+    if idx < chars.len() && chars[idx] == '.' {
+        has_frac = true;
+        idx += 1;
+        let frac_start = idx;
+        while idx < chars.len() {
+            match char_digit_value(chars[idx], radix_u) {
+                Some(d) => {
+                    frac_num = &frac_num * &radix_big + BigInt::from(d);
+                    frac_den *= &radix_big;
+                    idx += 1;
+                }
+                None => {
+                    return Err(str_numeric_error(source, idx, radix));
+                }
+            }
+        }
+        if idx == frac_start {
+            // Trailing dot with no fractional digits — treat as malformed
+            return Err(str_numeric_error(source, idx, radix));
+        }
+    }
+
+    if int_digits == 0 && !has_frac {
+        return Err(str_numeric_error(source, int_start, radix));
+    }
+
+    if has_frac {
+        // Combine: int_val + frac_num/frac_den
+        let combined_num = &int_val * &frac_den + &frac_num;
+        let combined_num = if negative {
+            -combined_num
+        } else {
+            combined_num
+        };
+        Ok(make_big_rat(combined_num, frac_den))
+    } else {
+        let val = if negative { -int_val } else { int_val };
+        // Try to represent as Int (i64) if it fits, otherwise BigInt
+        use num_traits::ToPrimitive;
+        if let Some(n) = val.to_i64() {
+            Ok(Value::Int(n))
+        } else {
+            Ok(Value::BigInt(std::sync::Arc::new(val)))
+        }
+    }
+}

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -613,6 +613,18 @@ impl Interpreter {
                 }
             }
             "split" => self.handle_split_function(args),
+            "parse-base" => {
+                let s = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let radix = match args.get(1) {
+                    Some(Value::Int(n)) => *n,
+                    Some(Value::Str(s)) => s.parse::<i64>().unwrap_or(10),
+                    _ => 10,
+                };
+                crate::builtins::parse_base::parse_base(&s, radix)
+            }
             // File I/O
             "slurp" => self.builtin_slurp(&args),
             "spurt" => self.builtin_spurt(&args),
@@ -846,6 +858,7 @@ impl Interpreter {
                 | "unimatch"
                 | "uniparse"
                 | "parse-names"
+                | "parse-base"
                 | "symlink"
                 | "link"
                 | "spurt"

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -87,6 +87,204 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Pod::Item"), attrs)
     }
 
+    fn make_pod_defn(term: String, contents: Vec<Value>, config: HashMap<String, Value>) -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert("term".to_string(), Value::str(term));
+        attrs.insert("contents".to_string(), Value::array(contents));
+        attrs.insert("config".to_string(), Value::hash(config));
+        Value::make_instance(Symbol::intern("Pod::Defn"), attrs)
+    }
+
+    /// Build a Pod::Defn from a single paragraph (used by `=for defn` and abbreviated `=defn`).
+    /// `inline` is the text appearing on the directive line after the directive token
+    /// (and after stripping config adverbs). For `=defn`, it may begin with `# ` to
+    /// request `:numbered`. The first non-blank line of the paragraph is the term;
+    /// remaining lines form a single Pod::Block::Para.
+    fn build_pod_defn_paragraph(
+        lines: &[&str],
+        start_idx: usize,
+        inline: &str,
+        mut config: HashMap<String, Value>,
+        end_target: Option<&str>,
+    ) -> (Value, usize) {
+        // Collect the paragraph lines (until blank line / pod directive).
+        let mut all_lines: Vec<String> = Vec::new();
+        let inline_trimmed = inline.trim();
+        if !inline_trimmed.is_empty() {
+            all_lines.push(inline_trimmed.to_string());
+        }
+        let mut idx = start_idx;
+        while idx < lines.len() {
+            let trimmed = lines[idx].trim_start();
+            if trimmed.is_empty() || Self::active_pod_directive(lines[idx], end_target).is_some() {
+                break;
+            }
+            all_lines.push(lines[idx].trim().to_string());
+            idx += 1;
+        }
+        // First non-empty line is the term; if it begins with `# `, set :numbered.
+        let mut term = String::new();
+        let mut term_idx = None;
+        for (i, line) in all_lines.iter().enumerate() {
+            if !line.is_empty() {
+                term = line.clone();
+                term_idx = Some(i);
+                break;
+            }
+        }
+        if let Some(rest) = term.strip_prefix('#') {
+            let rest = rest.trim_start();
+            term = rest.to_string();
+            config
+                .entry("numbered".to_string())
+                .or_insert(Value::Bool(true));
+        }
+        let body_lines: Vec<String> = match term_idx {
+            Some(i) => all_lines[i + 1..].to_vec(),
+            None => Vec::new(),
+        };
+        let mut contents: Vec<Value> = Vec::new();
+        if !body_lines.is_empty() {
+            let text = Self::normalize_pod_text(&body_lines);
+            let payload = if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![text]
+            };
+            contents.push(Self::make_pod_para(payload));
+        }
+        (Self::make_pod_defn(term, contents, config), idx)
+    }
+
+    /// Build a Pod::Defn from a `=begin defn ... =end defn` block.
+    /// First non-blank line of the first paragraph is the term; the remainder of
+    /// that paragraph (and each subsequent paragraph separated by blank lines)
+    /// becomes a Pod::Block::Para in `contents`.
+    fn build_pod_defn_delimited(
+        lines: &[&str],
+        start_idx: usize,
+        config: HashMap<String, Value>,
+    ) -> (Value, usize) {
+        let mut idx = start_idx;
+        // Collect paragraphs until `=end defn`.
+        let mut paragraphs: Vec<Vec<String>> = Vec::new();
+        let mut current: Vec<String> = Vec::new();
+        while idx < lines.len() {
+            let line = lines[idx];
+            if let Some((directive, rest)) = Self::active_pod_directive(line, Some("defn")) {
+                if directive == "end"
+                    && rest.split_whitespace().next().unwrap_or_default() == "defn"
+                {
+                    idx += 1;
+                    break;
+                }
+                // Other directives inside a defn block: stop collecting (paragraph break).
+                if !current.is_empty() {
+                    paragraphs.push(std::mem::take(&mut current));
+                }
+                idx += 1;
+                continue;
+            }
+            if line.trim().is_empty() {
+                if !current.is_empty() {
+                    paragraphs.push(std::mem::take(&mut current));
+                }
+                idx += 1;
+                continue;
+            }
+            current.push(line.trim().to_string());
+            idx += 1;
+        }
+        if !current.is_empty() {
+            paragraphs.push(current);
+        }
+        let mut term = String::new();
+        let mut contents: Vec<Value> = Vec::new();
+        let mut first = true;
+        for para in paragraphs {
+            if first {
+                first = false;
+                if para.is_empty() {
+                    continue;
+                }
+                term = para[0].clone();
+                let rest = &para[1..];
+                if !rest.is_empty() {
+                    let text = Self::normalize_pod_text(rest);
+                    let payload = if text.is_empty() {
+                        Vec::new()
+                    } else {
+                        vec![text]
+                    };
+                    contents.push(Self::make_pod_para(payload));
+                }
+            } else {
+                let text = Self::normalize_pod_text(&para);
+                let payload = if text.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![text]
+                };
+                contents.push(Self::make_pod_para(payload));
+            }
+        }
+        (Self::make_pod_defn(term, contents, config), idx)
+    }
+
+    /// Parse Pod config adverbs from a directive tail (e.g. `:numbered :foo(0)`).
+    /// Returns (config_map, leftover_text_after_adverbs).
+    /// Supported forms: `:key`, `:!key`, `:key(value)` where value is an integer
+    /// or bareword (true/false treated as Bool).
+    fn parse_pod_config(input: &str) -> (HashMap<String, Value>, &str) {
+        let mut config: HashMap<String, Value> = HashMap::new();
+        let mut s = input.trim_start();
+        loop {
+            if !s.starts_with(':') {
+                break;
+            }
+            let rest = &s[1..];
+            let (negated, rest) = if let Some(r) = rest.strip_prefix('!') {
+                (true, r)
+            } else {
+                (false, rest)
+            };
+            // Read identifier
+            let name_len = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                .map(char::len_utf8)
+                .sum::<usize>();
+            if name_len == 0 {
+                break;
+            }
+            let name = &rest[..name_len];
+            let after_name = &rest[name_len..];
+            let (value, after_val) = if let Some(after_paren) = after_name.strip_prefix('(') {
+                // Read until matching ')'
+                if let Some(close_idx) = after_paren.find(')') {
+                    let raw = after_paren[..close_idx].trim();
+                    let v = if let Ok(n) = raw.parse::<i64>() {
+                        Value::Int(n)
+                    } else if raw == "True" {
+                        Value::Bool(true)
+                    } else if raw == "False" {
+                        Value::Bool(false)
+                    } else {
+                        Value::str(raw.to_string())
+                    };
+                    (v, &after_paren[close_idx + 1..])
+                } else {
+                    break;
+                }
+            } else {
+                (Value::Bool(!negated), after_name)
+            };
+            config.insert(name.to_string(), value);
+            s = after_val.trim_start();
+        }
+        (config, s)
+    }
+
     fn make_pod_table(rows: Vec<Vec<String>>) -> Value {
         let mut attrs = HashMap::new();
         let contents = rows
@@ -348,6 +546,19 @@ impl Interpreter {
                         idx = next_idx.max(idx + 1);
                         continue;
                     }
+                    if target == "defn" {
+                        let (config, leftover) = Self::parse_pod_config(inline);
+                        let (defn, next_idx) = Self::build_pod_defn_paragraph(
+                            lines,
+                            idx + 1,
+                            leftover,
+                            config,
+                            end_target,
+                        );
+                        entries.push(defn);
+                        idx = next_idx.max(idx + 1);
+                        continue;
+                    }
                     let (para, next_idx) =
                         Self::collect_pod_para_with_inline(lines, idx + 1, inline, end_target);
                     let mut contents = Vec::new();
@@ -388,6 +599,15 @@ impl Interpreter {
                         entries.push(Self::make_pod_block(vec![Value::str(raw)]));
                         continue;
                     }
+                    if target == "defn" {
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (config, _) = Self::parse_pod_config(after_target);
+                        let (defn, next_idx) =
+                            Self::build_pod_defn_delimited(lines, idx + 1, config);
+                        entries.push(defn);
+                        idx = next_idx.max(idx + 1);
+                        continue;
+                    }
                     if let Some(level) = Self::parse_item_level(target) {
                         let (item_contents, next_idx) =
                             Self::collect_pod_entries(lines, idx + 1, Some(target));
@@ -415,6 +635,19 @@ impl Interpreter {
                         item_contents.push(para);
                     }
                     entries.push(Self::make_pod_item(level, item_contents));
+                    idx = next_idx.max(idx + 1);
+                    continue;
+                }
+                if directive == "defn" {
+                    let (config, leftover) = Self::parse_pod_config(rest);
+                    let (defn, next_idx) = Self::build_pod_defn_paragraph(
+                        lines,
+                        idx + 1,
+                        leftover,
+                        config,
+                        end_target,
+                    );
+                    entries.push(defn);
                     idx = next_idx.max(idx + 1);
                     continue;
                 }
@@ -516,6 +749,14 @@ impl Interpreter {
                         idx = next_idx.max(idx + 1);
                         continue;
                     }
+                    if target == "defn" {
+                        let (config, leftover) = Self::parse_pod_config(inline);
+                        let (defn, next_idx) =
+                            Self::build_pod_defn_paragraph(&lines, idx + 1, leftover, config, None);
+                        entries.push(defn);
+                        idx = next_idx.max(idx + 1);
+                        continue;
+                    }
                     let (para, next_idx) =
                         Self::collect_pod_para_with_inline(&lines, idx + 1, inline, None);
                     let mut contents = Vec::new();
@@ -556,6 +797,15 @@ impl Interpreter {
                         entries.push(Self::make_pod_block(vec![Value::str(raw)]));
                         continue;
                     }
+                    if target == "defn" {
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (config, _) = Self::parse_pod_config(after_target);
+                        let (defn, next_idx) =
+                            Self::build_pod_defn_delimited(&lines, idx + 1, config);
+                        entries.push(defn);
+                        idx = next_idx.max(idx + 1);
+                        continue;
+                    }
                     if let Some(level) = Self::parse_item_level(target) {
                         let (item_contents, next_idx) =
                             Self::collect_pod_entries(&lines, idx + 1, Some(target));
@@ -583,6 +833,14 @@ impl Interpreter {
                         item_contents.push(para);
                     }
                     entries.push(Self::make_pod_item(level, item_contents));
+                    idx = next_idx.max(idx + 1);
+                    continue;
+                }
+                if directive == "defn" {
+                    let (config, leftover) = Self::parse_pod_config(rest);
+                    let (defn, next_idx) =
+                        Self::build_pod_defn_paragraph(&lines, idx + 1, leftover, config, None);
+                    entries.push(defn);
                     idx = next_idx.max(idx + 1);
                     continue;
                 }

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -1177,6 +1177,7 @@ impl Interpreter {
                 "encode",
                 "uniparse",
                 "parse-names",
+                "parse-base",
                 "IO",
                 "Numeric",
                 "Int",

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    fn as_exception_value(value: Value) -> Value {
+    pub(crate) fn as_exception_value(value: Value) -> Value {
         match value {
             Value::Instance { class_name, .. }
                 if class_name.resolve().contains("Exception")

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -38,16 +38,17 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, flush_supplier_batch_taps, flush_supplier_line_taps,
-    flush_supplier_words_taps, get_classify_state, get_classify_sub_supplier_ids,
-    get_start_output_supplier_ids, last_supplier_tap_id, register_supplier_batch_tap,
-    register_supplier_classify_tap, register_supplier_done_callback, register_supplier_elems_tap,
-    register_supplier_flat_tap, register_supplier_lines_tap, register_supplier_produce_tap,
-    register_supplier_quit_callback, register_supplier_start_tap, register_supplier_tap,
-    register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    register_supplier_words_tap, supplier_emit_callbacks, supplier_produce_update_acc,
-    supplier_tap_count, supplier_unique_get_seen, supplier_unique_mark_seen,
-    take_supplier_done_callbacks, take_supplier_quit_callbacks, update_classify_state,
+    SupplierEmitAction, close_supplier_channel_taps, flush_supplier_batch_taps,
+    flush_supplier_line_taps, flush_supplier_words_taps, get_classify_state,
+    get_classify_sub_supplier_ids, get_start_output_supplier_ids, last_supplier_tap_id,
+    register_supplier_batch_tap, register_supplier_channel_tap, register_supplier_classify_tap,
+    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_flat_tap,
+    register_supplier_lines_tap, register_supplier_produce_tap, register_supplier_quit_callback,
+    register_supplier_start_tap, register_supplier_tap, register_supplier_tap_with_head_limit,
+    register_supplier_unique_tap, register_supplier_words_tap, supplier_emit_callbacks,
+    supplier_produce_update_acc, supplier_tap_count, supplier_unique_get_seen,
+    supplier_unique_mark_seen, take_supplier_done_callbacks, take_supplier_quit_callbacks,
+    update_classify_state,
 };
 
 use super::*;

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -53,6 +53,10 @@ struct SupplierTapSubscription {
     words_buffer: String,
     /// Flat transform: re-emit flattened sub-elements to this downstream supplier
     flat_downstream: Option<u64>,
+    /// Channel sink: when set, emitted values are pushed directly into this
+    /// SharedChannel instead of being delivered to a callback. Used by
+    /// `Supply.Channel` to bridge a live supplier into a Channel.
+    channel_sink: Option<crate::value::SharedChannel>,
     /// Stable identifier so taps can be closed individually.
     tap_id: u64,
     /// When set, this tap is closed and should no longer receive emits.
@@ -133,6 +137,60 @@ pub(in crate::runtime) fn last_supplier_tap_id(supplier_id: u64) -> Option<u64> 
     }
 }
 
+/// Register a channel sink tap on a supplier. Each emitted value is pushed
+/// into the channel; on done/quit the channel is closed (or failed).
+pub(in crate::runtime) fn register_supplier_channel_tap(
+    supplier_id: u64,
+    channel: crate::value::SharedChannel,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .taps
+            .push(SupplierTapSubscription {
+                callback: Value::Nil,
+                line_mode: false,
+                line_chomp: true,
+                line_buffer: String::new(),
+                delay_seconds: 0.0,
+                unique_filter: None,
+                classify_state: None,
+                elems_trace: None,
+                head_limit: None,
+                head_count: 0,
+                produce_state: None,
+                start_state: None,
+                batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
+                flat_downstream: None,
+                channel_sink: Some(channel),
+                tap_id: next_tap_id(),
+                closed: false,
+            });
+    }
+}
+
+/// Close (or fail) all channel-sink taps registered on the given supplier.
+/// If `failure` is Some, the channel is failed with that value, otherwise
+/// it is closed cleanly.
+pub(in crate::runtime) fn close_supplier_channel_taps(supplier_id: u64, failure: Option<Value>) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get_mut(&supplier_id)
+    {
+        for tap in subs.taps.iter_mut() {
+            if let Some(ch) = tap.channel_sink.take() {
+                if let Some(ref err) = failure {
+                    ch.fail(err.clone());
+                } else {
+                    ch.close();
+                }
+                tap.closed = true;
+            }
+        }
+    }
+}
+
 pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, delay_seconds: f64) {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         map.entry(supplier_id)
@@ -155,6 +213,7 @@ pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, de
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -188,6 +247,7 @@ pub(in crate::runtime) fn register_supplier_tap_with_head_limit(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -221,6 +281,7 @@ pub(in crate::runtime) fn register_supplier_lines_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -253,6 +314,7 @@ pub(in crate::runtime) fn register_supplier_words_tap(
                 words_mode: true,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -292,6 +354,7 @@ pub(in crate::runtime) fn register_supplier_elems_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -362,6 +425,10 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
             if let Some(limit) = tap.head_limit
                 && tap.head_count >= limit
             {
+                continue;
+            }
+            if let Some(ref ch) = tap.channel_sink {
+                ch.send(emitted_value.clone());
                 continue;
             }
             if tap.line_mode {
@@ -598,6 +665,7 @@ pub(in crate::runtime) fn register_supplier_unique_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -634,6 +702,7 @@ pub(in crate::runtime) fn register_supplier_produce_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -672,6 +741,7 @@ pub(in crate::runtime) fn register_supplier_start_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -750,6 +820,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -927,6 +998,7 @@ pub(in crate::runtime) fn register_supplier_batch_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: None,
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });
@@ -961,6 +1033,7 @@ pub(in crate::runtime) fn register_supplier_flat_tap(
                 words_mode: false,
                 words_buffer: String::new(),
                 flat_downstream: Some(downstream_supplier_id),
+                channel_sink: None,
                 tap_id: next_tap_id(),
                 closed: false,
             });

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1218,13 +1218,28 @@ impl Interpreter {
                 Ok(source_values.last().cloned().unwrap_or(Value::Nil))
             }
             "Channel" => {
-                // Supply.Channel: create a Channel, send all supply values into it, close it
+                // Supply.Channel: create a Channel that receives all values
+                // emitted by the underlying supplier. Existing snapshot values
+                // are pushed first, then a live tap forwards future emits.
+                // The channel is closed when the supplier is done, or failed
+                // when the supplier quits.
                 let source_values = self.supply_get_values(attributes)?;
                 let ch = SharedChannel::new();
                 for v in source_values {
                     ch.send(v);
                 }
-                ch.close();
+                if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
+                    let (_, done, quit_reason) = supplier_snapshot(supplier_id);
+                    if let Some(reason) = quit_reason {
+                        ch.fail(reason);
+                    } else if done {
+                        ch.close();
+                    } else {
+                        register_supplier_channel_tap(supplier_id, ch.clone());
+                    }
+                } else {
+                    ch.close();
+                }
                 Ok(Value::Channel(ch))
             }
             "Supply" | "supply" => {
@@ -1388,6 +1403,7 @@ impl Interpreter {
             "done" => {
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_done(supplier_id);
+                    close_supplier_channel_taps(supplier_id, None);
                     // Flush batch buffers before done
                     for (dsid, batch) in flush_supplier_batch_taps(supplier_id) {
                         let batch_value = Value::array(batch);
@@ -1431,6 +1447,7 @@ impl Interpreter {
                     .unwrap_or_else(|| Value::str_from("Died"));
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_quit(supplier_id, reason.clone());
+                    close_supplier_channel_taps(supplier_id, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
@@ -1609,6 +1626,7 @@ impl Interpreter {
                 }
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
+                    close_supplier_channel_taps(sid, None);
                     // Flush batch buffers before done
                     for (dsid, batch) in flush_supplier_batch_taps(sid) {
                         let batch_value = Value::array(batch);
@@ -1666,6 +1684,7 @@ impl Interpreter {
                 }
                 if let Some(Value::Int(supplier_id)) = attrs.get("supplier_id") {
                     let sid = *supplier_id as u64;
+                    close_supplier_channel_taps(sid, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -1,6 +1,245 @@
 use super::super::*;
 
 impl Interpreter {
+    /// Heuristic: returns true if a regex subrule arg expression syntactically
+    /// looks like a fat-arrow Pair (`a => 1`), a colonpair (`:b(2)`), or a
+    /// `|`-flattening prefix (`|...`). For these forms we cannot easily
+    /// round-trip the value through a regex source string, so we keep the
+    /// original expression and let the match-time evaluator handle them.
+    pub(in crate::runtime) fn regex_arg_is_complex(arg: &str) -> bool {
+        let trimmed = arg.trim_start();
+        if trimmed.starts_with(':') || trimmed.starts_with('|') {
+            return true;
+        }
+        // Detect top-level `=>` (fat-arrow Pair).
+        let bytes: Vec<char> = arg.chars().collect();
+        let mut paren = 0i32;
+        let mut bracket = 0i32;
+        let mut brace = 0i32;
+        let mut quote: Option<char> = None;
+        let mut escaped = false;
+        let mut i = 0;
+        while i < bytes.len() {
+            let ch = bytes[i];
+            if let Some(q) = quote {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == q {
+                    quote = None;
+                }
+                i += 1;
+                continue;
+            }
+            match ch {
+                '\'' | '"' => quote = Some(ch),
+                '(' => paren += 1,
+                ')' => paren -= 1,
+                '[' => bracket += 1,
+                ']' => bracket -= 1,
+                '{' => brace += 1,
+                '}' => brace -= 1,
+                '=' if paren == 0
+                    && bracket == 0
+                    && brace == 0
+                    && i + 1 < bytes.len()
+                    && bytes[i + 1] == '>' =>
+                {
+                    return true;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        false
+    }
+
+    /// Returns true if a value can be safely formatted into a regex argument
+    /// list and re-evaluated to the same value. Conservative: only simple
+    /// scalar literals.
+    pub(in crate::runtime) fn value_is_round_trippable(value: &Value) -> bool {
+        matches!(
+            value,
+            Value::Int(_) | Value::Num(_) | Value::Str(_) | Value::Bool(_) | Value::Nil
+        )
+    }
+
+    /// Walk a regex pattern source and, inside each top-level `{ ... }` code
+    /// block, replace bare `$name` references for `param_names` with a
+    /// parenthesised literal of the value bound in `self.env`. This lets
+    /// regex code blocks see token parameters that would otherwise be lost
+    /// when the pattern is matched in the caller's environment.
+    pub(in crate::runtime) fn bake_bound_params_into_regex_code_blocks(
+        &self,
+        pattern: &str,
+        param_names: &[String],
+    ) -> String {
+        if param_names.is_empty() {
+            return pattern.to_string();
+        }
+        let chars: Vec<char> = pattern.chars().collect();
+        let mut out = String::new();
+        let mut i = 0usize;
+        while i < chars.len() {
+            let ch = chars[i];
+            // Skip <...> assertions / subrule calls; we only rewrite code blocks.
+            if ch == '<' {
+                let mut depth = 1usize;
+                out.push(ch);
+                i += 1;
+                let mut paren = 0usize;
+                let mut bracket = 0usize;
+                let mut brace = 0usize;
+                let mut quote: Option<char> = None;
+                let mut esc = false;
+                while i < chars.len() && depth > 0 {
+                    let c = chars[i];
+                    if let Some(q) = quote {
+                        if esc {
+                            esc = false;
+                        } else if c == '\\' {
+                            esc = true;
+                        } else if c == q {
+                            quote = None;
+                        }
+                    } else {
+                        match c {
+                            '\'' | '"' => quote = Some(c),
+                            '(' => paren += 1,
+                            ')' => paren = paren.saturating_sub(1),
+                            '[' => bracket += 1,
+                            ']' => bracket = bracket.saturating_sub(1),
+                            '{' => brace += 1,
+                            '}' => brace = brace.saturating_sub(1),
+                            '<' if paren == 0 && bracket == 0 && brace == 0 => depth += 1,
+                            '>' if paren == 0 && bracket == 0 && brace == 0 => depth -= 1,
+                            _ => {}
+                        }
+                    }
+                    out.push(c);
+                    i += 1;
+                }
+                continue;
+            }
+            if ch == '\\' {
+                out.push(ch);
+                i += 1;
+                if i < chars.len() {
+                    out.push(chars[i]);
+                    i += 1;
+                }
+                continue;
+            }
+            if ch == '{' {
+                // Capture body of code block.
+                let mut depth = 1usize;
+                let body_start = i + 1;
+                let mut j = i + 1;
+                while j < chars.len() && depth > 0 {
+                    let c = chars[j];
+                    if c == '{' {
+                        depth += 1;
+                    } else if c == '}' {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    j += 1;
+                }
+                let body: String = chars[body_start..j].iter().collect();
+                let baked = self.bake_params_in_code_text(&body, param_names);
+                out.push('{');
+                out.push_str(&baked);
+                if j < chars.len() {
+                    out.push('}');
+                    i = j + 1;
+                } else {
+                    i = j;
+                }
+                continue;
+            }
+            out.push(ch);
+            i += 1;
+        }
+        out
+    }
+
+    fn bake_params_in_code_text(&self, code: &str, param_names: &[String]) -> String {
+        let chars: Vec<char> = code.chars().collect();
+        let mut out = String::new();
+        let mut i = 0usize;
+        // Track quote state but allow $-substitution inside double-quoted
+        // strings (Raku interpolates them too).
+        let mut in_squote = false;
+        let mut escaped = false;
+        while i < chars.len() {
+            let ch = chars[i];
+            if in_squote {
+                out.push(ch);
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '\'' {
+                    in_squote = false;
+                }
+                i += 1;
+                continue;
+            }
+            if ch == '\'' {
+                in_squote = true;
+                out.push(ch);
+                i += 1;
+                continue;
+            }
+            // Skip backslash escapes outside of single-quoted strings.
+            if ch == '\\' && i + 1 < chars.len() {
+                out.push(ch);
+                out.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
+            if ch == '$' && i + 1 < chars.len() {
+                let next = chars[i + 1];
+                if next.is_alphabetic() || next == '_' {
+                    let mut j = i + 1;
+                    while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+                        j += 1;
+                    }
+                    let name: String = chars[i + 1..j].iter().collect();
+                    if param_names.iter().any(|p| p == &name)
+                        && let Some(val) = self.env.get(&name).cloned()
+                        && let Some(literal) = Self::value_to_raku_literal(&val)
+                    {
+                        out.push_str(&literal);
+                        i = j;
+                        continue;
+                    }
+                }
+            }
+            out.push(ch);
+            i += 1;
+        }
+        out
+    }
+
+    fn value_to_raku_literal(value: &Value) -> Option<String> {
+        match value {
+            Value::Int(n) => Some(n.to_string()),
+            Value::Num(n) => Some(format!("{n}e0")),
+            Value::Bool(true) => Some("True".to_string()),
+            Value::Bool(false) => Some("False".to_string()),
+            Value::Nil => Some("Nil".to_string()),
+            Value::Str(s) => {
+                let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+                Some(format!("'{escaped}'"))
+            }
+            _ => None,
+        }
+    }
+
     pub(in crate::runtime) fn interpolate_bound_regex_scalars(&self, pattern: &str) -> String {
         let chars: Vec<char> = pattern.chars().collect();
         let mut out = String::new();
@@ -27,12 +266,34 @@ impl Interpreter {
                 let mut depth = 1usize;
                 out.push(ch);
                 i += 1;
+                let mut paren = 0usize;
+                let mut bracket = 0usize;
+                let mut brace = 0usize;
+                let mut quote: Option<char> = None;
+                let mut esc = false;
                 while i < chars.len() && depth > 0 {
                     let c = chars[i];
-                    if c == '<' {
-                        depth += 1;
-                    } else if c == '>' {
-                        depth -= 1;
+                    if let Some(q) = quote {
+                        if esc {
+                            esc = false;
+                        } else if c == '\\' {
+                            esc = true;
+                        } else if c == q {
+                            quote = None;
+                        }
+                    } else {
+                        match c {
+                            '\'' | '"' => quote = Some(c),
+                            '(' => paren += 1,
+                            ')' => paren = paren.saturating_sub(1),
+                            '[' => bracket += 1,
+                            ']' => bracket = bracket.saturating_sub(1),
+                            '{' => brace += 1,
+                            '}' => brace = brace.saturating_sub(1),
+                            '<' if paren == 0 && bracket == 0 && brace == 0 => depth += 1,
+                            '>' if paren == 0 && bracket == 0 && brace == 0 => depth -= 1,
+                            _ => {}
+                        }
                     }
                     out.push(c);
                     i += 1;
@@ -119,11 +380,37 @@ impl Interpreter {
             let mut depth = 1usize;
             let start = i + 1;
             i += 1;
+            // Track nested parens/brackets/braces and quotes so that a
+            // closing `>` inside a subrule arg list (e.g. `<.foo(:b(2))>`)
+            // doesn't terminate the assertion prematurely.
+            let mut paren = 0usize;
+            let mut bracket = 0usize;
+            let mut brace = 0usize;
+            let mut quote: Option<char> = None;
+            let mut esc = false;
             while i < chars.len() && depth > 0 {
-                match chars[i] {
-                    '<' => depth += 1,
-                    '>' => depth -= 1,
-                    _ => {}
+                let c = chars[i];
+                if let Some(q) = quote {
+                    if esc {
+                        esc = false;
+                    } else if c == '\\' {
+                        esc = true;
+                    } else if c == q {
+                        quote = None;
+                    }
+                } else {
+                    match c {
+                        '\'' | '"' => quote = Some(c),
+                        '(' => paren += 1,
+                        ')' => paren = paren.saturating_sub(1),
+                        '[' => bracket += 1,
+                        ']' => bracket = bracket.saturating_sub(1),
+                        '{' => brace += 1,
+                        '}' => brace = brace.saturating_sub(1),
+                        '<' if paren == 0 && bracket == 0 && brace == 0 => depth += 1,
+                        '>' if paren == 0 && bracket == 0 && brace == 0 => depth -= 1,
+                        _ => {}
+                    }
                 }
                 i += 1;
             }
@@ -158,12 +445,24 @@ impl Interpreter {
 
             let mut rendered_args = Vec::new();
             for arg in &spec.arg_exprs {
+                // For complex / non-round-trippable values (Pair, Slip, Array, Hash, ...),
+                // keep the original argument expression so the match-time evaluator can
+                // re-evaluate and route them as named arguments or flatten Slips.
+                if Self::regex_arg_is_complex(arg) {
+                    rendered_args.push(arg.clone());
+                    continue;
+                }
                 let Some(value) = self.eval_regex_expr_value(arg, &default_caps) else {
                     return Err(RuntimeError::new(format!(
                         "Failed to evaluate regex argument expression: {arg}"
                     )));
                 };
-                rendered_args.push(Self::format_named_regex_arg_value(&value));
+                if Self::value_is_round_trippable(&value) {
+                    rendered_args.push(Self::format_named_regex_arg_value(&value));
+                } else {
+                    // Fallback: keep the raw expression so it is re-evaluated later.
+                    rendered_args.push(arg.clone());
+                }
             }
 
             out.push('<');

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -154,13 +154,9 @@ impl Interpreter {
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
             } else {
-                let mut values = Vec::new();
-                for arg in &spec.arg_exprs {
-                    let Some(v) = self.eval_regex_expr_value(arg, current_caps) else {
-                        return Vec::new();
-                    };
-                    values.push(v);
-                }
+                let Some(values) = self.eval_regex_arg_list(&spec.arg_exprs, current_caps) else {
+                    return Vec::new();
+                };
                 values
             };
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -308,12 +308,7 @@ impl Interpreter {
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
             } else {
-                let mut values = Vec::new();
-                for arg in &spec.arg_exprs {
-                    let v = self.eval_regex_expr_value(arg, &default_caps)?;
-                    values.push(v);
-                }
-                values
+                self.eval_regex_arg_list(&spec.arg_exprs, &default_caps)?
             };
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
             if !candidates.is_empty() {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -306,12 +306,7 @@ impl Interpreter {
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
             } else {
-                let mut values = Vec::new();
-                for arg in &spec.arg_exprs {
-                    let v = self.eval_regex_expr_value(arg, current_caps)?;
-                    values.push(v);
-                }
-                values
+                self.eval_regex_arg_list(&spec.arg_exprs, current_caps)?
             };
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
             if !candidates.is_empty() {

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -220,12 +220,7 @@ impl Interpreter {
                 Vec::new()
             } else {
                 let default_caps = RegexCaptures::default();
-                let mut values = Vec::new();
-                for arg in &spec.arg_exprs {
-                    let v = self.eval_regex_expr_value(arg, &default_caps)?;
-                    values.push(v);
-                }
-                values
+                self.eval_regex_arg_list(&spec.arg_exprs, &default_caps)?
             };
             let candidates = self.resolve_named_regex_candidates_in_pkg(
                 &spec,

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -382,6 +382,38 @@ impl Interpreter {
         env
     }
 
+    /// Evaluate a list of regex argument expressions, flattening any Slip
+    /// values produced by the `|` prefix. Returns `None` if any argument
+    /// fails to evaluate.
+    pub(in crate::runtime) fn eval_regex_arg_list(
+        &self,
+        exprs: &[String],
+        caps: &RegexCaptures,
+    ) -> Option<Vec<Value>> {
+        let mut out = Vec::new();
+        for arg in exprs {
+            let v = self.eval_regex_expr_value(arg, caps)?;
+            match v {
+                Value::Slip(items) => {
+                    for item in items.iter() {
+                        out.push(Self::normalize_pair_for_binding(item.clone()));
+                    }
+                }
+                other => out.push(Self::normalize_pair_for_binding(other)),
+            }
+        }
+        Some(out)
+    }
+
+    fn normalize_pair_for_binding(v: Value) -> Value {
+        if let Value::ValuePair(key, val) = &v
+            && let Value::Str(name) = key.as_ref()
+        {
+            return Value::Pair(name.to_string(), val.clone());
+        }
+        v
+    }
+
     pub(in crate::runtime) fn eval_regex_expr_value(
         &self,
         expr_src: &str,

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -94,6 +94,22 @@ impl Interpreter {
                         Value::Nil => String::new(),
                         other => other.to_string_value(),
                     };
+                    // Bake the bound parameter values into any `{ ... }` code
+                    // blocks of the pattern. This is needed because regex code
+                    // blocks execute in the outer interpreter env (which does
+                    // not contain the subrule's bound params).
+                    let param_names: Vec<String> = def
+                        .param_defs
+                        .iter()
+                        .filter(|pd| !pd.name.is_empty() && !pd.slurpy)
+                        .map(|pd| {
+                            pd.name
+                                .trim_start_matches([':', '@', '%', '&', '!', '.'])
+                                .to_string()
+                        })
+                        .collect();
+                    let pattern =
+                        interp.bake_bound_params_into_regex_code_blocks(&pattern, &param_names);
                     let pattern = interp.interpolate_bound_regex_scalars(&pattern);
                     if let Ok(instantiated) = interp.instantiate_named_regex_arg_calls(&pattern) {
                         let sym_val = Self::extract_sym_adverb(&def.name.resolve());

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1543,21 +1543,77 @@ impl Interpreter {
                                 }
                             }
                         } else {
-                            // Read content between < and >, handling nested <...>
+                            // Read content between < and >, handling nested <...>.
+                            // Also balance parens/brackets/braces and skip quoted
+                            // strings so `<.foo(a => 1)>` and `<.foo(|[3,4,5])>`
+                            // are not terminated by the inner `>` or by close
+                            // brackets that match opens inside the args list.
                             let mut name = String::new();
                             let mut angle_depth = 1usize;
+                            let mut paren_depth: usize = 0;
+                            let mut bracket_depth: usize = 0;
+                            let mut brace_depth: usize = 0;
+                            let mut quote: Option<char> = None;
+                            let mut escaped = false;
                             for ch in chars.by_ref() {
-                                if ch == '<' {
-                                    angle_depth += 1;
+                                if let Some(q) = quote {
                                     name.push(ch);
-                                } else if ch == '>' {
-                                    angle_depth -= 1;
-                                    if angle_depth == 0 {
-                                        break;
+                                    if escaped {
+                                        escaped = false;
+                                    } else if ch == '\\' {
+                                        escaped = true;
+                                    } else if ch == q {
+                                        quote = None;
                                     }
-                                    name.push(ch);
-                                } else {
-                                    name.push(ch);
+                                    continue;
+                                }
+                                match ch {
+                                    '\'' | '"' => {
+                                        quote = Some(ch);
+                                        name.push(ch);
+                                    }
+                                    '(' => {
+                                        paren_depth += 1;
+                                        name.push(ch);
+                                    }
+                                    ')' => {
+                                        paren_depth = paren_depth.saturating_sub(1);
+                                        name.push(ch);
+                                    }
+                                    '[' => {
+                                        bracket_depth += 1;
+                                        name.push(ch);
+                                    }
+                                    ']' => {
+                                        bracket_depth = bracket_depth.saturating_sub(1);
+                                        name.push(ch);
+                                    }
+                                    '{' => {
+                                        brace_depth += 1;
+                                        name.push(ch);
+                                    }
+                                    '}' => {
+                                        brace_depth = brace_depth.saturating_sub(1);
+                                        name.push(ch);
+                                    }
+                                    '<' if paren_depth == 0
+                                        && bracket_depth == 0
+                                        && brace_depth == 0 =>
+                                    {
+                                        angle_depth += 1;
+                                        name.push(ch);
+                                    }
+                                    '>' if paren_depth == 0
+                                        && bracket_depth == 0
+                                        && brace_depth == 0 =>
+                                    {
+                                        angle_depth -= 1;
+                                        if angle_depth == 0 {
+                                            break;
+                                        }
+                                        name.push(ch);
+                                    }
+                                    _ => name.push(ch),
                                 }
                             }
                             // Check for word alternation: < word1 word2 ... >

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -251,6 +251,24 @@ impl VM {
 
         let raw_items = if let Value::LazyList(ref ll) = iterable {
             self.force_lazy_list_vm(ll)?
+        } else if let Value::Channel(ref ch) = iterable {
+            // Drain the channel synchronously, blocking on receive until the
+            // channel is closed. Propagate any failure as an exception so the
+            // surrounding `start { }` / `try` can observe it.
+            let mut items = Vec::new();
+            loop {
+                match ch.receive_result() {
+                    Ok(Value::Nil) => break,
+                    Ok(v) => items.push(v),
+                    Err(cause) => {
+                        let ex = crate::runtime::Interpreter::as_exception_value(cause);
+                        let mut err = RuntimeError::new(ex.to_string_value());
+                        err.exception = Some(Box::new(ex));
+                        return Err(err);
+                    }
+                }
+            }
+            items
         } else {
             runtime::value_to_list(&iterable)
         };

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -6,6 +6,7 @@ roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t
 roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
+roast/S12-methods/accessors.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
 roast/S17-supply/categorize.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,3 +1,4 @@
+roast/S02-magicals/sub.t
 roast/S02-types/generics.t
 roast/S02-types/multi_dimensional_array.t
 roast/S03-sequence/misc.t


### PR DESCRIPTION
## Summary
- Implement Pod =defn parsing (delimited, paragraph and abbreviated forms).
- Construct Pod::Defn instances with term, contents (Pod::Block::Para), and config hash.
- Parse :adverb / :adverb(value) syntax for Pod block config; :numbered, :numbered(0), etc.
- Treat the `=defn # term` shorthand as setting the :numbered config flag.

## Test plan
- [x] roast/S26-documentation/14-defn.t passes all 30 subtests
- [x] cargo clippy -- -D warnings
- [x] cargo fmt
- [x] make test (only flake in t/lock.t, unrelated and passes on rerun)
- [x] Added to roast-whitelist.txt (LC_ALL=C sorted)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>