### PR TITLE
fix: pass S12-introspection/parents.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -558,6 +558,7 @@ roast/S12-introspection/can.t
 roast/S12-introspection/definite.t
 roast/S12-introspection/meta-class.t
 roast/S12-introspection/methods.t
+roast/S12-introspection/parents.t
 roast/S12-introspection/roles.t
 roast/S12-meta/classhow.t
 roast/S12-meta/grammarhow.t

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -855,7 +855,30 @@ impl Interpreter {
         let mut mro = if self.classes.contains_key(&class_name) {
             self.class_mro(&class_name)
         } else {
-            vec![class_name.clone()]
+            // Built-in type hierarchies for types that are not user-defined classes.
+            // Any/Mu are appended unconditionally below, so we only list the chain
+            // up to (but not including) Any here.
+            let builtin: &[&str] = match class_name.as_str() {
+                "Int" => &["Int", "Cool"],
+                "Num" => &["Num", "Cool"],
+                "Rat" | "FatRat" => &["Rat", "Cool"],
+                "Complex" => &["Complex", "Cool"],
+                "Str" => &["Str", "Cool"],
+                "Bool" => &["Bool", "Int", "Cool"],
+                "Array" => &["Array", "List", "Cool"],
+                "List" => &["List", "Cool"],
+                "Hash" => &["Hash", "Map", "Cool"],
+                "Map" => &["Map", "Cool"],
+                "Range" => &["Range", "Cool"],
+                "Seq" => &["Seq", "Cool"],
+                "Pair" => &["Pair"],
+                _ => &[],
+            };
+            if builtin.is_empty() {
+                vec![class_name.clone()]
+            } else {
+                builtin.iter().map(|s| s.to_string()).collect()
+            }
         };
         if self.package_looks_like_grammar(&class_name) {
             for parent in ["Grammar", "Match", "Capture", "Cool", "Any", "Mu"] {
@@ -1900,7 +1923,7 @@ impl Interpreter {
         };
         if tree {
             let result = self.parents_tree(&class_name);
-            return Ok(Value::array(result));
+            return Ok(Value::real_array(result));
         }
         let mro = self.classhow_mro_names(&args[0]);
         let parents_iter = mro.into_iter().skip(1);
@@ -1922,7 +1945,7 @@ impl Interpreter {
                 .map(|p| Value::Package(Symbol::intern(&p)))
                 .collect()
         };
-        Ok(Value::array(parents))
+        Ok(Value::real_array(parents))
     }
 
     fn parents_tree(&mut self, class_name: &str) -> Vec<Value> {
@@ -1947,11 +1970,13 @@ impl Interpreter {
                     if !any_subtree.is_empty() {
                         any_entry.extend(any_subtree);
                     } else {
-                        any_entry.push(Value::array(vec![Value::Package(Symbol::intern("Mu"))]));
+                        any_entry.push(Value::real_array(vec![Value::Package(Symbol::intern(
+                            "Mu",
+                        ))]));
                     }
-                    entry.push(Value::array(any_entry));
+                    entry.push(Value::real_array(any_entry));
                 }
-                Value::array(entry)
+                Value::real_array(entry)
             })
             .collect()
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3652,7 +3652,14 @@ impl Interpreter {
                 self.var_hash_key_constraints.remove(&key);
                 self.env.remove(&hash_key_meta_key);
             }
-            self.register_var_container_type_metadata(&key, &info);
+            // Only register container type metadata for container-sigil variables
+            // (`@a`, `%h`). For scalar parameters (e.g. `Mu $a`) the bound value
+            // may share an `Arc` with a caller's container, and tagging that Arc
+            // would corrupt the caller's container type metadata via Arc pointer
+            // keying (and Arc pointer reuse after drop).
+            if name.starts_with('@') || name.starts_with('%') {
+                self.register_var_container_type_metadata(&key, &info);
+            }
         } else {
             self.var_type_constraints.remove(&key);
             self.var_hash_key_constraints.remove(&key);


### PR DESCRIPTION
## Summary
- Add built-in ancestor chain handling in `classhow_mro_names` so `.^parents(:all)` on types like `Str`/`Int`/`Array` returns `Cool` in the chain.
- Return `.^parents(:tree)` nested values as `Value::real_array` so they smartmatch `Array`.
- Stop registering container-type metadata in `set_var_type_constraint` for scalar parameters. Passing `@p` to `Mu $a` was tagging `@p`'s inner `Arc` as `Mu`-typed via `Arc` pointer keying, and later `@p[i]` reads were treating genuine `Any` elements as "hole" sentinels and returning the stale `Mu` default.

## Test plan
- [x] `prove -e target/debug/mutsu roast/S12-introspection/parents.t` (59/59)
- [x] `make test`
- [x] `make roast`