### PR TITLE
perf: skip env clone in fast-call when function has no locals

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -265,6 +265,7 @@ roast/S04-declarations/implicit-parameter.t
 roast/S04-declarations/multiple.t
 roast/S04-declarations/our.t
 roast/S04-declarations/smiley.t
+roast/S04-declarations/state.t
 roast/S04-exception-handlers/catch.t
 roast/S04-exception-handlers/control.t
 roast/S04-exception-handlers/top-level.t

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -327,7 +327,17 @@ impl VM {
         cf: &CompiledFunction,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
-        let saved_env = self.interpreter.clone_env();
+        // Only save env when there are local variables to clean up.
+        // When the function has no locals, the env save/restore is a
+        // no-op (nothing to remove), but still causes an Arc clone that
+        // raises the refcount and triggers O(env_size) deep clones on
+        // any env write inside the function body (e.g. `$ = expr`).
+        let has_locals = !cf.code.locals.is_empty();
+        let saved_env = if has_locals {
+            Some(self.interpreter.clone_env())
+        } else {
+            None
+        };
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack_depth = self.stack.len();
         let saved_env_dirty = self.env_dirty;
@@ -431,18 +441,24 @@ impl VM {
         self.env_dirty = saved_env_dirty;
         self.locals_dirty = saved_locals_dirty;
 
-        // Restore env: if env was mutated, merge non-local changes back
-        if saved_env.ptr_eq(self.interpreter.env()) {
-            // No env changes, nothing to merge
-        } else {
-            let local_names: std::collections::HashSet<&String> = cf.code.locals.iter().collect();
-            let mut restored_env = saved_env;
-            for (k, v) in self.interpreter.env().iter() {
-                if !local_names.contains(k) {
-                    restored_env.insert(k.clone(), v.clone());
+        // Restore env: if env was mutated, merge non-local changes back.
+        // When has_locals is false, saved_env is None and no restore is needed
+        // (functions without locals cannot leak local variables into the
+        // caller's env — any env writes they do are intentional global state).
+        if let Some(saved_env) = saved_env {
+            if saved_env.ptr_eq(self.interpreter.env()) {
+                // No env changes, nothing to merge
+            } else {
+                let local_names: std::collections::HashSet<&String> =
+                    cf.code.locals.iter().collect();
+                let mut restored_env = saved_env;
+                for (k, v) in self.interpreter.env().iter() {
+                    if !local_names.contains(k) {
+                        restored_env.insert(k.clone(), v.clone());
+                    }
                 }
+                *self.interpreter.env_mut() = restored_env;
             }
-            *self.interpreter.env_mut() = restored_env;
         }
 
         // Restore caller's $_ after routine call.


### PR DESCRIPTION
## Summary

- Functions with no `my` declarations don't need env save/restore, but the unconditional `clone_env()` raised the Arc refcount to 2, triggering O(env_size) deep clones on every env write inside the function body
- Root cause: `sub foo() { $ = 42 }` called 2M times in `roast/S04-declarations/state.t` subtest 42 — `foo` has no locals, so each `$ = 42` assignment cloned the entire env HashMap
- Fix: skip `clone_env()` when `cf.code.locals.is_empty()`, keeping Arc refcount at 1 so all env writes stay O(1) in-place. Release build: 2M-iteration test now completes in ~12s (was timeout)
- Adds `roast/S04-declarations/state.t` to the whitelist (45/46 pass; subtest 38 is `#?rakudo todo` — known failure on Rakudo)

## Test plan

- [x] `roast/S04-declarations/state.t` completes in ~12s (was timeout), 45/46 subtests pass (38 is `#?rakudo todo`)
- [x] `make test` — all 3894 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt` — no formatting changes
- [x] `LC_ALL=C sort -c roast-whitelist.txt` — sort order correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)