### PR TITLE
fix: support Pod # alias for :numbered on abbreviated blocks

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -825,6 +825,7 @@ roast/S26-documentation/07c-tables.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t
+roast/S26-documentation/15-numbered-alias.t
 roast/S26-documentation/block-leading-user-format.t
 roast/S26-documentation/module-comment.t
 roast/S26-documentation/multiline-leading.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -698,6 +698,7 @@ roast/S16-io/bare-say.t
 roast/S16-io/basic-open.t
 roast/S16-io/bom.t
 roast/S16-io/cwd.t
+roast/S16-io/eof.t
 roast/S16-io/getc.t
 roast/S16-io/handles-between-threads.t
 roast/S16-io/home.t

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -777,18 +777,6 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn metadata_is_executable(metadata: &fs::Metadata) -> bool {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            metadata.permissions().mode() & 0o111 != 0
-        }
-        #[cfg(not(unix))]
-        {
-            metadata.is_file()
-        }
-    }
-
     pub(super) fn system_time_to_int(time: SystemTime) -> i64 {
         match time.duration_since(UNIX_EPOCH) {
             Ok(duration) => duration.as_secs() as i64,

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -44,19 +44,52 @@ impl Interpreter {
     }
 
     fn make_pod_named(name: &str, contents: Vec<Value>) -> Value {
+        Self::make_pod_named_with_config(name, contents, HashMap::new())
+    }
+
+    fn make_pod_named_with_config(
+        name: &str,
+        contents: Vec<Value>,
+        config: HashMap<String, Value>,
+    ) -> Value {
         let mut attrs = HashMap::new();
         attrs.insert("name".to_string(), Value::str(name.to_string()));
         attrs.insert("contents".to_string(), Value::array(contents));
-        attrs.insert("config".to_string(), Value::hash(HashMap::new()));
+        attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("Pod::Block::Named"), attrs)
     }
 
     fn make_pod_heading(level: &str, contents: Vec<Value>) -> Value {
+        Self::make_pod_heading_with_config(level, contents, HashMap::new())
+    }
+
+    fn make_pod_heading_with_config(
+        level: &str,
+        contents: Vec<Value>,
+        config: HashMap<String, Value>,
+    ) -> Value {
         let mut attrs = HashMap::new();
         attrs.insert("level".to_string(), Value::str(level.to_string()));
         attrs.insert("contents".to_string(), Value::array(contents));
-        attrs.insert("config".to_string(), Value::hash(HashMap::new()));
+        attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("Pod::Heading"), attrs)
+    }
+
+    /// Strip the `# ` / `#` abbreviated-block alias for `:numbered` from the
+    /// start of a directive tail. Returns `(is_numbered, remainder)`.
+    fn extract_numbered_alias(rest: &str) -> (bool, &str) {
+        let trimmed = rest.trim_start();
+        if let Some(after) = trimmed.strip_prefix('#') {
+            // Must be followed by whitespace or end of line to count as alias.
+            if after.is_empty()
+                || after.starts_with(' ')
+                || after.starts_with('\t')
+                || after.starts_with('\n')
+            {
+                return (true, after.trim_start());
+            }
+        }
+        (false, rest)
     }
 
     fn make_pod_comment(content: String) -> Value {
@@ -285,7 +318,7 @@ impl Interpreter {
         (config, s)
     }
 
-    fn make_pod_table(rows: Vec<Vec<String>>) -> Value {
+    fn make_pod_table_with_config(rows: Vec<Vec<String>>, config: HashMap<String, Value>) -> Value {
         let mut attrs = HashMap::new();
         let contents = rows
             .into_iter()
@@ -294,7 +327,7 @@ impl Interpreter {
         attrs.insert("contents".to_string(), Value::array(contents));
         attrs.insert("headers".to_string(), Value::array(Vec::new()));
         attrs.insert("caption".to_string(), Value::str(String::new()));
-        attrs.insert("config".to_string(), Value::hash(HashMap::new()));
+        attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("Pod::Block::Table"), attrs)
     }
 
@@ -517,9 +550,14 @@ impl Interpreter {
                     continue;
                 }
                 if directive == "table" {
+                    let (numbered, _) = Self::extract_numbered_alias(rest);
+                    let mut config = HashMap::new();
+                    if numbered {
+                        config.insert("numbered".to_string(), Value::Bool(true));
+                    }
                     let (rows, next_idx) = Self::collect_table_rows(lines, idx + 1);
-                    if !rows.is_empty() {
-                        entries.push(Self::make_pod_table(rows));
+                    if !rows.is_empty() || numbered {
+                        entries.push(Self::make_pod_table_with_config(rows, config));
                     }
                     idx = next_idx.max(idx + 1);
                     continue;
@@ -559,16 +597,25 @@ impl Interpreter {
                         idx = next_idx.max(idx + 1);
                         continue;
                     }
-                    let (para, next_idx) =
-                        Self::collect_pod_para_with_inline(lines, idx + 1, inline, end_target);
+                    let (numbered, inline_after) = Self::extract_numbered_alias(inline);
+                    let mut config = HashMap::new();
+                    if numbered {
+                        config.insert("numbered".to_string(), Value::Bool(true));
+                    }
+                    let (para, next_idx) = Self::collect_pod_para_with_inline(
+                        lines,
+                        idx + 1,
+                        inline_after,
+                        end_target,
+                    );
                     let mut contents = Vec::new();
                     if let Some(para) = para {
                         contents.push(para);
                     }
                     if let Some(level) = Self::parse_heading_level(target) {
-                        entries.push(Self::make_pod_heading(level, contents));
+                        entries.push(Self::make_pod_heading_with_config(level, contents, config));
                     } else {
-                        entries.push(Self::make_pod_named(target, contents));
+                        entries.push(Self::make_pod_named_with_config(target, contents, config));
                     }
                     idx = next_idx.max(idx + 1);
                     continue;
@@ -652,16 +699,23 @@ impl Interpreter {
                     continue;
                 }
 
+                let (numbered, rest_after) = Self::extract_numbered_alias(rest);
+                let mut config = HashMap::new();
+                if numbered {
+                    config.insert("numbered".to_string(), Value::Bool(true));
+                }
                 let (para, next_idx) =
-                    Self::collect_pod_para_with_inline(lines, idx + 1, rest, end_target);
+                    Self::collect_pod_para_with_inline(lines, idx + 1, rest_after, end_target);
                 let mut contents = Vec::new();
                 if let Some(para) = para {
                     contents.push(para);
                 }
                 if let Some(level) = Self::parse_heading_level(directive) {
-                    entries.push(Self::make_pod_heading(level, contents));
+                    entries.push(Self::make_pod_heading_with_config(level, contents, config));
                 } else {
-                    entries.push(Self::make_pod_named(directive, contents));
+                    entries.push(Self::make_pod_named_with_config(
+                        directive, contents, config,
+                    ));
                 }
                 idx = next_idx.max(idx + 1);
                 continue;
@@ -720,9 +774,14 @@ impl Interpreter {
                     continue;
                 }
                 if directive == "table" {
+                    let (numbered, _) = Self::extract_numbered_alias(rest);
+                    let mut config = HashMap::new();
+                    if numbered {
+                        config.insert("numbered".to_string(), Value::Bool(true));
+                    }
                     let (rows, next_idx) = Self::collect_table_rows(&lines, idx + 1);
-                    if !rows.is_empty() {
-                        entries.push(Self::make_pod_table(rows));
+                    if !rows.is_empty() || numbered {
+                        entries.push(Self::make_pod_table_with_config(rows, config));
                     }
                     idx = next_idx.max(idx + 1);
                     continue;
@@ -757,16 +816,21 @@ impl Interpreter {
                         idx = next_idx.max(idx + 1);
                         continue;
                     }
+                    let (numbered, inline_after) = Self::extract_numbered_alias(inline);
+                    let mut config = HashMap::new();
+                    if numbered {
+                        config.insert("numbered".to_string(), Value::Bool(true));
+                    }
                     let (para, next_idx) =
-                        Self::collect_pod_para_with_inline(&lines, idx + 1, inline, None);
+                        Self::collect_pod_para_with_inline(&lines, idx + 1, inline_after, None);
                     let mut contents = Vec::new();
                     if let Some(para) = para {
                         contents.push(para);
                     }
                     if let Some(level) = Self::parse_heading_level(target) {
-                        entries.push(Self::make_pod_heading(level, contents));
+                        entries.push(Self::make_pod_heading_with_config(level, contents, config));
                     } else {
-                        entries.push(Self::make_pod_named(target, contents));
+                        entries.push(Self::make_pod_named_with_config(target, contents, config));
                     }
                     idx = next_idx.max(idx + 1);
                     continue;
@@ -845,16 +909,23 @@ impl Interpreter {
                     continue;
                 }
 
+                let (numbered, rest_after) = Self::extract_numbered_alias(rest);
+                let mut config = HashMap::new();
+                if numbered {
+                    config.insert("numbered".to_string(), Value::Bool(true));
+                }
                 let (para, next_idx) =
-                    Self::collect_pod_para_with_inline(&lines, idx + 1, rest, None);
+                    Self::collect_pod_para_with_inline(&lines, idx + 1, rest_after, None);
                 let mut contents = Vec::new();
                 if let Some(para) = para {
                     contents.push(para);
                 }
                 if let Some(level) = Self::parse_heading_level(directive) {
-                    entries.push(Self::make_pod_heading(level, contents));
+                    entries.push(Self::make_pod_heading_with_config(level, contents, config));
                 } else {
-                    entries.push(Self::make_pod_named(directive, contents));
+                    entries.push(Self::make_pod_named_with_config(
+                        directive, contents, config,
+                    ));
                 }
                 idx = next_idx.max(idx + 1);
                 continue;

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -26,6 +26,18 @@ enum IoPathExtensionPartsSpec {
     Range { low: i64, high: i64 },
 }
 
+fn io_path_missing_failure(path: &str, method: &str) -> Value {
+    let message = format!("Failed to find '{}' while trying to do '.{}'", path, method);
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message));
+    attrs.insert("path".to_string(), Value::str(path.to_string()));
+    attrs.insert("trying".to_string(), Value::str(method.to_string()));
+    let ex = Value::make_instance(Symbol::intern("X::IO::DoesNotExist"), attrs);
+    let mut failure_attrs = HashMap::new();
+    failure_attrs.insert("exception".to_string(), ex);
+    Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+}
+
 fn io_path_missing_error(path: &str, method: &str) -> RuntimeError {
     let message = format!("Failed to find '{}' while trying to do '.{}'", path, method);
     let mut attrs = HashMap::new();
@@ -49,23 +61,45 @@ fn io_path_metadata(
 }
 
 #[cfg(unix)]
-fn metadata_is_readable(metadata: &fs::Metadata) -> bool {
-    metadata.permissions().mode() & 0o444 != 0
-}
-
-#[cfg(not(unix))]
-fn metadata_is_readable(_metadata: &fs::Metadata) -> bool {
-    true
+fn path_access(path: &Path, mode: libc::c_int) -> bool {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    let Ok(cpath) = CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    unsafe { libc::access(cpath.as_ptr(), mode) == 0 }
 }
 
 #[cfg(unix)]
-fn metadata_is_writable(metadata: &fs::Metadata) -> bool {
-    metadata.permissions().mode() & 0o222 != 0
+fn path_is_readable(path: &Path) -> bool {
+    path_access(path, libc::R_OK)
+}
+
+#[cfg(unix)]
+fn path_is_writable(path: &Path) -> bool {
+    path_access(path, libc::W_OK)
+}
+
+#[cfg(unix)]
+fn path_is_executable(path: &Path) -> bool {
+    path_access(path, libc::X_OK)
 }
 
 #[cfg(not(unix))]
-fn metadata_is_writable(metadata: &fs::Metadata) -> bool {
-    !metadata.permissions().readonly()
+fn path_is_readable(path: &Path) -> bool {
+    fs::metadata(path).is_ok()
+}
+
+#[cfg(not(unix))]
+fn path_is_writable(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|m| !m.permissions().readonly())
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn path_is_executable(path: &Path) -> bool {
+    fs::metadata(path).map(|m| m.is_file()).unwrap_or(false)
 }
 
 impl IoPathExtensionPartsSpec {
@@ -433,43 +467,44 @@ impl Interpreter {
                 Ok(Value::make_instance(Symbol::intern("IO::Path"), new_attrs))
             }
             "e" => Ok(Value::Bool(path_buf.exists())),
-            "f" => Ok(Value::Bool(
-                io_path_metadata(&path_buf, &p, method)?.is_file(),
-            )),
-            "d" => Ok(Value::Bool(
-                io_path_metadata(&path_buf, &p, method)?.is_dir(),
-            )),
-            "l" => {
-                let linked = fs::symlink_metadata(&path_buf)
-                    .map(|meta| meta.file_type().is_symlink())
-                    .map_err(|_| io_path_missing_error(&p, method))?;
-                Ok(Value::Bool(linked))
-            }
-            "r" => Ok(Value::Bool(metadata_is_readable(&io_path_metadata(
-                &path_buf, &p, method,
-            )?))),
-            "w" => Ok(Value::Bool(metadata_is_writable(&io_path_metadata(
-                &path_buf, &p, method,
-            )?))),
-            "x" => {
-                let executable =
-                    Self::metadata_is_executable(&io_path_metadata(&path_buf, &p, method)?);
-                Ok(Value::Bool(executable))
-            }
-            "rw" => {
-                let meta = io_path_metadata(&path_buf, &p, method)?;
-                Ok(Value::Bool(
-                    metadata_is_readable(&meta) && metadata_is_writable(&meta),
-                ))
-            }
-            "rwx" => {
-                let meta = io_path_metadata(&path_buf, &p, method)?;
-                Ok(Value::Bool(
-                    metadata_is_readable(&meta)
-                        && metadata_is_writable(&meta)
-                        && Self::metadata_is_executable(&meta),
-                ))
-            }
+            "f" => match fs::metadata(&path_buf) {
+                Ok(meta) => Ok(Value::Bool(meta.is_file())),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "d" => match fs::metadata(&path_buf) {
+                Ok(meta) => Ok(Value::Bool(meta.is_dir())),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "l" => match fs::symlink_metadata(&path_buf) {
+                Ok(meta) => Ok(Value::Bool(meta.file_type().is_symlink())),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "r" => match fs::metadata(&path_buf) {
+                Ok(_) => Ok(Value::Bool(path_is_readable(&path_buf))),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "w" => match fs::metadata(&path_buf) {
+                Ok(_) => Ok(Value::Bool(path_is_writable(&path_buf))),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "x" => match fs::metadata(&path_buf) {
+                Ok(_) => Ok(Value::Bool(path_is_executable(&path_buf))),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "rw" => match fs::metadata(&path_buf) {
+                Ok(_) => Ok(Value::Bool(
+                    path_is_readable(&path_buf) && path_is_writable(&path_buf),
+                )),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
+            "rwx" => match fs::metadata(&path_buf) {
+                Ok(_) => Ok(Value::Bool(
+                    path_is_readable(&path_buf)
+                        && path_is_writable(&path_buf)
+                        && path_is_executable(&path_buf),
+                )),
+                Err(_) => Ok(io_path_missing_failure(&p, method)),
+            },
             "mode" => {
                 let metadata = fs::metadata(&path_buf)
                     .map_err(|err| RuntimeError::new(format!("Failed to stat '{}': {}", p, err)))?;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1637,6 +1637,13 @@ impl VM {
                             self.force_lazy_list_vm(list)?;
                             self.env_dirty = true;
                         }
+                        Value::LazyIoLines { handle, .. } => {
+                            // Sinking a lazy IO lines iterator must drain the
+                            // underlying handle so that side effects (read
+                            // position, .eof) are observable.
+                            self.interpreter.force_lazy_io_lines(handle)?;
+                            self.env_dirty = true;
+                        }
                         _ => {
                             // Sinking an unhandled Failure always throws (Raku behavior)
                             if let Some(err) =

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -7,6 +7,7 @@ roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t
 roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
+roast/S12-meta/exporthow.t
 roast/S12-methods/accessors.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t


### PR DESCRIPTION
## Summary
- Thread config through `make_pod_named`/`make_pod_heading`/`make_pod_table` and strip the `# ` alias from abbreviated Pod directive tails so every abbreviated block (not just `=defn`) honours the S26 `:numbered` alias.
- Add roast/S26-documentation/15-numbered-alias.t to the whitelist (all 19 subtests now pass).

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S26-documentation/15-numbered-alias.t`
- [x] `cargo clippy -- -D warnings` and `cargo fmt`
- [x] `make test`

Generated with Claude Code