### PR TITLE
docs: defer roast/S02-magicals/dollar-underscore.t

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -78,7 +78,12 @@
 - [ ] roast/S02-magicals/dollar_bang.t
   - 14/15 pass. Test 7 fails: modifying a constant should set `$!`
 - [ ] roast/S02-magicals/dollar-underscore.t
-  - 0/? pass. Parse error at line 5
+  - 17/23 pass. Failing tests need real Perl 6 container/aliasing semantics for `$_`:
+    - Test 14: pointy block with empty signature `-> { ... }` should die with "Too many positionals" when given an arg from `for`.
+    - Test 16: `my $a := $_; $_ = 30; for 1..3 { $a++ }` expects 33 — `$a` must alias the same container as `$_`, surviving `for`'s topic rebinding.
+    - Test 18: inside `for 11,12 -> $a { if 1 { $_ = 2 } }`, the inner if-block must alias outer `$_` so that `$_ = 2` persists across iterations (currently `BlockScope` drops all changes to `$_`).
+    - Tests 21, 23: subs must establish a fresh `$_` topic that does not flow from/to the caller's `$_`.
+  - All five blockers require treating `$_` as a real container with binding (`:=`) vs assignment (`=`) distinction, not a plain Value in the env. Deferred to too_difficult.txt.
 - [ ] roast/S02-magicals/env.t
   - 0/? pass. Parse error at line 23
 - [x] roast/S02-magicals/file_line.t

--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -1,3 +1,4 @@
+roast/S02-magicals/dollar-underscore.t (17/23 pass; needs container-based `$_` semantics — `:=` vs `=` aliasing, fresh `$_` per sub call, empty pointy signature arity check, BlockScope must propagate plain assignment to `$_` while keeping `:=` block-local)
 roast/S02-magicals/sub.t
 roast/S02-types/generics.t
 roast/S02-types/multi_dimensional_array.t


### PR DESCRIPTION
## Summary
- 17/23 subtests in `roast/S02-magicals/dollar-underscore.t` already pass.
- The remaining 6 failures all require real Perl 6 container/aliasing semantics for `$_` (binding vs assignment distinction, fresh `$_` per sub call, empty pointy signature arity check, `BlockScope` propagation of plain assignment to `$_` while keeping `:=` block-local).
- These cannot be addressed without a broader redesign of how mutsu represents scalar containers, so this PR documents the blockers in `TODO_roast/S02.md` and adds the test to `too_difficult.txt`.

## Test plan
- [x] No code changes; docs-only update.
- [x] `make test` unaffected.

Generated with Claude Code