### PR TITLE
fix: throw X::ControlFlow::Return for return outside routine

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -98,7 +98,10 @@
 - [ ] roast/S04-statements/repeat.t
   - 8/21 pass (1-8). Only 10 tests reached; crashes at test 10 with `X::ControlFlow`. Basic `repeat {} while/until` works including redo. Failures: unknown issue at test 9-10, rest not reached. Difficulty: Medium
 - [ ] roast/S04-statements/return.t
-  - 12/26 pass (1, 3, 7-14, 16, 20). Failures: bare return with parens (2), bare return in statement modifiers (4-6), test 15 unknown, proxied return (17-18), `.return` method (19), INIT/CHECK return (21-22), tests 23-26 not reached. Difficulty: Medium
+  - 24/26 pass. Failures:
+    - 22 (CHECK return): needs CHECK-time error wrapping in `X::Comp::BeginTime` with `.exception` referencing `X::ControlFlow::Return`.
+    - 23 (X::ControlFlow::Return out-of-dynamic-scope on `eager sub { ^1 .map: { return } }()`): mutsu evaluates `.map` eagerly so the return is caught by the still-active enclosing routine instead of escaping after `eager` forces a lazy Seq. Needs proper laziness for `.map` plus `eager`'s forcing semantics.
+    - The other 24 cases (including bare top-level `return`, returns in for/while/until/loop/do, INIT-time return, lexotic return, and three out-of-dynamic-scope variants) now produce a real `X::ControlFlow::Return` exception with the correct `out-of-dynamic-scope` attribute.
 - [ ] roast/S04-statements/sink.t
   - 6/10 pass (11 reached, plan 10). Tests 2-3, 6-8, 10 pass. Failures: .unshift in sink context (1), map in sunk for (4-5), sub in sunk for (9), loop sink (11). Difficulty: Medium
 - [ ] roast/S04-statements/terminator.t

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -71,6 +71,7 @@ impl Compiler {
             .unwrap_or(false);
         let mut sub_compiler = Compiler::new();
         sub_compiler.is_routine = true;
+        sub_compiler.lexically_in_routine = true;
         let arity = param_defs
             .iter()
             .filter(|p| !p.named && (!p.slurpy || p.name == "_capture"))
@@ -406,6 +407,10 @@ impl Compiler {
     ) -> CompiledCode {
         let mut sub_compiler = Compiler::new();
         sub_compiler.is_routine = is_routine;
+        // A closure body is lexically inside a routine if either the parent
+        // already is, or the parent itself is a routine.
+        sub_compiler.lexically_in_routine =
+            is_routine || self.is_routine || self.lexically_in_routine;
         // Propagate last_source_line so closures inside blocks that
         // lack their own SetLine can still inherit the line from the
         // enclosing statement.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -56,6 +56,10 @@ pub(crate) struct Compiler {
     /// Whether we are compiling inside a routine (sub/method). `return` outside
     /// a routine must throw X::ControlFlow::Return instead of normal return.
     pub(crate) is_routine: bool,
+    /// Whether the enclosing lexical scope contains a routine (sub/method).
+    /// Used to decide whether `return` in a non-routine block should perform
+    /// a non-local return (via CX::Return) or throw X::ControlFlow::Return.
+    pub(crate) lexically_in_routine: bool,
     /// When true, the current VarDecl is from a `:=` bind declaration.
     bind_vardecl: bool,
     /// Variables declared as `constant` (no Scalar container).
@@ -79,6 +83,7 @@ impl Compiler {
             dynamic_scope_names: None,
             accessed_dynamic_vars: std::collections::HashSet::new(),
             is_routine: false,
+            lexically_in_routine: false,
             bind_vardecl: false,
             constant_vars: std::collections::HashSet::new(),
             last_source_line: None,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1270,7 +1270,8 @@ impl Compiler {
                 if self.is_routine {
                     self.code.emit(OpCode::Return);
                 } else {
-                    self.code.emit(OpCode::ReturnFromNonRoutine);
+                    self.code
+                        .emit(OpCode::ReturnFromNonRoutine(self.lexically_in_routine));
                 }
             }
             Stmt::Die(expr) => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -688,8 +688,15 @@ pub(crate) enum OpCode {
 
     // -- Functions --
     Return,
-    /// Return used outside a routine — throws X::ControlFlow::Return exception.
-    ReturnFromNonRoutine,
+    /// Return used outside a routine.
+    /// The `bool` payload is `true` if the op is lexically nested inside a
+    /// routine (a closure/block in a sub) — in that case `return` should
+    /// perform a non-local return up to the enclosing routine, and only
+    /// become an `X::ControlFlow::Return` exception when no enclosing routine
+    /// is on the dynamic call stack (out-of-dynamic-scope).
+    /// When `false`, the op is at top level with no lexical routine and
+    /// throws `X::ControlFlow::Return` directly.
+    ReturnFromNonRoutine(bool),
     RegisterSub(u32),
     RegisterToken(u32),
     RegisterProtoSub(u32),

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1358,6 +1358,7 @@ impl Interpreter {
             .collect();
         let mut compiler = crate::compiler::Compiler::new();
         compiler.is_routine = !self.routine_stack.is_empty();
+        compiler.lexically_in_routine = !self.routine_stack.is_empty();
         let scope = if let Some((pkg, routine)) = self.routine_stack.last() {
             format!("{}::&{}", pkg, routine)
         } else {
@@ -1663,8 +1664,13 @@ impl Interpreter {
                 }
             }
 
-            // Compile once, reuse VM for every iteration
-            let compiler = crate::compiler::Compiler::new();
+            // Compile once, reuse VM for every iteration.
+            // `return` inside this block should propagate up to the
+            // lexically enclosing routine (if any), so mark the fresh
+            // compiler as being lexically nested inside a routine whenever
+            // a routine is currently on the dynamic call stack.
+            let mut compiler = crate::compiler::Compiler::new();
+            compiler.lexically_in_routine = !self.routine_stack.is_empty();
             let (code, compiled_fns) = compiler.compile(&data.body);
 
             let underscore = "_".to_string();
@@ -2078,8 +2084,13 @@ impl Interpreter {
                 return Ok((Value::array(result), list_items));
             }
 
-            // Compile once, reuse VM for every iteration
-            let compiler = crate::compiler::Compiler::new();
+            // Compile once, reuse VM for every iteration.
+            // `return` inside this block should propagate up to the
+            // lexically enclosing routine (if any), so mark the fresh
+            // compiler as being lexically nested inside a routine whenever
+            // a routine is currently on the dynamic call stack.
+            let mut compiler = crate::compiler::Compiler::new();
+            compiler.lexically_in_routine = !self.routine_stack.is_empty();
             let (code, compiled_fns) = compiler.compile(&data.body);
 
             let underscore = "_".to_string();

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -818,6 +818,7 @@ impl Interpreter {
         }
         let mut compiler = crate::compiler::Compiler::new();
         compiler.is_routine = !self.routine_stack.is_empty();
+        compiler.lexically_in_routine = !self.routine_stack.is_empty();
         compiler.set_current_package(self.current_package.clone());
         let (code, compiled_fns) = compiler.compile(stmts);
         let interp = std::mem::take(self);

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -780,6 +780,7 @@ impl Interpreter {
                     if !needs_full_binding {
                         let mut compiler = crate::compiler::Compiler::new();
                         compiler.is_routine = !self.routine_stack.is_empty();
+                        compiler.lexically_in_routine = !self.routine_stack.is_empty();
                         let scope = if let Some((pkg, routine)) = self.routine_stack.last() {
                             format!("{}::&{}", pkg, routine)
                         } else {

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -556,14 +556,13 @@ impl RuntimeError {
     }
 
     /// X::ControlFlow::Return - Return outside of routine
-    #[allow(dead_code)]
     pub(crate) fn controlflow_return(out_of_dynamic_scope: bool) -> Self {
         let msg = "Attempt to return outside of any Routine".to_string();
         let mut attrs = HashMap::new();
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         attrs.insert(
             "out-of-dynamic-scope".to_string(),
-            Value::Bool(!out_of_dynamic_scope),
+            Value::Bool(out_of_dynamic_scope),
         );
         Self::typed("X::ControlFlow::Return", attrs)
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -324,6 +324,20 @@ impl VM {
                 }
                 self.sync_state_locals(code);
                 self.interpreter.pop_once_scope();
+                // An uncaught CX::Return signal that escapes the top-level
+                // VM loop means the lexical target routine was not on the
+                // dynamic call stack when `return` executed, so it surfaces
+                // as `X::ControlFlow::Return` with out-of-dynamic-scope set.
+                // Only perform this conversion when the current dynamic call
+                // stack contains no routine — otherwise the return is meant
+                // for an enclosing routine that will catch it via its own
+                // call-frame handling further up the stack.
+                if e.is_return && self.interpreter.routine_stack().is_empty() {
+                    return (
+                        self.interpreter,
+                        Err(RuntimeError::controlflow_return(true)),
+                    );
+                }
                 return (self.interpreter, Err(e));
             }
             if self.interpreter.is_halted() {
@@ -2228,12 +2242,21 @@ impl VM {
                 }
                 return Err(RuntimeError::return_signal(val));
             }
-            OpCode::ReturnFromNonRoutine => {
+            OpCode::ReturnFromNonRoutine(lexically_in_routine) => {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
-                // In a non-routine closure (pointy block, bare block),
-                // `return` propagates as a CX::Return signal up to the
-                // enclosing routine boundary.
-                return Err(RuntimeError::return_signal(val));
+                if *lexically_in_routine {
+                    // Closure/block lexically inside a routine: propagate a
+                    // CX::Return signal up to the enclosing routine boundary.
+                    // If the signal escapes all frames up to the VM top-level,
+                    // the lexical target routine is no longer on the dynamic
+                    // call stack, so it will surface as
+                    // `X::ControlFlow::Return` with `out-of-dynamic-scope`.
+                    return Err(RuntimeError::return_signal(val));
+                }
+                // No lexical routine at all (e.g. top-level `return`): throw
+                // X::ControlFlow::Return directly.
+                let _ = val;
+                return Err(RuntimeError::controlflow_return(false));
             }
 
             // -- Environment variable access --

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -4,6 +4,7 @@ roast/S02-types/multi_dimensional_array.t
 roast/S03-binding/attributes.t
 roast/S03-sequence/misc.t
 roast/S04-exceptions/exceptions-alternatives.t
+roast/S04-statements/return.t
 roast/S05-capture/alias.t
 roast/S05-capture/caps.t
 roast/S05-mass/recursive.t


### PR DESCRIPTION
## Summary
- `return` outside a Routine now produces `X::ControlFlow::Return` with the spec'd `out-of-dynamic-scope` attribute, instead of leaking an internal `CX::Return` control signal.
- Tracks lexical routine nesting on the compiler so a `return` inside a non-routine block knows whether to perform a non-local return into an enclosing routine or to throw directly.
- Brings `roast/S04-statements/return.t` from 12/26 to 24/26 passing.

## Remaining failures (deferred via `too_difficult.txt` + `TODO_roast/S04.md`)
- Test 22 (CHECK-time `return`): needs CHECK-phase exception wrapping in `X::Comp::BeginTime`.
- Test 23 (`eager sub { ^1 .map: { return } }()`): needs lazy `.map` so `eager` forces the seq after the inner sub has already returned.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test` (all green)
- [x] `make roast` (all green)
- [x] `target/debug/mutsu roast/S04-statements/return.t` (24/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)