### PR TITLE
fix: pass all 48 subtests in roast/S03-binding/arrays.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -141,6 +141,7 @@ roast/S02-types/undefined-types.t
 roast/S02-types/unicode.t
 roast/S02-types/version-stress.t
 roast/S02-types/version.t
+roast/S03-binding/arrays.t
 roast/S03-binding/closure.t
 roast/S03-binding/hashes.t
 roast/S03-binding/ro.t

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -16,6 +16,13 @@ impl Compiler {
             self.pop_dynamic_scope_lexical(saved);
             return;
         }
+        let has_bound_array_len = stmts.iter().any(|s| {
+            matches!(s,
+                Stmt::Expr(Expr::Call { name, .. })
+                if name.resolve() == "__mutsu_record_bound_array_len"
+            )
+        });
+        let has_mark_bind = stmts.iter().any(|s| matches!(s, Stmt::MarkBind));
         // Hoist sub declarations
         self.hoist_sub_decls(stmts, true);
         for (i, stmt) in stmts.iter().enumerate() {
@@ -124,6 +131,15 @@ impl Compiler {
                     }
                     _ => {}
                 }
+            }
+            if has_bound_array_len
+                && let Stmt::VarDecl { name, .. } = stmt
+                && name.starts_with('@')
+            {
+                self.bind_vardecl = true;
+            }
+            if has_mark_bind && matches!(stmt, Stmt::VarDecl { .. }) {
+                self.bind_vardecl = true;
             }
             self.compile_stmt(stmt);
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -110,6 +110,13 @@ impl Compiler {
         }
     }
 
+    fn is_simple_var_expr(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_) | Expr::CodeVar(_)
+        )
+    }
+
     pub(crate) fn qualify_variable_name(&self, name: &str) -> String {
         if self.current_package.contains("::&") {
             // Sub/method state scopes use package-like names (e.g. GLOBAL::&foo/1)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -578,12 +578,13 @@ impl Compiler {
                     let qualified = self.qualify_variable_name(name);
                     let idx = self.code.add_constant(Value::str(qualified));
                     self.code.emit(OpCode::GetOurVar(idx));
-                } else if self.bind_vardecl && !name.starts_with('@') && !name.starts_with('%') {
-                    // `:=` binding for scalar VarDecl: use compile_call_arg
-                    // so WrapVarRef is emitted and the VM can set up aliases.
-                    // Set scalar_bind_autovivify so that Index expressions
-                    // emit IndexAutovivify (for hash element binding like
-                    // `my $b := %h<foo><baz>`).
+                } else if self.bind_vardecl
+                    && (!name.starts_with('@') && !name.starts_with('%')
+                        || Self::is_simple_var_expr(expr))
+                {
+                    // `:=` binding for VarDecl: use compile_call_arg so WrapVarRef
+                    // is emitted and the VM can set up aliases.  For @/% targets,
+                    // only emit WrapVarRef when the RHS is a simple variable.
                     self.bind_vardecl = false;
                     self.scalar_bind_autovivify = true;
                     self.compile_call_arg(expr);

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -166,6 +166,8 @@ impl VM {
         for v in &values {
             let v = self.interpreter.auto_fetch_proxy(v)?;
             check_rat_divide_by_zero(&v)?;
+            // Resolve bound-element sentinels inside arrays before gist
+            let v = self.resolve_bound_array_elements(v);
             if needs_method_dispatch(&v) {
                 parts.push(self.interpreter.render_gist_value(&v));
             } else {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -514,4 +514,41 @@ impl VM {
             Ok(Value::Bool(matched))
         }
     }
+
+    /// Resolve bound-element sentinels inside an Array value.
+    ///
+    /// When an array element has been bound (`@a[1] := $var`), mutsu stores a
+    /// sentinel `Pair("__mutsu_bound_array_ref", var_name)` in the underlying
+    /// Vec.  This method replaces every such sentinel with the current value of
+    /// the referenced variable, so that callers that iterate elements (e.g.
+    /// stringification, `say`, `gist`) see the live value instead of the
+    /// internal marker.
+    pub(super) fn resolve_bound_array_elements(&self, val: Value) -> Value {
+        use super::vm_var_ops::BOUND_ARRAY_REF_SENTINEL;
+        if let Value::Array(ref items, kind) = val {
+            let needs_resolve = items
+                .iter()
+                .any(|v| matches!(v, Value::Pair(name, _) if name == BOUND_ARRAY_REF_SENTINEL));
+            if !needs_resolve {
+                return val;
+            }
+            let resolved: Vec<Value> = items
+                .iter()
+                .map(|v| match v {
+                    Value::Pair(name, source) if name == BOUND_ARRAY_REF_SENTINEL => {
+                        let source_name = source.to_string_value();
+                        self.interpreter
+                            .env()
+                            .get(&source_name)
+                            .cloned()
+                            .unwrap_or(Value::Nil)
+                    }
+                    other => other.clone(),
+                })
+                .collect();
+            Value::Array(std::sync::Arc::new(resolved), kind)
+        } else {
+            val
+        }
+    }
 }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -722,6 +722,8 @@ impl VM {
             self.stack.push(result);
             return Ok(());
         }
+        // Resolve bound-element sentinels inside arrays before stringification
+        let val = self.resolve_bound_array_elements(val);
         self.stack
             .push(Value::str(crate::runtime::utils::coerce_to_str(&val)));
         Ok(())

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1413,9 +1413,10 @@ impl VM {
                     // Sentinel present — write will propagate, allow it
                 }
                 Some(false) => {
-                    // No sentinel but bound metadata exists — this is a
-                    // non-bound readonly index, reject the write.
-                    return Err(RuntimeError::assignment_ro(None));
+                    // No sentinel but bound metadata exists — the binding was
+                    // broken (e.g. by splice removing the element).  Clean up
+                    // the stale metadata and allow the write.
+                    self.remove_bound_index(&var_name, &encoded_idx);
                 }
                 None => {
                     // Array was reset or index is gone — stale metadata, allow write
@@ -2611,6 +2612,71 @@ impl VM {
                 }
             } else if is_bind {
                 // `:=` binding preserves the container type (e.g. List stays List).
+                // Type-check: only Positional values can be bound to @-sigiled vars.
+                let is_positional = match &raw_popped {
+                    Value::Array(..)
+                    | Value::LazyList(_)
+                    | Value::LazyIoLines { .. }
+                    | Value::Seq(_)
+                    | Value::Slip(_)
+                    | Value::Range(..)
+                    | Value::RangeExcl(..)
+                    | Value::RangeExclStart(..)
+                    | Value::RangeExclBoth(..)
+                    | Value::GenericRange { .. }
+                    | Value::Nil => true,
+                    // Instance objects are Positional only if they implement
+                    // the Positional role (or Array subclass etc.), but not
+                    // Failure or arbitrary classes.
+                    Value::Instance { class_name, .. } => {
+                        let cn = class_name.resolve();
+                        matches!(
+                            cn.as_str(),
+                            "Array"
+                                | "List"
+                                | "Slip"
+                                | "Seq"
+                                | "Range"
+                                | "Buf"
+                                | "Blob"
+                                | "utf8"
+                                | "buf8"
+                                | "buf16"
+                                | "buf32"
+                        ) || self
+                            .interpreter
+                            .class_composed_roles(&cn)
+                            .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
+                    }
+                    _ => false,
+                };
+                if !is_positional {
+                    let got_type = crate::runtime::utils::value_type_name(&raw_popped);
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("got".to_string(), raw_popped.clone());
+                    attrs.insert(
+                        "expected".to_string(),
+                        Value::Package(crate::symbol::Symbol::intern("Positional")),
+                    );
+                    attrs.insert("symbol".to_string(), Value::str(name.clone()));
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Type check failed in binding; expected Positional but got {}",
+                            got_type
+                        )),
+                    );
+                    let ex = Value::make_instance(
+                        crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+                        attrs,
+                    );
+                    let mut err = RuntimeError::new(format!(
+                        "Type check failed in binding; expected Positional but got {}",
+                        got_type
+                    ));
+                    err.exception = Some(Box::new(ex));
+                    return Err(err);
+                }
                 match raw_popped {
                     Value::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),
                     Value::LazyIoLines { .. } => {
@@ -2631,7 +2697,13 @@ impl VM {
                         let forced = self.force_if_lazy_io_lines(raw_popped)?;
                         runtime::coerce_to_array(forced)
                     }
-                    other => runtime::coerce_to_array(other),
+                    other => {
+                        // Resolve bound-element sentinels before coercing to
+                        // array.  Assignment (not binding) creates new
+                        // containers, so bound refs must be snapshotted.
+                        let other = self.resolve_bound_array_elements(other);
+                        runtime::coerce_to_array(other)
+                    }
                 }
             };
             // Preserve shaped array property on re-assignment

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -618,6 +618,14 @@ impl VM {
         self.interpreter.env_mut().insert(key, Value::hash(map));
     }
 
+    /// Remove a bound-index marker (e.g. after splice breaks the binding).
+    pub(super) fn remove_bound_index(&mut self, var_name: &str, encoded: &str) {
+        let key = format!("__mutsu_bound_index::{}", var_name);
+        if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+            Arc::make_mut(map).remove(encoded);
+        }
+    }
+
     pub(super) fn mark_initialized_index(&mut self, var_name: &str, encoded: String) {
         // Assigning a slot clears any deleted-index marker so subsequent
         // `:exists` checks report the slot as present again.


### PR DESCRIPTION
## Summary
- Resolve bound-element sentinels (`__mutsu_bound_array_ref`) when stringifying arrays via `~@array` and `say @array`
- Clean up stale bound-index metadata after `splice` breaks element bindings, allowing subsequent assignment
- Preserve container identity when `@array := $scalar` by using in-place mutation for shared Arcs
- Add `X::TypeCheck::Binding` error when binding non-Positional values to `@`-sigiled variables (Int, Str, Failure, etc.)
- Detect bind context in `compile_block_inline` so `my @a := 1` throws correctly in EVAL and expression-final positions
- Resolve bound refs when assigning (not binding) arrays to new variables so copies don't share bindings
- Emit `WrapVarRef` for `@array := $var` bindings so the VM sets up proper aliases

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S03-binding/arrays.t` passes all 48 subtests
- [x] `make test` passes (all 471 files, 3802 tests)
- [x] No regressions in `roast/S32-array/delete.t`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)