### PR TITLE
fix: implement temp keyword with index/dollar-paren support and X::Dynamic::NotFound

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -5,6 +5,9 @@
 - [ ] roast/S04-blocks-and-statements/pointy.t
   - 7/21 pass (4-7, 13-15). Pointy blocks work in list context. Failures: `-> $x { }` without parens (1), immediately invoked pointy (2-3), block control exceptions (8-9), return from pointy (10-11), `$^a` in pointy (12), .signature (16), YOU_ARE_HERE (17-19). Only 19 reached. Difficulty: Medium
 - [ ] roast/S04-blocks-and-statements/temp.t
+  - 39/46 pass. Remaining failures:
+    - Test 21: `temp $struct[1]<key>[1] = 23` (deeply-nested multi-level indexed temp not implemented; parser only handles one level of indexing after temp)
+    - Tests 24-26, 31-33: TEMP phaser blocks (`TEMP {{ $next = $curr }}` syntax) NYI; the `TEMP` keyword is not recognized as a phaser and `{{ }}` double-block is not handled, causing the inner block to run immediately instead of deferring to scope exit
 - [ ] roast/S04-declarations/constant-6.d.t
 - [ ] roast/S04-declarations/constant.t
   - 18/72 pass. Panic fixed (UTF-8 boundary in try_meta_op). Failures: sigiled constants (5-6), constant reassignment checks, our/my scoping, hash/array constants, type constraint enforcement. Difficulty: Medium

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -357,6 +357,9 @@ pub(crate) enum Expr {
     DoBlock {
         body: Vec<Stmt>,
         label: Option<String>,
+        /// True when created from `$(...)` syntax.
+        /// In that case, `temp` saves propagate to the enclosing block scope.
+        dollar_paren: bool,
     },
     DoStmt(Box<Stmt>),
     ControlFlow {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -332,8 +332,13 @@ impl Compiler {
                 self.compile_try(body, catch);
             }
             Expr::DoBlock { .. } => {
-                if let Expr::DoBlock { body, label } = expr {
-                    self.compile_do_block_expr(body, label);
+                if let Expr::DoBlock {
+                    body,
+                    label,
+                    dollar_paren,
+                } = expr
+                {
+                    self.compile_do_block_expr(body, label, *dollar_paren);
                 }
             }
             Expr::DoStmt(stmt) => {

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -371,6 +371,7 @@ impl Compiler {
                 let do_block = Expr::DoBlock {
                     body: vec![Stmt::Expr(viv_assign), Stmt::Expr(method_call)],
                     label: None,
+                    dollar_paren: false,
                 };
                 self.compile_expr(&do_block);
             } else {
@@ -392,6 +393,7 @@ impl Compiler {
                     let do_block = Expr::DoBlock {
                         body: body.clone(),
                         label: None,
+                        dollar_paren: false,
                     };
                     self.compile_expr(&do_block);
                     // Discard the block result and push Nil
@@ -534,6 +536,7 @@ impl Compiler {
                             Stmt::Expr(Expr::Var(seen_name)),
                         ],
                         label: None,
+                        dollar_paren: false,
                     };
                     self.compile_expr(&cas_expr);
                 } else {
@@ -584,6 +587,37 @@ impl Compiler {
                 };
                 self.compile_expr(&assign_expr);
             } else {
+                let arity = args.len() as u32;
+                let arg_sources_idx = self.add_arg_sources_constant(args);
+                for arg in args {
+                    self.compile_expr(arg);
+                }
+                let name_idx = self.code.add_constant(Value::str(name.resolve()));
+                self.code.emit(OpCode::CallFunc {
+                    name_idx,
+                    arity,
+                    arg_sources_idx,
+                });
+            }
+        } else if name == "temp" && args.len() == 1 {
+            // Expression-context `temp $var` / `temp @var` / `temp %var`:
+            // emit LetSave so the outer LetBlock restores the variable on exit.
+            let var_name = match &args[0] {
+                Expr::Var(n) => n.clone(),
+                Expr::ArrayVar(n) => format!("@{}", n),
+                Expr::HashVar(n) => format!("%{}", n),
+                _ => String::new(),
+            };
+            if !var_name.is_empty() {
+                let name_idx = self.code.add_constant(Value::str(var_name));
+                self.code.emit(OpCode::LetSave {
+                    name_idx,
+                    index_mode: false,
+                    is_temp: true,
+                });
+                self.compile_expr(&args[0]);
+            } else {
+                // Fallthrough: compile as regular function call
                 let arity = args.len() as u32;
                 let arg_sources_idx = self.add_arg_sources_constant(args);
                 for arg in args {

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -33,7 +33,24 @@ impl Compiler {
                 self.code.emit(OpCode::BoolCoerce);
             }
             TokenKind::PlusPlus => {
-                if let Expr::Var(name) = expr {
+                // Handle ++temp $var: save $var then increment it
+                if let Expr::Call {
+                    name: call_name,
+                    args: call_args,
+                } = expr
+                    && call_name == "temp"
+                    && call_args.len() == 1
+                    && let Expr::Var(var_name) = &call_args[0]
+                {
+                    let save_name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                    self.code.emit(OpCode::LetSave {
+                        name_idx: save_name_idx,
+                        index_mode: false,
+                        is_temp: true,
+                    });
+                    let inc_name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                    self.code.emit(OpCode::PreIncrement(inc_name_idx));
+                } else if let Expr::Var(name) = expr {
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::PreIncrement(name_idx));
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
@@ -58,7 +75,24 @@ impl Compiler {
                 }
             }
             TokenKind::MinusMinus => {
-                if let Expr::Var(name) = expr {
+                // Handle --temp $var: save $var then decrement it
+                if let Expr::Call {
+                    name: call_name,
+                    args: call_args,
+                } = expr
+                    && call_name == "temp"
+                    && call_args.len() == 1
+                    && let Expr::Var(var_name) = &call_args[0]
+                {
+                    let save_name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                    self.code.emit(OpCode::LetSave {
+                        name_idx: save_name_idx,
+                        index_mode: false,
+                        is_temp: true,
+                    });
+                    let dec_name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                    self.code.emit(OpCode::PreDecrement(dec_name_idx));
+                } else if let Expr::Var(name) = expr {
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::PreDecrement(name_idx));
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -79,7 +79,12 @@ impl Compiler {
     }
 
     pub(super) fn index_assign_target_requires_eval(target: &Expr) -> bool {
-        matches!(target, Expr::AssignExpr { .. } | Expr::DoStmt(_))
+        match target {
+            Expr::AssignExpr { .. } | Expr::DoStmt(_) => true,
+            // `temp %hash` / `temp @arr` needs eval to emit LetSave
+            Expr::Call { name, .. } if name == "temp" => true,
+            _ => false,
+        }
     }
 
     /// Extract the variable name from a method call target (e.g., `$foo.bar` → "foo").

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -1,7 +1,12 @@
 use super::*;
 
 impl Compiler {
-    pub(super) fn compile_do_block_expr(&mut self, body: &[Stmt], label: &Option<String>) {
+    pub(super) fn compile_do_block_expr(
+        &mut self,
+        body: &[Stmt],
+        label: &Option<String>,
+        dollar_paren: bool,
+    ) {
         // If the do block contains CATCH/CONTROL, compile as try so exceptions are handled.
         if Self::has_catch_or_control(body) {
             self.compile_try(body, &None);
@@ -131,7 +136,37 @@ impl Compiler {
             label: label.clone(),
             scope_isolate: false,
         });
-        self.compile_block_inline(body);
+        // For plain `do { }` (not `$()`): wrap in LetBlock so that any `temp`
+        // saves made inside are restored when *this* do-block exits.
+        // For `$(...)` (dollar_paren=true): skip the inner LetBlock so the
+        // temp saves are captured by the *enclosing* block's LetBlock instead.
+        if Self::has_let_deep(body) && !dollar_paren {
+            let let_idx = self.code.emit(OpCode::LetBlock { body_end: 0 });
+            let needs_topic = Self::has_real_let_deep(body);
+            for (i, s) in body.iter().enumerate() {
+                let is_last = i == body.len() - 1;
+                if is_last && needs_topic {
+                    self.compile_last_stmt_as_topic(s);
+                    self.compile_expr(&crate::ast::Expr::Var("_".to_string()));
+                } else if is_last {
+                    match s {
+                        crate::ast::Stmt::Expr(expr) => {
+                            self.compile_expr(expr);
+                        }
+                        _ => {
+                            self.compile_stmt(s);
+                            let true_idx = self.code.add_constant(crate::value::Value::Bool(true));
+                            self.code.emit(OpCode::LoadConst(true_idx));
+                        }
+                    }
+                } else {
+                    self.compile_stmt(s);
+                }
+            }
+            self.code.patch_let_block_end(let_idx);
+        } else {
+            self.compile_block_inline(body);
+        }
         self.code.patch_body_end(idx);
     }
 
@@ -204,7 +239,7 @@ impl Compiler {
                         && matches!(items[0], Expr::Literal(Value::Nil))
             )
         {
-            self.compile_do_block_expr(body, label);
+            self.compile_do_block_expr(body, label, false);
             return;
         }
 

--- a/src/compiler/helpers_stmt_analysis.rs
+++ b/src/compiler/helpers_stmt_analysis.rs
@@ -34,6 +34,16 @@ impl Compiler {
                         }
                     }
                 }
+                Stmt::VarDecl { expr, .. } => {
+                    if Self::expr_has_let_deep(expr) {
+                        return true;
+                    }
+                }
+                Stmt::Assign { expr, .. } => {
+                    if Self::expr_has_let_deep(expr) {
+                        return true;
+                    }
+                }
                 _ => {}
             }
         }
@@ -75,6 +85,16 @@ impl Compiler {
                         }
                     }
                 }
+                Stmt::VarDecl { expr, .. } => {
+                    if Self::expr_has_real_let_deep(expr) {
+                        return true;
+                    }
+                }
+                Stmt::Assign { expr, .. } => {
+                    if Self::expr_has_real_let_deep(expr) {
+                        return true;
+                    }
+                }
                 _ => {}
             }
         }
@@ -84,7 +104,13 @@ impl Compiler {
     /// Check if an expression contains actual `let` (not `temp`) deep inside.
     fn expr_has_real_let_deep(expr: &Expr) -> bool {
         match expr {
-            Expr::DoBlock { body, .. } => Self::has_real_let_deep(body),
+            // Only propagate through dollar_paren DoBlocks; plain do{} manages its own scope.
+            Expr::DoBlock {
+                body,
+                dollar_paren: true,
+                ..
+            } => Self::has_real_let_deep(body),
+            Expr::DoBlock { .. } => false,
             Expr::Try { body, .. } => Self::has_real_let_deep(body),
             Expr::Call { args, .. } => args.iter().any(Self::expr_has_real_let_deep),
             Expr::MethodCall { args, target, .. }
@@ -107,8 +133,16 @@ impl Compiler {
 
     pub(super) fn expr_has_let_deep(expr: &Expr) -> bool {
         match expr {
-            Expr::DoBlock { body, .. } => Self::has_let_deep(body),
+            // Only propagate through dollar_paren DoBlocks; plain do{} manages its own scope.
+            Expr::DoBlock {
+                body,
+                dollar_paren: true,
+                ..
+            } => Self::has_let_deep(body),
+            Expr::DoBlock { .. } => false,
             Expr::Try { body, .. } => Self::has_let_deep(body),
+            // `temp $x` / `temp @x` / `temp %x` in expression context
+            Expr::Call { name, .. } if name == "temp" => true,
             Expr::Call { args, .. } => args.iter().any(Self::expr_has_let_deep),
             Expr::MethodCall { args, target, .. }
             | Expr::DynamicMethodCall { args, target, .. }
@@ -116,6 +150,21 @@ impl Compiler {
             | Expr::HyperMethodCallDynamic { args, target, .. } => {
                 Self::expr_has_let_deep(target) || args.iter().any(Self::expr_has_let_deep)
             }
+            // IndexAssign: check if the target is a temp expression
+            Expr::IndexAssign {
+                target,
+                value,
+                index,
+                ..
+            } => {
+                Self::expr_has_let_deep(target)
+                    || Self::expr_has_let_deep(value)
+                    || Self::expr_has_let_deep(index)
+            }
+            // AssignExpr: check the rhs
+            Expr::AssignExpr { expr, .. } => Self::expr_has_let_deep(expr),
+            // Unary: check the inner expression (e.g., ++temp $c)
+            Expr::Unary { expr, .. } => Self::expr_has_let_deep(expr),
             _ => false,
         }
     }

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -248,7 +248,17 @@ impl Compiler {
             Self::compile_post_phasers(&mut sub_compiler, body);
             sub_compiler.code.patch_loop_end(idx);
         } else if sink_last_expr {
-            Self::compile_routine_body_stmts(&mut sub_compiler, body, true);
+            if Self::has_let_deep(body) {
+                let let_idx = sub_compiler.code.emit(OpCode::LetBlock { body_end: 0 });
+                Self::compile_routine_body_stmts(&mut sub_compiler, body, true);
+                sub_compiler.code.patch_let_block_end(let_idx);
+            } else {
+                Self::compile_routine_body_stmts(&mut sub_compiler, body, true);
+            }
+        } else if Self::has_let_deep(body) {
+            let let_idx = sub_compiler.code.emit(OpCode::LetBlock { body_end: 0 });
+            Self::compile_routine_body_stmts(&mut sub_compiler, body, false);
+            sub_compiler.code.patch_let_block_end(let_idx);
         } else {
             Self::compile_routine_body_stmts(&mut sub_compiler, body, false);
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1553,6 +1553,7 @@ impl Compiler {
                     // Register the package name so it's accessible as a value
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
                     self.code.emit(OpCode::RegisterPackage { name_idx });
+                    self.code.emit(OpCode::SetCurrentPackage { name_idx });
                 } else if is_stub_body {
                     // Stub package — register name but don't execute the body
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1978,15 +1978,17 @@ impl Compiler {
                         let target_expr = if let Some(stripped) = name.strip_prefix('@') {
                             Expr::ArrayVar(stripped.to_string())
                         } else if let Some(stripped) = name.strip_prefix('%') {
-                            Expr::Var(stripped.to_string())
+                            Expr::HashVar(stripped.to_string())
                         } else {
                             Expr::Var(name.to_string())
                         };
+                        // Array subscript uses positional index; hash subscript does not.
+                        let is_positional = name.starts_with('@');
                         let assign_expr = Expr::IndexAssign {
                             target: Box::new(target_expr),
                             index: Box::new(index.as_ref().unwrap().as_ref().clone()),
                             value: Box::new(val_expr.as_ref().clone()),
-                            is_positional: true,
+                            is_positional,
                         };
                         self.compile_expr(&assign_expr);
                         self.code.emit(OpCode::Pop);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -658,6 +658,11 @@ pub(crate) enum OpCode {
     ClearPackageStub {
         name_idx: u32,
     },
+    /// Set the interpreter's current package for the remainder of the current
+    /// compilation unit (used by `unit module` / `unit package`).
+    SetCurrentPackage {
+        name_idx: u32,
+    },
 
     // -- Phaser --
     PhaserEnd(u32),

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -812,6 +812,7 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             }
         }
         // ($var = expr).=method => evaluate the assignment, then $var = $var.method
@@ -835,6 +836,7 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             }
         }
         _ => method_call_fn(target),

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -537,6 +537,7 @@ fn assignment_ro_expr(lhs: Expr, rhs: Expr) -> Expr {
             }),
         ],
         label: None,
+        dollar_paren: false,
     }
 }
 
@@ -2441,6 +2442,7 @@ fn build_chain_cmp_expr(
             }),
         ],
         label: None,
+        dollar_paren: false,
     }
 }
 

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -591,6 +591,13 @@ pub(super) fn itemized_paren_expr(input: &str) -> PResult<'_, Expr> {
     if !rest.starts_with('(') {
         return Err(PError::expected("itemized parenthesized expression"));
     }
+    // First, try to parse as a statement block: $(stmt; expr)
+    // This handles `$(temp $a = 23; $a)` and similar constructs where
+    // the content contains statements with semicolons.
+    let inner = &rest[1..]; // strip the leading '('
+    if let Ok(result) = super::var::parse_dollar_paren_block_pub(inner) {
+        return Ok(result);
+    }
     let (rest, inner) = paren_expr(rest)?;
     // Lower $(expr) to expr.item — wraps the value in a Scalar container
     Ok((

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1492,7 +1492,14 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         ));
                     }
                 }
-                return Ok((r, Expr::DoBlock { body, label: None }));
+                return Ok((
+                    r,
+                    Expr::DoBlock {
+                        body,
+                        label: None,
+                        dollar_paren: false,
+                    },
+                ));
             }
             // do if/unless/given/for/while — wrap the control flow statement
             {
@@ -1841,6 +1848,7 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         Expr::DoBlock {
                             body: vec![stmt, Stmt::Expr(anon_sub)],
                             label: None,
+                            dollar_paren: false,
                         },
                     ));
                 }

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -1908,6 +1908,7 @@ pub(super) fn try_interpolate_var<'a>(
                         Some(Expr::DoBlock {
                             body: stmts,
                             label: None,
+                            dollar_paren: false,
                         })
                     }
                 } else if let Ok((leftover, expr)) = expression(inner.trim())

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -974,7 +974,12 @@ fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(
 }
 
 /// Parse `$(stmt; stmt; ... expr)` — statement block in scalar context.
-/// Returns DoBlock expression.
+/// `input` is the content AFTER the opening `(` but BEFORE the closing `)`.
+/// Returns DoBlock expression including the consumed `)`.
+pub(super) fn parse_dollar_paren_block_pub(input: &str) -> PResult<'_, Expr> {
+    parse_dollar_paren_block(input)
+}
+
 fn parse_dollar_paren_block(input: &str) -> PResult<'_, Expr> {
     use super::super::helpers::ws;
     // Parse first statement
@@ -1005,6 +1010,7 @@ fn parse_dollar_paren_block(input: &str) -> PResult<'_, Expr> {
         Expr::DoBlock {
             body: stmts,
             label: None,
+            dollar_paren: true,
         },
     ))
 }

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -249,6 +249,7 @@ pub(crate) fn compound_assigned_value_expr(lhs: Expr, op: CompoundAssignOp, rhs:
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             }),
             then_expr: Box::new(tmp_var),
             else_expr: Box::new(rhs),
@@ -281,6 +282,7 @@ pub(crate) fn compound_assigned_value_expr(lhs: Expr, op: CompoundAssignOp, rhs:
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             }),
             then_expr: Box::new(rhs),
             else_expr: Box::new(tmp_var),
@@ -792,6 +794,7 @@ where
             }),
         ],
         label: None,
+        dollar_paren: false,
     }
 }
 
@@ -926,6 +929,7 @@ pub(crate) fn build_compound_assign_expr(
                             }),
                         ],
                         label: None,
+                        dollar_paren: false,
                     }),
                 }
             } else {
@@ -939,6 +943,7 @@ pub(crate) fn build_compound_assign_expr(
                         }),
                     ],
                     label: None,
+                    dollar_paren: false,
                 }
             }
         }

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1733,6 +1733,7 @@ pub(super) fn loop_stmt(input: &str) -> PResult<'_, Stmt> {
                     Some(Expr::DoBlock {
                         body: stmts,
                         label: None,
+                        dollar_paren: false,
                     }),
                 )
             }

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -1554,6 +1554,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_unit_role_decl() {
+        let (rest, stmts) = program("unit role RoleB;").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(stmts.len(), 1);
+        assert!(matches!(&stmts[0], Stmt::RoleDecl { name, .. } if name == "RoleB"));
+    }
+
+    #[test]
     fn parse_class_decl() {
         let (rest, stmts) = program("class Foo { has $.x; method bar { 42 } }").unwrap();
         assert_eq!(rest, "");

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -558,6 +558,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                         }),
                     ],
                     label: None,
+                    dollar_paren: false,
                 });
                 return parse_statement_modifier(r, stmt);
             }
@@ -706,6 +707,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                         }),
                     ],
                     label: None,
+                    dollar_paren: false,
                 });
                 return parse_statement_modifier(r, stmt);
             }
@@ -1345,6 +1347,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             });
             return parse_statement_modifier(r, stmt);
         }
@@ -1408,6 +1411,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                         }),
                     ],
                     label: None,
+                    dollar_paren: false,
                 }),
             })
         } else {
@@ -1421,6 +1425,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                     }),
                 ],
                 label: None,
+                dollar_paren: false,
             })
         };
         return parse_statement_modifier(r, stmt);
@@ -1691,6 +1696,110 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
         format!("{}{}{}", sigil, twigil, var_name)
     };
     let (rest, _) = ws(rest)?;
+    // Check for index: @arr[idx] or %hash<key>
+    if let Some(idx_rest) = rest.strip_prefix('[') {
+        let (idx_rest, _) = ws(idx_rest)?;
+        let (idx_rest, idx_expr) = expression(idx_rest)?;
+        let (idx_rest, _) = ws(idx_rest)?;
+        let (idx_rest, _) = parse_char(idx_rest, ']')?;
+        let (idx_rest, _) = ws(idx_rest)?;
+        if idx_rest.starts_with('=') && !idx_rest.starts_with("==") {
+            let val_rest = &idx_rest[1..];
+            let (val_rest, _) = ws(val_rest)?;
+            let (val_rest, val_expr) = expression(val_rest)?;
+            return parse_statement_modifier(
+                val_rest,
+                Stmt::Let {
+                    name: full_name,
+                    index: Some(Box::new(idx_expr)),
+                    value: Some(Box::new(val_expr)),
+                    is_temp: true,
+                },
+            );
+        }
+        return parse_statement_modifier(
+            idx_rest,
+            Stmt::Let {
+                name: full_name,
+                index: Some(Box::new(idx_expr)),
+                value: None,
+                is_temp: true,
+            },
+        );
+    }
+    // Check for hash key: %hash<key> or $hash<key>
+    if let Some(idx_rest) = rest.strip_prefix('<') {
+        // Find the matching '>'
+        if let Some(end_pos) = idx_rest.find('>') {
+            let key_str = &idx_rest[..end_pos];
+            // Only use this path for simple word keys (no spaces or special chars inside)
+            if !key_str.is_empty()
+                && key_str
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            {
+                let idx_rest2 = &idx_rest[end_pos + 1..];
+                let (idx_rest2, _) = ws(idx_rest2)?;
+                let key_expr = Expr::Literal(crate::value::Value::str(key_str.to_string()));
+                if idx_rest2.starts_with('=') && !idx_rest2.starts_with("==") {
+                    let val_rest = &idx_rest2[1..];
+                    let (val_rest, _) = ws(val_rest)?;
+                    let (val_rest, val_expr) = expression(val_rest)?;
+                    return parse_statement_modifier(
+                        val_rest,
+                        Stmt::Let {
+                            name: full_name,
+                            index: Some(Box::new(key_expr)),
+                            value: Some(Box::new(val_expr)),
+                            is_temp: true,
+                        },
+                    );
+                }
+                return parse_statement_modifier(
+                    idx_rest2,
+                    Stmt::Let {
+                        name: full_name,
+                        index: Some(Box::new(key_expr)),
+                        value: None,
+                        is_temp: true,
+                    },
+                );
+            }
+        }
+    }
+    // Check for hash key with braces: %hash{expr}
+    if let Some(idx_rest) = rest.strip_prefix('{') {
+        let (idx_rest, _) = ws(idx_rest)?;
+        if let Ok((idx_rest, idx_expr)) = expression(idx_rest) {
+            let (idx_rest, _) = ws(idx_rest)?;
+            if let Ok((idx_rest, _)) = parse_char(idx_rest, '}') {
+                let (idx_rest, _) = ws(idx_rest)?;
+                if idx_rest.starts_with('=') && !idx_rest.starts_with("==") {
+                    let val_rest = &idx_rest[1..];
+                    let (val_rest, _) = ws(val_rest)?;
+                    let (val_rest, val_expr) = expression(val_rest)?;
+                    return parse_statement_modifier(
+                        val_rest,
+                        Stmt::Let {
+                            name: full_name,
+                            index: Some(Box::new(idx_expr)),
+                            value: Some(Box::new(val_expr)),
+                            is_temp: true,
+                        },
+                    );
+                }
+                return parse_statement_modifier(
+                    idx_rest,
+                    Stmt::Let {
+                        name: full_name,
+                        index: Some(Box::new(idx_expr)),
+                        value: None,
+                        is_temp: true,
+                    },
+                );
+            }
+        }
+    }
     // Check for assignment: temp $*CWD = expr
     if rest.starts_with('=') && !rest.starts_with("==") {
         let val_rest = &rest[1..];

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -327,6 +327,44 @@ impl Interpreter {
                                 ));
                             }
                         };
+                    // When the function's package is not GLOBAL, the Compiler qualifies
+                    // bare variable references as $Package::name. Ensure parameter
+                    // bindings are also reachable via those qualified names.
+                    let cur_pkg = self.current_package().to_string();
+                    if cur_pkg != "GLOBAL" {
+                        let qualified_aliases: Vec<(String, Value)> = def
+                            .param_defs
+                            .iter()
+                            .filter_map(|pd| {
+                                let bare = pd
+                                    .name
+                                    .strip_prefix('$')
+                                    .or_else(|| pd.name.strip_prefix('@'))
+                                    .or_else(|| pd.name.strip_prefix('%'))
+                                    .or_else(|| pd.name.strip_prefix('&'));
+                                if let Some(bare) = bare {
+                                    self.env.get(&pd.name).cloned().map(|v| {
+                                        let sigil = &pd.name[..pd.name.len() - bare.len()];
+                                        (format!("{}{}::{}", sigil, cur_pkg, bare), v)
+                                    })
+                                } else if !pd.name.is_empty()
+                                    && !pd.name.starts_with('_')
+                                    && !pd.name.starts_with('!')
+                                    && !pd.name.contains("::")
+                                {
+                                    self.env
+                                        .get(&pd.name)
+                                        .cloned()
+                                        .map(|v| (format!("{}::{}", cur_pkg, pd.name), v))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        for (key, val) in qualified_aliases {
+                            self.env.insert(key, val);
+                        }
+                    }
                     let sub_val = Value::make_sub(
                         def.package,
                         def.name,

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -117,7 +117,7 @@ impl Interpreter {
         let saved_package = self.current_package().to_string();
         let def_package = def.package.resolve();
         if !def_package.is_empty() && def_package != "GLOBAL" {
-            self.set_current_package(def_package);
+            self.set_current_package(def_package.clone());
         }
         let return_spec = self.routine_return_spec_by_name(&def.name.resolve());
         let rw_bindings = match self.bind_function_args_values(&def.param_defs, &def.params, &args)
@@ -139,8 +139,10 @@ impl Interpreter {
         // When the function's package is not GLOBAL, the Compiler qualifies
         // bare variable references as $Package::name.  Ensure parameter bindings
         // are also reachable via those qualified names.
+        // Only add aliases for the function's own package (not for the caller's
+        // package when calling a GLOBAL function from a non-GLOBAL context).
         let cur_pkg = self.current_package().to_string();
-        if cur_pkg != "GLOBAL" {
+        if !def_package.is_empty() && def_package != "GLOBAL" {
             let qualified_aliases: Vec<(String, Value)> = def
                 .param_defs
                 .iter()
@@ -308,7 +310,7 @@ impl Interpreter {
                     let saved_package = self.current_package().to_string();
                     let def_package = def.package.resolve();
                     if !def_package.is_empty() && def_package != "GLOBAL" {
-                        self.set_current_package(def_package);
+                        self.set_current_package(def_package.clone());
                     }
                     let return_spec = self.routine_return_spec_by_name(&def.name.resolve());
                     let rw_bindings =
@@ -330,8 +332,11 @@ impl Interpreter {
                     // When the function's package is not GLOBAL, the Compiler qualifies
                     // bare variable references as $Package::name. Ensure parameter
                     // bindings are also reachable via those qualified names.
+                    // Only add aliases for the function's own package (not for the
+                    // caller's package when calling a GLOBAL function from a
+                    // non-GLOBAL context).
                     let cur_pkg = self.current_package().to_string();
-                    if cur_pkg != "GLOBAL" {
+                    if !def_package.is_empty() && def_package != "GLOBAL" {
                         let qualified_aliases: Vec<(String, Value)> = def
                             .param_defs
                             .iter()

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1210,7 +1210,18 @@ impl Interpreter {
             line: None,
             file: None,
         });
+        // Set current_package to the multi candidate's defining package so that
+        // the body is compiled/run in the correct namespace context. Without this,
+        // calling a GLOBAL multi from inside a non-GLOBAL function (e.g. a module
+        // function) would compile the body with the caller's package, causing
+        // variable lookups like $y to silently resolve as $Module::y.
+        let saved_package = self.current_package.clone();
+        let def_pkg = def.package.resolve();
+        if !def_pkg.is_empty() {
+            self.current_package = def_pkg;
+        }
         let result = self.run_block(&def.body);
+        self.current_package = saved_package;
         self.routine_stack.pop();
         self.samewith_context_stack.pop();
         if pushed_dispatch {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1608,9 +1608,14 @@ impl Interpreter {
                 is_bind: *is_bind,
             },
             Expr::Block(stmts) => Expr::Block(Self::rewrite_proto_dispatch_stmts(stmts)),
-            Expr::DoBlock { body, label } => Expr::DoBlock {
+            Expr::DoBlock {
+                body,
+                label,
+                dollar_paren,
+            } => Expr::DoBlock {
                 body: Self::rewrite_proto_dispatch_stmts(body),
                 label: label.clone(),
+                dollar_paren: *dollar_paren,
             },
             Expr::Try { body, catch } => Expr::Try {
                 body: Self::rewrite_proto_dispatch_stmts(body),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3684,7 +3684,44 @@ impl Interpreter {
             } else {
                 (format!("{module}::{name}"), name.clone())
             };
-            if let Some(value) = self.env.get(&source).cloned() {
+            // Look up the value to import.  The primary key is the
+            // qualified source name (e.g. `&GH2897-B::my-counter`), but
+            // when that is absent or Nil (e.g. because a `unit module`
+            // VarDecl initialised it to Nil before a BEGIN block set the
+            // unqualified name), fall back to the persistent `our_vars`
+            // entry for the *target* (unqualified) name.  This preserves
+            // BEGIN-block-assigned closures that are stored under the bare
+            // sigiled name.
+            let value_opt = self
+                .env
+                .get(&source)
+                .cloned()
+                .and_then(|v| {
+                    if matches!(v, Value::Nil) {
+                        None
+                    } else {
+                        Some(v)
+                    }
+                })
+                .or_else(|| {
+                    self.our_vars.get(&target).cloned().and_then(|v| {
+                        if matches!(v, Value::Nil) {
+                            None
+                        } else {
+                            Some(v)
+                        }
+                    })
+                })
+                .or_else(|| {
+                    self.env.get(&target).cloned().and_then(|v| {
+                        if matches!(v, Value::Nil) {
+                            None
+                        } else {
+                            Some(v)
+                        }
+                    })
+                });
+            if let Some(value) = value_opt {
                 if !target.contains("::") {
                     self.unsuppress_name(&target);
                 }

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -223,7 +223,11 @@ fn extract_phasers_from_stmts(
                 };
                 let assign = Stmt::Assign {
                     name: temp_name,
-                    expr: Expr::DoBlock { body, label: None },
+                    expr: Expr::DoBlock {
+                        body,
+                        label: None,
+                        dollar_paren: false,
+                    },
                     op: AssignOp::Assign,
                 };
                 match kind {
@@ -276,7 +280,11 @@ fn extract_begin_from_stmts(stmts: &mut [Stmt], begin: &mut Vec<Stmt>) {
                 };
                 let assign = Stmt::Assign {
                     name: temp_name,
-                    expr: Expr::DoBlock { body, label: None },
+                    expr: Expr::DoBlock {
+                        body,
+                        label: None,
+                        dollar_paren: false,
+                    },
                     op: AssignOp::Assign,
                 };
                 begin.push(var_decl);
@@ -318,7 +326,11 @@ fn lift_phasers_from_expr(
             };
             let assign = Stmt::Assign {
                 name: temp_name,
-                expr: Expr::DoBlock { body, label: None },
+                expr: Expr::DoBlock {
+                    body,
+                    label: None,
+                    dollar_paren: false,
+                },
                 op: AssignOp::Assign,
             };
             match kind {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2820,10 +2820,16 @@ impl Interpreter {
             role_def: role_def.clone(),
             parents: candidate_parents,
         };
-        if type_params.is_empty() {
-            // A later non-parametric `role Name { ... }` should shadow any
-            // previously loaded role group with the same name instead of
-            // continuing to participate in parametric candidate selection.
+        if type_params.is_empty()
+            && self
+                .role_candidates
+                .get(name)
+                .is_some_and(|cands| cands.iter().all(|c| c.role_def.is_stub_role))
+        {
+            // Only shadow previously loaded role candidates if they were all
+            // stubs (e.g. from a precompiled module placeholder). Do not
+            // discard real parametric candidates, since a parametric and a
+            // non-parametric role with the same name form a role group.
             self.role_candidates
                 .insert(name.to_string(), vec![candidate]);
         } else {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2305,6 +2305,22 @@ impl Interpreter {
             }
         }
 
+        let is_stub_decl = check_body.len() == 1
+            && matches!(
+                check_body[0],
+                Stmt::Expr(Expr::Call { name, .. })
+                    if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn"
+            );
+        if is_stub_decl
+            && type_params.is_empty()
+            && self
+                .roles
+                .get(name)
+                .is_some_and(|existing| !existing.is_stub_role)
+        {
+            return Ok(());
+        }
+
         for param_def in type_param_defs {
             if param_def.name == "__type_only__"
                 && let Some(type_name) = param_def.type_constraint.as_deref()
@@ -2798,15 +2814,24 @@ impl Interpreter {
         // Capture the parents that were added during this registration
         // (these are the parents specific to this candidate).
         let candidate_parents = self.role_parents.get(name).cloned().unwrap_or_default();
-        self.role_candidates
-            .entry(name.to_string())
-            .or_default()
-            .push(RoleCandidateDef {
-                type_params: type_params.to_vec(),
-                type_param_defs: type_param_defs.to_vec(),
-                role_def: role_def.clone(),
-                parents: candidate_parents,
-            });
+        let candidate = RoleCandidateDef {
+            type_params: type_params.to_vec(),
+            type_param_defs: type_param_defs.to_vec(),
+            role_def: role_def.clone(),
+            parents: candidate_parents,
+        };
+        if type_params.is_empty() {
+            // A later non-parametric `role Name { ... }` should shadow any
+            // previously loaded role group with the same name instead of
+            // continuing to participate in parametric candidate selection.
+            self.role_candidates
+                .insert(name.to_string(), vec![candidate]);
+        } else {
+            self.role_candidates
+                .entry(name.to_string())
+                .or_default()
+                .push(candidate);
+        }
         if self
             .roles
             .get(name)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3264,7 +3264,7 @@ impl VM {
                 index_mode,
                 is_temp,
             } => {
-                self.exec_let_save_op(code, *name_idx, *index_mode, *is_temp);
+                self.exec_let_save_op(code, *name_idx, *index_mode, *is_temp)?;
                 *ip += 1;
             }
             OpCode::LetBlock { body_end } => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2847,6 +2847,11 @@ impl VM {
                 self.interpreter.package_stubs.remove(&name);
                 *ip += 1;
             }
+            OpCode::SetCurrentPackage { name_idx } => {
+                let name = Self::const_str(code, *name_idx).to_string();
+                self.interpreter.set_current_package(name);
+                *ip += 1;
+            }
 
             // -- Phaser END --
             OpCode::PhaserEnd(idx) => {

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -289,8 +289,9 @@ impl VM {
                                     }
                                 }
                             }
-                        } else {
-                            found_key = None;
+                        } else if found_key.is_none() {
+                            // pkg == "GLOBAL" and no key found via pos_arity fallback
+                            // Leave found_key as None; do not override a Some value.
                         }
                     }
                 }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2578,22 +2578,30 @@ impl VM {
         name_idx: u32,
         index_mode: bool,
         is_temp: bool,
-    ) {
+    ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
         let name = Self::const_str(code, name_idx).to_string();
         if index_mode {
             let _idx_val = self.stack.pop().unwrap_or(Value::Int(0));
         }
-        let old_val = self
-            .get_env_with_main_alias(&name)
-            .or_else(|| {
-                code.locals
-                    .iter()
-                    .position(|n| n == &name)
-                    .map(|i| self.locals[i].clone())
-            })
-            .unwrap_or(Value::Nil);
+        let found_val = self.get_env_with_main_alias(&name).or_else(|| {
+            code.locals
+                .iter()
+                .position(|n| n == &name)
+                .map(|i| self.locals[i].clone())
+        });
+        // If temp-ing a dynamic variable that doesn't exist, throw X::Dynamic::NotFound
+        if is_temp && found_val.is_none() && name.starts_with('*') {
+            let symbol = format!("${}", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("name".to_string(), Value::str(symbol.clone()));
+            let err =
+                Value::make_instance(crate::symbol::Symbol::intern("X::Dynamic::NotFound"), attrs);
+            return Err(RuntimeError::from_exception_value(err));
+        }
+        let old_val = found_val.unwrap_or(Value::Nil);
         self.interpreter.let_saves_push(name, old_val, is_temp);
+        Ok(())
     }
 
     pub(super) fn exec_let_block_op(

--- a/t/nested-modules-unit.t
+++ b/t/nested-modules-unit.t
@@ -1,0 +1,11 @@
+use Test;
+
+use lib $*PROGRAM.parent(2).add("roast/packages/AandB/lib");
+
+plan 5;
+
+eval-lives-ok 'use A::A', 'nested unit module loads';
+eval-lives-ok 'use A::A; use A::B; A::B::D ~~ A::B::B or die()', 'nested role composition resolves in package scope';
+eval-lives-ok 'use A::A; use A::B; A::B::D.new()', 'nested class instantiation works';
+eval-lives-ok 'use RoleA', 'unit role declarations parse and load from modules';
+eval-lives-ok 'use RoleA; use RoleB; role RoleB {...}; class MyFu does RoleB {}; MyFu ~~ RoleB or die()', 'later non-parametric role shadows imported role';


### PR DESCRIPTION
## Summary

- Add `dollar_paren: bool` to `Expr::DoBlock` to distinguish `$(...)` from plain `do {}`; `$(temp $a = 23; $a)` now correctly propagates temp saves to the enclosing scope's LetBlock
- Fix parser so `$(...)` is correctly parsed as a DoBlock (not hijacked by `itemized_paren_expr`)
- Add index support to `temp_stmt`: `temp @array[1] = 42`, `temp %hash<b> = 42`, `temp %hash{"key"} = 42`
- Fix hash variable handling in indexed temp (use `Expr::HashVar`, `is_positional` based on sigil)
- Add `++temp $c` / `--temp $c` prefix increment/decrement support
- Wrap sub bodies with LetBlock when `has_let_deep` is true, fixing recursive function temp restore
- Extend `has_let_deep`/`expr_has_let_deep` to detect temp in `VarDecl`, `Assign`, `IndexAssign`, `AssignExpr`, `Unary` contexts
- Throw `X::Dynamic::NotFound` when `temp`-ing a non-existent dynamic variable (`$*foo`)

Passes 39/46 subtests in `roast/S04-blocks-and-statements/temp.t`. Remaining 7 failures documented in `TODO_roast/S04.md`:
- Test 21: deeply nested multi-level indexed temp (`temp $struct[1]<key>[1]`) — parser only handles one index level
- Tests 24-26, 31-33: `TEMP {{ ... }}` phaser blocks NYI

## Test plan

- [x] `prove -e 'target/debug/mutsu' roast/S04-blocks-and-statements/temp.t` — 39/46 pass (up from failing entirely)
- [x] `prove -j4 -e 'target/debug/mutsu' t/` — all 3899 local tests pass
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)