### PR TITLE
feat: add HyperSeq/RaceSeq value types for .hyper/.race

### DIFF
--- a/TODO_roast/S07.md
+++ b/TODO_roast/S07.md
@@ -1,6 +1,10 @@
 # S07 - iterators, lazy
 
 - [ ] roast/S07-hyperrace/basics.t
+  - HyperSeq/RaceSeq types implemented, most tests pass
+  - BLOCKER: Tests 7, 18, 44, 55 use Promise/await inside .hyper/.race .map blocks that require actual parallelism — deadlocks in single-threaded mode
+  - BLOCKER: Test 90 uses concurrent `start` blocks — requires threading
+  - Remaining: tests 33-37, 70-74 (Buf slice .fmt comparison), test 84 (s/.../.../ in hyper context), tests 88-89 (X::Seq::Consumed)
 - [ ] roast/S07-hyperrace/for.t
 - [x] roast/S07-hyperrace/stress.t
 - [ ] roast/S07-iterationbuffer/iterationbuffer.t

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -356,9 +356,15 @@ pub(super) fn dispatch(
             if matches!(target, Value::LazyList(_)) {
                 return Some(None);
             }
-            // Single-threaded: just materialize into an array
+            // Single-threaded: materialize and wrap in HyperSeq/RaceSeq
             let items = runtime::value_to_list(target);
-            Some(Some(Ok(Value::array(items))))
+            let arc = std::sync::Arc::new(items);
+            let result = if method == "hyper" {
+                Value::HyperSeq(arc)
+            } else {
+                Value::RaceSeq(arc)
+            };
+            Some(Some(Ok(result)))
         }
         "NFC" | "NFD" | "NFKC" | "NFKD" => {
             use unicode_normalization::UnicodeNormalization;

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2086,6 +2086,88 @@ impl Interpreter {
             return Err(err);
         }
 
+        // .hyper/.race with named args: validate and wrap
+        if matches!(method, "hyper" | "race") && !args.is_empty() {
+            let mut batch_val: Option<i64> = None;
+            let mut degree_val: Option<i64> = None;
+            for arg in &args {
+                let (key, val) = match arg {
+                    Value::Pair(k, v) => (k.clone(), to_int(v)),
+                    Value::ValuePair(k, v) => (k.to_string_value(), to_int(v)),
+                    _ => continue,
+                };
+                match key.as_str() {
+                    "batch" => batch_val = Some(val),
+                    "degree" => degree_val = Some(val),
+                    _ => {}
+                }
+            }
+            if let Some(b) = batch_val
+                && b <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("method".to_string(), Value::str(method.to_string()));
+                attrs.insert("name".to_string(), Value::str("batch".to_string()));
+                attrs.insert("value".to_string(), Value::Int(b));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!("Invalid value '{}' for 'batch' on '{}'", b, method)),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            if let Some(d) = degree_val
+                && d <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("method".to_string(), Value::str(method.to_string()));
+                attrs.insert("name".to_string(), Value::str("degree".to_string()));
+                attrs.insert("value".to_string(), Value::Int(d));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid value '{}' for 'degree' on '{}'",
+                        d, method
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            let items = value_to_list(&target);
+            let arc = std::sync::Arc::new(items);
+            return Ok(if method == "hyper" {
+                Value::HyperSeq(arc)
+            } else {
+                Value::RaceSeq(arc)
+            });
+        }
+
+        // HyperSeq/RaceSeq: delegate to array for most methods
+        if matches!(&target, Value::HyperSeq(_) | Value::RaceSeq(_)) {
+            let is_hyper = matches!(&target, Value::HyperSeq(_));
+            let items = match &target {
+                Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                _ => unreachable!(),
+            };
+            match method {
+                "hyper" => return Ok(Value::HyperSeq(items)),
+                "race" => return Ok(Value::RaceSeq(items)),
+                "is-lazy" => return Ok(Value::Bool(false)),
+                "map" | "grep" => {
+                    let array_target = Value::Array(items, crate::value::ArrayKind::List);
+                    let result = self.call_method_with_values(array_target, method, args)?;
+                    let result_items = value_to_list(&result);
+                    return Ok(if is_hyper {
+                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                    } else {
+                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                    });
+                }
+                _ => {
+                    let array_target = Value::Array(items, crate::value::ArrayKind::List);
+                    return self.call_method_with_values(array_target, method, args);
+                }
+            }
+        }
+
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -92,6 +92,8 @@ impl Interpreter {
             Value::Version { .. } => "Version",
             Value::Slip(_) => "Slip",
             Value::Seq(_) => "Seq",
+            Value::HyperSeq(_) => "HyperSeq",
+            Value::RaceSeq(_) => "RaceSeq",
             Value::Promise(_) => "Promise",
             Value::Channel(_) => "Channel",
             Value::Whatever => "Whatever",

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -198,13 +198,26 @@ impl Interpreter {
         if constraint == "Positional"
             && matches!(
                 value_type,
-                "Array" | "List" | "Seq" | "Range" | "Buf" | "Blob" | "Capture"
+                "Array"
+                    | "List"
+                    | "Seq"
+                    | "HyperSeq"
+                    | "RaceSeq"
+                    | "Range"
+                    | "Buf"
+                    | "Blob"
+                    | "Capture"
             )
         {
             return true;
         }
         // Array is-a List in Raku type hierarchy
-        if constraint == "List" && matches!(value_type, "Array" | "List" | "Seq") {
+        if constraint == "List"
+            && matches!(
+                value_type,
+                "Array" | "List" | "Seq" | "HyperSeq" | "RaceSeq"
+            )
+        {
             return true;
         }
         if constraint == "Associative"

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -448,7 +448,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             }
             Value::hash(map)
         }
-        Value::Seq(items) | Value::Slip(items) => {
+        Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) | Value::Slip(items) => {
             let mut map = HashMap::new();
             let mut i = 0;
             while i < items.len() {
@@ -661,7 +661,9 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
                 Value::real_array(value_to_list(&value))
             }
         }
-        Value::Slip(items) | Value::Seq(items) => Value::Array(items, ArrayKind::Array),
+        Value::Slip(items) | Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+            Value::Array(items, ArrayKind::Array)
+        }
         Value::LazyList(_) => value,
         Value::Hash(ref map) => {
             // Hash assigned to @-var: flatten into pairs
@@ -746,7 +748,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
         }
         Value::Pair(k, v) => format!("{} => {}", k, gist_value(v)),
         Value::ValuePair(k, v) => format!("{} => {}", gist_value(k), gist_value(v)),
-        Value::Seq(items) | Value::Slip(items) => {
+        Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) | Value::Slip(items) => {
             format!(
                 "({})",
                 items.iter().map(gist_value).collect::<Vec<_>>().join(" ")
@@ -1299,6 +1301,8 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Regex(_) | Value::RegexWithAdverbs { .. } => "Regex",
         Value::Version { .. } => "Version",
         Value::Seq(_) => "Seq",
+        Value::HyperSeq(_) => "HyperSeq",
+        Value::RaceSeq(_) => "RaceSeq",
         Value::Slip(_) => "Slip",
         Value::Promise(_) => "Promise",
         Value::Channel(_) => "Channel",
@@ -1483,7 +1487,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
     match val {
         Value::Array(items, kind) if kind.is_itemized() => vec![val.clone()],
         Value::Array(items, ..) => items.to_vec(),
-        Value::Seq(items) => items.to_vec(),
+        Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => items.to_vec(),
         Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
         Value::Hash(items) => items
             .iter()
@@ -2991,7 +2995,7 @@ pub(crate) fn to_int(v: &Value) -> i64 {
         Value::Str(s) => s.parse().unwrap_or(0),
         Value::Array(items, ..) => items.len() as i64,
         Value::Hash(items) => items.len() as i64,
-        Value::Seq(items) => items.len() as i64,
+        Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => items.len() as i64,
         Value::Slip(items) => items.len() as i64,
         Value::Instance { attributes, .. } => attributes.get("__mutsu_int_value").map_or(0, to_int),
         _ => 0,

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -835,7 +835,10 @@ impl Value {
                     s
                 }
             }
-            Value::Seq(items) | Value::Slip(items) => items
+            Value::Seq(items)
+            | Value::HyperSeq(items)
+            | Value::RaceSeq(items)
+            | Value::Slip(items) => items
                 .iter()
                 .map(|v| v.to_str_context())
                 .collect::<Vec<_>>()

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -761,6 +761,10 @@ pub enum Value {
         values: Arc<Vec<Value>>,
     },
     Seq(Arc<Vec<Value>>),
+    /// HyperSeq: result of `.hyper` — preserves order, single-threaded implementation.
+    HyperSeq(Arc<Vec<Value>>),
+    /// RaceSeq: result of `.race` — unordered parallel, single-threaded implementation.
+    RaceSeq(Arc<Vec<Value>>),
     Slip(Arc<Vec<Value>>),
     LazyList(Arc<LazyList>),
     Version {

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -227,7 +227,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 values: ser_values?,
             })
         }
-        Value::Seq(items) => {
+        Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
             let ser_items: Result<Vec<_>, _> = items.iter().map(value_to_ser).collect();
             Ok(SerValue::Seq(ser_items?))
         }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -385,7 +385,7 @@ impl Value {
                 JunctionKind::None => values.iter().all(|v| !v.truthy()),
             },
             Value::Slip(items) => !items.is_empty(),
-            Value::Seq(items) => !items.is_empty(),
+            Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => !items.is_empty(),
             Value::LazyList(_) => true,
             Value::Promise(p) => p.is_resolved(),
             Value::Channel(_) => true,
@@ -440,6 +440,8 @@ impl Value {
             Value::Complex(_, _) => "Complex",
             Value::Array(..) | Value::LazyList(_) => "Array",
             Value::Seq(_) => "Seq",
+            Value::HyperSeq(_) => "HyperSeq",
+            Value::RaceSeq(_) => "RaceSeq",
             Value::Hash(_) => "Hash",
             Value::Set(_, is_mutable) => {
                 if *is_mutable {
@@ -657,8 +659,21 @@ impl Value {
                     false
                 }
             }
+            "HyperSeq" => {
+                matches!(self, Value::HyperSeq(_))
+            }
+            "RaceSeq" => {
+                matches!(self, Value::RaceSeq(_))
+            }
             "Seq" | "List" => {
-                matches!(self, Value::Array(..) | Value::LazyList(_) | Value::Slip(_))
+                matches!(
+                    self,
+                    Value::Array(..)
+                        | Value::LazyList(_)
+                        | Value::Slip(_)
+                        | Value::HyperSeq(_)
+                        | Value::RaceSeq(_)
+                )
             }
             "Positional" => {
                 matches!(
@@ -770,6 +785,8 @@ pub(crate) fn what_type_name(val: &Value) -> String {
         Value::Complex(_, _) => "Complex".to_string(),
         Value::Array(..) | Value::LazyList(_) => "Array".to_string(),
         Value::Seq(_) => "Seq".to_string(),
+        Value::HyperSeq(_) => "HyperSeq".to_string(),
+        Value::RaceSeq(_) => "RaceSeq".to_string(),
         Value::Hash(_) => "Hash".to_string(),
         Value::Set(_, is_mutable) => {
             if *is_mutable {

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -680,6 +680,8 @@ impl Value {
                     self,
                     Value::Array(..)
                         | Value::LazyList(_)
+                        | Value::HyperSeq(_)
+                        | Value::RaceSeq(_)
                         | Value::Range(_, _)
                         | Value::RangeExcl(_, _)
                         | Value::RangeExclStart(_, _)

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -58,7 +58,10 @@ impl VM {
 
     pub(super) fn append_slip_value(args: &mut Vec<Value>, slip_val: Value) {
         match slip_val {
-            Value::Array(elements, ..) | Value::Seq(elements) => {
+            Value::Array(elements, ..)
+            | Value::Seq(elements)
+            | Value::HyperSeq(elements)
+            | Value::RaceSeq(elements) => {
                 args.extend(elements.iter().cloned());
             }
             Value::Capture { positional, named } => {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -52,6 +52,144 @@ impl VM {
                 err.return_value = Some(target);
                 return Err(err);
             }
+            // .hyper/.race with named arguments: validate, then create HyperSeq/RaceSeq
+            if matches!(method.as_str(), "hyper" | "race") {
+                // Extract batch/degree for validation
+                let mut batch: Option<i64> = None;
+                let mut degree: Option<i64> = None;
+                for arg in &args {
+                    let (key, val) = match arg {
+                        Value::Pair(k, v) => (k.clone(), crate::runtime::to_int(v)),
+                        Value::ValuePair(k, v) => (k.to_string_value(), crate::runtime::to_int(v)),
+                        _ => continue,
+                    };
+                    match key.as_str() {
+                        "batch" => batch = Some(val),
+                        "degree" => degree = Some(val),
+                        _ => {}
+                    }
+                }
+                if let Some(b) = batch
+                    && b <= 0
+                {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("method".to_string(), Value::str(method.clone()));
+                    attrs.insert("name".to_string(), Value::str("batch".to_string()));
+                    attrs.insert("value".to_string(), Value::Int(b));
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!("Invalid value '{}' for 'batch' on '{}'", b, method)),
+                    );
+                    return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+                }
+                if let Some(d) = degree
+                    && d <= 0
+                {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("method".to_string(), Value::str(method.clone()));
+                    attrs.insert("name".to_string(), Value::str("degree".to_string()));
+                    attrs.insert("value".to_string(), Value::Int(d));
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Invalid value '{}' for 'degree' on '{}'",
+                            d, method
+                        )),
+                    );
+                    return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+                }
+                // Create HyperSeq/RaceSeq
+                let items = crate::runtime::value_to_list(&target);
+                let arc = std::sync::Arc::new(items);
+                let result = if method == "hyper" {
+                    Value::HyperSeq(arc)
+                } else {
+                    Value::RaceSeq(arc)
+                };
+                self.stack.push(result);
+                self.env_dirty = true;
+                return Ok(());
+            }
+            // HyperSeq/RaceSeq: delegate methods
+            if matches!(&target, Value::HyperSeq(_) | Value::RaceSeq(_)) {
+                let is_hyper = matches!(&target, Value::HyperSeq(_));
+                let items_arc = match &target {
+                    Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                    _ => unreachable!(),
+                };
+                match method.as_str() {
+                    "hyper" => {
+                        self.stack.push(Value::HyperSeq(items_arc));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "race" => {
+                        self.stack.push(Value::RaceSeq(items_arc));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "is-lazy" => {
+                        self.stack.push(Value::Bool(false));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "^name" => {
+                        self.stack.push(Value::str(
+                            if is_hyper { "HyperSeq" } else { "RaceSeq" }.to_string(),
+                        ));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "WHAT" => {
+                        self.stack.push(Value::Package(Symbol::intern(if is_hyper {
+                            "HyperSeq"
+                        } else {
+                            "RaceSeq"
+                        })));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "defined" => {
+                        self.stack.push(Value::Bool(true));
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    "map" | "grep" => {
+                        let array_target = Value::Array(items_arc, crate::value::ArrayKind::List);
+                        let call_result = if let Some(nr) =
+                            self.try_native_method(&array_target, Symbol::intern(&method), &args)
+                        {
+                            nr
+                        } else {
+                            self.try_compiled_method_or_interpret(array_target, &method, args)
+                        };
+                        let result_val = call_result?;
+                        let result_items = crate::runtime::value_to_list(&result_val);
+                        let wrapped = if is_hyper {
+                            Value::HyperSeq(Arc::new(result_items))
+                        } else {
+                            Value::RaceSeq(Arc::new(result_items))
+                        };
+                        self.stack.push(wrapped);
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    _ => {
+                        // Convert to array and delegate
+                        let array_target = Value::Array(items_arc, crate::value::ArrayKind::List);
+                        let call_result = if let Some(nr) =
+                            self.try_native_method(&array_target, Symbol::intern(&method), &args)
+                        {
+                            nr
+                        } else {
+                            self.try_compiled_method_or_interpret(array_target, &method, args)
+                        };
+                        self.stack.push(call_result?);
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                }
+            }
             if let Some(native_result) =
                 self.try_native_method(&target, Symbol::intern(&method), &args)
             {
@@ -406,6 +544,143 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // .hyper/.race with named arguments in mut path
+        if matches!(method.as_str(), "hyper" | "race") && !args.is_empty() {
+            let mut batch: Option<i64> = None;
+            let mut degree: Option<i64> = None;
+            for arg in &args {
+                let (key, val) = match arg {
+                    Value::Pair(k, v) => (k.clone(), crate::runtime::to_int(v)),
+                    Value::ValuePair(k, v) => (k.to_string_value(), crate::runtime::to_int(v)),
+                    _ => continue,
+                };
+                match key.as_str() {
+                    "batch" => batch = Some(val),
+                    "degree" => degree = Some(val),
+                    _ => {}
+                }
+            }
+            if let Some(b) = batch
+                && b <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "method".to_string(),
+                    Value::str(method.as_str().to_string()),
+                );
+                attrs.insert("name".to_string(), Value::str("batch".to_string()));
+                attrs.insert("value".to_string(), Value::Int(b));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid value '{}' for 'batch' on '{}'",
+                        b,
+                        method.as_str()
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            if let Some(d) = degree
+                && d <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "method".to_string(),
+                    Value::str(method.as_str().to_string()),
+                );
+                attrs.insert("name".to_string(), Value::str("degree".to_string()));
+                attrs.insert("value".to_string(), Value::Int(d));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid value '{}' for 'degree' on '{}'",
+                        d,
+                        method.as_str()
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            let items = crate::runtime::value_to_list(&target);
+            let arc = std::sync::Arc::new(items);
+            let result = if method == "hyper" {
+                Value::HyperSeq(arc)
+            } else {
+                Value::RaceSeq(arc)
+            };
+            self.stack.push(result);
+            self.env_dirty = true;
+            return Ok(());
+        }
+        // HyperSeq/RaceSeq delegation in mut path
+        if matches!(&target, Value::HyperSeq(_) | Value::RaceSeq(_)) {
+            let is_hyper = matches!(&target, Value::HyperSeq(_));
+            match method.as_str() {
+                "hyper" | "race" | "is-lazy" | "^name" | "WHAT" | "defined" => {
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    let result = match method.as_str() {
+                        "hyper" => Value::HyperSeq(items_arc),
+                        "race" => Value::RaceSeq(items_arc),
+                        "is-lazy" => Value::Bool(false),
+                        "defined" => Value::Bool(true),
+                        "^name" => {
+                            let name = if is_hyper { "HyperSeq" } else { "RaceSeq" };
+                            Value::str(name.to_string())
+                        }
+                        "WHAT" => {
+                            let name = if is_hyper { "HyperSeq" } else { "RaceSeq" };
+                            Value::Package(Symbol::intern(name))
+                        }
+                        _ => unreachable!(),
+                    };
+                    self.stack.push(result);
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "map" | "grep" => {
+                    // Delegate to array, then wrap result
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    let array_target = Value::Array(items_arc, crate::value::ArrayKind::List);
+                    let call_result = if let Some(native_result) =
+                        self.try_native_method(&array_target, Symbol::intern(&method), &args)
+                    {
+                        native_result
+                    } else {
+                        self.try_compiled_method_mut_or_interpret(
+                            &target_name,
+                            array_target,
+                            &method,
+                            args,
+                        )
+                    };
+                    let result_val = call_result?;
+                    let result_items = crate::runtime::value_to_list(&result_val);
+                    let wrapped = if is_hyper {
+                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                    } else {
+                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                    };
+                    self.stack.push(wrapped);
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                _ => {
+                    // For all other methods, convert to List and delegate
+                }
+            }
+        }
+        // Convert HyperSeq/RaceSeq to List for remaining method dispatch
+        let target = match target {
+            Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                Value::Array(items, crate::value::ArrayKind::List)
+            }
+            other => other,
+        };
         // Auto-vivify undefined values (Nil, Any, Mu type objects) to empty Arrays
         // for mutating list methods. In Raku, calling push/unshift/append/prepend on
         // an undefined variable auto-vivifies it to an Array.

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -287,6 +287,165 @@ impl VM {
         } else {
             target
         };
+        // .hyper/.race with named arguments (batch, degree): validate and wrap
+        if matches!(method.as_str(), "hyper" | "race") && !args.is_empty() {
+            // Extract named args (batch, degree) and validate
+            let mut batch: Option<i64> = None;
+            let mut degree: Option<i64> = None;
+            for arg in &args {
+                let (key, val) = match arg {
+                    Value::Pair(k, v) => (k.clone(), crate::runtime::to_int(v)),
+                    Value::ValuePair(k, v) => (k.to_string_value(), crate::runtime::to_int(v)),
+                    _ => continue,
+                };
+                match key.as_str() {
+                    "batch" => batch = Some(val),
+                    "degree" => degree = Some(val),
+                    _ => {}
+                }
+            }
+            // Validate batch
+            if let Some(b) = batch
+                && b <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "method".to_string(),
+                    Value::str(method.as_str().to_string()),
+                );
+                attrs.insert("name".to_string(), Value::str("batch".to_string()));
+                attrs.insert("value".to_string(), Value::Int(b));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid value '{}' for 'batch' on '{}'",
+                        b,
+                        method.as_str()
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            // Validate degree
+            if let Some(d) = degree
+                && d <= 0
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "method".to_string(),
+                    Value::str(method.as_str().to_string()),
+                );
+                attrs.insert("name".to_string(), Value::str("degree".to_string()));
+                attrs.insert("value".to_string(), Value::Int(d));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid value '{}' for 'degree' on '{}'",
+                        d,
+                        method.as_str()
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Invalid::Value", attrs));
+            }
+            // Materialize and wrap
+            let items = crate::runtime::value_to_list(&target);
+            let arc = std::sync::Arc::new(items);
+            let result = if method == "hyper" {
+                Value::HyperSeq(arc)
+            } else {
+                Value::RaceSeq(arc)
+            };
+            self.stack.push(result);
+            self.env_dirty = true;
+            return Ok(());
+        }
+        // HyperSeq/RaceSeq delegation: unwrap, dispatch on inner list, wrap back for map/grep
+        let hyper_race_wrap = if matches!(&target, Value::HyperSeq(_) | Value::RaceSeq(_)) {
+            match method.as_str() {
+                "hyper" => {
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    self.stack.push(Value::HyperSeq(items_arc));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "race" => {
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    self.stack.push(Value::RaceSeq(items_arc));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "is-lazy" => {
+                    self.stack.push(Value::Bool(false));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "^name" => {
+                    let name = if matches!(&target, Value::HyperSeq(_)) {
+                        "HyperSeq"
+                    } else {
+                        "RaceSeq"
+                    };
+                    self.stack.push(Value::str(name.to_string()));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "WHAT" => {
+                    let name = if matches!(&target, Value::HyperSeq(_)) {
+                        "HyperSeq"
+                    } else {
+                        "RaceSeq"
+                    };
+                    self.stack.push(Value::Package(Symbol::intern(name)));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "isa" | "does" => {
+                    let type_name = if !args.is_empty() {
+                        match &args[0] {
+                            Value::Package(name) => name.resolve(),
+                            Value::Str(s) => (**s).clone(),
+                            _ => args[0].to_string_value(),
+                        }
+                    } else {
+                        String::new()
+                    };
+                    let my_name = if matches!(&target, Value::HyperSeq(_)) {
+                        "HyperSeq"
+                    } else {
+                        "RaceSeq"
+                    };
+                    let result = type_name == my_name
+                        || type_name == "Seq"
+                        || type_name == "Any"
+                        || type_name == "Mu"
+                        || type_name == "Cool";
+                    self.stack.push(Value::Bool(result));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "defined" => {
+                    self.stack.push(Value::Bool(true));
+                    self.env_dirty = true;
+                    return Ok(());
+                }
+                "map" | "grep" => Some(matches!(&target, Value::HyperSeq(_))),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        // Convert HyperSeq/RaceSeq to List for method dispatch
+        let target = match target {
+            Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                Value::Array(items, crate::value::ArrayKind::List)
+            }
+            other => other,
+        };
         // Regex.Bool / Regex.so: smartmatch against $_ (needs runtime context)
         if matches!(method.as_str(), "Bool" | "so")
             && args.is_empty()
@@ -498,6 +657,18 @@ impl VM {
                         self.stack.push(call_result?);
                         self.env_dirty = true;
                     }
+                }
+                // Wrap map/grep results back into HyperSeq/RaceSeq
+                if let Some(is_hyper) = hyper_race_wrap
+                    && let Some(result) = self.stack.pop()
+                {
+                    let result_items = crate::runtime::value_to_list(&result);
+                    let wrapped = if is_hyper {
+                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                    } else {
+                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                    };
+                    self.stack.push(wrapped);
                 }
             }
         }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -414,16 +414,8 @@ impl VM {
                     } else {
                         String::new()
                     };
-                    let my_name = if matches!(&target, Value::HyperSeq(_)) {
-                        "HyperSeq"
-                    } else {
-                        "RaceSeq"
-                    };
-                    let result = type_name == my_name
-                        || type_name == "Seq"
-                        || type_name == "Any"
-                        || type_name == "Mu"
-                        || type_name == "Cool";
+                    // Delegate to isa_check which handles the full type hierarchy
+                    let result = target.isa_check(&type_name);
                     self.stack.push(Value::Bool(result));
                     self.env_dirty = true;
                     return Ok(());

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -168,7 +168,9 @@ fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
 fn get_list_elements(v: &Value) -> Option<&[Value]> {
     match v {
         Value::Array(elems, _) => Some(elems.as_slice()),
-        Value::Seq(elems) => Some(elems.as_slice()),
+        Value::Seq(elems) | Value::HyperSeq(elems) | Value::RaceSeq(elems) => {
+            Some(elems.as_slice())
+        }
         Value::Slip(elems) => Some(elems.as_slice()),
         _ => None,
     }
@@ -1077,9 +1079,11 @@ impl VM {
         let value = self.stack.pop().unwrap_or(Value::Nil);
         let scalarized = match value {
             Value::Nil => Value::Int(0),
-            Value::Array(items, _) | Value::Seq(items) | Value::Slip(items) => {
-                Value::Int(items.len() as i64)
-            }
+            Value::Array(items, _)
+            | Value::Seq(items)
+            | Value::HyperSeq(items)
+            | Value::RaceSeq(items)
+            | Value::Slip(items) => Value::Int(items.len() as i64),
             Value::Capture { positional, .. } => Value::Int(positional.len() as i64),
             Value::Instance {
                 class_name,


### PR DESCRIPTION
## Summary
- Add `HyperSeq` and `RaceSeq` as proper Value enum variants instead of returning plain arrays from `.hyper`/`.race`
- Implement method delegation: `.map`/`.grep` preserve HyperSeq/RaceSeq wrapper, other methods delegate to inner list
- Add `X::Invalid::Value` exception for invalid `batch`/`degree` parameters (<=0)
- Handle all dispatch paths: VM static method calls, VM dynamic method calls, and interpreter fallback
- Correctly report `^name`, `WHAT`, `isa`, `is-lazy`, `defined` for these types

## Test plan
- [x] `make test` passes (all 471 tests, 3802 subtests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [ ] `make roast` passes (in progress)
- Tests 7/18/44/55/90 in `roast/S07-hyperrace/basics.t` require actual threading (Promise/await inside hyper .map blocks) and cannot pass in single-threaded mode — documented in TODO_roast/S07.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)