### PR TITLE
fix: pass S26-documentation/wacky.t by improving Pod doc comment handling

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -853,6 +853,7 @@ roast/S26-documentation/block-leading-user-format.t
 roast/S26-documentation/module-comment.t
 roast/S26-documentation/multiline-leading.t
 roast/S26-documentation/multiline-trailing.t
+roast/S26-documentation/wacky.t
 roast/S26-documentation/why-leading.t
 roast/S28-named-variables/cwd.t
 roast/S28-named-variables/init-instant.t

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2442,6 +2442,8 @@ impl Interpreter {
         let mut multi_counters: HashMap<String, usize> = HashMap::new();
         // Track current function name for scoping parameter docs
         let mut current_sub: Option<String> = None;
+        // Counter for uniquifying anonymous sub doc keys
+        let mut anon_sub_counter: usize = 0;
 
         fn extract_ident(s: &str) -> String {
             s.trim_start()
@@ -2878,6 +2880,16 @@ impl Interpreter {
                 }
             }
 
+            // Handle bare anonymous sub anywhere in the line (e.g. "is sub {")
+            if s.contains("sub {") || s.contains("sub{") {
+                return Some((
+                    "&<anon>".to_string(),
+                    false,
+                    DocDeclKind::Sub,
+                    DispatchPrefix::None,
+                ));
+            }
+
             // Handle block assignments: "my $var = {" or "my $var = {;"
             // This allows doc comments to attach to blocks assigned to variables.
             if let Some(eq_pos) = s.find('=') {
@@ -3045,15 +3057,36 @@ impl Interpreter {
             let (line_without_trailing, inline_trailing) = extract_inline_trailing(trimmed);
             let check_line = line_without_trailing.trim();
 
+            // When a line contains multiple declarations separated by ';',
+            // try the last segment first so trailing #= attaches to the last
+            // declarant (e.g. "has $.first; has $.second; #= comment").
+            let last_seg = if check_line.contains(';') {
+                check_line.split(';').rev().find_map(|seg| {
+                    let seg = seg.trim();
+                    if !seg.is_empty() {
+                        try_extract_declarant(seg, &current_class)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            };
+
             if let Some((name, is_class_like, kind, dispatch)) =
-                try_extract_declarant(check_line, &current_class)
+                last_seg.or_else(|| try_extract_declarant(check_line, &current_class))
             {
                 // For multi declarations, generate a unique key to avoid
-                // overwriting proto or other multi variants
+                // overwriting proto or other multi variants.
+                // For anonymous subs, also uniquify to avoid collisions.
                 let doc_key = if dispatch == DispatchPrefix::Multi {
                     let counter = multi_counters.entry(name.clone()).or_insert(0);
                     let key = format!("{}/multi.{}", name, counter);
                     *counter += 1;
+                    key
+                } else if name == "&<anon>" {
+                    let key = format!("&<anon>.{}", anon_sub_counter);
+                    anon_sub_counter += 1;
                     key
                 } else {
                     name.clone()
@@ -3100,6 +3133,17 @@ impl Interpreter {
                 // Track the current function for parameter scoping
                 if kind == super::DocDeclKind::Sub {
                     current_sub = Some(name.clone());
+                }
+                // Check for inline #| on the same line as a sub declaration
+                // (e.g. "sub foo( #| leading for param") — sets pending_leading
+                // for the next parameter
+                if kind == super::DocDeclKind::Sub
+                    && let Some(hash_pipe_pos) = trimmed.find("#|")
+                {
+                    let doc_text = trimmed[hash_pipe_pos + 2..].trim();
+                    if !doc_text.is_empty() {
+                        pending_leading = append_doc_text(pending_leading.take(), doc_text);
+                    }
                 }
                 if is_class_like {
                     class_stack.push(current_class.take());

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -3301,7 +3301,21 @@ impl Interpreter {
                 }
                 let (lwt, _) = extract_inline_trailing(trimmed2);
                 let ck = lwt.trim();
-                if let Some((name, is_cls, kind, dispatch)) = try_extract_declarant(ck, &cur_class2)
+                // Also try last segment for multi-declaration lines
+                let last_seg2 = if ck.contains(';') {
+                    ck.split(';').rev().find_map(|seg| {
+                        let seg = seg.trim();
+                        if !seg.is_empty() {
+                            try_extract_declarant(seg, &cur_class2)
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
+                if let Some((name, is_cls, kind, dispatch)) =
+                    last_seg2.or_else(|| try_extract_declarant(ck, &cur_class2))
                 {
                     // Generate the same key as the first pass
                     let doc_key = if dispatch == DispatchPrefix::Multi {
@@ -3317,6 +3331,21 @@ impl Interpreter {
                             mi += 1;
                             if mi > 100 {
                                 break format!("{}/multi.{}", name, mi);
+                            }
+                        }
+                    } else if name == "&<anon>" {
+                        // Find the next anon key that hasn't been seen
+                        let mut ai = 0usize;
+                        loop {
+                            let candidate_key = format!("&<anon>.{}", ai);
+                            if !seen_names.contains(&candidate_key)
+                                && self.doc_comments.contains_key(&candidate_key)
+                            {
+                                break candidate_key;
+                            }
+                            ai += 1;
+                            if ai > 100 {
+                                break format!("&<anon>.{}", ai);
                             }
                         }
                     } else {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -418,18 +418,22 @@ impl Interpreter {
                 return Ok(Self::make_pod_declarator(doc, target.clone()));
             }
         }
-        // For anonymous bare blocks, try to find a doc comment by source line proximity
+        // For anonymous subs/bare blocks, try to find a doc comment by source line proximity
         if let Value::Sub(sub_data) = target
             && sub_data.name == ""
-            && sub_data.is_bare_block
             && let Some(src_line) = sub_data.source_line
         {
-            // Find the block:* doc comment whose source_line is closest
+            let prefix = if sub_data.is_bare_block {
+                "block:"
+            } else {
+                "&<anon>"
+            };
+            // Find the doc comment whose source_line is closest
             // to (and at or after) the sub's source line
             let mut best_match: Option<&super::DocComment> = None;
             let mut best_dist = u32::MAX;
             for dc in self.doc_comments.values() {
-                if dc.wherefore_name.starts_with("block:")
+                if dc.wherefore_name.starts_with(prefix)
                     && let Some(dc_line) = dc.source_line
                 {
                     let dist = if dc_line >= src_line {


### PR DESCRIPTION
## Summary
- Detect anonymous subs anywhere in a line (e.g. `is sub {`) for doc comment attachment
- Uniquify anonymous sub doc keys and use source line proximity lookup to avoid collisions
- Handle multiple declarations on one line by trying the last semicolon-separated segment first for trailing `#=` attachment
- Extract inline `#|` comments from sub declaration lines for parameter doc attachment

All 29 subtests pass (5 TODO tests that also fail on raku are correctly handled as TODO).

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S26-documentation/wacky.t` passes
- [x] `make test` passes (471 files, 3802 tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)