### PR TITLE
chore: mark roast/S11-repository/cur-current-distribution.t as too_difficult

### DIFF
--- a/too_difficult.txt
+++ b/too_difficult.txt
@@ -12,6 +12,7 @@ roast/S05-mass/recursive.t
 roast/S06-advanced/lexical-subs.t
 roast/S06-advanced/return-prioritization.t
 roast/S11-modules/versioning.t
+roast/S11-repository/cur-current-distribution.t (requires entire CompUnit::Repository::FileSystem and ::Installation subsystems, Distribution::Path, $?DISTRIBUTION variable, -M command-line module loading honoring META6.json provides, and make-temp-dir; spans modules/distribution/repository plumbing far beyond a single PR)
 roast/S11-repository/curli-install.t
 roast/S12-meta/exporthow.t
 roast/S12-methods/accessors.t


### PR DESCRIPTION
## Summary
- Test requires the full CompUnit::Repository::FileSystem and ::Installation subsystems, Distribution::Path, $?DISTRIBUTION, -M command-line loading honoring META6.json provides, and make-temp-dir.
- Scope spans modules/distribution/repository plumbing far beyond a single PR; marking as too_difficult per CLAUDE.md guidance.

## Test plan
- [x] raku passes the test (confirmed all 3 subtests pass on rakudo)
- [x] mutsu currently fails all 3 subtests