### PR TITLE
chore: defer roast/S17-procasync/encoding.t

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -28,6 +28,11 @@
 - [ ] roast/S17-procasync/basic.t
 - [ ] roast/S17-procasync/bind-handles.t
 - [ ] roast/S17-procasync/encoding.t
+  - Deferred (too_difficult.txt). Requires multiple unrelated language gaps:
+    1. Supply `tap(quit => ...)` must fire when child output is invalid UTF-8 (encoding-error detection at the read layer).
+    2. `Proc::Async.new(..., :enc('latin-1'))` constructor must encode stdin writes (`print`/`put`/`say`/`write`) and decode stdout/stderr per the requested encoding instead of always treating bytes as UTF-8.
+    3. Per-call encoding override on `$proc.stdout(:enc(...))` / `$proc.stderr(:enc(...))`.
+    4. `$*IN.slurp` currently returns empty even when stdin has bytes available, so the child scripts in this test cannot read their input. This is a prerequisite that affects more than just this test.
 - [ ] roast/S17-procasync/kill.t
 - [ ] roast/S17-procasync/many-processes-no-close-stdin.t
   - Was passing trivially (colon-pair hash parsed as block, is_run expectations not tested). Now properly tests expectations; fails because Proc::Async not supported.

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -10,6 +10,7 @@ roast/S11-modules/versioning.t
 roast/S12-methods/accessors.t
 roast/S14-traits/attributes.t
 roast/S17-lowlevel/semaphore.t
+roast/S17-procasync/encoding.t
 roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t


### PR DESCRIPTION
## Summary
- Adds `roast/S17-procasync/encoding.t` to `too_difficult.txt`.
- Documents the blockers in `TODO_roast/S17.md`.

The test fails because of several unrelated gaps in mutsu:
1. Supply `tap(quit => ...)` is not fired when child output is invalid UTF-8 (no encoding-error detection at the read layer).
2. `Proc::Async.new(..., :enc('latin-1'))` does not encode stdin writes (`print`/`put`/`say`/`write`) nor decode stdout/stderr in the requested encoding; everything is treated as UTF-8.
3. Per-call `:enc(...)` override on `\$proc.stdout` / `\$proc.stderr` is unsupported.
4. `\$*IN.slurp` returns empty even when stdin has bytes available, so the child `-e` scripts in this test cannot read their input. This is a prerequisite that affects more than just this test.

## Test plan
- [x] `LC_ALL=C sort -c too_difficult.txt`
- [x] Confirmed `raku roast/S17-procasync/encoding.t` passes (1..13 ok).
- [x] Confirmed `timeout 30 target/debug/mutsu roast/S17-procasync/encoding.t` fails the listed gaps before deferral.