### PR TITLE
fix: Lock::Async.lock returns Promise; unlock throws X::Lock::Async::NotLocked

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -743,6 +743,7 @@ roast/S17-promise/basic.t
 roast/S17-promise/in.t
 roast/S17-promise/lock-async-stress.t
 roast/S17-promise/lock-async-stress2.t
+roast/S17-promise/lock-async.t
 roast/S17-promise/single-assignment.t
 roast/S17-promise/stress.t
 roast/S17-scheduler/at.t

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -198,6 +198,7 @@ impl Compiler {
                     || name == "receive"
                     || name == "getc"
                     || name == "get"
+                    || name == "lock"
                     || (name == "new" && matches!(target.as_ref(), Expr::BareWord(n) if n == "Promise"))
                     || Self::xx_lhs_needs_reeval(target)
         ) || matches!(

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1888,6 +1888,9 @@ impl Interpreter {
                     let mut attrs = HashMap::new();
                     let lock_id = super::native_methods::next_lock_id() as i64;
                     attrs.insert("lock-id".to_string(), Value::Int(lock_id));
+                    if class_name.resolve() == "Lock::Async" {
+                        attrs.insert("async".to_string(), Value::Bool(true));
+                    }
                     return Ok(Value::make_instance(*class_name, attrs));
                 }
                 "Slip" => {

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -39,8 +39,18 @@ impl Interpreter {
                 let lock = lock_runtime_by_id(lock_id)
                     .ok_or_else(|| RuntimeError::new("Lock.lock could not find lock state"))?;
                 let me = current_thread_id();
-                acquire_lock(&lock, me)?;
-                Ok(Value::Nil)
+                // Lock::Async.lock() returns a Promise; plain Lock.lock() returns Nil.
+                let is_async = attributes
+                    .get("async")
+                    .map(|v| matches!(v, Value::Bool(true)))
+                    .unwrap_or(false);
+                if is_async {
+                    let promise = async_acquire_lock(&lock, me)?;
+                    Ok(Value::Promise(promise))
+                } else {
+                    acquire_lock(&lock, me)?;
+                    Ok(Value::Nil)
+                }
             }
             "unlock" => {
                 let lock_id = match attributes.get("lock-id") {
@@ -51,8 +61,16 @@ impl Interpreter {
                 };
                 let lock = lock_runtime_by_id(lock_id)
                     .ok_or_else(|| RuntimeError::new("Lock.unlock could not find lock state"))?;
-                let me = current_thread_id();
-                release_lock(&lock, me)?;
+                let is_async = attributes
+                    .get("async")
+                    .map(|v| matches!(v, Value::Bool(true)))
+                    .unwrap_or(false);
+                if is_async {
+                    async_release_lock(&lock)?;
+                } else {
+                    let me = current_thread_id();
+                    release_lock(&lock, me)?;
+                }
                 Ok(Value::Nil)
             }
             "condition" => {

--- a/src/runtime/native_methods/state_lock.rs
+++ b/src/runtime/native_methods/state_lock.rs
@@ -8,6 +8,10 @@ use super::state::cancellation_map;
 pub(super) struct LockState {
     pub(super) owner: Option<std::thread::ThreadId>,
     pub(super) recursion: u64,
+    /// FIFO queue of async Promises waiting to acquire the lock
+    /// (Lock::Async.lock() returns a Promise that becomes Kept when the
+    /// waiter becomes the lock owner).
+    pub(super) async_waiters: std::collections::VecDeque<crate::value::SharedPromise>,
 }
 
 #[derive(Debug, Default)]
@@ -117,6 +121,72 @@ pub(crate) fn release_lock(
             "Cannot unlock a Lock not owned by current thread",
         )),
     }
+}
+
+/// Async-flavored lock acquisition used by Lock::Async.lock().
+/// Returns a Promise that is Kept immediately if the lock is free, or
+/// Planned and enqueued if another waiter holds it. The caller holding
+/// the lock must call `async_release_lock` to pass ownership to the
+/// next waiter (keeping their Promise).
+pub(crate) fn async_acquire_lock(
+    runtime: &LockRuntime,
+    me: std::thread::ThreadId,
+) -> Result<crate::value::SharedPromise, RuntimeError> {
+    let mut state = runtime
+        .state
+        .lock()
+        .map_err(|_| RuntimeError::new("Lock state is poisoned"))?;
+    let promise = crate::value::SharedPromise::new();
+    if state.owner.is_none() && state.async_waiters.is_empty() {
+        state.owner = Some(me);
+        state.recursion = 1;
+        // Promise resolves immediately.
+        let _ = promise.try_keep(crate::value::Value::Nil);
+    } else {
+        state.async_waiters.push_back(promise.clone());
+    }
+    Ok(promise)
+}
+
+/// Async-flavored unlock: if a waiter is queued, hand ownership to it
+/// and keep its Promise. Throws X::Lock::Async::NotLocked when the lock
+/// is not held.
+pub(crate) fn async_release_lock(runtime: &LockRuntime) -> Result<(), RuntimeError> {
+    let mut state = runtime
+        .state
+        .lock()
+        .map_err(|_| RuntimeError::new("Lock state is poisoned"))?;
+    if state.owner.is_none() {
+        let mut err = RuntimeError::new("Cannot unlock an unlocked lock");
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            crate::value::Value::str_from("Cannot unlock an unlocked lock"),
+        );
+        let ex = crate::value::Value::make_instance(
+            crate::symbol::Symbol::intern("X::Lock::Async::NotLocked"),
+            attrs,
+        );
+        err.exception = Some(Box::new(ex));
+        return Err(err);
+    }
+    if let Some(next) = state.async_waiters.pop_front() {
+        // Transfer ownership to the next waiter and keep their Promise.
+        // We use the current thread's id as the owner because async locks
+        // do not track per-thread ownership in a meaningful way in our
+        // single-threaded unit test model; cross-thread behavior still
+        // works because the queue ordering is preserved.
+        state.owner = Some(current_thread_id());
+        state.recursion = 1;
+        drop(state);
+        let _ = next.try_keep(crate::value::Value::Nil);
+    } else {
+        state.owner = None;
+        state.recursion = 0;
+        drop(state);
+        runtime.lock_cv.notify_one();
+    }
+    Ok(())
 }
 
 pub(super) fn ensure_condition(


### PR DESCRIPTION
## Summary
- `Lock::Async.lock()` now returns a Promise (Kept immediately if free, Planned and queued otherwise).
- `Lock::Async.unlock()` hands ownership to the next queued waiter, keeping its Promise. Throws typed `X::Lock::Async::NotLocked` when not held.
- Added `lock` method to the `xx`-thunky list so `\$lock.lock() xx 5` produces 5 distinct Promises.

## Test plan
- [x] roast/S17-promise/lock-async.t passes 37/37 subtests
- [x] Added to roast-whitelist.txt (sorted)
- [x] make test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)