### PR TITLE
fix: curry * ~~ Type as WhateverCode and give start blocks fresh $/ and $!

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -59,6 +59,12 @@
 - [ ] roast/S17-promise/nonblocking-await.t
 - [ ] roast/S17-promise/single-assignment.t
 - [ ] roast/S17-promise/start.t
+  - 49/65 pass (1-50 except 45). Blockers:
+    - Test 45: substitution replacement `$/.chars()` not interpolated (replacement treated as literal)
+    - Tests 51-53: `.backtrace` method not implemented on exceptions
+    - Test 58: EVAL grammar in threads fails (lives-ok)
+    - Tests 61-64: `$*SCHEDULER.uncaught_handler` not implemented
+    - Test 65: TAP counter sync issue in threads
 - [ ] roast/S17-promise/stress.t
 - [ ] roast/S17-promise/then.t
 - [ ] roast/S17-scheduler/at.t

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -274,8 +274,10 @@ pub(in crate::parser) fn should_wrap_whatevercode(expr: &Expr) -> bool {
         return false;
     }
     match expr {
-        // SmartMatch: Whatever on RHS is handled at runtime. LHS bare * and
-        // compound expressions are handled at runtime too — don't curry.
+        // SmartMatch: Whatever on RHS is handled at runtime (autoprime).
+        // LHS compound Whatever curries (e.g. `*.abs ~~ Code`), but bare
+        // `* ~~ Type` currying is handled in the precedence parser where we can
+        // distinguish a true bare * operand from a parenthesized ((*)).
         Expr::Binary {
             op: TokenKind::SmartMatch,
             ..
@@ -776,6 +778,16 @@ fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
             }
             body_expr
         }
+        // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
+        Expr::Binary {
+            left,
+            op: op @ TokenKind::SmartMatch,
+            right,
+        } => Expr::Binary {
+            left: Box::new(replace_whatever_numbered(left, counter)),
+            op: op.clone(),
+            right: right.clone(),
+        },
         Expr::Binary { left, op, right } => Expr::Binary {
             left: Box::new(replace_whatever_numbered(left, counter)),
             op: op.clone(),
@@ -1044,6 +1056,16 @@ fn replace_whatever_single(expr: &Expr) -> Expr {
                 Expr::Var("_".to_string())
             }
         }
+        // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
+        Expr::Binary {
+            left,
+            op: op @ TokenKind::SmartMatch,
+            right,
+        } => Expr::Binary {
+            left: Box::new(replace_whatever_single(left)),
+            op: op.clone(),
+            right: right.clone(),
+        },
         Expr::Binary { left, op, right } => Expr::Binary {
             left: Box::new(replace_whatever_single(left)),
             op: op.clone(),

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -2240,6 +2240,31 @@ fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             if super::should_wrap_whatevercode(&left) {
                 left = super::wrap_whatevercode(&left);
             }
+            // Bare `* ~~ Type` curries to WhateverCode `{ $_ ~~ Type }`.
+            // This is only done here (not in should_curry_whatever) because at the
+            // top-level wrapping stage, parenthesized `((*)) ~~ Type` also has
+            // Expr::Whatever as LHS and should NOT curry — only a true bare `*`
+            // operand in the precedence parser should trigger this.
+            // We distinguish bare `*` from `((*))` by checking whether the consumed
+            // input for the LHS started with `(`.
+            if matches!(&left, Expr::Whatever) {
+                let lhs_text = input[..input.len() - rest.len()].trim_start();
+                if !lhs_text.starts_with('(') {
+                    let sm_expr = Expr::Binary {
+                        left: Box::new(Expr::Var("_".to_string())),
+                        op: op.token_kind(),
+                        right: Box::new(right),
+                    };
+                    return Ok((
+                        r,
+                        Expr::Lambda {
+                            param: "_".to_string(),
+                            body: vec![crate::ast::Stmt::Expr(sm_expr)],
+                            is_whatever_code: true,
+                        },
+                    ));
+                }
+            }
         }
         // When the smartmatch RHS is a regex literal, do not chain with
         // subsequent comparison operators.  The regex literal terminates the

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -68,6 +68,20 @@ impl Interpreter {
         let parent_handles_snapshot: std::collections::HashSet<usize> =
             self.handles.keys().copied().collect();
 
+        // Raku gives each start block fresh $/ and $!.
+        // Strip these from the closure's captured env so they don't override
+        // the fresh Nil values set in clone_for_thread.
+        let block = if let Value::Sub(ref data) = block {
+            let mut new_data = (**data).clone();
+            new_data.env.remove("/");
+            new_data.env.remove("!");
+            new_data.env.remove("$/");
+            new_data.env.remove("$!");
+            Value::Sub(std::sync::Arc::new(new_data))
+        } else {
+            block
+        };
+
         std::thread::spawn(move || {
             let vm = crate::vm::VM::new(thread_interp);
             let (mut thread_interp, result) = vm.call_value(block, vec![]);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4156,6 +4156,10 @@ impl Interpreter {
                 // Skip internal variables and topic variables
                 if key == "_"
                     || key == "@_"
+                    || key == "/"
+                    || key == "!"
+                    || key == "$/"
+                    || key == "$!"
                     || key.starts_with("__mutsu_")
                     || key.starts_with("&")
                     || key == "?LINE"
@@ -4367,6 +4371,11 @@ impl Interpreter {
             },
             is_thread_clone: true,
         };
+        // Raku gives each start block fresh $/ and $! (they are lexically scoped).
+        cloned.env.insert("/".to_string(), Value::Nil);
+        cloned.env.insert("!".to_string(), Value::Nil);
+        cloned.env.insert("$/".to_string(), Value::Nil);
+        cloned.env.insert("$!".to_string(), Value::Nil);
         cloned.init_io_environment();
         cloned
     }


### PR DESCRIPTION
## Summary
- `* ~~ Type` now correctly curries into WhateverCode `{ $_ ~~ Type }`, enabling patterns like `@a.map(* ~~ Int)`. Parenthesized `((*)) ~~ Type` remains a runtime smartmatch, preserving existing behavior.
- Start blocks now get fresh `$/` and `$!` variables (Nil), matching Raku semantics where each `start` block has its own lexical match/error variables.
- Together these bring roast/S17-promise/start.t from 17/65 to 49/65 passing subtests.

## Test plan
- [x] `make test` passes (all 471 test files, 3802 tests)
- [x] `make roast` passes (all 1110 whitelisted files)
- [x] `* ~~ Int` creates WhateverCode: `say (* ~~ Int).WHAT` => `(WhateverCode)`
- [x] `((*)) ~~ HyperWhatever:D` remains Bool: `say (((*)) ~~ HyperWhatever:D)` => `False`
- [x] Fresh `$/` in start: `my $/ = 42; say await(start { $/ })` => `Nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)