### PR TITLE
fix: implement regex features and class-scoped sub visibility

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -632,6 +632,8 @@ roast/S14-traits/variables.t
 roast/S15-literals/identifiers.t
 roast/S15-literals/numbers.t
 roast/S15-nfg/GraphemeBreakTest-0.t
+roast/S15-nfg/GraphemeBreakTest-1.t
+roast/S15-nfg/GraphemeBreakTest-2.t
 roast/S15-nfg/case-change.t
 roast/S15-nfg/cgj.t
 roast/S15-nfg/concat-stable.t

--- a/src/regex_validate.rs
+++ b/src/regex_validate.rs
@@ -556,10 +556,16 @@ fn validate_backslash_sequence(esc: char) -> Result<(), RuntimeError> {
     // Known valid backslash sequences in Raku regex
     match esc {
         'd' | 'D' | 'w' | 'W' | 's' | 'S' | 'n' | 'N' | 't' | 'T' | 'r' | 'R' | 'x' | 'o' | 'c'
-        | 'C' | 'X' | 'O' | 'v' | 'V' | 'h' | 'H' | 'e' | 'E' | 'b' | 'B' | 'f' | 'F' | '0' => {
-            Ok(())
-        }
+        | 'C' | 'X' | 'O' | 'v' | 'V' | 'h' | 'H' | 'e' | 'E' | 'f' | 'F' | '0' => Ok(()),
         // Obsolete Perl 5 backslash sequences
+        'b' => Err(RuntimeError::obsolete(
+            "\\b as a word boundary",
+            "<?wb> (word boundary) or <!wb> (not a word boundary)",
+        )),
+        'B' => Err(RuntimeError::obsolete(
+            "\\B as a word boundary",
+            "<?wb> (word boundary) or <!wb> (not a word boundary)",
+        )),
         'A' => Err(RuntimeError::obsolete(
             "\\A as beginning-of-string matcher",
             "^",

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1068,7 +1068,18 @@ impl Interpreter {
             .unwrap_or_default();
         self.routine_stack
             .push((owner_class.to_string(), method_name_for_stack));
+        // Set current_package to the receiver class so that the compiler
+        // qualifies function calls with the correct package prefix,
+        // allowing class-scoped subs (e.g. `sub helper` in a class body)
+        // to be found by methods in the same class.
+        // Set current_package so the compiler qualifies function calls
+        // with the class name, allowing class-scoped subs to be found.
+        let saved_package = self.current_package.clone();
+        if self.has_class_scoped_subs(receiver_class_name) {
+            self.current_package = receiver_class_name.to_string();
+        }
         let block_result = self.run_block(&method_def.body);
+        self.current_package = saved_package;
         self.routine_stack.pop();
         let implicit_return = self.env.get("_").cloned();
         let result = match block_result {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -596,6 +596,8 @@ enum RegexAtom {
     CaptureGroup(RegexPattern),
     Alternation(Vec<RegexPattern>),
     SequentialAlternation(Vec<RegexPattern>),
+    /// Conjunction: all branches must match at the same position; longest match wins
+    Conjunction(Vec<RegexPattern>),
     ZeroWidth,
     CodeAssertion {
         code: String,
@@ -670,6 +672,8 @@ enum RegexQuant {
     ZeroOrOne,
     /// `** min..max` — repeat exactly min to max times (max=None means unbounded)
     Repeat(usize, Option<usize>),
+    /// `** {code}` — repeat count determined at runtime by evaluating code block
+    RepeatCode(String),
 }
 
 #[derive(Clone)]
@@ -783,6 +787,9 @@ pub struct Interpreter {
     role_hides: HashMap<String, Vec<String>>,
     role_type_params: HashMap<String, Vec<String>>,
     class_role_param_bindings: HashMap<String, HashMap<String, Value>>,
+    /// Private subs declared in class bodies, keyed by class name.
+    /// Maps class_name -> { "&sub_name" -> Value }.
+    class_subs: HashMap<String, HashMap<String, Value>>,
     attribute_build_overrides: HashMap<(String, String), Value>,
     /// Evaluated `is default(...)` values for class attributes.
     /// Maps (class_name, attr_name) to the default value that should be restored when Nil is assigned.
@@ -2768,6 +2775,7 @@ impl Interpreter {
             role_hides: HashMap::new(),
             role_type_params: HashMap::new(),
             class_role_param_bindings: HashMap::new(),
+            class_subs: HashMap::new(),
             attribute_build_overrides: HashMap::new(),
             class_attribute_defaults: HashMap::new(),
             class_attribute_is_types: HashMap::new(),
@@ -4263,6 +4271,17 @@ impl Interpreter {
         self.classes.contains_key(name)
     }
 
+    /// Check if a class has scoped subs declared in its body.
+    pub(crate) fn has_class_scoped_subs(&self, class_name: &str) -> bool {
+        self.class_subs
+            .get(class_name)
+            .is_some_and(|subs| !subs.is_empty())
+            || self.class_subs.keys().any(|k| {
+                k.ends_with(&format!("::{}", class_name))
+                    || class_name.ends_with(&format!("::{}", k))
+            })
+    }
+
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`
@@ -4400,6 +4419,7 @@ impl Interpreter {
             role_hides: self.role_hides.clone(),
             role_type_params: self.role_type_params.clone(),
             class_role_param_bindings: self.class_role_param_bindings.clone(),
+            class_subs: self.class_subs.clone(),
             attribute_build_overrides: self.attribute_build_overrides.clone(),
             class_attribute_defaults: self.class_attribute_defaults.clone(),
             class_attribute_is_types: self.class_attribute_is_types.clone(),

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -117,6 +117,74 @@ impl Interpreter {
         }
     }
 
+    /// Evaluate a `** {code}` quantifier code block and return (min, max).
+    /// The code should return either a numeric value (exact count) or a Range.
+    pub(super) fn eval_regex_repeat_code(
+        &self,
+        code: &str,
+        caps: &RegexCaptures,
+    ) -> Option<(usize, Option<usize>)> {
+        let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
+        let env = self.make_regex_eval_env(caps);
+        let mut interp = Interpreter {
+            env,
+            functions: self.functions.clone(),
+            token_defs: self.token_defs.clone(),
+            current_package: self.current_package.clone(),
+            ..Default::default()
+        };
+        let val = match interp.eval_block_value(&stmts) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match &val {
+            Value::Range(start, end) => {
+                let min = (*start).max(0) as usize;
+                let max = if *end == i64::MAX {
+                    None
+                } else {
+                    Some((*end).max(0) as usize)
+                };
+                Some((min, max))
+            }
+            Value::RangeExcl(start, end) => {
+                let min = (*start).max(0) as usize;
+                let max = if *end == i64::MAX {
+                    None
+                } else {
+                    Some(((*end) - 1).max(0) as usize)
+                };
+                Some((min, max))
+            }
+            Value::RangeExclStart(start, end) => {
+                let min = ((*start) + 1).max(0) as usize;
+                let max = if *end == i64::MAX {
+                    None
+                } else {
+                    Some((*end).max(0) as usize)
+                };
+                Some((min, max))
+            }
+            Value::RangeExclBoth(start, end) => {
+                let min = ((*start) + 1).max(0) as usize;
+                let max = if *end == i64::MAX {
+                    None
+                } else {
+                    Some(((*end) - 1).max(0) as usize)
+                };
+                Some((min, max))
+            }
+            _ => {
+                let n = val.to_f64();
+                if n.is_nan() || n.is_infinite() {
+                    return None;
+                }
+                let n = n.max(0.0) as usize;
+                Some((n, Some(n)))
+            }
+        }
+    }
+
     /// Enable eager collection of plain code blocks during regex matching.
     /// When enabled, code blocks are recorded even if the overall match fails.
     pub(in crate::runtime) fn enable_eager_code_blocks(&self) {

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -134,6 +134,9 @@ fn strip_marks_atom(atom: &RegexAtom) -> RegexAtom {
         RegexAtom::SequentialAlternation(alts) => {
             RegexAtom::SequentialAlternation(alts.iter().map(strip_marks_pattern).collect())
         }
+        RegexAtom::Conjunction(branches) => {
+            RegexAtom::Conjunction(branches.iter().map(strip_marks_pattern).collect())
+        }
         RegexAtom::GoalMatch {
             goal,
             inner,

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -62,6 +62,36 @@ impl Interpreter {
             out.reverse();
             return out;
         }
+        if let RegexAtom::Conjunction(branches) = atom {
+            // ALL branches must match at the same position.
+            let mut longest_end = 0usize;
+            let mut longest_caps = current_caps.clone();
+            for branch in branches {
+                if let Some((end, caps)) =
+                    self.regex_match_end_from_caps_in_pkg(branch, chars, pos, pkg)
+                {
+                    if end >= longest_end {
+                        longest_end = end;
+                        longest_caps = caps;
+                    }
+                } else {
+                    return Vec::new();
+                }
+            }
+            let mut new_caps = current_caps.clone();
+            for (k, v) in longest_caps.named {
+                new_caps.named.entry(k).or_default().extend(v);
+            }
+            new_caps.positional.append(&mut longest_caps.positional);
+            new_caps
+                .positional_subcaps
+                .append(&mut longest_caps.positional_subcaps);
+            new_caps
+                .positional_quantified
+                .append(&mut longest_caps.positional_quantified);
+            new_caps.code_blocks.append(&mut longest_caps.code_blocks);
+            return vec![(longest_end, new_caps)];
+        }
         if let RegexAtom::Group(pattern) = atom {
             let mut out = Vec::new();
             for (end, mut inner_caps) in

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -101,7 +101,17 @@ impl Interpreter {
                         stack.push((idx + 1, p));
                     }
                 }
-                RegexQuant::Repeat(min, max) => {
+                RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
+                    let (min, max) = match &token.quant {
+                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::RepeatCode(code) => {
+                            match self.eval_regex_repeat_code(code, &RegexCaptures::default()) {
+                                Some((min, max)) => (min, max),
+                                None => continue,
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
                     let mut current = pos;
                     let mut count = 0usize;
                     let mut positions = Vec::new();
@@ -186,6 +196,19 @@ impl Interpreter {
                     }
                 }
                 return None;
+            }
+            RegexAtom::Conjunction(branches) => {
+                let mut longest_end = 0usize;
+                for branch in branches {
+                    if let Some(end) = self.regex_match_end_from_in_pkg(branch, chars, pos, pkg) {
+                        if end > longest_end {
+                            longest_end = end;
+                        }
+                    } else {
+                        return None;
+                    }
+                }
+                return Some(longest_end);
             }
             RegexAtom::ZeroWidth => {
                 return Some(pos);
@@ -552,6 +575,7 @@ impl Interpreter {
             | RegexAtom::CaptureGroup(_)
             | RegexAtom::Alternation(_)
             | RegexAtom::SequentialAlternation(_)
+            | RegexAtom::Conjunction(_)
             | RegexAtom::GoalMatch { .. }
             | RegexAtom::Newline
             | RegexAtom::NotNewline

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -83,6 +83,38 @@ impl Interpreter {
                 }
                 return best;
             }
+            RegexAtom::Conjunction(branches) => {
+                // ALL branches must match from the same position.
+                // The result is the longest match among the branches.
+                let mut longest_end = 0usize;
+                let mut longest_caps = current_caps.clone();
+                for branch in branches {
+                    if let Some((next, inner_caps)) =
+                        self.regex_match_end_from_caps_in_pkg(branch, chars, pos, pkg)
+                    {
+                        if next >= longest_end {
+                            longest_end = next;
+                            longest_caps = inner_caps;
+                        }
+                    } else {
+                        // If any branch fails, the whole conjunction fails
+                        return None;
+                    }
+                }
+                let mut new_caps = current_caps.clone();
+                for (k, v) in longest_caps.named {
+                    new_caps.named.entry(k).or_default().extend(v);
+                }
+                new_caps.positional.append(&mut longest_caps.positional);
+                new_caps
+                    .positional_subcaps
+                    .append(&mut longest_caps.positional_subcaps);
+                new_caps
+                    .positional_quantified
+                    .append(&mut longest_caps.positional_quantified);
+                new_caps.code_blocks.append(&mut longest_caps.code_blocks);
+                return Some((longest_end, new_caps));
+            }
             RegexAtom::SequentialAlternation(alternatives) => {
                 for alt in alternatives {
                     if let Some((next, mut inner_caps)) =

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -322,7 +322,17 @@ impl Interpreter {
                         }
                     }
                 }
-                RegexQuant::Repeat(min, max) => {
+                RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
+                    let (min, max) = match &token.quant {
+                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::RepeatCode(code) => {
+                            match self.eval_regex_repeat_code(code, &caps) {
+                                Some((min, max)) => (min, max),
+                                None => continue, // code eval failed, no match
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
                     let base_len = caps.positional.len();
                     let stride = count_capture_groups(&token.atom);
                     let mut positions = Vec::new();

--- a/src/runtime/regex/regex_match_nocap.rs
+++ b/src/runtime/regex/regex_match_nocap.rs
@@ -97,7 +97,17 @@ impl Interpreter {
                         stack.push((idx + 1, p));
                     }
                 }
-                RegexQuant::Repeat(min, max) => {
+                RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
+                    let (min, max) = match &token.quant {
+                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::RepeatCode(code) => {
+                            match self.eval_regex_repeat_code(code, &RegexCaptures::default()) {
+                                Some((min, max)) => (min, max),
+                                None => continue,
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
                     // Match atom between min and max times
                     let mut positions = Vec::new();
                     let mut current = pos;

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -355,6 +355,100 @@ impl Interpreter {
         (parts, is_sequential)
     }
 
+    /// Split a regex pattern on top-level `&` (conjunction) or `&&`.
+    /// Returns the parts; if there's only one part, no conjunction was present.
+    fn split_top_level_conjunction(pattern: &str) -> Vec<String> {
+        let mut parts = Vec::new();
+        let mut current = String::new();
+        let mut depth_paren = 0i32;
+        let mut depth_bracket = 0i32;
+        let mut depth_brace = 0i32;
+        let mut depth_angle = 0i32;
+        let mut escaped = false;
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        let mut chars = pattern.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if escaped {
+                current.push(ch);
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                current.push(ch);
+                escaped = true;
+                continue;
+            }
+            if ch == '\'' && !in_double_quote {
+                in_single_quote = !in_single_quote;
+                current.push(ch);
+                continue;
+            }
+            if ch == '"' && !in_single_quote {
+                in_double_quote = !in_double_quote;
+                current.push(ch);
+                continue;
+            }
+            if in_single_quote || in_double_quote {
+                current.push(ch);
+                continue;
+            }
+            match ch {
+                '(' => {
+                    depth_paren += 1;
+                    current.push(ch);
+                }
+                ')' => {
+                    depth_paren -= 1;
+                    current.push(ch);
+                }
+                '[' => {
+                    depth_bracket += 1;
+                    current.push(ch);
+                }
+                ']' => {
+                    depth_bracket -= 1;
+                    current.push(ch);
+                }
+                '{' => {
+                    depth_brace += 1;
+                    current.push(ch);
+                }
+                '}' => {
+                    depth_brace -= 1;
+                    current.push(ch);
+                }
+                '<' => {
+                    depth_angle += 1;
+                    current.push(ch);
+                }
+                '>' => {
+                    if depth_angle > 0 {
+                        depth_angle -= 1;
+                    }
+                    current.push(ch);
+                }
+                '&' if depth_paren == 0
+                    && depth_bracket == 0
+                    && depth_brace == 0
+                    && depth_angle == 0 =>
+                {
+                    // Skip && (also conjunction, same semantics for now)
+                    if chars.peek() == Some(&'&') {
+                        chars.next();
+                    }
+                    parts.push(std::mem::take(&mut current));
+                }
+                _ => current.push(ch),
+            }
+        }
+        if !current.is_empty() || !parts.is_empty() {
+            parts.push(current);
+        }
+        parts
+    }
+
     fn has_unquoted_ltm_separator(pattern: &str) -> bool {
         let mut in_single = false;
         let mut in_double = false;
@@ -785,6 +879,45 @@ impl Interpreter {
                 });
             } else if alt_patterns.len() == 1 {
                 return alt_patterns.into_iter().next();
+            }
+        }
+
+        // Check for conjunction (`&` or `&&`) at the top level.
+        // Conjunction has higher precedence than alternation, so this runs
+        // after alternation splitting found no `|`.
+        let conj_parts = Self::split_top_level_conjunction(source);
+        if conj_parts.len() > 1 {
+            let mut conj_patterns = Vec::new();
+            for part in &conj_parts {
+                let part_src = part.trim();
+                if part_src.is_empty() {
+                    continue;
+                }
+                let part_pat = if ignore_case && !part_src.starts_with(":i") {
+                    format!(":i {}", part_src)
+                } else {
+                    part_src.to_string()
+                };
+                if let Some(p) = self.parse_regex(&part_pat) {
+                    conj_patterns.push(p);
+                }
+            }
+            if conj_patterns.len() > 1 {
+                return Some(RegexPattern {
+                    tokens: vec![RegexToken {
+                        atom: RegexAtom::Conjunction(conj_patterns),
+                        quant: RegexQuant::One,
+                        named_capture: None,
+                        ratchet: false,
+                        frugal: false,
+                    }],
+                    anchor_start: false,
+                    anchor_end: false,
+                    ignore_case,
+                    ignore_mark,
+                });
+            } else if conj_patterns.len() == 1 {
+                return conj_patterns.into_iter().next();
             }
         }
 
@@ -1260,6 +1393,26 @@ impl Interpreter {
                                 RegexAtom::Literal('X')
                             }
                         }
+                        'b' => {
+                            // Bare \b is obsolete Perl 5 syntax — reject with X::Obsolete
+                            PENDING_REGEX_ERROR.with(|e| {
+                                *e.borrow_mut() = Some(RuntimeError::obsolete(
+                                    "\\b as a word boundary",
+                                    "<?wb> (word boundary) or <!wb> (not a word boundary)",
+                                ));
+                            });
+                            return None;
+                        }
+                        'B' => {
+                            // Bare \B is obsolete Perl 5 syntax — reject with X::Obsolete
+                            PENDING_REGEX_ERROR.with(|e| {
+                                *e.borrow_mut() = Some(RuntimeError::obsolete(
+                                    "\\B as a word boundary",
+                                    "<?wb> (word boundary) or <!wb> (not a word boundary)",
+                                ));
+                            });
+                            return None;
+                        }
                         other => RegexAtom::Literal(other),
                     }
                 }
@@ -1302,6 +1455,7 @@ impl Interpreter {
                                 Some('t') => literal.push('\t'),
                                 Some('r') => literal.push('\r'),
                                 Some('f') => literal.push('\u{000C}'),
+                                Some('b') => literal.push('\u{0008}'), // backspace
                                 Some('0') => literal.push('\0'),
                                 Some('c') | Some('C') => {
                                     // \c[NAME] or \c[NAME1, NAME2] inside double-quoted regex string
@@ -1987,7 +2141,51 @@ impl Interpreter {
                     // Capture group: (...)
                     let mut group_pattern = String::new();
                     let mut depth = 1;
-                    for ch in chars.by_ref() {
+                    let mut in_comment = false;
+                    while let Some(ch) = chars.next() {
+                        if in_comment {
+                            group_pattern.push(ch);
+                            if ch == '\n' {
+                                in_comment = false;
+                            }
+                            continue;
+                        }
+                        if ch == '#' {
+                            // '#' starts a comment — everything until newline is comment
+                            in_comment = true;
+                            group_pattern.push(ch);
+                            continue;
+                        }
+                        if ch == '\\' {
+                            // Backslash escape — push both chars without interpreting
+                            group_pattern.push(ch);
+                            if let Some(next) = chars.next() {
+                                group_pattern.push(next);
+                            }
+                            continue;
+                        }
+                        if ch == '\'' {
+                            // Single-quoted string — skip until closing quote
+                            group_pattern.push(ch);
+                            for sq in chars.by_ref() {
+                                group_pattern.push(sq);
+                                if sq == '\'' {
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
+                        if ch == '"' {
+                            // Double-quoted string — skip until closing quote
+                            group_pattern.push(ch);
+                            for dq in chars.by_ref() {
+                                group_pattern.push(dq);
+                                if dq == '"' {
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
                         if ch == '(' {
                             depth += 1;
                             group_pattern.push(ch);
@@ -2000,6 +2198,20 @@ impl Interpreter {
                         } else {
                             group_pattern.push(ch);
                         }
+                    }
+                    // If depth > 0, the group was never closed — parse error
+                    if depth > 0 {
+                        PENDING_REGEX_ERROR.with(|e| {
+                            *e.borrow_mut() = Some(RuntimeError::typed("X::Comp::Group", {
+                                let mut attrs = std::collections::HashMap::new();
+                                attrs.insert(
+                                    "message".to_string(),
+                                    Value::str("Unmatched ( in regex".to_string()),
+                                );
+                                attrs
+                            }));
+                        });
+                        return None;
                     }
                     let (alternatives, cap_is_sequential) =
                         Self::split_top_level_alternation(&group_pattern);
@@ -2222,6 +2434,7 @@ impl Interpreter {
                     }
                 }
             }
+            let mut starstar_frugal = false;
             if let Some(q) = chars.peek().copied() {
                 quant = match q {
                     '*' => {
@@ -2233,32 +2446,60 @@ impl Interpreter {
                         if chars.peek() == Some(&'*') {
                             // `**` quantifier: parse count or range
                             chars.next();
-                            // Skip whitespace after **
+                            // Handle frugal modifier: **? means non-greedy
+                            starstar_frugal = if chars.peek() == Some(&'?') {
+                                chars.next();
+                                true
+                            } else {
+                                false
+                            };
+                            // Skip whitespace after ** or **?
                             while chars.peek().is_some_and(|ch| ch.is_whitespace()) {
                                 chars.next();
                             }
-                            // Parse the count/range: N, N..M, N..*
-                            let mut count_str = String::new();
-                            while chars
-                                .peek()
-                                .is_some_and(|ch| ch.is_ascii_digit() || *ch == '.' || *ch == '*')
-                            {
-                                count_str.push(chars.next().unwrap());
-                            }
-                            let (min, max) =
-                                if let Some((min_str, max_str)) = count_str.split_once("..") {
-                                    let min = min_str.parse::<usize>().unwrap_or(0);
-                                    let max = if max_str == "*" {
-                                        None
+                            if chars.peek() == Some(&'{') {
+                                // `** {code}` — code block quantifier
+                                chars.next(); // skip '{'
+                                let mut code = String::new();
+                                let mut depth = 1usize;
+                                for ch in chars.by_ref() {
+                                    if ch == '{' {
+                                        depth += 1;
+                                        code.push(ch);
+                                    } else if ch == '}' {
+                                        depth -= 1;
+                                        if depth == 0 {
+                                            break;
+                                        }
+                                        code.push(ch);
                                     } else {
-                                        max_str.parse::<usize>().ok()
+                                        code.push(ch);
+                                    }
+                                }
+                                RegexQuant::RepeatCode(code)
+                            } else {
+                                // Parse the count/range: N, N..M, N..*
+                                let mut count_str = String::new();
+                                while chars.peek().is_some_and(|ch| {
+                                    ch.is_ascii_digit() || *ch == '.' || *ch == '*'
+                                }) {
+                                    count_str.push(chars.next().unwrap());
+                                }
+                                let (min, max) =
+                                    if let Some((min_str, max_str)) = count_str.split_once("..") {
+                                        let min = min_str.parse::<usize>().unwrap_or(0);
+                                        let max = if max_str == "*" {
+                                            None
+                                        } else {
+                                            max_str.parse::<usize>().ok()
+                                        };
+                                        (min, max)
+                                    } else {
+                                        let exact = count_str.parse::<usize>().unwrap_or(1);
+                                        (exact, Some(exact))
                                     };
-                                    (min, max)
-                                } else {
-                                    let exact = count_str.parse::<usize>().unwrap_or(1);
-                                    (exact, Some(exact))
-                                };
-                            RegexQuant::Repeat(min, max)
+                                RegexQuant::Repeat(min, max)
+                            }
                         } else {
                             RegexQuant::ZeroOrMore
                         }
@@ -2275,7 +2516,9 @@ impl Interpreter {
                 };
             }
             // Handle frugal (non-greedy) modifier: `*?`, `+?`, `??`
-            let token_frugal = if !matches!(quant, RegexQuant::One) && chars.peek() == Some(&'?') {
+            let token_frugal = if starstar_frugal {
+                true
+            } else if !matches!(quant, RegexQuant::One) && chars.peek() == Some(&'?') {
                 chars.next();
                 true
             } else {
@@ -2871,6 +3114,8 @@ impl Interpreter {
                     't' => EscResult::Char('\t'),
                     'r' => EscResult::Char('\r'),
                     'f' => EscResult::Char('\u{000C}'),
+                    'b' => EscResult::Char('\u{0008}'), // backspace
+                    'B' => EscResult::NegChar('\u{0008}'), // not backspace
                     '0' => EscResult::Char('\0'),
                     'd' => EscResult::Item(ClassItem::Digit),
                     'D' => EscResult::Item(ClassItem::NegDigit),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1285,6 +1285,8 @@ impl Interpreter {
                 class_own_attrs.insert(attr_name.resolve());
             }
         }
+        let saved_functions_keys: HashSet<String> =
+            self.functions.keys().map(|k| k.resolve()).collect();
         for stmt in flattened_body {
             match stmt {
                 Stmt::HasDecl {
@@ -1901,6 +1903,21 @@ impl Interpreter {
                     }
                 }
             }
+            // Check if any new functions were registered under the class package
+            // during body processing (e.g., class-scoped subs).
+            // Only count functions that are actual subs (not methods, which are
+            // registered via MethodDecl and stored in the class methods table).
+            if let Stmt::SubDecl { name: sub_name, .. } = stmt {
+                let fq = format!("{}::{}", name, sub_name);
+                if self.functions.contains_key(&Symbol::intern(&fq))
+                    && !saved_functions_keys.contains(&fq)
+                {
+                    self.class_subs
+                        .entry(name.to_string())
+                        .or_default()
+                        .insert(fq, Value::Bool(true));
+                }
+            }
             self.classes.insert(name.to_string(), class_def.clone());
         }
         self.current_package = saved_package;
@@ -2159,7 +2176,12 @@ impl Interpreter {
                         );
                     }
                 }
-                // Execute other statements in the class body (e.g., sub declarations)
+                // Sub declarations in the class body should persist across scope
+                // boundaries so that methods can call them. Use run_block_raw
+                // instead of eval_block_value to avoid function registry rollback.
+                Stmt::SubDecl { .. } => {
+                    let _ = self.run_block_raw(std::slice::from_ref(stmt));
+                }
                 other => {
                     let _ = self.eval_block_value(std::slice::from_ref(other));
                 }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -67,6 +67,14 @@ impl VM {
             self.interpreter.env_mut().remove("?ROLE");
         }
 
+        // Set current_package so class-scoped subs are found during method execution.
+        // Only change package if the class has subs declared in its body.
+        let saved_package = self.interpreter.current_package().to_string();
+        if self.interpreter.has_class_scoped_subs(receiver_class_name) {
+            self.interpreter
+                .set_current_package(receiver_class_name.to_string());
+        }
+
         // Set self and __ANON_STATE__ (used by `$.foo` desugaring inside methods)
         self.interpreter
             .env_mut()
@@ -179,6 +187,7 @@ impl VM {
                         if !self.interpreter.type_matches_value(expected, &base) {
                             self.interpreter.restore_var_bindings(saved_var_bindings);
                             self.interpreter.pop_method_class();
+                            self.interpreter.set_current_package(saved_package.clone());
                             self.stack.truncate(saved_stack_depth);
                             let frame = self.pop_call_frame();
                             *self.interpreter.env_mut() = frame.saved_env;
@@ -318,6 +327,7 @@ impl VM {
                 Err(e) => {
                     self.interpreter.restore_var_bindings(saved_var_bindings);
                     self.interpreter.pop_method_class();
+                    self.interpreter.set_current_package(saved_package.clone());
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
                     *self.interpreter.env_mut() = frame.saved_env;
@@ -533,6 +543,7 @@ impl VM {
 
         self.interpreter.pop_routine();
         self.interpreter.pop_method_class();
+        self.interpreter.set_current_package(saved_package);
         let _frame = self.pop_call_frame();
         *self.interpreter.env_mut() = merged_env;
 


### PR DESCRIPTION
## Summary
- Reject bare `\b`/`\B` in regex with X::Obsolete (Perl 5 word boundary syntax)
- Support `\b` (backspace) in character classes `<[\b]>` and quoted regex strings `"\b"`
- Handle `#` comments inside capture groups (detect unclosed groups as X::Comp::Group)
- Implement regex conjunction operator `&` (all branches must match at same position)
- Support `** {code}` quantifier with runtime Range/Int evaluation
- Fix `**?` frugal modifier parsing (consume `?` before count/range)
- Make class-scoped subs visible to methods by setting current_package during method dispatch
- Add 2 newly passing roast tests to whitelist (1103→1105)

These changes bring roast/S05-metasyntax/regex.t from 36/55 to 53/55 passing (test 48 needs complex Inf/NaN/Rat quantifier support; test 55 also fails on Rakudo).

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `make test` passes (only flaky t/lock.t test 10)
- [x] `make roast` passes (only pre-existing S32-io/spurt.t test 36)
- [x] roast/S05-metasyntax/regex.t: 53/55 subtests pass
- [x] t/role-submethods-6e.t passes (no regression from current_package change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)