### PR TITLE
fix: fix %(expr) hash context and @<name>/%<name> capture variable parsing

### DIFF
--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -631,8 +631,8 @@ pub(super) fn list_context_paren_expr(input: &str) -> PResult<'_, Expr> {
 
 /// Parse hash-context parenthesized expression: `%(...)`.
 ///
-/// In Raku, `%(values)` builds a Hash from the given key-value pairs.
-/// We lower this to a call to `hash(...)`.
+/// In Raku, `%(expr)` coerces the expression into hash context.
+/// We lower this to a method call `.hash` on the inner expression.
 pub(super) fn hash_context_paren_expr(input: &str) -> PResult<'_, Expr> {
     let Some(rest) = input.strip_prefix('%') else {
         return Err(PError::expected("hash-context parenthesized expression"));
@@ -641,19 +641,14 @@ pub(super) fn hash_context_paren_expr(input: &str) -> PResult<'_, Expr> {
         return Err(PError::expected("hash-context parenthesized expression"));
     }
     let (rest, inner) = paren_expr(rest)?;
-    let args = match inner {
-        Expr::Grouped(ref boxed) => match boxed.as_ref() {
-            Expr::ArrayLiteral(items) => items.clone(),
-            other => vec![other.clone()],
-        },
-        Expr::ArrayLiteral(ref items) => items.clone(),
-        other => vec![other],
-    };
     Ok((
         rest,
-        Expr::Call {
+        Expr::MethodCall {
+            target: Box::new(inner),
             name: Symbol::intern("hash"),
-            args,
+            args: vec![],
+            modifier: None,
+            quoted: false,
         },
     ))
 }

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -648,6 +648,28 @@ pub(super) fn array_var(input: &str) -> PResult<'_, Expr> {
             "X::Obsolete: Unsupported use of @{expr}. In Raku please use: @(expr).".to_string(),
         ));
     }
+    // Handle @<name> — list coercion of a named capture variable from $/
+    // (e.g., after a regex match, @<fie> gives the positional elements of $<fie>)
+    if twigil.is_empty()
+        && rest.starts_with('<')
+        && let Some(after_lt) = rest.strip_prefix('<')
+        && let Some(end) = after_lt.find('>')
+    {
+        let name = &after_lt[..end];
+        if !name.is_empty() {
+            let after_gt = &after_lt[end + 1..];
+            return Ok((
+                after_gt,
+                Expr::MethodCall {
+                    target: Box::new(Expr::CaptureVar(name.to_string())),
+                    name: crate::symbol::Symbol::intern("list"),
+                    args: vec![],
+                    modifier: None,
+                    quoted: false,
+                },
+            ));
+        }
+    }
     // Bare @ (anonymous array variable) — each occurrence gets a unique name
     let next_is_ident =
         !rest.is_empty() && rest.chars().next().is_some_and(is_raku_identifier_start);
@@ -731,6 +753,28 @@ pub(super) fn hash_var(input: &str) -> PResult<'_, Expr> {
                 args: vec![inner],
             },
         ));
+    }
+    // Handle %<name> — hash coercion of a named capture variable from $/
+    // (e.g., after a regex match, %<foe> gives the hash view of $<foe>)
+    if twigil.is_empty()
+        && rest.starts_with('<')
+        && let Some(after_lt) = rest.strip_prefix('<')
+        && let Some(end) = after_lt.find('>')
+    {
+        let name = &after_lt[..end];
+        if !name.is_empty() {
+            let after_gt = &after_lt[end + 1..];
+            return Ok((
+                after_gt,
+                Expr::MethodCall {
+                    target: Box::new(Expr::CaptureVar(name.to_string())),
+                    name: crate::symbol::Symbol::intern("hash"),
+                    args: vec![],
+                    modifier: None,
+                    quoted: false,
+                },
+            ));
+        }
     }
     // Bare % (anonymous hash variable)
     let next_is_ident =


### PR DESCRIPTION
## Summary
- Fix `%(expr)` hash context operator to call `.hash` on inner expression instead of `hash(...)` function. The previous implementation broke `%($/)` on Match objects (and other non-pair-list values) because `hash()` expects flat key-value pairs, while `.hash` properly coerces any object to hash context. This was a regression from PR #2301.
- Add `@<name>` and `%<name>` parsing as named capture variable access with list/hash coercion. Previously `@<fie>` was parsed as a bare anonymous array followed by an associative index `<fie>`, causing "Type Array does not support associative indexing" runtime error. Now correctly parsed as `$<fie>.list` and `$<fie>.hash` respectively.

## Test results
- `roast/S05-capture/subrule.t`: 46/46 passing (was 4/46 after PR #2301)
- `roast/S02-literals/adverbs.t`: 35/35 passing (was 26/35, tests 27-28 are TODO)

## Test plan
- [x] Both roast tests pass with `prove -e 'target/release/mutsu'`
- [x] `make test` passes (449 cargo tests + 3899 prove tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] Verified `%(a => 1, b => 2)` still works correctly (hash construction via `.hash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)