### PR TITLE
fix: implement container identity (=:=) for bound hash elements

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -107,6 +107,7 @@ roast/S02-types/anon_block.t
 roast/S02-types/array_extending.t
 roast/S02-types/array_ref.t
 roast/S02-types/assigning-refs.t
+roast/S02-types/autovivification.t
 roast/S02-types/bag-iterator.t
 roast/S02-types/baggy.t
 roast/S02-types/bool.t

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -323,6 +323,29 @@ impl Compiler {
                 });
                 return;
             }
+            // Mixed case: one side is a named variable (with a local slot holding
+            // a DeferredHashAccess from `:=` binding), the other is an Index expression.
+            // Use GetLocalRaw + IndexAutovivifyLazy + ContainerEqRaw.
+            if let Some(slot) = self.container_eq_var_slot(left)
+                && matches!(right, Expr::Index { .. })
+            {
+                self.code.emit(OpCode::GetLocalRaw(slot));
+                self.scalar_bind_autovivify = true;
+                self.compile_expr(right);
+                self.scalar_bind_autovivify = false;
+                self.code.emit(OpCode::ContainerEqRaw);
+                return;
+            }
+            if let Some(slot) = self.container_eq_var_slot(right)
+                && matches!(left, Expr::Index { .. })
+            {
+                self.scalar_bind_autovivify = true;
+                self.compile_expr(left);
+                self.scalar_bind_autovivify = false;
+                self.code.emit(OpCode::GetLocalRaw(slot));
+                self.code.emit(OpCode::ContainerEqRaw);
+                return;
+            }
             let left_fresh = Self::expr_is_fresh_container(left);
             let right_fresh = Self::expr_is_fresh_container(right);
             let flags =

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -255,6 +255,16 @@ impl Compiler {
         }
     }
 
+    /// If `expr` is a Var with a known local slot, return the slot index.
+    /// Used by `=:=` to emit GetLocalRaw for container identity checks.
+    pub(super) fn container_eq_var_slot(&self, expr: &Expr) -> Option<u32> {
+        if let Expr::Var(name) = expr {
+            self.local_map.get(name.as_str()).copied()
+        } else {
+            None
+        }
+    }
+
     pub(super) fn expr_is_fresh_container(expr: &Expr) -> bool {
         match expr {
             // Indexing into an array/hash element produces a value that

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -14,6 +14,9 @@ pub(crate) enum OpCode {
 
     // -- Variables --
     GetLocal(u32),
+    /// Like GetLocal but does NOT resolve DeferredHashAccess/HashSlotRef values.
+    /// Used by `=:=` to compare raw container references.
+    GetLocalRaw(u32),
     SetLocal(u32),
     GetGlobal(u32),
     SetGlobal(u32),
@@ -115,6 +118,10 @@ pub(crate) enum OpCode {
         left_name_idx: u32,
         right_name_idx: u32,
     },
+    /// Container identity (`=:=`) using raw container values.
+    /// Compares DeferredHashAccess/HashSlotRef values by checking if they
+    /// point to the same hash slot (Arc::ptr_eq + key equality).
+    ContainerEqRaw,
 
     // -- String comparison --
     StrEq,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1490,6 +1490,10 @@ impl VM {
                 self.exec_container_eq_indexed_op(code, *left_name_idx, *right_name_idx);
                 *ip += 1;
             }
+            OpCode::ContainerEqRaw => {
+                self.exec_container_eq_raw_op();
+                *ip += 1;
+            }
 
             // -- String comparison --
             OpCode::StrEq => {
@@ -3257,6 +3261,10 @@ impl VM {
             // -- Local variables --
             OpCode::GetLocal(idx) => {
                 self.exec_get_local_op(code, *idx)?;
+                *ip += 1;
+            }
+            OpCode::GetLocalRaw(idx) => {
+                self.exec_get_local_raw_op(code, *idx);
                 *ip += 1;
             }
             OpCode::SetLocal(idx) => {

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -565,6 +565,59 @@ impl VM {
         self.stack.push(Value::Bool(result));
     }
 
+    /// Container identity (`=:=`) using raw container values.
+    /// Compares DeferredHashAccess and HashSlotRef values to check if they
+    /// reference the same hash slot.
+    pub(super) fn exec_container_eq_raw_op(&mut self) {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let result =
+            Self::containers_same_slot(&left, &right) || Self::containers_same_slot(&right, &left);
+        self.stack.push(Value::Bool(result));
+    }
+
+    /// Check if two raw container values (DeferredHashAccess / HashSlotRef)
+    /// point to the same hash slot.
+    fn containers_same_slot(a: &Value, b: &Value) -> bool {
+        // Extract (arc, key) from each side
+        let a_ref = Self::extract_hash_ref(a);
+        let b_ref = Self::extract_hash_ref(b);
+        if let (Some((a_arc, a_key)), Some((b_arc, b_key))) = (a_ref, b_ref) {
+            Arc::ptr_eq(a_arc, b_arc) && a_key == b_key
+        } else {
+            // Both are the same value identity (for non-hash-ref cases)
+            crate::runtime::values_identical(a, b)
+        }
+    }
+
+    /// Extract the (hash Arc, key) from a HashSlotRef or DeferredHashAccess.
+    /// For DeferredHashAccess, resolves the parent_slot to find the inner hash.
+    fn extract_hash_ref(val: &Value) -> Option<(&Arc<HashMap<String, Value>>, &str)> {
+        match val {
+            Value::HashSlotRef { hash, key } => Some((hash, key.as_str())),
+            Value::DeferredHashAccess { parent_slot, key } => {
+                // The parent_slot is a HashSlotRef. Read its value to get the inner hash.
+                // But we need the Arc, not the resolved value. So we need to look
+                // at the hash pointed to by parent_slot, read its entry, and if that
+                // entry is a Hash, get its Arc.
+                if let Value::HashSlotRef {
+                    hash: parent_hash,
+                    key: parent_key,
+                } = parent_slot.as_ref()
+                {
+                    // Read the value at parent_key in parent_hash
+                    let ptr = Arc::as_ptr(parent_hash);
+                    let inner_val = unsafe { (*ptr).get(parent_key.as_str()) };
+                    if let Some(Value::Hash(inner_arc)) = inner_val {
+                        return Some((inner_arc, key.as_str()));
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
     /// For an encoded source like "@b\0idx\01", look up the raw array element
     /// and if it has a BOUND_ARRAY_REF_SENTINEL, return the bound source name.
     fn get_binding_source_of_indexed(&self, encoded: &str) -> Option<String> {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2680,6 +2680,15 @@ impl VM {
         Ok(())
     }
 
+    /// Like `exec_get_local_op` but does NOT resolve DeferredHashAccess/HashSlotRef.
+    /// Pushes the raw local value, preserving container references for `=:=` checks.
+    pub(super) fn exec_get_local_raw_op(&mut self, code: &CompiledCode, idx: u32) {
+        self.ensure_locals_synced(code);
+        let idx = idx as usize;
+        let val = self.locals[idx].clone();
+        self.stack.push(val);
+    }
+
     pub(super) fn exec_get_local_op(
         &mut self,
         code: &CompiledCode,


### PR DESCRIPTION
## Summary
- Add `GetLocalRaw` and `ContainerEqRaw` opcodes for raw container reference comparison
- Detect mixed var/index operands in `=:=` compiler and emit specialized opcodes
- `GetLocalRaw` pushes the raw local value without resolving DeferredHashAccess
- `ContainerEqRaw` compares DeferredHashAccess and HashSlotRef by checking Arc pointer equality and key match
- Passes all 22 subtests in `roast/S02-types/autovivification.t`

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S02-types/autovivification.t` passes all 22 subtests
- [x] `make test` passes (482 files, 3899 tests)
- [x] All 1178 whitelisted roast tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)