### PR TITLE
fix: implement BIND-POS and DELETE-POS for non-native arrays

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -33,6 +33,13 @@
 - [ ] roast/S32-basics/xxKEY.t
 - [ ] roast/S32-basics/xxPOS-native.t
 - [ ] roast/S32-basics/xxPOS.t
+  - 11/64 pass (1-11). BIND-POS and DELETE-POS now implemented for non-native arrays.
+  - Blocker 1: Sigilless variable naming collision -- `my $a` inside `for ... -> \a` overwrites sigilless `a` because both map to env key `a` (mutsu strips `$` prefix from scalar variables). Causes crash at test 12. Architectural fix required.
+  - Blocker 2: True container binding for BIND-POS not implemented -- changing `$b` after `.BIND-POS(0,$b)` should reflect in array element. Requires shared mutable container (e.g., `Rc<RefCell<Value>>`). Tests 14, 17, 35, 38.
+  - Blocker 3: Tests 43-53 require xxPOS methods on undefined `$a` (auto-vivification to Array).
+  - Blocker 4: Tests 54-58 `#?rakudo skip` block (BIND-POS on Any:U). Even raku fails here.
+  - Blocker 5: Tests 61-63 multi-dimensional EXISTS-POS with Failure from negative index.
+  - Blocker 6: Test 64 requires `but` mixin with role implementing AT-POS + `substr-rw`.
 - [ ] roast/S32-container/buf.t
 - [ ] roast/S32-container/cat.t
   - 1/6 pass. Regression: previously passed but now 5/6 tests fail.

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1711,13 +1711,80 @@ impl Interpreter {
                     );
                     return Ok(value.clone());
                 }
-                ("BIND-POS", [_, _]) => {
-                    return Err(RuntimeError::new("Cannot bind to a natively typed array"));
+                ("BIND-POS", [idx, value]) => {
+                    // Native typed arrays (e.g. array[int]) cannot be bound
+                    let is_native = self.env.iter().any(|(name, bound)| {
+                        if let Value::Array(existing, ..) = bound
+                            && std::sync::Arc::ptr_eq(existing, items)
+                            && let Some(constraint) = self.var_type_constraint(name)
+                        {
+                            crate::runtime::native_types::is_native_array_element_type(&constraint)
+                        } else {
+                            false
+                        }
+                    });
+                    if is_native {
+                        return Err(RuntimeError::new("Cannot bind to a natively typed array"));
+                    }
+                    let index = match idx {
+                        Value::Int(i) if *i >= 0 => Some(*i as usize),
+                        Value::Num(f) if *f >= 0.0 => Some(*f as usize),
+                        _ => None,
+                    };
+                    let Some(index) = index else {
+                        return Err(RuntimeError::new("Cannot BIND-POS with a negative index"));
+                    };
+                    let mut updated = items.to_vec();
+                    if index >= updated.len() {
+                        updated.resize(index + 1, Value::Package(Symbol::intern("Any")));
+                    }
+                    updated[index] = Value::Scalar(Box::new(value.clone()));
+                    self.overwrite_array_bindings_by_identity(
+                        items,
+                        Value::Array(std::sync::Arc::new(updated), *arr_kind),
+                    );
+                    return Ok(value.clone());
                 }
-                ("DELETE-POS", [_]) => {
-                    return Err(RuntimeError::new(
-                        "Cannot delete from a natively typed array",
-                    ));
+                ("DELETE-POS", [idx]) => {
+                    // Native typed arrays (e.g. array[int]) cannot be deleted from
+                    let is_native = self.env.iter().any(|(name, bound)| {
+                        if let Value::Array(existing, ..) = bound
+                            && std::sync::Arc::ptr_eq(existing, items)
+                            && let Some(constraint) = self.var_type_constraint(name)
+                        {
+                            crate::runtime::native_types::is_native_array_element_type(&constraint)
+                        } else {
+                            false
+                        }
+                    });
+                    if is_native {
+                        return Err(RuntimeError::new(
+                            "Cannot delete from a natively typed array",
+                        ));
+                    }
+                    let index = match idx {
+                        Value::Int(i) if *i >= 0 => Some(*i as usize),
+                        Value::Num(f) if *f >= 0.0 => Some(*f as usize),
+                        _ => None,
+                    };
+                    let Some(index) = index else {
+                        return Err(RuntimeError::new("Cannot DELETE-POS with a negative index"));
+                    };
+                    let mut updated = items.to_vec();
+                    let deleted = if index < updated.len() {
+                        let old = std::mem::replace(&mut updated[index], Value::Nil);
+                        match old {
+                            Value::Scalar(inner) => *inner,
+                            v => v,
+                        }
+                    } else {
+                        Value::Nil
+                    };
+                    self.overwrite_array_bindings_by_identity(
+                        items,
+                        Value::Array(std::sync::Arc::new(updated), *arr_kind),
+                    );
+                    return Ok(deleted);
                 }
                 ("clone", _) => {
                     let cloned = items.to_vec();


### PR DESCRIPTION
## Summary
- Implement single-dimension `BIND-POS` and `DELETE-POS` methods for regular (non-native) arrays
- Previously these always threw "Cannot bind/delete from a natively typed array" regardless of array type
- Native typed arrays (e.g. `array[int]`) still correctly reject BIND-POS and DELETE-POS
- Update `TODO_roast/S32.md` with detailed blockers for `roast/S32-basics/xxPOS.t`

## Details
The roast test `S32-basics/xxPOS.t` cannot pass fully due to multiple deeper architectural issues:
1. **Sigilless variable naming collision**: `my $a` inside `for ... -> \a` overwrites sigilless `a` (both map to env key `a`)
2. **True container binding**: BIND-POS needs shared mutable containers for proper semantics
3. **Auto-vivification**: xxPOS on undefined scalars needs Array auto-vivification
4. **Multi-dim EXISTS-POS with Failure**: negative index handling
5. **Mixin AT-POS**: `but` mixin with role implementing AT-POS + substr-rw

## Test plan
- [x] `prove -e target/debug/mutsu t/array-pos-native.t` passes (native arrays still reject BIND-POS/DELETE-POS)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)