### PR TITLE
fix: pass all 1453 subtests in roast/S32-str/val.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1096,6 +1096,7 @@ roast/S32-str/trim.t
 roast/S32-str/uc.t
 roast/S32-str/uniparse.t
 roast/S32-str/utf8-c8.t
+roast/S32-str/val.t
 roast/S32-str/windows-1251-windows-1252-encode-decode.t
 roast/S32-str/words.t
 roast/S32-temporal/Date.t

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -253,6 +253,7 @@ impl Compiler {
             source_var_names,
             autothread_junctions: false,
             explicit_zero_params: false,
+            multi_param_names: Vec::new(),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1085,6 +1085,7 @@ impl Compiler {
                     source_var_names,
                     autothread_junctions,
                     explicit_zero_params: *explicit_zero_params,
+                    multi_param_names: params.clone(),
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -546,6 +546,9 @@ pub(crate) enum OpCode {
         /// When true, the block explicitly declared zero parameters (`-> {}`).
         /// Passing any argument should throw "Too many positionals passed".
         explicit_zero_params: bool,
+        /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
+        /// Used to temporarily clear sigilless readonly flags before binding.
+        multi_param_names: Vec<String>,
     },
     /// C-style loop: [cond opcodes][body opcodes][step opcodes].
     /// Layout after CStyleLoop: cond at [ip+1..cond_end), body at [cond_end..step_start),

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -47,7 +47,11 @@ impl Interpreter {
                         type_name
                     ))));
                 }
-                let numeric = args[0].clone();
+                // Unwrap allomorphic (Mixin) arguments to get the inner numeric value
+                let numeric = match &args[0] {
+                    Value::Mixin(inner, _) => (**inner).clone(),
+                    other => other.clone(),
+                };
                 let string = args[1].to_string_value();
                 let mut mixins = std::collections::HashMap::new();
                 mixins.insert("Str".to_string(), Value::str(string));

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -45,7 +45,12 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
         return try_parse_generic_radix(body).map(|v| apply_sign(v, sign));
     }
 
-    // Try 0-prefixed radix (0x, 0o, 0b, 0d)
+    // Try multiplicative notation `N*B**K` (e.g., `2*10**3`, `0b1111*10**3`)
+    if let Some(v) = try_parse_multiplicative(body, sign) {
+        return Some(v);
+    }
+
+    // Try 0-prefixed radix (0x, 0o, 0b, 0d) with optional fractional part
     if body.starts_with('0')
         && body.len() >= 3
         && let Some(v) = try_parse_0_radix(body)
@@ -53,7 +58,7 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
         return Some(apply_sign(v, sign));
     }
 
-    // Try fraction `N/D`
+    // Try fraction `N/D` (with optional decimal parts and signed denominators)
     if let Some(v) = try_parse_fraction(body, sign) {
         return Some(v);
     }
@@ -148,7 +153,100 @@ fn try_parse_inf_nan(s: &str) -> Option<Value> {
     }
 }
 
-/// Parse `0x`, `0o`, `0b`, `0d` prefixed integers.
+/// Parse multiplicative notation: `N*B**K` (e.g., `2*10**3`, `42.25*10**4`)
+/// The base B can have an optional sign: `N*+B**K`, `N*-B**K`
+/// The exponent K can also have an optional sign: `N*B**+K`
+fn try_parse_multiplicative(body: &str, sign: i32) -> Option<Value> {
+    let star_pos = body.find('*')?;
+    let left = &body[..star_pos];
+    let right = &body[star_pos + 1..];
+
+    // Right side must contain ** (power notation)
+    let pow_pos = right.find("**")?;
+    let base_str = &right[..pow_pos];
+    let exp_str = &right[pow_pos + 2..];
+
+    // Parse left (coefficient): can be integer, decimal, or 0-prefixed radix
+    let coeff = parse_coefficient(left)?;
+
+    // Parse base with optional sign
+    let (base_sign, base_body) = strip_sign(base_str);
+    let base_clean = strip_underscores(base_body)?;
+    if base_clean.is_empty() || !base_clean.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let base_int: i64 = base_clean.parse().ok()?;
+    let base_int = if base_sign < 0 { -base_int } else { base_int };
+
+    // Parse exponent with optional sign
+    let (exp_sign, exp_body) = strip_sign(exp_str);
+    let exp_clean = strip_underscores(exp_body)?;
+    if exp_clean.is_empty() || !exp_clean.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let exp_val: i32 = exp_clean.parse().ok()?;
+    let exp_val = if exp_sign < 0 { -exp_val } else { exp_val };
+
+    // Try to produce an exact integer or Rat result when possible
+    if exp_val >= 0
+        && let Some(power) = (base_int).checked_pow(exp_val as u32)
+    {
+        match &coeff {
+            Value::Int(n) => {
+                if let Some(result) = n.checked_mul(power) {
+                    let result = if sign < 0 { -result } else { result };
+                    return Some(Value::Int(result));
+                }
+            }
+            Value::Rat(n, d) => {
+                if let Some(result_n) = n.checked_mul(power) {
+                    let result_n = if sign < 0 { -result_n } else { result_n };
+                    return Some(crate::value::make_rat(result_n, *d));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let result = value_to_f64(&coeff) * (base_int as f64).powi(exp_val);
+    let result = if sign < 0 { -result } else { result };
+    Some(Value::Num(result))
+}
+
+/// Parse a coefficient for multiplicative notation.
+/// Can be plain integer, decimal, or 0-prefixed radix number (with optional fractional part).
+fn parse_coefficient(s: &str) -> Option<Value> {
+    // Try 0-prefixed radix first
+    if s.starts_with('0')
+        && s.len() >= 3
+        && let Some(v) = try_parse_0_radix(s)
+    {
+        return Some(v);
+    }
+    // Try decimal with dot
+    if let Some(v) = try_parse_decimal_rat(s, 1) {
+        return Some(v);
+    }
+    // Try plain integer
+    try_parse_plain_int(s, 1)
+}
+
+/// Convert a Value to f64 for arithmetic operations.
+fn value_to_f64(v: &Value) -> f64 {
+    match v {
+        Value::Int(i) => *i as f64,
+        Value::Num(f) => *f,
+        Value::Rat(n, d) if *d != 0 => *n as f64 / *d as f64,
+        Value::FatRat(n, d) if *d != 0 => *n as f64 / *d as f64,
+        Value::BigInt(n) => {
+            use num_traits::ToPrimitive;
+            n.to_f64().unwrap_or(f64::INFINITY)
+        }
+        _ => 0.0,
+    }
+}
+
+/// Parse `0x`, `0o`, `0b`, `0d` prefixed numbers (with optional fractional part).
 fn try_parse_0_radix(body: &str) -> Option<Value> {
     let (base, digits) = match body.as_bytes().get(1)? {
         b'x' | b'X' => (16, &body[2..]),
@@ -158,6 +256,30 @@ fn try_parse_0_radix(body: &str) -> Option<Value> {
         _ => return None,
     };
 
+    // Check for fractional part (e.g., 0b111.11)
+    if let Some(dot_pos) = digits.find('.') {
+        let int_part = &digits[..dot_pos];
+        let frac_part = &digits[dot_pos + 1..];
+
+        let int_clean = strip_underscores_radix_body(int_part)?;
+        let frac_clean = strip_underscores_radix_body(frac_part)?;
+
+        if int_clean.is_empty() || frac_clean.is_empty() {
+            return None;
+        }
+
+        // Validate digits for base
+        validate_radix_digits(&int_clean, base)?;
+        validate_radix_digits(&frac_clean, base)?;
+
+        // Calculate: int_part + frac_part / base^frac_len as Rat
+        let int_val = i64::from_str_radix(&int_clean, base).ok()?;
+        let frac_val = i64::from_str_radix(&frac_clean, base).ok()?;
+        let denom = (base as i64).checked_pow(frac_clean.len() as u32)?;
+        let numer = int_val.checked_mul(denom)?.checked_add(frac_val)?;
+        return Some(crate::value::make_rat(numer, denom));
+    }
+
     // Allow leading underscore after 0b/0o/0x/0d prefix (Raku allows `0b_1`)
     let clean = strip_underscores_radix_body(digits)?;
     if clean.is_empty() {
@@ -165,17 +287,7 @@ fn try_parse_0_radix(body: &str) -> Option<Value> {
     }
 
     // Check all digits valid for base
-    for c in clean.chars() {
-        let dv = match c {
-            '0'..='9' => c as u32 - '0' as u32,
-            'a'..='f' => 10 + c as u32 - 'a' as u32,
-            'A'..='F' => 10 + c as u32 - 'A' as u32,
-            _ => return None,
-        };
-        if dv >= base {
-            return None;
-        }
-    }
+    validate_radix_digits(&clean, base)?;
 
     if let Ok(n) = i64::from_str_radix(&clean, base) {
         Some(Value::Int(n))
@@ -186,6 +298,22 @@ fn try_parse_0_radix(body: &str) -> Option<Value> {
             .ok()
             .map(|b| Value::BigInt(std::sync::Arc::new(b)))
     }
+}
+
+/// Validate that all characters are valid digits for the given base.
+fn validate_radix_digits(s: &str, base: u32) -> Option<()> {
+    for c in s.chars() {
+        let dv = match c {
+            '0'..='9' => c as u32 - '0' as u32,
+            'a'..='f' => 10 + c as u32 - 'a' as u32,
+            'A'..='F' => 10 + c as u32 - 'A' as u32,
+            _ => return None,
+        };
+        if dv >= base {
+            return None;
+        }
+    }
+    Some(())
 }
 
 /// Strip underscores in radix body (allows leading underscore like `0b_1`).
@@ -210,9 +338,17 @@ fn try_parse_generic_radix(body: &str) -> Option<Value> {
         return None;
     }
 
-    let rest = after_base.strip_prefix('<')?;
-    let close_pos = rest.find('>')?;
-    if !rest[close_pos + 1..].trim().is_empty() {
+    // Support both <> and «» (French/guillemet) delimiters
+    let (rest, close_char) = if let Some(r) = after_base.strip_prefix('<') {
+        (r, '>')
+    } else if let Some(r) = after_base.strip_prefix('\u{ab}') {
+        // «
+        (r, '\u{bb}') // »
+    } else {
+        return None;
+    };
+    let close_pos = rest.find(close_char)?;
+    if !rest[close_pos + close_char.len_utf8()..].trim().is_empty() {
         return None;
     }
     let digits_body = &rest[..close_pos];
@@ -262,26 +398,66 @@ fn try_parse_fraction(body: &str, sign: i32) -> Option<Value> {
     let num_str = &body[..slash_pos];
     let den_str = &body[slash_pos + 1..];
 
-    // Both parts must be plain integers (no dots, no e, no radix)
-    let num_clean = strip_underscores(num_str)?;
-    let den_clean = strip_underscores(den_str)?;
+    // Parse numerator (can be integer or decimal with underscores)
+    let (num_n, num_d) = parse_fraction_part(num_str, false)?;
+    // Parse denominator (can have optional sign, can be integer or decimal)
+    let (den_n, den_d) = parse_fraction_part(den_str, true)?;
 
-    // Must be pure digits
-    if num_clean.is_empty()
-        || den_clean.is_empty()
-        || !num_clean.chars().all(|c| c.is_ascii_digit())
-        || !den_clean.chars().all(|c| c.is_ascii_digit())
-    {
+    if den_n == 0 && den_d == 0 {
         return None;
     }
 
-    let n: i64 = num_clean.parse().ok()?;
-    let d: i64 = den_clean.parse().ok()?;
-    if d == 0 {
+    // Result is (num_n/num_d) / (den_n/den_d) = (num_n * den_d) / (num_d * den_n)
+    let result_n = num_n.checked_mul(den_d)?;
+    let result_d = num_d.checked_mul(den_n.abs())?;
+    if result_d == 0 {
         return None;
     }
-    let n = if sign < 0 { -n } else { n };
-    Some(crate::value::make_rat(n, d))
+
+    let result_n = if sign < 0 { -result_n } else { result_n };
+    let result_n = if den_n < 0 { -result_n } else { result_n };
+    Some(crate::value::make_rat(result_n, result_d))
+}
+
+/// Parse a numerator or denominator part of a fraction.
+/// Returns (numerator, denominator) as a rational number.
+/// When `allow_sign` is true, the part can have a leading +/- sign.
+fn parse_fraction_part(s: &str, allow_sign: bool) -> Option<(i64, i64)> {
+    let (part_sign, body) = if allow_sign { strip_sign(s) } else { (1, s) };
+
+    if let Some(dot_pos) = body.find('.') {
+        // Decimal part (e.g., "42.15" or "15.45")
+        let int_str = &body[..dot_pos];
+        let frac_str = &body[dot_pos + 1..];
+        let int_clean = strip_underscores(int_str)?;
+        let frac_clean = strip_underscores(frac_str)?;
+        let int_clean = if int_clean.is_empty() {
+            "0".to_string()
+        } else {
+            int_clean
+        };
+        if !int_clean.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        if frac_clean.is_empty() || !frac_clean.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let int_val: i64 = int_clean.parse().ok()?;
+        let frac_val: i64 = frac_clean.parse().ok()?;
+        let denom = 10i64.checked_pow(frac_clean.len() as u32)?;
+        let numer = int_val.checked_mul(denom)?.checked_add(frac_val)?;
+        let numer = if part_sign < 0 { -numer } else { numer };
+        Some((numer, denom))
+    } else {
+        // Plain integer
+        let clean = strip_underscores(body)?;
+        if clean.is_empty() || !clean.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let val: i64 = clean.parse().ok()?;
+        let val = if part_sign < 0 { -val } else { val };
+        Some((val, 1))
+    }
 }
 
 /// Parse scientific notation: `123e0`, `123.0e2`, `1_2_3E0_0`, etc.
@@ -386,7 +562,13 @@ fn try_parse_decimal_rat(body: &str, sign: i32) -> Option<Value> {
     let int_clean = strip_underscores(int_str)?;
     let frac_clean = strip_underscores(frac_str)?;
 
-    if int_clean.is_empty() || !int_clean.chars().all(|c| c.is_ascii_digit()) {
+    // Allow empty integer part (e.g., ".13" → "0.13")
+    let int_clean = if int_clean.is_empty() {
+        "0".to_string()
+    } else {
+        int_clean
+    };
+    if !int_clean.chars().all(|c| c.is_ascii_digit()) {
         return None;
     }
     if frac_clean.is_empty() || !frac_clean.chars().all(|c| c.is_ascii_digit()) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2508,6 +2508,7 @@ impl VM {
                 source_var_names,
                 autothread_junctions,
                 explicit_zero_params,
+                multi_param_names,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -2525,6 +2526,7 @@ impl VM {
                     source_var_names: source_var_names.clone(),
                     autothread_junctions: *autothread_junctions,
                     explicit_zero_params: *explicit_zero_params,
+                    multi_param_names: multi_param_names.clone(),
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -18,6 +18,9 @@ pub(super) struct ForLoopSpec {
     pub(super) autothread_junctions: bool,
     /// When true, `-> {}` was used — throw on any items.
     pub(super) explicit_zero_params: bool,
+    /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
+    /// Used to temporarily clear sigilless readonly flags before binding.
+    pub(super) multi_param_names: Vec<String>,
 }
 
 pub(super) struct WhileLoopSpec {
@@ -403,6 +406,19 @@ impl VM {
         } else {
             None
         };
+        // Save multi-param values and readonly state so they can be restored
+        // after the loop (inner loops must not clobber outer scope bindings).
+        let saved_multi_params: Vec<(String, Option<Value>, bool, Option<Value>)> = spec
+            .multi_param_names
+            .iter()
+            .map(|name| {
+                let val = self.interpreter.env().get(name).cloned();
+                let was_readonly = self.interpreter.readonly_vars().contains(name);
+                let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
+                let sigilless_ro = self.interpreter.env().get(&sigilless_key).cloned();
+                (name.clone(), val, was_readonly, sigilless_ro)
+            })
+            .collect();
         let total_items = chunked_items.len();
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate() {
             self.topic_source_var = if writes_back_topic {
@@ -440,6 +456,16 @@ impl VM {
                 && let Some(ref name) = param_name
             {
                 self.interpreter.mark_readonly(name);
+            }
+            // Temporarily clear readonly flags for multi-param names
+            // so the bind stmts (Stmt::Assign) at the start of the body can
+            // re-bind variables that may be readonly from an outer scope.
+            for mp_name in &spec.multi_param_names {
+                // Clear regular readonly flag
+                self.interpreter.unmark_readonly(mp_name);
+                // Clear sigilless readonly flag
+                let key = format!("__mutsu_sigilless_readonly::{}", mp_name);
+                self.interpreter.env_mut().insert(key, Value::Bool(false));
             }
             'body_redo: loop {
                 match self.run_range(code, body_start, loop_end, compiled_fns) {
@@ -678,6 +704,25 @@ impl VM {
             && let Some(ref name) = param_name
         {
             self.interpreter.readonly_vars_mut().remove(name);
+        }
+        // Restore saved multi-param values and readonly state
+        for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {
+            if let Some(v) = saved_val {
+                self.interpreter.env_mut().insert(name.clone(), v);
+            } else {
+                self.interpreter.env_mut().remove(&name);
+            }
+            if was_readonly {
+                self.interpreter.mark_readonly(&name);
+            } else {
+                self.interpreter.unmark_readonly(&name);
+            }
+            let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
+            if let Some(ro_val) = sigilless_ro {
+                self.interpreter.env_mut().insert(sigilless_key, ro_val);
+            } else {
+                self.interpreter.env_mut().remove(&sigilless_key);
+            }
         }
         self.topic_source_var = saved_topic_source;
         if spec.restore_topic {


### PR DESCRIPTION
## Summary
- Fix for-loop multi-param scoping so inner loops don't clobber outer sigilless variable bindings
- Fix allomorph constructors (IntStr.new, RatStr.new, etc.) to unwrap Mixin arguments, fixing `eqv` comparisons
- Extend the numeric string parser (`str_numeric.rs`) with support for:
  - Fractional radix numbers (`0b111.11`, `0o111.11`, `0x1a.ff`)
  - Multiplicative notation (`N*B**K`, e.g., `2*10**3`, `42.25*10**4`)
  - Leading-dot decimals (`.13`)
  - Guillemet delimiters for generic radix (`:10«42»`)
  - Fractions with signed/decimal parts (`42/-15`, `42.15/15.45`)

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S32-str/val.t` passes all 1453 subtests
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)