### PR TITLE
fix: improve val() allomorphics and .Numeric for radix, Unicode, and complex numbers

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -6,7 +6,7 @@ use crate::value::{RuntimeError, Value};
 use num_traits::{ToPrimitive, Zero};
 use std::sync::Arc;
 
-use super::{normalize_unicode_digits, parse_raku_int_from_str};
+use super::parse_raku_int_from_str;
 
 pub(super) fn dispatch(
     target: &Value,
@@ -634,22 +634,8 @@ pub(super) fn dispatch(
                 }
                 Value::Rat(n, d) if *d != 0 => Value::Num(*n as f64 / *d as f64),
                 Value::Str(s) => {
-                    let trimmed = s.trim();
-                    if let Ok(i) = trimmed.parse::<i64>() {
-                        Value::Int(i)
-                    } else if let Ok(f) = trimmed.parse::<f64>() {
-                        Value::Num(f)
-                    } else if let Some(normalized) = normalize_unicode_digits(trimmed) {
-                        if let Ok(i) = normalized.parse::<i64>() {
-                            Value::Int(i)
-                        } else if let Ok(f) = normalized.parse::<f64>() {
-                            Value::Num(f)
-                        } else {
-                            return Some(Some(Err(RuntimeError::new(format!(
-                                "X::Str::Numeric: Cannot convert string '{}' to a number",
-                                s
-                            )))));
-                        }
+                    if let Some(v) = crate::runtime::str_numeric::parse_raku_str_to_numeric(s) {
+                        v
                     } else {
                         return Some(Some(Err(RuntimeError::new(format!(
                             "X::Str::Numeric: Cannot convert string '{}' to a number",

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -392,106 +392,33 @@ pub(crate) fn builtin_val(args: &[Value]) -> Value {
         Value::mixin(val, mixins)
     }
 
-    // Try complex (must end with 'i')
-    if let Some(complex) = try_parse_complex(word) {
-        return make_allomorphic(complex, &original);
+    // Try Unicode vulgar fractions (single character like ½, ⅓, ¼, etc.)
+    if let Some(rat_val) = try_parse_unicode_fraction(word) {
+        return make_allomorphic(rat_val, &original);
     }
 
-    // Try integer
-    if let Ok(i) = word.parse::<i64>() {
-        return make_allomorphic(Value::Int(i), &original);
+    // Use the comprehensive Raku numeric string parser
+    if let Some(numeric) = crate::runtime::str_numeric::parse_raku_str_to_numeric(word) {
+        return make_allomorphic(numeric, &original);
     }
 
-    // Try Num (scientific notation with e/E)
-    if (word.contains('e') || word.contains('E')) && !word.ends_with('i') {
-        // Normalize U+2212 MINUS SIGN to ASCII minus
-        let normalized = word.replace('\u{2212}', "-");
-        if let Ok(f) = normalized.parse::<f64>() {
-            return make_allomorphic(Value::Num(f), &original);
-        }
-    }
-
-    // Try Rat (fraction notation like "1/5")
-    if word.contains('/') && !word.contains('.') && !word.contains('e') && !word.contains('E') {
-        let parts: Vec<&str> = word.splitn(2, '/').collect();
-        if parts.len() == 2
-            && let (Ok(n), Ok(d)) = (
-                parts[0].trim().parse::<i64>(),
-                parts[1].trim().parse::<i64>(),
-            )
-            && d != 0
-        {
-            return make_allomorphic(crate::value::make_rat(n, d), &original);
-        }
-    }
-
-    // Try Rat (decimal without exponent)
-    if word.contains('.') && !word.contains('e') && !word.contains('E') {
-        let normalized = word.replace('\u{2212}', "-");
-        if let Ok(f) = normalized.parse::<f64>() {
-            // Approximate as Rat: use fixed denominator approach
-            let scale = 10i64.pow(
-                normalized
-                    .find('.')
-                    .map(|p| normalized.len() - p - 1)
-                    .unwrap_or(0) as u32,
-            );
-            let numer = (f * scale as f64).round() as i64;
-            return make_allomorphic(crate::value::make_rat(numer, scale), &original);
-        }
-    }
-
-    // Plain string
+    // Plain string (not parseable as a number)
     Value::str(original.to_string())
 }
 
-fn try_parse_complex(word: &str) -> Option<Value> {
-    // Handle both "1+2i" and "1+Inf\i" / "1-Inf\i" / "1+NaN\i" forms
-    let (without_i, backslash_i) = if let Some(stripped) = word.strip_suffix("\\i") {
-        (stripped, true)
-    } else if let Some(stripped) = word.strip_suffix('i') {
-        (stripped, false)
-    } else {
+/// Try to parse a single Unicode vulgar fraction character (½, ⅓, ¼, etc.)
+fn try_parse_unicode_fraction(s: &str) -> Option<Value> {
+    let mut chars = s.chars();
+    let ch = chars.next()?;
+    // Must be exactly one character
+    if chars.next().is_some() {
         return None;
-    };
-
-    // Pure imaginary
-    if let Ok(imag) = without_i.parse::<f64>() {
-        return Some(Value::Complex(0.0, imag));
     }
-    // Handle pure imaginary with special values: "Inf\i", "-Inf\i", "NaN\i"
-    if backslash_i && let Some(imag) = parse_special_float(without_i) {
-        return Some(Value::Complex(0.0, imag));
+    let (n, d) = crate::builtins::unicode::unicode_rat_value(ch)?;
+    if d == 0 {
+        return None;
     }
-
-    // real+imag i
-    let bytes = without_i.as_bytes();
-    let mut split_pos = None;
-    for i in 1..bytes.len() {
-        if (bytes[i] == b'+' || bytes[i] == b'-') && bytes[i - 1] != b'e' && bytes[i - 1] != b'E' {
-            split_pos = Some(i);
-        }
-    }
-    let split_pos = split_pos?;
-    let real_str = &without_i[..split_pos];
-    let imag_str = &without_i[split_pos..];
-    let real: f64 = real_str.parse().ok()?;
-    let imag: f64 = if backslash_i {
-        // For \i form, imaginary part may be special float like "+Inf", "-Inf", "+NaN"
-        parse_special_float(imag_str).or_else(|| imag_str.parse().ok())?
-    } else {
-        imag_str.parse().ok()?
-    };
-    Some(Value::Complex(real, imag))
-}
-
-fn parse_special_float(s: &str) -> Option<f64> {
-    match s {
-        "Inf" | "+Inf" => Some(f64::INFINITY),
-        "-Inf" => Some(f64::NEG_INFINITY),
-        "NaN" | "+NaN" | "-NaN" => Some(f64::NAN),
-        _ => None,
-    }
+    Some(crate::value::make_rat(n, d))
 }
 
 impl Interpreter {

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -22,10 +22,9 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
     // them to their ASCII equivalents before further parsing.
     if s.chars().any(|c| {
         !c.is_ascii() && crate::builtins::unicode::unicode_decimal_digit_value(c).is_some()
-    }) {
-        if let Some(ascii_str) = normalize_unicode_decimal_digits(s) {
-            return parse_raku_str_to_numeric(&ascii_str);
-        }
+    }) && let Some(ascii_str) = normalize_unicode_decimal_digits(s)
+    {
+        return parse_raku_str_to_numeric(&ascii_str);
     }
 
     // Try Complex first (contains `i`)
@@ -391,14 +390,12 @@ fn try_parse_decimal_rat(body: &str, sign: i32) -> Option<Value> {
         int_clean.parse::<i64>(),
         frac_clean.parse::<i64>(),
         10i64.checked_pow(frac_clean.len() as u32),
-    ) {
-        if let Some(numer) = int_val
-            .checked_mul(denom)
-            .and_then(|v| v.checked_add(frac_val))
-        {
-            let numer = if sign < 0 { -numer } else { numer };
-            return Some(crate::value::make_rat(numer, denom));
-        }
+    ) && let Some(numer) = int_val
+        .checked_mul(denom)
+        .and_then(|v| v.checked_add(frac_val))
+    {
+        let numer = if sign < 0 { -numer } else { numer };
+        return Some(crate::value::make_rat(numer, denom));
     }
     // Overflow or too many digits: fall back to f64 approximation
     let combined = format!("{}.{}", int_clean, frac_clean);

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -392,7 +392,10 @@ fn try_parse_decimal_rat(body: &str, sign: i32) -> Option<Value> {
         frac_clean.parse::<i64>(),
         10i64.checked_pow(frac_clean.len() as u32),
     ) {
-        if let Some(numer) = int_val.checked_mul(denom).and_then(|v| v.checked_add(frac_val)) {
+        if let Some(numer) = int_val
+            .checked_mul(denom)
+            .and_then(|v| v.checked_add(frac_val))
+        {
             let numer = if sign < 0 { -numer } else { numer };
             return Some(crate::value::make_rat(numer, denom));
         }

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -386,12 +386,22 @@ fn try_parse_decimal_rat(body: &str, sign: i32) -> Option<Value> {
     }
 
     // Construct as Rat: integer_part * 10^frac_len + frac_part / 10^frac_len
-    let int_val: i64 = int_clean.parse().ok()?;
-    let frac_val: i64 = frac_clean.parse().ok()?;
-    let denom: i64 = 10i64.checked_pow(frac_clean.len() as u32)?;
-    let numer = int_val * denom + frac_val;
-    let numer = if sign < 0 { -numer } else { numer };
-    Some(crate::value::make_rat(numer, denom))
+    // Use checked arithmetic to avoid overflow for large inputs; fall back to Num.
+    if let (Ok(int_val), Ok(frac_val), Some(denom)) = (
+        int_clean.parse::<i64>(),
+        frac_clean.parse::<i64>(),
+        10i64.checked_pow(frac_clean.len() as u32),
+    ) {
+        if let Some(numer) = int_val.checked_mul(denom).and_then(|v| v.checked_add(frac_val)) {
+            let numer = if sign < 0 { -numer } else { numer };
+            return Some(crate::value::make_rat(numer, denom));
+        }
+    }
+    // Overflow or too many digits: fall back to f64 approximation
+    let combined = format!("{}.{}", int_clean, frac_clean);
+    let f: f64 = combined.parse().ok()?;
+    let f = if sign < 0 { -f } else { f };
+    Some(Value::Num(f))
 }
 
 /// Parse plain integer with underscores.

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -331,8 +331,17 @@ fn try_parse_scientific(body: &str, sign: i32) -> Option<Value> {
     };
     let exp = exp_sign * exp_val;
 
-    let result = mantissa * 10f64.powi(exp);
-    let result = if sign < 0 { -result } else { result };
+    // Parse the full normalized string as f64 directly for best precision.
+    // Computing mantissa * 10^exp compounds floating-point rounding errors.
+    let mantissa_clean = mantissa_str.replace('_', "");
+    let full_str = format!("{}e{}", mantissa_clean, exp);
+    let result = if let Ok(f) = full_str.parse::<f64>() {
+        if sign < 0 { -f } else { f }
+    } else {
+        // Fallback (should not normally happen)
+        let r = mantissa * 10f64.powi(exp);
+        if sign < 0 { -r } else { r }
+    };
     Some(Value::Num(result))
 }
 
@@ -538,7 +547,14 @@ fn parse_real_component_to_f64(s: &str) -> Option<f64> {
         }
         let exp_val: i32 = exp_clean.parse().ok()?;
         let exp = exp_sign * exp_val;
-        let result = mantissa * 10f64.powi(exp);
+        // Parse the full normalized string for best precision.
+        let mantissa_clean = mantissa_str.replace('_', "");
+        let full_str = format!("{}e{}", mantissa_clean, exp);
+        let result = if let Ok(f) = full_str.parse::<f64>() {
+            f
+        } else {
+            mantissa * 10f64.powi(exp)
+        };
         return Some(if sign < 0 { -result } else { result });
     }
 

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -18,6 +18,16 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
     let normalized = normalize_minus(s);
     let s = normalized.as_str();
 
+    // If the string contains Unicode decimal digits (Nd category), normalize
+    // them to their ASCII equivalents before further parsing.
+    if s.chars().any(|c| {
+        !c.is_ascii() && crate::builtins::unicode::unicode_decimal_digit_value(c).is_some()
+    }) {
+        if let Some(ascii_str) = normalize_unicode_decimal_digits(s) {
+            return parse_raku_str_to_numeric(&ascii_str);
+        }
+    }
+
     // Try Complex first (contains `i`)
     if let Some(v) = try_parse_complex(s) {
         return Some(v);
@@ -70,6 +80,22 @@ fn normalize_minus(s: &str) -> String {
     } else {
         s.to_string()
     }
+}
+
+/// Normalize a string of Unicode decimal digits (Nd category) to ASCII digits.
+/// Returns None if any non-ASCII character is NOT a decimal digit (Nd).
+fn normalize_unicode_decimal_digits(s: &str) -> Option<String> {
+    let mut result = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if ch.is_ascii() {
+            result.push(ch);
+        } else if let Some(d) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
+            result.push(char::from_digit(d, 10).unwrap());
+        } else {
+            return None;
+        }
+    }
+    Some(result)
 }
 
 /// Strip leading sign, returning (sign_multiplier, remaining_body).
@@ -389,7 +415,7 @@ fn try_parse_plain_int(body: &str, sign: i32) -> Option<Value> {
     }
 }
 
-/// Parse complex number strings like `1+2i`, `-1-2i`, `3+Inf\i`, etc.
+/// Parse complex number strings like `1+2i`, `-1-2i`, `3+Inf\i`, `42i`, `42\i`, etc.
 fn try_parse_complex(s: &str) -> Option<Value> {
     // Must end with 'i' (or `\i`)
     if !s.ends_with('i') {
@@ -404,39 +430,55 @@ fn try_parse_complex(s: &str) -> Option<Value> {
         &s[..s.len() - 1]
     };
 
-    // Find the split point between real and imaginary parts.
-    // The imaginary part starts with a `+` or `-` that is NOT:
-    // - at position 0
-    // - right after an 'e' or 'E' (part of exponent)
-    let split = find_complex_split(without_i)?;
+    if let Some(split) = find_complex_split(without_i) {
+        // Has both real and imaginary parts: "42+34i", "-1-2i", etc.
+        let real_str = &without_i[..split];
+        let imag_str = &without_i[split..]; // includes the sign
 
-    let real_str = &without_i[..split];
-    let imag_str = &without_i[split..]; // includes the sign
+        // Parse real part
+        let real_val = parse_real_component(real_str)?;
 
-    // Parse real part
-    let real_val = parse_real_component(real_str)?;
-
-    // Parse imaginary part (strip leading sign)
-    let (imag_sign, imag_body) = strip_sign(imag_str);
-    let imag_val = if imag_body.is_empty() {
-        // bare +i or -i: not handled here (rakudo skips these too)
-        return None;
-    } else if imag_body == "Inf" || imag_body == "NaN" {
-        // Inf/NaN as imaginary component requires `\i` suffix
-        if !has_backslash_i {
+        // Parse imaginary part (strip leading sign)
+        let (imag_sign, imag_body) = strip_sign(imag_str);
+        let imag_val = if imag_body.is_empty() {
+            // bare +i or -i: not handled here (rakudo skips these too)
             return None;
-        }
-        if imag_body == "Inf" {
-            f64::INFINITY
+        } else if imag_body == "Inf" || imag_body == "NaN" {
+            // Inf/NaN as imaginary component requires `\i` suffix
+            if !has_backslash_i {
+                return None;
+            }
+            if imag_body == "Inf" {
+                f64::INFINITY
+            } else {
+                f64::NAN
+            }
         } else {
-            f64::NAN
-        }
+            parse_real_component_to_f64(imag_body)?
+        };
+        let imag_val = if imag_sign < 0 { -imag_val } else { imag_val };
+        Some(Value::Complex(real_val, imag_val))
     } else {
-        parse_real_component_to_f64(imag_body)?
-    };
-    let imag_val = if imag_sign < 0 { -imag_val } else { imag_val };
-
-    Some(Value::Complex(real_val, imag_val))
+        // Pure imaginary: "42i", "-3.5i", "4_2i", "Inf\i", etc.
+        let (imag_sign, imag_body) = strip_sign(without_i);
+        let imag_val = if imag_body == "Inf" {
+            if has_backslash_i {
+                f64::INFINITY
+            } else {
+                return None;
+            }
+        } else if imag_body == "NaN" {
+            if has_backslash_i {
+                f64::NAN
+            } else {
+                return None;
+            }
+        } else {
+            parse_real_component_to_f64(imag_body)?
+        };
+        let imag_val = if imag_sign < 0 { -imag_val } else { imag_val };
+        Some(Value::Complex(0.0, imag_val))
+    }
 }
 
 /// Find the index where the imaginary part starts (a `+` or `-` not part of exponent).


### PR DESCRIPTION
## Summary

- Replace the ad-hoc `builtin_val()` parser with comprehensive `parse_raku_str_to_numeric()`, handling empty string (→ IntStr(0,"")), radix prefixes (`:16<2a>`, `0x..`), underscores (`4_2`), scientific notation, complex numbers (`42i`, `0+42i`), and Unicode digits
- Add `try_parse_unicode_fraction()` in `builtin_val` to convert single Unicode vulgar fraction characters (½, ⅓, ¼, etc.) to RatStr allomorphics
- Add `normalize_unicode_decimal_digits()` to `str_numeric.rs` so that Unicode Nd digit strings (Arabic-Indic, etc.) are normalized before parsing — fixes non-ASCII numerification regression in `S02-literals/numeric.t`
- Fix `try_parse_complex()` in `str_numeric.rs` to handle pure imaginary numbers (`42i`, `4_2i`) which previously returned plain Str instead of ComplexStr
- Update `.Numeric` coercion method to use `parse_raku_str_to_numeric()` for comprehensive string-to-number handling (replaces `normalize_unicode_digits`)
- Fix integer overflow in `try_parse_decimal_rat()` when input decimal has many digits — use checked arithmetic and fall back to Num (f64) instead of panicking

## Test plan

- [x] `roast/S02-literals/numeric.t` — non-ASCII numerification tests pass
- [x] `roast/S32-str/parse-base.t` — parse-base regression test (overflow fix)
- [x] `roast/S32-str/val.t` — val() allomorphic tests (first 2 subtests pass; remaining blocked by pre-existing readonly variable binding bug)
- [ ] CI runs `make test` and `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)