### PR TITLE
fix: pass array length to all WhateverCode params in subscript evaluation

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -141,9 +141,11 @@ impl VM {
             return Value::Array(Arc::new(indices), crate::value::ArrayKind::List);
         }
         if let Value::Sub(ref data) = idx {
-            let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
             let mut sub_env = data.env.clone();
-            sub_env.insert(param.to_string(), Value::Int(len));
+            // Pass length for ALL WhateverCode parameters (e.g. *-4 .. *-2 has 2 params)
+            for p in &data.params {
+                sub_env.insert(p.to_string(), Value::Int(len));
+            }
             let saved_env = std::mem::take(self.interpreter.env_mut());
             *self.interpreter.env_mut() = sub_env;
             let result = self
@@ -166,9 +168,10 @@ impl VM {
                 let mut resolved = Vec::with_capacity(items.len());
                 for item in items.iter() {
                     if let Value::Sub(data) = item {
-                        let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                         let mut sub_env = data.env.clone();
-                        sub_env.insert(param.to_string(), Value::Int(len));
+                        for p in &data.params {
+                            sub_env.insert(p.to_string(), Value::Int(len));
+                        }
                         let saved_env = std::mem::take(self.interpreter.env_mut());
                         *self.interpreter.env_mut() = sub_env;
                         let result = self
@@ -823,9 +826,10 @@ impl VM {
                 match val {
                     Value::Int(i) => *i,
                     Value::Sub(data) => {
-                        let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                         let mut sub_env = data.env.clone();
-                        sub_env.insert(param.to_string(), Value::Int(len));
+                        for p in &data.params {
+                            sub_env.insert(p.to_string(), Value::Int(len));
+                        }
                         let saved_env = std::mem::take(vm.interpreter.env_mut());
                         *vm.interpreter.env_mut() = sub_env;
                         let result = vm

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -12,9 +12,10 @@ impl VM {
         match &idx {
             Value::Sub(data) => {
                 let len = arr_len as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let resolved = self

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -270,9 +270,10 @@ impl VM {
                     for idx in indices.iter() {
                         // Resolve WhateverCode indices (e.g. *-1, *-3)
                         let resolved_idx = if let Value::Sub(data) = idx {
-                            let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                             let mut sub_env = data.env.clone();
-                            sub_env.insert(param.to_string(), Value::Int(len));
+                            for p in &data.params {
+                                sub_env.insert(p.to_string(), Value::Int(len));
+                            }
                             let saved_env = std::mem::take(self.interpreter.env_mut());
                             *self.interpreter.env_mut() = sub_env;
                             let result = self
@@ -433,9 +434,10 @@ impl VM {
             // WhateverCode index on Seq: (1,2,3).Seq[*-1]
             (Value::Seq(items), Value::Sub(ref data)) => {
                 let len = items.len() as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -525,9 +527,10 @@ impl VM {
             // Treat hash as a list of pairs with elems = hash.len()
             (Value::Hash(items), Value::Sub(ref data)) => {
                 let len = items.len() as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -830,9 +833,10 @@ impl VM {
             // WhateverCode index on Range: (1..8)[*-1]
             (ref range, Value::Sub(ref data)) if range.is_range() => {
                 let len = crate::runtime::Interpreter::range_elems_f64(range) as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -998,9 +1002,11 @@ impl VM {
             // WhateverCode index: @a[*-1] → evaluate the lambda with array length
             (Value::Array(ref items, ..), Value::Sub(ref data)) => {
                 let len = items.len() as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                // Pass array length for ALL WhateverCode parameters (e.g. *-4 .. *-2 has 2 params)
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -1062,9 +1068,10 @@ impl VM {
                 } else {
                     0
                 };
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -1111,9 +1118,10 @@ impl VM {
                         Value::Int(i) => *i,
                         Value::Whatever => len,
                         Value::Sub(data) => {
-                            let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                             let mut sub_env = data.env.clone();
-                            sub_env.insert(param.to_string(), Value::Int(len));
+                            for p in &data.params {
+                                sub_env.insert(p.to_string(), Value::Int(len));
+                            }
                             let saved_env = std::mem::take(self.interpreter.env_mut());
                             *self.interpreter.env_mut() = sub_env;
                             let result = self
@@ -1156,9 +1164,10 @@ impl VM {
             (Value::Uni { ref text, .. }, Value::Sub(ref data)) => {
                 let chars: Vec<char> = text.chars().collect();
                 let len = chars.len() as i64;
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(len));
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(len));
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self
@@ -1329,9 +1338,10 @@ impl VM {
                     Value::Array(..) | Value::Hash(_) | Value::Instance { .. }
                 ) =>
             {
-                let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
                 let mut sub_env = data.env.clone();
-                sub_env.insert(param.to_string(), Value::Int(1)); // elems = 1
+                for p in &data.params {
+                    sub_env.insert(p.to_string(), Value::Int(1)); // elems = 1
+                }
                 let saved_env = std::mem::take(self.interpreter.env_mut());
                 *self.interpreter.env_mut() = sub_env;
                 let idx = self

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -134,9 +134,10 @@ impl VM {
                 Value::Array(items, ..) => items.len() as i64,
                 _ => 0,
             };
-            let param = data.params.first().map(|s| s.as_str()).unwrap_or("_");
             let mut sub_env = data.env.clone();
-            sub_env.insert(param.to_string(), Value::Int(len));
+            for p in &data.params {
+                sub_env.insert(p.to_string(), Value::Int(len));
+            }
             let saved_env = std::mem::take(self.interpreter.env_mut());
             *self.interpreter.env_mut() = sub_env;
             let result = self

--- a/t/whatevercode-multiarg-subscript.t
+++ b/t/whatevercode-multiarg-subscript.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 8;
+
+# WhateverCode ranges as subscript indices (multi-param WhateverCode)
+{
+    my @a = 'a', 'b', 'c', 'e';
+    is ~@a[*-4 .. *-2], 'a b c', 'WhateverCode range as subscript: @a[*-4 .. *-2]';
+}
+
+{
+    my @a = 'a', 'b', 'c', 'd';
+    @a[*-4 .. *-1] = 'd', 'c', 'b', 'a';
+    is ~@a, 'd c b a', 'WhateverCode range as lvalue subscript';
+}
+
+{
+    my @a = 1, 2, 3, 4, 5;
+    is ~@a[*-3 .. *-1], '3 4 5', 'WhateverCode range last 3 elements';
+}
+
+{
+    my @a = 10, 20, 30, 40;
+    my @slice = @a[*-4 .. *-2];
+    is @slice.elems, 3, 'WhateverCode range slice has correct number of elements';
+}
+
+# Single-param WhateverCode still works
+{
+    my @a = 'x', 'y', 'z';
+    is @a[*-1], 'z', 'single WhateverCode subscript still works';
+}
+
+{
+    my @a = 1, 2, 3, 4, 5;
+    is @a[*-1], 5, 'single WhateverCode *-1';
+}
+
+# Range with one WhateverCode endpoint
+{
+    my @a = 'a', 'b', 'c', 'd', 'e';
+    is ~@a[0 .. *-2], 'a b c d', 'range with WhateverCode end: 0..*-2';
+}
+
+{
+    my @a = 'a', 'b', 'c', 'd', 'e';
+    is ~@a[*-3 .. 4], 'c d e', 'range with WhateverCode start: *-3..4';
+}


### PR DESCRIPTION
## Summary
- WhateverCode expressions like `*-4 .. *-2` create closures with 2+ parameters (one per `*` placeholder)
- When used as array subscript indices (e.g. `@a[*-4 .. *-2]`), only the first parameter was set to the array length, leaving others unbound
- This caused multi-`*` WhateverCode subscripts to silently produce empty/wrong results
- Fixed all 12 WhateverCode evaluation sites across `vm_var_index_ops`, `vm_var_assign_ops`, `vm_var_delete_ops`, and `vm_var_multidim_ops`

## Test plan
- [x] New test `t/whatevercode-multiarg-subscript.t` with 8 subtests covering multi-param and single-param WhateverCode subscripts
- [x] `make test` passes (480 files, 3915 tests)
- [x] `make roast` passes
- [x] Fixes roast `S02-types/array.t` subtests 58 ("end indices [*-4 .. *-2]") and 61 ("end range as lvalue")

🤖 Generated with [Claude Code](https://claude.com/claude-code)