### PR TITLE
feat: implement utf8-c8 encoding round-trip support

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1054,6 +1054,7 @@ roast/S32-str/tclc.t
 roast/S32-str/trim.t
 roast/S32-str/uc.t
 roast/S32-str/uniparse.t
+roast/S32-str/utf8-c8.t
 roast/S32-str/windows-1251-windows-1252-encode-decode.t
 roast/S32-str/words.t
 roast/S32-temporal/Date.t

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -128,6 +128,7 @@ pub(crate) fn num_to_rat_with_epsilon(f: f64, epsilon: f64) -> Value {
 fn normalize_builtin_encoding_label(name: &str) -> Option<String> {
     let lowered = name.to_lowercase();
     let normalized = match lowered.as_str() {
+        "utf8-c8" => "utf8-c8",
         "utf8" | "utf-8" => "utf-8",
         "utf16" | "utf-16" => "utf-16",
         "utf16le" | "utf-16le" => "utf-16le",
@@ -184,6 +185,7 @@ fn decode_bytes_with_builtin_encoding(
     encoding_name: &str,
 ) -> Result<String, RuntimeError> {
     match encoding_name {
+        "utf8-c8" => Ok(crate::runtime::utf8_c8::decode_utf8_c8(bytes)),
         "ascii" => Ok(bytes
             .iter()
             .map(|b| if *b <= 0x7F { *b as char } else { '\u{FFFD}' })

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -88,6 +88,7 @@ impl Interpreter {
             .to_lowercase();
 
         match encoding.as_str() {
+            "utf8-c8" => Ok(super::utf8_c8::encode_utf8_c8(input)),
             "ascii" => {
                 for ch in input.chars() {
                     if (ch as u32) > 0x7F {
@@ -149,6 +150,7 @@ impl Interpreter {
             .to_lowercase();
 
         match encoding.as_str() {
+            "utf8-c8" => Ok(super::utf8_c8::decode_utf8_c8(bytes)),
             "ascii" => Ok(bytes
                 .iter()
                 .map(|b| if *b <= 0x7F { *b as char } else { '\u{FFFD}' })

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -190,6 +190,7 @@ mod system;
 mod test_functions;
 pub(crate) mod types;
 mod unicode;
+pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) use self::registration_class::ClassDeclModifiers;
 

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -36,15 +36,15 @@ fn value_to_byte(v: &Value) -> Option<u8> {
     }
 }
 
-/// Decode all bytes as UTF-8, replacing invalid sequences with U+FFFD.
-/// Used for both "utf-8" and "utf8-c8" decoders. (utf8-c8 round-trips
-/// invalid bytes via synthetics in real Raku, but for the purpose of the
-/// roast tests we exercise here, lossy UTF-8 decoding is sufficient because
-/// the input is always valid UTF-8 — the value of utf8-c8 is that it does
-/// not error on invalid bytes.)
-// TODO: implement true utf8-c8 synthetic-codepoint round-tripping.
-fn decode_bytes(bytes: &[u8], translate_nl: bool) -> String {
-    let s = String::from_utf8_lossy(bytes).into_owned();
+/// Decode bytes using the appropriate encoding.
+/// For utf8-c8, invalid bytes are preserved as synthetic codepoints.
+/// For other encodings, invalid bytes are replaced with U+FFFD.
+fn decode_bytes(bytes: &[u8], translate_nl: bool, encoding: &str) -> String {
+    let s = if encoding == "utf8-c8" {
+        crate::runtime::utf8_c8::decode_utf8_c8(bytes)
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    };
     if translate_nl {
         s.replace("\r\n", "\n")
     } else {
@@ -54,7 +54,12 @@ fn decode_bytes(bytes: &[u8], translate_nl: bool) -> String {
 
 /// Decode as many complete UTF-8 characters as possible, returning
 /// (decoded_string, remaining_bytes).
-fn decode_available(bytes: &[u8]) -> (String, Vec<u8>) {
+fn decode_available(bytes: &[u8], encoding: &str) -> (String, Vec<u8>) {
+    if encoding == "utf8-c8" {
+        // utf8-c8 can always decode all bytes (invalid ones become synthetics)
+        let s = crate::runtime::utf8_c8::decode_utf8_c8(bytes);
+        return (s, Vec::new());
+    }
     let mut end = bytes.len();
     while end > 0 {
         if std::str::from_utf8(&bytes[..end]).is_ok() {
@@ -145,10 +150,16 @@ impl Interpreter {
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
                 let replacement = attributes.get("replacement");
-                let is_ascii = matches!(enc_name.to_lowercase().as_str(), "ascii" | "us-ascii");
+                let enc_lower = enc_name.to_lowercase();
+                let is_ascii = matches!(enc_lower.as_str(), "ascii" | "us-ascii");
+                let is_utf8_c8 = enc_lower == "utf8-c8";
 
                 let mut bytes: Vec<Value> = Vec::new();
-                if is_ascii {
+                if is_utf8_c8 {
+                    for b in crate::runtime::utf8_c8::encode_utf8_c8(&input) {
+                        bytes.push(Value::Int(b as i64));
+                    }
+                } else if is_ascii {
                     for ch in input.chars() {
                         if ch as u32 > 127 {
                             if let Some(repl) = replacement {
@@ -232,17 +243,25 @@ impl Interpreter {
             }
             "consume-all-chars" => {
                 let buf = decoder_buffer(&attributes);
+                let enc_name = attributes
+                    .get("encoding")
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
                 let translate_nl = attributes
                     .get("translate-nl")
                     .map(|v| v.truthy())
                     .unwrap_or(false);
-                let s = decode_bytes(&buf, translate_nl);
+                let s = decode_bytes(&buf, translate_nl, &enc_name);
                 attributes.insert("buffer".to_string(), Value::array(Vec::new()));
                 Ok((Value::str(s), attributes))
             }
             "consume-available-chars" => {
                 let buf = decoder_buffer(&attributes);
-                let (decoded, remaining) = decode_available(&buf);
+                let enc_name = attributes
+                    .get("encoding")
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let (decoded, remaining) = decode_available(&buf, &enc_name);
                 let translate_nl = attributes
                     .get("translate-nl")
                     .map(|v| v.truthy())

--- a/src/runtime/utf8_c8.rs
+++ b/src/runtime/utf8_c8.rs
@@ -1,0 +1,124 @@
+//! UTF-8 Clean-8 (utf8-c8) encoding support.
+//!
+//! utf8-c8 is Raku's encoding that allows round-tripping arbitrary byte
+//! sequences through strings. Valid UTF-8 is decoded normally; invalid
+//! bytes are represented as synthetic codepoints in the Supplementary
+//! Private Use Area-A (U+F0000..U+F00FF), where the low 8 bits encode
+//! the original byte value.
+//!
+//! When encoding back to utf8-c8, characters in U+F0000..U+F00FF are
+//! emitted as the corresponding single byte, and all other characters
+//! are emitted as standard UTF-8.
+
+/// Base codepoint for synthetic byte representations.
+const SYNTHETIC_BASE: u32 = 0xF0000;
+
+/// Decode a byte slice using the utf8-c8 scheme.
+///
+/// Valid UTF-8 sequences are decoded normally. Each byte that is part of
+/// an invalid sequence is individually mapped to the synthetic codepoint
+/// U+F0000 + byte_value.
+pub fn decode_utf8_c8(bytes: &[u8]) -> String {
+    let mut result = String::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Try to decode the longest valid UTF-8 sequence starting at i.
+        match std::str::from_utf8(&bytes[i..]) {
+            Ok(s) => {
+                // Remaining bytes are all valid UTF-8.
+                result.push_str(s);
+                break;
+            }
+            Err(e) => {
+                let valid_up_to = e.valid_up_to();
+                // Append the valid prefix.
+                if valid_up_to > 0 {
+                    // Safety: from_utf8 guarantees bytes[i..i+valid_up_to] is valid.
+                    let valid = std::str::from_utf8(&bytes[i..i + valid_up_to]).unwrap();
+                    result.push_str(valid);
+                    i += valid_up_to;
+                }
+                // Now bytes[i] starts an invalid sequence. Emit one synthetic char
+                // for the single bad byte.
+                let bad_byte = bytes[i];
+                let synthetic = char::from_u32(SYNTHETIC_BASE + bad_byte as u32)
+                    .expect("synthetic codepoint must be valid");
+                result.push(synthetic);
+                i += 1;
+            }
+        }
+    }
+    result
+}
+
+/// Encode a utf8-c8 string back to bytes.
+///
+/// Characters in the synthetic range U+F0000..U+F00FF are emitted as
+/// the single byte (codepoint - U+F0000). All other characters are
+/// emitted as standard UTF-8.
+pub fn encode_utf8_c8(s: &str) -> Vec<u8> {
+    let mut result = Vec::new();
+    for ch in s.chars() {
+        let cp = ch as u32;
+        if (SYNTHETIC_BASE..=SYNTHETIC_BASE + 0xFF).contains(&cp) {
+            result.push((cp - SYNTHETIC_BASE) as u8);
+        } else {
+            let mut buf = [0u8; 4];
+            let encoded = ch.encode_utf8(&mut buf);
+            result.extend_from_slice(encoded.as_bytes());
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_simple_invalid_byte() {
+        let input = vec![b'A', 0xFE, b'Z'];
+        let decoded = decode_utf8_c8(&input);
+        assert_eq!(decoded.chars().count(), 3);
+        assert_eq!(decoded.chars().next().unwrap(), 'A');
+        assert_eq!(decoded.chars().last().unwrap(), 'Z');
+        let encoded = encode_utf8_c8(&decoded);
+        assert_eq!(encoded, input);
+    }
+
+    #[test]
+    fn roundtrip_multiple_invalid_bytes() {
+        let input = vec![b'A', 0xFE, 0xFD, b'Z'];
+        let decoded = decode_utf8_c8(&input);
+        assert_eq!(decoded.chars().count(), 4);
+        let encoded = encode_utf8_c8(&decoded);
+        assert_eq!(encoded, input);
+    }
+
+    #[test]
+    fn roundtrip_trailing_invalid() {
+        let input = vec![b'A', b'B', 0xFC];
+        let decoded = decode_utf8_c8(&input);
+        assert_eq!(decoded.chars().count(), 3);
+        let encoded = encode_utf8_c8(&decoded);
+        assert_eq!(encoded, input);
+    }
+
+    #[test]
+    fn valid_utf8_passthrough() {
+        let input = "Hello, world!".as_bytes().to_vec();
+        let decoded = decode_utf8_c8(&input);
+        assert_eq!(decoded, "Hello, world!");
+        let encoded = encode_utf8_c8(&decoded);
+        assert_eq!(encoded, input);
+    }
+
+    #[test]
+    fn roundtrip_mixed_valid_invalid() {
+        let input = vec![b'L', 0xE9, b'o', b'n'];
+        let decoded = decode_utf8_c8(&input);
+        assert_eq!(decoded.chars().count(), 4);
+        let encoded = encode_utf8_c8(&decoded);
+        assert_eq!(encoded, input);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement proper UTF-8 Clean-8 (utf8-c8) encoding that round-trips arbitrary byte sequences through Raku strings
- Invalid UTF-8 bytes are decoded as synthetic codepoints (U+F0000+byte_value) and re-encoded back to original bytes
- Wired into all encode/decode paths: Buf.decode, Str.encode, Encoding::Encoder, Encoding::Decoder, and builtins

## Test plan
- [x] All 66 subtests in `roast/S32-str/utf8-c8.t` pass
- [x] Added to `roast-whitelist.txt` (sorted)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `make test` passes (only pre-existing flaky t/lock.t failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)