### PR TITLE
fix: improve typed hash smartmatch and metadata propagation

### DIFF
--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -23,6 +23,9 @@
     - `**` (hyperwhatever hammer) indexing
 - [ ] roast/S09-typed-arrays/arrays.t
 - [ ] roast/S09-typed-arrays/hashes.t
+  - 44/47 pass (test 25 is TODO, tests 42-44 fail)
+  - Tests 42-43: `.antipairs`/`.invert` on typed hash with `{Any}` keys returns stringified key instead of original type object. Requires Hash to preserve original non-string key objects (architectural change).
+  - Test 44: Self-referential hash assignment `(%h1 = %h1, %h2)` parsed incorrectly in `is-deeply` call context. Parser issue with parenthesized assignment as function argument.
 - [ ] roast/S09-typed-arrays/native-decl.t
 - [ ] roast/S09-typed-arrays/native-int.t
 - [ ] roast/S09-typed-arrays/native-num.t

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -519,7 +519,30 @@ impl Interpreter {
                     base.to_string()
                 }
             }
-            other => value_type_name(other).to_string(),
+            other => {
+                // Check container type metadata for typed Hash/Array
+                if let Some(info) = self.container_type_metadata(other) {
+                    match other {
+                        Value::Hash(_) => {
+                            if let Some(ref key_type) = info.key_type {
+                                return Ok(Value::str(format!(
+                                    "Hash[{},{}]",
+                                    info.value_type, key_type
+                                )));
+                            } else if info.value_type != "Any" && info.value_type != "Mu" {
+                                return Ok(Value::str(format!("Hash[{}]", info.value_type)));
+                            }
+                        }
+                        Value::Array(_, kind) if kind.is_real_array() => {
+                            if info.value_type != "Any" && info.value_type != "Mu" {
+                                return Ok(Value::str(format!("Array[{}]", info.value_type)));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                value_type_name(other).to_string()
+            }
         }))
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3951,6 +3951,22 @@ impl Interpreter {
         self.set_type_metadata.get(&id).cloned()
     }
 
+    /// Remove container type metadata for a value, breaking the association.
+    pub(crate) fn unregister_container_type_metadata(&mut self, value: &Value) {
+        match value {
+            Value::Array(items, ..) => {
+                let id = Arc::as_ptr(items) as usize;
+                self.array_type_metadata.remove(&id);
+            }
+            Value::Hash(items) => {
+                let id = Arc::as_ptr(items) as usize;
+                self.hash_type_metadata.remove(&id);
+            }
+            Value::Mixin(inner, _) => self.unregister_container_type_metadata(inner),
+            _ => {}
+        }
+    }
+
     pub(crate) fn container_type_metadata(&self, value: &Value) -> Option<ContainerTypeInfo> {
         match value {
             Value::Array(items, ..) => {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1043,6 +1043,44 @@ impl Interpreter {
                 } else {
                     None
                 };
+                // For Hash/Array values, also check container type metadata
+                let lhs_args = lhs_args.or_else(|| {
+                    let rhs_base_resolved = rhs_base.resolve();
+                    if matches!(left_value, Value::Hash(_))
+                        && (rhs_base_resolved == "Hash" || rhs_base_resolved == "Associative")
+                    {
+                        if let Some(info) = self.container_type_metadata(left_value) {
+                            let vt = &info.value_type;
+                            if let Some(ref kt) = info.key_type {
+                                if vt != "Any" || kt != "Str" {
+                                    return Some(vec![
+                                        Value::Package(crate::symbol::Symbol::intern(vt)),
+                                        Value::Package(crate::symbol::Symbol::intern(kt)),
+                                    ]);
+                                }
+                            } else if vt != "Any" && vt != "Mu" {
+                                return Some(vec![Value::Package(crate::symbol::Symbol::intern(
+                                    vt,
+                                ))]);
+                            }
+                        }
+                        None
+                    } else if matches!(left_value, Value::Array(..))
+                        && (rhs_base_resolved == "Array" || rhs_base_resolved == "Positional")
+                    {
+                        if let Some(info) = self.container_type_metadata(left_value) {
+                            let vt = &info.value_type;
+                            if vt != "Any" && vt != "Mu" {
+                                return Some(vec![Value::Package(crate::symbol::Symbol::intern(
+                                    vt,
+                                ))]);
+                            }
+                        }
+                        None
+                    } else {
+                        None
+                    }
+                });
                 let Some(lhs_args) = lhs_args else {
                     return false;
                 };
@@ -1130,6 +1168,18 @@ impl Interpreter {
                         Some(":D") => false, // Package is not defined
                         _ => true,
                     };
+                }
+                // For Hash ~~ Hash[V,K] smartmatch, only typed hashes match.
+                // In Raku, an untyped hash does NOT match Hash[Int] even if all
+                // values happen to be Int. This differs from parameter binding
+                // where Associative[Int] checks element types.
+                if matches!(left, Value::Hash(_))
+                    && let Some((hash_base, _)) =
+                        Self::parse_generic_constraint(&type_name_resolved)
+                    && (hash_base == "Hash" || hash_base == "Associative")
+                    && self.container_type_metadata(left).is_none()
+                {
+                    return false;
                 }
                 self.type_matches_value(&type_name_resolved, left)
             }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -354,13 +354,56 @@ impl Interpreter {
                     return false;
                 }
                 "Hash" | "Associative" => {
+                    // Handle Hash[ValueType,KeyType] with two type parameters
+                    let (value_type, key_type) = if let Some(comma_pos) = inner.find(',') {
+                        let vt = inner[..comma_pos].trim();
+                        let kt = inner[comma_pos + 1..].trim();
+                        (vt, Some(kt))
+                    } else {
+                        (inner, None)
+                    };
                     if let Value::Hash(map) = value {
-                        return map.values().all(|v| self.type_matches_value(inner, v));
+                        // Check container type metadata first (typed hashes)
+                        if let Some(metadata) = self.container_type_metadata(value) {
+                            let (vt_base, _) = strip_type_smiley(value_type);
+                            let (mvt_base, _) = strip_type_smiley(&metadata.value_type);
+                            let value_ok = Self::type_matches(vt_base, mvt_base)
+                                || Self::type_matches(mvt_base, vt_base)
+                                || vt_base == "Mu"
+                                || vt_base == "Any";
+                            let key_ok = if let Some(kt) = key_type {
+                                let (kt_base, _) = strip_type_smiley(kt);
+                                if let Some(ref mkt) = metadata.key_type {
+                                    let (mkt_base, _) = strip_type_smiley(mkt);
+                                    Self::type_matches(kt_base, mkt_base)
+                                        || Self::type_matches(mkt_base, kt_base)
+                                        || kt_base == "Mu"
+                                        || kt_base == "Any"
+                                } else {
+                                    kt_base == "Str" || kt_base == "Any" || kt_base == "Mu"
+                                }
+                            } else {
+                                true
+                            };
+                            return value_ok && key_ok;
+                        }
+                        // No metadata: check all values match the value type
+                        let values_ok =
+                            map.values().all(|v| self.type_matches_value(value_type, v));
+                        // If a key type constraint is given, check it against
+                        // default Str keys (strip smileys for comparison).
+                        let keys_ok = if let Some(kt) = key_type {
+                            let (kt_base, _) = strip_type_smiley(kt);
+                            kt_base == "Str" || kt_base == "Any" || kt_base == "Mu"
+                        } else {
+                            true
+                        };
+                        return values_ok && keys_ok;
                     }
                     if let Value::Array(items, ..) = value {
                         return items.iter().all(|item| {
                             if let Value::Pair(_, v) = item {
-                                self.type_matches_value(inner, v)
+                                self.type_matches_value(value_type, v)
                             } else {
                                 false
                             }

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -186,6 +186,17 @@ impl VM {
             }
         }
 
+        // When cloning a container (Hash/Array/Set/Bag/Mix) that has type
+        // metadata, copy the metadata to the cloned value so the clone
+        // preserves the type constraint (e.g. %h.clone ~~ Hash[Int,Int]).
+        if method_name == "clone"
+            && let Some(Ok(ref cloned)) = result
+            && let Some(info) = self.interpreter.container_type_metadata(target)
+        {
+            self.interpreter
+                .register_container_type_metadata(cloned, info);
+        }
+
         result
     }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2901,6 +2901,19 @@ impl VM {
             self.interpreter.clear_container_default(&val);
         }
         self.locals[idx] = val.clone();
+        // When assigning (not binding) to an untyped hash variable, clear
+        // stale container type metadata from Arc pointer reuse.
+        // Skip for attribute variables (.h, !h) which get typed metadata from
+        // the class definition, not from var_type_constraints.
+        if !is_bind
+            && name.starts_with('%')
+            && !name.contains('.')
+            && !name.contains('!')
+            && self.interpreter.var_type_constraint(name).is_none()
+            && self.interpreter.container_type_metadata(&val).is_some()
+        {
+            self.interpreter.unregister_container_type_metadata(&val);
+        }
         // When binding a typed hash/array to a variable, propagate the container's
         // type constraints to the variable so that subsequent element assignments
         // are type-checked (e.g. `my %h := Hash[Int].new; %h<a> = "b"` should die).


### PR DESCRIPTION
## Summary
- Hash smartmatch (`%h ~~ Hash[Int,Int]`) now correctly checks container type metadata for typed hashes
- `.^name` on typed Hash/Array returns parameterized name (e.g. `Hash[Int,Int]` instead of `Hash`)
- `.clone` on typed containers preserves type metadata so `%bound := %h.clone` retains the type
- Assignment from typed hash to untyped variable correctly strips type metadata
- Handle `Hash[V,K]` with two type parameters (value type and key type) in type matching
- Strip type smileys (`:D`/`:U`) when comparing container metadata types

Fixes 4 previously failing subtests in `roast/S09-typed-arrays/hashes.t` (tests 38-41, from 42/47 to 44/47 passing). Remaining failures:
- Tests 42-43: `.antipairs`/`.invert` on typed hash with `{Any}` keys needs non-string key preservation (architectural)
- Test 44: Parser issue with parenthesized assignment as function argument

## Test plan
- [x] `make test` passes
- [x] `make roast` passes (no regressions)
- [x] `roast/S02-types/is-type.t` passes (verified no regression)
- [x] `t/assuming-type-capture.t` passes (verified no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)