### PR TITLE
fix: pass roast/S32-array/delete-adverb.t fully

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -859,6 +859,7 @@ roast/S29-conversions/ord_and_chr.t
 roast/S32-array/bool.t
 roast/S32-array/create.t
 roast/S32-array/delete-adverb-native.t
+roast/S32-array/delete-adverb.t
 roast/S32-array/delete.t
 roast/S32-array/elems.t
 roast/S32-array/end.t

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -186,7 +186,22 @@ impl Compiler {
         if let Some(a) = arg {
             self.compile_expr(a);
         }
-        self.code.emit(OpCode::ExistsIndexAdv(flags));
+        // Emit the named variant when the target is an identifiable array
+        // variable — this lets the VM consult the deleted-index tracker so
+        // `@a[i]:delete:exists` reports the slot as missing even though
+        // the slot still holds a type-object hole after deletion.
+        let array_var_name = match target {
+            Expr::Index { target: t, .. } => Self::postfix_index_name(t)
+                .and_then(|n| if n.starts_with('@') { Some(n) } else { None }),
+            _ => None,
+        };
+        if let Some(name) = array_var_name {
+            let name_idx = self.code.add_constant(Value::str(name));
+            self.code
+                .emit(OpCode::ExistsIndexNamedAdv { name_idx, flags });
+        } else {
+            self.code.emit(OpCode::ExistsIndexAdv(flags));
+        }
 
         if delete
             && let Expr::Index {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -566,6 +566,14 @@ pub(crate) enum OpCode {
     ///        bits 4-7=adverb (0=None,1=Kv,2=NotKv,3=P,4=NotP,5=NotV,
     ///                         6=InvalidK,7=InvalidNotK,8=InvalidV)
     ExistsIndexAdv(u32),
+    /// Variant of ExistsIndexAdv that knows the array variable name and
+    /// consults the deleted-index tracker so `:delete` can report a slot
+    /// as missing even though the slot still holds a type-object hole.
+    /// Layout: (name_idx, flags) — same flag encoding as ExistsIndexAdv.
+    ExistsIndexNamedAdv {
+        name_idx: u32,
+        flags: u32,
+    },
 
     // -- Reduction ([+] @arr) --
     Reduction(u32),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3726,6 +3726,26 @@ impl Interpreter {
         self.var_defaults.get(name)
     }
 
+    /// Remove a variable's cached `is default(...)` value. Called on
+    /// variable redeclaration so a new `my @a` does not inherit the
+    /// default from an earlier same-named variable.
+    pub(crate) fn clear_var_default(&mut self, name: &str) {
+        self.var_defaults.remove(name);
+    }
+
+    /// Remove the pointer-keyed container default for the given value. Used
+    /// on variable redeclaration so a newly-allocated container whose Arc
+    /// pointer happens to collide with a previously-freed one does not
+    /// inherit the freed container's `is default(...)` value.
+    pub(crate) fn clear_container_default(&mut self, value: &Value) {
+        let id = match value {
+            Value::Array(items, ..) => Arc::as_ptr(items) as usize,
+            Value::Hash(map) => Arc::as_ptr(map) as usize,
+            _ => return,
+        };
+        self.container_defaults.remove(&id);
+    }
+
     /// Get the evaluated `is default(...)` value for a class attribute.
     pub(crate) fn class_attribute_default(
         &self,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2420,7 +2420,12 @@ impl VM {
                 *ip += 1;
             }
             OpCode::ExistsIndexAdv(flags) => {
-                self.exec_exists_index_adv_op(*flags)?;
+                self.exec_exists_index_adv_op(*flags, None)?;
+                *ip += 1;
+            }
+            OpCode::ExistsIndexNamedAdv { name_idx, flags } => {
+                let name = Self::const_str(code, *name_idx).to_string();
+                self.exec_exists_index_adv_op(*flags, Some(name))?;
                 *ip += 1;
             }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1159,6 +1159,53 @@ impl VM {
         name_idx: u32,
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
+        // Save type metadata and container default by pointer BEFORE the
+        // inner op runs. Auto-vivification and Arc::make_mut may
+        // reconstruct the array Arc, changing the pointer used as the
+        // metadata key. Reapply them on the final container so typed-array
+        // hole semantics and `is default(...)` are preserved.
+        let save_var_name = Self::const_str(code, name_idx).to_string();
+        let saved_type_meta_outer = self
+            .interpreter
+            .env()
+            .get(&save_var_name)
+            .and_then(|v| self.interpreter.container_type_metadata(v));
+        let saved_default_outer = self
+            .interpreter
+            .env()
+            .get(&save_var_name)
+            .and_then(|v| self.interpreter.container_default(v).cloned());
+        let result = self.exec_index_assign_expr_named_op_inner(code, name_idx, is_positional);
+        // Restore metadata on the post-assignment container if the
+        // identity-keyed map lost it.
+        if let Some(info) = saved_type_meta_outer
+            && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
+            && self
+                .interpreter
+                .container_type_metadata(&container)
+                .is_none()
+        {
+            self.interpreter
+                .register_container_type_metadata(&container, info);
+            // Sync the refreshed container pointer into locals so fast-path
+            // reads see the preserved metadata.
+            self.locals_set_by_name(code, &save_var_name, container);
+        }
+        if let Some(def) = saved_default_outer
+            && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
+            && self.interpreter.container_default(&container).is_none()
+        {
+            self.interpreter.set_container_default(&container, def);
+        }
+        result
+    }
+
+    fn exec_index_assign_expr_named_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        is_positional: bool,
+    ) -> Result<(), RuntimeError> {
         let original_var_name = Self::const_str(code, name_idx).to_string();
         // Resolve sigilless alias: if `h` is a sigilless alias for `%a`,
         // operate on `%a` directly so in-place mutations are visible.
@@ -2247,6 +2294,19 @@ impl VM {
         self.constant_context = false;
         self.explicit_initializer_context = false;
         self.vardecl_context = false;
+        // A redeclaration (`my @a` in a new scope) must not inherit the
+        // `is default(...)` trait from an earlier same-named variable,
+        // since var_defaults is keyed only by name. Drop any stale entry;
+        // if the current decl has its own `is default(...)` trait, the
+        // trait op will re-set it immediately after.
+        if is_vardecl {
+            let name = &code.locals[idx];
+            self.interpreter.clear_var_default(name);
+            // Clear the deleted-index tracker left over from a previous
+            // same-named variable in an outer scope.
+            let deleted_key = format!("__mutsu_deleted_index::{}", name);
+            self.interpreter.env_mut().remove(&deleted_key);
+        }
 
         // Fast path for simple scalar variables — skip all metadata checks
         if code.simple_locals[idx] && bind_source.is_none() && !is_bind {
@@ -2608,6 +2668,15 @@ impl VM {
             && let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val)
         {
             return Err(err);
+        }
+        // For variable redeclarations (`my @a` in a new scope), drop any
+        // pointer-keyed container default that an earlier same-named
+        // variable left behind. Arc pointers can be reused across
+        // allocations (especially in release builds) and would otherwise
+        // cause a freed container's `is default(...)` to leak into the
+        // new scope.
+        if is_vardecl {
+            self.interpreter.clear_container_default(&val);
         }
         self.locals[idx] = val.clone();
         // When binding a typed hash/array to a variable, propagate the container's

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1170,11 +1170,17 @@ impl VM {
             .env()
             .get(&save_var_name)
             .and_then(|v| self.interpreter.container_type_metadata(v));
-        let saved_default_outer = self
-            .interpreter
-            .env()
-            .get(&save_var_name)
-            .and_then(|v| self.interpreter.container_default(v).cloned());
+        // Guard against stale pointer-keyed defaults (Arc reuse across
+        // allocations): only trust the saved default when a name-based
+        // var_default is also registered.
+        let saved_default_outer = if self.interpreter.var_default(&save_var_name).is_some() {
+            self.interpreter
+                .env()
+                .get(&save_var_name)
+                .and_then(|v| self.interpreter.container_default(v).cloned())
+        } else {
+            None
+        };
         let result = self.exec_index_assign_expr_named_op_inner(code, name_idx, is_positional);
         // Restore metadata on the post-assignment container if the
         // identity-keyed map lost it.

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -152,15 +152,20 @@ impl VM {
             .env()
             .get(&var_name)
             .and_then(|v| self.interpreter.container_type_metadata(v));
-        // Save container default (pointer-keyed) before delete. Using
-        // container_default (not var_default) ensures we only apply the
-        // default that belongs to *this* container, not a leftover entry
-        // from a leaky `var_defaults` set by an earlier same-named var.
-        let saved_default = self
-            .interpreter
-            .env()
-            .get(&var_name)
-            .and_then(|v| self.interpreter.container_default(v).cloned());
+        // Save container default (pointer-keyed) before delete so we can
+        // re-apply it after `Arc::make_mut` changes the pointer. Only
+        // trust this when a name-based `var_default` is also registered
+        // for this variable: Arc pointers can be reused across
+        // allocations, so a stale pointer-keyed entry from a freed
+        // same-named container must not leak into the new container.
+        let saved_default = if self.interpreter.var_default(&var_name).is_some() {
+            self.interpreter
+                .env()
+                .get(&var_name)
+                .and_then(|v| self.interpreter.container_default(v).cloned())
+        } else {
+            None
+        };
         // Resolve WhateverCode indices (e.g. *-1) for array targets
         let idx = if let Some(container) = self.interpreter.env().get(&var_name).cloned() {
             self.resolve_delete_index_for_array(idx, &container)

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -152,6 +152,15 @@ impl VM {
             .env()
             .get(&var_name)
             .and_then(|v| self.interpreter.container_type_metadata(v));
+        // Save container default (pointer-keyed) before delete. Using
+        // container_default (not var_default) ensures we only apply the
+        // default that belongs to *this* container, not a leftover entry
+        // from a leaky `var_defaults` set by an earlier same-named var.
+        let saved_default = self
+            .interpreter
+            .env()
+            .get(&var_name)
+            .and_then(|v| self.interpreter.container_default(v).cloned());
         // Resolve WhateverCode indices (e.g. *-1) for array targets
         let idx = if let Some(container) = self.interpreter.env().get(&var_name).cloned() {
             self.resolve_delete_index_for_array(idx, &container)
@@ -187,6 +196,9 @@ impl VM {
         // Remove deleted indices from the initialized-index tracking set
         // so that trim_trailing_array_holes recognizes them as holes.
         self.unmark_initialized_indices(&var_name, &idx_for_unmark);
+        // Mark deleted positions so :exists can report them as missing even
+        // though the slot still holds a type-object hole value.
+        self.mark_deleted_indices(&var_name, &idx_for_unmark);
         // Remove deleted indices from the bound-index tracking set to sever bindings.
         self.unmark_bound_indices(&var_name, &idx_for_unmark);
         // Trim trailing holes from arrays after deletion.
@@ -195,7 +207,7 @@ impl VM {
         // If the deleted value is a hole (Nil or type object like Package("Any")),
         // substitute the container's default value if one was set via `is default(...)`.
         let result = if matches!(&result, Value::Nil | Value::Package(_)) {
-            if let Some(def) = self.interpreter.var_default(&var_name) {
+            if let Some(def) = &saved_default {
                 def.clone()
             } else {
                 result
@@ -216,17 +228,19 @@ impl VM {
                 .register_container_type_metadata(&container, info);
         }
         // Re-register container default if it was lost due to Arc::make_mut.
-        // Use var_default (name-based, survives mutations) as the source of
-        // truth, and sync it to the current container's pointer-based default.
-        if let Some(def) = self.interpreter.var_default(&var_name).cloned()
+        // Use the pointer-keyed container_default saved before delete so we
+        // don't inherit a leaked default from a same-named variable in an
+        // outer scope.
+        if let Some(def) = saved_default
             && let Some(container) = self.interpreter.env().get(&var_name).cloned()
+            && self.interpreter.container_default(&container).is_none()
         {
-            if self.interpreter.container_default(&container).is_none() {
-                self.interpreter
-                    .set_container_default(&container, def.clone());
-            }
-            // Sync env value to locals so reads through locals see the
-            // updated container with its default.
+            self.interpreter.set_container_default(&container, def);
+        }
+        // Sync env value to locals so reads through locals see the
+        // updated container after delete (Arc::make_mut may have changed
+        // the container pointer).
+        if let Some(container) = self.interpreter.env().get(&var_name).cloned() {
             self.locals_set_by_name(code, &var_name, container);
         }
         self.stack.push(result);
@@ -258,6 +272,23 @@ impl VM {
         hole_type: &str,
     ) -> Result<Value, RuntimeError> {
         match idx {
+            Value::Whatever => {
+                // `@a[*]:delete` — delete all elements, returning the
+                // previous contents of the array.
+                let len = match container {
+                    Value::Array(items, ..) => items.len(),
+                    _ => 0,
+                };
+                let indices: Vec<Value> = (0..len as i64).map(Value::Int).collect();
+                let mut results = Vec::with_capacity(indices.len());
+                for i in indices {
+                    let r =
+                        Self::delete_array_multidim(container, std::slice::from_ref(&i), hole_type)
+                            .unwrap_or(Value::Nil);
+                    results.push(r);
+                }
+                Ok(Value::array(results))
+            }
             Value::Array(indices, ..) => {
                 let indices_vec: Vec<Value> = indices.to_vec();
                 let mut results = Vec::with_capacity(indices_vec.len());

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -6,6 +6,7 @@ impl VM {
     pub(super) fn exec_exists_index_adv_op(
         &mut self,
         flags: u32,
+        array_var_name: Option<String>,
     ) -> Result<(), crate::value::RuntimeError> {
         let negated_flag = flags & 1 != 0;
         let has_arg = flags & 2 != 0;
@@ -516,10 +517,14 @@ impl VM {
         if !is_multi {
             // Single index
             let i = indices[0];
-            let exists = i >= 0
+            let slot_present = i >= 0
                 && items
                     .get(i as usize)
                     .is_some_and(|v| !matches!(v, Value::Nil));
+            let is_deleted = array_var_name
+                .as_deref()
+                .is_some_and(|n| self.is_deleted_index(n, i));
+            let exists = slot_present && !is_deleted;
             let result_bool = exists ^ effective_negated;
             let key = Value::Int(i);
             let result = match adverb_bits {
@@ -554,11 +559,14 @@ impl VM {
         let pairs: Vec<(i64, bool)> = indices
             .iter()
             .map(|&i| {
-                let exists = i >= 0
+                let slot_present = i >= 0
                     && items
                         .get(i as usize)
                         .is_some_and(|v| !matches!(v, Value::Nil));
-                (i, exists)
+                let is_deleted = array_var_name
+                    .as_deref()
+                    .is_some_and(|n| self.is_deleted_index(n, i));
+                (i, slot_present && !is_deleted)
             })
             .collect();
 

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -619,6 +619,14 @@ impl VM {
     }
 
     pub(super) fn mark_initialized_index(&mut self, var_name: &str, encoded: String) {
+        // Assigning a slot clears any deleted-index marker so subsequent
+        // `:exists` checks report the slot as present again.
+        {
+            let deleted_key = format!("__mutsu_deleted_index::{}", var_name);
+            if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&deleted_key) {
+                Arc::make_mut(map).remove(&encoded);
+            }
+        }
         let key = format!("__mutsu_initialized_index::{}", var_name);
         if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
             Arc::make_mut(map).insert(encoded, Value::Bool(true));
@@ -627,6 +635,73 @@ impl VM {
         let mut map = std::collections::HashMap::new();
         map.insert(encoded, Value::Bool(true));
         self.interpreter.env_mut().insert(key, Value::hash(map));
+    }
+
+    /// Mark the given indices as deleted. `:exists` on an array consults
+    /// this set so that a slot holding a type-object hole can be reported
+    /// as missing even though the slot value is not `Nil`.
+    pub(super) fn mark_deleted_indices(&mut self, var_name: &str, idx: &Value) {
+        let key = format!("__mutsu_deleted_index::{}", var_name);
+        let map = if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+            Arc::make_mut(map)
+        } else {
+            let m = std::collections::HashMap::new();
+            self.interpreter
+                .env_mut()
+                .insert(key.clone(), Value::hash(m));
+            match self.interpreter.env_mut().get_mut(&key) {
+                Some(Value::Hash(map)) => Arc::make_mut(map),
+                _ => return,
+            }
+        };
+        Self::mark_index_entries(map, idx);
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn unmark_deleted_indices(&mut self, var_name: &str, idx: &Value) {
+        let key = format!("__mutsu_deleted_index::{}", var_name);
+        let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) else {
+            return;
+        };
+        let m = Arc::make_mut(map);
+        Self::unmark_index_entries(m, idx);
+    }
+
+    pub(super) fn is_deleted_index(&self, var_name: &str, idx: i64) -> bool {
+        let key = format!("__mutsu_deleted_index::{}", var_name);
+        matches!(
+            self.interpreter.env().get(&key),
+            Some(Value::Hash(map)) if map.contains_key(&idx.to_string())
+        )
+    }
+
+    fn mark_index_entries(map: &mut std::collections::HashMap<String, Value>, idx: &Value) {
+        match idx {
+            Value::Array(items, ..) => {
+                for item in items.iter() {
+                    Self::mark_index_entries(map, item);
+                }
+            }
+            Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => {
+                let expanded = crate::runtime::utils::value_to_list(idx);
+                for item in &expanded {
+                    Self::mark_index_entries(map, item);
+                }
+            }
+            Value::Int(i) => {
+                map.insert(i.to_string(), Value::Bool(true));
+            }
+            Value::Num(f) => {
+                map.insert((*f as i64).to_string(), Value::Bool(true));
+            }
+            _ => {
+                map.insert(idx.to_string_value(), Value::Bool(true));
+            }
+        }
     }
 
     /// Remove deleted indices from the bound-index tracking set.


### PR DESCRIPTION
## Summary
- Implements `:delete:exists` on arrays via a new deleted-index tracker and `ExistsIndexNamedAdv` opcode so deleted slots report missing even while still holding a type-object hole.
- Supports `@a[*]:delete` (Whatever slice delete) and fixes several cross-scope leaks of `is default(...)` by clearing pointer-keyed container defaults on variable redeclaration.
- Preserves typed-array hole semantics across auto-vivifying element assignments by saving/reapplying container type metadata and default around `exec_index_assign_expr_named_op`.

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-array/delete-adverb.t` — 221/221
- [x] `make test` — all local prove tests pass
- [x] `make roast` — all whitelisted roast tests pass
- [x] Added `roast/S32-array/delete-adverb.t` to `roast-whitelist.txt`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>