### PR TITLE
fix: implement IO::Spec::Unix methods to pass roast/S32-io/io-spec-unix.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -911,6 +911,7 @@ roast/S32-io/io-path-symlink.t
 roast/S32-io/io-path-unix.t
 roast/S32-io/io-path-win.t
 roast/S32-io/io-spec-qnx.t
+roast/S32-io/io-spec-unix.t
 roast/S32-io/io-special.t
 roast/S32-io/mkdir_rmdir.t
 roast/S32-io/move.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1056,6 +1056,22 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
+    // IO::Path::Parts — .hash returns attributes as a Hash
+    if let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+        && class_name.resolve() == "IO::Path::Parts"
+        && (method == "hash" || method == "Hash")
+    {
+        let map: HashMap<String, Value> = attributes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        return Some(Ok(Value::hash(map)));
+    }
+
     // Match object methods
     if let Value::Instance {
         class_name,

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1006,6 +1006,12 @@ pub(crate) fn native_method_1arg(
             {
                 return None;
             }
+            // IO::Spec::* has its own split method
+            if let Value::Package(name) = target
+                && name.resolve().starts_with("IO::Spec")
+            {
+                return None;
+            }
             super::split::native_split_method(target, std::slice::from_ref(arg))
         }
         "lines" => {
@@ -2640,6 +2646,11 @@ pub(crate) fn native_method_2arg(
     if method == "split" {
         if let Value::Instance { class_name, .. } = target
             && (class_name == "Supply" || class_name == "IO::Handle")
+        {
+            return None;
+        }
+        if let Value::Package(name) = target
+            && name.resolve().starts_with("IO::Spec")
         {
             return None;
         }

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -1379,7 +1379,12 @@ impl Interpreter {
 
     pub(super) fn make_io_spec_instance(&self) -> Value {
         let attrs = HashMap::new();
-        Value::make_instance(Symbol::intern("IO::Spec"), attrs)
+        let class_name = if cfg!(target_os = "windows") {
+            "IO::Spec::Win32"
+        } else {
+            "IO::Spec::Unix"
+        };
+        Value::make_instance(Symbol::intern(class_name), attrs)
     }
 
     pub(super) fn make_distro_instance() -> Value {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -634,8 +634,11 @@ impl Interpreter {
                             return Ok(Value::str_from(""));
                         }
                         let path = first.map(|v| v.to_string_value()).unwrap_or_default();
+                        let is_qnx = cn == "IO::Spec::QNX";
                         let cleaned = if is_win32 {
                             Self::cleanup_io_path_lexical_win32(&path)
+                        } else if is_qnx {
+                            Self::canonpath_qnx(&path, parent)
                         } else {
                             Self::canonpath_unix(&path, parent)
                         };
@@ -671,6 +674,247 @@ impl Interpreter {
                         #[cfg(target_arch = "wasm32")]
                         let tmpdir_str = "/tmp".to_string();
                         return Ok(self.make_io_path_instance(&tmpdir_str));
+                    }
+                    "curdir" => return Ok(Value::str_from(".")),
+                    "rootdir" => return Ok(Value::str_from("/")),
+                    "updir" => return Ok(Value::str_from("..")),
+                    "catdir" => {
+                        let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
+                        if parts.is_empty() {
+                            return Ok(Value::str_from(""));
+                        }
+                        let mut joined = parts.join("/");
+                        joined.push('/');
+                        let result = Self::canonpath_unix(&joined, false);
+                        return Ok(Value::str(result));
+                    }
+                    "catfile" => {
+                        let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
+                        let joined = parts.join("/");
+                        let result = Self::canonpath_unix(&joined, false);
+                        return Ok(Value::str(result));
+                    }
+                    "curupdir" => {
+                        // Returns a matcher that accepts everything except "." and ".."
+                        return Ok(Value::make_instance(
+                            crate::symbol::Symbol::intern("IO::Spec::CurUpDir"),
+                            std::collections::HashMap::new(),
+                        ));
+                    }
+                    "path" => {
+                        let path_env = std::env::var("PATH").unwrap_or_default();
+                        if path_env.is_empty() {
+                            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+                        }
+                        let parts: Vec<Value> = path_env
+                            .split(':')
+                            .map(|p| {
+                                if p.is_empty() {
+                                    Value::str_from(".")
+                                } else {
+                                    Value::str(p.to_string())
+                                }
+                            })
+                            .collect();
+                        return Ok(Value::Seq(std::sync::Arc::new(parts)));
+                    }
+                    "splitpath" => {
+                        let path = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        // Split into (volume, directory, file)
+                        // On Unix, volume is always empty
+                        // If path ends with / or last component is . or ..,
+                        // treat entire path as directory with empty file
+                        let basename = path
+                            .rfind('/')
+                            .map(|pos| &path[pos + 1..])
+                            .unwrap_or(path.as_str());
+                        let (dir, file) =
+                            if path.ends_with('/') || basename == "." || basename == ".." {
+                                (path.as_str(), "")
+                            } else if let Some(pos) = path.rfind('/') {
+                                (&path[..=pos], &path[pos + 1..])
+                            } else {
+                                ("", path.as_str())
+                            };
+                        return Ok(Value::Array(
+                            std::sync::Arc::new(vec![
+                                Value::str_from(""),
+                                Value::str(dir.to_string()),
+                                Value::str(file.to_string()),
+                            ]),
+                            crate::value::ArrayKind::List,
+                        ));
+                    }
+                    "split" => {
+                        let path = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        // Returns a hash with volume, dirname, basename
+                        let (dirname, basename) = if path == "/" {
+                            ("/", "/")
+                        } else if path.ends_with('/') {
+                            // Trailing slash: strip it, then split
+                            let trimmed = path.trim_end_matches('/');
+                            if let Some(pos) = trimmed.rfind('/') {
+                                let dir = if pos == 0 { "/" } else { &trimmed[..pos] };
+                                (dir, &trimmed[pos + 1..])
+                            } else {
+                                (".", trimmed)
+                            }
+                        } else if let Some(pos) = path.rfind('/') {
+                            let dir = if pos == 0 { "/" } else { &path[..pos] };
+                            (dir, &path[pos + 1..])
+                        } else if path == "." {
+                            (".", ".")
+                        } else {
+                            (".", path.as_str())
+                        };
+                        let mut hash = std::collections::HashMap::new();
+                        hash.insert("volume".to_string(), Value::str_from(""));
+                        hash.insert("dirname".to_string(), Value::str(dirname.to_string()));
+                        hash.insert("basename".to_string(), Value::str(basename.to_string()));
+                        return Ok(Value::make_instance(
+                            crate::symbol::Symbol::intern("IO::Path::Parts"),
+                            hash,
+                        ));
+                    }
+                    "join" => {
+                        // On Unix, volume is ignored
+                        let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
+                        let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                        let result = if file.is_empty() {
+                            if dir.is_empty() { String::new() } else { dir }
+                        } else if dir.is_empty() || dir == "." {
+                            file
+                        } else if dir == "/" && file == "/" {
+                            "/".to_string()
+                        } else if dir.ends_with('/') {
+                            format!("{}{}", dir, file)
+                        } else {
+                            format!("{}/{}", dir, file)
+                        };
+                        return Ok(Value::str(result));
+                    }
+                    "splitdir" => {
+                        let path = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        if path.is_empty() {
+                            return Ok(Value::Array(
+                                std::sync::Arc::new(vec![Value::str_from("")]),
+                                crate::value::ArrayKind::List,
+                            ));
+                        }
+                        let parts: Vec<Value> =
+                            path.split('/').map(|s| Value::str(s.to_string())).collect();
+                        return Ok(Value::Array(
+                            std::sync::Arc::new(parts),
+                            crate::value::ArrayKind::List,
+                        ));
+                    }
+                    "catpath" => {
+                        let _vol = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
+                        let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                        let mut result = dir;
+                        if !file.is_empty() {
+                            if !result.is_empty() && !result.ends_with('/') {
+                                result.push('/');
+                            }
+                            result.push_str(&file);
+                        }
+                        return Ok(Value::str(result));
+                    }
+                    "abs2rel" => {
+                        let path_str = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        let base_str =
+                            args.get(1).map(|v| v.to_string_value()).unwrap_or_else(|| {
+                                std::env::current_dir()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_else(|_| ".".to_string())
+                            });
+                        let path = Self::canonpath_unix(&path_str, false);
+                        let base = Self::canonpath_unix(&base_str, false);
+                        let path_parts: Vec<&str> =
+                            path.split('/').filter(|s| !s.is_empty()).collect();
+                        let base_parts: Vec<&str> =
+                            base.split('/').filter(|s| !s.is_empty()).collect();
+                        // Find common prefix length
+                        let mut common = 0;
+                        while common < path_parts.len()
+                            && common < base_parts.len()
+                            && path_parts[common] == base_parts[common]
+                        {
+                            common += 1;
+                        }
+                        let ups = base_parts.len() - common;
+                        let mut result_parts: Vec<&str> = vec![".."; ups];
+                        result_parts.extend_from_slice(&path_parts[common..]);
+                        let result = if result_parts.is_empty() {
+                            ".".to_string()
+                        } else {
+                            result_parts.join("/")
+                        };
+                        return Ok(Value::str(result));
+                    }
+                    "rel2abs" => {
+                        let path_str = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        let base_str =
+                            args.get(1).map(|v| v.to_string_value()).unwrap_or_else(|| {
+                                std::env::current_dir()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_else(|_| ".".to_string())
+                            });
+                        if path_str.starts_with('/') {
+                            return Ok(Value::str(path_str));
+                        }
+                        let mut result = base_str;
+                        if !result.ends_with('/') {
+                            result.push('/');
+                        }
+                        result.push_str(&path_str);
+                        let cleaned = Self::canonpath_unix(&result, false);
+                        return Ok(Value::str(cleaned));
+                    }
+                    "basename" => {
+                        let path = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        // basename is the part after the last '/'
+                        let result = if let Some(pos) = path.rfind('/') {
+                            &path[pos + 1..]
+                        } else {
+                            path.as_str()
+                        };
+                        return Ok(Value::str(result.to_string()));
+                    }
+                    "extension" => {
+                        let path = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        // Extension is everything after the last '.' in the full path
+                        let result = if let Some(pos) = path.rfind('.') {
+                            &path[pos + 1..]
+                        } else {
+                            ""
+                        };
+                        return Ok(Value::str(result.to_string()));
                     }
                     _ => {}
                 }
@@ -1465,6 +1709,7 @@ impl Interpreter {
         // (handled by native_io_handle which slurps the file first).
         if method == "split"
             && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle")
+            && !matches!(&target, Value::Package(name) if name.resolve().starts_with("IO::Spec"))
         {
             return self.handle_split_method(target, args);
         }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -346,119 +346,21 @@ impl Interpreter {
                 }
             }
 
-            // IO::Spec methods
+            // IO::Spec::CurUpDir ACCEPTS
+            if class_name.resolve() == "IO::Spec::CurUpDir" && method == "ACCEPTS" {
+                let arg = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                // curupdir rejects "." and "..", accepts everything else
+                let result = arg != "." && arg != "..";
+                return Ok(Value::Bool(result));
+            }
+
+            // IO::Spec methods — delegate to Package-based handler
             if class_name == "IO::Spec" || class_name.resolve().starts_with("IO::Spec::") {
-                let is_win32 = class_name == "IO::Spec::Win32";
-                let sep = if is_win32 { "\\" } else { "/" };
-                let sep_char = if is_win32 { '\\' } else { '/' };
-                match method {
-                    "dir-sep" => {
-                        return Ok(Value::str_from(sep));
-                    }
-                    "join" => {
-                        let vol = args
-                            .first()
-                            .map(|v| v.to_string_value())
-                            .unwrap_or_default();
-                        let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
-                        let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
-                        let mut result = String::new();
-                        if !vol.is_empty() {
-                            result.push_str(&vol);
-                        }
-                        if !dir.is_empty() {
-                            if !result.is_empty()
-                                && !result.ends_with('/')
-                                && !result.ends_with('\\')
-                            {
-                                result.push(sep_char);
-                            }
-                            result.push_str(&dir);
-                        }
-                        if !file.is_empty() {
-                            if !result.is_empty()
-                                && !result.ends_with('/')
-                                && !result.ends_with('\\')
-                            {
-                                result.push(sep_char);
-                            }
-                            result.push_str(&file);
-                        }
-                        return Ok(Value::str(result));
-                    }
-                    "catdir" => {
-                        let parts: Vec<String> = args
-                            .iter()
-                            .map(|a| {
-                                if let Value::Array(items, ..) = a {
-                                    items
-                                        .iter()
-                                        .map(|v| v.to_string_value())
-                                        .collect::<Vec<_>>()
-                                        .join(sep)
-                                } else {
-                                    a.to_string_value()
-                                }
-                            })
-                            .collect();
-                        let joined = parts.join(sep);
-                        return Ok(Value::str(joined));
-                    }
-                    "catfile" => {
-                        let parts: Vec<String> = args
-                            .iter()
-                            .map(|a| {
-                                if let Value::Array(items, ..) = a {
-                                    items
-                                        .iter()
-                                        .map(|v| v.to_string_value())
-                                        .collect::<Vec<_>>()
-                                        .join(sep)
-                                } else {
-                                    a.to_string_value()
-                                }
-                            })
-                            .collect();
-                        let joined = parts.join(sep);
-                        return Ok(Value::str(joined));
-                    }
-                    "devnull" => {
-                        let devnull = if is_win32 { "NUL" } else { "/dev/null" };
-                        return Ok(Value::str_from(devnull));
-                    }
-                    "catpath" => {
-                        let vol = args
-                            .first()
-                            .map(|v| v.to_string_value())
-                            .unwrap_or_default();
-                        let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
-                        let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
-                        let mut result = String::new();
-                        if !vol.is_empty() {
-                            result.push_str(&vol);
-                        }
-                        if !dir.is_empty() {
-                            if !result.is_empty()
-                                && !result.ends_with('/')
-                                && !result.ends_with('\\')
-                            {
-                                result.push(sep_char);
-                            }
-                            result.push_str(&dir);
-                        }
-                        if !file.is_empty() {
-                            if !result.is_empty()
-                                && !result.ends_with('/')
-                                && !result.ends_with('\\')
-                            {
-                                result.push(sep_char);
-                            }
-                            result.push_str(&file);
-                        }
-                        return Ok(Value::str(result));
-                    }
-                    _ => {}
-                }
+                let pkg = Value::Package(*class_name);
+                return self.call_method_with_values(pkg, method, args);
             }
             if class_name == "CompUnit::Repository::FileSystem" {
                 match method {

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1211,9 +1211,18 @@ impl Interpreter {
     /// Strict Unix `IO::Spec::Unix.canonpath` implementation used by
     /// `IO::Spec::Unix` / `IO::Spec::QNX` etc. When `parent` is true, `..`
     /// segments are resolved lexically. Returns `''` for empty input.
-    /// Preserves a leading `//` (POSIX implementation-defined) but collapses
-    /// three or more leading slashes to a single `/`.
+    /// When `preserve_double_slash` is true, a leading `//` is kept
+    /// (POSIX implementation-defined, used by QNX).
     pub fn canonpath_unix(path: &str, parent: bool) -> String {
+        Self::canonpath_unix_inner(path, parent, false)
+    }
+
+    /// QNX variant that preserves a leading `//`.
+    pub fn canonpath_qnx(path: &str, parent: bool) -> String {
+        Self::canonpath_unix_inner(path, parent, true)
+    }
+
+    fn canonpath_unix_inner(path: &str, parent: bool, preserve_double_slash: bool) -> String {
         if path.is_empty() {
             return String::new();
         }
@@ -1224,7 +1233,7 @@ impl Interpreter {
         }
         let prefix = if leading == 0 {
             ""
-        } else if leading == 2 {
+        } else if preserve_double_slash && leading == 2 {
             "//"
         } else {
             "/"
@@ -1235,8 +1244,7 @@ impl Interpreter {
             .split('/')
             .filter(|s| !s.is_empty() && *s != ".")
             .collect();
-        // For "//"-prefixed paths, do not collapse leading `..` — POSIX leaves
-        // `//` implementation-defined and Rakudo's IO::Spec::Unix preserves it.
+        // For "//"-prefixed paths (QNX), do not collapse leading `..` past the prefix.
         let collapse_leading_dotdot = is_absolute && prefix == "/";
         let mut stack: Vec<&str> = Vec::new();
         if parent {


### PR DESCRIPTION
## Summary
- Implement comprehensive IO::Spec::Unix class methods: canonpath (fix leading slash collapsing), catdir, catfile, curdir, rootdir, updir, curupdir, path, splitpath, split, join, splitdir, catpath, abs2rel, rel2abs, basename, extension
- Fix `$*SPEC` to be an `IO::Spec::Unix` instance (was `IO::Spec`)
- Delegate Instance IO::Spec method calls to the Package handler to avoid code duplication
- Add IO::Path::Parts `.hash` support for the `split` method
- Preserve `//` prefix for QNX spec (separate from Unix)
- Add `roast/S32-io/io-spec-unix.t` to whitelist (all 133 subtests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-io/io-spec-unix.t` passes all 133 tests
- [x] `prove -e 'target/debug/mutsu' roast/S32-io/io-spec-qnx.t` still passes (no regression from canonpath change)
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)