### PR TITLE
chore: add 3 newly passing roast tests to whitelist (1182)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -124,6 +124,7 @@ roast/S02-types/infinity.t
 roast/S02-types/instants-and-durations.t
 roast/S02-types/int-uint.t
 roast/S02-types/is-type.t
+roast/S02-types/isDEPRECATED.t
 roast/S02-types/lazy-lists.t
 roast/S02-types/list.t
 roast/S02-types/lists.t


### PR DESCRIPTION
## Summary

- Add 3 newly passing roast tests to whitelist: isDEPRECATED, cas-int, batch
- Whitelist count: 1179 → 1182

## Test plan

- [x] All 3 tests verified with `prove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)