### PR TITLE
fix: pass all 38 subtests in roast/S12-methods/calling_sets.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -577,6 +577,7 @@ roast/S12-meta/classhow.t
 roast/S12-meta/grammarhow.t
 roast/S12-meta/primitives.t
 roast/S12-methods/attribute-params.t
+roast/S12-methods/calling_sets.t
 roast/S12-methods/calling_syntax.t
 roast/S12-methods/chaining.t
 roast/S12-methods/class-and-instance.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -182,6 +182,7 @@ pub(crate) enum Expr {
         target: Box<Expr>,
         name_expr: Box<Expr>,
         args: Vec<Expr>,
+        modifier: Option<char>,
     },
     HyperMethodCall {
         target: Box<Expr>,
@@ -997,6 +998,7 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             target,
             name_expr,
             args,
+            ..
         }
         | Expr::HyperMethodCallDynamic {
             target,
@@ -1287,6 +1289,7 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
             target,
             name_expr,
             args,
+            ..
         }
         | Expr::HyperMethodCallDynamic {
             target,
@@ -1490,6 +1493,7 @@ fn check_bare_var_expr(expr: &Expr, bare_name: &str, found: &mut bool) {
             target,
             name_expr,
             args,
+            ..
         }
         | Expr::HyperMethodCallDynamic {
             target,

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -184,8 +184,9 @@ impl Compiler {
                 target,
                 name_expr,
                 args,
+                modifier,
             } => {
-                self.compile_expr_dynamic_method(target, name_expr, args);
+                self.compile_expr_dynamic_method(target, name_expr, args, modifier);
             }
             // Hyper method call: target>>.method(args)
             Expr::HyperMethodCall {

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -246,6 +246,7 @@ impl Compiler {
         target: &Expr,
         name_expr: &Expr,
         args: &[Expr],
+        modifier: &Option<char>,
     ) {
         let target_var_name = match target {
             Expr::Var(n) => Some(n.clone()),
@@ -259,14 +260,19 @@ impl Compiler {
         for arg in args {
             self.compile_method_arg(arg);
         }
+        let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
         if let Some(var_name) = target_var_name {
             let target_name_idx = self.code.add_constant(Value::str(var_name));
             self.code.emit(OpCode::CallMethodDynamicMut {
                 arity,
                 target_name_idx,
+                modifier_idx,
             });
         } else {
-            self.code.emit(OpCode::CallMethodDynamic { arity });
+            self.code.emit(OpCode::CallMethodDynamic {
+                arity,
+                modifier_idx,
+            });
         }
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -310,12 +310,14 @@ pub(crate) enum OpCode {
     /// Stack layout: [target, name_str, arg0, arg1, ...]
     CallMethodDynamic {
         arity: u32,
+        modifier_idx: Option<u32>,
     },
     /// Dynamic method call on a variable target (allows mutation/writeback).
     /// Stack layout: [target, name_str, arg0, arg1, ...]
     CallMethodDynamicMut {
         arity: u32,
         target_name_idx: u32,
+        modifier_idx: Option<u32>,
     },
     /// Statement-level call: pop `arity` args, call name (no push).
     ExecCall {

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -818,10 +818,12 @@ fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
             target,
             name_expr,
             args,
+            modifier,
         } => Expr::DynamicMethodCall {
             target: Box::new(replace_whatever_numbered(target, counter)),
             name_expr: name_expr.clone(),
             args: args.clone(),
+            modifier: *modifier,
         },
         Expr::CallOn { target, args } => Expr::CallOn {
             target: Box::new(replace_whatever_numbered(target, counter)),
@@ -1096,10 +1098,12 @@ fn replace_whatever_single(expr: &Expr) -> Expr {
             target,
             name_expr,
             args,
+            modifier,
         } => Expr::DynamicMethodCall {
             target: Box::new(replace_whatever_single(target)),
             name_expr: name_expr.clone(),
             args: args.clone(),
+            modifier: *modifier,
         },
         Expr::CallOn { target, args } => Expr::CallOn {
             target: Box::new(replace_whatever_single(target)),
@@ -2429,6 +2433,7 @@ mod tests {
                 target,
                 name_expr,
                 args,
+                ..
             } => {
                 assert!(matches!(*target, Expr::Var(ref n) if n.as_str() == "m"));
                 assert!(matches!(*name_expr, Expr::AnonSub { .. }));

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -845,6 +845,7 @@ fn parse_dot_assign<'a>(input: &'a str, expr: Expr) -> PResult<'a, Expr> {
                     target: Box::new(target),
                     name_expr: Box::new(name_expr.clone()),
                     args: args.clone(),
+                    modifier: None,
                 })
             }
         };
@@ -1493,6 +1494,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         target: Box::new(expr),
                         name_expr: Box::new(name_expr),
                         args,
+                        modifier,
                     };
                     rest = r;
                     continue;
@@ -1527,6 +1529,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         target: Box::new(expr),
                         name_expr: Box::new(name_expr),
                         args,
+                        modifier,
                     };
                     rest = r_inner;
                     continue;
@@ -1535,6 +1538,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     target: Box::new(expr),
                     name_expr: Box::new(name_expr),
                     args: Vec::new(),
+                    modifier,
                 };
                 rest = r;
                 continue;
@@ -1756,6 +1760,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             target: Box::new(expr),
                             name_expr: Box::new(name_expr),
                             args,
+                            modifier,
                         };
                     }
                 }
@@ -1782,6 +1787,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             target: Box::new(expr),
                             name_expr: Box::new(name_expr),
                             args,
+                            modifier,
                         };
                         rest = r_name;
                         continue;
@@ -1790,6 +1796,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         target: Box::new(expr),
                         name_expr: Box::new(name_expr),
                         args: Vec::new(),
+                        modifier,
                     };
                     rest = r_name;
                     continue;
@@ -1806,6 +1813,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         target: Box::new(expr),
                         name_expr: Box::new(name_expr),
                         args,
+                        modifier,
                     };
                     rest = r_name;
                     continue;
@@ -1814,6 +1822,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     target: Box::new(expr),
                     name_expr: Box::new(name_expr),
                     args: Vec::new(),
+                    modifier,
                 };
                 rest = r_name;
                 continue;
@@ -1922,6 +1931,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             target: Box::new(expr),
                             name_expr: Box::new(name_expr),
                             args,
+                            modifier: Some('!'),
                         };
                     }
                 }

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1546,6 +1546,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     target: Box::new(method_target),
                     name_expr: Box::new(name_expr),
                     args,
+                    modifier: None,
                 },
             };
             return Ok((
@@ -2187,6 +2188,7 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
                     target: Box::new(var_expr),
                     name_expr: Box::new(name_expr),
                     args,
+                    modifier: None,
                 },
             };
             let stmt = Stmt::Assign {

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -325,6 +325,7 @@ fn expr_contains_whatever(expr: &Expr) -> bool {
             target,
             name_expr,
             args,
+            ..
         }
         | Expr::HyperMethodCallDynamic {
             target,

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1010,7 +1010,7 @@ impl Interpreter {
             }
 
             let candidates =
-                self.resolve_all_methods_with_owner(&class_name.resolve(), method, &args);
+                self.resolve_methods_per_mro_level(&class_name.resolve(), method, &args);
             if !candidates.is_empty() {
                 let mut attrs = (**attributes).clone();
                 let mut out = Vec::with_capacity(candidates.len());

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -328,6 +328,7 @@ impl Interpreter {
                     target,
                     name_expr,
                     args,
+                    ..
                 }
                 | Expr::HyperMethodCallDynamic {
                     target,
@@ -1036,6 +1037,17 @@ impl Interpreter {
                     attrs,
                 );
                 return Ok(out);
+            }
+            // If the method is defined but no multi candidate matched,
+            // produce a dispatch error.
+            let method_exists = self.class_mro(&class_name.resolve()).iter().any(|cn| {
+                self.classes
+                    .get(cn.as_str())
+                    .and_then(|c| c.methods.get(method))
+                    .is_some_and(|ovs| !ovs.is_empty())
+            });
+            if method_exists {
+                return Err(make_multi_no_match_error(method));
             }
         }
 

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -361,6 +361,7 @@ fn lift_phasers_from_expr(
             target,
             name_expr,
             args,
+            ..
         }
         | Expr::HyperMethodCallDynamic {
             target,

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -495,36 +495,80 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Vec<(String, MethodDef)> {
-        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
         let mro = self.class_mro(class_name);
-        let mut matches = Vec::new();
+        // Find which MRO levels define the method.
+        let mut defining_levels: Vec<String> = Vec::new();
         for cn in &mro {
+            let is_ancestor = cn != class_name;
             if let Some(overloads) = self
                 .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
                 .cloned()
             {
+                let has_visible = overloads
+                    .iter()
+                    .any(|d| !d.is_private && (!d.is_my || !is_ancestor));
+                if has_visible {
+                    defining_levels.push(cn.clone());
+                }
+            }
+        }
+        if defining_levels.is_empty() {
+            return Vec::new();
+        }
+        // Check if any level has multi methods.
+        let any_multi = defining_levels.iter().any(|cn| {
+            self.classes
+                .get(cn.as_str())
+                .and_then(|c| c.methods.get(method_name))
+                .is_some_and(|ovs| ovs.iter().any(|d| d.is_multi))
+        });
+        if !any_multi {
+            // Non-multi: return matching candidates directly (original behavior)
+            let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
+            let mut matches = Vec::new();
+            for cn in &defining_levels {
                 let is_ancestor = cn != class_name;
-                for def in overloads {
-                    if def.is_private {
-                        continue;
-                    }
-                    // Submethods are NOT inherited
-                    if def.is_my && is_ancestor {
-                        continue;
-                    }
-                    if self.method_args_match_for_invocant(
-                        class_name,
-                        &def,
-                        arg_values,
-                        role_bindings.as_ref(),
-                        None,
-                    ) {
-                        matches.push((cn.clone(), def));
+                if let Some(overloads) = self
+                    .classes
+                    .get(cn.as_str())
+                    .and_then(|c| c.methods.get(method_name))
+                    .cloned()
+                {
+                    for def in overloads {
+                        if def.is_private || (def.is_my && is_ancestor) {
+                            continue;
+                        }
+                        if self.method_args_match_for_invocant(
+                            class_name,
+                            &def,
+                            arg_values,
+                            role_bindings.as_ref(),
+                            None,
+                        ) {
+                            matches.push((cn.clone(), def));
+                        }
                     }
                 }
             }
+            return matches;
+        }
+        // Multi methods: for each defining level, resolve using the normal
+        // dispatch mechanism starting from that level's MRO.
+        let mut matches = Vec::new();
+        let mut any_failed = false;
+        for cn in &defining_levels {
+            if let Some(resolved) =
+                self.resolve_method_with_owner_impl(cn, method_name, arg_values, None)
+            {
+                matches.push(resolved);
+            } else {
+                any_failed = true;
+            }
+        }
+        if any_failed {
+            return Vec::new();
         }
         matches
     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -495,8 +495,50 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Vec<(String, MethodDef)> {
+        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
         let mro = self.class_mro(class_name);
-        // Find which MRO levels define the method.
+        let mut matches = Vec::new();
+        for cn in &mro {
+            if let Some(overloads) = self
+                .classes
+                .get(cn.as_str())
+                .and_then(|c| c.methods.get(method_name))
+                .cloned()
+            {
+                let is_ancestor = cn != class_name;
+                for def in overloads {
+                    if def.is_private {
+                        continue;
+                    }
+                    // Submethods are NOT inherited
+                    if def.is_my && is_ancestor {
+                        continue;
+                    }
+                    if self.method_args_match_for_invocant(
+                        class_name,
+                        &def,
+                        arg_values,
+                        role_bindings.as_ref(),
+                        None,
+                    ) {
+                        matches.push((cn.clone(), def));
+                    }
+                }
+            }
+        }
+        matches
+    }
+
+    /// Resolve methods for .*/,+ dispatch: one resolution per MRO level.
+    /// For multi methods, dispatches through the proto at each level.
+    /// Returns empty vec if any level has the method but no candidate matches.
+    pub(crate) fn resolve_methods_per_mro_level(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        arg_values: &[Value],
+    ) -> Vec<(String, MethodDef)> {
+        let mro = self.class_mro(class_name);
         let mut defining_levels: Vec<String> = Vec::new();
         for cn in &mro {
             let is_ancestor = cn != class_name;
@@ -517,7 +559,6 @@ impl Interpreter {
         if defining_levels.is_empty() {
             return Vec::new();
         }
-        // Check if any level has multi methods.
         let any_multi = defining_levels.iter().any(|cn| {
             self.classes
                 .get(cn.as_str())
@@ -525,37 +566,10 @@ impl Interpreter {
                 .is_some_and(|ovs| ovs.iter().any(|d| d.is_multi))
         });
         if !any_multi {
-            // Non-multi: return matching candidates directly (original behavior)
-            let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
-            let mut matches = Vec::new();
-            for cn in &defining_levels {
-                let is_ancestor = cn != class_name;
-                if let Some(overloads) = self
-                    .classes
-                    .get(cn.as_str())
-                    .and_then(|c| c.methods.get(method_name))
-                    .cloned()
-                {
-                    for def in overloads {
-                        if def.is_private || (def.is_my && is_ancestor) {
-                            continue;
-                        }
-                        if self.method_args_match_for_invocant(
-                            class_name,
-                            &def,
-                            arg_values,
-                            role_bindings.as_ref(),
-                            None,
-                        ) {
-                            matches.push((cn.clone(), def));
-                        }
-                    }
-                }
-            }
-            return matches;
+            // Non-multi: use the standard resolution
+            return self.resolve_all_methods_with_owner(class_name, method_name, arg_values);
         }
-        // Multi methods: for each defining level, resolve using the normal
-        // dispatch mechanism starting from that level's MRO.
+        // Multi methods: dispatch through proto at each level
         let mut matches = Vec::new();
         let mut any_failed = false;
         for cn in &defining_levels {

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -6,8 +6,8 @@ impl Interpreter {
             return true;
         }
         if constraint == "Any" {
-            // Junction is a direct subtype of Mu, not Any
-            return value_type != "Junction";
+            // Junction and Mu are direct subtypes of Mu, not Any
+            return !matches!(value_type, "Junction" | "Mu");
         }
         if constraint == value_type {
             return true;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2032,15 +2032,24 @@ impl VM {
                 }
                 *ip += 1;
             }
-            OpCode::CallMethodDynamic { arity } => {
-                self.exec_call_method_dynamic_op(code, *arity)?;
+            OpCode::CallMethodDynamic {
+                arity,
+                modifier_idx,
+            } => {
+                self.exec_call_method_dynamic_op(code, *arity, *modifier_idx)?;
                 *ip += 1;
             }
             OpCode::CallMethodDynamicMut {
                 arity,
                 target_name_idx,
+                modifier_idx,
             } => {
-                self.exec_call_method_dynamic_mut_op(code, *arity, *target_name_idx)?;
+                self.exec_call_method_dynamic_mut_op(
+                    code,
+                    *arity,
+                    *target_name_idx,
+                    *modifier_idx,
+                )?;
                 *ip += 1;
             }
             OpCode::CallMethodMut {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -167,6 +167,20 @@ impl VM {
         }
     }
 
+    /// Check if an error is a "method not found" error (as opposed to a
+    /// multi-dispatch failure or other runtime error). Used by .* to
+    /// suppress method-not-found but propagate dispatch failures.
+    pub(super) fn is_method_not_found_error(e: &RuntimeError) -> bool {
+        if let Some(ref ex) = e.exception
+            && let Value::Instance { class_name, .. } = ex.as_ref()
+        {
+            return class_name.resolve() == "X::Method::NotFound";
+        }
+        // Also catch unstructured method-not-found messages
+        e.message.contains("X::Method::NotFound")
+            || e.message.contains("Unknown method value dispatch")
+    }
+
     pub(super) fn rewrite_method_name(method_raw: &str, modifier: Option<&str>) -> String {
         match modifier {
             Some("^") => format!("^{}", method_raw),

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -7,8 +7,10 @@ impl VM {
         &mut self,
         code: &CompiledCode,
         arity: u32,
+        modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new("VM stack underflow in CallMethodDynamic"));
@@ -29,13 +31,35 @@ impl VM {
             .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamic target"))?;
         // Force lazy IO lines for non-lazy-preserving methods
         let method_name_str = name_val.to_string_value();
+        let method = Self::rewrite_method_name(&method_name_str, modifier.as_deref());
         let target = if matches!(&target, Value::LazyIoLines { .. })
-            && !matches!(method_name_str.as_str(), "kv" | "iterator" | "lazy")
+            && !matches!(method.as_str(), "kv" | "iterator" | "lazy")
         {
             self.force_if_lazy_io_lines(target)?
         } else {
             target
         };
+        // Handle .* and .+ modifiers
+        match modifier.as_deref() {
+            Some("+") => {
+                let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
+                self.stack.push(Value::array(vals));
+                self.env_dirty = true;
+                return Ok(());
+            }
+            Some("*") => {
+                match self.call_method_all_with_fallback(&target, &method, &args, false) {
+                    Ok(vals) => self.stack.push(Value::array(vals)),
+                    Err(e) if Self::is_method_not_found_error(&e) => {
+                        self.stack.push(Value::array(vec![]))
+                    }
+                    Err(e) => return Err(e),
+                }
+                self.env_dirty = true;
+                return Ok(());
+            }
+            _ => {}
+        }
         let call_result = if matches!(
             &name_val,
             Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
@@ -198,7 +222,16 @@ impl VM {
                 self.try_compiled_method_or_interpret(target, &method, args)
             }
         };
-        self.stack.push(call_result?);
+        match modifier.as_deref() {
+            Some("?") => match call_result {
+                Ok(val) => self.stack.push(val),
+                Err(e) if Self::is_method_not_found_error(&e) => self.stack.push(Value::Nil),
+                Err(e) => return Err(e),
+            },
+            _ => {
+                self.stack.push(call_result?);
+            }
+        }
         self.env_dirty = true;
         Ok(())
     }
@@ -208,9 +241,11 @@ impl VM {
         code: &CompiledCode,
         arity: u32,
         target_name_idx: u32,
+        modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
         let target_name = Self::const_str(code, target_name_idx).to_string();
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new(
@@ -231,6 +266,29 @@ impl VM {
             .stack
             .pop()
             .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamicMut"))?;
+        let method_name_str = name_val.to_string_value();
+        let method = Self::rewrite_method_name(&method_name_str, modifier.as_deref());
+        // Handle .* and .+ modifiers
+        match modifier.as_deref() {
+            Some("+") => {
+                let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
+                self.stack.push(Value::array(vals));
+                self.env_dirty = true;
+                return Ok(());
+            }
+            Some("*") => {
+                match self.call_method_all_with_fallback(&target, &method, &args, false) {
+                    Ok(vals) => self.stack.push(Value::array(vals)),
+                    Err(e) if Self::is_method_not_found_error(&e) => {
+                        self.stack.push(Value::array(vec![]))
+                    }
+                    Err(e) => return Err(e),
+                }
+                self.env_dirty = true;
+                return Ok(());
+            }
+            _ => {}
+        }
         let call_result = if matches!(
             &name_val,
             Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
@@ -240,7 +298,6 @@ impl VM {
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)?
         } else {
-            let method = name_val.to_string_value();
             self.interpreter
                 .call_method_mut_with_values(&target_name, target, &method, args)?
         };
@@ -711,7 +768,10 @@ impl VM {
             Some("*") => {
                 match self.call_method_all_with_fallback(&target, &method, &args, skip_native) {
                     Ok(vals) => self.stack.push(Value::array(vals)),
-                    Err(_) => self.stack.push(Value::array(vec![])),
+                    Err(e) if Self::is_method_not_found_error(&e) => {
+                        self.stack.push(Value::array(vec![]))
+                    }
+                    Err(e) => return Err(e),
                 }
                 self.env_dirty = true;
             }
@@ -751,10 +811,17 @@ impl VM {
                     self.try_compiled_method_mut_or_interpret(&target_name, target, &method, args)
                 };
                 match modifier.as_deref() {
-                    Some("?") => {
-                        self.stack.push(call_result.unwrap_or(Value::Nil));
-                        self.env_dirty = true;
-                    }
+                    Some("?") => match call_result {
+                        Ok(val) => {
+                            self.stack.push(val);
+                            self.env_dirty = true;
+                        }
+                        Err(e) if Self::is_method_not_found_error(&e) => {
+                            self.stack.push(Value::Nil);
+                            self.env_dirty = true;
+                        }
+                        Err(e) => return Err(e),
+                    },
                     _ => {
                         self.stack.push(call_result?);
                         self.env_dirty = true;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -494,6 +494,18 @@ impl VM {
         {
             return Err(err);
         }
+        // Pseudo-methods (WHAT, WHICH, etc.) cannot be used with .* or .+
+        if matches!(modifier.as_deref(), Some("*") | Some("+"))
+            && matches!(
+                method.as_str(),
+                "WHAT" | "WHICH" | "WHERE" | "HOW" | "WHY" | "WHO" | "DEFINITE" | "VAR"
+            )
+        {
+            return Err(RuntimeError::new(format!(
+                "Cannot use .{} on a non-identifier method call",
+                modifier.as_deref().unwrap()
+            )));
+        }
         // For .* and .+ modifiers, skip the single-dispatch call and go
         // directly to the all-methods-in-MRO path to avoid double execution.
         match modifier.as_deref() {
@@ -506,7 +518,10 @@ impl VM {
             Some("*") => {
                 match self.call_method_all_with_fallback(&target, &method, &args, skip_native) {
                     Ok(vals) => self.stack.push(Value::array(vals)),
-                    Err(_) => self.stack.push(Value::array(vec![])),
+                    Err(e) if Self::is_method_not_found_error(&e) => {
+                        self.stack.push(Value::array(vec![]))
+                    }
+                    Err(e) => return Err(e),
                 }
                 self.env_dirty = true;
             }
@@ -641,10 +656,17 @@ impl VM {
                     self.try_compiled_method_or_interpret(target, &method, args)
                 };
                 match modifier.as_deref() {
-                    Some("?") => {
-                        self.stack.push(call_result.unwrap_or(Value::Nil));
-                        self.env_dirty = true;
-                    }
+                    Some("?") => match call_result {
+                        Ok(val) => {
+                            self.stack.push(val);
+                            self.env_dirty = true;
+                        }
+                        Err(e) if Self::is_method_not_found_error(&e) => {
+                            self.stack.push(Value::Nil);
+                            self.env_dirty = true;
+                        }
+                        Err(e) => return Err(e),
+                    },
                     _ => {
                         self.stack.push(call_result?);
                         self.env_dirty = true;

--- a/t/parallel-dispatch-regression.t
+++ b/t/parallel-dispatch-regression.t
@@ -22,7 +22,7 @@ class PDRegMulti {
 
 my @m = (1..2).map({ PDRegMulti.new(v => $_) });
 # Hyper dispatch on @-variable returns Array (same container type as input)
-is-deeply @m».*mul(2), [[2, 102], [4, 104]], 'hyper .* returns all matching method candidates';
-is-deeply @m».+mul(2), [[2, 102], [4, 104]], 'hyper .+ returns all matching method candidates';
+is-deeply @m».*mul(2), [[2], [4]], 'hyper .* returns all matching method candidates';
+is-deeply @m».+mul(2), [[2], [4]], 'hyper .+ returns all matching method candidates';
 
 is (a => 1, a => 2)>>.<a>, '1 2', 'hyper >>.<key> works on pairs';


### PR DESCRIPTION
## Summary
- Add `modifier` field to `DynamicMethodCall` AST node so `.?`/`.*`/`.+` work with dynamic method names (e.g. `$c.*"$foo"()`)
- Fix `.*/+` with multi methods to dispatch through proto at each MRO level, correctly walking the inheritance hierarchy
- Make `.?` and `.*` only suppress method-not-found errors (X::Method::NotFound), not multi-dispatch failures
- Reject pseudo-methods (WHAT, WHICH, etc.) with `.*`/`.+` modifiers
- Fix `type_matches("Any", "Mu")` to return false (Mu is not a subtype of Any)
- Update `t/parallel-dispatch-regression.t` to match Raku behavior (verified with `raku`)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S12-methods/calling_sets.t` passes all 38 subtests
- [x] `make test` passes
- [x] `make roast` passes
- [x] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)