### PR TITLE
fix: thread junctions through %% and !%% operators

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -286,6 +286,17 @@
 - [x] roast/S02-types/version-stress.t
 - [x] roast/S02-types/version.t
 - [ ] roast/S02-types/whatever.t
-  - 0/? pass. Parse error at line 129
+  - 126/131 tests run, 93/126 pass. Blockers:
+    - Tests 52-53: Nested WhateverCode currying with user-defined operators (3+ `*` across nested calls)
+    - Tests 75-76: `&infix:<+>(*, 42)` should die, not Whatever-curry
+    - Tests 77-92: X+/Z+ meta-operators with Whatever-currying not implemented
+    - Tests 108-109: `*++`/`++*` WhateverCode with rw parameters
+    - Test 110: `*(42)` should throw X::Method::NotFound
+    - Test 111: Code.ACCEPTS does not preserve container (`=:=`)
+    - Test 115: is_run no-warning check for WhateverCode passed as arg
+    - Test 119: `none 2 ...^ * > expr` precedence (none as list prefix vs sequence op)
+    - Test 121: `Mu ~~ (*)` should return True (parenthesized Whatever distinction)
+    - Tests 122-131 don't run: depend on `where`+`is default`, `BEGIN`, regex curry, etc.
+    - Tests 42, 114, 117 also fail on raku (todo'd)
 - [ ] roast/S02-types/WHICH.t
   - 1652/1657 pass. Remaining: Nil.raku/gist returns "(Any)" instead of "Nil" (mutsu uses Value::Nil for both Nil and uninitialized Any); subtest using EVAL/start/supply not implemented

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1106,36 +1106,55 @@ impl VM {
     pub(super) fn exec_divisible_by_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let (l, r) = runtime::coerce_numeric(left.clone(), right);
-        let result = match (l, r) {
-            (Value::Int(_), Value::Int(0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero_full(
-                    Some(left),
-                    Some("infix:<%%>"),
-                ));
-            }
-            (Value::Int(a), Value::Int(b)) => Value::Bool(a % b == 0),
-            _ => Value::Bool(false),
-        };
+        // Thread over junctions
+        if matches!(left, Value::Junction { .. }) || matches!(right, Value::Junction { .. }) {
+            let result = self
+                .eval_binary_with_junctions(left, right, |vm, l, r| vm.divisible_by_values(l, r))?;
+            self.stack.push(result);
+            return Ok(());
+        }
+        let result = self.divisible_by_values(left.clone(), right)?;
         self.stack.push(result);
         Ok(())
+    }
+
+    fn divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
+        let (l, r) = runtime::coerce_numeric(left.clone(), right);
+        match (l, r) {
+            (Value::Int(_), Value::Int(0)) => Err(RuntimeError::numeric_divide_by_zero_full(
+                Some(left),
+                Some("infix:<%%>"),
+            )),
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a % b == 0)),
+            _ => Ok(Value::Bool(false)),
+        }
     }
 
     pub(super) fn exec_not_divisible_by_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let (l, r) = runtime::coerce_numeric(left.clone(), right);
-        let result = match (l, r) {
-            (Value::Int(_), Value::Int(0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero_full(
-                    Some(left),
-                    Some("infix:<%%>"),
-                ));
-            }
-            (Value::Int(a), Value::Int(b)) => Value::Bool(a % b != 0),
-            _ => Value::Bool(true),
-        };
+        // Thread over junctions
+        if matches!(left, Value::Junction { .. }) || matches!(right, Value::Junction { .. }) {
+            let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+                vm.not_divisible_by_values(l, r)
+            })?;
+            self.stack.push(result);
+            return Ok(());
+        }
+        let result = self.not_divisible_by_values(left.clone(), right)?;
         self.stack.push(result);
         Ok(())
+    }
+
+    fn not_divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
+        let (l, r) = runtime::coerce_numeric(left.clone(), right);
+        match (l, r) {
+            (Value::Int(_), Value::Int(0)) => Err(RuntimeError::numeric_divide_by_zero_full(
+                Some(left),
+                Some("infix:<%%>"),
+            )),
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a % b != 0)),
+            _ => Ok(Value::Bool(true)),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The divisibility operators (`%%` and `!%%`) were not threading over Junction values, causing `2 %% none()` to throw `X::Numeric::DivideByZero` instead of returning `True`
- Adds junction threading to both `exec_divisible_by_op` and `exec_not_divisible_by_op`, following the same pattern used by other binary operators (e.g., `~`, arithmetic ops)
- Updates `TODO_roast/S02.md` with detailed blocker analysis for `roast/S02-types/whatever.t` (93/126 passing after this fix)

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] `make test` passes (all 471 test files, 3802 subtests)
- [x] `make roast` passes (all 1128 whitelisted files)
- [x] Manual verification: `2 %% none()` returns `True`, `2 %% none(3,4)` returns `none(False, False)`, `6 %% any(2,3)` returns `any(True, True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)