### PR TITLE
perf: add fast path for ratcheted Named regex atoms in quantifier loops

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -294,6 +294,21 @@ pub(super) fn is_silent_named_atom(atom: &RegexAtom) -> bool {
     }
 }
 
+/// Check if a Named atom is non-silent (produces named captures) and has no arguments.
+/// Such atoms can use a fast path for ratcheted quantifiers.
+pub(super) fn is_named_atom_no_args(atom: &RegexAtom) -> bool {
+    if let RegexAtom::Named(name) = atom {
+        let trimmed = name.trim();
+        !trimmed.starts_with('.')
+            && !trimmed.starts_with('&')
+            && !trimmed.contains('(')
+            && !trimmed.contains(':')
+            && !trimmed.contains('=')
+    } else {
+        false
+    }
+}
+
 pub(super) fn is_simple_atom(atom: &RegexAtom) -> bool {
     matches!(
         atom,

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use super::regex_helpers::{
-    count_capture_groups, fold_quantified_captures, is_silent_named_atom, is_simple_atom,
+    count_capture_groups, fold_quantified_captures, is_named_atom_no_args, is_silent_named_atom,
+    is_simple_atom,
 };
 
 impl Interpreter {
@@ -166,6 +167,55 @@ impl Interpreter {
                             }
                         }
                         stack.push((idx + 1, current, caps));
+                    } else if token.ratchet
+                        && token.named_capture.is_none()
+                        && is_named_atom_no_args(&token.atom)
+                        && let Some((resolved, resolved_pkg)) =
+                            self.try_resolve_named_to_pattern(&token.atom, pkg)
+                    {
+                        // Fast path for ratcheted non-silent Named token (e.g. <huge>*).
+                        // Resolve the pattern once and loop directly, accumulating
+                        // named captures without re-parsing on each iteration.
+                        let capture_name = if let RegexAtom::Named(name) = &token.atom {
+                            name.trim().to_string()
+                        } else {
+                            String::new()
+                        };
+                        let mut current = pos;
+                        let mut current_caps = caps;
+                        while current < chars.len() {
+                            if let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
+                                &resolved,
+                                chars,
+                                current,
+                                &resolved_pkg,
+                            ) {
+                                if end == current {
+                                    break;
+                                }
+                                if !capture_name.is_empty() {
+                                    let captured: String = chars[current..end].iter().collect();
+                                    let mut subcap = inner_caps;
+                                    subcap.matched = captured.clone();
+                                    subcap.from = current;
+                                    subcap.to = end;
+                                    current_caps
+                                        .named_subcaps
+                                        .entry(capture_name.clone())
+                                        .or_default()
+                                        .push(subcap);
+                                    current_caps
+                                        .named
+                                        .entry(capture_name.clone())
+                                        .or_default()
+                                        .push(captured);
+                                }
+                                current = end;
+                            } else {
+                                break;
+                            }
+                        }
+                        stack.push((idx + 1, current, current_caps));
                     } else {
                         let base_len = caps.positional.len();
                         let stride = count_capture_groups(&token.atom);
@@ -269,6 +319,79 @@ impl Interpreter {
                             }
                         }
                         stack.push((idx + 1, current, caps));
+                    } else if token.ratchet
+                        && token.named_capture.is_none()
+                        && is_named_atom_no_args(&token.atom)
+                        && let Some((resolved, resolved_pkg)) =
+                            self.try_resolve_named_to_pattern(&token.atom, pkg)
+                    {
+                        // Fast path for ratcheted non-silent Named token (e.g. <huge>+).
+                        // Resolve the pattern once and loop directly.
+                        let capture_name = if let RegexAtom::Named(name) = &token.atom {
+                            name.trim().to_string()
+                        } else {
+                            String::new()
+                        };
+                        let Some((first_end, first_inner)) = self.regex_match_end_from_caps_in_pkg(
+                            &resolved,
+                            chars,
+                            pos,
+                            &resolved_pkg,
+                        ) else {
+                            continue;
+                        };
+                        let mut current = first_end;
+                        let mut current_caps = caps;
+                        if !capture_name.is_empty() {
+                            let captured: String = chars[pos..first_end].iter().collect();
+                            let mut subcap = first_inner;
+                            subcap.matched = captured.clone();
+                            subcap.from = pos;
+                            subcap.to = first_end;
+                            current_caps
+                                .named_subcaps
+                                .entry(capture_name.clone())
+                                .or_default()
+                                .push(subcap);
+                            current_caps
+                                .named
+                                .entry(capture_name.clone())
+                                .or_default()
+                                .push(captured);
+                        }
+                        while current < chars.len() {
+                            if let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
+                                &resolved,
+                                chars,
+                                current,
+                                &resolved_pkg,
+                            ) {
+                                if end == current {
+                                    break;
+                                }
+                                if !capture_name.is_empty() {
+                                    let captured: String = chars[current..end].iter().collect();
+                                    let mut subcap = inner_caps;
+                                    subcap.matched = captured.clone();
+                                    subcap.from = current;
+                                    subcap.to = end;
+                                    current_caps
+                                        .named_subcaps
+                                        .entry(capture_name.clone())
+                                        .or_default()
+                                        .push(subcap);
+                                    current_caps
+                                        .named
+                                        .entry(capture_name.clone())
+                                        .or_default()
+                                        .push(captured);
+                                }
+                                current = end;
+                            } else {
+                                break;
+                            }
+                        }
+                        stack.push((idx + 1, current, current_caps));
                     } else {
                         let base_len = caps.positional.len();
                         let stride = count_capture_groups(&token.atom);


### PR DESCRIPTION
## Summary

- Adds a fast path for ratcheted non-silent Named regex atoms (e.g. `<huge>+` in grammar tokens) in `ZeroOrMore` and `OneOrMore` quantifier handlers
- The pattern is resolved once and reused across all iterations, instead of creating a new Interpreter and re-parsing the regex string on each match
- Fixes timeout in `roast/S05-metasyntax/longest-alternative.t` where a token with 80 alternations was matched 10000 times

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` passes
- [x] `timeout 30 target/release/mutsu roast/S05-metasyntax/longest-alternative.t` completes (was timing out before)
- [x] `make test` shows no regressions
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)