### PR TITLE
fix: support Unicode case folding in :i regex for ligatures and sharp s

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -392,6 +392,7 @@ roast/S05-modifier/counted.t
 roast/S05-modifier/exhaustive.t
 roast/S05-modifier/global.t
 roast/S05-modifier/ignorecase-and-ignoremark.t
+roast/S05-modifier/ignorecase.t
 roast/S05-modifier/ignoremark.t
 roast/S05-modifier/ii.t
 roast/S05-modifier/my.t

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,3 +1,4 @@
+mod regex_casefold;
 mod regex_eval;
 mod regex_helpers;
 mod regex_interpolate;

--- a/src/runtime/regex/regex_casefold.rs
+++ b/src/runtime/regex/regex_casefold.rs
@@ -1,0 +1,187 @@
+use super::super::*;
+
+/// Unicode case-fold a single character. Returns the folded chars.
+/// Uses the "uppercase then lowercase" approximation of full Unicode case folding.
+/// Examples: 'ß' -> ['s','s'], 'ﬁ' -> ['f','i'], 'A' -> ['a']
+fn casefold_char(c: char) -> Vec<char> {
+    c.to_uppercase()
+        .collect::<String>()
+        .to_lowercase()
+        .chars()
+        .collect()
+}
+
+/// Returns true if a character case-folds to more than one character.
+fn has_multichar_fold(c: char) -> bool {
+    casefold_char(c).len() > 1
+}
+
+/// Case-fold text characters, expanding multi-char folds (e.g., 'ﬁ' -> 'f','i').
+/// Returns folded chars and a position map from folded index to original char index.
+/// The sentinel for one-past-end is also appended to the position map.
+pub(super) fn casefold_text(orig_chars: &[char]) -> (Vec<char>, Vec<usize>) {
+    let mut folded_chars: Vec<char> = Vec::new();
+    let mut pos_map: Vec<usize> = Vec::new();
+
+    for (idx, &c) in orig_chars.iter().enumerate() {
+        let folded = casefold_char(c);
+        for fc in folded {
+            folded_chars.push(fc);
+            pos_map.push(idx);
+        }
+    }
+    // sentinel for one-past-end
+    pos_map.push(orig_chars.len());
+    (folded_chars, pos_map)
+}
+
+/// Check whether text or pattern contains any characters with multi-char case folds.
+pub(super) fn needs_casefold_expansion(chars: &[char], pattern: &RegexPattern) -> bool {
+    // Check text
+    for &c in chars {
+        if has_multichar_fold(c) {
+            return true;
+        }
+    }
+    // Check pattern literals
+    pattern_has_multichar_fold(pattern)
+}
+
+fn pattern_has_multichar_fold(pattern: &RegexPattern) -> bool {
+    for token in &pattern.tokens {
+        if atom_has_multichar_fold(&token.atom) {
+            return true;
+        }
+    }
+    false
+}
+
+fn atom_has_multichar_fold(atom: &RegexAtom) -> bool {
+    match atom {
+        RegexAtom::Literal(ch) => has_multichar_fold(*ch),
+        RegexAtom::Group(p) | RegexAtom::CaptureGroup(p) => pattern_has_multichar_fold(p),
+        RegexAtom::Alternation(alts)
+        | RegexAtom::SequentialAlternation(alts)
+        | RegexAtom::Conjunction(alts) => alts.iter().any(pattern_has_multichar_fold),
+        RegexAtom::GoalMatch { goal, inner, .. } => {
+            pattern_has_multichar_fold(goal) || pattern_has_multichar_fold(inner)
+        }
+        RegexAtom::Lookaround { pattern, .. } => pattern_has_multichar_fold(pattern),
+        _ => false,
+    }
+}
+
+/// Case-fold all literal atoms in a RegexPattern (recursively).
+/// Multi-char folds (e.g., 'ß' -> 'ss') are expanded into Group patterns
+/// containing multiple Literal tokens.
+pub(super) fn casefold_pattern(pattern: &RegexPattern) -> RegexPattern {
+    RegexPattern {
+        tokens: pattern.tokens.iter().flat_map(casefold_token).collect(),
+        anchor_start: pattern.anchor_start,
+        anchor_end: pattern.anchor_end,
+        ignore_case: pattern.ignore_case,
+        ignore_mark: pattern.ignore_mark,
+    }
+}
+
+fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
+    let folded_atom = casefold_atom(&token.atom);
+    match folded_atom {
+        CasefoldedAtom::Single(atom) => vec![RegexToken {
+            atom,
+            quant: token.quant.clone(),
+            named_capture: token.named_capture.clone(),
+            secondary_named_capture: token.secondary_named_capture.clone(),
+            hash_capture: token.hash_capture.clone(),
+            ratchet: token.ratchet,
+            frugal: token.frugal,
+        }],
+        CasefoldedAtom::Multiple(chars) => {
+            // A literal that expanded to multiple chars (e.g., 'ß' -> 's','s').
+            // Wrap them in a Group so they're matched as a sequence.
+            let inner_tokens: Vec<RegexToken> = chars
+                .into_iter()
+                .map(|c| RegexToken {
+                    atom: RegexAtom::Literal(c),
+                    quant: RegexQuant::One,
+                    named_capture: None,
+                    secondary_named_capture: None,
+                    hash_capture: None,
+                    ratchet: token.ratchet,
+                    frugal: false,
+                })
+                .collect();
+            let group = RegexPattern {
+                tokens: inner_tokens,
+                anchor_start: false,
+                anchor_end: false,
+                ignore_case: false,
+                ignore_mark: false,
+            };
+            vec![RegexToken {
+                atom: RegexAtom::Group(group),
+                quant: token.quant.clone(),
+                named_capture: token.named_capture.clone(),
+                secondary_named_capture: token.secondary_named_capture.clone(),
+                hash_capture: token.hash_capture.clone(),
+                ratchet: token.ratchet,
+                frugal: token.frugal,
+            }]
+        }
+    }
+}
+
+enum CasefoldedAtom {
+    Single(RegexAtom),
+    Multiple(Vec<char>),
+}
+
+fn casefold_atom(atom: &RegexAtom) -> CasefoldedAtom {
+    match atom {
+        RegexAtom::Literal(ch) => {
+            let folded = casefold_char(*ch);
+            if folded.len() == 1 {
+                CasefoldedAtom::Single(RegexAtom::Literal(folded[0]))
+            } else {
+                CasefoldedAtom::Multiple(folded)
+            }
+        }
+        RegexAtom::Named(name) => {
+            // Case-fold the literal name text
+            let folded: String = name.chars().flat_map(casefold_char).collect();
+            CasefoldedAtom::Single(RegexAtom::Named(folded))
+        }
+        RegexAtom::Group(p) => CasefoldedAtom::Single(RegexAtom::Group(casefold_pattern(p))),
+        RegexAtom::CaptureGroup(p) => {
+            CasefoldedAtom::Single(RegexAtom::CaptureGroup(casefold_pattern(p)))
+        }
+        RegexAtom::Alternation(alts) => CasefoldedAtom::Single(RegexAtom::Alternation(
+            alts.iter().map(casefold_pattern).collect(),
+        )),
+        RegexAtom::SequentialAlternation(alts) => CasefoldedAtom::Single(
+            RegexAtom::SequentialAlternation(alts.iter().map(casefold_pattern).collect()),
+        ),
+        RegexAtom::Conjunction(branches) => CasefoldedAtom::Single(RegexAtom::Conjunction(
+            branches.iter().map(casefold_pattern).collect(),
+        )),
+        RegexAtom::GoalMatch {
+            goal,
+            inner,
+            goal_text,
+        } => CasefoldedAtom::Single(RegexAtom::GoalMatch {
+            goal: casefold_pattern(goal),
+            inner: casefold_pattern(inner),
+            goal_text: goal_text.clone(),
+        }),
+        RegexAtom::Lookaround {
+            pattern,
+            negated,
+            is_behind,
+        } => CasefoldedAtom::Single(RegexAtom::Lookaround {
+            pattern: casefold_pattern(pattern),
+            negated: *negated,
+            is_behind: *is_behind,
+        }),
+        other => CasefoldedAtom::Single(other.clone()),
+    }
+}

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -497,7 +497,15 @@ impl Interpreter {
         let matched = match atom {
             RegexAtom::Literal(ch) => {
                 if ignore_case {
-                    ch.to_lowercase().to_string() == c.to_lowercase().to_string()
+                    // In case-insensitive mode, a plain literal should not match
+                    // a synthetic grapheme (base + combining marks) because they
+                    // are different graphemes.
+                    let ge = grapheme_end(chars, pos);
+                    if ge > pos + 1 {
+                        false
+                    } else {
+                        ch.to_lowercase().to_string() == c.to_lowercase().to_string()
+                    }
                 } else {
                     *ch == c
                 }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -176,31 +176,56 @@ impl Interpreter {
         // case folds (e.g., 'ß' -> 'ss', 'ﬁ' -> 'fi'), pre-process both text
         // and pattern into case-folded form, match on folded forms, then map
         // positions back to the original text.
+        //
+        // Important: matches must start and end at "fold boundaries" — positions
+        // in folded space that correspond to the start of an original character's
+        // fold expansion. This prevents false matches in the middle of a fold
+        // (e.g., matching 't' from the expansion of 'ﬆ' -> 'st').
         if parsed.ignore_case && needs_casefold_expansion(&orig_chars, &parsed) {
             let (folded_chars, pos_map) = casefold_text(&orig_chars);
             let folded_parsed = casefold_pattern(&parsed);
             let orig_len = orig_chars.len();
+
+            // Helper: check if a position in folded space is at a fold boundary
+            // (i.e., the start of an original character's expansion).
+            let is_fold_boundary = |pos: usize| -> bool {
+                pos == 0 || pos >= folded_chars.len() || pos_map[pos] != pos_map[pos - 1]
+            };
+
             if folded_parsed.anchor_start {
                 return self
                     .regex_match_end_from_caps_in_pkg(&folded_parsed, &folded_chars, 0, &pkg)
-                    .map(|(end, mut caps)| {
+                    .and_then(|(end, mut caps)| {
+                        let end_pos = caps.capture_end.unwrap_or(end);
+                        if !is_fold_boundary(end_pos) {
+                            return None;
+                        }
                         let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
-                        let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
+                        let to = map_pos(end_pos, &pos_map, orig_len);
                         caps.from = from;
                         caps.to = to;
                         caps.matched = orig_chars[from..to].iter().collect();
-                        caps
+                        Some(caps)
                     });
             }
             for start in 0..=folded_chars.len() {
+                // Only try start positions at fold boundaries
+                if !is_fold_boundary(start) {
+                    continue;
+                }
                 if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &folded_parsed,
                     &folded_chars,
                     start,
                     &pkg,
                 ) {
+                    let end_pos = caps.capture_end.unwrap_or(end);
+                    // Only accept matches that end at fold boundaries
+                    if !is_fold_boundary(end_pos) {
+                        continue;
+                    }
                     let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
-                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
+                    let to = map_pos(end_pos, &pos_map, orig_len);
                     caps.from = from;
                     caps.to = to;
                     caps.matched = orig_chars[from..to].iter().collect();

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::regex_casefold::{casefold_pattern, casefold_text, needs_casefold_expansion};
 use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
 
 impl Interpreter {
@@ -157,6 +158,44 @@ impl Interpreter {
                 if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
                     &stripped_chars,
+                    start,
+                    &pkg,
+                ) {
+                    let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
+                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
+                    caps.from = from;
+                    caps.to = to;
+                    caps.matched = orig_chars[from..to].iter().collect();
+                    return Some(caps);
+                }
+            }
+            return None;
+        }
+
+        // When :i (ignorecase) is set and there are characters with multi-char
+        // case folds (e.g., 'ß' -> 'ss', 'ﬁ' -> 'fi'), pre-process both text
+        // and pattern into case-folded form, match on folded forms, then map
+        // positions back to the original text.
+        if parsed.ignore_case && needs_casefold_expansion(&orig_chars, &parsed) {
+            let (folded_chars, pos_map) = casefold_text(&orig_chars);
+            let folded_parsed = casefold_pattern(&parsed);
+            let orig_len = orig_chars.len();
+            if folded_parsed.anchor_start {
+                return self
+                    .regex_match_end_from_caps_in_pkg(&folded_parsed, &folded_chars, 0, &pkg)
+                    .map(|(end, mut caps)| {
+                        let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
+                        let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
+                        caps.from = from;
+                        caps.to = to;
+                        caps.matched = orig_chars[from..to].iter().collect();
+                        caps
+                    });
+            }
+            for start in 0..=folded_chars.len() {
+                if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
+                    &folded_parsed,
+                    &folded_chars,
                     start,
                     &pkg,
                 ) {


### PR DESCRIPTION
## Summary
- Implement proper Unicode case folding for case-insensitive regex matching (`:i`/`:ignorecase`)
- Handle multi-char case folds: `ß` <-> `SS`, `ﬁ` <-> `fi`, `ﬆ` <-> `st`, and other Unicode ligatures
- Pre-process text and pattern into case-folded form with position mapping when multi-char folds are detected (similar to existing `:m`/ignoremark handling)
- Fix synthetic grapheme matching so a plain literal with `:i` doesn't match a base character with combining marks

## Test plan
- [x] All 101 subtests in `roast/S05-modifier/ignorecase.t` pass
- [x] `make test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean
- [x] `roast-whitelist.txt` updated and sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)