### PR TITLE
perf: fast-path literal defaults in class constructors

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -280,7 +280,11 @@ impl Interpreter {
             for (attr_name, _is_public, default, _is_rw, _, _, _) in
                 self.collect_class_attributes(&class_name.resolve())
             {
-                let val = if let Some(expr) = default {
+                let val = if let Some(Expr::Literal(ref lit_val)) = default {
+                    // Fast path: simple literal defaults (e.g. native type
+                    // defaults like Int(0)) don't need interpretation.
+                    lit_val.clone()
+                } else if let Some(expr) = default {
                     self.eval_block_value(&[Stmt::Expr(expr)])?
                 } else {
                     // Native types have zero/empty defaults instead of Nil

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2619,43 +2619,50 @@ impl Interpreter {
                         let val = self.call_sub_value(build_override, Vec::new(), false)?;
                         Self::coerce_attr_value_by_sigil(val, sigil)
                     } else if let Some(expr) = default {
-                        let temp_self = Value::make_instance(*class_name, attrs.clone());
-                        let old_self = self.env.get("self").cloned();
-                        self.env.insert("self".to_string(), temp_self);
-                        // Set !attr_name and .attr_name in env so that $!a / $.a
-                        // references in default expressions resolve to already-
-                        // initialized attributes (e.g. `has $.c = $!a + $!b`).
-                        let mut saved_attr_env: Vec<(String, Option<Value>)> = Vec::new();
-                        for (a_name, a_val) in &attrs {
-                            let bang = format!("!{}", a_name);
-                            let dot = format!(".{}", a_name);
-                            saved_attr_env.push((bang.clone(), self.env.get(&bang).cloned()));
-                            saved_attr_env.push((dot.clone(), self.env.get(&dot).cloned()));
-                            self.env.insert(bang, a_val.clone());
-                            self.env.insert(dot, a_val.clone());
-                        }
-                        // Temporarily switch to the class package so that
-                        // class-scoped subs (e.g. `sub inner`) are found
-                        // when evaluating attribute default expressions.
-                        let saved_package = self.current_package.clone();
-                        self.current_package = class_key.to_string();
-                        let result = self.eval_block_value(&[Stmt::Expr(expr)]);
-                        self.current_package = saved_package;
-                        // Restore previous env state for attribute variables
-                        for (key, old_val) in saved_attr_env {
-                            if let Some(v) = old_val {
-                                self.env.insert(key, v);
-                            } else {
-                                self.env.remove(&key);
-                            }
-                        }
-                        if let Some(old) = old_self {
-                            self.env.insert("self".to_string(), old);
+                        // Fast path: simple literal defaults (e.g. from native types
+                        // like `has uint32 $.a` which generate `default: Int(0)`)
+                        // don't need env manipulation or self-binding.
+                        if let Expr::Literal(ref lit_val) = expr {
+                            Self::coerce_attr_value_by_sigil(lit_val.clone(), sigil)
                         } else {
-                            self.env.remove("self");
+                            let temp_self = Value::make_instance(*class_name, attrs.clone());
+                            let old_self = self.env.get("self").cloned();
+                            self.env.insert("self".to_string(), temp_self);
+                            // Set !attr_name and .attr_name in env so that $!a / $.a
+                            // references in default expressions resolve to already-
+                            // initialized attributes (e.g. `has $.c = $!a + $!b`).
+                            let mut saved_attr_env: Vec<(String, Option<Value>)> = Vec::new();
+                            for (a_name, a_val) in &attrs {
+                                let bang = format!("!{}", a_name);
+                                let dot = format!(".{}", a_name);
+                                saved_attr_env.push((bang.clone(), self.env.get(&bang).cloned()));
+                                saved_attr_env.push((dot.clone(), self.env.get(&dot).cloned()));
+                                self.env.insert(bang, a_val.clone());
+                                self.env.insert(dot, a_val.clone());
+                            }
+                            // Temporarily switch to the class package so that
+                            // class-scoped subs (e.g. `sub inner`) are found
+                            // when evaluating attribute default expressions.
+                            let saved_package = self.current_package.clone();
+                            self.current_package = class_key.to_string();
+                            let result = self.eval_block_value(&[Stmt::Expr(expr)]);
+                            self.current_package = saved_package;
+                            // Restore previous env state for attribute variables
+                            for (key, old_val) in saved_attr_env {
+                                if let Some(v) = old_val {
+                                    self.env.insert(key, v);
+                                } else {
+                                    self.env.remove(&key);
+                                }
+                            }
+                            if let Some(old) = old_self {
+                                self.env.insert("self".to_string(), old);
+                            } else {
+                                self.env.remove("self");
+                            }
+                            let val = result?;
+                            Self::coerce_attr_value_by_sigil(val, sigil)
                         }
-                        let val = result?;
-                        Self::coerce_attr_value_by_sigil(val, sigil)
                     } else {
                         match sigil {
                             '@' => {
@@ -2923,7 +2930,10 @@ impl Interpreter {
                             continue;
                         }
                         // Evaluate the default expression for this class's attribute
-                        let val = if let Some(expr) = default {
+                        let val = if let Some(Expr::Literal(ref lit_val)) = default {
+                            // Fast path: simple literal defaults
+                            Self::coerce_attr_value_by_sigil(lit_val.clone(), sigil)
+                        } else if let Some(expr) = default {
                             let temp_self = Value::make_instance(*class_name, attrs.clone());
                             let old_self = self.env.get("self").cloned();
                             self.env.insert("self".to_string(), temp_self);

--- a/t/native-type-class-perf.t
+++ b/t/native-type-class-perf.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 5;
+
+# Test that classes with native-typed attributes can be constructed efficiently.
+# This is a regression test for a performance bug where native type defaults
+# (e.g., `has uint32 $.a` generating `default: Int(0)`) triggered expensive
+# env manipulation on every construction, causing ~800us per attribute.
+
+my class Data {
+    has uint32 $.a;
+    has uint32 $.b;
+    has uint32 $.c;
+    has uint32 $.hashlen;
+}
+
+# Basic construction with no args
+{
+    my $d = Data.new;
+    is $d.a, 0, 'uint32 attr defaults to 0';
+    is $d.hashlen, 0, 'uint32 attr defaults to 0 (2)';
+}
+
+# Construction with named args
+{
+    my $d = Data.new(:a(42), :hashlen(32));
+    is $d.a, 42, 'uint32 attr set via named arg';
+    is $d.hashlen, 32, 'uint32 attr set via named arg (2)';
+}
+
+# Loop construction (should complete in reasonable time)
+{
+    my $count = 0;
+    for 1..1000 {
+        my $d = Data.new(:hashlen(32));
+        $count++ if $d.hashlen == 32;
+    }
+    is $count, 1000, 'constructed 1000 instances with native-typed attrs';
+}


### PR DESCRIPTION
## Summary
- Add fast path for `Expr::Literal` default expressions in class constructors (`dispatch_new` and `dispatch_bless`)
- When a class attribute has a simple literal default (e.g., native types like `has uint32 $.a` generate `default: Int(0)`), directly clone the value instead of creating a temporary self instance and manipulating the env
- This fixes the timeout in `roast/S02-types/signed-unsigned-native.t` -- construction time for a class with 4 uint32 attributes drops from ~3.2s to ~0.3s per 1000 iterations
- The roast test now runs in ~2s (release build) instead of timing out

## Performance improvement
| Scenario | Before | After |
|---|---|---|
| 1000x `Foo.new` (1 uint32 attr) | 1.07s | 0.13s |
| 1000x `Foo.new` (4 uint32 attrs) | 3.20s | 0.32s |
| 20000x `Data.new` (4 uint32 + 1 Buf attr) | >60s (timeout) | ~6s (debug) / ~1s (release) |

## Remaining failures
10/132 subtests in `roast/S02-types/signed-unsigned-native.t` still fail (tests 76-85): mixed signed/unsigned `!=` comparisons. Raku's native `!=` returns `False` when comparing uint and int types with negative signed operands (a MoarVM-specific behavior), while mutsu returns the mathematically correct `True`. Fixing this requires native type tracking on values, which is a separate architectural change.

## Test plan
- [x] New test `t/native-type-class-perf.t` verifying native-typed attribute defaults and construction performance
- [x] `make test` passes (all 481 test files)
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)