### PR TITLE
fix: prevent $-sigiled variables from shadowing class type objects

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -58,12 +58,25 @@ impl Compiler {
                 self.code.emit(OpCode::GetHashVar(name_idx));
             }
             Expr::BareWord(name) => {
+                // Only resolve to GetLocal for sigilless bindings (e.g. `my \Foo = ...`)
+                // or builtin-type-safe locals.  `$`-sigiled variables whose `$` was
+                // stripped share the same key in local_map but must NOT shadow type
+                // names, so they go through GetBareWord which checks the type registry.
                 if let Some(&slot) = self.local_map.get(name.as_str()) {
                     if crate::vm::VM::is_builtin_type(name) {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         self.code.emit(OpCode::GetBareWord(name_idx));
-                    } else {
+                    } else if self.sigilless_locals.contains(name.as_str())
+                        || self.constant_vars.contains(name.as_str())
+                    {
+                        // Sigilless bindings and constants: the bare word IS the
+                        // variable, so read directly from the local slot.
                         self.code.emit(OpCode::GetLocal(slot));
+                    } else {
+                        // The local is a `$`-sigiled variable — a bare word with the
+                        // same name should resolve as a type/package, not the variable.
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        self.code.emit(OpCode::GetBareWord(name_idx));
                     }
                 } else {
                     let name_idx = self.code.add_constant(Value::str(name.clone()));

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -150,6 +150,11 @@ impl Compiler {
         for pd in param_defs {
             if !pd.name.is_empty() {
                 sub_compiler.alloc_local(&pd.name);
+                // Track sigilless parameters so BareWord resolution uses
+                // GetLocal for them but not for `$`-sigiled params.
+                if pd.sigilless {
+                    sub_compiler.sigilless_locals.insert(pd.name.clone());
+                }
             }
             // Also allocate locals for sub_signature parameters (array unpacking)
             // so that they get proper local slots and don't leak between recursive calls.
@@ -479,6 +484,9 @@ impl Compiler {
         for pd in param_defs {
             if !pd.name.is_empty() {
                 sub_compiler.alloc_local(&pd.name);
+                if pd.sigilless {
+                    sub_compiler.sigilless_locals.insert(pd.name.clone());
+                }
             }
         }
         // Hoist sub declarations within the closure body

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -68,6 +68,10 @@ pub(crate) struct Compiler {
     scalar_bind_autovivify: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
+    /// Local names that are sigilless bindings (declared with `my \Foo = ...`
+    /// or as a sigilless parameter).  BareWord resolution only uses GetLocal
+    /// for names in this set; `$`-sigiled variables must not shadow type names.
+    sigilless_locals: std::collections::HashSet<String>,
     /// Last source line emitted via SetSourceLine (for tracking block definition lines).
     last_source_line: Option<i64>,
     /// Pending writebacks for Index expressions passed to function calls.
@@ -96,6 +100,7 @@ impl Compiler {
             bind_vardecl: false,
             scalar_bind_autovivify: false,
             constant_vars: std::collections::HashSet::new(),
+            sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -479,6 +479,9 @@ impl Compiler {
                 // Handled by SyntheticBlock detection; no-op when compiled standalone.
             }
             Stmt::MarkSigillessReadonly(name) => {
+                // Track sigilless locals so BareWord compilation can
+                // distinguish them from `$`-sigiled variables.
+                self.sigilless_locals.insert(name.clone());
                 // Set __mutsu_sigilless_readonly::NAME = true in env
                 let key = format!("__mutsu_sigilless_readonly::{}", name);
                 let key_idx = self.code.add_constant(Value::str(key));

--- a/t/class-var-namespace-separation.t
+++ b/t/class-var-namespace-separation.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# A $-sigiled variable with the same base name as a class should not
+# shadow the class type object.
+{
+    my $Foo;
+    class Foo { method bar { $Foo++ } };
+    is Foo.^name, 'Foo', 'class Foo accessible before $Foo modification';
+    Foo.new.bar;
+    is Foo.^name, 'Foo', 'class Foo still accessible after $Foo++';
+    Foo.new.bar;
+    is $Foo, 2, '$Foo was incremented correctly';
+    is Foo.^name, 'Foo', 'class Foo still accessible after second $Foo++';
+}
+
+# Sigilless variables should still shadow bare words
+{
+    my \Val = 42;
+    is Val, 42, 'sigilless variable Val resolves via bare word';
+}
+
+# Constants should resolve via bare word
+{
+    constant Limit = 100;
+    is Limit, 100, 'constant Limit resolves via bare word';
+}
+
+# $-sigiled variable should not interfere with class used as type
+{
+    my $Int = "hello";
+    is Int.^name, 'Int', 'builtin type Int not shadowed by $Int';
+    is $Int, "hello", '$Int retains its value';
+}


### PR DESCRIPTION
## Summary

- Fix a bug where `$Foo` (scalar variable) and `Foo` (class type object) collide because the compiler strips the `$` sigil and both use the same key `"Foo"` in the local variable map
- Track sigilless locals separately in the compiler so that `BareWord` compilation only uses `GetLocal` for sigilless bindings (`my \Foo = ...`) and constants, not for `$`-sigiled variables
- For `$`-sigiled variables that share a name with a class, `BareWord` now emits `GetBareWord` which has runtime type registry checks to correctly resolve the class

## Test plan

- [x] New test `t/class-var-namespace-separation.t` with 8 subtests covering: class/variable coexistence, sigilless variables, constants, builtin types
- [x] `make test` passes (482 files, 3899 tests)
- [x] All 29 whitelisted S12-class/S12-enum roast tests pass
- [x] First and last 50 whitelisted roast tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)