### PR TITLE
fix: perf regression in class attribute handling

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -533,6 +533,7 @@ roast/S11-modules/require.t
 roast/S11-modules/runtime.t
 roast/S12-attributes/augment-and-initialization.t
 roast/S12-attributes/clone.t
+roast/S12-attributes/defaults.t
 roast/S12-attributes/delegation.t
 roast/S12-attributes/inheritance.t
 roast/S12-attributes/mutators.t
@@ -542,6 +543,7 @@ roast/S12-attributes/smiley.t
 roast/S12-attributes/undeclared.t
 roast/S12-class/anonymous.t
 roast/S12-class/attributes-required.t
+roast/S12-class/attributes.t
 roast/S12-class/augment-supersede.t
 roast/S12-class/declaration-order.t
 roast/S12-class/extending-arrays.t
@@ -590,6 +592,7 @@ roast/S12-introspection/roles.t
 roast/S12-meta/classhow.t
 roast/S12-meta/grammarhow.t
 roast/S12-meta/primitives.t
+roast/S12-methods/attribute-params.t
 roast/S12-methods/calling_sets.t
 roast/S12-methods/calling_syntax.t
 roast/S12-methods/chaining.t

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -258,8 +258,11 @@ impl Interpreter {
                     .iter()
                     .all(|p| p == "Any" || p == "Mu" || p == "Cool")
                 && class_def.attributes.iter().all(
-                    |(_, _, _, is_required, type_constraint, sigil, _)| {
-                        *sigil == '$' && !is_required && type_constraint.is_none()
+                    |(_, _, _, is_required, type_constraint, sigil, where_constraint)| {
+                        *sigil == '$'
+                            && !is_required
+                            && type_constraint.is_none()
+                            && where_constraint.is_none()
                     },
                 )
                 && !class_def.attributes.is_empty()
@@ -272,16 +275,39 @@ impl Interpreter {
                         attrs.insert(key.clone(), *val.clone());
                     }
                 }
-                // Fill defaults for missing attributes
+                // Fill defaults for missing attributes (including Nil for uninitialized ones).
+                // Set up `self` as the partially-constructed instance so that
+                // default expressions referencing `self` (e.g. `has $.x = self.y`)
+                // work correctly. Update `self` after each default so that later
+                // defaults can see earlier defaults' values.
                 let class_attrs = self.collect_class_attributes(&cn_resolved);
+                let has_defaults = class_attrs.iter().any(|(_, _, d, ..)| d.is_some());
+                if has_defaults {
+                    let partial = Value::make_instance(*class_name, attrs.clone());
+                    self.env.insert("self".to_string(), partial.clone());
+                    self.env.insert("__ANON_STATE__".to_string(), partial);
+                }
                 for (attr_name, _is_public, default_expr, _, _, _, _) in &class_attrs {
-                    if !attrs.contains_key(attr_name)
-                        && let Some(expr) = default_expr
-                    {
-                        let val = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())])?;
-                        attrs.insert(attr_name.clone(), val);
+                    if !attrs.contains_key(attr_name) {
+                        if let Some(expr) = default_expr {
+                            let val =
+                                self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())])?;
+                            attrs.insert(attr_name.clone(), val);
+                            // Update self so later defaults see this value
+                            let updated = Value::make_instance(*class_name, attrs.clone());
+                            self.env.insert("self".to_string(), updated.clone());
+                            self.env.insert("__ANON_STATE__".to_string(), updated);
+                        } else {
+                            attrs.insert(attr_name.clone(), Value::Nil);
+                        }
                     }
                 }
+                if has_defaults {
+                    self.env.remove("self");
+                    self.env.remove("__ANON_STATE__");
+                }
+                // Add alias metadata for `has $x` (no twigil) attributes
+                self.add_alias_attribute_metadata(&cn_resolved, &mut attrs);
                 return Ok(Value::make_instance(*class_name, attrs));
             }
             let parametric = Self::parse_parametric_type_name(&cn_resolved);

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -29,6 +29,31 @@ impl VM {
         }
     }
 
+    /// Update any instances in `self.locals` that match the given class_name and id.
+    /// This is needed because the fast-path SetLocal for simple scalars writes only
+    /// to `self.locals` (not env), so `overwrite_instance_bindings_by_identity` which
+    /// only searches env will miss them.
+    pub(super) fn overwrite_instance_in_locals(
+        &mut self,
+        class_name: &str,
+        id: u64,
+        updated: &std::collections::HashMap<String, Value>,
+    ) {
+        let cn = crate::symbol::Symbol::intern(class_name);
+        for local in self.locals.iter_mut() {
+            if let Value::Instance {
+                class_name: existing_class,
+                id: existing_id,
+                ..
+            } = local
+                && *existing_class == cn
+                && *existing_id == id
+            {
+                *local = Value::make_instance_with_id(cn, updated.clone(), id);
+            }
+        }
+    }
+
     pub(super) fn try_exec_simple_shared_protect_block(
         &mut self,
         outer_code: &CompiledCode,
@@ -169,6 +194,7 @@ impl VM {
                                 id,
                                 new_attrs.clone(),
                             );
+                            self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -256,6 +282,7 @@ impl VM {
                         id,
                         new_attrs.clone(),
                     );
+                    self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                     if !self.interpreter.in_lvalue_assignment
                         && let Value::Proxy { ref fetcher, .. } = result
                     {
@@ -356,6 +383,7 @@ impl VM {
                                 id,
                                 new_attrs.clone(),
                             );
+                            self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -429,6 +457,7 @@ impl VM {
                         id,
                         new_attrs.clone(),
                     );
+                    self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                     if !self.interpreter.in_lvalue_assignment
                         && let Value::Proxy { ref fetcher, .. } = result
                     {


### PR DESCRIPTION
## Summary
- Fixed fast-path `.new()` not inserting attributes without defaults (broke `$!x = val` writeback)
- Fixed fast-path `.new()` missing alias metadata for `has $x` (no-twigil) attributes
- Fixed fast-path `.new()` not providing `self` during default evaluation, and not excluding `where` constraints
- Added `overwrite_instance_in_locals` to update instances in VM locals after method calls (SetLocal fast path skips env writes)

## Test plan
- [x] `prove -e mutsu roast/S12-class/attributes.t` (44/44 pass, was 40/44)
- [x] `prove -e mutsu roast/S12-attributes/defaults.t` (38/38 pass, was 32/38)
- [x] `prove -e mutsu roast/S12-methods/attribute-params.t` (21/21 pass, was 20/21)
- [x] `make test` passes (same pre-existing failures as main)
- [x] `make roast` whitelist tests all pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Added 3 tests to roast-whitelist.txt (sorted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)