### PR TITLE
docs: add monthly news for Feb-Apr 2026

### DIFF
--- a/news/2026-02.md
+++ b/news/2026-02.md
@@ -1,0 +1,50 @@
+# mutsu — 2026年2月の実装状況
+
+## 概要
+
+プロジェクト初期の大規模実装月。基盤となる VM・パーサー・ランタイムの構築と、roast テスト通過率の急速な向上を達成。
+
+- Whitelist: 147 → 566 (+419)
+- コミット: ~1229 件
+- PR: #22 〜 #682
+
+## ハイライト
+
+### 基盤構築
+
+- WASM ビルド対応 + Playwright E2E テスト (#401, #404)
+- pcre2 をオプション化して WASM ビルド修正 (#564)
+- methods.rs (8711行) を 6 モジュールに分割 (#648)
+- Sub/Routine/WeakSub dispatch を methods_sub.rs に抽出 (#676)
+- Promise/Channel dispatch を methods_promise.rs に抽出 (#650)
+- Supply/Proc::Async を別モジュールに抽出 (#681)
+- builtins_operators.rs にオペレータ dispatch を抽出
+
+### 言語機能
+
+- 演算子の優先度 trait (`is tighter/looser/equiv`) (#677)
+- Set の交差演算子 `(&)`/`∩` のクロスタイプ対応 (#675)
+- eqv 演算子で Array vs List を区別 (#682)
+- END phasers が die()/exit() 後も実行 (#476)
+- signal/act コールバック、raw stdout、lines 分割 (#418)
+- call-style reduction パースと S13-overloading/metaoperators.t 通過
+- Buf read/write bits セマンティクスと bigint bit マスク (#513)
+- Junction boolean-context セマンティクス (#504)
+- Supply.lines セマンティクス (#493)
+- S04 goto (#523)
+- S04 statement-modifiers if.t (#481)
+
+### AI フリート運用
+
+- ai-fleet.sh フリートマネージャー + tmux-status.sh (#632)
+- サンドボックスの中断再開対応 (#630)
+- ai-supervisor のヒストリー更新改善 (#620)
+
+## メトリクス
+
+| 指標 | 月初 | 月末 |
+|------|------|------|
+| Whitelist | 147 | 566 |
+| fail | 1048 | 554 |
+| error | 88 | 167 |
+| subtests_pass | 99,354 | 118,514 |

--- a/news/2026-03.md
+++ b/news/2026-03.md
@@ -1,0 +1,78 @@
+# mutsu — 2026年3月の実装状況
+
+## 概要
+
+roast 通過率を大幅に向上させた月。566 → 935 と 369 テスト追加。言語の中核機能を幅広く実装。
+
+- Whitelist: 566 → 935 (+369)
+- コミット: ~1208 件
+
+## ハイライト
+
+### 型システム・コンテナ
+
+- Failure の boolification 時に handled マーク、with/without の single-eval (#1875)
+- shaped array の shape 保持 (#1876)
+- Mix/MixHash のオリジナルキー型保持 (#1882)
+- hash autovivification for reduce with is raw parameters (#1880)
+- typed attribute array への push 型チェック (#1881)
+- BigRat → Num デグレード (分母が uint64 範囲外) (#2156)
+
+### OOP・dispatch
+
+- multi method dispatch + method wrap サポート (#1905)
+- ::?CLASS:D/:U invocant dispatch と X::Parameter::InvalidConcreteness (#1897)
+- nextsame/nextwith in proto-dispatched multi subs (#2160)
+- anonymous scalar assignment args の VarRef wrap (#1890)
+- invalid type smileys の reject (#1885)
+
+### 文字列・正規表現
+
+- `\c` decimal codepoint in regex
+- InASCII block と Numeric_Type<Value> in regex (#1903)
+- grapheme with combining marks の enumerated char class reject (#1894)
+- backslash escapes in regex character class bracket (#2164)
+- .trans regex+closure replacements で $_ を設定 (#1905)
+
+### I/O・エンコーディング
+
+- utf8-c8 エンコーディングラウンドトリップ (#2158)
+- buf16/Buf[uint16] の UTF-16 デコード (#2162)
+- IO::Spec::Win32 フルサポート (213 subtests) (#2147)
+- IO::Spec::Cygwin (#2145)
+- IO::Spec.devnull と Proc::Async stdout(:bin) (#1895)
+- slurp エンコーディングサポート、ARGFILES (#1896)
+- spurt.t 全 62 subtests 通過 (#2170)
+
+### モジュール・パッケージ
+
+- export tag filtering for module imports (#1898)
+- EVAL コンテキストでの undeclared name / class redeclaration 検出 (#1893)
+- QuantHash を known type constraints に追加 (#2152)
+
+### ドキュメンテーション
+
+- README の全面書き直し (#1888)
+- Pod config parsing (S26-documentation) (#2153)
+- Pod doc comment handling (wacky.t) (#2171)
+
+### Roast テスト (抜粋)
+
+- S03-operators/misc.t 全 78 subtests (#1877)
+- S02-types/flattening.t 全 50 subtests (#2154)
+- S06-operator-overloading/sub.t 全 29 subtests (#2151)
+- S05-mass/stdrules.t 全 193 subtests (#2166)
+- S26-documentation/why-leading.t 全 66 subtests (#2146)
+- S13-overloading/typecasting-long.t 39 tests (#2173)
+- S02-types/pair.t 174/182 (#2165)
+- S02-types/mix.t 240/244 (#2169)
+- S12-attributes/class.t 22/28 (#2161)
+
+## メトリクス
+
+| 指標 | 月初 | 月末 |
+|------|------|------|
+| Whitelist | 566 | 935 |
+| fail | 554 | 333 |
+| error | 167 | 18 |
+| subtests_pass | 118,514 | 165,000 |

--- a/news/2026-04.md
+++ b/news/2026-04.md
@@ -1,0 +1,61 @@
+# mutsu — 2026年4月の実装状況
+
+## 概要
+
+roast 通過率を 935 → 1083 に向上。ペースは3月より落ちたが、難易度の高い残りテストに取り組んだ月。
+
+- Whitelist: 935 → 1083 (+148)
+- コミット: ~251 件
+
+## ハイライト
+
+### 型システム
+
+- Set/Bag/Mix の ACCEPTS, STORE, Capture, lazy check, subclass (#2163)
+- HyperSeq/RaceSeq value types (#2167)
+- Junction の %% / !%% operator スレッディング (#2168)
+- Capture 型強制 — X::Cannot::Capture, Match.Capture, Range.Capture (#2159)
+- PartialEq for Uni values (eqv/is-deeply) (#2174)
+- scalar bind to nested hash elements (#2155)
+- X::PoisonedAlias と enum coercion Failure (#2172)
+
+### 日時・数値
+
+- DateTime/Instant/Duration temporal precision と leap second (#2150)
+- BigRat → Num デグレード (#2156)
+- term constants (i, NaN, Inf, Empty) の解決順序修正 (#2144)
+
+### I/O・エンコーディング
+
+- utf8-c8 encoding round-trip (#2158)
+- buf16/Buf[uint16] UTF-16 decode (#2162)
+- IO::Spec::Win32 full support (213 subtests) (#2147)
+- IO::Spec::Cygwin (#2145)
+- spurt.t 全 62 subtests (#2170)
+
+### OOP
+
+- nextsame/nextwith in proto-dispatched multi subs (#2160)
+- S12-attributes/class.t 22/28 (#2161)
+- S13-overloading/typecasting-long.t 39 tests (#2173)
+
+### 正規表現
+
+- backslash escapes in regex character class bracket (#2164)
+- S05-mass/stdrules.t 全 193 subtests (#2166)
+
+### ドキュメンテーション
+
+- Pod config parsing (S26-documentation/09-configuration.t) (#2153)
+- wacky.t Pod doc comment handling (#2171)
+- why-leading.t 全 66 subtests (#2146)
+
+## メトリクス
+
+| 指標 | 月初 | 月末 |
+|------|------|------|
+| Whitelist | 935 | 1083 |
+| fail | 333 | 181 |
+| error | 18 | 21 |
+| timeout | 10 | 11 |
+| subtests_pass | 165,000 | 169,344 |


### PR DESCRIPTION
## Summary
- Add retrospective monthly implementation reports
- Feb: 147→566 (+419), foundation & WASM & AI fleet
- Mar: 566→935 (+369), core language features & I/O
- Apr: 935→1083 (+148), harder tests & type system

🤖 Generated with [Claude Code](https://claude.com/claude-code)