### PR TITLE
fix: update ArraySlotRef/HashSlotRef after COW element assignment

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -243,6 +243,15 @@ impl VM {
 
     pub(super) fn sync_locals_from_env(&mut self, code: &CompiledCode) {
         for (i, name) in code.locals.iter().enumerate() {
+            // Don't overwrite ArraySlotRef/HashSlotRef locals with env values.
+            // These are live container references from `:=` binding and must
+            // not be replaced by stale env copies.
+            if matches!(
+                self.locals[i],
+                Value::ArraySlotRef { .. } | Value::HashSlotRef { .. }
+            ) {
+                continue;
+            }
             if let Some(val) = self.interpreter.env().get(name) {
                 self.locals[i] = val.clone();
                 continue;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2180,6 +2180,42 @@ impl VM {
                 .insert(original_var_name.clone(), updated_container.clone());
             self.update_local_if_exists(code, &original_var_name, &updated_container);
         }
+        // After element assignment, Arc::make_mut may have created a new Arc
+        // (COW). Sync ArraySlotRef/HashSlotRef locals so they reference the
+        // current container Arc, not a stale pre-COW copy.
+        {
+            let current = self
+                .get_env_with_main_alias(&var_name)
+                .or_else(|| self.interpreter.env().get(&original_var_name).cloned());
+            if let Some(ref container) = current {
+                let new_arc_ptr = match container {
+                    Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
+                    Value::Hash(arc) => Some(Arc::as_ptr(arc) as usize),
+                    _ => None,
+                };
+                if let Some(new_ptr) = new_arc_ptr {
+                    for local in self.locals.iter_mut() {
+                        match local {
+                            Value::ArraySlotRef { array, .. } => {
+                                if Arc::as_ptr(array) as usize != new_ptr
+                                    && let Value::Array(new_arc, _) = container
+                                {
+                                    *array = new_arc.clone();
+                                }
+                            }
+                            Value::HashSlotRef { hash, .. } => {
+                                if Arc::as_ptr(hash) as usize != new_ptr
+                                    && let Value::Hash(new_arc) = container
+                                {
+                                    *hash = new_arc.clone();
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
         self.stack.push(val);
         Ok(())
     }

--- a/t/container-bind-element.t
+++ b/t/container-bind-element.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 8;
+
+# Binding to array element - changes through original propagate to bound variable
+{
+    my @a = 1, 2, 3;
+    my $x := @a[1];
+    is $x, 2, 'bound array element has initial value';
+    @a[1] = 99;
+    is $x, 99, 'bound array element sees modification through original';
+}
+
+# Binding to hash element - changes through original propagate to bound variable
+{
+    my %h = a => 1, b => 2;
+    my $x := %h<a>;
+    is $x, 1, 'bound hash element has initial value';
+    %h<a> = 99;
+    is $x, 99, 'bound hash element sees modification through original';
+}
+
+# COW semantics: array assignment creates independent copy
+{
+    my @a = 1, 2, 3;
+    my @b = @a;
+    @b[0] = 99;
+    is @a[0], 1, 'array assignment creates independent copy';
+    is @b[0], 99, 'modified copy has new value';
+}
+
+# is copy parameter creates independent copy
+{
+    sub f(@arr is copy) {
+        @arr[0] = 99;
+    }
+    my @a = 1, 2, 3;
+    f(@a);
+    is @a[0], 1, 'is copy array parameter does not modify caller';
+}
+
+# is copy hash parameter creates independent copy
+{
+    sub g(%h is copy) {
+        %h<a> = 99;
+    }
+    my %h = a => 1;
+    g(%h);
+    is %h<a>, 1, 'is copy hash parameter does not modify caller';
+}


### PR DESCRIPTION
## Summary
- Fix binding to array/hash elements (`my $x := @a[1]`) so modifications through the original container are visible through the bound variable
- After `Arc::make_mut` (COW) during element assignment, scan locals for stale `ArraySlotRef`/`HashSlotRef` and update them to reference the current Arc
- Skip overwriting `ArraySlotRef`/`HashSlotRef` locals during `sync_locals_from_env` to prevent stale env copies from clobbering live container references

## Test plan
- [x] `my @a = 1,2,3; my $x := @a[1]; @a[1] = 99; say $x` outputs `99`
- [x] `my %h = a => 1; my $x := %h<a>; %h<a> = 99; say $x` outputs `99`
- [x] `my @a = 1,2,3; my @b = @a; @b[0] = 99; say @a[0]` outputs `1` (COW preserved)
- [x] `is copy` array/hash parameters don't leak mutations to caller
- [x] Works with `use Test` (env sync issue)
- [x] All existing binding tests pass (S03-binding/*)
- [x] `make test` passes (480+ tests)
- [x] `make roast` passes (1157 whitelisted tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)