### PR TITLE
feat: implement Str.indices, chaining eqv/before/after, Rat positions

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1048,6 +1048,7 @@ roast/S32-str/fc.t
 roast/S32-str/flip.t
 roast/S32-str/indent.t
 roast/S32-str/index.t
+roast/S32-str/indices.t
 roast/S32-str/lc.t
 roast/S32-str/length.t
 roast/S32-str/lines.t

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1099,6 +1099,10 @@ fn native_function_2arg(
                 None => Value::Nil,
             }))
         }
+        "indices" => {
+            // Fall through to runtime -- handles named params, overlap, etc.
+            None
+        }
         "rindex" => {
             // Fall through to runtime for arrays (list of needles)
             if matches!(arg2, Value::Array(..)) {

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -67,23 +67,18 @@ fn comparison_nonassoc_key(op: &TokenKind) -> Option<&'static str> {
         TokenKind::Ident(name) if name == "leg" => Some("leg"),
         TokenKind::Ident(name) if name == "cmp" => Some("cmp"),
         TokenKind::Ident(name) if name == "coll" => Some("coll"),
-        TokenKind::Ident(name) if name == "eqv" => Some("eqv"),
-        TokenKind::Ident(name) if name == "before" => Some("before"),
-        TokenKind::Ident(name) if name == "after" => Some("after"),
+        // eqv, before, after are chaining operators (not non-associative)
         _ => None,
     }
 }
 
 fn is_structural_comparison_op(op: ComparisonOp) -> bool {
+    // Only truly non-associative operators that return Order (not Bool).
+    // eqv, before, after are chaining operators and handled by the
+    // regular comparison chaining path.
     matches!(
         op,
-        ComparisonOp::Spaceship
-            | ComparisonOp::Leg
-            | ComparisonOp::Cmp
-            | ComparisonOp::Coll
-            | ComparisonOp::Eqv
-            | ComparisonOp::Before
-            | ComparisonOp::After
+        ComparisonOp::Spaceship | ComparisonOp::Leg | ComparisonOp::Cmp | ComparisonOp::Coll
     )
 }
 

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -841,6 +841,7 @@ pub(super) fn is_listop(name: &str) -> bool {
             | "emit"
             | "split"
             | "index"
+            | "indices"
             | "join"
             | "abs"
             | "exp"

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -573,6 +573,14 @@ impl Interpreter {
                 }
                 self.call_method_with_values(target, "index", method_args)
             }
+            "indices" => {
+                if args.is_empty() {
+                    return Err(RuntimeError::new("Too few positionals passed to 'indices'"));
+                }
+                let target = args[0].clone();
+                let method_args = args[1..].to_vec();
+                self.call_method_with_values(target, "indices", method_args)
+            }
             "rindex" => {
                 if args.is_empty() {
                     return Err(RuntimeError::new("Too few positionals passed to 'rindex'"));

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -152,6 +152,7 @@ impl Interpreter {
             "starts-with" => Some(self.dispatch_starts_with(target, &args)),
             "ends-with" => Some(self.dispatch_ends_with(target, &args)),
             "index" => Some(self.dispatch_index(target, &args)),
+            "indices" => Some(self.dispatch_indices(target, &args)),
             "rindex" => Some(self.dispatch_rindex(target, &args)),
             "substr-eq" => Some(self.dispatch_substr_eq(target, &args)),
             "substr" => Some(self.dispatch_substr(target, &args)),

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -776,6 +776,97 @@ impl Interpreter {
         }
     }
 
+    /// Str.indices(needle, pos?, :overlap, :i, :ignorecase, :m, :ignoremark)
+    pub(super) fn dispatch_indices(
+        &self,
+        target: Value,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if let Some(Value::Package(type_name)) = args.first() {
+            return Err(RuntimeError::new(format!(
+                "Cannot resolve caller indices({}:U)",
+                type_name
+            )));
+        }
+        let mut positional: Vec<Value> = Vec::new();
+        let mut ignore_case = false;
+        let mut ignore_mark = false;
+        let mut overlap = false;
+        for arg in args {
+            if let Value::Pair(key, value) = arg {
+                match key.as_str() {
+                    "i" | "ignorecase" => ignore_case = value.truthy(),
+                    "m" | "ignoremark" => ignore_mark = value.truthy(),
+                    "overlap" => overlap = value.truthy(),
+                    _ => {}
+                }
+            } else {
+                positional.push(arg.clone());
+            }
+        }
+        let needle = positional
+            .first()
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let start = if let Some(pos) = positional.get(1) {
+            match self.value_to_position(pos) {
+                Ok(v) => v,
+                Err(err) => {
+                    return Ok(Self::runtime_error_to_failure(err));
+                }
+            }
+        } else {
+            0
+        };
+        let text = target.to_string_value();
+        let len = text.chars().count() as i64;
+        if start < 0 {
+            return Ok(RuntimeError::out_of_range_failure(
+                "start",
+                Value::Int(start),
+                &format!("0..{}", len),
+            ));
+        }
+        let text_chars: Vec<char> = text.chars().collect();
+        let mut results: Vec<Value> = Vec::new();
+        if needle.is_empty() {
+            for i in (start as usize)..=text_chars.len() {
+                results.push(Value::Int(i as i64));
+            }
+        } else {
+            let needle_len = needle.chars().count();
+            let mut pos = start as usize;
+            while pos <= text_chars.len() {
+                let hay: String = text_chars[pos..].iter().collect();
+                let found = if ignore_case && ignore_mark {
+                    self.index_ignorecase_ignoremark(&hay, &needle)
+                } else if ignore_case {
+                    self.index_ignorecase(&hay, &needle)
+                } else if ignore_mark {
+                    self.index_ignoremark(&hay, &needle)
+                } else {
+                    hay.find(needle.as_str()).map(|p| hay[..p].chars().count())
+                };
+                match found {
+                    Some(char_pos) => {
+                        let absolute_pos = pos + char_pos;
+                        results.push(Value::Int(absolute_pos as i64));
+                        if overlap {
+                            pos = absolute_pos + 1;
+                        } else {
+                            pos = absolute_pos + needle_len;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        }
+        Ok(Value::Array(
+            std::sync::Arc::new(results),
+            crate::value::ArrayKind::List,
+        ))
+    }
+
     pub(super) fn dispatch_rindex(
         &self,
         target: Value,
@@ -971,6 +1062,13 @@ impl Interpreter {
                     Err(self.out_of_range_error(Value::Num(*f)))
                 } else {
                     Ok(*f as i64)
+                }
+            }
+            Value::Rat(n, d) => {
+                if *d == 0 {
+                    Err(self.out_of_range_error(Value::Rat(*n, *d)))
+                } else {
+                    Ok(*n / *d)
                 }
             }
             Value::Str(s) => Ok(s.parse::<i64>().unwrap_or(0)),


### PR DESCRIPTION
## Summary
- **Chaining eqv/before/after**: These operators were incorrectly treated as non-associative (like `<=>`). Per Raku spec, they are chaining operators. `3 eqv 3 eqv 3` now correctly returns `True`.
- **Str.indices method**: New method and builtin function implementing `Str.indices(needle, pos?, :overlap, :i, :m)`. Passes all 206 roast/S32-str/indices.t tests.
- **Rat position handling**: `value_to_position` now handles `Rat` values (e.g., `2.0` as position arg to `index`/`indices`/`rindex`/`contains`/`substr-eq`).

## Test plan
- [x] `make test` passes (all 480 prove tests, 3926 subtests)
- [x] `prove -e 'target/debug/mutsu' roast/S32-str/indices.t` passes (206/206)
- [x] Chained eqv: `3 eqv 3 eqv 3` returns True, `3 eqv 3 eqv 4` returns False
- [x] `<=>` still correctly rejects chaining
- [x] `roast/S32-str/indices.t` added to whitelist

Generated with [Claude Code](https://claude.com/claude-code)