### PR TITLE
fix: use ?LINE env var as fallback for warn line number

### DIFF
--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -282,7 +282,15 @@ impl Interpreter {
             .program_path
             .clone()
             .unwrap_or_else(|| "-e".to_string());
-        let line = self.test_pending_callsite_line.unwrap_or(1);
+        let line = self
+            .test_pending_callsite_line
+            .or_else(|| {
+                self.env().get("?LINE").and_then(|v| match v {
+                    Value::Int(n) => Some(*n),
+                    _ => None,
+                })
+            })
+            .unwrap_or(1);
         message.push_str(&format!("\n  in block <unit> at {} line {}", file, line));
         Err(RuntimeError::warn_signal(message))
     }


### PR DESCRIPTION
## Summary
- When `warn` is called from VM-compiled code, the line number was always showing as 1 because `test_pending_callsite_line` was not set by the VM dispatch path.
- Added fallback to read `?LINE` from the interpreter environment, which the VM correctly maintains via `SetSourceLine` opcodes.
- Now `warn "something"` on line 2 correctly shows `in block <unit> at file line 2` instead of `line 1`.

## Test plan
- [x] `target/debug/mutsu -e 'warn "something"'` shows `line 1` (correct)
- [x] Multi-line file with `warn` on line 2 shows `line 2` (was showing `line 1`)
- [x] `make test` passes (480 tests)
- [x] `make roast` passes (only pre-existing spurt.t failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)