### PR TITLE
fix: pass all JSON::Tiny upstream tests

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -36,13 +36,17 @@ pub(super) fn strip_marks_text(orig_chars: &[char]) -> (Vec<char>, Vec<usize>) {
         let grapheme_char_count = grapheme.chars().count();
         // NFD-decompose the entire grapheme and keep only non-combining-mark chars
         let bases: Vec<char> = grapheme.nfd().filter(|c| !is_combining_mark(*c)).collect();
-        // Among the bases, also drop Prepend characters (GCB=Prepend): these
-        // are format characters (Cf) at specific codepoints that form part of
-        // the grapheme cluster but are not the "base" letter.
-        let filtered: Vec<char> = bases.into_iter().filter(|c| !is_prepend_char(*c)).collect();
+        // Among the bases, drop Prepend characters and format characters (Cf)
+        // that form part of multi-char grapheme clusters (e.g., ZWJ U+200D).
+        // These are not the "base" letter of the grapheme.
+        let is_multi_char = grapheme_char_count > 1;
+        let filtered: Vec<char> = bases
+            .into_iter()
+            .filter(|c| !(is_prepend_char(*c) || is_multi_char && is_format_char(*c)))
+            .collect();
         if filtered.is_empty() {
-            // The entire grapheme is marks/prepends with no base — keep the
-            // first non-combining char so the grapheme is not silently lost.
+            // The entire grapheme is marks/format/prepends with no base — keep
+            // the first non-combining char so the grapheme is not silently lost.
             for ch in grapheme.nfd() {
                 if !is_combining_mark(ch) {
                     stripped_chars.push(ch);
@@ -82,6 +86,24 @@ fn is_prepend_char(c: char) -> bool {
         | '\u{11A3A}'
         | '\u{11A84}'..='\u{11A89}'
         | '\u{11D46}'
+    )
+}
+
+/// Check whether a character is a Unicode Format character (General_Category=Cf)
+/// that commonly appears within grapheme clusters as a non-base element.
+fn is_format_char(c: char) -> bool {
+    matches!(c,
+        '\u{00AD}'           // SOFT HYPHEN
+        | '\u{200B}'         // ZERO WIDTH SPACE
+        | '\u{200C}'         // ZERO WIDTH NON-JOINER
+        | '\u{200D}'         // ZERO WIDTH JOINER
+        | '\u{200E}'..='\u{200F}' // LRM, RLM
+        | '\u{2060}'..='\u{2064}' // WORD JOINER, etc.
+        | '\u{2066}'..='\u{2069}' // directional isolates
+        | '\u{206A}'..='\u{206F}' // deprecated format chars
+        | '\u{FEFF}'         // BOM / ZWNBSP
+        | '\u{FE00}'..='\u{FE0F}' // Variation Selectors 1-16
+        | '\u{E0100}'..='\u{E01EF}' // Variation Selectors 17-256
     )
 }
 

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -461,6 +461,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
     };
     match value {
         Value::Hash(_) => value,
+        Value::Scalar(inner) => coerce_to_hash(*inner),
         Value::Array(items, ..) => {
             // Flatten nested Hashes into pairs before building the hash.
             // This handles `%h = %h1, %h2` where each hash should be merged.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3165,6 +3165,7 @@ impl VM {
                     | Value::RangeExclStart(..)
                     | Value::RangeExclBoth(..)
                     | Value::GenericRange { .. }
+                    | Value::Uni { .. }
                     | Value::Nil => true,
                     // Instance objects are Positional only if they implement
                     // the Positional role (or Array subclass etc.), but not

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1281,6 +1281,38 @@ impl VM {
                         .collect(),
                 )
             }
+            (Value::Uni { ref text, .. }, Value::Range(a, b)) => {
+                let chars: Vec<char> = text.chars().collect();
+                let start = a.max(0) as usize;
+                let end = if Self::range_end_is_unbounded(b) {
+                    chars.len().saturating_sub(1)
+                } else {
+                    b.max(0) as usize
+                };
+                let slice: Vec<Value> = chars
+                    .iter()
+                    .take(end.min(chars.len().saturating_sub(1)) + 1)
+                    .skip(start)
+                    .map(|c| Value::Int(*c as i64))
+                    .collect();
+                Value::array(slice)
+            }
+            (Value::Uni { ref text, .. }, Value::RangeExcl(a, b)) => {
+                let chars: Vec<char> = text.chars().collect();
+                let start = a.max(0) as usize;
+                let end_excl = if Self::range_end_is_unbounded(b) {
+                    chars.len()
+                } else {
+                    b.max(0) as usize
+                };
+                let slice: Vec<Value> = chars
+                    .iter()
+                    .take(end_excl.min(chars.len()))
+                    .skip(start)
+                    .map(|c| Value::Int(*c as i64))
+                    .collect();
+                Value::array(slice)
+            }
             // Capture indexing: $capture<key> (named) or $capture[idx] (positional)
             (
                 Value::Capture {


### PR DESCRIPTION
## Summary

- Fix `:ignoremark` regex to strip Unicode format characters (Cf like ZWJ U+200D) from multi-char grapheme clusters, so base characters match correctly and consume the full grapheme
- Fix hash assignment to unwrap `Scalar` containers in `coerce_to_hash`, so itemized hashes (from `.item`) assign properly to `%`-sigiled variables
- Allow `Uni` (NFC/NFD/NFKC/NFKD) values to bind to `@`-sigiled variables and add Range/RangeExcl indexing support

## Test plan

- [x] All 6 JSON::Tiny upstream test files pass (126 tests total: 01-parse, 02-structure, 03-unicode, 04-roundtrip, 05-utf16, 06-meta-valid)
- [x] `t/json-tiny-compat.t` passes (48 tests)
- [x] `make test` passes (483 files, 3954 tests)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)