### PR TITLE
fix: pass all 41 subtests in roast/S12-class/inheritance.t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Roast whitelist is sorted
         run: make check-roast-whitelist
 
+      - name: Clean precomp cache and restore roast files
+        run: |
+          rm -rf ~/.cache/mutsu/precomp
+          git checkout -- roast/
+
       - name: Roast tests (make roast)
         run: prove -e 'timeout 30 target/release/mutsu' $(cat roast-whitelist.txt)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive_name: linux-x64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive_name: macos-x64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive_name: macos-arm64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.92.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-release-${{ matrix.target }}-
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libpcre2-dev
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz mutsu
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutsu-${{ matrix.archive_name }}
+          path: mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: mutsu-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,42 +1,203 @@
 # mutsu
 
-**Work in progress** -- A Raku (Perl 6) interpreter written in Rust.
+A Raku (Perl 6) interpreter written in Rust, using a bytecode VM architecture.
 
-mutsu aims to be a lightweight, embeddable Raku interpreter. It is under heavy active development and is **not yet suitable for production use**.
+mutsu parses Raku source into an AST, compiles it to bytecode, and executes it on a custom VM. It is under active development and improving rapidly, but is **not yet suitable for production use**.
 
 Try it in your browser: **https://tokuhirom.github.io/mutsu/** (WebAssembly demo)
 
+## Quick Start
+
+```bash
+cargo build --release
+./target/release/mutsu -e 'say "Hello, World!"'
+./target/release/mutsu script.raku
+```
+
+For interactive use:
+
+```bash
+./target/release/mutsu --repl
+```
+
 ## Status
 
-mutsu passes **1,010 out of ~1,300** official [Roast](https://github.com/Raku/roast) test files (~165,000 subtests), covering core language features including:
+mutsu passes **1,145 out of ~1,460** official [Roast](https://github.com/Raku/roast) test files. Compatibility is improving daily.
 
-- Variables, sigils, twigils, and lexical scoping
-- Control flow (if/unless/with/without, for, while, loop, given/when, repeat)
-- Classes, roles, inheritance, and composition
-- Multi dispatch, signatures, and parameter handling
-- Grammars, regexes, and pattern matching
-- Set, Bag, Mix types and operators
-- Exception handling (try/CATCH, fail, Failure)
+## What Works
+
+### Variables and Basic Types
+
+Int, Str, Rat, Num, Complex, Bool, Array, Hash, Range, Set, Bag, and Mix are all supported.
+
+```raku
+my $name = "Alice";
+my @numbers = 1, 2, 3;
+my %ages = alice => 30, bob => 25;
+my $ratio = 3/7;            # Rat: 0.428571
+my $z = 2+3i;               # Complex
+my $set = set <a b c>;
+say "b" (elem) $set;        # True
+```
+
+### Control Flow
+
+if/elsif/else, for, while, loop, given/when, unless, with/without, and repeat are supported.
+
+```raku
+for 1..5 -> $i { print "$i " }  # 1 2 3 4 5
+
+given 42 {
+    when 0..10   { say "small"  }
+    when 11..100 { say "medium" }
+    default      { say "big"    }
+}
+```
+
+### Subs, Multi Dispatch, and Signatures
+
+```raku
+sub greet(Str $name) { say "Hello, $name!" }
+greet("World");
+
+multi sub fizz(Int $n where * %% 15) { "FizzBuzz" }
+multi sub fizz(Int $n where * %% 3)  { "Fizz" }
+multi sub fizz(Int $n where * %% 5)  { "Buzz" }
+multi sub fizz(Int $n)               { $n }
+say fizz(15);  # FizzBuzz
+```
+
+### Classes, Roles, and Inheritance
+
+```raku
+role Greetable {
+    method greet() { say "Hello, I am {self.name}" }
+}
+
+class Person does Greetable {
+    has $.name;
+}
+
+Person.new(name => "Alice").greet;  # Hello, I am Alice
+
+class Animal { has $.name }
+class Dog is Animal {
+    method speak() { say "{self.name} says Woof!" }
+}
+Dog.new(name => "Rex").speak;       # Rex says Woof!
+```
+
+### Grammars and Regex
+
+```raku
+grammar CSV {
+    token TOP  { <line>+ % "\n" }
+    token line { <cell>+ % ","  }
+    token cell { <-[,\n]>*      }
+}
+say CSV.parse("a,b,c").so;  # True
+
+if "Hello123" ~~ /(\w+)(\d+)/ {
+    say ~$0;  # Hello12
+    say ~$1;  # 3
+}
+```
+
+### Functional Programming
+
+map, grep, reduce, sort, gather/take, sequences, and junctions.
+
+```raku
+say (1..10).grep(*.is-prime);           # (2 3 5 7)
+say [+] 1..100;                         # 5050
+say (1, 1, *+* ... *)[^10];            # (1 1 2 3 5 8 13 21 34 55)
+say gather { for 1..10 { take $_ if $_ %% 3 } }.list;  # (3 6 9)
+```
+
+### Exception Handling
+
+```raku
+try {
+    die "something went wrong";
+    CATCH { default { say "Caught: {.message}" } }
+}
+```
+
+### Promises
+
+```raku
+my $p = start { sleep 0.1; 42 };
+say await $p;  # 42
+```
+
+### Enums and Subset Types
+
+```raku
+enum Color <Red Green Blue>;
+say Red;            # Red
+say Green.value;    # 1
+
+subset Positive of Int where * > 0;
+my Positive $x = 5;
+```
+
+### File I/O
+
+```raku
+spurt "output.txt", "Hello from mutsu!\n";
+say slurp "output.txt";
+```
+
+### MAIN Sub for CLI Tools
+
+Define a `MAIN` sub to get automatic argument parsing and usage messages:
+
+```raku
+# greet.raku
+sub MAIN(Str $name) {
+    say "Hello, $name!";
+}
+```
+
+```
+$ mutsu greet.raku World
+Hello, World!
+$ mutsu greet.raku
+Usage:
+  greet.raku <name>
+```
+
+### And More
+
 - Phasers (BEGIN, INIT, ENTER, LEAVE, FIRST, NEXT, LAST, etc.)
-- IO, file handling, and Proc::Async
-- Promises, supplies, and basic concurrency
+- String methods (uc, lc, tc, split, join, chars, etc.)
+- Module loading (`use`)
+- Proc::Async for external processes
+- Complex number arithmetic
+- Set, Bag, Mix operations
+- Junctions (any, all, one, none)
 
-Many advanced features are still incomplete or missing. Compatibility is improving rapidly.
+## Known Limitations
 
-## Build & Run
+- **Single-threaded execution.** `start`/`await` work but run on a single thread.
+- **Incomplete container semantics.** Some binding and container behaviors differ from Rakudo.
+- **Limited exception types.** Not all `X::` exception classes are implemented.
+- **No package manager integration.** There is no zef/ecosystem support; `use` works for local modules only.
+- **Some advanced features are missing or incomplete.** Certain meta-programming, NativeCall, and supply/react patterns are not yet supported.
 
+## Building
+
+```bash
+cargo build              # Debug build
+cargo build --release    # Optimized build
+make test                # Run local tests (prove t/)
+make roast               # Run official Raku spec tests
 ```
-cargo build
-cargo run -- script.raku
-cargo run -- -e 'say "Hello, World!"'
-```
 
-## Test
+## Requirements
 
-```
-make test     # Local tests (prove t/)
-make roast    # Official Raku spec tests
-```
+- Rust 1.92.0+ (edition 2024)
+- A C compiler (for pcre2-sys)
 
 ## Architecture
 
@@ -44,14 +205,14 @@ make roast    # Official Raku spec tests
 Source -> Parser (src/parser/) -> Compiler (src/compiler/) -> VM (src/vm/) -> Output
 ```
 
-mutsu uses a bytecode VM architecture. Source code is parsed into an AST, compiled to bytecode (`OpCode` instructions), and executed by the VM.
+mutsu uses a bytecode VM architecture. Source code is parsed into an AST, compiled to bytecode (`OpCode` instructions), and executed by the VM. See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.
 
-## Requirements
+## Contributing
 
-- Rust 1.92.0+
-- A C compiler (for pcre2-sys)
+See [CLAUDE.md](CLAUDE.md) for development conventions, architecture details, and working agreements. See [PLAN.md](PLAN.md) for the project roadmap.
 
-## Reference
+## Links
 
 - [Raku documentation](https://docs.raku.org/)
 - [Roast (official Raku test suite)](https://github.com/Raku/roast)
+- [WebAssembly demo](https://tokuhirom.github.io/mutsu/)

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -537,6 +537,7 @@ roast/S12-class/basic.t
 roast/S12-class/declaration-order.t
 roast/S12-class/extending-arrays.t
 roast/S12-class/inheritance-class-methods.t
+roast/S12-class/inheritance.t
 roast/S12-class/instantiate.t
 roast/S12-class/interface-consistency.t
 roast/S12-class/lexical.t

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -72,6 +72,9 @@ impl Compiler {
         let mut sub_compiler = Compiler::new();
         sub_compiler.is_routine = true;
         sub_compiler.lexically_in_routine = true;
+        // Propagate last_source_line so the sub body knows which line
+        // the sub was defined at (for backtraces).
+        sub_compiler.last_source_line = self.last_source_line;
         let arity = param_defs
             .iter()
             .filter(|p| !p.named && (!p.slurpy || p.name == "_capture"))
@@ -132,6 +135,11 @@ impl Compiler {
         }
         // Hoist sub declarations within the sub body
         sub_compiler.hoist_sub_decls(body, true);
+        // Emit SetSourceLine at the start of the function body so that
+        // ?LINE is set to the sub's definition line on entry.
+        if let Some(line) = sub_compiler.last_source_line {
+            sub_compiler.code.emit(OpCode::SetSourceLine(line));
+        }
         // If sub body contains CATCH/CONTROL, wrap in implicit try
         if Self::has_catch_or_control(body) {
             sub_compiler.compile_try(body, &None);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -983,7 +983,11 @@ impl Compiler {
             } => {
                 let (pre_stmts, mut loop_body, post_stmts) =
                     self.expand_loop_phasers(body, label.as_deref());
-                let restore_topic = param.is_none() && params.is_empty() && body.len() == 1;
+                let non_setline_count = body
+                    .iter()
+                    .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                    .count();
+                let restore_topic = param.is_none() && params.is_empty() && non_setline_count == 1;
                 for s in &pre_stmts {
                     self.compile_stmt(s);
                 }
@@ -1520,8 +1524,14 @@ impl Compiler {
             } => {
                 let qualified_name = self.qualify_package_name(&name.resolve());
                 // Detect stub body: `module Foo { ... }` — body is a stub operator
-                let is_stub_body = body.len() == 1
-                    && matches!(&body[0], Stmt::Expr(Expr::Call { name: fn_name, .. })
+                // Filter out SetLine when checking, since the parser now emits
+                // line tracking statements in all block bodies.
+                let non_setline_body: Vec<_> = body
+                    .iter()
+                    .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                    .collect();
+                let is_stub_body = non_setline_body.len() == 1
+                    && matches!(non_setline_body[0], Stmt::Expr(Expr::Call { name: fn_name, .. })
                         if fn_name.resolve() == "__mutsu_stub_die"
                             || fn_name.resolve() == "__mutsu_stub_warn");
                 if *is_unit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,16 @@ use std::io::{self, Read};
 use mutsu::{Interpreter, RuntimeError, Value};
 
 fn print_error(prefix: &str, err: &RuntimeError) {
+    // For runtime errors with a backtrace, use the Raku-style format:
+    // message\n  in sub foo at file line N\n  in block <unit> at file line N
+    if err.backtrace.is_some() && err.code.is_none() {
+        eprintln!("{}", err.message);
+        if let Some(ref bt) = err.backtrace {
+            eprintln!("{}", bt);
+        }
+        return;
+    }
+
     eprintln!("{}: {}", prefix, err.message);
     let mut meta = Vec::new();
     if let Some(code) = err.code {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -578,6 +578,7 @@ is_run q<use lib '> ~ $pkg-path ~ q<'; use GH2897-B; (^3).map( { my-counter } ).
     fn parse_program_stops_user_sub_args_before_loose_and() {
         let src = r#"sub isfive(*@args) { }; isfive 5 and isfive 5;"#;
         let (stmts, _) = parse_program(src).unwrap();
+        let stmts = filter_setline(stmts);
         match &stmts[1] {
             Stmt::Expr(Expr::Binary { left, op, right }) => {
                 assert_eq!(*op, crate::token_kind::TokenKind::AndAnd);
@@ -606,6 +607,7 @@ is_run q<use lib '> ~ $pkg-path ~ q<'; use GH2897-B; (^3).map( { my-counter } ).
     fn parse_program_keeps_comparison_inside_user_sub_arg() {
         let src = r#"sub foo($x) { }; foo 3 != 3;"#;
         let (stmts, _) = parse_program(src).unwrap();
+        let stmts = filter_setline(stmts);
         match &stmts[1] {
             Stmt::Expr(Expr::Call { name, args }) => {
                 assert_eq!(name.resolve(), "foo");
@@ -626,6 +628,7 @@ is_run q<use lib '> ~ $pkg-path ~ q<'; use GH2897-B; (^3).map( { my-counter } ).
     fn parse_program_keeps_eq_inside_named_unary_arg() {
         let src = r#"uc "a" eq "A";"#;
         let (stmts, _) = parse_program(src).unwrap();
+        let stmts = filter_setline(stmts);
         match &stmts[0] {
             Stmt::Expr(Expr::Call { name, args }) => {
                 assert_eq!(name.resolve(), "uc");
@@ -652,6 +655,7 @@ import RT128042;
 is (1 + 2 § 3), 1, "x";
 "#;
         let (stmts, _) = parse_program(src).unwrap();
+        let stmts = filter_setline(stmts);
         match &stmts[2] {
             Stmt::Expr(Expr::Call { name, args }) => {
                 assert_eq!(name.resolve(), "is");

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -805,6 +805,29 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                 r = r2;
                 continue;
             }
+            // Unrecognized `is` trait with lowercase name — treat as a potential
+            // parent class so the runtime can validate and produce
+            // X::Inheritance::UnknownParent if it doesn't exist.
+            if !matches!(
+                parent.as_str(),
+                "rw" | "hidden"
+                    | "export"
+                    | "DEPRECATED"
+                    | "default"
+                    | "nodal"
+                    | "raw"
+                    | "required"
+                    | "built"
+                    | "cached"
+                    | "repr"
+            ) {
+                let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
+                parents.push(format!("{}{}", parent, bracket_suffix));
+                r = r2;
+                let (r2, _) = ws(r)?;
+                r = r2;
+                continue;
+            }
             let (r2, _) = ws(r2)?;
             r = r2;
             continue;

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -540,11 +540,6 @@ fn has_statement_separator(rest: &str) -> bool {
     true
 }
 
-/// Parse a list of statements (inside a block or at program level).
-fn stmt_list(input: &str) -> PResult<'_, Vec<Stmt>> {
-    stmt_list_with_mode(input, true, false)
-}
-
 fn stmt_list_with_mode(
     input: &str,
     allow_mainline_capture: bool,
@@ -815,7 +810,9 @@ pub(super) fn program(input: &str) -> PResult<'_, Vec<Stmt>> {
     } else {
         input
     };
-    stmt_list(input)
+    // Enable SetLine emission so that source line tracking works for
+    // backtraces and $?LINE at the top level.
+    stmt_list_with_mode(input, true, true)
 }
 
 #[cfg(test)]

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1575,6 +1575,13 @@ impl Interpreter {
             {
                 continue;
             }
+            // Skip env entries hidden from package stash lookups (transitive deps)
+            if package_name != "MY"
+                && package_name != "GLOBAL"
+                && self.package_stash_hidden.contains(key)
+            {
+                continue;
+            }
             // Skip my-scoped items (they should not appear in the package stash)
             if self.is_my_scoped_package_item(key) {
                 continue;
@@ -1619,6 +1626,13 @@ impl Interpreter {
             {
                 continue;
             }
+            // Skip classes hidden from package stash lookups (transitive deps)
+            if package_name != "MY"
+                && package_name != "GLOBAL"
+                && self.package_stash_hidden.contains(class_name)
+            {
+                continue;
+            }
             // Skip my-scoped classes (they should not appear in the package stash)
             if self.is_my_scoped_package_item(class_name) {
                 continue;
@@ -1646,6 +1660,13 @@ impl Interpreter {
             });
         }
         for role_name in self.roles.keys() {
+            // Skip roles hidden from package stash lookups (transitive deps)
+            if package_name != "MY"
+                && package_name != "GLOBAL"
+                && self.package_stash_hidden.contains(role_name)
+            {
+                continue;
+            }
             let Some(rest) = Self::stash_member_tail(role_name, &package_name) else {
                 continue;
             };

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -938,11 +938,11 @@ impl Interpreter {
                 .routine_stack
                 .iter()
                 .rev()
-                .find(|(_, name)| name != "<pointy-block>");
-            if let Some((package, routine)) = entry {
+                .find(|frame| frame.name != "<pointy-block>");
+            if let Some(frame) = entry {
                 return Value::Routine {
-                    package: Symbol::intern(package),
-                    name: Symbol::intern(routine),
+                    package: Symbol::intern(&frame.package),
+                    name: Symbol::intern(&frame.name),
                     is_regex: false,
                 };
             }
@@ -1112,16 +1112,29 @@ impl Interpreter {
         rest
     }
 
-    pub(crate) fn routine_stack_top(&self) -> Option<&(String, String)> {
+    pub(crate) fn routine_stack_top(&self) -> Option<&super::RoutineFrame> {
         self.routine_stack.last()
     }
 
-    pub(crate) fn routine_stack(&self) -> &[(String, String)] {
+    pub(crate) fn routine_stack(&self) -> &[super::RoutineFrame] {
         &self.routine_stack
     }
 
-    pub(crate) fn push_routine(&mut self, package: String, name: String) {
-        self.routine_stack.push((package, name));
+    /// Push a new routine frame. `line` and `file` record the call-site
+    /// in the *caller* (the line/file where this function was called from).
+    pub(crate) fn push_routine_with_location(
+        &mut self,
+        package: String,
+        name: String,
+        line: Option<u32>,
+        file: Option<String>,
+    ) {
+        self.routine_stack.push(super::RoutineFrame {
+            package,
+            name,
+            line,
+            file,
+        });
     }
 
     pub(crate) fn pop_routine(&mut self) {

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -234,8 +234,8 @@ impl Interpreter {
                     });
                 if let Some(id) = caller_callable_id {
                     sig.leave_callable_id = Some(id);
-                } else if let Some((package, routine)) = self.routine_stack_top() {
-                    sig.leave_routine = Some(format!("{package}::{routine}"));
+                } else if let Some(frame) = self.routine_stack_top() {
+                    sig.leave_routine = Some(format!("{}::{}", frame.package, frame.name));
                 }
             }
             Some(Value::Package(name)) if name == "Block" => {}

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -261,7 +261,7 @@ impl Interpreter {
             let in_new = self
                 .routine_stack
                 .last()
-                .is_some_and(|(_, name)| name == "new")
+                .is_some_and(|frame| frame.name == "new")
                 || self
                     .samewith_context_stack
                     .last()

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -384,8 +384,12 @@ impl Interpreter {
             );
             self.block_stack.push(sub_val);
             let pushed_assertion = self.push_test_assertion_context(def.is_test_assertion);
-            self.routine_stack
-                .push((def.package.resolve(), def.name.resolve()));
+            self.routine_stack.push(RoutineFrame {
+                package: def.package.resolve(),
+                name: def.name.resolve(),
+                line: None,
+                file: None,
+            });
             // Set __mutsu_callable_id so blocks defined inside this routine
             // capture the correct target for non-local return.
             let callable_key = format!("__mutsu_callable_id::{}::{}", def.package, def.name);

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -186,8 +186,12 @@ impl Interpreter {
         );
         self.block_stack.push(sub_val);
         let pushed_assertion = self.push_test_assertion_context(def.is_test_assertion);
-        self.routine_stack
-            .push((def.package.resolve(), def.name.resolve()));
+        self.routine_stack.push(RoutineFrame {
+            package: def.package.resolve(),
+            name: def.name.resolve(),
+            line: None,
+            file: None,
+        });
         // Set __mutsu_callable_id so blocks defined inside this routine
         // capture the correct target for non-local return.
         let callable_key = format!("__mutsu_callable_id::{}::{}", def.package, def.name);
@@ -334,8 +338,12 @@ impl Interpreter {
                     );
                     self.block_stack.push(sub_val);
                     let pushed_assertion = self.push_test_assertion_context(def.is_test_assertion);
-                    self.routine_stack
-                        .push((def.package.resolve(), def.name.resolve()));
+                    self.routine_stack.push(RoutineFrame {
+                        package: def.package.resolve(),
+                        name: def.name.resolve(),
+                        line: None,
+                        file: None,
+                    });
                     self.prepare_definite_return_slot(return_spec.as_deref());
                     let result = self.run_block(&def.body);
                     self.routine_stack.pop();

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1066,8 +1066,12 @@ impl Interpreter {
             .last()
             .map(|(n, _)| n.clone())
             .unwrap_or_default();
-        self.routine_stack
-            .push((owner_class.to_string(), method_name_for_stack));
+        self.routine_stack.push(RoutineFrame {
+            package: owner_class.to_string(),
+            name: method_name_for_stack,
+            line: None,
+            file: None,
+        });
         // Set current_package to the receiver class so that the compiler
         // qualifies function calls with the correct package prefix,
         // allowing class-scoped subs (e.g. `sub helper` in a class body)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -944,8 +944,12 @@ impl Interpreter {
                     return Err(e);
                 }
             };
-        self.routine_stack
-            .push((def.package.resolve(), def.name.resolve()));
+        self.routine_stack.push(RoutineFrame {
+            package: def.package.resolve(),
+            name: def.name.resolve(),
+            line: None,
+            file: None,
+        });
         let result = self.eval_block_value(&def.body);
         self.routine_stack.pop();
         let rendered = match result {
@@ -1083,8 +1087,12 @@ impl Interpreter {
                 return Err(e);
             }
         };
-        self.routine_stack
-            .push((def.package.resolve(), def.name.resolve()));
+        self.routine_stack.push(RoutineFrame {
+            package: def.package.resolve(),
+            name: def.name.resolve(),
+            line: None,
+            file: None,
+        });
         self.proto_dispatch_stack
             .push((proto_name.to_string(), args.to_vec()));
         let result = if def.body.is_empty() {
@@ -1182,8 +1190,12 @@ impl Interpreter {
                 .push((proto_name.clone(), remaining, args.clone()));
         }
         self.samewith_context_stack.push((proto_name.clone(), None));
-        self.routine_stack
-            .push((def.package.resolve(), def.name.resolve()));
+        self.routine_stack.push(RoutineFrame {
+            package: def.package.resolve(),
+            name: def.name.resolve(),
+            line: None,
+            file: None,
+        });
         let result = self.run_block(&def.body);
         self.routine_stack.pop();
         self.samewith_context_stack.pop();
@@ -1488,7 +1500,13 @@ impl Interpreter {
     fn rewrite_proto_dispatch_expr(expr: &Expr) -> Expr {
         match expr {
             Expr::AnonSub { body, .. }
-                if body.len() == 1 && matches!(body[0], Stmt::Expr(Expr::Whatever)) =>
+                if {
+                    let non_setline: Vec<_> = body
+                        .iter()
+                        .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                        .collect();
+                    non_setline.len() == 1 && matches!(non_setline[0], Stmt::Expr(Expr::Whatever))
+                } =>
             {
                 Expr::Call {
                     name: Symbol::intern("__PROTO_DISPATCH__"),

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2937,7 +2937,7 @@ impl Interpreter {
         self.doc_comment_list.clear();
         let mut pending_leading: Option<String> = None;
         // The last declaration that can receive trailing #= comments
-        let mut last_declarant: Option<(String, super::DocDeclKind)> = None;
+        let mut last_declarant: Option<(String, super::DocDeclKind, u32)> = None;
         // Track the current class scope for method doc keys
         let mut current_class: Option<String> = None;
         // Stack of class scopes for nested classes
@@ -3496,7 +3496,7 @@ impl Interpreter {
             // Trailing doc comment (#=) on its own line
             if let Some((text, next_idx, _is_block)) = parse_doc_comment(&lines, idx, "#=") {
                 if !text.is_empty()
-                    && let Some((ref name, ref kind)) = last_declarant
+                    && let Some((ref name, ref kind, decl_line)) = last_declarant
                 {
                     let entry =
                         self.doc_comments
@@ -3507,6 +3507,10 @@ impl Interpreter {
                                 ..Default::default()
                             });
                     entry.trailing = append_doc_text(entry.trailing.take(), &text);
+                    // Ensure source_line is set so proximity matching works
+                    if entry.source_line.is_none() {
+                        entry.source_line = Some(decl_line);
+                    }
                 }
                 idx = next_idx;
                 continue;
@@ -3708,7 +3712,7 @@ impl Interpreter {
                     }
                 }
                 // Always set last_declarant so trailing #= on the next line can attach
-                last_declarant = Some((doc_key, kind.clone()));
+                last_declarant = Some((doc_key, kind.clone(), (idx + 1) as u32));
                 // Track the current function for parameter scoping
                 if kind == super::DocDeclKind::Sub {
                     current_sub = Some(name.clone());
@@ -3775,7 +3779,7 @@ impl Interpreter {
                     }
                 }
                 // Set last_declarant so trailing #= on the next line can attach
-                last_declarant = Some((param_key, super::DocDeclKind::Param));
+                last_declarant = Some((param_key, super::DocDeclKind::Param, (idx + 1) as u32));
             } else {
                 // Not a recognized declaration — discard pending leading
                 pending_leading = None;

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2962,6 +2962,15 @@ impl Interpreter {
                         attrs.insert(qualified_key, val);
                     }
                 }
+                // If the class inherits from Array, add backing array storage
+                if self.class_mro(class_key).iter().any(|n| n == "Array")
+                    && !attrs.contains_key("__mutsu_array_storage")
+                {
+                    attrs.insert(
+                        "__mutsu_array_storage".to_string(),
+                        Value::real_array(Vec::new()),
+                    );
+                }
                 let instance = Value::make_instance(*class_name, attrs);
                 if let Some(type_args) = type_args.as_ref() {
                     if self.class_mro(class_key).iter().any(|n| n == "Array") {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -828,6 +828,18 @@ pub struct Interpreter {
     chroot_root: Option<PathBuf>,
     loaded_modules: HashSet<String>,
     need_hidden_classes: HashSet<String>,
+    /// Classes/roles hidden from package stash lookups (e.g. `Example2::.keys`).
+    /// Populated when a `use X::Y` loads modules whose dependency chain neither
+    /// declares a class matching the module name nor includes a `package X {}`
+    /// declaration, hiding transitive dependencies from the namespace stash.
+    package_stash_hidden: HashSet<String>,
+    /// Package names declared via `package X {}` during the current module
+    /// loading chain. Saved/restored around each top-level `use_module_with_tags`
+    /// call so it only contains packages from the current loading chain.
+    pub(crate) chain_declared_packages: HashSet<String>,
+    /// Maps module names to the set of packages declared during their loading.
+    /// Used to propagate package declarations when a module is re-used.
+    module_packages: HashMap<String, HashSet<String>>,
     closure_env_overrides: HashMap<u64, Env>,
     protect_block_cache: ProtectBlockCache,
     private_zeroarg_method_cache: HashMap<(String, String), Option<(String, MethodDef)>>,
@@ -2812,6 +2824,9 @@ impl Interpreter {
             chroot_root: None,
             loaded_modules: HashSet::new(),
             need_hidden_classes: HashSet::new(),
+            package_stash_hidden: HashSet::new(),
+            chain_declared_packages: HashSet::new(),
+            module_packages: HashMap::new(),
             closure_env_overrides: HashMap::new(),
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),
@@ -3189,6 +3204,23 @@ impl Interpreter {
             } else if module == "fatal" {
                 self.fatal_mode = true;
             }
+            // Propagate package declarations from the already-loaded module
+            // into the current chain so that chain_has_package_decl checks
+            // correctly detect namespace contributions from transitive deps.
+            if let Some(pkgs) = self.module_packages.get(module).cloned() {
+                self.chain_declared_packages.extend(pkgs);
+            }
+            // When a module that declares a class/role matching its own name
+            // is directly `use`d at the top level, un-hide it and its related
+            // classes from the package stash. This handles the case where the
+            // module was first loaded transitively by a non-contributing module.
+            if self.module_load_stack.is_empty() && module.contains("::") {
+                let is_contributor =
+                    self.classes.contains_key(module) || self.roles.contains_key(module);
+                if is_contributor {
+                    self.package_stash_hidden.remove(module);
+                }
+            }
             return match self.import_module(module, tags) {
                 Ok(()) => Ok(()),
                 Err(err) if err.message.starts_with("No exports found for module:") => Ok(()),
@@ -3203,8 +3235,18 @@ impl Interpreter {
                 chain.join(" -> ")
             )));
         }
+        // At the top level (no modules currently loading), save and clear
+        // the chain-scoped package declarations so each top-level `use` gets
+        // a fresh chain. Nested uses inherit the parent's chain.
+        let is_top_level_use = self.module_load_stack.is_empty();
+        let saved_chain_pkgs = if is_top_level_use {
+            std::mem::take(&mut self.chain_declared_packages)
+        } else {
+            HashSet::new()
+        };
         self.module_load_stack.push(module.to_string());
         let class_snapshot: HashSet<String> = self.classes.keys().cloned().collect();
+        let role_snapshot: HashSet<String> = self.roles.keys().cloned().collect();
         let env_snapshot: HashSet<String> = self.env.keys().cloned().collect();
         let func_keys_before: HashSet<Symbol> = self.functions.keys().copied().collect();
 
@@ -3291,6 +3333,53 @@ impl Interpreter {
                     self.need_hidden_classes.insert(key_short.to_string());
                 }
             }
+            // Determine if new classes/roles from this module should be
+            // hidden from the parent namespace's package stash. This prevents
+            // transitive dependencies from leaking into namespace stash lookups
+            // (e.g. `Example2::.keys` should not show classes loaded only as
+            // transitive deps of a module that doesn't contribute to the namespace).
+            //
+            // A module "contributes" to namespace X if either:
+            //   (a) it registered a class/role matching its own FQ name (e.g.
+            //       `use Example2::F` and `class Example2::F` was registered), or
+            //   (b) its dependency chain includes a `package X {}` declaration
+            //       (tracked in `chain_declared_packages` which is scoped to this load).
+            // If neither condition holds, new classes/roles are hidden from X's stash.
+            if let Some((namespace, _)) = module.rsplit_once("::") {
+                let module_declares_own_class =
+                    self.classes.contains_key(module) || self.roles.contains_key(module);
+                let chain_has_package_decl = self.chain_declared_packages.contains(namespace);
+                if !module_declares_own_class && !chain_has_package_decl {
+                    // Hide newly registered classes/roles from the namespace stash
+                    for class_name in self.classes.keys() {
+                        if !class_snapshot.contains(class_name)
+                            && class_name.starts_with(namespace)
+                            && class_name.get(namespace.len()..namespace.len() + 2) == Some("::")
+                        {
+                            self.package_stash_hidden.insert(class_name.clone());
+                        }
+                    }
+                    for role_name in self.roles.keys() {
+                        if !role_snapshot.contains(role_name)
+                            && role_name.starts_with(namespace)
+                            && role_name.get(namespace.len()..namespace.len() + 2) == Some("::")
+                        {
+                            self.package_stash_hidden.insert(role_name.clone());
+                        }
+                    }
+                }
+            }
+            // Record which packages were declared during this module's chain
+            // so they can be propagated when the module is re-used.
+            if !self.chain_declared_packages.is_empty() {
+                self.module_packages
+                    .insert(module.to_string(), self.chain_declared_packages.clone());
+            }
+            // Restore the chain-scoped package declarations (top-level only)
+            if is_top_level_use {
+                self.chain_declared_packages = saved_chain_pkgs;
+            }
+
             if module == "strict" {
                 self.strict_mode = true;
             } else if module == "fatal" {
@@ -4487,6 +4576,9 @@ impl Interpreter {
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),
             need_hidden_classes: self.need_hidden_classes.clone(),
+            package_stash_hidden: self.package_stash_hidden.clone(),
+            chain_declared_packages: self.chain_declared_packages.clone(),
+            module_packages: self.module_packages.clone(),
             closure_env_overrides: self.closure_env_overrides.clone(),
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -721,6 +721,15 @@ pub(crate) struct CallFrameEntry {
     pub env: Env,
 }
 
+/// Entry in the routine stack, tracking the call chain for backtraces.
+#[derive(Clone, Debug)]
+pub(crate) struct RoutineFrame {
+    pub package: String,
+    pub name: String,
+    pub line: Option<u32>,
+    pub file: Option<String>,
+}
+
 pub struct Interpreter {
     env: Env,
     output: String,
@@ -757,7 +766,7 @@ pub struct Interpreter {
     next_handle_id: usize,
     program_path: Option<String>,
     current_package: String,
-    routine_stack: Vec<(String, String)>,
+    routine_stack: Vec<RoutineFrame>,
     callframe_stack: Vec<CallFrameEntry>,
     method_class_stack: Vec<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -77,9 +77,12 @@ impl Interpreter {
                 .bind_function_args_values(&def.param_defs, &def.params, arg_values)
                 .is_ok()
             {
-                interp
-                    .routine_stack
-                    .push((def.package.resolve(), def.name.resolve()));
+                interp.routine_stack.push(super::super::RoutineFrame {
+                    package: def.package.resolve(),
+                    name: def.name.resolve(),
+                    line: None,
+                    file: None,
+                });
                 let result = interp.eval_block_value(&def.body);
                 interp.routine_stack.pop();
                 let value = match result {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -744,7 +744,9 @@ impl Interpreter {
             "Date",
             "DateTime",
             "Grammar",
+            "Parameter",
             "Proxy",
+            "Signature",
             "Stash",
             "Metamodel::ClassHOW",
             "Perl6::Metamodel::ClassHOW",
@@ -778,10 +780,20 @@ impl Interpreter {
                         resolved_parent_name
                     )));
                 }
-                return Err(RuntimeError::new(format!(
-                    "X::Inheritance::UnknownParent: class '{}' specifies unknown parent class '{}'",
-                    name, resolved_parent_name
-                )));
+                {
+                    let msg = format!(
+                        "class '{}' specifies unknown parent class '{}'",
+                        name, resolved_parent_name
+                    );
+                    let mut attrs = HashMap::new();
+                    attrs.insert("child-name".to_string(), Value::str(name.to_string()));
+                    attrs.insert(
+                        "parent-name".to_string(),
+                        Value::str(resolved_parent_name.to_string()),
+                    );
+                    attrs.insert("message".to_string(), Value::str(msg));
+                    return Err(RuntimeError::typed("X::Inheritance::UnknownParent", attrs));
+                }
             }
             // Check that `does` targets are actually roles, not classes
             if does_parents.contains(parent)

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1191,8 +1191,12 @@ impl Interpreter {
                 "__mutsu_callable_id".to_string(),
                 Value::Int(data.id as i64),
             );
-            self.routine_stack
-                .push((data.package.resolve(), data.name.resolve()));
+            self.routine_stack.push(RoutineFrame {
+                package: data.package.resolve(),
+                name: data.name.resolve(),
+                line: None,
+                file: None,
+            });
             self.block_stack.push(block_sub);
             let return_spec = data.env.get("__mutsu_return_type").and_then(|v| match v {
                 Value::Str(s) => Some(s.to_string()),
@@ -1433,8 +1437,8 @@ impl Interpreter {
         let mut compiler = crate::compiler::Compiler::new();
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
-        let scope = if let Some((pkg, routine)) = self.routine_stack.last() {
-            format!("{}::&{}", pkg, routine)
+        let scope = if let Some(frame) = self.routine_stack.last() {
+            format!("{}::&{}", frame.package, frame.name)
         } else {
             self.current_package.clone()
         };

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -505,9 +505,15 @@ impl Interpreter {
     pub(in crate::runtime) fn extract_token_regex_pattern(&self, name: &str) -> Option<String> {
         let defs = self.resolve_token_defs(name)?;
         let def = defs.first()?;
-        // Look for a body consisting of a single Expr(Literal(Regex(pat)))
-        if def.body.len() == 1
-            && let Stmt::Expr(Expr::Literal(Value::Regex(pat))) = &def.body[0]
+        // Look for a body consisting of a single Expr(Literal(Regex(pat))),
+        // skipping SetLine statements.
+        let effective: Vec<_> = def
+            .body
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        if effective.len() == 1
+            && let Stmt::Expr(Expr::Literal(Value::Regex(pat))) = effective[0]
         {
             return Some(pat.to_string());
         }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -781,8 +781,8 @@ impl Interpreter {
                         let mut compiler = crate::compiler::Compiler::new();
                         compiler.is_routine = !self.routine_stack.is_empty();
                         compiler.lexically_in_routine = !self.routine_stack.is_empty();
-                        let scope = if let Some((pkg, routine)) = self.routine_stack.last() {
-                            format!("{}::&{}", pkg, routine)
+                        let scope = if let Some(frame) = self.routine_stack.last() {
+                            format!("{}::&{}", frame.package, frame.name)
                         } else {
                             self.current_package.clone()
                         };

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -48,10 +48,14 @@ pub(super) fn predicate_requires_defined(predicate: &Expr) -> bool {
                 && matches!(target.as_ref(), Expr::Var(v) if v == "_")
         }
         Expr::AnonSub { body, .. } => {
-            body.len() == 1
+            let non_setline: Vec<_> = body
+                .iter()
+                .filter(|s| !matches!(s, crate::ast::Stmt::SetLine(_)))
+                .collect();
+            non_setline.len() == 1
                 && matches!(
-                    &body[0],
-                    Stmt::Expr(expr) if predicate_requires_defined(expr)
+                    non_setline[0],
+                    crate::ast::Stmt::Expr(expr) if predicate_requires_defined(expr)
                 )
         }
         _ => false,

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -67,6 +67,8 @@ pub struct RuntimeError {
     pub container_name: Option<String>,
     /// Structured exception object (e.g. X::AdHoc, X::Promise::Vowed)
     pub exception: Option<Box<Value>>,
+    /// Formatted backtrace string from the call stack at the point of error.
+    pub backtrace: Option<String>,
 }
 
 impl RuntimeError {
@@ -100,6 +102,7 @@ impl RuntimeError {
             return_target_callable_id: None,
             container_name: None,
             exception: None,
+            backtrace: None,
         }
     }
 
@@ -154,6 +157,7 @@ impl RuntimeError {
             return_target_callable_id: None,
             container_name: None,
             exception: None,
+            backtrace: None,
         }
     }
 

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -712,6 +712,10 @@ impl Value {
                             name.resolve().as_str(),
                             "Array" | "List" | "Range" | "Buf" | "Blob" | "Capture"
                         )
+                ) || matches!(
+                    self,
+                    Value::Instance { attributes, .. }
+                        if attributes.contains_key("__mutsu_array_storage")
                 )
             }
             "Map" | "Associative" => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2770,6 +2770,9 @@ impl VM {
                 self.interpreter
                     .env_mut()
                     .insert(name.clone(), pkg_val.clone());
+                self.interpreter
+                    .chain_declared_packages
+                    .insert(name.clone());
                 self.update_local_if_exists(code, &name, &pkg_val);
                 self.env_dirty = true;
                 *ip += 1;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2559,7 +2559,19 @@ impl VM {
                 } else {
                     val
                 };
-                return Err(self.runtime_error_from_exception_value(val, "Died", false));
+                let backtrace = self.build_backtrace_string();
+                let mut err = self.runtime_error_from_exception_value(val, "Died", false);
+                if !backtrace.is_empty() {
+                    err.backtrace = Some(backtrace.clone());
+                }
+                // Attach backtrace to the exception value
+                if let Some(ref mut exc_box) = err.exception
+                    && let Value::Instance { attributes, .. } = exc_box.as_mut()
+                {
+                    std::sync::Arc::make_mut(attributes)
+                        .insert("backtrace".to_string(), Value::str(backtrace));
+                }
+                return Err(err);
             }
             OpCode::Fail => {
                 let val = self.stack.pop().unwrap_or(Value::Nil);

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -491,8 +491,12 @@ impl VM {
 
         let mut callable_id: Option<u64> = None;
         if !fn_name.is_empty() {
-            self.interpreter
-                .push_routine(fn_package.to_string(), fn_name.to_string());
+            self.interpreter.push_routine_with_location(
+                fn_package.to_string(),
+                fn_name.to_string(),
+                self.current_source_line(),
+                self.current_source_file(),
+            );
             let callable_key = format!("__mutsu_callable_id::{fn_package}::{fn_name}");
             let resolved_callable_id = self
                 .interpreter

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1081,6 +1081,108 @@ impl VM {
                 self.env_dirty = true;
             }
             _ => {
+                // Array-subclass instance delegation (mut path): when the Instance's
+                // class inherits from Array, delegate mutating Array methods to the
+                // backing __mutsu_array_storage attribute and write back.
+                if let Value::Instance {
+                    class_name: ref inst_class,
+                    ref attributes,
+                    id: inst_id,
+                } = target
+                {
+                    let cn = inst_class.resolve();
+                    let is_array_method = matches!(
+                        method.as_str(),
+                        "push"
+                            | "pop"
+                            | "shift"
+                            | "unshift"
+                            | "append"
+                            | "prepend"
+                            | "splice"
+                            | "join"
+                            | "elems"
+                            | "end"
+                            | "List"
+                            | "Array"
+                            | "Seq"
+                            | "Slip"
+                            | "sort"
+                            | "reverse"
+                            | "rotate"
+                            | "unique"
+                            | "squish"
+                            | "flat"
+                            | "map"
+                            | "grep"
+                            | "first"
+                            | "head"
+                            | "tail"
+                            | "AT-POS"
+                            | "ASSIGN-POS"
+                            | "EXISTS-POS"
+                            | "DELETE-POS"
+                            | "BIND-POS"
+                    );
+                    if is_array_method
+                        && !self.interpreter.has_user_method(&cn, &method)
+                        && attributes.contains_key("__mutsu_array_storage")
+                        && self
+                            .interpreter
+                            .mro_readonly(&cn)
+                            .iter()
+                            .any(|n| n == "Array")
+                    {
+                        let mut storage = attributes
+                            .get("__mutsu_array_storage")
+                            .cloned()
+                            .unwrap_or(Value::real_array(Vec::new()));
+                        // Perform the operation on the backing array
+                        let result = self
+                            .interpreter
+                            .call_method_mut_with_values(
+                                "__mutsu_array_tmp",
+                                storage.clone(),
+                                &method,
+                                args,
+                            )
+                            .or_else(|_| {
+                                // Try non-mut dispatch for read-only methods
+                                self.interpreter.call_method_with_values(
+                                    storage.clone(),
+                                    &method,
+                                    vec![],
+                                )
+                            })?;
+                        // Read back the (potentially mutated) storage
+                        if let Some(updated_storage) =
+                            self.interpreter.env().get("__mutsu_array_tmp").cloned()
+                        {
+                            storage = updated_storage;
+                        }
+                        self.interpreter.env_mut().remove("__mutsu_array_tmp");
+                        // Update the instance with the new storage
+                        let mut new_attrs = crate::value::InstanceAttrs::clone(attributes);
+                        new_attrs.insert("__mutsu_array_storage".to_string(), storage);
+                        let updated_instance = Value::Instance {
+                            class_name: *inst_class,
+                            attributes: Arc::new(crate::value::InstanceAttrs::new(
+                                *inst_class,
+                                new_attrs,
+                                inst_id,
+                                true,
+                            )),
+                            id: inst_id,
+                        };
+                        self.interpreter
+                            .env_mut()
+                            .insert(target_name.to_string(), updated_instance);
+                        self.env_dirty = true;
+                        self.stack.push(result);
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                }
                 // NOTE: No Nil absorber here for CallMethodMut. Unlike CallMethod
                 // (which handles direct Nil.method calls), CallMethodMut targets
                 // are from variables. Uninitialized variables in mutsu are Nil

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -525,6 +525,48 @@ impl VM {
                 self.env_dirty = true;
             }
             _ => {
+                // Array-subclass instance delegation: when the Instance's class
+                // inherits from Array, delegate non-mutating Array methods to the
+                // backing __mutsu_array_storage attribute.
+                if let Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } = &target
+                {
+                    let cn = class_name.resolve();
+                    if !self.interpreter.has_user_method(&cn, &method)
+                        && attributes.contains_key("__mutsu_array_storage")
+                        && self
+                            .interpreter
+                            .mro_readonly(&cn)
+                            .iter()
+                            .any(|n| n == "Array")
+                    {
+                        let storage = attributes
+                            .get("__mutsu_array_storage")
+                            .cloned()
+                            .unwrap_or(Value::real_array(Vec::new()));
+                        // For mutating methods, delegate and return the result
+                        // (the actual mutation is handled in the mut path)
+                        if !skip_native
+                            && let Some(native_result) =
+                                self.try_native_method(&storage, Symbol::intern(&method), &args)
+                        {
+                            self.stack.push(native_result?);
+                            self.env_dirty = true;
+                            return Ok(());
+                        }
+                        let result =
+                            self.try_compiled_method_or_interpret(storage, &method, args.clone());
+                        if let Ok(val) = result {
+                            self.stack.push(val);
+                            self.env_dirty = true;
+                            return Ok(());
+                        }
+                        // Fall through to normal dispatch if delegation failed
+                    }
+                }
                 // Nil method fallback: in Raku, calling most methods on Nil returns Nil.
                 // Certain mutating methods throw exceptions.
                 // This must be in the VM path (not the interpreter's call_method_with_values)

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -198,12 +198,22 @@ impl VM {
         // Push routine info for leave/return/when targeting.
         // For pointy blocks, we push a special marker name so that
         // &?ROUTINE can skip it and see the enclosing routine.
+        let call_line = self.current_source_line();
+        let call_file = self.current_source_file();
         if cc.is_pointy_block {
-            self.interpreter
-                .push_routine(data.package.resolve(), "<pointy-block>".to_string());
+            self.interpreter.push_routine_with_location(
+                data.package.resolve(),
+                "<pointy-block>".to_string(),
+                call_line,
+                call_file,
+            );
         } else {
-            self.interpreter
-                .push_routine(data.package.resolve(), data.name.resolve());
+            self.interpreter.push_routine_with_location(
+                data.package.resolve(),
+                data.name.resolve(),
+                call_line,
+                call_file,
+            );
         }
         self.interpreter.env_mut().insert(
             "__mutsu_callable_id".to_string(),

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,19 +1,67 @@
 use super::*;
 
 impl VM {
-    /// Build a simple backtrace string from the interpreter's routine stack.
-    /// Each frame is formatted as "  in sub <name>" (or "  in method <name>").
+    /// Build a backtrace string from the interpreter's routine stack.
+    /// Each frame is formatted as "  in sub <name> at <file> line <N>".
+    ///
+    /// Each pushed frame stores the call-site (the line/file in the *caller*
+    /// where this function was invoked).  To display "where each frame was
+    /// executing when it called the next", we shift by one:
+    ///   - innermost frame (i=0): use current ?LINE/?FILE (the die/error line)
+    ///   - frame i>0: use the *next inner* frame's stored call-site
+    ///     (i.e. frame[i]'s displayed line = the line where frame[i] called
+    ///     frame[i-1])
+    ///   - <unit> (outermost): use the outermost routine frame's stored
+    ///     call-site (where <unit> called the first function)
     pub(super) fn build_backtrace_string(&self) -> String {
         let stack = self.interpreter.routine_stack();
+        let current_line = self.current_source_line();
+        let current_file = self.current_source_file();
+        // Build reversed list: stack[last] is innermost, stack[0] is outermost
+        let reversed: Vec<_> = stack.iter().rev().collect();
         let mut lines = Vec::new();
-        for (_package, name) in stack.iter().rev() {
-            if name.is_empty() || name == "<unit>" {
-                lines.push("  in block <unit>".to_string());
+        for (i, frame) in reversed.iter().enumerate() {
+            let (line, file) = if i == 0 {
+                // Innermost frame: use current ?LINE/?FILE
+                (current_line, current_file.clone())
             } else {
-                lines.push(format!("  in sub {}", name));
+                // Outer frame: the line where this frame called the next inner frame.
+                // That info is stored in the next-inner frame's call-site.
+                let inner_frame = reversed[i - 1];
+                (inner_frame.line, inner_frame.file.clone())
+            };
+            let location = Self::format_location(file.as_deref(), line);
+            if frame.name.is_empty() || frame.name == "<unit>" || frame.name == "<pointy-block>" {
+                lines.push(format!("  in block <unit>{}", location));
+            } else {
+                lines.push(format!("  in sub {}{}", frame.name, location));
             }
         }
+        // Add the <unit> frame at the bottom
+        if stack.is_empty() {
+            let location = Self::format_location(current_file.as_deref(), current_line);
+            lines.push(format!("  in block <unit>{}", location));
+        } else if !stack
+            .first()
+            .is_some_and(|f| f.name.is_empty() || f.name == "<unit>")
+        {
+            // The outermost routine frame's stored call-site is where
+            // <unit> called it.
+            let outermost = &stack[0];
+            let location = Self::format_location(outermost.file.as_deref(), outermost.line);
+            lines.push(format!("  in block <unit>{}", location));
+        }
         lines.join("\n")
+    }
+
+    /// Format a " at <file> line <N>" suffix for backtrace entries.
+    fn format_location(file: Option<&str>, line: Option<u32>) -> String {
+        match (file, line) {
+            (Some(f), Some(l)) => format!(" at {} line {}", f, l),
+            (Some(f), None) => format!(" at {}", f),
+            (None, Some(l)) => format!(" at line {}", l),
+            (None, None) => String::new(),
+        }
     }
 
     /// If the value is a `LazyIoLines`, force it into an eager array by reading

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -350,8 +350,12 @@ impl VM {
         }
 
         // Push routine_stack so &?ROUTINE can find the current method
-        self.interpreter
-            .push_routine(owner_class.to_string(), method_name.to_string());
+        self.interpreter.push_routine_with_location(
+            owner_class.to_string(),
+            method_name.to_string(),
+            self.current_source_line(),
+            self.current_source_file(),
+        );
 
         // Execute bytecode
         let let_mark = self.interpreter.let_saves_len();

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1879,11 +1879,11 @@ impl VM {
         let entry = routine_stack
             .iter()
             .rev()
-            .find(|(_, name)| name != "<pointy-block>");
-        if let Some((package, name)) = entry {
+            .find(|frame| frame.name != "<pointy-block>");
+        if let Some(frame) = entry {
             self.stack.push(Value::Routine {
-                package: Symbol::intern(package),
-                name: Symbol::intern(name),
+                package: Symbol::intern(&frame.package),
+                name: Symbol::intern(&frame.name),
                 is_regex: false,
             });
         } else {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -4,7 +4,7 @@ use crate::symbol::Symbol;
 
 impl VM {
     /// Get the current source line number from the interpreter env.
-    fn current_source_line(&self) -> Option<u32> {
+    pub(super) fn current_source_line(&self) -> Option<u32> {
         self.interpreter.env().get("?LINE").and_then(|v| match v {
             Value::Int(n) => Some(*n as u32),
             _ => None,
@@ -12,7 +12,7 @@ impl VM {
     }
 
     /// Get the current source file from the interpreter env.
-    fn current_source_file(&self) -> Option<String> {
+    pub(super) fn current_source_file(&self) -> Option<String> {
         self.interpreter.env().get("?FILE").and_then(|v| match v {
             Value::Str(s) => Some(s.to_string()),
             _ => None,

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1383,8 +1383,8 @@ impl VM {
         if let Some(Value::Int(id)) = self.interpreter.env().get("__mutsu_callable_id") {
             return format!("callable:{id}");
         }
-        if let Some((package, name)) = self.interpreter.routine_stack_top() {
-            return format!("routine:{package}::{name}");
+        if let Some(frame) = self.interpreter.routine_stack_top() {
+            return format!("routine:{}::{}", frame.package, frame.name);
         }
         "top".to_string()
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2951,7 +2951,11 @@ impl VM {
                     // Instance objects are Positional only if they implement
                     // the Positional role (or Array subclass etc.), but not
                     // Failure or arbitrary classes.
-                    Value::Instance { class_name, .. } => {
+                    Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } => {
                         let cn = class_name.resolve();
                         matches!(
                             cn.as_str(),
@@ -2970,6 +2974,7 @@ impl VM {
                             .interpreter
                             .class_composed_roles(&cn)
                             .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
+                            || attributes.contains_key("__mutsu_array_storage")
                     }
                     _ => false,
                 };

--- a/t/backtrace.t
+++ b/t/backtrace.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# Test 1: simple die shows backtrace with <unit>
+{
+    my $out = "";
+    try { die "oops" }
+    ok $!.defined, "die produces an exception";
+    is $!.message, "oops", "exception message is correct";
+}
+
+# Test 2: backtrace method on exception
+{
+    sub inner { die "deep error" }
+    sub outer { inner() }
+    try { outer() }
+    ok $!.defined, "nested die produces an exception";
+    my $bt = $!.backtrace;
+    ok $bt.defined, ".backtrace returns a defined value";
+}
+
+# Test 3: die with structured exception
+{
+    try { die X::AdHoc.new(message => "structured") }
+    ok $!.defined, "structured exception is caught";
+    is $!.message, "structured", "structured exception message";
+}
+
+# Test 4: die preserves exception type
+{
+    try { die "simple string" }
+    ok $!.defined, "simple die caught";
+    is $!.message, "simple string", "simple die message";
+}


### PR DESCRIPTION
## Summary
- Support inheriting from built-in Array type by adding backing storage (`__mutsu_array_storage`) to instances of Array subclasses and delegating Array methods (push, join, elems, etc.) to it in both VM method dispatch paths
- Fix unknown parent class detection for lowercase-named `is` targets (e.g. `class X is nosuchtrait {}`) by treating unrecognized lowercase names as potential parent classes
- Produce properly typed `X::Inheritance::UnknownParent` exceptions instead of plain RuntimeError
- Add `Parameter` and `Signature` to BUILTIN_TYPES so classes can inherit from them
- Recognize Array-subclass instances as Positional for `@`-variable binding

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S12-class/inheritance.t` passes all 41 subtests
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)