### PR TITLE
fix: handle buf16/Buf[uint16] decode as UTF-16 code units

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -629,6 +629,7 @@ roast/S15-nfg/cgj.t
 roast/S15-nfg/concatenation.t
 roast/S15-nfg/crlf-encoding.t
 roast/S15-nfg/emoji-test.t
+roast/S15-nfg/from-buf.t
 roast/S15-nfg/from-file.t
 roast/S15-nfg/grapheme-break.t
 roast/S15-nfg/long-uni.t

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -258,7 +258,10 @@ fn decode_buf_target_bytes(target: &Value, encoding_name: &str) -> Option<Vec<u8
         return Some(Vec::new());
     };
 
-    if class_name == "utf16" {
+    let cn = class_name.resolve();
+    // buf16 / Buf[uint16] / utf16 store 16-bit code units; expand each to 2 bytes
+    let is_wide = cn == "utf16" || cn == "buf16" || cn == "Buf[uint16]";
+    if is_wide {
         let use_be = encoding_name == "utf-16be";
         let mut out = Vec::with_capacity(items.len() * 2);
         for item in items.iter() {
@@ -298,7 +301,8 @@ pub(crate) fn decode_buf_method(
         return None;
     }
 
-    let default_encoding = if class_name == "utf16" {
+    let cn = class_name.resolve();
+    let default_encoding = if cn == "utf16" || cn == "buf16" || cn == "Buf[uint16]" {
         "utf-16"
     } else {
         "utf-8"

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -100,11 +100,9 @@ impl Interpreter {
         } = target
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            let default_encoding = if class_name == "utf16" {
-                "utf-16"
-            } else {
-                "utf-8"
-            };
+            let cn = class_name.resolve();
+            let is_wide = cn == "utf16" || cn == "buf16" || cn == "Buf[uint16]";
+            let default_encoding = if is_wide { "utf-16" } else { "utf-8" };
             let encoding = args
                 .first()
                 .map(|v| v.to_string_value())
@@ -113,7 +111,7 @@ impl Interpreter {
                 .find_encoding(&encoding)
                 .map(|e| e.name.as_str().to_lowercase())
                 .unwrap_or_else(|| encoding.to_lowercase());
-            let bytes = if class_name == "utf16" {
+            let bytes = if is_wide {
                 if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
                     let use_be = normalized_encoding == "utf-16be";
                     let mut out = Vec::with_capacity(items.len() * 2);


### PR DESCRIPTION
## Summary
- Fix `buf16.decode('utf-16')` which was truncating 16-bit code units to 8-bit bytes, causing "Invalid utf-16 byte length" errors
- Extend the existing `utf16` special handling to also cover `buf16` and `Buf[uint16]` class names in both the builtins decode path and the runtime decode dispatch
- Adds `roast/S15-nfg/from-buf.t` to the whitelist (6/6 passing)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S15-nfg/from-buf.t` passes (6/6)
- [x] `make test` passes (only pre-existing `t/lock.t` flake)
- [x] `make roast` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)