### PR TITLE
fix: degrade BigRat to Num when denominator exceeds uint64 range

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -237,7 +237,7 @@
 - [ ] roast/S02-types/nominalizables.t
   - 0/? pass. Parse error at line 30
 - [ ] roast/S02-types/num.t
-  - 0/? pass. Parse error at line 431
+  - 108/112 pass. Tests 109-112 fail (same failures as raku itself: num%0e0, 0e0%0e0, num/0e0, num**-1e20 Failure handling)
 - [ ] roast/S02-types/pair.t
   - 0/? pass. Parse error at line 13
 - [x] roast/S02-types/parsing-bool.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::runtime;
 use crate::symbol::Symbol;
-use crate::value::{RuntimeError, Value, make_big_rat, make_rat};
+use crate::value::{RuntimeError, Value, make_big_fat_rat, make_big_rat, make_rat};
 use num_bigint::{BigInt as NumBigInt, Sign};
 use num_traits::{Signed, ToPrimitive, Zero};
 
@@ -91,6 +91,17 @@ fn needs_bigrat_path(l: &Value, r: &Value) -> bool {
         Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigRat(_, _)
     );
     has_big && has_rat
+}
+
+/// Check if a value should be treated as FatRat for arithmetic.
+/// This includes Value::FatRat and Value::BigRat when the denominator exceeds u64,
+/// since only FatRat operations can produce such values (regular Rat degrades to Num).
+fn is_fat_rat_like(v: &Value) -> bool {
+    match v {
+        Value::FatRat(_, _) => true,
+        Value::BigRat(_, d) => d.to_u64().is_none(),
+        _ => false,
+    }
 }
 
 /// Safely convert a BigInt ratio to f64, handling cases where both
@@ -518,17 +529,21 @@ fn arith_add_coerced(l: Value, r: Value) -> Value {
     } else if let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
         && needs_bigrat_path(&l, &r)
     {
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
-        match make_big_rat(an * bd.clone() + bn * ad.clone(), ad * bd) {
-            Value::Rat(n, d) if has_fat_rat => Value::FatRat(n, d),
-            other => other,
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
+        if has_fat_rat {
+            match make_big_fat_rat(an * bd.clone() + bn * ad.clone(), ad * bd) {
+                Value::Rat(n, d) => Value::FatRat(n, d),
+                other => other,
+            }
+        } else {
+            make_big_rat(an * bd.clone() + bn * ad.clone(), ad * bd)
         }
     } else if let (Some((an, ad)), Some((bn, bd))) =
         (runtime::to_rat_parts(&l), runtime::to_rat_parts(&r))
     {
         let has_rat = matches!(l, Value::Rat(_, _) | Value::FatRat(_, _))
             || matches!(r, Value::Rat(_, _) | Value::FatRat(_, _));
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         if has_rat {
             if has_fat_rat {
                 let n = an * bd + bn * ad;
@@ -671,17 +686,21 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
     } else if let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
         && needs_bigrat_path(&l, &r)
     {
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
-        match make_big_rat(an * bd.clone() - bn * ad.clone(), ad * bd) {
-            Value::Rat(n, d) if has_fat_rat => Value::FatRat(n, d),
-            other => other,
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
+        if has_fat_rat {
+            match make_big_fat_rat(an * bd.clone() - bn * ad.clone(), ad * bd) {
+                Value::Rat(n, d) => Value::FatRat(n, d),
+                other => other,
+            }
+        } else {
+            make_big_rat(an * bd.clone() - bn * ad.clone(), ad * bd)
         }
     } else if let (Some((an, ad)), Some((bn, bd))) =
         (runtime::to_rat_parts(&l), runtime::to_rat_parts(&r))
     {
         let has_rat = matches!(l, Value::Rat(_, _) | Value::FatRat(_, _))
             || matches!(r, Value::Rat(_, _) | Value::FatRat(_, _));
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         if has_rat {
             if has_fat_rat {
                 let n = an * bd - bn * ad;
@@ -747,17 +766,21 @@ pub(crate) fn arith_mul(left: Value, right: Value) -> Value {
     } else if let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
         && needs_bigrat_path(&l, &r)
     {
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
-        match make_big_rat(an * bn, ad * bd) {
-            Value::Rat(n, d) if has_fat_rat => Value::FatRat(n, d),
-            other => other,
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
+        if has_fat_rat {
+            match make_big_fat_rat(an * bn, ad * bd) {
+                Value::Rat(n, d) => Value::FatRat(n, d),
+                other => other,
+            }
+        } else {
+            make_big_rat(an * bn, ad * bd)
         }
     } else if let (Some((an, ad)), Some((bn, bd))) =
         (runtime::to_rat_parts(&l), runtime::to_rat_parts(&r))
     {
         let has_rat = matches!(l, Value::Rat(_, _) | Value::FatRat(_, _))
             || matches!(r, Value::Rat(_, _) | Value::FatRat(_, _));
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         if has_rat {
             if has_fat_rat {
                 let n = an * bn;
@@ -835,12 +858,16 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
             }
             return Ok(Value::Num(lf / rf));
         }
-        let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         let has_big_rat = matches!(l, Value::BigRat(_, _)) || matches!(r, Value::BigRat(_, _));
         if (has_fat_rat || has_big_rat)
             && let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
         {
-            let result = make_big_rat(an * bd, ad * bn);
+            let result = if has_fat_rat {
+                make_big_fat_rat(an * bd, ad * bn)
+            } else {
+                make_big_rat(an * bd, ad * bn)
+            };
             return Ok(match result {
                 Value::Rat(n, d) if has_fat_rat => Value::FatRat(n, d),
                 other => other,
@@ -862,7 +889,7 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
         {
             let has_rat = matches!(l, Value::Rat(_, _) | Value::FatRat(_, _))
                 || matches!(r, Value::Rat(_, _) | Value::FatRat(_, _));
-            let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+            let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
             if has_rat || matches!((&l, &r), (Value::Int(_), Value::Int(_))) {
                 return Ok(if has_fat_rat {
                     if let (Some(n), Some(d)) = (an.checked_mul(bd), ad.checked_mul(bn)) {
@@ -870,7 +897,7 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
                     } else {
                         let n = NumBigInt::from(an) * NumBigInt::from(bd);
                         let d = NumBigInt::from(ad) * NumBigInt::from(bn);
-                        let result = make_big_rat(n, d);
+                        let result = make_big_fat_rat(n, d);
                         match result {
                             Value::Rat(n, d) => Value::FatRat(n, d),
                             other => other,
@@ -953,7 +980,7 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
             // Rational modulo with divisor-sign semantics.
             let num = num_integer::Integer::mod_floor(&(an * bd), &(ad * bn));
             let den = ad * bd;
-            let has_fat_rat = matches!(l, Value::FatRat(_, _)) || matches!(r, Value::FatRat(_, _));
+            let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
             Ok(if has_fat_rat {
                 make_fat_rat(num, den)
             } else {
@@ -1153,7 +1180,7 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 } else {
                     let nn = NumBigInt::from(n).pow(p);
                     let dd = NumBigInt::from(d).pow(p);
-                    match make_big_rat(nn, dd) {
+                    match make_big_fat_rat(nn, dd) {
                         Value::Rat(nn, dd) => Value::FatRat(nn, dd),
                         other => other,
                     }
@@ -1166,7 +1193,7 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 } else {
                     let nn = NumBigInt::from(d).pow(p);
                     let dd = NumBigInt::from(n).pow(p);
-                    match make_big_rat(nn, dd) {
+                    match make_big_fat_rat(nn, dd) {
                         Value::Rat(nn, dd) => Value::FatRat(nn, dd),
                         other => other,
                     }
@@ -1288,7 +1315,13 @@ pub(crate) fn arith_negate(val: Value) -> Result<Value, RuntimeError> {
                 Ok(Value::Num(-(n as f64) / d as f64))
             }
         }
-        Value::BigRat(n, d) => Ok(crate::value::make_big_rat(-n, d)),
+        Value::BigRat(ref n, ref d) => {
+            if is_fat_rat_like(&val) {
+                Ok(make_big_fat_rat(-n.clone(), d.clone()))
+            } else {
+                Ok(make_big_rat(-n.clone(), d.clone()))
+            }
+        }
         Value::Complex(r, i) => {
             // Canonicalize -0.0 to 0.0 so that e.g. (-i).reals gives (0e0, -1e0)
             let nr = if r == 0.0 { 0.0 } else { -r };

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -1,6 +1,6 @@
 use crate::builtins::primality::{is_prime_bigint, is_prime_i64};
 use crate::symbol::Symbol;
-use crate::value::{RuntimeError, Value, make_big_rat, make_rat};
+use crate::value::{RuntimeError, Value, make_big_fat_rat, make_rat};
 use std::collections::HashMap;
 
 /// Type coercion and specialized 0-arg methods: numerator, denominator, nude,
@@ -43,7 +43,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Value::Rat(nn, dd) => Value::FatRat(nn, dd),
                 other => other,
             })),
-            Value::BigRat(n, d) => Some(Ok(match make_big_rat(n.clone(), d.clone()) {
+            Value::BigRat(n, d) => Some(Ok(match make_big_fat_rat(n.clone(), d.clone()) {
                 Value::Rat(nn, dd) => Value::FatRat(nn, dd),
                 Value::BigRat(nn, dd) => Value::BigRat(nn, dd),
                 other => other,

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1621,7 +1621,7 @@ impl Interpreter {
                     return Ok(make_rat(a, b));
                 }
                 "FatRat" => {
-                    use crate::value::make_big_rat;
+                    use crate::value::make_big_fat_rat;
                     use num_bigint::BigInt;
                     let a = match args.first() {
                         Some(Value::BigInt(bi)) => (**bi).clone(),
@@ -1633,7 +1633,7 @@ impl Interpreter {
                         Some(v) => BigInt::from(to_int(v)),
                         None => BigInt::from(1),
                     };
-                    return Ok(match make_big_rat(a, b) {
+                    return Ok(match make_big_fat_rat(a, b) {
                         Value::Rat(n, d) => Value::FatRat(n, d),
                         Value::BigRat(n, d) => Value::BigRat(n, d),
                         other => other,

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -499,16 +499,7 @@ impl Value {
                 } else if d.abs().to_string().len() > 20 {
                     // For BigRats with very large denominators (beyond uint64 range),
                     // fall back to Num-based formatting like Raku does for standard Rats.
-                    // Use scaled integer division to get a float value even when both
-                    // n and d are too large for f64 individually.
-                    let sign = n.is_negative() ^ d.is_negative();
-                    let na = n.abs();
-                    let da = d.abs();
-                    // Scale numerator up to get enough precision for f64
-                    let scaled = &na * NumBigInt::from(10u64).pow(20);
-                    let div = &scaled / &da;
-                    let val = div.to_f64().unwrap_or(0.0) / 1e20;
-                    let val = if sign { -val } else { val };
+                    let val = crate::value::bigrat_to_f64(n, d);
                     // Use the Num Str formatting
                     Value::Num(val).to_string_value()
                 } else if has_terminating_decimal_bigint(d) {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -489,7 +489,42 @@ pub fn make_rat(num: i64, den: i64) -> Value {
     Value::Rat(n, d)
 }
 
+/// Create a Rat from BigInt numerator/denominator.
+/// Per Raku spec, Rat denominators are limited to uint64 range.
+/// When the reduced denominator exceeds this, degrade to Num.
+/// Use `make_big_fat_rat` for FatRat contexts that should never degrade.
 pub fn make_big_rat(num: NumBigInt, den: NumBigInt) -> Value {
+    if den.is_zero() {
+        if num.is_zero() {
+            return Value::Rat(0, 0);
+        }
+        return if num.is_positive() {
+            Value::Rat(1, 0)
+        } else {
+            Value::Rat(-1, 0)
+        };
+    }
+    let g = num.gcd(&den);
+    let mut n = num / &g;
+    let mut d = den / &g;
+    if d.is_negative() {
+        n = -n;
+        d = -d;
+    }
+    if let (Some(n_i64), Some(d_i64)) = (n.to_i64(), d.to_i64()) {
+        Value::Rat(n_i64, d_i64)
+    } else {
+        // Check if denominator exceeds uint64 range — if so, degrade to Num
+        if d.to_u64().is_none() {
+            return Value::Num(bigrat_to_f64(&n, &d));
+        }
+        Value::BigRat(n, d)
+    }
+}
+
+/// Create a FatRat from BigInt numerator/denominator.
+/// Unlike `make_big_rat`, this never degrades to Num — FatRat has unlimited precision.
+pub fn make_big_fat_rat(num: NumBigInt, den: NumBigInt) -> Value {
     if den.is_zero() {
         if num.is_zero() {
             return Value::Rat(0, 0);
@@ -512,6 +547,44 @@ pub fn make_big_rat(num: NumBigInt, den: NumBigInt) -> Value {
     } else {
         Value::BigRat(n, d)
     }
+}
+
+/// Convert a BigInt ratio n/d to f64 with correct rounding.
+/// Uses bit-level scaling to avoid precision loss from independent to_f64() conversions.
+pub fn bigrat_to_f64(n: &NumBigInt, d: &NumBigInt) -> f64 {
+    if d.is_zero() {
+        return if n.is_zero() {
+            f64::NAN
+        } else if n.is_negative() {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+    }
+    let sign = n.is_negative() != d.is_negative();
+    let na = n.abs();
+    let da = d.abs();
+    if na.is_zero() {
+        return if sign { -0.0 } else { 0.0 };
+    }
+    // Compute bit counts to estimate the magnitude of the result.
+    // Then shift so the quotient has ~55 significant bits (enough for f64 + rounding).
+    let n_bits = na.bits();
+    let d_bits = da.bits();
+    let target_bits: u64 = 55;
+    // We want quotient = (na << shift) / da to have ~target_bits significant bits.
+    // quotient_bits ~ n_bits + shift - d_bits, so shift = target_bits - n_bits + d_bits.
+    let shift = if d_bits + target_bits > n_bits {
+        (d_bits + target_bits - n_bits) as u32
+    } else {
+        0u32
+    };
+    let scaled = &na << shift;
+    let quotient = &scaled / &da;
+    let qf = quotient.to_f64().unwrap_or(f64::INFINITY);
+    // Scale back: divide by 2^shift
+    let result = qf * 2.0f64.powi(-(shift as i32));
+    if sign { -result } else { result }
 }
 
 /// Distinguishes the five array/list container kinds.


### PR DESCRIPTION
## Summary
- Per Raku spec, Rat denominators are limited to uint64 range. When arithmetic produces a denominator exceeding this limit, the result should degrade to Num. FatRat never degrades.
- `make_big_rat()` now degrades to Num via a precision-preserving `bigrat_to_f64()` when the reduced denominator exceeds u64
- New `make_big_fat_rat()` preserves BigRat for FatRat contexts (no degradation)
- Fixed `is_fat_rat_like()` to detect BigRat originating from FatRat contexts (denominator > u64)
- Fixed BigRat display and negation to preserve FatRat identity
- Fixes test 103 in `roast/S02-types/num.t` (108/112 now pass; remaining 4 failures also fail on Rakudo itself)
- Also fixes pre-existing regression in `roast/S32-num/fatrat.t` (288/288 now pass)

## Test plan
- [x] `cargo test --lib` passes (441 tests)
- [x] `make test` passes (all 471 prove tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `roast/S32-num/fatrat.t` passes (288/288)
- [x] `roast/S02-types/num.t` 108/112 pass (remaining 4 also fail on raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)