### PR TITLE
fix: implement .subst adverbs :x, :nth, :p, :c and fix $/ on non-match

### DIFF
--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -306,10 +306,36 @@ impl Interpreter {
         let text = target.to_string_value();
         let mut positional: Vec<Value> = Vec::new();
         let mut global = false;
+        let mut nth: Option<Vec<i64>> = None;
+        let mut x_count: Option<Value> = None;
+        let mut pos_start: Option<usize> = None;
+        let mut continue_from: Option<usize> = None;
+        let mut _samecase = false;
+        let mut _samemark = false;
+        let mut _samespace = false;
         for arg in args {
             if let Value::Pair(key, value) = arg {
                 match key.as_str() {
                     "g" | "global" => global = value.truthy(),
+                    "x" => x_count = Some(*value.clone()),
+                    "nth" => {
+                        match value.as_ref() {
+                            Value::Int(n) => nth = Some(vec![*n]),
+                            Value::Array(items, _) => {
+                                nth = Some(items.iter().map(|v: &Value| v.to_f64() as i64).collect());
+                            }
+                            _ => nth = Some(vec![value.to_f64() as i64]),
+                        }
+                    }
+                    "1st" | "first" if value.truthy() => nth = Some(vec![1]),
+                    "2nd" | "second" if value.truthy() => nth = Some(vec![2]),
+                    "3rd" | "third" if value.truthy() => nth = Some(vec![3]),
+                    "4th" | "fourth" if value.truthy() => nth = Some(vec![4]),
+                    "p" | "pos" => pos_start = Some(value.to_f64() as usize),
+                    "c" | "continue" => continue_from = Some(value.to_f64() as usize),
+                    "samecase" | "ii" => _samecase = value.truthy(),
+                    "samemark" | "mm" => _samemark = value.truthy(),
+                    "samespace" | "ss" => _samespace = value.truthy(),
                     _ => {}
                 }
             } else {
@@ -331,6 +357,35 @@ impl Interpreter {
                 .as_ref()
                 .map(|v| v.to_string_value())
                 .unwrap_or_default()
+        };
+
+        // Helper to determine how many matches to use based on :x
+        let resolve_x_count = |x: &Option<Value>| -> Option<(usize, usize)> {
+            match x {
+                None => None,
+                Some(Value::Int(n)) => Some((*n as usize, *n as usize)),
+                Some(Value::Str(s)) if s.as_str() == "Inf" || s.as_str() == "*" => {
+                    Some((0, usize::MAX))
+                }
+                Some(Value::Whatever) | Some(Value::Sub(_)) | Some(Value::WeakSub(_)) => {
+                    Some((0, usize::MAX))
+                }
+                Some(Value::Range(lo, hi)) => {
+                    if *lo > *hi {
+                        Some((usize::MAX, 0)) // Empty range: always fail
+                    } else {
+                        Some((*lo as usize, *hi as usize))
+                    }
+                }
+                Some(Value::RangeExcl(lo, hi)) => {
+                    Some((*lo as usize, (*hi as usize).saturating_sub(1)))
+                }
+                Some(Value::RangeExclStart(lo, hi)) => Some(((*lo as usize) + 1, *hi as usize)),
+                Some(Value::RangeExclBoth(lo, hi)) => {
+                    Some(((*lo as usize) + 1, (*hi as usize).saturating_sub(1)))
+                }
+                Some(v) => Some((v.to_f64() as usize, v.to_f64() as usize)),
+            }
         };
 
         match pattern {
@@ -356,11 +411,74 @@ impl Interpreter {
                     self.regex_match_all_with_captures(&pat, &text)
                 };
                 if all_captures.is_empty() {
+                    self.env.insert("/".to_string(), Value::Nil);
                     return Ok(Value::str(text));
                 }
                 let chars: Vec<char> = text.chars().collect();
-                if pat_global {
-                    let selected = self.select_non_overlapping_matches(all_captures);
+
+                let has_adverbs = nth.is_some() || x_count.is_some()
+                    || pos_start.is_some() || continue_from.is_some();
+
+                if has_adverbs || pat_global {
+                    let mut selected = self.select_non_overlapping_matches(all_captures);
+
+                    // Apply :c(N) - filter matches starting from character position N
+                    if let Some(c) = continue_from {
+                        selected.retain(|cap| cap.from >= c);
+                    }
+
+                    // Apply :p(N) - first match must start at exactly position N
+                    // If it doesn't, return original string (failure)
+                    if let Some(p) = pos_start {
+                        // Filter to matches at or after position p
+                        selected.retain(|cap| cap.from >= p);
+                        // The first remaining match must be exactly at p
+                        if selected.is_empty() || selected[0].from != p {
+                            self.env.insert("/".to_string(), Value::Nil);
+                            return Ok(Value::str(text));
+                        }
+                    }
+
+                    // If no :g, :x, :nth - single match mode
+                    if !pat_global && x_count.is_none() && nth.is_none() {
+                        selected.truncate(1);
+                    }
+
+                    // Apply :nth - select specific 1-based match indices
+                    if let Some(ref nth_list) = nth {
+                        let total = selected.len();
+                        let mut indices: Vec<usize> = Vec::new();
+                        for &n in nth_list {
+                            if n >= 1 && (n as usize) <= total {
+                                indices.push(n as usize - 1);
+                            }
+                        }
+                        indices.sort();
+                        indices.dedup();
+                        let new_selected: Vec<_> = indices
+                            .iter()
+                            .filter_map(|&i| selected.get(i).cloned())
+                            .collect();
+                        selected = new_selected;
+                    }
+
+                    // Apply :x(N) - select exactly N matches (or range)
+                    if let Some((lo, hi)) = resolve_x_count(&x_count) {
+                        let count = selected.len();
+                        if count < lo {
+                            self.env.insert("/".to_string(), Value::Nil);
+                            return Ok(Value::str(text));
+                        }
+                        if count > hi {
+                            selected.truncate(hi);
+                        }
+                    }
+
+                    if selected.is_empty() {
+                        self.env.insert("/".to_string(), Value::Nil);
+                        return Ok(Value::str(text));
+                    }
+
                     let mut result = String::new();
                     let mut last_end = 0;
                     for captures in &selected {
@@ -423,8 +541,70 @@ impl Interpreter {
                 }
             }
             Value::Str(pat) => {
-                if global {
-                    Ok(Value::str(text.replace(pat.as_str(), &replacement_str)))
+                let has_adverbs = nth.is_some() || x_count.is_some()
+                    || pos_start.is_some() || continue_from.is_some();
+                if has_adverbs || global {
+                    let pat_str = pat.as_str();
+                    let mut str_matches: Vec<(usize, usize)> = Vec::new();
+                    let mut search_start = 0;
+                    while let Some(pos) = text[search_start..].find(pat_str) {
+                        let abs_pos = search_start + pos;
+                        str_matches.push((abs_pos, abs_pos + pat_str.len()));
+                        search_start = abs_pos + pat_str.len().max(1);
+                    }
+
+                    let char_indices: Vec<(usize, usize)> = str_matches
+                        .iter()
+                        .map(|&(start, end)| {
+                            let cs = text[..start].chars().count();
+                            let ce = text[..end].chars().count();
+                            (cs, ce)
+                        })
+                        .collect();
+
+                    let mut keep: Vec<usize> = (0..str_matches.len()).collect();
+
+                    if let Some(c) = continue_from {
+                        keep.retain(|&i| char_indices[i].0 >= c);
+                    }
+                    if let Some(p) = pos_start {
+                        keep.retain(|&i| char_indices[i].0 == p);
+                    }
+                    if !global && nth.is_none() && x_count.is_none() {
+                        keep.truncate(1);
+                    }
+                    if let Some(ref nth_list) = nth {
+                        let total = keep.len();
+                        let mut selected: Vec<usize> = Vec::new();
+                        for &n in nth_list {
+                            if n >= 1 && (n as usize) <= total {
+                                selected.push(keep[n as usize - 1]);
+                            }
+                        }
+                        selected.sort();
+                        selected.dedup();
+                        keep = selected;
+                    }
+                    if let Some((lo, hi)) = resolve_x_count(&x_count) {
+                        let count = keep.len();
+                        if count < lo {
+                            return Ok(Value::str(text));
+                        }
+                        if count > hi {
+                            keep.truncate(hi);
+                        }
+                    }
+
+                    let mut result = String::new();
+                    let mut last_end = 0;
+                    for &idx in &keep {
+                        let (start, end) = str_matches[idx];
+                        result.push_str(&text[last_end..start]);
+                        result.push_str(&replacement_str);
+                        last_end = end;
+                    }
+                    result.push_str(&text[last_end..]);
+                    Ok(Value::str(result))
                 } else {
                     Ok(Value::str(text.replacen(pat.as_str(), &replacement_str, 1)))
                 }

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -318,15 +318,13 @@ impl Interpreter {
                 match key.as_str() {
                     "g" | "global" => global = value.truthy(),
                     "x" => x_count = Some(*value.clone()),
-                    "nth" => {
-                        match value.as_ref() {
-                            Value::Int(n) => nth = Some(vec![*n]),
-                            Value::Array(items, _) => {
-                                nth = Some(items.iter().map(|v: &Value| v.to_f64() as i64).collect());
-                            }
-                            _ => nth = Some(vec![value.to_f64() as i64]),
+                    "nth" => match value.as_ref() {
+                        Value::Int(n) => nth = Some(vec![*n]),
+                        Value::Array(items, _) => {
+                            nth = Some(items.iter().map(|v: &Value| v.to_f64() as i64).collect());
                         }
-                    }
+                        _ => nth = Some(vec![value.to_f64() as i64]),
+                    },
                     "1st" | "first" if value.truthy() => nth = Some(vec![1]),
                     "2nd" | "second" if value.truthy() => nth = Some(vec![2]),
                     "3rd" | "third" if value.truthy() => nth = Some(vec![3]),
@@ -416,8 +414,10 @@ impl Interpreter {
                 }
                 let chars: Vec<char> = text.chars().collect();
 
-                let has_adverbs = nth.is_some() || x_count.is_some()
-                    || pos_start.is_some() || continue_from.is_some();
+                let has_adverbs = nth.is_some()
+                    || x_count.is_some()
+                    || pos_start.is_some()
+                    || continue_from.is_some();
 
                 if has_adverbs || pat_global {
                     let mut selected = self.select_non_overlapping_matches(all_captures);
@@ -541,8 +541,10 @@ impl Interpreter {
                 }
             }
             Value::Str(pat) => {
-                let has_adverbs = nth.is_some() || x_count.is_some()
-                    || pos_start.is_some() || continue_from.is_some();
+                let has_adverbs = nth.is_some()
+                    || x_count.is_some()
+                    || pos_start.is_some()
+                    || continue_from.is_some();
                 if has_adverbs || global {
                     let pat_str = pat.as_str();
                     let mut str_matches: Vec<(usize, usize)> = Vec::new();


### PR DESCRIPTION
## Summary
- Implement `:x(N)`, `:x(lo..hi)`, `:nth(N)`, `:p(N)`, `:c(N)` adverbs for `.subst()` method
- Set `$/` to `Nil` when `.subst()` regex pattern finds no match
- Support `:1st`, `:2nd`, `:3rd`, `:4th` shorthand adverbs for `:nth`
- Handle empty ranges in `:x` (e.g., `:x(3..2)`) correctly as no-replacement

Together with the parser fix in the previous commit (S[pattern] = expr fallback to expression parsing), this takes `roast/S05-substitution/subst.t` from **0 tests** (compile error) to **117 of 132 passing**.

## Test plan
- [x] `cargo run --release -- roast/S05-substitution/subst.t` passes 117/132 tests
- [x] Remaining 15 failures are pre-existing limitations (`:x(*)` WhateverCode priming, `samemark`/`samespace` Unicode features, return value count semantics, error detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)