### PR TITLE
chore: restore 3 whitelist entries removed by PR #2301

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -39,6 +39,7 @@ roast/S02-lexical-conventions/unicode-whitespace.t
 roast/S02-lexical-conventions/unicode.t
 roast/S02-lists/indexing.t
 roast/S02-lists/tree.t
+roast/S02-literals/adverbs.t
 roast/S02-literals/array-interpolation.t
 roast/S02-literals/autoref.t
 roast/S02-literals/char-by-name.t
@@ -330,6 +331,7 @@ roast/S04-statements/with.t
 roast/S05-capture/dot.t
 roast/S05-capture/match-object.t
 roast/S05-capture/named.t
+roast/S05-capture/subrule.t
 roast/S05-grammar/action-stubs.t
 roast/S05-grammar/example.t
 roast/S05-grammar/inheritance.t
@@ -422,6 +424,7 @@ roast/S06-advanced/stub.t
 roast/S06-currying/assuming-and-mmd.t
 roast/S06-currying/misc.t
 roast/S06-currying/named.t
+roast/S06-currying/positional.t
 roast/S06-currying/slurpy.t
 roast/S06-multi/by-trait.t
 roast/S06-multi/compile-time.t


### PR DESCRIPTION
## Summary
- Restore `adverbs.t`, `subrule.t`, `positional.t` removed by #2301 and not included in #2308's fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)