### PR TITLE
fix: autothread junction keys in hash subscript access

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -157,6 +157,7 @@ roast/S03-feeds/basic.t
 roast/S03-junctions/associative.t
 roast/S03-junctions/autothreading.t
 roast/S03-junctions/boolean-context.t
+roast/S03-junctions/misc.t
 roast/S03-metaops/cross.t
 roast/S03-metaops/eager-hyper.t
 roast/S03-metaops/misc.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1557,6 +1557,48 @@ impl VM {
         {
             self.set_env_with_main_alias(&var_name, self.locals[slot].clone());
         }
+        // Junction autothreading: when writing back with a junction index,
+        // expand the junction and assign each element separately.
+        if let Value::Junction {
+            values: junc_keys, ..
+        } = &idx
+        {
+            let junc_vals = if let Value::Junction { values: jv, .. } = &val {
+                jv.clone()
+            } else {
+                // Same value for all junction elements
+                Arc::new(vec![val.clone(); junc_keys.len()])
+            };
+            for (i, key) in junc_keys.iter().enumerate() {
+                let v = junc_vals.get(i).cloned().unwrap_or(Value::Nil);
+                let k = key.to_string_value();
+                if var_name.starts_with('%') {
+                    if !matches!(self.interpreter.env().get(&var_name), Some(Value::Hash(_))) {
+                        self.interpreter.env_mut().insert(
+                            var_name.clone(),
+                            Value::hash(std::collections::HashMap::new()),
+                        );
+                    }
+                    if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(&var_name) {
+                        let h = Arc::make_mut(hash);
+                        h.insert(k, v);
+                    }
+                } else if let Some(idx_usize) = Self::index_to_usize(key) {
+                    // For array variables with junction index, use numeric indices
+                    if let Some(Value::Array(items, ..)) =
+                        self.interpreter.env_mut().get_mut(&var_name)
+                    {
+                        let arr = Arc::make_mut(items);
+                        if idx_usize >= arr.len() {
+                            arr.resize(idx_usize + 1, Value::Package(Symbol::intern("Any")));
+                        }
+                        arr[idx_usize] = v;
+                    }
+                }
+            }
+            self.stack.push(val);
+            return Ok(());
+        }
         match &idx {
             Value::Array(keys, ..) => {
                 let mut vals = self.assignment_rhs_values(&val)?;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -51,6 +51,29 @@ impl VM {
             other => other.clone(),
         };
 
+        // Junction autothreading: when indexing a hash with a junction key,
+        // expand the junction and create a slot ref for each element.
+        if let Value::Junction { kind, values } = &index
+            && matches!(&resolved, Value::Hash(_))
+        {
+            let kind = kind.clone();
+            let junction_values = values.clone();
+            let mut results = Vec::with_capacity(junction_values.len());
+            for val in junction_values.iter() {
+                let key = Value::hash_key_encode(val);
+                if let Some(slot_ref) = resolved.hash_autovivify(&key) {
+                    results.push(slot_ref);
+                } else {
+                    results.push(Value::Nil);
+                }
+            }
+            self.stack.push(Value::Junction {
+                kind,
+                values: Arc::new(results),
+            });
+            return Ok(());
+        }
+
         match &resolved {
             Value::Hash(_) => {
                 let key = Value::hash_key_encode(&index);


### PR DESCRIPTION
## Summary
- When indexing a hash with a junction key (e.g. `%h{any(0,1)}.push: 42`), expand the junction so each element becomes a separate hash key, matching Raku's autothreading semantics
- Previously the junction was stringified as a single key like `"any(0, 1)"`
- Adds junction handling to both `exec_index_autovivify_op` (slot ref creation) and `exec_index_assign_expr_named_op` (writeback)
- Adds `roast/S03-junctions/misc.t` (155 tests) to the whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S03-junctions/misc.t` passes all 155 tests
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)