### PR TITLE
fix: make triangle reduce on infinite ranges truly lazy

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -197,6 +197,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                             compiled_code: None,
                             compiled_fns: None,
                             elems_count: Some(Value::BigInt(factorial)),
+                            scan_spec: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
@@ -217,6 +218,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                     compiled_code: None,
                     compiled_fns: None,
                     elems_count: Some(Value::BigInt(factorial)),
+                    scan_spec: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -188,8 +188,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Array(items, ..) | Value::Seq(items) => Some(Ok(Value::Slip(items.clone()))),
             Value::Slip(_) => Some(Ok(target.clone())),
             Value::LazyList(ll) => {
-                let items = ll.cache.lock().unwrap().clone().unwrap_or_default();
-                Some(Ok(Value::Slip(std::sync::Arc::new(items))))
+                if ll.scan_spec.is_some() {
+                    let items = ll.force_scan_to(200_000);
+                    Some(Ok(Value::Slip(std::sync::Arc::new(items))))
+                } else {
+                    let items = ll.cache.lock().unwrap().clone().unwrap_or_default();
+                    Some(Ok(Value::Slip(std::sync::Arc::new(items))))
+                }
             }
             Value::Range(..)
             | Value::RangeExcl(..)

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1001,6 +1001,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     compiled_code: None,
                     compiled_fns: None,
                     elems_count: Some(Value::BigInt(factorial)),
+                    scan_spec: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -106,6 +106,10 @@ pub(super) fn dispatch(
                             compiled_code: list.compiled_code.clone(),
                             compiled_fns: list.compiled_fns.clone(),
                             elems_count: list.elems_count.clone(),
+                            scan_spec: list
+                                .scan_spec
+                                .as_ref()
+                                .map(|s| std::sync::Mutex::new(s.lock().unwrap().clone())),
                         },
                     )))));
                 }
@@ -146,6 +150,7 @@ pub(super) fn dispatch(
                     compiled_code: None,
                     compiled_fns: None,
                     elems_count: None,
+                    scan_spec: None,
                 },
             )))))
         }

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1280,8 +1280,12 @@ impl Interpreter {
                 Value::Seq(elems) => items.extend(elems.iter().cloned()),
                 Value::Slip(elems) => items.extend(elems.iter().cloned()),
                 Value::LazyList(ll) => {
-                    let cached = ll.cache.lock().unwrap().clone().unwrap_or_default();
-                    items.extend(cached);
+                    if ll.scan_spec.is_some() {
+                        items.extend(ll.force_scan_to(200_000));
+                    } else {
+                        let cached = ll.cache.lock().unwrap().clone().unwrap_or_default();
+                        items.extend(cached);
+                    }
                 }
                 other => items.push(other.clone()),
             }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1336,6 +1336,10 @@ impl Interpreter {
                         compiled_code: list.compiled_code.clone(),
                         compiled_fns: list.compiled_fns.clone(),
                         elems_count: list.elems_count.clone(),
+                        scan_spec: list
+                            .scan_spec
+                            .as_ref()
+                            .map(|s| std::sync::Mutex::new(s.lock().unwrap().clone())),
                     }))
                 } else {
                     v

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -935,6 +935,107 @@ impl LazyList {
             scan_spec: Some(Mutex::new(spec)),
         }
     }
+
+    /// Force a scan-based lazy list to compute up to `needed` elements.
+    /// Uses builtin arithmetic for common operators. Returns the cached elements.
+    /// This can be called from contexts without VM access (builtins, interpreter).
+    pub(crate) fn force_scan_to(&self, needed: usize) -> Vec<Value> {
+        let scan_mutex = match &self.scan_spec {
+            Some(s) => s,
+            None => return self.cache.lock().unwrap().clone().unwrap_or_default(),
+        };
+
+        let mut spec = scan_mutex.lock().unwrap();
+        let mut cache_guard = self.cache.lock().unwrap();
+        let out = cache_guard.get_or_insert_with(Vec::new);
+
+        if out.len() >= needed {
+            return out[..needed].to_vec();
+        }
+
+        let remaining = needed - out.len();
+        let already = spec.computed_count;
+        let source = spec.source.clone();
+        let base_op = spec.op.clone();
+        let negate = spec.negate;
+
+        // Generate source values
+        let new_values: Vec<Value> = match &source {
+            Value::Range(a, b) => {
+                let start = *a + already as i64;
+                let end = if *b == i64::MAX {
+                    *a + needed as i64
+                } else {
+                    *b
+                };
+                (start..=end).take(remaining).map(Value::Int).collect()
+            }
+            Value::RangeExcl(a, b) => {
+                let start = *a + already as i64;
+                let end = if *b == i64::MAX {
+                    *a + needed as i64
+                } else {
+                    *b
+                };
+                (start..end).take(remaining).map(Value::Int).collect()
+            }
+            _ => {
+                let items = crate::runtime::utils::value_to_list(&source);
+                items.into_iter().skip(already).take(remaining).collect()
+            }
+        };
+
+        let mut acc = spec.accumulator.clone();
+        for val in new_values {
+            acc = Some(match acc.take() {
+                None => {
+                    out.push(val.clone());
+                    val
+                }
+                Some(prev) => {
+                    let v = Self::scan_binary_op(&base_op, prev, val);
+                    let v = if negate { Value::Bool(!v.truthy()) } else { v };
+                    out.push(v.clone());
+                    v
+                }
+            });
+            spec.computed_count += 1;
+        }
+        spec.accumulator = acc;
+        out.clone()
+    }
+
+    /// Apply a binary operator for scan reduction. Supports common builtin ops.
+    fn scan_binary_op(op: &str, left: Value, right: Value) -> Value {
+        match op {
+            "+" => crate::builtins::arith::arith_add(left, right).unwrap_or(Value::Nil),
+            "-" => crate::builtins::arith::arith_sub(left, right),
+            "*" => crate::builtins::arith::arith_mul(left, right),
+            "/" => crate::builtins::arith::arith_div(left, right).unwrap_or(Value::Nil),
+            "%" | "mod" => crate::builtins::arith::arith_mod(left, right).unwrap_or(Value::Nil),
+            "**" => crate::builtins::arith::arith_pow(left, right),
+            "~" => Value::str(format!(
+                "{}{}",
+                left.to_string_value(),
+                right.to_string_value()
+            )),
+            "max" => {
+                if left.to_f64() >= right.to_f64() {
+                    left
+                } else {
+                    right
+                }
+            }
+            "min" => {
+                if left.to_f64() <= right.to_f64() {
+                    left
+                } else {
+                    right
+                }
+            }
+            _ => Value::Nil, // Unsupported op — VM path handles these
+        }
+    }
 }
 
 // --- LazyThunkData: deferred evaluation with caching ---

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -860,6 +860,22 @@ pub(crate) enum VersionPart {
     Whatever,
 }
 
+/// Specification for a lazy scan (triangle) reduction.
+/// Stored in `LazyList` to allow on-demand element computation.
+#[derive(Debug, Clone)]
+pub(crate) struct ScanSpec {
+    /// The base operator name (e.g. "+", "*", "~").
+    pub(crate) op: String,
+    /// Whether to negate the result of each step.
+    pub(crate) negate: bool,
+    /// The source value to iterate over (typically a Range variant).
+    pub(crate) source: Value,
+    /// The accumulator state after the last computed element.
+    pub(crate) accumulator: Option<Value>,
+    /// The number of elements already computed (matches cache length).
+    pub(crate) computed_count: usize,
+}
+
 #[derive(Debug)]
 pub(crate) struct LazyList {
     pub(crate) body: Vec<Stmt>,
@@ -872,6 +888,8 @@ pub(crate) struct LazyList {
     /// Known element count for combinatorial lazy sequences (e.g. n! for permutations).
     /// When set, numeric coercion uses this value instead of materializing all elements.
     pub(crate) elems_count: Option<Value>,
+    /// Scan (triangle reduce) specification for lazy on-demand computation.
+    pub(crate) scan_spec: Option<Mutex<ScanSpec>>,
 }
 
 impl Clone for LazyList {
@@ -883,6 +901,10 @@ impl Clone for LazyList {
             compiled_code: self.compiled_code.clone(),
             compiled_fns: self.compiled_fns.clone(),
             elems_count: self.elems_count.clone(),
+            scan_spec: self
+                .scan_spec
+                .as_ref()
+                .map(|s| Mutex::new(s.lock().unwrap().clone())),
         }
     }
 }
@@ -897,6 +919,20 @@ impl LazyList {
             compiled_code: None,
             compiled_fns: None,
             elems_count: None,
+            scan_spec: None,
+        }
+    }
+
+    /// Create a lazy scan (triangle reduce) list that computes elements on demand.
+    pub(crate) fn new_scan(spec: ScanSpec) -> Self {
+        Self {
+            body: Vec::new(),
+            env: crate::env::Env::new(),
+            cache: Mutex::new(Some(Vec::new())),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: Some(Mutex::new(spec)),
         }
     }
 }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -399,7 +399,13 @@ impl VM {
                 .iter()
                 .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
                 .collect(),
-            Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
+            Value::LazyList(ll) => {
+                if ll.scan_spec.is_some() {
+                    ll.force_scan_to(200_000)
+                } else {
+                    ll.cache.lock().unwrap().clone().unwrap_or_default()
+                }
+            }
             Value::Range(..)
             | Value::RangeExcl(..)
             | Value::RangeExclStart(..)

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -158,6 +158,11 @@ impl VM {
         &mut self,
         list: &LazyList,
     ) -> Result<Vec<Value>, RuntimeError> {
+        // Handle scan-based lazy lists: compute elements on demand
+        if list.scan_spec.is_some() {
+            return self.force_scan_lazy_list(list, 200_000);
+        }
+
         // Check cache first
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);
@@ -307,6 +312,146 @@ impl VM {
     }
 
     /// Force a LazyList into a Seq by evaluating the gather body.
+    /// Force a scan-based LazyList, computing up to `needed` elements.
+    /// Elements are computed incrementally and cached in the LazyList.
+    pub(super) fn force_scan_lazy_list(
+        &mut self,
+        list: &LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let scan_mutex = match &list.scan_spec {
+            Some(s) => s,
+            None => return Ok(Vec::new()),
+        };
+
+        // Read current state under lock, then release before calling reduction methods
+        let (base_op, negate, source, mut acc, already, cached_len) = {
+            let spec = scan_mutex.lock().unwrap();
+            let cache_guard = list.cache.lock().unwrap();
+            let cached_len = cache_guard.as_ref().map_or(0, |v| v.len());
+            if cached_len >= needed {
+                return Ok(cache_guard.as_ref().unwrap()[..needed].to_vec());
+            }
+            (
+                spec.op.clone(),
+                spec.negate,
+                spec.source.clone(),
+                spec.accumulator.clone(),
+                spec.computed_count,
+                cached_len,
+            )
+        };
+
+        let callable = self.reduction_callable_for_op(&base_op);
+        let remaining = needed - cached_len;
+
+        // Collect new source values to iterate over
+        let new_values: Vec<Value> = match &source {
+            Value::Range(a, b) => {
+                let start = *a + already as i64;
+                let end = if *b == i64::MAX {
+                    *a + needed as i64
+                } else {
+                    *b
+                };
+                (start..=end).take(remaining).map(Value::Int).collect()
+            }
+            Value::RangeExcl(a, b) => {
+                let start = *a + already as i64;
+                let end = if *b == i64::MAX {
+                    *a + needed as i64
+                } else {
+                    *b
+                };
+                (start..end).take(remaining).map(Value::Int).collect()
+            }
+            Value::RangeExclStart(a, b) => {
+                let first = *a + 1;
+                let start = first + already as i64;
+                let end = if *b == i64::MAX {
+                    first + needed as i64
+                } else {
+                    *b
+                };
+                (start..=end).take(remaining).map(Value::Int).collect()
+            }
+            Value::RangeExclBoth(a, b) => {
+                let first = *a + 1;
+                let start = first + already as i64;
+                let end = if *b == i64::MAX {
+                    first + needed as i64
+                } else {
+                    *b
+                };
+                (start..end).take(remaining).map(Value::Int).collect()
+            }
+            Value::GenericRange {
+                start,
+                end,
+                excl_start,
+                ..
+            } => {
+                let end_f = end.to_f64();
+                let is_infinite = end_f.is_infinite() && end_f.is_sign_positive();
+                let start_i = start.as_ref().to_f64() as i64;
+                let first_i = if *excl_start { start_i + 1 } else { start_i };
+                let iter_start = first_i + already as i64;
+                let iter_end = if is_infinite {
+                    iter_start + remaining as i64
+                } else {
+                    (end_f as i64).min(iter_start + remaining as i64)
+                };
+                (iter_start..=iter_end)
+                    .take(remaining)
+                    .map(Value::Int)
+                    .collect()
+            }
+            _ => {
+                let items = crate::runtime::utils::value_to_list(&source);
+                items.into_iter().skip(already).take(remaining).collect()
+            }
+        };
+
+        // Compute new scan elements (no locks held)
+        let mut new_out: Vec<Value> = Vec::new();
+        let mut computed = already;
+
+        for val in new_values {
+            acc = Some(match acc.take() {
+                None => {
+                    new_out.push(val.clone());
+                    val
+                }
+                Some(prev) => {
+                    let call_args = vec![prev, val];
+                    let v =
+                        self.reduction_step_with_args(&base_op, callable.as_ref(), call_args)?;
+                    let v = if negate { Value::Bool(!v.truthy()) } else { v };
+                    new_out.push(v.clone());
+                    v
+                }
+            });
+            computed += 1;
+        }
+
+        // Update spec and cache under lock
+        {
+            let mut spec = scan_mutex.lock().unwrap();
+            spec.accumulator = acc;
+            spec.computed_count = computed;
+
+            let mut cache_guard = list.cache.lock().unwrap();
+            let out = cache_guard.get_or_insert_with(Vec::new);
+            out.extend(new_out);
+
+            if out.len() >= needed {
+                Ok(out[..needed].to_vec())
+            } else {
+                Ok(out.clone())
+            }
+        }
+    }
+
     fn force_lazy_if_needed(&mut self, val: Value) -> Result<Value, RuntimeError> {
         if let Value::LazyList(ll) = &val {
             let items = self.force_lazy_list_vm(ll)?;

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -219,7 +219,7 @@ impl VM {
         }
     }
 
-    fn reduction_callable_for_op(&self, op: &str) -> Option<Value> {
+    pub(super) fn reduction_callable_for_op(&self, op: &str) -> Option<Value> {
         if let Some(name) = op.strip_prefix('&') {
             let callable = self.interpreter.resolve_code_var(name);
             if matches!(
@@ -311,7 +311,7 @@ impl VM {
         params.len().max(2)
     }
 
-    fn reduction_step_with_args(
+    pub(super) fn reduction_step_with_args(
         &mut self,
         base_op: &str,
         callable: Option<&Value>,
@@ -1726,149 +1726,29 @@ impl VM {
     }
 
     /// Lazily evaluate a triangle (scan) reduction on an infinite/lazy range.
-    /// Produces a `LazyList` so that `.is-lazy` returns True and only the
-    /// needed prefix is materialized when indexed.
+    /// Produces a `LazyList` with a `ScanSpec` so that additional elements
+    /// can be computed on demand. Pre-computes an initial batch of elements
+    /// so that common operations like `.Slip` and `.join` work immediately.
     fn exec_lazy_scan_reduction(
         &mut self,
         base_op: &str,
         negate: bool,
         list_value: &Value,
     ) -> Result<(), RuntimeError> {
-        const LAZY_SCAN_CAP: usize = 200_000;
-
-        let callable = self.reduction_callable_for_op(base_op);
-        let mut out = Vec::new();
-        let mut acc: Option<Value> = None;
-        #[allow(unused_assignments)]
-        let mut count = 0usize;
-
-        // Macro-like helper for processing a single element in the scan.
-        macro_rules! scan_step {
-            ($val:expr) => {
-                #[allow(unused_assignments)]
-                {
-                    acc = Some(match acc.take() {
-                        None => {
-                            out.push($val.clone());
-                            $val
-                        }
-                        Some(prev) => {
-                            let call_args = vec![prev, $val];
-                            let v = self.reduction_step_with_args(
-                                base_op,
-                                callable.as_ref(),
-                                call_args,
-                            )?;
-                            let v = if negate { Value::Bool(!v.truthy()) } else { v };
-                            out.push(v.clone());
-                            v
-                        }
-                    });
-                    count += 1;
-                }
-            };
-        }
-
-        match list_value {
-            Value::Range(a, b) => {
-                let end = if *b == i64::MAX {
-                    *a + LAZY_SCAN_CAP as i64
-                } else {
-                    *b
-                };
-                for i in *a..=end {
-                    if count >= LAZY_SCAN_CAP {
-                        break;
-                    }
-                    let val = Value::Int(i);
-                    scan_step!(val);
-                }
-            }
-            Value::RangeExcl(a, b) => {
-                let end = if *b == i64::MAX {
-                    *a + LAZY_SCAN_CAP as i64
-                } else {
-                    *b
-                };
-                for i in *a..end {
-                    if count >= LAZY_SCAN_CAP {
-                        break;
-                    }
-                    let val = Value::Int(i);
-                    scan_step!(val);
-                }
-            }
-            Value::RangeExclStart(a, b) => {
-                let start = *a + 1;
-                let end = if *b == i64::MAX {
-                    start + LAZY_SCAN_CAP as i64
-                } else {
-                    *b
-                };
-                for i in start..=end {
-                    if count >= LAZY_SCAN_CAP {
-                        break;
-                    }
-                    let val = Value::Int(i);
-                    scan_step!(val);
-                }
-            }
-            Value::RangeExclBoth(a, b) => {
-                let start = *a + 1;
-                let end = if *b == i64::MAX {
-                    start + LAZY_SCAN_CAP as i64
-                } else {
-                    *b
-                };
-                for i in start..end {
-                    if count >= LAZY_SCAN_CAP {
-                        break;
-                    }
-                    let val = Value::Int(i);
-                    scan_step!(val);
-                }
-            }
-            Value::GenericRange {
-                start,
-                end,
-                excl_start,
-                excl_end,
-            } => {
-                let end_f = end.to_f64();
-                let is_infinite = end_f.is_infinite() && end_f.is_sign_positive();
-                let start_i = start.as_ref().to_f64() as i64;
-                let first_i = if *excl_start { start_i + 1 } else { start_i };
-                // Use integer iteration when both endpoints are integer-like
-                for idx in 0..LAZY_SCAN_CAP {
-                    let i = first_i + idx as i64;
-                    if !is_infinite {
-                        if *excl_end && i as f64 >= end_f {
-                            break;
-                        }
-                        if !*excl_end && i as f64 > end_f {
-                            break;
-                        }
-                    }
-                    let val = Value::Int(i);
-                    scan_step!(val);
-                }
-            }
-            Value::LazyList(ll) => {
-                let items = self.force_lazy_list_vm(ll)?;
-                for val in items.into_iter().take(LAZY_SCAN_CAP) {
-                    scan_step!(val);
-                }
-            }
-            _ => {
-                let items = runtime::value_to_list(list_value);
-                for val in items.into_iter().take(LAZY_SCAN_CAP) {
-                    scan_step!(val);
-                }
-            }
-        }
-
-        let ll = crate::value::LazyList::new_cached(out);
-        self.stack.push(Value::LazyList(std::sync::Arc::new(ll)));
+        let spec = crate::value::ScanSpec {
+            op: base_op.to_string(),
+            negate,
+            source: list_value.clone(),
+            accumulator: None,
+            computed_count: 0,
+        };
+        let ll = crate::value::LazyList::new_scan(spec);
+        let ll = std::sync::Arc::new(ll);
+        // Pre-compute an initial batch so that eager consumers (e.g. .Slip,
+        // .join) that read the cache directly get a useful prefix.
+        const INITIAL_BATCH: usize = 1_000;
+        self.force_scan_lazy_list(&ll, INITIAL_BATCH)?;
+        self.stack.push(Value::LazyList(ll));
         Ok(())
     }
 

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -120,6 +120,29 @@ impl VM {
             return None;
         };
 
+        // Handle .Slip/.List/.Seq on scan-based LazyList by forcing elements via VM.
+        if result.is_none()
+            && let Value::LazyList(ll) = target
+            && ll.scan_spec.is_some()
+            && matches!(method_name.as_str(), "Slip" | "List" | "Seq" | "Array")
+        {
+            match self.force_lazy_list_vm(ll) {
+                Ok(items) => {
+                    let val = match method_name.as_str() {
+                        "Slip" => Value::Slip(std::sync::Arc::new(items)),
+                        "List" => {
+                            Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+                        }
+                        "Seq" => Value::Seq(std::sync::Arc::new(items)),
+                        "Array" => Value::real_array(items),
+                        _ => unreachable!(),
+                    };
+                    return Some(Ok(val));
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+
         if method_name == "decode" {
             return result.map(|res| {
                 res.map(|value| match value {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -42,6 +42,7 @@ impl VM {
                 compiled_code: Some(std::sync::Arc::new(compiled_code)),
                 compiled_fns: Some(std::sync::Arc::new(compiled_fns)),
                 elems_count: None,
+                scan_spec: None,
             };
             let val = Value::LazyList(std::sync::Arc::new(list));
             self.stack.push(val);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -154,7 +154,19 @@ impl VM {
             target = self.force_if_lazy_io_lines(target)?;
         }
         if let Value::LazyList(ref ll) = target {
-            let forced = if matches!(
+            let forced = if ll.scan_spec.is_some() {
+                // Scan-based lazy list: compute only as many elements as needed
+                let needed = match &index {
+                    Value::Int(i) if *i >= 0 => Some((*i as usize).saturating_add(1)),
+                    Value::Range(_, end) if *end >= 0 => Some((*end as usize).saturating_add(1)),
+                    Value::RangeExcl(_, end) if *end > 0 => Some(*end as usize),
+                    _ => None,
+                };
+                match needed {
+                    Some(n) => self.force_scan_lazy_list(ll, n)?,
+                    None => self.force_lazy_list_vm(ll)?,
+                }
+            } else if matches!(
                 ll.env.get("__mutsu_lazylist_from_gather"),
                 Some(Value::Bool(true))
             ) {


### PR DESCRIPTION
## Summary
- Triangle (scan) reduction on infinite/lazy ranges (e.g. `[\*] 1..*`) previously pre-computed 200,000 elements eagerly, causing timeouts for expensive operations like multiplication where BigInt numbers grow astronomically
- Added `ScanSpec` to `LazyList` to store scan parameters and compute elements incrementally on demand
- Pre-computes an initial batch of 1,000 elements for eager consumers like `.Slip` and `.join`
- When indexed (e.g. `([\*] 1..*).[^10]`), only computes as many elements as needed

## Test plan
- [x] `timeout 10 target/debug/mutsu -e 'say ([\*] 1..*).[^10].join(", ")'` returns correct factorials instantly
- [x] `([\*] 1..*).is-lazy` returns `True`
- [x] `[\+] 1..5` still works correctly for finite ranges
- [x] `t/reduction-scan-slip.t` passes (`.Slip` on infinite scan lists)
- [x] `roast/S03-metaops/reduce.t` completes in <1 second (was timing out at 30s)
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)