### PR TITLE
fix: improve DateTime/Instant/Duration temporal precision and leap seconds

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -333,6 +333,7 @@
 - [ ] roast/S32-temporal/calendar.t
 - [ ] roast/S32-temporal/Date.t
 - [ ] roast/S32-temporal/DateTime-Instant-Duration.t
+  - 64/68 subtests pass; remaining 4 need: does-ok Rational role check, Duration % Real dispatch, Duration.new.tai Rat storage
 - [ ] roast/S32-temporal/DateTime.t
 - [ ] roast/S32-temporal/greg-jd-frac-seconds.t
 - [x] roast/S32-temporal/juliandate.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -183,6 +183,25 @@ fn instance_instant_value(value: &Value) -> Option<f64> {
         _ => None,
     }
 }
+fn instance_instant_raw(value: &Value) -> Option<Value> {
+    match value {
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name == "Instant" => attributes.get("value").cloned(),
+        _ => None,
+    }
+}
+fn value_sub(a: Value, b: Value) -> Value {
+    let (l, r) = runtime::coerce_numeric(a, b);
+    if let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r)) {
+        return crate::value::make_big_rat(an * &bd - bn * &ad, ad * bd);
+    }
+    Value::Num(
+        runtime::to_float_value(&l).unwrap_or(0.0) - runtime::to_float_value(&r).unwrap_or(0.0),
+    )
+}
 
 fn instance_duration_value(value: &Value) -> Option<f64> {
     match value {
@@ -555,27 +574,21 @@ fn arith_add_coerced(l: Value, r: Value) -> Value {
 }
 
 pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
-    if let (Some(a), Some(b)) = (
-        instance_instant_value(&left),
-        instance_instant_value(&right),
-    ) {
-        // Instant - Instant returns a Duration
-        return make_duration(a - b);
+    if let (Some(a), Some(b)) = (instance_instant_raw(&left), instance_instant_raw(&right)) {
+        return make_duration(runtime::to_float_value(&value_sub(a, b)).unwrap_or(0.0));
     }
-    // Instant - Duration => Instant
-    if let Some(a) = instance_instant_value(&left)
+    if let Some(a) = instance_instant_raw(&left)
         && let Some(dur) = instance_duration_value(&right)
     {
         let mut attrs = std::collections::HashMap::new();
-        attrs.insert("value".to_string(), Value::Num(a - dur));
+        attrs.insert("value".to_string(), value_sub(a, Value::Num(dur)));
         return Value::make_instance(Symbol::intern("Instant"), attrs);
     }
-    if let Some(a) = instance_instant_value(&left)
+    if let Some(a) = instance_instant_raw(&left)
         && right.is_numeric()
     {
-        let delta = runtime::to_float_value(&right).unwrap_or(0.0);
         let mut attrs = std::collections::HashMap::new();
-        attrs.insert("value".to_string(), Value::Num(a - delta));
+        attrs.insert("value".to_string(), value_sub(a, right));
         return Value::make_instance(Symbol::intern("Instant"), attrs);
     }
     // Duration - Duration returns Duration
@@ -901,6 +914,15 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
 }
 
 pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError> {
+    if let Some(dur) = instance_duration_value(&left)
+        && right.is_numeric()
+    {
+        let rhs = runtime::to_float_value(&right).unwrap_or(0.0);
+        if rhs == 0.0 {
+            return Err(RuntimeError::numeric_divide_by_zero());
+        }
+        return Ok(make_duration(dur.rem_euclid(rhs)));
+    }
     let (mut l, mut r) = runtime::coerce_numeric(left, right);
     // Mixed Num/Rat modulo should use floating semantics; routing through
     // exact-rational reduction loses expected precision behavior for cases like

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -869,6 +869,121 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
+    // Instant methods: to-posix, DateTime, Date, tai
+    if let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+    {
+        if class_name == "Instant" {
+            use crate::builtins::methods_0arg::temporal;
+            match method {
+                "to-posix" => {
+                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let tai = crate::runtime::to_float_value(&val).unwrap_or(0.0);
+                    let tai_int = tai.floor() as i64;
+                    let mut is_leap = false;
+                    for &(threshold, cumulative) in temporal::LEAP_SECONDS.iter().skip(1) {
+                        if tai_int == threshold + (cumulative - 1) {
+                            is_leap = true;
+                            break;
+                        }
+                    }
+                    let posix = temporal::instant_to_posix(tai);
+                    let posix_val = if posix == posix.floor() {
+                        Value::Int(posix as i64)
+                    } else {
+                        Value::Num(posix)
+                    };
+                    return Some(Ok(Value::array(vec![posix_val, Value::Bool(is_leap)])));
+                }
+                "DateTime" => {
+                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let (tai_int, tai_frac) = match &val {
+                        Value::Rat(n, d) if *d != 0 => (*n / *d, (*n % *d) as f64 / *d as f64),
+                        _ => {
+                            let f = crate::runtime::to_float_value(&val).unwrap_or(0.0);
+                            (f.floor() as i64, f - f.floor())
+                        }
+                    };
+                    let (y, m, d, h, mi, s) =
+                        temporal::instant_to_datetime_leap_aware_parts(tai_int, tai_frac, 0);
+                    return Some(Ok(temporal::make_datetime(y, m, d, h, mi, s, 0)));
+                }
+                "Date" => {
+                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let tai = crate::runtime::to_float_value(&val).unwrap_or(0.0);
+                    let posix = temporal::instant_to_posix(tai);
+                    let (y, m, d) = temporal::epoch_days_to_civil((posix / 86400.0).floor() as i64);
+                    return Some(Ok(temporal::make_date(y, m, d)));
+                }
+                "tai" => {
+                    return Some(Ok(attributes
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Int(0))));
+                }
+                _ => {}
+            }
+        }
+        if class_name == "Duration" {
+            match method {
+                "narrow" => {
+                    let val = attributes.get("value").cloned().unwrap_or(Value::Num(0.0));
+                    // Delegate narrow to the inner numeric value
+                    match val {
+                        Value::Num(f) if f.is_finite() => {
+                            let rounded = f.round();
+                            if (f - rounded).abs() <= f.abs().max(rounded.abs()) * 1e-15
+                                || (f == 0.0 && rounded == 0.0)
+                            {
+                                return Some(Ok(Value::Int(rounded as i64)));
+                            }
+                            // Convert Num to Rat for narrow
+                            let s = format!("{}", f);
+                            if let Some(dot) = s.find('.') {
+                                let dec = s.len() - dot - 1;
+                                let mut den = 1i64;
+                                for _ in 0..dec {
+                                    den *= 10;
+                                }
+                                let num_s: String = s.chars().filter(|c| *c != '.').collect();
+                                if let Ok(num) = num_s.parse::<i64>() {
+                                    let g = {
+                                        let (mut a, mut b) = (num.abs(), den);
+                                        while b != 0 {
+                                            let t = b;
+                                            b = a % b;
+                                            a = t;
+                                        }
+                                        a.max(1)
+                                    };
+                                    return Some(Ok(Value::Rat(num / g, den / g)));
+                                }
+                            }
+                            return Some(Ok(Value::Num(f)));
+                        }
+                        Value::Num(f) => return Some(Ok(Value::Num(f))),
+                        Value::Rat(n, d) if d != 0 && n % d == 0 => {
+                            return Some(Ok(Value::Int(n / d)));
+                        }
+                        Value::Rat(n, d) => return Some(Ok(Value::Rat(n, d))),
+                        Value::Int(i) => return Some(Ok(Value::Int(i))),
+                        _ => return Some(Ok(val)),
+                    }
+                }
+                "tai" => {
+                    return Some(Ok(attributes
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Num(0.0))));
+                }
+                _ => {}
+            }
+        }
+    }
+
     // Buf/Blob.Str throws X::Buf::AsStr
     if (method == "Str" || method == "Stringy")
         && let Value::Instance { class_name, .. } = target

--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -586,7 +586,7 @@ fn gcd_i64(a: i64, b: i64) -> i64 {
 /// Leap seconds table: (posix_timestamp_of_insertion, cumulative_leap_seconds).
 /// Each entry marks a point where a leap second was inserted.
 /// Raku's Instant uses TAI-like time = POSIX + offset (including leap seconds).
-const LEAP_SECONDS: &[(i64, i64)] = &[
+pub const LEAP_SECONDS: &[(i64, i64)] = &[
     (63_072_000, 10),    // 1972-01-01
     (78_796_800, 11),    // 1972-07-01
     (94_694_400, 12),    // 1973-01-01
@@ -655,6 +655,27 @@ pub fn instant_to_posix(instant: f64) -> f64 {
 /// Convert DateTime components to a leap-aware instant value.
 /// Unlike `posix_to_instant(datetime_to_posix(...))`, this keeps leap second
 /// values (`second in [60, 61)`) distinct from the following `:00` second.
+pub fn datetime_to_instant_parts(
+    year: i64,
+    month: i64,
+    day: i64,
+    hour: i64,
+    minute: i64,
+    second: f64,
+    timezone: i64,
+) -> (i64, f64) {
+    let sec_floor = second.floor() as i64;
+    let sec_frac = second - sec_floor as f64;
+    let epoch_days = civil_to_epoch_days(year, month, day);
+    let posix_int = epoch_days * 86_400 + hour * 3_600 + minute * 60 + sec_floor - timezone;
+    let leap_secs = leap_seconds_at(posix_int as f64 + sec_frac);
+    let mut tai_int = posix_int + leap_secs;
+    if second >= 60.0 {
+        tai_int -= 1;
+    }
+    (tai_int, sec_frac)
+}
+
 pub fn datetime_to_instant_leap_aware(
     year: i64,
     month: i64,
@@ -664,47 +685,50 @@ pub fn datetime_to_instant_leap_aware(
     second: f64,
     timezone: i64,
 ) -> f64 {
-    let posix = datetime_to_posix(year, month, day, hour, minute, second, timezone);
-    let mut instant = posix_to_instant(posix);
-    if second >= 60.0 {
-        instant -= 1.0;
-    }
-    instant
+    let (int_part, frac) =
+        datetime_to_instant_parts(year, month, day, hour, minute, second, timezone);
+    int_part as f64 + frac
 }
 
 /// Convert leap-aware instant value back to DateTime components in a timezone.
+pub fn instant_to_datetime_leap_aware_parts(
+    instant_int: i64,
+    instant_frac: f64,
+    timezone: i64,
+) -> (i64, i64, i64, i64, i64, f64) {
+    for &(threshold, cumulative) in LEAP_SECONDS.iter().skip(1) {
+        let leap_start = threshold + (cumulative - 1);
+        if instant_int == leap_start {
+            let local_int = (threshold - 1) + timezone;
+            let day_secs = local_int.rem_euclid(86_400);
+            let epoch_days = (local_int - day_secs) / 86_400;
+            let (y, m, d) = epoch_days_to_civil(epoch_days);
+            let h = day_secs / 3_600;
+            let mi = (day_secs % 3_600) / 60;
+            return (y, m, d, h, mi, 60.0 + instant_frac);
+        }
+    }
+    let mut posix_int = instant_int;
+    for _ in 0..3 {
+        let ls = leap_seconds_at(posix_int as f64);
+        posix_int = instant_int - ls;
+    }
+    let local_int = posix_int + timezone;
+    let day_secs = local_int.rem_euclid(86_400);
+    let epoch_days = (local_int - day_secs) / 86_400;
+    let (y, m, d) = epoch_days_to_civil(epoch_days);
+    let h = day_secs / 3_600;
+    let mi = (day_secs % 3_600) / 60;
+    (y, m, d, h, mi, (day_secs % 60) as f64 + instant_frac)
+}
+
 pub fn instant_to_datetime_leap_aware(
     instant: f64,
     timezone: i64,
 ) -> (i64, i64, i64, i64, i64, f64) {
-    for &(threshold, cumulative) in LEAP_SECONDS.iter().skip(1) {
-        let leap_start = threshold as f64 + (cumulative - 1) as f64;
-        if instant >= leap_start && instant < leap_start + 1.0 {
-            let frac = instant - leap_start;
-            let local = (threshold - 1) as f64 + frac + timezone as f64;
-            let total_i = local.floor() as i64;
-            let local_frac = local - total_i as f64;
-            let day_secs = total_i.rem_euclid(86_400);
-            let epoch_days = (total_i - day_secs) / 86_400;
-            let (y, m, d) = epoch_days_to_civil(epoch_days);
-            let h = day_secs / 3_600;
-            let mi = (day_secs % 3_600) / 60;
-            let s = 60.0 + local_frac;
-            return (y, m, d, h, mi, s);
-        }
-    }
-
-    let posix = instant_to_posix(instant);
-    let local = posix + timezone as f64;
-    let total_i = local.floor() as i64;
-    let frac = local - total_i as f64;
-    let day_secs = total_i.rem_euclid(86_400);
-    let epoch_days = (total_i - day_secs) / 86_400;
-    let (y, m, d) = epoch_days_to_civil(epoch_days);
-    let h = day_secs / 3_600;
-    let mi = (day_secs % 3_600) / 60;
-    let s = (day_secs % 60) as f64 + frac;
-    (y, m, d, h, mi, s)
+    let instant_int = instant.floor() as i64;
+    let instant_frac = instant - instant_int as f64;
+    instant_to_datetime_leap_aware_parts(instant_int, instant_frac, timezone)
 }
 
 #[cfg(test)]

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -26,7 +26,7 @@ fn f64_to_decimal_rat(f: f64) -> Value {
     Value::Num(f)
 }
 
-fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
+pub(crate) fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
     while b != 0 {
         let t = b;
         b = a % b;
@@ -97,10 +97,9 @@ pub fn date_method_0arg(
         }
         "DateTime" => Some(Ok(make_datetime(year, month, day, 0, 0, 0.0, 0))),
         "Instant" => {
-            let posix = civil_to_epoch_days(year, month, day) as f64 * 86400.0;
-            let tai = posix_to_instant(posix);
+            let (int_part, _) = datetime_to_instant_parts(year, month, day, 0, 0, 0.0, 0);
             let mut attrs = HashMap::new();
-            attrs.insert("value".to_string(), Value::Num(tai));
+            attrs.insert("value".to_string(), Value::Int(int_part));
             Some(Ok(Value::make_instance(Symbol::intern("Instant"), attrs)))
         }
         "raku" | "perl" => Some(Ok(Value::str(format!(
@@ -226,10 +225,18 @@ pub fn datetime_method_0arg(
             Some(Ok(crate::value::make_rat(n, d)))
         }
         "Instant" => {
-            let posix = datetime_to_posix(year, month, day, hour, minute, second, timezone);
-            let tai = posix_to_instant(posix);
+            let (int_part, frac) =
+                datetime_to_instant_parts(year, month, day, hour, minute, second, timezone);
             let mut attrs = HashMap::new();
-            attrs.insert("value".to_string(), Value::Num(tai));
+            if frac == 0.0 {
+                attrs.insert("value".to_string(), Value::Int(int_part));
+            } else {
+                let scale = 1_000_000_000i64;
+                let frac_num = (frac * scale as f64).round() as i64;
+                let num = int_part * scale + frac_num;
+                let g = gcd_i64(num.abs(), scale);
+                attrs.insert("value".to_string(), Value::Rat(num / g, scale / g));
+            }
             Some(Ok(Value::make_instance(Symbol::intern("Instant"), attrs)))
         }
         "DateTime" => Some(Ok(make_datetime(

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -886,13 +886,51 @@ impl Interpreter {
                     return Ok(Self::version_from_value(arg));
                 }
                 "Duration" => {
-                    let secs = args
-                        .first()
-                        .map(to_float_value)
-                        .unwrap_or(Some(0.0))
-                        .unwrap_or(0.0);
+                    let secs = if let Some(arg) = args.first() {
+                        if let Value::Str(s) = arg {
+                            match s.parse::<f64>() {
+                                Ok(f) => f,
+                                Err(_) => {
+                                    let mut err = RuntimeError::new(format!(
+                                        "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
+                                        s
+                                    ));
+                                    let mut eattrs = HashMap::new();
+                                    eattrs.insert("source".to_string(), Value::str(s.to_string()));
+                                    eattrs.insert("pos".to_string(), Value::Int(0));
+                                    eattrs.insert(
+                                        "reason".to_string(),
+                                        Value::str(
+                                            "base-10 number must begin with valid digits or '.'"
+                                                .to_string(),
+                                        ),
+                                    );
+                                    err.exception = Some(Box::new(Value::make_instance(
+                                        Symbol::intern("X::Str::Numeric"),
+                                        eattrs,
+                                    )));
+                                    return Err(err);
+                                }
+                            }
+                        } else {
+                            to_float_value(arg).unwrap_or(0.0)
+                        }
+                    } else {
+                        0.0
+                    };
+                    let val = if secs.is_infinite() {
+                        if secs > 0.0 {
+                            Value::Rat(1, 0)
+                        } else {
+                            Value::Rat(-1, 0)
+                        }
+                    } else if secs.is_nan() {
+                        Value::Rat(0, 0)
+                    } else {
+                        Value::Num(secs)
+                    };
                     let mut attrs = HashMap::new();
-                    attrs.insert("value".to_string(), Value::Num(secs));
+                    attrs.insert("value".to_string(), val);
                     return Ok(Value::make_instance(Symbol::intern("Duration"), attrs));
                 }
                 "StrDistance" => {
@@ -968,12 +1006,10 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Instant" => {
-                                // Convert Instant to Date via POSIX
-                                let tai = match attributes.get("value") {
-                                    Some(Value::Num(v)) => *v,
-                                    Some(Value::Int(v)) => *v as f64,
-                                    _ => 0.0,
-                                };
+                                let tai = attributes
+                                    .get("value")
+                                    .and_then(crate::runtime::to_float_value)
+                                    .unwrap_or(0.0);
                                 let posix = temporal::instant_to_posix(tai);
                                 let epoch_days = (posix / 86400.0).floor() as i64;
                                 let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
@@ -1185,24 +1221,26 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Instant" => {
-                                let tai = match attributes.get("value") {
-                                    Some(Value::Num(n)) => *n,
-                                    Some(Value::Int(n)) => *n as f64,
-                                    _ => 0.0,
+                                let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                                let (tai_int, tai_frac) = match &val {
+                                    Value::Rat(n, d) if *d != 0 => {
+                                        (*n / *d, (*n % *d) as f64 / *d as f64)
+                                    }
+                                    _ => {
+                                        let f = crate::runtime::to_float_value(&val).unwrap_or(0.0);
+                                        (f.floor() as i64, f - f.floor())
+                                    }
                                 };
-                                // Convert from TAI (Instant) to POSIX
-                                let epoch = temporal::instant_to_posix(tai);
-                                let total_i = epoch.floor() as i64;
-                                let frac = epoch - total_i as f64;
-                                let day_secs = total_i.rem_euclid(86400);
-                                let epoch_days = (total_i - day_secs) / 86400;
-                                let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
+                                let (y, m, d, h, mi, s) =
+                                    temporal::instant_to_datetime_leap_aware_parts(
+                                        tai_int, tai_frac, timezone,
+                                    );
                                 year = y;
                                 month = m;
                                 day = d;
-                                hour = day_secs / 3600;
-                                minute = (day_secs % 3600) / 60;
-                                second = (day_secs % 60) as f64 + frac;
+                                hour = h;
+                                minute = mi;
+                                second = s;
                                 has_named = true;
                             }
                             other if other.is_numeric() => {


### PR DESCRIPTION
## Summary
- Store Instant values as Rat instead of f64 to preserve fractional second precision during subtraction
- Use integer-based Instant↔POSIX conversion to keep fractional seconds exact
- Fix DateTime.Instant to use leap-aware conversion (second=60 is now distinct from second=0 of next day)
- Fix DateTime.new(Instant) to use leap-aware + timezone-aware conversion
- Add Instant methods: to-posix, DateTime, Date, tai
- Add Duration methods: narrow, tai
- Add Duration % Real arithmetic and Duration.new string validation (X::Str::Numeric)

## Test plan
- [x] `prove -e target/debug/mutsu roast/S32-temporal/DateTime-Instant-Duration.t` passes 64/68 subtests (up from 22/34)
- [x] `make test` passes (all 471 test files, 3802 subtests)
- [ ] `make roast` (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)