### PR TITLE
fix: pass all 19 subtests in roast/S06-signature/types.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -481,6 +481,7 @@ roast/S06-signature/slurpy-placeholders.t
 roast/S06-signature/sub-ref.t
 roast/S06-signature/tree-node-parameters.t
 roast/S06-signature/type-capture.t
+roast/S06-signature/types.t
 roast/S06-signature/unpack-array.t
 roast/S06-signature/unpack-object.t
 roast/S06-signature/unspecified.t

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -7,10 +7,70 @@ use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use num_traits::{Signed, ToPrimitive, Zero};
 
+/// Check if a Package type object is calling a :D-requiring numeric method.
+/// Returns X::Parameter::InvalidConcreteness error if so.
+fn check_numeric_type_object_method(
+    target: &Value,
+    method: &str,
+) -> Option<Option<Result<Value, RuntimeError>>> {
+    if let Value::Package(pkg_name) = target {
+        let name = pkg_name.resolve();
+        // Numeric types whose instances have these methods
+        let is_numeric_type = matches!(
+            name.as_ref(),
+            "Int" | "UInt" | "Num" | "Rat" | "FatRat" | "Complex" | "Cool" | "Numeric"
+        );
+        if !is_numeric_type {
+            return None;
+        }
+        // Methods that require :D (a concrete instance)
+        let is_d_method = matches!(
+            method,
+            "abs"
+                | "sign"
+                | "sqrt"
+                | "exp"
+                | "log"
+                | "log2"
+                | "log10"
+                | "ceiling"
+                | "floor"
+                | "round"
+                | "truncate"
+                | "narrow"
+                | "lsb"
+                | "msb"
+                | "base"
+                | "polymod"
+        );
+        if !is_d_method {
+            return None;
+        }
+        // Determine the parent numeric type for the error
+        let expected_type = match name.as_ref() {
+            "UInt" => "Int",
+            _ => &name,
+        };
+        return Some(Some(Err(RuntimeError::parameter_invalid_concreteness(
+            expected_type,
+            &name,
+            method,
+            "self",
+            true, // should_be_concrete
+            true, // param_is_invocant
+        ))));
+    }
+    None
+}
+
 pub(super) fn dispatch(
     target: &Value,
     method: &str,
 ) -> Option<Option<Result<Value, RuntimeError>>> {
+    // Type objects calling :D-requiring numeric methods
+    if let result @ Some(_) = check_numeric_type_object_method(target, method) {
+        return result;
+    }
     match method {
         "elems" => {
             if let Value::LazyList(list) = target {

--- a/src/parser/primary/number.rs
+++ b/src/parser/primary/number.rs
@@ -241,6 +241,10 @@ pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
         if r.starts_with('+') || r.starts_with('-') {
             exp_part.push_str(&r[..1]);
             r = &r[1..];
+        } else if r.starts_with('\u{2212}') {
+            // U+2212 MINUS SIGN — normalize to ASCII minus
+            exp_part.push('-');
+            r = &r['\u{2212}'.len_utf8()..];
         }
         // An underscore immediately after `e`/`E` (or its sign) is a hard
         // syntax error per Raku spec — emit X::Syntax::Confused.
@@ -296,6 +300,9 @@ pub(super) fn decimal(input: &str) -> PResult<'_, Expr> {
         if r.starts_with('+') || r.starts_with('-') {
             exp.push_str(&r[..1]);
             r = &r[1..];
+        } else if r.starts_with('\u{2212}') {
+            exp.push('-');
+            r = &r['\u{2212}'.len_utf8()..];
         }
         if let Some((r2, exp_digits)) = scan_decimal_digits(r) {
             exp.push_str(&exp_digits);
@@ -379,6 +386,9 @@ pub(super) fn dot_decimal(input: &str) -> PResult<'_, Expr> {
         if r.starts_with('+') || r.starts_with('-') {
             exp.push_str(&r[..1]);
             r = &r[1..];
+        } else if r.starts_with('\u{2212}') {
+            exp.push('-');
+            r = &r['\u{2212}'.len_utf8()..];
         }
         if let Some((r2, exp_digits)) = scan_decimal_digits(r) {
             exp.push_str(&exp_digits);

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1120,6 +1120,42 @@ pub(super) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         {
             type_constraint = Some(tc);
             r2
+        } else if r2.starts_with('{') || r2.starts_with(',') || r2.starts_with("-->") {
+            // Type-only parameter in pointy block (e.g., `-> True { }`, `-> Int { }`)
+            let tc_for_bool = if tc == "True" || tc == "False" {
+                super::super::add_parse_warning(format!(
+                    "Potential difficulties:\n    Literal values in signatures are smartmatched against and smartmatch with `{}` will always {}. Use the `where` clause instead.",
+                    tc,
+                    if tc == "True" { "succeed" } else { "fail" }
+                ));
+                "Bool".to_string()
+            } else {
+                tc.clone()
+            };
+            return Ok((
+                r2,
+                ParamDef {
+                    name: "__type_only__".to_string(),
+                    default: None,
+                    multi_invocant: true,
+                    required: false,
+                    named: false,
+                    slurpy: false,
+                    double_slurpy: false,
+                    onearg: false,
+                    sigilless: false,
+                    type_constraint: Some(tc_for_bool),
+                    literal_value: None,
+                    sub_signature: None,
+                    outer_sub_signature: None,
+                    code_signature: None,
+                    where_constraint: None,
+                    traits: Vec::new(),
+                    optional_marker: false,
+                    is_invocant: false,
+                    shape_constraints: None,
+                },
+            ));
         } else {
             rest
         }

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -877,6 +877,7 @@ pub(super) fn parse_single_param(input: &str) -> PResult<'_, ParamDef> {
         } else if r2.starts_with(')')
             || r2.starts_with(',')
             || r2.starts_with(']')
+            || r2.starts_with('{')
             || r2.starts_with("-->")
         {
             // True/False in signature position are literal Bool values, not type names.
@@ -885,6 +886,11 @@ pub(super) fn parse_single_param(input: &str) -> PResult<'_, ParamDef> {
             // a Bool type constraint. Smartmatch against False always fails, so
             // sub f(False) would reject all calls (equivalent to an impossible constraint).
             if tc == "True" || tc == "False" {
+                super::super::add_parse_warning(format!(
+                    "Potential difficulties:\n    Literal values in signatures are smartmatched against and smartmatch with `{}` will always {}. Use the `where` clause instead.",
+                    tc,
+                    if tc == "True" { "succeed" } else { "fail" }
+                ));
                 let mut p = make_param("__type_only__".to_string());
                 p.type_constraint = Some("Bool".to_string());
                 p.named = named;
@@ -971,6 +977,7 @@ pub(super) fn parse_single_param(input: &str) -> PResult<'_, ParamDef> {
             || after_lit.starts_with(',')
             || after_lit.starts_with(';')
             || after_lit.starts_with(']')
+            || after_lit.starts_with('{')
             || after_lit.starts_with("-->"))
     {
         let mut p = make_param("__literal__".to_string());

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -565,7 +565,7 @@ impl Interpreter {
                 .map(|f| Value::str(f.clone()))
                 .unwrap_or(Value::Nil)));
         }
-        if method == "of" && args.is_empty() {
+        if matches!(method, "of" | "returns") && args.is_empty() {
             let type_name = self
                 .callable_return_type(target)
                 .unwrap_or_else(|| "Mu".to_string());

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -890,6 +890,32 @@ impl Interpreter {
                         {
                             // Binding accepts numeric widening into Num parameters.
                         } else if !self.type_matches_value(&resolved_constraint, &value) {
+                            // :D/:U smiley mismatch → X::Parameter::InvalidConcreteness
+                            let (base_type, smiley) =
+                                crate::runtime::types::strip_type_smiley(&resolved_constraint);
+                            if smiley.is_some_and(|s| s == ":D" || s == ":U")
+                                && self.type_matches_value(base_type, &value)
+                            {
+                                let should_be_concrete = smiley == Some(":D");
+                                let got_type = if let Value::Package(pkg) = &value {
+                                    pkg.resolve().to_string()
+                                } else {
+                                    crate::runtime::value_type_name(&value).to_string()
+                                };
+                                let routine = self
+                                    .samewith_context_stack
+                                    .last()
+                                    .map(|(name, _)| name.as_str())
+                                    .unwrap_or("<anon>");
+                                return Err(RuntimeError::parameter_invalid_concreteness(
+                                    base_type,
+                                    &got_type,
+                                    routine,
+                                    &pd.name,
+                                    should_be_concrete,
+                                    pd.is_invocant,
+                                ));
+                            }
                             let display_name = if pd.name == "__type_only__" {
                                 format!("parameter '{}'", resolved_constraint)
                             } else {

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -44,6 +44,14 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
     if !native_types::is_native_int_type(base) {
         return Ok(val);
     }
+    // Type objects cannot be unboxed to native types
+    if let Value::Package(pkg_name) = &val {
+        return Err(crate::value::RuntimeError::new(format!(
+            "Cannot unbox a type object ({}) to {}.",
+            pkg_name.resolve(),
+            base
+        )));
+    }
     let big_val = match &val {
         Value::Int(n) => NumBigInt::from(*n),
         Value::BigInt(n) => (**n).clone(),

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -411,6 +411,25 @@ impl Interpreter {
                     }
                     return false;
                 }
+                "Callable" | "Code" | "Sub" | "Routine" | "Block" | "Method" => {
+                    // Callable[ReturnType] — check if value is callable and has a matching return type
+                    if value.as_sub().is_some()
+                        || matches!(
+                            value,
+                            Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
+                        )
+                    {
+                        let return_type = self
+                            .callable_return_type(value)
+                            .unwrap_or_else(|| "Mu".to_string());
+                        return Self::type_matches(&return_type, inner)
+                            || self.type_matches_value(
+                                inner,
+                                &Value::Package(Symbol::intern(&return_type)),
+                            );
+                    }
+                    return false;
+                }
                 "Buf" | "Blob" => {
                     if let Value::Instance {
                         class_name,

--- a/t/smiley-params.t
+++ b/t/smiley-params.t
@@ -5,23 +5,23 @@ plan 8;
 sub takes-defined-int(Int:D $x) { $x }
 is takes-defined-int(42), 42, 'Int:D parameter accepts defined Int values';
 throws-like { takes-defined-int(Int) },
-    X::TypeCheck::Binding::Parameter,
+    X::Parameter::InvalidConcreteness,
     'Int:D parameter rejects Int type object';
 
 sub takes-undefined-int(Int:U $x) { $x.gist }
 is takes-undefined-int(Int), '(Int)', 'Int:U parameter accepts Int type object';
 throws-like { takes-undefined-int(42) },
-    X::TypeCheck::Binding::Parameter,
+    X::Parameter::InvalidConcreteness,
     'Int:U parameter rejects defined Int values';
 
 sub takes-defined-str(Str:D $s) { $s }
 is takes-defined-str('ok'), 'ok', 'Str:D parameter accepts defined Str values';
 throws-like { takes-defined-str(Str) },
-    X::TypeCheck::Binding::Parameter,
+    X::Parameter::InvalidConcreteness,
     'Str:D parameter rejects Str type object';
 
 sub takes-undefined-str(Str:U $s) { $s.gist }
 is takes-undefined-str(Str), '(Str)', 'Str:U parameter accepts Str type object';
 throws-like { takes-undefined-str('nope') },
-    X::TypeCheck::Binding::Parameter,
+    X::Parameter::InvalidConcreteness,
     'Str:U parameter rejects defined Str values';


### PR DESCRIPTION
## Summary
- Add `.returns` method on Sub/Code objects (mirrors `.of`)
- Support `Callable[ReturnType]` in smartmatch and type matching
- Throw `X::Parameter::InvalidConcreteness` for `:D`/`:U` smiley constraint violations in sub parameter binding
- Reject type objects passed to native `int` parameters with "Cannot unbox a type object" error
- Parse U+2212 MINUS SIGN in scientific notation exponents (`1e−2`)
- Support type-only parameters in pointy blocks (`-> True { }`, `-> Int { }`)
- Emit compile-time "smartmatch" warning for `True`/`False` literal signature params
- Throw `X::Parameter::InvalidConcreteness` when numeric type objects call `:D`-requiring methods like `.abs`

## Test plan
- [x] All 19 subtests in `roast/S06-signature/types.t` pass
- [x] `make test` passes (updated `t/smiley-params.t` to expect new exception type)
- [x] Whitelisted roast tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)