### PR TITLE
fix: add is_bind to AssignExpr and implement rebind semantics for expression-context :=

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -78,12 +78,8 @@
 - [ ] roast/S02-magicals/dollar_bang.t
   - 14/15 pass. Test 7 fails: modifying a constant should set `$!`
 - [ ] roast/S02-magicals/dollar-underscore.t
-  - 17/23 pass. Failing tests need real Perl 6 container/aliasing semantics for `$_`:
-    - Test 14: pointy block with empty signature `-> { ... }` should die with "Too many positionals" when given an arg from `for`.
-    - Test 16: `my $a := $_; $_ = 30; for 1..3 { $a++ }` expects 33 — `$a` must alias the same container as `$_`, surviving `for`'s topic rebinding.
-    - Test 18: inside `for 11,12 -> $a { if 1 { $_ = 2 } }`, the inner if-block must alias outer `$_` so that `$_ = 2` persists across iterations (currently `BlockScope` drops all changes to `$_`).
-    - Tests 21, 23: subs must establish a fresh `$_` topic that does not flow from/to the caller's `$_`.
-  - All five blockers require treating `$_` as a real container with binding (`:=`) vs assignment (`=`) distinction, not a plain Value in the env. Deferred to too_difficult.txt.
+  - 22/23 pass. Only test 16 fails:
+    - Test 16: `my $a := $_; $_ = 30; for 1..3 { $a++ }` expects 33 — requires `for` loop to use a lexically-scoped inner `$_` that shadows the outer `$_`. Currently mutsu's `for` loop clobbers the outer `$_` with each iteration value, so `$a` (bound to outer `$_`) gets overwritten by the loop topic instead of being incremented.
 - [ ] roast/S02-magicals/env.t
   - 0/? pass. Parse error at line 23
 - [x] roast/S02-magicals/file_line.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -294,6 +294,10 @@ pub(crate) enum Expr {
     AssignExpr {
         name: String,
         expr: Box<Expr>,
+        /// True when parsed from `:=` (bind) rather than `=` (assign).
+        /// When `true`, the expression should rebind the variable rather
+        /// than write through any existing alias.
+        is_bind: bool,
     },
     Unary {
         op: TokenKind,
@@ -531,6 +535,9 @@ pub(crate) enum Stmt {
         mode: ForMode,
         /// True when `<->` is used, making all params rw.
         rw_block: bool,
+        /// True when `-> {}` (empty pointy block) was used, meaning the block
+        /// explicitly declares zero parameters. Passing any argument should throw.
+        explicit_zero_params: bool,
     },
     Say(Vec<Expr>),
     Put(Vec<Expr>),

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -258,8 +258,12 @@ impl Compiler {
                 self.compile_expr_postfix_dec(expr);
             }
             // Assignment as expression
-            Expr::AssignExpr { name, expr } => {
-                self.compile_expr_assign(name, expr);
+            Expr::AssignExpr {
+                name,
+                expr,
+                is_bind,
+            } => {
+                self.compile_expr_assign(name, expr, *is_bind);
             }
             // Capture variable ($0, $1, etc.)
             Expr::CaptureVar(name) => {

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -580,6 +580,7 @@ impl Compiler {
                         target: Box::new(args[1].clone()),
                         args: vec![args[0].clone()],
                     }),
+                    is_bind: false,
                 };
                 self.compile_expr(&assign_expr);
             } else {

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -232,6 +232,7 @@ impl Compiler {
                     modifier: None,
                     quoted: false,
                 }),
+                is_bind: false,
             };
             self.compile_expr(&rewritten);
             return;

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -2,7 +2,29 @@ use super::*;
 
 impl Compiler {
     /// Compile AssignExpr: assignment as expression.
-    pub(super) fn compile_expr_assign(&mut self, name: &str, expr: &Expr) {
+    pub(super) fn compile_expr_assign(&mut self, name: &str, expr: &Expr, is_bind: bool) {
+        // When `is_bind` is true, this is a `:=` rebind in expression context
+        // (e.g., `if $_ := $c { }`). We compile it like `Stmt::Assign { op: Bind }`
+        // so the old alias is broken and a new one is set up.
+        if is_bind {
+            // Signal rebind context for cleanup of old bind pairs / aliases.
+            self.code.emit(OpCode::MarkRebindContext);
+            self.compile_call_arg(expr);
+            self.emit_set_named_var(name);
+            // Leave the assigned value on the stack (expression context).
+            if let Some(&slot) = self.local_map.get(name) {
+                self.code.emit(OpCode::GetLocal(slot));
+            } else {
+                let name_idx = self
+                    .code
+                    .add_constant(Value::str(self.qualify_variable_name(name)));
+                self.code.emit(OpCode::GetGlobal(name_idx));
+            }
+            // Tag for container-ref consumers.
+            let name_idx = self.code.add_constant(Value::str(name.to_string()));
+            self.code.emit(OpCode::TagContainerRef(name_idx));
+            return;
+        }
         // $.attr = expr — In Raku, this first resolves self.attr (method call),
         // then assigns to the resulting lvalue container. If the accessor doesn't
         // exist, the method call throws. Compile as: first call self.attr() to

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -100,7 +100,7 @@ impl Compiler {
     /// Compile a method call argument. Named args (AssignExpr) are
     /// compiled as Pair values so they survive VM execution.
     pub(super) fn compile_method_arg(&mut self, arg: &Expr) {
-        if let Expr::AssignExpr { name, expr } = arg {
+        if let Expr::AssignExpr { name, expr, .. } = arg {
             // `foo(arg = 1)` in method-call argument position is treated as a named
             // argument only for sigilless identifiers. Sigiled targets (`$x = ...`,
             // `@x = ...`, `%x = ...`) are real assignment expressions.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -138,7 +138,7 @@ impl Compiler {
     pub(super) fn body_mutates_topic(stmts: &[Stmt]) -> bool {
         fn expr_mutates_topic(expr: &Expr) -> bool {
             match expr {
-                Expr::AssignExpr { name, .. } => name == "_",
+                Expr::AssignExpr { .. } => false,
                 Expr::Unary { expr, .. } => expr_mutates_topic(expr),
                 Expr::Binary { left, right, .. } => {
                     expr_mutates_topic(left) || expr_mutates_topic(right)
@@ -163,7 +163,9 @@ impl Compiler {
 
         fn stmt_mutates_topic(stmt: &Stmt) -> bool {
             match stmt {
-                Stmt::Assign { name, .. } => name == "_",
+                Stmt::Assign { name, op, .. } => {
+                    name == "_" && matches!(op, crate::ast::AssignOp::Bind)
+                }
                 Stmt::Expr(expr) => expr_mutates_topic(expr),
                 Stmt::If {
                     then_branch,

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -136,44 +136,50 @@ impl Compiler {
     }
 
     pub(super) fn body_mutates_topic(stmts: &[Stmt]) -> bool {
-        fn expr_mutates_topic(expr: &Expr) -> bool {
+        // Only check if the *first* statement assigns `$_` directly.
+        // This detects `with`-style topic switches (where the parser inserts a
+        // `$_ = <expr>` as the first statement of the then-branch) but avoids
+        // falsely triggering on user code like `if COND { ...; $_ = 2 }` where
+        // the assignment is NOT at the start. The Block wrapping created when
+        // this returns true causes BlockScope to save/restore `$_`, isolating
+        // the `with` topic from the outer scope.
+        matches!(stmts.first(), Some(Stmt::Assign { name, .. }) if name == "_")
+    }
+
+    /// Returns true only if the body contains a `$_ :=` rebind — used by the
+    /// `while` loop to decide whether to wrap the body in a `Stmt::Block` so
+    /// that the rebind is lexically scoped per iteration, without clobbering
+    /// the outer topic. Unlike `body_mutates_topic`, plain `$_ =` (assignment)
+    /// does NOT trigger Block wrapping for while loops.
+    pub(super) fn body_rebinds_topic(stmts: &[Stmt]) -> bool {
+        fn expr_rebinds_topic(expr: &Expr) -> bool {
             match expr {
-                Expr::AssignExpr { .. } => false,
-                Expr::Unary { expr, .. } => expr_mutates_topic(expr),
+                Expr::AssignExpr { name, is_bind, .. } => name == "_" && *is_bind,
+                Expr::Unary { expr, .. } => expr_rebinds_topic(expr),
                 Expr::Binary { left, right, .. } => {
-                    expr_mutates_topic(left) || expr_mutates_topic(right)
+                    expr_rebinds_topic(left) || expr_rebinds_topic(right)
                 }
                 Expr::MethodCall { target, args, .. } => {
-                    expr_mutates_topic(target) || args.iter().any(expr_mutates_topic)
+                    expr_rebinds_topic(target) || args.iter().any(expr_rebinds_topic)
                 }
-                Expr::Call { args, .. } => args.iter().any(expr_mutates_topic),
-                Expr::IndexAssign {
-                    target,
-                    index,
-                    value,
-                    ..
-                } => {
-                    expr_mutates_topic(target)
-                        || expr_mutates_topic(index)
-                        || expr_mutates_topic(value)
-                }
+                Expr::Call { args, .. } => args.iter().any(expr_rebinds_topic),
                 _ => false,
             }
         }
 
-        fn stmt_mutates_topic(stmt: &Stmt) -> bool {
+        fn stmt_rebinds_topic(stmt: &Stmt) -> bool {
             match stmt {
                 Stmt::Assign { name, op, .. } => {
                     name == "_" && matches!(op, crate::ast::AssignOp::Bind)
                 }
-                Stmt::Expr(expr) => expr_mutates_topic(expr),
+                Stmt::Expr(expr) => expr_rebinds_topic(expr),
                 Stmt::If {
                     then_branch,
                     else_branch,
                     ..
                 } => {
-                    super::Compiler::body_mutates_topic(then_branch)
-                        || super::Compiler::body_mutates_topic(else_branch)
+                    super::Compiler::body_rebinds_topic(then_branch)
+                        || super::Compiler::body_rebinds_topic(else_branch)
                 }
                 Stmt::While { body, .. }
                 | Stmt::Block(body)
@@ -182,13 +188,13 @@ impl Compiler {
                 | Stmt::Control(body)
                 | Stmt::When { body, .. }
                 | Stmt::Given { body, .. }
-                | Stmt::Default(body) => super::Compiler::body_mutates_topic(body),
-                Stmt::For { body, .. } => super::Compiler::body_mutates_topic(body),
+                | Stmt::Default(body) => super::Compiler::body_rebinds_topic(body),
+                Stmt::For { body, .. } => super::Compiler::body_rebinds_topic(body),
                 _ => false,
             }
         }
 
-        stmts.iter().any(stmt_mutates_topic)
+        stmts.iter().any(stmt_rebinds_topic)
     }
 
     /// Compile a block body, automatically wrapping in implicit try if it contains

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -252,6 +252,7 @@ impl Compiler {
             kv_mode: false,
             source_var_names,
             autothread_junctions: false,
+            explicit_zero_params: false,
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -123,6 +123,7 @@ impl Compiler {
                 label,
                 mode,
                 rw_block,
+                explicit_zero_params,
             } => Stmt::For {
                 iterable: iterable.clone(),
                 param: param.clone(),
@@ -138,6 +139,7 @@ impl Compiler {
                 label: label.clone(),
                 mode: *mode,
                 rw_block: *rw_block,
+                explicit_zero_params: *explicit_zero_params,
             },
             Stmt::Loop {
                 init,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -959,7 +959,9 @@ impl Compiler {
                 // When the loop body contains `$_ := expr` (topic rebind via `:=`), wrap
                 // the body in a BlockScope so the rebind is lexically scoped per iteration.
                 // BlockScope naturally prevents `$_` from propagating out.
-                let body_rebinds_topic = Self::body_mutates_topic(&loop_body);
+                // Note: plain `$_ =` does NOT trigger wrapping — that would break `with`-block
+                // topic restoration which relies on `body_mutates_topic` for isolation.
+                let body_rebinds_topic = Self::body_rebinds_topic(&loop_body);
                 let loop_idx = self.code.emit(OpCode::WhileLoop {
                     cond_end: 0,
                     body_end: 0,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -956,16 +956,24 @@ impl Compiler {
                 for s in &pre_stmts {
                     self.compile_stmt(s);
                 }
+                // When the loop body contains `$_ := expr` (topic rebind via `:=`), wrap
+                // the body in a BlockScope so the rebind is lexically scoped per iteration.
+                // BlockScope naturally prevents `$_` from propagating out.
+                let body_rebinds_topic = Self::body_mutates_topic(&loop_body);
                 let loop_idx = self.code.emit(OpCode::WhileLoop {
                     cond_end: 0,
                     body_end: 0,
                     label: label.clone(),
                     collect: false,
-                    isolate_topic: Self::body_mutates_topic(&loop_body),
+                    isolate_topic: false,
                 });
                 self.compile_condition_expr(cond);
                 self.code.patch_while_cond_end(loop_idx);
-                self.compile_body_with_implicit_try(&loop_body);
+                if body_rebinds_topic {
+                    self.compile_stmt(&Stmt::Block(loop_body.clone()));
+                } else {
+                    self.compile_body_with_implicit_try(&loop_body);
+                }
                 self.code.patch_loop_end(loop_idx);
                 for s in &post_stmts {
                     self.compile_stmt(s);
@@ -980,6 +988,7 @@ impl Compiler {
                 label,
                 mode,
                 rw_block,
+                explicit_zero_params,
             } => {
                 let (pre_stmts, mut loop_body, post_stmts) =
                     self.expand_loop_phasers(body, label.as_deref());
@@ -1069,6 +1078,7 @@ impl Compiler {
                     kv_mode,
                     source_var_names,
                     autothread_junctions,
+                    explicit_zero_params: *explicit_zero_params,
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -539,6 +539,9 @@ pub(crate) enum OpCode {
         /// When true, Junction items are expanded into their eigenstates
         /// (parameter type is Any or more specific, not Mu or Junction).
         autothread_junctions: bool,
+        /// When true, the block explicitly declared zero parameters (`-> {}`).
+        /// Passing any argument should throw "Too many positionals passed".
+        explicit_zero_params: bool,
     },
     /// C-style loop: [cond opcodes][body opcodes][step opcodes].
     /// Layout after CStyleLoop: cond at [ip+1..cond_end), body at [cond_end..step_start),

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -1298,7 +1298,7 @@ mod tests {
         let (rest, expr) = expression("($x += 2) *= 3").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::AssignExpr { name, expr } => {
+            Expr::AssignExpr { name, expr, .. } => {
                 assert_eq!(name, "x");
                 assert!(matches!(*expr, Expr::Binary { .. }));
             }
@@ -1311,7 +1311,7 @@ mod tests {
         let (rest, expr) = expression("(@a ||= 42) += 10").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::AssignExpr { name, expr } => {
+            Expr::AssignExpr { name, expr, .. } => {
                 assert_eq!(name, "@a");
                 assert!(matches!(*expr, Expr::Binary { .. }));
             }

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -761,14 +761,17 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
         Expr::Var(name) => Expr::AssignExpr {
             name: name.clone(),
             expr: Box::new(method_call_fn(target)),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(method_call_fn(target)),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(method_call_fn(target)),
+            is_bind: false,
         },
         Expr::Index {
             target: idx_target,
@@ -828,6 +831,7 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
                     Stmt::Expr(Expr::AssignExpr {
                         name: assign_name,
                         expr: Box::new(method_result),
+                        is_bind: false,
                     }),
                 ],
                 label: None,

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -420,6 +420,7 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             Expr::AssignExpr {
                 name,
                 expr: Box::new(rhs),
+                is_bind: false,
             },
         )),
         Expr::ArrayVar(name) => Ok((
@@ -427,6 +428,7 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             Expr::AssignExpr {
                 name: format!("@{}", name),
                 expr: Box::new(rhs),
+                is_bind: false,
             },
         )),
         Expr::HashVar(name) => Ok((
@@ -434,6 +436,7 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             Expr::AssignExpr {
                 name: format!("%{}", name),
                 expr: Box::new(rhs),
+                is_bind: false,
             },
         )),
         Expr::Index {
@@ -491,6 +494,7 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             Expr::AssignExpr {
                 name,
                 expr: Box::new(rhs),
+                is_bind: false,
             },
         )),
         Expr::CallOn { target, args } => Ok((
@@ -548,14 +552,17 @@ fn assign_to_target_expr(target: Expr, value: Expr) -> Expr {
         Expr::Var(name) => Expr::AssignExpr {
             name,
             expr: Box::new(value),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(value),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(value),
+            is_bind: false,
         },
         Expr::Index {
             target,
@@ -639,6 +646,7 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
         Expr::Var(name) => Expr::AssignExpr {
             name: name.clone(),
             expr: Box::new(compound_assigned_value_expr(Expr::Var(name), op, value)),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name.clone()),
@@ -647,10 +655,12 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
                 op,
                 value,
             )),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name.clone()),
             expr: Box::new(compound_assigned_value_expr(Expr::HashVar(name), op, value)),
+            is_bind: false,
         },
         Expr::Index {
             target,
@@ -681,23 +691,40 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
                 value: Box::new(compound_assigned_value_expr(lhs_expr, op, value)),
             }
         }
-        Expr::AssignExpr { name, expr } => {
+        Expr::AssignExpr {
+            name,
+            expr,
+            is_bind: _,
+        } => {
             if op_name == "=" {
                 return Expr::AssignExpr {
                     name,
                     expr: Box::new(value),
+                    is_bind: false,
                 };
             }
             let Some(op) = compound_assign_op_from_name(op_name) else {
-                return assignment_ro_expr(Expr::AssignExpr { name, expr }, value);
+                return assignment_ro_expr(
+                    Expr::AssignExpr {
+                        name,
+                        expr,
+                        is_bind: false,
+                    },
+                    value,
+                );
             };
             Expr::AssignExpr {
                 name: name.clone(),
                 expr: Box::new(compound_assigned_value_expr(
-                    Expr::AssignExpr { name, expr },
+                    Expr::AssignExpr {
+                        name,
+                        expr,
+                        is_bind: false,
+                    },
                     op,
                     value,
                 )),
+                is_bind: false,
             }
         }
         Expr::MethodCall {
@@ -739,14 +766,17 @@ fn list_lvalue_assign_expr(items: Vec<Expr>, rhs: Expr) -> Option<Expr> {
         Expr::Var(name) => Some(Expr::AssignExpr {
             name,
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::ArrayVar(name) => Some(Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::HashVar(name) => Some(Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::Index {
             target,
@@ -1649,6 +1679,7 @@ fn build_pipe_feed_expr(source: Expr, sink: Expr) -> Expr {
         Expr::Var(name) => Expr::AssignExpr {
             name,
             expr: Box::new(source),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name),
@@ -1656,14 +1687,17 @@ fn build_pipe_feed_expr(source: Expr, sink: Expr) -> Expr {
                 name: Symbol::intern("__mutsu_feed_array_assign"),
                 args: vec![source],
             }),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(source),
+            is_bind: false,
         },
         Expr::CodeVar(name) => Expr::AssignExpr {
             name: format!("&{}", name),
             expr: Box::new(source),
+            is_bind: false,
         },
         Expr::Index {
             target,
@@ -1711,6 +1745,7 @@ fn build_append_feed_expr(source: Expr, sink: Expr) -> Expr {
                 name: Symbol::intern("__mutsu_feed_append"),
                 args: vec![Expr::Var(name), source],
             }),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name.clone()),
@@ -1718,6 +1753,7 @@ fn build_append_feed_expr(source: Expr, sink: Expr) -> Expr {
                 name: Symbol::intern("__mutsu_feed_append"),
                 args: vec![Expr::ArrayVar(name), source],
             }),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name.clone()),
@@ -1725,6 +1761,7 @@ fn build_append_feed_expr(source: Expr, sink: Expr) -> Expr {
                 name: Symbol::intern("__mutsu_feed_append"),
                 args: vec![Expr::HashVar(name), source],
             }),
+            is_bind: false,
         },
         Expr::Index {
             target,

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -55,6 +55,7 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
                     Expr::AssignExpr {
                         name: assign_name,
                         expr: Box::new(rhs),
+                        is_bind: false,
                     },
                 )
             } else if let Some(stripped) = r2.strip_prefix("::=").or_else(|| r2.strip_prefix(":="))
@@ -67,6 +68,7 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
                     Expr::AssignExpr {
                         name: assign_name,
                         expr: Box::new(rhs),
+                        is_bind: false,
                     },
                 )
             } else if let Some((stripped, op)) =
@@ -84,6 +86,7 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
                             op: op.token_kind(),
                             right: Box::new(rhs),
                         }),
+                        is_bind: false,
                     },
                 )
             } else {

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -164,6 +164,7 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             label,
             mode,
             rw_block,
+            explicit_zero_params,
         } => Stmt::For {
             iterable,
             param,
@@ -173,6 +174,7 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             label,
             mode,
             rw_block,
+            explicit_zero_params,
         },
         Stmt::Given { topic, body } => Stmt::Given {
             topic,

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -489,6 +489,7 @@ fn build_topic_subst_compound_expr(
             modifier: None,
             quoted: false,
         }),
+        is_bind: false,
     })
 }
 
@@ -541,6 +542,7 @@ fn build_topic_subst_expr(
             modifier: None,
             quoted: false,
         }),
+        is_bind: false,
     })
 }
 
@@ -1858,6 +1860,7 @@ pub(super) fn topic_method_call(input: &str) -> PResult<'_, Expr> {
                 Expr::AssignExpr {
                     name: "_".to_string(),
                     expr: Box::new(method_call),
+                    is_bind: false,
                 },
             ));
         }

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -10,16 +10,21 @@ use crate::value::Value;
 use super::{ident, is_stmt_modifier_keyword, try_parse_assign_expr};
 
 fn regroup_assign_expr_metaop_rhs(expr: Expr) -> Expr {
-    let Expr::AssignExpr { name, expr } = expr else {
+    let Expr::AssignExpr { name, expr, .. } = expr else {
         return expr;
     };
     let Expr::ArrayLiteral(mut items) = *expr else {
-        return Expr::AssignExpr { name, expr };
+        return Expr::AssignExpr {
+            name,
+            expr,
+            is_bind: false,
+        };
     };
     let Some(last) = items.pop() else {
         return Expr::AssignExpr {
             name,
             expr: Box::new(Expr::ArrayLiteral(items)),
+            is_bind: false,
         };
     };
     match last {
@@ -38,6 +43,7 @@ fn regroup_assign_expr_metaop_rhs(expr: Expr) -> Expr {
                     left: Box::new(Expr::ArrayLiteral(items)),
                     right,
                 }),
+                is_bind: false,
             }
         }
         other => {
@@ -45,6 +51,7 @@ fn regroup_assign_expr_metaop_rhs(expr: Expr) -> Expr {
             Expr::AssignExpr {
                 name,
                 expr: Box::new(Expr::ArrayLiteral(items)),
+                is_bind: false,
             }
         }
     }
@@ -52,12 +59,13 @@ fn regroup_assign_expr_metaop_rhs(expr: Expr) -> Expr {
 
 fn split_assignment_rhs_call_args(expr: Expr) -> (Expr, Vec<Expr>) {
     match expr {
-        Expr::AssignExpr { name, expr } => {
+        Expr::AssignExpr { name, expr, .. } => {
             let (rhs, extras) = split_assignment_rhs_call_args(*expr);
             (
                 Expr::AssignExpr {
                     name,
                     expr: Box::new(rhs),
+                    is_bind: false,
                 },
                 extras,
             )
@@ -716,7 +724,7 @@ mod tests {
         let (rest, args) = parse_stmt_call_args("(@d = 1,3 Z 2,4), \"desc\";").unwrap();
         assert_eq!(rest, ";");
         match &args[0] {
-            CallArg::Positional(Expr::AssignExpr { name, expr }) => {
+            CallArg::Positional(Expr::AssignExpr { name, expr, .. }) => {
                 assert_eq!(name, "@d");
                 match expr.as_ref() {
                     Expr::MetaOp {

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -808,7 +808,7 @@ pub(crate) fn build_compound_assign_expr(
         Expr::AssignExpr {
             name,
             expr,
-            is_bind,
+            is_bind: _,
         } => {
             // ($x += 2) *= 3 → first evaluate inner assign, then apply outer op
             // to the variable's value and assign back.

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -685,14 +685,17 @@ fn list_lvalue_assign_expr(items: Vec<Expr>, rhs: Expr) -> Option<Expr> {
         Expr::Var(name) => Some(Expr::AssignExpr {
             name,
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::ArrayVar(name) => Some(Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::HashVar(name) => Some(Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         }),
         Expr::Index {
             target,
@@ -718,7 +721,11 @@ pub(crate) fn rewrite_scalar_assignment_rhs_as_sink(name: String, rhs: Expr) -> 
         } if name.starts_with('$') && matches!(meta.as_str(), "X" | "Z") => Some(Expr::MetaOp {
             meta,
             op,
-            left: Box::new(Expr::AssignExpr { name, expr: left }),
+            left: Box::new(Expr::AssignExpr {
+                name,
+                expr: left,
+                is_bind: false,
+            }),
             right,
         }),
         _ => None,
@@ -798,30 +805,42 @@ pub(crate) fn build_compound_assign_expr(
         other => other,
     };
     Ok(match lhs {
-        Expr::AssignExpr { name, expr } => {
+        Expr::AssignExpr {
+            name,
+            expr,
+            is_bind,
+        } => {
             // ($x += 2) *= 3 → first evaluate inner assign, then apply outer op
             // to the variable's value and assign back.
             // This becomes: { let _ = ($x = $x + 2); $x = $x * 3 }
             Expr::AssignExpr {
                 name: name.clone(),
                 expr: Box::new(Expr::Binary {
-                    left: Box::new(Expr::AssignExpr { name, expr }),
+                    left: Box::new(Expr::AssignExpr {
+                        name,
+                        expr,
+                        is_bind: false,
+                    }),
                     op: op.token_kind(),
                     right: Box::new(rhs),
                 }),
+                is_bind: false,
             }
         }
         Expr::Var(name) => Expr::AssignExpr {
             name: name.clone(),
             expr: Box::new(compound_assigned_value_expr(Expr::Var(name), op, rhs)),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(compound_assigned_value_expr(Expr::ArrayVar(name), op, rhs)),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(compound_assigned_value_expr(Expr::HashVar(name), op, rhs)),
+            is_bind: false,
         },
         Expr::Index { target, index, .. } => {
             return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
@@ -873,6 +892,7 @@ pub(crate) fn build_compound_assign_expr(
         Expr::BareWord(name) => Expr::AssignExpr {
             name: name.clone(),
             expr: Box::new(compound_assigned_value_expr(Expr::BareWord(name), op, rhs)),
+            is_bind: false,
         },
         Expr::BracketArray(items, tc) => Expr::Binary {
             left: Box::new(Expr::BracketArray(items, tc)),
@@ -943,6 +963,7 @@ fn build_custom_compound_assign_expr(
                 right: vec![rhs],
                 modifier: None,
             }),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name.clone()),
@@ -952,6 +973,7 @@ fn build_custom_compound_assign_expr(
                 right: vec![rhs],
                 modifier: None,
             }),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name.clone()),
@@ -961,6 +983,7 @@ fn build_custom_compound_assign_expr(
                 right: vec![rhs],
                 modifier: None,
             }),
+            is_bind: false,
         },
         Expr::Index { target, index, .. } => {
             return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
@@ -992,6 +1015,7 @@ fn build_meta_assign_expr(lhs: Expr, meta: String, op: String, rhs: Expr) -> Res
                 left: Box::new(Expr::Var(name)),
                 right: Box::new(rhs),
             }),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name.clone()),
@@ -1001,6 +1025,7 @@ fn build_meta_assign_expr(lhs: Expr, meta: String, op: String, rhs: Expr) -> Res
                 left: Box::new(Expr::ArrayVar(name)),
                 right: Box::new(rhs),
             }),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name.clone()),
@@ -1010,6 +1035,7 @@ fn build_meta_assign_expr(lhs: Expr, meta: String, op: String, rhs: Expr) -> Res
                 left: Box::new(Expr::HashVar(name)),
                 right: Box::new(rhs),
             }),
+            is_bind: false,
         },
         Expr::Index {
             target,
@@ -1081,7 +1107,7 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
                         is_positional,
                     },
                 ));
-            } else if let Expr::AssignExpr { name, expr } = inner_assign {
+            } else if let Expr::AssignExpr { name, expr, .. } = inner_assign {
                 let mut items = vec![*expr];
                 let mut r = rest_inner;
                 while r.starts_with(',') && !r.starts_with(",,") {
@@ -1102,6 +1128,7 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
                     Expr::AssignExpr {
                         name,
                         expr: Box::new(Expr::ArrayLiteral(items)),
+                        is_bind: false,
                     },
                 ));
             }
@@ -1193,14 +1220,17 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
             Expr::Var(name) => Expr::AssignExpr {
                 name,
                 expr: Box::new(rhs),
+                is_bind: true,
             },
             Expr::ArrayVar(name) => Expr::AssignExpr {
                 name: format!("@{}", name),
                 expr: Box::new(rhs),
+                is_bind: true,
             },
             Expr::HashVar(name) => Expr::AssignExpr {
                 name: format!("%{}", name),
                 expr: Box::new(rhs),
+                is_bind: true,
             },
             Expr::Index {
                 target,
@@ -1271,14 +1301,17 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
         Expr::Var(name) => Expr::AssignExpr {
             name,
             expr: Box::new(rhs),
+            is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
             name: format!("@{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         },
         Expr::HashVar(name) => Expr::AssignExpr {
             name: format!("%{}", name),
             expr: Box::new(rhs),
+            is_bind: false,
         },
         Expr::Index {
             target,
@@ -1346,12 +1379,13 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
         Expr::BareWord(name) => Expr::AssignExpr {
             name,
             expr: Box::new(rhs),
+            is_bind: false,
         },
         // Fallback for other lvalue expressions (e.g. HyperIndex %h{|| @a})
         other => callable_lvalue_assign_expr(other, Vec::new(), rhs),
     };
     if is_atomic {
-        if let Expr::AssignExpr { name, expr } = expr {
+        if let Expr::AssignExpr { name, expr, .. } = expr {
             return Ok((
                 rest,
                 Expr::Call {
@@ -1573,6 +1607,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 Expr::AssignExpr {
                     name,
                     expr: Box::new(method_expr),
+                    is_bind: false,
                 },
             ));
         }
@@ -1653,6 +1688,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     modifier: None,
                     quoted: false,
                 }),
+                is_bind: false,
             },
         ));
     }
@@ -1673,6 +1709,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     op,
                     rhs,
                 )),
+                is_bind: false,
             },
         ));
     }
@@ -1699,6 +1736,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                         compound_op,
                         rhs,
                     )),
+                    is_bind: false,
                 },
             ));
         }
@@ -1717,6 +1755,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     left: Box::new(var_expr),
                     right: Box::new(rhs),
                 }),
+                is_bind: false,
             },
         ));
     }
@@ -1742,6 +1781,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     left: Box::new(var_expr),
                     right: Box::new(rhs),
                 }),
+                is_bind: false,
             },
         ));
     }
@@ -1763,6 +1803,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     right: vec![rhs],
                     modifier: None,
                 }),
+                is_bind: false,
             },
         ));
     }
@@ -1778,6 +1819,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             Expr::AssignExpr {
                 name,
                 expr: Box::new(rhs),
+                is_bind: true,
             },
         ));
     }
@@ -1835,6 +1877,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 None => Expr::AssignExpr {
                     name,
                     expr: Box::new(rhs),
+                    is_bind: false,
                 },
             },
         ));

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -457,7 +457,7 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, iterable) = parse_comma_or_expr(r)?;
         let (r, _) = ws(r)?;
-        let (r, (param, param_def, params, rw_block)) = parse_for_params(r)?;
+        let (r, (param, param_def, params, rw_block, explicit_zero_params)) = parse_for_params(r)?;
         let (r, _) = ws(r)?;
         let (r, body) = block(r)?;
         return Ok((
@@ -471,6 +471,7 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 label: Some(label),
                 mode: crate::ast::ForMode::Normal,
                 rw_block,
+                explicit_zero_params,
             },
         ));
     }
@@ -540,6 +541,7 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 label: Some(label),
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
+                explicit_zero_params: false,
             },
         ));
     }
@@ -559,6 +561,7 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 label: Some(label),
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
+                explicit_zero_params: false,
             },
         ));
     }
@@ -574,8 +577,8 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
     ))
 }
 
-/// Parsed for-loop parameter info: `(param, param_def, params, rw_block)`.
-type ForParams = (Option<String>, Option<ParamDef>, Vec<String>, bool);
+/// Parsed for-loop parameter info: `(param, param_def, params, rw_block, explicit_zero_params)`.
+type ForParams = (Option<String>, Option<ParamDef>, Vec<String>, bool, bool);
 
 /// Parse for loop parameters: -> $param or -> $a, $b
 /// Returns `(param, param_def, params, rw_block)`.
@@ -603,8 +606,9 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
     if let Some(stripped) = pointy_stripped {
         let (r, _) = ws(stripped)?;
         // Zero-parameter pointy block: for @a -> { ... }
+        // Explicitly declares zero params — passing any arg should throw.
         if r.starts_with('{') {
-            return Ok((r, (None, None, Vec::new(), rw_block)));
+            return Ok((r, (None, None, Vec::new(), rw_block, true)));
         }
         // Parenthesized destructuring pointy param:
         //   -> ($a, $b) { ... }
@@ -640,7 +644,13 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             };
             return Ok((
                 r,
-                (Some(unpack_name), Some(unpack_def), Vec::new(), rw_block),
+                (
+                    Some(unpack_name),
+                    Some(unpack_def),
+                    Vec::new(),
+                    rw_block,
+                    false,
+                ),
             ));
         }
         // Parenthesized pointy parameter list: -> ($a, $b) { ... }
@@ -652,7 +662,7 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             let (r, _) = parse_char(r, ')')?;
             let (r, _) = skip_pointy_return_type(r)?;
             if sub_params.is_empty() {
-                return Ok((r, (None, None, Vec::new(), rw_block)));
+                return Ok((r, (None, None, Vec::new(), rw_block, false)));
             }
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
@@ -678,7 +688,13 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             };
             return Ok((
                 r,
-                (Some(unpack_name), Some(unpack_def), Vec::new(), rw_block),
+                (
+                    Some(unpack_name),
+                    Some(unpack_def),
+                    Vec::new(),
+                    rw_block,
+                    false,
+                ),
             ));
         }
         // Positional destructuring pointy param: -> [$a, $b] { ... }
@@ -726,7 +742,13 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             };
             return Ok((
                 r,
-                (Some(unpack_name), Some(unpack_def), Vec::new(), rw_block),
+                (
+                    Some(unpack_name),
+                    Some(unpack_def),
+                    Vec::new(),
+                    rw_block,
+                    false,
+                ),
             ));
         }
         let (r, mut first_def) = parse_for_pointy_param(r)?;
@@ -772,13 +794,16 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 r = r2;
             }
             let (r, _) = skip_pointy_return_type(r)?;
-            Ok((r, (None, None, params, any_rw)))
+            Ok((r, (None, None, params, any_rw, false)))
         } else {
             let (r, _) = skip_pointy_return_type(r)?;
-            Ok((r, (Some(first), Some(first_def), Vec::new(), rw_block)))
+            Ok((
+                r,
+                (Some(first), Some(first_def), Vec::new(), rw_block, false),
+            ))
         }
     } else {
-        Ok((input, (None, None, Vec::new(), false)))
+        Ok((input, (None, None, Vec::new(), false, false)))
     }
 }
 
@@ -1013,7 +1038,8 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
         (r, iterable, false)
     };
     let (rest, _) = ws(rest)?;
-    let (rest, (param, param_def, params, rw_block)) = parse_for_params(rest)?;
+    let (rest, (param, param_def, params, rw_block, explicit_zero_params)) =
+        parse_for_params(rest)?;
     let rw_block = rw_block || rw_detected;
     let (rest, _) = ws(rest)?;
     let (rest, body) = block(rest)?;
@@ -1042,6 +1068,7 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
             label: None,
             mode,
             rw_block,
+            explicit_zero_params,
         },
     ))
 }
@@ -1450,7 +1477,8 @@ pub(super) fn while_stmt(input: &str) -> PResult<'_, Stmt> {
     let (rest, cond) = condition_expr(rest)?;
     let (rest, _) = ws(rest)?;
     let (rest, param_binding) = if rest.starts_with("->") {
-        let (rest, (param, _param_def, params, _rw_block)) = parse_for_params(rest)?;
+        let (rest, (param, _param_def, params, _rw_block, _explicit_zero)) =
+            parse_for_params(rest)?;
         if !params.is_empty() {
             return Err(PError::expected_at("single while pointy parameter", rest));
         }
@@ -1465,6 +1493,7 @@ pub(super) fn while_stmt(input: &str) -> PResult<'_, Stmt> {
             Expr::AssignExpr {
                 name: param.clone(),
                 expr: Box::new(cond),
+                is_bind: false,
             }
         } else {
             cond
@@ -1503,7 +1532,8 @@ pub(super) fn until_stmt(input: &str) -> PResult<'_, Stmt> {
     let (rest, cond) = condition_expr(rest)?;
     let (rest, _) = ws(rest)?;
     let (rest, param_binding) = if rest.starts_with("->") {
-        let (rest, (param, _param_def, params, _rw_block)) = parse_for_params(rest)?;
+        let (rest, (param, _param_def, params, _rw_block, _explicit_zero)) =
+            parse_for_params(rest)?;
         if !params.is_empty() {
             return Err(PError::expected_at("single until pointy parameter", rest));
         }
@@ -1517,6 +1547,7 @@ pub(super) fn until_stmt(input: &str) -> PResult<'_, Stmt> {
         Expr::AssignExpr {
             name: param.clone(),
             expr: Box::new(cond),
+            is_bind: false,
         }
     } else {
         cond
@@ -1756,7 +1787,7 @@ pub(super) fn repeat_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, cond) = condition_expr(r)?;
         let (r, _) = ws(r)?;
-        let (r, (param, _param_def, params, _rw_block)) = parse_for_params(r)?;
+        let (r, (param, _param_def, params, _rw_block, _explicit_zero)) = parse_for_params(r)?;
         let (r, _) = ws(r)?;
         let (r, body) = block(r)?;
         let (r, _) = ws(r)?;
@@ -1779,6 +1810,7 @@ pub(super) fn repeat_stmt(input: &str) -> PResult<'_, Stmt> {
         let step = repeat_param.map(|name| Expr::AssignExpr {
             name,
             expr: Box::new(Expr::Literal(crate::value::Value::Bool(true))),
+            is_bind: false,
         });
         return Ok((
             r,
@@ -1796,7 +1828,7 @@ pub(super) fn repeat_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, cond) = condition_expr(r)?;
         let (r, _) = ws(r)?;
-        let (r, (param, _param_def, params, _rw_block)) = parse_for_params(r)?;
+        let (r, (param, _param_def, params, _rw_block, _explicit_zero)) = parse_for_params(r)?;
         let (r, _) = ws(r)?;
         let (r, body) = block(r)?;
         let (r, _) = ws(r)?;
@@ -1819,6 +1851,7 @@ pub(super) fn repeat_stmt(input: &str) -> PResult<'_, Stmt> {
         let step = repeat_param.map(|name| Expr::AssignExpr {
             name,
             expr: Box::new(Expr::Literal(crate::value::Value::Bool(true))),
+            is_bind: false,
         });
         return Ok((
             r,
@@ -1948,7 +1981,7 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // Check for optional pointy block: -> $param { ... }, -> \param { ... },
     // or -> (SIGNATURE) { ... } (sub-signature destructuring)
     let (rest, param_name, param_def) = if rest.starts_with("->") || rest.starts_with("<->") {
-        let (r, (param, param_def, _params, _rw_block)) = parse_for_params(rest)?;
+        let (r, (param, param_def, _params, _rw_block, _explicit_zero)) = parse_for_params(rest)?;
         (r, param, param_def)
     } else {
         (rest, None, None)

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -1194,7 +1194,7 @@ mod tests {
                 assert_eq!(stmts.len(), 2);
                 assert!(matches!(
                     &stmts[0],
-                    Stmt::Expr(Expr::AssignExpr { name, expr })
+                    Stmt::Expr(Expr::AssignExpr { name, expr, .. })
                         if name == "x" && matches!(expr.as_ref(), Expr::Var(n) if n == "y")
                 ));
                 assert!(matches!(
@@ -1899,7 +1899,7 @@ mod tests {
         let (rest, expr) = assign::try_parse_assign_expr("$y [R/]= 1").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::AssignExpr { name, expr } => {
+            Expr::AssignExpr { name, expr, .. } => {
                 assert_eq!(name, "y");
                 match *expr {
                     Expr::MetaOp {
@@ -1947,7 +1947,7 @@ mod tests {
         let (rest, expr) = assign::try_parse_assign_expr("@a X*= 10").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::AssignExpr { name, expr } => {
+            Expr::AssignExpr { name, expr, .. } => {
                 assert_eq!(name, "@a");
                 match *expr {
                     Expr::MetaOp {

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -278,6 +278,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 label: None,
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
+                explicit_zero_params: false,
             },
         )));
     }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1476,6 +1476,7 @@ impl Interpreter {
                 params,
                 mode,
                 rw_block,
+                explicit_zero_params,
             } => Stmt::For {
                 iterable: Self::rewrite_proto_dispatch_expr(iterable),
                 body: Self::rewrite_proto_dispatch_stmts(body),
@@ -1485,6 +1486,7 @@ impl Interpreter {
                 params: params.clone(),
                 mode: *mode,
                 rw_block: *rw_block,
+                explicit_zero_params: *explicit_zero_params,
             },
             Stmt::Loop {
                 init,
@@ -1596,9 +1598,14 @@ impl Interpreter {
                 value: Box::new(Self::rewrite_proto_dispatch_expr(value)),
                 is_positional: *is_positional,
             },
-            Expr::AssignExpr { name, expr } => Expr::AssignExpr {
+            Expr::AssignExpr {
+                name,
+                expr,
+                is_bind,
+            } => Expr::AssignExpr {
                 name: name.clone(),
                 expr: Box::new(Self::rewrite_proto_dispatch_expr(expr)),
+                is_bind: *is_bind,
             },
             Expr::Block(stmts) => Expr::Block(Self::rewrite_proto_dispatch_stmts(stmts)),
             Expr::DoBlock { body, label } => Expr::DoBlock {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2499,6 +2499,7 @@ impl VM {
                 kv_mode,
                 source_var_names,
                 autothread_junctions,
+                explicit_zero_params,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -2515,6 +2516,7 @@ impl VM {
                     kv_mode: *kv_mode,
                     source_var_names: source_var_names.clone(),
                     autothread_junctions: *autothread_junctions,
+                    explicit_zero_params: *explicit_zero_params,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -16,6 +16,8 @@ pub(super) struct ForLoopSpec {
     pub(super) kv_mode: bool,
     pub(super) source_var_names: Vec<String>,
     pub(super) autothread_junctions: bool,
+    /// When true, `-> {}` was used — throw on any items.
+    pub(super) explicit_zero_params: bool,
 }
 
 pub(super) struct WhileLoopSpec {
@@ -312,6 +314,13 @@ impl VM {
         } else {
             raw_items
         };
+        // When `-> {}` was used (explicit zero params), throw if any items would be passed.
+        if spec.explicit_zero_params && !items.is_empty() {
+            return Err(RuntimeError::new(format!(
+                "Too many positionals passed; expected 0 arguments but got {}",
+                items.len()
+            )));
+        }
         self.env_dirty = true;
         let body_start = *ip + 1;
         let loop_end = spec.body_end as usize;


### PR DESCRIPTION
## Summary

- Adds `is_bind: bool` field to `Expr::AssignExpr` to distinguish `:=` (bind) from `=` (assign) in expression context
- When `is_bind` is true, the compiler emits `MarkRebindContext` so the VM breaks existing alias chains instead of writing through them
- Adds `explicit_zero_params` field to `Stmt::For` / `ForLoop` opcode for `-> {}` detection
- Fixes `roast/S02-magicals/dollar-underscore.t`: 17/23 → 22/23 passing (tests 11, 14, 18 now pass)
- Updates `TODO_roast/S02.md` to reflect the new state

## Test plan

- [x] All 481 local tests pass (`make test`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `roast/S02-magicals/dollar-underscore.t` improved from 17/23 to 22/23 passing
- [ ] Test 16 deferred: requires `for` loop lexical scoping of `$_` per iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)