### PR TITLE
fix: pass all 21 subtests in roast/S32-io/slurp.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -951,6 +951,7 @@ roast/S32-io/out-buffering.t
 roast/S32-io/rename.t
 roast/S32-io/seek.t
 roast/S32-io/signals.t
+roast/S32-io/slurp.t
 roast/S32-io/socket-accept-and-working-threads.t
 roast/S32-io/socket-fail-invalid-values.t
 roast/S32-io/socket-host-port-split.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -2507,6 +2507,9 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         || rest_trimmed.starts_with(']')
         || is_stmt_modifier_ahead(rest_trimmed)
         || rest_trimmed.is_empty();
+    // For zero-arg bare-word functions (e.g. slurp, set), a following '.'
+    // means a method call on the result, so treat it as a terminator too.
+    let is_terminator_or_dot = is_terminator || rest_trimmed.starts_with('.');
 
     // User-declared and imported subs can be called with no args as bare words
     // in statement position (e.g., `make-temp-dir;`).
@@ -2528,7 +2531,7 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     if matches!(
         name.as_str(),
         "await" | "slip" | "set" | "bag" | "mix" | "slurp"
-    ) && is_terminator
+    ) && is_terminator_or_dot
     {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2489,6 +2489,11 @@ impl Interpreter {
             }
             "encoding" => {
                 if let Some(arg) = args.first() {
+                    // Nil means switch to binary mode (no encoding)
+                    if matches!(arg, Value::Nil) {
+                        self.set_handle_encoding(&target_val, Some("bin".to_string()))?;
+                        return Ok(Value::Nil);
+                    }
                     let encoding = arg.to_string_value();
                     if encoding == "bin" {
                         self.set_handle_encoding(&target_val, Some("bin".to_string()))?;


### PR DESCRIPTION
## Summary
- Handle `Nil` argument in `IO::Handle.encoding()` to switch to binary mode (e.g. `$*ARGFILES.encoding: Nil`)
- Parse zero-arg built-in functions (`slurp`, `set`, etc.) followed by `.` as function calls so method chaining works (e.g. `slurp.decode`)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-io/slurp.t` passes all 21 subtests
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes (flaky `t/lock.t` and `t/prompt-behavior.t` unrelated)
- [x] `make roast` passes (flaky `roast/S32-list/reverse.t` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)