### PR TITLE
chore: mark S03-binding/attributes.t as too_difficult

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,6 +1,7 @@
 roast/S02-magicals/sub.t
 roast/S02-types/generics.t
 roast/S02-types/multi_dimensional_array.t
+roast/S03-binding/attributes.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t


### PR DESCRIPTION
## Summary
- Rakudo itself fails to compile roast/S03-binding/attributes.t (Klass3 block uses undeclared `$!x`; the `#?rakudo skip` cannot save it because the compile error happens first).
- Per workflow, add the file to too_difficult.txt so the roast picker skips it.

## Test plan
- [x] Confirmed `raku roast/S03-binding/attributes.t` errors with `Attribute $!x not declared in class Klass3`