### PR TITLE
fix: correct junction concat threading and add OUR:: stash support

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -582,6 +582,10 @@ impl Interpreter {
         self.our_vars.get(key)
     }
 
+    pub(crate) fn our_vars_iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.our_vars.iter()
+    }
+
     pub(crate) fn set_our_var(&mut self, key: String, value: Value) {
         self.our_vars.insert(key, value);
     }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -450,16 +450,92 @@ impl VM {
     pub(super) fn exec_concat_op(&mut self) {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Thread over junctions
+        // Thread over junctions — concat uses left-first threading
+        // (unlike arithmetic/comparison which uses right-first for tighter
+        // junctions). When both operands are junctions and the right is
+        // tighter, we thread left first and swap the junction kinds.
         if matches!(left, Value::Junction { .. }) || matches!(right, Value::Junction { .. }) {
-            let result = self
-                .eval_binary_with_junctions(left, right, |vm, l, r| Ok(vm.concat_values(l, r)))
-                .unwrap_or(Value::Nil);
+            let result = self.eval_concat_with_junctions(left, right);
             self.stack.push(result);
             return;
         }
         let result = self.concat_values(left, right);
         self.stack.push(result);
+    }
+
+    fn eval_concat_with_junctions(&mut self, left: Value, right: Value) -> Value {
+        // Auto-FETCH and decontainerize
+        let left = self
+            .interpreter
+            .auto_fetch_proxy(&left)
+            .unwrap_or(left)
+            .decontainerize()
+            .clone();
+        let right = self
+            .interpreter
+            .auto_fetch_proxy(&right)
+            .unwrap_or(right)
+            .decontainerize()
+            .clone();
+        // Both junctions: thread left first, swap kinds if right is tighter
+        if let (Value::Junction { kind: lk, .. }, Value::Junction { kind: rk, .. }) =
+            (&left, &right)
+        {
+            let need_swap = Self::thread_right_first(lk, rk);
+            let rk = rk.clone();
+            let lk = lk.clone();
+            if let Value::Junction { kind, values } = left {
+                let results: Vec<Value> = values
+                    .iter()
+                    .cloned()
+                    .map(|v| self.eval_concat_with_junctions(v, right.clone()))
+                    .collect();
+                let mut result = Value::junction(kind, results);
+                if need_swap {
+                    result = Self::swap_junction_kinds(result, &rk, &lk);
+                }
+                return result;
+            }
+        }
+        if let Value::Junction { kind, values } = left {
+            let results: Vec<Value> = values
+                .iter()
+                .cloned()
+                .map(|v| self.eval_concat_with_junctions(v, right.clone()))
+                .collect();
+            return Value::junction(kind, results);
+        }
+        if let Value::Junction { kind, values } = right {
+            let results: Vec<Value> = values
+                .iter()
+                .cloned()
+                .map(|v| self.eval_concat_with_junctions(left.clone(), v))
+                .collect();
+            return Value::junction(kind, results);
+        }
+        self.concat_values(left, right)
+    }
+
+    fn swap_junction_kinds(
+        value: Value,
+        new_outer: &crate::value::JunctionKind,
+        new_inner: &crate::value::JunctionKind,
+    ) -> Value {
+        if let Value::Junction { values, .. } = value {
+            let swapped: Vec<Value> = values
+                .iter()
+                .map(|v| {
+                    if let Value::Junction { values: inner, .. } = v {
+                        Value::junction(new_inner.clone(), inner.to_vec())
+                    } else {
+                        v.clone()
+                    }
+                })
+                .collect();
+            Value::junction(new_outer.clone(), swapped)
+        } else {
+            value
+        }
     }
 
     fn concat_values(&self, left: Value, right: Value) -> Value {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -265,7 +265,7 @@ impl VM {
         }
     }
 
-    fn thread_right_first(
+    pub(super) fn thread_right_first(
         left: &crate::value::JunctionKind,
         right: &crate::value::JunctionKind,
     ) -> bool {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3678,6 +3678,15 @@ impl VM {
             self.stack.push(Value::Hash(Arc::new(entries)));
             return;
         }
+        if name.strip_suffix("::") == Some("OUR") {
+            let mut entries: HashMap<String, Value> = HashMap::new();
+            for (key, val) in self.interpreter.our_vars_iter() {
+                let display_key = Self::add_sigil_prefix(key);
+                entries.insert(display_key, val.clone());
+            }
+            self.stack.push(Value::Hash(Arc::new(entries)));
+            return;
+        }
         if let Some(package) = name.strip_suffix("::")
             && package != "MY"
         {


### PR DESCRIPTION
## Summary
- Fix junction concatenation (`~`) to use left-first threading with kind swap when the right junction is tighter (all/none vs any/one), matching Raku's semantics. Arithmetic/comparison operators continue to use right-first threading correctly.
- Add `OUR::` pseudo-stash read support so `OUR::.<$var>` can look up `our`-scoped variables.

## Test plan
- [x] `any("a","b","c") ~ all("d","e")` produces `all(any("ad","ae"), any("bd","be"), any("cd","ce"))` (matching Raku)
- [x] `all("a","b","c") ~ any("d","e")` produces the same result as above (symmetric)
- [x] `any(1,2,40) > all(5,10,15)` collapses to `True` (no regression on comparison)
- [x] `any(1,2) + all(10,20)` produces `all(any(11,12), any(21,22))` (no regression on arithmetic)
- [x] `our $x = 42; say OUR::.<$x>` outputs `42`
- [x] `make test` passes
- [x] `make roast` passes (no regressions vs main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)