### PR TITLE
fix: support $* twigil variables in regex patterns

### DIFF
--- a/src/regex_validate.rs
+++ b/src/regex_validate.rs
@@ -123,6 +123,10 @@ pub(crate) fn validate_regex_syntax(pattern: &str) -> Result<(), RuntimeError> {
                             || ch == '{'
                             || ch == '('
                             || ch == '!'
+                            || ch == '*'
+                            || ch == '?'
+                            || ch == '^'
+                            || ch == '.'
                             || ch.is_ascii_digit()
                     });
                     if !is_var {
@@ -644,6 +648,15 @@ fn skip_variable_ref(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
         }
         Some(&c) if c.is_ascii_digit() => {
             while chars.peek().is_some_and(|ch| ch.is_ascii_digit()) {
+                chars.next();
+            }
+        }
+        Some(&c) if c == '*' || c == '?' || c == '^' || c == '.' => {
+            chars.next();
+            while chars
+                .peek()
+                .is_some_and(|ch| ch.is_alphanumeric() || *ch == '_' || *ch == '-')
+            {
                 chars.next();
             }
         }

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -325,8 +325,16 @@ impl Interpreter {
                     } else {
                         None
                     }
-                } else if j < chars.len() && (chars[j].is_alphabetic() || chars[j] == '_') {
+                } else if j < chars.len()
+                    && (chars[j].is_alphabetic()
+                        || chars[j] == '_'
+                        || matches!(chars[j], '*' | '?' | '^' | '.'))
+                {
                     let name_start = j;
+                    // Skip twigil if present
+                    if matches!(chars[j], '*' | '?' | '^' | '.') {
+                        j += 1;
+                    }
                     while j < chars.len()
                         && (chars[j].is_alphanumeric() || chars[j] == '_' || chars[j] == '-')
                     {

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2758,6 +2758,7 @@ impl Interpreter {
                     let mut group_pattern = String::new();
                     let mut depth = 1;
                     let mut in_comment = false;
+                    let mut angle_depth = 0u32;
                     while let Some(ch) = chars.next() {
                         if in_comment {
                             group_pattern.push(ch);
@@ -2766,8 +2767,17 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '#' {
-                            // '#' starts a comment — everything until newline is comment
+                        if ch == '<' {
+                            angle_depth += 1;
+                            group_pattern.push(ch);
+                            continue;
+                        }
+                        if ch == '>' && angle_depth > 0 {
+                            angle_depth -= 1;
+                            group_pattern.push(ch);
+                            continue;
+                        }
+                        if ch == '#' && angle_depth == 0 {
                             in_comment = true;
                             group_pattern.push(ch);
                             continue;
@@ -3467,8 +3477,16 @@ impl Interpreter {
                         i = j + 1;
                         continue;
                     }
-                } else if j < chars.len() && (chars[j].is_alphabetic() || chars[j] == '_') {
+                } else if j < chars.len()
+                    && (chars[j].is_alphabetic()
+                        || chars[j] == '_'
+                        || matches!(chars[j], '*' | '?' | '^' | '.'))
+                {
                     let name_start = j;
+                    // Skip twigil if present
+                    if matches!(chars[j], '*' | '?' | '^' | '.') {
+                        j += 1;
+                    }
                     while j < chars.len()
                         && (chars[j].is_alphanumeric() || chars[j] == '_' || chars[j] == '-')
                     {
@@ -3653,15 +3671,20 @@ impl Interpreter {
         let mut i = 0;
         while i < chars.len() {
             if chars[i] == '$' {
-                let j = i + 1;
+                let mut j = i + 1;
+                // Skip twigil if present
+                if j < chars.len() && matches!(chars[j], '*' | '?' | '^' | '.') {
+                    j += 1;
+                }
                 if j < chars.len() && (chars[j].is_alphabetic() || chars[j] == '_') {
+                    let name_start = i + 1; // include twigil in name
                     let mut end = j;
                     while end < chars.len()
                         && (chars[end].is_alphanumeric() || chars[end] == '_' || chars[end] == '-')
                     {
                         end += 1;
                     }
-                    let name: String = chars[j..end].iter().collect();
+                    let name: String = chars[name_start..end].iter().collect();
                     if self.env.get(&name).is_none() && self.env.get(&format!("${name}")).is_none()
                     {
                         let symbol = format!("${name}");


### PR DESCRIPTION
## Summary

- Support `$*`, `$?`, `$^`, `$.` twigil variables inside regex patterns (previously `$*FOO` was treated as end-of-string anchor `$` followed by quantifier `*`)
- Fix `#` inside `< >` angle brackets in regex capture groups — `< # ^ / >` is a quote-word alternation, not a comment
- These are prerequisites for Template::Mustache module support

## Test plan

- [x] `$*FOO` in regex now matches correctly
- [x] `(< # ^ >)` capture group with angle-bracket word list works
- [x] `make test` passes (483 files, 3954 tests)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)