### PR TITLE
fix: support :ignoremark regex in capture groups for JSON::Tiny

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -92,7 +92,7 @@ pub(super) fn strip_marks_pattern(pattern: &RegexPattern) -> RegexPattern {
         anchor_start: pattern.anchor_start,
         anchor_end: pattern.anchor_end,
         ignore_case: pattern.ignore_case,
-        ignore_mark: pattern.ignore_mark,
+        ignore_mark: false,
     }
 }
 

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -542,10 +542,10 @@ impl Interpreter {
                 // In Raku, enumerated char classes like <[Dd]> match whole graphemes.
                 // If the grapheme has combining marks, exact Char/Range items should
                 // NOT match (e.g., "D + combining marks" is not the same as "D").
+                // However, negated classes should still match (the grapheme is clearly
+                // NOT one of the excluded characters).
                 let ge = grapheme_end(chars, pos);
-                if ge > pos + 1 && class_has_only_exact_chars(class) {
-                    // Grapheme has combining marks and class only has exact chars;
-                    // no match.
+                if ge > pos + 1 && !class.negated && class_has_only_exact_chars(class) {
                     false
                 } else {
                     self.regex_match_class_ignorecase(class, c, ignore_case)

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -70,6 +70,28 @@ impl Interpreter {
         start: usize,
         pkg: &str,
     ) -> Vec<(usize, RegexCaptures)> {
+        // When :m (ignoremark) is set on the pattern, strip combining marks
+        // from both text and pattern, match on the stripped versions, then
+        // map positions back to the original text.
+        if pattern.ignore_mark {
+            use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
+            let text_slice = &chars[start..];
+            let (stripped_chars, pos_map) = strip_marks_text(text_slice);
+            let stripped_pattern = strip_marks_pattern(pattern);
+            let mut results =
+                self.regex_match_ends_from_caps_in_pkg(&stripped_pattern, &stripped_chars, 0, pkg);
+            let orig_len = text_slice.len();
+            for (end, caps) in &mut results {
+                *end = map_pos(*end, &pos_map, orig_len) + start;
+                if let Some(cs) = caps.capture_start.as_mut() {
+                    *cs = map_pos(*cs, &pos_map, orig_len) + start;
+                }
+                if let Some(ce) = caps.capture_end.as_mut() {
+                    *ce = map_pos(*ce, &pos_map, orig_len) + start;
+                }
+            }
+            return results;
+        }
         let apply_named_capture =
             |token: &RegexToken, from: usize, to: usize, caps: RegexCaptures| -> RegexCaptures {
                 let Some(name) = token.named_capture.as_ref() else {


### PR DESCRIPTION
## Summary
- Fix `:ignoremark` regex adverb support in capture groups, enabling JSON::Tiny to pass all 93 upstream parse tests (previously 92/93)
- Fix negated char classes to correctly match graphemes with combining marks

## Changes
- `regex_match_core.rs`: Apply `ignore_mark` handling in `regex_match_ends_from_caps_in_pkg` (capture group matching)
- `regex_helpers.rs`: Set `ignore_mark: false` in `strip_marks_pattern` to prevent infinite recursion
- `regex_match_atom_simple.rs`: Skip grapheme-rejection logic for negated char classes

## Test plan
- [x] `prove -e 'target/debug/mutsu -I tmp/json-tiny/lib' tmp/json-tiny/t/01-parse.t` — 93/93 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)