### PR TITLE
feat: add performance benchmark suite (mutsu vs raku)

### DIFF
--- a/benchmarks/bench-array.raku
+++ b/benchmarks/bench-array.raku
@@ -1,0 +1,27 @@
+# Array operations - push, map, grep, sort
+my $checksum = 0;
+
+# Push
+my @arr;
+for 1..10000 -> $i {
+    @arr.push($i);
+}
+$checksum += @arr.elems;
+
+# Map
+my @doubled = @arr.map(* * 2);
+$checksum += @doubled[0] + @doubled[*-1];
+
+# Grep
+my @evens = @arr.grep(* %% 2);
+$checksum += @evens.elems;
+
+# Sort (descending)
+my @sorted = @arr.sort({ $^b <=> $^a });
+$checksum += @sorted[0];
+
+# Reverse
+my @rev = @arr.reverse;
+$checksum += @rev[0];
+
+say "checksum = $checksum";

--- a/benchmarks/bench-class.raku
+++ b/benchmarks/bench-class.raku
@@ -1,0 +1,43 @@
+# OOP - class instantiation, method calls, inheritance
+class Animal {
+    has $.name;
+    has $.legs;
+
+    method describe() {
+        return $.name ~ " has " ~ $.legs ~ " legs";
+    }
+}
+
+class Dog is Animal {
+    has $.breed;
+
+    method bark() {
+        return "Woof!";
+    }
+
+    method full-info() {
+        return self.describe() ~ " (" ~ $.breed ~ ")";
+    }
+}
+
+my $checksum = 0;
+
+# Object creation and method calls
+for 1..5000 -> $i {
+    my $dog = Dog.new(name => "Rex", legs => 4, breed => "Labrador");
+    my $desc = $dog.full-info();
+    $checksum += $desc.chars;
+    $checksum += $dog.bark().chars;
+}
+
+# Polymorphism
+my @animals;
+for 1..2000 -> $i {
+    @animals.push(Animal.new(name => "Cat", legs => 4));
+    @animals.push(Dog.new(name => "Rex", legs => 4, breed => "Lab"));
+}
+for @animals -> $a {
+    $checksum += $a.describe().chars;
+}
+
+say "checksum = $checksum";

--- a/benchmarks/bench-fib.raku
+++ b/benchmarks/bench-fib.raku
@@ -1,0 +1,13 @@
+# Recursive fibonacci - tests function call overhead and recursion
+sub fib(Int $n --> Int) {
+    if $n <= 1 {
+        return $n;
+    }
+    return fib($n - 1) + fib($n - 2);
+}
+
+my $result = 0;
+for 1..25 -> $i {
+    $result = fib($i);
+}
+say "fib(25) = $result";

--- a/benchmarks/bench-hash.raku
+++ b/benchmarks/bench-hash.raku
@@ -1,0 +1,26 @@
+# Hash operations - insert, lookup, delete
+my $checksum = 0;
+
+# Insert
+my %h;
+for 1..10000 -> $i {
+    %h{"key-$i"} = $i;
+}
+$checksum += %h.elems;
+
+# Lookup
+for 1..10000 -> $i {
+    $checksum += %h{"key-$i"};
+}
+
+# Keys and values
+$checksum += %h.keys.elems;
+$checksum += %h.values.elems;
+
+# Delete
+for 1..5000 -> $i {
+    %h{"key-$i"}:delete;
+}
+$checksum += %h.elems;
+
+say "checksum = $checksum";

--- a/benchmarks/bench-startup.raku
+++ b/benchmarks/bench-startup.raku
@@ -1,0 +1,1 @@
+say "hello";

--- a/benchmarks/bench-string.raku
+++ b/benchmarks/bench-string.raku
@@ -1,0 +1,25 @@
+# String operations - concat, split, join, regex matching
+my $checksum = 0;
+
+# String concatenation
+my $s = "";
+for 1..10000 -> $i {
+    $s = $s ~ "x";
+}
+$checksum += $s.chars;
+
+# Split and join
+for 1..1000 -> $i {
+    my @parts = "the quick brown fox jumps over the lazy dog".split(" ");
+    my $joined = @parts.join("-");
+    $checksum += $joined.chars;
+}
+
+# Regex matching
+for 1..5000 -> $i {
+    if "hello world 42 foo" ~~ /\d+/ {
+        $checksum += 1;
+    }
+}
+
+say "checksum = $checksum";

--- a/benchmarks/run-benchmarks.sh
+++ b/benchmarks/run-benchmarks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Performance benchmark suite: mutsu vs raku
+# Usage: ./benchmarks/run-benchmarks.sh [--mutsu-only|--raku-only]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MUTSU="$REPO_DIR/target/release/mutsu"
+
+if [ ! -f "$MUTSU" ]; then
+    echo "ERROR: Release build not found at $MUTSU"
+    echo "Run: cargo build --release"
+    exit 1
+fi
+
+if ! command -v raku &>/dev/null; then
+    echo "WARNING: raku not found, will only run mutsu benchmarks"
+    RAKU_AVAILABLE=0
+else
+    RAKU_AVAILABLE=1
+fi
+
+MODE="both"
+if [ "${1:-}" = "--mutsu-only" ]; then
+    MODE="mutsu"
+elif [ "${1:-}" = "--raku-only" ]; then
+    MODE="raku"
+fi
+
+BENCHMARKS=(
+    "bench-startup.raku:Startup (say hello)"
+    "bench-fib.raku:Fibonacci (recursive, fib(1..25))"
+    "bench-string.raku:String ops (concat/split/regex)"
+    "bench-array.raku:Array ops (push/map/grep/sort)"
+    "bench-hash.raku:Hash ops (insert/lookup/delete)"
+    "bench-class.raku:OOP (classes/methods/inheritance)"
+)
+
+# Measure wall-clock time of a command, return seconds with 3 decimal places
+measure() {
+    local cmd="$1"
+    local file="$2"
+    # Use bash TIMEFORMAT for sub-second precision
+    local result
+    result=$( { TIMEFORMAT='%3R'; time $cmd "$file" > /dev/null 2>&1; } 2>&1 )
+    echo "$result"
+}
+
+# Print header
+echo ""
+echo "## mutsu Performance Benchmarks"
+echo ""
+echo "| Benchmark | mutsu (s) | raku (s) | Ratio (mutsu/raku) |"
+echo "|-----------|-----------|----------|--------------------|"
+
+for entry in "${BENCHMARKS[@]}"; do
+    IFS=':' read -r file label <<< "$entry"
+    filepath="$SCRIPT_DIR/$file"
+
+    mutsu_time="-"
+    raku_time="-"
+    ratio="-"
+
+    if [ "$MODE" != "raku" ]; then
+        mutsu_time=$(measure "$MUTSU" "$filepath")
+    fi
+
+    if [ "$MODE" != "mutsu" ] && [ "$RAKU_AVAILABLE" = "1" ]; then
+        raku_time=$(measure "raku" "$filepath")
+    fi
+
+    # Calculate ratio if both times are available
+    if [ "$mutsu_time" != "-" ] && [ "$raku_time" != "-" ]; then
+        ratio=$(awk "BEGIN { printf \"%.2f\", $mutsu_time / $raku_time }")
+        ratio="${ratio}x"
+    fi
+
+    printf "| %-37s | %9s | %8s | %18s |\n" "$label" "$mutsu_time" "$raku_time" "$ratio"
+done
+
+echo ""
+echo "_Lower is better. Ratio < 1.0 means mutsu is faster._"
+echo ""


### PR DESCRIPTION
## Summary
- Add `benchmarks/` directory with 6 Raku benchmark scripts covering startup time, recursive fibonacci, string operations, array operations, hash operations, and OOP (class/method/inheritance)
- Add `benchmarks/run-benchmarks.sh` runner that measures both mutsu and raku, outputs a markdown comparison table
- Each benchmark prints a checksum to prevent dead code elimination

## Initial results (this machine)

| Benchmark | mutsu (s) | raku (s) | Ratio (mutsu/raku) |
|-----------|-----------|----------|--------------------|
| Startup (say hello)                   |     0.006 |    0.135 |              0.04x |
| Fibonacci (recursive, fib(1..25))     |    22.302 |    0.283 |             78.81x |
| String ops (concat/split/regex)       |     0.748 |    0.295 |              2.54x |
| Array ops (push/map/grep/sort)        |    12.608 |    0.277 |             45.52x |
| Hash ops (insert/lookup/delete)       |     3.065 |    0.261 |             11.74x |
| OOP (classes/methods/inheritance)     |     1.832 |    0.337 |              5.44x |

mutsu startup is 25x faster than raku. Compute-heavy benchmarks show room for optimization, particularly in function call overhead (fibonacci) and array operations.

## Test plan
- [x] All 6 benchmarks run successfully with mutsu
- [x] All 6 benchmarks run successfully with raku
- [x] `run-benchmarks.sh` produces correct comparison table
- [x] No benchmark results committed (only scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)