### PR TITLE
fix: pass all 55 subtests in roast/S05-metasyntax/regex.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -370,6 +370,7 @@ roast/S05-metasyntax/interpolating-closure.t
 roast/S05-metasyntax/lookaround.t
 roast/S05-metasyntax/null.t
 roast/S05-metasyntax/proto-token-ltm.t
+roast/S05-metasyntax/regex.t
 roast/S05-metasyntax/sequential-alternation.t
 roast/S05-metasyntax/single-quotes.t
 roast/S05-metasyntax/unicode-property-pair.t

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -182,6 +182,10 @@ impl Interpreter {
             self.env.insert("/".to_string(), match_obj.clone());
             Ok(match_obj)
         } else {
+            // Propagate any pending quantifier-value error (e.g., from ** {code} quantifiers)
+            if let Some(err) = Self::take_pending_regex_error() {
+                return Err(err);
+            }
             Ok(Value::Nil)
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -597,6 +597,9 @@ struct RegexToken {
     atom: RegexAtom,
     quant: RegexQuant,
     named_capture: Option<String>,
+    /// Secondary named capture for capturing subrule aliases like `$<alias>=<builtin_class>`.
+    /// When set, the matched text is also stored under this name (the original rule name).
+    secondary_named_capture: Option<String>,
     /// Hash aliasing: `%<name>=(...)` captures build a hash
     hash_capture: Option<String>,
     ratchet: bool,
@@ -2519,6 +2522,7 @@ impl Interpreter {
         register_x("X::Syntax::Regex::SolitaryQuantifier", "X::Syntax");
         register_x("X::Syntax::Regex::NullRegex", "X::Syntax");
         register_x("X::Syntax::Regex::NonQuantifiable", "X::Syntax");
+        register_x("X::Syntax::Regex::QuantifierValue", "X::Syntax");
         register_x("X::Syntax::Term::MissingInitializer", "X::Syntax");
         register_x("X::Syntax::WithoutElse", "X::Syntax");
         register_x("X::Syntax::UnlessElse", "X::Syntax");

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -117,8 +117,32 @@ impl Interpreter {
         }
     }
 
+    /// Create an X::Syntax::Regex::QuantifierValue exception with the given flag attribute set to True.
+    pub(super) fn make_quantifier_value_error(flag: &str, message: &str) -> RuntimeError {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.to_string()));
+        attrs.insert(flag.to_string(), Value::Bool(true));
+        let ex = Value::make_instance(
+            crate::symbol::Symbol::intern("X::Syntax::Regex::QuantifierValue"),
+            attrs,
+        );
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(ex));
+        err
+    }
+
+    /// Set a pending quantifier-value error in the thread-local error store.
+    pub(super) fn set_quantifier_value_error(flag: &str, message: &str) {
+        let err = Self::make_quantifier_value_error(flag, message);
+        crate::runtime::regex_parse::PENDING_REGEX_ERROR.with(|e| {
+            *e.borrow_mut() = Some(err);
+        });
+    }
+
     /// Evaluate a `** {code}` quantifier code block and return (min, max).
     /// The code should return either a numeric value (exact count) or a Range.
+    /// Returns None if the code fails to evaluate or produces an invalid/infinite value;
+    /// in invalid cases a pending error is set via PENDING_REGEX_ERROR for the caller to propagate.
     pub(super) fn eval_regex_repeat_code(
         &self,
         code: &str,
@@ -137,6 +161,22 @@ impl Interpreter {
             Ok(v) => v,
             Err(_) => return None,
         };
+
+        /// Helper: check if a Value is a non-numeric type (Str/Bool/etc.) for range endpoints.
+        fn is_non_numeric_value(v: &Value) -> bool {
+            matches!(v, Value::Str(_) | Value::Bool(_))
+        }
+
+        /// Helper: extract f64 from a Value, treating NaN/Inf specially.
+        fn endpoint_to_f64(v: &Value) -> f64 {
+            match v {
+                Value::Num(n) => *n,
+                Value::Int(i) => *i as f64,
+                Value::Rat(n, d) => *n as f64 / *d as f64,
+                _ => v.to_f64(),
+            }
+        }
+
         match &val {
             Value::Range(start, end) => {
                 let min = (*start).max(0) as usize;
@@ -145,6 +185,13 @@ impl Interpreter {
                 } else {
                     Some((*end).max(0) as usize)
                 };
+                // Check for empty range (min > max)
+                if let Some(max_val) = max
+                    && min > max_val
+                {
+                    Self::set_quantifier_value_error("empty-range", "Quantifier range is empty");
+                    return None;
+                }
                 Some((min, max))
             }
             Value::RangeExcl(start, end) => {
@@ -154,6 +201,12 @@ impl Interpreter {
                 } else {
                     Some(((*end) - 1).max(0) as usize)
                 };
+                if let Some(max_val) = max
+                    && min > max_val
+                {
+                    Self::set_quantifier_value_error("empty-range", "Quantifier range is empty");
+                    return None;
+                }
                 Some((min, max))
             }
             Value::RangeExclStart(start, end) => {
@@ -163,6 +216,12 @@ impl Interpreter {
                 } else {
                     Some((*end).max(0) as usize)
                 };
+                if let Some(max_val) = max
+                    && min > max_val
+                {
+                    Self::set_quantifier_value_error("empty-range", "Quantifier range is empty");
+                    return None;
+                }
                 Some((min, max))
             }
             Value::RangeExclBoth(start, end) => {
@@ -172,11 +231,117 @@ impl Interpreter {
                 } else {
                     Some(((*end) - 1).max(0) as usize)
                 };
+                if let Some(max_val) = max
+                    && min > max_val
+                {
+                    Self::set_quantifier_value_error("empty-range", "Quantifier range is empty");
+                    return None;
+                }
                 Some((min, max))
+            }
+            Value::GenericRange {
+                start,
+                end,
+                excl_start,
+                excl_end,
+            } => {
+                // Check for non-numeric range endpoints (e.g., strings, NaN endpoints)
+                if is_non_numeric_value(start.as_ref()) || is_non_numeric_value(end.as_ref()) {
+                    Self::set_quantifier_value_error(
+                        "non-numeric-range",
+                        "Quantifier range has non-numeric endpoint",
+                    );
+                    return None;
+                }
+                let start_f = endpoint_to_f64(start.as_ref());
+                let end_f = endpoint_to_f64(end.as_ref());
+                // NaN in either endpoint → non-numeric-range
+                if start_f.is_nan() || end_f.is_nan() {
+                    Self::set_quantifier_value_error(
+                        "non-numeric-range",
+                        "Quantifier range has non-numeric (NaN) endpoint",
+                    );
+                    return None;
+                }
+                // Inf as start → error (infinite lower bound)
+                if start_f.is_infinite() && start_f > 0.0 {
+                    Self::set_quantifier_value_error("inf", "Quantifier lower bound is Inf");
+                    return None;
+                }
+                // Compute min and max.
+                // For float ranges, Raku uses floor for the inclusive bound
+                // and floor+1 for the exclusive bound.
+                let min_f = if start_f.is_infinite() && start_f < 0.0 {
+                    // -Inf start: effective min is 0
+                    0.0
+                } else if *excl_start {
+                    start_f.floor() + 1.0
+                } else {
+                    start_f.floor()
+                };
+                let min = if min_f < 0.0 { 0 } else { min_f as usize };
+
+                let max = if end_f.is_infinite() && end_f > 0.0 {
+                    None // +Inf end → unbounded
+                } else {
+                    let max_f = if *excl_end {
+                        end_f.ceil() - 1.0
+                    } else {
+                        end_f.floor()
+                    };
+                    let max_val = if max_f < 0.0 { 0 } else { max_f as usize };
+                    Some(max_val)
+                };
+                // Empty range check
+                if let Some(max_val) = max
+                    && min > max_val
+                {
+                    Self::set_quantifier_value_error("empty-range", "Quantifier range is empty");
+                    return None;
+                }
+                Some((min, max))
+            }
+            Value::Str(s) => {
+                // String values that cannot parse as a number are non-numeric
+                match s.trim().parse::<f64>() {
+                    Ok(n) if n.is_nan() => {
+                        Self::set_quantifier_value_error(
+                            "non-numeric",
+                            "Quantifier value is not numeric",
+                        );
+                        None
+                    }
+                    Ok(n) if n.is_infinite() && n > 0.0 => {
+                        Self::set_quantifier_value_error("inf", "Quantifier value is Inf");
+                        None
+                    }
+                    Ok(n) => {
+                        let n = n.max(0.0) as usize;
+                        Some((n, Some(n)))
+                    }
+                    Err(_) => {
+                        // Non-parseable string like "meow"
+                        Self::set_quantifier_value_error(
+                            "non-numeric",
+                            "Quantifier value is not numeric",
+                        );
+                        None
+                    }
+                }
             }
             _ => {
                 let n = val.to_f64();
-                if n.is_nan() || n.is_infinite() {
+                // Non-numeric value (NaN)
+                if n.is_nan() {
+                    Self::set_quantifier_value_error(
+                        "non-numeric",
+                        "Quantifier value is not numeric",
+                    );
+                    return None;
+                }
+                // Positive Inf is an error; negative Inf is treated as 0.
+                if n.is_infinite() && n > 0.0 {
+                    Self::set_quantifier_value_error("inf", "Quantifier value is Inf");
                     return None;
                 }
                 let n = n.max(0.0) as usize;

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -101,6 +101,7 @@ fn strip_marks_token(token: &RegexToken) -> RegexToken {
         atom: strip_marks_atom(&token.atom),
         quant: token.quant.clone(),
         named_capture: token.named_capture.clone(),
+        secondary_named_capture: token.secondary_named_capture.clone(),
         hash_capture: token.hash_capture.clone(),
         ratchet: token.ratchet,
         frugal: token.frugal,

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -104,7 +104,18 @@ impl Interpreter {
                 }
                 RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
                     let (min, max) = match &token.quant {
-                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::Repeat(min, max) => {
+                            if let Some(max_val) = *max
+                                && *min > max_val
+                            {
+                                Self::set_quantifier_value_error(
+                                    "empty-range",
+                                    "Quantifier range is empty",
+                                );
+                                continue;
+                            }
+                            (*min, *max)
+                        }
                         RegexQuant::RepeatCode(code) => {
                             match self.eval_regex_repeat_code(code, &RegexCaptures::default()) {
                                 Some((min, max)) => (min, max),

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -81,7 +81,16 @@ impl Interpreter {
                     .named
                     .entry(name.clone())
                     .or_default()
-                    .push(captured);
+                    .push(captured.clone());
+                // Also capture under the secondary name (e.g., original builtin class name
+                // when using `$<alias>=<builtin_class>` syntax).
+                if let Some(secondary) = token.secondary_named_capture.as_ref() {
+                    updated
+                        .named
+                        .entry(secondary.clone())
+                        .or_default()
+                        .push(captured);
+                }
                 updated
             };
         let apply_hash_capture = |token: &RegexToken,
@@ -599,7 +608,19 @@ impl Interpreter {
                 }
                 RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
                     let (min, max) = match &token.quant {
-                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::Repeat(min, max) => {
+                            // Block-less empty range: /x ** 2..1/ should throw
+                            if let Some(max_val) = *max
+                                && *min > max_val
+                            {
+                                Self::set_quantifier_value_error(
+                                    "empty-range",
+                                    "Quantifier range is empty",
+                                );
+                                continue;
+                            }
+                            (*min, *max)
+                        }
                         RegexQuant::RepeatCode(code) => {
                             match self.eval_regex_repeat_code(code, &caps) {
                                 Some((min, max)) => (min, max),

--- a/src/runtime/regex/regex_match_nocap.rs
+++ b/src/runtime/regex/regex_match_nocap.rs
@@ -99,7 +99,18 @@ impl Interpreter {
                 }
                 RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
                     let (min, max) = match &token.quant {
-                        RegexQuant::Repeat(min, max) => (*min, *max),
+                        RegexQuant::Repeat(min, max) => {
+                            if let Some(max_val) = *max
+                                && *min > max_val
+                            {
+                                Self::set_quantifier_value_error(
+                                    "empty-range",
+                                    "Quantifier range is empty",
+                                );
+                                continue;
+                            }
+                            (*min, *max)
+                        }
                         RegexQuant::RepeatCode(code) => {
                             match self.eval_regex_repeat_code(code, &RegexCaptures::default()) {
                                 Some((min, max)) => (min, max),

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -105,6 +105,7 @@ fn rewrite_tilde_tokens(
                     quant: RegexQuant::One,
                     named_capture: None,
                     hash_capture: None,
+                    secondary_named_capture: None,
                     ratchet: false,
                     frugal: false,
                 };
@@ -130,6 +131,7 @@ fn rewrite_tilde_tokens(
                 quant: RegexQuant::One,
                 named_capture: None,
                 hash_capture: None,
+                secondary_named_capture: None,
                 ratchet: false,
                 frugal: false,
             });
@@ -254,6 +256,7 @@ fn regex_single_quote_atom(literal: String, ignore_case: bool) -> RegexAtom {
                 quant: RegexQuant::One,
                 named_capture: None,
                 hash_capture: None,
+                secondary_named_capture: None,
                 ratchet: false,
                 frugal: false,
             })
@@ -808,6 +811,16 @@ impl Interpreter {
             // quoted string, or backslash escape.
             let is_single_atom = Self::is_single_regex_atom(atom);
             if is_single_atom {
+                // Detect empty range (e.g. 2..1) before LTM expansion: skip expansion
+                // so the normal Repeat quantifier match arm can detect and throw the error.
+                if let Some((min_str, max_str)) = count_spec.split_once("..")
+                    && max_str != "*"
+                    && let (Ok(min_val), Some(max_val)) =
+                        (min_str.parse::<usize>(), max_str.parse::<usize>().ok())
+                    && min_val > max_val
+                {
+                    return pattern.to_string();
+                }
                 return Self::build_ltm_expansion(atom, count_spec, sep_mode, sep);
             }
             // Fall through to let the normal parser handle ** quantifiers
@@ -1171,6 +1184,7 @@ impl Interpreter {
                         quant: RegexQuant::One,
                         named_capture: None,
                         hash_capture: None,
+                        secondary_named_capture: None,
                         ratchet: false,
                         frugal: false,
                     }],
@@ -1211,6 +1225,7 @@ impl Interpreter {
                         quant: RegexQuant::One,
                         named_capture: None,
                         hash_capture: None,
+                        secondary_named_capture: None,
                         ratchet: false,
                         frugal: false,
                     }],
@@ -1249,6 +1264,7 @@ impl Interpreter {
                                 quant: RegexQuant::ZeroOrMore,
                                 named_capture: None,
                                 hash_capture: None,
+                                secondary_named_capture: None,
                                 ratchet,
                                 frugal: false,
                             });
@@ -1274,6 +1290,7 @@ impl Interpreter {
                             },
                             named_capture: None,
                             hash_capture: None,
+                            secondary_named_capture: None,
                             ratchet,
                             frugal: false,
                         });
@@ -1299,6 +1316,7 @@ impl Interpreter {
                         quant: RegexQuant::One,
                         named_capture: None,
                         hash_capture: None,
+                        secondary_named_capture: None,
                         ratchet,
                         frugal: false,
                     });
@@ -1316,6 +1334,7 @@ impl Interpreter {
                     quant: RegexQuant::One,
                     named_capture: None,
                     hash_capture: None,
+                    secondary_named_capture: None,
                     ratchet,
                     frugal: false,
                 });
@@ -1337,6 +1356,7 @@ impl Interpreter {
                         quant: RegexQuant::One,
                         named_capture: pending_named_capture.take(),
                         hash_capture: None,
+                        secondary_named_capture: None,
                         ratchet,
                         frugal: false,
                     });
@@ -1371,6 +1391,7 @@ impl Interpreter {
                     quant: RegexQuant::One,
                     named_capture: None,
                     hash_capture: None,
+                    secondary_named_capture: None,
                     ratchet,
                     frugal: false,
                 });
@@ -1448,6 +1469,7 @@ impl Interpreter {
                         quant: RegexQuant::One,
                         named_capture: pending_named_capture.take(),
                         hash_capture: None,
+                        secondary_named_capture: None,
                         ratchet,
                         frugal: false,
                     });
@@ -1679,6 +1701,7 @@ impl Interpreter {
                                         quant: RegexQuant::One,
                                         named_capture: None,
                                         hash_capture: None,
+                                        secondary_named_capture: None,
                                         ratchet: false,
                                         frugal: false,
                                     });
@@ -1951,6 +1974,7 @@ impl Interpreter {
                                         quant: RegexQuant::One,
                                         named_capture: None,
                                         hash_capture: None,
+                                        secondary_named_capture: None,
                                         ratchet: false,
                                         frugal: false,
                                     }],
@@ -2168,6 +2192,7 @@ impl Interpreter {
                                                     quant: RegexQuant::One,
                                                     named_capture: None,
                                                     hash_capture: None,
+                                                    secondary_named_capture: None,
                                                     ratchet: false,
                                                     frugal: false,
                                                 })
@@ -2252,6 +2277,7 @@ impl Interpreter {
                                                             quant: RegexQuant::One,
                                                             named_capture: None,
                                                             hash_capture: None,
+                                                            secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
                                                         },
@@ -2267,6 +2293,7 @@ impl Interpreter {
                                                             quant: RegexQuant::ZeroOrMore,
                                                             named_capture: None,
                                                             hash_capture: None,
+                                                            secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
                                                         },
@@ -2290,6 +2317,7 @@ impl Interpreter {
                                                     quant: RegexQuant::One,
                                                     named_capture: None,
                                                     hash_capture: None,
+                                                    secondary_named_capture: None,
                                                     ratchet: false,
                                                     frugal: false,
                                                 }],
@@ -2449,6 +2477,7 @@ impl Interpreter {
                                                         quant: RegexQuant::One,
                                                         named_capture: None,
                                                         hash_capture: None,
+                                                        secondary_named_capture: None,
                                                         ratchet: false,
                                                         frugal: false,
                                                     },
@@ -2462,6 +2491,7 @@ impl Interpreter {
                                                         quant: RegexQuant::ZeroOrMore,
                                                         named_capture: None,
                                                         hash_capture: None,
+                                                        secondary_named_capture: None,
                                                         ratchet: false,
                                                         frugal: false,
                                                     },
@@ -2629,6 +2659,7 @@ impl Interpreter {
                                 quant: RegexQuant::One,
                                 named_capture: None,
                                 hash_capture: None,
+                                secondary_named_capture: None,
                                 ratchet: false,
                                 frugal: false,
                             }],
@@ -2909,13 +2940,22 @@ impl Interpreter {
             } else {
                 ratchet // inherit from pattern-level :ratchet flag
             };
+            // When both a user alias ($<name>=) and a builtin class name are pending,
+            // the alias becomes the primary capture and the builtin name becomes secondary.
+            let primary_named = pending_named_capture.take();
+            let secondary_named = if primary_named.is_some() {
+                // Alias takes precedence; builtin name (if any) becomes secondary capture.
+                pending_builtin_named_capture.take()
+            } else {
+                None
+            };
+            let primary_named = primary_named.or_else(|| pending_builtin_named_capture.take());
             tokens.push(RegexToken {
                 atom,
                 quant,
-                named_capture: pending_named_capture
-                    .take()
-                    .or(pending_builtin_named_capture.take()),
+                named_capture: primary_named,
                 hash_capture: pending_hash_capture.take(),
+                secondary_named_capture: secondary_named,
                 ratchet: token_ratchet,
                 frugal: token_frugal,
             });

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -57,13 +57,6 @@ impl Interpreter {
                 .collect()
         };
         attrs.insert("list".to_string(), Value::array(positional));
-        eprintln!(
-            "DEBUG_MATCHED: {} named={} positional={} hash_captures={}",
-            captures.matched,
-            captures.named.len(),
-            captures.positional.len(),
-            captures.hash_captures.len()
-        );
         let mut named = HashMap::new();
         for (k, v) in &captures.named {
             let vals: Vec<Value> = v
@@ -75,13 +68,6 @@ impl Interpreter {
             } else {
                 named.insert(k.clone(), Value::array(vals));
             }
-        }
-        eprintln!(
-            "REGEX_CAPTURES: hash_captures len = {}",
-            captures.hash_captures.len()
-        );
-        for (k, v) in &captures.hash_captures {
-            eprintln!("  hash {}: {:?}", k, v);
         }
         // Add hash captures from %<name>=(...) aliasing
         for (hash_name, entries) in &captures.hash_captures {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1200,6 +1200,7 @@ pub(crate) fn is_known_compound_type(name: &str) -> bool {
             | "X::Syntax::Regex::Adverb"
             | "X::Syntax::Regex::MalformedRange"
             | "X::Syntax::Regex::NonQuantifiable"
+            | "X::Syntax::Regex::QuantifierValue"
             | "X::Syntax::Regex::NullRegex"
             | "X::Syntax::Regex::SolitaryBacktrackControl"
             | "X::Syntax::Regex::SolitaryQuantifier"


### PR DESCRIPTION
## Summary

- Implements `X::Syntax::Regex::QuantifierValue` exception type thrown by `** {code}` quantifiers when given invalid values (non-numeric strings like "meow", NaN, positive Inf, empty ranges)
- Adds `secondary_named_capture` field to `RegexToken` so `$<alias>=<builtin>` syntax captures under both the user alias and the original builtin class name (fixes test 55)
- Detects block-less empty ranges (e.g., `/x ** 2..1/`) by skipping LTM expansion, letting the normal `Repeat` quantifier arm set the pending error at match time (fixes tests 5, 6)
- Uses `floor()` instead of `ceil()` for inclusive float range start bounds so `1.7..2.2` frugal matches 1 char (min=floor(1.7)=1), not 2 (fixes frugal float range tests)

## Test plan

- [ ] `prove -e 'target/release/mutsu' roast/S05-metasyntax/regex.t` → all 55 subtests pass
- [ ] `make test` → all 481 local tests pass
- [ ] Full roast whitelist (1161 files) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)