### PR TITLE
fix: implement proper scalar binding semantics (roast S03-binding/scalars.t)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -141,6 +141,7 @@ roast/S02-types/version.t
 roast/S03-binding/closure.t
 roast/S03-binding/hashes.t
 roast/S03-binding/ro.t
+roast/S03-binding/scalars.t
 roast/S03-buf/read-int.t
 roast/S03-buf/read-num.t
 roast/S03-buf/read-write-bits.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -826,6 +826,8 @@ impl Compiler {
                     if name.starts_with('@') {
                         self.code.emit(OpCode::MarkBindContext);
                     }
+                    // Signal rebind context for cleanup of old bind pairs.
+                    self.code.emit(OpCode::MarkRebindContext);
                     self.compile_call_arg(expr);
                 } else {
                     self.compile_assignment_rhs_for_target(name, expr);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -70,6 +70,9 @@ pub(crate) enum OpCode {
     WrapVarRef(u32),
     /// Signal that the next SetLocal is a `:=` bind (preserve container type for `@` vars).
     MarkBindContext,
+    /// Signal that the next SetLocal is a `:=` rebind (not a VarDecl).
+    /// Triggers cleanup of old bind pairs and reverse aliases.
+    MarkRebindContext,
 
     // -- String --
     Concat,

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -595,7 +595,13 @@ impl Interpreter {
                                 varref_from_value(&args[positional_idx]).map(|(name, _)| name)
                             });
                         if let Some(source_name) = source_name {
-                            rw_bindings.push((pd.name.clone(), source_name));
+                            rw_bindings.push((pd.name.clone(), source_name.clone()));
+                            // Set up a sigilless alias so that subsequent `:=`
+                            // bindings (e.g. `$a := $arg`) can transitively
+                            // resolve through the `is rw` parameter to the
+                            // caller's variable.
+                            let alias_key = format!("__mutsu_sigilless_alias::{}", pd.name);
+                            self.env.insert(alias_key, Value::str(source_name));
                         } else if is_rw {
                             return Err(RuntimeError::new(format!(
                                 "X::Parameter::RW: '{}' expects a writable variable argument",

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -117,6 +117,11 @@ impl Interpreter {
         &mut self.readonly_vars
     }
 
+    /// Check if a variable is readonly.
+    pub(crate) fn is_readonly(&self, name: &str) -> bool {
+        self.readonly_vars.contains(name)
+    }
+
     /// Mark a variable as readonly.
     pub(crate) fn mark_readonly(&mut self, name: &str) {
         self.readonly_vars.insert(name.to_string());

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -92,6 +92,9 @@ pub(crate) struct VM {
     resume_ip: Option<usize>,
     /// When true, the next SetLocal is a `:=` bind (preserves container type for `@` vars).
     bind_context: bool,
+    /// When true, the next SetLocal is a `:=` rebind (not VarDecl).
+    /// Used to trigger cleanup of old bind pairs and reverse aliases.
+    rebind_context: bool,
     /// When true, the next SetLocal skips @/% container coercion (for `constant @x`).
     constant_context: bool,
     /// When true, the next SetLocal came from an explicit initializer (`= expr`).
@@ -126,6 +129,11 @@ pub(crate) struct VM {
     /// each active BlockScope. Used during BlockScope restoration to avoid
     /// propagating block-local variable values to the outer scope.
     block_declared_vars: Vec<std::collections::HashSet<String>>,
+    /// Pending alias-based bind pairs created by `:=` binding inside closures
+    /// (e.g. `$a := $arg` where `$arg is rw`).  Each entry is
+    /// (target_name, source_name): after the closure returns, the caller
+    /// creates local_bind_pairs from these so writes to source propagate to target.
+    pending_alias_bind_names: Vec<(String, String)>,
 }
 
 impl VM {
@@ -264,6 +272,7 @@ impl VM {
             locals_dirty: false,
             resume_ip: None,
             bind_context: false,
+            rebind_context: false,
             constant_context: false,
             explicit_initializer_context: false,
             vardecl_context: false,
@@ -276,6 +285,7 @@ impl VM {
             multi_candidates_cache: HashMap::new(),
             multi_candidates_cache_gen: 0,
             block_declared_vars: Vec::new(),
+            pending_alias_bind_names: Vec::new(),
         }
     }
 
@@ -1010,7 +1020,7 @@ impl VM {
                     return Err(RuntimeError::assignment_ro(None));
                 }
                 if let Some(source_name) = bind_source {
-                    let mut resolved_source = source_name;
+                    let mut resolved_source = source_name.clone();
                     let mut seen = std::collections::HashSet::new();
                     while seen.insert(resolved_source.clone()) {
                         let key = format!("__mutsu_sigilless_alias::{}", resolved_source);
@@ -1021,10 +1031,23 @@ impl VM {
                     }
                     self.interpreter
                         .env_mut()
-                        .insert(alias_key.clone(), Value::str(resolved_source));
+                        .insert(alias_key.clone(), Value::str(resolved_source.clone()));
+                    // Propagate readonly status from the source variable.
+                    // Binding to a readonly parameter should make the target
+                    // readonly as well (persisted in env for cross-scope survival).
+                    let source_readonly = self.interpreter.is_readonly(&source_name);
                     self.interpreter
                         .env_mut()
-                        .insert(readonly_key.clone(), Value::Bool(false));
+                        .insert(readonly_key.clone(), Value::Bool(source_readonly));
+                    if source_readonly {
+                        self.interpreter.mark_readonly(&name);
+                    }
+                    // Record pending alias bind for the caller to create
+                    // local_bind_pairs after the closure returns.
+                    if !source_readonly {
+                        self.pending_alias_bind_names
+                            .push((name.clone(), resolved_source));
+                    }
                 }
                 if raw_mode && name.starts_with('@') {
                     // For `constant @x`, bypass set_shared_var's List→Array
@@ -1220,6 +1243,10 @@ impl VM {
             }
             OpCode::MarkBindContext => {
                 self.bind_context = true;
+                *ip += 1;
+            }
+            OpCode::MarkRebindContext => {
+                self.rebind_context = true;
                 *ip += 1;
             }
             OpCode::MarkConstantContext => {
@@ -2940,6 +2967,17 @@ impl VM {
             OpCode::CheckReadOnly(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
                 self.interpreter.check_readonly_for_modify(name)?;
+                // Also check env-based readonly status set by cross-scope
+                // `:=` binding (e.g. binding to a readonly sub parameter
+                // in a closure).  The readonly_vars set is scope-local
+                // and gets restored on frame pop, but the env key persists.
+                let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
+                if matches!(
+                    self.interpreter.env().get(&readonly_key),
+                    Some(Value::Bool(true))
+                ) {
+                    return Err(RuntimeError::assignment_ro(Some(name)));
+                }
                 *ip += 1;
             }
             OpCode::MarkVarReadonly(name_idx) => {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -482,6 +482,18 @@ impl VM {
                 restored_env.insert(k.clone(), v.clone());
             }
         }
+        // Write back readonly/alias metadata for captured variables that were
+        // modified inside the closure (e.g. `$a := $arg` where `$a` is captured).
+        for captured_name in &captured_names {
+            let readonly_key = format!("__mutsu_sigilless_readonly::{}", captured_name);
+            if let Some(v) = self.interpreter.env().get(&readonly_key).cloned() {
+                restored_env.insert(readonly_key, v);
+            }
+            let alias_key = format!("__mutsu_sigilless_alias::{}", captured_name);
+            if let Some(v) = self.interpreter.env().get(&alias_key).cloned() {
+                restored_env.insert(alias_key, v);
+            }
+        }
         self.interpreter
             .merge_sigilless_alias_writes(&mut restored_env, self.interpreter.env());
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -879,6 +879,8 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // Lazily convert pending alias bind names into local_bind_pairs.
+        self.resolve_pending_alias_binds(code);
         let name = Self::const_str(code, name_idx);
         // Handle $CALLER::varname++ — increment through caller scope
         if let Some((bare_name, depth)) = crate::compiler::Compiler::parse_caller_prefix(name) {
@@ -912,6 +914,22 @@ impl VM {
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
+        // Propagate via local_bind_pairs (for `:=` bindings within this scope
+        // or cross-scope bindings resolved by resolve_pending_alias_binds).
+        if let Some(source_idx) = code.locals.iter().position(|n| n == name) {
+            let mut env_updates = Vec::new();
+            for &(src, tgt) in &self.local_bind_pairs {
+                if src == source_idx {
+                    self.locals[tgt] = new_val.clone();
+                    env_updates.push((code.locals[tgt].clone(), new_val.clone()));
+                }
+            }
+            // Also update env so ensure_locals_synced doesn't overwrite
+            // with stale data.
+            for (target_name, val) in env_updates {
+                self.set_env_with_main_alias(&target_name, val);
+            }
+        }
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
         let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
             if let Value::Str(name) = v {
@@ -2246,6 +2264,7 @@ impl VM {
                 return Ok(());
             }
         }
+        // Disabled: GetLocal alias following for cross-scope binding
         let atomic_name = name.strip_prefix('$').unwrap_or(&name);
         let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
         // Only use the scalar atomic fast path for scalar ($) variables.
@@ -2335,10 +2354,12 @@ impl VM {
         let raw_popped = self.stack.pop().unwrap_or(Value::Nil);
         let (raw_popped, bind_source) = Self::extract_varref_binding(raw_popped);
         let is_bind = self.bind_context || bind_source.is_some();
+        let is_rebind = self.rebind_context;
         let is_constant = self.constant_context;
         let has_explicit_initializer = self.explicit_initializer_context;
         let is_vardecl = self.vardecl_context;
         self.bind_context = false;
+        self.rebind_context = false;
         self.constant_context = false;
         self.explicit_initializer_context = false;
         self.vardecl_context = false;
@@ -2355,6 +2376,9 @@ impl VM {
             let deleted_key = format!("__mutsu_deleted_index::{}", name);
             self.interpreter.env_mut().remove(&deleted_key);
         }
+
+        // Lazily convert pending alias bind names into local_bind_pairs.
+        self.resolve_pending_alias_binds(code);
 
         // Fast path for simple scalar variables — skip all metadata checks
         if code.simple_locals[idx] && bind_source.is_none() && !is_bind {
@@ -2432,6 +2456,23 @@ impl VM {
             // from firing).
             self.interpreter
                 .set_shared_var(name, self.locals[idx].clone());
+            // When rebinding (`$x := expr`), remove old bind pairs and reverse aliases.
+            if is_rebind {
+                self.local_bind_pairs.retain(|&(source, _)| source != idx);
+                let mut aliases_to_remove = Vec::new();
+                let prefix = "__mutsu_sigilless_alias::";
+                for (k, v) in self.interpreter.env().iter() {
+                    if let Some(_var_name) = k.strip_prefix(prefix)
+                        && let Value::Str(target) = v
+                        && target.as_str() == name
+                    {
+                        aliases_to_remove.push(k.clone());
+                    }
+                }
+                for k in aliases_to_remove {
+                    self.interpreter.env_mut().remove(&k);
+                }
+            }
             // Propagate value to variables bound to this one via `:=` binding.
             // Uses local_bind_pairs recorded at binding time to avoid
             // cross-scope name collisions.
@@ -2675,6 +2716,27 @@ impl VM {
         }
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
             self.interpreter.reset_atomic_var_key(name);
+        }
+        // When rebinding a variable (`$x := expr`), remove any existing
+        // bind pairs where this slot was the source.  Rebinding replaces
+        // the container, so previously bound targets must stop tracking.
+        if is_rebind {
+            self.local_bind_pairs.retain(|&(source, _)| source != idx);
+            // Also remove env-based aliases that point TO this variable,
+            // so GetLocal alias-following doesn't read the new value.
+            let mut aliases_to_remove = Vec::new();
+            let prefix = "__mutsu_sigilless_alias::";
+            for (k, v) in self.interpreter.env().iter() {
+                if let Some(_var_name) = k.strip_prefix(prefix)
+                    && let Value::Str(target) = v
+                    && target.as_str() == name
+                {
+                    aliases_to_remove.push(k.clone());
+                }
+            }
+            for k in aliases_to_remove {
+                self.interpreter.env_mut().remove(&k);
+            }
         }
         if let Some(source_name) = bind_source {
             let resolved_source = self.resolve_sigilless_alias_source_name(&source_name);
@@ -3362,5 +3424,39 @@ impl VM {
             .to_i64()
             .map(Value::Int)
             .unwrap_or_else(|| Value::bigint(wrapped)))
+    }
+
+    /// Lazily convert pending alias bind names (from closure `:=` bindings)
+    /// into local_bind_pairs now that we have access to the outer code.
+    fn resolve_pending_alias_binds(&mut self, code: &CompiledCode) {
+        if self.pending_alias_bind_names.is_empty() {
+            return;
+        }
+        let pending = std::mem::take(&mut self.pending_alias_bind_names);
+        for (target_name, source_name) in pending {
+            if let Some(target_idx) = code.locals.iter().position(|n| n == &target_name)
+                && let Some(source_idx) = code.locals.iter().position(|n| n == &source_name)
+                && source_idx != target_idx
+            {
+                // Add bidirectional bind pairs: source->target AND target->source.
+                // This ensures writes to either variable propagate to the other.
+                if !self.local_bind_pairs.contains(&(source_idx, target_idx)) {
+                    self.local_bind_pairs.push((source_idx, target_idx));
+                }
+                if !self.local_bind_pairs.contains(&(target_idx, source_idx)) {
+                    self.local_bind_pairs.push((target_idx, source_idx));
+                }
+                // Sync the target local from the source local or env so the
+                // initial value is correct (the closure may have set the
+                // target via SetGlobal but locals are stale from the frame
+                // restore).
+                let source_val = if let Some(v) = self.interpreter.env().get(&source_name) {
+                    v.clone()
+                } else {
+                    self.locals[source_idx].clone()
+                };
+                self.locals[target_idx] = source_val;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Implements proper `:=` binding semantics for scalar variables, fixing all 5 previously failing subtests in `roast/S03-binding/scalars.t`
- Adds `MarkRebindContext` opcode for rebinding cleanup (removing stale bind pairs and reverse aliases when a variable is rebound)
- Propagates readonly status when binding to readonly sub parameters across closure boundaries
- Creates bidirectional local bind pairs for `is rw` parameter container aliasing through closures
- Adds `roast/S03-binding/scalars.t` to the whitelist (all 33 subtests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S03-binding/scalars.t` passes all 33 tests
- [x] `make test` passes (471 files, 3802 tests)
- [x] `make roast` passes (1114 files, 178355 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)