### PR TITLE
fix: END phasers use current env values instead of stale captured values

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -287,6 +287,7 @@ roast/S04-phasers/end.t
 roast/S04-phasers/enter-leave.t
 roast/S04-phasers/exit-in-check.t
 roast/S04-phasers/first.t
+roast/S04-phasers/in-eval.t
 roast/S04-phasers/in-loop.t
 roast/S04-phasers/init.t
 roast/S04-phasers/interpolate.t

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -871,13 +871,16 @@ impl Interpreter {
                 // Track which keys are being added from captured env
                 // (not already present) so we can remove them after.
                 let mut overlay_keys: Vec<String> = Vec::new();
-                // Overlay captured lexical env on top of current env
-                // so both globals and captured lexicals are visible
+                // Overlay captured lexical env on top of current env.
+                // Only add variables that are NOT already in self.env —
+                // variables that exist in both should keep their current
+                // (final) value, since the program may have continued to
+                // modify them after the END phaser was registered.
                 for (k, v) in captured_env {
                     if !self.env.contains_key(k) {
                         overlay_keys.push(k.clone());
+                        self.env.insert(k.clone(), v.clone());
                     }
-                    self.env.insert(k.clone(), v.clone());
                 }
                 self.run_block(body)?;
                 // Remove only the overlay keys (captured lexicals not in


### PR DESCRIPTION
## Summary
- Fix END phaser environment overlay in `finish()` to only add variables not already present in the current env, preventing stale captured values from overwriting current (final) values
- When an END phaser was registered inside a closure (e.g. via EVAL), the captured env snapshot would overwrite shared variables at program exit
- Adds `roast/S04-phasers/in-eval.t` to whitelist (35 tests)

## Test plan
- [x] `prove -e 'target/release/mutsu' roast/S04-phasers/in-eval.t` passes (35/35)
- [x] `make test` passes (no new regressions)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)