### PR TITLE
fix: support .does() with parameterized roles and named role params

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -629,6 +629,7 @@ roast/S14-roles/lexical.t
 roast/S14-roles/namespaced.t
 roast/S14-roles/parameter-subtyping.t
 roast/S14-roles/parameterized-basic.t
+roast/S14-roles/parameterized-mixin.t
 roast/S14-roles/parameterized-type.t
 roast/S14-roles/rw.t
 roast/S14-roles/stubs.t

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -464,7 +464,43 @@ impl Interpreter {
             }
             "does" if args.len() >= 2 => {
                 let invocant = &args[args.len() - 2];
-                let type_name = match args.last().unwrap() {
+                let role_arg = args.last().unwrap();
+                // Handle ParametricRole directly to compare type args properly
+                if let Value::ParametricRole {
+                    base_name,
+                    type_args,
+                } = role_arg
+                {
+                    let base = base_name.resolve();
+                    if let Value::Mixin(_, mixins) = invocant {
+                        let key = format!("__mutsu_role_typeargs__{}", base);
+                        let has_role = invocant.does_check(&base);
+                        let args_match =
+                            if let Some(Value::Array(actual_args, ..)) = mixins.get(&key) {
+                                actual_args.len() == type_args.len()
+                                    && actual_args
+                                        .iter()
+                                        .zip(type_args.iter())
+                                        .all(|(a, e)| self.parametric_arg_subtypes(a, e))
+                            } else {
+                                type_args.is_empty()
+                            };
+                        return Ok(Value::Bool(has_role && args_match));
+                    }
+                    return Ok(Value::Bool(self.type_matches_value(
+                        &format!(
+                                "{}[{}]",
+                                base,
+                                type_args
+                                    .iter()
+                                    .map(|a| a.to_string_value())
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ),
+                        invocant,
+                    )));
+                }
+                let type_name = match role_arg {
                     Value::Package(name) => name.resolve(),
                     Value::Str(name) => name.to_string(),
                     Value::Instance { class_name, .. } => class_name.resolve(),

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -162,10 +162,36 @@ impl Interpreter {
                     mixins.get(&enum_type.resolve()),
                     Some(Value::Enum { key, .. }) if key == probe_key
                 ),
+                Value::ParametricRole {
+                    base_name,
+                    type_args,
+                } => {
+                    let base = base_name.resolve();
+                    let has_role = target.does_check(&base)
+                        || mixins.contains_key(&base)
+                        || mixins.contains_key(&format!("__mutsu_role__{}", base));
+                    if has_role {
+                        let key = format!("__mutsu_role_typeargs__{}", base);
+                        if let Some(Value::Array(actual_args, ..)) = mixins.get(&key) {
+                            actual_args.len() == type_args.len()
+                                && actual_args
+                                    .iter()
+                                    .zip(type_args.iter())
+                                    .all(|(a, e)| self.parametric_arg_subtypes(a, e))
+                        } else {
+                            type_args.is_empty()
+                        }
+                    } else {
+                        false
+                    }
+                }
                 Value::Package(name) => {
                     let n = name.resolve();
+                    let base = n.split('[').next().unwrap_or(&n);
                     mixins.contains_key(&n)
+                        || mixins.contains_key(base)
                         || mixins.contains_key(&format!("__mutsu_role__{}", n))
+                        || mixins.contains_key(&format!("__mutsu_role__{}", base))
                         || self.type_matches_value(&n, target)
                 }
                 Value::Str(name) => {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -186,6 +186,15 @@ fn looks_like_type_arg_expr(input: &str) -> bool {
 
 fn should_treat_role_arg_as_type_expr(input: &str) -> bool {
     let trimmed = input.trim();
+    // Colonpair syntax like `:a(1)` or `:foo(42)` is a named argument, not a type.
+    if trimmed.starts_with(':')
+        && trimmed
+            .chars()
+            .nth(1)
+            .is_some_and(|c| c.is_ascii_lowercase())
+    {
+        return false;
+    }
     looks_like_type_arg_expr(trimmed)
         && (trimmed.contains(':') || trimmed.contains('(') || trimmed.contains("::"))
 }
@@ -544,7 +553,35 @@ impl Interpreter {
 
         matches.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
         let selected = matches.remove(0).0;
-        Ok(Some((selected.role_def, selected.type_params, arg_values)))
+        // Properly bind args (handling named params, defaults, etc.) and extract
+        // resolved values per param name, instead of using raw positional zip.
+        let resolved_values = if !selected.type_param_defs.is_empty() {
+            let saved_env = self.env.clone();
+            let candidate_param_names: Vec<String> = selected
+                .type_param_defs
+                .iter()
+                .map(|pd| pd.name.clone())
+                .collect();
+            let _ = self.bind_function_args_values(
+                &selected.type_param_defs,
+                &candidate_param_names,
+                &arg_values,
+            );
+            let mut resolved = Vec::with_capacity(selected.type_params.len());
+            for param_name in &selected.type_params {
+                let value = self.env.get(param_name).cloned().unwrap_or(Value::Nil);
+                resolved.push(value);
+            }
+            self.env = saved_env;
+            resolved
+        } else {
+            arg_values
+        };
+        Ok(Some((
+            selected.role_def,
+            selected.type_params,
+            resolved_values,
+        )))
     }
 
     fn resolve_declared_type_name(&self, name: &str) -> String {
@@ -2482,24 +2519,46 @@ impl Interpreter {
                         .entry(name.to_string())
                         .or_default()
                         .push(role_name_str.clone());
-                    let type_subs: Vec<(String, String)> = if let Some(parent_type_params) =
-                        self.role_type_params.get(base_role_name)
-                    {
-                        if let Some(bracket_start) = role_name_str.find('[') {
-                            let args_str =
-                                &role_name_str[bracket_start + 1..role_name_str.len() - 1];
-                            let type_args = parse_role_type_args(args_str);
-                            parent_type_params
+                    // Use resolve_role_candidate to properly handle named
+                    // arguments and default values in parameterized role
+                    // composition.
+                    let type_subs: Vec<(String, String)> =
+                        if let Some((_, resolved_param_names, resolved_values)) =
+                            self.resolve_role_candidate(&role_name_str)?
+                        {
+                            // Store the resolved param bindings so they are
+                            // available when the child role is punned to a class
+                            // and methods referencing role params are dispatched.
+                            let bindings = self
+                                .class_role_param_bindings
+                                .entry(name.to_string())
+                                .or_default();
+                            for (p, v) in resolved_param_names.iter().zip(resolved_values.iter()) {
+                                bindings.insert(p.clone(), v.clone());
+                            }
+                            resolved_param_names
                                 .iter()
-                                .zip(type_args.iter())
-                                .map(|(p, a)| (p.clone(), a.clone()))
+                                .zip(resolved_values.iter())
+                                .map(|(p, v)| (p.clone(), type_value_name(v)))
                                 .collect()
+                        } else if let Some(parent_type_params) =
+                            self.role_type_params.get(base_role_name)
+                        {
+                            if let Some(bracket_start) = role_name_str.find('[') {
+                                let args_str =
+                                    &role_name_str[bracket_start + 1..role_name_str.len() - 1];
+                                let type_args = parse_role_type_args(args_str);
+                                parent_type_params
+                                    .iter()
+                                    .zip(type_args.iter())
+                                    .map(|(p, a)| (p.clone(), a.clone()))
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            }
                         } else {
                             Vec::new()
-                        }
-                    } else {
-                        Vec::new()
-                    };
+                        };
                     for attr in &role.attributes {
                         if role_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
                             // Already present. Only a real conflict if both

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -252,6 +252,27 @@ impl Interpreter {
             other => (other, HashMap::new()),
         };
         mixins.insert(format!("__mutsu_role__{}", role_name), Value::Bool(true));
+        // Store the type arguments so that `.does(Role[args])` can check them.
+        if !role_args.is_empty() {
+            mixins.insert(
+                format!("__mutsu_role_typeargs__{}", role_name),
+                Value::array(role_args.to_vec()),
+            );
+            // Store per-parameter bindings so that methods with type-parameterized
+            // constraints (e.g. `method hi(vartype $foo)`) can resolve the type
+            // variables during dispatch.
+            let param_names = self
+                .role_type_params
+                .get(role_name)
+                .cloned()
+                .unwrap_or_default();
+            for (param_name, type_arg) in param_names.iter().zip(role_args.iter()) {
+                mixins.insert(
+                    format!("__mutsu_role_param__{}", param_name),
+                    type_arg.clone(),
+                );
+            }
+        }
         // Store the role's unique ID so that different lexical roles with the
         // same name (e.g. two `my role A { }` in different scopes) produce
         // distinct mixin maps, making `===` return False for values mixed with


### PR DESCRIPTION
## Summary
- Fix `.does(Role[args])` and `.^does(Role[args])` to correctly return True for mixin values by storing type args in mixin maps and handling ParametricRole values in dispatch
- Fix role-to-role composition with named parameters (`role B does A[:a(1)]`) by properly resolving colonpair syntax and using name-based arg binding with defaults
- Propagate role param bindings during role composition so punned class methods can access role parameters

## Test plan
- [x] All 28 subtests pass in `roast/S14-roles/parameterized-mixin.t`
- [x] `make test` passes
- [x] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)