### PR TITLE
chore: mark roast/S32-io/io-path-cygwin.t as too difficult

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -17,5 +17,6 @@ roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t
 roast/S32-io/child-secure.t
+roast/S32-io/io-path-cygwin.t
 roast/S32-list/categorize.t
 roast/S32-temporal/local.t


### PR DESCRIPTION
## Summary
- Subtest 37 ('absolute inverts relative with resolve') fails on upstream Rakudo itself, so this test cannot fully pass in mutsu either.
- Document the upstream blocker by adding the test to `too_difficult.txt`.

## Test plan
- [x] Verified `raku roast/S32-io/io-path-cygwin.t` fails subtest 37 on Rakudo

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>