### PR TITLE
fix: improve grammar infrastructure for JSON::Tiny from-json arrays

### DIFF
--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -620,11 +620,23 @@ pub(super) fn array_var(input: &str) -> PResult<'_, Expr> {
     };
     // Contextualized scalar specials (e.g., @$/, @$_): parse `$...` then lift
     // to an array variable targeting the same underlying name.
-    if twigil.is_empty()
-        && rest.starts_with('$')
-        && let Ok((r2, Expr::Var(name))) = scalar_var(rest)
-    {
-        return Ok((r2, Expr::ArrayVar(name)));
+    if twigil.is_empty() && rest.starts_with('$') {
+        // Handle @$<name> — list coercion of a named capture variable
+        if let Ok((r2, expr @ Expr::CaptureVar(_))) = scalar_var(rest) {
+            return Ok((
+                r2,
+                Expr::MethodCall {
+                    target: Box::new(expr),
+                    name: crate::symbol::Symbol::intern("list"),
+                    args: vec![],
+                    modifier: None,
+                    quoted: false,
+                },
+            ));
+        }
+        if let Ok((r2, Expr::Var(name))) = scalar_var(rest) {
+            return Ok((r2, Expr::ArrayVar(name)));
+        }
     }
     // Bare @ (anonymous array variable) — each occurrence gets a unique name
     let next_is_ident =

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -218,7 +218,7 @@ impl Interpreter {
             for (i, v) in captures.positional.iter().enumerate() {
                 self.env.insert(i.to_string(), Value::str(v.clone()));
             }
-            let match_obj = Value::make_match_object_full(
+            let match_obj = Value::make_match_object_full_q(
                 captures.matched,
                 captures.from as i64,
                 captures.to as i64,
@@ -228,6 +228,7 @@ impl Interpreter {
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
                 Some(&text),
+                &captures.named_quantified,
             );
             let match_obj = if let Value::Instance {
                 class_name,
@@ -341,9 +342,22 @@ impl Interpreter {
                 0
             });
             for (child_name, child_match) in children {
-                let updated_child =
-                    self.invoke_grammar_actions(child_match, actions, &child_name)?;
-                updated_named.insert(child_name, updated_child);
+                if let Value::Array(items, meta) = &child_match {
+                    let mut updated_items = Vec::with_capacity(items.len());
+                    for item in items.as_ref() {
+                        let updated_item =
+                            self.invoke_grammar_actions(item.clone(), actions, &child_name)?;
+                        updated_items.push(updated_item);
+                    }
+                    updated_named.insert(
+                        child_name,
+                        Value::Array(Arc::new(updated_items), *meta),
+                    );
+                } else {
+                    let updated_child =
+                        self.invoke_grammar_actions(child_match, actions, &child_name)?;
+                    updated_named.insert(child_name, updated_child);
+                }
             }
             updated_attrs.insert("named".to_string(), Value::hash(updated_named));
         }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -349,10 +349,7 @@ impl Interpreter {
                             self.invoke_grammar_actions(item.clone(), actions, &child_name)?;
                         updated_items.push(updated_item);
                     }
-                    updated_named.insert(
-                        child_name,
-                        Value::Array(Arc::new(updated_items), *meta),
-                    );
+                    updated_named.insert(child_name, Value::Array(Arc::new(updated_items), *meta));
                 } else {
                     let updated_child =
                         self.invoke_grammar_actions(child_match, actions, &child_name)?;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -581,6 +581,8 @@ pub(crate) struct RegexCaptures {
     pub(crate) regex_vars: HashMap<String, Value>,
     /// The winning :sym<> variant name, if this match was from a protoregex.
     pub(crate) sym: Option<String>,
+    /// Named captures from quantified tokens — always stored as arrays in Match.
+    pub(crate) named_quantified: HashSet<String>,
 }
 
 #[derive(Clone)]

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -329,6 +329,10 @@ pub(super) fn merge_regex_captures(
     for (k, v) in src.named.drain() {
         dst.named.entry(k).or_default().extend(v);
     }
+    for (k, v) in src.named_subcaps.drain() {
+        dst.named_subcaps.entry(k).or_default().extend(v);
+    }
+    dst.named_quantified.extend(src.named_quantified.drain());
     dst.positional.append(&mut src.positional);
     dst.positional_subcaps.append(&mut src.positional_subcaps);
     dst.positional_quantified

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -101,6 +101,12 @@ impl Interpreter {
                 for (k, v) in inner_caps.named.drain() {
                     new_caps.named.entry(k).or_default().extend(v);
                 }
+                for (k, v) in inner_caps.named_subcaps.drain() {
+                    new_caps.named_subcaps.entry(k).or_default().extend(v);
+                }
+                new_caps
+                    .named_quantified
+                    .extend(inner_caps.named_quantified.drain());
                 for v in inner_caps.positional.drain(..) {
                     new_caps.positional.push(v);
                 }
@@ -153,6 +159,16 @@ impl Interpreter {
                 for (k, v) in inner_caps.named.drain() {
                     new_caps.named.entry(k).or_default().extend(v);
                 }
+                for (k, v) in &inner_caps.named_subcaps {
+                    new_caps
+                        .named_subcaps
+                        .entry(k.clone())
+                        .or_default()
+                        .extend(v.clone());
+                }
+                new_caps
+                    .named_quantified
+                    .extend(inner_caps.named_quantified.iter().cloned());
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                 // Store inner captures as subcaptures of this group
                 let mut subcap = inner_caps;

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -22,6 +22,12 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
+                        for (k, v) in inner_caps.named_subcaps.drain() {
+                            new_caps.named_subcaps.entry(k).or_default().extend(v);
+                        }
+                        new_caps
+                            .named_quantified
+                            .extend(inner_caps.named_quantified.drain());
                         new_caps.positional.extend(inner_caps.positional);
                         new_caps
                             .positional_subcaps
@@ -193,6 +199,16 @@ impl Interpreter {
                             .or_default()
                             .extend(v.clone());
                     }
+                    for (k, v) in &inner_caps.named_subcaps {
+                        new_caps
+                            .named_subcaps
+                            .entry(k.clone())
+                            .or_default()
+                            .extend(v.clone());
+                    }
+                    new_caps
+                        .named_quantified
+                        .extend(inner_caps.named_quantified.iter().cloned());
                     // Store inner captures as subcaptures of this group
                     let mut subcap = inner_caps.clone();
                     subcap.matched = captured.clone();
@@ -436,6 +452,9 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
+                        new_caps
+                            .named_quantified
+                            .extend(inner_caps.named_quantified.drain());
                         for v in inner_caps.positional.drain(..) {
                             new_caps.positional.push(v);
                         }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -3,8 +3,54 @@ use super::regex_helpers::{
     count_capture_groups, fold_quantified_captures, is_named_atom_no_args, is_silent_named_atom,
     is_simple_atom,
 };
+use std::collections::HashSet;
 
 impl Interpreter {
+    /// Collect all named capture names inside a regex atom (recursively).
+    fn collect_named_captures_in_atom(atom: &RegexAtom, out: &mut HashSet<String>) {
+        match atom {
+            RegexAtom::Named(name) => {
+                let spec = Self::parse_named_regex_lookup_spec(name);
+                if !spec.silent {
+                    let cap = spec
+                        .capture_name
+                        .unwrap_or_else(|| spec.lookup_name.clone());
+                    if !cap.is_empty() {
+                        out.insert(cap);
+                    }
+                }
+            }
+            RegexAtom::Group(pat) | RegexAtom::CaptureGroup(pat) => {
+                for tok in &pat.tokens {
+                    if let Some(name) = tok.named_capture.as_ref() {
+                        out.insert(name.clone());
+                    }
+                    Self::collect_named_captures_in_atom(&tok.atom, out);
+                }
+            }
+            RegexAtom::Alternation(alts) | RegexAtom::SequentialAlternation(alts) => {
+                for alt in alts {
+                    for tok in &alt.tokens {
+                        if let Some(name) = tok.named_capture.as_ref() {
+                            out.insert(name.clone());
+                        }
+                        Self::collect_named_captures_in_atom(&tok.atom, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Collect all named capture names from a regex token.
+    fn collect_quantified_names_for_token(token: &RegexToken) -> HashSet<String> {
+        let mut names = HashSet::new();
+        if let Some(name) = token.named_capture.as_ref() {
+            names.insert(name.clone());
+        }
+        Self::collect_named_captures_in_atom(&token.atom, &mut names);
+        names
+    }
     pub(super) fn regex_match_end_from_caps_in_pkg(
         &self,
         pattern: &RegexPattern,
@@ -183,6 +229,9 @@ impl Interpreter {
                         };
                         let mut current = pos;
                         let mut current_caps = caps;
+                        if !capture_name.is_empty() {
+                            current_caps.named_quantified.insert(capture_name.clone());
+                        }
                         while current < chars.len() {
                             if let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
                                 &resolved,
@@ -219,6 +268,9 @@ impl Interpreter {
                     } else {
                         let base_len = caps.positional.len();
                         let stride = count_capture_groups(&token.atom);
+                        let mut caps = caps;
+                        caps.named_quantified
+                            .extend(Self::collect_quantified_names_for_token(token));
                         let mut positions = Vec::new();
                         positions.push((pos, caps.clone()));
                         let mut current = pos;
@@ -343,6 +395,7 @@ impl Interpreter {
                         let mut current = first_end;
                         let mut current_caps = caps;
                         if !capture_name.is_empty() {
+                            current_caps.named_quantified.insert(capture_name.clone());
                             let captured: String = chars[pos..first_end].iter().collect();
                             let mut subcap = first_inner;
                             subcap.matched = captured.clone();
@@ -395,6 +448,9 @@ impl Interpreter {
                     } else {
                         let base_len = caps.positional.len();
                         let stride = count_capture_groups(&token.atom);
+                        let mut caps = caps;
+                        caps.named_quantified
+                            .extend(Self::collect_quantified_names_for_token(token));
                         let (mut current, mut current_caps) = match self
                             .regex_match_atom_with_capture_in_pkg(
                                 &token.atom,
@@ -466,6 +522,9 @@ impl Interpreter {
                     };
                     let base_len = caps.positional.len();
                     let stride = count_capture_groups(&token.atom);
+                    let mut caps = caps;
+                    caps.named_quantified
+                        .extend(Self::collect_quantified_names_for_token(token));
                     let mut positions = Vec::new();
                     if min == 0 {
                         positions.push((pos, caps.clone()));

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -554,7 +554,9 @@ impl Interpreter {
             return None;
         }
         let last_body = body.chars().last()?;
-        if !matches!(last_body, '>' | ']' | ')' | '}') {
+        // Only handle angle-bracket subrule atoms like `<value>*`.
+        // Do NOT strip quantifiers from bracket groups like `[\w+]+`.
+        if last_body != '>' {
             return None;
         }
         let count_spec = match quant {

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -543,6 +543,29 @@ impl Interpreter {
         false
     }
 
+    /// Strip a quantifier from a bracket-delimited atom like `<value>*`.
+    fn strip_bracket_quantifier(atom: &str) -> Option<(String, String)> {
+        let quant = atom.chars().last()?;
+        if !matches!(quant, '?' | '+' | '*') {
+            return None;
+        }
+        let body = &atom[..atom.len() - quant.len_utf8()];
+        if body.is_empty() {
+            return None;
+        }
+        let last_body = body.chars().last()?;
+        if !matches!(last_body, '>' | ']' | ')' | '}') {
+            return None;
+        }
+        let count_spec = match quant {
+            '*' => "0..*",
+            '+' => "1..*",
+            '?' => "0..1",
+            _ => return None,
+        };
+        Some((body.to_string(), count_spec.to_string()))
+    }
+
     fn split_simple_quantified_atom(atom: &str) -> Option<(String, String)> {
         let quant = atom.chars().last()?;
         if !matches!(quant, '?' | '+' | '*') {
@@ -618,6 +641,10 @@ impl Interpreter {
                     prefix,
                     Self::build_ltm_expansion(&quantified_tail, "1..*", sep_mode, sep)
                 );
+            }
+            // Handle bracket-delimited atoms with quantifiers (e.g. `<value>*`)
+            if let Some((base, count_spec)) = Self::strip_bracket_quantifier(&atom) {
+                return Self::build_ltm_expansion(&base, &count_spec, sep_mode, sep);
             }
             return Self::build_ltm_expansion(&atom, "1..*", sep_mode, sep);
         }
@@ -722,12 +749,21 @@ impl Interpreter {
                 }
             }
             None => {
-                let mut out = build_exact_list(min);
-                out.push_str(&format!("({sep}{atom})*"));
-                if allow_trailing_sep {
-                    out.push_str(&format!("({sep})?"));
+                if min == 0 {
+                    // 0..* with separator: [atom(sep atom)*]?
+                    let mut inner = format!("{atom}({sep}{atom})*");
+                    if allow_trailing_sep {
+                        inner.push_str(&format!("({sep})?"));
+                    }
+                    format!("[{inner}]?")
+                } else {
+                    let mut out = build_exact_list(min);
+                    out.push_str(&format!("({sep}{atom})*"));
+                    if allow_trailing_sep {
+                        out.push_str(&format!("({sep})?"));
+                    }
+                    out
                 }
-                out
             }
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2119,6 +2119,34 @@ impl Value {
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
         orig: Option<&str>,
     ) -> Self {
+        Self::make_match_object_full_q(
+            matched,
+            from,
+            to,
+            positional,
+            named,
+            named_subcaps,
+            positional_subcaps,
+            positional_quantified,
+            orig,
+            &HashSet::new(),
+        )
+    }
+
+    /// Like make_match_object_full but with named_quantified tracking.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn make_match_object_full_q(
+        matched: String,
+        from: i64,
+        to: i64,
+        positional: &[String],
+        named: &HashMap<String, Vec<String>>,
+        named_subcaps: &HashMap<String, Vec<crate::runtime::RegexCaptures>>,
+        positional_subcaps: &[Option<crate::runtime::RegexCaptures>],
+        positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
+        orig: Option<&str>,
+        named_quantified: &HashSet<String>,
+    ) -> Self {
         fn make_capture_match(s: &str, orig: Option<&str>, search_from: usize) -> Value {
             let mut attrs = HashMap::new();
             attrs.insert("str".to_string(), Value::str(s.to_string()));
@@ -2206,7 +2234,7 @@ impl Value {
                         make_capture_match(s, orig, search_start)
                     })
                     .collect();
-                if vals.len() == 1 {
+                if vals.len() == 1 && !caps.named_quantified.contains(key) {
                     sub_named.insert(key.clone(), vals[0].clone());
                 } else {
                     sub_named.insert(key.clone(), Value::array(vals));
@@ -2286,7 +2314,7 @@ impl Value {
                     make_capture_match(s, orig, search_start)
                 })
                 .collect();
-            if vals.len() == 1 {
+            if vals.len() == 1 && !named_quantified.contains(key) {
                 named_caps_map.insert(key.clone(), vals[0].clone());
             } else {
                 named_caps_map.insert(key.clone(), Value::array(vals));

--- a/t/json-tiny-compat.t
+++ b/t/json-tiny-compat.t
@@ -16,7 +16,7 @@ unless "tmp/json-tiny/lib/JSON/Tiny.pm".IO.e {
 use lib 'tmp/json-tiny/lib';
 use JSON::Tiny;
 
-plan 21;
+plan 26;
 
 # to-json: numbers
 is to-json(42), '42', 'to-json integer';
@@ -60,5 +60,12 @@ is from-json('true'), True, 'from-json true';
 is from-json('false'), False, 'from-json false';
 ok !from-json('null').defined, 'from-json null is undefined';
 
+# from-json: arrays
+is-deeply from-json('[1, 2, 3]'), [1, 2, 3], 'from-json array of ints';
+is-deeply from-json('[true, false, null]'), [True, False, Any], 'from-json array of mixed';
+is-deeply from-json('[[1, 2], [3]]'), [[1, 2], [3]], 'from-json nested arrays';
+
 # from-json: grammar parses JSON structures (smoke test)
 ok JSON::Tiny::Grammar.parse('{"a": 1}').defined, 'grammar parses JSON object';
+ok JSON::Tiny::Grammar.parse('[1, 2]').defined, 'grammar parses JSON array';
+ok JSON::Tiny::Grammar.parse('"hello"').defined, 'grammar parses JSON string';


### PR DESCRIPTION
## Summary
- Track quantified named captures (`named_quantified` field on `RegexCaptures`) so captures from `<value>*` or `<str>*` are always stored as arrays in Match objects
- Propagate `named_subcaps` and `named_quantified` through all regex capture merge operations (Group, CaptureGroup, Alternation, GoalMatch, Conjunction, etc.)
- Fix separator quantifier expansion (`<atom> * % sep`) for bracket-delimited atoms to correctly handle zero-or-more patterns
- Parse `@$<name>` as list coercion of capture variable (needed for `+@$<str>` in JSON::Tiny::Actions)
- Handle array-valued named captures in grammar action dispatch (recurse into each element)

These changes enable `from-json` to correctly parse arrays like `[1,2,3]`, `[true, false, null]`, and nested arrays via JSON::Tiny. String and object parsing still have remaining issues tracked separately.

## Test plan
- [x] `t/json-tiny-compat.t` passes (26 tests including new array from-json tests)
- [x] `t/regex-unicode-single-quotes.t` passes (no regression from separator expansion changes)
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)