### PR TITLE
fix: improve S02-types/mix.t from 234/244 to 240/244 passing

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -637,7 +637,13 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
         Value::Mix(m, _) => {
             let mut named = HashMap::new();
             for (k, v) in m.iter() {
-                named.insert(k.clone(), Value::Num(*v));
+                // Use Int when the weight is a whole number
+                let val = if v.fract() == 0.0 && v.is_finite() {
+                    Value::Int(*v as i64)
+                } else {
+                    Value::Num(*v)
+                };
+                named.insert(k.clone(), val);
             }
             Ok(Value::Capture {
                 positional: vec![],

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -537,7 +537,9 @@ pub(super) fn dispatch(
         }),
         "keyof" => Some(match target {
             Value::Bag(_, _) | Value::Set(_, _) | Value::Mix(_, _) => {
-                Some(Ok(Value::Package(Symbol::intern("Mu"))))
+                // Fall through to runtime to check container type metadata
+                // for parameterized types (e.g., Mix[Int])
+                None
             }
             Value::Hash(_) => None,
             Value::Package(name) | Value::CustomType { name, .. } => {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -306,8 +306,11 @@ pub(crate) fn native_method_0arg(
     let method = method_sym.resolve();
     let method = method.as_str();
 
-    // Scalar containers are transparent for method dispatch.
+    // Scalar containers are transparent for method dispatch (except .VAR).
     if let Value::Scalar(inner) = target {
+        if method == "VAR" {
+            return Some(Ok(Value::Package(crate::symbol::Symbol::intern("Scalar"))));
+        }
         return native_method_0arg(inner, method_sym);
     }
 

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -702,6 +702,30 @@ pub(crate) fn native_method_1arg(
             };
             Some(Ok(Value::Bool(result)))
         }
+        "ACCEPTS" if matches!(target, Value::Bag(..)) => {
+            let result = match (target, arg) {
+                (Value::Bag(bag1, _), Value::Bag(bag2, _)) => {
+                    bag1.len() == bag2.len()
+                        && bag1.iter().all(|(k, v)| bag2.get(k).copied() == Some(*v))
+                }
+                _ => false,
+            };
+            Some(Ok(Value::Bool(result)))
+        }
+        "ACCEPTS" if matches!(target, Value::Mix(..)) => {
+            let result = match (target, arg) {
+                (Value::Mix(mix1, _), Value::Mix(mix2, _)) => {
+                    mix1.len() == mix2.len()
+                        && mix1.iter().all(|(k, v)| {
+                            mix2.get(k)
+                                .copied()
+                                .is_some_and(|v2| (v - v2).abs() < f64::EPSILON)
+                        })
+                }
+                _ => false,
+            };
+            Some(Ok(Value::Bool(result)))
+        }
         // ACCEPTS for Pair: checks if the argument has the matching key->value
         "ACCEPTS" if matches!(target, Value::Pair(..) | Value::ValuePair(..)) => {
             let (pk, pv) = match target {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -200,8 +200,12 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        // Scalar containers are transparent for method dispatch (except .item itself)
+        // Scalar containers are transparent for method dispatch (except .item and .VAR)
         if let Value::Scalar(inner) = target {
+            if method == "VAR" {
+                // Return an opaque Scalar type object so .^name returns "Scalar"
+                return Ok(Value::Package(Symbol::intern("Scalar")));
+            }
             return self.call_method_with_values(*inner, method, args);
         }
         // .return method: triggers a return from the enclosing sub with the invocant
@@ -2087,6 +2091,24 @@ impl Interpreter {
                 return Ok(Value::Package(Symbol::intern(key_type)));
             }
             return Ok(Value::Package(Symbol::intern("Str(Any)")));
+        }
+
+        // .keyof on Mix/Set/Bag - check container type metadata for parameterized types
+        if method == "keyof"
+            && args.is_empty()
+            && matches!(
+                &target,
+                Value::Mix(_, _) | Value::Set(_, _) | Value::Bag(_, _)
+            )
+        {
+            if let Some(info) = self.container_type_metadata(&target)
+                && let Some(ref declared_type) = info.declared_type
+                && let Some(bracket_pos) = declared_type.find('[')
+            {
+                let param = &declared_type[bracket_pos + 1..declared_type.len() - 1];
+                return Ok(Value::Package(Symbol::intern(param)));
+            }
+            return Ok(Value::Package(Symbol::intern("Mu")));
         }
 
         // Complex->Num conversion

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1396,6 +1396,22 @@ impl Interpreter {
             self.env.insert(target_var.to_string(), updated);
             return Ok(current);
         }
+        // .keyof on Mix/Set/Bag variables: check type constraint for parameterized type
+        if method == "keyof"
+            && args.is_empty()
+            && matches!(
+                &target,
+                Value::Mix(_, _) | Value::Set(_, _) | Value::Bag(_, _)
+            )
+        {
+            if let Some(constraint) = self.var_type_constraint(target_var)
+                && let Some(bracket_pos) = constraint.find('[')
+            {
+                let param = &constraint[bracket_pos + 1..constraint.len() - 1];
+                return Ok(Value::Package(Symbol::intern(param)));
+            }
+            return Ok(Value::Package(Symbol::intern("Mu")));
+        }
         if method == "VAR" && args.is_empty() {
             // Proxy (including subclasses): .VAR returns the proxy wrapped as a
             // ProxyObject so that subsequent method calls don't auto-FETCH.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1930,6 +1930,50 @@ impl Interpreter {
                             add_item(&mut weights, &mut original_keys, &mut has_non_str_keys, arg);
                         }
                     }
+                    // Type check for parameterized Mix/MixHash (e.g. Mix[Int].new(<a b c>))
+                    if let Some(ref ta) = type_args
+                        && let Some(constraint) = ta.first()
+                        && constraint.starts_with(char::is_uppercase)
+                        && constraint != "Any"
+                        && constraint != "Mu"
+                    {
+                        let items_to_check: Vec<Value> = if args.len() == 1 {
+                            let arg = &args[0];
+                            if matches!(arg, Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _))
+                            {
+                                vec![arg.clone()]
+                            } else {
+                                Self::value_to_list(arg)
+                            }
+                        } else {
+                            args.clone()
+                        };
+                        for item in &items_to_check {
+                            if !self.type_matches_value(constraint, item) {
+                                let got_type = crate::value::what_type_name(item);
+                                let got_repr = item.to_string_value();
+                                let msg = format!(
+                                    "Type check failed in binding; expected {} but got {} (\"{}\")",
+                                    constraint, got_type, got_repr,
+                                );
+                                let mut attrs = std::collections::HashMap::new();
+                                attrs.insert("message".to_string(), Value::str(msg.clone()));
+                                attrs.insert("operation".to_string(), Value::str_from("bind"));
+                                attrs.insert("got".to_string(), item.clone());
+                                attrs.insert(
+                                    "expected".to_string(),
+                                    Value::Package(Symbol::intern(constraint)),
+                                );
+                                let ex = Value::make_instance(
+                                    Symbol::intern("X::TypeCheck::Binding"),
+                                    attrs,
+                                );
+                                let mut err = RuntimeError::new(msg);
+                                err.exception = Some(Box::new(ex));
+                                return Err(err);
+                            }
+                        }
+                    }
                     let is_hash_variant = class_name.resolve() == "MixHash";
                     let result = if has_non_str_keys {
                         if is_hash_variant {

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -260,6 +260,29 @@ impl Interpreter {
             .unwrap_or(value)
     }
 
+    /// Try to coerce a string to a specific type (e.g., "42" -> Int(42)).
+    /// Returns None if coercion is not possible or not applicable.
+    pub(crate) fn try_coerce_str_to_type(&self, s: &str, type_name: &str) -> Option<Value> {
+        match type_name {
+            "Int" => s.parse::<i64>().ok().map(Value::Int),
+            "Num" => s.parse::<f64>().ok().map(Value::Num),
+            "Rat" => {
+                if let Ok(n) = s.parse::<i64>() {
+                    Some(Value::Rat(n, 1))
+                } else {
+                    None
+                }
+            }
+            "Str" => Some(Value::str(s.to_string())),
+            "Bool" => match s {
+                "True" => Some(Value::Bool(true)),
+                "False" => Some(Value::Bool(false)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub(crate) fn try_coerce_value_for_constraint(
         &mut self,
         constraint: &str,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -936,6 +936,32 @@ impl VM {
                 }
                 // Check readonly variables (e.g., $*USAGE)
                 self.interpreter.check_readonly_for_modify(&name)?;
+                // Prevent re-assignment of immutable containers (Mix, Set, Bag)
+                // Only when the variable has an explicit immutable type constraint
+                // (e.g., `my %h is Mix`), not for regular scalar variables holding
+                // an immutable value.
+                if let Some(constraint) = self.interpreter.var_type_constraint(&name) {
+                    let base = constraint.split('[').next().unwrap_or(&constraint);
+                    if matches!(base, "Mix" | "Set" | "Bag")
+                        && let Some(existing) = self.interpreter.env().get(&name)
+                        && matches!(
+                            existing,
+                            Value::Mix(_, false) | Value::Set(_, false) | Value::Bag(_, false)
+                        )
+                    {
+                        let type_name = match existing {
+                            Value::Mix(..) => "Mix",
+                            Value::Set(..) => "Set",
+                            Value::Bag(..) => "Bag",
+                            _ => unreachable!(),
+                        };
+                        return Err(RuntimeError::new(format!(
+                            "Cannot modify an immutable {} ({})",
+                            type_name,
+                            existing.to_string_value()
+                        )));
+                    }
+                }
                 // Reject assignment to immutable type objects (e.g., `Foo .= new`)
                 if !name.starts_with('$')
                     && !name.starts_with('@')

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -347,6 +347,78 @@ impl VM {
             }
             self.env_dirty = true;
         }
+        // Preserve the container type of the target for QuantHash types.
+        // The items list was produced by value_to_list, which yields Pairs
+        // in HashMap iteration order. Reconstruct the same type using the
+        // keys from those pairs and the transformed results.
+        match &target {
+            Value::Mix(_, is_mutable) => {
+                let mut weights = std::collections::HashMap::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        weights.insert(
+                            key,
+                            crate::runtime::utils::to_float_value(result).unwrap_or(0.0),
+                        );
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::mix_hash(weights)
+                } else {
+                    Value::mix(weights)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            Value::Bag(_, is_mutable) => {
+                let mut counts = std::collections::HashMap::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        counts.insert(key, crate::runtime::utils::to_int(result));
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::bag_hash(counts)
+                } else {
+                    Value::bag(counts)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            Value::Set(_, is_mutable) => {
+                let mut elems = std::collections::HashSet::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        if result.truthy() {
+                            elems.insert(key);
+                        }
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::set_hash(elems)
+                } else {
+                    Value::set(elems)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            _ => {}
+        }
         // Preserve the container type of the target: Array->Array, List->List
         let result_kind = match &target {
             Value::Array(_, kind) if kind.is_real_array() => ArrayKind::Array,
@@ -492,6 +564,75 @@ impl VM {
                 *kind,
             );
             self.env_dirty = true;
+        }
+        // Preserve the container type of the target for QuantHash types
+        match &target {
+            Value::Mix(_, is_mutable) => {
+                let mut weights = std::collections::HashMap::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        weights.insert(
+                            key,
+                            crate::runtime::utils::to_float_value(result).unwrap_or(0.0),
+                        );
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::mix_hash(weights)
+                } else {
+                    Value::mix(weights)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            Value::Bag(_, is_mutable) => {
+                let mut counts = std::collections::HashMap::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        counts.insert(key, crate::runtime::utils::to_int(result));
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::bag_hash(counts)
+                } else {
+                    Value::bag(counts)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            Value::Set(_, is_mutable) => {
+                let mut elems = std::collections::HashSet::new();
+                for (i, item) in items.iter().enumerate() {
+                    if let Some(result) = results.get(i) {
+                        let key = match item {
+                            Value::Pair(k, _) => k.clone(),
+                            Value::ValuePair(k, _) => k.to_string_value(),
+                            other => other.to_string_value(),
+                        };
+                        if result.truthy() {
+                            elems.insert(key);
+                        }
+                    }
+                }
+                let result = if *is_mutable {
+                    Value::set_hash(elems)
+                } else {
+                    Value::set(elems)
+                };
+                self.stack.push(result);
+                return Ok(());
+            }
+            _ => {}
         }
         // Preserve the container type of the target
         let result_kind = match &target {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -762,7 +762,7 @@ impl VM {
                     Some(Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _)) => true,
                     _ => false,
                 };
-                let instance = if has_init_values {
+                let mut instance = if has_init_values {
                     let init_val = current_val.unwrap();
                     // If already the target QuantHash type, use it directly
                     let already_target = matches!(
@@ -796,6 +796,74 @@ impl VM {
                     let type_obj = Value::Package(crate::symbol::Symbol::intern(base_trait));
                     self.try_compiled_method_or_interpret(type_obj, "new", vec![])?
                 };
+                // Type check for parameterized QuantHash (e.g. Mix[Int], Set[Str])
+                // and store typed original_keys so .keys returns typed values
+                if let Some(bracket_pos) = trait_name.find('[') {
+                    let constraint = &trait_name[bracket_pos + 1..trait_name.len() - 1];
+                    if constraint.starts_with(char::is_uppercase)
+                        && constraint != "Any"
+                        && constraint != "Mu"
+                    {
+                        let keys: Vec<String> = match &instance {
+                            Value::Mix(m, _) => m.weights.keys().cloned().collect(),
+                            Value::Bag(b, _) => b.counts.keys().cloned().collect(),
+                            Value::Set(s, _) => s.elements.iter().cloned().collect(),
+                            _ => vec![],
+                        };
+                        // Try to coerce keys to the constraint type for type checking
+                        let mut typed_keys = std::collections::HashMap::new();
+                        for key in &keys {
+                            let coerced = self.interpreter.try_coerce_str_to_type(key, constraint);
+                            if let Some(ref typed_val) = coerced {
+                                if !self.interpreter.type_matches_value(constraint, typed_val) {
+                                    let got_type = crate::value::what_type_name(typed_val);
+                                    return Err(RuntimeError::new(format!(
+                                        "Type check failed in binding; expected {} but got {} (\"{}\")",
+                                        constraint, got_type, key
+                                    )));
+                                }
+                                typed_keys.insert(key.clone(), typed_val.clone());
+                            } else {
+                                // Can't coerce to type - check original string
+                                let key_val = Value::str(key.clone());
+                                if !self.interpreter.type_matches_value(constraint, &key_val) {
+                                    let got_type = crate::value::what_type_name(&key_val);
+                                    return Err(RuntimeError::new(format!(
+                                        "Type check failed in binding; expected {} but got {} (\"{}\")",
+                                        constraint, got_type, key
+                                    )));
+                                }
+                            }
+                        }
+                        // Store typed keys in the QuantHash so .keys returns typed values
+                        if !typed_keys.is_empty() {
+                            instance = match instance {
+                                Value::Mix(data, mutable) => {
+                                    let new_data = crate::value::MixData::with_original_keys(
+                                        data.weights.clone(),
+                                        typed_keys,
+                                    );
+                                    Value::Mix(std::sync::Arc::new(new_data), mutable)
+                                }
+                                Value::Bag(data, mutable) => {
+                                    let new_data = crate::value::BagData::with_original_keys(
+                                        data.counts.clone(),
+                                        typed_keys,
+                                    );
+                                    Value::Bag(std::sync::Arc::new(new_data), mutable)
+                                }
+                                Value::Set(data, mutable) => {
+                                    let new_data = crate::value::SetData::with_original_keys(
+                                        data.elements.clone(),
+                                        typed_keys,
+                                    );
+                                    Value::Set(std::sync::Arc::new(new_data), mutable)
+                                }
+                                other => other,
+                            };
+                        }
+                    }
+                }
                 // Register container type metadata so assignment operations
                 // know to coerce back to BagHash/SetHash/etc.
                 let info = crate::runtime::ContainerTypeInfo {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1323,6 +1323,26 @@ impl VM {
                 ));
             }
         }
+        // Mix/Set/Bag: prevent auto-vivification of undefined typed variables.
+        // When `my Mix $m; $m<key> = val`, the variable is undefined (Nil or
+        // type object) but has an immutable type constraint.
+        {
+            let current_val = self.interpreter.env().get(&var_name).cloned();
+            let is_undefined = current_val.is_none()
+                || matches!(&current_val, Some(Value::Nil))
+                || matches!(&current_val, Some(Value::Package(_)));
+            if is_undefined {
+                let constraint_owned = self.interpreter.var_type_constraint(&var_name);
+                let type_name_check = declared_type.as_deref().or(constraint_owned.as_deref());
+                if type_name_check.is_some_and(|t| matches!(t, "Mix" | "Set" | "Bag")) {
+                    let type_name = type_name_check.unwrap_or("Mix");
+                    return Err(RuntimeError::new(format!(
+                        "Cannot auto-vivify an immutable {}",
+                        type_name
+                    )));
+                }
+            }
+        }
         // Immutable List/Range containers - prevent assignment and binding
         if let Some(target_val) = self.interpreter.env().get(&var_name) {
             let is_immutable = matches!(
@@ -2526,6 +2546,26 @@ impl VM {
                 return Err(RuntimeError::new(
                     runtime::utils::type_check_assignment_error(name, &constraint, &Value::Nil),
                 ));
+            }
+            // Prevent re-initialization of immutable containers (Mix, Set, Bag)
+            if !is_vardecl
+                && !is_bind
+                && matches!(
+                    &self.locals[idx],
+                    Value::Mix(_, false) | Value::Set(_, false) | Value::Bag(_, false)
+                )
+            {
+                let type_name = match &self.locals[idx] {
+                    Value::Mix(..) => "Mix",
+                    Value::Set(..) => "Set",
+                    Value::Bag(..) => "Bag",
+                    _ => unreachable!(),
+                };
+                return Err(RuntimeError::new(format!(
+                    "Cannot modify an immutable {} ({})",
+                    type_name,
+                    self.locals[idx].to_string_value()
+                )));
             }
             if is_constant || is_bind {
                 // `:=` binding or `constant %x` preserves containers — skip coercion.


### PR DESCRIPTION
## Summary
- Fix `.item.VAR.^name` to return `"Scalar"` instead of the inner type name
- Implement `ACCEPTS` for `Bag` and `Mix` types (equality checking)
- Prevent auto-vivification of immutable typed variables (`my Mix $m; $m<key> = val`)
- Prevent re-assignment of `%h is Mix` variables
- Add type checking for parameterized `Mix[Int].new(<a b c>)` (throws `X::TypeCheck::Binding`)
- Support parameterized Mix `.keys` returning typed values and `.keyof` returning the type parameter
- Fix `Mix.Capture` to return Int weights for whole numbers
- Preserve Mix/Bag/Set container types through hyper method (`>>`) operations

## Remaining failures (4/244)
- Tests 187-189: Read-only loop variable binding for `for $m.values/pairs/kv` (requires fundamental for-loop semantics change)
- Test 195: `.hash` keys stringified (requires Hash to support non-string keys)

## Test plan
- [x] `make test` passes
- [x] `make roast` passes
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/mix.t` shows 240/244 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)