### PR TITLE
fix: parse adjacent colonpairs and return Failure from indir

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1131,7 +1131,8 @@ fn try_parse_no_paren_invocant_colon_call<'a>(
     // If the colon is immediately followed by an identifier char, `!`, or a sigil,
     // it's a colonpair (e.g. `:r`, `:!d`, `:$var`), not an invocant colon.
     if let Some(c) = after_colon.chars().next() {
-        if c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&' {
+        if c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&'
+        {
             return Ok((rest_after_first_arg, None));
         }
     }

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1127,6 +1127,14 @@ fn try_parse_no_paren_invocant_colon_call<'a>(
     }
 
     let after_colon = &r_ws[1..];
+
+    // If the colon is immediately followed by an identifier char, `!`, or a sigil,
+    // it's a colonpair (e.g. `:r`, `:!d`, `:$var`), not an invocant colon.
+    if let Some(c) = after_colon.chars().next() {
+        if c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&' {
+            return Ok((rest_after_first_arg, None));
+        }
+    }
     let (mut r, _) = ws(after_colon)?;
 
     if let Some(after_comma) = r.strip_prefix(',') {

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1130,11 +1130,16 @@ fn try_parse_no_paren_invocant_colon_call<'a>(
 
     // If the colon is immediately followed by an identifier char, `!`, or a sigil,
     // it's a colonpair (e.g. `:r`, `:!d`, `:$var`), not an invocant colon.
-    if let Some(c) = after_colon.chars().next() {
-        if c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&'
-        {
-            return Ok((rest_after_first_arg, None));
-        }
+    if let Some(c) = after_colon.chars().next()
+        && (c.is_alphabetic()
+            || c == '_'
+            || c == '!'
+            || c == '$'
+            || c == '@'
+            || c == '%'
+            || c == '&')
+    {
+        return Ok((rest_after_first_arg, None));
     }
     let (mut r, _) = ws(after_colon)?;
 

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -249,30 +249,28 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
         exception: None,
     })?;
     let (rest_ws, _) = ws(rest)?;
-    // Only attempt the invocant-colon path when the first arg is positional.
-    // If it's a Named arg (colonpair like :r), a following ':' is another
-    // colonpair, not an invocant colon.
-    if rest_ws.starts_with(':')
-        && !rest_ws.starts_with("::")
-        && matches!(&first, CallArg::Positional(_))
-    {
-        let invocant_expr = match first {
-            CallArg::Positional(expr) => expr,
-            _ => unreachable!(),
-        };
-        args.push(CallArg::Invocant(invocant_expr));
-        let after_colon = &rest_ws[1..];
-        let (after_colon, _) = ws(after_colon)?;
-        if after_colon.starts_with(';')
-            || after_colon.is_empty()
-            || after_colon.starts_with('}')
-            || after_colon.starts_with(')')
-        {
-            return Ok((after_colon, args));
+    if rest_ws.starts_with(':') && !rest_ws.starts_with("::") {
+        // Only treat as invocant colon if the first arg was positional.
+        // If the first arg was a colonpair (Named), the next `:` is another colonpair.
+        if matches!(first, CallArg::Positional(_)) {
+            let invocant_expr = match first {
+                CallArg::Positional(expr) => expr,
+                _ => unreachable!(),
+            };
+            args.push(CallArg::Invocant(invocant_expr));
+            let after_colon = &rest_ws[1..];
+            let (after_colon, _) = ws(after_colon)?;
+            if after_colon.starts_with(';')
+                || after_colon.is_empty()
+                || after_colon.starts_with('}')
+                || after_colon.starts_with(')')
+            {
+                return Ok((after_colon, args));
+            }
+            let (after_args, mut more) = parse_remaining_call_args(after_colon)?;
+            args.append(&mut more);
+            return Ok((after_args, args));
         }
-        let (after_args, mut more) = parse_remaining_call_args(after_colon)?;
-        args.append(&mut more);
-        return Ok((after_args, args));
     }
     args.extend(expand_call_arg(first));
     loop {
@@ -280,10 +278,10 @@ pub(super) fn parse_remaining_call_args(input: &str) -> PResult<'_, Vec<CallArg>
         // Adjacent colonpairs without commas: foo :a :b :c or foo :a:b:c
         if r.starts_with(':')
             && !r.starts_with("::")
-            && let Ok((r2, arg)) = parse_single_call_arg(r)
+            && let Ok((r3, arg)) = parse_single_call_arg(r)
         {
             args.extend(expand_call_arg(arg));
-            rest = r2;
+            rest = r3;
             continue;
         }
         if !r.starts_with(',') {

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -389,6 +389,7 @@ impl Interpreter {
                 }
             }
         }
+        let dir_from_cwd = requested_opt.is_none();
         let requested = requested_opt.unwrap_or_else(|| {
             self.get_dynamic_string("$*CWD")
                 .unwrap_or_else(|| ".".to_string())
@@ -409,10 +410,12 @@ impl Interpreter {
             {
                 return;
             }
-            let out_path = if requested_is_absolute {
-                path_buf.join(basename)
-            } else if requested == "." {
+            // When dir() is called with no explicit path (using $*CWD) or with ".",
+            // return just basenames. Otherwise prefix with the requested path.
+            let out_path = if dir_from_cwd || requested == "." {
                 PathBuf::from(basename)
+            } else if requested_is_absolute {
+                path_buf.join(basename)
             } else {
                 requested_path.join(basename)
             };
@@ -421,10 +424,12 @@ impl Interpreter {
                 "path".to_string(),
                 Value::str(Self::stringify_path(&out_path)),
             );
-            if let Some(cwd) = &requested_cwd_opt
-                && !out_path.is_absolute()
-            {
-                attrs.insert("cwd".to_string(), Value::str(cwd.clone()));
+            if !out_path.is_absolute() {
+                if let Some(cwd) = &requested_cwd_opt {
+                    attrs.insert("cwd".to_string(), Value::str(cwd.clone()));
+                } else if dir_from_cwd && requested_is_absolute {
+                    attrs.insert("cwd".to_string(), Value::str(Self::stringify_path(&path_buf)));
+                }
             }
             entries.push(Value::make_instance(Symbol::intern("IO::Path"), attrs));
         };
@@ -748,7 +753,7 @@ impl Interpreter {
             self.resolve_path(&Self::stringify_path(&path_buf))
         };
         if !absolute_target.exists() {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!(
                     "Failed to chdir to '{}': no such file or directory",
@@ -757,13 +762,13 @@ impl Interpreter {
             ));
         }
         if require_dir && !absolute_target.is_dir() {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!("Failed to chdir to '{}': not a directory", requested),
             ));
         }
         if !has_required_mode_bits(&absolute_target, require_read, require_write, require_exec) {
-            return Err(io_exception_error(
+            return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!("Failed to chdir to '{}': permission denied", requested),
             ));

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -428,7 +428,10 @@ impl Interpreter {
                 if let Some(cwd) = &requested_cwd_opt {
                     attrs.insert("cwd".to_string(), Value::str(cwd.clone()));
                 } else if dir_from_cwd && requested_is_absolute {
-                    attrs.insert("cwd".to_string(), Value::str(Self::stringify_path(&path_buf)));
+                    attrs.insert(
+                        "cwd".to_string(),
+                        Value::str(Self::stringify_path(&path_buf)),
+                    );
                 }
             }
             entries.push(Value::make_instance(Symbol::intern("IO::Path"), attrs));


### PR DESCRIPTION
## Summary
- Fix parser to allow adjacent colonpairs without commas in no-paren listop calls (e.g. `foo :r:w:x, ...` or `foo :r :w :x, ...`). Previously the second colonpair was misinterpreted as an invocant colon, causing a parse error.
- Fix `try_parse_no_paren_invocant_colon_call` to distinguish colonpairs (`:name`, `:!name`, `:$var`) from invocant colons by checking the character after `:`.
- Fix `indir` to return `Failure` values instead of throwing exceptions when path doesn't exist or permissions are insufficient, matching Raku semantics.
- Fix `dir()` with no explicit path to return basename-only entries instead of absolute paths.

Roast test `S32-io/indir.t`: **0/77 -> 75/77** subtests passing.

## Test plan
- [x] `cargo test --release` passes
- [x] `cargo run --release -- roast/S32-io/indir.t` shows 75/77 passing
- [x] Invocant colon syntax still works (e.g. `42.base: 16`)
- [x] Adjacent colonpairs work in both no-paren and paren call forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)