### PR TITLE
fix: increase per-file timeout for roast/S29-context/sleep.t to 60s

### DIFF
--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -23,6 +23,11 @@ per_file_timeout() {
       # This test uses sleep 2*$_ with $_ up to 9, parallel start blocks take ~18s.
       echo 60
       ;;
+    roast/S29-context/sleep.t)
+      # This test has four 3-second sleep calls plus a subprocess, totalling ~18s locally
+      # and potentially more on slower CI machines.
+      echo 60
+      ;;
     *)
       echo "$DEFAULT_TIMEOUT"
       ;;


### PR DESCRIPTION
## Summary

- `roast/S29-context/sleep.t` has four 3-second `sleep`/`sleep-timer`/`sleep-until` calls plus an `is_run` subprocess that spawns a 3-second subprocess, totalling ~18 seconds locally
- With the default 30-second `timeout` in `scripts/run-roast-test.sh`, the test reliably times out on slower CI machines
- Added a 60-second per-file override for `roast/S29-context/sleep.t` (matching the pattern already used for other time-heavy tests like `allof.t` and `unique.t`)

The test itself was already in `roast-whitelist.txt` and all 23 subtests pass; this change just prevents CI from killing it before it finishes.

## Test plan

- [x] `bash scripts/run-roast-test.sh roast/S29-context/sleep.t` exits 0 with all 23 subtests passing (~18s)
- [x] No Rust code changes; no `make test` regression risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)