### PR TITLE
fix: implement proper uniname/uninames for all codepoint categories

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -722,6 +722,7 @@ roast/S15-string-types/NFK-types.t
 roast/S15-string-types/Str.t
 roast/S15-string-types/Uni.t
 roast/S15-unicode-information/unimatch-general.t
+roast/S15-unicode-information/uniname.t
 roast/S15-unicode-information/uniprop.t
 roast/S15-unicode-information/unival.t
 roast/S16-filehandles/argfiles.t

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -350,16 +350,45 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             }
         }
         "uniname" => {
+            match arg {
+                Value::Int(i) => match super::unicode::uniname_from_int(*i) {
+                    Ok(name) => Some(Ok(Value::str(name))),
+                    Err(e) => Some(Err(e)),
+                },
+                Value::Package(name) => {
+                    // Type objects like Str, Int should throw X::Multi::NoMatch
+                    let msg = format!(
+                        "Cannot resolve caller uniname({}); none of these signatures matches:\n    (\\what)",
+                        name
+                    );
+                    let mut attrs = HashMap::new();
+                    attrs.insert("message".to_string(), Value::str(msg.clone()));
+                    let ex = Value::make_instance(Symbol::intern("X::Multi::NoMatch"), attrs);
+                    let mut err = RuntimeError::new(&msg);
+                    err.exception = Some(Box::new(ex));
+                    Some(Err(err))
+                }
+                _ => {
+                    let s = arg.to_string_value();
+                    if s.is_empty() {
+                        return Some(Ok(Value::Nil));
+                    }
+                    if let Some(ch) = s.chars().next() {
+                        let name = unicode_char_name(ch);
+                        Some(Ok(Value::str(name)))
+                    } else {
+                        Some(Ok(Value::Nil))
+                    }
+                }
+            }
+        }
+        "uninames" => {
             let s = arg.to_string_value();
-            if s.is_empty() {
-                return Some(Ok(Value::Nil));
-            }
-            if let Some(ch) = s.chars().next() {
-                let name = unicode_char_name(ch);
-                Some(Ok(Value::str(name)))
-            } else {
-                Some(Ok(Value::Nil))
-            }
+            let names: Vec<Value> = s
+                .chars()
+                .map(|ch| Value::str(unicode_char_name(ch)))
+                .collect();
+            Some(Ok(Value::array(names)))
         }
         "uniparse" | "parse-names" => {
             let s = arg.to_string_value();

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -110,16 +110,23 @@ pub(super) fn dispatch(
                 crate::builtins::unicode::unicode_general_category(ch),
             ))))
         }
-        "uniname" => {
-            let s = target.to_string_value();
-            if s.is_empty() {
-                return Some(Some(Ok(Value::Nil)));
+        "uniname" => match target {
+            Value::Int(i) => match crate::builtins::unicode::uniname_from_int(*i) {
+                Ok(name) => Some(Some(Ok(Value::str(name)))),
+                Err(e) => Some(Some(Err(e))),
+            },
+            Value::Package(_) => Some(Some(Err(make_no_match_error("uniname")))),
+            _ => {
+                let s = target.to_string_value();
+                if s.is_empty() {
+                    return Some(Some(Ok(Value::Nil)));
+                }
+                let ch = s.chars().next().unwrap();
+                Some(Some(Ok(Value::str(
+                    crate::builtins::unicode::unicode_char_name(ch),
+                ))))
             }
-            let ch = s.chars().next().unwrap();
-            Some(Some(Ok(Value::str(
-                crate::builtins::unicode::unicode_char_name(ch),
-            ))))
-        }
+        },
         "uninames" => {
             let s = target.to_string_value();
             let names: Vec<Value> = s

--- a/src/builtins/unicode.rs
+++ b/src/builtins/unicode.rs
@@ -428,117 +428,75 @@ pub(crate) fn unicode_decimal_digit_value(c: char) -> Option<u32> {
     }
 }
 
-/// Return Unicode character name for a given character
-/// Basic implementation covering ASCII and common Latin-1 characters
-pub(crate) fn unicode_char_name(ch: char) -> String {
-    match ch {
-        '0' => "DIGIT ZERO".to_string(),
-        '1' => "DIGIT ONE".to_string(),
-        '2' => "DIGIT TWO".to_string(),
-        '3' => "DIGIT THREE".to_string(),
-        '4' => "DIGIT FOUR".to_string(),
-        '5' => "DIGIT FIVE".to_string(),
-        '6' => "DIGIT SIX".to_string(),
-        '7' => "DIGIT SEVEN".to_string(),
-        '8' => "DIGIT EIGHT".to_string(),
-        '9' => "DIGIT NINE".to_string(),
-        'A' => "LATIN CAPITAL LETTER A".to_string(),
-        'B' => "LATIN CAPITAL LETTER B".to_string(),
-        'C' => "LATIN CAPITAL LETTER C".to_string(),
-        'D' => "LATIN CAPITAL LETTER D".to_string(),
-        'E' => "LATIN CAPITAL LETTER E".to_string(),
-        'F' => "LATIN CAPITAL LETTER F".to_string(),
-        'G' => "LATIN CAPITAL LETTER G".to_string(),
-        'H' => "LATIN CAPITAL LETTER H".to_string(),
-        'I' => "LATIN CAPITAL LETTER I".to_string(),
-        'J' => "LATIN CAPITAL LETTER J".to_string(),
-        'K' => "LATIN CAPITAL LETTER K".to_string(),
-        'L' => "LATIN CAPITAL LETTER L".to_string(),
-        'M' => "LATIN CAPITAL LETTER M".to_string(),
-        'N' => "LATIN CAPITAL LETTER N".to_string(),
-        'O' => "LATIN CAPITAL LETTER O".to_string(),
-        'P' => "LATIN CAPITAL LETTER P".to_string(),
-        'Q' => "LATIN CAPITAL LETTER Q".to_string(),
-        'R' => "LATIN CAPITAL LETTER R".to_string(),
-        'S' => "LATIN CAPITAL LETTER S".to_string(),
-        'T' => "LATIN CAPITAL LETTER T".to_string(),
-        'U' => "LATIN CAPITAL LETTER U".to_string(),
-        'V' => "LATIN CAPITAL LETTER V".to_string(),
-        'W' => "LATIN CAPITAL LETTER W".to_string(),
-        'X' => "LATIN CAPITAL LETTER X".to_string(),
-        'Y' => "LATIN CAPITAL LETTER Y".to_string(),
-        'Z' => "LATIN CAPITAL LETTER Z".to_string(),
-        'a' => "LATIN SMALL LETTER A".to_string(),
-        'b' => "LATIN SMALL LETTER B".to_string(),
-        'c' => "LATIN SMALL LETTER C".to_string(),
-        'd' => "LATIN SMALL LETTER D".to_string(),
-        'e' => "LATIN SMALL LETTER E".to_string(),
-        'f' => "LATIN SMALL LETTER F".to_string(),
-        'g' => "LATIN SMALL LETTER G".to_string(),
-        'h' => "LATIN SMALL LETTER H".to_string(),
-        'i' => "LATIN SMALL LETTER I".to_string(),
-        'j' => "LATIN SMALL LETTER J".to_string(),
-        'k' => "LATIN SMALL LETTER K".to_string(),
-        'l' => "LATIN SMALL LETTER L".to_string(),
-        'm' => "LATIN SMALL LETTER M".to_string(),
-        'n' => "LATIN SMALL LETTER N".to_string(),
-        'o' => "LATIN SMALL LETTER O".to_string(),
-        'p' => "LATIN SMALL LETTER P".to_string(),
-        'q' => "LATIN SMALL LETTER Q".to_string(),
-        'r' => "LATIN SMALL LETTER R".to_string(),
-        's' => "LATIN SMALL LETTER S".to_string(),
-        't' => "LATIN SMALL LETTER T".to_string(),
-        'u' => "LATIN SMALL LETTER U".to_string(),
-        'v' => "LATIN SMALL LETTER V".to_string(),
-        'w' => "LATIN SMALL LETTER W".to_string(),
-        'x' => "LATIN SMALL LETTER X".to_string(),
-        'y' => "LATIN SMALL LETTER Y".to_string(),
-        'z' => "LATIN SMALL LETTER Z".to_string(),
-        ' ' => "SPACE".to_string(),
-        '!' => "EXCLAMATION MARK".to_string(),
-        '"' => "QUOTATION MARK".to_string(),
-        '#' => "NUMBER SIGN".to_string(),
-        '$' => "DOLLAR SIGN".to_string(),
-        '%' => "PERCENT SIGN".to_string(),
-        '&' => "AMPERSAND".to_string(),
-        '\'' => "APOSTROPHE".to_string(),
-        '(' => "LEFT PARENTHESIS".to_string(),
-        ')' => "RIGHT PARENTHESIS".to_string(),
-        '*' => "ASTERISK".to_string(),
-        '+' => "PLUS SIGN".to_string(),
-        ',' => "COMMA".to_string(),
-        '-' => "HYPHEN-MINUS".to_string(),
-        '.' => "FULL STOP".to_string(),
-        '/' => "SOLIDUS".to_string(),
-        ':' => "COLON".to_string(),
-        ';' => "SEMICOLON".to_string(),
-        '<' => "LESS-THAN SIGN".to_string(),
-        '=' => "EQUALS SIGN".to_string(),
-        '>' => "GREATER-THAN SIGN".to_string(),
-        '?' => "QUESTION MARK".to_string(),
-        '@' => "COMMERCIAL AT".to_string(),
-        '[' => "LEFT SQUARE BRACKET".to_string(),
-        '\\' => "REVERSE SOLIDUS".to_string(),
-        ']' => "RIGHT SQUARE BRACKET".to_string(),
-        '^' => "CIRCUMFLEX ACCENT".to_string(),
-        '_' => "LOW LINE".to_string(),
-        '`' => "GRAVE ACCENT".to_string(),
-        '{' => "LEFT CURLY BRACKET".to_string(),
-        '|' => "VERTICAL LINE".to_string(),
-        '}' => "RIGHT CURLY BRACKET".to_string(),
-        '~' => "TILDE".to_string(),
-        '\n' => "LINE FEED (LF)".to_string(),
-        '\r' => "CARRIAGE RETURN (CR)".to_string(),
-        '\t' => "CHARACTER TABULATION".to_string(),
-        _ => {
-            // Use unicode_names2 crate for full Unicode name lookup
-            if let Some(name) = unicode_names2::name(ch) {
-                name.to_string()
-            } else {
-                format!("U+{:04X}", ch as u32)
-            }
-        }
+/// Check if a codepoint is a Unicode noncharacter.
+fn is_noncharacter(cp: u32) -> bool {
+    // U+FDD0..U+FDEF
+    if (0xFDD0..=0xFDEF).contains(&cp) {
+        return true;
     }
+    // U+xFFFE and U+xFFFF for each plane (0x0..0x10)
+    let low = cp & 0xFFFF;
+    if low == 0xFFFE || low == 0xFFFF {
+        let plane = cp >> 16;
+        return plane <= 0x10;
+    }
+    false
+}
+
+/// Check if a codepoint is a Unicode control character (Cc category).
+fn is_control_char(cp: u32) -> bool {
+    cp <= 0x1F || (0x7F..=0x9F).contains(&cp)
+}
+
+/// Return the Unicode character name for a codepoint (u32).
+/// Handles all special categories: control, noncharacter, reserved, etc.
+pub(crate) fn unicode_char_name_by_codepoint(cp: u32) -> String {
+    // Noncharacters
+    if is_noncharacter(cp) {
+        return format!("<noncharacter-{:04X}>", cp);
+    }
+    // Try to convert to char
+    if let Some(ch) = char::from_u32(cp) {
+        // Try unicode_names2 first
+        if let Some(name) = unicode_names2::name(ch) {
+            return name.to_string();
+        }
+        // Control characters without a name
+        if is_control_char(cp) {
+            return format!("<control-{:04X}>", cp);
+        }
+        // Has a char but no name and not control -> reserved/unassigned
+        format!("<reserved-{:04X}>", cp)
+    } else {
+        // Invalid char (surrogates etc.)
+        format!("<reserved-{:04X}>", cp)
+    }
+}
+
+/// Return Unicode character name for a given character
+pub(crate) fn unicode_char_name(ch: char) -> String {
+    unicode_char_name_by_codepoint(ch as u32)
+}
+
+/// Return the uniname result for an integer codepoint.
+/// Returns Err for out-of-range codepoints (>= 0x110000).
+/// Returns `<illegal>` for negative codepoints.
+pub(crate) fn uniname_from_int(codepoint: i64) -> Result<String, crate::value::RuntimeError> {
+    if codepoint < 0 {
+        return Ok("<illegal>".to_string());
+    }
+    let cp = codepoint as u64;
+    if cp > 0x10FFFF {
+        let msg = format!("Unassigned codepoint: 0x{:X}", cp);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+        let ex =
+            crate::value::Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), attrs);
+        let mut err = crate::value::RuntimeError::new(&msg);
+        err.exception = Some(Box::new(ex));
+        return Err(err);
+    }
+    Ok(unicode_char_name_by_codepoint(cp as u32))
 }
 
 /// Return the Unicode General Category abbreviation for a character.

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -886,6 +886,7 @@ pub(super) fn is_listop(name: &str) -> bool {
             | "uniprop"
             | "unimatch"
             | "uniname"
+            | "uninames"
             | "unival"
             | "univals"
             | "lines"

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -880,6 +880,7 @@ impl Interpreter {
                 | "zprintf"
                 | "printf"
                 | "uniname"
+                | "uninames"
                 | "uniprop"
                 | "unimatch"
                 | "uniparse"

--- a/src/runtime/did_you_mean.rs
+++ b/src/runtime/did_you_mean.rs
@@ -89,6 +89,7 @@ pub(crate) fn known_methods_for_type(type_name: &str) -> &'static [&'static str]
             "trim-trailing",
             "uc",
             "uniname",
+            "uninames",
             "unival",
             "uppercase",
             "lowercase",


### PR DESCRIPTION
## Summary
- Rewrote `unicode_char_name` to use `unicode_names2` crate for all lookups instead of hardcoded ASCII match table, with proper labels for control (`<control-XXXX>`), noncharacter (`<noncharacter-XXXX>`), reserved (`<reserved-XXXX>`), and illegal (`<illegal>`) codepoints per Raku spec
- Added Int codepoint support to both `uniname()` function and `.uniname` method (previously only handled Str input)
- Added `uninames()` as a builtin function (was only available as a method)
- Added proper X::Multi::NoMatch errors for type object arguments and X::AdHoc for out-of-range codepoints

## Test plan
- [x] All 46 subtests in `roast/S15-unicode-information/uniname.t` pass
- [x] `prove -e 'target/debug/mutsu' roast/S15-unicode-information/uniname.t` exits cleanly
- [x] `make test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] Added to `roast-whitelist.txt` (sorted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)