### PR TITLE
fix: improve package scope visibility for our/my package declarations

### DIFF
--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -178,9 +178,15 @@ pub(super) fn try_keyword_dispatch(
     if keyword("module", rest).is_some() {
         return module_decl(rest).map(Some);
     }
-    // my package Name { ... }
+    // my/our package Name { ... }
+    // `our package` keeps `is_my = false` so the package stays visible
+    // outside its declaring block scope.
     if keyword("package", rest).is_some() {
-        return package_decl_my(rest).map(Some);
+        let (r, mut stmt) = package_decl_my(rest)?;
+        if is_our && let Stmt::Package { is_my, .. } = &mut stmt {
+            *is_my = false;
+        }
+        return Ok(Some((r, stmt)));
     }
     // my subset Name of BaseType where ...
     if keyword("subset", rest).is_some() {

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1412,6 +1412,9 @@ impl Interpreter {
         }
         if let Some(value) = self.env.get(name)
             && !matches!(value, Value::Nil)
+            // Skip `my`-scoped package items for indirect type lookup (::())
+            // since they should not be visible outside their declaring scope.
+            && !self.is_my_scoped_package_item(name)
         {
             return value.clone();
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2918,6 +2918,9 @@ impl VM {
                     .chain_declared_packages
                     .insert(name.clone());
                 self.update_local_if_exists(code, &name, &pkg_val);
+                // Mark as my-scoped so the package is hidden from global
+                // lookups and package stash resolution outside its scope.
+                self.interpreter.mark_my_scoped_package_item(name.clone());
                 // Mark as block-declared so the name is cleaned up
                 // when the enclosing block scope exits.
                 if let Some(set) = self.block_declared_vars.last_mut() {

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -233,39 +233,6 @@ impl VM {
                     || Self::is_type_with_smiley(bare, &self.interpreter))
             {
                 Value::Package(Symbol::intern(Self::resolve_type_alias(bare)))
-            } else if self.interpreter.has_type(name)
-                || Self::is_builtin_type(name)
-                || self.interpreter.env().contains_key(name)
-            {
-                Value::Package(Symbol::intern(name))
-            } else if let Some((pkg_part, sub_part)) = name.rsplit_once("::") {
-                // If the last component starts with a lowercase letter, this is
-                // likely a sub/symbol reference, not a type name.
-                let looks_like_sub = sub_part
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c.is_ascii_lowercase());
-                if looks_like_sub {
-                    // Check if the package prefix is known.
-                    let pkg_exists = self.interpreter.has_type(pkg_part)
-                        || Self::is_builtin_type(pkg_part)
-                        || self.interpreter.env().contains_key(pkg_part);
-                    if pkg_exists {
-                        // Package exists but the symbol inside it was not found.
-                        return Err(RuntimeError::new(format!(
-                            "Could not find symbol '&{}' in '{}'",
-                            sub_part, pkg_part,
-                        )));
-                    }
-                    // Package prefix is also unknown — report error.
-                    return Err(RuntimeError::new(format!(
-                        "Could not find symbol '&{}' in '{}'",
-                        sub_part, pkg_part,
-                    )));
-                }
-                // Uppercase last component — treat as a type object
-                // (many Raku types like X::AdHoc are referenced before declaration).
-                Value::Package(Symbol::intern(name))
             } else {
                 Value::Package(Symbol::intern(name))
             }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -233,6 +233,41 @@ impl VM {
                     || Self::is_type_with_smiley(bare, &self.interpreter))
             {
                 Value::Package(Symbol::intern(Self::resolve_type_alias(bare)))
+            } else if self.interpreter.has_type(name)
+                || Self::is_builtin_type(name)
+                || self.interpreter.env().contains_key(name)
+            {
+                Value::Package(Symbol::intern(name))
+            } else if let Some((pkg_part, sub_part)) = name.rsplit_once("::") {
+                // The name looks like a package-qualified sub/symbol reference.
+                // Check if the package prefix is known; if not, report an error.
+                let pkg_exists = self.interpreter.has_type(pkg_part)
+                    || Self::is_builtin_type(pkg_part)
+                    || self.interpreter.env().contains_key(pkg_part);
+                if pkg_exists {
+                    // Package exists but the symbol inside it was not found.
+                    return Err(RuntimeError::new(format!(
+                        "Could not find symbol '&{}' in '{}'",
+                        sub_part, pkg_part,
+                    )));
+                }
+                // Package prefix is also unknown.
+                // If the last component starts with a lowercase letter, this is
+                // likely a sub/symbol reference that failed (e.g. `Our::Pkg::func`),
+                // not a type object reference. Treat as unknown symbol.
+                if sub_part
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_lowercase())
+                {
+                    return Err(RuntimeError::new(format!(
+                        "Could not find symbol '&{}' in '{}'",
+                        sub_part, pkg_part,
+                    )));
+                }
+                // Uppercase last component — treat as a type object
+                // (many Raku types like X::AdHoc are referenced before declaration).
+                Value::Package(Symbol::intern(name))
             } else {
                 Value::Package(Symbol::intern(name))
             }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -239,27 +239,25 @@ impl VM {
             {
                 Value::Package(Symbol::intern(name))
             } else if let Some((pkg_part, sub_part)) = name.rsplit_once("::") {
-                // The name looks like a package-qualified sub/symbol reference.
-                // Check if the package prefix is known; if not, report an error.
-                let pkg_exists = self.interpreter.has_type(pkg_part)
-                    || Self::is_builtin_type(pkg_part)
-                    || self.interpreter.env().contains_key(pkg_part);
-                if pkg_exists {
-                    // Package exists but the symbol inside it was not found.
-                    return Err(RuntimeError::new(format!(
-                        "Could not find symbol '&{}' in '{}'",
-                        sub_part, pkg_part,
-                    )));
-                }
-                // Package prefix is also unknown.
                 // If the last component starts with a lowercase letter, this is
-                // likely a sub/symbol reference that failed (e.g. `Our::Pkg::func`),
-                // not a type object reference. Treat as unknown symbol.
-                if sub_part
+                // likely a sub/symbol reference, not a type name.
+                let looks_like_sub = sub_part
                     .chars()
                     .next()
-                    .is_some_and(|c| c.is_ascii_lowercase())
-                {
+                    .is_some_and(|c| c.is_ascii_lowercase());
+                if looks_like_sub {
+                    // Check if the package prefix is known.
+                    let pkg_exists = self.interpreter.has_type(pkg_part)
+                        || Self::is_builtin_type(pkg_part)
+                        || self.interpreter.env().contains_key(pkg_part);
+                    if pkg_exists {
+                        // Package exists but the symbol inside it was not found.
+                        return Err(RuntimeError::new(format!(
+                            "Could not find symbol '&{}' in '{}'",
+                            sub_part, pkg_part,
+                        )));
+                    }
+                    // Package prefix is also unknown — report error.
                     return Err(RuntimeError::new(format!(
                         "Could not find symbol '&{}' in '{}'",
                         sub_part, pkg_part,


### PR DESCRIPTION
## Summary
- Fix `our package` being incorrectly parsed as `my package`, causing the package to be treated as lexically scoped
- Mark `my`-scoped packages so they are excluded from global `::()` symbol lookups
- Skip `my`-scoped package items in indirect type lookup (`resolve_indirect_type_name`)

Reduces `roast/S10-packages/scope.t` failures from 3 to 2 (tests 14, 18, 21 → tests 14, 18 remaining).
- Test 21 fixed: `my`-scoped packages now correctly excluded from `::()` global lookup
- Test 14 (bareword fallback for unknown packages) and test 18 (lexical scope for `my` package calls) require deeper architectural changes

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S10-packages/scope.t` shows 22/24 passing (was 21/24)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)