### PR TITLE
fix: deepmap on typed arrays returns List when results violate constraint

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -983,6 +983,7 @@ roast/S32-list/classify-list.t
 roast/S32-list/combinations.t
 roast/S32-list/create.t
 roast/S32-list/cross.t
+roast/S32-list/deepmap.t
 roast/S32-list/duckmap.t
 roast/S32-list/end.t
 roast/S32-list/first-end-k.t

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2347,7 +2347,16 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                let arr_kind = if kind.is_real_array() {
+                let mut use_real_array = kind.is_real_array();
+                // If the source array has a type constraint (e.g. `my Str @a`)
+                // and the mapped values don't conform, downgrade to a List.
+                if use_real_array && let Some(info) = self.container_type_metadata(target) {
+                    let vt = &info.value_type;
+                    if !vt.is_empty() && result.iter().any(|v| !v.isa_check(vt)) {
+                        use_real_array = false;
+                    }
+                }
+                let arr_kind = if use_real_array {
                     if itemize_result {
                         crate::value::ArrayKind::ItemArray
                     } else {


### PR DESCRIPTION
## Summary
- When `deepmap` is called on a typed array (e.g. `my Str @a`) and the mapped values don't conform to the element type constraint, return a plain List instead of an Array
- Adds `roast/S32-list/deepmap.t` to whitelist (all 14 subtests now pass, up from 13/14)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-list/deepmap.t` passes all 14 subtests
- [x] `make test` shows no regressions
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)