### PR TITLE
chore: mark roast/S26-documentation/07b-tables.t too_difficult

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -21,6 +21,7 @@ roast/S17-lowlevel/semaphore.t
 roast/S17-procasync/encoding.t
 roast/S17-supply/categorize.t
 roast/S17-supply/migrate.t
+roast/S26-documentation/07b-tables.t (requires parse-time validation of empty =begin table/=end table; that validation regresses 12-non-breaking-space.t which depends on mutsu's broken BEGIN-at-end-of-file phaser ordering producing an empty runtime EVAL'd table)
 roast/S32-array/perl.t
 roast/S32-hash/perl.t
 roast/S32-io/child-secure.t


### PR DESCRIPTION
## Summary
- Mark roast/S26-documentation/07b-tables.t as too_difficult, blocked on BEGIN phaser ordering

## Details
07b-tables.t requires parse-time validation that empty `=begin table / =end table` blocks die. Implementing that validation (the natural fix in `src/parser/helpers.rs::pod_block`) regresses the whitelisted `12-non-breaking-space.t`, which uses `gen-pod` + `EVAL` to dynamically build a table. Because mutsu's BEGIN-at-end-of-file phaser does not run before the earlier `my @nbchars; my $nbchar-count = @nbchars.elems;` initializer, the runtime table ends up empty and the new validation throws.

The existing TODO in `src/parser/helpers.rs` already documents this exact blocker. Marking too_difficult until BEGIN ordering is fixed.

## Test plan
- [x] No code changes; only too_difficult.txt updated