### PR TITLE
fix: support CX::Take/Emit/Done/X::Control in CONTROL blocks

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -255,6 +255,7 @@ roast/S04-declarations/multiple.t
 roast/S04-declarations/our.t
 roast/S04-declarations/smiley.t
 roast/S04-exception-handlers/catch.t
+roast/S04-exception-handlers/control.t
 roast/S04-exception-handlers/top-level.t
 roast/S04-exceptions/control_across_runloop.t
 roast/S04-exceptions/fail-6e.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -914,7 +914,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
             }
-            "resume" => return Some(Ok(Value::Nil)),
+            "resume" => return Some(Err(RuntimeError::resume_signal())),
             "gist" | "Str" => {
                 return Some(Ok(attributes
                     .get("message")
@@ -1016,7 +1016,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         } = target
     {
         let cn = class_name.resolve();
-        if cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::") || cn == "Failure" {
+        // Only the core exception classes use the fast path. For CX::* we
+        // fall through to the slow path, which can inspect the class's
+        // composed roles (e.g. X::Control) to decide whether the throw
+        // should raise a control exception.
+        if cn == "Exception" || cn.starts_with("X::") || cn == "Failure" {
             let msg = attributes
                 .get("message")
                 .map(|v| v.to_string_value())

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -453,8 +453,12 @@ impl Compiler {
             stmts
         };
         self.hoist_sub_decls(stmts, false);
-        // If the top-level body contains a CATCH block, wrap in implicit try.
-        let has_catch = stmts.iter().any(|s| matches!(s, Stmt::Catch(_)));
+        // If the top-level body contains a CATCH or CONTROL block, wrap in
+        // an implicit try so the phaser can observe exceptions / control
+        // signals from the surrounding statements.
+        let has_catch = stmts
+            .iter()
+            .any(|s| matches!(s, Stmt::Catch(_) | Stmt::Control(_)));
         if has_catch {
             self.compile_try(stmts, &None);
             self.code.emit(OpCode::Pop);

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -93,6 +93,23 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             }
             Stmt::Expr(expr)
         }
+        Stmt::Call { name, args } if name.resolve().as_str() == "emit" => {
+            // Statement-form `emit ARGS;` becomes `$emitter.emit(ARGS)`.
+            let positional_args: Vec<Expr> = args
+                .into_iter()
+                .filter_map(|arg| match arg {
+                    crate::ast::CallArg::Positional(expr) => Some(expr),
+                    _ => None,
+                })
+                .collect();
+            Stmt::Expr(Expr::MethodCall {
+                target: Box::new(Expr::Var(emitter_name.to_string())),
+                name: Symbol::intern("emit"),
+                args: positional_args,
+                modifier: None,
+                quoted: false,
+            })
+        }
         Stmt::ReactDone => Stmt::SyntheticBlock(vec![
             Stmt::Expr(Expr::MethodCall {
                 target: Box::new(Expr::Var(emitter_name.to_string())),

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1911,8 +1911,8 @@ pub(super) fn block_stmt(input: &str) -> PResult<'_, Stmt> {
 /// Test/Test::Util functions are NOT listed here — they are registered dynamically
 /// via `register_module_exports()` when `use Test` / `use Test::Util` is parsed.
 pub(super) const KNOWN_CALLS: &[&str] = &[
-    "dd", "exit", "proceed", "succeed", "done", "push", "pop", "shift", "unshift", "append",
-    "prepend", "elems", "chars", "defined", "warn", "leave", "EVAL", "EVALFILE",
+    "dd", "exit", "proceed", "succeed", "done", "emit", "push", "pop", "shift", "unshift",
+    "append", "prepend", "elems", "chars", "defined", "warn", "leave", "EVAL", "EVALFILE",
 ];
 
 /// Check if a name is a known statement-level function call.

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -441,8 +441,18 @@ impl Interpreter {
                         crate::value::ArrayKind::List,
                     )
                 };
-                self.take_value(value.clone())?;
-                Ok(value)
+                if self.gather_items_len() > 0 {
+                    self.take_value(value.clone())?;
+                    Ok(value)
+                } else {
+                    Err(RuntimeError::take_signal(value))
+                }
+            }
+            "emit" => {
+                // Top-level `emit` outside a supply block raises a CX::Emit
+                // control exception that a CONTROL block can observe.
+                let value = args.first().cloned().unwrap_or(Value::Nil);
+                Err(RuntimeError::emit_signal(value))
             }
             "return" => {
                 let mut err = RuntimeError::new("return");

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -222,15 +222,14 @@ impl Interpreter {
             } = &target
         {
             let cn = class_name.resolve();
+            let mro = self.class_mro(&cn);
+            let does_x_control = cn == "X::Control" || mro.iter().any(|p| p == "X::Control");
             let is_exception = cn == "Exception"
                 || cn == "Failure"
                 || cn.starts_with("X::")
                 || cn.starts_with("CX::")
-                || self
-                    .class_mro(&cn)
-                    .iter()
-                    .any(|p| p == "Exception" || p == "Failure");
-            if is_exception {
+                || mro.iter().any(|p| p == "Exception" || p == "Failure");
+            if is_exception || does_x_control {
                 if method == "resume" {
                     return Err(crate::value::RuntimeError::resume_signal());
                 }
@@ -246,6 +245,17 @@ impl Interpreter {
                     })
                     .unwrap_or_else(|| target.to_string_value());
                 let mut err = crate::value::RuntimeError::new(&msg);
+                // Classes doing X::Control throw as control exceptions so
+                // CONTROL blocks catch them instead of CATCH.
+                if does_x_control {
+                    err.is_done = true;
+                }
+                // Throwing/rethrowing a CX::Warn re-raises it as a warn
+                // signal so the default handler writes to stderr and
+                // execution continues.
+                if cn == "CX::Warn" {
+                    err.is_warn = true;
+                }
                 err.exception = Some(Box::new(target.clone()));
                 return Err(err);
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2619,6 +2619,22 @@ impl Interpreter {
                         deferred_body_stmts: Vec::new(),
                     },
                 );
+                roles.insert(
+                    "X::Control".to_string(),
+                    RoleDef {
+                        attributes: Vec::new(),
+                        methods: HashMap::new(),
+                        is_stub_role: false,
+                        is_hidden: false,
+                        is_rw: false,
+                        captured_env: None,
+                        wildcard_handles: Vec::new(),
+                        role_id: 0,
+                        attribute_conflicts: Vec::new(),
+                        own_attribute_names: std::collections::HashSet::new(),
+                        deferred_body_stmts: Vec::new(),
+                    },
+                );
                 // CompUnit::Repository role with required stub methods
                 {
                     let stub_body = vec![Stmt::Expr(Expr::Call {

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -51,6 +51,9 @@ pub struct RuntimeError {
     /// Set when UNDO phasers run in response to the fail.
     pub fail_handled: bool,
     pub is_warn: bool,
+    pub is_take: bool,
+    pub is_emit: bool,
+    pub is_done: bool,
     pub is_leave: bool,
     pub is_resume: bool,
     pub is_react_done: bool,
@@ -85,6 +88,9 @@ impl RuntimeError {
             is_fail: false,
             fail_handled: false,
             is_warn: false,
+            is_take: false,
+            is_emit: false,
+            is_done: false,
             is_leave: false,
             is_resume: false,
             is_react_done: false,
@@ -136,6 +142,9 @@ impl RuntimeError {
             is_fail: false,
             fail_handled: false,
             is_warn: false,
+            is_take: false,
+            is_emit: false,
+            is_done: false,
             is_leave: false,
             is_resume: false,
             is_react_done: false,
@@ -222,6 +231,24 @@ impl RuntimeError {
         Self {
             message: message.into(),
             is_warn: true,
+            ..Self::new("")
+        }
+    }
+
+    pub(crate) fn take_signal(value: Value) -> Self {
+        Self {
+            message: "CX::Take".to_string(),
+            is_take: true,
+            return_value: Some(value),
+            ..Self::new("")
+        }
+    }
+
+    pub(crate) fn emit_signal(value: Value) -> Self {
+        Self {
+            message: "CX::Emit".to_string(),
+            is_emit: true,
+            return_value: Some(value),
             ..Self::new("")
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -532,7 +532,15 @@ impl VM {
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
                     }
-                    ip += 1;
+                    // If a resume point was recorded for the original warn
+                    // site (e.g., when a CONTROL block rethrew the CX::Warn),
+                    // resume there so execution continues after the warn
+                    // rather than past whatever op propagated the signal.
+                    if let Some(resume_point) = self.resume_ip.take() {
+                        ip = resume_point;
+                    } else {
+                        ip += 1;
+                    }
                     continue;
                 }
                 return Err(e);
@@ -1870,7 +1878,24 @@ impl VM {
                 arity,
                 arg_sources_idx,
             } => {
-                self.exec_call_func_op(code, *name_idx, *arity, *arg_sources_idx, compiled_fns)?;
+                match self.exec_call_func_op(
+                    code,
+                    *name_idx,
+                    *arity,
+                    *arg_sources_idx,
+                    compiled_fns,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // Record a resume point so a call that raises a
+                        // control signal (e.g. `warn`) can be resumed after
+                        // the call site by `.resume` in a CONTROL block.
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::CallFuncSlip {
@@ -1908,7 +1933,13 @@ impl VM {
                     Err(e) => {
                         // Record a resume point so a method that throws can
                         // be resumed after the call site by .resume in CATCH.
-                        self.resume_ip = Some(*ip + 1);
+                        // Don't overwrite an existing resume_ip: when the
+                        // method call is itself a `.resume`/`.rethrow` that
+                        // re-raises a control signal, the original resume
+                        // point (e.g. after `warn`) must be preserved.
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
                         return Err(e);
                     }
                 }
@@ -1970,7 +2001,21 @@ impl VM {
                 arity,
                 arg_sources_idx,
             } => {
-                self.exec_exec_call_op(code, *name_idx, *arity, *arg_sources_idx, compiled_fns)?;
+                match self.exec_exec_call_op(
+                    code,
+                    *name_idx,
+                    *arity,
+                    *arg_sources_idx,
+                    compiled_fns,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::ExecCallPairs { name_idx, arity } => {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -43,6 +43,14 @@ impl VM {
     }
 
     fn control_signal_topic_value(signal: &RuntimeError) -> Option<Value> {
+        // User-defined classes doing X::Control carry their original
+        // exception instance. Surface it directly so CONTROL blocks see the
+        // real type rather than a generic CX::Done wrapper.
+        if signal.is_done
+            && let Some(ex) = signal.exception.as_ref()
+        {
+            return Some((**ex).clone());
+        }
         let class_name = if signal.is_last {
             Some("CX::Last")
         } else if signal.is_next {
@@ -55,6 +63,12 @@ impl VM {
             Some("CX::Succeed")
         } else if signal.is_warn {
             Some("CX::Warn")
+        } else if signal.is_take {
+            Some("CX::Take")
+        } else if signal.is_emit {
+            Some("CX::Emit")
+        } else if signal.is_done || signal.is_react_done {
+            Some("CX::Done")
         } else if signal.is_return {
             Some("CX::Return")
         } else {
@@ -62,14 +76,22 @@ impl VM {
         }?;
 
         let mut attrs = std::collections::HashMap::new();
-        attrs.insert(
-            "message".to_string(),
-            Value::str(if signal.message.is_empty() {
-                class_name.to_string()
-            } else {
-                signal.message.clone()
-            }),
-        );
+        // `warn` appends a "\n  in block ..." location annotation to its
+        // message for the default uncaught-warn printer. When a CONTROL
+        // block observes the CX::Warn, `.message` should be just the user
+        // text without the location, so strip the appended suffix.
+        let message_text = if signal.message.is_empty() {
+            class_name.to_string()
+        } else if signal.is_warn {
+            signal
+                .message
+                .split_once("\n  in block ")
+                .map(|(user, _)| user.to_string())
+                .unwrap_or_else(|| signal.message.clone())
+        } else {
+            signal.message.clone()
+        };
+        attrs.insert("message".to_string(), Value::str(message_text));
         if let Some(label) = signal.label.as_ref() {
             attrs.insert("label".to_string(), Value::str(label.clone()));
         }
@@ -1641,8 +1663,13 @@ impl VM {
             ip,
             compiled_fns,
         );
-        // Restore the outer resume_ip so an outer .resume sees the right point.
-        self.resume_ip = saved_resume_ip;
+        // Restore the outer resume_ip so an outer .resume sees the right
+        // point. When the inner block escaped with an error (e.g. rethrow
+        // of CX::Warn), keep the inner resume_ip so an outer handler can
+        // resume at the original call site.
+        if result.is_ok() {
+            self.resume_ip = saved_resume_ip;
+        }
         result
     }
 
@@ -1716,7 +1743,13 @@ impl VM {
                     Err(e)
                 }
             }
-            Err(e) if e.return_value.is_some() && !e.is_succeed && !e.is_warn => {
+            Err(e)
+                if e.return_value.is_some()
+                    && !e.is_succeed
+                    && !e.is_warn
+                    && !e.is_take
+                    && !e.is_emit =>
+            {
                 self.interpreter.discard_let_saves(let_mark);
                 Err(e)
             }
@@ -1728,7 +1761,11 @@ impl VM {
                     || e.is_redo
                     || e.is_proceed
                     || e.is_succeed
-                    || e.is_warn)
+                    || e.is_warn
+                    || e.is_take
+                    || e.is_emit
+                    || e.is_done
+                    || e.is_react_done)
                     && control_begin >= end =>
             {
                 self.interpreter.discard_let_saves(let_mark);
@@ -1740,23 +1777,92 @@ impl VM {
                     || e.is_redo
                     || e.is_proceed
                     || e.is_succeed
-                    || e.is_warn)
+                    || e.is_warn
+                    || e.is_take
+                    || e.is_emit
+                    || e.is_done
+                    || e.is_react_done)
                     && control_begin < end =>
             {
                 self.interpreter.discard_let_saves(let_mark);
                 self.stack.truncate(saved_depth);
                 let saved_topic = self.interpreter.env().get("_").cloned();
-                if let Some(signal_topic) = Self::control_signal_topic_value(&e) {
-                    self.interpreter
-                        .env_mut()
-                        .insert("_".to_string(), signal_topic);
-                }
                 let saved_when = self.interpreter.when_matched();
-                self.interpreter.set_when_matched(false);
-                match self.run_range(code, control_begin, end, compiled_fns) {
-                    Ok(()) => {}
-                    Err(e) if e.is_succeed => {}
-                    Err(e) => return Err(e),
+                let mut pending_err = e;
+                loop {
+                    if let Some(signal_topic) = Self::control_signal_topic_value(&pending_err) {
+                        self.interpreter
+                            .env_mut()
+                            .insert("_".to_string(), signal_topic);
+                    }
+                    self.interpreter.set_when_matched(false);
+                    let control_result = self.run_range(code, control_begin, end, compiled_fns);
+                    let next_resume = match control_result {
+                        Ok(()) => None,
+                        Err(ref ce) if ce.is_succeed => None,
+                        // Re-throwing a CX::Warn from CONTROL acts like the
+                        // default warn handler: print to stderr and resume.
+                        Err(ce) if ce.is_warn => {
+                            if !self.interpreter.warning_suppressed() {
+                                self.interpreter.write_warn_to_stderr(&ce.message);
+                            }
+                            self.resume_ip.take()
+                        }
+                        Err(ce) if ce.is_resume => {
+                            let _ = ce;
+                            self.resume_ip.take()
+                        }
+                        Err(ce) => {
+                            self.interpreter.set_when_matched(saved_when);
+                            if let Some(v) = saved_topic {
+                                self.interpreter.env_mut().insert("_".to_string(), v);
+                            } else {
+                                self.interpreter.env_mut().remove("_");
+                            }
+                            return Err(ce);
+                        }
+                    };
+                    match next_resume {
+                        None => break,
+                        Some(resume_point) => {
+                            self.interpreter.set_when_matched(saved_when);
+                            if let Some(v) = saved_topic.clone() {
+                                self.interpreter.env_mut().insert("_".to_string(), v);
+                            } else {
+                                self.interpreter.env_mut().remove("_");
+                            }
+                            if has_control {
+                                self.interpreter.control_handler_depth += 1;
+                            }
+                            let body_result =
+                                self.run_range(code, resume_point, catch_begin, compiled_fns);
+                            if has_control {
+                                self.interpreter.control_handler_depth -= 1;
+                            }
+                            match body_result {
+                                Ok(()) => {
+                                    *ip = end;
+                                    return Ok(());
+                                }
+                                Err(new_err)
+                                    if new_err.is_last
+                                        || new_err.is_next
+                                        || new_err.is_redo
+                                        || new_err.is_proceed
+                                        || new_err.is_succeed
+                                        || new_err.is_warn
+                                        || new_err.is_take
+                                        || new_err.is_emit
+                                        || new_err.is_done
+                                        || new_err.is_react_done =>
+                                {
+                                    pending_err = new_err;
+                                    continue;
+                                }
+                                Err(new_err) => return Err(new_err),
+                            }
+                        }
+                    }
                 }
                 self.interpreter.set_when_matched(saved_when);
                 if let Some(v) = saved_topic {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1904,7 +1904,14 @@ impl VM {
 
     pub(super) fn exec_take_op(&mut self) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap_or(Value::Nil);
-        self.interpreter.take_value(val)
+        if self.interpreter.gather_items_len() > 0 {
+            self.interpreter.take_value(val)
+        } else {
+            // No enclosing gather — raise a CX::Take control exception so a
+            // CONTROL block can observe it. Unhandled, this propagates up
+            // and becomes a runtime error.
+            Err(RuntimeError::take_signal(val))
+        }
     }
 
     pub(super) fn exec_package_scope_op(


### PR DESCRIPTION
## Summary
- Implement `CX::Take` / `CX::Emit` / `CX::Done` control signals and pre-register the `X::Control` role so user classes that compose it throw via CONTROL instead of CATCH
- Support `.resume` / `.rethrow` semantics on CX::Warn with a loop-based CONTROL dispatcher that re-enters the handler for subsequent signals in the same body, and wrap top-level units implicitly when a CONTROL block is present
- Add `roast/S04-exception-handlers/control.t` to the whitelist (all 17 subtests now pass)

## Test plan
- [x] `prove -e target/debug/mutsu roast/S04-exception-handlers/control.t` (17/17 pass)
- [x] `make test`
- [x] `make roast`
- [x] `cargo clippy -- -D warnings` and `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)