### PR TITLE
fix: handle backslash escapes in regex character class bracket extraction

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -355,6 +355,7 @@ roast/S05-metachars/newline.t
 roast/S05-metachars/tilde.t
 roast/S05-metasyntax/assertions.t
 roast/S05-metasyntax/changed.t
+roast/S05-metasyntax/charset.t
 roast/S05-metasyntax/delimiters.t
 roast/S05-metasyntax/interpolating-closure.t
 roast/S05-metasyntax/lookaround.t

--- a/src/regex_validate.rs
+++ b/src/regex_validate.rs
@@ -691,6 +691,7 @@ fn validate_bracket_class_content(content: &str) -> Result<(), RuntimeError> {
         }
         if found_close {
             check_bracket_body_for_perl5_range(&body)?;
+            check_bracket_body_for_nfg_synthetic(&body)?;
         }
         // Advance past the consumed content (bracket body + closing ']')
         remaining = &remaining[start + 1 + consumed..];
@@ -827,6 +828,55 @@ fn check_bracket_body_for_perl5_range(body: &str) -> Result<(), RuntimeError> {
             prev_was_alnum = false;
         } else {
             prev_was_alnum = c.is_alphanumeric();
+        }
+    }
+    Ok(())
+}
+
+/// Check a bracket class body for NFG synthetic characters (base char + combining marks).
+/// These cannot be used as range endpoints.
+#[allow(clippy::result_large_err)]
+fn check_bracket_body_for_nfg_synthetic(body: &str) -> Result<(), RuntimeError> {
+    let mut chars = body.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            // Skip escape sequences
+            if let Some(&esc) = chars.peek() {
+                chars.next();
+                if matches!(esc, 'c' | 'C' | 'x' | 'X' | 'o') && chars.peek() == Some(&'[') {
+                    chars.next(); // skip '['
+                    let mut depth = 1;
+                    for ch in chars.by_ref() {
+                        if ch == '[' {
+                            depth += 1;
+                        } else if ch == ']' {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } else if c == ' ' {
+            // Skip whitespace
+        } else if chars
+            .peek()
+            .is_some_and(|ch| unicode_normalization::char::is_combining_mark(*ch))
+        {
+            // Base character followed by combining mark(s) — NFG synthetic
+            let mut grapheme = c.to_string();
+            while chars
+                .peek()
+                .is_some_and(|ch| unicode_normalization::char::is_combining_mark(*ch))
+            {
+                grapheme.push(chars.next().unwrap());
+            }
+            let msg = format!(
+                "Cannot use {} as a range endpoint, as it is not a single codepoint",
+                grapheme
+            );
+            return Err(RuntimeError::new(msg));
         }
     }
     Ok(())

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1573,8 +1573,20 @@ impl Interpreter {
                                     }
                                     continue;
                                 }
+                                // Handle backslash escapes inside bracket classes:
+                                // \[ and \] should not affect bracket_depth, etc.
+                                if escaped {
+                                    escaped = false;
+                                    name.push(ch);
+                                    continue;
+                                }
+                                if ch == '\\' && bracket_depth > 0 {
+                                    escaped = true;
+                                    name.push(ch);
+                                    continue;
+                                }
                                 match ch {
-                                    '\'' | '"' => {
+                                    '\'' | '"' if bracket_depth == 0 => {
                                         quote = Some(ch);
                                         name.push(ch);
                                     }


### PR DESCRIPTION
## Summary
- Fix backslash-escaped characters (`\[`, `\{`, `\\`, `\"`, etc.) inside bracket character classes being incorrectly tracked for bracket/brace depth in the `<...>` extraction loop
- Fix quote characters (`"`, `'`) inside bracket classes incorrectly triggering quote mode
- Add parse-time validation for NFG synthetic characters in bracket classes (base char + combining marks)
- Adds `roast/S05-metasyntax/charset.t` to whitelist (55/55 passing)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S05-metasyntax/charset.t` — all 55 subtests pass
- [x] `make test` — all local tests pass
- [x] `make roast` — all whitelisted roast tests pass
- [x] `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)