### PR TITLE
fix: support double-sigil interpolation in strings and detect undeclared vars

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -59,6 +59,7 @@ roast/S02-literals/pod.t
 roast/S02-literals/quoting-unicode.t
 roast/S02-literals/quoting.t
 roast/S02-literals/radix.t
+roast/S02-literals/string-interpolation.t
 roast/S02-literals/sub-calls.t
 roast/S02-literals/subscript.t
 roast/S02-literals/types.t

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -1560,6 +1560,141 @@ fn parse_shell_words_index(content: &str) -> Expr {
     Expr::Literal(Value::str(trimmed.to_string()))
 }
 
+/// Handle double-sigil interpolation patterns like `@$name[]`, `%$name{}`, `$$name[]`, etc.
+/// The outer sigil determines the context and expected postcircumfix, the inner sigil+name
+/// identifies the variable. Returns `Some(remaining_input)` on success.
+fn try_double_sigil_interp<'a, F>(
+    rest: &'a str,
+    parts: &mut Vec<Expr>,
+    current: &mut String,
+    parse_postcircumfix_index: F,
+) -> Option<&'a str>
+where
+    F: Fn(&'a str, Expr) -> (Expr, &'a str),
+{
+    let bytes = rest.as_bytes();
+    if bytes.len() < 3 {
+        return None;
+    }
+    let outer_sigil = bytes[0] as char;
+    let inner_sigil = bytes[1] as char;
+    if !matches!(outer_sigil, '$' | '@' | '%' | '&') {
+        return None;
+    }
+    if !matches!(inner_sigil, '$' | '@' | '%' | '&') {
+        return None;
+    }
+    // The char after the inner sigil must start a variable name
+    let after_inner = &rest[2..];
+    let first_name_char = after_inner.as_bytes().first().copied().unwrap_or(0) as char;
+    if !first_name_char.is_alphabetic() && first_name_char != '_' {
+        return None;
+    }
+    // Parse the variable name
+    let end = after_inner
+        .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
+        .unwrap_or(after_inner.len());
+    let name = &after_inner[..end];
+    let after_name = &after_inner[end..];
+
+    // Build the inner variable expression
+    // For &name, use BareWord so the undeclared-name check catches it
+    let inner_expr = match inner_sigil {
+        '$' => Expr::Var(name.to_string()),
+        '@' => Expr::ArrayVar(name.to_string()),
+        '%' => Expr::HashVar(name.to_string()),
+        '&' => Expr::BareWord(name.to_string()),
+        _ => unreachable!(),
+    };
+
+    // Check for postcircumfix that matches the outer sigil's context
+    let mut remainder = after_name;
+    let mut consumed = false;
+    match outer_sigil {
+        '$' | '@' => {
+            // Expect [] for zen-slice or [expr]
+            if let Some(r) = remainder.strip_prefix("[]") {
+                remainder = r;
+                consumed = true;
+            } else if remainder.starts_with('[') {
+                let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
+                if r.len() < remainder.len() {
+                    if !current.is_empty() {
+                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                    }
+                    parts.push(expr);
+                    return Some(r);
+                }
+            }
+        }
+        '%' => {
+            // Expect {} for zen-slice or {expr}
+            if let Some(r) = remainder.strip_prefix("{}") {
+                remainder = r;
+                consumed = true;
+            } else if remainder.starts_with('{') {
+                let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
+                if r.len() < remainder.len() {
+                    if !current.is_empty() {
+                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                    }
+                    parts.push(expr);
+                    return Some(r);
+                }
+            }
+        }
+        '&' => {
+            // Expect () for call
+            if let Some(r) = remainder.strip_prefix("()") {
+                remainder = r;
+                consumed = true;
+            } else if remainder.starts_with('(') {
+                let mut depth = 0usize;
+                let mut paren_end = None;
+                for (idx, ch) in remainder.char_indices() {
+                    if ch == '(' {
+                        depth += 1;
+                    } else if ch == ')' {
+                        depth -= 1;
+                        if depth == 0 {
+                            paren_end = Some(idx);
+                            break;
+                        }
+                    }
+                }
+                if let Some(pe) = paren_end {
+                    consumed = true;
+                    remainder = &remainder[pe + 1..];
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // For @/$ context without postcircumfix, also check for {} and method calls
+    if !consumed && matches!(outer_sigil, '$' | '@') {
+        let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
+        if r.len() < remainder.len() {
+            if !current.is_empty() {
+                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+            }
+            parts.push(expr);
+            return Some(r);
+        }
+        return None;
+    }
+
+    if !consumed {
+        return None;
+    }
+
+    if !current.is_empty() {
+        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+    }
+    parts.push(inner_expr);
+    Some(remainder)
+}
+
 /// Try to interpolate a `$var` or `@var` at the current position.
 /// Returns `Some(remaining_input)` if interpolation was performed, `None` otherwise.
 pub(super) fn try_interpolate_var<'a>(
@@ -1829,9 +1964,22 @@ pub(super) fn try_interpolate_var<'a>(
                 }
             }
         }
+        // Double-sigil interpolation: $$name, $@name, $%name, $&name
+        if let Some(result) =
+            try_double_sigil_interp(rest, parts, current, parse_postcircumfix_index)
+        {
+            return Some(result);
+        }
     }
     if rest.starts_with('@') && rest.len() > 1 {
         let next = rest.as_bytes()[1] as char;
+        // Double-sigil interpolation: @$name, @@name, @%name, @&name
+        if matches!(next, '$' | '@' | '%' | '&')
+            && let Some(result) =
+                try_double_sigil_interp(rest, parts, current, parse_postcircumfix_index)
+        {
+            return Some(result);
+        }
         if next.is_alphabetic() || next == '_' {
             let var_rest = &rest[1..];
             let end = var_rest
@@ -1866,6 +2014,13 @@ pub(super) fn try_interpolate_var<'a>(
     }
     if rest.starts_with('%') && rest.len() > 1 {
         let next = rest.as_bytes()[1] as char;
+        // Double-sigil interpolation: %$name, %@name, %%name, %&name
+        if matches!(next, '$' | '@' | '%' | '&')
+            && let Some(result) =
+                try_double_sigil_interp(rest, parts, current, parse_postcircumfix_index)
+        {
+            return Some(result);
+        }
         if next.is_alphabetic() || next == '_' {
             let var_rest = &rest[1..];
             let end = var_rest
@@ -1915,6 +2070,13 @@ pub(super) fn try_interpolate_var<'a>(
     // &func() interpolation — only with parentheses
     if rest.starts_with('&') && rest.len() > 1 {
         let next = rest.as_bytes()[1] as char;
+        // Double-sigil interpolation: &$name, &@name, &%name
+        if matches!(next, '$' | '@' | '%')
+            && let Some(result) =
+                try_double_sigil_interp(rest, parts, current, parse_postcircumfix_index)
+        {
+            return Some(result);
+        }
         if next.is_alphabetic() || next == '_' {
             let var_rest = &rest[1..];
             let end = var_rest

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -211,10 +211,11 @@ impl Interpreter {
         for stmt in stmts {
             Self::check_self_referential_init(stmt)?;
             Self::collect_declared_vars(stmt, &mut declared);
-            if let Some(var_name) = self.find_undeclared_var_in_stmt(stmt, &declared) {
-                let symbol = format!("${}", var_name);
+            if let Some((sigil, var_name)) = self.find_undeclared_var_in_stmt(stmt, &declared) {
+                let symbol = format!("{}{}", sigil, var_name);
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert("name".to_string(), Value::str(symbol.clone()));
+                attrs.insert("symbol".to_string(), Value::str(symbol.clone()));
                 attrs.insert(
                     "message".to_string(),
                     Value::str(format!("Variable '{}' is not declared.", symbol)),
@@ -329,12 +330,12 @@ impl Interpreter {
     }
 
     /// Find an undeclared Var reference in a statement.
-    /// Returns the variable name (without sigil) if undeclared, None otherwise.
+    /// Returns (sigil, name) if undeclared, None otherwise.
     fn find_undeclared_var_in_stmt(
         &self,
         stmt: &Stmt,
         declared: &HashSet<String>,
-    ) -> Option<String> {
+    ) -> Option<(&'static str, String)> {
         match stmt {
             Stmt::Say(exprs) | Stmt::Print(exprs) | Stmt::Note(exprs) | Stmt::Put(exprs) => {
                 for expr in exprs {
@@ -342,10 +343,10 @@ impl Interpreter {
                         && !self.has_function(name)
                         && !self.has_class(name)
                     {
-                        return Some(name.clone());
+                        return Some(("$", name.clone()));
                     }
-                    if let Some(name) = self.find_undeclared_var_in_expr(expr, declared) {
-                        return Some(name);
+                    if let Some(result) = self.find_undeclared_var_in_expr(expr, declared) {
+                        return Some(result);
                     }
                 }
                 None
@@ -356,11 +357,12 @@ impl Interpreter {
     }
 
     /// Find an undeclared Var reference in an expression.
+    /// Returns (sigil, name) if undeclared, None otherwise.
     fn find_undeclared_var_in_expr(
         &self,
         expr: &Expr,
         declared: &HashSet<String>,
-    ) -> Option<String> {
+    ) -> Option<(&'static str, String)> {
         match expr {
             Expr::Var(name) => {
                 // Skip special variables, variables with twigils, and capture vars ($0, $1, ...)
@@ -394,7 +396,50 @@ impl Interpreter {
                 if self.has_function(name) || self.has_class(name) {
                     return None;
                 }
-                Some(name.clone())
+                Some(("$", name.clone()))
+            }
+            Expr::ArrayVar(name) => {
+                let sigiled = format!("@{}", name);
+                if declared.contains(name) || declared.contains(&sigiled) {
+                    return None;
+                }
+                if self.env.contains_key(&sigiled) || self.env.contains_key(name) {
+                    return None;
+                }
+                Some(("@", name.clone()))
+            }
+            Expr::HashVar(name) => {
+                let sigiled = format!("%{}", name);
+                if declared.contains(name) || declared.contains(&sigiled) {
+                    return None;
+                }
+                if self.env.contains_key(&sigiled) || self.env.contains_key(name) {
+                    return None;
+                }
+                Some(("%", name.clone()))
+            }
+            // Recurse into string interpolation, indexing, and method calls
+            Expr::StringInterpolation(parts) => {
+                for part in parts {
+                    if let Some(result) = self.find_undeclared_var_in_expr(part, declared) {
+                        return Some(result);
+                    }
+                }
+                None
+            }
+            Expr::Index { target, index, .. } => self
+                .find_undeclared_var_in_expr(target, declared)
+                .or_else(|| self.find_undeclared_var_in_expr(index, declared)),
+            Expr::MethodCall { target, args, .. } => {
+                if let Some(result) = self.find_undeclared_var_in_expr(target, declared) {
+                    return Some(result);
+                }
+                for arg in args {
+                    if let Some(result) = self.find_undeclared_var_in_expr(arg, declared) {
+                        return Some(result);
+                    }
+                }
+                None
             }
             _ => None,
         }
@@ -606,6 +651,16 @@ impl Interpreter {
                 .or_else(|| self.find_undeclared_name_in_expr(right, local_classes, declared)),
             Expr::Unary { expr, .. } => {
                 self.find_undeclared_name_in_expr(expr, local_classes, declared)
+            }
+            Expr::StringInterpolation(parts) => {
+                for part in parts {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(part, local_classes, declared)
+                    {
+                        return Some(name);
+                    }
+                }
+                None
             }
             _ => None,
         }


### PR DESCRIPTION
## Summary
- Implement parsing of double-sigil patterns in string interpolation (e.g., `@$var[]`, `%$var{}`, `$$var[]`, `&$var()`, `@@var[]`, `%@var{}`, `@%var[]`, `%%var{}`, `&%var()`, `@&name[]`, `%&name{}`) so undeclared variable references are properly detected
- Extend the undeclared variable checker to recurse into StringInterpolation, Index, and MethodCall AST nodes, and to detect undeclared `@array` and `%hash` variables (not just `$scalar`)
- Add `roast/S02-literals/string-interpolation.t` to the whitelist (all 42 subtests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-literals/string-interpolation.t` passes all 42 tests
- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] `make test` no new regressions
- [x] `make roast` no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)