### PR TITLE
fix: implement LTM for regex | alternation

### DIFF
--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -11,7 +11,7 @@ impl Interpreter {
                         return Some(goal);
                     }
                 }
-                RegexAtom::Alternation(alts) => {
+                RegexAtom::Alternation(alts) | RegexAtom::SequentialAlternation(alts) => {
                     for alt in alts {
                         if let Some(goal) = Self::first_goal_name(alt) {
                             return Some(goal);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -578,6 +578,7 @@ enum RegexAtom {
     Group(RegexPattern),
     CaptureGroup(RegexPattern),
     Alternation(Vec<RegexPattern>),
+    SequentialAlternation(Vec<RegexPattern>),
     ZeroWidth,
     CodeAssertion {
         code: String,

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -131,6 +131,9 @@ fn strip_marks_atom(atom: &RegexAtom) -> RegexAtom {
         RegexAtom::Alternation(alts) => {
             RegexAtom::Alternation(alts.iter().map(strip_marks_pattern).collect())
         }
+        RegexAtom::SequentialAlternation(alts) => {
+            RegexAtom::SequentialAlternation(alts.iter().map(strip_marks_pattern).collect())
+        }
         RegexAtom::GoalMatch {
             goal,
             inner,
@@ -311,7 +314,7 @@ pub(super) fn count_capture_groups(atom: &RegexAtom) -> usize {
     match atom {
         RegexAtom::CaptureGroup(_) => 1,
         RegexAtom::Group(pat) => count_pattern_capture_groups(pat),
-        RegexAtom::Alternation(alts) => {
+        RegexAtom::Alternation(alts) | RegexAtom::SequentialAlternation(alts) => {
             // All alternatives should produce the same number of captures
             alts.iter()
                 .map(count_pattern_capture_groups)

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -12,6 +12,33 @@ impl Interpreter {
         ignore_case: bool,
     ) -> Vec<(usize, RegexCaptures)> {
         if let RegexAtom::Alternation(alternatives) = atom {
+            let mut indexed: Vec<(usize, usize, RegexCaptures)> = Vec::new();
+            for (i, alt) in alternatives.iter().enumerate() {
+                if let Some((next, mut inner_caps)) =
+                    self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
+                {
+                    let mut new_caps = current_caps.clone();
+                    for (k, v) in inner_caps.named.drain() {
+                        new_caps.named.entry(k).or_default().extend(v);
+                    }
+                    new_caps.positional.append(&mut inner_caps.positional);
+                    new_caps
+                        .positional_subcaps
+                        .append(&mut inner_caps.positional_subcaps);
+                    new_caps
+                        .positional_quantified
+                        .append(&mut inner_caps.positional_quantified);
+                    new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                    indexed.push((i, next, new_caps));
+                }
+            }
+            indexed.sort_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)));
+            return indexed
+                .into_iter()
+                .map(|(_, end, caps)| (end, caps))
+                .collect();
+        }
+        if let RegexAtom::SequentialAlternation(alternatives) = atom {
             let mut out = Vec::new();
             for alt in alternatives {
                 if let Some((next, mut inner_caps)) =
@@ -32,7 +59,6 @@ impl Interpreter {
                     out.push((next, new_caps));
                 }
             }
-            // Stack matching is LIFO; reverse so the first alternative is explored first.
             out.reverse();
             return out;
         }
@@ -125,7 +151,9 @@ impl Interpreter {
             }
             return deduped;
         }
-        if let RegexAtom::Alternation(alternatives) = atom {
+        if let RegexAtom::Alternation(alternatives)
+        | RegexAtom::SequentialAlternation(alternatives) = atom
+        {
             let mut out = Vec::new();
             for alt in alternatives {
                 for (end, mut inner_caps) in

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -169,6 +169,17 @@ impl Interpreter {
                 return None;
             }
             RegexAtom::Alternation(alternatives) => {
+                let mut best: Option<usize> = None;
+                for alt in alternatives {
+                    if let Some(end) = self.regex_match_end_from_in_pkg(alt, chars, pos, pkg)
+                        && (best.is_none() || end > best.unwrap())
+                    {
+                        best = Some(end);
+                    }
+                }
+                return best;
+            }
+            RegexAtom::SequentialAlternation(alternatives) => {
                 for alt in alternatives {
                     if let Some(end) = self.regex_match_end_from_in_pkg(alt, chars, pos, pkg) {
                         return Some(end);
@@ -526,6 +537,7 @@ impl Interpreter {
             RegexAtom::Group(_)
             | RegexAtom::CaptureGroup(_)
             | RegexAtom::Alternation(_)
+            | RegexAtom::SequentialAlternation(_)
             | RegexAtom::GoalMatch { .. }
             | RegexAtom::Newline
             | RegexAtom::NotNewline

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -83,6 +83,28 @@ impl Interpreter {
                 }
                 return best;
             }
+            RegexAtom::SequentialAlternation(alternatives) => {
+                for alt in alternatives {
+                    if let Some((next, mut inner_caps)) =
+                        self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
+                    {
+                        let mut new_caps = current_caps.clone();
+                        for (k, v) in inner_caps.named.drain() {
+                            new_caps.named.entry(k).or_default().extend(v);
+                        }
+                        new_caps.positional.append(&mut inner_caps.positional);
+                        new_caps
+                            .positional_subcaps
+                            .append(&mut inner_caps.positional_subcaps);
+                        new_caps
+                            .positional_quantified
+                            .append(&mut inner_caps.positional_quantified);
+                        new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                        return Some((next, new_caps));
+                    }
+                }
+                return None;
+            }
             RegexAtom::ZeroWidth
             | RegexAtom::UnicodePropAssert { .. }
             | RegexAtom::LeftWordBoundary

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -249,7 +249,7 @@ impl Interpreter {
 
     /// Split a regex pattern on top-level `|` or `||` alternation operators.
     /// Respects grouping: `(...)`, `[...]`, `{...}`, `<...>` and escapes.
-    fn split_top_level_alternation(pattern: &str) -> Vec<String> {
+    fn split_top_level_alternation(pattern: &str) -> (Vec<String>, bool) {
         let mut parts = Vec::new();
         let mut current = String::new();
         let mut depth_paren = 0i32;
@@ -259,6 +259,7 @@ impl Interpreter {
         let mut escaped = false;
         let mut in_single_quote = false;
         let mut in_double_quote = false;
+        let mut is_sequential = false;
         let mut chars = pattern.chars().peekable();
 
         while let Some(ch) = chars.next() {
@@ -338,9 +339,10 @@ impl Interpreter {
                     && depth_brace == 0
                     && depth_angle == 0 =>
                 {
-                    // Skip second | for ||
+                    // Check for || (sequential alternation)
                     if chars.peek() == Some(&'|') {
                         chars.next();
+                        is_sequential = true;
                     }
                     parts.push(std::mem::take(&mut current));
                 }
@@ -350,7 +352,7 @@ impl Interpreter {
         if !current.is_empty() || !parts.is_empty() {
             parts.push(current);
         }
-        parts
+        (parts, is_sequential)
     }
 
     fn has_unquoted_ltm_separator(pattern: &str) -> bool {
@@ -743,7 +745,7 @@ impl Interpreter {
             source = source.trim_end();
         }
         // Handle top-level alternation (| or ||)
-        let top_alts = Self::split_top_level_alternation(source);
+        let (top_alts, is_sequential) = Self::split_top_level_alternation(source);
         if top_alts.len() > 1 {
             let mut alt_patterns = Vec::new();
             for alt in &top_alts {
@@ -762,8 +764,12 @@ impl Interpreter {
                 }
             }
             if alt_patterns.len() > 1 {
-                let atom = try_collapse_alternation_to_charclass(&alt_patterns)
-                    .unwrap_or(RegexAtom::Alternation(alt_patterns));
+                let atom = if is_sequential {
+                    RegexAtom::SequentialAlternation(alt_patterns)
+                } else {
+                    try_collapse_alternation_to_charclass(&alt_patterns)
+                        .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                };
                 return Some(RegexPattern {
                     tokens: vec![RegexToken {
                         atom,
@@ -1870,7 +1876,8 @@ impl Interpreter {
                             group_pattern.push(ch);
                         }
                     }
-                    let alternatives = Self::split_top_level_alternation(&group_pattern);
+                    let (alternatives, cap_is_sequential) =
+                        Self::split_top_level_alternation(&group_pattern);
                     let needs_capture_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();
@@ -1902,8 +1909,12 @@ impl Interpreter {
                                 alt_patterns.push(p);
                             }
                         }
-                        let group_atom = try_collapse_alternation_to_charclass(&alt_patterns)
-                            .unwrap_or(RegexAtom::Alternation(alt_patterns));
+                        let group_atom = if cap_is_sequential {
+                            RegexAtom::SequentialAlternation(alt_patterns)
+                        } else {
+                            try_collapse_alternation_to_charclass(&alt_patterns)
+                                .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                        };
                         let group_pat = RegexPattern {
                             tokens: vec![RegexToken {
                                 atom: group_atom,
@@ -1969,7 +1980,8 @@ impl Interpreter {
                         }
                     }
                     // Parse the group as top-level alternation, including `||`.
-                    let alternatives = Self::split_top_level_alternation(&group_pattern);
+                    let (alternatives, bracket_is_sequential) =
+                        Self::split_top_level_alternation(&group_pattern);
                     let needs_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();
@@ -2003,8 +2015,12 @@ impl Interpreter {
                                 alt_patterns.push(p);
                             }
                         }
-                        try_collapse_alternation_to_charclass(&alt_patterns)
-                            .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                        if bracket_is_sequential {
+                            RegexAtom::SequentialAlternation(alt_patterns)
+                        } else {
+                            try_collapse_alternation_to_charclass(&alt_patterns)
+                                .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                        }
                     } else {
                         let parsed_group = if needs_scope {
                             let mut scoped = String::new();


### PR DESCRIPTION
## Summary
- Implement Longest Token Matching (LTM) for Raku's `|` regex alternation operator
- Add `SequentialAlternation` variant to distinguish `||` (first-match) from `|` (longest-match)
- Update parser, simple matcher, capture-aware matcher, and exhaustive matcher

## Details
Raku's `|` tries all alternatives and picks the longest match, while `||` uses first-match semantics. Previously mutsu treated both identically (first-match). This change fixes 12 of 20 failing subtests in `roast/S05-metasyntax/longest-alternative.t`.

Remaining 7 real failures require more complex LTM features:
- Grammar action methods not being called
- Proto token dispatch
- `<.ws>` implicit LTM stopping  
- Non-constant variables not participating in LTM
- Sequential alternation interaction with LTM

## Test plan
- [x] `make test` passes (all 471 tests)
- [x] `make roast` passes (all 1110 whitelisted tests, no regressions)
- [x] Basic LTM works: `'aaa' ~~ m/a|aa/` returns `aa` (was `a`)
- [x] Backtracking still works: `'ab' ~~ / [ab | a] b /` returns `ab`
- [x] Exhaustive matching preserved: `:ex` modifier finds all alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)