### PR TITLE
fix: accumulate named captures for repeated grammar subrules

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -284,6 +284,16 @@ pub(super) fn grapheme_end(chars: &[char], pos: usize) -> usize {
 /// Check if an atom is "simple" — it only advances position without producing
 /// any captures. Used to enable a fast path in ratcheted quantifier loops
 /// that avoids cloning RegexCaptures on every iteration.
+/// Returns true when a Named regex atom is "silent" (produces no implicit
+/// named capture).  Silent names start with `.` (e.g. `<.ws>`).
+pub(super) fn is_silent_named_atom(atom: &RegexAtom) -> bool {
+    if let RegexAtom::Named(name) = atom {
+        name.trim().starts_with('.')
+    } else {
+        false
+    }
+}
+
 pub(super) fn is_simple_atom(atom: &RegexAtom) -> bool {
     matches!(
         atom,

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -1,5 +1,7 @@
 use super::super::*;
-use super::regex_helpers::{count_capture_groups, fold_quantified_captures, is_simple_atom};
+use super::regex_helpers::{
+    count_capture_groups, fold_quantified_captures, is_silent_named_atom, is_simple_atom,
+};
 
 impl Interpreter {
     pub(super) fn regex_match_end_from_caps_in_pkg(
@@ -139,11 +141,14 @@ impl Interpreter {
                         stack.push((idx + 1, current, caps));
                     } else if token.ratchet
                         && token.named_capture.is_none()
+                        && is_silent_named_atom(&token.atom)
                         && let Some((resolved, resolved_pkg)) =
                             self.try_resolve_named_to_pattern(&token.atom, pkg)
                     {
                         // Fast path for ratcheted Named token: resolve pattern once,
-                        // match directly without creating new Interpreter per iteration
+                        // match directly without creating new Interpreter per iteration.
+                        // Only used for silent atoms (e.g. <.ws>) that don't produce
+                        // implicit named captures.
                         let mut current = pos;
                         while current < chars.len() {
                             if let Some(end) = self.regex_match_end_from_in_pkg(
@@ -236,10 +241,13 @@ impl Interpreter {
                         stack.push((idx + 1, current, caps));
                     } else if token.ratchet
                         && token.named_capture.is_none()
+                        && is_silent_named_atom(&token.atom)
                         && let Some((resolved, resolved_pkg)) =
                             self.try_resolve_named_to_pattern(&token.atom, pkg)
                     {
-                        // Fast path for ratcheted Named token
+                        // Fast path for ratcheted Named token.
+                        // Only used for silent atoms (e.g. <.ws>) that don't produce
+                        // implicit named captures.
                         let Some(mut current) =
                             self.regex_match_end_from_in_pkg(&resolved, chars, pos, &resolved_pkg)
                         else {

--- a/t/grammar-named-capture.t
+++ b/t/grammar-named-capture.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 14;
+
+# Repeated named subrule with quantifier and separator
+{
+    grammar G {
+        token TOP { <word>+ % \s+ }
+        token word { \w+ }
+    }
+    my $m = G.parse("hello world");
+    ok $m.defined, 'grammar with <word>+ % \\s+ parses';
+    is $m<word>.elems, 2, '<word> captures 2 elements';
+    is ~$m<word>[0], 'hello', '<word>[0] is hello';
+    is ~$m<word>[1], 'world', '<word>[1] is world';
+}
+
+# Three words
+{
+    grammar G3 {
+        token TOP { <word>+ % \s+ }
+        token word { \w+ }
+    }
+    my $m = G3.parse("a b c");
+    ok $m.defined, 'grammar with 3 words parses';
+    is $m<word>.elems, 3, '<word> captures 3 elements';
+    is ~$m<word>[0], 'a', '<word>[0] is a';
+    is ~$m<word>[2], 'c', '<word>[2] is c';
+}
+
+# Multiple same-name subrules (non-quantified)
+{
+    grammar G2 {
+        token TOP { <num> '-' <num> }
+        token num { \d+ }
+    }
+    my $m2 = G2.parse("42-99");
+    ok $m2.defined, 'grammar with two <num> parses';
+    is $m2<num>.elems, 2, '<num> captures 2 elements';
+    is ~$m2<num>[0], '42', '<num>[0] is 42';
+    is ~$m2<num>[1], '99', '<num>[1] is 99';
+}
+
+# Single named subrule (non-repeated)
+{
+    grammar G4 {
+        token TOP { <word> }
+        token word { \w+ }
+    }
+    my $m = G4.parse("hello");
+    ok $m.defined, 'single <word> parses';
+    is ~$m<word>, 'hello', '<word> is hello for single match';
+}


### PR DESCRIPTION
## Summary
- Fixed grammar named captures for repeated subrules (`<word>+ % \s+`) producing `Nil` instead of an Array of Match objects
- The ratcheted Named atom fast path in `regex_match_core.rs` was skipping capture tracking entirely; now restricted to silent atoms (e.g. `<.ws>`) only
- Added `is_silent_named_atom()` helper to distinguish capturing vs non-capturing named atoms

## Test plan
- [x] New test `t/grammar-named-capture.t` with 14 subtests covering repeated, multiple, and single named subrule captures
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `make roast` passes (only pre-existing `spurt.t`/`reverse.t` failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)