### PR TITLE
fix: support does on Hash/Array, fix andthen topic, add mixin attr accessors

### DIFF
--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -179,9 +179,11 @@ impl Compiler {
             }
             TokenKind::OrElse => {
                 self.compile_expr(left);
+                self.code.emit(OpCode::SaveTopic);
                 self.code.emit(OpCode::Dup);
                 self.code.emit(OpCode::CallDefined);
                 let jump_undef = self.code.emit(OpCode::JumpIfFalse(0));
+                self.code.emit(OpCode::RestoreTopic);
                 let jump_end = self.code.emit(OpCode::Jump(0));
                 self.code.patch_jump(jump_undef);
                 self.code.emit(OpCode::Dup);
@@ -195,11 +197,13 @@ impl Compiler {
                     arity: 2,
                     arg_sources_idx: None,
                 });
+                self.code.emit(OpCode::RestoreTopic);
                 self.code.patch_jump(jump_end);
                 return;
             }
             TokenKind::AndThen => {
                 self.compile_expr(left);
+                self.code.emit(OpCode::SaveTopic);
                 self.code.emit(OpCode::Dup);
                 self.code.emit(OpCode::CallDefined);
                 let jump_undef = self.code.emit(OpCode::JumpIfFalse(0));
@@ -214,11 +218,13 @@ impl Compiler {
                     arity: 2,
                     arg_sources_idx: None,
                 });
+                self.code.emit(OpCode::RestoreTopic);
                 let jump_end = self.code.emit(OpCode::Jump(0));
                 self.code.patch_jump(jump_undef);
                 self.code.emit(OpCode::Pop);
                 let empty_idx = self.code.add_constant(Value::slip(vec![]));
                 self.code.emit(OpCode::LoadConst(empty_idx));
+                self.code.emit(OpCode::RestoreTopic);
                 self.code.patch_jump(jump_end);
                 return;
             }
@@ -311,6 +317,8 @@ impl Compiler {
                 let var_name = match left {
                     Expr::Var(name) => Some(name.clone()),
                     Expr::BareWord(name) => Some(name.clone()),
+                    Expr::HashVar(name) => Some(format!("%{}", name)),
+                    Expr::ArrayVar(name) => Some(format!("@{}", name)),
                     _ => None,
                 };
                 if let Some(name) = var_name {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -38,6 +38,8 @@ pub(crate) enum OpCode {
         tc_idx: u32,
     },
     SetTopic,
+    SaveTopic,
+    RestoreTopic,
     GetArrayVar(u32),
     GetHashVar(u32),
     GetBareWord(u32),

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -787,6 +787,7 @@ fn parse_assignment_rhs_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     }
 }
 
+
 fn not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     if input.starts_with("not")
         && !is_ident_char(input.as_bytes().get(3).copied())

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -787,7 +787,6 @@ fn parse_assignment_rhs_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     }
 }
 
-
 fn not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     if input.starts_with("not")
         && !is_ident_char(input.as_bytes().get(3).copied())

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -215,10 +215,14 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     // assignment. If the expression is `expr andthen { block }`, split it so
     // the declaration assigns `expr` and the andthen runs as a side effect.
     let (expr, post_andthen) = match expr {
-        Expr::Binary { left, op: op @ (crate::token_kind::TokenKind::AndThen
-            | crate::token_kind::TokenKind::OrElse
-            | crate::token_kind::TokenKind::NotAndThen), right }
-        => (*left, Some((op, *right))),
+        Expr::Binary {
+            left,
+            op:
+                op @ (crate::token_kind::TokenKind::AndThen
+                | crate::token_kind::TokenKind::OrElse
+                | crate::token_kind::TokenKind::NotAndThen),
+            right,
+        } => (*left, Some((op, *right))),
         other => (other, None),
     };
     let expr = match expr {

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -211,6 +211,16 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     } else {
         expression(rest)?
     };
+    // In Raku, andthen/orelse/notandthen have lower precedence than declaration
+    // assignment. If the expression is `expr andthen { block }`, split it so
+    // the declaration assigns `expr` and the andthen runs as a side effect.
+    let (expr, post_andthen) = match expr {
+        Expr::Binary { left, op: op @ (crate::token_kind::TokenKind::AndThen
+            | crate::token_kind::TokenKind::OrElse
+            | crate::token_kind::TokenKind::NotAndThen), right }
+        => (*left, Some((op, *right))),
+        other => (other, None),
+    };
     let expr = match expr {
         Expr::MetaOp {
             meta,
@@ -290,6 +300,17 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         } else {
             (rest, stmt)
         };
+        let stmt = if let Some((op, rhs)) = post_andthen.clone() {
+            let var_ref = Expr::Var(s.name.clone());
+            let andthen_expr = Expr::Binary {
+                left: Box::new(var_ref),
+                op,
+                right: Box::new(rhs),
+            };
+            Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(andthen_expr)])
+        } else {
+            stmt
+        };
         if s.apply_modifier {
             return parse_statement_modifier(rest, stmt);
         }
@@ -323,6 +344,17 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         consume_scalar_decl_trailing_comma(rest, stmt)?
     } else {
         (rest, stmt)
+    };
+    let stmt = if let Some((op, rhs)) = post_andthen {
+        let var_ref = Expr::Var(s.name.clone());
+        let andthen_expr = Expr::Binary {
+            left: Box::new(var_ref),
+            op,
+            right: Box::new(rhs),
+        };
+        Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(andthen_expr)])
+    } else {
+        stmt
     };
     if s.apply_modifier {
         return parse_statement_modifier(rest, stmt);

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -387,6 +387,16 @@ impl Interpreter {
         self.env.insert("/".to_string(), match_obj.clone());
         self.env.remove("made");
         self.action_made = None;
+        // Save and clear old named capture env vars so parent captures don't leak
+        let saved_named_captures: Vec<(String, Value)> = self
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with('<') && k.ends_with('>'))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        for (k, _) in &saved_named_captures {
+            self.env.remove(k);
+        }
         // Set named capture env vars (<a>, <b>, etc.) so $<a> works inside action methods
         if let Some(Value::Hash(named_hash)) = updated_attrs.get("named") {
             for (k, v) in named_hash.iter() {
@@ -468,6 +478,21 @@ impl Interpreter {
             self.env.insert("_".to_string(), old_topic);
         } else {
             self.env.remove("_");
+        }
+        // Restore saved named capture env vars from parent scope
+        {
+            let current_named: Vec<String> = self
+                .env
+                .keys()
+                .filter(|k| k.starts_with('<') && k.ends_with('>'))
+                .cloned()
+                .collect();
+            for k in current_named {
+                self.env.remove(&k);
+            }
+            for (k, v) in saved_named_captures {
+                self.env.insert(k, v);
+            }
         }
 
         match method_result {

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -18,6 +18,23 @@ impl Interpreter {
             if let Some(mixin_val) = mixins.get(method) {
                 return Some(Ok(mixin_val.clone()));
             }
+            // Check role attribute accessors: has $.foo stores as __mutsu_attr__foo
+            let attr_key = format!("__mutsu_attr__{}", method);
+            if let Some(attr_val) = mixins.get(&attr_key) {
+                let is_public = mixins
+                    .keys()
+                    .filter_map(|k| k.strip_prefix("__mutsu_role__"))
+                    .any(|role_name| {
+                        self.roles.get(role_name).is_some_and(|role| {
+                            role.attributes
+                                .iter()
+                                .any(|(name, is_pub, ..)| name == method && *is_pub)
+                        })
+                    });
+                if is_public {
+                    return Some(Ok(attr_val.clone()));
+                }
+            }
             for mixin_val in mixins.values() {
                 if let Value::Enum { enum_type, key, .. } = mixin_val {
                     if method == key.resolve() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -74,6 +74,7 @@ pub(crate) struct VM {
     substitution_in_smartmatch: bool,
     /// Tracks the last value passed to SetTopic, used as the REPL display value.
     last_topic_value: Option<Value>,
+    topic_save_stack: Vec<Value>,
     /// Container name from when/default body (for Scalar container binding)
     container_ref_var: Option<String>,
     /// When true, the container ref is reversed (e.g. `for @a.reverse`)
@@ -275,6 +276,7 @@ impl VM {
             transliterate_in_smartmatch: false,
             substitution_in_smartmatch: false,
             last_topic_value: None,
+            topic_save_stack: Vec::new(),
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,
@@ -1255,6 +1257,17 @@ impl VM {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 self.last_topic_value = Some(val.clone());
                 self.interpreter.env_mut().insert("_".to_string(), val);
+                *ip += 1;
+            }
+            OpCode::SaveTopic => {
+                let current = self.interpreter.env().get("_").cloned().unwrap_or(Value::Nil);
+                self.topic_save_stack.push(current);
+                *ip += 1;
+            }
+            OpCode::RestoreTopic => {
+                if let Some(saved) = self.topic_save_stack.pop() {
+                    self.interpreter.env_mut().insert("_".to_string(), saved);
+                }
                 *ip += 1;
             }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1260,7 +1260,12 @@ impl VM {
                 *ip += 1;
             }
             OpCode::SaveTopic => {
-                let current = self.interpreter.env().get("_").cloned().unwrap_or(Value::Nil);
+                let current = self
+                    .interpreter
+                    .env()
+                    .get("_")
+                    .cloned()
+                    .unwrap_or(Value::Nil);
                 self.topic_save_stack.push(current);
                 *ip += 1;
             }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -243,6 +243,15 @@ impl VM {
 
     pub(super) fn sync_locals_from_env(&mut self, code: &CompiledCode) {
         for (i, name) in code.locals.iter().enumerate() {
+            // Don't overwrite ArraySlotRef/HashSlotRef locals with env values.
+            // These are live container references from `:=` binding and must
+            // not be replaced by stale env copies.
+            if matches!(
+                self.locals[i],
+                Value::ArraySlotRef { .. } | Value::HashSlotRef { .. }
+            ) {
+                continue;
+            }
             if let Some(val) = self.interpreter.env().get(name) {
                 self.locals[i] = val.clone();
                 continue;


### PR DESCRIPTION
## Summary
- **`does` on Hash/Array variables**: `%h does role :: { ... }` and `@a does role :: { ... }` now correctly update the variable (previously only worked with `$` scalars)
- **`andthen`/`orelse` topic preservation**: new `SaveTopic`/`RestoreTopic` VM opcodes prevent `$_` corruption in enclosing `for` loops when `andthen` is used inside the loop body
- **Mixin role attribute accessors**: `.foo` on a value with a mixed-in role containing `has $.foo` now correctly returns the attribute value
- **Declaration `andthen` splitting**: `my $to = expr andthen { block }` correctly assigns `expr` to `$to` and runs the `andthen` block as a side effect, matching Raku precedence rules

These fixes unblock several roast tests that use `make-test-dist` from `Test::Util`, which relies on all four features.

## Test plan
- [x] `%h does role :: { has $.foo = "hello" }; say %h.foo` prints `hello`
- [x] `@a does role :: { has $.tag = "tagged" }; say @a.tag` prints `tagged`  
- [x] `for ("a","b") { my $x = $_ andthen { .uc }; say $_ }` prints `a` then `b` (topic preserved)
- [x] `my $to = IO.child(...) andthen {.parent.mkdir unless .parent.e}; $to.spurt(...)` correctly assigns IO::Path to `$to`

🤖 Generated with [Claude Code](https://claude.com/claude-code)