### PR TITLE
fix: add QuantHash to known type constraints

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -111,6 +111,7 @@ roast/S02-types/bool.t
 roast/S02-types/built-in.t
 roast/S02-types/catch_type_cast_mismatch.t
 roast/S02-types/compact.t
+roast/S02-types/declare.t
 roast/S02-types/fatrat.t
 roast/S02-types/hash_ref.t
 roast/S02-types/hyperwhatever.t
@@ -837,6 +838,7 @@ roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
 roast/S26-documentation/07c-tables.t
+roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -838,7 +838,6 @@ roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
 roast/S26-documentation/07c-tables.t
-roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -812,6 +812,7 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "BagHash"
             | "Mix"
             | "MixHash"
+            | "QuantHash"
             | "Blob"
             | "Buf"
             | "Junction"

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -29,6 +29,7 @@ fn is_core_raku_type(name: &str) -> bool {
             | "SetHash"
             | "BagHash"
             | "MixHash"
+            | "QuantHash"
             | "Capture"
             | "Signature"
             | "Parameter"


### PR DESCRIPTION
## Summary
- Added `QuantHash` to `is_known_type_constraint()` in `src/runtime/utils.rs` and `is_core_raku_type()` in `src/vm/vm_misc_ops.rs`
- This allows `my QuantHash $x` declarations to work, which was the only blocker for roast/S02-types/declare.t
- Added roast/S02-types/declare.t to the whitelist (all 70 subtests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/declare.t` passes (70/70)
- [x] `make test` passes (only pre-existing flaky t/lock.t failure)
- [x] `make roast` passes (only pre-existing failures in smiley.t, construction-recursion.t, reverse.t)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)