### PR TITLE
chore: mark roast/S05-capture/caps.t as too difficult

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -3,6 +3,7 @@
 - [ ] roast/S05-capture/alias.t
 - [ ] roast/S05-capture/array-alias.t
 - [ ] roast/S05-capture/caps.t
+  - 25/43 pass. Fails at `.caps on % separator` / `.caps on %% separator` for `(<.alpha>) +% (<.punct>)` style patterns. Mutsu's LTM-expansion approach rewrites `X +% Y` into `X (Y X)*`, which assigns new positional capture indices to the repeated atom/sep pairs instead of reusing the outer numbering. Raku assigns captures by their source position (atom=$0, sep=$1, reused across iterations). A correct fix requires either native engine support for separator quantifiers (`+%`, `*%`, `+%%`, `*%%`) via a dedicated `SeparatedRepeat` regex token, or support for explicit positional capture assignment (`$0=(...)`) so the expansion can renumber captures. Both are substantial regex-engine work.
 - [ ] roast/S05-capture/dot.t
   - 46/61 pass. Silent subrule capture leak fixed. Remaining: nested positional captures $0[0] (tests 25-28), backreferences $0 inside regex (tests 29-33), named backreferences (tests 34-39, TODO in rakudo too)
 - [ ] roast/S05-capture/hash.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -5,6 +5,7 @@ roast/S03-binding/attributes.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
 roast/S05-capture/alias.t
+roast/S05-capture/caps.t
 roast/S05-mass/recursive.t
 roast/S11-modules/versioning.t
 roast/S11-repository/curli-install.t


### PR DESCRIPTION
## Summary
- Records `roast/S05-capture/caps.t` as too difficult and documents the blocker in `TODO_roast/S05.md`.
- 25/43 subtests pass. Remaining failures are at `.caps on % separator` / `.caps on %% separator` for patterns like `(<.alpha>) +% (<.punct>)`.
- The LTM-expansion preprocessor rewrites `X +% Y` into `X (Y X)*`, which introduces new positional capture indices for the repeated atom/sep instead of reusing the outer source-position numbering that Raku specifies (atom=$0, sep=$1, reused each iteration).
- A correct fix needs either native regex-engine support for separator quantifiers (`+%`, `*%`, `+%%`, `*%%`) via a `SeparatedRepeat` regex token, or support for explicit positional capture assignment (`$0=(...)`) so the expansion can renumber captures. Both are substantial regex-engine work.

## Test plan
- [x] `raku roast/S05-capture/caps.t` confirms expected plan (43 tests pass on Rakudo).
- [x] `timeout 30 target/debug/mutsu roast/S05-capture/caps.t` reproduces the `% / %%` failures.
- [ ] CI (`make test` + `make roast`).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>