### PR TITLE
fix: pass all 112 subtests in roast/S02-types/hash.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -113,6 +113,7 @@ roast/S02-types/catch_type_cast_mismatch.t
 roast/S02-types/compact.t
 roast/S02-types/fatrat.t
 roast/S02-types/flattening.t
+roast/S02-types/hash.t
 roast/S02-types/hash_ref.t
 roast/S02-types/hyperwhatever.t
 roast/S02-types/infinity.t

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -287,6 +287,12 @@ impl Compiler {
 
     /// Compile Index expression (target[index] or target{index}).
     pub(super) fn compile_expr_index(&mut self, target: &Expr, index: &Expr, is_positional: bool) {
+        // When in scalar bind context (`:=`), emit IndexAutovivify for
+        // associative indexing so that the VM auto-vivifies intermediate
+        // hashes and returns a HashSlotRef.
+        // This enables `my $b := %h<foo><baz>; $b = 42`.
+        let use_autovivify = self.scalar_bind_autovivify && !is_positional;
+
         // Special case: %*ENV<key> compiles to GetEnvIndex
         if let Expr::HashVar(name) = target {
             if name == "*ENV" {
@@ -296,17 +302,29 @@ impl Compiler {
                 } else {
                     self.compile_expr(target);
                     self.compile_expr(index);
-                    self.code.emit(OpCode::Index { is_positional });
+                    if use_autovivify {
+                        self.code.emit(OpCode::IndexAutovivify);
+                    } else {
+                        self.code.emit(OpCode::Index { is_positional });
+                    }
                 }
             } else {
                 self.compile_expr(target);
                 self.compile_expr(index);
-                self.code.emit(OpCode::Index { is_positional });
+                if use_autovivify {
+                    self.code.emit(OpCode::IndexAutovivify);
+                } else {
+                    self.code.emit(OpCode::Index { is_positional });
+                }
             }
         } else {
             self.compile_expr(target);
             self.compile_expr(index);
-            self.code.emit(OpCode::Index { is_positional });
+            if use_autovivify {
+                self.code.emit(OpCode::IndexAutovivify);
+            } else {
+                self.code.emit(OpCode::Index { is_positional });
+            }
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -62,6 +62,10 @@ pub(crate) struct Compiler {
     pub(crate) lexically_in_routine: bool,
     /// When true, the current VarDecl is from a `:=` bind declaration.
     bind_vardecl: bool,
+    /// When true, Index expressions should emit IndexAutovivify instead of
+    /// Index.  Set only during scalar `:=` bind VarDecl compilation so that
+    /// `my $b := %h<foo><baz>` creates a HashSlotRef.
+    scalar_bind_autovivify: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
     /// Last source line emitted via SetSourceLine (for tracking block definition lines).
@@ -85,6 +89,7 @@ impl Compiler {
             is_routine: false,
             lexically_in_routine: false,
             bind_vardecl: false,
+            scalar_bind_autovivify: false,
             constant_vars: std::collections::HashSet::new(),
             last_source_line: None,
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -581,8 +581,13 @@ impl Compiler {
                 } else if self.bind_vardecl && !name.starts_with('@') && !name.starts_with('%') {
                     // `:=` binding for scalar VarDecl: use compile_call_arg
                     // so WrapVarRef is emitted and the VM can set up aliases.
+                    // Set scalar_bind_autovivify so that Index expressions
+                    // emit IndexAutovivify (for hash element binding like
+                    // `my $b := %h<foo><baz>`).
                     self.bind_vardecl = false;
+                    self.scalar_bind_autovivify = true;
                     self.compile_call_arg(expr);
+                    self.scalar_bind_autovivify = false;
                 } else {
                     let rhs_expr = if has_default_trait
                         && !name.starts_with('@')

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -393,6 +393,10 @@ pub(crate) enum OpCode {
     Index {
         is_positional: bool,
     },
+    /// Like Index, but auto-vivifies intermediate hash entries and returns
+    /// a `HashSlotRef` for the final key.  Used for `:=` bind to hash elements
+    /// (e.g. `my $b := %h<foo><baz>`).
+    IndexAutovivify,
     DeleteIndexNamed(u32),
     DeleteIndexExpr,
     /// Multi-dimensional indexing: @a[$x;$y;$z]

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -470,6 +470,7 @@ fn handle_binding(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     let mark_scalar_readonly =
         !s.is_array && !bound_name.starts_with('%') && super::scalar_binding_rhs_is_readonly(&expr);
     let bind_to_var = matches!(expr, Expr::Var(_));
+    let bind_to_index = matches!(expr, Expr::Index { .. });
     let stmt = Stmt::VarDecl {
         name: s.name,
         expr,
@@ -506,7 +507,7 @@ fn handle_binding(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         Stmt::SyntheticBlock(stmts)
     } else if mark_scalar_readonly {
         Stmt::SyntheticBlock(vec![Stmt::MarkReadonly(bound_name), stmt])
-    } else if bind_to_var {
+    } else if bind_to_var || bind_to_index {
         Stmt::SyntheticBlock(vec![Stmt::MarkBind, stmt])
     } else {
         stmt

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2085,6 +2085,10 @@ impl VM {
                 self.exec_index_op_with_positional(*is_positional)?;
                 *ip += 1;
             }
+            OpCode::IndexAutovivify => {
+                self.exec_index_autovivify_op()?;
+                *ip += 1;
+            }
             OpCode::DeleteIndexNamed(name_idx) => {
                 self.exec_delete_index_named_op(code, *name_idx)?;
                 *ip += 1;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -36,6 +36,49 @@ impl VM {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Auto-vivifying index: creates intermediate Hash entries and returns
+    /// a `HashSlotRef` so that `:=` bind to nested hash elements works.
+    /// Stack: [target, key] -> [HashSlotRef]
+    pub(super) fn exec_index_autovivify_op(&mut self) -> Result<(), RuntimeError> {
+        let index = self.stack.pop().unwrap();
+        let target = self.stack.pop().unwrap();
+        let key = Value::hash_key_encode(&index);
+
+        // If the target is a HashSlotRef, resolve its value first.
+        let hash_val = match &target {
+            Value::HashSlotRef { .. } => target.hash_slot_read(),
+            other => other.clone(),
+        };
+
+        match &hash_val {
+            Value::Hash(_) => {
+                if let Some(slot_ref) = hash_val.hash_autovivify(&key) {
+                    self.stack.push(slot_ref);
+                } else {
+                    self.stack.push(Value::Nil);
+                }
+            }
+            // If the target is Nil/Any (not yet vivified), create an empty hash
+            // inside the HashSlotRef and then auto-vivify the key.
+            _ if matches!(&target, Value::HashSlotRef { .. }) => {
+                let new_hash = Value::hash(std::collections::HashMap::new());
+                target.hash_slot_write(new_hash.clone());
+                if let Some(slot_ref) = new_hash.hash_autovivify(&key) {
+                    self.stack.push(slot_ref);
+                } else {
+                    self.stack.push(Value::Nil);
+                }
+            }
+            _ => {
+                // Fallback: just do a normal index read
+                self.stack.push(target);
+                self.stack.push(index);
+                return self.exec_index_op_with_positional(false);
+            }
+        }
+        Ok(())
+    }
+
     /// Backward-compatible wrapper: defaults to associative indexing.
     pub(super) fn exec_index_op(&mut self) -> Result<(), RuntimeError> {
         self.exec_index_op_with_positional(false)


### PR DESCRIPTION
## Summary
- Add `IndexAutovivify` opcode that auto-vivifies intermediate hash entries and returns a `HashSlotRef`, enabling `my $b := %h<foo><baz>; $b = 42` to correctly vivify the nested hash element
- Parser now emits `MarkBind` for scalar `:=` bind to Index expressions (not just Var expressions)
- Uses a dedicated `scalar_bind_autovivify` compiler flag to avoid interfering with array/hash bind paths
- Adds `roast/S02-types/hash.t` (112 subtests) to the whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/hash.t` passes all 112 tests
- [x] `make test` passes (all 3802 subtests)
- [x] `make roast` passes (no new failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)