### PR TITLE
feat: return Backtrace object from .backtrace instead of plain string

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1133,6 +1133,92 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
+    // Backtrace methods: .Str, .gist, .list, .elems
+    if let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+    {
+        let cn = class_name.resolve();
+        if cn == "Backtrace" {
+            match method {
+                "Str" | "Stringy" => {
+                    let text = attributes
+                        .get("text")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_default();
+                    return Some(Ok(Value::str(text)));
+                }
+                "gist" => {
+                    let count = attributes
+                        .get("frames")
+                        .map(|v| crate::runtime::utils::value_to_list(v).len())
+                        .unwrap_or(0);
+                    return Some(Ok(Value::str(format!("Backtrace({} frames)", count))));
+                }
+                "list" | "List" => {
+                    if let Some(frames) = attributes.get("frames") {
+                        return Some(Ok(frames.clone()));
+                    }
+                    return Some(Ok(Value::array(vec![])));
+                }
+                "elems" => {
+                    if let Some(frames) = attributes.get("frames") {
+                        let count = crate::runtime::utils::value_to_list(frames).len();
+                        return Some(Ok(Value::Int(count as i64)));
+                    }
+                    return Some(Ok(Value::Int(0)));
+                }
+                _ => {}
+            }
+        } else if cn == "Backtrace::Frame" {
+            match method {
+                "subname" => {
+                    return Some(Ok(attributes
+                        .get("subname")
+                        .cloned()
+                        .unwrap_or(Value::str(String::new()))));
+                }
+                "file" => {
+                    return Some(Ok(attributes
+                        .get("file")
+                        .cloned()
+                        .unwrap_or(Value::str(String::new()))));
+                }
+                "line" => {
+                    return Some(Ok(attributes.get("line").cloned().unwrap_or(Value::Int(0))));
+                }
+                "Str" | "gist" => {
+                    let subname = attributes
+                        .get("subname")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_default();
+                    let file = attributes
+                        .get("file")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_default();
+                    let line = attributes
+                        .get("line")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| "0".to_string());
+                    if subname == "<unit>" {
+                        return Some(Ok(Value::str(format!(
+                            "  in block <unit> at {} line {}",
+                            file, line
+                        ))));
+                    } else {
+                        return Some(Ok(Value::str(format!(
+                            "  in sub {} at {} line {}",
+                            subname, file, line
+                        ))));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     // .resume on exception objects
     if method == "resume"
         && let Value::Instance { class_name, .. } = target

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -580,6 +580,14 @@ impl Value {
                 class_name,
                 attributes,
                 ..
+            } if class_name == "Backtrace" => attributes
+                .get("text")
+                .map(|v: &Value| v.to_string_value())
+                .unwrap_or_default(),
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
             } if class_name == "IO::Path" => attributes
                 .get("path")
                 .map(|v: &Value| v.to_string_value())

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2568,19 +2568,20 @@ impl VM {
                 } else {
                     val
                 };
-                let backtrace = self.build_backtrace_string();
+                let backtrace_str = self.build_backtrace_string();
+                let backtrace_val = self.build_backtrace_value();
                 let current_line = self.current_source_line();
                 let current_file = self.current_source_file();
                 let mut err = self.runtime_error_from_exception_value(val, "Died", false);
-                if !backtrace.is_empty() {
-                    err.backtrace = Some(backtrace.clone());
+                if !backtrace_str.is_empty() {
+                    err.backtrace = Some(backtrace_str);
                 }
                 // Attach backtrace, line, and file to the exception value
                 if let Some(ref mut exc_box) = err.exception
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
                     let attrs = std::sync::Arc::make_mut(attributes);
-                    attrs.insert("backtrace".to_string(), Value::str(backtrace));
+                    attrs.insert("backtrace".to_string(), backtrace_val);
                     if let Some(line) = current_line {
                         attrs
                             .entry("line".to_string())
@@ -2615,7 +2616,7 @@ impl VM {
                 };
                 // Build a backtrace from the routine stack so that
                 // Exception.gist can show where the fail originated.
-                let backtrace = self.build_backtrace_string();
+                let backtrace_val = self.build_backtrace_value();
                 let current_line = self.current_source_line();
                 let current_file = self.current_source_file();
                 let mut err = self.runtime_error_from_exception_value(val, "Failed", true);
@@ -2624,7 +2625,7 @@ impl VM {
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
                     let attrs = std::sync::Arc::make_mut(attributes);
-                    attrs.insert("backtrace".to_string(), Value::str(backtrace));
+                    attrs.insert("backtrace".to_string(), backtrace_val);
                     if let Some(line) = current_line {
                         attrs
                             .entry("line".to_string())

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1899,7 +1899,10 @@ impl VM {
                         exc_attrs.insert("line".to_string(), Value::Int(line as i64));
                     }
                     if let Some(ref bt) = e.backtrace {
-                        exc_attrs.insert("backtrace".to_string(), Value::str(bt.clone()));
+                        // Build a Backtrace object from the string for
+                        // legacy errors that only have a string backtrace.
+                        let bt_val = Self::backtrace_value_from_string(bt);
+                        exc_attrs.insert("backtrace".to_string(), bt_val);
                     }
                     Value::make_instance(Symbol::intern("Exception"), exc_attrs)
                 };

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -54,6 +54,123 @@ impl VM {
         lines.join("\n")
     }
 
+    /// Build a structured Backtrace Value from the interpreter's routine stack.
+    /// Returns a `Backtrace` instance whose `frames` attribute is a list of
+    /// `Backtrace::Frame` instances (each with `.subname`, `.file`, `.line`)
+    /// and whose `text` attribute is the formatted backtrace string.
+    pub(super) fn build_backtrace_value(&self) -> Value {
+        use crate::symbol::Symbol;
+        use std::collections::HashMap;
+
+        let stack = self.interpreter.routine_stack();
+        let current_line = self.current_source_line();
+        let current_file = self.current_source_file();
+        let reversed: Vec<_> = stack.iter().rev().collect();
+
+        let mut frames = Vec::new();
+        let mut text_lines = Vec::new();
+
+        for (i, frame) in reversed.iter().enumerate() {
+            let (line, file) = if i == 0 {
+                (current_line, current_file.clone())
+            } else {
+                let inner_frame = reversed[i - 1];
+                (inner_frame.line, inner_frame.file.clone())
+            };
+            let subname = if frame.name.is_empty()
+                || frame.name == "<unit>"
+                || frame.name == "<pointy-block>"
+            {
+                "<unit>".to_string()
+            } else {
+                frame.name.clone()
+            };
+
+            let location = Self::format_location(file.as_deref(), line);
+            if subname == "<unit>" {
+                text_lines.push(format!("  in block <unit>{}", location));
+            } else {
+                text_lines.push(format!("  in sub {}{}", subname, location));
+            }
+
+            let mut frame_attrs = HashMap::new();
+            frame_attrs.insert("subname".to_string(), Value::str(subname));
+            frame_attrs.insert(
+                "file".to_string(),
+                file.map(Value::str).unwrap_or(Value::str(String::new())),
+            );
+            frame_attrs.insert(
+                "line".to_string(),
+                line.map(|l| Value::Int(l as i64)).unwrap_or(Value::Int(0)),
+            );
+            frames.push(Value::make_instance(
+                Symbol::intern("Backtrace::Frame"),
+                frame_attrs,
+            ));
+        }
+
+        // Add <unit> frame at bottom if needed
+        if stack.is_empty() {
+            let location = Self::format_location(current_file.as_deref(), current_line);
+            text_lines.push(format!("  in block <unit>{}", location));
+
+            let mut frame_attrs = HashMap::new();
+            frame_attrs.insert("subname".to_string(), Value::str("<unit>".to_string()));
+            frame_attrs.insert(
+                "file".to_string(),
+                current_file
+                    .clone()
+                    .map(Value::str)
+                    .unwrap_or(Value::str(String::new())),
+            );
+            frame_attrs.insert(
+                "line".to_string(),
+                current_line
+                    .map(|l| Value::Int(l as i64))
+                    .unwrap_or(Value::Int(0)),
+            );
+            frames.push(Value::make_instance(
+                Symbol::intern("Backtrace::Frame"),
+                frame_attrs,
+            ));
+        } else if !stack
+            .first()
+            .is_some_and(|f| f.name.is_empty() || f.name == "<unit>")
+        {
+            let outermost = &stack[0];
+            let location = Self::format_location(outermost.file.as_deref(), outermost.line);
+            text_lines.push(format!("  in block <unit>{}", location));
+
+            let mut frame_attrs = HashMap::new();
+            frame_attrs.insert("subname".to_string(), Value::str("<unit>".to_string()));
+            frame_attrs.insert(
+                "file".to_string(),
+                outermost
+                    .file
+                    .clone()
+                    .map(Value::str)
+                    .unwrap_or(Value::str(String::new())),
+            );
+            frame_attrs.insert(
+                "line".to_string(),
+                outermost
+                    .line
+                    .map(|l| Value::Int(l as i64))
+                    .unwrap_or(Value::Int(0)),
+            );
+            frames.push(Value::make_instance(
+                Symbol::intern("Backtrace::Frame"),
+                frame_attrs,
+            ));
+        }
+
+        let text = text_lines.join("\n");
+        let mut bt_attrs = HashMap::new();
+        bt_attrs.insert("frames".to_string(), Value::array(frames));
+        bt_attrs.insert("text".to_string(), Value::str(text));
+        Value::make_instance(Symbol::intern("Backtrace"), bt_attrs)
+    }
+
     /// Format a " at <file> line <N>" suffix for backtrace entries.
     fn format_location(file: Option<&str>, line: Option<u32>) -> String {
         match (file, line) {
@@ -62,6 +179,68 @@ impl VM {
             (None, Some(l)) => format!(" at line {}", l),
             (None, None) => String::new(),
         }
+    }
+
+    /// Build a Backtrace Value from a pre-formatted backtrace string.
+    /// Parses the string lines to extract frame info (best-effort).
+    pub(super) fn backtrace_value_from_string(bt_str: &str) -> Value {
+        use crate::symbol::Symbol;
+        use std::collections::HashMap;
+
+        let mut frames = Vec::new();
+        for line in bt_str.lines() {
+            let trimmed = line.trim();
+            // Parse lines like "  in sub foo at file.raku line 5"
+            // or "  in block <unit> at -e line 1"
+            let subname;
+            let rest;
+            if let Some(after_sub) = trimmed.strip_prefix("in sub ") {
+                if let Some(at_pos) = after_sub.find(" at ") {
+                    subname = after_sub[..at_pos].to_string();
+                    rest = &after_sub[at_pos..];
+                } else {
+                    subname = after_sub.to_string();
+                    rest = "";
+                }
+            } else if let Some(after_block) = trimmed.strip_prefix("in block ") {
+                if let Some(at_pos) = after_block.find(" at ") {
+                    subname = after_block[..at_pos].to_string();
+                    rest = &after_block[at_pos..];
+                } else {
+                    subname = after_block.to_string();
+                    rest = "";
+                }
+            } else {
+                continue;
+            }
+
+            let mut file = String::new();
+            let mut line_no: i64 = 0;
+            if let Some(at_rest) = rest.strip_prefix(" at ") {
+                if let Some(line_pos) = at_rest.rfind(" line ") {
+                    file = at_rest[..line_pos].to_string();
+                    if let Ok(n) = at_rest[line_pos + 6..].parse::<i64>() {
+                        line_no = n;
+                    }
+                } else {
+                    file = at_rest.to_string();
+                }
+            }
+
+            let mut frame_attrs = HashMap::new();
+            frame_attrs.insert("subname".to_string(), Value::str(subname));
+            frame_attrs.insert("file".to_string(), Value::str(file));
+            frame_attrs.insert("line".to_string(), Value::Int(line_no));
+            frames.push(Value::make_instance(
+                Symbol::intern("Backtrace::Frame"),
+                frame_attrs,
+            ));
+        }
+
+        let mut bt_attrs = HashMap::new();
+        bt_attrs.insert("frames".to_string(), Value::array(frames));
+        bt_attrs.insert("text".to_string(), Value::str(bt_str.to_string()));
+        Value::make_instance(Symbol::intern("Backtrace"), bt_attrs)
     }
 
     /// If the value is a `LazyIoLines`, force it into an eager array by reading

--- a/t/backtrace-object.t
+++ b/t/backtrace-object.t
@@ -1,0 +1,46 @@
+use Test;
+plan 14;
+
+# Basic: .backtrace returns a Backtrace object
+try { die "oops" };
+my $bt = $!.backtrace;
+is $bt.^name, 'Backtrace', '.backtrace returns Backtrace object';
+
+# .list returns a list of frames
+my @frames = $bt.list;
+ok @frames.elems >= 1, '.list returns at least one frame';
+
+# Each frame is a Backtrace::Frame
+my $f = @frames[*-1];
+is $f.^name, 'Backtrace::Frame', 'frame is Backtrace::Frame';
+
+# Frame has .subname, .file, .line
+is $f.subname, '<unit>', 'outermost frame subname is <unit>';
+ok $f.line > 0, 'frame .line is positive';
+ok $f.file.chars > 0, 'frame .file is non-empty';
+
+# .Str returns the text representation
+my $str = $bt.Str;
+ok $str.contains('in block <unit>'), '.Str contains "in block <unit>"';
+
+# .gist returns "Backtrace(N frames)"
+my $gist = $bt.gist;
+ok $gist.contains('Backtrace('), '.gist starts with Backtrace(';
+ok $gist.contains('frames)'), '.gist ends with frames)';
+
+# say on backtrace uses gist
+# (We just check gist format, not actual say output)
+ok $gist ~~ /^ 'Backtrace(' \d+ ' frames)' $/, '.gist format is Backtrace(N frames)';
+
+# Multi-frame backtrace
+sub foo { die "inner" }
+try { foo() };
+my $bt2 = $!.backtrace;
+my @frames2 = $bt2.list;
+ok @frames2.elems >= 2, 'multi-frame backtrace has >= 2 frames';
+is @frames2[0].subname, 'foo', 'first frame subname is foo';
+is @frames2[*-1].subname, '<unit>', 'last frame subname is <unit>';
+
+# Backtrace stringifies when used in string context
+my $str2 = ~$bt2;
+ok $str2.contains('in sub foo'), 'stringified backtrace contains "in sub foo"';


### PR DESCRIPTION
## Summary
- `.backtrace` on exceptions now returns a `Backtrace` instance instead of a plain string
- `Backtrace` supports `.list` (returns `Backtrace::Frame` objects), `.Str` (text), `.gist` ("Backtrace(N frames)"), `.elems`
- Each `Backtrace::Frame` has `.subname`, `.file`, `.line` methods
- Backtrace objects stringify to the backtrace text, so `say $!.backtrace.Str` still works as before
- Exception `.gist` continues to work correctly (appends backtrace text to message)

## Test plan
- [x] New `t/backtrace-object.t` with 14 tests covering all Backtrace/Frame methods
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)