### PR TITLE
fix: use downstream supplier snapshot in tap-ok for batch supplies

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -782,7 +782,6 @@ roast/S17-supply/Channel.t
 roast/S17-supply/Promise.t
 roast/S17-supply/Seq.t
 roast/S17-supply/act.t
-roast/S17-supply/batch.t
 roast/S17-supply/classify.t
 roast/S17-supply/collate.t
 roast/S17-supply/comb.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -782,6 +782,7 @@ roast/S17-supply/Channel.t
 roast/S17-supply/Promise.t
 roast/S17-supply/Seq.t
 roast/S17-supply/act.t
+roast/S17-supply/batch.t
 roast/S17-supply/classify.t
 roast/S17-supply/collate.t
 roast/S17-supply/comb.t

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -174,8 +174,28 @@ impl Interpreter {
                 self.supply_emit_buffer.push(Vec::new());
                 self.supply_emit_timed_buffer.push(Vec::new());
                 let _ = self.call_sub_value(after_tap_cb, vec![], false);
-                let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
+                let raw_emitted = self.supply_emit_buffer.pop().unwrap_or_default();
                 let timed_emitted = self.supply_emit_timed_buffer.pop().unwrap_or_default();
+
+                // For supplier-backed supplies (batch, flat, etc.), the raw
+                // supply_emit_buffer contains upstream values before transformation.
+                // The properly transformed values (batched lists, flattened items,
+                // etc.) are emitted to the downstream supplier. Use the downstream
+                // supplier snapshot instead of raw emissions.
+                let emitted = if let Value::Instance { ref attributes, .. } = supply
+                    && let Some(Value::Int(sid)) = attributes.get("supplier_id")
+                {
+                    let (snap_values, _, _) =
+                        crate::runtime::native_methods::supplier_snapshot(*sid as u64);
+                    if !snap_values.is_empty() {
+                        snap_values
+                    } else {
+                        raw_emitted
+                    }
+                } else {
+                    raw_emitted
+                };
+
                 let emitted = if let Value::Instance { ref attributes, .. } = supply {
                     if matches!(attributes.get("elems_filter"), Some(Value::Bool(true))) {
                         let interval = attributes


### PR DESCRIPTION
## Summary
- Fixed tap-ok built-in to use downstream supplier snapshot for supplier-backed supplies (batch, flat, etc.) instead of raw supply_emit_buffer values
- The supply_emit_buffer captured raw upstream values before transformation, causing is-deeply comparisons to fail when batched lists were expected
- Added roast/S17-supply/batch.t to whitelist (1150 -> 1151)

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S17-supply/batch.t` passes reliably (5/5 runs)
- [x] `make test` passes (all 480 tests, 3926 subtests)
- [x] `make roast` passes (no new regressions)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)