### PR TITLE
fix: restore $_ topic after lives-ok/dies-ok blocks and support Range+Mixin arithmetic

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -404,8 +404,46 @@ fn range_divide_float(range_val: &Value, n: f64) -> Option<Value> {
     })
 }
 
+// ── Mixin-Range arithmetic helper ────────────────────────────────────
+/// If the left operand is a Mixin wrapping a Range (e.g. `(2..^5) but Meows`),
+/// perform the arithmetic on the inner Range and re-wrap the result with the
+/// same Mixin. Returns `None` if neither operand is a Mixin-wrapped Range.
+fn mixin_range_arith<F>(left: Value, right: Value, op: F) -> Option<Result<Value, RuntimeError>>
+where
+    F: Fn(Value, Value) -> Result<Value, RuntimeError>,
+{
+    match &left {
+        Value::Mixin(inner, mixins) if inner.is_range() => {
+            let inner_val = (**inner).clone();
+            let mix_clone = (**mixins).clone();
+            Some(op(inner_val, right).map(|r| Value::mixin(r, mix_clone)))
+        }
+        _ => None,
+    }
+}
+
+/// Same as `mixin_range_arith` but for non-Result arithmetic functions.
+fn mixin_range_arith_val<F>(left: Value, right: Value, op: F) -> Option<Value>
+where
+    F: Fn(Value, Value) -> Value,
+{
+    match &left {
+        Value::Mixin(inner, mixins) if inner.is_range() => {
+            let result = op((**inner).clone(), right);
+            Some(Value::mixin(result, (**mixins).clone()))
+        }
+        _ => None,
+    }
+}
+
 // ── Arithmetic operators ─────────────────────────────────────────────
 pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError> {
+    // Mixin-wrapped Range + Real (or Real + Mixin Range): perform Range arithmetic and re-wrap
+    if let Some(result) = mixin_range_arith(left.clone(), right.clone(), arith_add)
+        .or_else(|| mixin_range_arith(right.clone(), left.clone(), arith_add))
+    {
+        return result;
+    }
     // Range + Int: shift both bounds
     match (&left, &right) {
         (Value::Range(a, b), Value::Int(n)) => return Ok(Value::Range(a + n, b + n)),
@@ -652,6 +690,10 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
         let (y, m, d) = temporal::epoch_days_to_civil(new_days);
         return temporal::make_date(y, m, d);
     }
+    // Mixin-wrapped Range - Real: perform Range arithmetic and re-wrap
+    if let Some(result) = mixin_range_arith_val(left.clone(), right.clone(), arith_sub) {
+        return result;
+    }
     match (&left, &right) {
         (Value::Range(a, b), Value::Int(n)) => return Value::Range(a - n, b - n),
         (Value::RangeExcl(a, b), Value::Int(n)) => return Value::RangeExcl(a - n, b - n),
@@ -750,6 +792,12 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
 }
 
 pub(crate) fn arith_mul(left: Value, right: Value) -> Value {
+    // Mixin-wrapped Range * Real: perform Range arithmetic and re-wrap
+    if let Some(result) = mixin_range_arith_val(left.clone(), right.clone(), arith_mul)
+        .or_else(|| mixin_range_arith_val(right.clone(), left.clone(), arith_mul))
+    {
+        return result;
+    }
     // Range * Numeric: scale both bounds, preserving exclusivity
     if let Some(range) = range_scale(&left, &right).or_else(|| range_scale(&right, &left)) {
         return range;
@@ -829,6 +877,10 @@ pub(crate) fn arith_mul(left: Value, right: Value) -> Value {
 }
 
 pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError> {
+    // Mixin-wrapped Range / Real: perform Range arithmetic and re-wrap
+    if let Some(result) = mixin_range_arith(left.clone(), right.clone(), arith_div) {
+        return result;
+    }
     // Range / Numeric: scale both bounds down
     if let Some(range) = range_divide(&left, &right) {
         return Ok(range);

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -9,14 +9,25 @@ impl Interpreter {
         let ok = match &block {
             Value::Sub(data) => {
                 self.push_caller_env();
-                let saved_topic = self.env.get("$_").cloned();
+                // Save both "$_" (sigiled) and "_" (bare) since the block's
+                // eval_block_value sets "_" via SetTopic and we must restore it.
+                let saved_topic_sigil = self.env.get("$_").cloned();
+                let saved_topic_bare = self.env.get("_").cloned();
                 let result = self.eval_block_value(&data.body).is_ok();
-                match saved_topic {
+                match saved_topic_sigil {
                     Some(v) => {
                         self.env.insert("$_".to_string(), v);
                     }
                     None => {
                         self.env.remove("$_");
+                    }
+                }
+                match saved_topic_bare {
+                    Some(v) => {
+                        self.env.insert("_".to_string(), v);
+                    }
+                    None => {
+                        self.env.remove("_");
                     }
                 }
                 self.pop_caller_env();
@@ -35,7 +46,9 @@ impl Interpreter {
         let ok = match &block {
             Value::Sub(data) => {
                 self.push_caller_env();
-                let saved_topic = self.env.get("$_").cloned();
+                // Save both "$_" (sigiled) and "_" (bare) since eval_block_value sets "_".
+                let saved_topic_sigil = self.env.get("$_").cloned();
+                let saved_topic_bare = self.env.get("_").cloned();
                 let result = self.eval_block_value(&data.body);
                 let died = match &result {
                     Err(_) => true,
@@ -44,12 +57,20 @@ impl Interpreter {
                         Self::is_failure_value(val)
                     }
                 };
-                match saved_topic {
+                match saved_topic_sigil {
                     Some(v) => {
                         self.env.insert("$_".to_string(), v);
                     }
                     None => {
                         self.env.remove("$_");
+                    }
+                }
+                match saved_topic_bare {
+                    Some(v) => {
+                        self.env.insert("_".to_string(), v);
+                    }
+                    None => {
+                        self.env.remove("_");
                     }
                 }
                 self.pop_caller_env();


### PR DESCRIPTION
## Summary

- Fixed `$_` topic variable leaking from `lives-ok`/`dies-ok` block evaluation: `eval_block_value` sets `env["_"]` (bare key) to the block's last result, but the save/restore only guarded `env["$_"]` (sigiled key). After `lives-ok { expr }`, `$_` would change to the block's return value, breaking subsequent code that read `$_`.

- Fixed arithmetic on `Value::Mixin` wrapping a Range (e.g. `(2..^5) but Meows`): `arith_add`/`sub`/`mul`/`div` now detect Mixin-wrapped Ranges, unwrap the inner Range, perform the arithmetic, and re-wrap the result with the same Mixin. This enables `(range but Role) + N` to produce a `(shifted-range but Role)`.

## Effect

`roast/S03-operators/range.t` now runs all 181 subtests (was stopping at 119) and passes 155 of them (up from 119). The 26 remaining failures are pre-existing issues (R.. reverse-range operators, X::Worry::Precedence::Range warnings not firing, and Range*Mixin representation differences).

## Test plan

- [x] `make test` passes
- [x] `roast/S03-operators/range.t` runs to completion (181 tests, was 119)
- [x] No regressions in roast whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)