### PR TITLE
fix: make &?ROUTINE work in anonymous subs for self-recursion

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -944,6 +944,16 @@ impl Interpreter {
                 .rev()
                 .find(|frame| frame.name != "<pointy-block>");
             if let Some(frame) = entry {
+                // Anonymous subs are pushed with "<anon>" as the sentinel name.
+                // Return the block_stack Sub directly so callers can invoke it.
+                if frame.name.is_empty() || frame.name == "<anon>" {
+                    if let Some(val) = self.block_stack.last().cloned()
+                        && matches!(val, Value::Sub(_))
+                    {
+                        return val;
+                    }
+                    return Value::Nil;
+                }
                 return Value::Routine {
                     package: Symbol::intern(&frame.package),
                     name: Symbol::intern(&frame.name),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -1184,14 +1184,21 @@ impl VM {
         );
         self.interpreter.push_block(sub_val);
 
+        // Always push a routine frame so that &?ROUTINE works inside anonymous
+        // subs too. Use "<anon>" as a sentinel name when fn_name is empty.
+        let routine_push_name = if fn_name.is_empty() {
+            "<anon>".to_string()
+        } else {
+            fn_name.to_string()
+        };
+        self.interpreter.push_routine_with_location(
+            fn_package.to_string(),
+            routine_push_name,
+            self.current_source_line(),
+            self.current_source_file(),
+        );
         let mut callable_id: Option<u64> = None;
         if !fn_name.is_empty() {
-            self.interpreter.push_routine_with_location(
-                fn_package.to_string(),
-                fn_name.to_string(),
-                self.current_source_line(),
-                self.current_source_file(),
-            );
             let callable_key = format!("__mutsu_callable_id::{fn_package}::{fn_name}");
             let resolved_callable_id = self
                 .interpreter
@@ -1224,9 +1231,7 @@ impl VM {
             .push_test_assertion_context(is_test_assertion);
 
         if cf.empty_sig && !args.is_empty() {
-            if !fn_name.is_empty() {
-                self.interpreter.pop_routine();
-            }
+            self.interpreter.pop_routine();
             self.interpreter
                 .pop_test_assertion_context(pushed_assertion);
             self.interpreter.pop_caller_env();
@@ -1276,9 +1281,7 @@ impl VM {
                 Ok(bindings) => bindings,
                 Err(e) => {
                     self.interpreter.set_current_package(saved_package);
-                    if !fn_name.is_empty() {
-                        self.interpreter.pop_routine();
-                    }
+                    self.interpreter.pop_routine();
                     self.interpreter
                         .pop_test_assertion_context(pushed_assertion);
                     self.interpreter.pop_caller_env();
@@ -1458,9 +1461,7 @@ impl VM {
         }
 
         self.interpreter.set_current_package(saved_package);
-        if !fn_name.is_empty() {
-            self.interpreter.pop_routine();
-        }
+        self.interpreter.pop_routine();
         self.interpreter
             .pop_test_assertion_context(pushed_assertion);
         self.interpreter.pop_block();

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1762,6 +1762,17 @@ impl VM {
             .rev()
             .find(|frame| frame.name != "<pointy-block>");
         if let Some(frame) = entry {
+            // Anonymous subs are pushed with "<anon>" as the sentinel name.
+            // Return the block_stack Sub directly so callers can invoke it.
+            if frame.name.is_empty() || frame.name == "<anon>" {
+                if let Some(val) = self.interpreter.block_stack_top().cloned()
+                    && matches!(val, Value::Sub(_))
+                {
+                    self.stack.push(val);
+                    return Ok(());
+                }
+                return Err(RuntimeError::undeclared_symbols("Undeclared name"));
+            }
             self.stack.push(Value::Routine {
                 package: Symbol::intern(&frame.package),
                 name: Symbol::intern(&frame.name),


### PR DESCRIPTION
## Summary

- Anonymous subs now push a routine frame with `<anon>` as a sentinel name so `&?ROUTINE` can find the current sub
- `resolve_code_var` and `exec_routine_magic_op` now detect the `<anon>` sentinel and return the `block_stack` Sub value directly instead of `Value::Routine` (which would fail to dispatch by name)
- All three pop_routine guards that were conditioned on `!fn_name.is_empty()` are now unconditional, matching the always-push behavior

## Test plan

- [x] `my $f = sub ($n) { $n < 2 ?? 1 !! $n * &?ROUTINE($n - 1) }; say $f(3)` → outputs `6`
- [x] Named subs still work: `sub named($n) { $n < 2 ?? 1 !! $n * &?ROUTINE($n - 1) }; say named(5)` → outputs `120`
- [x] Unit tests: 449 passed, 0 failed
- [x] `cargo clippy -- -D warnings` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)