### PR TITLE
fix: support shared container semantics for clone and chained accessor assignment

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -526,6 +526,7 @@ roast/S11-modules/re-export.t
 roast/S11-modules/require.t
 roast/S11-modules/runtime.t
 roast/S12-attributes/augment-and-initialization.t
+roast/S12-attributes/clone.t
 roast/S12-attributes/defaults.t
 roast/S12-attributes/delegation.t
 roast/S12-attributes/inheritance.t

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -225,6 +225,38 @@ impl Compiler {
             };
             self.compile_expr(&method_call);
         }
+        // Rewrite push($obj.attr, val...)/unshift/append/prepend on method call targets.
+        // Compile as __mutsu_push_through_accessor($obj, "attr", "push", vals...) so the
+        // mutation propagates to all instances sharing the same array container.
+        else if args.len() >= 2
+            && matches!(
+                name.resolve().as_str(),
+                "push" | "unshift" | "append" | "prepend"
+            )
+            && matches!(&args[0], Expr::MethodCall { args: mc_args, .. } if mc_args.is_empty())
+        {
+            if let Expr::MethodCall {
+                target: mc_target,
+                name: mc_name,
+                ..
+            } = &args[0]
+            {
+                let builtin_name = Symbol::intern("__mutsu_push_through_accessor");
+                let mut new_args: Vec<Expr> = vec![
+                    (**mc_target).clone(),
+                    Expr::Literal(Value::str(mc_name.resolve())),
+                    Expr::Literal(Value::str(name.resolve())),
+                ];
+                for arg in &args[1..] {
+                    new_args.push(arg.clone());
+                }
+                let call = Expr::Call {
+                    name: builtin_name,
+                    args: new_args,
+                };
+                self.compile_expr(&call);
+            }
+        }
         // Rewrite push(@arr, val...)/unshift(@arr, val...)/append/prepend/splice -> @arr.method(val...)
         // splice needs only 1 arg (the array); others need at least 2
         else if !args.is_empty()

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -194,6 +194,7 @@ impl Interpreter {
             "leave" => self.builtin_leave(&args),
             "return-rw" => self.builtin_return_rw(&args),
             "__mutsu_assign_method_lvalue" => self.builtin_assign_method_lvalue(&args),
+            "__mutsu_push_through_accessor" => self.builtin_push_through_accessor(&args),
             "__mutsu_index_assign_method_lvalue" => self.builtin_index_assign_method_lvalue(&args),
             "__mutsu_assign_named_sub_lvalue" => self.builtin_assign_named_sub_lvalue(&args),
             "__mutsu_assign_callable_lvalue" => self.builtin_assign_callable_lvalue(&args),

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -250,6 +250,16 @@ impl Interpreter {
         // Get the current container via the accessor
         let current = self.call_method_with_values(target.clone(), &method, Vec::new())?;
 
+        // Save Arc pointers before modifying (for shared container propagation)
+        let old_array_arc = match &current {
+            Value::Array(arc, ..) => Some(arc.clone()),
+            _ => None,
+        };
+        let old_hash_arc = match &current {
+            Value::Hash(arc) => Some(arc.clone()),
+            _ => None,
+        };
+
         // Check if index is multi-dimensional (array of indices like [2, 1] from [2;1])
         let dims: Vec<usize> = if let Value::Array(ref items, ..) = index {
             items
@@ -290,6 +300,16 @@ impl Interpreter {
                 _ => return Ok(value),
             }
         };
+
+        // Propagate container changes to all instances sharing the same
+        // Arc (handles clone semantics where multiple instances share the
+        // same array/hash container).
+        if let Some(old_arc) = &old_array_arc {
+            self.propagate_shared_array_in_instances(old_arc, &updated);
+        }
+        if let Some(old_arc) = &old_hash_arc {
+            self.propagate_shared_hash_in_instances(old_arc, &updated);
+        }
 
         // Write back via the setter
         self.assign_method_lvalue_with_values(
@@ -395,6 +415,75 @@ impl Interpreter {
             method_args,
             value,
         )
+    }
+
+    /// Handle push/unshift/append/prepend through an instance accessor.
+    /// Called as __mutsu_push_through_accessor(instance, attr_name, method, vals...).
+    /// Mutates the array/hash attribute in-place and propagates the change to all
+    /// env bindings that share the same Arc (e.g. after clone).
+    pub(super) fn builtin_push_through_accessor(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if args.len() < 3 {
+            return Err(RuntimeError::new(
+                "__mutsu_push_through_accessor expects instance, attr_name, method, and values",
+            ));
+        }
+        let target = args[0].clone();
+        let attr_name = args[1].to_string_value();
+        let method = args[2].to_string_value();
+        let push_args: Vec<Value> = args[3..].to_vec();
+
+        let Value::Instance {
+            class_name,
+            attributes,
+            id: target_id,
+        } = &target
+        else {
+            // Fallback: just call the method on the accessor result
+            let accessor_val = self.call_method_with_values(target, &attr_name, vec![])?;
+            return self.call_method_with_values(accessor_val, &method, push_args);
+        };
+
+        let attr_key = attr_name.clone();
+        let current = attributes.get(&attr_key).cloned().unwrap_or(Value::Nil);
+        let old_array_arc = match &current {
+            Value::Array(arc, ..) => Some(arc.clone()),
+            _ => None,
+        };
+        let old_hash_arc = match &current {
+            Value::Hash(arc) => Some(arc.clone()),
+            _ => None,
+        };
+
+        // Call the mutating method via a temp variable
+        let temp_var = format!("__mutsu_push_accessor_tmp_{}", target_id);
+        self.env.insert(temp_var.clone(), current.clone());
+        let result =
+            self.call_method_mut_with_values(&temp_var, current.clone(), &method, push_args)?;
+        let new_value = self.env.get(&temp_var).cloned().unwrap_or(result.clone());
+        self.env.remove(&temp_var);
+
+        // Update the instance attribute
+        let mut updated = (**attributes).clone();
+        updated.insert(attr_key, new_value.clone());
+        let cn = *class_name;
+        let tid = *target_id;
+
+        // Propagate to all env bindings referencing this instance
+        self.overwrite_instance_bindings_by_identity(&cn.resolve(), tid, updated);
+
+        // Also propagate the array/hash change to all instances sharing
+        // the same Arc (handles clone semantics).
+        if let Some(old_arc) = &old_array_arc {
+            self.propagate_shared_array_in_instances(old_arc, &new_value);
+        }
+        if let Some(old_arc) = &old_hash_arc {
+            self.propagate_shared_hash_in_instances(old_arc, &new_value);
+        }
+
+        Ok(result)
     }
 
     pub(super) fn builtin_subscript_adverb(

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -336,6 +336,79 @@ impl Interpreter {
         }
     }
 
+    /// Find all Instance values in the env whose attributes contain an array
+    /// with the same Arc pointer as `needle`, and replace that attribute with
+    /// `replacement`. This handles clone semantics where multiple instances
+    /// share the same array container.
+    pub(crate) fn propagate_shared_array_in_instances(
+        &mut self,
+        needle: &std::sync::Arc<Vec<Value>>,
+        replacement: &Value,
+    ) {
+        let mut updates: Vec<(String, Symbol, u64, String)> = Vec::new();
+        for (var_name, value) in self.env.iter() {
+            if let Value::Instance {
+                class_name,
+                attributes,
+                id,
+            } = value
+            {
+                for (attr_key, attr_val) in attributes.iter() {
+                    if let Value::Array(arc, ..) = attr_val
+                        && std::sync::Arc::ptr_eq(arc, needle)
+                    {
+                        updates.push((var_name.clone(), *class_name, *id, attr_key.clone()));
+                    }
+                }
+            }
+        }
+        for (var_name, class_name, id, attr_key) in updates {
+            if let Some(Value::Instance { attributes, .. }) = self.env.get(&var_name) {
+                let mut updated = (**attributes).clone();
+                updated.insert(attr_key, replacement.clone());
+                self.env.insert(
+                    var_name,
+                    Value::make_instance_with_id(class_name, updated, id),
+                );
+            }
+        }
+    }
+
+    /// Same as `propagate_shared_array_in_instances` but for Hash attributes.
+    pub(crate) fn propagate_shared_hash_in_instances(
+        &mut self,
+        needle: &std::sync::Arc<std::collections::HashMap<String, Value>>,
+        replacement: &Value,
+    ) {
+        let mut updates: Vec<(String, Symbol, u64, String)> = Vec::new();
+        for (var_name, value) in self.env.iter() {
+            if let Value::Instance {
+                class_name,
+                attributes,
+                id,
+            } = value
+            {
+                for (attr_key, attr_val) in attributes.iter() {
+                    if let Value::Hash(arc) = attr_val
+                        && std::sync::Arc::ptr_eq(arc, needle)
+                    {
+                        updates.push((var_name.clone(), *class_name, *id, attr_key.clone()));
+                    }
+                }
+            }
+        }
+        for (var_name, class_name, id, attr_key) in updates {
+            if let Some(Value::Instance { attributes, .. }) = self.env.get(&var_name) {
+                let mut updated = (**attributes).clone();
+                updated.insert(attr_key, replacement.clone());
+                self.env.insert(
+                    var_name,
+                    Value::make_instance_with_id(class_name, updated, id),
+                );
+            }
+        }
+    }
+
     pub(crate) fn overwrite_instance_bindings_by_identity(
         &mut self,
         class_name: &str,
@@ -1203,12 +1276,17 @@ impl Interpreter {
                     assigned_value = def;
                 }
                 updated.insert(attr_key.clone(), assigned_value.clone());
+                // Always propagate the change to all env bindings referencing
+                // this instance (by identity). This handles chained accessor
+                // assignment like `$outer.inner.arr = ...` where target_var
+                // may be None but the instance is reachable through other
+                // env bindings.
+                self.overwrite_instance_bindings_by_identity(
+                    &class_name.resolve(),
+                    target_id,
+                    updated.clone(),
+                );
                 if let Some(var_name) = target_var {
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        target_id,
-                        updated.clone(),
-                    );
                     self.env.insert(
                         var_name.to_string(),
                         Value::make_instance_with_id(class_name, updated, target_id),


### PR DESCRIPTION
## Summary
- Implement `push $obj.attr, val` through a new `__mutsu_push_through_accessor` builtin that mutates instance attributes in-place
- Add `propagate_shared_array_in_instances` and `propagate_shared_hash_in_instances` to propagate container mutations to all instances sharing the same Arc (e.g. after `.clone`)
- Fix chained accessor assignment (`$outer.inner.attr = val`) by always calling `overwrite_instance_bindings_by_identity` even without a target variable name

## Test plan
- [x] All 44 subtests in `roast/S12-attributes/clone.t` pass (was 38/44)
- [x] `make test` passes (480 files, 3926 tests)
- [x] `make roast` passes (pre-existing failures in num.t and spurt.t only)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)