### PR TITLE
fix: implement nextsame/nextwith in proto-dispatched multi subs

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -578,6 +578,7 @@ roast/S12-methods/chaining.t
 roast/S12-methods/class-and-instance.t
 roast/S12-methods/default-trait.t
 roast/S12-methods/defer-call.t
+roast/S12-methods/defer-next.t
 roast/S12-methods/delegation.t
 roast/S12-methods/fallback.t
 roast/S12-methods/how.t

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1059,9 +1059,15 @@ impl Interpreter {
             }
         }
         // Push onto routine_stack so that `return` inside the method body
-        // compiles as `Return` (not `ReturnFromNonRoutine`).
+        // compiles as `Return` (not `ReturnFromNonRoutine`), and so that
+        // `&?ROUTINE` can find the current method name.
+        let method_name_for_stack = self
+            .samewith_context_stack
+            .last()
+            .map(|(n, _)| n.clone())
+            .unwrap_or_default();
         self.routine_stack
-            .push((owner_class.to_string(), String::new()));
+            .push((owner_class.to_string(), method_name_for_stack));
         let block_result = self.run_block(&method_def.body);
         self.routine_stack.pop();
         let implicit_return = self.env.get("_").cloned();

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1018,7 +1018,7 @@ impl Interpreter {
         None
     }
 
-    fn resolve_proto_function(&self, name: &str) -> Option<FunctionDef> {
+    pub(super) fn resolve_proto_function(&self, name: &str) -> Option<FunctionDef> {
         if name.contains("::") {
             return self.proto_functions.get(&Symbol::intern(name)).cloned();
         }
@@ -1171,10 +1171,25 @@ impl Interpreter {
                 return Err(e);
             }
         };
+        // Set up multi dispatch stack so nextsame/nextwith can walk through
+        // remaining candidates when called inside a proto-dispatched multi sub.
+        // Get candidates in dispatch order (same sorting as resolve_function_with_types)
+        // and take all candidates after the first (current) match.
+        let remaining = self.resolve_remaining_proto_candidates(&proto_name, &args, &def);
+        let pushed_dispatch = !remaining.is_empty();
+        if pushed_dispatch {
+            self.multi_dispatch_stack
+                .push((proto_name.clone(), remaining, args.clone()));
+        }
+        self.samewith_context_stack.push((proto_name.clone(), None));
         self.routine_stack
             .push((def.package.resolve(), def.name.resolve()));
         let result = self.run_block(&def.body);
         self.routine_stack.pop();
+        self.samewith_context_stack.pop();
+        if pushed_dispatch {
+            self.multi_dispatch_stack.pop();
+        }
         let implicit_return = self.env.get("_").cloned().unwrap_or(Value::Nil);
         let mut restored_env = saved_env.clone();
         self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
@@ -1185,6 +1200,78 @@ impl Interpreter {
             Err(e) => Err(e),
             Ok(()) => Ok(implicit_return),
         }
+    }
+
+    /// Collect remaining multi candidates after the current one, in dispatch order.
+    /// Uses the same candidate sorting as resolve_function_with_types to ensure
+    /// nextsame/nextwith walk candidates in the correct order.
+    fn resolve_remaining_proto_candidates(
+        &mut self,
+        name: &str,
+        args: &[Value],
+        current_def: &FunctionDef,
+    ) -> Vec<FunctionDef> {
+        let arity = args
+            .iter()
+            .filter(|v| !matches!(v, Value::Pair(..)))
+            .count();
+        let prefix_local = format!("{}::{}/{}:", self.current_package, name, arity);
+        let prefix_global = format!("GLOBAL::{}/{}:", name, arity);
+        let generic_keys = [
+            format!("{}::{}/{}", self.current_package, name, arity),
+            format!("GLOBAL::{}/{}", name, arity),
+        ];
+        // Collect all candidates (typed + generic) like resolve_function_with_types
+        let mut candidates: Vec<(String, FunctionDef)> = self
+            .functions
+            .iter()
+            .filter(|(key, _)| {
+                let ks = key.resolve();
+                ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
+            })
+            .map(|(key, def)| (key.resolve(), def.clone()))
+            .collect();
+        for key in &generic_keys {
+            let key_sym = Symbol::intern(key);
+            let m_prefix = format!("{}__m", key);
+            let more: Vec<(String, FunctionDef)> = self
+                .functions
+                .iter()
+                .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
+                .map(|(k, def)| (k.resolve(), def.clone()))
+                .collect();
+            candidates.extend(more);
+        }
+        // Sort by specificity (same as resolve_function_with_types)
+        self.sort_candidates_by_specificity(&mut candidates);
+        // Walk sorted candidates: find all matching ones, skip duplicates,
+        // and return everything after the current candidate.
+        let current_fp = crate::ast::function_body_fingerprint(
+            &current_def.params,
+            &current_def.param_defs,
+            &current_def.body,
+        );
+        let mut seen_fps = std::collections::HashSet::new();
+        let mut found_current = false;
+        let mut remaining = Vec::new();
+        for (_key, cand) in &candidates {
+            let fp =
+                crate::ast::function_body_fingerprint(&cand.params, &cand.param_defs, &cand.body);
+            if !seen_fps.insert(fp) {
+                continue; // duplicate
+            }
+            if !self.args_match_param_types(args, &cand.param_defs) {
+                continue; // doesn't match
+            }
+            if !found_current {
+                if fp == current_fp {
+                    found_current = true;
+                }
+                continue;
+            }
+            remaining.push(cand.clone());
+        }
+        remaining
     }
 
     fn rewrite_proto_dispatch_stmts(body: &[Stmt]) -> Vec<Stmt> {

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -215,6 +215,24 @@ impl Interpreter {
                 name, sig_gist
             ))));
         }
+        if method == "dispatcher" && args.is_empty() {
+            let qualified = format!("{}::{}", package, name);
+            if self.resolve_proto_function(&qualified).is_some() {
+                return Some(Ok(Value::Routine {
+                    package: Symbol::intern(package),
+                    name: Symbol::intern(name),
+                    is_regex: false,
+                }));
+            }
+            if self.resolve_proto_function_with_alias(name).is_some() {
+                return Some(Ok(Value::Routine {
+                    package: Symbol::intern(package),
+                    name: Symbol::intern(name),
+                    is_regex: false,
+                }));
+            }
+            return Some(Ok(target.clone()));
+        }
         if method == "can" {
             let method_name = args
                 .first()
@@ -235,6 +253,7 @@ impl Interpreter {
                     | "Str"
                     | "gist"
                     | "can"
+                    | "dispatcher"
             );
             return Some(Ok(Value::Bool(can)));
         }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -925,7 +925,9 @@ impl Interpreter {
                 return self.call_function(&name_str, args);
             }
             // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
-            if !args.is_empty() {
+            // Only use this when the package is a known class.
+            let pkg = package.resolve();
+            if !args.is_empty() && !pkg.is_empty() && pkg != "GLOBAL" && self.has_class(&pkg) {
                 let invocant = args[0].clone();
                 let method_args = args[1..].to_vec();
                 return self.call_method_with_values(invocant, &name_str, method_args);

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -911,14 +911,26 @@ impl Interpreter {
             other => other,
         };
         if let Value::Routine { package, name, .. } = &func {
-            // Try fully-qualified name first (e.g. "A::foo"), then bare name
             if package != "" && package != "GLOBAL" {
                 let fq = format!("{package}::{name}");
                 if self.resolve_function(&fq).is_some() {
                     return self.call_function(&fq, args);
                 }
             }
-            return self.call_function(&name.resolve(), args);
+            let name_str = name.resolve();
+            if self.resolve_function(&name_str).is_some()
+                || self.has_proto(&name_str)
+                || self.has_multi_candidates(&name_str)
+            {
+                return self.call_function(&name_str, args);
+            }
+            // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
+            if !args.is_empty() {
+                let invocant = args[0].clone();
+                let method_args = args[1..].to_vec();
+                return self.call_method_with_values(invocant, &name_str, method_args);
+            }
+            return self.call_function(&name_str, args);
         }
         if let Value::Junction { kind, values } = func {
             let mut results = Vec::with_capacity(values.len());

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -319,6 +319,20 @@ impl VM {
                     return self.interpreter.call_function(&fq, args);
                 }
             }
+            if self.interpreter.has_function(&name_str)
+                || self.interpreter.has_proto(&name_str)
+                || self.interpreter.has_multi_candidates(&name_str)
+            {
+                return self.interpreter.call_function(&name_str, args);
+            }
+            // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
+            if !args.is_empty() && !pkg.is_empty() && pkg != "GLOBAL" {
+                let invocant = args[0].clone();
+                let method_args = args[1..].to_vec();
+                return self
+                    .interpreter
+                    .call_method_with_values(invocant, &name_str, method_args);
+            }
             return self.interpreter.call_function(&name_str, args);
         }
 

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -326,7 +326,12 @@ impl VM {
                 return self.interpreter.call_function(&name_str, args);
             }
             // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
-            if !args.is_empty() && !pkg.is_empty() && pkg != "GLOBAL" {
+            // Only use this when the package is a known class.
+            if !args.is_empty()
+                && !pkg.is_empty()
+                && pkg != "GLOBAL"
+                && self.interpreter.has_class(&pkg)
+            {
                 let invocant = args[0].clone();
                 let method_args = args[1..].to_vec();
                 return self

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -339,6 +339,10 @@ impl VM {
             }
         }
 
+        // Push routine_stack so &?ROUTINE can find the current method
+        self.interpreter
+            .push_routine(owner_class.to_string(), method_name.to_string());
+
         // Execute bytecode
         let let_mark = self.interpreter.let_saves_len();
         let mut ip = 0;
@@ -527,6 +531,7 @@ impl VM {
         }
         self.interpreter.restore_var_bindings(restored_bindings);
 
+        self.interpreter.pop_routine();
         self.interpreter.pop_method_class();
         let _frame = self.pop_call_frame();
         *self.interpreter.env_mut() = merged_env;


### PR DESCRIPTION
## Summary
- Enable `roast/S12-methods/defer-next.t` (all 26 subtests pass)
- Implement multi dispatch stack setup in proto sub dispatch, so `nextsame`/`nextwith` can walk through remaining candidates
- Implement `&?ROUTINE.dispatcher()` method on Routine values to return the proto sub/method
- Fix `&?ROUTINE` in compiled methods by pushing method name onto routine_stack in VM method dispatch
- Add fallback method dispatch for Routine values referencing class methods

## Test plan
- [x] All 26 subtests in `roast/S12-methods/defer-next.t` pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `make test` passes (pre-existing failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)