### PR TITLE
fix: reject plan skip-all inside Block subtest callable

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -845,6 +845,7 @@ roast/S22-package-format/local.t
 roast/S24-testing/0-compile.t
 roast/S24-testing/1-basic.t
 roast/S24-testing/10-is-approx.t
+roast/S24-testing/11-plan-skip-all-subtests.t
 roast/S24-testing/11-plan-skip-all.t
 roast/S24-testing/12-subtest-todo.t
 roast/S24-testing/13-cmp-ok.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -753,6 +753,9 @@ pub struct Interpreter {
     warn_suppression_depth: usize,
     test_state: Option<TestState>,
     subtest_depth: usize,
+    /// Stack tracking whether each nested subtest callable is a Sub (true) or Block (false).
+    /// Used by `plan skip-all` to reject Block callables.
+    subtest_callable_is_sub: Vec<bool>,
     halted: bool,
     exit_code: i64,
     /// When true, `exit` sets the `halted` flag instead of calling
@@ -2622,6 +2625,7 @@ impl Interpreter {
             warn_suppression_depth: 0,
             test_state: None,
             subtest_depth: 0,
+            subtest_callable_is_sub: Vec::new(),
             halted: false,
             exit_code: 0,
             nested_mode: false,
@@ -4572,6 +4576,7 @@ impl Interpreter {
                 }
             },
             subtest_depth: 0,
+            subtest_callable_is_sub: Vec::new(),
             halted: false,
             exit_code: 0,
             nested_mode: self.nested_mode,

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -55,6 +55,8 @@ impl Interpreter {
         self.test_state = Some(TestState::new());
         self.halted = false;
         self.subtest_depth += 1;
+        // Default to true (Sub); callers like test_fn_subtest override after.
+        self.subtest_callable_is_sub.push(true);
         SubtestContext {
             parent_test_state,
             parent_output,
@@ -78,6 +80,7 @@ impl Interpreter {
         self.output = ctx.parent_output;
         self.halted = ctx.parent_halted;
         self.subtest_depth = self.subtest_depth.saturating_sub(1);
+        self.subtest_callable_is_sub.pop();
         let parent_forced_todo_reason = self.test_state.as_ref().and_then(|state| {
             let next = state.ran + 1;
             state

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -134,6 +134,20 @@ impl Interpreter {
 
     pub(crate) fn test_fn_plan(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if let Some(reason) = Self::named_value(args, "skip-all") {
+            // In Raku, `plan skip-all` inside a subtest uses `return` to exit the
+            // callable. `return` only works in a Sub or Method, not a Block.
+            // If we're inside a subtest with a Block callable, die with an error.
+            if self.subtest_depth > 0
+                && let Some(&false) = self.subtest_callable_is_sub.last()
+            {
+                let msg = "Must give `subtest` a (Sub) or a (Method) to be able to use \
+                           `skip-all` plan inside, but you gave a (Block)";
+                self.stderr_output.push_str(msg);
+                self.stderr_output.push('\n');
+                self.exit_code = 1;
+                self.halted = true;
+                return Err(RuntimeError::new(msg));
+            }
             self.test_state.get_or_insert_with(TestState::new).planned = Some(0);
             let reason_str = reason.to_string_value();
             if reason_str.is_empty() || reason_str == "True" {

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -30,7 +30,18 @@ impl Interpreter {
                 .unwrap_or(Value::Nil);
             (label, block)
         };
+        // Detect whether the callable is a Sub/Method (supports `return`) or a Block.
+        // `plan skip-all` inside a subtest uses `return`, which only works for Subs.
+        let callable_is_sub = match &block {
+            Value::Sub(data) => !data.is_bare_block,
+            Value::Routine { .. } => true,
+            _ => false,
+        };
         let ctx = self.begin_subtest();
+        // Override the default (true) set by begin_subtest
+        if let Some(last) = self.subtest_callable_is_sub.last_mut() {
+            *last = callable_is_sub;
+        }
         let saved_env = self.env.clone();
         let saved_functions = self.functions.clone();
         let saved_proto_functions = self.proto_functions.clone();
@@ -44,6 +55,31 @@ impl Interpreter {
         let saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
         let run_result = self.call_sub_value(block, vec![], true);
+        // If `plan skip-all` was used inside a Block callable, the error is fatal
+        // and should propagate out of the subtest entirely (matching Raku behavior).
+        if let Err(ref e) = run_result
+            && e.message.starts_with("Must give `subtest`")
+        {
+            // Restore state before propagating
+            self.test_state = ctx.parent_test_state;
+            self.output = ctx.parent_output;
+            self.halted = ctx.parent_halted;
+            self.subtest_depth = self.subtest_depth.saturating_sub(1);
+            self.subtest_callable_is_sub.pop();
+            self.env = saved_env;
+            self.functions = saved_functions;
+            self.proto_functions = saved_proto_functions;
+            self.token_defs = saved_token_defs;
+            self.proto_subs = saved_proto_subs;
+            self.proto_tokens = saved_proto_tokens;
+            self.classes = saved_classes;
+            self.class_trusts = saved_class_trusts;
+            self.roles = saved_roles;
+            self.subsets = saved_subsets;
+            self.type_metadata = saved_type_metadata;
+            self.restore_var_type_constraints(saved_var_type_constraints);
+            return Err(run_result.unwrap_err());
+        }
         let mut merged_env = saved_env.clone();
         for (k, v) in &self.env {
             if k == "_" || k == "$_" {


### PR DESCRIPTION
## Summary
- Track whether each subtest callable is a Sub or Block via a `subtest_callable_is_sub` stack on the Interpreter
- When `plan skip-all` is used inside a subtest with a Block callable, die with "Must give `subtest` a (Sub) or a (Method)..." matching Raku behavior
- Add `roast/S24-testing/11-plan-skip-all-subtests.t` to the whitelist (all 4 subtests pass)

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S24-testing/11-plan-skip-all-subtests.t` passes
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)