### PR TITLE
fix: implement StrDistance and read-only topic for tr/// operator

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -387,6 +387,7 @@ roast/S05-substitution/match.t
 roast/S05-syntactic-categories/new-symbols.t
 roast/S05-transliteration/79778.t
 roast/S05-transliteration/trans-TR-operator.t
+roast/S05-transliteration/trans-tr-lowercase-operator.t
 roast/S05-transliteration/trans.t
 roast/S05-transliteration/with-closure.t
 roast/S06-advanced/callframe.t

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -1037,11 +1037,21 @@ fn find_quote_word_close(input: &str, close: &str) -> Option<usize> {
 
 /// Find the closing `>` for `<...>`, handling nested `<>` pairs
 /// (e.g. `<:13<01>/:13<07>>`).
+pub(super) fn find_nested_angle_close_pub(input: &str) -> Option<usize> {
+    find_nested_angle_close(input)
+}
+
 fn find_nested_angle_close(input: &str) -> Option<usize> {
     let mut depth: usize = 0;
     let mut i = 0usize;
-    while i < input.len() {
-        let b = input.as_bytes()[i];
+    let bytes = input.as_bytes();
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Backslash escapes the next byte (allows `\<`, `\>`, `\\` etc.)
+        if b == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
         if b == b'<' {
             depth += 1;
         } else if b == b'>' {
@@ -1224,6 +1234,36 @@ pub(crate) fn angle_word_expr(word: &str) -> Expr {
     Expr::Literal(angle_word_value(word))
 }
 
+/// Unescape backslash sequences in a `<...>` word.
+/// Per Raku spec, `<...>` is `q:w` quoting which only processes a small set of
+/// backslash escapes: `\\` → `\`, `\<` → `<`, `\>` → `>`, `\ ` → space (allows
+/// embedded spaces in a word), `\#` → `#`. Other backslash sequences (e.g. `\n`)
+/// are kept literally.
+fn unescape_angle_word(word: &str) -> String {
+    let mut out = String::with_capacity(word.len());
+    let mut chars = word.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\'
+            && let Some(next) = chars.next()
+        {
+            match next {
+                '\\' => out.push('\\'),
+                '<' => out.push('<'),
+                '>' => out.push('>'),
+                ' ' => out.push(' '),
+                '#' => out.push('#'),
+                other => {
+                    out.push('\\');
+                    out.push(other);
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
 pub(crate) fn angle_word_value(word: &str) -> Value {
     angle_word_value_impl(word, false)
 }
@@ -1241,6 +1281,16 @@ fn angle_word_value_impl(word: &str, fraction_allomorphic: bool) -> Value {
     // We represent allomorphs as Mixin(numeric_value, {"Str": Str(word)}).
     // For single-element <2/3>, fraction notation produces a plain Rat, not RatStr.
     // For multi-element lists, fractions produce RatStr.
+
+    // Process backslash escapes within the word: `\\` → `\`, `\<`/`\>` → `<`/`>`,
+    // `\ ` → space (allows embedded spaces in a word).
+    let unescaped_storage;
+    let word: &str = if word.contains('\\') {
+        unescaped_storage = unescape_angle_word(word);
+        unescaped_storage.as_str()
+    } else {
+        word
+    };
 
     // Normalize U+2212 MINUS SIGN to ASCII minus for numeric parsing.
     // The allomorphic Str part retains the original word spelling.

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -951,18 +951,18 @@ pub(in crate::parser) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     // :name<value> (angle-bracket colonpair, equivalent to :name("value"))
     if rest.starts_with('<') && !rest.starts_with("<<") && !rest.starts_with("<=") {
         let inner = &rest[1..];
-        if let Some(close) = inner.find('>') {
+        if let Some(close) = super::container::find_nested_angle_close_pub(inner) {
             let content = &inner[..close];
             let r = &inner[close + 1..];
             let words = split_angle_words(content);
             if !words.is_empty() {
                 let val_expr = if words.len() == 1 {
-                    Expr::Literal(Value::str(words[0].to_string()))
+                    Expr::Literal(super::container::angle_word_value(words[0]))
                 } else {
                     Expr::ArrayLiteral(
                         words
                             .into_iter()
-                            .map(|w| Expr::Literal(Value::str(w.to_string())))
+                            .map(|w| Expr::Literal(super::container::angle_word_value(w)))
                             .collect(),
                     )
                 };

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1968,7 +1968,23 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // The body uses $_ which was set in the condition block.
     // We still prepend topicalize(&tmp_var) as a no-op marker so that
     // $_ is visible in the body scope (but it's already set by the condition).
-    let mut with_body = vec![topicalize(&tmp_var)];
+    // If the topic source is a literal value, wrap $_ in a Mixin marked as
+    // read-only so that mutating ops like tr/// throw X::Assignment::RO.
+    // Encoding the read-only flag in the value itself avoids leaking marker
+    // variables across exception boundaries.
+    let topic_assign = if let Expr::Literal(lit) = &cond_expr {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("__mutsu_topic_ro__".to_string(), Value::Bool(true));
+        let wrapped = Value::mixin(lit.clone(), overrides);
+        Stmt::Assign {
+            name: "_".to_string(),
+            op: AssignOp::Assign,
+            expr: Expr::Literal(wrapped),
+        }
+    } else {
+        topicalize(&tmp_var)
+    };
+    let mut with_body = vec![topic_assign];
     // If a named parameter was given (-> $param), also assign it
     if let Some(ref pname) = param_name {
         // Check if this is a sub-signature destructuring (e.g. -> ($x) or -> (Int() $x is copy))

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -895,6 +895,23 @@ impl Interpreter {
                     attrs.insert("value".to_string(), Value::Num(secs));
                     return Ok(Value::make_instance(Symbol::intern("Duration"), attrs));
                 }
+                "StrDistance" => {
+                    let mut before = String::new();
+                    let mut after = String::new();
+                    for arg in &args {
+                        if let Value::Pair(key, value) = arg {
+                            match key.as_str() {
+                                "before" => before = value.to_string_value(),
+                                "after" => after = value.to_string_value(),
+                                _ => {}
+                            }
+                        }
+                    }
+                    let mut attrs = HashMap::new();
+                    attrs.insert("before".to_string(), Value::str(before));
+                    attrs.insert("after".to_string(), Value::str(after));
+                    return Ok(Value::make_instance(Symbol::intern("StrDistance"), attrs));
+                }
                 "Date" => {
                     use crate::builtins::methods_0arg::temporal;
                     let mut year: i64 = 1970;

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -763,6 +763,14 @@ impl Value {
                 .get("contents")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "StrDistance" => attributes
+                .get("after")
+                .map(|v: &Value| v.to_string_value())
+                .unwrap_or_default(),
             Value::Instance { class_name, .. } => format!("{}()", class_name),
             Value::Junction { kind, values } => {
                 let kind_str = match kind {

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -236,6 +236,18 @@ impl Value {
             | (Value::Promise(_), Value::Promise(_))
             | (Value::Channel(_), Value::Channel(_))
             | (Value::Uni { .. }, Value::Uni { .. }) => self == other,
+            // Mixin with only the read-only topic marker is transparent
+            // (used by `with literal { ... }` to flag immutable $_).
+            (Value::Mixin(inner, mix), other)
+                if mix.len() == 1 && mix.contains_key("__mutsu_topic_ro__") =>
+            {
+                inner.eqv(other)
+            }
+            (other, Value::Mixin(inner, mix))
+                if mix.len() == 1 && mix.contains_key("__mutsu_topic_ro__") =>
+            {
+                other.eqv(inner)
+            }
             // Mixin (allomorphs): compare both base values and mixin maps with eqv
             (Value::Mixin(a, a_mix), Value::Mixin(b, b_mix)) => {
                 if !a.eqv(b) {

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -188,6 +188,31 @@ impl Value {
                 let (by, bm, bd) = crate::builtins::methods_0arg::temporal::date_attrs(b_attrs);
                 ay == by && am == bm && ad == bd
             }
+            // StrDistance instances: structural equality on before/after
+            (
+                Value::Instance {
+                    class_name: cn_a,
+                    attributes: a_attrs,
+                    ..
+                },
+                Value::Instance {
+                    class_name: cn_b,
+                    attributes: b_attrs,
+                    ..
+                },
+            ) if cn_a == "StrDistance" && cn_b == "StrDistance" => {
+                let before_eq = match (a_attrs.get("before"), b_attrs.get("before")) {
+                    (Some(a), Some(b)) => a.eqv(b),
+                    (None, None) => true,
+                    _ => false,
+                };
+                let after_eq = match (a_attrs.get("after"), b_attrs.get("after")) {
+                    (Some(a), Some(b)) => a.eqv(b),
+                    (None, None) => true,
+                    _ => false,
+                };
+                before_eq && after_eq
+            }
             // Other Instance types: use identity comparison
             (Value::Instance { .. }, Value::Instance { .. }) => self == other,
             // Nil and Package("Any") are eqv: both represent the undefined type object Any.

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -860,13 +860,18 @@ impl VM {
         if self.in_smartmatch_rhs {
             self.transliterate_in_smartmatch = true;
         }
-        // tr/// returns a StrDistance object holding both the original and the
-        // transliterated string. It stringifies to the `after` value.
-        let mut sd_attrs = std::collections::HashMap::new();
-        sd_attrs.insert("before".to_string(), Value::str(text));
-        sd_attrs.insert("after".to_string(), Value::str(translated));
-        let sd = Value::make_instance(Symbol::intern("StrDistance"), sd_attrs);
-        self.stack.push(sd);
+        // tr/// (destructive) returns a StrDistance object holding both the
+        // original and the transliterated string; it stringifies to `after`.
+        // TR/// (non-destructive) returns a plain Str with the translated text.
+        let result = if non_destructive {
+            Value::str(translated)
+        } else {
+            let mut sd_attrs = std::collections::HashMap::new();
+            sd_attrs.insert("before".to_string(), Value::str(text));
+            sd_attrs.insert("after".to_string(), Value::str(translated));
+            Value::make_instance(Symbol::intern("StrDistance"), sd_attrs)
+        };
+        self.stack.push(result);
         Ok(())
     }
 

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -822,26 +822,51 @@ impl VM {
             .get("_")
             .cloned()
             .unwrap_or(Value::Nil);
+        // If $_ is bound to a read-only topic (e.g. `with 'literal' { ... }`),
+        // tr/// must throw X::Assignment::RO. The `with` desugaring marks the
+        // topic value with a Mixin override `__mutsu_topic_ro__` when the
+        // condition expression is a literal.
+        if !non_destructive
+            && let Value::Mixin(_, overrides) = &target
+            && overrides.contains_key("__mutsu_topic_ro__")
+        {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!(
+                    "Cannot modify an immutable Str ({})",
+                    target.to_string_value()
+                )),
+            );
+            attrs.insert("value".to_string(), target);
+            return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+        }
         let text = target.to_string_value();
 
         let translated = crate::builtins::transliterate::transliterate(
             &text, from, to, delete, squash, complement,
         );
-        let result = Value::str(translated);
+        let translated_value = Value::str(translated.clone());
 
         // tr/// (lowercase) always modifies $_; TR/// (uppercase) only modifies
         // $_ in smartmatch context (so that $var ~~ TR/// writes back to $var).
         if !non_destructive || self.in_smartmatch_rhs {
             self.interpreter
                 .env_mut()
-                .insert("_".to_string(), result.clone());
+                .insert("_".to_string(), translated_value);
         }
         // Signal to the smartmatch handler that this is a transliterate result
         // so it returns the result directly (as StrDistance) instead of comparing.
         if self.in_smartmatch_rhs {
             self.transliterate_in_smartmatch = true;
         }
-        self.stack.push(result);
+        // tr/// returns a StrDistance object holding both the original and the
+        // transliterated string. It stringifies to the `after` value.
+        let mut sd_attrs = std::collections::HashMap::new();
+        sd_attrs.insert("before".to_string(), Value::str(text));
+        sd_attrs.insert("after".to_string(), Value::str(translated));
+        let sd = Value::make_instance(Symbol::intern("StrDistance"), sd_attrs);
+        self.stack.push(sd);
         Ok(())
     }
 

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -334,6 +334,7 @@ impl VM {
                 | "WhateverCode"
                 | "HyperWhatever"
                 | "Stash"
+                | "StrDistance"
                 | "Scalar"
                 | "SetHash"
                 | "BagHash"


### PR DESCRIPTION
## Summary
- tr/// now returns a `StrDistance` instance (stringifies to `after`); add `StrDistance.new(:before, :after)` and structural `eqv`.
- Process backslash escapes (`\\`, `\<`, `\>`, `\ `, `\#`) inside `<...>` word quoting and `:name<...>` colonpair angle forms.
- `with literal { ... }` marks `$_` as read-only via a Mixin override so mutating ops like tr/// throw `X::Assignment::RO`.
- Whitelist `roast/S05-transliteration/trans-tr-lowercase-operator.t` (all 13 subtests pass).

## Test plan
- [x] cargo build
- [x] cargo clippy -- -D warnings
- [x] cargo fmt
- [x] make test (all 471 files pass)
- [x] target test passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)