### PR TITLE
Defer roast/S32-hash/perl.t (Scalar-container .raku semantics)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -62,6 +62,7 @@
 - [ ] roast/S32-hash/pairs.t
   - 17/26 pass (1-2, 4-10, 12-18, 20). Good `.pairs` support on hashes. Failures: element count (3, 11), rw aliases (19, 21), `:p` adverb form (22-26). Difficulty: Medium
 - [ ] roast/S32-hash/perl.t
+  - 43/55 pass. The 12 failing subtests are all "Hash in Scalar and deconted Hash perlify differently" — the test asserts that `my $a = h; $a.raku` (Hash in Scalar container) renders as `${...}` while `$a := h; $a.raku` (deconted) renders as `{...}`. mutsu does not model `Value::Scalar(Hash)` containers on `$`-sigiled variables: both `=` and `:=` end up storing the raw Hash in the local slot, so the two `.raku` strings are identical. Fixing requires a proper Scalar-container model on `$` slots (track item-context per slot, wrap on load, ensure dispatch sites unwrap). Same blocker as S32-array/perl.t. Added to too_difficult.txt.
   - 13/55 pass (1-13). Fixed: keyof returns Str(Any), constrained hash .raku format. Remaining blockers: circular hash .raku (test 14), EVAL("{}") parses as block not hash (tests 16+), range-to-hash assignment (test 15), Hash[Any].new parameterization (tests 16+)
 - [ ] roast/S32-hash/push.t
 - [ ] roast/S32-hash/slice.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -16,6 +16,7 @@ roast/S17-procasync/encoding.t
 roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t
+roast/S32-hash/perl.t
 roast/S32-io/child-secure.t
 roast/S32-io/io-path-cygwin.t
 roast/S32-list/categorize.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -17,5 +17,6 @@ roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
 roast/S32-array/perl.t
 roast/S32-io/child-secure.t
+roast/S32-io/io-path-cygwin.t
 roast/S32-list/categorize.t
 roast/S32-temporal/local.t


### PR DESCRIPTION
## Summary

- 43/55 subtests of `roast/S32-hash/perl.t` already pass. The remaining 12 are all "Hash in Scalar and deconted Hash perlify differently" assertions.
- They require modeling a real `Value::Scalar(Hash)` container on `$`-sigiled variables so that `my $a = h; $a.raku` renders as `\${...}` while `\$a := h; \$a.raku` renders as `{...}`. mutsu currently stores the raw Hash in both cases, so the two `.raku` strings are identical and the test's `isnt` checks fail.
- Same blocker already deferred for `roast/S32-array/perl.t`. Adding `S32-hash/perl.t` to `too_difficult.txt` and recording the reason in `TODO_roast/S32.md`.

## Test plan

- [x] `LC_ALL=C sort -c too_difficult.txt`
- [x] No code changes; CI should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)