### PR TITLE
fix: pass roast/S12-construction/roles-6e.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -557,6 +557,7 @@ roast/S12-construction/construction.t
 roast/S12-construction/destruction.t
 roast/S12-construction/named-params-in-BUILD.t
 roast/S12-construction/new.t
+roast/S12-construction/roles-6e.t
 roast/S12-enums/anonymous.t
 roast/S12-enums/as-role.t
 roast/S12-enums/misc.t

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -412,7 +412,20 @@ impl Interpreter {
                     }
                     result
                 };
-                let coerced = self.atomic_assign_coerced_value(&name, new_val)?;
+                // If the block returned a value equal to the old value or Nil
+                // but the variable itself was modified (e.g., `{ $x = expr }`),
+                // use the variable's current value from the env. This handles
+                // blocks that modify the variable as a side effect.
+                let effective_new = if new_val == current || matches!(new_val, Value::Nil) {
+                    self.env.get(&name).cloned().unwrap_or(new_val)
+                } else {
+                    new_val
+                };
+                let coerced = self.atomic_assign_coerced_value(&name, effective_new)?;
+                // Restore the env variable to `current` before the CAS comparison,
+                // so that atomic_current_value (which falls back to env) reads the
+                // pre-block snapshot rather than the value the block may have modified.
+                self.env.insert(name.clone(), current.clone());
 
                 let mut updated = false;
                 {

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1087,6 +1087,40 @@ impl Interpreter {
         } else {
             result
         };
+        // If `self` in the env was updated (e.g. by overwrite_instance_bindings_by_identity
+        // after a nested method call like `self.some-method(...)`), sync the attribute env
+        // variables (!attr, .attr) from `self`'s updated attributes. Without this,
+        // attribute mutations made by nested method calls on `self` would be lost during
+        // the writeback below, because the env variables still hold the pre-call values.
+        if let Some(Value::Instance {
+            attributes: self_attrs,
+            ..
+        }) = self.env.get("self")
+        {
+            let self_attrs_snapshot: Vec<(String, Value)> = self_attrs
+                .iter()
+                .filter(|(k, _)| !k.contains('\0'))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            for (attr_name, attr_val) in self_attrs_snapshot {
+                let env_key = format!("!{}", attr_name);
+                let public_env_key = format!(".{}", attr_name);
+                let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
+                let private_unchanged = self.env.get(&env_key).is_some_and(|v| *v == original);
+                let public_unchanged = self
+                    .env
+                    .get(&public_env_key)
+                    .is_some_and(|v| *v == original);
+                // Only sync if neither the private nor public env variable
+                // was modified by the method body. This preserves direct
+                // mutations like `$.count++` (which modifies .count) while
+                // still propagating changes from nested method calls.
+                if private_unchanged && public_unchanged {
+                    self.env.insert(env_key, attr_val.clone());
+                    self.env.insert(public_env_key, attr_val);
+                }
+            }
+        }
         for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
             // Skip class-qualified private attribute keys
             if attr_name.contains('\0') {

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -663,9 +663,18 @@ impl Interpreter {
                             .and_then(|name| name.as_ref())
                             .cloned()
                         {
+                            // Compile-time pseudo-variables (?CLASS, ?ROLE, ?PACKAGE, etc.)
+                            // should NOT be re-resolved from the callee's env because the
+                            // env may have already overwritten them (e.g., ?CLASS is set to
+                            // the method's owner class). Use the argument value as-is.
+                            let is_compile_time_pseudo = source_name.starts_with('?');
                             let resolved_source =
                                 self.resolve_sigilless_alias_source_name(&source_name);
-                            if let Some(source_val) = self.env.get(&resolved_source).cloned() {
+                            if is_compile_time_pseudo {
+                                self.env.remove(&alias_key);
+                                self.env.insert(readonly_key, Value::Bool(true));
+                            } else if let Some(source_val) = self.env.get(&resolved_source).cloned()
+                            {
                                 value = source_val;
                                 self.env.insert(alias_key, Value::str(resolved_source));
                                 self.env.insert(readonly_key, Value::Bool(false));

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -231,6 +231,13 @@ impl VM {
         // bare variable name in the environment.
         if let Some(bare) = Self::pseudo_package_unqualified_name(name) {
             self.interpreter.env_mut().insert(bare, value);
+        } else if let Some(bare) = name.strip_prefix("GLOBAL::") {
+            // For unsigiled GLOBAL-qualified names (e.g. "GLOBAL::x" from
+            // `$x` at top level), also update the bare name in the env so
+            // that lookups by bare name see the latest value.
+            if self.interpreter.env().contains_key(bare) {
+                self.interpreter.env_mut().insert(bare.to_string(), value);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix DESTROY attribute propagation: sync attribute env variables from `self` after nested method calls so mutations by `self.method()` are visible to the caller
- Fix sigilless pseudo-variable binding: skip re-resolving `$?CLASS`/`$?ROLE` from callee's env in `Mu \type` parameter binding, preventing incorrect value substitution
- Fix CAS 2-arg block form: handle blocks that modify the variable via assignment (e.g., `cas $x, { $x = expr }`) by using the env value as fallback
- Fix GLOBAL:: env writeback: update bare env keys for unsigiled GLOBAL-qualified names so variable lookups see the latest value

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S12-construction/roles-6e.t` passes all 3 subtests
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `make roast` passes (only pre-existing `cas-loop.t` and `spurt.t` failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)