### PR TITLE
fix: propagate := bind alias writes for env-based vars like $_

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -74,6 +74,7 @@ roast/S02-magicals/USER.t
 roast/S02-magicals/VM.t
 roast/S02-magicals/args.t
 roast/S02-magicals/block.t
+roast/S02-magicals/dollar-underscore.t
 roast/S02-magicals/dollar_bang.t
 roast/S02-magicals/env.t
 roast/S02-magicals/file_line.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1217,6 +1217,31 @@ impl VM {
                     self.set_env_with_main_alias(&source_name, val.clone());
                     self.update_local_if_exists(code, &source_name, &val);
                 }
+                // Reverse alias propagation: find all variables that are
+                // bound TO this variable (i.e. `my $x := $name`) and update
+                // them so the alias stays in sync.
+                {
+                    let prefix = "__mutsu_sigilless_alias::";
+                    let reverse_targets: Vec<String> = self
+                        .interpreter
+                        .env()
+                        .iter()
+                        .filter_map(|(k, v)| {
+                            if let Some(var_name) = k.strip_prefix(prefix)
+                                && let Value::Str(target) = v
+                                && target.as_str() == name
+                            {
+                                Some(var_name.to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    for target_var in reverse_targets {
+                        self.set_env_with_main_alias(&target_var, val.clone());
+                        self.update_local_if_exists(code, &target_var, &val);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::SetVarType { name_idx, tc_idx } => {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2344,6 +2344,23 @@ impl VM {
             }
         }
         *self.interpreter.env_mut() = restored_env;
+        // After block scope restoration, sync `:=` alias bindings.
+        // If a local variable was modified inside the block and has a
+        // sigilless alias (e.g. `my $a := $_`), propagate the local's
+        // current value to the alias target in env so they stay in sync.
+        for (idx, name) in code.locals.iter().enumerate() {
+            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+            if let Some(Value::Str(target)) = self.interpreter.env().get(&alias_key).cloned() {
+                let local_val = &self.locals[idx];
+                if let Some(env_val) = self.interpreter.env().get(target.as_str())
+                    && local_val != env_val
+                {
+                    self.interpreter
+                        .env_mut()
+                        .insert(target.to_string(), local_val.clone());
+                }
+            }
+        }
         // Drop readonly flags for block-declared variables so a later outer
         // `my` redeclaration of the same name is not marked as readonly by
         // the now-gone binding (`my %h := SetHash.new(...)` inside a block

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -473,6 +473,7 @@ impl VM {
             })
             .unwrap_or_default();
         self.interpreter.use_module_with_tags(module, &tags)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -497,6 +498,7 @@ impl VM {
             })
             .unwrap_or_default();
         self.interpreter.import_module(module, &tags)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -508,6 +510,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
         self.interpreter.no_module(module)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }
@@ -519,6 +522,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
         self.interpreter.need_module(module)?;
+        self.fn_resolve_gen += 1;
         self.env_dirty = true;
         Ok(())
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2637,7 +2637,6 @@ impl VM {
                 return Ok(());
             }
         }
-        // Disabled: GetLocal alias following for cross-scope binding
         let atomic_name = name.strip_prefix('$').unwrap_or(&name);
         let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
         // Only use the scalar atomic fast path for scalar ($) variables.
@@ -2874,6 +2873,19 @@ impl VM {
                 for &(source, target) in &self.local_bind_pairs {
                     if source == idx {
                         self.locals[target] = new_val.clone();
+                    }
+                }
+            }
+            // Propagate to env-based alias targets (for `:=` bindings where
+            // the source is an env variable like `$_`).
+            {
+                let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+                if let Some(Value::Str(target)) = self.interpreter.env().get(&alias_key).cloned() {
+                    let is_co_local = code.locals.iter().any(|n| n == target.as_str());
+                    if !is_co_local {
+                        self.interpreter
+                            .env_mut()
+                            .insert(target.to_string(), self.locals[idx].clone());
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- When `my $a := $_` binds a local to an env-based variable, writes to either side now propagate correctly
- SetGlobal reverse alias propagation: when writing to `$_`, finds all variables bound to it (like `$a`) and updates them
- SetLocal forward alias propagation: when writing to `$a`, updates the env alias target (`$_`)
- BlockScope restoration: syncs alias bindings after env restore so modifications inside blocks persist

## Test plan
- [x] All 23 subtests in `roast/S02-magicals/dollar-underscore.t` pass
- [x] Added to `roast-whitelist.txt`
- [x] `make test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)