### PR TITLE
fix: improve multi dispatch with subsignature parameters

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -35,7 +35,7 @@ impl Interpreter {
     }
 
     fn candidate_uses_order_sensitive_dispatch(&self, def: &FunctionDef) -> bool {
-        Self::dispatch_visible_params(def).any(|p| {
+        let outer_check = Self::dispatch_visible_params(def).any(|p| {
             p.literal_value.is_some()
                 || p.where_constraint.is_some()
                 || p.type_constraint
@@ -43,6 +43,24 @@ impl Interpreter {
                     .map(Self::constraint_base_name)
                     .map(|base| self.subsets.contains_key(base))
                     .unwrap_or(false)
+        });
+        if outer_check {
+            return true;
+        }
+        // Also check subsignature params for order-sensitive dispatch
+        def.param_defs.iter().any(|p| {
+            p.sub_signature.as_ref().is_some_and(|sub_params| {
+                sub_params.iter().any(|sp| {
+                    sp.literal_value.is_some()
+                        || sp.where_constraint.is_some()
+                        || sp
+                            .type_constraint
+                            .as_deref()
+                            .map(Self::constraint_base_name)
+                            .map(|base| self.subsets.contains_key(base))
+                            .unwrap_or(false)
+                })
+            })
         })
     }
 
@@ -71,6 +89,30 @@ impl Interpreter {
                     p.traits.iter().any(|t| t == "raw"),
                     p.traits.iter().any(|t| t == "copy"),
                 )
+            })
+            .collect()
+    }
+
+    /// Compute dispatch shape for subsignature params (e.g. `|c(Int $x is rw)`).
+    /// This is used to detect when tied candidates differ in subsignature details.
+    /// Only includes `multi_invocant` params (params before `;;`).
+    fn candidate_subsig_dispatch_shape(&self, def: &FunctionDef) -> Vec<DispatchShape> {
+        def.param_defs
+            .iter()
+            .flat_map(|p| {
+                p.sub_signature.iter().flat_map(|sub_params| {
+                    sub_params.iter().filter(|sp| sp.multi_invocant).map(|sp| {
+                        (
+                            sp.type_constraint.clone(),
+                            sp.named,
+                            sp.sub_signature.is_some(),
+                            sp.literal_value.is_some(),
+                            sp.traits.iter().any(|t| t == "rw"),
+                            sp.traits.iter().any(|t| t == "raw"),
+                            sp.traits.iter().any(|t| t == "copy"),
+                        )
+                    })
+                })
             })
             .collect()
     }
@@ -201,6 +243,19 @@ impl Interpreter {
                 shape.sort();
                 shape == best_shape_sorted
             })
+            // If candidates differ in subsignature details (e.g. `is rw` trait),
+            // they are not truly tied — the first matching candidate wins.
+            && {
+                let subsig_shapes: Vec<Vec<DispatchShape>> = tied
+                    .iter()
+                    .map(|def| {
+                        let mut shape = self.candidate_subsig_dispatch_shape(def);
+                        shape.sort();
+                        shape
+                    })
+                    .collect();
+                subsig_shapes.windows(2).all(|w| w[0] == w[1])
+            }
         {
             // `is default` trait tie-breaking: if exactly one tied candidate
             // has `is_default`, prefer it over the others.
@@ -217,16 +272,37 @@ impl Interpreter {
         Some(matches.remove(0))
     }
 
+    /// Iterate over all subsignature params that participate in dispatch
+    fn subsig_dispatch_params(def: &FunctionDef) -> Vec<&ParamDef> {
+        def.param_defs
+            .iter()
+            .flat_map(|p| {
+                p.sub_signature
+                    .iter()
+                    .flat_map(|sub_params| sub_params.iter().filter(|sp| sp.multi_invocant))
+            })
+            .collect()
+    }
+
     fn candidate_specificity_rank(
         &self,
         def: &FunctionDef,
     ) -> (usize, usize, usize, usize, usize, usize, usize, usize) {
+        let subsig_params = Self::subsig_dispatch_params(def);
         let literal_value_count = Self::dispatch_visible_params(def)
             .filter(|p| p.literal_value.is_some())
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| p.literal_value.is_some())
+                .count();
         let where_count = Self::dispatch_visible_params(def)
             .filter(|p| p.where_constraint.is_some())
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| p.where_constraint.is_some())
+                .count();
         let subset_type_count = Self::dispatch_visible_params(def)
             .filter(|p| {
                 p.type_constraint
@@ -235,7 +311,17 @@ impl Interpreter {
                     .map(|base| self.subsets.contains_key(base))
                     .unwrap_or(false)
             })
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| {
+                    p.type_constraint
+                        .as_deref()
+                        .map(Self::constraint_base_name)
+                        .map(|base| self.subsets.contains_key(base))
+                        .unwrap_or(false)
+                })
+                .count();
         let typed_param_count = Self::dispatch_visible_params(def)
             .filter(|p| {
                 p.type_constraint.is_some()
@@ -244,26 +330,49 @@ impl Interpreter {
                             || p.name.starts_with('%')
                             || p.name.starts_with('&')))
             })
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| {
+                    p.type_constraint.is_some()
+                        || (!p.slurpy
+                            && (p.name.starts_with('@')
+                                || p.name.starts_with('%')
+                                || p.name.starts_with('&')))
+                })
+                .count();
         let subsig_count = Self::dispatch_visible_params(def)
             .filter(|p| p.sub_signature.is_some())
             .count();
         let named_count = Self::dispatch_visible_params(def)
             .filter(|p| p.named)
-            .count();
+            .count()
+            + subsig_params.iter().filter(|p| p.named).count();
         // Required named params (`:$a!`) are more specific than optional ones
         let required_named_count = def
             .param_defs
             .iter()
             .filter(|p| p.named && p.required)
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| p.named && p.required)
+                .count();
         let trait_count = Self::dispatch_visible_params(def)
             .filter(|p| {
                 p.traits
                     .iter()
                     .any(|t| matches!(t.as_str(), "rw" | "raw" | "copy"))
             })
-            .count();
+            .count()
+            + subsig_params
+                .iter()
+                .filter(|p| {
+                    p.traits
+                        .iter()
+                        .any(|t| matches!(t.as_str(), "rw" | "raw" | "copy"))
+                })
+                .count();
         (
             literal_value_count,
             where_count,
@@ -1289,6 +1398,8 @@ impl Interpreter {
             let untyped_key = format!("{}/{}", name, arity);
             let untyped_key_sym = Symbol::intern(&untyped_key);
             let untyped_m_prefix = format!("{}__m", untyped_key);
+            // Also search all arities to find capture/slurpy candidates
+            let all_arity_prefix = format!("{}/", name);
             let mut candidates: Vec<(String, FunctionDef)> = self
                 .functions
                 .iter()
@@ -1297,6 +1408,7 @@ impl Interpreter {
                     ks.starts_with(&prefix)
                         || **key == untyped_key_sym
                         || ks.starts_with(&untyped_m_prefix)
+                        || ks.starts_with(&all_arity_prefix)
                 })
                 .map(|(key, def)| (key.resolve(), def.clone()))
                 .collect();

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1057,6 +1057,7 @@ impl Interpreter {
                 new_env.insert(k.clone(), v.clone());
             }
             self.env = new_env.clone();
+            let pre_binding_env = self.env.clone();
             let rw_bindings =
                 match self.bind_function_args_values(&data.param_defs, &data.params, &call_args) {
                     Ok(bindings) => bindings,
@@ -1067,6 +1068,15 @@ impl Interpreter {
                         return Err(e);
                     }
                 };
+            // Record keys whose values were changed by parameter binding
+            // (including subsignature params) so we can exclude them from
+            // closure env persistence later.
+            let binding_modified_keys: std::collections::HashSet<String> = self
+                .env
+                .iter()
+                .filter(|(k, v)| pre_binding_env.get(k.as_str()) != Some(v))
+                .map(|(k, _)| k.clone())
+                .collect();
             new_env = self.env.clone();
             if data.params.is_empty() {
                 for arg in &sanitized_args {
@@ -1188,8 +1198,15 @@ impl Interpreter {
             if persist_closure_env {
                 let mut persisted_closure_env = closure_base_env.clone();
                 for key in closure_base_env.keys() {
-                    if let Some(value) = self.env.get(key).cloned() {
-                        persisted_closure_env.insert(key.clone(), value);
+                    if binding_modified_keys.contains(key) {
+                        // This key was modified by param/subsig binding —
+                        // use the pre-binding value to avoid leaking
+                        // temporary bindings into the closure env.
+                        if let Some(pre_val) = pre_binding_env.get(key).cloned() {
+                            persisted_closure_env.insert(key.clone(), pre_val);
+                        }
+                    } else if let Some(cur_val) = self.env.get(key).cloned() {
+                        persisted_closure_env.insert(key.clone(), cur_val);
                     }
                 }
                 self.closure_env_overrides

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -63,15 +63,17 @@ impl Interpreter {
                 let mut arg_for_checks: Option<Value> = if pd.slurpy || is_capture_param {
                     if is_capture_param {
                         // |c capture params preserve both positional and named parts.
+                        // Keep VarRef wrappers in positional values so that
+                        // sub_signature_matches_value can check `is rw` traits.
                         let mut positional = Vec::new();
                         let mut named = std::collections::HashMap::new();
                         let remaining = args.get(i..).unwrap_or(&[]);
                         for arg in remaining {
-                            let arg = unwrap_varref_value(arg.clone());
-                            if let Value::Pair(key, val) = arg {
+                            let unwrapped = unwrap_varref_value(arg.clone());
+                            if let Value::Pair(key, val) = unwrapped {
                                 named.insert(key, *val);
                             } else {
-                                positional.push(arg);
+                                positional.push(arg.clone());
                             }
                         }
                         Some(Value::Capture { positional, named })
@@ -111,13 +113,41 @@ impl Interpreter {
                     args.get(i).cloned().map(unwrap_varref_value)
                 } else if is_subsig_capture {
                     let remaining = args.get(i..).unwrap_or(&[]);
-                    Some(sub_signature_target_from_remaining_args(
-                        &remaining
-                            .iter()
-                            .cloned()
-                            .map(unwrap_varref_value)
-                            .collect::<Vec<_>>(),
-                    ))
+                    let unwrapped: Vec<_> =
+                        remaining.iter().cloned().map(unwrap_varref_value).collect();
+                    // Separate Pair args into the named map only when
+                    // they represent named arguments (their keys match
+                    // named subsignature params), not when they are
+                    // objects being destructured.
+                    let named_param_names: std::collections::HashSet<&str> = pd
+                        .sub_signature
+                        .as_ref()
+                        .map(|sub_params| {
+                            sub_params
+                                .iter()
+                                .filter(|sp| sp.named)
+                                .map(|sp| {
+                                    sp.name
+                                        .strip_prefix('$')
+                                        .or_else(|| sp.name.strip_prefix('@'))
+                                        .or_else(|| sp.name.strip_prefix('%'))
+                                        .unwrap_or(sp.name.as_str())
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let pairs_match_named = unwrapped.iter().any(|a| {
+                        if let Value::Pair(key, _) = a {
+                            named_param_names.contains(key.as_str())
+                        } else {
+                            false
+                        }
+                    });
+                    Some(if pairs_match_named {
+                        capture_target_from_remaining_args(&unwrapped)
+                    } else {
+                        sub_signature_target_from_remaining_args(&unwrapped)
+                    })
                 } else {
                     args.get(i).cloned().map(unwrap_varref_value)
                 };
@@ -359,9 +389,10 @@ impl Interpreter {
                     i += 1;
                 }
             }
-            let has_named_slurpy = param_defs
-                .iter()
-                .any(|pd| pd.slurpy && (pd.name.starts_with('%') || pd.sigilless));
+            let has_named_slurpy = param_defs.iter().any(|pd| {
+                (pd.slurpy && (pd.name.starts_with('%') || pd.sigilless))
+                    || (pd.name == "__subsig__" && pd.sub_signature.is_some())
+            });
             if !has_named_slurpy {
                 for arg in args {
                     let arg = unwrap_varref_value(arg.clone());

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -591,8 +591,30 @@ impl Interpreter {
                     if pd.name == "__subsig__"
                         && let Some(sub_params) = &pd.sub_signature
                     {
-                        let capture =
-                            sub_signature_target_from_remaining_args(&args[positional_idx..]);
+                        let remaining = &args[positional_idx..];
+                        let named_param_names: std::collections::HashSet<&str> = sub_params
+                            .iter()
+                            .filter(|sp| sp.named)
+                            .map(|sp| {
+                                sp.name
+                                    .strip_prefix('$')
+                                    .or_else(|| sp.name.strip_prefix('@'))
+                                    .or_else(|| sp.name.strip_prefix('%'))
+                                    .unwrap_or(sp.name.as_str())
+                            })
+                            .collect();
+                        let pairs_match_named = remaining.iter().any(|a| {
+                            if let Value::Pair(key, _) = a {
+                                named_param_names.contains(key.as_str())
+                            } else {
+                                false
+                            }
+                        });
+                        let capture = if pairs_match_named {
+                            capture_target_from_remaining_args(remaining)
+                        } else {
+                            sub_signature_target_from_remaining_args(remaining)
+                        };
                         bind_sub_signature_from_value(self, sub_params, &capture)?;
                         positional_idx = args.len();
                         continue;
@@ -1078,13 +1100,26 @@ impl Interpreter {
                         let target = self.env.get(&pd.name).cloned().unwrap_or(Value::Nil);
                         bind_sub_signature_from_value(self, sub_params, &target)?;
                     }
+                } else if pd.name == "__subsig__"
+                    && let Some(sub_params) = &pd.sub_signature
+                {
+                    // Anonymous capture subsignature with no args: bind empty capture
+                    let empty_capture = Value::Capture {
+                        positional: Vec::new(),
+                        named: std::collections::HashMap::new(),
+                    };
+                    bind_sub_signature_from_value(self, sub_params, &empty_capture)?;
                 } else if !pd.optional_marker && !pd.name.is_empty() {
                     // Positional parameter with no default and no `?` marker is required.
                     // Count required and total positional params for the error message.
                     let total_positional = param_defs
                         .iter()
                         .filter(|p| {
-                            !p.named && !p.slurpy && !p.double_slurpy && !p.name.starts_with(':')
+                            !(p.named
+                                || p.slurpy
+                                || p.double_slurpy
+                                || p.name.starts_with(':')
+                                || (p.name == "__subsig__" && p.sub_signature.is_some()))
                         })
                         .count();
                     let positional_arg_count = args

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -13,10 +13,11 @@ mod type_registry;
 // Re-export public items from submodules
 pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
 pub(in crate::runtime) use signature::{
-    bind_named_rename_sub_signature, bind_sub_signature_from_value, flatten_into_slurpy,
-    indexed_varref_from_value, make_varref_value, sigilless_alias_key, sigilless_readonly_key,
-    sub_signature_matches_value, sub_signature_target_from_remaining_args, unwrap_varref_value,
-    varref_from_value, wrap_native_int_for_binding,
+    bind_named_rename_sub_signature, bind_sub_signature_from_value,
+    capture_target_from_remaining_args, flatten_into_slurpy, indexed_varref_from_value,
+    make_varref_value, sigilless_alias_key, sigilless_readonly_key, sub_signature_matches_value,
+    sub_signature_target_from_remaining_args, unwrap_varref_value, varref_from_value,
+    wrap_native_int_for_binding,
 };
 // Internal re-exports used by submodules via `use super::*`
 use signature::code_signature_matches_value;

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -213,7 +213,7 @@ pub(in crate::runtime) fn sub_signature_matches_value(
         if pd.slurpy {
             continue;
         }
-        let mut candidate = if pd.named {
+        let mut raw_candidate = if pd.named {
             extract_named_from_unpack_target(interpreter, value, &pd.name)
         } else if positional_idx < positional.len() {
             let v = positional[positional_idx].clone();
@@ -222,20 +222,28 @@ pub(in crate::runtime) fn sub_signature_matches_value(
         } else {
             None
         };
-        if candidate.is_none()
+        if raw_candidate.is_none()
             && let Some(default) = &pd.default
         {
-            candidate = interpreter
+            raw_candidate = interpreter
                 .eval_block_value(&[Stmt::Expr(default.clone())])
                 .ok();
         }
-        let Some(candidate) = candidate else {
-            // Optional params are OK without a value
-            if pd.optional_marker || pd.default.is_some() {
+        let Some(raw_candidate) = raw_candidate else {
+            // Optional params are OK without a value.
+            // Named params without `!` are optional by default.
+            if pd.optional_marker || pd.default.is_some() || (pd.named && !pd.required) {
                 continue;
             }
             return false;
         };
+        // For multi-dispatch: `is rw` params require a writable variable argument.
+        // Check VarRef wrapping on the raw (not yet unwrapped) candidate.
+        if pd.traits.iter().any(|t| t == "rw") && varref_from_value(&raw_candidate).is_none() {
+            return false;
+        }
+        // Unwrap VarRef for type checking
+        let candidate = unwrap_varref_value(raw_candidate);
         if let Some(constraint) = &pd.type_constraint
             && !interpreter.type_matches_value(constraint, &candidate)
         {
@@ -251,6 +259,34 @@ pub(in crate::runtime) fn sub_signature_matches_value(
         {
             return false;
         }
+        // Check where constraint
+        if let Some(where_expr) = &pd.where_constraint {
+            let saved = interpreter.env.clone();
+            interpreter.env.insert("_".to_string(), candidate.clone());
+            if !pd.name.is_empty() {
+                interpreter.env.insert(pd.name.clone(), candidate.clone());
+            }
+            let ok = match where_expr.as_ref() {
+                Expr::AnonSub { body, .. } => interpreter
+                    .eval_block_value(body)
+                    .map(|v| v.truthy())
+                    .unwrap_or(false),
+                Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
+                    interpreter
+                        .eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
+                        .map(|v| v.truthy())
+                        .unwrap_or(false)
+                }
+                expr => interpreter
+                    .eval_block_value(&[Stmt::Expr(expr.clone())])
+                    .map(|v| interpreter.smart_match(&candidate, &v))
+                    .unwrap_or(false),
+            };
+            interpreter.env = saved;
+            if !ok {
+                return false;
+            }
+        }
         if let Some(sub) = &pd.sub_signature
             && !sub_signature_matches_value(interpreter, sub, &candidate)
         {
@@ -258,9 +294,32 @@ pub(in crate::runtime) fn sub_signature_matches_value(
         }
     }
     // If there are unconsumed positional elements and no slurpy param, the match fails
-    let has_slurpy = sub_params.iter().any(|p| p.slurpy);
-    if !has_slurpy && positional_idx < positional.len() {
+    let has_any_slurpy = sub_params.iter().any(|p| p.slurpy);
+    if !has_any_slurpy && positional_idx < positional.len() {
         return false;
+    }
+    // If there are unconsumed named args and no named slurpy (*%_), the match fails
+    let has_named_slurpy = sub_params
+        .iter()
+        .any(|p| p.slurpy && (p.name.starts_with('%') || p.sigilless));
+    if !has_named_slurpy {
+        let named = named_values_from_unpack_target(value);
+        let consumed_named: std::collections::HashSet<&str> = sub_params
+            .iter()
+            .filter(|p| p.named)
+            .map(|p| {
+                p.name
+                    .strip_prefix('$')
+                    .or_else(|| p.name.strip_prefix('@'))
+                    .or_else(|| p.name.strip_prefix('%'))
+                    .unwrap_or(p.name.as_str())
+            })
+            .collect();
+        for key in named.keys() {
+            if !consumed_named.contains(key.as_str()) {
+                return false;
+            }
+        }
     }
     true
 }
@@ -357,8 +416,12 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
             candidate = Some(interpreter.eval_block_value(&[Stmt::Expr(default_expr.clone())])?);
         }
         let Some(mut candidate) = candidate else {
-            // If the param is required (not optional, no default), error
-            if !sub_pd.optional_marker && sub_pd.default.is_none() {
+            // If the param is required (not optional, no default), error.
+            // Named params without `!` are optional by default.
+            let is_optional = sub_pd.optional_marker
+                || sub_pd.default.is_some()
+                || (sub_pd.named && !sub_pd.required);
+            if !is_optional {
                 return Err(RuntimeError::new(
                     "Too few positional arguments in sub-signature binding".to_string(),
                 ));
@@ -439,6 +502,21 @@ pub(in crate::runtime) fn sub_signature_target_from_remaining_args(args: &[Value
         positional: args.to_vec(),
         named: std::collections::HashMap::new(),
     }
+}
+
+/// Like `sub_signature_target_from_remaining_args` but separates Pair args
+/// into the named map. Used for anonymous capture subsignatures `| (...)`.
+pub(in crate::runtime) fn capture_target_from_remaining_args(args: &[Value]) -> Value {
+    let mut positional = Vec::new();
+    let mut named = std::collections::HashMap::new();
+    for arg in args {
+        if let Value::Pair(key, val) = arg {
+            named.insert(key.clone(), *val.clone());
+        } else {
+            positional.push(arg.clone());
+        }
+    }
+    Value::Capture { positional, named }
 }
 
 pub(in crate::runtime) fn callable_signature_info(


### PR DESCRIPTION
## Summary
- Fixes multi dispatch handling for subsignature parameters (`|c(...)` and `| (...)`) across 9 areas: `is rw` trait checking, unconsumed named arg validation, `where` constraint evaluation, specificity ranking with subsig params, anonymous capture binding, `__subsig__` named arg absorption, package-qualified proto dispatch, optional named params, and Pair arg separation for captures
- Achieves 94/95 subtests passing in `roast/S06-multi/subsignature.t` (up from 0/95)
- Test 92 remains blocked by a closure env scoping issue when subsignature param names shadow outer variables (requires deeper env model changes)

## Test plan
- [x] `prove -e target/debug/mutsu roast/S06-multi/subsignature.t` passes 94/95 (test 92 is the only real failure; tests 4,43,59,61,63,65,88 are `#?rakudo todo`)
- [x] `make test` passes (t/lock.t has pre-existing flakiness)
- [x] `make roast` shows no regressions
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)