### PR TITLE
fix: improve package scope handling for nested package blocks

### DIFF
--- a/TODO_roast/S10.md
+++ b/TODO_roast/S10.md
@@ -9,5 +9,10 @@
   - No longer panics (`Unknown call: our` fixed by parsing `our` declarations), but still fails all subtests because `require/use/no` return values and `%*INC` updates are not yet implemented correctly.
 - [ ] roast/S10-packages/require-and-use.t
 - [ ] roast/S10-packages/scope.t
-  - No longer panics; still has broad package-scope semantic failures (module `use/require` scoping, import visibility, and `%*INC` behavior).
+  - 20/24 subtests pass. Remaining failures involve (a) `Our::Package::pkg` /
+    `cant_see_pkg()` should die when the inner package is not in scope (mutsu
+    currently returns a bareword instead of dying), (b) `PackageTest::Our::Package`
+    type-object lookup resolving to the wrong package, and (c) `$?PACKAGE`
+    inside a method of a `my package`/nested `our package` declaration not
+    qualifying the package name correctly.
 - [ ] roast/S10-packages/use-with-class.t

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -99,6 +99,16 @@ impl Compiler {
         } else {
             format!("{}::&{}/{}", self.current_package, name, arity)
         };
+        // Preserve the enclosing package for $?PACKAGE resolution.
+        // The state_scope assigned to current_package below is a mangled name
+        // (e.g. `Test2::&pkg/0`) used to scope state variables; it is not the
+        // package the sub was declared in. `$?PACKAGE` must resolve to the
+        // declaring package, so capture that here before overwriting.
+        sub_compiler.enclosing_package = Some(
+            self.enclosing_package
+                .clone()
+                .unwrap_or_else(|| self.current_package.clone()),
+        );
         sub_compiler.set_current_package(state_scope);
         // Pre-allocate locals for parameters
         for param in params {

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1589,7 +1589,17 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
     } else {
         (after_sigil, "")
     };
-    let (rest, var_name) = super::ident(after_twigil)?;
+    let (mut rest, mut var_name) = super::ident(after_twigil)?;
+    // Support package-qualified names: `temp $Foo::Bar::scalar`. Consume any
+    // additional `::ident` segments and append them to var_name.
+    while let Some(after_sep) = rest.strip_prefix("::") {
+        if let Ok((after_seg, seg)) = super::ident_pub(after_sep) {
+            var_name = format!("{}::{}", var_name, seg);
+            rest = after_seg;
+        } else {
+            break;
+        }
+    }
     // Build full env key including twigil
     let full_name = if sigil == '$' {
         if twigil.is_empty() {

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1682,6 +1682,7 @@ impl Interpreter {
             self.token_defs.clone(),
             self.proto_subs.clone(),
             self.proto_tokens.clone(),
+            self.our_scoped_functions.keys().copied().collect(),
         )
     }
 
@@ -1694,15 +1695,33 @@ impl Interpreter {
     }
 
     fn restore_routine_registry_impl(&mut self, snapshot: RoutineRegistrySnapshot, is_eval: bool) {
-        let (functions, proto_functions, token_defs, proto_subs, proto_tokens) = snapshot;
+        let (functions, proto_functions, token_defs, proto_subs, proto_tokens, our_scoped_keys) =
+            snapshot;
         // Collect our-scoped functions that were newly added during this block
         // (not present in the snapshot) that need to persist after scope restoration.
-        // Only preserve functions whose package matches the current package (i.e., not
-        // functions from loaded modules with different packages).
+        // Preserve functions defined in the current package (original behavior)
+        // OR functions newly registered during this block (so nested package
+        // declarations like `{ package Foo { our sub bar {} } }` survive). We
+        // distinguish "newly registered during this block" by tracking the set
+        // of our_scoped_functions keys that existed at snapshot time.
         let current_pkg = self.current_package.clone();
         let mut new_our: Vec<(Symbol, FunctionDef)> = Vec::new();
         for (key, def) in &self.our_scoped_functions {
-            if !functions.contains_key(key) && def.package.resolve() == current_pkg {
+            if functions.contains_key(key) {
+                continue;
+            }
+            let def_pkg = def.package.resolve();
+            // Always preserve same-package subs (original behavior).
+            if def_pkg == current_pkg {
+                new_our.push((*key, def.clone()));
+                continue;
+            }
+            // Also preserve subs that were newly added to our_scoped_functions
+            // during this block (i.e. their key was not in the snapshot). This
+            // covers nested `package Foo { our sub bar {} }` blocks. Subs from
+            // module loading (`use Foo`) are typically already in the snapshot
+            // by the time the block is restored, so they are not preserved here.
+            if !our_scoped_keys.contains(key) {
                 new_our.push((*key, def.clone()));
             }
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -985,6 +985,7 @@ pub(crate) type RoutineRegistrySnapshot = (
     HashMap<Symbol, Vec<FunctionDef>>,
     HashSet<String>,
     HashSet<String>,
+    HashSet<Symbol>,
 );
 
 pub(crate) type ImportScopeSnapshot = (HashSet<Symbol>, HashSet<String>, NewlineMode, bool, bool);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2339,6 +2339,31 @@ impl VM {
         let current_env = self.interpreter.env().clone();
         let mut restored_env = saved_env.clone();
         for (k, v) in current_env {
+            // Package-qualified names (e.g. Test1::ns, Foo::Bar) are package-global
+            // and must propagate out of any block scope where they were declared.
+            // Sigils may appear before the qualifier (e.g. &Test1::ns, $Foo::var).
+            // Skip internal VM metadata keys (which contain `::` but are not
+            // user-visible package names, e.g. `__mutsu_var_meta::x`).
+            let stripped = k.trim_start_matches(['$', '@', '%', '&']);
+            let is_package_qualified = stripped.contains("::") && !stripped.starts_with("__mutsu_");
+            if is_package_qualified {
+                restored_env.insert(k, v);
+                continue;
+            }
+            // Package type objects declared inside a block (e.g.
+            // `{ package Foo { ... } }`) must remain visible outside the
+            // block as type objects, just like classes/roles. The
+            // `RegisterPackage` opcode stores them in env under the bare
+            // package name. Restrict this to keys that look like a real
+            // package identifier (uppercase ASCII start, not internal/
+            // special variables like `_` or `__mutsu_*`).
+            if matches!(&v, Value::Package(_))
+                && !saved_env.contains_key(&k)
+                && k.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            {
+                restored_env.insert(k, v);
+                continue;
+            }
             if saved_env.contains_key(&k) {
                 // Lexical topic is block-scoped; don't write inner `$_` back
                 // to the outer scope on block exit.


### PR DESCRIPTION
## Summary

Improves `roast/S10-packages/scope.t` from 12/24 to 20/24 passing
subtests. Addresses several issues with `our sub` declarations inside
nested `package` blocks and `temp` on package-qualified variables.

- Propagate package-qualified env keys (`Test1::ns`, `&Foo::bar`) and
  `Value::Package` type objects out of block scopes so nested package
  declarations remain visible.
- Snapshot `our_scoped_functions` keys so the restore step can preserve
  subs newly registered during a block (covers nested
  `{ package Foo { our sub bar {} } }`) without leaking subs from
  `use`-loaded modules.
- Set `enclosing_package` when compiling normal sub bodies so
  `$?PACKAGE` resolves to the declaring package rather than the mangled
  state-scope name.
- Parse package-qualified names in `temp $Foo::bar`.

The remaining 4 failing subtests of `scope.t` (deeply nested package
visibility, `dies-ok` for unscoped lookups, `$?PACKAGE` for `my package`
declarations) are documented in `TODO_roast/S10.md`.

## Test plan

- [x] `make test` passes (3802 tests)
- [x] `make roast` passes the whitelist
- [x] `roast/S10-packages/scope.t`: 20/24 subtests now pass (was 12/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)