### PR TITLE
fix: implement parallel execution for hyper/race map and grep

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3766,6 +3766,16 @@ impl Interpreter {
         self.output_emitted = false;
     }
 
+    /// Take the output buffer, leaving it empty.
+    pub(crate) fn take_output(&mut self) -> String {
+        std::mem::take(&mut self.output)
+    }
+
+    /// Take the stderr buffer, leaving it empty.
+    pub(crate) fn take_stderr_output(&mut self) -> String {
+        std::mem::take(&mut self.stderr_output)
+    }
+
     /// Returns true if any output was emitted since the last `clear_output`.
     pub fn has_output_emitted(&self) -> bool {
         self.output_emitted

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -28,6 +28,7 @@ mod vm_dispatch_helpers;
 mod vm_env_helpers;
 mod vm_helpers;
 mod vm_hyper_method_ops;
+mod vm_hyper_race_parallel;
 mod vm_method_dispatch;
 mod vm_misc_ops;
 mod vm_native_dispatch;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -424,7 +424,37 @@ impl VM {
                     self.env_dirty = true;
                     return Ok(());
                 }
-                "map" | "grep" => Some(matches!(&target, Value::HyperSeq(_))),
+                "map" | "grep" => {
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    // For small lists, use parallel execution so inter-item
+                    // synchronization (e.g. Promise await chains) works.
+                    // For large lists, fall through to the sequential array
+                    // map/grep path which is more efficient.
+                    if items_arc.len() < 1000 {
+                        let is_hyper = matches!(&target, Value::HyperSeq(_));
+                        let block = if !args.is_empty() {
+                            args[0].clone()
+                        } else {
+                            Value::Nil
+                        };
+                        let is_map = method == "map";
+                        let result =
+                            self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
+                        let wrapped = if is_hyper {
+                            Value::HyperSeq(Arc::new(result))
+                        } else {
+                            Value::RaceSeq(Arc::new(result))
+                        };
+                        self.stack.push(wrapped);
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    // Large list: fall through to array-based dispatch
+                    Some(matches!(&target, Value::HyperSeq(_)))
+                }
                 _ => None,
             }
         } else {

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+impl VM {
+    /// Parallel map/grep for HyperSeq/RaceSeq.
+    /// Each item is processed in its own thread to support concurrent
+    /// operations like `await` inside the map/grep block.
+    pub(super) fn exec_hyper_race_map_grep(
+        &mut self,
+        items: &[Value],
+        block: Value,
+        is_map: bool,
+        _is_hyper: bool,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        if items.is_empty() {
+            return Ok(Vec::new());
+        }
+        // For grep with non-callable arguments (Regex, Type, etc.),
+        // fall back to sequential smartmatch-based grep.
+        let is_callable = matches!(
+            block,
+            Value::Sub(..) | Value::WeakSub(..) | Value::Routine { .. } | Value::Mixin(..)
+        );
+        if !is_map && !is_callable {
+            return self.exec_hyper_grep_smartmatch(items, &block);
+        }
+        // Cap concurrency. For small lists (<=64 items), give each item its
+        // own thread so that inter-item synchronization (e.g. Promises) works.
+        // The caller ensures items.len() < 1000 before calling this method.
+        // TODO: store batch/degree on HyperSeq/RaceSeq so user params are used.
+        let degree = if items.len() <= 64 { items.len() } else { 4 };
+        let batch_size = std::cmp::max(1, items.len().div_ceil(degree));
+        let batches: Vec<Vec<Value>> = items
+            .chunks(batch_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+        let num_batches = batches.len();
+        type ThreadResult = (
+            crate::runtime::Interpreter,
+            Result<Vec<Value>, RuntimeError>,
+            String,
+            String,
+        );
+        let mut handles: Vec<std::thread::JoinHandle<ThreadResult>> =
+            Vec::with_capacity(num_batches);
+        for batch in batches {
+            let thread_interp = self.interpreter.clone_for_thread();
+            let block_clone = block.clone();
+            let is_map_flag = is_map;
+            handles.push(std::thread::spawn(move || {
+                let mut vm = crate::vm::VM::new(thread_interp);
+                let mut results = Vec::with_capacity(batch.len());
+                let mut error: Option<RuntimeError> = None;
+                for item in &batch {
+                    if error.is_some() {
+                        break;
+                    }
+                    match vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None) {
+                        Ok(val) => {
+                            if is_map_flag {
+                                if let Value::Slip(ref s) = val {
+                                    results.extend(s.iter().cloned());
+                                } else {
+                                    results.push(val);
+                                }
+                            } else if val.truthy() {
+                                results.push(item.clone());
+                            }
+                        }
+                        Err(e) => {
+                            error = Some(e);
+                        }
+                    }
+                }
+                let output = vm.interpreter.take_output();
+                let stderr = vm.interpreter.take_stderr_output();
+                let final_result = match error {
+                    Some(e) => Err(e),
+                    None => Ok(results),
+                };
+                (vm.interpreter, final_result, output, stderr)
+            }));
+        }
+        let mut all_results = Vec::with_capacity(items.len());
+        let mut first_error: Option<RuntimeError> = None;
+        for handle in handles {
+            let (thread_interp, batch_result, output, stderr) =
+                handle.join().unwrap_or_else(|_| {
+                    let interp = self.interpreter.clone_for_thread();
+                    (
+                        interp,
+                        Err(RuntimeError::new("Thread panicked in hyper/race")),
+                        String::new(),
+                        String::new(),
+                    )
+                });
+            self.interpreter.emit_output(&output);
+            self.interpreter.emit_stderr(&stderr);
+            // Shared vars are synced through the shared Arc<RwLock<>>
+            drop(thread_interp);
+            match batch_result {
+                Ok(results) => {
+                    if first_error.is_none() {
+                        all_results.extend(results);
+                    }
+                }
+                Err(e) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+        // Sync any shared variable updates from threads back to our env
+        self.interpreter.sync_shared_vars_to_env();
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+        Ok(all_results)
+    }
+
+    /// Sequential grep using smartmatch for non-callable matchers.
+    fn exec_hyper_grep_smartmatch(
+        &mut self,
+        items: &[Value],
+        matcher: &Value,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let mut results = Vec::with_capacity(items.len());
+        for item in items {
+            if self.vm_smart_match(item, matcher) {
+                results.push(item.clone());
+            }
+        }
+        Ok(results)
+    }
+}


### PR DESCRIPTION
## Summary

- Implements actual parallel execution for `.hyper().map()` and `.hyper().grep()` (and `.race()` equivalents) using threads, fixing deadlocks when map/grep blocks contain inter-item synchronization (e.g. Promise await chains)
- For small lists (<1000 items), each batch runs in its own thread; for large lists, falls back to the efficient sequential array-based map/grep path to avoid clone_for_thread overhead
- Handles grep with non-callable matchers (Regex, types) via sequential smartmatch fallback

## Test plan

- [x] `roast/S07-hyperrace/basics.t` completes in ~4s instead of timing out (76/90 pass, 14 failures are pre-existing Buf/regex/iterator issues)
- [x] `roast/S07-hyperrace/stress.t` still fully passes (10/10)
- [x] `roast/S32-list/grep.t` still fully passes (50/50, including hyper/race grep with Regex)
- [x] `make test` passes
- [x] `make roast` passes (only flaky threading tests show intermittent failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)