### PR TITLE
fix: implement $*SCHEDULER.uncaught_handler for sunk broken promises

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -119,7 +119,19 @@ impl Interpreter {
                     } else {
                         Value::str(e.message)
                     };
-                    promise.break_with(error_val, output, stderr);
+                    promise.break_with(error_val.clone(), output, stderr);
+                    // Call uncaught_handler if set, running in a helper thread
+                    // so we don't block the promise thread.
+                    if let Some(handler) =
+                        crate::runtime::native_methods::state_scheduler::get_uncaught_handler()
+                    {
+                        let handler_interp = thread_interp.clone_for_thread();
+                        let ex_val = error_val;
+                        std::thread::spawn(move || {
+                            let vm = crate::vm::VM::new(handler_interp);
+                            let (_interp, _result) = vm.call_value(handler, vec![ex_val]);
+                        });
+                    }
                 }
             }
         });

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1300,6 +1300,37 @@ impl Interpreter {
                 }
                 return Ok(assigned_value);
             }
+            // Try native mutable method dispatch for native classes (e.g. Scheduler.uncaught_handler)
+            if self.is_native_method(&class_name.resolve(), method) {
+                let mut all_args = method_args.clone();
+                all_args.push(value.clone());
+                match self.call_native_instance_method_mut(
+                    &class_name.resolve(),
+                    (*attributes).clone(),
+                    method,
+                    all_args,
+                ) {
+                    Ok((result, updated_attrs)) => {
+                        self.overwrite_instance_bindings_by_identity(
+                            &class_name.resolve(),
+                            target_id,
+                            updated_attrs.clone(),
+                        );
+                        if let Some(var_name) = target_var {
+                            self.env.insert(
+                                var_name.to_string(),
+                                Value::make_instance_with_id(class_name, updated_attrs, target_id),
+                            );
+                        }
+                        return Ok(result);
+                    }
+                    Err(err) => {
+                        if !err.message.starts_with("No native mutable method") {
+                            return Err(err);
+                        }
+                    }
+                }
+            }
             return Err(super::methods_signature::make_multi_no_match_error(method));
         } else {
             return Err(super::methods_signature::make_multi_no_match_error(method));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1489,7 +1489,10 @@ impl Interpreter {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["cue"].iter().map(|s| s.to_string()).collect(),
+                native_methods: ["cue", "uncaught_handler"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
                 mro: vec!["ThreadPoolScheduler".to_string()],
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
@@ -1504,7 +1507,10 @@ impl Interpreter {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["cue"].iter().map(|s| s.to_string()).collect(),
+                native_methods: ["cue", "uncaught_handler"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
                 mro: vec!["CurrentThreadScheduler".to_string()],
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -248,7 +248,14 @@ impl Interpreter {
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
         let dispatch_class = if matches!(
             class_name,
-            "Promise" | "Channel" | "Supply" | "Supplier" | "Proc::Async" | "Encoding::Decoder"
+            "Promise"
+                | "Channel"
+                | "Supply"
+                | "Supplier"
+                | "Proc::Async"
+                | "Encoding::Decoder"
+                | "ThreadPoolScheduler"
+                | "CurrentThreadScheduler"
         ) {
             Some(class_name.to_string())
         } else {
@@ -261,6 +268,8 @@ impl Interpreter {
                         | "Supplier"
                         | "Proc::Async"
                         | "Encoding::Decoder"
+                        | "ThreadPoolScheduler"
+                        | "CurrentThreadScheduler"
                 )
             })
         };
@@ -273,6 +282,9 @@ impl Interpreter {
             }
             "Proc::Async" => self.native_proc_async_mut(attributes, method, args),
             "Encoding::Decoder" => Self::native_encoding_decoder_mut(attributes, method, args),
+            "ThreadPoolScheduler" | "CurrentThreadScheduler" => {
+                Interpreter::native_scheduler_mut(attributes, method, args)
+            }
             _ => Err(RuntimeError::new(format!(
                 "No native mutable method '{}' on '{}'",
                 method, class_name

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 use super::state::*;
 use super::state_lock::*;
-use super::state_scheduler::*;
+use super::state_scheduler::{self, *};
 use super::state_supplier::close_supplier_tap;
 
 /// Parameters for a scheduled cue operation.
@@ -228,8 +228,32 @@ impl Interpreter {
                 }
                 Ok(cancellation)
             }
+            "uncaught_handler" => {
+                // Getter: return current uncaught_handler or Nil
+                Ok(state_scheduler::get_uncaught_handler().unwrap_or(Value::Nil))
+            }
             _ => Err(RuntimeError::new(format!(
                 "No native method '{}' on Scheduler",
+                method
+            ))),
+        }
+    }
+
+    /// Mutable dispatch for Scheduler: handles uncaught_handler setter.
+    /// Returns (result_value, updated_attributes).
+    pub(in crate::runtime) fn native_scheduler_mut(
+        attributes: HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        match method {
+            "uncaught_handler" => {
+                let handler = args.into_iter().next().unwrap_or(Value::Nil);
+                state_scheduler::set_uncaught_handler(handler.clone());
+                Ok((handler, attributes))
+            }
+            _ => Err(RuntimeError::new(format!(
+                "No native mutable method '{}' on Scheduler",
                 method
             ))),
         }

--- a/src/runtime/native_methods/state_scheduler.rs
+++ b/src/runtime/native_methods/state_scheduler.rs
@@ -2,6 +2,29 @@ use crate::runtime::*;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+// --- Global uncaught_handler for $*SCHEDULER ---
+
+type UncaughtHandlerStore = std::sync::Mutex<Option<Value>>;
+
+fn uncaught_handler_store() -> &'static UncaughtHandlerStore {
+    static HANDLER: OnceLock<UncaughtHandlerStore> = OnceLock::new();
+    HANDLER.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Get the current uncaught_handler value (None if not set).
+pub(in crate::runtime) fn get_uncaught_handler() -> Option<Value> {
+    uncaught_handler_store().lock().unwrap().clone()
+}
+
+/// Set the uncaught_handler. Pass Value::Nil to clear it.
+pub(in crate::runtime) fn set_uncaught_handler(handler: Value) {
+    let mut guard = uncaught_handler_store().lock().unwrap();
+    match &handler {
+        Value::Nil => *guard = None,
+        _ => *guard = Some(handler),
+    }
+}
+
 // --- FakeScheduler support (for Test::Tap) ---
 
 /// A scheduled item in a FakeScheduler.


### PR DESCRIPTION
## Summary

- Add global uncaught_handler storage in `state_scheduler.rs` with get/set functions
- Implement `uncaught_handler` getter in `native_scheduler` and `uncaught_handler` setter in `native_scheduler_mut`
- Register `ThreadPoolScheduler` and `CurrentThreadScheduler` with `uncaught_handler` as a native method
- Fix `assign_method_lvalue_with_values` to try native mutable method dispatch when no class attribute or user method is found
- Invoke the uncaught handler in `spawn_callable_promise` when a sunk `start` block throws

This enables tests 61-65 in `roast/S17-promise/start.t` to pass (previously they produced "No matching candidates for method: uncaught_handler").

## Test plan

- [x] `make test` passes (481 tests)
- [x] Tests 61-65 in `roast/S17-promise/start.t` now pass (`$*SCHEDULER.uncaught_handler` setter/getter works, handler is called for broken sunk promises)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)