### PR TITLE
fix: validate =begin table content and treat + as visible column separator

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -857,6 +857,7 @@ roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
 roast/S26-documentation/07a-tables.t
+roast/S26-documentation/07b-tables.t
 roast/S26-documentation/07c-tables.t
 roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -182,14 +182,13 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
     if keyword == "begin" {
         // =begin IDENTIFIER ... =end IDENTIFIER
         // Match the identifier and ignore nested matching begin/end blocks.
-        // TODO: validate =begin table content (empty tables, consecutive row
-        // separators, mixed column separators) once BEGIN block timing is fixed
-        // so that tests generating tables at runtime don't regress.
         let begin_line_end = rest.find('\n').unwrap_or(rest.len());
         let begin_line = &rest[..begin_line_end];
         let target = begin_line.split_whitespace().next().unwrap_or("");
+        let is_table = target == "table";
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();
         let mut depth = 1usize;
+        let mut content_lines: Vec<&str> = Vec::new();
 
         while !remaining.is_empty() {
             let line_end = remaining.find('\n').unwrap_or(remaining.len());
@@ -202,9 +201,16 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
                 } else if directive == "end" && directive_target == target {
                     depth -= 1;
                     if depth == 0 {
+                        if is_table {
+                            validate_pod_table(&content_lines)?;
+                        }
                         return Ok((next, ""));
                     }
                 }
+            }
+
+            if is_table && depth == 1 {
+                content_lines.push(line);
             }
 
             remaining = next;
@@ -285,8 +291,8 @@ fn validate_pod_table(lines: &[&str]) -> PResult<'static, ()> {
             prev_was_separator = true;
         } else {
             prev_was_separator = false;
-            // Check column separator type: visible (`|`) vs whitespace-only
-            if trimmed.contains('|') {
+            // Check column separator type: visible (`|` or `+`) vs whitespace-only
+            if trimmed.contains('|') || trimmed.contains('+') {
                 has_visible_sep = true;
             } else if trimmed.contains("  ") {
                 // Two or more consecutive spaces indicate whitespace column separator


### PR DESCRIPTION
## Summary
- Extend Pod table validation to `=begin table`/`=end table` blocks (previously only validated for `=table` paragraph form), so that empty tables are properly rejected as parse errors
- Recognize `+` as a visible column separator alongside `|` to avoid false positives in mixed-separator detection when tables use `+` as column separators
- Add `roast/S26-documentation/07b-tables.t` to whitelist (4/4 tests passing)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S26-documentation/07a-tables.t` passes (no regression)
- [x] `prove -e 'target/debug/mutsu' roast/S26-documentation/07b-tables.t` passes (newly passing)
- [ ] CI passes (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)