### PR TITLE
fix: implement PartialEq for Uni values to fix eqv/is-deeply

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -626,6 +626,7 @@ roast/S14-roles/typecheck.t
 roast/S14-traits/variables.t
 roast/S15-literals/identifiers.t
 roast/S15-literals/numbers.t
+roast/S15-nfg/GraphemeBreakTest-0.t
 roast/S15-nfg/case-change.t
 roast/S15-nfg/cgj.t
 roast/S15-nfg/concatenation.t

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1511,6 +1511,9 @@ impl PartialEq for Value {
                     false
                 }
             }
+            (Value::Uni { form: af, text: at }, Value::Uni { form: bf, text: bt }) => {
+                af == bf && at == bt
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary
- Add missing `Value::Uni` case to `PartialEq for Value` implementation, which was causing all Uni comparisons to return false
- This fixes `is-deeply` (which uses `eqv`, which delegates to `PartialEq` for Uni) when comparing NFC/NFD/NFKC/NFKD normalized values
- Add `roast/S15-nfg/GraphemeBreakTest-0.t` (200 subtests) to the whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S15-nfg/GraphemeBreakTest-0.t` passes all 200 subtests
- [x] `make test` passes
- [x] `make roast` passes (no new regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)