### PR TITLE
fix: handle IO::Path ~~ Str smartmatch and add chdir.t to whitelist

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -939,6 +939,7 @@ roast/S32-io/IO-Socket-Async.t
 roast/S32-io/IO-Socket-INET-UNIX.t
 roast/S32-io/IO-Socket-INET.t
 roast/S32-io/chdir-process.t
+roast/S32-io/chdir.t
 roast/S32-io/copy.t
 roast/S32-io/dir.t
 roast/S32-io/io-path-extension.t

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1450,6 +1450,12 @@ impl Interpreter {
                     false
                 }
             }
+            // IO::Path ~~ Str: compare path string representation with string.
+            // In Raku, Str.ACCEPTS(IO::Path) stringifies the IO::Path and compares.
+            // This handles cases like `dir().grep("filename")` after chdir.
+            (Value::Instance { class_name: cn, .. }, Value::Str(_)) if cn == "IO::Path" => {
+                left.to_string_value() == right.to_string_value()
+            }
             // Instance ~~ Type or other: identity check (false)
             (Value::Instance { .. }, _) | (_, Value::Instance { .. }) => false,
             // Range ~~ Range: LHS is subset of RHS.

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -544,6 +544,13 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             )
         }
 
+        // IO::Path ~~ Str: compare path string representation with string.
+        // In Raku, Str.ACCEPTS(IO::Path) stringifies the IO::Path and compares.
+        // This handles cases like `dir().grep("filename")` after chdir.
+        (Value::Instance { class_name: cn, .. }, Value::Str(s)) if cn == "IO::Path" => {
+            Some(left.to_string_value() == s.as_str())
+        }
+
         // Instance ~~ Instance identity check (generic, after all specific instance checks).
         // Exclude Signature (needs special ACCEPTS logic) and X::AdHoc (needs payload delegation).
         (


### PR DESCRIPTION
## Summary
- Add IO::Path ~~ Str case to `pure_smart_match` in `vm/vm_smart_match.rs`: stringifies the IO::Path and compares to the string, matching Raku's `Str.ACCEPTS(IO::Path)` semantics
- Add same case to interpreter `smart_match` in `runtime/seq_helpers/smart_match.rs` to handle slow-path cases
- Add `roast/S32-io/chdir.t` to the whitelist (all 82 subtests now pass)

This fixes `dir().grep("filename")` after chdir, where grep uses smartmatch (`~~`) to compare IO::Path entries against a string.

## Test plan
- [ ] `prove -e 'target/debug/mutsu' roast/S32-io/chdir.t` passes all 82 subtests
- [ ] `make test` passes without regressions
- [ ] `LC_ALL=C sort -c roast-whitelist.txt` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)