### PR TITLE
fix: pass all 57 subtests in roast/S26-documentation/why-both.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -864,6 +864,7 @@ roast/S26-documentation/module-comment.t
 roast/S26-documentation/multiline-leading.t
 roast/S26-documentation/multiline-trailing.t
 roast/S26-documentation/wacky.t
+roast/S26-documentation/why-both.t
 roast/S26-documentation/why-leading.t
 roast/S28-named-variables/cwd.t
 roast/S28-named-variables/init-instant.t

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2948,6 +2948,8 @@ impl Interpreter {
         let mut current_sub: Option<String> = None;
         // Counter for uniquifying anonymous sub doc keys
         let mut anon_sub_counter: usize = 0;
+        // Track role declaration counts for uniquifying parametric role variants
+        let mut role_counters: HashMap<String, usize> = HashMap::new();
 
         fn extract_ident(s: &str) -> String {
             s.trim_start()
@@ -3178,11 +3180,17 @@ impl Interpreter {
         }
 
         /// Try to extract a declarant name from a line, handling various declaration patterns.
-        /// Returns (name, is_class_like, kind, dispatch_prefix)
+        /// Returns (name, is_class_like, kind, dispatch_prefix, callable_type_override)
         fn try_extract_declarant(
             trimmed: &str,
             current_class: &Option<String>,
-        ) -> Option<(String, bool, super::DocDeclKind, DispatchPrefix)> {
+        ) -> Option<(
+            String,
+            bool,
+            super::DocDeclKind,
+            DispatchPrefix,
+            Option<&'static str>,
+        )> {
             use super::DocDeclKind;
             // Strip optional scope declarators
             let s = trimmed
@@ -3202,7 +3210,13 @@ impl Interpreter {
                         } else {
                             name
                         };
-                        return Some((full_name, true, DocDeclKind::Package, DispatchPrefix::None));
+                        return Some((
+                            full_name,
+                            true,
+                            DocDeclKind::Package,
+                            DispatchPrefix::None,
+                            None,
+                        ));
                     }
                 }
             }
@@ -3218,7 +3232,13 @@ impl Interpreter {
                     } else {
                         name
                     };
-                    return Some((full_name, true, DocDeclKind::Package, DispatchPrefix::None));
+                    return Some((
+                        full_name,
+                        true,
+                        DocDeclKind::Package,
+                        DispatchPrefix::None,
+                        None,
+                    ));
                 }
             }
 
@@ -3288,7 +3308,14 @@ impl Interpreter {
                     } else {
                         DocDeclKind::Sub
                     };
-                    return Some((full_name, false, kind, dispatch_prefix));
+                    let callable_type = if kw.starts_with("submethod") {
+                        Some("Submethod")
+                    } else if kw.starts_with("method") {
+                        Some("Method")
+                    } else {
+                        None
+                    };
+                    return Some((full_name, false, kind, dispatch_prefix, callable_type));
                 }
             }
 
@@ -3301,6 +3328,7 @@ impl Interpreter {
                         false,
                         DocDeclKind::Sub,
                         dispatch_prefix,
+                        None,
                     ));
                 }
             }
@@ -3331,7 +3359,13 @@ impl Interpreter {
                         } else {
                             format!("$!{}", name)
                         };
-                        return Some((full_name, false, DocDeclKind::Attr, DispatchPrefix::None));
+                        return Some((
+                            full_name,
+                            false,
+                            DocDeclKind::Attr,
+                            DispatchPrefix::None,
+                            None,
+                        ));
                     }
                 }
             }
@@ -3340,7 +3374,13 @@ impl Interpreter {
             if let Some(rest) = s.strip_prefix("enum ") {
                 let name = extract_ident(rest);
                 if !name.is_empty() {
-                    return Some((name, false, DocDeclKind::Package, DispatchPrefix::None));
+                    return Some((
+                        name,
+                        false,
+                        DocDeclKind::Package,
+                        DispatchPrefix::None,
+                        None,
+                    ));
                 }
             }
 
@@ -3348,7 +3388,13 @@ impl Interpreter {
             if let Some(rest) = s.strip_prefix("subset ") {
                 let name = extract_ident(rest);
                 if !name.is_empty() {
-                    return Some((name, false, DocDeclKind::Package, DispatchPrefix::None));
+                    return Some((
+                        name,
+                        false,
+                        DocDeclKind::Package,
+                        DispatchPrefix::None,
+                        None,
+                    ));
                 }
             }
 
@@ -3356,7 +3402,13 @@ impl Interpreter {
             if let Some(rest) = s.strip_prefix("unit module") {
                 let name = extract_ident(rest);
                 if !name.is_empty() {
-                    return Some((name, false, DocDeclKind::Package, DispatchPrefix::None));
+                    return Some((
+                        name,
+                        false,
+                        DocDeclKind::Package,
+                        DispatchPrefix::None,
+                        None,
+                    ));
                 }
             }
 
@@ -3380,6 +3432,7 @@ impl Interpreter {
                         false,
                         DocDeclKind::Sub,
                         DispatchPrefix::None,
+                        None,
                     ));
                 }
             }
@@ -3391,6 +3444,7 @@ impl Interpreter {
                     false,
                     DocDeclKind::Sub,
                     DispatchPrefix::None,
+                    None,
                 ));
             }
 
@@ -3415,6 +3469,7 @@ impl Interpreter {
                                 false,
                                 DocDeclKind::Sub,
                                 DispatchPrefix::None,
+                                None,
                             ));
                         }
                     }
@@ -3577,12 +3632,20 @@ impl Interpreter {
                 None
             };
 
-            if let Some((name, is_class_like, kind, dispatch)) =
+            if let Some((name, is_class_like, kind, dispatch, callable_type_ovr)) =
                 last_seg.or_else(|| try_extract_declarant(check_line, &current_class))
             {
                 // For multi declarations, generate a unique key to avoid
                 // overwriting proto or other multi variants.
                 // For anonymous subs, also uniquify to avoid collisions.
+                // For re-declared roles (parametric variants), uniquify too.
+                let is_role_decl = {
+                    let s = check_line
+                        .strip_prefix("my ")
+                        .or_else(|| check_line.strip_prefix("our "))
+                        .unwrap_or(check_line);
+                    s.starts_with("role ")
+                };
                 let doc_key = if dispatch == DispatchPrefix::Multi {
                     let counter = multi_counters.entry(name.clone()).or_insert(0);
                     let key = format!("{}/multi.{}", name, counter);
@@ -3591,6 +3654,15 @@ impl Interpreter {
                 } else if name == "&<anon>" {
                     let key = format!("&<anon>.{}", anon_sub_counter);
                     anon_sub_counter += 1;
+                    key
+                } else if is_role_decl {
+                    let counter = role_counters.entry(name.clone()).or_insert(0);
+                    let key = if *counter == 0 {
+                        name.clone()
+                    } else {
+                        format!("{}/role.{}", name, counter)
+                    };
+                    *counter += 1;
                     key
                 } else {
                     name.clone()
@@ -3613,6 +3685,9 @@ impl Interpreter {
                     entry.kind = kind.clone();
                     entry.is_proto = dispatch == DispatchPrefix::Proto;
                     entry.source_line = Some((idx + 1) as u32);
+                    if let Some(ct) = callable_type_ovr {
+                        entry.callable_type_override = Some(ct.to_string());
+                    }
                     if has_leading {
                         entry.leading = leading;
                     }
@@ -3672,28 +3747,35 @@ impl Interpreter {
                     }
                 }
             } else if let Some(param_name) = try_extract_param_name(check_line) {
-                if let Some(leading) = pending_leading.take() {
-                    // Key parameter docs by "sub_name::param_name" to avoid
-                    // collisions when the same param name appears in different subs
-                    let param_key = if let Some(ref sub_name) = current_sub {
-                        format!("{}::{}", sub_name, param_name)
-                    } else {
-                        param_name.clone()
-                    };
-                    self.doc_comments.insert(
-                        param_key.clone(),
-                        DocComment {
+                // Key parameter docs by "sub_name::param_name" to avoid
+                // collisions when the same param name appears in different subs
+                let param_key = if let Some(ref sub_name) = current_sub {
+                    format!("{}::{}", sub_name, param_name)
+                } else {
+                    param_name.clone()
+                };
+                let leading = pending_leading.take();
+                let has_leading = leading.is_some();
+                let has_inline_trailing = inline_trailing.is_some();
+                if has_leading || has_inline_trailing {
+                    let entry = self
+                        .doc_comments
+                        .entry(param_key.clone())
+                        .or_insert_with(|| DocComment {
                             wherefore_name: param_name.clone(),
-                            leading: Some(leading),
-                            trailing: None,
                             kind: super::DocDeclKind::Param,
-                            is_proto: false,
-                            return_type: None,
-                            source_line: Some((idx + 1) as u32),
-                        },
-                    );
+                            ..Default::default()
+                        });
+                    entry.source_line = Some((idx + 1) as u32);
+                    if has_leading {
+                        entry.leading = leading;
+                    }
+                    if let Some(ref trail) = inline_trailing {
+                        entry.trailing = append_doc_text(entry.trailing.take(), trail);
+                    }
                 }
-                last_declarant = None;
+                // Set last_declarant so trailing #= on the next line can attach
+                last_declarant = Some((param_key, super::DocDeclKind::Param));
             } else {
                 // Not a recognized declaration — discard pending leading
                 pending_leading = None;
@@ -3818,7 +3900,7 @@ impl Interpreter {
                 } else {
                     None
                 };
-                if let Some((name, is_cls, kind, dispatch)) =
+                if let Some((name, is_cls, kind, dispatch, _callable_type_ovr)) =
                     last_seg2.or_else(|| try_extract_declarant(ck, &cur_class2))
                 {
                     // Generate the same key as the first pass
@@ -3850,6 +3932,28 @@ impl Interpreter {
                             ai += 1;
                             if ai > 100 {
                                 break format!("&<anon>.{}", ai);
+                            }
+                        }
+                    } else if {
+                        let s_check = ck
+                            .strip_prefix("my ")
+                            .or_else(|| ck.strip_prefix("our "))
+                            .unwrap_or(ck);
+                        s_check.starts_with("role ")
+                    } && seen_names.contains(&name)
+                    {
+                        // Role re-declaration (parametric variant) — find the next role key
+                        let mut ri = 1usize;
+                        loop {
+                            let candidate_key = format!("{}/role.{}", name, ri);
+                            if !seen_names.contains(&candidate_key)
+                                && self.doc_comments.contains_key(&candidate_key)
+                            {
+                                break candidate_key;
+                            }
+                            ri += 1;
+                            if ri > 100 {
+                                break format!("{}/role.{}", name, ri);
                             }
                         }
                     } else {
@@ -3926,13 +4030,12 @@ impl Interpreter {
                     if dc.wherefore_name.starts_with("block:") {
                         Value::Package(crate::symbol::Symbol::intern("Block"))
                     } else {
-                        // Proto/only subs (not methods) have ^name "Routine",
-                        // regular subs and methods have "Sub" in mutsu.
-                        // Methods have wherefore_name containing "::" (e.g., "C::meth")
-                        // or not starting with "&".
+                        // Use callable_type_override if set (Method, Submethod)
                         let is_standalone_sub =
                             dc.wherefore_name.starts_with('&') || !dc.wherefore_name.contains("::");
-                        let base_type = if dc.is_proto && is_standalone_sub {
+                        let base_type = if let Some(ref ct) = dc.callable_type_override {
+                            ct.as_str()
+                        } else if dc.is_proto && is_standalone_sub {
                             "Routine"
                         } else {
                             "Sub"

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -27,6 +27,16 @@ impl Interpreter {
             }
             full_param_defs.extend(def.param_defs.iter().cloned());
             let mut env = crate::env::Env::new();
+            // Set callable type for .^name to return Method/Submethod
+            let callable_type = if def.is_submethod {
+                "Submethod"
+            } else {
+                "Method"
+            };
+            env.insert(
+                "__mutsu_callable_type".to_string(),
+                Value::str_from(callable_type),
+            );
             if has_multi {
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
@@ -63,6 +73,16 @@ impl Interpreter {
             }
             full_param_defs.extend(def.param_defs.iter().cloned());
             let mut env = crate::env::Env::new();
+            // Set callable type for .^name to return Method/Submethod
+            let callable_type = if def.is_submethod {
+                "Submethod"
+            } else {
+                "Method"
+            };
+            env.insert(
+                "__mutsu_callable_type".to_string(),
+                Value::str_from(callable_type),
+            );
             if has_multi {
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
@@ -149,6 +169,16 @@ impl Interpreter {
                 let mut full_param_defs = vec![Self::make_invocant_param(class_name)];
                 full_param_defs.extend(def.param_defs.iter().cloned());
                 let mut env = crate::env::Env::new();
+                // Set callable type for .^name to return Method/Submethod
+                let callable_type = if def.is_submethod {
+                    "Submethod"
+                } else {
+                    "Method"
+                };
+                env.insert(
+                    "__mutsu_callable_type".to_string(),
+                    Value::str_from(callable_type),
+                );
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
                     Value::str(class_name.to_string()),
@@ -541,6 +571,7 @@ impl Interpreter {
                     delegation: None,
                     is_default: false,
                     deprecated_message: None,
+                    is_submethod: false,
                 };
                 // If the class doesn't exist yet (e.g. built-in types like Rat, Int, Str),
                 // create a stub ClassDef so methods can be added dynamically.
@@ -601,6 +632,7 @@ impl Interpreter {
                     delegation: None,
                     is_default: false,
                     deprecated_message: None,
+                    is_submethod: false,
                 };
                 if let Some(class_def) = self.classes.get_mut(&class_name) {
                     class_def.methods.entry(method_name).or_default().push(def);
@@ -714,7 +746,21 @@ impl Interpreter {
                 if let Some(candidates) = self.role_candidates.get(&base_name) {
                     let values = candidates
                         .iter()
-                        .map(|_| Value::Package(Symbol::intern(&base_name)))
+                        .enumerate()
+                        .map(|(idx, _)| {
+                            // Create Instance values with candidate index so
+                            // .WHY can look up per-candidate doc comments
+                            let mut attrs = std::collections::HashMap::new();
+                            attrs.insert(
+                                "__mutsu_role_candidate_idx".to_string(),
+                                Value::Int(idx as i64),
+                            );
+                            attrs.insert(
+                                "__mutsu_role_base_name".to_string(),
+                                Value::str(base_name.clone()),
+                            );
+                            Value::make_instance(Symbol::intern(&base_name), attrs)
+                        })
                         .collect::<Vec<_>>();
                     return Ok(Value::array(values));
                 }

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -73,6 +73,7 @@ impl Interpreter {
             Value::Routine { .. } => "Sub",
             Value::Sub(data) => match data.env.get("__mutsu_callable_type") {
                 Some(Value::Str(kind)) if kind.as_str() == "Method" => "Method",
+                Some(Value::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",
                 Some(Value::Str(kind)) if kind.as_str() == "WhateverCode" => "WhateverCode",
                 _ => "Sub",
             },
@@ -298,7 +299,7 @@ impl Interpreter {
     }
 
     /// Dispatch .WHY method — returns a Pod::Block::Declarator instance
-    pub(super) fn dispatch_why(&self, target: &Value) -> Result<Value, RuntimeError> {
+    pub(super) fn dispatch_why(&mut self, target: &Value) -> Result<Value, RuntimeError> {
         // Return declarator doc comment attached to this type/package/sub
         let keys: Vec<String> = match target {
             Value::Package(name) => vec![name.resolve()],
@@ -307,7 +308,22 @@ impl Interpreter {
                 attributes,
                 ..
             } => {
-                if class_name == "Attribute" {
+                // Role candidate with index metadata
+                if let Some(Value::Int(idx)) = attributes.get("__mutsu_role_candidate_idx") {
+                    let base_name = attributes
+                        .get("__mutsu_role_base_name")
+                        .and_then(|v| match v {
+                            Value::Str(s) => Some(s.to_string()),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| class_name.resolve());
+                    let mut k = Vec::new();
+                    if *idx > 0 {
+                        k.push(format!("{}/role.{}", base_name, idx));
+                    }
+                    k.push(base_name);
+                    k
+                } else if class_name == "Attribute" {
                     // Attribute objects: look up by "ClassName::$!attrname"
                     let mut k = Vec::new();
                     if let Some(Value::Str(attr_name)) = attributes.get("name") {
@@ -415,9 +431,15 @@ impl Interpreter {
             }
             _ => vec![],
         };
+        // Try to find matching doc comment, checking cache first for each key
         for key in keys {
+            if let Some(cached) = self.why_cache.get(&key) {
+                return Ok(cached.clone());
+            }
             if let Some(doc) = self.doc_comments.get(&key) {
-                return Ok(Self::make_pod_declarator(doc, target.clone()));
+                let pod = Self::make_pod_declarator(doc, target.clone());
+                self.why_cache.insert(key, pod.clone());
+                return Ok(pod);
             }
         }
         // For anonymous subs/bare blocks, try to find a doc comment by source line proximity

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -234,6 +234,9 @@ pub(crate) struct DocComment {
     pub return_type: Option<String>,
     /// Source line number (1-based) where the declaration appears.
     pub source_line: Option<u32>,
+    /// For Sub kind: what type to use in $=pod WHEREFORE (e.g. "Method", "Submethod").
+    /// None means use default logic (Sub/Routine).
+    pub callable_type_override: Option<String>,
 }
 
 impl DocComment {
@@ -339,6 +342,8 @@ pub(crate) struct MethodDef {
     pub(crate) is_default: bool,
     /// `is DEPRECATED` message: None = not deprecated.
     pub(crate) deprecated_message: Option<String>,
+    /// Whether this is a submethod (not inherited by subclasses).
+    pub(crate) is_submethod: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -767,6 +772,8 @@ pub struct Interpreter {
     doc_comments: HashMap<String, DocComment>,
     /// Ordered list of doc comments for $=pod
     doc_comment_list: Vec<DocComment>,
+    /// Cache for .WHY results so identity checks (=:=) work
+    why_cache: HashMap<String, Value>,
     type_metadata: HashMap<String, HashMap<String, Value>>,
     when_matched: bool,
     gather_items: Vec<Vec<Value>>,
@@ -2599,6 +2606,7 @@ impl Interpreter {
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),
             doc_comment_list: Vec::new(),
+            why_cache: HashMap::new(),
             type_metadata: HashMap::new(),
             when_matched: false,
             gather_items: Vec::new(),
@@ -2751,6 +2759,7 @@ impl Interpreter {
                         delegation: None,
                         is_default: false,
                         deprecated_message: None,
+                        is_submethod: false,
                     };
                     let mut methods = HashMap::new();
                     for name in ["id", "need", "load", "loaded"] {
@@ -4405,6 +4414,7 @@ impl Interpreter {
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),
             doc_comment_list: Vec::new(),
+            why_cache: HashMap::new(),
             type_metadata: self.type_metadata.clone(),
             when_matched: false,
             gather_items: Vec::new(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -129,6 +129,7 @@ fn make_delegation_method(attr_var_name: &str, target_method: &str) -> MethodDef
         delegation: Some((attr_var_name.to_string(), target_method.to_string())),
         is_default: false,
         deprecated_message: None,
+        is_submethod: false,
     }
 }
 
@@ -256,6 +257,7 @@ fn substitute_type_params_in_method(
         delegation: method.delegation.clone(),
         is_default: method.is_default,
         deprecated_message: method.deprecated_message.clone(),
+        is_submethod: method.is_submethod,
     }
 }
 
@@ -1523,6 +1525,7 @@ impl Interpreter {
                         delegation: None,
                         is_default: *is_default_candidate,
                         deprecated_message: deprecated_message.clone(),
+                        is_submethod: *is_submethod,
                     };
                     // `my method` and `our method` are NOT part of the class
                     // method table — they are only callable as functions.
@@ -2033,6 +2036,7 @@ impl Interpreter {
                     is_rw,
                     is_private,
                     is_my,
+                    is_submethod,
                     return_type,
                     is_default_candidate,
                     ..
@@ -2099,6 +2103,7 @@ impl Interpreter {
                         delegation: None,
                         is_default: *is_default_candidate,
                         deprecated_message: None,
+                        is_submethod: *is_submethod,
                     };
                     if let Some(class_def) = self.classes.get_mut(name) {
                         if *multi {
@@ -2637,6 +2642,7 @@ impl Interpreter {
                         delegation: None,
                         is_default: *is_default_candidate,
                         deprecated_message: None,
+                        is_submethod: *is_submethod,
                     };
                     // `my method` in roles are role-private, skip method table.
                     // Submethods (is_submethod) DO get composed even though

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -110,6 +110,7 @@ impl Interpreter {
                     delegation: None,
                     is_default: *is_default_candidate,
                     deprecated_message: deprecated_message.clone(),
+                    is_submethod: false,
                 };
                 if let Some(class_def) = self.classes.get_mut(&class_name) {
                     if *multi {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1290,6 +1290,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Nil => "Any",
         Value::Sub(data) => match data.env.get("__mutsu_callable_type") {
             Some(Value::Str(kind)) if kind.as_str() == "Method" => "Method",
+            Some(Value::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",
             Some(Value::Str(kind)) if kind.as_str() == "WhateverCode" => "WhateverCode",
             Some(Value::Str(kind)) if kind.as_str() == "Block" => "Block",
             _ => {

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -491,6 +491,7 @@ impl Value {
             }
             Value::Sub(data) => match data.env.get("__mutsu_callable_type") {
                 Some(Value::Str(kind)) if kind.as_str() == "Method" => "Method",
+                Some(Value::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",
                 Some(Value::Str(kind)) if kind.as_str() == "WhateverCode" => "WhateverCode",
                 _ => "Sub",
             },


### PR DESCRIPTION
## Summary
- Fix parameter trailing `#=` doc comments not attaching (set `last_declarant` after param processing)
- Fix `.^name` returning `Sub` instead of `Method`/`Submethod` for methods from `^lookup`
- Fix parametric role variants sharing the same doc comment key (uniquify with `/role.N` suffix)
- Add WHY cache so identity checks (`=:=`) between `Boxer.WHY` and `Boxer.^candidates[0].WHY` work
- Fix `$=pod` WHEREFORE types to use `callable_type_override` for Method/Submethod entries

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S26-documentation/why-both.t` passes all 57 subtests
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (only flaky t/lock.t timing test may intermittently fail)
- [x] `make roast` passes with new test added to whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)