### PR TITLE
fix: allow declarator keywords as pair keys

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -54,6 +54,7 @@ roast/S02-literals/listquote.t
 roast/S02-literals/misc-interpolation.t
 roast/S02-literals/numeric.t
 roast/S02-literals/pair-boolean.t
+roast/S02-literals/pairs.t
 roast/S02-literals/pod.t
 roast/S02-literals/quoting-unicode.t
 roast/S02-literals/quoting.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1286,6 +1286,27 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     let (rest, name) = super::super::stmt::parse_raku_ident(input)?;
     let name = normalize_raku_identifier(name);
 
+    // If the identifier is followed by `=>` (fat arrow), treat it as a pair
+    // key regardless of whether it would otherwise be a declarator keyword.
+    // e.g., `(my => 1)`, `(sub => 1)`, `(class => 1)` are all valid pairs.
+    {
+        let after_ws = rest.trim_start();
+        if after_ws.starts_with("=>") && !after_ws.starts_with("==>") {
+            let (r, _) = ws(rest)?;
+            let r2 = &r[2..];
+            let (r2, _) = ws(r2)?;
+            let (r2, value) = crate::parser::expr::parse_fat_arrow_value(r2)?;
+            return Ok((
+                r2,
+                Expr::Binary {
+                    left: Box::new(Expr::Literal(Value::str(name))),
+                    op: crate::token_kind::TokenKind::FatArrow,
+                    right: Box::new(value),
+                },
+            ));
+        }
+    }
+
     // Handle special expression keywords before qualified name resolution
     match name.as_str() {
         "infix" | "prefix" | "postfix" | "circumfix" | "postcircumfix" => {

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -68,6 +68,15 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
         .or_else(|| keyword("our", input))
         .or_else(|| keyword("state", input))
         .ok_or_else(|| PError::expected("my/our/state declaration"))?;
+    // If the keyword is immediately followed by `=>`, it's being used as a
+    // pair key (e.g., `(my => 1)`). Refuse to parse it as a declaration so
+    // that the caller can fall back to treating it as a bareword.
+    {
+        let after_ws = rest.trim_start();
+        if after_ws.starts_with("=>") && !after_ws.starts_with("==>") {
+            return Err(PError::expected("my/our/state declaration"));
+        }
+    }
     let (mut rest, _) = ws1(rest)?;
 
     // my enum Foo <...>


### PR DESCRIPTION
## Summary
- Raku allows reserved words (`my`, `our`, `sub`, `class`, etc.) to be used as pair keys when followed by `=>`. Mutsu previously raised a fatal `X::Syntax::Malformed` for inputs like `(my => 1)`.
- `identifier_or_call` now short-circuits to a FatArrow Pair whenever any identifier is followed by `=>`, before dispatching keyword-specific handlers.
- `my_decl_inner` refuses to parse `my/our/state` as a declaration when the keyword is immediately followed by `=>`, so parsing falls through to the bareword path.
- Adds `roast/S02-literals/pairs.t` to the whitelist (passes 84/84).

## Test plan
- [x] `prove -e target/debug/mutsu roast/S02-literals/pairs.t` (passes)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `make test`