### PR TITLE
fix: add ArraySlotRef for nested structure binding

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -5,6 +5,7 @@
 - [ ] roast/S03-binding/closure.t
 - [ ] roast/S03-binding/hashes.t
 - [ ] roast/S03-binding/nested.t
+  42/43 pass. Test 37 fails: self-referential structure binding ($struct[1]<key><subkey>[1] := $struct[1]<key>) requires proper container model to propagate writes through nested element aliases back to parent hash entries.
 - [ ] roast/S03-binding/ro.t
 - [ ] roast/S03-binding/scalars.t
 - [ ] roast/S03-buf/read-int.t

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -287,11 +287,12 @@ impl Compiler {
 
     /// Compile Index expression (target[index] or target{index}).
     pub(super) fn compile_expr_index(&mut self, target: &Expr, index: &Expr, is_positional: bool) {
-        // When in scalar bind context (`:=`), emit IndexAutovivify for
-        // associative indexing so that the VM auto-vivifies intermediate
-        // hashes and returns a HashSlotRef.
-        // This enables `my $b := %h<foo><baz>; $b = 42`.
-        let use_autovivify = self.scalar_bind_autovivify && !is_positional;
+        // When in scalar bind context (`:=`), emit IndexAutovivify so that
+        // the VM auto-vivifies intermediate hashes (returning HashSlotRef)
+        // or returns ArraySlotRef for positional indexing.
+        // This enables `my $b := %h<foo><baz>; $b = 42` and
+        // `my $b := @a[1]; $b = 42`.
+        let use_autovivify = self.scalar_bind_autovivify;
 
         // Special case: %*ENV<key> compiles to GetEnvIndex
         if let Expr::HashVar(name) = target {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -168,6 +168,9 @@ impl Interpreter {
             Value::HashSlotRef { .. } => {
                 return self.dispatch_what(&target.hash_slot_read(), args);
             }
+            Value::ArraySlotRef { .. } => {
+                return self.dispatch_what(&target.array_slot_read(), args);
+            }
         };
         let visible_type_name = if crate::value::is_internal_anon_type_name(type_name) {
             ""

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1372,6 +1372,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         }
         Value::LazyIoLines { .. } => "Seq",
         Value::HashSlotRef { .. } => "Scalar",
+        Value::ArraySlotRef { .. } => "Scalar",
     }
 }
 

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -892,6 +892,7 @@ impl Value {
                 }
             }
             Value::HashSlotRef { .. } => self.hash_slot_read().to_string_value(),
+            Value::ArraySlotRef { .. } => self.array_slot_read().to_string_value(),
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -844,6 +844,13 @@ pub enum Value {
         hash: Arc<HashMap<String, Value>>,
         key: String,
     },
+    /// A reference to an array slot, used for binding to array elements.
+    /// Reading this value returns the current value at the index (or Nil).
+    /// Assigning to it writes back to the parent array via interior mutation.
+    ArraySlotRef {
+        array: Arc<Vec<Value>>,
+        index: usize,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1645,6 +1652,50 @@ impl Value {
             let ptr = Arc::as_ptr(hash) as *mut HashMap<String, Value>;
             unsafe {
                 (*ptr).insert(key.clone(), val);
+            }
+        }
+    }
+
+    /// Create an ArraySlotRef pointing to a specific index in an array.
+    /// Uses interior mutation to ensure the array is large enough.
+    pub fn array_slot_ref(&self, idx: usize) -> Option<Value> {
+        if let Value::Array(arc, _kind) = self {
+            // SAFETY: mutsu is single-threaded.
+            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            unsafe {
+                // Ensure the array is large enough
+                while (&(*ptr)).len() <= idx {
+                    (&mut (*ptr)).push(Value::Nil);
+                }
+            }
+            Some(Value::ArraySlotRef {
+                array: arc.clone(),
+                index: idx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Read the current value from an ArraySlotRef.
+    pub fn array_slot_read(&self) -> Value {
+        if let Value::ArraySlotRef { array, index } = self {
+            let ptr = Arc::as_ptr(array);
+            unsafe { (&(*ptr)).get(*index).cloned().unwrap_or(Value::Nil) }
+        } else {
+            self.clone()
+        }
+    }
+
+    /// Write a value to an ArraySlotRef's parent array at the stored index.
+    pub fn array_slot_write(&self, val: Value) {
+        if let Value::ArraySlotRef { array, index } = self {
+            let ptr = Arc::as_ptr(array) as *mut Vec<Value>;
+            unsafe {
+                while (&(*ptr)).len() <= *index {
+                    (&mut (*ptr)).push(Value::Nil);
+                }
+                (&mut (*ptr))[*index] = val;
             }
         }
     }

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -305,7 +305,8 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         | Value::CustomTypeInstance { .. }
         | Value::LazyThunk(_)
         | Value::LazyIoLines { .. }
-        | Value::HashSlotRef { .. } => Err(format!(
+        | Value::HashSlotRef { .. }
+        | Value::ArraySlotRef { .. } => Err(format!(
             "cannot serialize Value variant: {:?}",
             std::mem::discriminant(v)
         )),

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -432,6 +432,7 @@ impl Value {
             }
             Value::LazyIoLines { .. } => true,
             Value::HashSlotRef { .. } => self.hash_slot_read().truthy(),
+            Value::ArraySlotRef { .. } => self.array_slot_read().truthy(),
         }
     }
 
@@ -561,6 +562,7 @@ impl Value {
             }
             Value::LazyIoLines { .. } => "Seq",
             Value::HashSlotRef { .. } => return self.hash_slot_read().isa_check(type_name),
+            Value::ArraySlotRef { .. } => return self.array_slot_read().isa_check(type_name),
         };
         if my_type == type_name {
             return true;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -308,6 +308,13 @@ impl VM {
             RuntimeError::new("VM stack underflow in CallOnValue target".to_string())
         })?;
 
+        // Resolve slot refs to their underlying values before dispatch
+        let target = match &target {
+            Value::HashSlotRef { .. } => target.hash_slot_read(),
+            Value::ArraySlotRef { .. } => target.array_slot_read(),
+            _ => target,
+        };
+
         // Upgrade WeakSub (e.g., &?BLOCK) to strong Sub before dispatch
         let target = if let Value::WeakSub(ref weak) = target {
             match weak.upgrade() {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1910,7 +1910,17 @@ impl VM {
                                         &val,
                                         Value::Array(source_items, ..) if Arc::ptr_eq(items, source_items)
                                     );
-                                    let arr = Arc::make_mut(items);
+                                    // Use in-place mutation when the array is shared
+                                    // (strong_count > 1) to preserve identity semantics
+                                    // and support ArraySlotRef binding.
+                                    // SAFETY: mutsu is single-threaded.
+                                    let use_inplace =
+                                        Arc::strong_count(items) > 1 && !var_name.starts_with('@');
+                                    let arr: &mut Vec<Value> = if use_inplace {
+                                        unsafe { &mut *(Arc::as_ptr(items) as *mut _) }
+                                    } else {
+                                        Arc::make_mut(items)
+                                    };
                                     if i >= arr.len() {
                                         arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
                                     }
@@ -2307,12 +2317,25 @@ impl VM {
             match inner_val {
                 Value::Array(arr, _) => {
                     // Hash-containing-Array: $hash<key>[idx] = val
+                    // Use interior mutation when the array is shared (supports
+                    // ArraySlotRef and cross-variable identity).
                     if let Ok(i) = outer_key.parse::<usize>() {
-                        let a = Arc::make_mut(arr);
-                        if i >= a.len() {
-                            a.resize(i + 1, Value::Nil);
+                        if Arc::strong_count(arr) > 1 {
+                            // SAFETY: mutsu is single-threaded.
+                            let ptr = Arc::as_ptr(arr) as *mut Vec<Value>;
+                            unsafe {
+                                while (&(*ptr)).len() <= i {
+                                    (&mut (*ptr)).push(Value::Nil);
+                                }
+                                (&mut (*ptr))[i] = val.clone();
+                            }
+                        } else {
+                            let a = Arc::make_mut(arr);
+                            if i >= a.len() {
+                                a.resize(i + 1, Value::Nil);
+                            }
+                            a[i] = val.clone();
                         }
-                        a[i] = val.clone();
                     }
                 }
                 Value::Hash(h) => {
@@ -2333,15 +2356,36 @@ impl VM {
     /// Stack order: target (bottom), index, value (top).
     /// If the target hash has `__callframe_depth`, routes through set_caller_var.
     pub(super) fn exec_index_assign_generic_op(&mut self) -> Result<(), RuntimeError> {
-        let val = self.stack.pop().unwrap_or(Value::Nil);
+        let raw_val = self.stack.pop().unwrap_or(Value::Nil);
         let idx = self.stack.pop().unwrap_or(Value::Nil);
         let target = self.stack.pop().unwrap_or(Value::Nil);
         let key = idx.to_string_value();
 
+        // Detect bind marker (__mutsu_bind_index_value) and extract the actual value
+        let (val, bind_source) = match raw_val {
+            Value::Pair(ref name, ref payload) if name == "__mutsu_bind_index_value" => {
+                match payload.as_ref() {
+                    Value::Array(items, ..) if items.len() >= 2 => {
+                        let value = items.first().cloned().unwrap_or(Value::Nil);
+                        let source = match items.get(1) {
+                            Some(Value::Array(srcs, ..)) => srcs.first().and_then(|s| match s {
+                                Value::Str(name) if !name.is_empty() => Some((**name).clone()),
+                                _ => None,
+                            }),
+                            _ => None,
+                        };
+                        (value, source)
+                    }
+                    other => (other.clone(), None),
+                }
+            }
+            other => (other, None),
+        };
+
         match &target {
-            Value::Hash(h) => {
+            Value::Hash(arc) => {
                 // Check for callframe .my hash with depth marker
-                if let Some(Value::Int(depth)) = h.get("__callframe_depth") {
+                if let Some(Value::Int(depth)) = arc.get("__callframe_depth") {
                     let depth = *depth as usize;
                     // Strip sigil from key to get bare variable name
                     let bare_name =
@@ -2355,8 +2399,65 @@ impl VM {
                     self.stack.push(val);
                     return Ok(());
                 }
-                // Regular hash: just do the assignment (on a temporary — won't persist)
+                // Interior mutation: write into the hash via raw pointer
+                // so the change is visible to all holders of the same Arc.
+                let ptr = Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
+                unsafe {
+                    (*ptr).insert(key.clone(), val.clone());
+                }
+                // For bind mode, set up a HashSlotRef on the source variable
+                if let Some(source_name) = &bind_source {
+                    let slot_ref = Value::HashSlotRef {
+                        hash: arc.clone(),
+                        key,
+                    };
+                    self.interpreter
+                        .env_mut()
+                        .insert(source_name.clone(), slot_ref.clone());
+                    self.env_dirty = true;
+                }
                 self.stack.push(val);
+            }
+            Value::Array(arc, _kind) => {
+                // Interior mutation: write into the array via raw pointer
+                // so the change is visible to all holders of the same Arc.
+                if let Ok(i) = key.parse::<usize>() {
+                    let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                    unsafe {
+                        while (&(*ptr)).len() <= i {
+                            (&mut (*ptr)).push(Value::Nil);
+                        }
+                        (&mut (*ptr))[i] = val.clone();
+                    }
+                    // For bind mode, set up an ArraySlotRef on the source variable
+                    if let Some(source_name) = &bind_source {
+                        let slot_ref = Value::ArraySlotRef {
+                            array: arc.clone(),
+                            index: i,
+                        };
+                        self.interpreter
+                            .env_mut()
+                            .insert(source_name.clone(), slot_ref.clone());
+                        self.env_dirty = true;
+                    }
+                }
+                self.stack.push(val);
+            }
+            Value::HashSlotRef { .. } => {
+                // Resolve the HashSlotRef and assign into the resolved container.
+                let resolved = target.hash_slot_read();
+                self.stack.push(resolved);
+                self.stack.push(idx);
+                self.stack.push(val);
+                return self.exec_index_assign_generic_op();
+            }
+            Value::ArraySlotRef { .. } => {
+                // Resolve the ArraySlotRef and assign into the resolved container.
+                let resolved = target.array_slot_read();
+                self.stack.push(resolved);
+                self.stack.push(idx);
+                self.stack.push(val);
+                return self.exec_index_assign_generic_op();
             }
             Value::Instance {
                 class_name,
@@ -2539,8 +2640,16 @@ impl VM {
                 return Ok(());
             }
             // If the current value is a HashSlotRef, write back to the parent hash
-            if let Value::HashSlotRef { .. } = &self.locals[idx] {
+            // (unless rebinding, which replaces the ref with a new value).
+            if !is_rebind && let Value::HashSlotRef { .. } = &self.locals[idx] {
                 self.locals[idx].hash_slot_write(val);
+                self.locals_dirty = true;
+                return Ok(());
+            }
+            // If the current value is an ArraySlotRef, write back to the parent array
+            // (unless rebinding, which replaces the ref with a new value).
+            if !is_rebind && let Value::ArraySlotRef { .. } = &self.locals[idx] {
+                self.locals[idx].array_slot_write(val);
                 self.locals_dirty = true;
                 return Ok(());
             }
@@ -3091,8 +3200,22 @@ impl VM {
             return Ok(());
         }
         // If the current value is a HashSlotRef, write back to the parent hash
-        if !is_bind && let Value::HashSlotRef { .. } = &self.locals[idx] {
+        // (unless rebinding, which replaces the ref with a new value).
+        if !is_bind
+            && !is_rebind
+            && let Value::HashSlotRef { .. } = &self.locals[idx]
+        {
             self.locals[idx].hash_slot_write(val);
+            self.locals_dirty = true;
+            return Ok(());
+        }
+        // If the current value is an ArraySlotRef, write back to the parent array
+        // (unless rebinding, which replaces the ref with a new value).
+        if !is_bind
+            && !is_rebind
+            && let Value::ArraySlotRef { .. } = &self.locals[idx]
+        {
+            self.locals[idx].array_slot_write(val);
             self.locals_dirty = true;
             return Ok(());
         }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -36,31 +36,48 @@ impl VM {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
-    /// Auto-vivifying index: creates intermediate Hash entries and returns
-    /// a `HashSlotRef` so that `:=` bind to nested hash elements works.
-    /// Stack: [target, key] -> [HashSlotRef]
+    /// Auto-vivifying index: creates intermediate Hash/Array entries and returns
+    /// a `HashSlotRef` or `ArraySlotRef` so that `:=` bind to nested elements works.
+    /// Stack: [target, key] -> [HashSlotRef | ArraySlotRef]
     pub(super) fn exec_index_autovivify_op(&mut self) -> Result<(), RuntimeError> {
         let index = self.stack.pop().unwrap();
         let target = self.stack.pop().unwrap();
-        let key = Value::hash_key_encode(&index);
 
-        // If the target is a HashSlotRef, resolve its value first.
-        let hash_val = match &target {
+        // Resolve slot refs to their underlying value for type dispatch.
+        let resolved = match &target {
             Value::HashSlotRef { .. } => target.hash_slot_read(),
+            Value::ArraySlotRef { .. } => target.array_slot_read(),
             other => other.clone(),
         };
 
-        match &hash_val {
+        match &resolved {
             Value::Hash(_) => {
-                if let Some(slot_ref) = hash_val.hash_autovivify(&key) {
+                let key = Value::hash_key_encode(&index);
+                if let Some(slot_ref) = resolved.hash_autovivify(&key) {
                     self.stack.push(slot_ref);
                 } else {
                     self.stack.push(Value::Nil);
                 }
             }
-            // If the target is Nil/Any (not yet vivified), create an empty hash
-            // inside the HashSlotRef and then auto-vivify the key.
+            Value::Array(..) => {
+                // Positional autovivify: return an ArraySlotRef
+                if let Some(idx) = Self::index_to_usize(&index) {
+                    if let Some(slot_ref) = resolved.array_slot_ref(idx) {
+                        self.stack.push(slot_ref);
+                    } else {
+                        self.stack.push(Value::Nil);
+                    }
+                } else {
+                    // Fallback for non-integer index
+                    self.stack.push(target);
+                    self.stack.push(index);
+                    return self.exec_index_op_with_positional(true);
+                }
+            }
+            // If the target is Nil/Any (not yet vivified) inside a HashSlotRef,
+            // create an empty hash and then auto-vivify the key.
             _ if matches!(&target, Value::HashSlotRef { .. }) => {
+                let key = Value::hash_key_encode(&index);
                 let new_hash = Value::hash(std::collections::HashMap::new());
                 target.hash_slot_write(new_hash.clone());
                 if let Some(slot_ref) = new_hash.hash_autovivify(&key) {
@@ -117,6 +134,13 @@ impl VM {
             let resolved = target.hash_slot_read();
             // If the resolved value is a Hash, push it as the target for indexing.
             // This supports chained autovivification (e.g. %h<a><b><c>).
+            self.stack.push(resolved);
+            self.stack.push(index);
+            return self.exec_index_op_with_positional(is_positional);
+        }
+        // If target is an ArraySlotRef, resolve it to the actual value and re-index.
+        if let Value::ArraySlotRef { .. } = &target {
+            let resolved = target.array_slot_read();
             self.stack.push(resolved);
             self.stack.push(index);
             return self.exec_index_op_with_positional(is_positional);


### PR DESCRIPTION
## Summary
- Adds `Value::ArraySlotRef` (analogous to `HashSlotRef`) to support binding to nested array elements via `:=`
- Extends `IndexAutovivify` opcode to handle positional indexing, returning `ArraySlotRef` in bind context
- Uses interior mutation (raw pointer) instead of `Arc::make_mut` in `IndexAssignGeneric` for arrays and hashes, preserving Arc identity across nested structure assignments
- Handles `ArraySlotRef`/`HashSlotRef` resolution in `CallOnValue` dispatch (fixes embedded sub calls like `$struct[1]<key>()<subkey>[1]`)
- Skips slot ref write-through on rebind (`:=` to new value) to correctly break binding links
- Supports LHS binding (`nested_element := $var`) via bind marker detection in generic index assignment

Achieves 42/43 passing subtests in `roast/S03-binding/nested.t`. The remaining test 37 (self-referential structure binding where an array slot is bound to a parent hash entry) requires a proper container model to propagate writes bidirectionally.

## Test plan
- [x] `make test` passes (all 3802 tests)
- [x] `make roast` passes (cas-int.t flaky threading timeout is pre-existing)
- [x] `prove -e target/debug/mutsu roast/S03-binding/nested.t` shows 42/43 passing
- [x] No regressions in existing binding tests (arrays, closure, hashes, ro, scalars all still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)