### PR TITLE
fix: pass all 193 subtests in roast/S05-mass/stdrules.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -342,6 +342,7 @@ roast/S05-mass/properties-contributory.t
 roast/S05-mass/properties-derived.t
 roast/S05-mass/properties-general.t
 roast/S05-mass/properties-script.t
+roast/S05-mass/stdrules.t
 roast/S05-match/arrayhash.t
 roast/S05-match/basics.t
 roast/S05-match/blocks.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -645,6 +645,12 @@ enum RegexAtom {
     Backref(usize),
     /// `$<name>` — backreference to named capture group
     NamedBackref(String),
+    /// `<?same>` / `<!same>` — zero-width assertion: adjacent chars are same/different
+    SameAssertion {
+        negated: bool,
+    },
+    /// `<at(N)>` — zero-width assertion: match at position N
+    AtPosition(usize),
     /// Internal marker used while rewriting `left ~ goal inner`.
     TildeMarker,
     /// Goal matching produced by `~`: match `inner` first, then `goal`,

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -412,6 +412,14 @@ pub(super) fn matches_named_builtin(name: &str, c: char) -> bool {
         "blank" => c == '\t' || c == ' ' || c == '\u{A0}',
         "cntrl" => c.is_control(),
         "punct" => check_unicode_property("Punctuation", c),
+        "graph" => {
+            // graph: visible characters — not whitespace, not control, not unassigned surrogates
+            !c.is_whitespace() && !c.is_control()
+        }
+        "print" => {
+            // print: graph + space-like characters (but not control characters)
+            !c.is_control()
+        }
         _ => false,
     }
 }

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -318,11 +318,8 @@ impl Interpreter {
                     return if *negated { Some(pos) } else { None };
                 }
                 let same = chars[pos - 1] == chars[pos];
-                return if *negated {
-                    if !same { Some(pos) } else { None }
-                } else {
-                    if same { Some(pos) } else { None }
-                };
+                let pass = if *negated { !same } else { same };
+                return if pass { Some(pos) } else { None };
             }
             RegexAtom::AtPosition(target) => {
                 // <at(N)> succeeds when current position == N

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -311,6 +311,23 @@ impl Interpreter {
                 let result = if *negated { !prop_match } else { prop_match };
                 return if result { Some(pos) } else { None };
             }
+            RegexAtom::SameAssertion { negated } => {
+                // <?same> succeeds when chars[pos-1] == chars[pos]
+                // <!same> succeeds when chars[pos-1] != chars[pos]
+                if pos == 0 || pos >= chars.len() {
+                    return if *negated { Some(pos) } else { None };
+                }
+                let same = chars[pos - 1] == chars[pos];
+                return if *negated {
+                    if !same { Some(pos) } else { None }
+                } else {
+                    if same { Some(pos) } else { None }
+                };
+            }
+            RegexAtom::AtPosition(target) => {
+                // <at(N)> succeeds when current position == N
+                return if pos == *target { Some(pos) } else { None };
+            }
             _ => {}
         }
         if let RegexAtom::Named(name) = atom {
@@ -556,7 +573,9 @@ impl Interpreter {
             | RegexAtom::StartOfLine
             | RegexAtom::TildeMarker
             | RegexAtom::EndOfLine
-            | RegexAtom::WsRule => unreachable!(),
+            | RegexAtom::WsRule
+            | RegexAtom::SameAssertion { .. }
+            | RegexAtom::AtPosition(_) => unreachable!(),
         };
         if matched {
             match atom {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -111,7 +111,9 @@ impl Interpreter {
             | RegexAtom::RightWordBoundary
             | RegexAtom::StartOfLine
             | RegexAtom::EndOfLine
-            | RegexAtom::WsRule => {
+            | RegexAtom::WsRule
+            | RegexAtom::SameAssertion { .. }
+            | RegexAtom::AtPosition(_) => {
                 return self
                     .regex_match_atom_in_pkg(atom, chars, pos, pkg, ignore_case)
                     .map(|next| (next, current_caps.clone()));

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1676,6 +1676,103 @@ impl Interpreter {
                                         name: prop_name.to_string(),
                                         negated: true,
                                     }
+                                } else if let Some(negated_name) = trimmed.strip_prefix('!') {
+                                    if negated_name.is_empty() {
+                                        // <!> — always-fail (handled as Named("!") downstream)
+                                        RegexAtom::Named(name)
+                                    } else if negated_name == "same" || negated_name == ".same" {
+                                        // <!same> — zero-width assertion: next two chars are different
+                                        RegexAtom::SameAssertion { negated: true }
+                                    } else {
+                                        // <!alpha>, <!digit>, etc. — zero-width negative assertion for named class
+                                        let clean_name =
+                                            negated_name.strip_prefix('.').unwrap_or(negated_name);
+                                        let is_known = matches!(
+                                            clean_name,
+                                            "alpha"
+                                                | "upper"
+                                                | "lower"
+                                                | "digit"
+                                                | "xdigit"
+                                                | "space"
+                                                | "alnum"
+                                                | "blank"
+                                                | "cntrl"
+                                                | "punct"
+                                                | "graph"
+                                                | "print"
+                                                | "ws"
+                                                | "ident"
+                                        );
+                                        if is_known {
+                                            let inner_atom = if clean_name == "ident" {
+                                                RegexAtom::Group(RegexPattern {
+                                                    tokens: vec![
+                                                        RegexToken {
+                                                            atom: RegexAtom::CharClass(CharClass {
+                                                                items: vec![
+                                                                    ClassItem::NamedBuiltin(
+                                                                        "alpha".to_string(),
+                                                                    ),
+                                                                ],
+                                                                negated: false,
+                                                            }),
+                                                            quant: RegexQuant::One,
+                                                            named_capture: None,
+                                                            ratchet: false,
+                                                            frugal: false,
+                                                        },
+                                                        RegexToken {
+                                                            atom: RegexAtom::CharClass(CharClass {
+                                                                items: vec![
+                                                                    ClassItem::NamedBuiltin(
+                                                                        "alnum".to_string(),
+                                                                    ),
+                                                                ],
+                                                                negated: false,
+                                                            }),
+                                                            quant: RegexQuant::ZeroOrMore,
+                                                            named_capture: None,
+                                                            ratchet: false,
+                                                            frugal: false,
+                                                        },
+                                                    ],
+                                                    anchor_start: false,
+                                                    anchor_end: false,
+                                                    ignore_case,
+                                                    ignore_mark,
+                                                })
+                                            } else {
+                                                RegexAtom::CharClass(CharClass {
+                                                    items: vec![ClassItem::NamedBuiltin(
+                                                        clean_name.to_string(),
+                                                    )],
+                                                    negated: false,
+                                                })
+                                            };
+                                            let inner_pattern = RegexPattern {
+                                                tokens: vec![RegexToken {
+                                                    atom: inner_atom,
+                                                    quant: RegexQuant::One,
+                                                    named_capture: None,
+                                                    ratchet: false,
+                                                    frugal: false,
+                                                }],
+                                                anchor_start: false,
+                                                anchor_end: false,
+                                                ignore_case,
+                                                ignore_mark,
+                                            };
+                                            RegexAtom::Lookaround {
+                                                pattern: inner_pattern,
+                                                negated: true,
+                                                is_behind: false,
+                                            }
+                                        } else {
+                                            // Not a known builtin — pass through as Named
+                                            RegexAtom::Named(name)
+                                        }
+                                    } // close else (non-empty negated_name)
                                 } else if trimmed.starts_with(":!") || trimmed.starts_with("-:") {
                                     // <:!PropName> or <-:PropName> — negated Unicode property
                                     let prop_name = &trimmed[2..];
@@ -1761,6 +1858,17 @@ impl Interpreter {
                                     }
                                     try_collapse_alternation_to_charclass(&alt_patterns)
                                         .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                                } else if trimmed == "?same" || trimmed == "?.same" {
+                                    // <?same> — zero-width assertion: next two chars are the same
+                                    RegexAtom::SameAssertion { negated: false }
+                                } else if trimmed.starts_with("at(") && trimmed.ends_with(')') {
+                                    // <at(N)> — zero-width assertion: match at position N
+                                    let inner = &trimmed[3..trimmed.len() - 1];
+                                    if let Ok(pos) = inner.trim().parse::<usize>() {
+                                        RegexAtom::AtPosition(pos)
+                                    } else {
+                                        RegexAtom::Named(name)
+                                    }
                                 } else {
                                     // Strip dot prefix for non-capturing named calls
                                     // <.alpha> is the same as <alpha> but without named capture
@@ -1773,7 +1881,8 @@ impl Interpreter {
                                     // Check for named character classes
                                     match class_name {
                                         "alpha" | "upper" | "lower" | "digit" | "xdigit"
-                                        | "space" | "alnum" | "blank" | "cntrl" | "punct" => {
+                                        | "space" | "alnum" | "blank" | "cntrl" | "punct"
+                                        | "graph" | "print" => {
                                             // Set builtin named capture so $<alpha>, $<digit>, etc. work
                                             // (only for non-dot calls)
                                             if !is_dot_call {
@@ -1789,6 +1898,10 @@ impl Interpreter {
                                         }
                                         "ident" => {
                                             // <ident> = <alpha> <alnum>*
+                                            if !is_dot_call {
+                                                pending_builtin_named_capture =
+                                                    Some("ident".to_string());
+                                            }
                                             RegexAtom::Group(RegexPattern {
                                                 tokens: vec![
                                                     RegexToken {
@@ -3053,7 +3166,11 @@ impl Interpreter {
         }
 
         if positive_items.is_empty() && negative_items.is_empty() {
-            return None;
+            // <[]> or <-[]> — empty bracket class: always fails (matches no character)
+            return Some(RegexAtom::CharClass(CharClass {
+                items: vec![],
+                negated: false,
+            }));
         }
 
         if negative_items.is_empty() {
@@ -3258,6 +3375,8 @@ impl Interpreter {
                             | "blank"
                             | "cntrl"
                             | "punct"
+                            | "graph"
+                            | "print"
                             | "ws"
                     );
                     if !is_known_builtin {
@@ -3285,13 +3404,21 @@ impl Interpreter {
                 }
             }
         }
-        if positive_items.is_empty() {
+        if positive_items.is_empty() && negative_items.is_empty() {
             return None;
         }
-        Some(RegexAtom::CompositeClass {
-            positive: positive_items,
-            negative: negative_items,
-        })
+        if positive_items.is_empty() {
+            // Purely negated: <-alpha> means "any character NOT matching alpha"
+            Some(RegexAtom::CharClass(CharClass {
+                items: negative_items,
+                negated: true,
+            }))
+        } else {
+            Some(RegexAtom::CompositeClass {
+                positive: positive_items,
+                negative: negative_items,
+            })
+        }
     }
 
     /// Find the end of a named class part in a combined class expression.


### PR DESCRIPTION
## Summary
- Add `graph` and `print` named character classes to the regex engine
- Handle `<!alpha>`, `<!digit>`, etc. as zero-width negative lookahead assertions for named classes
- Fix `<-alpha>`, `<-digit>`, etc. (pure negated named class) in `parse_combined_class` which previously returned `None` when `positive_items` was empty
- Add `<ident>` named capture support so `$/<ident>` returns the matched text
- Implement `<?same>` / `<!same>` zero-width assertions for comparing adjacent characters
- Implement `<at(N)>` zero-width position assertion
- Fix `<[]>` and `<-[]>` to correctly fail as empty bracket classes (previously skipped, causing false matches)

## Test plan
- [x] All 193 subtests in `roast/S05-mass/stdrules.t` pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes (pre-existing failures only)
- [x] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)