### PR TITLE
chore: mark roast/S11-repository/curli-install.t as too difficult

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -7,6 +7,7 @@ roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t
 roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
+roast/S11-repository/curli-install.t
 roast/S12-meta/exporthow.t
 roast/S12-methods/accessors.t
 roast/S14-traits/attributes.t
@@ -15,6 +16,6 @@ roast/S17-procasync/encoding.t
 roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t
-roast/S32-list/categorize.t
 roast/S32-io/child-secure.t
+roast/S32-list/categorize.t
 roast/S32-temporal/local.t


### PR DESCRIPTION
## Summary
- Adds `roast/S11-repository/curli-install.t` to `too_difficult.txt`.
- The test requires a full `CompUnit::Repository::Installable` implementation: `inst#` short-id in `use lib`, `Distribution::Hash`, `CompUnit::DependencySpecification`, `$*REPO.install()` with on-disk persistence, `CompUnit.handle.globalish-package`, `GLOBALish.WHO.merge-symbols`, and the CURI `need` pipeline. Out of scope for a single focused PR.

## Test plan
- [x] `LC_ALL=C sort -c too_difficult.txt`