### PR TITLE
fix: optimize named-param calls and fix array ++/-- sharing

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -462,6 +462,7 @@ roast/S06-signature/introspection.t
 roast/S06-signature/mixed-placeholders.t
 roast/S06-signature/multi-invocant.t
 roast/S06-signature/multidimensional.t
+roast/S06-signature/named-parameters.t
 roast/S06-signature/named-placeholders.t
 roast/S06-signature/named-renaming.t
 roast/S06-signature/optional.t

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -28,6 +28,10 @@ per_file_timeout() {
       # and potentially more on slower CI machines.
       echo 60
       ;;
+    roast/S06-signature/named-parameters.t)
+      # This test has a 1M-iteration hot loop (test 100) that takes ~8s on release builds.
+      echo 60
+      ;;
     *)
       echo "$DEFAULT_TIMEOUT"
       ;;

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -297,8 +297,10 @@ impl Compiler {
             is_raw,
             param_local_slots: None,
             has_inner_subs: false,
+            named_param_slots: None,
         };
         cf.precompute_param_local_slots();
+        cf.precompute_named_param_slots();
         cf.detect_inner_subs();
         self.compiled_functions.insert(key, cf);
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1182,6 +1182,11 @@ pub(crate) struct CompiledFunction {
     /// When true, parameters must be written to env (not just locals) so that
     /// nested functions can capture them via closure.
     pub(crate) has_inner_subs: bool,
+    /// Pre-computed mapping for named parameters: (match_key, local_slot, sub_sig_slots).
+    /// sub_sig_slots is a list of (inner_key, inner_slot) for sub_signature aliases.
+    /// Used by the OTF named call fast path to avoid name-based lookup per call.
+    #[allow(clippy::type_complexity)]
+    pub(crate) named_param_slots: Option<Vec<(String, usize, Vec<(String, usize)>)>>,
 }
 
 impl CompiledFunction {
@@ -1206,6 +1211,57 @@ impl CompiledFunction {
         }
         if !slots.is_empty() {
             self.param_local_slots = Some(slots);
+        }
+    }
+
+    /// Pre-compute the mapping for named parameters: match_key -> (local_slot, sub_sig_slots).
+    pub(crate) fn precompute_named_param_slots(&mut self) {
+        if self.param_defs.is_empty() || !self.param_defs.iter().all(|pd| pd.named) {
+            return;
+        }
+        let mut slots = Vec::new();
+        for pd in &self.param_defs {
+            let match_key = pd
+                .name
+                .strip_prefix('@')
+                .or_else(|| pd.name.strip_prefix('%'))
+                .unwrap_or(&pd.name);
+            let match_key = match_key
+                .strip_prefix('!')
+                .or_else(|| match_key.strip_prefix('.'))
+                .unwrap_or(match_key)
+                .to_string();
+            let slot = self
+                .code
+                .locals
+                .iter()
+                .position(|n| n == &pd.name)
+                .unwrap_or(0);
+            // Pre-compute sub_signature alias slots
+            let mut sub_sig_slots = Vec::new();
+            if let Some(ref sub_params) = pd.sub_signature {
+                for sub_pd in sub_params {
+                    if !sub_pd.named {
+                        continue;
+                    }
+                    let inner_key = sub_pd
+                        .name
+                        .strip_prefix(':')
+                        .unwrap_or(&sub_pd.name)
+                        .to_string();
+                    let inner_slot = self
+                        .code
+                        .locals
+                        .iter()
+                        .position(|n| n == &sub_pd.name)
+                        .unwrap_or(0);
+                    sub_sig_slots.push((inner_key, inner_slot));
+                }
+            }
+            slots.push((match_key, slot, sub_sig_slots));
+        }
+        if !slots.is_empty() {
+            self.named_param_slots = Some(slots);
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -146,6 +146,12 @@ pub(crate) struct VM {
     /// (target_name, source_name): after the closure returns, the caller
     /// creates local_bind_pairs from these so writes to source propagate to target.
     pending_alias_bind_names: Vec<(String, String)>,
+    /// On-the-fly compiled function call cache: maps function name to its
+    /// compiled form. Used to avoid going through the interpreter fallback
+    /// for user-defined functions that were compiled on-the-fly.
+    otf_call_cache: HashMap<Symbol, CompiledFunction>,
+    /// The generation at which otf_call_cache was last valid.
+    otf_call_cache_gen: u64,
 }
 
 impl VM {
@@ -303,6 +309,8 @@ impl VM {
             pos_light_call_cache_gen: 0,
             block_declared_vars: Vec::new(),
             pending_alias_bind_names: Vec::new(),
+            otf_call_cache: HashMap::new(),
+            otf_call_cache_gen: 0,
         }
     }
 

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -93,12 +93,19 @@ impl VM {
                 is_raw: def.is_raw,
                 param_local_slots: None,
                 has_inner_subs: false,
+                named_param_slots: None,
             };
             cf.precompute_param_local_slots();
+            cf.precompute_named_param_slots();
             cf.detect_inner_subs();
             self.otf_compile_cache.insert(cache_key, cf.clone());
             cf
         };
+
+        // Cache by name for fast lookup in exec_call_func_op
+        let name_sym = Symbol::intern(&name);
+        self.otf_call_cache.insert(name_sym, cf.clone());
+        self.otf_call_cache_gen = self.fn_resolve_gen;
 
         // Set up samewith and multi-dispatch context that call_compiled_function_named
         // expects the caller to manage (mirrors exec_call_fn_op).
@@ -560,7 +567,6 @@ impl VM {
             && !cf.is_rw
             && !cf.is_raw
             && !cf.empty_sig
-            && cf.params.is_empty()
             && !cf.param_defs.is_empty()
             && cf.param_defs.iter().all(|pd| {
                 pd.named

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -101,6 +101,60 @@ impl VM {
             }
         }
 
+        // OTF-compiled function cache check: for user-defined functions that
+        // were compiled on-the-fly (not in compiled_fns), use the cached
+        // compiled form to avoid the expensive interpreter fallback.
+        // We take() the CF from the cache to avoid holding a borrow on self,
+        // then put it back after the call.
+        {
+            let name_str = Self::const_str(code, name_idx);
+            let name_sym = Symbol::intern(name_str);
+            if self.otf_call_cache_gen == self.fn_resolve_gen {
+                if let Some(cf) = self.otf_call_cache.remove(&name_sym)
+                    && !cf.has_inner_subs
+                {
+                    let arity_usize = arity as usize;
+                    if self.stack.len() >= arity_usize {
+                        let start = self.stack.len() - arity_usize;
+                        let args: Vec<Value> = self.stack.drain(start..).collect();
+
+                        let result = if Self::is_light_call_eligible(&cf, name_str) {
+                            self.call_compiled_function_light(&cf, args, compiled_fns)
+                        } else if Self::is_positional_light_call_eligible(&cf, name_str) {
+                            self.call_compiled_function_positional_light(&cf, &args, compiled_fns)
+                        } else {
+                            let pkg = self.interpreter.current_package().to_string();
+                            self.interpreter.push_samewith_context(name_str, None);
+                            let pushed_dispatch =
+                                self.interpreter.push_multi_dispatch_frame(name_str, &args);
+                            let r = self.call_compiled_function_named(
+                                &cf,
+                                args,
+                                compiled_fns,
+                                &pkg,
+                                name_str,
+                            );
+                            self.interpreter.pop_samewith_context();
+                            if pushed_dispatch {
+                                self.interpreter.pop_multi_dispatch();
+                            }
+                            r
+                        };
+                        // Put CF back in cache
+                        self.otf_call_cache.insert(name_sym, cf);
+                        self.stack.push(result?);
+                        self.env_dirty = true;
+                        return Ok(());
+                    }
+                    // Put CF back if we couldn't use it (stack underflow)
+                    self.otf_call_cache.insert(name_sym, cf);
+                }
+            } else {
+                self.otf_call_cache.clear();
+                self.otf_call_cache_gen = self.fn_resolve_gen;
+            }
+        }
+
         // If there's a lexical `&name` override — either as a compiled local
         // slot (e.g. from a `&foo` parameter binding) or in the env — it
         // shadows package-level subs. Skip the fast path and dispatch via
@@ -588,6 +642,27 @@ impl VM {
                 self.try_native_function(Symbol::intern(name), &args)
             {
                 native_result
+            } else if !self.is_interpreter_handled_function(name)
+                && !self.has_multi_candidates_cached(name)
+                && let Some(def) = self.interpreter.resolve_function_with_types(name, &args)
+                && !Self::function_body_needs_interpreter(&def.body)
+                // Only OTF-compile simple functions: no default params, no
+                // code params (&foo), no where constraints, no closures.
+                && def.param_defs.iter().all(|pd| {
+                    pd.default.is_none()
+                        && pd.where_constraint.is_none()
+                        && pd.code_signature.is_none()
+                        && !pd.name.starts_with('&')
+                })
+            {
+                // On-the-fly compile: compile the function definition to
+                // bytecode and execute via the VM, avoiding the slow
+                // tree-walking interpreter path. The compiled result is
+                // cached in otf_compile_cache for subsequent calls.
+                // Skip functions with class/role declarations or complex
+                // parameter signatures as they need the full interpreter
+                // path for correct behavior.
+                self.compile_and_call_function_def(&def, args, compiled_fns)
             } else {
                 // Sync VM locals to env before spawning threads so closures capture them
                 if name == "start" {
@@ -600,6 +675,41 @@ impl VM {
                 let auto_fetch = name != "substr-rw";
                 self.interpreter.maybe_fetch_rw_proxy(result?, auto_fetch)
             }
+        }
+    }
+
+    /// Check if a function body contains constructs that require
+    /// the full interpreter path (class/role declarations, start blocks).
+    fn function_body_needs_interpreter(body: &[crate::ast::Stmt]) -> bool {
+        use crate::ast::Stmt;
+        for stmt in body {
+            match stmt {
+                Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } => return true,
+                Stmt::Expr(expr) => {
+                    if Self::expr_needs_interpreter(expr) {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    fn expr_needs_interpreter(expr: &crate::ast::Expr) -> bool {
+        use crate::ast::Expr;
+        match expr {
+            Expr::DoStmt(stmt) => Self::function_body_needs_interpreter(std::slice::from_ref(stmt)),
+            Expr::Block(body) => Self::function_body_needs_interpreter(body),
+            Expr::MethodCall { target, args, .. } => {
+                Self::expr_needs_interpreter(target)
+                    || args.iter().any(Self::expr_needs_interpreter)
+            }
+            Expr::Call { name, args } => {
+                // start blocks need the interpreter for proper thread spawning
+                name.resolve() == "start" || args.iter().any(Self::expr_needs_interpreter)
+            }
+            _ => false,
         }
     }
 }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -671,6 +671,9 @@ impl VM {
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function(name, args);
                 self.interpreter.set_pending_call_arg_sources(None);
+                // Interpreter function calls (e.g. `require`) may register
+                // new subs — invalidate function resolution caches.
+                self.fn_resolve_gen += 1;
                 // substr-rw returns a Proxy that must be preserved (not auto-FETCHed)
                 let auto_fetch = name != "substr-rw";
                 self.interpreter.maybe_fetch_rw_proxy(result?, auto_fetch)

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -473,6 +473,7 @@ impl VM {
             })
             .unwrap_or_default();
         self.interpreter.use_module_with_tags(module, &tags)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -497,6 +498,7 @@ impl VM {
             })
             .unwrap_or_default();
         self.interpreter.import_module(module, &tags)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -508,6 +510,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
         self.interpreter.no_module(module)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -519,6 +522,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
         self.interpreter.need_module(module)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1199,7 +1199,7 @@ impl VM {
             .is_some_and(|t| t == "SetHash");
         let idx_val = self.stack.pop().unwrap_or(Value::Nil);
         let key = idx_val.to_string_value();
-        let mut container = self.get_env_with_main_alias(&name);
+        let container = self.get_env_with_main_alias(&name);
         let current = if let Some(container_value) = container.as_ref() {
             match container_value {
                 Value::Hash(h) => h.get(&key).cloned().unwrap_or(Value::Nil),
@@ -1240,61 +1240,87 @@ impl VM {
         } else {
             self.decrement_value_smart(&effective)?
         };
-        if let Some(container_value) = container.as_mut() {
-            match container_value {
-                Value::Hash(h) => {
-                    Arc::make_mut(h).insert(key, new_val.clone());
-                }
-                Value::Array(arr, ..) => {
-                    if let Ok(i) = idx_val.to_string_value().parse::<usize>() {
-                        let a = Arc::make_mut(arr);
-                        while a.len() <= i {
-                            a.push(Value::Nil);
+        // Modify the container in-place in the env to preserve Arc sharing
+        // (e.g. when two variables reference the same array via Arc).
+        // First try to modify via env_mut().get_mut() to avoid clone.
+        let modified_in_place =
+            if let Some(container_value) = self.interpreter.env_mut().get_mut(&name) {
+                match container_value {
+                    Value::Hash(h) => {
+                        Arc::make_mut(h).insert(key.clone(), new_val.clone());
+                        true
+                    }
+                    Value::Array(arr, ..) => {
+                        if let Ok(i) = idx_val.to_string_value().parse::<usize>() {
+                            // Use in-place mutation when the array is shared
+                            // (strong_count > 1) to preserve identity semantics,
+                            // matching the behavior of index assignment.
+                            // SAFETY: mutsu is single-threaded.
+                            let use_inplace = Arc::strong_count(arr) > 1 && !name.starts_with('@');
+                            let a: &mut Vec<Value> = if use_inplace {
+                                unsafe { &mut *(Arc::as_ptr(arr) as *mut _) }
+                            } else {
+                                Arc::make_mut(arr)
+                            };
+                            while a.len() <= i {
+                                a.push(Value::Nil);
+                            }
+                            a[i] = new_val.clone();
+                            true
+                        } else {
+                            false
                         }
-                        a[i] = new_val.clone();
                     }
+                    Value::Mix(mix, is_mutable) => {
+                        if !*is_mutable {
+                            return Err(RuntimeError::assignment_ro(Some("Mix")));
+                        }
+                        let m = Arc::make_mut(mix);
+                        if new_val.truthy() {
+                            m.insert(key.clone(), Self::mix_assignment_weight(&new_val));
+                        } else {
+                            m.remove(&key);
+                        }
+                        true
+                    }
+                    Value::Set(set, is_mutable) => {
+                        if !*is_mutable {
+                            return Err(RuntimeError::assignment_ro(Some("Set")));
+                        }
+                        let s = Arc::make_mut(set);
+                        if new_val.truthy() {
+                            s.insert(key.clone());
+                        } else {
+                            s.remove(&key);
+                        }
+                        true
+                    }
+                    Value::Bag(bag, is_mutable) => {
+                        if !*is_mutable {
+                            return Err(RuntimeError::assignment_ro(Some("Bag")));
+                        }
+                        let b = Arc::make_mut(bag);
+                        let n = match &new_val {
+                            Value::Int(i) => *i,
+                            _ => 0,
+                        };
+                        if n > 0 {
+                            b.insert(key.clone(), n);
+                        } else {
+                            b.remove(&key);
+                        }
+                        true
+                    }
+                    _ => false,
                 }
-                Value::Mix(mix, is_mutable) => {
-                    if !*is_mutable {
-                        return Err(RuntimeError::assignment_ro(Some("Mix")));
-                    }
-                    let m = Arc::make_mut(mix);
-                    if new_val.truthy() {
-                        m.insert(key, Self::mix_assignment_weight(&new_val));
-                    } else {
-                        m.remove(&key);
-                    }
-                }
-                Value::Set(set, is_mutable) => {
-                    if !*is_mutable {
-                        return Err(RuntimeError::assignment_ro(Some("Set")));
-                    }
-                    let s = Arc::make_mut(set);
-                    if new_val.truthy() {
-                        s.insert(key);
-                    } else {
-                        s.remove(&key);
-                    }
-                }
-                Value::Bag(bag, is_mutable) => {
-                    if !*is_mutable {
-                        return Err(RuntimeError::assignment_ro(Some("Bag")));
-                    }
-                    let b = Arc::make_mut(bag);
-                    let n = match &new_val {
-                        Value::Int(i) => *i,
-                        _ => 0,
-                    };
-                    if n > 0 {
-                        b.insert(key, n);
-                    } else {
-                        b.remove(&key);
-                    }
-                }
-                _ => {}
+            } else {
+                false
+            };
+        if modified_in_place {
+            // Update local slot to match the modified env value
+            if let Some(val) = self.interpreter.env().get(&name).cloned() {
+                self.update_local_if_exists(code, &name, &val);
             }
-            self.set_env_with_main_alias(&name, container_value.clone());
-            self.update_local_if_exists(code, &name, container_value);
         }
         if return_new {
             self.stack.push(new_val);


### PR DESCRIPTION
## Summary
- Optimize named-parameter function calls by adding on-the-fly compilation with caching (`otf_call_cache`), avoiding the slow interpreter fallback path. The 1M-iteration hot loop in roast test 100 now completes in ~8s instead of timing out.
- Fix `$a[0]++` / `$a[0]--` breaking Arc sharing when two variables reference the same array (e.g. `my $b = $a`). Uses unsafe in-place mutation matching the existing pattern in index assignment.
- Relax `is_light_call_eligible` to not require `cf.params.is_empty()` when `param_defs` is present, enabling the light call path for named-param functions.
- Add `roast/S06-signature/named-parameters.t` to whitelist (all 104 subtests pass)

## Test plan
- [x] All 104 subtests in `roast/S06-signature/named-parameters.t` pass
- [x] `cargo test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Existing named-param tests pass (`t/named-params.t`, `t/named-arg-rightmost-wins.t`, etc.)
- [x] Array mutation tests pass (`t/array-mutate.t`, `t/increment-operator.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)