### PR TITLE
chore: defer roast/S06-advanced/return-prioritization.t (rakudo bug)

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -10,6 +10,7 @@ roast/S05-capture/array-alias.t
 roast/S05-capture/caps.t
 roast/S05-mass/recursive.t
 roast/S06-advanced/lexical-subs.t
+roast/S06-advanced/return-prioritization.t
 roast/S11-modules/versioning.t
 roast/S11-repository/curli-install.t
 roast/S12-meta/exporthow.t


### PR DESCRIPTION
## Summary
- Rakudo itself fails `roast/S06-advanced/return-prioritization.t` at subtest 5 with `Attempt to return outside of any Routine` when reaching `LEAVE return 1;` on line 31.
- Since the reference implementation cannot pass this test, add it to `too_difficult.txt` per the roast workflow.

## Test plan
- [x] Confirmed `raku roast/S06-advanced/return-prioritization.t` dies after 4 oks