### PR TITLE
fix: wrap negative values for uint/uint64 and fix inline native decl expr

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -269,7 +269,7 @@
 - [ ] roast/S02-types/sigils-and-types.t
   - 0/? pass. Parse error at line 78
 - [ ] roast/S02-types/signed-unsigned-native.t
-  - 91/132 pass. Failures: unsigned int type checks (tests 31-35), equality on uint/int cross-type (tests 66-75), less-than on int/uint cross-type (tests 91-95), and related cross-type comparisons (96-132)
+  - 122/132 pass. Remaining 10 failures: `!=` mixed signed/unsigned comparisons (tests 76-85). Raku's `!=` for native ints uses native bit-level comparison (both uint8(-1)=255 and int8(-1)=-1 have 0xFF bit pattern), but mutsu compares mathematical values. Fixing requires tracking native type info on Value variants.
 - [ ] roast/S02-types/stash.t
   - 0/1 pass. Runtime error: `Unknown method: new on Stash` — Stash type not implemented
 - [ ] roast/S02-types/subscripts_and_context.t

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -42,6 +42,7 @@ impl Compiler {
                 is_state,
                 is_our,
                 is_dynamic: ast_is_dynamic,
+                type_constraint,
                 ..
             } => {
                 let is_dynamic = *ast_is_dynamic || self.var_is_dynamic(name);
@@ -114,8 +115,32 @@ impl Compiler {
                         let idx = self.code.add_constant(Value::str(qualified));
                         self.code.emit(OpCode::SetGlobal(idx));
                     } else {
-                        self.code.emit(OpCode::Dup);
-                        self.emit_set_named_var(name);
+                        // For native int types, the value may be wrapped during
+                        // assignment (e.g., -1 -> 255 for uint8). We need to
+                        // return the wrapped value, so emit TypeCheck (which
+                        // wraps on the stack) then Dup, then store.
+                        let is_native_int = type_constraint
+                            .as_ref()
+                            .is_some_and(|tc| crate::runtime::native_types::is_native_int_type(tc));
+                        if is_native_int {
+                            let tc = type_constraint.as_ref().unwrap();
+                            // Set type constraint so future assignments also wrap
+                            let name_idx2 = self.code.add_constant(Value::str(name.clone()));
+                            let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                            self.code.emit(OpCode::SetVarType {
+                                name_idx: name_idx2,
+                                tc_idx,
+                            });
+                            // TypeCheck wraps the value on the stack for native types
+                            let tc_idx2 = self.code.add_constant(Value::str(tc.clone()));
+                            self.code.emit(OpCode::TypeCheck(tc_idx2, None));
+                            // Now Dup the wrapped value and store
+                            self.code.emit(OpCode::Dup);
+                            self.emit_set_named_var(name);
+                        } else {
+                            self.code.emit(OpCode::Dup);
+                            self.emit_set_named_var(name);
+                        }
                     }
                 }
                 let name_idx = self.code.add_constant(Value::str(name.clone()));

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -52,8 +52,15 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
     if native_types::is_in_native_range(base, &big_val) {
         return Ok(val);
     }
-    // Full-width native types don't wrap — they should throw on overflow.
-    if matches!(base, "int" | "int64" | "uint" | "uint64") {
+    // Full-width signed native types don't wrap — they should throw on overflow.
+    if matches!(base, "int" | "int64") {
+        return Err(crate::value::RuntimeError::new(format!(
+            "Cannot unbox {} bit wide bigint into native integer",
+            big_val.bits()
+        )));
+    }
+    // Full-width unsigned types: positive overflow throws, negative values wrap.
+    if matches!(base, "uint" | "uint64") && big_val > NumBigInt::from(0u64) {
         return Err(crate::value::RuntimeError::new(format!(
             "Cannot unbox {} bit wide bigint into native integer",
             big_val.bits()

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2792,13 +2792,23 @@ impl VM {
         };
 
         // Wrap out-of-range values for smaller native types (like C semantics).
-        // Full-width types (int/int64/uint/uint64) throw on overflow.
+        // Full-width signed types (int/int64) throw on overflow.
+        // Unsigned types (uint/uint64) wrap negative values to unsigned range.
         let wrapped = if !native_types::is_in_native_range(type_name, &big_val) {
-            if matches!(type_name, "int" | "int64" | "uint" | "uint64") {
+            if matches!(type_name, "int" | "int64") {
                 return Err(RuntimeError::new(format!(
                     "Cannot unbox {} bit wide bigint into native integer",
                     big_val.bits()
                 )));
+            }
+            if matches!(type_name, "uint" | "uint64") {
+                // Positive values exceeding u64 range should throw
+                if big_val > NumBigInt::from(0u64) {
+                    return Err(RuntimeError::new(format!(
+                        "Cannot unbox {} bit wide bigint into native integer",
+                        big_val.bits()
+                    )));
+                }
             }
             native_types::wrap_native_int(type_name, &big_val)
         } else {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3506,20 +3506,40 @@ impl VM {
         if !native_types::is_native_int_type(base) {
             return Ok(val);
         }
-        // Full-width native types don't wrap — they should throw on overflow.
-        if matches!(base, "int" | "int64" | "uint" | "uint64") {
+        // Full-width signed native types don't wrap — they should throw on overflow.
+        if matches!(base, "int" | "int64") {
             if let Value::BigInt(ref n) = val {
-                // For unsigned types, values that fit in u64 are valid
-                if matches!(base, "uint" | "uint64") && n.to_u64().is_some() {
-                    return Ok(val);
-                }
-                // For signed types, any BigInt is too large (i64 values are Value::Int)
-                // For unsigned types that didn't fit in u64, also too large
                 let bits = n.bits();
                 return Err(RuntimeError::new(format!(
                     "Cannot unbox {} bit wide bigint into native integer",
                     bits
                 )));
+            }
+            return Ok(val);
+        }
+        // Full-width unsigned native types: BigInt values that fit in u64 are valid,
+        // negative Value::Int values need wrapping (like C unsigned semantics).
+        if matches!(base, "uint" | "uint64") {
+            if let Value::BigInt(ref n) = val {
+                if n.to_u64().is_some() {
+                    return Ok(val);
+                }
+                let bits = n.bits();
+                return Err(RuntimeError::new(format!(
+                    "Cannot unbox {} bit wide bigint into native integer",
+                    bits
+                )));
+            }
+            // Value::Int with negative value needs wrapping to unsigned range
+            if let Value::Int(n) = &val
+                && *n < 0
+            {
+                let big_val = NumBigInt::from(*n);
+                let wrapped = native_types::wrap_native_int(base, &big_val);
+                return Ok(wrapped
+                    .to_i64()
+                    .map(Value::Int)
+                    .unwrap_or_else(|| Value::bigint(wrapped)));
             }
             return Ok(val);
         }


### PR DESCRIPTION
## Summary
- Fix uint/uint64 native types to properly wrap negative values (e.g., `my uint64 $x = -1` now gives 18446744073709551615 instead of erroring with "Cannot unbox N bit wide bigint")
- Fix inline native int declarations in expression context (e.g., `(my byte $x = +^0)`) to return the wrapped value (255) instead of the original unwrapped value (-1)
- Update TODO_roast/S02.md: signed-unsigned-native.t now passes 122/132 (up from 91/132)

## Test plan
- [x] `timeout 60 target/debug/mutsu roast/S02-types/signed-unsigned-native.t` passes 122/132 tests
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `make test` passes (only pre-existing t/lock.t flaky failure)
- [x] `make roast` passes (only pre-existing roast/S32-io/spurt.t failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)