### PR TITLE
fix: pass all 62 subtests in roast/S32-io/spurt.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -941,6 +941,7 @@ roast/S32-io/signals.t
 roast/S32-io/socket-accept-and-working-threads.t
 roast/S32-io/socket-fail-invalid-values.t
 roast/S32-io/socket-host-port-split.t
+roast/S32-io/spurt.t
 roast/S32-io/tell.t
 roast/S32-list/are.t
 roast/S32-list/batch.t

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -188,7 +188,24 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn builtin_spurt(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_spurt(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // If the first argument is an IO::Handle, delegate to IO::Handle.spurt
+        if let Some(Value::Instance {
+            class_name,
+            attributes,
+            ..
+        }) = args.first()
+            && class_name == "IO::Handle"
+        {
+            let content_value = args
+                .get(1)
+                .cloned()
+                .unwrap_or(Value::Str(String::new().into()));
+            let method_args = std::iter::once(content_value)
+                .chain(args.iter().skip(2).cloned())
+                .collect();
+            return self.native_io_handle(attributes, "spurt", method_args);
+        }
         let path = args
             .first()
             .map(|v| v.to_string_value())
@@ -199,11 +216,13 @@ impl Interpreter {
             .ok_or_else(|| RuntimeError::new("spurt requires a content argument"))?;
         let mut append = false;
         let mut createonly = false;
+        let mut enc: Option<String> = None;
         for arg in args.iter().skip(2) {
             if let Value::Pair(key, val) = arg {
                 match key.as_str() {
                     "append" => append = val.truthy(),
                     "createonly" => createonly = val.truthy(),
+                    "enc" => enc = Some(val.to_string_value()),
                     _ => {}
                 }
             }
@@ -230,15 +249,25 @@ impl Interpreter {
             }
         } else {
             let content = content_value.to_string_value();
+            let bytes = if let Some(ref enc_name) = enc {
+                match self.encode_with_encoding(&content, enc_name) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Ok(io_exception_failure("X::IO::Spurt", e.message));
+                    }
+                }
+            } else {
+                content.into_bytes()
+            };
             if append {
                 use std::io::Write;
                 fs::OpenOptions::new()
                     .append(true)
                     .create(true)
                     .open(&resolved)
-                    .and_then(|mut file| file.write_all(content.as_bytes()))
+                    .and_then(|mut file| file.write_all(&bytes))
             } else {
-                fs::write(&resolved, &content)
+                fs::write(&resolved, &bytes)
             }
         };
         match write_result {

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -882,11 +882,13 @@ impl Interpreter {
                     .unwrap_or(Value::Str(String::new().into()));
                 let mut append = false;
                 let mut createonly = false;
+                let mut enc: Option<String> = None;
                 for arg in args.iter().skip(1) {
                     if let Value::Pair(key, val) = arg {
                         match key.as_str() {
                             "append" => append = val.truthy(),
                             "createonly" => createonly = val.truthy(),
+                            "enc" => enc = Some(val.to_string_value()),
                             _ => {}
                         }
                     }
@@ -912,15 +914,25 @@ impl Interpreter {
                     }
                 } else {
                     let content = content_value.to_string_value();
+                    let bytes = if let Some(ref enc_name) = enc {
+                        match self.encode_with_encoding(&content, enc_name) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                return Ok(io_exception_failure("X::IO::Spurt", e.message));
+                            }
+                        }
+                    } else {
+                        content.into_bytes()
+                    };
                     if append {
                         use std::io::Write;
                         fs::OpenOptions::new()
                             .append(true)
                             .create(true)
                             .open(&path_buf)
-                            .and_then(|mut file| file.write_all(content.as_bytes()))
+                            .and_then(|mut file| file.write_all(&bytes))
                     } else {
-                        fs::write(&path_buf, &content)
+                        fs::write(&path_buf, &bytes)
                     }
                 };
                 match write_result {
@@ -2348,6 +2360,33 @@ impl Interpreter {
                     content.push_str(&self.render_str_value(arg));
                 }
                 self.write_to_handle_value_trying(&target_val, &content, true, "put")?;
+                Ok(Value::Bool(true))
+            }
+            "spurt" => {
+                // IO::Handle.spurt($data) -- write data to the handle
+                let content_value = args
+                    .first()
+                    .cloned()
+                    .unwrap_or(Value::Str(String::new().into()));
+                let is_buf = crate::vm::VM::is_buf_value(&content_value);
+                if is_buf {
+                    let bytes = crate::vm::VM::extract_buf_bytes(&content_value);
+                    self.write_bytes_to_handle_value(&target_val, &bytes)?;
+                } else {
+                    let content = content_value.to_string_value();
+                    // Determine encoding from the handle's state
+                    let enc = if let Ok(state) = self.handle_state_mut(&target_val) {
+                        state.encoding.clone()
+                    } else {
+                        "utf-8".to_string()
+                    };
+                    let bytes = if enc == "utf-8" || enc == "utf8" {
+                        content.into_bytes()
+                    } else {
+                        self.encode_with_encoding(&content, &enc)?
+                    };
+                    self.write_bytes_to_handle_value(&target_val, &bytes)?;
+                }
                 Ok(Value::Bool(true))
             }
             "flush" => {

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -502,7 +502,21 @@ impl Interpreter {
                     }
                 }
                 if !found && let Some(default_expr) = &pd.default {
+                    // Save $_ so that evaluating the default expression does not
+                    // leak the topic into the caller's scope.
+                    let saved_topic = self.env.get("_").cloned();
+                    let saved_dollar_topic = self.env.get("$_").cloned();
                     let value = self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?;
+                    if let Some(t) = saved_topic {
+                        self.env.insert("_".to_string(), t);
+                    } else {
+                        self.env.remove("_");
+                    }
+                    if let Some(t) = saved_dollar_topic {
+                        self.env.insert("$_".to_string(), t);
+                    } else {
+                        self.env.remove("$_");
+                    }
                     let value = self.checked_default_param_value(pd, value)?;
                     let value = if pd
                         .type_constraint
@@ -1034,7 +1048,21 @@ impl Interpreter {
                     }
                     positional_idx += 1;
                 } else if let Some(default_expr) = &pd.default {
+                    // Save $_ so that evaluating the default expression does not
+                    // leak the topic into the caller's scope.
+                    let saved_topic = self.env.get("_").cloned();
+                    let saved_dollar_topic = self.env.get("$_").cloned();
                     let value = self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?;
+                    if let Some(t) = saved_topic {
+                        self.env.insert("_".to_string(), t);
+                    } else {
+                        self.env.remove("_");
+                    }
+                    if let Some(t) = saved_dollar_topic {
+                        self.env.insert("$_".to_string(), t);
+                    } else {
+                        self.env.remove("$_");
+                    }
                     let value = self.checked_default_param_value(pd, value)?;
                     if let Some(captured_name) = pd
                         .type_constraint


### PR DESCRIPTION
## Summary
- Fix `$_` topic variable leak from default parameter evaluation in function calls (e.g., `sub foo($a, $b, $c = $b, |args)` was corrupting `$_` in the caller's scope)
- Add `:enc` parameter support to `spurt` and `IO::Path.spurt` for non-UTF-8 encodings (e.g., Latin-1)
- Implement `IO::Handle.spurt` method and `spurt($fh, $data)` function form for writing to open file handles

## Test plan
- [x] `prove -e target/debug/mutsu roast/S32-io/spurt.t` passes all 62 subtests
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `make roast` passes all whitelisted tests
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)