### PR TITLE
fix: handle literal [ in char classes and support regex alias assertions

### DIFF
--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -847,27 +847,48 @@ fn scan_to_delim_inner(
                     return None;
                 }
             }
-            let mut bracket_depth = 1u32;
-            loop {
-                match chars.next() {
-                    Some((_, '\\')) => {
-                        chars.next(); // skip escaped char
+            // Inside a Raku character class like <[...]>, <-[...]+[...]>, etc.
+            // We scan bracket groups sequentially. Inside each [...], an
+            // unescaped '[' is a literal character (only '\]' escapes ']').
+            // After ']', we check for compound class operators (+[, -[) or
+            // the closing '>'.
+            'char_class: loop {
+                // Scan inside a [...] group until unescaped ']'
+                loop {
+                    match chars.next() {
+                        Some((_, '\\')) => {
+                            chars.next(); // skip escaped char
+                        }
+                        Some((_, ']')) => {
+                            break; // end of this bracket group
+                        }
+                        Some(_) => {}
+                        None => return None,
                     }
-                    Some((_, ']')) => {
-                        bracket_depth -= 1;
-                        if bracket_depth == 0 {
-                            // Consume the closing >
-                            if let Some((_, '>')) = chars.next() {
-                                // done
-                            }
+                }
+                // After ']', check for compound class or closing '>'
+                let saved = chars.clone();
+                match chars.next() {
+                    Some((_, '>')) => break, // done
+                    Some((_, '+' | '-')) => {
+                        if let Some((_, '[')) = chars.next() {
+                            continue 'char_class;
+                        }
+                        // Not a compound group; try consuming '>'
+                        chars = saved;
+                        if let Some((_, '>')) = chars.next() {
                             break;
                         }
+                        break;
                     }
-                    Some((_, '[')) => {
-                        bracket_depth += 1;
+                    Some((_, '[')) => continue 'char_class,
+                    _ => {
+                        chars = saved;
+                        if let Some((_, '>')) = chars.next() {
+                            break;
+                        }
+                        break;
                     }
-                    Some(_) => {}
-                    None => return None,
                 }
             }
         } else if !p5_mode

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -247,6 +247,9 @@ pub(super) struct NamedRegexLookupSpec {
     pub(super) lookup_name: String,
     pub(super) capture_name: Option<String>,
     pub(super) arg_exprs: Vec<String>,
+    /// When true, the alias replaces the original capture name (dot-call alias).
+    /// `<foo=.alpha>` sets this to true; `<foo=alpha>` leaves it false.
+    pub(super) alias_replaces_original: bool,
 }
 
 /// Check if a character is a "word" character for word boundary purposes.

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::super::unicode::check_unicode_property;
 use super::regex_helpers::{
     CaseFoldIter, class_has_only_exact_chars, grapheme_end, is_word_char, matches_named_builtin,
 };
@@ -397,6 +398,37 @@ impl Interpreter {
                     return None;
                 }
                 return Some(next);
+            }
+            // Fallback: check if lookup_name is a builtin character class
+            let is_builtin_class = matches!(spec.lookup_name.as_str(),
+                "alpha" | "upper" | "lower" | "digit" | "xdigit"
+                | "space" | "alnum" | "blank" | "cntrl" | "punct"
+                | "graph" | "print");
+            if is_builtin_class {
+                if pos < chars.len() && matches_named_builtin(&spec.lookup_name, chars[pos]) {
+                    return Some(pos + 1);
+                }
+                return None; // builtin class doesn't match — no error
+            }
+            // Unicode property fallback: :Letter, :!Letter, -:Letter
+            let (uni_prop, uni_negated) = if let Some(prop) = spec.lookup_name.strip_prefix(":!") {
+                (Some(prop), true)
+            } else if let Some(prop) = spec.lookup_name.strip_prefix("-:") {
+                (Some(prop), true)
+            } else if let Some(prop) = spec.lookup_name.strip_prefix(':') {
+                (Some(prop), false)
+            } else {
+                (None, false)
+            };
+            if let Some(prop_name) = uni_prop {
+                if pos < chars.len() {
+                    let matches = check_unicode_property(prop_name, chars[pos]);
+                    let matches = if uni_negated { !matches } else { matches };
+                    if matches {
+                        return Some(pos + 1);
+                    }
+                }
+                return None;
             }
             // Named rule not found — report error for valid identifier names.
             // Skip error for names containing special chars (likely parser

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -1,5 +1,5 @@
-use super::super::*;
 use super::super::unicode::check_unicode_property;
+use super::super::*;
 use super::regex_helpers::{
     CaseFoldIter, class_has_only_exact_chars, grapheme_end, is_word_char, matches_named_builtin,
 };
@@ -400,10 +400,21 @@ impl Interpreter {
                 return Some(next);
             }
             // Fallback: check if lookup_name is a builtin character class
-            let is_builtin_class = matches!(spec.lookup_name.as_str(),
-                "alpha" | "upper" | "lower" | "digit" | "xdigit"
-                | "space" | "alnum" | "blank" | "cntrl" | "punct"
-                | "graph" | "print");
+            let is_builtin_class = matches!(
+                spec.lookup_name.as_str(),
+                "alpha"
+                    | "upper"
+                    | "lower"
+                    | "digit"
+                    | "xdigit"
+                    | "space"
+                    | "alnum"
+                    | "blank"
+                    | "cntrl"
+                    | "punct"
+                    | "graph"
+                    | "print"
+            );
             if is_builtin_class {
                 if pos < chars.len() && matches_named_builtin(&spec.lookup_name, chars[pos]) {
                     return Some(pos + 1);

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -1,5 +1,5 @@
-use super::super::*;
 use super::super::unicode::check_unicode_property;
+use super::super::*;
 use super::regex_helpers::{is_word_char, matches_named_builtin, merge_regex_captures};
 
 impl Interpreter {
@@ -528,16 +528,30 @@ impl Interpreter {
             // Fallback: check if lookup_name is a builtin character class
             // (e.g., alpha, digit, etc.). This handles <foo=alpha> aliases
             // where "alpha" is not a user-defined token but a builtin.
-            let is_builtin_class = matches!(spec.lookup_name.as_str(),
-                "alpha" | "upper" | "lower" | "digit" | "xdigit"
-                | "space" | "alnum" | "blank" | "cntrl" | "punct"
-                | "graph" | "print");
-            if is_builtin_class {
-                if pos >= chars.len() || !matches_named_builtin(&spec.lookup_name, chars[pos]) {
-                    return None; // builtin class doesn't match here — no error, just no match
-                }
+            let is_builtin_class = matches!(
+                spec.lookup_name.as_str(),
+                "alpha"
+                    | "upper"
+                    | "lower"
+                    | "digit"
+                    | "xdigit"
+                    | "space"
+                    | "alnum"
+                    | "blank"
+                    | "cntrl"
+                    | "punct"
+                    | "graph"
+                    | "print"
+            );
+            if is_builtin_class
+                && (pos >= chars.len() || !matches_named_builtin(&spec.lookup_name, chars[pos]))
+            {
+                return None; // builtin class doesn't match here — no error, just no match
             }
-            if is_builtin_class && pos < chars.len() && matches_named_builtin(&spec.lookup_name, chars[pos]) {
+            if is_builtin_class
+                && pos < chars.len()
+                && matches_named_builtin(&spec.lookup_name, chars[pos])
+            {
                 let end = pos + 1;
                 let mut new_caps = current_caps.clone();
                 let captured: String = chars[pos..end].iter().collect();
@@ -546,10 +560,12 @@ impl Interpreter {
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let mut subcap = RegexCaptures::default();
-                    subcap.matched = captured.clone();
-                    subcap.from = pos;
-                    subcap.to = end;
+                    let subcap = RegexCaptures {
+                        matched: captured.clone(),
+                        from: pos,
+                        to: end,
+                        ..Default::default()
+                    };
                     new_caps
                         .named_subcaps
                         .entry(capture_name.to_string())
@@ -562,14 +578,19 @@ impl Interpreter {
                         .push(captured.clone());
                     // For <foo=alpha>, also capture under the original name.
                     // For <foo=.alpha>, the dot suppresses the original name.
-                    if spec.capture_name.is_some() && capture_name != spec.lookup_name && !spec.alias_replaces_original {
+                    if spec.capture_name.is_some()
+                        && capture_name != spec.lookup_name
+                        && !spec.alias_replaces_original
+                    {
                         new_caps
                             .capture_alias_map
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
-                        let mut subcap2 = RegexCaptures::default();
-                        subcap2.matched = captured.clone();
-                        subcap2.from = pos;
-                        subcap2.to = end;
+                        let subcap2 = RegexCaptures {
+                            matched: captured.clone(),
+                            from: pos,
+                            to: end,
+                            ..Default::default()
+                        };
                         new_caps
                             .named_subcaps
                             .entry(spec.lookup_name.to_string())
@@ -612,10 +633,12 @@ impl Interpreter {
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let mut subcap = RegexCaptures::default();
-                    subcap.matched = captured.clone();
-                    subcap.from = pos;
-                    subcap.to = end;
+                    let subcap = RegexCaptures {
+                        matched: captured.clone(),
+                        from: pos,
+                        to: end,
+                        ..Default::default()
+                    };
                     new_caps
                         .named_subcaps
                         .entry(capture_name.to_string())

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use super::regex_helpers::{is_word_char, merge_regex_captures};
+use super::super::unicode::check_unicode_property;
+use super::regex_helpers::{is_word_char, matches_named_builtin, merge_regex_captures};
 
 impl Interpreter {
     pub(super) fn regex_match_atom_with_capture_in_pkg(
@@ -519,6 +520,110 @@ impl Interpreter {
                     new_caps
                         .named
                         .entry(spec.lookup_name.to_string())
+                        .or_default()
+                        .push(captured);
+                }
+                return Some((end, new_caps));
+            }
+            // Fallback: check if lookup_name is a builtin character class
+            // (e.g., alpha, digit, etc.). This handles <foo=alpha> aliases
+            // where "alpha" is not a user-defined token but a builtin.
+            let is_builtin_class = matches!(spec.lookup_name.as_str(),
+                "alpha" | "upper" | "lower" | "digit" | "xdigit"
+                | "space" | "alnum" | "blank" | "cntrl" | "punct"
+                | "graph" | "print");
+            if is_builtin_class {
+                if pos >= chars.len() || !matches_named_builtin(&spec.lookup_name, chars[pos]) {
+                    return None; // builtin class doesn't match here — no error, just no match
+                }
+            }
+            if is_builtin_class && pos < chars.len() && matches_named_builtin(&spec.lookup_name, chars[pos]) {
+                let end = pos + 1;
+                let mut new_caps = current_caps.clone();
+                let captured: String = chars[pos..end].iter().collect();
+                let capture_name = spec
+                    .capture_name
+                    .as_deref()
+                    .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
+                if let Some(capture_name) = capture_name {
+                    let mut subcap = RegexCaptures::default();
+                    subcap.matched = captured.clone();
+                    subcap.from = pos;
+                    subcap.to = end;
+                    new_caps
+                        .named_subcaps
+                        .entry(capture_name.to_string())
+                        .or_default()
+                        .push(subcap);
+                    new_caps
+                        .named
+                        .entry(capture_name.to_string())
+                        .or_default()
+                        .push(captured.clone());
+                    // For <foo=alpha>, also capture under the original name.
+                    // For <foo=.alpha>, the dot suppresses the original name.
+                    if spec.capture_name.is_some() && capture_name != spec.lookup_name && !spec.alias_replaces_original {
+                        new_caps
+                            .capture_alias_map
+                            .insert(capture_name.to_string(), spec.lookup_name.clone());
+                        let mut subcap2 = RegexCaptures::default();
+                        subcap2.matched = captured.clone();
+                        subcap2.from = pos;
+                        subcap2.to = end;
+                        new_caps
+                            .named_subcaps
+                            .entry(spec.lookup_name.to_string())
+                            .or_default()
+                            .push(subcap2);
+                        new_caps
+                            .named
+                            .entry(spec.lookup_name.to_string())
+                            .or_default()
+                            .push(captured);
+                    }
+                }
+                return Some((end, new_caps));
+            }
+            // Fallback: check if lookup_name is a Unicode property assertion
+            // (e.g., :Letter, :!Letter, -:Letter). Handles <foo=:Letter> aliases.
+            let (uni_prop, uni_negated) = if let Some(prop) = spec.lookup_name.strip_prefix(":!") {
+                (Some(prop), true)
+            } else if let Some(prop) = spec.lookup_name.strip_prefix("-:") {
+                (Some(prop), true)
+            } else if let Some(prop) = spec.lookup_name.strip_prefix(':') {
+                (Some(prop), false)
+            } else {
+                (None, false)
+            };
+            if let Some(prop_name) = uni_prop {
+                if pos >= chars.len() {
+                    return None;
+                }
+                let matches = check_unicode_property(prop_name, chars[pos]);
+                let matches = if uni_negated { !matches } else { matches };
+                if !matches {
+                    return None;
+                }
+                let end = pos + 1;
+                let mut new_caps = current_caps.clone();
+                let captured: String = chars[pos..end].iter().collect();
+                let capture_name = spec
+                    .capture_name
+                    .as_deref()
+                    .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
+                if let Some(capture_name) = capture_name {
+                    let mut subcap = RegexCaptures::default();
+                    subcap.matched = captured.clone();
+                    subcap.from = pos;
+                    subcap.to = end;
+                    new_caps
+                        .named_subcaps
+                        .entry(capture_name.to_string())
+                        .or_default()
+                        .push(subcap);
+                    new_caps
+                        .named
+                        .entry(capture_name.to_string())
                         .or_default()
                         .push(captured);
                 }

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -323,10 +323,17 @@ impl Interpreter {
             return (name, args);
         }
         if let Some(colon_idx) = Self::find_top_level_call_colon(trimmed) {
-            let name = trimmed[..colon_idx].trim().to_string();
-            let arg_src = trimmed[colon_idx + 1..].trim();
-            let args = Self::split_regex_arg_list(arg_src);
-            return (name, args);
+            // Don't split on colon that's part of a Unicode property prefix
+            // (e.g., ":Letter", ":!Letter", "-:Letter"), not a method call colon.
+            let is_unicode_prop_colon = colon_idx == 0
+                || (colon_idx == 1 && trimmed.starts_with('-'))
+                || (colon_idx == 1 && trimmed.starts_with('!'));
+            if !is_unicode_prop_colon {
+                let name = trimmed[..colon_idx].trim().to_string();
+                let arg_src = trimmed[colon_idx + 1..].trim();
+                let args = Self::split_regex_arg_list(arg_src);
+                return (name, args);
+            }
         }
         (trimmed.to_string(), Vec::new())
     }
@@ -340,6 +347,7 @@ impl Interpreter {
         }
         let mut token_lookup = false;
         let mut capture_name = None;
+        let mut alias_replaces_original = false;
 
         // Look for alias syntax <name=.subrule>, <name=&subrule>, <name=subrule>.
         // Only match `=` that is NOT part of `=>` (fat-arrow pair syntax in args)
@@ -358,16 +366,19 @@ impl Interpreter {
                     raw = stripped.trim();
                     token_lookup = true;
                     silent = false;
+                    alias_replaces_original = true;
                 } else if let Some(stripped) = rhs.strip_prefix('.') {
                     // <name=.subrule> — call .subrule (non-capturing), capture under name
                     capture_name = Some(lhs.to_string());
                     raw = stripped.trim();
                     silent = false;
+                    alias_replaces_original = true;
                 } else {
-                    // <name=subrule> — call subrule, capture under name
+                    // <name=subrule> — call subrule, capture under name AND original
                     capture_name = Some(lhs.to_string());
                     raw = rhs;
                     silent = false;
+                    alias_replaces_original = false;
                 }
             }
         }
@@ -384,6 +395,7 @@ impl Interpreter {
             lookup_name,
             capture_name,
             arg_exprs,
+            alias_replaces_original,
         }
     }
 

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -304,26 +304,62 @@ fn skip_char_class_content(
         return false;
     }
     current.push(open_ch);
-    let mut bracket_depth = 0u32;
-    while let Some(c) = chars.next() {
-        current.push(c);
-        match c {
-            '\\' => {
-                if let Some(esc) = chars.next() {
-                    current.push(esc);
-                }
-            }
-            '[' => bracket_depth += 1,
-            ']' => {
-                bracket_depth -= 1;
-                if bracket_depth == 0 {
-                    if chars.peek() == Some(&'>') {
-                        current.push(chars.next().unwrap());
-                    }
+    // Scan bracket groups sequentially. Inside each [...], an unescaped '['
+    // is a literal character. After ']', check for compound operators (+[, -[)
+    // or the closing '>'.
+    let mut entered_first = false;
+    'char_class: loop {
+        if !entered_first {
+            // Consume chars until we hit the first '['
+            while let Some(c) = chars.next() {
+                current.push(c);
+                if c == '[' {
                     break;
                 }
             }
-            _ => {}
+            entered_first = true;
+        }
+        // Scan inside a [...] group until unescaped ']'
+        loop {
+            match chars.next() {
+                Some('\\') => {
+                    current.push('\\');
+                    if let Some(esc) = chars.next() {
+                        current.push(esc);
+                    }
+                }
+                Some(']') => {
+                    current.push(']');
+                    break;
+                }
+                Some(c) => current.push(c),
+                None => break 'char_class,
+            }
+        }
+        // After ']', check for compound class or closing '>'
+        match chars.peek() {
+            Some(&'>') => {
+                current.push(chars.next().unwrap());
+                break;
+            }
+            Some(&('+' | '-')) => {
+                let op = chars.next().unwrap();
+                current.push(op);
+                if chars.peek() == Some(&'[') {
+                    current.push(chars.next().unwrap());
+                    continue 'char_class;
+                }
+                // Not a compound group
+                if chars.peek() == Some(&'>') {
+                    current.push(chars.next().unwrap());
+                }
+                break;
+            }
+            Some(&'[') => {
+                current.push(chars.next().unwrap());
+                continue 'char_class;
+            }
+            _ => break,
         }
     }
     true

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -311,7 +311,7 @@ fn skip_char_class_content(
     'char_class: loop {
         if !entered_first {
             // Consume chars until we hit the first '['
-            while let Some(c) = chars.next() {
+            for c in chars.by_ref() {
                 current.push(c);
                 if c == '[' {
                     break;


### PR DESCRIPTION
## Summary
- Fix `scan_to_delim` and runtime `skip_char_class_content` to treat `[` as literal inside `[...]` character class groups. Previously, patterns like `<-[/*?[]>` caused parse errors because bracket depth tracking treated `[` as a nested bracket opener.
- Add builtin character class and Unicode property fallbacks in regex match handlers so `<foo=alpha>`, `<foo=:Letter>`, `<bar=:!Letter>`, and `<baz=-:Letter>` alias forms work correctly instead of erroring with "No such method".
- Fix `parse_regex_lookup_target` to not split on leading `:` or `-:` (Unicode property prefixes, not method call colons).
- Add `alias_replaces_original` flag to `NamedRegexLookupSpec` to distinguish `<foo=alpha>` (keep both capture names) from `<foo=.alpha>` (only alias name).

This takes `roast/S05-metasyntax/angle-brackets.t` from 0 tests (parse error at line 327) to 51 tests running with 40 passing.

## Test plan
- [x] `cargo check` passes
- [x] `roast/S05-metasyntax/angle-brackets.t` runs 51 tests (40 pass, was 0 before)
- [ ] Verify no regressions in related regex tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)