### PR TITLE
feat: support from-json via grammar features for JSON::Tiny

### DIFF
--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -765,10 +765,25 @@ fn scan_to_delim_inner(
         } else if !p5_mode && c == '>' && input[i + 1..].starts_with('>') {
             // >> is a right word boundary assertion — skip both chars
             chars.next(); // consume second >
-        } else if !p5_mode && c == '<' && input[i + 1..].starts_with('[') {
-            // Skip character class <[...]> content without interpreting quotes
-            // Handles <['"]>, <[\s]>, etc.
-            chars.next(); // consume the '[' we already checked
+        } else if !p5_mode
+            && c == '<'
+            && (input[i + 1..].starts_with('[')
+                || input[i + 1..].starts_with("-[")
+                || input[i + 1..].starts_with("+[")
+                || input[i + 1..].starts_with("!["))
+        {
+            // Skip character class <[...]>, <-[...]>, <+[...]>, <![...]> content
+            // without interpreting quotes. Handles <['"]>, <-["\\\t]>, etc.
+            // Advance past any prefix chars before '['
+            loop {
+                if let Some((_, ch)) = chars.next() {
+                    if ch == '[' {
+                        break;
+                    }
+                } else {
+                    return None;
+                }
+            }
             let mut bracket_depth = 1u32;
             loop {
                 match chars.next() {

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -534,6 +534,11 @@ fn inject_implicit_rule_ws(pattern: &str) -> String {
                 | (_, '$')
                 | ('<', _)
                 | (_, '>')
+                | (_, '*')
+                | (_, '+')
+                | (_, '?')
+                | (_, '%')
+                | ('%', _)
         )
     }
 
@@ -622,6 +627,136 @@ fn inject_implicit_rule_ws(pattern: &str) -> String {
         i += 1;
     }
     out.trim().to_string()
+}
+
+/// In a `rule`, the `%` separator quantifier should allow optional whitespace
+/// around the separator. This function finds `% SEPARATOR` patterns and wraps
+/// the separator with `[ <.ws>? SEPARATOR <.ws>? ]`.
+fn inject_separator_ws(pattern: &str) -> String {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::new();
+    let mut i = 0usize;
+    let mut escaped = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    while i < chars.len() {
+        let c = chars[i];
+        if escaped {
+            out.push(c);
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if c == '\\' {
+            out.push(c);
+            escaped = true;
+            i += 1;
+            continue;
+        }
+        if c == '\'' && !in_double {
+            in_single = !in_single;
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        if c == '"' && !in_single {
+            in_double = !in_double;
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        if in_single || in_double {
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        // Look for `%` followed by a separator expression
+        if c == '%' {
+            out.push('%');
+            i += 1;
+            // Skip whitespace after %
+            while i < chars.len() && chars[i].is_whitespace() {
+                out.push(chars[i]);
+                i += 1;
+            }
+            if i >= chars.len() {
+                continue;
+            }
+            // Extract the separator expression
+            let sep_start = i;
+            if chars[i] == '[' {
+                // Bracketed separator: % [ ... ]
+                // Scan to matching ]
+                let mut depth = 1usize;
+                i += 1;
+                while i < chars.len() && depth > 0 {
+                    if chars[i] == '[' {
+                        depth += 1;
+                    } else if chars[i] == ']' {
+                        depth -= 1;
+                    } else if chars[i] == '\\' {
+                        i += 1; // skip escaped char
+                    }
+                    i += 1;
+                }
+                let sep: String = chars[sep_start..i].iter().collect();
+                out.push_str(&format!("[ <.ws>? {} <.ws>? ]", sep.trim()));
+            } else {
+                // Non-bracketed separator: % \, or % ","
+                // Collect the separator atom (could be \X, 'str', "str", or a single char)
+                let atom_start = i;
+                if chars[i] == '\'' {
+                    // Single-quoted string
+                    i += 1;
+                    while i < chars.len() && chars[i] != '\'' {
+                        if chars[i] == '\\' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                    if i < chars.len() {
+                        i += 1;
+                    } // skip closing '
+                } else if chars[i] == '"' {
+                    // Double-quoted string
+                    i += 1;
+                    while i < chars.len() && chars[i] != '"' {
+                        if chars[i] == '\\' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                    if i < chars.len() {
+                        i += 1;
+                    } // skip closing "
+                } else if chars[i] == '\\' {
+                    // Backslash-escaped char
+                    i += 2;
+                } else if chars[i] == '<' {
+                    // Angle-bracket assertion
+                    let mut depth = 1usize;
+                    i += 1;
+                    while i < chars.len() && depth > 0 {
+                        if chars[i] == '<' {
+                            depth += 1;
+                        } else if chars[i] == '>' {
+                            depth -= 1;
+                        }
+                        i += 1;
+                    }
+                } else {
+                    // Single character separator
+                    i += 1;
+                }
+                let sep: String = chars[atom_start..i].iter().collect();
+                out.push_str(&format!("[ <.ws>? {} <.ws>? ]", sep.trim()));
+            }
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
 }
 
 fn normalize_token_pattern(pattern: &str) -> String {
@@ -1372,6 +1507,7 @@ pub(super) fn token_decl(input: &str) -> PResult<'_, Stmt> {
     pattern = normalize_token_pattern(&pattern);
     if is_rule {
         pattern = inject_implicit_rule_ws(&pattern);
+        pattern = inject_separator_ws(&pattern);
         if name.contains(":sym<") || name.contains(":sym\u{ab}") {
             if !pattern.ends_with(' ') {
                 pattern.push(' ');
@@ -1606,6 +1742,63 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 export_tags: Vec::new(),
                 body: Vec::new(),
                 is_rw: false,
+                language_version: super::simple::current_language_version(),
+            },
+        ));
+    }
+    // unit grammar Name;  — declare a grammar at the file scope.
+    // unit grammar Name is Parent;
+    if let Some(r) = keyword("grammar", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, name) = qualified_ident(r)?;
+        let (r, _) = ws(r)?;
+        let mut r = r;
+        let mut parents = Vec::new();
+        let mut does_parents = Vec::new();
+        loop {
+            if let Some(r2) = keyword("is", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, parent) = if let Some(stripped) = r2.strip_prefix("::") {
+                    let (r3, ident_part) = qualified_ident(stripped)?;
+                    (r3, format!("::{}", ident_part))
+                } else {
+                    qualified_ident(r2)?
+                };
+                parents.push(parent);
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            }
+            if let Some(r2) = keyword("does", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, role_name) = qualified_ident(r2)?;
+                parents.push(role_name.clone());
+                does_parents.push(role_name);
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            }
+            break;
+        }
+        // Default parent is Grammar if no `is` clause
+        if parents.is_empty() && name != "Grammar" {
+            parents.push("Grammar".to_string());
+        }
+        let (r, _) = opt_char(r, ';');
+        super::simple::register_user_type(&name);
+        return Ok((
+            r,
+            Stmt::ClassDecl {
+                name: Symbol::intern(&name),
+                name_expr: None,
+                parents,
+                class_is_rw: false,
+                is_hidden: false,
+                is_lexical: false,
+                hidden_parents: vec![],
+                does_parents,
+                repr: None,
+                body: Vec::new(),
                 language_version: super::simple::current_language_version(),
             },
         ));

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -952,22 +952,36 @@ impl Interpreter {
         });
         let result = self.eval_block_value(&def.body);
         self.routine_stack.pop();
+        // Apply <sym> instantiation for proto token :sym<> variants
+        let instantiate_sym = |pat: &str| -> String { Self::instantiate_token_pattern(def, pat) };
         let rendered = match result {
-            Ok(Value::Regex(pat)) => self
-                .instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&pat))
-                .map(Some),
-            Ok(Value::Str(s)) => self
-                .instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&s))
-                .map(Some),
+            Ok(Value::Regex(pat)) => {
+                let pat = instantiate_sym(&pat);
+                self.instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&pat))
+                    .map(Some)
+            }
+            Ok(Value::Str(s)) => {
+                let s = instantiate_sym(&s);
+                self.instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&s))
+                    .map(Some)
+            }
             Ok(Value::Nil) => Ok(None),
             Ok(other) => Ok(Some(other.to_string_value())),
             Err(e) if e.return_value.is_some() => match e.return_value.unwrap() {
-                Value::Regex(pat) => self
-                    .instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&pat))
-                    .map(Some),
-                Value::Str(s) => self
-                    .instantiate_named_regex_arg_calls(&self.interpolate_bound_regex_scalars(&s))
-                    .map(Some),
+                Value::Regex(pat) => {
+                    let pat = instantiate_sym(&pat);
+                    self.instantiate_named_regex_arg_calls(
+                        &self.interpolate_bound_regex_scalars(&pat),
+                    )
+                    .map(Some)
+                }
+                Value::Str(s) => {
+                    let s = instantiate_sym(&s);
+                    self.instantiate_named_regex_arg_calls(
+                        &self.interpolate_bound_regex_scalars(&s),
+                    )
+                    .map(Some)
+                }
                 Value::Nil => Ok(None),
                 other => Ok(Some(other.to_string_value())),
             },

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -361,6 +361,12 @@ impl Interpreter {
                 self.env.insert(format!("<{}>", k), v.clone());
             }
         }
+        // Set positional capture env vars ($0, $1, ...) so they work inside action methods
+        if let Some(Value::Array(pos_arr, _)) = updated_attrs.get("list") {
+            for (i, v) in pos_arr.iter().enumerate() {
+                self.env.insert(i.to_string(), v.clone());
+            }
+        }
         // Also set $_ to the match (for `.make:` syntax)
         let saved_topic = self.env.get("_").cloned();
         self.env.insert("_".to_string(), match_obj.clone());

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -341,10 +341,17 @@ impl Interpreter {
         let mut token_lookup = false;
         let mut capture_name = None;
 
-        if let Some((lhs, rhs)) = raw.split_once('=') {
-            let lhs = lhs.trim();
-            let rhs = rhs.trim();
-            if !lhs.is_empty() {
+        // Look for alias syntax <name=.subrule>, <name=&subrule>, <name=subrule>.
+        // Only match `=` that is NOT part of `=>` (fat-arrow pair syntax in args)
+        // and where the LHS is a simple identifier (no parens, which would indicate
+        // we're inside an argument list like `<.foo(a => 1)>`).
+        if let Some(eq_pos) = raw.find('=')
+            && !raw[eq_pos + 1..].starts_with('>')
+        {
+            let lhs = raw[..eq_pos].trim();
+            let rhs = raw[eq_pos + 1..].trim();
+            // LHS must be a simple identifier (no parens, commas, colons, etc.)
+            if !lhs.is_empty() && !lhs.contains('(') && !lhs.contains(',') && !lhs.contains(':') {
                 if let Some(stripped) = rhs.strip_prefix('&') {
                     // <name=&subrule> — call &subrule, capture under name
                     capture_name = Some(lhs.to_string());

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -113,7 +113,10 @@ impl Interpreter {
             .map(|(end, _)| end)
     }
 
-    pub(super) fn instantiate_token_pattern(def: &FunctionDef, pattern: &str) -> String {
+    pub(in crate::runtime) fn instantiate_token_pattern(
+        def: &FunctionDef,
+        pattern: &str,
+    ) -> String {
         let Some(sym) = Self::extract_sym_adverb(&def.name.resolve()) else {
             return pattern.to_string();
         };
@@ -341,13 +344,24 @@ impl Interpreter {
         if let Some((lhs, rhs)) = raw.split_once('=') {
             let lhs = lhs.trim();
             let rhs = rhs.trim();
-            if !lhs.is_empty()
-                && let Some(stripped) = rhs.strip_prefix('&')
-            {
-                capture_name = Some(lhs.to_string());
-                raw = stripped.trim();
-                token_lookup = true;
-                silent = false;
+            if !lhs.is_empty() {
+                if let Some(stripped) = rhs.strip_prefix('&') {
+                    // <name=&subrule> — call &subrule, capture under name
+                    capture_name = Some(lhs.to_string());
+                    raw = stripped.trim();
+                    token_lookup = true;
+                    silent = false;
+                } else if let Some(stripped) = rhs.strip_prefix('.') {
+                    // <name=.subrule> — call .subrule (non-capturing), capture under name
+                    capture_name = Some(lhs.to_string());
+                    raw = stripped.trim();
+                    silent = false;
+                } else {
+                    // <name=subrule> — call subrule, capture under name
+                    capture_name = Some(lhs.to_string());
+                    raw = rhs;
+                    silent = false;
+                }
             }
         }
         if !token_lookup && let Some(stripped) = raw.strip_prefix('&') {

--- a/t/json-tiny-compat.t
+++ b/t/json-tiny-compat.t
@@ -13,9 +13,10 @@ unless "tmp/json-tiny/lib/JSON/Tiny.pm".IO.e {
     exit 0;
 }
 
+use lib 'tmp/json-tiny/lib';
 use JSON::Tiny;
 
-plan 14;
+plan 21;
 
 # to-json: numbers
 is to-json(42), '42', 'to-json integer';
@@ -48,3 +49,16 @@ is to-json(["a", "b"]), '[ "a", "b" ]', 'to-json array of strings';
     ok $json.contains('[ 1, 2 ]'), 'to-json nested array in hash';
     ok $json.contains('true'), 'to-json nested bool in hash';
 }
+
+# from-json: numbers
+is from-json('42'), 42, 'from-json integer';
+is from-json('3.14'), 3.14, 'from-json decimal';
+is from-json('-7'), -7, 'from-json negative integer';
+
+# from-json: booleans and null
+is from-json('true'), True, 'from-json true';
+is from-json('false'), False, 'from-json false';
+ok !from-json('null').defined, 'from-json null is undefined';
+
+# from-json: grammar parses JSON structures (smoke test)
+ok JSON::Tiny::Grammar.parse('{"a": 1}').defined, 'grammar parses JSON object';


### PR DESCRIPTION
## Summary
- Implements several general-purpose grammar/regex improvements that enable JSON::Tiny's `from-json` function to work
- Adds `unit grammar` parser support, `<name=.subrule>` alias syntax, negated character class handling in token body scanner, `<sym>` instantiation in dynamic token eval, rule sigspace fixes for quantifiers/separators, and positional capture propagation in grammar action dispatch
- Adds 7 new `from-json` tests to `t/json-tiny-compat.t` (numbers, booleans, null, grammar parsing)

### What works now
- `from-json("42")` -> 42
- `from-json("3.14")` -> 3.14
- `from-json("true")` -> True
- `from-json("false")` -> False
- `from-json("null")` -> (Any)
- `JSON::Tiny::Grammar.parse(...)` correctly parses numbers, strings, arrays, objects

### Known limitations (future work)
- `from-json` for strings returns incorrect values due to `+@$<str>` coercion not working properly in action methods
- `from-json` for arrays/objects returns `Nil` because quantified named captures (`<value>* % ','`) don't propagate subcaptures to action methods
- These are pre-existing limitations in the action dispatch and regex capture system

## Test plan
- [x] `make test` passes (478 files, 3890 tests)
- [x] `make roast` — no new regressions (grammar/signatures.t was already failing)
- [x] `t/json-tiny-compat.t` passes all 21 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)