### PR TITLE
fix: grammar action class-level my vars, utf16.new with Seq, and stack overflow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,19 @@ fn handle_negated_long_option(
 }
 
 fn main() {
+    // Spawn the real entry point on a thread with a larger stack to avoid
+    // stack overflows during deeply-recursive grammar matching.
+    let builder = std::thread::Builder::new().stack_size(32 * 1024 * 1024);
+    let handler = builder
+        .spawn(run_main)
+        .expect("failed to spawn main thread");
+    match handler.join() {
+        Ok(()) => {}
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+fn run_main() {
     let args: Vec<String> = env::args().collect();
 
     let mut dump_ast = false;

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1081,6 +1081,10 @@ impl Interpreter {
         let saved_package = self.current_package.clone();
         if self.has_class_scoped_subs(receiver_class_name) {
             self.current_package = receiver_class_name.to_string();
+        } else if self.current_package != "GLOBAL" {
+            // Reset to GLOBAL so class-level `my` variables are not falsely
+            // qualified with the caller's package (e.g. grammar name).
+            self.current_package = "GLOBAL".to_string();
         }
         let block_result = self.run_block(&method_def.body);
         self.current_package = saved_package;

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1500,6 +1500,7 @@ impl Interpreter {
                         .flat_map(|a| match a {
                             Value::Int(i) => vec![Value::Int(*i)],
                             Value::Array(items, ..) => items.to_vec(),
+                            Value::Seq(items) | Value::Slip(items) => items.to_vec(),
                             Value::Range(start, end) => (*start..=*end).map(Value::Int).collect(),
                             Value::RangeExcl(start, end) => {
                                 (*start..*end).map(Value::Int).collect()

--- a/t/json-tiny-compat.t
+++ b/t/json-tiny-compat.t
@@ -16,7 +16,7 @@ unless "tmp/json-tiny/lib/JSON/Tiny.pm".IO.e {
 use lib 'tmp/json-tiny/lib';
 use JSON::Tiny;
 
-plan 41;
+plan 48;
 
 # to-json: numbers
 is to-json(42), '42', 'to-json integer';
@@ -116,3 +116,20 @@ ok JSON::Tiny::Grammar.subparse('n', :rule<str_escape>).defined,
     my $d = from-json('{"items":[10,20,30]}');
     is-deeply $d<items>, [10, 20, 30], 'from-json object with array value';
 }
+
+# from-json: escaped characters in strings (requires class-level my %h fix)
+is-deeply from-json('["\""]'), ['"'], 'from-json escaped quote';
+is-deeply from-json('["\\\\" ]'), ['\\'], 'from-json escaped backslash';
+is-deeply from-json('["\\/"]'), ['/'], 'from-json escaped slash';
+is-deeply from-json('["\\t\\n"]'), ["\t\n"], 'from-json escaped tab and newline';
+
+# from-json: unicode escapes (requires utf16.new Seq fix)
+is-deeply from-json('["\\u2685"]'), ["\x[2685]"], 'from-json \\uXXXX unicode escape';
+{
+    my $d = from-json('{ "a" : "b\\u00E5" }');
+    is $d<a>, "b\x[E5]", 'from-json unicode escape in object value';
+}
+
+# Grammar parse: deeply nested structures (requires larger stack)
+ok JSON::Tiny::Grammar.parse('[[[[[[[[[[[[[[[[[[["deep"]]]]]]]]]]]]]]]]]]]').defined,
+   'grammar parses deeply nested arrays without stack overflow';


### PR DESCRIPTION
## Summary
- Fix grammar action methods not seeing class-level `my` variables (e.g., `%h` in JSON::Tiny::Actions) by resetting `current_package` to GLOBAL when running method bodies without class-scoped subs
- Handle `Seq`/`Slip` arguments in `utf16.new()`/`utf8.new()` constructors so `.map()` results are consumed correctly
- Increase main thread stack to 32MB to prevent stack overflow during deeply-recursive grammar matching

## Test plan
- [x] `prove -e 'target/debug/mutsu -I tmp/json-tiny/lib' t/json-tiny-compat.t` passes (48 tests including 7 new ones)
- [x] JSON::Tiny 02-structure.t: 9/10 (was 7/10, escaped strings now work)
- [x] JSON::Tiny 03-unicode.t: 4/4 (was 2/4, unicode escapes now work)
- [x] JSON::Tiny 01-parse.t: 92/93 (was stack overflow crash)
- [x] JSON::Tiny 04-roundtrip.t: 15/17 (was 13/17)
- [ ] `make test` passes
- [ ] `make roast` passes

Generated with [Claude Code](https://claude.com/claude-code)