### PR TITLE
fix: pass all 60 subtests in roast/S02-types/subset-6e.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -136,6 +136,7 @@ roast/S02-types/set-iterator.t
 roast/S02-types/sigils-and-types.t
 roast/S02-types/stash.t
 roast/S02-types/subscripts_and_context.t
+roast/S02-types/subset-6e.t
 roast/S02-types/type.t
 roast/S02-types/undefined-types.t
 roast/S02-types/unicode.t

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -333,6 +333,30 @@ impl Interpreter {
                 self.env.insert("?LINE".to_string(), Value::Int(line));
             }
             self.push_caller_env();
+            // When the function has where constraints and there is a &name Sub
+            // in env (which carries closure env), merge the Sub's captured
+            // variables so where-constraint expressions can access them.
+            let fn_name = def.name.resolve();
+            if def
+                .param_defs
+                .iter()
+                .any(|pd| pd.where_constraint.is_some())
+            {
+                let ampname = format!("&{}", fn_name);
+                if let Some(Value::Sub(ref sub_data)) = self.env.get(&ampname).cloned() {
+                    for (k, v) in &sub_data.env {
+                        if !k.starts_with("__mutsu_")
+                            && !k.starts_with("?")
+                            && !k.starts_with("!")
+                            && k != "_"
+                            && k != "@_"
+                            && k != "%_"
+                        {
+                            self.env.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+            }
             let rw_bindings =
                 match self.bind_function_args_values(&def.param_defs, &def.params, args) {
                     Ok(bindings) => bindings,

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -372,10 +372,18 @@ impl Interpreter {
                             self.env.remove("_");
                         }
                         if !ok {
-                            return Err(RuntimeError::new(format!(
+                            let mut err = RuntimeError::new(format!(
                                 "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
                                 pd.name
-                            )));
+                            ));
+                            let mut ex_attrs = std::collections::HashMap::new();
+                            ex_attrs.insert("message".to_string(), Value::str(err.message.clone()));
+                            let exception = Value::make_instance(
+                                Symbol::intern("X::TypeCheck::Binding::Parameter"),
+                                ex_attrs,
+                            );
+                            err.exception = Some(Box::new(exception));
+                            return Err(err);
                         }
                     }
                     // Unpack sub-signature from the slurpy array (e.g., *[$a, $b, $c])
@@ -857,7 +865,11 @@ impl Interpreter {
                     }
                     // Implicit Any constraint: untyped $ parameters default to Any,
                     // which rejects Junction (a direct subtype of Mu, not Any).
+                    // Skip when a where constraint is present: the where clause
+                    // handles the type checking, and junctions should be passed
+                    // through to the where clause for proper checking.
                     if pd.type_constraint.is_none()
+                        && pd.where_constraint.is_none()
                         && !pd.name.starts_with('@')
                         && !pd.name.starts_with('%')
                         && !pd.name.starts_with('&')
@@ -876,8 +888,10 @@ impl Interpreter {
                         ));
                         let mut ex_attrs = std::collections::HashMap::new();
                         ex_attrs.insert("message".to_string(), Value::str(err.message.clone()));
-                        let exception =
-                            Value::make_instance(Symbol::intern("X::TypeCheck::Binding"), ex_attrs);
+                        let exception = Value::make_instance(
+                            Symbol::intern("X::TypeCheck::Binding::Parameter"),
+                            ex_attrs,
+                        );
                         err.exception = Some(Box::new(exception));
                         return Err(err);
                     }
@@ -1012,10 +1026,18 @@ impl Interpreter {
                             }
                         }
                         if !ok {
-                            return Err(RuntimeError::new(format!(
+                            let mut err = RuntimeError::new(format!(
                                 "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
                                 pd.name
-                            )));
+                            ));
+                            let mut ex_attrs = std::collections::HashMap::new();
+                            ex_attrs.insert("message".to_string(), Value::str(err.message.clone()));
+                            let exception = Value::make_instance(
+                                Symbol::intern("X::TypeCheck::Binding::Parameter"),
+                                ex_attrs,
+                            );
+                            err.exception = Some(Box::new(exception));
+                            return Err(err);
                         }
                     }
                     // Resolve type capture prefixes (e.g., `::T` → `Int`) so

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -357,10 +357,8 @@ impl VM {
         // callers (e.g. eval_block_value) can observe side effects.
         self.sync_env_from_locals(code);
         let last_stack_value = self.stack.last().cloned();
-        (
-            self.interpreter,
-            Ok(last_stack_value.or(self.last_topic_value)),
-        )
+        let fallback = self.last_topic_value;
+        (self.interpreter, Ok(last_stack_value.or(fallback)))
     }
 
     /// Invoke a callable value using the VM fast paths when available and

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -123,7 +123,11 @@ impl VM {
                 if let Value::Pair(key, _) = &args[idx] {
                     if let Some(pd) = pds.iter().find(|pd| pd.named && pd.name == *key) {
                         if let Some(tc) = &pd.type_constraint {
-                            return !matches!(tc.as_str(), "Mu" | "Junction");
+                            if matches!(tc.as_str(), "Mu" | "Junction") {
+                                return false;
+                            }
+                            let resolved_base = self.interpreter.resolve_subset_base_type(tc);
+                            return !matches!(resolved_base, "Mu" | "Junction");
                         }
                         return true; // No type constraint = default Any
                     }
@@ -136,7 +140,18 @@ impl VM {
                 if let Some(pd) = positional_pds.get(idx) {
                     // Don't auto-thread if param accepts Mu or Junction
                     if let Some(tc) = &pd.type_constraint {
-                        return !matches!(tc.as_str(), "Mu" | "Junction");
+                        if matches!(tc.as_str(), "Mu" | "Junction") {
+                            return false;
+                        }
+                        // Don't auto-thread if the type constraint is a subset
+                        // whose ultimate base type is Mu or Junction — the
+                        // junction should be passed as-is to the subset's
+                        // where-clause check.
+                        let resolved_base = self.interpreter.resolve_subset_base_type(tc);
+                        if matches!(resolved_base, "Mu" | "Junction") {
+                            return false;
+                        }
+                        return true;
                     }
                     // No type constraint means default Any — needs auto-threading
                     return true;

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -543,6 +543,28 @@ impl VM {
         if !fn_package.is_empty() && fn_package != "GLOBAL" {
             self.interpreter.set_current_package(fn_package.to_string());
         }
+        // When the function has where constraints and there is a &name Sub in
+        // env (which carries closure env), merge the Sub's captured variables
+        // into the current env so where-constraint expressions can access them.
+        if !fn_name.is_empty() && cf.param_defs.iter().any(|pd| pd.where_constraint.is_some()) {
+            let ampname = format!("&{}", fn_name);
+            if let Some(Value::Sub(ref sub_data)) = self.interpreter.env().get(&ampname).cloned() {
+                for (k, v) in &sub_data.env {
+                    // Skip internal variables, parameters, and sigiled variables
+                    // that belong to the calling scope. Only merge simple lexical
+                    // variables that the where constraint might reference.
+                    if !k.starts_with("__mutsu_")
+                        && !k.starts_with("?")
+                        && !k.starts_with("!")
+                        && k != "_"
+                        && k != "@_"
+                        && k != "%_"
+                    {
+                        self.interpreter.env_mut().insert(k.clone(), v.clone());
+                    }
+                }
+            }
+        }
         // Skip bind_function_args_values for 0-arg functions with no params,
         // avoiding the @_ env insert that triggers Arc::make_mut deep clone.
         let rw_bindings = if args.is_empty() && cf.param_defs.is_empty() && cf.params.is_empty() {
@@ -676,7 +698,7 @@ impl VM {
             }
         }
 
-        let ret_val = if result.is_ok() {
+        let mut ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::Nil)
             } else {
@@ -685,6 +707,32 @@ impl VM {
         } else {
             Value::Nil
         };
+        // Raku semantics: `sub foo(...) { ... }` as the last statement
+        // of a block returns the Sub. If the return value is Nil/Any and
+        // the last opcode was RegisterSub, create the Sub value.
+        if result.is_ok()
+            && (matches!(ret_val, Value::Nil)
+                || matches!(&ret_val, Value::Package(n) if n.resolve() == "Any"))
+            && let Some(crate::opcode::OpCode::RegisterSub(idx)) = cf.code.ops.last()
+            && let crate::ast::Stmt::SubDecl {
+                name: sub_name,
+                params,
+                param_defs,
+                body,
+                is_rw,
+                ..
+            } = &cf.code.stmt_pool[*idx as usize]
+        {
+            ret_val = Value::make_sub(
+                Symbol::intern(self.interpreter.current_package()),
+                *sub_name,
+                params.clone(),
+                param_defs.clone(),
+                body.clone(),
+                *is_rw,
+                self.interpreter.env().clone(),
+            );
+        }
 
         self.stack.truncate(saved_stack_depth);
 

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -4,10 +4,11 @@ impl VM {
     /// Find the first positional argument that is a Junction and whose corresponding
     /// parameter type constraint does not accept Junction (i.e., needs auto-threading).
     /// Returns the index of that argument, or None if no auto-threading is needed.
-    fn find_junction_autothread_arg(
+    fn find_junction_autothread_arg_with_pointy(
         &self,
         data: &crate::value::SubData,
         args: &[Value],
+        is_pointy_block: bool,
     ) -> Option<usize> {
         // Collect positional param_defs (skip named)
         let positional_params: Vec<&crate::ast::ParamDef> = data
@@ -39,15 +40,21 @@ impl VM {
                 // Check if the corresponding param accepts Junction
                 if let Some(pd) = positional_params.get(positional_idx) {
                     let constraint = pd.type_constraint.as_deref().unwrap_or(
-                        if pd.name.starts_with('$') || pd.name.is_empty() {
-                            "Any" // implicit Any for $-sigiled params
+                        if is_pointy_block || pd.name.starts_with('@') || pd.name.starts_with('%') {
+                            "Mu" // pointy blocks and array/hash sigils: implicit Mu
                         } else {
-                            "Mu" // no constraint for other sigils
+                            "Any" // scalar params ($x stored as "x"): implicit Any
                         },
                     );
                     // Mu and Junction accept junctions directly
-                    if constraint != "Mu" && constraint != "Junction" {
-                        return Some(i);
+                    if constraint == "Mu" || constraint == "Junction" {
+                        // No auto-threading needed
+                    } else {
+                        // Check if constraint is a subset with Mu/Junction base
+                        let resolved_base = self.interpreter.resolve_subset_base_type(constraint);
+                        if resolved_base != "Mu" && resolved_base != "Junction" {
+                            return Some(i);
+                        }
                     }
                 }
                 // If no param_def found (extra args), implicit Any rejects Junction
@@ -110,7 +117,10 @@ impl VM {
         // corresponding parameter's type constraint does not accept Junction (i.e., is
         // not Mu or Junction), call the closure once per eigenvalue and collect results
         // into a new Junction of the same kind.
-        if let Some(junction_idx) = self.find_junction_autothread_arg(data, &args)
+        // For pointy blocks (-> { }), untyped params have implicit Mu, so skip
+        // auto-threading when the param has no type constraint.
+        if let Some(junction_idx) =
+            self.find_junction_autothread_arg_with_pointy(data, &args, cc.is_pointy_block)
             && let Value::Junction { kind, values } = &args[junction_idx]
         {
             let kind = kind.clone();

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -336,6 +336,10 @@ impl VM {
                     custom_traits,
                 )?;
             }
+            // Note: we intentionally do NOT push the Sub onto the stack or
+            // store it in env here. The interpreter's trailing_sub_value
+            // mechanism handles returning the Sub when it's the last statement
+            // of a block. Pushing would interfere with stack depth tracking.
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterSub expects SubDecl"))


### PR DESCRIPTION
## Summary
- Fix where-constraint closure variable capture: merge captured env from `&name` Sub into calling env before evaluating where constraints
- Fix junction auto-threading for subset types: skip auto-threading when subset base type is Mu/Junction
- Fix junction auto-threading for pointy blocks: use implicit Mu type (not Any) so junctions pass to the where clause directly
- Fix `X::TypeCheck::Binding::Parameter` exception type for where constraint failures
- Skip implicit Any type check when where constraint is present, allowing junctions through to the where clause
- Add trailing_sub_value support to compiled function dispatch, matching the interpreter's behavior

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/subset-6e.t` passes all 60 subtests
- [x] `make test` passes (only flaky lock.t)
- [x] `make roast` passes (only pre-existing spurt.t temp file issue)
- [x] No regressions in bare-sigil, flip-flop, return-exception, code-variable, scoped-named-subs tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)