### PR TITLE
fix: implement full Pod config parsing (98 subtests)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -837,6 +837,7 @@ roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
 roast/S26-documentation/07c-tables.t
+roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t
 roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -199,10 +199,26 @@ impl Interpreter {
     }
 
     fn make_pod_code(text: String) -> Value {
+        Self::make_pod_code_with_config(text, HashMap::new())
+    }
+
+    fn make_pod_code_with_config(text: String, config: HashMap<String, Value>) -> Value {
         let mut attrs = HashMap::new();
-        attrs.insert("contents".to_string(), Value::array(vec![Value::str(text)]));
-        attrs.insert("config".to_string(), Value::hash(HashMap::new()));
+        let contents = if config.contains_key("allow") {
+            Self::parse_formatting_codes(&text)
+        } else {
+            vec![Value::str(text)]
+        };
+        attrs.insert("contents".to_string(), Value::array(contents));
+        attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("Pod::Block::Code"), attrs)
+    }
+
+    fn make_pod_config(type_name: &str, config: HashMap<String, Value>) -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert("type".to_string(), Value::str(type_name.to_string()));
+        attrs.insert("config".to_string(), Value::hash(config));
+        Value::make_instance(Symbol::intern("Pod::Config"), attrs)
     }
 
     fn make_pod_item(level: i64, contents: Vec<Value>) -> Value {
@@ -357,10 +373,9 @@ impl Interpreter {
         (Self::make_pod_defn(term, contents, config), idx)
     }
 
-    /// Parse Pod config adverbs from a directive tail (e.g. `:numbered :foo(0)`).
-    /// Returns (config_map, leftover_text_after_adverbs).
-    /// Supported forms: `:key`, `:!key`, `:key(value)` where value is an integer
-    /// or bareword (true/false treated as Bool).
+    /// Parse Pod config adverbs from a directive tail.
+    /// Supports all Raku Pod config value forms including `:key<str>`, `:key(val)`,
+    /// `:key[val]`, `:key{k=>v}`, `:!key`, `:NNNkey`, lists, hashes, typed scalars.
     fn parse_pod_config(input: &str) -> (HashMap<String, Value>, &str) {
         let mut config: HashMap<String, Value> = HashMap::new();
         let mut s = input.trim_start();
@@ -374,6 +389,27 @@ impl Interpreter {
             } else {
                 (false, rest)
             };
+            // Check for `:NNNkey` numeric prefix shorthand
+            let digit_prefix_len = rest.bytes().take_while(|b| b.is_ascii_digit()).count();
+            if digit_prefix_len > 0 && !negated {
+                let after_digits = &rest[digit_prefix_len..];
+                let name_len = after_digits
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                    .map(char::len_utf8)
+                    .sum::<usize>();
+                if name_len > 0 {
+                    let name = &after_digits[..name_len];
+                    let num_str = &rest[..digit_prefix_len];
+                    let val = num_str
+                        .parse::<i64>()
+                        .map(Value::Int)
+                        .unwrap_or_else(|_| Value::str(num_str.to_string()));
+                    config.insert(name.to_string(), val);
+                    s = after_digits[name_len..].trim_start();
+                    continue;
+                }
+            }
             // Read identifier
             let name_len = rest
                 .chars()
@@ -385,20 +421,33 @@ impl Interpreter {
             }
             let name = &rest[..name_len];
             let after_name = &rest[name_len..];
-            let (value, after_val) = if let Some(after_paren) = after_name.strip_prefix('(') {
-                // Read until matching ')'
-                if let Some(close_idx) = after_paren.find(')') {
-                    let raw = after_paren[..close_idx].trim();
-                    let v = if let Ok(n) = raw.parse::<i64>() {
-                        Value::Int(n)
-                    } else if raw == "True" {
-                        Value::Bool(true)
-                    } else if raw == "False" {
-                        Value::Bool(false)
-                    } else {
-                        Value::str(raw.to_string())
-                    };
-                    (v, &after_paren[close_idx + 1..])
+            let (value, after_val) = if let Some(after_open) = after_name.strip_prefix('<') {
+                // :key<value> -- angle bracket form (always Str)
+                if let Some(close_idx) = after_open.find('>') {
+                    let raw = &after_open[..close_idx];
+                    (Value::str(raw.to_string()), &after_open[close_idx + 1..])
+                } else {
+                    break;
+                }
+            } else if after_name.starts_with('(') || after_name.starts_with('[') {
+                let (open, close) = if after_name.starts_with('(') {
+                    ('(', ')')
+                } else {
+                    ('[', ']')
+                };
+                let after_open = &after_name[1..];
+                if let Some(close_idx) = Self::find_balanced_close(after_open, open, close) {
+                    let inner = &after_open[..close_idx];
+                    let v = Self::parse_pod_config_value(inner);
+                    (v, &after_open[close_idx + 1..])
+                } else {
+                    break;
+                }
+            } else if let Some(after_brace) = after_name.strip_prefix('{') {
+                if let Some(close_idx) = Self::find_balanced_close(after_brace, '{', '}') {
+                    let inner = &after_brace[..close_idx];
+                    let v = Self::parse_pod_config_hash(inner);
+                    (v, &after_brace[close_idx + 1..])
                 } else {
                     break;
                 }
@@ -409,6 +458,374 @@ impl Interpreter {
             s = after_val.trim_start();
         }
         (config, s)
+    }
+
+    fn find_balanced_close(input: &str, open: char, close: char) -> Option<usize> {
+        let mut depth = 0i32;
+        let mut chars = input.char_indices();
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        while let Some((i, c)) = chars.next() {
+            if in_single_quote {
+                if c == '\'' {
+                    in_single_quote = false;
+                }
+                continue;
+            }
+            if in_double_quote {
+                if c == '\\' {
+                    chars.next();
+                    continue;
+                }
+                if c == '"' {
+                    in_double_quote = false;
+                }
+                continue;
+            }
+            if c == '\'' {
+                in_single_quote = true;
+                continue;
+            }
+            if c == '"' {
+                in_double_quote = true;
+                continue;
+            }
+            if c == open {
+                depth += 1;
+            } else if c == close {
+                if depth == 0 {
+                    return Some(i);
+                }
+                depth -= 1;
+            }
+        }
+        None
+    }
+
+    fn parse_pod_config_value(inner: &str) -> Value {
+        let trimmed = inner.trim();
+        if Self::pod_config_is_list(trimmed) {
+            let items = Self::parse_pod_config_list_items(trimmed);
+            if items.len() == 1 {
+                return items.into_iter().next().unwrap();
+            }
+            return Value::array(items);
+        }
+        Self::parse_pod_config_scalar(trimmed)
+    }
+
+    fn pod_config_is_list(input: &str) -> bool {
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut depth = 0i32;
+        let mut chars = input.chars();
+        while let Some(c) = chars.next() {
+            if in_single {
+                if c == '\'' {
+                    in_single = false;
+                }
+                continue;
+            }
+            if in_double {
+                if c == '\\' {
+                    chars.next();
+                    continue;
+                }
+                if c == '"' {
+                    in_double = false;
+                }
+                continue;
+            }
+            if c == '\'' {
+                in_single = true;
+            } else if c == '"' {
+                in_double = true;
+            } else if c == '(' || c == '[' || c == '{' {
+                depth += 1;
+            } else if c == ')' || c == ']' || c == '}' {
+                depth -= 1;
+            } else if c == ',' && depth == 0 {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn parse_pod_config_list_items(input: &str) -> Vec<Value> {
+        let mut items = Vec::new();
+        let mut start = 0;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut depth = 0i32;
+        let bytes = input.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let c = input[i..].chars().next().unwrap();
+            let clen = c.len_utf8();
+            if in_single {
+                if c == '\'' {
+                    in_single = false;
+                }
+                i += clen;
+                continue;
+            }
+            if in_double {
+                if c == '\\' {
+                    i += clen;
+                    if i < bytes.len() {
+                        i += input[i..].chars().next().map_or(1, |c2| c2.len_utf8());
+                    }
+                    continue;
+                }
+                if c == '"' {
+                    in_double = false;
+                }
+                i += clen;
+                continue;
+            }
+            if c == '\'' {
+                in_single = true;
+            } else if c == '"' {
+                in_double = true;
+            } else if c == '(' || c == '[' || c == '{' {
+                depth += 1;
+            } else if c == ')' || c == ']' || c == '}' {
+                depth -= 1;
+            } else if c == ',' && depth == 0 {
+                items.push(Self::parse_pod_config_scalar(input[start..i].trim()));
+                start = i + 1;
+                i += 1;
+                continue;
+            }
+            i += clen;
+        }
+        if start < input.len() {
+            items.push(Self::parse_pod_config_scalar(input[start..].trim()));
+        }
+        items
+    }
+
+    fn parse_pod_config_scalar(raw: &str) -> Value {
+        if raw.is_empty() {
+            return Value::str(String::new());
+        }
+        if raw == "True" {
+            return Value::Bool(true);
+        }
+        if raw == "False" {
+            return Value::Bool(false);
+        }
+        if raw.starts_with('\'') && raw.ends_with('\'') && raw.len() >= 2 {
+            return Value::str(raw[1..raw.len() - 1].to_string());
+        }
+        if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
+            let inner = &raw[1..raw.len() - 1];
+            let mut result = String::new();
+            let mut chars = inner.chars();
+            while let Some(c) = chars.next() {
+                if c == '\\' {
+                    if let Some(next) = chars.next() {
+                        match next {
+                            'n' => result.push('\n'),
+                            't' => result.push('\t'),
+                            '"' => result.push('"'),
+                            '\\' => result.push('\\'),
+                            _ => {
+                                result.push('\\');
+                                result.push(next);
+                            }
+                        }
+                    }
+                } else {
+                    result.push(c);
+                }
+            }
+            return Value::str(result);
+        }
+        if raw.starts_with("Q[") && raw.ends_with(']') {
+            return Value::str(raw[2..raw.len() - 1].to_string());
+        }
+        let num_str = raw.strip_prefix('+').unwrap_or(raw);
+        if !num_str.is_empty()
+            && (num_str.starts_with('-') || num_str.as_bytes()[0].is_ascii_digit())
+        {
+            let digits_str = num_str.strip_prefix('-').unwrap_or(num_str);
+            if !digits_str.is_empty() && digits_str.chars().all(|c| c.is_ascii_digit()) {
+                if let Ok(n) = num_str.parse::<i64>() {
+                    return Value::Int(n);
+                }
+                if let Ok(n) = num_str.parse::<num_bigint::BigInt>() {
+                    return Value::BigInt(std::sync::Arc::new(n));
+                }
+                return Value::str(raw.to_string());
+            }
+            if Self::looks_like_num(num_str)
+                && let Ok(f) = num_str.parse::<f64>()
+            {
+                return Value::Num(f);
+            }
+        }
+        Value::str(raw.to_string())
+    }
+
+    fn looks_like_num(s: &str) -> bool {
+        let s = s.strip_prefix('-').unwrap_or(s);
+        if s.is_empty() {
+            return false;
+        }
+        let mut has_dot = false;
+        let mut has_e = false;
+        let mut chars = s.chars().peekable();
+        while let Some(&c) = chars.peek() {
+            if c.is_ascii_digit() {
+                chars.next();
+            } else if c == '.' && !has_dot && !has_e {
+                has_dot = true;
+                chars.next();
+            } else if (c == 'e' || c == 'E') && !has_e {
+                has_e = true;
+                chars.next();
+                if chars.peek().is_some_and(|&c2| c2 == '+' || c2 == '-') {
+                    chars.next();
+                }
+            } else {
+                return false;
+            }
+        }
+        has_dot || has_e
+    }
+
+    fn parse_pod_config_hash(inner: &str) -> Value {
+        let mut map: HashMap<String, Value> = HashMap::new();
+        let items = Self::split_pod_config_top_level(inner, ',');
+        let mut pending_key: Option<String> = None;
+        for item in items {
+            let item = item.trim();
+            if item.is_empty() {
+                continue;
+            }
+            if let Some(arrow_pos) = Self::find_fat_arrow(item) {
+                pending_key = None;
+                let key = Self::unquote_pod_config_key(item[..arrow_pos].trim());
+                let val_str = item[arrow_pos + 2..].trim();
+                map.insert(key, Self::parse_pod_config_scalar(val_str));
+            } else if let Some(key) = pending_key.take() {
+                map.insert(key, Self::parse_pod_config_scalar(item));
+            } else {
+                pending_key = Some(Self::unquote_pod_config_key(item));
+            }
+        }
+        Value::hash(map)
+    }
+
+    fn find_fat_arrow(input: &str) -> Option<usize> {
+        let mut in_single = false;
+        let mut in_double = false;
+        let bytes = input.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let c = input[i..].chars().next().unwrap();
+            let clen = c.len_utf8();
+            if in_single {
+                if c == '\'' {
+                    in_single = false;
+                }
+                i += clen;
+                continue;
+            }
+            if in_double {
+                if c == '\\' {
+                    i += clen;
+                    if i < bytes.len() {
+                        i += input[i..].chars().next().map_or(1, |c2| c2.len_utf8());
+                    }
+                    continue;
+                }
+                if c == '"' {
+                    in_double = false;
+                }
+                i += clen;
+                continue;
+            }
+            if c == '\'' {
+                in_single = true;
+                i += clen;
+                continue;
+            }
+            if c == '"' {
+                in_double = true;
+                i += clen;
+                continue;
+            }
+            if c == '=' && i + 1 < bytes.len() && bytes[i + 1] == b'>' {
+                return Some(i);
+            }
+            i += clen;
+        }
+        None
+    }
+
+    fn unquote_pod_config_key(s: &str) -> String {
+        if s.len() >= 2
+            && ((s.starts_with('\'') && s.ends_with('\''))
+                || (s.starts_with('"') && s.ends_with('"')))
+        {
+            s[1..s.len() - 1].to_string()
+        } else {
+            s.to_string()
+        }
+    }
+
+    fn split_pod_config_top_level(input: &str, delim: char) -> Vec<&str> {
+        let mut parts = Vec::new();
+        let mut start = 0;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut depth = 0i32;
+        let mut i = 0;
+        let input_bytes = input.as_bytes();
+        while i < input_bytes.len() {
+            let c = input[i..].chars().next().unwrap();
+            let clen = c.len_utf8();
+            if in_single {
+                if c == '\'' {
+                    in_single = false;
+                }
+                i += clen;
+                continue;
+            }
+            if in_double {
+                if c == '\\' {
+                    i += clen;
+                    if i < input_bytes.len() {
+                        i += input[i..].chars().next().map_or(1, |c2| c2.len_utf8());
+                    }
+                    continue;
+                }
+                if c == '"' {
+                    in_double = false;
+                }
+                i += clen;
+                continue;
+            }
+            if c == '\'' {
+                in_single = true;
+            } else if c == '"' {
+                in_double = true;
+            } else if c == '(' || c == '[' || c == '{' {
+                depth += 1;
+            } else if c == ')' || c == ']' || c == '}' {
+                depth -= 1;
+            } else if c == delim && depth == 0 {
+                parts.push(&input[start..i]);
+                start = i + clen;
+            }
+            i += clen;
+        }
+        if start <= input.len() {
+            parts.push(&input[start..]);
+        }
+        parts
     }
 
     fn make_pod_table_with_config(rows: Vec<Vec<String>>, config: HashMap<String, Value>) -> Value {
@@ -726,14 +1143,25 @@ impl Interpreter {
                     idx = next_idx.max(idx + 1);
                     continue;
                 }
+                if directive == "config" {
+                    let type_name = rest.split_whitespace().next().unwrap_or_default();
+                    let after_type = rest
+                        .strip_prefix(type_name)
+                        .map(str::trim_start)
+                        .unwrap_or_default();
+                    let (cfg, _) = Self::parse_pod_config(after_type);
+                    entries.push(Self::make_pod_config(type_name, cfg));
+                    idx += 1;
+                    continue;
+                }
                 if directive == "table" {
-                    let (numbered, _) = Self::extract_numbered_alias(rest);
-                    let mut config = HashMap::new();
+                    let (numbered, rest_after) = Self::extract_numbered_alias(rest);
+                    let (mut config, _) = Self::parse_pod_config(rest_after);
                     if numbered {
                         config.insert("numbered".to_string(), Value::Bool(true));
                     }
                     let (rows, next_idx) = Self::collect_table_rows(lines, idx + 1);
-                    if !rows.is_empty() || numbered {
+                    if !rows.is_empty() || numbered || !config.is_empty() {
                         entries.push(Self::make_pod_table_with_config(rows, config));
                     }
                     idx = next_idx.max(idx + 1);
@@ -774,17 +1202,36 @@ impl Interpreter {
                         idx = next_idx.max(idx + 1);
                         continue;
                     }
+                    if target == "table" {
+                        let (numbered, inline_after) = Self::extract_numbered_alias(inline);
+                        let (mut config, _) = Self::parse_pod_config(inline_after);
+                        if numbered {
+                            config.insert("numbered".to_string(), Value::Bool(true));
+                        }
+                        let (rows, next_idx) = Self::collect_table_rows(lines, idx + 1);
+                        entries.push(Self::make_pod_table_with_config(rows, config));
+                        idx = next_idx.max(idx + 1);
+                        continue;
+                    }
                     let (numbered, inline_after) = Self::extract_numbered_alias(inline);
-                    let mut config = HashMap::new();
+                    let (mut config, leftover) = Self::parse_pod_config(inline_after);
                     if numbered {
                         config.insert("numbered".to_string(), Value::Bool(true));
                     }
-                    let (para, next_idx) = Self::collect_pod_para_with_inline(
-                        lines,
-                        idx + 1,
-                        inline_after,
-                        end_target,
-                    );
+                    let mut cont_idx = idx + 1;
+                    while cont_idx < lines.len() {
+                        let cont = lines[cont_idx].trim_start();
+                        if cont.starts_with("= ") || cont.starts_with("=\t") {
+                            let cont_str = cont[1..].trim_start();
+                            let (more, _) = Self::parse_pod_config(cont_str);
+                            config.extend(more);
+                            cont_idx += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    let (para, next_idx) =
+                        Self::collect_pod_para_with_inline(lines, cont_idx, leftover, end_target);
                     let mut contents = Vec::new();
                     if let Some(para) = para {
                         contents.push(para);
@@ -835,6 +1282,8 @@ impl Interpreter {
                     if target == "code" {
                         // =begin code ... =end code → Pod::Block::Code
                         // Collect raw text (no inner directive parsing)
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (code_config, _) = Self::parse_pod_config(after_target);
                         idx += 1;
                         let mut code_lines: Vec<&str> = Vec::new();
                         while idx < lines.len() {
@@ -869,7 +1318,40 @@ impl Interpreter {
                             .join("\n");
                         // Trim trailing newlines
                         let text = text.trim_end_matches('\n').to_string();
-                        entries.push(Self::make_pod_code(text));
+                        entries.push(Self::make_pod_code_with_config(text, code_config));
+                        continue;
+                    }
+                    if target == "table" {
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (tbl_config, _) = Self::parse_pod_config(after_target);
+                        idx += 1;
+                        let mut table_lines: Vec<&str> = Vec::new();
+                        while idx < lines.len() {
+                            if let Some((ed, er)) =
+                                Self::active_pod_directive(lines[idx], Some("table"))
+                                && ed == "end"
+                                && er.split_whitespace().next().unwrap_or_default() == "table"
+                            {
+                                idx += 1;
+                                break;
+                            }
+                            table_lines.push(lines[idx]);
+                            idx += 1;
+                        }
+                        let mut rows = Vec::new();
+                        for line in &table_lines {
+                            let tl = line.trim();
+                            if tl.is_empty() || Self::is_pod_table_separator(tl) {
+                                continue;
+                            }
+                            let cells: Vec<String> = if tl.contains('|') {
+                                tl.split('|').map(|c| c.trim().to_string()).collect()
+                            } else {
+                                tl.split_whitespace().map(|c| c.to_string()).collect()
+                            };
+                            rows.push(cells);
+                        }
+                        entries.push(Self::make_pod_table_with_config(rows, tbl_config));
                         continue;
                     }
                     if let Some(level) = Self::parse_item_level(target) {
@@ -1000,14 +1482,25 @@ impl Interpreter {
                     idx = next_idx.max(idx + 1);
                     continue;
                 }
+                if directive == "config" {
+                    let type_name = rest.split_whitespace().next().unwrap_or_default();
+                    let after_type = rest
+                        .strip_prefix(type_name)
+                        .map(str::trim_start)
+                        .unwrap_or_default();
+                    let (cfg, _) = Self::parse_pod_config(after_type);
+                    entries.push(Self::make_pod_config(type_name, cfg));
+                    idx += 1;
+                    continue;
+                }
                 if directive == "table" {
-                    let (numbered, _) = Self::extract_numbered_alias(rest);
-                    let mut config = HashMap::new();
+                    let (numbered, rest_after) = Self::extract_numbered_alias(rest);
+                    let (mut config, _) = Self::parse_pod_config(rest_after);
                     if numbered {
                         config.insert("numbered".to_string(), Value::Bool(true));
                     }
                     let (rows, next_idx) = Self::collect_table_rows(&lines, idx + 1);
-                    if !rows.is_empty() || numbered {
+                    if !rows.is_empty() || numbered || !config.is_empty() {
                         entries.push(Self::make_pod_table_with_config(rows, config));
                     }
                     idx = next_idx.max(idx + 1);
@@ -1044,12 +1537,24 @@ impl Interpreter {
                         continue;
                     }
                     let (numbered, inline_after) = Self::extract_numbered_alias(inline);
-                    let mut config = HashMap::new();
+                    let (mut config, leftover) = Self::parse_pod_config(inline_after);
                     if numbered {
                         config.insert("numbered".to_string(), Value::Bool(true));
                     }
+                    let mut cont_idx = idx + 1;
+                    while cont_idx < lines.len() {
+                        let cont = lines[cont_idx].trim_start();
+                        if cont.starts_with("= ") || cont.starts_with("=\t") {
+                            let cont_str = cont[1..].trim_start();
+                            let (more, _) = Self::parse_pod_config(cont_str);
+                            config.extend(more);
+                            cont_idx += 1;
+                        } else {
+                            break;
+                        }
+                    }
                     let (para, next_idx) =
-                        Self::collect_pod_para_with_inline(&lines, idx + 1, inline_after, None);
+                        Self::collect_pod_para_with_inline(&lines, cont_idx, leftover, None);
                     let mut contents = Vec::new();
                     if let Some(para) = para {
                         contents.push(para);
@@ -1098,7 +1603,8 @@ impl Interpreter {
                         continue;
                     }
                     if target == "code" {
-                        // =begin code ... =end code → Pod::Block::Code
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (code_config, _) = Self::parse_pod_config(after_target);
                         idx += 1;
                         let mut code_lines: Vec<&str> = Vec::new();
                         while idx < lines.len() {
@@ -1131,7 +1637,40 @@ impl Interpreter {
                             .collect::<Vec<_>>()
                             .join("\n");
                         let text = text.trim_end_matches('\n').to_string();
-                        entries.push(Self::make_pod_code(text));
+                        entries.push(Self::make_pod_code_with_config(text, code_config));
+                        continue;
+                    }
+                    if target == "table" {
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (tbl_config, _) = Self::parse_pod_config(after_target);
+                        idx += 1;
+                        let mut table_lines: Vec<&str> = Vec::new();
+                        while idx < lines.len() {
+                            if let Some((ed, er)) =
+                                Self::active_pod_directive(lines[idx], Some("table"))
+                                && ed == "end"
+                                && er.split_whitespace().next().unwrap_or_default() == "table"
+                            {
+                                idx += 1;
+                                break;
+                            }
+                            table_lines.push(lines[idx]);
+                            idx += 1;
+                        }
+                        let mut rows = Vec::new();
+                        for line in &table_lines {
+                            let tl = line.trim();
+                            if tl.is_empty() || Self::is_pod_table_separator(tl) {
+                                continue;
+                            }
+                            let cells: Vec<String> = if tl.contains('|') {
+                                tl.split('|').map(|c| c.trim().to_string()).collect()
+                            } else {
+                                tl.split_whitespace().map(|c| c.to_string()).collect()
+                            };
+                            rows.push(cells);
+                        }
+                        entries.push(Self::make_pod_table_with_config(rows, tbl_config));
                         continue;
                     }
                     if let Some(level) = Self::parse_item_level(target) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2134,6 +2134,21 @@ impl Interpreter {
             },
         );
         classes.insert(
+            "Pod::Config".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: HashSet::new(),
+                mro: vec!["Pod::Config".to_string()],
+                attribute_types: HashMap::new(),
+                attribute_smileys: HashMap::new(),
+                wildcard_handles: Vec::new(),
+                alias_attributes: HashSet::new(),
+                class_level_attrs: HashMap::new(),
+            },
+        );
+        classes.insert(
             "Pod::Item".to_string(),
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -722,6 +722,11 @@ impl Value {
                         || class_name == "Pod::Block::Table"
                         || class_name == "Pod::Item"
             ),
+            "Pod::Config" => matches!(
+                self,
+                Value::Instance { class_name, .. }
+                    if class_name == "Pod::Config"
+            ),
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary
- Implement comprehensive Pod config adverb parsing supporting all Raku value forms: `:key<str>`, `:key(42)`, `:key[True]`, `:key(1, 'b', 2.3)`, `:key{a => 1}`, quoted strings, `Q[]` quoting, scientific notation, bigints, `:NNNkey` numeric prefix shorthand, and multi-line `=` continuation lines
- Add `Pod::Config` class and `=config` directive support
- Pass config to `=begin code`, `=begin table`, `=for table`, and generic `=for` directives; parse `:allow<B>` on code blocks to enable formatting code processing

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S26-documentation/09-configuration.t` passes all 98 subtests
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes
- [x] Added to `roast-whitelist.txt` (sorted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)