### PR TITLE
fix: pass all 50 subtests in roast/S02-types/flattening.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -112,6 +112,7 @@ roast/S02-types/built-in.t
 roast/S02-types/catch_type_cast_mismatch.t
 roast/S02-types/compact.t
 roast/S02-types/fatrat.t
+roast/S02-types/flattening.t
 roast/S02-types/hash_ref.t
 roast/S02-types/hyperwhatever.t
 roast/S02-types/infinity.t

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -924,6 +924,10 @@ pub(super) fn sub_decl_body(
             .into_iter()
             .filter_map(|arg| match arg {
                 crate::ast::CallArg::Positional(e) => Some(e),
+                crate::ast::CallArg::Slip(e) => Some(Expr::Unary {
+                    op: crate::token_kind::TokenKind::Pipe,
+                    expr: Box::new(e),
+                }),
                 _ => None,
             })
             .collect();

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1571,7 +1571,6 @@ impl Interpreter {
                 | "squish"
                 | "produce"
                 | "map"
-                | "flat"
                 | "batch"
                 | "rotor"
                 | "rotate"

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -40,6 +40,14 @@ fn flatten_append_args(args: Vec<Value>) -> Vec<Value> {
         match &args[0] {
             Value::Array(vals, kind) if !kind.is_itemized() => vals.to_vec(),
             Value::Seq(vals) => vals.to_vec(),
+            Value::Hash(map) => {
+                // Flatten hash into key-value pairs
+                let mut result = Vec::new();
+                for (k, v) in map.iter() {
+                    result.push(Value::Pair(k.clone(), Box::new(v.clone())));
+                }
+                result
+            }
             _ => args,
         }
     } else {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -663,6 +663,14 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
         }
         Value::Slip(items) | Value::Seq(items) => Value::Array(items, ArrayKind::Array),
         Value::LazyList(_) => value,
+        Value::Hash(ref map) => {
+            // Hash assigned to @-var: flatten into pairs
+            let pairs: Vec<Value> = map
+                .iter()
+                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .collect();
+            Value::real_array(pairs)
+        }
         other => Value::real_array(vec![other]),
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -850,6 +850,17 @@ impl VM {
                             .and_then(|bare| self.interpreter.env().get(bare).cloned())
                     })
                     .unwrap_or(Value::Nil);
+                // When @-sigil dereferences a Hash, convert to a list of pairs
+                let val = match val {
+                    Value::Hash(ref map) => {
+                        let pairs: Vec<Value> = map
+                            .iter()
+                            .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                            .collect();
+                        Value::real_array(pairs)
+                    }
+                    other => other,
+                };
                 self.stack.push(val);
                 *ip += 1;
             }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -125,6 +125,23 @@ impl VM {
         } else {
             index
         };
+        // Itemized arrays ($[...]) used as indices should be numified (for
+        // positional access) or stringified (for associative access) rather
+        // than treated as slices.
+        let index = if let Value::Array(ref items, kind) = index
+            && kind.is_itemized()
+        {
+            if is_positional {
+                // Numify: elems count
+                Value::Int(items.len() as i64)
+            } else {
+                // Stringify: space-separated
+                let parts: Vec<String> = items.iter().map(|v| v.to_str_context()).collect();
+                Value::Str(std::sync::Arc::new(parts.join(" ")))
+            }
+        } else {
+            index
+        };
         let result = match (target, index) {
             // Whatever (*) index on Array: @a[*] returns all elements as a List
             (Value::Array(items, _is_arr), Value::Whatever) => {


### PR DESCRIPTION
## Summary
- Flatten Hash into pairs in `flatten_append_args` so `append @a, %hash` works correctly
- Flatten Hash into pairs in `coerce_to_array` for `my @a = %hash` assignment
- Convert `@$hash` sigil-deref to array of pairs in `GetArrayVar` VM handler
- Numify/stringify itemized arrays (`$[...]`) used as subscript indices
- Preserve `|expr` slip args in immediate sub invocation parsing (`sub foo(...) { }( |True )`)
- Allow `.flat` on Supply type objects (returns one-element list instead of erroring)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/flattening.t` passes all 50 subtests
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes (only pre-existing t/lock.t failure)
- [x] `make roast` passes all whitelisted tests
- [x] Added to roast-whitelist.txt (sorted)

Generated with [Claude Code](https://claude.com/claude-code)