### PR TITLE
fix: implement full IO::Spec::Win32 support (213 subtests)

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -615,7 +615,6 @@ impl Interpreter {
                 let is_cygwin = cn == "IO::Spec::Cygwin";
                 match method {
                     "canonpath" => {
-                        // Separate positional and named args (e.g. `:parent`).
                         let mut positional: Vec<&Value> = Vec::new();
                         let mut parent = false;
                         for a in &args {
@@ -628,7 +627,6 @@ impl Interpreter {
                             }
                         }
                         let first = positional.first().copied();
-                        // Undefined invocant (Any / Nil / type object) -> ''
                         let is_undef =
                             matches!(first, None | Some(Value::Nil) | Some(Value::Package(_)));
                         if is_undef {
@@ -637,7 +635,7 @@ impl Interpreter {
                         let path = first.map(|v| v.to_string_value()).unwrap_or_default();
                         let is_qnx = cn == "IO::Spec::QNX";
                         let cleaned = if is_win32 {
-                            Self::cleanup_io_path_lexical_win32(&path)
+                            Self::canonpath_win32(&path, parent)
                         } else if is_cygwin {
                             Self::canonpath_cygwin(&path, parent)
                         } else if is_qnx {
@@ -653,14 +651,17 @@ impl Interpreter {
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
                         let abs = if is_win32 {
-                            // Drive-letter, UNC, or leading slash/backslash.
                             let bytes = path.as_bytes();
-                            (bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic())
-                                || path.starts_with('/')
-                                || path.starts_with('\\')
+                            let drive_abs = bytes.len() >= 3
+                                && bytes[0].is_ascii_alphabetic()
+                                && bytes[1] == b':'
+                                && (bytes[2] == b'\\' || bytes[2] == b'/');
+                            let unc = bytes.len() >= 2
+                                && ((bytes[0] == b'\\' && bytes[1] == b'\\')
+                                    || (bytes[0] == b'/' && bytes[1] == b'/'));
+                            let leading = path.starts_with('/') || path.starts_with('\\');
+                            drive_abs || unc || leading
                         } else {
-                            // Unix: starts with '/'. Use chars().next() so that a
-                            // leading '/' followed by combining marks still counts.
                             path.starts_with('/')
                         };
                         return Ok(Value::Bool(abs));
@@ -669,7 +670,7 @@ impl Interpreter {
                         return Ok(Value::str_from(if is_win32 { "\\" } else { "/" }));
                     }
                     "devnull" => {
-                        return Ok(Value::str_from(if is_win32 { "NUL" } else { "/dev/null" }));
+                        return Ok(Value::str_from(if is_win32 { "nul" } else { "/dev/null" }));
                     }
                     "tmpdir" => {
                         #[cfg(not(target_arch = "wasm32"))]
@@ -679,12 +680,17 @@ impl Interpreter {
                         return Ok(self.make_io_path_instance(&tmpdir_str));
                     }
                     "curdir" => return Ok(Value::str_from(".")),
-                    "rootdir" => return Ok(Value::str_from("/")),
+                    "rootdir" => {
+                        return Ok(Value::str_from(if is_win32 { "\\" } else { "/" }));
+                    }
                     "updir" => return Ok(Value::str_from("..")),
                     "catdir" => {
                         let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
                         if parts.is_empty() {
                             return Ok(Value::str_from(""));
+                        }
+                        if is_win32 {
+                            return Ok(Value::str(Self::win32_catdir(&parts)));
                         }
                         let mut joined = parts.join("/");
                         joined.push('/');
@@ -693,18 +699,25 @@ impl Interpreter {
                     }
                     "catfile" => {
                         let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
+                        if is_win32 {
+                            return Ok(Value::str(Self::win32_catfile(&parts)));
+                        }
                         let joined = parts.join("/");
                         let result = Self::canonpath_unix(&joined, false);
                         return Ok(Value::str(result));
                     }
                     "curupdir" => {
-                        // Returns a matcher that accepts everything except "." and ".."
                         return Ok(Value::make_instance(
                             crate::symbol::Symbol::intern("IO::Spec::CurUpDir"),
                             std::collections::HashMap::new(),
                         ));
                     }
                     "path" => {
+                        if is_win32 {
+                            return Ok(Value::Seq(
+                                std::sync::Arc::new(Self::win32_path_from_env()),
+                            ));
+                        }
                         let path_env = std::env::var("PATH").unwrap_or_default();
                         if path_env.is_empty() {
                             return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
@@ -722,20 +735,60 @@ impl Interpreter {
                         return Ok(Value::Seq(std::sync::Arc::new(parts)));
                     }
                     "splitpath" => {
-                        let path = args
+                        let mut positional: Vec<&Value> = Vec::new();
+                        let mut nofile = false;
+                        for a in &args {
+                            if let Value::Pair(k, v) = a {
+                                if k == "nofile" {
+                                    nofile = v.truthy();
+                                }
+                            } else {
+                                positional.push(a);
+                            }
+                        }
+                        let path = positional
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
-                        // Split into (volume, directory, file)
-                        // On Unix, volume is always empty
-                        // If path ends with / or last component is . or ..,
-                        // treat entire path as directory with empty file
+                        if is_win32 {
+                            let (volume, after_vol) = Self::split_win32_volume_normalized(&path);
+                            let (dir, file) = if nofile
+                                || after_vol.ends_with('/')
+                                || after_vol.ends_with('\\')
+                            {
+                                (after_vol.to_string(), String::new())
+                            } else {
+                                let last_sep = after_vol.rfind(['/', '\\']);
+                                let basename = last_sep
+                                    .map(|pos| &after_vol[pos + 1..])
+                                    .unwrap_or(&after_vol);
+                                if basename == "." || basename == ".." {
+                                    (after_vol.to_string(), String::new())
+                                } else if let Some(pos) = last_sep {
+                                    (
+                                        after_vol[..=pos].to_string(),
+                                        after_vol[pos + 1..].to_string(),
+                                    )
+                                } else {
+                                    (String::new(), after_vol.to_string())
+                                }
+                            };
+                            return Ok(Value::Array(
+                                std::sync::Arc::new(vec![
+                                    Value::str(volume),
+                                    Value::str(dir),
+                                    Value::str(file),
+                                ]),
+                                crate::value::ArrayKind::List,
+                            ));
+                        }
                         let basename = path
                             .rfind('/')
                             .map(|pos| &path[pos + 1..])
                             .unwrap_or(path.as_str());
                         let (dir, file) =
-                            if path.ends_with('/') || basename == "." || basename == ".." {
+                            if nofile || path.ends_with('/') || basename == "." || basename == ".."
+                            {
                                 (path.as_str(), "")
                             } else if let Some(pos) = path.rfind('/') {
                                 (&path[..=pos], &path[pos + 1..])
@@ -756,23 +809,65 @@ impl Interpreter {
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
-                        // For Cygwin, convert backslashes to forward slashes first
+                        if is_win32 {
+                            let (volume, after_vol) = Self::split_win32_volume(&raw_path);
+                            let rest = after_vol;
+                            let is_sep = |c: char| c == '/' || c == '\\';
+                            let only_seps = !rest.is_empty() && rest.chars().all(is_sep);
+                            let (dirname, basename) = if only_seps {
+                                ("\\".to_string(), "\\".to_string())
+                            } else if rest.ends_with('/') || rest.ends_with('\\') {
+                                let trimmed = rest.trim_end_matches(['/', '\\']);
+                                if let Some(pos) = trimmed.rfind(['/', '\\']) {
+                                    let dir = if pos == 0 {
+                                        "\\".to_string()
+                                    } else {
+                                        trimmed[..pos].to_string()
+                                    };
+                                    (dir, trimmed[pos + 1..].to_string())
+                                } else {
+                                    (".".to_string(), trimmed.to_string())
+                                }
+                            } else if let Some(pos) = rest.rfind(['/', '\\']) {
+                                let dir = if pos == 0 {
+                                    "\\".to_string()
+                                } else {
+                                    rest[..pos].to_string()
+                                };
+                                (dir, rest[pos + 1..].to_string())
+                            } else if rest == "." {
+                                (".".to_string(), ".".to_string())
+                            } else if rest.is_empty() {
+                                if volume.starts_with("//") || volume.starts_with("\\\\") {
+                                    ("\\".to_string(), "\\".to_string())
+                                } else {
+                                    (".".to_string(), String::new())
+                                }
+                            } else {
+                                (".".to_string(), rest.to_string())
+                            };
+                            let mut hash = std::collections::HashMap::new();
+                            hash.insert("volume".to_string(), Value::str(volume));
+                            hash.insert("dirname".to_string(), Value::str(dirname));
+                            hash.insert("basename".to_string(), Value::str(basename));
+                            return Ok(Value::make_instance(
+                                crate::symbol::Symbol::intern("IO::Path::Parts"),
+                                hash,
+                            ));
+                        }
                         let path = if is_cygwin {
                             raw_path.replace('\\', "/")
                         } else {
                             raw_path
                         };
-                        // Extract volume for Cygwin (drive letter or UNC)
                         let (volume, rest) = if is_cygwin {
                             Self::split_cygwin_volume(&path)
                         } else {
                             ("".to_string(), path.clone())
                         };
-                        // Returns a hash with volume, dirname, basename
                         let (dirname, basename) = if rest == "/" {
                             ("/", "/")
                         } else if rest.ends_with('/') {
-                            // Trailing slash: strip it, then split
                             let trimmed = rest.trim_end_matches('/');
                             if let Some(pos) = trimmed.rfind('/') {
                                 let dir = if pos == 0 { "/" } else { &trimmed[..pos] };
@@ -804,6 +899,39 @@ impl Interpreter {
                             .unwrap_or_default();
                         let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
                         let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                        if is_win32 {
+                            let path_part = if file.is_empty() {
+                                if dir.is_empty() { String::new() } else { dir }
+                            } else if dir.is_empty() || dir == "." {
+                                file
+                            } else {
+                                let dir_is_sep = dir.chars().all(|c| c == '/' || c == '\\');
+                                let file_is_sep = file.chars().all(|c| c == '/' || c == '\\');
+                                if dir_is_sep && file_is_sep {
+                                    dir
+                                } else if dir.ends_with('/') || dir.ends_with('\\') {
+                                    format!("{}{}", dir, file)
+                                } else {
+                                    format!("{}\\{}", dir, file)
+                                }
+                            };
+                            let result = if !vol.is_empty() {
+                                if vol.starts_with("\\\\") {
+                                    let path_only_seps = !path_part.is_empty()
+                                        && path_part.chars().all(|c| c == '/' || c == '\\');
+                                    if path_only_seps || path_part.is_empty() {
+                                        vol
+                                    } else {
+                                        format!("{}{}", vol, path_part)
+                                    }
+                                } else {
+                                    format!("{}{}", vol, path_part)
+                                }
+                            } else {
+                                path_part
+                            };
+                            return Ok(Value::str(result));
+                        }
                         let path_part = if file.is_empty() {
                             if dir.is_empty() { String::new() } else { dir }
                         } else if dir.is_empty() || dir == "." {
@@ -815,8 +943,7 @@ impl Interpreter {
                         } else {
                             format!("{}/{}", dir, file)
                         };
-                        // Prepend volume for Cygwin/Win32
-                        let result = if (is_cygwin || is_win32) && !vol.is_empty() {
+                        let result = if is_cygwin && !vol.is_empty() {
                             format!("{}{}", vol, path_part)
                         } else {
                             path_part
@@ -834,8 +961,13 @@ impl Interpreter {
                                 crate::value::ArrayKind::List,
                             ));
                         }
-                        let parts: Vec<Value> =
-                            path.split('/').map(|s| Value::str(s.to_string())).collect();
+                        let parts: Vec<Value> = if is_win32 {
+                            path.split(['/', '\\'])
+                                .map(|s| Value::str(s.to_string()))
+                                .collect()
+                        } else {
+                            path.split('/').map(|s| Value::str(s.to_string())).collect()
+                        };
                         return Ok(Value::Array(
                             std::sync::Arc::new(parts),
                             crate::value::ArrayKind::List,
@@ -848,14 +980,17 @@ impl Interpreter {
                             .unwrap_or_default();
                         let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
                         let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                        let sep = if is_win32 { '\\' } else { '/' };
                         let mut result = dir;
                         if !file.is_empty() {
-                            if !result.is_empty() && !result.ends_with('/') {
-                                result.push('/');
+                            if !result.is_empty()
+                                && !result.ends_with('/')
+                                && !result.ends_with('\\')
+                            {
+                                result.push(sep);
                             }
                             result.push_str(&file);
                         }
-                        // Prepend volume for Cygwin/Win32
                         if (is_cygwin || is_win32) && !vol.is_empty() {
                             result = format!("{}{}", vol, result);
                         }
@@ -872,13 +1007,54 @@ impl Interpreter {
                                     .map(|p| p.to_string_lossy().to_string())
                                     .unwrap_or_else(|_| ".".to_string())
                             });
+                        if is_win32 {
+                            let path_canon = Self::canonpath_win32(&path_str, false);
+                            let base_canon = Self::canonpath_win32(&base_str, false);
+                            let (path_vol, path_rest) =
+                                Self::split_win32_volume_normalized(&path_canon);
+                            let (base_vol, base_rest) =
+                                Self::split_win32_volume_normalized(&base_canon);
+                            if path_vol != base_vol
+                                && ((!path_vol.is_empty()
+                                    && !base_vol.is_empty()
+                                    && path_vol.to_uppercase() != base_vol.to_uppercase())
+                                    || (path_vol.is_empty() != base_vol.is_empty())
+                                    || (path_vol.starts_with("\\\\")
+                                        != base_vol.starts_with("\\\\")))
+                            {
+                                return Ok(Value::str(path_canon));
+                            }
+                            let path_parts: Vec<&str> = path_rest
+                                .split(['/', '\\'])
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            let base_parts: Vec<&str> = base_rest
+                                .split(['/', '\\'])
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            let mut common = 0;
+                            while common < path_parts.len()
+                                && common < base_parts.len()
+                                && path_parts[common].eq_ignore_ascii_case(base_parts[common])
+                            {
+                                common += 1;
+                            }
+                            let ups = base_parts.len() - common;
+                            let mut result_parts: Vec<&str> = vec![".."; ups];
+                            result_parts.extend_from_slice(&path_parts[common..]);
+                            let result = if result_parts.is_empty() {
+                                ".".to_string()
+                            } else {
+                                result_parts.join("\\")
+                            };
+                            return Ok(Value::str(result));
+                        }
                         let path = Self::canonpath_unix(&path_str, false);
                         let base = Self::canonpath_unix(&base_str, false);
                         let path_parts: Vec<&str> =
                             path.split('/').filter(|s| !s.is_empty()).collect();
                         let base_parts: Vec<&str> =
                             base.split('/').filter(|s| !s.is_empty()).collect();
-                        // Find common prefix length
                         let mut common = 0;
                         while common < path_parts.len()
                             && common < base_parts.len()
@@ -907,6 +1083,28 @@ impl Interpreter {
                                     .map(|p| p.to_string_lossy().to_string())
                                     .unwrap_or_else(|_| ".".to_string())
                             });
+                        if is_win32 {
+                            let (path_vol, path_rest) =
+                                Self::split_win32_volume_normalized(&path_str);
+                            if !path_vol.is_empty()
+                                && (path_rest.starts_with('/') || path_rest.starts_with('\\'))
+                            {
+                                return Ok(Value::str(Self::canonpath_win32(&path_str, false)));
+                            }
+                            if path_str.starts_with('\\') || path_str.starts_with('/') {
+                                let (base_vol, _) = Self::split_win32_volume_normalized(&base_str);
+                                return Ok(Value::str(Self::canonpath_win32(
+                                    &format!("{}{}", base_vol, path_str),
+                                    false,
+                                )));
+                            }
+                            let mut result = base_str.clone();
+                            if !result.ends_with('/') && !result.ends_with('\\') {
+                                result.push('\\');
+                            }
+                            result.push_str(&path_str);
+                            return Ok(Value::str(Self::canonpath_win32(&result, false)));
+                        }
                         if path_str.starts_with('/') {
                             return Ok(Value::str(path_str));
                         }
@@ -915,19 +1113,25 @@ impl Interpreter {
                             result.push('/');
                         }
                         result.push_str(&path_str);
-                        let cleaned = Self::canonpath_unix(&result, false);
-                        return Ok(Value::str(cleaned));
+                        return Ok(Value::str(Self::canonpath_unix(&result, false)));
                     }
                     "basename" => {
                         let path = args
                             .first()
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
-                        // basename is the part after the last '/'
-                        let result = if let Some(pos) = path.rfind('/') {
-                            &path[pos + 1..]
+                        let result = if is_win32 {
+                            if let Some(pos) = path.rfind(['/', '\\']) {
+                                &path[pos + 1..]
+                            } else {
+                                path.as_str()
+                            }
                         } else {
-                            path.as_str()
+                            if let Some(pos) = path.rfind('/') {
+                                &path[pos + 1..]
+                            } else {
+                                path.as_str()
+                            }
                         };
                         return Ok(Value::str(result.to_string()));
                     }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1126,12 +1126,10 @@ impl Interpreter {
                             } else {
                                 path.as_str()
                             }
+                        } else if let Some(pos) = path.rfind('/') {
+                            &path[pos + 1..]
                         } else {
-                            if let Some(pos) = path.rfind('/') {
-                                &path[pos + 1..]
-                            } else {
-                                path.as_str()
-                            }
+                            path.as_str()
                         };
                         return Ok(Value::str(result.to_string()));
                     }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -371,7 +371,9 @@ impl Interpreter {
                             format!("{}{}{}", base, sep, p)
                         }
                     };
-                    Ok(Value::str(abs))
+                    // Canonicalize the result
+                    let cleaned = Self::canonpath_win32(&abs, false);
+                    Ok(Value::str(cleaned))
                 } else {
                     let base = args.first().map(|v| v.to_string_value());
                     if let Some(base) = base {
@@ -1347,6 +1349,75 @@ impl Interpreter {
         (String::new(), path.to_string())
     }
 
+    /// Extract Win32 volume (drive letter or UNC) from a path.
+    /// Returns (volume, rest) where rest is everything after the volume.
+    /// The volume preserves original slash style; callers should normalize if needed.
+    pub fn split_win32_volume(path: &str) -> (String, String) {
+        let bytes = path.as_bytes();
+        // UNC path: \\server\share or //server/share
+        if bytes.len() >= 2
+            && ((bytes[0] == b'\\' && bytes[1] == b'\\') || (bytes[0] == b'/' && bytes[1] == b'/'))
+        {
+            let after = &path[2..];
+            // Server name must be non-empty and not start with a separator
+            if !after.is_empty() && !after.starts_with('/') && !after.starts_with('\\') {
+                if let Some(server_end) = after.find(['/', '\\']) {
+                    let share_start = server_end + 1;
+                    let share_end = after[share_start..]
+                        .find(['/', '\\'])
+                        .map(|p| share_start + p)
+                        .unwrap_or(after.len());
+                    let volume = path[..2 + share_end].to_string();
+                    let rest = path[2 + share_end..].to_string();
+                    return (volume, rest);
+                }
+                // Only server, no share -- whole thing is volume
+                return (path.to_string(), String::new());
+            }
+        }
+        // Drive letter: X:
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let vol = path[..2].to_string();
+            let rest = path[2..].to_string();
+            return (vol, rest);
+        }
+        // No volume
+        (String::new(), path.to_string())
+    }
+
+    /// Like `split_win32_volume` but normalizes the volume (/ -> \).
+    pub fn split_win32_volume_normalized(path: &str) -> (String, String) {
+        let (vol, rest) = Self::split_win32_volume(path);
+        (vol.replace('/', "\\"), rest)
+    }
+
+    /// Win32 `.path` method: reads PATH (or Path), splits on `;`,
+    /// strips `"` characters from each entry, always prepends ".".
+    pub fn win32_path_from_env() -> Vec<Value> {
+        // PATH overrides Path
+        let path_env = if let Ok(v) = std::env::var("PATH") {
+            Some(v)
+        } else {
+            std::env::var("Path").ok()
+        };
+        let mut result = vec![Value::str_from(".")];
+        let raw = match path_env {
+            None => return result, // env unset -> (".",)
+            Some(v) => v,
+        };
+        if raw.is_empty() {
+            return result; // empty -> (".",)
+        }
+        // Win32 PATH parsing: split on `;`, strip `"` chars, skip empties.
+        for entry in raw.split(';') {
+            let cleaned: String = entry.chars().filter(|&c| c != '"').collect();
+            if !cleaned.is_empty() {
+                result.push(Value::str(cleaned));
+            }
+        }
+        result
+    }
+
     pub fn cleanup_io_path_lexical(path: &str) -> String {
         if path.is_empty() {
             return ".".to_string();
@@ -1391,55 +1462,233 @@ impl Interpreter {
         if out.is_empty() { ".".to_string() } else { out }
     }
 
-    /// Win32-specific cleanup: always uses `\` as separator.
-    pub fn cleanup_io_path_lexical_win32(path: &str) -> String {
+    /// Win32-specific canonpath with optional `:parent` resolution.
+    pub fn canonpath_win32(path: &str, parent: bool) -> String {
         if path.is_empty() {
-            return ".".to_string();
+            return String::new();
         }
         let mut prefix = String::new();
         let mut rest = path;
-        // Check for UNC paths
         let bytes = path.as_bytes();
+        // Check for UNC paths (\\server\share or //server/share)
+        // A valid UNC needs a non-empty server name that is not "." or "..".
         if path.len() >= 2
             && ((bytes[0] == b'\\' && bytes[1] == b'\\') || (bytes[0] == b'/' && bytes[1] == b'/'))
         {
-            // Extract UNC volume
             let after = &path[2..];
-            if let Some(sep1) = after.find(['/', '\\']) {
-                let after_server = &after[sep1 + 1..];
-                let share_end = after_server.find(['/', '\\']).unwrap_or(after_server.len());
-                let unc_end = 2 + sep1 + 1 + share_end;
-                prefix = path[..unc_end].replace('/', "\\");
-                rest = &path[unc_end..];
-            } else {
-                return path.replace('/', "\\");
+            let server_name = after.split(['/', '\\']).next().unwrap_or("");
+            let has_server = !server_name.is_empty() && server_name != "." && server_name != "..";
+            if has_server {
+                if let Some(sep1) = after.find(['/', '\\']) {
+                    let after_server = &after[sep1 + 1..];
+                    let share_end = after_server.find(['/', '\\']).unwrap_or(after_server.len());
+                    let unc_end = 2 + sep1 + 1 + share_end;
+                    prefix = path[..unc_end].replace('/', "\\");
+                    rest = &path[unc_end..];
+                } else {
+                    return path.replace('/', "\\");
+                }
             }
+            // else: not a valid UNC (e.g. "//" or "////"), treat as absolute path
         } else if path.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
-            prefix = path[..2].to_string();
+            // Drive letter -- uppercase it
+            let mut p = String::new();
+            p.push(bytes[0].to_ascii_uppercase() as char);
+            p.push(':');
+            prefix = p;
             rest = &path[2..];
         }
+
+        let is_unc = prefix.starts_with("\\\\");
         let is_absolute = rest.starts_with('/') || rest.starts_with('\\');
-        let mut stack: Vec<&str> = Vec::new();
+
+        let mut stack: Vec<String> = Vec::new();
         for seg in rest.split(['/', '\\']) {
             if seg.is_empty() || seg == "." {
                 continue;
             }
             if seg == ".." {
-                if !is_absolute || !stack.is_empty() {
-                    stack.push(seg);
+                if is_unc {
+                    // UNC paths: never go above \\server\share
+                    continue;
                 }
+                if parent {
+                    if stack.last().is_some_and(|last| *last != "..") {
+                        stack.pop();
+                        continue;
+                    }
+                    if is_absolute {
+                        continue;
+                    }
+                    stack.push("..".to_string());
+                } else {
+                    if is_absolute && stack.is_empty() {
+                        continue;
+                    }
+                    stack.push("..".to_string());
+                }
+                continue;
+            }
+            stack.push(seg.to_string());
+        }
+
+        let joined = stack.join("\\");
+        let mut out = prefix;
+        if is_absolute {
+            // For UNC paths, only add \ if there are segments to append
+            if !is_unc || !joined.is_empty() {
+                out.push('\\');
+            }
+        }
+        if !joined.is_empty() {
+            out.push_str(&joined);
+        }
+
+        if out.is_empty() { ".".to_string() } else { out }
+    }
+
+    // Legacy wrapper
+    pub fn cleanup_io_path_lexical_win32(path: &str) -> String {
+        Self::canonpath_win32(path, false)
+    }
+
+    /// Win32 catdir: join directory parts and canonicalize.
+    pub fn win32_catdir(parts: &[String]) -> String {
+        if parts.is_empty() {
+            return String::new();
+        }
+        let first_nonempty_idx = parts.iter().position(|p| !p.is_empty());
+        let had_leading_empties = first_nonempty_idx.is_some_and(|i| i > 0);
+
+        let (volume, first_rest) = if let Some(idx) = first_nonempty_idx {
+            if had_leading_empties {
+                (String::new(), (idx, parts[idx].clone()))
+            } else {
+                let (v, r) = Self::split_win32_volume_normalized(&parts[idx]);
+                (v, (idx, r))
+            }
+        } else {
+            (String::new(), (0, String::new()))
+        };
+
+        let starts_absolute = if first_nonempty_idx.is_some() {
+            let rest_starts_sep = first_rest.1.starts_with('/') || first_rest.1.starts_with('\\');
+            if !volume.is_empty() {
+                rest_starts_sep
+            } else {
+                had_leading_empties || rest_starts_sep
+            }
+        } else {
+            false
+        };
+
+        let mut all_segs: Vec<&str> = Vec::new();
+        for (i, part) in parts.iter().enumerate() {
+            let p = if Some(i) == first_nonempty_idx && !volume.is_empty() {
+                first_rest.1.as_str()
+            } else {
+                part.as_str()
+            };
+            for seg in p.split(['/', '\\']) {
+                all_segs.push(seg);
+            }
+        }
+
+        let mut stack: Vec<&str> = Vec::new();
+        let is_unc = volume.starts_with("\\\\");
+        for seg in &all_segs {
+            if seg.is_empty() || *seg == "." {
+                continue;
+            }
+            if *seg == ".." {
+                if is_unc || (starts_absolute && stack.is_empty()) {
+                    continue;
+                }
+                stack.push(seg);
                 continue;
             }
             stack.push(seg);
         }
+
         let joined = stack.join("\\");
-        let mut out = prefix;
-        if is_absolute {
+        let mut out = volume;
+        if (starts_absolute && !is_unc) || (is_unc && !joined.is_empty()) {
             out.push('\\');
         }
         if !joined.is_empty() {
             out.push_str(&joined);
         }
+
+        if out.is_empty() { ".".to_string() } else { out }
+    }
+
+    /// Win32 catfile: like catdir but without trailing separator treatment.
+    pub fn win32_catfile(parts: &[String]) -> String {
+        if parts.is_empty() {
+            return String::new();
+        }
+        let first_nonempty_idx = parts.iter().position(|p| !p.is_empty());
+        let had_leading_empties = first_nonempty_idx.is_some_and(|i| i > 0);
+
+        let (volume, first_rest) = if let Some(idx) = first_nonempty_idx {
+            if had_leading_empties {
+                (String::new(), (idx, parts[idx].clone()))
+            } else {
+                let (v, r) = Self::split_win32_volume_normalized(&parts[idx]);
+                (v, (idx, r))
+            }
+        } else {
+            (String::new(), (0, String::new()))
+        };
+
+        let starts_absolute = if first_nonempty_idx.is_some() {
+            let rest_starts_sep = first_rest.1.starts_with('/') || first_rest.1.starts_with('\\');
+            if !volume.is_empty() {
+                rest_starts_sep
+            } else {
+                had_leading_empties || rest_starts_sep
+            }
+        } else {
+            false
+        };
+
+        let mut all_segs: Vec<&str> = Vec::new();
+        for (i, part) in parts.iter().enumerate() {
+            let p = if Some(i) == first_nonempty_idx && !volume.is_empty() {
+                first_rest.1.as_str()
+            } else {
+                part.as_str()
+            };
+            for seg in p.split(['/', '\\']) {
+                all_segs.push(seg);
+            }
+        }
+
+        let mut stack: Vec<&str> = Vec::new();
+        let is_unc = volume.starts_with("\\\\");
+        for seg in &all_segs {
+            if seg.is_empty() || *seg == "." {
+                continue;
+            }
+            if *seg == ".." {
+                if is_unc || (starts_absolute && stack.is_empty()) {
+                    continue;
+                }
+                stack.push(seg);
+                continue;
+            }
+            stack.push(seg);
+        }
+
+        let joined = stack.join("\\");
+        let mut out = volume;
+        if (starts_absolute && !is_unc) || (is_unc && !joined.is_empty()) {
+            out.push('\\');
+        }
+        if !joined.is_empty() {
+            out.push_str(&joined);
+        }
+
         if out.is_empty() { ".".to_string() } else { out }
     }
 

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -10,6 +10,26 @@ impl Value {
     ///   1 eqv 1.0  → False  (Int vs Num)
     ///   [1,2] eqv (1,2)  → False  (Array vs List)
     pub(crate) fn eqv(&self, other: &Self) -> bool {
+        // Junction threading: if either side is a junction, thread eqv
+        // through it and return the boolean result of the junction.
+        if let Value::Junction { kind, values } = other {
+            let results: Vec<bool> = values.iter().map(|v| self.eqv(v)).collect();
+            return match kind {
+                crate::value::JunctionKind::Any => results.iter().any(|&b| b),
+                crate::value::JunctionKind::All => results.iter().all(|&b| b),
+                crate::value::JunctionKind::One => results.iter().filter(|&&b| b).count() == 1,
+                crate::value::JunctionKind::None => results.iter().all(|&b| !b),
+            };
+        }
+        if let Value::Junction { kind, values } = self {
+            let results: Vec<bool> = values.iter().map(|v| v.eqv(other)).collect();
+            return match kind {
+                crate::value::JunctionKind::Any => results.iter().any(|&b| b),
+                crate::value::JunctionKind::All => results.iter().all(|&b| b),
+                crate::value::JunctionKind::One => results.iter().filter(|&&b| b).count() == 1,
+                crate::value::JunctionKind::None => results.iter().all(|&b| !b),
+            };
+        }
         match (self, other) {
             // Arrays/Lists: must be same container type (Array vs List) and recursively eqv
             // eqv ignores Scalar wrapping — only Array vs List distinction matters


### PR DESCRIPTION
## Summary
- Implement comprehensive Win32 path handling in IO::Spec::Win32 to pass all 213 subtests in roast/S32-io/io-spec-win.t
- Add canonpath_win32 with :parent support, drive letter uppercasing, and UNC path handling
- Add Win32-specific implementations for catdir, catfile, splitpath, split, join, catpath, abs2rel, rel2abs, splitdir, basename, path, is-absolute, rootdir, and devnull
- Fix eqv to thread through junctions, enabling is-deeply to work with junction elements inside sequences
- Add roast/S32-io/io-spec-win.t to the whitelist

## Test plan
- [x] All 213 subtests in roast/S32-io/io-spec-win.t pass
- [x] make test passes (471 files, 3802 tests)
- [x] make roast passes (1117 files, 179094 tests)
- [x] cargo clippy -- -D warnings passes
- [x] cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)