### PR TITLE
fix: pass all 29 subtests in roast/S06-operator-overloading/sub.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -419,6 +419,7 @@ roast/S06-operator-overloading/circumfix.t
 roast/S06-operator-overloading/methods.t
 roast/S06-operator-overloading/prefix.t
 roast/S06-operator-overloading/semicolon.t
+roast/S06-operator-overloading/sub.t
 roast/S06-operator-overloading/term.t
 roast/S06-operator-overloading/workout.t
 roast/S06-other/anon-hashes-vs-blocks.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1282,6 +1282,30 @@ fn parse_require_expr<'a>(input: &'a str, rest: &'a str) -> PResult<'a, Expr> {
     Ok((rest, make_call_expr("require".to_string(), input, args)))
 }
 
+/// Try to extend an identifier with colon-pair adverbs (e.g. `meow:foo<bar>`).
+/// Returns the extended name and remaining input, or the original name and input unchanged.
+fn try_extend_colon_name<'a>(input: &'a str, base: &str) -> (&'a str, String) {
+    let mut rest = input;
+    let mut name = base.to_string();
+    while rest.starts_with(':') && !rest.starts_with(":<") && !rest.starts_with(":<<") {
+        let r = &rest[1..];
+        // Try to parse identifier part
+        if let Ok((r2, part)) =
+            take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')
+            && let Some(after_open) = r2.strip_prefix('<')
+            && let Some(end) = after_open.find('>')
+        {
+            name.push(':');
+            name.push_str(part);
+            name.push_str(&r2[..=end + 1]);
+            rest = &r2[end + 2..];
+            continue;
+        }
+        break;
+    }
+    (rest, name)
+}
+
 pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     let (rest, name) = super::super::stmt::parse_raku_ident(input)?;
     let name = normalize_raku_identifier(name);
@@ -1304,6 +1328,44 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     right: Box::new(value),
                 },
             ));
+        }
+    }
+
+    // Try to extend the identifier with colon-pair adverbs (e.g. meow:foo<bar>)
+    // if the extended name matches a known user-defined sub.
+    {
+        let (extended_rest, extended_name) = try_extend_colon_name(rest, &name);
+        if extended_name != name
+            && crate::parser::stmt::simple::is_user_declared_sub(&extended_name)
+        {
+            let (r, _) = ws(extended_rest)?;
+            if let Some(r) = r.strip_prefix('(') {
+                let (r, _) = ws(r)?;
+                let full_name = Symbol::intern(&extended_name);
+                if let Some(r) = r.strip_prefix(')') {
+                    return Ok((
+                        r,
+                        Expr::Call {
+                            name: full_name,
+                            args: vec![],
+                        },
+                    ));
+                }
+                let (r, args) = parse_call_arg_list(r)?;
+                let (r, _) = ws(r)?;
+                let Some(r) = r.strip_prefix(')') else {
+                    return Err(PError::expected("')'"));
+                };
+                return Ok((
+                    r,
+                    Expr::Call {
+                        name: full_name,
+                        args,
+                    },
+                ));
+            }
+            // No parens — bare reference
+            return Ok((extended_rest, Expr::BareWord(extended_name)));
         }
     }
 

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -199,6 +199,9 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
         try_primary!(container::itemized_paren_expr(input));
         try_primary!(container::itemized_bracket_expr(input));
         try_primary!(container::itemized_brace_expr(input));
+        // User-declared circumfix operators must be checked before variable parsers
+        // so that e.g. circumfix:<@ @> is recognized before `@` is parsed as an array sigil.
+        try_primary!(ident::declared_circumfix_op(input));
         try_primary!(var::scalar_var(input));
         try_primary!(var::array_var(input));
         try_primary!(container::percent_hash_literal(input));
@@ -223,7 +226,6 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
         try_primary!(misc::anon_class_expr(input));
         // anonymous grammar: grammar { ... }
         try_primary!(misc::anon_grammar_expr(input));
-        try_primary!(ident::declared_circumfix_op(input));
 
         match ident::identifier_or_call(input) {
             Ok(r) => Ok(r),

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -359,64 +359,134 @@ pub(super) fn parse_sub_name(input: &str) -> PResult<'_, String> {
             return Ok((after_close, full_name));
         }
     }
+    // Handle all bracket forms: :['op'], :["op"], :["op1", "op2"], :[sym], :[sym1, sym2]
     if is_op_category
         && rest.starts_with(":[")
-        && let Some(after_open) = rest.strip_prefix(":['")
-        && let Some(end_pos) = after_open.find("']")
+        && let Some(result) = parse_bracket_op_name(&rest[2..], &base)
     {
-        let op_symbol = unescape_operator_single_quoted(&after_open[..end_pos]);
-        let after_close = &after_open[end_pos + 2..];
-        let full_name = format!("{}:<{}>", base, op_symbol);
-        return Ok((after_close, full_name));
+        return Ok(result);
     }
-    if is_op_category
-        && rest.starts_with(":[")
-        && let Some(after_open) = rest.strip_prefix(":[\"")
-        && let Some(end_pos) = after_open.find("\"]")
-    {
-        let op_symbol = unescape_operator_double_quoted(&after_open[..end_pos]);
-        let after_close = &after_open[end_pos + 2..];
-        let full_name = format!("{}:<{}>", base, op_symbol);
-        return Ok((after_close, full_name));
+    Ok((rest, base))
+}
+
+/// Parse the content inside `:[...]` for operator sub names.
+/// Handles: `["op"]`, `['op']`, `["op1", "op2"]`, `[sym]`, `[sym1, sym2]`
+/// Returns `(remaining_input, full_name)` on success.
+fn parse_bracket_op_name<'a>(input: &'a str, base: &str) -> Option<(&'a str, String)> {
+    let bracket_end = find_closing_bracket(input)?;
+    let content = &input[..bracket_end];
+    let after_close = &input[bracket_end + 1..];
+
+    let parts = parse_bracket_parts(content)?;
+    if parts.is_empty() {
+        return None;
     }
-    // Bare identifier form: infix:[sym] or circumfix:[sym1, sym2]
-    // where the identifiers are compile-time constants
-    if is_op_category
-        && let Some(after_open) = rest.strip_prefix(":[")
-        && let Some(end_pos) = after_open.find(']')
-    {
-        let content = after_open[..end_pos].trim();
-        // Check if content contains comma-separated parts (for circumfix)
-        let parts: Vec<&str> = content.split(',').map(|s| s.trim()).collect();
-        let mut resolved_parts = Vec::new();
-        let mut all_resolved = true;
-        for part in &parts {
-            let p = part.trim_matches(|c: char| c == '"' || c == '\'');
-            // Try to resolve as a compile-time constant
-            if let Some(value) = super::simple::lookup_compile_time_constant(p) {
-                resolved_parts.push(value);
-            } else if let Some(bare) = p.strip_prefix('$') {
-                if let Some(value) = super::simple::lookup_compile_time_constant(bare) {
-                    resolved_parts.push(value);
-                } else if let Some(value) = super::simple::lookup_compile_time_constant(p) {
-                    resolved_parts.push(value);
-                } else {
-                    all_resolved = false;
-                    break;
+
+    let op_symbol = parts.join(" ");
+    let full_name = format!("{}:<{}>", base, op_symbol);
+    Some((after_close, full_name))
+}
+
+/// Find the position of the closing `]`, skipping over quoted strings.
+fn find_closing_bracket(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b']' => return Some(i),
+            b'"' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                    } else if bytes[i] == b'"' {
+                        i += 1;
+                        break;
+                    } else {
+                        i += 1;
+                    }
                 }
-            } else {
-                all_resolved = false;
+            }
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        i += 1;
+                        break;
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Parse comma-separated parts inside brackets.
+/// Each part can be a double-quoted string, single-quoted string, or bare identifier.
+fn parse_bracket_parts(content: &str) -> Option<Vec<String>> {
+    let mut parts = Vec::new();
+    let mut rest = content.trim();
+
+    while !rest.is_empty() {
+        if !parts.is_empty() {
+            rest = rest.strip_prefix(',')?.trim();
+            if rest.is_empty() {
                 break;
             }
         }
-        if all_resolved && !resolved_parts.is_empty() {
-            let after_close = &after_open[end_pos + 1..];
-            let op_symbol = resolved_parts.join(" ");
-            let full_name = format!("{}:<{}>", base, op_symbol);
-            return Ok((after_close, full_name));
+        if let Some(after_quote) = rest.strip_prefix('"') {
+            let mut end = 0;
+            let mut escaped = false;
+            for (i, c) in after_quote.char_indices() {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if c == '\\' {
+                    escaped = true;
+                    continue;
+                }
+                if c == '"' {
+                    end = i;
+                    break;
+                }
+            }
+            let raw = &after_quote[..end];
+            parts.push(unescape_operator_double_quoted(raw));
+            rest = after_quote[end + 1..].trim();
+        } else if let Some(after_quote) = rest.strip_prefix('\'') {
+            if let Some(end) = after_quote.find('\'') {
+                let raw = &after_quote[..end];
+                parts.push(unescape_operator_single_quoted(raw));
+                rest = after_quote[end + 1..].trim();
+            } else {
+                return None;
+            }
+        } else {
+            let ident_end = rest
+                .find(|c: char| c == ',' || c == ']' || c.is_whitespace())
+                .unwrap_or(rest.len());
+            let ident = rest[..ident_end].trim();
+            if let Some(value) = super::simple::lookup_compile_time_constant(ident) {
+                parts.push(value);
+            } else if let Some(bare) = ident.strip_prefix('$') {
+                if let Some(value) = super::simple::lookup_compile_time_constant(bare) {
+                    parts.push(value);
+                } else if let Some(value) = super::simple::lookup_compile_time_constant(ident) {
+                    parts.push(value);
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+            rest = rest[ident_end..].trim();
         }
     }
-    Ok((rest, base))
+    Some(parts)
 }
 
 /// Validate that circumfix/postcircumfix operators have exactly 2 delimiter parts.


### PR DESCRIPTION
## Summary
- Fix bracket-delimited operator name parsing for multi-part forms like `circumfix:["@", "@"]` which were incorrectly stored as `circumfix:<@", "@>` instead of `circumfix:<@ @>`
- Move user-declared circumfix operator matching before variable parsers so openers like `@` are recognized as circumfix delimiters before being consumed as array sigils
- Support colon-name extended sub names at call sites (e.g. `meow:foo<bar>()`) by extending identifier parsing to check for matching user-defined subs

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-operator-overloading/sub.t` passes all 29 subtests
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] `make test` passes (only pre-existing `t/prompt-behavior.t` failure)
- [x] `make roast` passes all whitelisted tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)