### PR TITLE
feat: implement is DEPRECATED deprecation tracking

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -200,7 +200,7 @@
 - [ ] roast/S02-types/int-uint.t
   - 0/? pass. Parse error at line 9
 - [ ] roast/S02-types/isDEPRECATED.t
-  - 0/14 pass. Test 1 fails: `.report` method not implemented — `is DEPRECATED` trait not supported
+  - 7/14 pass (tests 1-4,7 pass; 5,6 are TODO NYI in raku itself). Test 8 fails: method deprecation line tracking inside blocks with heredocs reports wrong line number. Tests 9-14 not reached.
 - [ ] roast/S02-types/is-type.t
   - 0/? pass. Parse error at line 56
 - [ ] roast/S02-types/lazy-lists.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -686,6 +686,9 @@ pub(crate) enum Stmt {
         is_default: Option<Expr>,
         /// `is Type` trait — container type for `@`/`%` attributes (e.g. `is Buf`, `is BagHash`)
         is_type: Option<String>,
+        /// `is DEPRECATED` message: None = not deprecated, Some("") = deprecated without message,
+        /// Some(msg) = deprecated with custom message.
+        deprecated_message: Option<String>,
     },
     MethodDecl {
         name: Symbol,

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -37,6 +37,7 @@ impl Compiler {
             let self_idx = self.code.add_constant(Value::str(self_name));
             self.code.emit(OpCode::GetGlobal(self_idx));
             let method_idx = self.code.add_constant(Value::str(attr_name.to_string()));
+            self.emit_source_line_if_known();
             self.code.emit(OpCode::CallMethod {
                 name_idx: method_idx,
                 arity: 0,

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -65,6 +65,7 @@ impl Compiler {
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
         // Use CallMethod (non-mut) for read-only special variables like $!
         // so they benefit from the Nil dispatch path in CallMethod.
+        self.emit_source_line_if_known();
         if target_name == "!" {
             self.code.emit(OpCode::CallMethod {
                 name_idx,
@@ -126,6 +127,7 @@ impl Compiler {
                 for arg in args {
                     self.compile_method_arg(arg);
                 }
+                self.emit_source_line_if_known();
                 self.code.emit(OpCode::CallMethodMut {
                     name_idx,
                     arity,
@@ -149,6 +151,7 @@ impl Compiler {
                     self.compile_method_arg(arg);
                 }
                 let name_idx = self.code.add_constant(Value::str(name_resolved));
+                self.emit_source_line_if_known();
                 self.code.emit(OpCode::CallMethod {
                     name_idx,
                     arity,
@@ -273,6 +276,7 @@ impl Compiler {
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
+        self.emit_source_line_if_known();
         self.code.emit(OpCode::CallMethod {
             name_idx,
             arity,
@@ -303,6 +307,7 @@ impl Compiler {
             self.compile_method_arg(arg);
         }
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
+        self.emit_source_line_if_known();
         if let Some(var_name) = target_var_name {
             let target_name_idx = self.code.add_constant(Value::str(var_name));
             self.code.emit(OpCode::CallMethodDynamicMut {

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -136,14 +136,15 @@ impl Compiler {
     }
 
     pub(super) fn body_mutates_topic(stmts: &[Stmt]) -> bool {
-        // Only check if the *first* statement assigns `$_` directly.
+        // Only check if the *first* non-SetLine statement assigns `$_` directly.
         // This detects `with`-style topic switches (where the parser inserts a
         // `$_ = <expr>` as the first statement of the then-branch) but avoids
         // falsely triggering on user code like `if COND { ...; $_ = 2 }` where
         // the assignment is NOT at the start. The Block wrapping created when
         // this returns true causes BlockScope to save/restore `$_`, isolating
         // the `with` topic from the outer scope.
-        matches!(stmts.first(), Some(Stmt::Assign { name, .. }) if name == "_")
+        let first_real = stmts.iter().find(|s| !matches!(s, Stmt::SetLine(_)));
+        matches!(first_real, Some(Stmt::Assign { name, .. }) if name == "_")
     }
 
     /// Returns true only if the body contains a `$_ :=` rebind — used by the

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -57,6 +57,34 @@ impl Compiler {
         is_rw: bool,
         is_raw: bool,
     ) {
+        self.compile_sub_body_with_deprecation(
+            name,
+            params,
+            param_defs,
+            return_type,
+            body,
+            multi,
+            state_group,
+            is_rw,
+            is_raw,
+            None,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn compile_sub_body_with_deprecation(
+        &mut self,
+        name: &str,
+        params: &[String],
+        param_defs: &[crate::ast::ParamDef],
+        return_type: Option<&String>,
+        body: &[Stmt],
+        multi: bool,
+        state_group: Option<&str>,
+        is_rw: bool,
+        is_raw: bool,
+        deprecated_info: Option<(String, String, String, String)>,
+    ) {
         // Before compiling the sub body, check for heredoc interpolations
         // that reference variables not visible at the outer scope (where the
         // heredoc terminator physically appears in Raku).
@@ -298,6 +326,7 @@ impl Compiler {
             param_local_slots: None,
             has_inner_subs: false,
             named_param_slots: None,
+            deprecated_info,
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_param_slots();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -101,6 +101,15 @@ impl Compiler {
         }
     }
 
+    /// Emit a SetSourceLine opcode for the current source line, if known.
+    /// Used before method/function calls to ensure ?LINE is up-to-date for
+    /// deprecation tracking and error reporting.
+    pub(super) fn emit_source_line_if_known(&mut self) {
+        if let Some(line) = self.last_source_line {
+            self.code.emit(OpCode::SetSourceLine(line));
+        }
+    }
+
     pub(crate) fn set_current_package(&mut self, package: String) {
         self.current_package = package;
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1686,6 +1686,7 @@ impl Compiler {
                 multi,
                 is_rw,
                 is_raw,
+                custom_traits,
                 ..
             } => {
                 // Validate placeholder conflicts for subs with implicit params
@@ -1726,7 +1727,27 @@ impl Compiler {
                     None
                 };
                 let name_str = name.resolve();
-                self.compile_sub_body(
+                // Extract deprecation info from custom_traits
+                let deprecated_info = custom_traits.iter().find_map(|(t, _)| {
+                    if t == "DEPRECATED" {
+                        Some((
+                            "Sub".to_string(),
+                            name_str.clone(),
+                            self.current_package.clone(),
+                            String::new(),
+                        ))
+                    } else {
+                        t.strip_prefix("DEPRECATED:").map(|msg| {
+                            (
+                                "Sub".to_string(),
+                                name_str.clone(),
+                                self.current_package.clone(),
+                                msg.to_string(),
+                            )
+                        })
+                    }
+                });
+                self.compile_sub_body_with_deprecation(
                     &name_str,
                     params,
                     param_defs,
@@ -1736,9 +1757,10 @@ impl Compiler {
                     state_group.as_deref(),
                     *is_rw,
                     *is_raw,
+                    deprecated_info.clone(),
                 );
                 for (alt_params, alt_param_defs) in signature_alternates {
-                    self.compile_sub_body(
+                    self.compile_sub_body_with_deprecation(
                         &name_str,
                         alt_params,
                         alt_param_defs,
@@ -1748,6 +1770,7 @@ impl Compiler {
                         state_group.as_deref(),
                         *is_rw,
                         *is_raw,
+                        deprecated_info.clone(),
                     );
                 }
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1187,6 +1187,9 @@ pub(crate) struct CompiledFunction {
     /// Used by the OTF named call fast path to avoid name-based lookup per call.
     #[allow(clippy::type_complexity)]
     pub(crate) named_param_slots: Option<Vec<(String, usize, Vec<(String, usize)>)>>,
+    /// Deprecation info: (kind, name, package, message).
+    /// When set, every call records a deprecation event.
+    pub(crate) deprecated_info: Option<(String, String, String, String)>,
 }
 
 impl CompiledFunction {

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -63,6 +63,7 @@ fn has_decl_list(input: &str) -> PResult<'_, Stmt> {
             is_my: false,
             is_default: None,
             is_type: None,
+            deprecated_message: None,
         });
         let (r, _) = ws(rest)?;
         rest = r;
@@ -183,6 +184,7 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
     let mut is_required: Option<Option<String>> = None;
     let mut is_default_trait: Option<Expr> = None;
     let mut is_type: Option<String> = None;
+    let mut deprecated_message: Option<String> = None;
     while let Some(r) = keyword("is", rest) {
         let (r, _) = ws1(r)?;
         let (r, trait_name) = ident(r)?;
@@ -245,6 +247,67 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
                 }
             }
             is_required = Some(None);
+        } else if trait_name == "DEPRECATED" {
+            // `is DEPRECATED` or `is DEPRECATED("message")`
+            let (r_ws, _) = ws(r)?;
+            if let Some(inner) = r_ws.strip_prefix('(') {
+                let (inner, _) = ws(inner)?;
+                // Parse the message string
+                if let Some(double_quoted) = inner.strip_prefix('"') {
+                    let end = double_quoted.find('"').ok_or_else(|| {
+                        PError::expected("closing quote in is DEPRECATED message")
+                    })?;
+                    let msg = double_quoted[..end].to_string();
+                    let after = &double_quoted[end + 1..];
+                    let (after, _) = ws(after)?;
+                    let after = after
+                        .strip_prefix(')')
+                        .ok_or_else(|| PError::expected("closing paren in is DEPRECATED"))?;
+                    deprecated_message = Some(msg);
+                    rest = after;
+                    let (r2, _) = ws(rest)?;
+                    rest = r2;
+                    continue;
+                } else if let Some(single_quoted) = inner.strip_prefix('\'') {
+                    let end = single_quoted.find('\'').ok_or_else(|| {
+                        PError::expected("closing quote in is DEPRECATED message")
+                    })?;
+                    let msg = single_quoted[..end].to_string();
+                    let after = &single_quoted[end + 1..];
+                    let (after, _) = ws(after)?;
+                    let after = after
+                        .strip_prefix(')')
+                        .ok_or_else(|| PError::expected("closing paren in is DEPRECATED"))?;
+                    deprecated_message = Some(msg);
+                    rest = after;
+                    let (r2, _) = ws(rest)?;
+                    rest = r2;
+                    continue;
+                }
+                // Non-string expression in parens — find closing paren
+                let mut depth = 1u32;
+                let mut idx = 0;
+                for (i, ch) in inner.char_indices() {
+                    match ch {
+                        '(' => depth += 1,
+                        ')' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                idx = i;
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                let after = &inner[idx + 1..];
+                deprecated_message = Some(String::new());
+                rest = after;
+                let (r2, _) = ws(rest)?;
+                rest = r2;
+                continue;
+            }
+            deprecated_message = Some(String::new());
         } else if trait_name
             .chars()
             .next()
@@ -497,6 +560,7 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             is_my: false,
             is_default: is_default_trait,
             is_type,
+            deprecated_message,
         },
     ))
 }

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -338,6 +338,7 @@ pub(super) fn try_dot_twigil_attr<'a>(
             is_my: !is_our && !is_state,
             is_default: None,
             is_type: None,
+            deprecated_message: None,
         };
         if apply_modifier {
             return parse_statement_modifier(after_name, stmt).map(Some);

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -151,6 +151,38 @@ impl Interpreter {
         }
     }
 
+    /// Peek at the callsite line from args without consuming or sanitizing them.
+    pub(crate) fn peek_callsite_line(args: &[Value]) -> Option<i64> {
+        for arg in args {
+            match arg {
+                Value::Pair(key, value) if key == TEST_CALLSITE_LINE_KEY => {
+                    return match value.as_ref() {
+                        Value::Int(i) => Some(*i),
+                        Value::BigInt(i) => i.to_string().parse::<i64>().ok(),
+                        Value::Num(n) => Some(*n as i64),
+                        Value::Str(s) => s.parse::<i64>().ok(),
+                        _ => None,
+                    };
+                }
+                Value::ValuePair(key, value) => {
+                    if let Value::Str(name) = key.as_ref()
+                        && name.as_str() == TEST_CALLSITE_LINE_KEY
+                    {
+                        return match value.as_ref() {
+                            Value::Int(i) => Some(*i),
+                            Value::BigInt(i) => i.to_string().parse::<i64>().ok(),
+                            Value::Num(n) => Some(*n as i64),
+                            Value::Str(s) => s.parse::<i64>().ok(),
+                            _ => None,
+                        };
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
     pub(crate) fn sanitize_call_args(&self, args: &[Value]) -> (Vec<Value>, Option<i64>) {
         let mut out = Vec::with_capacity(args.len());
         let mut callsite_line = None;
@@ -189,6 +221,10 @@ impl Interpreter {
             }
         }
         (out, callsite_line)
+    }
+
+    pub(crate) fn pending_callsite_line(&self) -> Option<i64> {
+        self.test_pending_callsite_line
     }
 
     pub(crate) fn set_pending_callsite_line(&mut self, line: Option<i64>) {

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -4,18 +4,28 @@ use crate::ast::FunctionDef;
 impl Interpreter {
     /// Check if a function has the `is DEPRECATED` trait and record a deprecation event.
     pub(crate) fn check_deprecation_for_def(&self, def: &FunctionDef) {
+        self.check_deprecation_for_def_with_line(def, None);
+    }
+
+    /// Check if a function has the `is DEPRECATED` trait and record a deprecation event,
+    /// using an explicit callsite line if provided.
+    pub(crate) fn check_deprecation_for_def_with_line(
+        &self,
+        def: &FunctionDef,
+        callsite_line: Option<i64>,
+    ) {
         if let Some(ref msg) = def.deprecated_message {
             let file = self
                 .env
                 .get("*PROGRAM-NAME")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            let line = self
-                .env
-                .get("?LINE")
-                .and_then(|v| match v {
-                    Value::Int(i) => Some(*i),
-                    _ => None,
+            let line = callsite_line
+                .or_else(|| {
+                    self.env.get("?LINE").and_then(|v| match v {
+                        Value::Int(i) => Some(*i),
+                        _ => None,
+                    })
                 })
                 .unwrap_or(0);
             let kind = if def.is_method { "Method" } else { "Sub" };
@@ -33,17 +43,28 @@ impl Interpreter {
 
     /// Check deprecation for a method call using name, package, and message.
     pub(crate) fn check_deprecation_for_method(&self, name: &str, package: &str, message: &str) {
+        self.check_deprecation_for_method_with_line(name, package, message, None);
+    }
+
+    /// Check deprecation for a method call, using an explicit callsite line if provided.
+    pub(crate) fn check_deprecation_for_method_with_line(
+        &self,
+        name: &str,
+        package: &str,
+        message: &str,
+        callsite_line: Option<i64>,
+    ) {
         let file = self
             .env
             .get("*PROGRAM-NAME")
             .map(|v| v.to_string_value())
             .unwrap_or_default();
-        let line = self
-            .env
-            .get("?LINE")
-            .and_then(|v| match v {
-                Value::Int(i) => Some(*i),
-                _ => None,
+        let line = callsite_line
+            .or_else(|| {
+                self.env.get("?LINE").and_then(|v| match v {
+                    Value::Int(i) => Some(*i),
+                    _ => None,
+                })
             })
             .unwrap_or(0);
         super::deprecation::record_deprecation("Method", name, package, message, &file, line);

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -767,7 +767,8 @@ impl Interpreter {
         }
         // Check for `is DEPRECATED` trait on the method
         if let Some(ref msg) = method_def.deprecated_message {
-            self.check_deprecation_for_method(method_name, &owner_class, msg);
+            let cl = self.test_pending_callsite_line;
+            self.check_deprecation_for_method_with_line(method_name, &owner_class, msg, cl);
         }
         let result = self.run_instance_method_resolved(
             receiver_class_name,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -698,14 +698,24 @@ impl Interpreter {
             }
             // Fallback: auto-generated accessor for public attributes
             if args.is_empty() {
-                let class_attrs = self.collect_class_attributes(&class_name.resolve());
+                let cn = class_name.resolve();
+                let class_attrs = self.collect_class_attributes(&cn);
                 if class_attrs.is_empty() {
                     if let Some(val) = attributes.get(method) {
+                        // Check for deprecated attribute accessor
+                        if let Some(msg) = self.class_attribute_deprecated(&cn, method).cloned() {
+                            self.check_deprecation_for_method(method, &cn, &msg);
+                        }
                         return Ok(val.clone());
                     }
                 } else {
                     for (attr_name, is_public, ..) in &class_attrs {
                         if *is_public && attr_name == method {
+                            // Check for deprecated attribute accessor
+                            if let Some(msg) = self.class_attribute_deprecated(&cn, method).cloned()
+                            {
+                                self.check_deprecation_for_method(method, &cn, &msg);
+                            }
                             return Ok(attributes.get(method).cloned().unwrap_or(Value::Nil));
                         }
                     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -842,6 +842,9 @@ pub struct Interpreter {
     /// `is Type` traits on `@`/`%` class attributes (e.g. `has @.a is Buf`, `has %.h is BagHash`).
     /// Maps (class_name, attr_name) to the type name.
     class_attribute_is_types: HashMap<(String, String), String>,
+    /// `is DEPRECATED` messages on class attributes.
+    /// Maps (class_name, attr_name) to the deprecation message.
+    class_attribute_deprecated: HashMap<(String, String), String>,
     subsets: HashMap<String, SubsetDef>,
     proto_subs: HashSet<String>,
     proto_tokens: HashSet<String>,
@@ -2853,6 +2856,7 @@ impl Interpreter {
             attribute_build_overrides: HashMap::new(),
             class_attribute_defaults: HashMap::new(),
             class_attribute_is_types: HashMap::new(),
+            class_attribute_deprecated: HashMap::new(),
             subsets: HashMap::new(),
             proto_subs: HashSet::new(),
             proto_tokens: HashSet::new(),
@@ -4108,6 +4112,16 @@ impl Interpreter {
             .get(&(class_name.to_string(), attr_name.to_string()))
     }
 
+    /// Get the `is DEPRECATED` message for a class attribute accessor.
+    pub(crate) fn class_attribute_deprecated(
+        &self,
+        class_name: &str,
+        attr_name: &str,
+    ) -> Option<&String> {
+        self.class_attribute_deprecated
+            .get(&(class_name.to_string(), attr_name.to_string()))
+    }
+
     /// Set the element default for a container (Array/Hash) by Arc pointer identity.
     pub(crate) fn set_container_default(&mut self, value: &Value, default: Value) {
         let id = match value {
@@ -4687,6 +4701,7 @@ impl Interpreter {
             attribute_build_overrides: self.attribute_build_overrides.clone(),
             class_attribute_defaults: self.class_attribute_defaults.clone(),
             class_attribute_is_types: self.class_attribute_is_types.clone(),
+            class_attribute_deprecated: self.class_attribute_deprecated.clone(),
             subsets: self.subsets.clone(),
             proto_subs: self.proto_subs.clone(),
             proto_tokens: self.proto_tokens.clone(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1373,6 +1373,7 @@ impl Interpreter {
                     is_my,
                     is_default,
                     is_type,
+                    deprecated_message,
                 } => {
                     let attr_name_str = attr_name.resolve();
 
@@ -1450,6 +1451,10 @@ impl Interpreter {
                     if let Some(it) = is_type {
                         self.class_attribute_is_types
                             .insert((name.to_string(), attr_name_str.clone()), it.clone());
+                    }
+                    if let Some(dm) = deprecated_message {
+                        self.class_attribute_deprecated
+                            .insert((name.to_string(), attr_name_str.clone()), dm.clone());
                     }
                     let attr_var_name = if *is_public {
                         format!(".{}", attr_name_str)
@@ -2212,6 +2217,7 @@ impl Interpreter {
                     is_my: _,
                     is_default: _,
                     is_type: _,
+                    deprecated_message: _,
                 } => {
                     let attr_name_str = attr_name.resolve();
                     let attr_var_name = if *is_public {
@@ -2427,6 +2433,7 @@ impl Interpreter {
                     is_my: _,
                     is_default: _,
                     is_type: _,
+                    deprecated_message: _,
                 } => {
                     let attr_name_str = attr_name.resolve();
                     role_def.own_attribute_names.insert(attr_name_str.clone());

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -3,6 +3,28 @@ use crate::runtime::types::unwrap_varref_value;
 use crate::symbol::Symbol;
 
 impl VM {
+    /// Record a deprecation event for a compiled function if it has deprecation info.
+    fn record_cf_deprecation(&self, cf: &CompiledFunction) {
+        if let Some((ref kind, ref name, ref package, ref msg)) = cf.deprecated_info {
+            let cl = self.interpreter.pending_callsite_line();
+            let file = self
+                .interpreter
+                .env()
+                .get("*PROGRAM-NAME")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            let line = cl
+                .or_else(|| {
+                    self.interpreter.env().get("?LINE").and_then(|v| match v {
+                        Value::Int(i) => Some(*i),
+                        _ => None,
+                    })
+                })
+                .unwrap_or(0);
+            crate::runtime::deprecation::record_deprecation(kind, name, package, msg, &file, line);
+        }
+    }
+
     /// Cached version of `interpreter.has_multi_candidates()`.
     /// Uses `fn_resolve_gen` for invalidation so it's O(1) on cache hit.
     pub(super) fn has_multi_candidates_cached(&mut self, name: &str) -> bool {
@@ -55,7 +77,12 @@ impl VM {
         args: Vec<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
-        self.interpreter.check_deprecation_for_def(def);
+        // Use the pending callsite line for deprecation tracking,
+        // since ?LINE in env may not reflect the call site yet.
+        let callsite_line = crate::runtime::Interpreter::peek_callsite_line(&args)
+            .or_else(|| self.interpreter.pending_callsite_line());
+        self.interpreter
+            .check_deprecation_for_def_with_line(def, callsite_line);
         let name = def.name.resolve();
         let pkg = def.package.resolve();
 
@@ -82,6 +109,15 @@ impl VM {
                 }
                 compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
             };
+            let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
+                let kind = if def.is_method { "Method" } else { "Sub" };
+                (
+                    kind.to_string(),
+                    def.name.resolve(),
+                    def.package.resolve(),
+                    msg.clone(),
+                )
+            });
             let mut cf = CompiledFunction {
                 code: cc,
                 params: def.params.clone(),
@@ -94,6 +130,7 @@ impl VM {
                 param_local_slots: None,
                 has_inner_subs: false,
                 named_param_slots: None,
+                deprecated_info,
             };
             cf.precompute_param_local_slots();
             cf.precompute_named_param_slots();
@@ -375,6 +412,7 @@ impl VM {
         cf: &CompiledFunction,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        self.record_cf_deprecation(cf);
         // Only save env when there are local variables to clean up.
         // When the function has no locals, the env save/restore is a
         // no-op (nothing to remove), but still causes an Arc clone that
@@ -644,6 +682,7 @@ impl VM {
         args: &[Value],
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        self.record_cf_deprecation(cf);
         let param_slots = cf.param_local_slots.as_ref().unwrap();
         let positional_count = param_slots.len();
         let actual_count = args.len();
@@ -886,6 +925,7 @@ impl VM {
         args: Vec<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        self.record_cf_deprecation(cf);
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_locals_dirty = self.locals_dirty;
@@ -1225,6 +1265,8 @@ impl VM {
         if callsite_line.is_some() {
             self.interpreter.set_pending_callsite_line(callsite_line);
         }
+        // Record deprecation for cached compiled functions
+        self.record_cf_deprecation(cf);
         // Inject callsite line BEFORE push_call_frame so the parent env
         // contains the updated ?LINE. This avoids triggering Arc::make_mut
         // deep clone after the env Arc is shared with the call frame.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -59,6 +59,11 @@ impl VM {
                         if !has_junction {
                             let start = self.stack.len() - arity_usize;
                             let args: Vec<Value> = self.stack.drain(start..).collect();
+                            // Extract callsite line for deprecation tracking
+                            let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
+                            if cl.is_some() {
+                                self.interpreter.set_pending_callsite_line(cl);
+                            }
                             let result = self.call_compiled_function_positional_light(
                                 cf,
                                 &args,
@@ -89,6 +94,11 @@ impl VM {
                     if self.stack.len() >= arity_usize {
                         let start = self.stack.len() - arity_usize;
                         let args: Vec<Value> = self.stack.drain(start..).collect();
+                        // Extract callsite line for deprecation tracking
+                        let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
+                        if cl.is_some() {
+                            self.interpreter.set_pending_callsite_line(cl);
+                        }
                         let result = self.call_compiled_function_light(cf, args, compiled_fns)?;
                         self.stack.push(result);
                         self.env_dirty = true;
@@ -117,6 +127,12 @@ impl VM {
                     if self.stack.len() >= arity_usize {
                         let start = self.stack.len() - arity_usize;
                         let args: Vec<Value> = self.stack.drain(start..).collect();
+
+                        // Extract callsite line for deprecation tracking
+                        let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
+                        if cl.is_some() {
+                            self.interpreter.set_pending_callsite_line(cl);
+                        }
 
                         let result = if Self::is_light_call_eligible(&cf, name_str) {
                             self.call_compiled_function_light(&cf, args, compiled_fns)
@@ -204,10 +220,15 @@ impl VM {
                 && Self::is_fast_call_eligible(cf, name_str)
                 && !cf.is_raw
             {
-                // Pop the callsite pair arg(s) from the stack without processing
+                // Pop the callsite pair arg(s) from the stack and extract callsite line
                 let arity = arity as usize;
-                if self.stack.len() >= arity {
-                    self.stack.truncate(self.stack.len() - arity);
+                if self.stack.len() >= arity && arity > 0 {
+                    let start = self.stack.len() - arity;
+                    let popped: Vec<Value> = self.stack.drain(start..).collect();
+                    let cl = crate::runtime::Interpreter::peek_callsite_line(&popped);
+                    if cl.is_some() {
+                        self.interpreter.set_pending_callsite_line(cl);
+                    }
                 }
                 self.ensure_env_synced(code);
                 let result = self.call_compiled_function_fast(cf, compiled_fns)?;
@@ -606,7 +627,10 @@ impl VM {
                 } else {
                     let resolved_def = self.interpreter.resolve_function_with_types(name, &args);
                     if let Some(ref def) = resolved_def {
-                        self.interpreter.check_deprecation_for_def(def);
+                        let cl = crate::runtime::Interpreter::peek_callsite_line(&args)
+                            .or_else(|| self.interpreter.pending_callsite_line());
+                        self.interpreter
+                            .check_deprecation_for_def_with_line(def, cl);
                     }
                     resolved_def
                         .map(|def| def.package.resolve())

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -18,6 +18,16 @@ impl VM {
         invocant: Option<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        // Check for `is DEPRECATED` trait on the method
+        if let Some(ref msg) = method_def.deprecated_message {
+            let cl = self.interpreter.pending_callsite_line();
+            self.interpreter.check_deprecation_for_method_with_line(
+                method_name,
+                owner_class,
+                msg,
+                cl,
+            );
+        }
         // Build the base (self) value
         let mut base = if let Some(inv) = invocant {
             inv


### PR DESCRIPTION
## Summary
- Implement `is DEPRECATED` trait tracking for subs, methods, and attribute accessors
- Fix deprecation callsite line tracking across all VM call fast paths (positional light, named light, OTF cache, compiled fast)
- Add `deprecated_info` to `CompiledFunction` for cached deprecation tracking
- Parse `is DEPRECATED("msg")` on `has` attribute declarations and track in class registry
- Emit `SetSourceLine` before method calls in compiler for accurate line reporting
- Enable SetLine emission in block bodies for proper `$?LINE` tracking
- Fix `body_mutates_topic` to skip SetLine statements, preserving `$_` scoping in if/while blocks

Partially fixes roast/S02-types/isDEPRECATED.t (7/14 subtests pass; tests 5,6 are TODO NYI in raku itself). Test 8 has remaining method deprecation line tracking issue inside blocks with heredocs.

## Test plan
- [x] `make test` passes (no regressions)
- [x] Tests 1-4 of isDEPRECATED.t pass (sub deprecation)
- [x] Test 7 passes (method call counter)
- [x] `t/topic-bind-conditions.t` passes (no regression from SetLine changes)
- [x] `t/return-exception.t` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)