### PR TITLE
feat: add release workflow for mise support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive_name: linux-x64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive_name: macos-x64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive_name: macos-arm64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.92.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-release-${{ matrix.target }}-
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libpcre2-dev
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz mutsu
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutsu-${{ matrix.archive_name }}
+          path: mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: mutsu-*.tar.gz


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that triggers on `v*` tag push
- Builds release binaries for 3 platforms: Linux x64, macOS x64, macOS ARM64
- Creates a GitHub Release with `mutsu-{version}-{os}-{arch}.tar.gz` archives attached
- Enables installation via `mise install github:tokuhirom/mutsu`

mise's `github:` backend auto-discovers release assets matching `{name}-{version}-{os}-{arch}.tar.gz`, so no plugin or extra config is needed.

### Usage after tagging a release:
```bash
# Install latest
mise install github:tokuhirom/mutsu

# Pin in .mise.toml
[tools]
"github:tokuhirom/mutsu" = "latest"
```

## Test plan
- [ ] Verify YAML syntax is valid (done locally with Python yaml parser)
- [ ] CI passes on this PR (no functional code changes)
- [ ] After merge, create a test tag `v0.1.0` and verify the release workflow runs and produces artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)