### PR TITLE
fix: parse adjacent colonpairs and return Failure from chdir

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -2578,12 +2578,13 @@ fn make_call_expr_from_listop_args<'a>(
     loop {
         let (r2, _) = ws(r)?;
         // Adjacent colonpairs without commas: foo :a :b :c or foo :a:b:c
-        if r2.starts_with(':') && !r2.starts_with("::") {
-            if let Ok((r3, arg)) = parse_listop_arg(r2) {
-                args.push(arg);
-                r = r3;
-                continue;
-            }
+        if r2.starts_with(':')
+            && !r2.starts_with("::")
+            && let Ok((r3, arg)) = parse_listop_arg(r2)
+        {
+            args.push(arg);
+            r = r3;
+            continue;
         }
         if !r2.starts_with(',') || r2.starts_with(",,") {
             break;

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1114,6 +1114,11 @@ fn try_parse_no_paren_invocant_colon_call<'a>(
     if !r_ws.starts_with(':') || r_ws.starts_with("::") {
         return Ok((rest_after_first_arg, None));
     }
+    // If the first arg is a colonpair (FatArrow Pair like :r, :!d, :name(val)),
+    // a following ':' is another colonpair, not an invocant colon.
+    if matches!(&first_arg, Expr::Binary { op: crate::token_kind::TokenKind::FatArrow, .. }) {
+        return Ok((rest_after_first_arg, None));
+    }
 
     let after_colon = &r_ws[1..];
     let (mut r, _) = ws(after_colon)?;
@@ -2566,6 +2571,14 @@ fn make_call_expr_from_listop_args<'a>(
     let mut r = r;
     loop {
         let (r2, _) = ws(r)?;
+        // Adjacent colonpairs without commas: foo :a :b :c or foo :a:b:c
+        if r2.starts_with(':') && !r2.starts_with("::") {
+            if let Ok((r3, arg)) = parse_listop_arg(r2) {
+                args.push(arg);
+                r = r3;
+                continue;
+            }
+        }
         if !r2.starts_with(',') || r2.starts_with(",,") {
             break;
         }

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1116,7 +1116,13 @@ fn try_parse_no_paren_invocant_colon_call<'a>(
     }
     // If the first arg is a colonpair (FatArrow Pair like :r, :!d, :name(val)),
     // a following ':' is another colonpair, not an invocant colon.
-    if matches!(&first_arg, Expr::Binary { op: crate::token_kind::TokenKind::FatArrow, .. }) {
+    if matches!(
+        &first_arg,
+        Expr::Binary {
+            op: crate::token_kind::TokenKind::FatArrow,
+            ..
+        }
+    ) {
         return Ok((rest_after_first_arg, None));
     }
 

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -278,12 +278,13 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
     loop {
         let (r, _) = ws(rest)?;
         // Adjacent colonpairs without commas: foo :a :b :c or foo :a:b:c
-        if r.starts_with(':') && !r.starts_with("::") {
-            if let Ok((r2, arg)) = parse_single_call_arg(r) {
-                args.extend(expand_call_arg(arg));
-                rest = r2;
-                continue;
-            }
+        if r.starts_with(':')
+            && !r.starts_with("::")
+            && let Ok((r2, arg)) = parse_single_call_arg(r)
+        {
+            args.extend(expand_call_arg(arg));
+            rest = r2;
+            continue;
         }
         if !r.starts_with(',') {
             return Ok((r, args));

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -252,7 +252,10 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
     // Only attempt the invocant-colon path when the first arg is positional.
     // If it's a Named arg (colonpair like :r), a following ':' is another
     // colonpair, not an invocant colon.
-    if rest_ws.starts_with(':') && !rest_ws.starts_with("::") && matches!(&first, CallArg::Positional(_)) {
+    if rest_ws.starts_with(':')
+        && !rest_ws.starts_with("::")
+        && matches!(&first, CallArg::Positional(_))
+    {
         let invocant_expr = match first {
             CallArg::Positional(expr) => expr,
             _ => unreachable!(),

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -249,14 +249,13 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
         exception: None,
     })?;
     let (rest_ws, _) = ws(rest)?;
-    if rest_ws.starts_with(':') && !rest_ws.starts_with("::") {
+    // Only attempt the invocant-colon path when the first arg is positional.
+    // If it's a Named arg (colonpair like :r), a following ':' is another
+    // colonpair, not an invocant colon.
+    if rest_ws.starts_with(':') && !rest_ws.starts_with("::") && matches!(&first, CallArg::Positional(_)) {
         let invocant_expr = match first {
             CallArg::Positional(expr) => expr,
-            _ => {
-                return Err(PError::expected(
-                    "positional argument before invocant colon",
-                ));
-            }
+            _ => unreachable!(),
         };
         args.push(CallArg::Invocant(invocant_expr));
         let after_colon = &rest_ws[1..];
@@ -275,6 +274,14 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
     args.extend(expand_call_arg(first));
     loop {
         let (r, _) = ws(rest)?;
+        // Adjacent colonpairs without commas: foo :a :b :c or foo :a:b:c
+        if r.starts_with(':') && !r.starts_with("::") {
+            if let Ok((r2, arg)) = parse_single_call_arg(r) {
+                args.extend(expand_call_arg(arg));
+                rest = r2;
+                continue;
+            }
+        }
         if !r.starts_with(',') {
             return Ok((r, args));
         }

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -955,6 +955,9 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                     | "built"
                     | "cached"
                     | "repr"
+                    | "open"
+                    | "closed"
+                    | "final"
             ) {
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 parents.push(format!("{}{}", parent, bracket_suffix));

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -124,6 +124,18 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             return Ok((stripped, current_stmt));
         }
 
+        // In Raku, a stray `)` before `;` or at end of statement is allowed
+        // (e.g. `throws-like 'code', Exception, 'msg');`).
+        if let Some(after_paren) = rest.strip_prefix(')') {
+            let (after, _) = ws(after_paren)?;
+            if let Some(stripped) = after.strip_prefix(';') {
+                return Ok((stripped, current_stmt));
+            }
+            if after.is_empty() || after.starts_with('}') {
+                return Ok((after, current_stmt));
+            }
+        }
+
         // If at end of input or block, return as-is
         if rest.is_empty() || rest.starts_with('}') {
             return Ok((rest, current_stmt));

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -124,18 +124,6 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             return Ok((stripped, current_stmt));
         }
 
-        // In Raku, a stray `)` before `;` or at end of statement is allowed
-        // (e.g. `throws-like 'code', Exception, 'msg');`).
-        if let Some(after_paren) = rest.strip_prefix(')') {
-            let (after, _) = ws(after_paren)?;
-            if let Some(stripped) = after.strip_prefix(';') {
-                return Ok((stripped, current_stmt));
-            }
-            if after.is_empty() || after.starts_with('}') {
-                return Ok((after, current_stmt));
-            }
-        }
-
         // If at end of input or block, return as-is
         if rest.is_empty() || rest.starts_with('}') {
             return Ok((rest, current_stmt));

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -671,7 +671,7 @@ impl Interpreter {
             self.resolve_path(&Self::stringify_path(&path_buf))
         };
         if !absolute_target.exists() {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!(
                     "Failed to chdir to '{}': no such file or directory",
@@ -680,13 +680,13 @@ impl Interpreter {
             ));
         }
         if require_dir && !absolute_target.is_dir() {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!("Failed to chdir to '{}': not a directory", requested),
             ));
         }
         if !has_required_mode_bits(&absolute_target, require_read, require_write, require_exec) {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!("Failed to chdir to '{}': permission denied", requested),
             ));


### PR DESCRIPTION
## Summary
- Fix parser to handle adjacent colonpairs without commas (e.g., `foo :r:w:x, ...` or `foo :r :w :x, ...`) in both statement-level (`parse_remaining_call_args`) and expression-level (`make_call_expr_from_listop_args`) function call arguments
- Skip invocant-colon interpretation when the first argument is itself a colonpair (Named arg), preventing misparse of `:r:w` as "`:r` invocant-colon `w`"
- Change `builtin_chdir` to return `Failure` values (via `io_exception_failure`) instead of throwing exceptions (via `io_exception_error`), matching Raku semantics where `chdir` returns a `Failure` on error

## Test results
- **Before**: `roast/S32-io/chdir.t` failed at compile time (0/82 subtests)
- **After**: 81/82 subtests pass; the remaining failure is test 82 (`chdir into IO::Path respects its :CWD attribute`) which requires IO::Path `.CWD` accessor support

## Test plan
- [x] `cargo test --release` passes all 449 unit tests
- [x] `cargo run --release -- roast/S32-io/chdir.t` passes 81/82 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)