### PR TITLE
fix: implement IO::Spec::Cygwin path handling

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -910,6 +910,7 @@ roast/S32-io/io-path-subclasses.t
 roast/S32-io/io-path-symlink.t
 roast/S32-io/io-path-unix.t
 roast/S32-io/io-path-win.t
+roast/S32-io/io-spec-cygwin.t
 roast/S32-io/io-spec-qnx.t
 roast/S32-io/io-spec-unix.t
 roast/S32-io/io-special.t

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -612,6 +612,7 @@ impl Interpreter {
             let cn = name.resolve();
             if cn.starts_with("IO::Spec") {
                 let is_win32 = cn == "IO::Spec::Win32";
+                let is_cygwin = cn == "IO::Spec::Cygwin";
                 match method {
                     "canonpath" => {
                         // Separate positional and named args (e.g. `:parent`).
@@ -637,6 +638,8 @@ impl Interpreter {
                         let is_qnx = cn == "IO::Spec::QNX";
                         let cleaned = if is_win32 {
                             Self::cleanup_io_path_lexical_win32(&path)
+                        } else if is_cygwin {
+                            Self::canonpath_cygwin(&path, parent)
                         } else if is_qnx {
                             Self::canonpath_qnx(&path, parent)
                         } else {
@@ -749,32 +752,44 @@ impl Interpreter {
                         ));
                     }
                     "split" => {
-                        let path = args
+                        let raw_path = args
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
+                        // For Cygwin, convert backslashes to forward slashes first
+                        let path = if is_cygwin {
+                            raw_path.replace('\\', "/")
+                        } else {
+                            raw_path
+                        };
+                        // Extract volume for Cygwin (drive letter or UNC)
+                        let (volume, rest) = if is_cygwin {
+                            Self::split_cygwin_volume(&path)
+                        } else {
+                            ("".to_string(), path.clone())
+                        };
                         // Returns a hash with volume, dirname, basename
-                        let (dirname, basename) = if path == "/" {
+                        let (dirname, basename) = if rest == "/" {
                             ("/", "/")
-                        } else if path.ends_with('/') {
+                        } else if rest.ends_with('/') {
                             // Trailing slash: strip it, then split
-                            let trimmed = path.trim_end_matches('/');
+                            let trimmed = rest.trim_end_matches('/');
                             if let Some(pos) = trimmed.rfind('/') {
                                 let dir = if pos == 0 { "/" } else { &trimmed[..pos] };
                                 (dir, &trimmed[pos + 1..])
                             } else {
                                 (".", trimmed)
                             }
-                        } else if let Some(pos) = path.rfind('/') {
-                            let dir = if pos == 0 { "/" } else { &path[..pos] };
-                            (dir, &path[pos + 1..])
-                        } else if path == "." {
+                        } else if let Some(pos) = rest.rfind('/') {
+                            let dir = if pos == 0 { "/" } else { &rest[..pos] };
+                            (dir, &rest[pos + 1..])
+                        } else if rest == "." {
                             (".", ".")
                         } else {
-                            (".", path.as_str())
+                            (".", rest.as_str())
                         };
                         let mut hash = std::collections::HashMap::new();
-                        hash.insert("volume".to_string(), Value::str_from(""));
+                        hash.insert("volume".to_string(), Value::str(volume));
                         hash.insert("dirname".to_string(), Value::str(dirname.to_string()));
                         hash.insert("basename".to_string(), Value::str(basename.to_string()));
                         return Ok(Value::make_instance(
@@ -783,10 +798,13 @@ impl Interpreter {
                         ));
                     }
                     "join" => {
-                        // On Unix, volume is ignored
+                        let vol = args
+                            .first()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
                         let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
                         let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
-                        let result = if file.is_empty() {
+                        let path_part = if file.is_empty() {
                             if dir.is_empty() { String::new() } else { dir }
                         } else if dir.is_empty() || dir == "." {
                             file
@@ -796,6 +814,12 @@ impl Interpreter {
                             format!("{}{}", dir, file)
                         } else {
                             format!("{}/{}", dir, file)
+                        };
+                        // Prepend volume for Cygwin/Win32
+                        let result = if (is_cygwin || is_win32) && !vol.is_empty() {
+                            format!("{}{}", vol, path_part)
+                        } else {
+                            path_part
                         };
                         return Ok(Value::str(result));
                     }
@@ -818,7 +842,7 @@ impl Interpreter {
                         ));
                     }
                     "catpath" => {
-                        let _vol = args
+                        let vol = args
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
@@ -830,6 +854,10 @@ impl Interpreter {
                                 result.push('/');
                             }
                             result.push_str(&file);
+                        }
+                        // Prepend volume for Cygwin/Win32
+                        if (is_cygwin || is_win32) && !vol.is_empty() {
+                            result = format!("{}{}", vol, result);
                         }
                         return Ok(Value::str(result));
                     }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1286,6 +1286,67 @@ impl Interpreter {
         out
     }
 
+    /// Cygwin `IO::Spec::Cygwin.canonpath`: converts backslashes to forward
+    /// slashes, strips drive-letter prefix, then delegates to Unix canonpath
+    /// (preserving leading `//` like QNX).
+    pub fn canonpath_cygwin(path: &str, parent: bool) -> String {
+        if path.is_empty() {
+            return String::new();
+        }
+        // Convert backslashes to forward slashes
+        let converted = path.replace('\\', "/");
+        // Extract drive letter prefix if present (e.g. "c:" or "C:")
+        let (prefix, rest) = if converted.len() >= 2
+            && converted.as_bytes()[0].is_ascii_alphabetic()
+            && converted.as_bytes()[1] == b':'
+        {
+            (&converted[..2], &converted[2..])
+        } else {
+            ("", converted.as_str())
+        };
+        // Cygwin preserves leading // (like QNX)
+        let canon = Self::canonpath_unix_inner(rest, parent, true);
+        if prefix.is_empty() {
+            canon
+        } else {
+            format!("{}{}", prefix, canon)
+        }
+    }
+
+    /// Split a Cygwin path into (volume, rest).
+    /// Handles UNC paths (//server/share -> volume="//server/share", rest="/")
+    /// and drive letters (c:/foo -> volume="c:", rest="/foo").
+    pub fn split_cygwin_volume(path: &str) -> (String, String) {
+        let bytes = path.as_bytes();
+        // UNC path: //server/share
+        if bytes.len() >= 2 && bytes[0] == b'/' && bytes[1] == b'/' {
+            // Find end of server name
+            if let Some(server_end) = path[2..].find('/') {
+                let share_start = 2 + server_end + 1;
+                // Find end of share name
+                let share_end = path[share_start..]
+                    .find('/')
+                    .map(|p| share_start + p)
+                    .unwrap_or(path.len());
+                let volume = path[..share_end].to_string();
+                let rest = if share_end >= path.len() {
+                    "/".to_string()
+                } else {
+                    path[share_end..].to_string()
+                };
+                return (volume, rest);
+            }
+        }
+        // Drive letter: X:
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let vol = path[..2].to_string();
+            let rest = path[2..].to_string();
+            return (vol, rest);
+        }
+        // No volume
+        (String::new(), path.to_string())
+    }
+
     pub fn cleanup_io_path_lexical(path: &str) -> String {
         if path.is_empty() {
             return ".".to_string();


### PR DESCRIPTION
## Summary
- Add `canonpath_cygwin` that converts backslashes to forward slashes, handles drive letter prefixes, and preserves leading `//` (like QNX)
- Add `split_cygwin_volume` to extract drive letters (`c:`) and UNC paths (`//server/share`) as volume
- Update `split`, `join`, and `catpath` methods to handle volume for Cygwin/Win32 specs
- All 116 subtests in `roast/S32-io/io-spec-cygwin.t` now pass; added to whitelist

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S32-io/io-spec-cygwin.t` passes all 116 subtests
- [x] `make test` passes
- [x] `make roast` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `roast-whitelist.txt` sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)