### PR TITLE
fix: implement X::PoisonedAlias and return Failure for enum coercion errors

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -61,7 +61,7 @@
 - [ ] roast/S12-enums/as-role.t
   - 6/9 pass. Tests 1, 5, 9 fail: enum member accessor methods (`.No`, `.Yes`, `.Dunno`) on objects with applied enum role. Requires `does`/`but` operators with enum parameters and enum-as-role composition. Difficulty: High
 - [ ] roast/S12-enums/basic.t
-  - 25/54 pass. Good basic enum support. Failures: Pair arithmetic (6), `.does()` for enum type (7-8), given/when with enum (11), parens/starting-point syntax (17), Pair of one element (20), type enforcement (25), short name without parens (26), `.pick`/`.pick(2)` (30-31), double-colon namespace (32), redeclared values (36-37), iteration (39-41). Difficulty: Medium
+  - 50/54 pass. Tests 8-11 fail (enum smartmatch with `but` mixin, also fails on raku with `#?rakudo todo`). Cannot whitelist until `but` mixin enum support is implemented.
 - [ ] roast/S12-enums/misc.t
   - 12/28 pass (1, 6-14, 16, 28). Good enum support for basic features. Failures: enum in module/package/grammar (2-4), enum as method error (5), export (15), constant list enum values (17), ACCEPTS (18), .pairs/.kv/.keys/.values/.antipairs/.invert on enum with Array values (19-24), .new error (25), matching (26-27). Difficulty: Medium
 - [ ] roast/S12-enums/non-int.t

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -152,7 +152,7 @@ impl Interpreter {
             if let Some(enum_value) = self.coerce_to_enum_variant(name, &variants, first.clone()) {
                 return Ok(enum_value);
             }
-            // Throw X::Enum::NoValue
+            // Return a Failure wrapping X::Enum::NoValue (lazy exception, like Raku)
             let value_str = first.to_string_value();
             let msg = format!("No value '{}' found in enum {}", value_str, name);
             let mut attrs = std::collections::HashMap::new();
@@ -160,9 +160,12 @@ impl Interpreter {
             attrs.insert("type".to_string(), Value::Package(Symbol::intern(name)));
             attrs.insert("value".to_string(), first);
             let ex = Value::make_instance(Symbol::intern("X::Enum::NoValue"), attrs);
-            let mut err = RuntimeError::new(msg);
-            err.exception = Some(Box::new(ex));
-            return Err(err);
+            let mut failure_attrs = std::collections::HashMap::new();
+            failure_attrs.insert("exception".to_string(), ex);
+            return Ok(Value::make_instance(
+                Symbol::intern("Failure"),
+                failure_attrs,
+            ));
         }
         // Calling a type with a type object argument constructs a coercion type
         // object (e.g. Str(Any), Int(Str), Child(Parent)).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -924,6 +924,11 @@ pub struct Interpreter {
     method_wrap_chains: HashMap<(String, String, usize), Vec<(u64, Value)>>,
     /// Names suppressed by `anon class`. These bare words should error as undeclared.
     suppressed_names: HashSet<String>,
+    /// Bare enum variant names poisoned by redeclaration from different enums.
+    /// Maps bare name -> latest enum package name.
+    poisoned_enum_aliases: HashMap<String, String>,
+    /// Per-scope stack of bare enum names introduced, for cleanup on scope exit.
+    enum_scope_names: Vec<Vec<String>>,
     /// Fully-qualified names of `my`-scoped classes/subs inside packages.
     /// These should NOT appear in the parent package's stash.
     my_scoped_package_items: HashSet<String>,
@@ -2826,6 +2831,8 @@ impl Interpreter {
             wrap_dispatch_stack: Vec::new(),
             method_wrap_chains: HashMap::new(),
             suppressed_names: HashSet::new(),
+            poisoned_enum_aliases: HashMap::new(),
+            enum_scope_names: vec![Vec::new()],
             my_scoped_package_items: HashSet::new(),
             lexical_class_scopes: Vec::new(),
             last_value: None,
@@ -3012,6 +3019,47 @@ impl Interpreter {
 
     pub(crate) fn is_name_suppressed(&self, name: &str) -> bool {
         self.suppressed_names.contains(name)
+    }
+
+    /// Check if a bare enum variant name is poisoned (declared by multiple enums).
+    pub(crate) fn is_poisoned_enum_alias(&self, name: &str) -> Option<&str> {
+        self.poisoned_enum_aliases.get(name).map(|s| s.as_str())
+    }
+
+    /// Record a bare enum name in the current scope for poisoning detection.
+    /// Only marks as poisoned if the name was already declared in the *same*
+    /// scope level by a different enum.
+    pub(crate) fn register_enum_bare_name(&mut self, name: &str, enum_type: &str) {
+        // Check only the current scope for the same name from a different enum
+        if let Some(current_scope) = self.enum_scope_names.last()
+            && current_scope.iter().any(|n| n == name)
+            && let Some(Value::Enum {
+                enum_type: prev_type,
+                ..
+            }) = self.env.get(name)
+            && prev_type.resolve() != enum_type
+        {
+            self.poisoned_enum_aliases
+                .insert(name.to_string(), enum_type.to_string());
+        }
+        if let Some(scope) = self.enum_scope_names.last_mut() {
+            scope.push(name.to_string());
+        }
+    }
+
+    /// Push a new enum scope frame (called on block enter).
+    pub(crate) fn push_enum_scope(&mut self) {
+        self.enum_scope_names.push(Vec::new());
+    }
+
+    /// Pop an enum scope frame, removing poisoned aliases for names
+    /// that were introduced in the exiting scope.
+    pub(crate) fn pop_enum_scope(&mut self) {
+        if let Some(names) = self.enum_scope_names.pop() {
+            for name in names {
+                self.poisoned_enum_aliases.remove(&name);
+            }
+        }
     }
 
     /// Resolve a suppressed nested class short name to its qualified form.
@@ -4414,6 +4462,8 @@ impl Interpreter {
             wrap_dispatch_stack: Vec::new(),
             method_wrap_chains: self.method_wrap_chains.clone(),
             suppressed_names: self.suppressed_names.clone(),
+            poisoned_enum_aliases: self.poisoned_enum_aliases.clone(),
+            enum_scope_names: self.enum_scope_names.clone(),
             my_scoped_package_items: self.my_scoped_package_items.clone(),
             lexical_class_scopes: self.lexical_class_scopes.clone(),
             last_value: None,

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -880,6 +880,10 @@ impl Interpreter {
                     enum_val.clone(),
                 );
             }
+            // Track for poisoned alias detection before inserting
+            if !is_anonymous {
+                self.register_enum_bare_name(key, enum_type_name);
+            }
             self.env.insert(key.clone(), enum_val);
         }
         // Register exports if `is export`

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2253,6 +2253,7 @@ impl VM {
         self.interpreter.push_once_scope(once_scope);
         self.interpreter.push_block_scope_depth();
         self.interpreter.push_lexical_class_scope();
+        self.interpreter.push_enum_scope();
         let stack_base = self.stack.len();
         let topic_before = self.last_topic_value.clone();
         // If ENTER died, skip the body but still run LEAVE phasers
@@ -2447,6 +2448,7 @@ impl VM {
         }
         // Note: `our`-scoped variables persist in our_vars and are accessible
         // via package-qualified names (e.g., $Pkg::var) after block exit.
+        self.interpreter.pop_enum_scope();
         self.interpreter.pop_lexical_class_scope();
         self.interpreter.pop_block_scope_depth();
         self.interpreter.pop_once_scope();
@@ -2539,6 +2541,7 @@ impl VM {
         let stack_base = self.stack.len();
         let once_scope = self.interpreter.next_once_scope_id();
         self.interpreter.push_once_scope(once_scope);
+        self.interpreter.push_enum_scope();
         let saved_env = if scope_isolate {
             Some((self.interpreter.env().clone(), self.locals.clone()))
         } else {
@@ -2584,6 +2587,7 @@ impl VM {
                 Err(e) => break Err(e),
             }
         };
+        self.interpreter.pop_enum_scope();
         self.interpreter.pop_once_scope();
         // Restore scope if scope_isolate is true
         if let Some((saved_env, saved_locals)) = saved_env {

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -84,6 +84,33 @@ impl VM {
             if matches!(v, Value::Enum { .. } | Value::Nil)
                 || matches!(v, Value::Package(pkg) if pkg.resolve() != name)
             {
+                // Check for poisoned enum aliases
+                if matches!(v, Value::Enum { .. })
+                    && !name.contains("::")
+                    && let Some(pkg_name) = self.interpreter.is_poisoned_enum_alias(name)
+                {
+                    let pkg_name = pkg_name.to_string();
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Cannot directly use poisoned alias '{name}' because it \
+                             was declared by several enums. Please access it via \
+                             explicit package name like: '{pkg_name}::{name}'"
+                        )),
+                    );
+                    attrs.insert("alias".to_string(), Value::str(name.to_string()));
+                    attrs.insert("package-name".to_string(), Value::str(pkg_name.clone()));
+                    attrs.insert("package-type".to_string(), Value::str("enum".to_string()));
+                    let ex = Value::make_instance(Symbol::intern("X::PoisonedAlias"), attrs);
+                    let mut err = RuntimeError::new(format!(
+                        "Cannot directly use poisoned alias '{name}' because it was \
+                         declared by several enums. Please access it via explicit \
+                         package name like: '{pkg_name}::{name}'"
+                    ));
+                    err.exception = Some(Box::new(ex));
+                    return Err(err);
+                }
                 v.clone()
             } else if self.interpreter.has_type(name) || Self::is_builtin_type(name) {
                 Value::Package(Symbol::intern(Self::resolve_type_alias(name)))

--- a/t/enum.t
+++ b/t/enum.t
@@ -70,9 +70,9 @@ is Day.enums.elems, 7, "Day.enums returns hash with 7 elements";
 
 # Parenthesized enum variants can use colonpair and quoted-string entries.
 enum day (:Sun(1), 'Mon', 'Tue', 'Wed');
-is day(Tue), day(3), "day(Tue) same as day(3)";
-my $today = "Today" but day(Tue);
-ok $today.day ~~ day, "day(Tue).day is a day";
-ok $today.day == Tue, "day(Tue) == Tue";
+is day(day::Tue), day(3), "day(day::Tue) same as day(3)";
+my $today = "Today" but day(day::Tue);
+ok $today.day ~~ day, "day(day::Tue).day is a day";
+ok $today.day == day::Tue, "day(day::Tue) == day::Tue";
 lives-ok { day($today) }, "day(\$today) lives";
-ok $today.Tue, "day(Tue).Tue";
+ok $today.Tue, "day(day::Tue).Tue";


### PR DESCRIPTION
## Summary

- Implement X::PoisonedAlias exception for bare enum variant names redeclared by multiple enums in the same scope
- Scope-aware poisoning detection using push/pop enum scope tracking (supports block scopes and do-blocks)
- Return Failure (lazy exception) instead of throwing immediately for enum coercion errors (X::Enum::NoValue), matching Raku's behavior
- Update t/enum.t to use qualified names where bare names are now correctly poisoned

Improves roast/S12-enums/basic.t from 48/54 to 50/54 passing. Tests 8-11 also fail on raku (marked `#?rakudo todo` for but-mixin enum support).

## Test plan
- [x] `make test` passes (all 471 test files)
- [x] `make roast` passes (all whitelisted tests)
- [x] `prove -e 'target/debug/mutsu' roast/S12-enums/basic.t` runs 54 tests, only 8-11 fail (same as raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)