### PR TITLE
fix: interior mutation for shared arrays (container semantics)

### DIFF
--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -209,6 +209,32 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Interior mutation: if the target Array has shared references
+        // (Arc refcount > 1), mutate in-place so all references see the
+        // change. This matches Raku's container semantics.
+        if let Value::Array(ref arc, _) = target
+            && Arc::strong_count(arc) > 1
+            && matches!(method, "push" | "append" | "unshift" | "prepend")
+        {
+            let vals: Vec<Value> = match method {
+                "push" => Self::normalize_push_args_for_copy(args),
+                "append" => flatten_append_args(args),
+                "unshift" => Self::normalize_push_args_for_copy(args),
+                "prepend" => flatten_append_args(args),
+                _ => unreachable!(),
+            };
+            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            unsafe {
+                if matches!(method, "unshift" | "prepend") {
+                    let mut combined = vals;
+                    combined.append(&mut (*ptr));
+                    *ptr = combined;
+                } else {
+                    (*ptr).extend(vals);
+                }
+            }
+            return Ok(target);
+        }
         let mut items = match target {
             Value::Array(ref v, ..) => v.to_vec(),
             _ => Vec::new(),

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2254,6 +2254,22 @@ impl Interpreter {
                         }
                         return Ok(Value::Array(Arc::clone(arc_items), *kind));
                     }
+                    // Interior mutation: if the target Array has shared references
+                    // (Arc refcount > 1), mutate in-place so all references see the
+                    // change. This matches Raku's container semantics.
+                    if let Value::Array(ref arc_items, _) = target
+                        && Arc::strong_count(arc_items) > 1
+                    {
+                        let vals = if method == "append" {
+                            flatten_append_args(normalized_args)
+                        } else {
+                            normalized_args
+                        };
+                        for v in vals {
+                            target.array_push_in_place(v);
+                        }
+                        return Ok(target);
+                    }
                     let mut items = match &target {
                         Value::Array(v, ..) => v.to_vec(),
                         _ => Vec::new(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1881,6 +1881,23 @@ impl Value {
         }
     }
 
+    /// Push a value to an Array in-place using interior mutation.
+    /// This allows shared references (Arc refcount > 1) to see the mutation,
+    /// matching Raku's container semantics where all references share state.
+    /// Safety: same assumptions as hash_autovivify — callers ensure no
+    /// concurrent reads/writes to the same Arc.
+    pub fn array_push_in_place(&self, val: Value) -> bool {
+        if let Value::Array(arc, _) = self {
+            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            unsafe {
+                (*ptr).push(val);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Read the current value from a DeferredHashAccess.
     /// Returns Any if the path doesn't exist yet.
     pub fn deferred_hash_read(&self) -> Value {


### PR DESCRIPTION
## Summary

- When an Array's Arc has refcount > 1 (shared references), push/append/unshift/prepend now mutate in-place via unsafe interior mutation instead of cloning via Arc::make_mut
- This matches Raku's container semantics where all references to the same array see mutations
- Uses the same interior mutation approach already established for hash operations

This is the key blocker for Template::Mustache grammar actions which use:
```raku
@frames.unshift: $%x;
@frames[0]<contents>.push: $hunk;
# %x<contents> must see the push
```

## Test plan

- [x] `@f[0]<contents>.push` now propagates to original hash
- [x] `cargo clippy -- -D warnings` clean
- [ ] `make test` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)