### PR TITLE
fix: resolve type captures in return type checks, compound assignment, and declarations

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -466,6 +466,7 @@ roast/S06-signature/slurpy-and-interpolation.t
 roast/S06-signature/slurpy-placeholders.t
 roast/S06-signature/sub-ref.t
 roast/S06-signature/tree-node-parameters.t
+roast/S06-signature/type-capture.t
 roast/S06-signature/unpack-array.t
 roast/S06-signature/unpack-object.t
 roast/S06-signature/unspecified.t

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -856,6 +856,10 @@ pub(crate) fn build_compound_assign_expr(
                 assigned_value,
             )
         }
+        Expr::BareWord(name) => Expr::AssignExpr {
+            name: name.clone(),
+            expr: Box::new(compound_assigned_value_expr(Expr::BareWord(name), op, rhs)),
+        },
         Expr::BracketArray(items, tc) => Expr::Binary {
             left: Box::new(Expr::BracketArray(items, tc)),
             op: op.token_kind(),

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -415,6 +415,9 @@ impl Interpreter {
             }
             self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
             self.merge_sigilless_alias_writes(&mut restored_env, &self.env);
+            let effective_return_spec = return_spec
+                .as_deref()
+                .map(|spec| self.resolved_type_capture_name(spec));
             self.env = restored_env;
             self.restore_readonly_vars(saved_readonly);
             self.samewith_context_stack.pop();
@@ -440,7 +443,8 @@ impl Interpreter {
                     return result;
                 }
             }
-            let finalized = self.finalize_return_with_spec(result, return_spec.as_deref());
+            let finalized =
+                self.finalize_return_with_spec(result, effective_return_spec.as_deref());
             return finalized.and_then(|v| {
                 let v = if def.is_raw {
                     // Mark Proxy as decontainerized so the VM's auto-FETCH doesn't strip it

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -1018,6 +1018,16 @@ impl Interpreter {
                             )));
                         }
                     }
+                    // Resolve type capture prefixes (e.g., `::T` → `Int`) so
+                    // that the stored variable type constraint uses the
+                    // concrete captured type name, not the raw `::T` token.
+                    let bound_type_constraint = bound_type_constraint.map(|tc| {
+                        if let Some(captured_name) = tc.strip_prefix("::") {
+                            self.resolved_type_capture_name(captured_name)
+                        } else {
+                            self.resolved_type_capture_name(&tc)
+                        }
+                    });
                     if !pd.name.is_empty()
                         && pd.name != "__type_only__"
                         && !pd.name.starts_with("__type_capture__")

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -50,6 +50,20 @@ impl Interpreter {
                 other => other.to_string_value(),
             };
         }
+        // Handle composite type specs where the base name is a type capture
+        // but has suffixes like `:D`, `:U`, `()`, `:D()`, etc.
+        // E.g., `T:D()` where `T` is a captured type should resolve to `Int:D()`.
+        if let Some(suffix_start) = constraint.find([':', '('])
+            && let (base, suffix) = (&constraint[..suffix_start], &constraint[suffix_start..])
+            && self.has_type_capture_binding(base)
+            && let Some(value) = self.env.get(base)
+        {
+            let resolved_base = match value {
+                Value::Package(name) => name.resolve(),
+                other => other.to_string_value(),
+            };
+            return format!("{}{}", resolved_base, suffix);
+        }
         constraint.to_string()
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1160,7 +1160,10 @@ impl VM {
             }
             OpCode::SetVarType { name_idx, tc_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                let constraint = Self::const_str(code, *tc_idx).to_string();
+                let raw_constraint = Self::const_str(code, *tc_idx).to_string();
+                // Resolve type capture variables (e.g., `T` → `Int` when `::T`
+                // was captured earlier in the signature).
+                let constraint = self.interpreter.resolved_type_capture_name(&raw_constraint);
                 // Clear stale atomic CAS state when an @-variable is
                 // (re-)declared with a type constraint like atomicint.
                 if name.starts_with('@') && constraint == "atomicint" {


### PR DESCRIPTION
## Summary
- Fix type capture variable (::T) resolution in 5 code paths: return type checking from closures, compound assignment on bare words, parameter binding type constraints, SetVarType VM opcode, and composite type specs (e.g., T:D())
- All 17 subtests in roast/S06-signature/type-capture.t now pass
- Added to roast-whitelist.txt

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-signature/type-capture.t` passes (17/17)
- [x] `make test` passes
- [x] `make roast` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)