### PR TITLE
fix: END phasers in EVAL use live variable values instead of stale snapshots

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -288,6 +288,7 @@ roast/S04-phasers/end.t
 roast/S04-phasers/enter-leave.t
 roast/S04-phasers/exit-in-check.t
 roast/S04-phasers/first.t
+roast/S04-phasers/in-eval.t
 roast/S04-phasers/in-loop.t
 roast/S04-phasers/init.t
 roast/S04-phasers/interpolate.t

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -872,12 +872,15 @@ impl Interpreter {
                 // (not already present) so we can remove them after.
                 let mut overlay_keys: Vec<String> = Vec::new();
                 // Overlay captured lexical env on top of current env
-                // so both globals and captured lexicals are visible
+                // so both globals and captured lexicals are visible.
+                // Only insert variables that are NOT already in the current env —
+                // existing variables should keep their live values rather than
+                // being overwritten with stale captured snapshots.
                 for (k, v) in captured_env {
                     if !self.env.contains_key(k) {
                         overlay_keys.push(k.clone());
+                        self.env.insert(k.clone(), v.clone());
                     }
-                    self.env.insert(k.clone(), v.clone());
                 }
                 self.run_block(body)?;
                 // Remove only the overlay keys (captured lexicals not in


### PR DESCRIPTION
## Summary
- Fixed END phasers registered inside EVAL'd closures using stale captured environment snapshots instead of live variable values at program exit
- The `finish()` method now only overlays captured variables that are missing from the current env, preserving live bindings for shared variables
- Adds `roast/S04-phasers/in-eval.t` to the whitelist (all 35 tests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-phasers/in-eval.t` — all 35 tests pass (was 34/35)
- [x] `make test` — all 484 files, 3959 tests pass
- [x] No clippy warnings in changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)