### PR TITLE
fix: throw X::Syntax::Confused for unknown postfix operators and two-terms-in-a-row

### DIFF
--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -133,9 +133,19 @@ impl Interpreter {
                         return Ok(Value::Complex(0.0, num_val));
                     }
                     _ => {
-                        // Fall through to the generic unknown function error below
+                        // Unknown postfix operator is a syntax error in Raku (X::Syntax::Confused)
+                        return Err(RuntimeError::syntax_confused_with_reason(format!(
+                            "Bogus postfix: {}",
+                            op
+                        )));
                     }
                 }
+            } else {
+                // Unknown postfix operator with no args is still a syntax error
+                return Err(RuntimeError::syntax_confused_with_reason(format!(
+                    "Bogus postfix: {}",
+                    op
+                )));
             }
         }
         if (self.loaded_modules.contains("Test")

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -627,6 +627,15 @@ impl RuntimeError {
         Self::typed_msg("X::Syntax::Confused", message)
     }
 
+    /// X::Syntax::Confused with a reason attribute (for "Two terms in a row" etc.)
+    pub(crate) fn syntax_confused_with_reason(reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(reason.clone()));
+        attrs.insert("reason".to_string(), Value::str(reason));
+        Self::typed("X::Syntax::Confused", attrs)
+    }
+
     /// X::Syntax::Malformed - Malformed syntax
     #[allow(dead_code)]
     pub(crate) fn syntax_malformed(what: &str, message: impl Into<String>) -> Self {

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1653,10 +1653,9 @@ impl VM {
                         attrs.insert("of".to_string(), Value::Package(Symbol::intern("Mu")));
                         return Ok(Value::make_instance(Symbol::intern("Method"), attrs));
                     }
-                    Err(RuntimeError::new(format!(
-                        "Confused: two terms in a row (unknown infix function: {})",
-                        name
-                    )))
+                    Err(RuntimeError::syntax_confused_with_reason(
+                        "Two terms in a row",
+                    ))
                 } else {
                     if let Some(op_name) = infix_name {
                         let op_env_name = format!("&{}", op_name);
@@ -1692,10 +1691,9 @@ impl VM {
                             attrs.insert("of".to_string(), Value::Package(Symbol::intern("Mu")));
                             return Ok(Value::make_instance(Symbol::intern("Method"), attrs));
                         }
-                        Err(RuntimeError::new(format!(
-                            "Confused: two terms in a row (unknown infix function: {})",
-                            name
-                        )))
+                        Err(RuntimeError::syntax_confused_with_reason(
+                            "Two terms in a row",
+                        ))
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add `syntax_confused_with_reason()` helper to `RuntimeError` that creates a proper `X::Syntax::Confused` typed exception with `.reason` attribute
- Update "two terms in a row" infix function errors to use the new helper (so `.reason` is set)
- Unknown postfix operators (e.g. `5!`) now throw `X::Syntax::Confused` instead of `X::Undeclared::Symbols`

## Motivation

Fixes test 19 in `roast/S06-operator-overloading/imported-subs.t`:
```
throws-like '5!', X::Syntax::Confused;
```
This was failing because `5!` incorrectly produced `X::Undeclared::Symbols` ("Unknown function: postfix:<!>") instead of `X::Syntax::Confused`.

Result: 17/20 subtests now pass (was 16/20). Tests 15-17 remain blocked on a module export scoping issue (non-exported `infix:<notthere>` from `use Exportops` is still accessible in EVAL context).

## Test plan

- `prove -e 'target/debug/mutsu' roast/S06-operator-overloading/imported-subs.t` — 17/20 pass
- `make test` — all 481 local tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)