### PR TITLE
fix: pass all 55 subtests in roast/S15-nfg/concat-stable.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -632,6 +632,7 @@ roast/S15-literals/numbers.t
 roast/S15-nfg/GraphemeBreakTest-0.t
 roast/S15-nfg/case-change.t
 roast/S15-nfg/cgj.t
+roast/S15-nfg/concat-stable.t
 roast/S15-nfg/concatenation.t
 roast/S15-nfg/crlf-encoding.t
 roast/S15-nfg/emoji-test.t

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -194,6 +194,8 @@ impl Compiler {
                     || name == "pick"
                     || name == "roll"
                     || name == "take"
+                    || name == "shift"
+                    || name == "pop"
                     || name == "readchars"
                     || name == "receive"
                     || name == "getc"

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -32,6 +32,74 @@ impl VM {
         }
     }
 
+    /// Fast path for `@var.shift xx N` and `@var.pop xx N`.
+    /// Drains N elements in bulk instead of running a thunk N times.
+    fn try_bulk_shift_pop(
+        &mut self,
+        data: &crate::value::SubData,
+        n: usize,
+    ) -> Result<Option<Vec<Value>>, RuntimeError> {
+        use crate::ast::{Expr, Stmt};
+        if data.body.len() != 1 {
+            return Ok(None);
+        }
+        let (var_name, is_shift) = match &data.body[0] {
+            Stmt::Expr(Expr::MethodCall {
+                target, name, args, ..
+            }) if args.is_empty() && (name.resolve() == "shift" || name.resolve() == "pop") => {
+                let vname = match target.as_ref() {
+                    Expr::Var(v) => v.clone(),
+                    Expr::ArrayVar(v) => format!("@{}", v),
+                    _ => return Ok(None),
+                };
+                (vname, name.resolve() == "shift")
+            }
+            _ => return Ok(None),
+        };
+        // Look up the array in env
+        let arr_key = if var_name.starts_with('@') {
+            var_name.clone()
+        } else {
+            format!("@{}", var_name)
+        };
+        let target_val = self
+            .interpreter
+            .env()
+            .get(&arr_key)
+            .or_else(|| self.interpreter.env().get(&var_name))
+            .cloned();
+        let Value::Array(arc_items, kind) = target_val.unwrap_or(Value::Nil) else {
+            return Ok(None);
+        };
+        if !kind.is_real_array() {
+            return Ok(None);
+        }
+        let mut items = (*arc_items).clone();
+        let actual_n = n.min(items.len());
+        let result = if is_shift {
+            let rest = items.split_off(actual_n);
+            let shifted = items;
+            items = rest;
+            shifted
+        } else {
+            // pop
+            let split_at = items.len().saturating_sub(actual_n);
+            let popped: Vec<Value> = items.drain(split_at..).rev().collect();
+            popped
+        };
+        // Write the mutated array back
+        let lookup_key = if self.interpreter.env().contains_key(&arr_key) {
+            &arr_key
+        } else {
+            &var_name
+        };
+        self.interpreter
+            .env_mut()
+            .insert(lookup_key.to_string(), Value::Array(Arc::new(items), kind));
+        self.env_dirty = true;
+        Ok(Some(result))
+    }
+
     /// VM-native implementation of xx-repeat for thunks.
     /// Compiles the thunk body once and runs it N times via `run_reuse`,
     /// avoiding the interpreter roundtrip through `eval_xx_repeat_thunk`.
@@ -99,8 +167,19 @@ impl VM {
 
         self.stack = saved_stack;
         self.locals = saved_locals;
-        // Restore env
+        // Restore env, but keep mutations to arrays (e.g. shift/pop
+        // inside the thunk should persist).
         for (k, orig) in saved {
+            // If the thunk mutated an array variable (e.g. via .shift),
+            // keep the mutated version instead of restoring the original.
+            let current = self.interpreter.env().get(&k).cloned();
+            let should_keep_current = matches!(
+                (&orig, &current),
+                (Some(Value::Array(..)), Some(Value::Array(..)))
+            );
+            if should_keep_current {
+                continue;
+            }
             match orig {
                 Some(v) => {
                     self.interpreter.env_mut().insert(k, v);
@@ -656,6 +735,11 @@ impl VM {
             && let Value::Int(n) = right
         {
             let n = n.max(0) as usize;
+            // Fast path: @var.shift xx N or @var.pop xx N — bulk drain
+            if let Some(items) = self.try_bulk_shift_pop(&data, n)? {
+                self.stack.push(Value::Seq(Arc::new(items)));
+                return Ok(());
+            }
             let items = self.vm_xx_repeat_thunk(data.as_ref(), n)?;
             self.stack.push(Value::Seq(Arc::new(items)));
             return Ok(());

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -289,6 +289,76 @@ fn normalize_subst_replacement(template: &str) -> String {
                 out.push('&');
                 chars.next();
             }
+            'n' => {
+                out.push('\n');
+                chars.next();
+            }
+            'r' => {
+                out.push('\r');
+                chars.next();
+            }
+            't' => {
+                out.push('\t');
+                chars.next();
+            }
+            '0' => {
+                out.push('\0');
+                chars.next();
+            }
+            'a' => {
+                out.push('\x07'); // BEL
+                chars.next();
+            }
+            'b' => {
+                out.push('\x08'); // BS
+                chars.next();
+            }
+            'e' => {
+                out.push('\x1B'); // ESC
+                chars.next();
+            }
+            'f' => {
+                out.push('\x0C'); // FF
+                chars.next();
+            }
+            'x' => {
+                chars.next(); // consume 'x'
+                if chars.peek() == Some(&'[') {
+                    chars.next(); // consume '['
+                    let mut hex = String::new();
+                    while let Some(&c) = chars.peek() {
+                        if c == ']' {
+                            chars.next();
+                            break;
+                        }
+                        hex.push(c);
+                        chars.next();
+                    }
+                    // Support space-separated multi-codepoint: \x[48 65 6C]
+                    for part in hex.split_whitespace() {
+                        if let Ok(cp) = u32::from_str_radix(part, 16)
+                            && let Some(c) = char::from_u32(cp)
+                        {
+                            out.push(c);
+                        }
+                    }
+                } else {
+                    let mut hex = String::new();
+                    while let Some(&c) = chars.peek() {
+                        if c.is_ascii_hexdigit() && hex.len() < 2 {
+                            hex.push(c);
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    if let Ok(cp) = u32::from_str_radix(&hex, 16)
+                        && let Some(c) = char::from_u32(cp)
+                    {
+                        out.push(c);
+                    }
+                }
+            }
             _ => out.push('\\'),
         }
     }


### PR DESCRIPTION
## Summary
- Handle escape sequences (`\r`, `\n`, `\t`, `\0`, `\a`, `\b`, `\e`, `\f`, `\x`) in `s///` and `S///` replacement strings
- Add `shift`/`pop` to the `xx`-reeval whitelist so `@array.shift xx N` re-evaluates each call
- Preserve array mutations made inside `xx`-reeval thunks instead of restoring pre-thunk state
- Add bulk shift/pop fast path for `@array.shift xx N` to avoid O(n^2) performance

## Test plan
- [x] `prove -e 'timeout 30 target/debug/mutsu' roast/S15-nfg/concat-stable.t` passes all 55 subtests
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)