### PR TITLE
feat: implement .line, .file, and .backtrace methods on exception objects

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -328,7 +328,7 @@ pub(crate) fn native_method_0arg(
     if matches!(target, Value::Nil)
         && matches!(
             method,
-            "message" | "payload" | "backtrace" | "exception" | "handled"
+            "message" | "payload" | "backtrace" | "exception" | "handled" | "line" | "file"
         )
     {
         return Some(Ok(Value::Nil));
@@ -1107,6 +1107,24 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         && let Some(payload) = attributes.get("payload")
                     {
                         return Some(Ok(payload.clone()));
+                    }
+                    return Some(Ok(Value::str(String::new())));
+                }
+                "line" => {
+                    if let Some(line) = attributes.get("line") {
+                        return Some(Ok(line.clone()));
+                    }
+                    return Some(Ok(Value::Nil));
+                }
+                "file" => {
+                    if let Some(file) = attributes.get("file") {
+                        return Some(Ok(file.clone()));
+                    }
+                    return Some(Ok(Value::Nil));
+                }
+                "backtrace" => {
+                    if let Some(bt) = attributes.get("backtrace") {
+                        return Some(Ok(bt.clone()));
                     }
                     return Some(Ok(Value::str(String::new())));
                 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2560,16 +2560,28 @@ impl VM {
                     val
                 };
                 let backtrace = self.build_backtrace_string();
+                let current_line = self.current_source_line();
+                let current_file = self.current_source_file();
                 let mut err = self.runtime_error_from_exception_value(val, "Died", false);
                 if !backtrace.is_empty() {
                     err.backtrace = Some(backtrace.clone());
                 }
-                // Attach backtrace to the exception value
+                // Attach backtrace, line, and file to the exception value
                 if let Some(ref mut exc_box) = err.exception
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
-                    std::sync::Arc::make_mut(attributes)
-                        .insert("backtrace".to_string(), Value::str(backtrace));
+                    let attrs = std::sync::Arc::make_mut(attributes);
+                    attrs.insert("backtrace".to_string(), Value::str(backtrace));
+                    if let Some(line) = current_line {
+                        attrs
+                            .entry("line".to_string())
+                            .or_insert(Value::Int(line as i64));
+                    }
+                    if let Some(ref file) = current_file {
+                        attrs
+                            .entry("file".to_string())
+                            .or_insert(Value::str_from(file));
+                    }
                 }
                 return Err(err);
             }
@@ -2595,13 +2607,25 @@ impl VM {
                 // Build a backtrace from the routine stack so that
                 // Exception.gist can show where the fail originated.
                 let backtrace = self.build_backtrace_string();
+                let current_line = self.current_source_line();
+                let current_file = self.current_source_file();
                 let mut err = self.runtime_error_from_exception_value(val, "Failed", true);
-                // Attach backtrace to the exception value
+                // Attach backtrace, line, and file to the exception value
                 if let Some(ref mut exc_box) = err.exception
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
-                    std::sync::Arc::make_mut(attributes)
-                        .insert("backtrace".to_string(), Value::str(backtrace));
+                    let attrs = std::sync::Arc::make_mut(attributes);
+                    attrs.insert("backtrace".to_string(), Value::str(backtrace));
+                    if let Some(line) = current_line {
+                        attrs
+                            .entry("line".to_string())
+                            .or_insert(Value::Int(line as i64));
+                    }
+                    if let Some(ref file) = current_file {
+                        attrs
+                            .entry("file".to_string())
+                            .or_insert(Value::str_from(file));
+                    }
                 }
                 return Err(err);
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1895,6 +1895,12 @@ impl VM {
                 } else {
                     let mut exc_attrs = std::collections::HashMap::new();
                     exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
+                    if let Some(line) = e.line {
+                        exc_attrs.insert("line".to_string(), Value::Int(line as i64));
+                    }
+                    if let Some(ref bt) = e.backtrace {
+                        exc_attrs.insert("backtrace".to_string(), Value::str(bt.clone()));
+                    }
                     Value::make_instance(Symbol::intern("Exception"), exc_attrs)
                 };
                 let saved_topic = self.interpreter.env().get("_").cloned();

--- a/t/exception-methods.t
+++ b/t/exception-methods.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 8;
+
+# Basic .message method
+{
+    try { die "oops" };
+    is $!.message, "oops", '$!.message returns the error message';
+}
+
+# .line method returns an Int
+{
+    try { die "test" };
+    ok $!.line.defined, '$!.line is defined';
+    isa-ok $!.line, Int, '$!.line returns an Int';
+}
+
+# .file method returns a Str
+{
+    try { die "test" };
+    ok $!.file.defined, '$!.file is defined';
+    isa-ok $!.file, Str, '$!.file returns a Str';
+}
+
+# .backtrace method returns a string
+{
+    try { die "test" };
+    ok $!.backtrace.defined, '$!.backtrace is defined';
+}
+
+# When $! is Nil (no error), methods return Nil
+{
+    try { 1 + 1 };
+    ok !$!.message.defined, '$!.message is Nil when no error';
+    ok !$!.line.defined, '$!.line is Nil when no error';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- Expose `.line`, `.file`, `.message`, and `.backtrace` methods on caught exception objects (`$!`)
- Die and Fail opcodes now attach source line/file attributes to exception values
- Try/catch fallback path also propagates line/backtrace info to synthesized Exception instances
- Nil absorber covers `.line` and `.file` so `$!.line` returns Nil when no error occurred

## Test plan
- [x] `try { die "oops" }; say $!.line; say $!.file; say $!.message` outputs `1`, `-e`, `oops`
- [x] New test file `t/exception-methods.t` passes (8 subtests)
- [x] `make test` passes (474 test files)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)