### PR TITLE
fix: support grab/grabpairs with Callable and Scalar decontainerization

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -168,8 +168,9 @@
 - [ ] roast/S02-types/baggy.t
   - 0/? pass. Parse error at line 60
 - [ ] roast/S02-types/baghash.t
-  - 265/290 pass (plan 344). Execution stops at test 290 due to BagHash .kv/.values proxy container mutation not implemented.
-  - Blockers: proxy containers for BagHash .values/.kv/.pairs mutation, parameterized BagHash[T], .BagHash coercion on nested List+Hash, named arg handling in .new
+  - 273/290 pass (plan 344). Execution stops at test 290 due to BagHash .kv proxy mutation crash.
+  - Fixed: grab/grabpairs with Callable arg, $(...) scalar decontainerization in arithmetic
+  - Blockers: proxy containers for BagHash .values/.kv/.pairs mutation (14 tests), parameterized BagHash[T] type constraints (2), named arg handling in .new (1), object keys in Hash (1), BagHash type autovivification (1)
 - [ ] roast/S02-types/bag-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/bag.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2185,6 +2185,23 @@ impl Interpreter {
 
         // SetHash.grab / SetHash.grabpairs: remove random elements, mutating the Set
         if matches!(&target, Value::Set(_, true)) && matches!(method, "grab" | "grabpairs") {
+            // Resolve Callable args: call with .elems to get count
+            let args = if !args.is_empty() && args[0].as_sub().is_some() {
+                let callable = args[0].clone();
+                let method_sym = crate::symbol::Symbol::intern("elems");
+                let input = crate::builtins::native_method_0arg(&target, method_sym)
+                    .unwrap_or(Ok(Value::Int(0)))?;
+                let count = self.call_sub_value(callable, vec![input], false)?;
+                let count_int = match &count {
+                    Value::Int(n) => Value::Int(*n),
+                    Value::Num(f) => Value::Int(*f as i64),
+                    Value::Rat(n, d) if *d != 0 => Value::Int(*n / *d),
+                    _ => count.clone(),
+                };
+                vec![count_int]
+            } else {
+                args
+            };
             // NaN check for grab count
             if !args.is_empty()
                 && let Value::Num(f) = &args[0]
@@ -2241,6 +2258,29 @@ impl Interpreter {
 
         // BagHash.grab / BagHash.grabpairs: remove random elements, mutating the Bag
         if matches!(&target, Value::Bag(_, true)) && matches!(method, "grab" | "grabpairs") {
+            // Resolve Callable args: call with .total (grab) or .elems (grabpairs)
+            let args = if !args.is_empty() && args[0].as_sub().is_some() {
+                let callable = args[0].clone();
+                let input = if method == "grabpairs" {
+                    let method_sym = crate::symbol::Symbol::intern("elems");
+                    crate::builtins::native_method_0arg(&target, method_sym)
+                        .unwrap_or(Ok(Value::Int(0)))?
+                } else {
+                    let method_sym = crate::symbol::Symbol::intern("total");
+                    crate::builtins::native_method_0arg(&target, method_sym)
+                        .unwrap_or(Ok(Value::Int(0)))?
+                };
+                let count = self.call_sub_value(callable, vec![input], false)?;
+                let count_int = match &count {
+                    Value::Int(n) => Value::Int(*n),
+                    Value::Num(f) => Value::Int(*f as i64),
+                    Value::Rat(n, d) if *d != 0 => Value::Int(*n / *d),
+                    _ => count.clone(),
+                };
+                vec![count_int]
+            } else {
+                args
+            };
             // NaN check for grab/grabpairs count
             if !args.is_empty()
                 && let Value::Num(f) = &args[0]
@@ -2328,6 +2368,29 @@ impl Interpreter {
 
         // MixHash.grabpairs: remove random pairs and return them, mutating the Mix
         if matches!(&target, Value::Mix(_, _)) && matches!(method, "grabpairs" | "grab") {
+            // Resolve Callable args
+            let args = if !args.is_empty() && args[0].as_sub().is_some() {
+                let callable = args[0].clone();
+                let input = if method == "grabpairs" {
+                    let method_sym = crate::symbol::Symbol::intern("elems");
+                    crate::builtins::native_method_0arg(&target, method_sym)
+                        .unwrap_or(Ok(Value::Int(0)))?
+                } else {
+                    let method_sym = crate::symbol::Symbol::intern("total");
+                    crate::builtins::native_method_0arg(&target, method_sym)
+                        .unwrap_or(Ok(Value::Int(0)))?
+                };
+                let count = self.call_sub_value(callable, vec![input], false)?;
+                let count_int = match &count {
+                    Value::Int(n) => Value::Int(*n),
+                    Value::Num(f) => Value::Int(*f as i64),
+                    Value::Rat(n, d) if *d != 0 => Value::Int(*n / *d),
+                    _ => count.clone(),
+                };
+                vec![count_int]
+            } else {
+                args
+            };
             let mix = match &target {
                 Value::Mix(m, _) => (**m).clone(),
                 _ => unreachable!(),

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1967,6 +1967,7 @@ pub(crate) fn parse_radix_number_body(body: &str, base: u32) -> Option<Value> {
 
 pub(crate) fn coerce_to_numeric(val: Value) -> Value {
     match val {
+        Value::Scalar(inner) => coerce_to_numeric(*inner),
         Value::Mixin(inner, _) => coerce_to_numeric(inner.as_ref().clone()),
         Value::Int(_)
         | Value::BigInt(_)

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -325,6 +325,9 @@ impl VM {
         // Auto-FETCH Proxy containers in binary operations
         let left = self.interpreter.auto_fetch_proxy(&left)?;
         let right = self.interpreter.auto_fetch_proxy(&right)?;
+        // Decontainerize Scalar wrappers
+        let left = left.decontainerize().clone();
+        let right = right.decontainerize().clone();
         if let (
             Value::Junction {
                 kind: left_kind,


### PR DESCRIPTION
## Summary
- Handle Callable arguments (e.g., `* / 2`) in SetHash/BagHash/MixHash `.grab` and `.grabpairs` methods by resolving the callable with `.total` or `.elems` before computing the grab count
- Decontainerize `Value::Scalar` in binary arithmetic operations so `$(expr) * N` evaluates correctly instead of returning 0
- Add `Scalar` unwrapping in `coerce_to_numeric` for consistent numeric coercion

## Test plan
- [x] `make test` passes (473 files, 3831 tests)
- [x] `make roast` passes (1145 files, 180939 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] Improves roast/S02-types/baghash.t from 265/290 to 273/290 passing (plan 344)
- [x] Remaining baghash.t blockers documented in TODO_roast/S02.md (proxy containers, parameterized types, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)