### PR TITLE
fix: grammar aliased capture action dispatch and regex char class alternations

### DIFF
--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -181,7 +181,7 @@ impl Interpreter {
             if let Some(err) = Self::take_pending_regex_error() {
                 return Err(err);
             }
-            let Some(captures) = captures else {
+            let Some(mut captures) = captures else {
                 let goal = Self::take_pending_goal_failure().or_else(|| {
                     self.parse_regex(&pattern)
                         .and_then(|p| Self::first_goal_name(&p))
@@ -218,6 +218,7 @@ impl Interpreter {
             for (i, v) in captures.positional.iter().enumerate() {
                 self.env.insert(i.to_string(), Value::str(v.clone()));
             }
+            let alias_map = std::mem::take(&mut captures.capture_alias_map);
             let match_obj = Value::make_match_object_full_q(
                 captures.matched,
                 captures.from as i64,
@@ -242,6 +243,13 @@ impl Interpreter {
                 }
                 if let Some(ref act) = actions_obj {
                     attrs.insert("actions".to_string(), act.clone());
+                }
+                if !alias_map.is_empty() {
+                    let alias_hash: HashMap<String, Value> = alias_map
+                        .iter()
+                        .map(|(k, v)| (k.clone(), Value::str(v.clone())))
+                        .collect();
+                    attrs.insert("capture_alias_map".to_string(), Value::hash(alias_hash));
                 }
                 Value::make_instance(*class_name, attrs)
             } else {
@@ -306,6 +314,16 @@ impl Interpreter {
         result
     }
 
+    /// Extract `action_name` from a Match object (set for aliased captures).
+    fn get_action_name(match_obj: &Value) -> Option<String> {
+        if let Value::Instance { attributes, .. } = match_obj
+            && let Some(Value::Str(action_name)) = attributes.get("action_name")
+        {
+            return Some(action_name.to_string());
+        }
+        None
+    }
+
     /// Walk the match tree bottom-up and invoke action methods on the actions object.
     fn invoke_grammar_actions(
         &mut self,
@@ -328,7 +346,6 @@ impl Interpreter {
         let mut updated_attrs = attributes.clone();
         if let Some(Value::Hash(named_hash)) = attributes.get("named") {
             let mut updated_named = named_hash.as_ref().clone();
-            // Sort children by their match position (from attribute) to preserve grammar order
             let mut children: Vec<(String, Value)> = named_hash
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -345,14 +362,18 @@ impl Interpreter {
                 if let Value::Array(items, meta) = &child_match {
                     let mut updated_items = Vec::with_capacity(items.len());
                     for item in items.as_ref() {
+                        let dispatch_name =
+                            Self::get_action_name(item).unwrap_or_else(|| child_name.clone());
                         let updated_item =
-                            self.invoke_grammar_actions(item.clone(), actions, &child_name)?;
+                            self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?;
                         updated_items.push(updated_item);
                     }
                     updated_named.insert(child_name, Value::Array(Arc::new(updated_items), *meta));
                 } else {
+                    let dispatch_name =
+                        Self::get_action_name(&child_match).unwrap_or_else(|| child_name.clone());
                     let updated_child =
-                        self.invoke_grammar_actions(child_match, actions, &child_name)?;
+                        self.invoke_grammar_actions(child_match, actions, &dispatch_name)?;
                     updated_named.insert(child_name, updated_child);
                 }
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -583,6 +583,11 @@ pub(crate) struct RegexCaptures {
     pub(crate) sym: Option<String>,
     /// Named captures from quantified tokens — always stored as arrays in Match.
     pub(crate) named_quantified: HashSet<String>,
+    /// For aliased captures like `<str=.str_escape>`, maps capture name to
+    /// original rule name for grammar action dispatch.
+    pub(crate) capture_alias_map: HashMap<String, String>,
+    /// The original rule name when this capture was stored under an alias.
+    pub(crate) action_name: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -333,6 +333,9 @@ pub(super) fn merge_regex_captures(
         dst.named_subcaps.entry(k).or_default().extend(v);
     }
     dst.named_quantified.extend(src.named_quantified.drain());
+    for (k, v) in src.capture_alias_map.drain() {
+        dst.capture_alias_map.insert(k, v);
+    }
     dst.positional.append(&mut src.positional);
     dst.positional_subcaps.append(&mut src.positional_subcaps);
     dst.positional_quantified

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -270,6 +270,17 @@ impl Interpreter {
                                     .entry(capture_name.to_string())
                                     .or_default()
                                     .push(captured);
+                                if spec.capture_name.is_some() && capture_name != spec.lookup_name {
+                                    new_caps
+                                        .capture_alias_map
+                                        .insert(capture_name.to_string(), spec.lookup_name.clone());
+                                    if let Some(subcaps) =
+                                        new_caps.named_subcaps.get_mut(capture_name)
+                                        && let Some(last) = subcaps.last_mut()
+                                    {
+                                        last.action_name = Some(spec.lookup_name.clone());
+                                    }
+                                }
                             } else {
                                 // Silent subrule — merge named captures only (not positional).
                                 let mut inner_caps = inner_caps;

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -28,6 +28,9 @@ impl Interpreter {
                         new_caps
                             .named_quantified
                             .extend(inner_caps.named_quantified.drain());
+                        for (k, v) in inner_caps.capture_alias_map.drain() {
+                            new_caps.capture_alias_map.insert(k, v);
+                        }
                         new_caps.positional.extend(inner_caps.positional);
                         new_caps
                             .positional_subcaps
@@ -69,6 +72,15 @@ impl Interpreter {
                         let mut new_caps = current_caps.clone();
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
+                        }
+                        for (k, v) in inner_caps.named_subcaps.drain() {
+                            new_caps.named_subcaps.entry(k).or_default().extend(v);
+                        }
+                        new_caps
+                            .named_quantified
+                            .extend(inner_caps.named_quantified.drain());
+                        for (k, v) in inner_caps.capture_alias_map.drain() {
+                            new_caps.capture_alias_map.insert(k, v);
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
                         new_caps
@@ -446,6 +458,16 @@ impl Interpreter {
                             .entry(capture_name.to_string())
                             .or_default()
                             .push(captured);
+                        if spec.capture_name.is_some() && capture_name != spec.lookup_name {
+                            new_caps
+                                .capture_alias_map
+                                .insert(capture_name.to_string(), spec.lookup_name.clone());
+                            if let Some(subcaps) = new_caps.named_subcaps.get_mut(capture_name)
+                                && let Some(last) = subcaps.last_mut()
+                            {
+                                last.action_name = Some(spec.lookup_name.clone());
+                            }
+                        }
                     } else {
                         // No capture name — merge inner captures flat
                         let mut inner_caps = inner_caps;

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -281,6 +281,51 @@ fn split_prop_args(s: &str) -> (&str, Option<&str>) {
     (s, None)
 }
 
+/// Skip `<[...]>` character class content where quotes are literal.
+fn skip_char_class_content(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+    current: &mut String,
+    open_ch: char,
+) -> bool {
+    let is_char_class = {
+        let tmp = chars.clone();
+        let mut it = tmp;
+        let c1 = it.next();
+        let c2 = it.next();
+        matches!(
+            (c1, c2),
+            (Some('['), _) | (Some('-' | '+' | '!'), Some('['))
+        )
+    };
+    if !is_char_class {
+        return false;
+    }
+    current.push(open_ch);
+    let mut bracket_depth = 0u32;
+    while let Some(c) = chars.next() {
+        current.push(c);
+        match c {
+            '\\' => {
+                if let Some(esc) = chars.next() {
+                    current.push(esc);
+                }
+            }
+            '[' => bracket_depth += 1,
+            ']' => {
+                bracket_depth -= 1;
+                if bracket_depth == 0 {
+                    if chars.peek() == Some(&'>') {
+                        current.push(chars.next().unwrap());
+                    }
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
 impl Interpreter {
     fn regex_alternation_separator(out: &str) -> Option<&'static str> {
         let trimmed = out.trim_end_matches(char::is_whitespace);
@@ -380,9 +425,11 @@ impl Interpreter {
                 }
                 '<' => {
                     if chars.peek() == Some(&'<') {
-                        // << is a word boundary, not an angle bracket pair
                         current.push(ch);
                         current.push(chars.next().unwrap());
+                        continue;
+                    }
+                    if skip_char_class_content(&mut chars, &mut current, ch) {
                         continue;
                     }
                     depth_angle += 1;
@@ -390,7 +437,6 @@ impl Interpreter {
                 }
                 '>' => {
                     if chars.peek() == Some(&'>') {
-                        // >> is a word boundary, not an angle bracket pair
                         current.push(ch);
                         current.push(chars.next().unwrap());
                         continue;
@@ -486,6 +532,9 @@ impl Interpreter {
                     current.push(ch);
                 }
                 '<' => {
+                    if skip_char_class_content(&mut chars, &mut current, ch) {
+                        continue;
+                    }
                     depth_angle += 1;
                     current.push(ch);
                 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2253,6 +2253,17 @@ impl Value {
             if let Some(ref sym_val) = caps.sym {
                 attrs.insert("sym_variant".to_string(), Value::str(sym_val.clone()));
             }
+            if let Some(ref action_name) = caps.action_name {
+                attrs.insert("action_name".to_string(), Value::str(action_name.clone()));
+            }
+            if !caps.capture_alias_map.is_empty() {
+                let alias_hash: HashMap<String, Value> = caps
+                    .capture_alias_map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Value::str(v.clone())))
+                    .collect();
+                attrs.insert("capture_alias_map".to_string(), Value::hash(alias_hash));
+            }
             Value::make_instance(Symbol::intern("Match"), attrs)
         }
 

--- a/t/grammar-alias-actions.t
+++ b/t/grammar-alias-actions.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 8;
+
+# Test 1-3: regex alternation with quote chars in character classes
+is ('n' ~~ / <["\\/bfnrt]> | 'u' /).Str, 'n',
+   'char class with " in alternation matches n';
+is ('"' ~~ / <["\\/bfnrt]> | 'u' /).Str, '"',
+   'char class with " in alternation matches "';
+is ('u' ~~ / <["\\/bfnrt]> | 'u' /).Str, 'u',
+   'alternation second branch matches u';
+
+# Test 4-5: grammar alias capture action dispatch
+# When using <alias=.rule>, the action method for "rule" should be called,
+# not the method for "alias".
+grammar TestGrammar {
+    token TOP { [ <str> | '\\' <str=.esc> ]* }
+    token str { <-[\\]>+ }
+    token esc { <[nrt]> }
+}
+
+class TestActions {
+    method TOP($/) {
+        make $<str>>>.made.join;
+    }
+    method str($/) { make ~$/ }
+    method esc($/) { make "ESC:" ~ ~$/ }
+}
+
+my $m = TestGrammar.parse('a\\nb', :actions(TestActions.new));
+ok $m.defined, 'grammar with alias captures parses';
+is $m<str>[1].made, 'ESC:n',
+   'aliased capture dispatches to original rule action';
+
+# Test 6-8: individual match elements have correct made values
+is $m<str>[0].made, 'a', 'non-aliased capture uses its own action';
+is $m<str>[2].made, 'b', 'non-aliased capture after alias uses its own action';
+is $m.made, 'aESC:nb', 'TOP made combines all str captures correctly';

--- a/t/json-tiny-compat.t
+++ b/t/json-tiny-compat.t
@@ -16,7 +16,7 @@ unless "tmp/json-tiny/lib/JSON/Tiny.pm".IO.e {
 use lib 'tmp/json-tiny/lib';
 use JSON::Tiny;
 
-plan 26;
+plan 30;
 
 # to-json: numbers
 is to-json(42), '42', 'to-json integer';
@@ -69,3 +69,14 @@ is-deeply from-json('[[1, 2], [3]]'), [[1, 2], [3]], 'from-json nested arrays';
 ok JSON::Tiny::Grammar.parse('{"a": 1}').defined, 'grammar parses JSON object';
 ok JSON::Tiny::Grammar.parse('[1, 2]').defined, 'grammar parses JSON array';
 ok JSON::Tiny::Grammar.parse('"hello"').defined, 'grammar parses JSON string';
+
+# from-json: strings
+is from-json('"hello"'), 'hello', 'from-json simple string';
+is from-json('"hello world"'), 'hello world', 'from-json string with space';
+
+# from-json: array of strings
+is-deeply from-json('["a", "b", "c"]'), ["a", "b", "c"], 'from-json array of strings';
+
+# Grammar str_escape token (used internally by string parsing)
+ok JSON::Tiny::Grammar.subparse('n', :rule<str_escape>).defined,
+   'grammar str_escape token matches n';


### PR DESCRIPTION
## Summary
- Fix regex alternation splitting when `"` appears inside `<[...]>` character classes (e.g., `<["\\/bfnrt]> | 'u'` was incorrectly parsed)
- Fix grammar action dispatch for aliased captures: `<str=.str_escape>` now calls `str_escape` action method, not `str`
- Propagate `named_subcaps`, `named_quantified`, and alias maps through Alternation and Group handlers

These fixes enable JSON::Tiny's `from-json` to correctly parse string values, fixing the infrastructure needed for `from-json('"hello"')` to work.

## Test plan
- [x] New `t/grammar-alias-actions.t` — tests char class in alternation and aliased capture action dispatch
- [x] Extended `t/json-tiny-compat.t` — adds from-json string tests and str_escape token test
- [x] `cargo clippy -- -D warnings` passes
- [x] Existing grammar/regex tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)