### PR TITLE
fix: whenever blocks inside supply receive emitted values instead of Supplier object

### DIFF
--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -512,10 +512,20 @@ impl Interpreter {
                 // For on-demand supplies, execute the callback to produce values
                 let mut on_demand_quit: Option<Value> = None;
                 let values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
+                    // Give the emitter a supplier_id so that when a `whenever`
+                    // body calls `$emitter.emit(val)`, the value can be dispatched
+                    // to taps registered on this emitter. The outer tap_cb will
+                    // be registered lazily below only when `whenever` subscriptions
+                    // are found, to avoid double-delivery for plain `emit` calls.
+                    let emitter_supplier_id = next_supplier_id();
                     let emitter = Value::make_instance(Symbol::intern("Supplier"), {
                         let mut a = HashMap::new();
                         a.insert("emitted".to_string(), Value::array(Vec::new()));
                         a.insert("done".to_string(), Value::Bool(false));
+                        a.insert(
+                            "supplier_id".to_string(),
+                            Value::Int(emitter_supplier_id as i64),
+                        );
                         a
                     });
                     // Use supply_emit_buffer to collect emitted values
@@ -559,6 +569,16 @@ impl Interpreter {
                                 // will be caught during emit dispatch and
                                 // routed to the quit handler.
                                 register_supplier_tap(supplier_id, body_cb, 0.0);
+                                // Register the outer tap callback on the emitter
+                                // so that `$emitter.emit(val)` inside the body
+                                // forwards values to the outer tap subscriber.
+                                if Self::supply_has_active_callback(&tap_cb) {
+                                    register_supplier_tap(
+                                        emitter_supplier_id,
+                                        tap_cb.clone(),
+                                        delay_seconds,
+                                    );
+                                }
                                 // Register the outer quit handler on the inner
                                 // supplier so that errors propagate correctly.
                                 if let Some(ref qf) = quit_cb {
@@ -2003,10 +2023,20 @@ impl Interpreter {
                 let has_unique = matches!(attrs.get("unique_filter"), Some(Value::Bool(true)));
                 let mut on_demand_quit: Option<Value> = None;
                 let values = if let Some(on_demand_cb) = attrs.get("on_demand_callback").cloned() {
+                    // Give the emitter a supplier_id so that when a `whenever`
+                    // body calls `$emitter.emit(val)`, the value can be dispatched
+                    // to taps registered on this emitter. The outer tap_cb will
+                    // be registered lazily below only when `whenever` subscriptions
+                    // are found, to avoid double-delivery for plain `emit` calls.
+                    let emitter_supplier_id = next_supplier_id();
                     let emitter = Value::make_instance(Symbol::intern("Supplier"), {
                         let mut a = HashMap::new();
                         a.insert("emitted".to_string(), Value::array(Vec::new()));
                         a.insert("done".to_string(), Value::Bool(false));
+                        a.insert(
+                            "supplier_id".to_string(),
+                            Value::Int(emitter_supplier_id as i64),
+                        );
                         a
                     });
                     self.supply_emit_buffer.push(Vec::new());
@@ -2040,6 +2070,16 @@ impl Interpreter {
                             {
                                 let supplier_id = *sid as u64;
                                 register_supplier_tap(supplier_id, body_cb, 0.0);
+                                // Register the outer tap callback on the emitter
+                                // so that `$emitter.emit(val)` inside the body
+                                // forwards values to the outer tap subscriber.
+                                if Self::supply_has_active_callback(&tap_cb) {
+                                    register_supplier_tap(
+                                        emitter_supplier_id,
+                                        tap_cb.clone(),
+                                        delay_seconds,
+                                    );
+                                }
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(supplier_id, qf.clone());
                                 }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -613,6 +613,19 @@ impl Interpreter {
         param: &Option<String>,
         body: &[Stmt],
     ) -> Result<(), RuntimeError> {
+        // If the source is a Supplier, convert it to its associated Supply
+        // so that subscription registration and tap dispatch work correctly.
+        // Without this, `whenever $supplier { ... }` inside a `supply` block
+        // would pass the Supplier object itself as the subscription source,
+        // which the tap dispatch code does not recognize (it expects Supply).
+        let supply_val = if let Value::Instance { class_name, .. } = &supply_val
+            && (class_name == "Supplier" || class_name == "Supplier::Preserving")
+        {
+            self.call_method_with_values(supply_val, "Supply", vec![])?
+        } else {
+            supply_val
+        };
+
         let (main_body, last_bodies, quit_bodies) = Self::split_whenever_body_phasers(body);
         let callback = Value::make_sub(
             Symbol::intern(&self.current_package),

--- a/t/supply-whenever-supplier.t
+++ b/t/supply-whenever-supplier.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 5;
+
+# Basic: whenever block receives emitted value, not the Supplier object
+{
+    my $sup = Supplier.new;
+    my @collected;
+    my $s = supply { whenever $sup { emit $_ * 2; } };
+    $s.tap({ @collected.push($_) });
+    $sup.emit(21);
+    is @collected[0], 42, 'whenever block receives emitted value via $_';
+}
+
+# Multiple emits
+{
+    my $sup = Supplier.new;
+    my @collected;
+    my $s = supply { whenever $sup { emit $_ + 1; } };
+    $s.tap({ @collected.push($_) });
+    $sup.emit(10);
+    $sup.emit(20);
+    $sup.emit(30);
+    is @collected.elems, 3, 'multiple emits all received';
+    is @collected.join(','), '11,21,31', 'all emitted values transformed correctly';
+}
+
+# Explicit parameter
+{
+    my $sup = Supplier.new;
+    my @collected;
+    my $s = supply { whenever $sup -> $val { emit $val * 3; } };
+    $s.tap({ @collected.push($_) });
+    $sup.emit(7);
+    is @collected[0], 21, 'whenever with explicit param receives emitted value';
+}
+
+# Supplier::Preserving
+{
+    my $sup = Supplier::Preserving.new;
+    my @collected;
+    my $s = supply { whenever $sup { emit $_ * 2; } };
+    $s.tap({ @collected.push($_) });
+    $sup.emit(5);
+    is @collected[0], 10, 'Supplier::Preserving emitted value received in whenever';
+}


### PR DESCRIPTION
## Summary

- Fixed a bug where `whenever $supplier { ... }` inside a `supply` block received the Supplier object itself as `$_` instead of the emitted value
- In `run_whenever_with_value`, Supplier objects are now converted to their associated Supply before registering subscriptions
- On-demand emitters now have a `supplier_id` and the outer tap callback is lazily registered when `whenever` subscriptions are found, enabling `$emitter.emit(val)` to forward values correctly

## Test plan

- [x] New test `t/supply-whenever-supplier.t` with 5 cases: basic emit, multiple emits, explicit parameter, Supplier::Preserving
- [x] `make test` passes (484 files, 3912 tests)
- [x] Existing supply tests (`t/supply-error.t`, `t/supply-syntax-basic.t`) pass without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)