### PR TITLE
fix: IO::Pipe methods, exit(Bool), and reverse(LazyIoLines)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -727,6 +727,10 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             _ => Some(Ok(Value::Int(1))),
         },
         "reverse" => {
+            // LazyIoLines needs the interpreter to materialize — fall through
+            if matches!(arg, Value::LazyIoLines { .. }) {
+                return None;
+            }
             if let Some(shape) = crate::runtime::utils::shaped_array_shape(arg) {
                 if shape.len() > 1 {
                     return Some(Err(RuntimeError::illegal_on_fixed_dimension_array(

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1220,7 +1220,7 @@ impl Interpreter {
         Ok(Value::slip(items))
     }
 
-    pub(super) fn builtin_reverse(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_reverse(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // If multiple args, reverse the list of args
         if args.len() > 1 {
             let mut items: Vec<Value> = args.to_vec();
@@ -1232,6 +1232,20 @@ impl Interpreter {
             Some(Value::Array(mut items, ..)) => {
                 Arc::make_mut(&mut items).reverse();
                 Value::Array(items, ArrayKind::List)
+            }
+            Some(Value::LazyIoLines { ref handle, .. }) => {
+                // Materialize all lines from the lazy IO source, then reverse
+                let mut lines = Vec::new();
+                while let Some(line) = self.read_line_from_handle_value(handle)? {
+                    lines.push(Value::str(line));
+                }
+                lines.reverse();
+                Value::Array(Arc::new(lines), ArrayKind::List)
+            }
+            Some(Value::Seq(items)) => {
+                let mut v = items.to_vec();
+                v.reverse();
+                Value::Array(Arc::new(v), ArrayKind::List)
             }
             Some(Value::Str(s)) => {
                 // reverse() on a string in list context returns the string as-is

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -253,6 +253,15 @@ impl Interpreter {
     pub(super) fn builtin_exit(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let code = match args.first() {
             Some(Value::Int(i)) => *i,
+            Some(Value::Bool(b)) => {
+                if *b {
+                    1
+                } else {
+                    0
+                }
+            }
+            Some(Value::Num(f)) => *f as i64,
+            Some(other) => other.to_f64() as i64,
             _ => 0,
         };
         self.halted = true;

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -48,6 +48,15 @@ pub(crate) fn io_pipe_state_map() -> &'static IoPipeStateMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
+/// Maps pipe-id to the parent Proc instance so that IO::Pipe.close and
+/// IO::Pipe.proc can return the owning Proc.
+type PipeProcMap = std::sync::Mutex<HashMap<i64, Value>>;
+
+pub(crate) fn pipe_proc_map() -> &'static PipeProcMap {
+    static MAP: OnceLock<PipeProcMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
 /// Options extracted from named arguments for run/shell.
 struct ProcOptions {
     cwd: Option<String>,
@@ -598,13 +607,39 @@ impl Interpreter {
         attrs.insert("signal".to_string(), Value::Int(signal));
         attrs.insert("pid".to_string(), Value::Int(pid));
         attrs.insert("command".to_string(), command);
+        let mut pipe_ids = Vec::new();
         if let Some(err_content) = captured_err {
-            attrs.insert("err".to_string(), Self::make_io_pipe(err_content));
+            let pipe = Self::make_io_pipe(err_content);
+            if let Value::Instance {
+                attributes: ref a, ..
+            } = pipe
+                && let Some(Value::Int(id)) = a.get("pipe-id")
+            {
+                pipe_ids.push(*id);
+            }
+            attrs.insert("err".to_string(), pipe);
         }
         if let Some(out_content) = captured_out {
-            attrs.insert("out".to_string(), Self::make_io_pipe(out_content));
+            let pipe = Self::make_io_pipe(out_content);
+            if let Value::Instance {
+                attributes: ref a, ..
+            } = pipe
+                && let Some(Value::Int(id)) = a.get("pipe-id")
+            {
+                pipe_ids.push(*id);
+            }
+            attrs.insert("out".to_string(), pipe);
         }
-        Value::make_instance(Symbol::intern("Proc"), attrs)
+        let proc_val = Value::make_instance(Symbol::intern("Proc"), attrs);
+        // Register pipe-id -> Proc mapping so IO::Pipe.close/.proc can return the Proc
+        if !pipe_ids.is_empty()
+            && let Ok(mut map) = pipe_proc_map().lock()
+        {
+            for id in pipe_ids {
+                map.insert(id, proc_val.clone());
+            }
+        }
+        proc_val
     }
 
     /// Create an IO::Pipe instance wrapping captured content. Allocates

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -328,9 +328,16 @@ impl Interpreter {
                     | "close"
                     | "split"
                     | "print"
+                    | "say"
+                    | "put"
+                    | "flush"
+                    | "write"
                     | "get"
                     | "lines"
                     | "eof"
+                    | "proc"
+                    | "IO"
+                    | "path"
             )
         {
             return true;

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2737,6 +2737,83 @@ impl Interpreter {
                     }
                     return Ok(Value::Bool(true));
                 }
+                "say" => {
+                    // Write to the child's stdin with a trailing newline
+                    if let Ok(map) = super::native_methods::proc_stdin_map().lock()
+                        && let Some(stdin_arc) = map.get(&pid_u32)
+                        && let Ok(mut guard) = stdin_arc.lock()
+                        && let Some(ref mut stdin) = *guard
+                    {
+                        use std::io::Write;
+                        for arg in args {
+                            let s = arg.to_string_value();
+                            let _ = stdin.write_all(s.as_bytes());
+                        }
+                        let _ = stdin.write_all(b"\n");
+                        let _ = stdin.flush();
+                    }
+                    return Ok(Value::Bool(true));
+                }
+                "put" => {
+                    // Same as say for IO handles
+                    if let Ok(map) = super::native_methods::proc_stdin_map().lock()
+                        && let Some(stdin_arc) = map.get(&pid_u32)
+                        && let Ok(mut guard) = stdin_arc.lock()
+                        && let Some(ref mut stdin) = *guard
+                    {
+                        use std::io::Write;
+                        for arg in args {
+                            let s = arg.to_string_value();
+                            let _ = stdin.write_all(s.as_bytes());
+                        }
+                        let _ = stdin.write_all(b"\n");
+                        let _ = stdin.flush();
+                    }
+                    return Ok(Value::Bool(true));
+                }
+                "flush" => {
+                    if let Ok(map) = super::native_methods::proc_stdin_map().lock()
+                        && let Some(stdin_arc) = map.get(&pid_u32)
+                        && let Ok(mut guard) = stdin_arc.lock()
+                        && let Some(ref mut stdin) = *guard
+                    {
+                        use std::io::Write;
+                        let _ = stdin.flush();
+                    }
+                    return Ok(Value::Bool(true));
+                }
+                "write" => {
+                    // Write binary data (Buf/Blob) to stdin
+                    if let Ok(map) = super::native_methods::proc_stdin_map().lock()
+                        && let Some(stdin_arc) = map.get(&pid_u32)
+                        && let Ok(mut guard) = stdin_arc.lock()
+                        && let Some(ref mut stdin) = *guard
+                    {
+                        use std::io::Write;
+                        for arg in args {
+                            match arg {
+                                Value::Instance {
+                                    class_name,
+                                    attributes,
+                                    ..
+                                } if class_name.resolve() == "Buf"
+                                    || class_name.resolve() == "Blob" =>
+                                {
+                                    if let Some(Value::Array(bytes, _)) = attributes.get("data") {
+                                        let data: Vec<u8> =
+                                            bytes.iter().map(|v| v.to_f64() as u8).collect();
+                                        let _ = stdin.write_all(&data);
+                                    }
+                                }
+                                _ => {
+                                    let s = arg.to_string_value();
+                                    let _ = stdin.write_all(s.as_bytes());
+                                }
+                            }
+                        }
+                    }
+                    return Ok(Value::Bool(true));
+                }
                 "close" => {
                     // Close the child's stdin (drop it)
                     if let Ok(map) = super::native_methods::proc_stdin_map().lock()
@@ -2831,8 +2908,28 @@ impl Interpreter {
                 {
                     state.closed = true;
                 }
-                // TODO: should return the parent Proc object for identity
+                // Return the parent Proc object so that `$pipe.close === $proc`
+                if let Some(id) = pipe_id
+                    && let Ok(map) = super::builtins_system::pipe_proc_map().lock()
+                    && let Some(proc_val) = map.get(&id)
+                {
+                    return Ok(proc_val.clone());
+                }
                 Ok(Value::Bool(true))
+            }
+            "proc" => {
+                // Return the parent Proc object
+                if let Some(id) = pipe_id
+                    && let Ok(map) = super::builtins_system::pipe_proc_map().lock()
+                    && let Some(proc_val) = map.get(&id)
+                {
+                    return Ok(proc_val.clone());
+                }
+                Ok(Value::Nil)
+            }
+            "IO" | "path" => {
+                // Returns the IO::Path type object (not an instance)
+                Ok(Value::Package(crate::symbol::Symbol::intern("IO::Path")))
             }
             "split" => {
                 // Basic split for IO::Pipe


### PR DESCRIPTION
## Summary
- Fix IO::Pipe.close to return the parent Proc object (enabling `$pipe.close === $proc`)
- Add IO::Pipe.proc, .IO, .path, .say, .put, .flush, .write methods
- Fix `exit(True)` to exit with code 1 (handle Bool/Num/other numeric types)
- Fix `reverse lines` to correctly materialize LazyIoLines before reversing

These changes enable 11 of 16 subtests in `roast/S32-io/pipe.t` to pass (up from 0).

## Test plan
- [x] `cargo test` passes (449 tests)
- [x] `make test` passes (482 files, 3899 tests)
- [x] `roast/S32-list/reverse.t`, `roast/S03-metaops/reverse.t`, `roast/S17-supply/reverse.t` still pass
- [x] First 50 whitelisted roast tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)