### PR TITLE
feat: JSON::Tiny to-json compatibility

### DIFF
--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1139,22 +1139,27 @@ fn find_and_extract_exports(module: &str) -> Vec<InlineModuleExport> {
     }
 }
 
-/// Search lib_paths and program directory for a `.rakumod` file matching the module name.
+/// Search lib_paths and program directory for a `.rakumod` / `.pm6` / `.pm` file
+/// matching the module name.
 fn find_module_file(module: &str) -> Option<String> {
-    let filename = format!("{}.rakumod", module.replace("::", "/"));
+    let base_name = module.replace("::", "/");
+    let extensions = [".rakumod", ".pm6", ".pm"];
     // First, search configured lib paths
     let result = LIB_PATHS.with(|paths| {
         let paths = paths.borrow();
-        for base in paths.iter() {
-            let base_path = std::path::Path::new(base);
-            let candidate = base_path.join(&filename);
-            if candidate.exists() {
-                return Some(candidate.to_string_lossy().into_owned());
-            }
-            // Also check lib/ subdirectory
-            let candidate = base_path.join("lib").join(&filename);
-            if candidate.exists() {
-                return Some(candidate.to_string_lossy().into_owned());
+        for ext in &extensions {
+            let filename = format!("{}{}", base_name, ext);
+            for base in paths.iter() {
+                let base_path = std::path::Path::new(base);
+                let candidate = base_path.join(&filename);
+                if candidate.exists() {
+                    return Some(candidate.to_string_lossy().into_owned());
+                }
+                // Also check lib/ subdirectory
+                let candidate = base_path.join("lib").join(&filename);
+                if candidate.exists() {
+                    return Some(candidate.to_string_lossy().into_owned());
+                }
             }
         }
         None
@@ -1165,18 +1170,21 @@ fn find_module_file(module: &str) -> Option<String> {
     // Fall back: search relative to program file (same as runtime's load_module)
     PROGRAM_PATH.with(|pp| {
         let pp = pp.borrow();
-        if let Some(path) = pp.as_ref()
-            && let Some(parent) = std::path::Path::new(path).parent()
-        {
-            let candidate = parent.join(&filename);
+        for ext in &extensions {
+            let filename = format!("{}{}", base_name, ext);
+            if let Some(path) = pp.as_ref()
+                && let Some(parent) = std::path::Path::new(path).parent()
+            {
+                let candidate = parent.join(&filename);
+                if candidate.exists() {
+                    return Some(candidate.to_string_lossy().into_owned());
+                }
+            }
+            // Last resort: current directory
+            let candidate = std::path::Path::new(".").join(&filename);
             if candidate.exists() {
                 return Some(candidate.to_string_lossy().into_owned());
             }
-        }
-        // Last resort: current directory
-        let candidate = std::path::Path::new(".").join(&filename);
-        if candidate.exists() {
-            return Some(candidate.to_string_lossy().into_owned());
         }
         None
     })

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1685,7 +1685,7 @@ impl Interpreter {
         let current = self.env.clone();
         let mut restored = saved_env.clone();
         for key in saved_env.keys() {
-            if params.iter().any(|p| p == key) || key == "@_" {
+            if params.iter().any(|p| p == key) || key == "_" || key == "@_" || key == "%_" {
                 continue;
             }
             if let Some(v) = current.get(key) {

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -156,6 +156,22 @@ impl Interpreter {
             "reduce" => Some(self.dispatch_reduce_method(target, args)),
             "elems" => self.dispatch_elems_method(target, args),
             "map" => Some(self.dispatch_map_method(target, args)),
+            "flatmap" => {
+                // flatmap is equivalent to .map(...).flat
+                Some(self.dispatch_map_method(target, args).map(|mapped| {
+                    let items = Self::value_to_list(&mapped);
+                    let mut flat_items = Vec::new();
+                    for item in items {
+                        match item {
+                            Value::Array(sub_items, _) | Value::Seq(sub_items) => {
+                                flat_items.extend(sub_items.iter().cloned());
+                            }
+                            other => flat_items.push(other),
+                        }
+                    }
+                    Value::Seq(std::sync::Arc::new(flat_items))
+                }))
+            }
             "duckmap" => {
                 let block = args.first().cloned().unwrap_or(Value::Nil);
                 Some(self.duckmap_iterate(&block, &target))

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -41,6 +41,21 @@ fn make_solitary_tilde_quantifier_error() -> RuntimeError {
     err
 }
 
+/// Check if a regex token is a whitespace-like token (WsRule or <.ws> subrule call).
+fn is_ws_like_token(token: &RegexToken) -> bool {
+    match &token.atom {
+        RegexAtom::WsRule => true,
+        RegexAtom::Named(name) => {
+            let mut raw = name.trim();
+            if let Some(stripped) = raw.strip_prefix('.') {
+                raw = stripped.trim();
+            }
+            raw == "ws" || raw == "ws?"
+        }
+        _ => false,
+    }
+}
+
 fn rewrite_tilde_tokens(
     tokens: Vec<RegexToken>,
     ignore_case: bool,
@@ -53,15 +68,62 @@ fn rewrite_tilde_tokens(
             if !matches!(tokens[i].quant, RegexQuant::One) {
                 return Err(make_solitary_tilde_quantifier_error());
             }
-            if out.is_empty() || i + 2 >= tokens.len() {
+            if out.is_empty() {
                 return Ok(tokens);
             }
-            let goal_token = tokens[i + 1].clone();
-            let inner_token = tokens[i + 2].clone();
+            // Remove trailing ws-like token from out (before tilde) — inserted
+            // by sigspace between the opener and `~`.
+            let had_pre_ws = out.last().is_some_and(is_ws_like_token);
+            if had_pre_ws {
+                out.pop();
+            }
+            // Skip ws-like tokens after the tilde to find the goal (closer)
+            let mut j = i + 1;
+            while j < tokens.len() && is_ws_like_token(&tokens[j]) {
+                j += 1;
+            }
+            if j >= tokens.len() {
+                return Ok(tokens);
+            }
+            let goal_token = tokens[j].clone();
+            // Skip ws-like tokens after the goal to find the inner (content)
+            let mut k = j + 1;
+            while k < tokens.len() && is_ws_like_token(&tokens[k]) {
+                k += 1;
+            }
+            if k >= tokens.len() {
+                return Ok(tokens);
+            }
+            let inner_token = tokens[k].clone();
+            // Build the inner pattern: the single content token, optionally
+            // surrounded by WsRule so `rule` sigspace allows whitespace between
+            // opener/content and content/closer.
+            let mut inner_tokens = Vec::new();
+            if had_pre_ws {
+                let ws_tok = RegexToken {
+                    atom: RegexAtom::WsRule,
+                    quant: RegexQuant::One,
+                    named_capture: None,
+                    ratchet: false,
+                    frugal: false,
+                };
+                inner_tokens.push(ws_tok.clone());
+                inner_tokens.push(inner_token);
+                inner_tokens.push(ws_tok);
+            } else {
+                inner_tokens.push(inner_token);
+            }
+            let inner_pattern = RegexPattern {
+                tokens: inner_tokens,
+                anchor_start: false,
+                anchor_end: false,
+                ignore_case,
+                ignore_mark,
+            };
             out.push(RegexToken {
                 atom: RegexAtom::GoalMatch {
                     goal: single_token_pattern(goal_token.clone(), ignore_case, ignore_mark),
-                    inner: single_token_pattern(inner_token, ignore_case, ignore_mark),
+                    inner: inner_pattern,
                     goal_text: goal_text_for_token(&goal_token),
                 },
                 quant: RegexQuant::One,
@@ -69,7 +131,11 @@ fn rewrite_tilde_tokens(
                 ratchet: false,
                 frugal: false,
             });
-            i += 3;
+            // Skip past the inner token and any trailing ws-like tokens
+            i = k + 1;
+            while i < tokens.len() && is_ws_like_token(&tokens[i]) {
+                i += 1;
+            }
             continue;
         }
         out.push(tokens[i].clone());
@@ -3164,6 +3230,25 @@ impl Interpreter {
                                 all_negated_escapes = false;
                             }
                             EscResult::Multi
+                        } else if chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+                            // \c32 — decimal codepoint
+                            let mut num_str = String::new();
+                            while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+                                num_str.push(chars.next().unwrap());
+                            }
+                            if let Ok(cp) = num_str.parse::<u32>() {
+                                if let Some(ch) = char::from_u32(cp) {
+                                    if is_neg {
+                                        EscResult::NegChar(ch)
+                                    } else {
+                                        EscResult::Char(ch)
+                                    }
+                                } else {
+                                    EscResult::Char(esc)
+                                }
+                            } else {
+                                EscResult::Char(esc)
+                            }
                         } else {
                             EscResult::Char(esc)
                         }
@@ -3542,6 +3627,29 @@ impl Interpreter {
                 'r' => Some('\r'),
                 'f' => Some('\u{000C}'),
                 '0' => Some('\0'),
+                'c' => {
+                    if chars.peek() == Some(&'[') {
+                        chars.next();
+                        let mut cname = String::new();
+                        while let Some(&c) = chars.peek() {
+                            if c == ']' {
+                                chars.next();
+                                break;
+                            }
+                            cname.push(c);
+                            chars.next();
+                        }
+                        crate::token_kind::lookup_unicode_char_by_name(cname.trim())
+                    } else if chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+                        let mut num_str = String::new();
+                        while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+                            num_str.push(chars.next().unwrap());
+                        }
+                        num_str.parse::<u32>().ok().and_then(char::from_u32)
+                    } else {
+                        Some(esc)
+                    }
+                }
                 'x' => {
                     if chars.peek() == Some(&'[') {
                         chars.next();

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -934,13 +934,18 @@ impl Interpreter {
 
     /// Resolve a module name to a file path by searching lib paths and standard locations.
     pub(super) fn resolve_module_path(&self, module: &str) -> Option<std::path::PathBuf> {
-        let filename = format!("{}.rakumod", module.replace("::", "/"));
+        let base_name = module.replace("::", "/");
+        // Try .rakumod first, then .pm6, then .pm (Raku module resolution order)
+        let extensions = [".rakumod", ".pm6", ".pm"];
         let mut candidates: Vec<std::path::PathBuf> = Vec::new();
-        for base in &self.lib_paths {
-            let base_path = Path::new(base);
-            candidates.push(base_path.join(&filename));
-            // Also check lib/ subdirectory (Raku distribution layout)
-            candidates.push(base_path.join("lib").join(&filename));
+        for ext in &extensions {
+            let filename = format!("{}{}", base_name, ext);
+            for base in &self.lib_paths {
+                let base_path = Path::new(base);
+                candidates.push(base_path.join(&filename));
+                // Also check lib/ subdirectory (Raku distribution layout)
+                candidates.push(base_path.join("lib").join(&filename));
+            }
         }
         if candidates.is_empty()
             && let Some(path) = &self.program_path
@@ -948,7 +953,10 @@ impl Interpreter {
             && !parent.as_os_str().is_empty()
             && parent.is_dir()
         {
-            candidates.push(parent.join(&filename));
+            for ext in &extensions {
+                let filename = format!("{}{}", base_name, ext);
+                candidates.push(parent.join(&filename));
+            }
         }
         if let Some(path) = &self.program_path {
             let top_module = module.split("::").next().unwrap_or(module);
@@ -956,21 +964,24 @@ impl Interpreter {
                 if ancestor.as_os_str().is_empty() {
                     continue;
                 }
-                candidates.push(
-                    ancestor
-                        .join("packages")
-                        .join(top_module)
-                        .join("lib")
-                        .join(&filename),
-                );
-                candidates.push(
-                    ancestor
-                        .join("roast")
-                        .join("packages")
-                        .join(top_module)
-                        .join("lib")
-                        .join(&filename),
-                );
+                for ext in &extensions {
+                    let filename = format!("{}{}", base_name, ext);
+                    candidates.push(
+                        ancestor
+                            .join("packages")
+                            .join(top_module)
+                            .join("lib")
+                            .join(&filename),
+                    );
+                    candidates.push(
+                        ancestor
+                            .join("roast")
+                            .join("packages")
+                            .join(top_module)
+                            .join("lib")
+                            .join(&filename),
+                    );
+                }
             }
         }
         candidates.into_iter().find(|path| path.exists())

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -1156,6 +1156,9 @@ impl VM {
                 .collect();
             let local_names: std::collections::HashSet<&String> = cf.code.locals.iter().collect();
             for (k, v) in self.interpreter.env().iter() {
+                if k == "_" || k == "@_" || k == "%_" {
+                    continue;
+                }
                 if restored_env.contains_key(k)
                     && !local_names.contains(k)
                     && !rw_sources.contains(k)

--- a/t/json-tiny-compat.t
+++ b/t/json-tiny-compat.t
@@ -1,0 +1,50 @@
+use Test;
+
+# This test requires JSON::Tiny. Run with:
+#   prove -e 'target/debug/mutsu -I tmp/json-tiny/lib' t/json-tiny-compat.t
+# Or: MUTSULIB=tmp/json-tiny/lib prove -e 'target/debug/mutsu' t/json-tiny-compat.t
+#
+# Automatically skipped when JSON::Tiny module files are not present.
+
+unless "tmp/json-tiny/lib/JSON/Tiny.pm".IO.e {
+    plan 1;
+    skip "JSON::Tiny not installed (run: git clone https://github.com/moritz/json.git tmp/json-tiny)", 1;
+    done-testing;
+    exit 0;
+}
+
+use JSON::Tiny;
+
+plan 14;
+
+# to-json: numbers
+is to-json(42), '42', 'to-json integer';
+is to-json(3.14), '3.14', 'to-json decimal';
+
+# to-json: strings
+is to-json("hello world"), '"hello world"', 'to-json simple string';
+is to-json("with \"quotes\""), '"with \\"quotes\\""', 'to-json string with quotes';
+is to-json("line\nbreak"), '"line\\nbreak"', 'to-json string with newline';
+
+# to-json: booleans and null
+is to-json(True), 'true', 'to-json True';
+is to-json(False), 'false', 'to-json False';
+is to-json(Any), 'null', 'to-json Any (null)';
+
+# to-json: arrays
+is to-json([1, 2, 3]), '[ 1, 2, 3 ]', 'to-json array of ints';
+is to-json(["a", "b"]), '[ "a", "b" ]', 'to-json array of strings';
+
+# to-json: hashes
+{
+    my $json = to-json({name => "test"});
+    ok $json.contains('"name"'), 'to-json hash contains key';
+    ok $json.contains('"test"'), 'to-json hash contains value';
+}
+
+# to-json: nested structures
+{
+    my $json = to-json({list => [1, 2], flag => True});
+    ok $json.contains('[ 1, 2 ]'), 'to-json nested array in hash';
+    ok $json.contains('true'), 'to-json nested bool in hash';
+}


### PR DESCRIPTION
## Summary
- Enable mutsu to run JSON::Tiny's `to-json` function (serialization direction) with output identical to Raku
- Fix module resolution to support `.pm6` and `.pm` extensions (both parser and runtime)
- Implement `.flatmap` method needed by JSON::Tiny's hash serializer
- Fix `\c` decimal codepoint syntax in regex character classes (`\c32..\c126`)
- Fix topic variable (`$_`) leaking from proto-dispatched function calls
- Fix `~` (tilde/balanced matching) in `rule` declarations by properly handling sigspace-inserted `<.ws>` tokens

## Test plan
- [x] `t/json-tiny-compat.t` -- 14 tests covering to-json for numbers, strings, bools, null, arrays, hashes, nested structures (auto-skipped when JSON::Tiny not installed)
- [x] `t/regex-tilde.t` -- 7 existing tests still pass
- [x] `roast/S05-metachars/tilde.t` -- all 30 subtests now pass (previously had failures)
- [x] `make test` -- no regressions
- [x] `make roast` -- no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)