### PR TITLE
fix: lexical `&foo` parameter shadows package sub for bare calls

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -7,7 +7,13 @@
 - [ ] roast/S06-advanced/dispatching.t
   - 4/8 subtests pass (subtests 1, 4-skip, 5-skip, 7-skip, 8 pass). Subtests 2-3 fail: callwith/callsame wrapper dispatch not fully working. Subtest 6 fails: nextsame dispatch chain broken when multi method calls another method.
 - [ ] roast/S06-advanced/lexical-subs.t
-  - 0/13 pass (6 reached). Indirect lexical sub calls fail, `&foo` reference syntax, lexical scope visibility for subs, `&foo` as parameter. Difficulty: Medium-High (needs `&name` sub reference support)
+  - 8/13 pass. Remaining failures require multiple independent features:
+    (1) test 2: throws-like EVAL'd undeclared-symbol check for lexically shadowed sub (X::Undeclared::Symbols).
+    (2) test 6: `&infix:<@@>` as parameter must shadow same-named package infix op — fix needs extending to the infix dispatch path (runtime::builtins_operators / vm::vm_string_regex_ops call_infix_fallback).
+    (3) test 9: `my sub a { }` inside an inner block leaks into outer scope; lexical-sub scoping doesn't get popped when block ends.
+    (4) test 10: `package Foo { sub f { } }` entries are visible as `Foo::f` even without scoping modifiers; packaged subs should not be globally reachable.
+    (5) test 11: duplicate `sub a { }; sub a { }` at same scope should throw X::Redeclaration.
+    Moved to too_difficult.txt because each failure is its own non-trivial feature; see PR for partial fix (lexical `&foo` parameter precedence).
 - [ ] roast/S06-advanced/recurse.t
   - 0/? pass. Stack overflow crash. Recursive sub calls cause unbounded stack growth. Difficulty: Medium (need stack depth limit or tail-call optimization)
 - [ ] roast/S06-advanced/return_function.t

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -9,6 +9,22 @@ impl VM {
     /// builtin, and unconditionally routing every `has_function` name through
     /// `call_function_fallback` changes dispatch in ways that affect things
     /// like MAIN/GENERATE-USAGE handling.
+    /// True if the `&name` value in env comes from a lexical override
+    /// (e.g. `sub callit(&foo) { ... }`) rather than the normal package
+    /// binding for the named sub. A lexical override has a different
+    /// identity (its stored `SubData.name` does not match `name`) — either
+    /// because it's an anonymous block passed as `&foo`, or because it's a
+    /// different sub with the same parameter name.
+    pub(super) fn env_callable_is_lexical_override(val: &Value, name: &str) -> bool {
+        if let Value::Sub(sub) = val {
+            let stored = sub.name.resolve();
+            // Anonymous block or mismatched name => lexical override.
+            stored.is_empty() || stored != name
+        } else {
+            false
+        }
+    }
+
     pub(super) fn is_user_shadowable_builtin(name: &str) -> bool {
         matches!(
             name,
@@ -24,10 +40,39 @@ impl VM {
         arg_sources_idx: Option<u32>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
+        // If there's a lexical `&name` override — either as a compiled local
+        // slot (e.g. from a `&foo` parameter binding) or in the env — it
+        // shadows package-level subs. Skip the fast path and dispatch via
+        // the lexical callable below.
+        self.ensure_env_synced(code);
+        let lexical_override: Option<Value> = {
+            let name_str = Self::const_str(code, name_idx);
+            // Only look for a lexical override when there is actually a
+            // same-named package sub to shadow. When no package sub exists,
+            // the normal dispatch path already handles lexical `&name`
+            // bindings correctly (via its own env lookup), and avoiding
+            // this branch prevents regressions where dispatching through
+            // `call_sub_value` behaves differently (e.g. dynamic `$*ERR`
+            // handling for `note` inside a caller-provided block).
+            if self.interpreter.has_proto(name_str)
+                || self.interpreter.has_multi_candidates(name_str)
+                || !self.interpreter.has_function(name_str)
+            {
+                None
+            } else {
+                let ampname = format!("&{}", name_str);
+                // First check local slots (parameter bindings live here).
+                let from_local = self.locals_get_by_name(code, &ampname);
+                let candidate =
+                    from_local.or_else(|| self.interpreter.env().get(&ampname).cloned());
+                candidate.filter(|v| Self::env_callable_is_lexical_override(v, name_str))
+            }
+        };
+        let has_lexical_override = lexical_override.is_some();
         // Early fast path: for cached zero-arg compiled functions, skip ALL the
         // expensive arg processing, CALL-ME check, wrap chain check, autothread, etc.
         // Only the callsite line pair (if present) needs to be popped from the stack.
-        if arity <= 1 {
+        if !has_lexical_override && arity <= 1 {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = Symbol::intern(name_str);
             let cache_key = (name_sym, 0usize, Vec::<String>::new());
@@ -136,6 +181,15 @@ impl VM {
             && let Some(sub_val) = self.interpreter.get_wrapped_sub(&name)
         {
             let result = self.interpreter.call_sub_value(sub_val, args, false)?;
+            self.stack.push(result);
+            self.env_dirty = true;
+            return Ok(());
+        }
+
+        // Lexical `&name` binding (e.g. from `sub callit(&foo) { foo(1) }`)
+        // takes precedence over package-level compiled subs.
+        if let Some(callable) = lexical_override {
+            let result = self.interpreter.call_sub_value(callable, args, false)?;
             self.stack.push(result);
             self.env_dirty = true;
             return Ok(());

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -6,6 +6,7 @@ roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t
 roast/S05-mass/recursive.t
+roast/S06-advanced/lexical-subs.t
 roast/S11-modules/versioning.t
 roast/S11-repository/curli-install.t
 roast/S12-meta/exporthow.t


### PR DESCRIPTION
## Summary
- When a sub takes a `&foo` parameter, bare `foo(...)` inside its body now dispatches through the parameter binding instead of the package-level `sub foo` of the same name.
- Detected in VM `exec_call_func_op` by inspecting local slots / env for an `&name` binding whose stored `SubData.name` differs from the call name (anonymous blocks, renamed subs).
- Guarded by `has_function(name)` so that non-shadowing cases (e.g. `sub cap(&code) { code() }`) keep the old dispatch path, preserving dynamic-scope behavior for blocks using `$*ERR` etc.

## Roast impact
- `roast/S06-advanced/lexical-subs.t`: 7/13 -> 8/13 (tests 4 & 5 now pass).
- Remaining 5 failures are independent features: lexical sub scope cleanup, package sub isolation, sub redeclaration errors, `&infix:<op>` parameter shadowing, EVAL undeclared-symbol detection. Recorded in `too_difficult.txt` with notes in `TODO_roast/S06.md`.

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S06-advanced/lexical-subs.t` shows 8/13 passing.
- [x] `make test` — no regressions (pre-existing flaky `t/lock.t` only).
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)