### PR TITLE
fix: pass all 25 subtests in roast/S04-declarations/constant-6.d.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -256,6 +256,7 @@ roast/S03-smartmatch/signature-signature.t
 roast/S04-blocks-and-statements/let.t
 roast/S04-blocks-and-statements/pointy-rw.t
 roast/S04-blocks-and-statements/pointy.t
+roast/S04-declarations/constant-6.d.t
 roast/S04-declarations/implicit-parameter.t
 roast/S04-declarations/multiple.t
 roast/S04-declarations/our.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -519,8 +519,23 @@ impl Compiler {
                 }
                 // Track constant declarations so the compiler can avoid itemizing
                 // them in `for` loops (constants have no Scalar container).
-                if custom_traits.iter().any(|(t, _)| t == "__constant") {
+                let is_constant_decl = custom_traits.iter().any(|(t, _)| t == "__constant");
+                if is_constant_decl {
                     self.constant_vars.insert(name.clone());
+                }
+                // X::ParametricConstant: typed @/% constants are forbidden
+                if is_constant_decl
+                    && type_constraint.is_some()
+                    && (name.starts_with('@') || name.starts_with('%'))
+                {
+                    let err = Value::make_instance(
+                        Symbol::intern("X::ParametricConstant"),
+                        std::collections::HashMap::new(),
+                    );
+                    let idx = self.code.add_constant(err);
+                    self.code.emit(OpCode::LoadConst(idx));
+                    self.code.emit(OpCode::Die);
+                    return;
                 }
                 let is_dynamic = *is_dynamic || self.var_is_dynamic(name);
                 let name_idx = self.code.add_constant(Value::str(name.clone()));

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1383,6 +1383,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     if rest.starts_with(',') && !rest.starts_with(",,") {
         let mut exprs = vec![expr];
         let mut r = rest;
+        let mut trailing_comma = false;
 
         // Collect comma-separated expressions
         while r.starts_with(',') && !r.starts_with(",,") {
@@ -1395,8 +1396,10 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 break;
             }
 
-            // Stop at semicolon, closing brace, or end of input
+            // Stop at semicolon, closing brace, or end of input.
+            // A trailing comma before `}` creates a list (e.g. `42,`).
             if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') {
+                trailing_comma = r2.starts_with('}');
                 r = r2;
                 break;
             }
@@ -1409,11 +1412,13 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
 
         // Without a trailing statement modifier, keep this as a plain comma
         // expression statement (do not split into multiple statements).
+        // A trailing comma before `}` always creates a list, even with
+        // a single element (e.g. `{ 42, }` gives `(42,)`).
         if !is_stmt_modifier_keyword(r) {
-            let expr = if exprs.len() == 1 {
-                exprs.remove(0)
-            } else {
+            let expr = if trailing_comma || exprs.len() > 1 {
                 Expr::ArrayLiteral(exprs)
+            } else {
+                exprs.remove(0)
             };
             add_xor_sink_warnings(&expr);
             return Ok((r, Stmt::Expr(expr)));

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -564,7 +564,18 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                     let message = format!(
                         "Odd number of elements found where hash initializer expected: found {total_items} element(s); last element seen: {last_item}"
                     );
-                    return Err(RuntimeError::new(message));
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert(
+                        "message".to_string(),
+                        crate::value::Value::str(message.clone()),
+                    );
+                    let ex = crate::value::Value::make_instance(
+                        crate::symbol::Symbol::intern("X::Hash::Store::OddNumber"),
+                        attrs,
+                    );
+                    let mut err = RuntimeError::new(message);
+                    err.exception = Some(Box::new(ex));
+                    return Err(err);
                 };
                 map.insert(Value::hash_key_encode(&other), value);
             }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -998,6 +998,8 @@ impl VM {
                     // Constants with @ sigil coerce to List (not Array).
                     // `constant @x = 42` gives `(42,)`, not `[42]`.
                     // Explicit Arrays ([1,2,3]) are preserved.
+                    // Instance objects that do Positional are kept as-is
+                    // (they already went through CoerceToList).
                     match raw_val {
                         Value::Array(items, kind) if kind.is_real_array() => {
                             Value::Array(items, kind)
@@ -1005,11 +1007,42 @@ impl VM {
                         Value::Array(items, _) => {
                             Value::Array(items, crate::value::ArrayKind::List)
                         }
+                        Value::Instance { ref class_name, .. } => {
+                            let cn = class_name.resolve();
+                            let does_positional = matches!(
+                                cn.as_str(),
+                                "Array"
+                                    | "List"
+                                    | "Slip"
+                                    | "Seq"
+                                    | "Range"
+                                    | "Buf"
+                                    | "Blob"
+                                    | "utf8"
+                                    | "buf8"
+                                    | "buf16"
+                                    | "buf32"
+                            ) || self
+                                .interpreter
+                                .class_composed_roles(&cn)
+                                .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
+                            if does_positional {
+                                raw_val
+                            } else {
+                                Value::Array(
+                                    std::sync::Arc::new(vec![raw_val]),
+                                    crate::value::ArrayKind::List,
+                                )
+                            }
+                        }
                         other => Value::Array(
                             std::sync::Arc::new(vec![other]),
                             crate::value::ArrayKind::List,
                         ),
                     }
+                } else if raw_mode && name.starts_with('%') {
+                    // `constant %x` coerces non-Associative values to Map.
+                    self.coerce_constant_hash_value(&name, raw_val)?
                 } else if raw_mode {
                     raw_val
                 } else if name.starts_with('%') {
@@ -1808,6 +1841,94 @@ impl VM {
                         std::sync::Arc::new(items.to_vec()),
                         crate::value::ArrayKind::List,
                     ),
+                    // Hash values are flattened to pairs for constant @.
+                    Value::Hash(ref map) => {
+                        let pairs: Vec<Value> = map
+                            .iter()
+                            .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                            .collect();
+                        Value::Array(std::sync::Arc::new(pairs), crate::value::ArrayKind::List)
+                    }
+                    // Instance objects: check if Positional; if so keep as-is,
+                    // otherwise call .cache for coercion (constant @ semantics).
+                    Value::Instance { ref class_name, .. } => {
+                        let cn = class_name.resolve();
+                        let does_positional = matches!(
+                            cn.as_str(),
+                            "Array"
+                                | "List"
+                                | "Slip"
+                                | "Seq"
+                                | "Range"
+                                | "Buf"
+                                | "Blob"
+                                | "utf8"
+                                | "buf8"
+                                | "buf16"
+                                | "buf32"
+                        ) || self
+                            .interpreter
+                            .class_composed_roles(&cn)
+                            .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
+                        if does_positional {
+                            val
+                        } else {
+                            // Call .cache on non-Positional to coerce.
+                            // Skip native methods so user-defined .cache is called.
+                            let cached =
+                                self.call_method_all_with_fallback(&val, "cache", &[], true)?;
+                            let cached_val = cached.into_iter().next().unwrap_or(Value::Nil);
+                            // Check that .cache returned a Positional
+                            let is_pos = matches!(
+                                &cached_val,
+                                Value::Array(..)
+                                    | Value::Seq(_)
+                                    | Value::Slip(_)
+                                    | Value::LazyList(_)
+                                    | Value::LazyIoLines { .. }
+                            );
+                            if !is_pos {
+                                let got_type = crate::runtime::utils::value_type_name(&cached_val);
+                                let mut attrs = std::collections::HashMap::new();
+                                attrs.insert("got".to_string(), cached_val);
+                                attrs.insert(
+                                    "expected".to_string(),
+                                    Value::Package(crate::symbol::Symbol::intern("Positional")),
+                                );
+                                attrs.insert(
+                                    "message".to_string(),
+                                    Value::str(format!(
+                                        "Type check failed in assignment; expected Positional but got {}",
+                                        got_type
+                                    )),
+                                );
+                                let ex = Value::make_instance(
+                                    crate::symbol::Symbol::intern("X::TypeCheck"),
+                                    attrs,
+                                );
+                                let mut err = RuntimeError::new(format!(
+                                    "Type check failed in assignment; expected Positional but got {}",
+                                    got_type
+                                ));
+                                err.exception = Some(Box::new(ex));
+                                return Err(err);
+                            }
+                            // Coerce cached result to List
+                            match cached_val {
+                                Value::Array(items, _) => {
+                                    Value::Array(items, crate::value::ArrayKind::List)
+                                }
+                                Value::Seq(items) => Value::Array(
+                                    std::sync::Arc::new(items.to_vec()),
+                                    crate::value::ArrayKind::List,
+                                ),
+                                other => Value::Array(
+                                    std::sync::Arc::new(vec![other]),
+                                    crate::value::ArrayKind::List,
+                                ),
+                            }
+                        }
+                    }
                     other => Value::Array(
                         std::sync::Arc::new(vec![other]),
                         crate::value::ArrayKind::List,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -360,6 +360,131 @@ impl VM {
         Ok(hash_val)
     }
 
+    /// Coerce a value for `constant %x = ...` assignment.
+    /// Associative values (Hash, Pair, Bag, Set, Mix) are preserved.
+    /// Non-Associative values (Lists, Arrays) are coerced to Map.
+    /// Instance objects that don't do Associative get `.Map` called.
+    pub(crate) fn coerce_constant_hash_value(
+        &mut self,
+        name: &str,
+        value: Value,
+    ) -> Result<Value, RuntimeError> {
+        match &value {
+            // Associative types are preserved as-is
+            Value::Hash(_) | Value::Pair(..) | Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+                Ok(value)
+            }
+            // Instance objects: check if they do Associative
+            Value::Instance { class_name, .. } => {
+                let cn = class_name.resolve();
+                let does_associative = matches!(
+                    cn.as_str(),
+                    "Hash"
+                        | "Map"
+                        | "Pair"
+                        | "Set"
+                        | "Bag"
+                        | "Mix"
+                        | "SetHash"
+                        | "BagHash"
+                        | "MixHash"
+                ) || self
+                    .interpreter
+                    .class_composed_roles(&cn)
+                    .is_some_and(|roles| roles.iter().any(|r| r == "Associative"));
+                if does_associative {
+                    Ok(value)
+                } else {
+                    // Call .Map on non-Associative to coerce.
+                    // Skip native methods so user-defined .Map is called.
+                    let mapped = self.call_method_all_with_fallback(&value, "Map", &[], true)?;
+                    let mapped_val = mapped.into_iter().next().unwrap_or(Value::Nil);
+                    // Check that .Map returned an Associative
+                    let is_assoc = matches!(
+                        &mapped_val,
+                        Value::Hash(_)
+                            | Value::Pair(..)
+                            | Value::Set(..)
+                            | Value::Bag(..)
+                            | Value::Mix(..)
+                    );
+                    if !is_assoc {
+                        let got_type = crate::runtime::utils::value_type_name(&mapped_val);
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("got".to_string(), mapped_val);
+                        attrs.insert(
+                            "expected".to_string(),
+                            Value::Package(crate::symbol::Symbol::intern("Associative")),
+                        );
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!(
+                                "Type check failed in assignment to {}; expected Associative but got {}",
+                                name, got_type
+                            )),
+                        );
+                        let ex = Value::make_instance(
+                            crate::symbol::Symbol::intern("X::TypeCheck"),
+                            attrs,
+                        );
+                        let mut err = RuntimeError::new(format!(
+                            "Type check failed in assignment to {}; expected Associative but got {}",
+                            name, got_type
+                        ));
+                        err.exception = Some(Box::new(ex));
+                        return Err(err);
+                    }
+                    // Register as Map
+                    let info = crate::runtime::ContainerTypeInfo {
+                        value_type: String::new(),
+                        key_type: None,
+                        declared_type: Some("Map".to_string()),
+                    };
+                    self.interpreter
+                        .register_container_type_metadata(&mapped_val, info);
+                    Ok(mapped_val)
+                }
+            }
+            // Non-Associative values: coerce to Map
+            Value::Array(items, _) => {
+                let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
+                let info = crate::runtime::ContainerTypeInfo {
+                    value_type: String::new(),
+                    key_type: None,
+                    declared_type: Some("Map".to_string()),
+                };
+                self.interpreter
+                    .register_container_type_metadata(&hash, info);
+                Ok(hash)
+            }
+            Value::Seq(items) | Value::Slip(items) => {
+                let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
+                let info = crate::runtime::ContainerTypeInfo {
+                    value_type: String::new(),
+                    key_type: None,
+                    declared_type: Some("Map".to_string()),
+                };
+                self.interpreter
+                    .register_container_type_metadata(&hash, info);
+                Ok(hash)
+            }
+            _ => {
+                // For other types (Int, Str, etc.), coerce to Map via
+                // build_hash_from_items which raises X::Hash::Store::OddNumber
+                // for odd element counts (e.g., `constant %h = 42`).
+                let hash = runtime::utils::build_hash_from_items(vec![value])?;
+                let info = crate::runtime::ContainerTypeInfo {
+                    value_type: String::new(),
+                    key_type: None,
+                    declared_type: Some("Map".to_string()),
+                };
+                self.interpreter
+                    .register_container_type_metadata(&hash, info);
+                Ok(hash)
+            }
+        }
+    }
+
     fn mix_assignment_weight(value: &Value) -> f64 {
         match value {
             Value::Int(i) => *i as f64,
@@ -2568,10 +2693,14 @@ impl VM {
                     self.locals[idx].to_string_value()
                 )));
             }
-            if is_constant || is_bind {
-                // `:=` binding or `constant %x` preserves containers — skip coercion.
-                // `constant %x = :42foo` keeps the Pair; `constant %x = bag(...)` keeps the Bag.
+            if is_bind {
+                // `:=` binding preserves containers — skip coercion.
                 raw_popped
+            } else if is_constant {
+                // `constant %x` preserves Associative containers (Hash, Bag, Set, Mix, Pair).
+                // Non-Associative values (Lists) are coerced to Map.
+                // Non-Associative Instance objects get .Map called for coercion.
+                self.coerce_constant_hash_value(name, raw_popped)?
             } else {
                 self.coerce_hash_var_value(name, raw_popped)?
             }
@@ -2589,6 +2718,8 @@ impl VM {
             let mut assigned = if is_constant {
                 // `constant @x` stores a List, not an Array.
                 // Explicit Arrays ([1,2,3]) are preserved.
+                // Instance objects that do Positional are kept as-is.
+                // Non-Positional objects have .cache called for coercion.
                 match raw_popped {
                     Value::Array(items, kind) if kind.is_real_array() => Value::Array(items, kind),
                     Value::Array(items, _) => Value::Array(items, crate::value::ArrayKind::List),
@@ -2604,6 +2735,89 @@ impl VM {
                         let forced = self.force_if_lazy_io_lines(raw_popped)?;
                         let items = runtime::value_to_list(&forced);
                         Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+                    }
+                    Value::Instance { ref class_name, .. } => {
+                        // Check if Instance does Positional — if so, keep as-is.
+                        let cn = class_name.resolve();
+                        let does_positional = matches!(
+                            cn.as_str(),
+                            "Array"
+                                | "List"
+                                | "Slip"
+                                | "Seq"
+                                | "Range"
+                                | "Buf"
+                                | "Blob"
+                                | "utf8"
+                                | "buf8"
+                                | "buf16"
+                                | "buf32"
+                        ) || self
+                            .interpreter
+                            .class_composed_roles(&cn)
+                            .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
+                        if does_positional {
+                            raw_popped
+                        } else {
+                            // Call .cache on non-Positional to coerce.
+                            // Skip native methods so user-defined .cache is called.
+                            let cached = self.call_method_all_with_fallback(
+                                &raw_popped,
+                                "cache",
+                                &[],
+                                true,
+                            )?;
+                            let cached_val = cached.into_iter().next().unwrap_or(Value::Nil);
+                            // Check that .cache returned a Positional
+                            let is_pos = matches!(
+                                &cached_val,
+                                Value::Array(..)
+                                    | Value::Seq(_)
+                                    | Value::Slip(_)
+                                    | Value::LazyList(_)
+                                    | Value::LazyIoLines { .. }
+                            );
+                            if !is_pos {
+                                let got_type = crate::runtime::utils::value_type_name(&cached_val);
+                                let mut attrs = std::collections::HashMap::new();
+                                attrs.insert("got".to_string(), cached_val);
+                                attrs.insert(
+                                    "expected".to_string(),
+                                    Value::Package(crate::symbol::Symbol::intern("Positional")),
+                                );
+                                attrs.insert(
+                                    "message".to_string(),
+                                    Value::str(format!(
+                                        "Type check failed in assignment to {}; expected Positional but got {}",
+                                        name, got_type
+                                    )),
+                                );
+                                let ex = Value::make_instance(
+                                    crate::symbol::Symbol::intern("X::TypeCheck"),
+                                    attrs,
+                                );
+                                let mut err = RuntimeError::new(format!(
+                                    "Type check failed in assignment to {}; expected Positional but got {}",
+                                    name, got_type
+                                ));
+                                err.exception = Some(Box::new(ex));
+                                return Err(err);
+                            }
+                            // Coerce cached result to List
+                            match cached_val {
+                                Value::Array(items, _) => {
+                                    Value::Array(items, crate::value::ArrayKind::List)
+                                }
+                                Value::Seq(items) => Value::Array(
+                                    std::sync::Arc::new(items.to_vec()),
+                                    crate::value::ArrayKind::List,
+                                ),
+                                other => Value::Array(
+                                    std::sync::Arc::new(vec![other]),
+                                    crate::value::ArrayKind::List,
+                                ),
+                            }
+                        }
                     }
                     other => Value::Array(
                         std::sync::Arc::new(vec![other]),


### PR DESCRIPTION
## Summary
- Implement X::ParametricConstant for typed @/% constants
- Add .cache coercion for non-Positional objects assigned to constant @
- Add .Map coercion for non-Associative objects assigned to constant %
- Coerce Lists to Map for constant % declarations
- Fix trailing comma in block bodies creating lists (e.g. `{ 42, }` -> `(42,)`)
- Add X::Hash::Store::OddNumber exception structure to build_hash_from_items

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-declarations/constant-6.d.t` passes all 25 subtests
- [x] `make test` passes (471 tests)
- [x] `make roast` passes (no regressions from changes)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)