### PR TITLE
fix: pass roast/S13-overloading/typecasting-long.t (39 tests)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -604,6 +604,7 @@ roast/S13-overloading/fallbacks-deep.t
 roast/S13-overloading/metaoperators.t
 roast/S13-overloading/multiple-signatures.t
 roast/S13-overloading/operators.t
+roast/S13-overloading/typecasting-long.t
 roast/S13-syntax/aliasing.t
 roast/S13-type-casting/methods.t
 roast/S14-roles/anonymous.t

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -315,7 +315,11 @@ impl Compiler {
                 };
                 if let Some(name) = var_name {
                     self.compile_expr(left);
+                    // Set does-context flag so role calls with args return Pairs
+                    // instead of throwing X::Coerce::Impossible.
+                    self.code.emit(OpCode::SetDoesContext(true));
                     self.compile_expr(right);
+                    self.code.emit(OpCode::SetDoesContext(false));
                     let name_idx = self.code.add_constant(Value::str(name));
                     self.code.emit(OpCode::DoesVar(name_idx));
                     return;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -160,6 +160,9 @@ pub(crate) enum OpCode {
     Isa,
     Does,
     DoesVar(u32),
+    /// Set/clear the in_does_rhs flag so role calls return Pairs instead of
+    /// throwing X::Coerce::Impossible during `does` RHS evaluation.
+    SetDoesContext(bool),
 
     // -- Pair --
     MakePair,

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -556,6 +556,30 @@ impl Interpreter {
                     }
                 }
             }
+            // Role called with args but no CALL-ME/COERCE/new:
+            // In `does` context, return a Pair for role application.
+            // Otherwise, throw X::Coerce::Impossible.
+            if !args.is_empty() {
+                if self.in_does_rhs {
+                    return Ok(Value::Pair(
+                        name.to_string(),
+                        Box::new(Value::array(args.to_vec())),
+                    ));
+                }
+                let source_type = crate::runtime::value_type_name(&args[0]).to_string();
+                let msg = format!(
+                    "Impossible coercion from '{}' into '{}': no acceptable coercion method found",
+                    source_type, name
+                );
+                return Err(RuntimeError::typed(
+                    "X::Coerce::Impossible",
+                    std::collections::HashMap::from([
+                        ("target-type".to_string(), Value::str(name.to_string())),
+                        ("from-type".to_string(), Value::str(source_type)),
+                        ("message".to_string(), Value::str(msg)),
+                    ]),
+                ));
+            }
             return Ok(Value::Pair(
                 name.to_string(),
                 Box::new(Value::array(args.to_vec())),
@@ -610,15 +634,28 @@ impl Interpreter {
             );
         }
 
-        // Fallback: if name is a known class/role with CALL-ME, invoke it on the type object
-        if (self.has_class(name) && self.has_user_method(name, "CALL-ME"))
-            || (self.has_role(name) && self.role_has_method(name, "CALL-ME"))
+        // Fallback: if name is a known class/role with CALL-ME, invoke it on the type object.
+        // When called with no args (e.g. A()), Raku treats it as a coercion type literal
+        // rather than invoking CALL-ME — only A.() (dotted form) invokes CALL-ME with no args.
+        if !args.is_empty()
+            && ((self.has_class(name) && self.has_user_method(name, "CALL-ME"))
+                || (self.has_role(name) && self.role_has_method(name, "CALL-ME")))
         {
             return self.call_method_with_values(
                 Value::Package(Symbol::intern(name)),
                 "CALL-ME",
                 args.to_vec(),
             );
+        }
+
+        // TypeName() with no args produces a coercion type TypeName(Any)
+        if args.is_empty()
+            && (self.has_type(name)
+                || crate::runtime::utils::is_known_type_constraint(name)
+                || self.subsets.contains_key(name)
+                || self.roles.contains_key(name))
+        {
+            return Ok(Value::Package(Symbol::intern(&format!("{name}(Any)"))));
         }
 
         // comb($matcher, $str) or comb($matcher, $str, $limit)

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -272,6 +272,8 @@ impl Interpreter {
             || matches!(type_name.as_str(), "UInt" | "NativeInt")
         {
             "Perl6::Metamodel::SubsetHOW"
+        } else if crate::runtime::types::parse_coercion_type(&type_name).is_some() {
+            "Perl6::Metamodel::CoercionHOW"
         } else {
             "Perl6::Metamodel::ClassHOW"
         };

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -10,6 +10,7 @@ impl Interpreter {
             || cn == "Perl6::Metamodel::EnumHOW"
             || cn == "Perl6::Metamodel::CurriedRoleHOW"
             || cn == "Perl6::Metamodel::ParametricRoleGroupHOW"
+            || cn == "Perl6::Metamodel::CoercionHOW"
     }
 
     /// Check if a method name is a ClassHOW method.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -43,6 +43,12 @@ impl Interpreter {
         if let Value::Instance { class_name, .. } = &target {
             return self.dispatch_new(Value::Package(*class_name), args);
         }
+        // Calling .new() on a Mixin(Instance{..}, ..) delegates to the class constructor
+        if let Value::Mixin(inner, _) = &target
+            && let Value::Instance { class_name, .. } = inner.as_ref()
+        {
+            return self.dispatch_new(Value::Package(*class_name), args);
+        }
         // Calling .new() on a concrete Array delegates to the type constructor.
         // If the array has type metadata (e.g. array[str]), use the declared type.
         if let Value::Array(..) = &target {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -820,6 +820,10 @@ pub struct Interpreter {
     pub(crate) suppress_exports: bool,
     /// When true, rw routine calls should not auto-FETCH Proxy return values.
     pub(crate) in_lvalue_assignment: bool,
+    /// When true, a role call with non-matching args returns a Pair instead of
+    /// throwing X::Coerce::Impossible. Set during the RHS evaluation of `does`
+    /// so that `$x does Role("arg")` works as a role application.
+    pub(crate) in_does_rhs: bool,
     /// When true, hash indexing with a missing key autovivifies (creates an
     /// empty Hash entry and returns it).  Set during reduce with `is raw`
     /// callbacks so that container semantics are preserved.
@@ -2786,6 +2790,7 @@ impl Interpreter {
             unit_module_loading_stack: Vec::new(),
             suppress_exports: false,
             in_lvalue_assignment: false,
+            in_does_rhs: false,
             hash_autovivify: false,
             newline_mode: NewlineMode::Lf,
             import_scope_stack: Vec::new(),
@@ -4417,6 +4422,7 @@ impl Interpreter {
             unit_module_loading_stack: Vec::new(),
             suppress_exports: false,
             in_lvalue_assignment: false,
+            in_does_rhs: false,
             hash_autovivify: false,
             newline_mode: self.newline_mode,
             import_scope_stack: Vec::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1513,6 +1513,10 @@ impl VM {
                 self.exec_does_var_op(code, *name_idx)?;
                 *ip += 1;
             }
+            OpCode::SetDoesContext(flag) => {
+                self.interpreter.in_does_rhs = *flag;
+                *ip += 1;
+            }
 
             // -- Pair --
             OpCode::MakePair => {


### PR DESCRIPTION
## Summary
- Fix Mixin `.new` delegation so COERCE on role puns works
- Add `Perl6::Metamodel::CoercionHOW` support for `.HOW` on coercion types
- Make `A()` produce coercion type literal instead of calling CALL-ME
- Throw `X::Coerce::Impossible` for role calls without COERCE/CALL-ME
- Add `SetDoesContext` opcode to bracket `does` RHS evaluation

## Test plan
- [x] All 39 subtests in `roast/S13-overloading/typecasting-long.t` pass
- [x] `make test` passes (471 files, 3802 tests)
- [x] `make roast` passes (no regressions vs main)
- [x] `t/coercion-type-regressions.t` still passes
- [x] `t/imperative-does-parameterized-role.t` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)