### PR TITLE
fix: fix double usage output and improve MAIN sub argument handling

### DIFF
--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -51,8 +51,8 @@ impl Interpreter {
         // Check for --help flag
         if raw_args.iter().any(|a| a == "--help") {
             let usage = self.generate_usage_message(&main_def);
-            // --help prints to stdout
-            let text = format!("{}\n", usage);
+            // --help prints to stdout with "Usage:" prefix, exit 0
+            let text = format!("Usage:\n{}\n", usage);
             self.emit_output(&text);
             return Ok(());
         }
@@ -411,9 +411,23 @@ impl Interpreter {
         candidate: &FunctionDef,
         parsed: &ParsedMainArgs,
     ) -> Result<(), RuntimeError> {
+        // Coerce positional string args to match parameter type constraints.
+        // CLI args are always strings, but MAIN parameters may be typed as
+        // Int, Num, Rat, etc. and Raku coerces automatically.
+        let positional_params: Vec<&ParamDef> = candidate
+            .param_defs
+            .iter()
+            .filter(|p| !p.named && !p.slurpy && !p.double_slurpy)
+            .collect();
+
         let mut args = Vec::new();
-        for arg in &parsed.positional {
-            args.push(arg.clone());
+        for (i, arg) in parsed.positional.iter().enumerate() {
+            let coerced = if let Some(pd) = positional_params.get(i) {
+                Self::coerce_cli_arg(arg, pd)
+            } else {
+                arg.clone()
+            };
+            args.push(coerced);
         }
         for (name, value) in &parsed.named {
             args.push(Value::Pair(name.clone(), Box::new(value.clone())));
@@ -453,12 +467,10 @@ impl Interpreter {
             let result = self.call_function("GENERATE-USAGE", vec![])?;
             let msg = result.to_string_value();
             let output = format!("{}\n", msg);
-            self.stderr_output.push_str(&output);
-            eprint!("{}", output);
+            self.emit_stderr(&output);
         } else {
             let output = format!("Usage:\n{}\n", usage);
-            self.stderr_output.push_str(&output);
-            eprint!("{}", output);
+            self.emit_stderr(&output);
         }
 
         self.exit_code = 2;
@@ -479,7 +491,8 @@ impl Interpreter {
     fn generate_usage_from_candidates(&self, candidates: &[FunctionDef]) -> String {
         let program = self
             .env
-            .get("$*PROGRAM-NAME")
+            .get("*PROGRAM-NAME")
+            .or_else(|| self.env.get("$*PROGRAM-NAME"))
             .map(|v| v.to_string_value())
             .unwrap_or_else(|| "program".to_string());
 
@@ -503,6 +516,9 @@ impl Interpreter {
                     parts.push(format!("[<{}>...]", name));
                 } else if pd.double_slurpy {
                     // Skip slurpy hash in usage
+                } else if let Some(ref lit) = pd.literal_value {
+                    // Literal parameter — show the literal value
+                    parts.push(lit.to_string_value());
                 } else {
                     let name = pd.name.trim_start_matches(['$', '@', '%', '\\']);
                     if pd.default.is_some() || pd.optional_marker {
@@ -515,5 +531,34 @@ impl Interpreter {
             lines.push(parts.join(" "));
         }
         lines.join("\n")
+    }
+
+    /// Coerce a CLI argument (always a string) to the type required by a
+    /// MAIN parameter definition.  Returns the original value if no
+    /// coercion is needed or if coercion fails.
+    fn coerce_cli_arg(arg: &Value, pd: &ParamDef) -> Value {
+        let tc = match &pd.type_constraint {
+            Some(t) => t.as_str(),
+            None => return arg.clone(),
+        };
+        let s = arg.to_string_value();
+        match tc {
+            "Int" => s.parse::<i64>().map(Value::Int).unwrap_or_else(|_| {
+                // Try big-int style
+                arg.clone()
+            }),
+            "Num" => s
+                .parse::<f64>()
+                .map(Value::Num)
+                .unwrap_or_else(|_| arg.clone()),
+            "Rat" => {
+                if let Ok(n) = s.parse::<f64>() {
+                    Value::Num(n)
+                } else {
+                    arg.clone()
+                }
+            }
+            _ => arg.clone(),
+        }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3735,6 +3735,18 @@ impl Interpreter {
         self.is_thread_clone
     }
 
+    /// Write a message to stderr, respecting nested mode.
+    /// In nested mode the output is buffered for later inspection;
+    /// otherwise it is emitted directly so `flush_stderr_buffer` does
+    /// not duplicate it.
+    pub(crate) fn emit_stderr(&mut self, text: &str) {
+        if self.nested_mode {
+            self.stderr_output.push_str(text);
+        } else {
+            eprint!("{}", text);
+        }
+    }
+
     pub(crate) fn write_warn_to_stderr(&mut self, message: &str) {
         let msg = format!("{}\n", message);
         if self.is_thread_clone

--- a/t/main-sub.t
+++ b/t/main-sub.t
@@ -1,8 +1,49 @@
 use Test;
-plan 1;
+plan 8;
 
-# MAIN sub is called automatically after the program body
-# We verify by having MAIN produce output
-sub MAIN() {
-    ok True, 'MAIN sub was called';
+# Test 1: Basic MAIN with string arg
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN(Str $name) { say "Hello, $name" }', 'World', :out, :err);
+    is $result.out.slurp(:close).trim, "Hello, World", "MAIN with positional Str arg";
+}
+
+# Test 2: MAIN sub is called automatically (no args case)
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN() { say "called" }', :out, :err);
+    is $result.out.slurp(:close).trim, "called", "MAIN sub with no args is called";
+}
+
+# Test 3: Usage message on missing required args (single print)
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN(Str $name) { say "Hello, $name" }', :out, :err);
+    my $err = $result.err.slurp(:close);
+    my $count = $err.comb("Usage:").elems;
+    is $count, 1, "Usage message printed exactly once";
+}
+
+# Test 4: --help shows usage on stdout
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN(Str $name) { say "Hello, $name" }', '--help', :out, :err);
+    my $out = $result.out.slurp(:close);
+    ok $out.contains("Usage:"), "--help shows Usage on stdout";
+    ok $out.contains("<name>"), "--help shows parameter name";
+}
+
+# Test 5: Exit code 0 on success
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN(Str $name) { say "Hello, $name" }', 'World', :out, :err);
+    is $result.exitcode, 0, "Exit code 0 on successful MAIN dispatch";
+}
+
+# Test 6: Exit code non-zero on usage error
+{
+    my $result = run($*EXECUTABLE, '-e', 'sub MAIN(Str $name) { say "Hello, $name" }', :out, :err);
+    ok $result.exitcode != 0, "Non-zero exit code on usage error";
+}
+
+# Test 7: multi MAIN dispatch with Int coercion
+{
+    my $code = 'multi sub MAIN("greet", Str $name) { say "Hello, $name" }; multi sub MAIN("add", Int $a, Int $b) { say $a + $b }';
+    my $result = run($*EXECUTABLE, '-e', $code, 'add', '3', '5', :out, :err);
+    is $result.out.slurp(:close).trim, "8", "multi MAIN with Int coercion";
 }


### PR DESCRIPTION
## Summary
- Fix duplicate usage message when MAIN dispatch fails (was printing to both stderr buffer and stderr directly, causing double output on flush)
- Add CLI argument type coercion for MAIN parameters (e.g., string "3" -> Int 3)
- Show literal parameter values in multi MAIN usage messages instead of `<__literal__>`
- Add "Usage:" prefix to `--help` output to match Raku behavior
- Fix `$*PROGRAM-NAME` lookup to use correct env key

## Test plan
- [x] `make test` passes (471 files, 3809 tests)
- [x] `make roast` passes (pre-existing failures only)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `t/main-sub.t` covers: single MAIN, no-args MAIN, usage dedup, --help, exit codes, multi MAIN with Int coercion

🤖 Generated with [Claude Code](https://claude.com/claude-code)