### PR TITLE
fix: return Failure for Num division/modulo by zero and power underflow

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -130,6 +130,7 @@ roast/S02-types/native.t
 roast/S02-types/nested_arrays.t
 roast/S02-types/nested_pairs.t
 roast/S02-types/nominalizables.t
+roast/S02-types/num.t
 roast/S02-types/parsing-bool.t
 roast/S02-types/range-iterator.t
 roast/S02-types/resolved-in-setting.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -909,14 +909,23 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
             }
         }
         Ok(match (&l, &r) {
-            (Value::Num(_), Value::Num(b)) if *b == 0.0 => {
-                return Err(RuntimeError::numeric_divide_by_zero());
+            (Value::Num(a), Value::Num(b)) if *b == 0.0 => {
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(Value::Num(*a)),
+                    Some("/"),
+                ));
             }
-            (Value::Int(_), Value::Num(b)) if *b == 0.0 => {
-                return Ok(RuntimeError::divide_by_zero_failure(None, None));
+            (Value::Int(a), Value::Num(b)) if *b == 0.0 => {
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(Value::Int(*a)),
+                    Some("/"),
+                ));
             }
             (Value::Num(_), Value::Int(b)) if *b == 0 => {
-                return Ok(RuntimeError::divide_by_zero_failure(None, None));
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(l.clone()),
+                    Some("/"),
+                ));
             }
             (Value::Num(a), Value::Num(b)) => Value::Num(a / b),
             (Value::Int(a), Value::Num(b)) => Value::Num(*a as f64 / b),
@@ -924,13 +933,19 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
             (Value::Num(a), Value::BigInt(b)) => {
                 let bf = runtime::to_float_value(&Value::BigInt(b.clone())).unwrap_or(1.0);
                 if bf == 0.0 {
-                    return Err(RuntimeError::numeric_divide_by_zero());
+                    return Ok(RuntimeError::divide_by_zero_failure(
+                        Some(Value::Num(*a)),
+                        Some("/"),
+                    ));
                 }
                 Value::Num(a / bf)
             }
             (Value::BigInt(a), Value::Num(b)) => {
                 if *b == 0.0 {
-                    return Err(RuntimeError::numeric_divide_by_zero());
+                    return Ok(RuntimeError::divide_by_zero_failure(
+                        Some(Value::BigInt(a.clone())),
+                        Some("/"),
+                    ));
                 }
                 let af = runtime::to_float_value(&Value::BigInt(a.clone())).unwrap_or(0.0);
                 Value::Num(af / b)
@@ -1014,12 +1029,18 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
                 (Value::BigInt(a), Value::BigInt(b)) => {
                     Value::from_bigint(num_integer::Integer::mod_floor(a.as_ref(), b.as_ref()))
                 }
-                (Value::Num(_), Value::Num(0.0)) => {
-                    return Err(RuntimeError::numeric_divide_by_zero_full(None, Some("%")));
+                (Value::Num(a), Value::Num(0.0)) => {
+                    return Ok(RuntimeError::divide_by_zero_failure(
+                        Some(Value::Num(a)),
+                        Some("%"),
+                    ));
                 }
                 (Value::Num(a), Value::Num(b)) => Value::Num(float_mod_floor(a, b)),
-                (_, Value::Num(0.0)) => {
-                    return Err(RuntimeError::numeric_divide_by_zero_full(None, Some("%")));
+                (ref lv, Value::Num(0.0)) => {
+                    return Ok(RuntimeError::divide_by_zero_failure(
+                        Some(lv.clone()),
+                        Some("%"),
+                    ));
                 }
                 (Value::Int(a), Value::Num(b)) => Value::Num(float_mod_floor(a as f64, b)),
                 (Value::Num(a), Value::Int(b)) => Value::Num(float_mod_floor(a, b as f64)),
@@ -1052,12 +1073,18 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
             (Value::BigInt(a), Value::BigInt(b)) => {
                 Value::from_bigint(num_integer::Integer::mod_floor(a.as_ref(), b.as_ref()))
             }
-            (Value::Num(_), Value::Num(0.0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero_full(None, Some("%")));
+            (Value::Num(a), Value::Num(0.0)) => {
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(Value::Num(a)),
+                    Some("%"),
+                ));
             }
             (Value::Num(a), Value::Num(b)) => Value::Num(float_mod_floor(a, b)),
-            (_, Value::Num(0.0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero_full(None, Some("%")));
+            (ref lv, Value::Num(0.0)) => {
+                return Ok(RuntimeError::divide_by_zero_failure(
+                    Some(lv.clone()),
+                    Some("%"),
+                ));
             }
             (Value::Int(a), Value::Num(b)) => Value::Num(float_mod_floor(a as f64, b)),
             (Value::Num(a), Value::Int(b)) => Value::Num(float_mod_floor(a, b as f64)),
@@ -1282,7 +1309,14 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                     Value::Num(a.powf(b.as_ref().to_f64().unwrap_or(f64::INFINITY)))
                 }
             }
-            (Value::Num(a), Value::Num(b)) => Value::Num(a.powf(b)),
+            (Value::Num(a), Value::Num(b)) => {
+                let result = a.powf(b);
+                if result == 0.0 && a != 0.0 && b.is_finite() && b < 0.0 {
+                    RuntimeError::numeric_underflow_failure()
+                } else {
+                    Value::Num(result)
+                }
+            }
             (base, exp) => powf_or_zero(&base, &exp),
         }
     }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1105,6 +1105,7 @@ pub(crate) fn is_known_compound_type(name: &str) -> bool {
             | "X::NotParametric"
             | "X::Numeric::DivideByZero"
             | "X::Numeric::Real"
+            | "X::Numeric::Underflow"
             | "X::Obsolete"
             | "X::OutOfRange"
             | "X::Package::Stubbed"

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -481,6 +481,19 @@ impl RuntimeError {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Create a Failure wrapping an X::Numeric::Underflow exception.
+    pub(crate) fn numeric_underflow_failure() -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            Value::str("Numeric underflow".to_string()),
+        );
+        let ex = Value::make_instance(Symbol::intern("X::Numeric::Underflow"), attrs);
+        let mut failure_attrs = HashMap::new();
+        failure_attrs.insert("exception".to_string(), ex);
+        Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+    }
+
     /// X::Undeclared - Undeclared name
     #[allow(dead_code)]
     pub(crate) fn undeclared(what: &str, name: &str) -> Self {


### PR DESCRIPTION
## Summary
- Num / 0e0, Num % 0e0 now return Failure (soft error) instead of throwing X::Numeric::DivideByZero, matching Raku's behavior for Num types
- Failure includes `numerator` and `using` attributes as required by roast tests
- Num ** Num that underflows to 0.0 returns Failure wrapping X::Numeric::Underflow
- Added roast/S02-types/num.t to whitelist (all 112 tests now pass)

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S02-types/num.t` passes (112/112)
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes (excluding known flaky t/lock.t)
- [x] Int division by zero still throws hard error as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)