### PR TITLE
fix: negated char class with :i, standalone m// result, user-defined Unicode infix

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -386,6 +386,7 @@ roast/S05-modifier/counted-match.t
 roast/S05-modifier/counted.t
 roast/S05-modifier/exhaustive.t
 roast/S05-modifier/global.t
+roast/S05-modifier/ignorecase-and-ignoremark.t
 roast/S05-modifier/ignoremark.t
 roast/S05-modifier/ii.t
 roast/S05-modifier/my.t

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -408,8 +408,9 @@ impl Compiler {
             rhs_end: 0,
             negate: false,
             lhs_var,
-            // m// standalone (not in ~~ context) behaves like m// for result purposes
-            rhs_is_match_regex: true,
+            // Standalone m// (not in ~~ context) returns Nil on failure, not False.
+            // Setting this to false makes smart_match_op return $/ (Nil) on failure.
+            rhs_is_match_regex: false,
         });
         // RHS: load the regex constant
         let idx = self.code.add_constant(v.clone());

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -208,12 +208,12 @@ pub(super) fn parse_additive_op(r: &str) -> Option<(AdditiveOp, usize)> {
 }
 
 pub(super) fn parse_multiplicative_op(r: &str) -> Option<(MultiplicativeOp, usize)> {
-    // Unicode: × (U+00D7) multiplication
-    if r.starts_with('\u{00D7}') {
+    // Unicode: multiply (U+00D7) -- skip if user-defined infix exists
+    if r.starts_with('\u{00D7}') && !super::super::stmt::simple::is_user_defined_infix("\u{00D7}") {
         return Some((MultiplicativeOp::Mul, '\u{00D7}'.len_utf8()));
     }
-    // Unicode: ÷ (U+00F7) division
-    if r.starts_with('\u{00F7}') {
+    // Unicode: divide (U+00F7) -- skip if user-defined infix exists
+    if r.starts_with('\u{00F7}') && !super::super::stmt::simple::is_user_defined_infix("\u{00F7}") {
         return Some((MultiplicativeOp::Div, '\u{00F7}'.len_utf8()));
     }
     if r.starts_with("+&") {

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -661,6 +661,19 @@ fn is_syntax_conflicting_infix(op: &str) -> bool {
     )
 }
 
+/// Check whether a given operator symbol is registered as a user-defined
+/// `infix:<...>` in the current lexical scope.
+pub(in crate::parser) fn is_user_defined_infix(symbol: &str) -> bool {
+    SCOPES.with(|s| {
+        let scopes = s.borrow();
+        let canonical = format!("infix:<{symbol}>");
+        scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.user_subs.contains(&canonical))
+    })
+}
+
 /// Match a user-declared infix operator (symbol form) against the current input.
 /// Returns `(symbol, consumed_len)` when input begins with an in-scope
 /// `infix:<...>` operator symbol. This handles both non-alphabetic symbols

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -288,7 +288,22 @@ impl Interpreter {
         ignore_case: bool,
     ) -> bool {
         if ignore_case {
-            // When ignore_case is set, check if any case variant of c matches the class
+            if class.negated {
+                // For negated classes with :i, char matches only if ALL case
+                // variants are NOT in the positive set. If any variant IS in the
+                // positive set the char should be excluded by the negation.
+                let pos_class = CharClass {
+                    negated: false,
+                    items: class.items.clone(),
+                };
+                for variant in CaseFoldIter::new(c) {
+                    if self.regex_match_class(&pos_class, variant) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            // For positive classes, any case variant matching is sufficient
             for variant in CaseFoldIter::new(c) {
                 if self.regex_match_class(class, variant) {
                     return true;


### PR DESCRIPTION
## Summary
- Fix negated regex character classes (`<-[A]>`) with `:i` (ignorecase) to correctly exclude all case variants, not just one
- Fix standalone `m//` (matching against `$_`) to return `Nil` on failure instead of `False`, matching Raku semantics
- Allow user-defined `sub infix:<x>` / `sub infix:<div>` to override built-in Unicode multiply/divide operators

## Test plan
- [x] `roast/S05-modifier/ignorecase-and-ignoremark.t` now passes all 24 tests (added to whitelist)
- [x] `make test` passes
- [x] `make roast` passes

Generated with [Claude Code](https://claude.com/claude-code)