### PR TITLE
fix: pass all 22 subtests in roast/S02-types/autovivification.t

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -169,6 +169,17 @@ impl Compiler {
                 let idx = self.code.add_constant(Value::str_from("Nil"));
                 self.code.emit(OpCode::LoadConst(idx));
             }
+            // Method call on nested-index target with mutating method -- writeback via IndexAssign.
+            // e.g. %h<a><b>.push(1, 2) => %h<a><b> = %h<a><b>.push(1, 2)
+            Expr::MethodCall {
+                target,
+                name,
+                args,
+                modifier,
+                quoted,
+            } if Self::is_nested_mutating_method_on_index(target, name) => {
+                self.compile_expr_nested_method_writeback(target, name, args, modifier, *quoted);
+            }
             // Method call on non-variable target (no writeback needed)
             Expr::MethodCall {
                 target,

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -362,14 +362,32 @@ impl Compiler {
                     },
                 };
                 let method_call = Expr::MethodCall {
-                    target: Box::new(slot),
+                    target: Box::new(slot.clone()),
                     name: *name,
                     args: args[1..].to_vec(),
                     modifier: None,
                     quoted: false,
                 };
+                // Write the method call result back to the slot so that
+                // nested hash mutations (e.g. `push %h<a><b>, 1, 2`)
+                // are visible through the parent hash.
+                let writeback = Expr::IndexAssign {
+                    target: match &slot {
+                        Expr::Index { target, .. } => target.clone(),
+                        _ => unreachable!(),
+                    },
+                    index: match &slot {
+                        Expr::Index { index, .. } => index.clone(),
+                        _ => unreachable!(),
+                    },
+                    value: Box::new(method_call),
+                    is_positional: match &slot {
+                        Expr::Index { is_positional, .. } => *is_positional,
+                        _ => true,
+                    },
+                };
                 let do_block = Expr::DoBlock {
-                    body: vec![Stmt::Expr(viv_assign), Stmt::Expr(method_call)],
+                    body: vec![Stmt::Expr(viv_assign), Stmt::Expr(writeback)],
                     label: None,
                 };
                 self.compile_expr(&do_block);
@@ -664,6 +682,9 @@ impl Compiler {
                     arity,
                     arg_sources_idx,
                 });
+                // Emit writeback for any Index expressions that were passed
+                // as `is rw` arguments (temp variable -> original slot).
+                self.emit_index_rw_writebacks();
             }
         }
     }

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -309,11 +309,8 @@ impl Compiler {
 
     /// Compile Index expression (target[index] or target{index}).
     pub(super) fn compile_expr_index(&mut self, target: &Expr, index: &Expr, is_positional: bool) {
-        // When in scalar bind context (`:=`), emit IndexAutovivify so that
-        // the VM auto-vivifies intermediate hashes (returning HashSlotRef)
-        // or returns ArraySlotRef for positional indexing.
-        // This enables `my $b := %h<foo><baz>; $b = 42` and
-        // `my $b := @a[1]; $b = 42`.
+        // When in scalar bind context (`:=`), emit IndexAutovivifyLazy so that
+        // binding alone doesn't autovivify (deferred until assignment).
         let use_autovivify = self.scalar_bind_autovivify;
 
         // Special case: %*ENV<key> compiles to GetEnvIndex
@@ -326,7 +323,7 @@ impl Compiler {
                     self.compile_expr(target);
                     self.compile_expr(index);
                     if use_autovivify {
-                        self.code.emit(OpCode::IndexAutovivify);
+                        self.code.emit(OpCode::IndexAutovivifyLazy);
                     } else {
                         self.code.emit(OpCode::Index { is_positional });
                     }
@@ -335,7 +332,7 @@ impl Compiler {
                 self.compile_expr(target);
                 self.compile_expr(index);
                 if use_autovivify {
-                    self.code.emit(OpCode::IndexAutovivify);
+                    self.code.emit(OpCode::IndexAutovivifyLazy);
                 } else {
                     self.code.emit(OpCode::Index { is_positional });
                 }
@@ -344,7 +341,7 @@ impl Compiler {
             self.compile_expr(target);
             self.compile_expr(index);
             if use_autovivify {
-                self.code.emit(OpCode::IndexAutovivify);
+                self.code.emit(OpCode::IndexAutovivifyLazy);
             } else {
                 self.code.emit(OpCode::Index { is_positional });
             }

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -177,7 +177,7 @@ impl Compiler {
     pub(super) fn expr_is_fresh_container(expr: &Expr) -> bool {
         match expr {
             // Indexing into an array/hash element produces a value that
-            // was copied into the array, hence a distinct container.
+            // was copied into the container, hence a distinct container.
             Expr::Index { .. } => true,
             _ => false,
         }

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -168,6 +168,48 @@ impl Compiler {
         }
     }
 
+    /// Compile mutating method on a nested Index target by rewriting as
+    /// IndexAssign writeback. E.g. `%h<a><b>.push(1,2)` becomes
+    /// `do { my $__tmp = %h<a><b>.push(1,2); %h<a><b> = $__tmp }`.
+    /// Uses compile_expr_method_generic for the method call to avoid
+    /// infinite recursion.
+    pub(super) fn compile_expr_nested_method_writeback(
+        &mut self,
+        target: &Expr,
+        name: &Symbol,
+        args: &[Expr],
+        modifier: &Option<char>,
+        quoted: bool,
+    ) {
+        if let Expr::Index {
+            target: idx_target,
+            index: idx_key,
+            is_positional,
+        } = target
+        {
+            // Compile the method call (generic path, no recursion risk)
+            self.compile_expr_method_generic(target, name, args, modifier, quoted);
+            // Now stack has the method result. Write it back to the slot.
+            // Create an IndexAssign expression: target[key] = <stack top>.
+            // We store the result in a temp global, then compile the assignment.
+            let tmp_name = format!("__mutsu_nested_method_wb_{}", self.code.constants.len());
+            let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
+            self.code.emit(OpCode::SetGlobal(tmp_idx));
+            // Now compile the IndexAssign
+            let tmp_var = Expr::Var(tmp_name);
+            let writeback = Expr::IndexAssign {
+                target: idx_target.clone(),
+                index: idx_key.clone(),
+                value: Box::new(tmp_var),
+                is_positional: *is_positional,
+            };
+            self.compile_expr(&writeback);
+        } else {
+            // Fallback: compile normally
+            self.compile_expr_method_generic(target, name, args, modifier, quoted);
+        }
+    }
+
     /// Compile method call on non-variable target (no writeback needed).
     pub(super) fn compile_expr_method_generic(
         &mut self,

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -29,6 +29,33 @@ impl Compiler {
         }
     }
 
+    /// Check if a method call is a mutating method on a *nested* Index target
+    /// (e.g. `%h<a><b>.push(...)` where the immediate target is Index and its
+    /// inner target is also an Index). The single-level case is already handled
+    /// by `is_mutating_method_on_index`.
+    pub(super) fn is_nested_mutating_method_on_index(
+        target: &Expr,
+        method_name: &crate::symbol::Symbol,
+    ) -> bool {
+        let method = method_name.resolve();
+        let is_mutating = matches!(
+            method.as_str(),
+            "push" | "pop" | "shift" | "unshift" | "append" | "prepend" | "splice"
+        );
+        if !is_mutating {
+            return false;
+        }
+        // Only match nested Index (Index whose target is another Index)
+        if let Expr::Index {
+            target: idx_target, ..
+        } = target
+        {
+            matches!(idx_target.as_ref(), Expr::Index { .. })
+        } else {
+            false
+        }
+    }
+
     /// Extract the variable name from a DoStmt(VarDecl { .. }) expression,
     /// used for `++state $` patterns.
     pub(super) fn extract_vardecl_name(expr: &Expr) -> Option<String> {

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -161,9 +161,76 @@ impl Compiler {
             Expr::AssignExpr { name, .. } => Some(name.clone()),
             _ => None,
         };
-        if let Some(name) = source_name {
+        // For Index expressions, create temp variables for `is rw` writeback
+        // and wrap with VarRef so `is rw` parameters can bind through.
+        if matches!(arg, Expr::Index { .. }) {
+            let tmp = format!("__mutsu_index_rw_arg_{}", self.code.constants.len());
+            let orig = format!("__mutsu_index_rw_orig_{}", self.code.constants.len());
+            let tmp_idx = self.code.add_constant(Value::str(tmp.clone()));
+            let orig_idx = self.code.add_constant(Value::str(orig.clone()));
+            self.code.emit(OpCode::Dup);
+            self.code.emit(OpCode::SetGlobal(tmp_idx));
+            self.code.emit(OpCode::Dup);
+            self.code.emit(OpCode::SetGlobal(orig_idx));
+            self.pending_index_rw_writebacks
+                .push((arg.clone(), tmp.clone(), orig.clone()));
+            let name_idx = self.code.add_constant(Value::str(tmp));
+            self.code.emit(OpCode::WrapVarRef(name_idx));
+        } else if let Some(name) = source_name {
             let name_idx = self.code.add_constant(Value::str(name));
             self.code.emit(OpCode::WrapVarRef(name_idx));
+        }
+    }
+
+    /// Emit writeback code for Index expressions passed as function arguments.
+    /// After a function call, if any `is rw` parameter modified the temp variable,
+    /// we write the new value back to the original hash/array slot.
+    /// Only writes back when the temp value differs from the original value
+    /// (using `===` identity check).
+    pub(super) fn emit_index_rw_writebacks(&mut self) {
+        let writebacks = std::mem::take(&mut self.pending_index_rw_writebacks);
+        if writebacks.is_empty() {
+            return;
+        }
+        for (index_expr, tmp_name, orig_name) in writebacks {
+            if let Expr::Index {
+                target,
+                index,
+                is_positional,
+            } = &index_expr
+            {
+                // Save the call result
+                let result_tmp = format!("__mutsu_call_result_{}", self.code.constants.len());
+                let result_idx = self.code.add_constant(Value::str(result_tmp));
+                self.code.emit(OpCode::SetGlobal(result_idx));
+
+                // Compare current temp value with original value.
+                // If they're identical (===), skip writeback.
+                let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
+                let orig_idx = self.code.add_constant(Value::str(orig_name));
+                self.code.emit(OpCode::GetGlobal(tmp_idx));
+                self.code.emit(OpCode::GetGlobal(orig_idx));
+                self.code.emit(OpCode::StrictEq);
+                // If equal (True), skip writeback
+                let skip_idx = self.code.emit(OpCode::JumpIfTrue(0));
+                // Values differ: pop comparison result and do the writeback
+                self.code.emit(OpCode::Pop); // pop False from StrictEq
+                let writeback = Expr::IndexAssign {
+                    target: target.clone(),
+                    index: index.clone(),
+                    value: Box::new(Expr::Var(tmp_name)),
+                    is_positional: *is_positional,
+                };
+                self.compile_expr(&writeback);
+                self.code.emit(OpCode::Pop); // discard assignment result
+                let jump_to_restore = self.code.emit(OpCode::Jump(0));
+                // Skip target: pop True from StrictEq
+                self.code.patch_jump(skip_idx);
+                self.code.emit(OpCode::Pop); // pop True from StrictEq
+                // Restore point
+                self.code.patch_jump(jump_to_restore);
+                self.code.emit(OpCode::GetGlobal(result_idx));
+            }
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -70,6 +70,11 @@ pub(crate) struct Compiler {
     constant_vars: std::collections::HashSet<String>,
     /// Last source line emitted via SetSourceLine (for tracking block definition lines).
     last_source_line: Option<i64>,
+    /// Pending writebacks for Index expressions passed to function calls.
+    /// After the call returns, if the `is rw` parameter was written to,
+    /// we need to write the temp variable value back to the original hash/array slot.
+    /// Each entry is (original Index Expr, temp variable name).
+    pub(super) pending_index_rw_writebacks: Vec<(Expr, String, String)>,
 }
 
 impl Compiler {
@@ -92,6 +97,7 @@ impl Compiler {
             scalar_bind_autovivify: false,
             constant_vars: std::collections::HashSet::new(),
             last_source_line: None,
+            pending_index_rw_writebacks: Vec::new(),
         }
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -405,9 +405,15 @@ pub(crate) enum OpCode {
         is_positional: bool,
     },
     /// Like Index, but auto-vivifies intermediate hash entries and returns
-    /// a `HashSlotRef` for the final key.  Used for `:=` bind to hash elements
-    /// (e.g. `my $b := %h<foo><baz>`).
+    /// a `HashSlotRef` for the final key.  Used by IndexAutovivifyLazy's
+    /// fallback path for non-hash targets.
+    #[allow(dead_code)]
     IndexAutovivify,
+    /// Like IndexAutovivify but does NOT create the hash entry if missing.
+    /// Returns a HashSlotRef that defers creation until write.
+    /// Used for the outermost level of `:=` bind so that binding alone
+    /// does not autovivify (e.g. `my $b := %h<a><b>` keeps %h empty).
+    IndexAutovivifyLazy,
     DeleteIndexNamed(u32),
     DeleteIndexExpr,
     /// Multi-dimensional indexing: @a[$x;$y;$z]

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -171,6 +171,7 @@ impl Interpreter {
             Value::ArraySlotRef { .. } => {
                 return self.dispatch_what(&target.array_slot_read(), args);
             }
+            Value::DeferredHashAccess { .. } => "Any",
         };
         let visible_type_name = if crate::value::is_internal_anon_type_name(type_name) {
             ""

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -84,6 +84,7 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
         Value::Nil | Value::Package(_) => false,
         Value::Slip(items) if items.is_empty() => false,
         Value::Instance { class_name, .. } if class_name == "Failure" => false,
+        Value::DeferredHashAccess { .. } => false,
         _ => true,
     }
 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1375,6 +1375,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::LazyIoLines { .. } => "Seq",
         Value::HashSlotRef { .. } => "Scalar",
         Value::ArraySlotRef { .. } => "Scalar",
+        Value::DeferredHashAccess { .. } => "Any",
     }
 }
 

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -901,6 +901,7 @@ impl Value {
             }
             Value::HashSlotRef { .. } => self.hash_slot_read().to_string_value(),
             Value::ArraySlotRef { .. } => self.array_slot_read().to_string_value(),
+            Value::DeferredHashAccess { .. } => self.deferred_hash_read().to_string_value(),
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -881,6 +881,15 @@ pub enum Value {
         array: Arc<Vec<Value>>,
         index: usize,
     },
+    /// A deferred hash access path for binding. Acts as Any for reads.
+    /// When written to, it creates all intermediate hashes and inserts the value.
+    /// Used for `my $b := %h<a><b>` to defer autovivification until assignment.
+    DeferredHashAccess {
+        /// The parent HashSlotRef (points to the first-level key in the root hash)
+        parent_slot: Box<Value>,
+        /// The key for the nested access
+        key: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1790,6 +1799,21 @@ impl Value {
         }
     }
 
+    /// Like `hash_autovivify` but does NOT create the entry if missing.
+    /// Returns a HashSlotRef that can be used for deferred autovivification:
+    /// reading from it returns Any/Nil for missing keys, writing to it
+    /// inserts the entry.
+    pub fn hash_slot_ref_lazy(&self, key: &str) -> Option<Value> {
+        if let Value::Hash(arc) = self {
+            Some(Value::HashSlotRef {
+                hash: arc.clone(),
+                key: key.to_string(),
+            })
+        } else {
+            None
+        }
+    }
+
     /// Autovivify a hash entry with a scalar value (for binding/assignment).
     /// Inserts the given value at the key if missing, or replaces the existing value.
     /// Returns the value stored at the key after the operation.
@@ -1830,6 +1854,51 @@ impl Value {
             unsafe {
                 (*ptr).insert(key.clone(), val);
             }
+        }
+    }
+
+    /// Write a value through a DeferredHashAccess, autovivifying the path.
+    /// Creates intermediate hashes as needed and inserts the final value.
+    pub fn deferred_hash_write(&self, val: Value) {
+        if let Value::DeferredHashAccess { parent_slot, key } = self {
+            // First, ensure the parent slot has a hash
+            let parent_value = parent_slot.hash_slot_read();
+            let inner_hash = if let Value::Hash(_) = &parent_value {
+                parent_value
+            } else {
+                // Create a new hash and write it to the parent slot
+                let new_hash = Value::hash(HashMap::new());
+                parent_slot.hash_slot_write(new_hash.clone());
+                new_hash
+            };
+            // Now write the value to the inner hash at the given key
+            if let Value::Hash(arc) = &inner_hash {
+                let ptr = Arc::as_ptr(arc) as *mut HashMap<String, Value>;
+                unsafe {
+                    (*ptr).insert(key.clone(), val);
+                }
+            }
+        }
+    }
+
+    /// Read the current value from a DeferredHashAccess.
+    /// Returns Any if the path doesn't exist yet.
+    pub fn deferred_hash_read(&self) -> Value {
+        if let Value::DeferredHashAccess { parent_slot, key } = self {
+            let parent_value = parent_slot.hash_slot_read();
+            if let Value::Hash(arc) = &parent_value {
+                let ptr = Arc::as_ptr(arc);
+                unsafe {
+                    (*ptr)
+                        .get(key.as_str())
+                        .cloned()
+                        .unwrap_or(Value::Package(crate::symbol::Symbol::intern("Any")))
+                }
+            } else {
+                Value::Package(crate::symbol::Symbol::intern("Any"))
+            }
+        } else {
+            self.clone()
         }
     }
 

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -306,7 +306,8 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         | Value::LazyThunk(_)
         | Value::LazyIoLines { .. }
         | Value::HashSlotRef { .. }
-        | Value::ArraySlotRef { .. } => Err(format!(
+        | Value::ArraySlotRef { .. }
+        | Value::DeferredHashAccess { .. } => Err(format!(
             "cannot serialize Value variant: {:?}",
             std::mem::discriminant(v)
         )),

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -433,6 +433,7 @@ impl Value {
             Value::LazyIoLines { .. } => true,
             Value::HashSlotRef { .. } => self.hash_slot_read().truthy(),
             Value::ArraySlotRef { .. } => self.array_slot_read().truthy(),
+            Value::DeferredHashAccess { .. } => false,
         }
     }
 
@@ -563,6 +564,7 @@ impl Value {
             Value::LazyIoLines { .. } => "Seq",
             Value::HashSlotRef { .. } => return self.hash_slot_read().isa_check(type_name),
             Value::ArraySlotRef { .. } => return self.array_slot_read().isa_check(type_name),
+            Value::DeferredHashAccess { .. } => "Any",
         };
         if my_type == type_name {
             return true;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2320,6 +2320,10 @@ impl VM {
                 self.exec_index_autovivify_op()?;
                 *ip += 1;
             }
+            OpCode::IndexAutovivifyLazy => {
+                self.exec_index_autovivify_lazy_op()?;
+                *ip += 1;
+            }
             OpCode::DeleteIndexNamed(name_idx) => {
                 self.exec_delete_index_named_op(code, *name_idx)?;
                 *ip += 1;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -614,12 +614,25 @@ impl VM {
                         // Any:U autovivification: push/append/unshift/prepend on
                         // an undefined value creates a new Array.
                         "push" | "append" | "unshift" | "prepend" => {
-                            let arr: Vec<Value> =
-                                if matches!(method.as_str(), "unshift" | "prepend") {
-                                    args.to_vec()
-                                } else {
-                                    args
-                                };
+                            let arr: Vec<Value> = match method.as_str() {
+                                "append" | "prepend" => {
+                                    // Flatten list arguments for append/prepend
+                                    let mut flat = Vec::new();
+                                    for arg in &args {
+                                        match arg {
+                                            Value::Array(items, _)
+                                            | Value::Seq(items)
+                                            | Value::Slip(items) => {
+                                                flat.extend(items.iter().cloned());
+                                            }
+                                            other => flat.push(other.clone()),
+                                        }
+                                    }
+                                    flat
+                                }
+                                "unshift" => args.to_vec(),
+                                _ => args,
+                            };
                             self.stack.push(Value::real_array(arr));
                             self.env_dirty = true;
                             return Ok(());
@@ -642,10 +655,23 @@ impl VM {
                 if matches!(method.as_str(), "push" | "append" | "unshift" | "prepend")
                     && matches!(&target, Value::Package(name) if name.resolve() == "Any" || name.resolve() == "Mu")
                 {
-                    let arr: Vec<Value> = if matches!(method.as_str(), "unshift" | "prepend") {
-                        args.to_vec()
-                    } else {
-                        args
+                    let arr: Vec<Value> = match method.as_str() {
+                        "append" | "prepend" => {
+                            let mut flat = Vec::new();
+                            for arg in &args {
+                                match arg {
+                                    Value::Array(items, _)
+                                    | Value::Seq(items)
+                                    | Value::Slip(items) => {
+                                        flat.extend(items.iter().cloned());
+                                    }
+                                    other => flat.push(other.clone()),
+                                }
+                            }
+                            flat
+                        }
+                        "unshift" => args.to_vec(),
+                        _ => args,
                     };
                     self.stack.push(Value::real_array(arr));
                     self.env_dirty = true;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2676,6 +2676,11 @@ impl VM {
             return Ok(());
         }
         let val = self.locals[idx].clone();
+        // Resolve DeferredHashAccess to its current value (Any if path doesn't exist)
+        if let Value::DeferredHashAccess { .. } = &val {
+            self.stack.push(val.deferred_hash_read());
+            return Ok(());
+        }
         // Force lazy thunks transparently on access
         if let Value::LazyThunk(ref thunk_data) = val {
             let forced = self.force_lazy_thunk(thunk_data)?;
@@ -2769,6 +2774,13 @@ impl VM {
             // (unless rebinding, which replaces the ref with a new value).
             if !is_rebind && let Value::HashSlotRef { .. } = &self.locals[idx] {
                 self.locals[idx].hash_slot_write(val);
+                self.locals_dirty = true;
+                return Ok(());
+            }
+            // If the current value is a DeferredHashAccess (from lazy binding),
+            // autovivify the path and write the value.
+            if !is_rebind && let Value::DeferredHashAccess { .. } = &self.locals[idx] {
+                self.locals[idx].deferred_hash_write(val);
                 self.locals_dirty = true;
                 return Ok(());
             }
@@ -3337,6 +3349,16 @@ impl VM {
             && let Value::HashSlotRef { .. } = &self.locals[idx]
         {
             self.locals[idx].hash_slot_write(val);
+            self.locals_dirty = true;
+            return Ok(());
+        }
+        // If the current value is a DeferredHashAccess (from lazy binding),
+        // autovivify the path and write the value.
+        if !is_bind
+            && !is_rebind
+            && let Value::DeferredHashAccess { .. } = &self.locals[idx]
+        {
+            self.locals[idx].deferred_hash_write(val);
             self.locals_dirty = true;
             return Ok(());
         }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -120,6 +120,50 @@ impl VM {
         Ok(())
     }
 
+    /// Lazy variant of IndexAutovivify: returns a HashSlotRef without creating
+    /// the hash entry if it doesn't exist. Used for `:=` bind expressions
+    /// so that `my $b := %h<a><b>` doesn't autovivify until assignment.
+    pub(super) fn exec_index_autovivify_lazy_op(&mut self) -> Result<(), RuntimeError> {
+        let index = self.stack.pop().unwrap();
+        let target = self.stack.pop().unwrap();
+
+        let resolved = match &target {
+            Value::HashSlotRef { .. } => target.hash_slot_read(),
+            Value::ArraySlotRef { .. } => target.array_slot_read(),
+            Value::Scalar(inner) => inner.as_ref().clone(),
+            other => other.clone(),
+        };
+
+        match &resolved {
+            Value::Hash(_) => {
+                let key = Value::hash_key_encode(&index);
+                // Use lazy ref: don't create the entry
+                if let Some(slot_ref) = resolved.hash_slot_ref_lazy(&key) {
+                    self.stack.push(slot_ref);
+                } else {
+                    self.stack.push(Value::Nil);
+                }
+            }
+            // When the target is a HashSlotRef pointing to a non-existent key
+            // (resolved to Any/Nil), in lazy mode create a DeferredHashAccess
+            // that will autovivify on write.
+            _ if matches!(&target, Value::HashSlotRef { .. }) => {
+                let key = Value::hash_key_encode(&index);
+                self.stack.push(Value::DeferredHashAccess {
+                    parent_slot: Box::new(target),
+                    key,
+                });
+            }
+            _ => {
+                // Fallback to normal autovivify for non-hash targets
+                self.stack.push(target);
+                self.stack.push(index);
+                return self.exec_index_autovivify_op();
+            }
+        }
+        Ok(())
+    }
+
     /// Backward-compatible wrapper: defaults to associative indexing.
     pub(super) fn exec_index_op(&mut self) -> Result<(), RuntimeError> {
         self.exec_index_op_with_positional(false)


### PR DESCRIPTION
## Summary
- Implement deferred autovivification for `:=` binding to nested hash elements (`my $b := %h<a><b>` no longer eagerly creates hash entries)
- Support `is rw` parameters with hash/array element arguments via temp variable writeback
- Fix nested hash mutation writeback for `.push()`, `.append()`, `.unshift()`, `.prepend()` methods and sub-form equivalents
- Flatten args for append/prepend on undefined values (Any autovivification)
- Add `IndexAutovivifyLazy` opcode and `DeferredHashAccess` Value variant

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/autovivification.t` passes all 22 subtests
- [x] `make test` passes (482 files, 3899 tests)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)