### PR TITLE
fix: pass roast/S32-basics/warn.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -865,6 +865,7 @@ roast/S32-array/rotate.t
 roast/S32-array/shift.t
 roast/S32-array/unshift.t
 roast/S32-basics/pairup.t
+roast/S32-basics/warn.t
 roast/S32-basics/xxPOS-native.t
 roast/S32-container/cat.t
 roast/S32-container/roundrobin.t

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -272,6 +272,18 @@ impl Interpreter {
         for arg in args {
             message.push_str(&arg.to_string_value());
         }
+        if message.is_empty() {
+            message = "Warning: something's wrong".to_string();
+        }
+        // Append a Raku-style source location annotation so that the
+        // stderr output includes a file/line reference. The callsite line
+        // was set by the VM right before dispatching this builtin.
+        let file = self
+            .program_path
+            .clone()
+            .unwrap_or_else(|| "-e".to_string());
+        let line = self.test_pending_callsite_line.unwrap_or(1);
+        message.push_str(&format!("\n  in block <unit> at {} line {}", file, line));
         Err(RuntimeError::warn_signal(message))
     }
 
@@ -294,6 +306,9 @@ impl Interpreter {
         let mut message = String::new();
         for arg in args {
             message.push_str(&arg.to_string_value());
+        }
+        if message.is_empty() {
+            message = "Warning: something's wrong".to_string();
         }
         Err(RuntimeError::warn_signal(message))
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -723,6 +723,11 @@ pub struct Interpreter {
     method_class_stack: Vec<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
     test_pending_callsite_line: Option<i64>,
+    /// Number of active CONTROL handlers in the current VM stack. Tracked
+    /// on the interpreter (rather than per-VM) so that nested VMs (e.g.
+    /// EVAL) can observe handlers installed by the outer VM and propagate
+    /// warn/control signals appropriately.
+    pub(crate) control_handler_depth: u32,
     test_assertion_line_stack: Vec<i64>,
     block_stack: Vec<Value>,
     doc_comments: HashMap<String, DocComment>,
@@ -2494,6 +2499,7 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
+            control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),
@@ -3571,9 +3577,16 @@ impl Interpreter {
             self.warn_output.push_str(&msg);
             return;
         }
-        self.stderr_output.push_str(&msg);
         self.warn_output.push_str(&msg);
-        eprint!("{}", msg);
+        // In nested mode (e.g. in-process `is_run`), buffer to
+        // `stderr_output` so the caller can inspect captured stderr.
+        // Otherwise emit directly to the real stderr; if we also pushed
+        // into `stderr_output`, the final flush would duplicate it.
+        if self.nested_mode {
+            self.stderr_output.push_str(&msg);
+        } else {
+            eprint!("{}", msg);
+        }
     }
 
     pub(crate) fn push_warn_suppression(&mut self) {
@@ -4172,6 +4185,7 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
+            control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -126,8 +126,6 @@ pub(crate) struct VM {
     /// each active BlockScope. Used during BlockScope restoration to avoid
     /// propagating block-local variable values to the outer scope.
     block_declared_vars: Vec<std::collections::HashSet<String>>,
-    /// Depth counter for active CONTROL handlers in try-catch.
-    control_handler_depth: u32,
 }
 
 impl VM {
@@ -278,7 +276,6 @@ impl VM {
             multi_candidates_cache: HashMap::new(),
             multi_candidates_cache_gen: 0,
             block_declared_vars: Vec::new(),
-            control_handler_depth: 0,
         }
     }
 
@@ -312,7 +309,7 @@ impl VM {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn {
+                if e.is_warn && self.interpreter.control_handler_depth == 0 {
                     if !self.interpreter.warning_suppressed() {
                         self.interpreter.write_warn_to_stderr(&e.message);
                     }
@@ -398,7 +395,7 @@ impl VM {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn {
+                if e.is_warn && self.interpreter.control_handler_depth == 0 {
                     if !self.interpreter.warning_suppressed() {
                         self.interpreter.write_warn_to_stderr(&e.message);
                     }
@@ -528,7 +525,7 @@ impl VM {
                     continue;
                 }
                 // Handle warn signals inline when no CONTROL handler is active.
-                if e.is_warn && self.control_handler_depth == 0 {
+                if e.is_warn && self.interpreter.control_handler_depth == 0 {
                     if !self.interpreter.warning_suppressed() {
                         self.interpreter.write_warn_to_stderr(&e.message);
                     }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1637,11 +1637,11 @@ impl VM {
         let end = body_end as usize;
         let has_control = control_begin < end;
         if has_control {
-            self.control_handler_depth += 1;
+            self.interpreter.control_handler_depth += 1;
         }
         let body_result = self.run_range(code, body_start, catch_begin, compiled_fns);
         if has_control {
-            self.control_handler_depth -= 1;
+            self.interpreter.control_handler_depth -= 1;
         }
         match body_result {
             Ok(()) => {
@@ -1689,6 +1689,20 @@ impl VM {
                 }
             }
             Err(e) if e.return_value.is_some() && !e.is_succeed && !e.is_warn => {
+                self.interpreter.discard_let_saves(let_mark);
+                Err(e)
+            }
+            // Control signals (warn, last, next, redo, etc.) without a CONTROL
+            // block must propagate up — `try` alone does not catch them.
+            Err(e)
+                if (e.is_last
+                    || e.is_next
+                    || e.is_redo
+                    || e.is_proceed
+                    || e.is_succeed
+                    || e.is_warn)
+                    && control_begin >= end =>
+            {
                 self.interpreter.discard_let_saves(let_mark);
                 Err(e)
             }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -658,14 +658,30 @@ impl VM {
         let val = self.stack.pop().unwrap();
         // Auto-FETCH Proxy containers
         let val = self.interpreter.auto_fetch_proxy(&val)?;
-        // Type objects (Mu, Any, etc.) cannot be string-coerced
+        // Mu itself has no Str candidate — stringifying it is a hard
+        // error (Rakudo dies with `Cannot resolve caller prefix:<~>(Mu:U)`).
         if let Value::Package(name) = &val
-            && matches!(name.resolve().as_str(), "Mu" | "Any")
+            && name.resolve() == "Mu"
         {
             return Err(RuntimeError::new(format!(
                 "Cannot resolve caller prefix:<~>({}:U); none of these signatures matches:\n    (\\a)",
                 name.resolve()
             )));
+        }
+        // Any and other Cool-descended type objects stringify to the empty
+        // string with a warning (Rakudo emits `Use of uninitialized value
+        // of type Any in string context.`).
+        if let Value::Package(name) = &val
+            && name.resolve() == "Any"
+        {
+            let msg = format!(
+                "Use of uninitialized value of type {} in string context.\nMethods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
+                name.resolve()
+            );
+            return Err(RuntimeError::warn_signal_with_resume(
+                msg,
+                Value::str(String::new()),
+            ));
         }
         // Stringifying an unhandled Failure throws
         if let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val) {


### PR DESCRIPTION
## Summary
- Make `try` propagate control signals (CX::Warn, CX::Last, etc.) when there is no CONTROL block, so an outer CONTROL handler on an enclosing block can catch them.
- Move the CONTROL-handler depth counter from VM to Interpreter so nested VMs (EVAL, etc.) see outer handlers and propagate warnings correctly.
- Stringifying `Any` now warns and resumes with `""` (Mu still dies).
- `warn` with no args defaults to `Warning: something's wrong` and appends ` in block <unit> at <file> line N`.
- `write_warn_to_stderr` no longer double-emits in top-level mode.
- Add `roast/S32-basics/warn.t` to the whitelist.

## Test plan
- [x] `make test`
- [x] `make roast`
- [x] `prove -e target/debug/mutsu roast/S32-basics/warn.t`

Generated with Claude Code.