### PR TITLE
fix: pass all 47 subtests in roast/S09-typed-arrays/hashes.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -508,6 +508,7 @@ roast/S09-multidim/indexing.t
 roast/S09-multidim/methods.t
 roast/S09-multidim/subs.t
 roast/S09-subscript/multidim-assignment.t
+roast/S09-typed-arrays/hashes.t
 roast/S09-typed-arrays/native-decl.t
 roast/S10-packages/export.t
 roast/S10-packages/joined-namespaces.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -139,7 +139,8 @@ fn invert_value(target: &Value) -> Option<Value> {
     match target {
         Value::Hash(items) => {
             for (k, v) in items.iter() {
-                extend_inverted_pairs(&mut result, Value::str(k.clone()), v);
+                let orig_key = crate::runtime::utils::hash_typed_key(target, k);
+                extend_inverted_pairs(&mut result, orig_key, v);
             }
         }
         Value::Bag(items, _) => {
@@ -577,20 +578,19 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 return Some(Ok(Value::array(pairs)));
             }
             match target {
-                Value::Hash(items) => Some(Ok(Value::array(
-                    items
+                Value::Hash(items) => {
+                    let pairs: Vec<Value> = items
                         .iter()
-                        .map(|(k, v)| match v {
-                            Value::Str(s) => {
-                                Value::Pair(s.to_string(), Box::new(Value::str(k.clone())))
+                        .map(|(k, v)| {
+                            let orig_key = crate::runtime::utils::hash_typed_key(target, k);
+                            match v {
+                                Value::Str(s) => Value::Pair(s.to_string(), Box::new(orig_key)),
+                                _ => Value::ValuePair(Box::new(v.clone()), Box::new(orig_key)),
                             }
-                            _ => Value::ValuePair(
-                                Box::new(v.clone()),
-                                Box::new(Value::str(k.clone())),
-                            ),
                         })
-                        .collect(),
-                ))),
+                        .collect();
+                    Some(Ok(Value::array(pairs)))
+                }
                 Value::Bag(items, _) => Some(Ok(Value::array(
                     items
                         .iter()

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -10,6 +10,10 @@ use crate::value::Value;
 use super::{ident, is_stmt_modifier_keyword, try_parse_assign_expr};
 
 fn regroup_assign_expr_metaop_rhs(expr: Expr) -> Expr {
+    // Handle Grouped(AssignExpr{...}) from parenthesized assignments
+    if let Expr::Grouped(inner) = expr {
+        return Expr::Grouped(Box::new(regroup_assign_expr_metaop_rhs(*inner)));
+    }
     let Expr::AssignExpr { name, expr, .. } = expr else {
         return expr;
     };

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1123,13 +1123,15 @@ fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
                     r = r2;
                 }
                 let (r, _) = parse_char(r, ')')?;
+                // Wrap in Grouped so that expand_call_arg does not split the
+                // parenthesized assignment's RHS back into separate call args.
                 return Ok((
                     r,
-                    Expr::AssignExpr {
+                    Expr::Grouped(Box::new(Expr::AssignExpr {
                         name,
                         expr: Box::new(Expr::ArrayLiteral(items)),
                         is_bind: false,
-                    },
+                    })),
                 ));
             }
         }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -78,6 +78,52 @@ fn shaped_array_ids() -> &'static Mutex<HashMap<usize, Vec<usize>>> {
     SHAPED_ARRAY_IDS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Global registry of original (non-string) keys for object hashes.
+/// Keyed by the hash's Arc pointer identity.
+fn hash_original_keys_registry() -> &'static Mutex<HashMap<usize, HashMap<String, Value>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<usize, HashMap<String, Value>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Register original keys for a hash value.
+pub(crate) fn register_hash_original_keys(hash: &Value, original_keys: HashMap<String, Value>) {
+    if original_keys.is_empty() {
+        return;
+    }
+    if let Value::Hash(arc) = hash {
+        let id = Arc::as_ptr(arc) as usize;
+        if let Ok(mut reg) = hash_original_keys_registry().lock() {
+            reg.insert(id, original_keys);
+        }
+    }
+}
+
+/// Snapshot the original keys for a hash, if any are registered.
+pub(crate) fn hash_original_keys_snapshot(hash: &Value) -> Option<HashMap<String, Value>> {
+    if let Value::Hash(arc) = hash {
+        let id = Arc::as_ptr(arc) as usize;
+        if let Ok(reg) = hash_original_keys_registry().lock() {
+            return reg.get(&id).cloned();
+        }
+    }
+    None
+}
+
+/// Retrieve the original (typed) key value for a hash entry, if available.
+/// Falls back to the string key if no original key is registered.
+pub(crate) fn hash_typed_key(hash: &Value, str_key: &str) -> Value {
+    if let Value::Hash(arc) = hash {
+        let id = Arc::as_ptr(arc) as usize;
+        if let Ok(reg) = hash_original_keys_registry().lock()
+            && let Some(orig_keys) = reg.get(&id)
+            && let Some(orig) = orig_keys.get(str_key)
+        {
+            return orig.clone();
+        }
+    }
+    Value::str(str_key.to_string())
+}
+
 fn grep_view_bindings() -> &'static Mutex<GrepViewMap> {
     static GREP_VIEW_BINDINGS: OnceLock<Mutex<GrepViewMap>> = OnceLock::new();
     GREP_VIEW_BINDINGS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -431,26 +477,37 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                 }
             }
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
             let mut i = 0;
             while i < flat.len() {
                 if let Value::Pair(k, v) = &flat[i] {
                     map.insert(k.clone(), *v.clone());
                     i += 1;
                 } else if let Value::ValuePair(k, v) = &flat[i] {
-                    map.insert(k.to_string_value(), *v.clone());
+                    let str_key = k.to_string_value();
+                    if !matches!(k.as_ref(), Value::Str(_)) {
+                        original_keys.insert(str_key.clone(), *k.clone());
+                    }
+                    map.insert(str_key, *v.clone());
                     i += 1;
                 } else {
-                    let key = flat[i].to_string_value();
+                    let key_val = &flat[i];
+                    let str_key = key_val.to_string_value();
+                    if !matches!(key_val, Value::Str(_)) {
+                        original_keys.insert(str_key.clone(), key_val.clone());
+                    }
                     let val = if i + 1 < flat.len() {
                         flat[i + 1].clone()
                     } else {
                         Value::Nil
                     };
-                    map.insert(key, val);
+                    map.insert(str_key, val);
                     i += 2;
                 }
             }
-            Value::hash(map)
+            let result = Value::hash(map);
+            register_hash_original_keys(&result, original_keys);
+            result
         }
         Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) | Value::Slip(items) => {
             let mut map = HashMap::new();
@@ -550,6 +607,7 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
         .map(Value::to_string_value)
         .unwrap_or_else(|| "Nil".to_string());
     let mut map = HashMap::new();
+    let mut original_keys: HashMap<String, Value> = HashMap::new();
     let mut iter = items.into_iter();
     while let Some(item) = iter.next() {
         match item {
@@ -557,7 +615,11 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                 map.insert(key, *boxed_val);
             }
             Value::ValuePair(key, boxed_val) => {
-                map.insert(Value::hash_key_encode(&key), *boxed_val);
+                let str_key = Value::hash_key_encode(&key);
+                if !matches!(key.as_ref(), Value::Str(_)) {
+                    original_keys.insert(str_key.clone(), *key);
+                }
+                map.insert(str_key, *boxed_val);
             }
             other => {
                 let Some(value) = iter.next() else {
@@ -577,11 +639,17 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                     err.exception = Some(Box::new(ex));
                     return Err(err);
                 };
-                map.insert(Value::hash_key_encode(&other), value);
+                let str_key = Value::hash_key_encode(&other);
+                if !matches!(&other, Value::Str(_)) {
+                    original_keys.insert(str_key.clone(), other);
+                }
+                map.insert(str_key, value);
             }
         }
     }
-    Ok(Value::hash(map))
+    let result = Value::hash(map);
+    register_hash_original_keys(&result, original_keys);
+    Ok(result)
 }
 
 /// Maximum number of elements when expanding an infinite range into an Array.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -664,6 +664,10 @@ impl VM {
         if var_name.starts_with('%')
             && let Value::Hash(map) = value
         {
+            // Preserve original keys from the source hash before coercion
+            // (coercion creates a new Arc, losing the registration).
+            let saved_original_keys =
+                runtime::utils::hash_original_keys_snapshot(&Value::Hash(map.clone()));
             let value_constraint = self.interpreter.var_type_constraint(var_name);
             let key_constraint = self.interpreter.var_hash_key_constraint(var_name);
             let mut coerced_map = std::collections::HashMap::with_capacity(map.len());
@@ -726,7 +730,12 @@ impl VM {
                 };
                 coerced_map.insert(coerced_key, coerced_val);
             }
-            return Ok(Value::hash(coerced_map));
+            let result = Value::hash(coerced_map);
+            // Re-register original keys on the new hash Arc.
+            if let Some(orig) = saved_original_keys {
+                runtime::utils::register_hash_original_keys(&result, orig);
+            }
+            return Ok(result);
         }
 
         Ok(value)


### PR DESCRIPTION
## Summary
- Fix parser bug where parenthesized hash assignments `(%h1 = %h1, %h2)` in statement-level call args were split into separate arguments by `expand_call_arg`
- Add global registry for original non-string hash keys (type objects, Ints) so `.antipairs` and `.invert` can recover them
- Preserve original keys across hash type coercion in `coerce_typed_container_assignment`

## Test plan
- [ ] `prove -e 'target/debug/mutsu' roast/S09-typed-arrays/hashes.t` passes all 47 subtests
- [ ] `make test` passes (no regressions)
- [ ] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)