### PR TITLE
fix: perf optimization regressions in env handling and positional light calls

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -77,6 +77,7 @@ roast/S02-magicals/args.t
 roast/S02-magicals/block.t
 roast/S02-magicals/dollar-underscore.t
 roast/S02-magicals/dollar_bang.t
+roast/S02-magicals/env.t
 roast/S02-magicals/file_line.t
 roast/S02-magicals/pid.t
 roast/S02-magicals/progname.t
@@ -724,6 +725,7 @@ roast/S15-unicode-information/uniprop.t
 roast/S15-unicode-information/unival.t
 roast/S16-filehandles/argfiles.t
 roast/S16-filehandles/chmod.t
+roast/S16-filehandles/filestat.t
 roast/S16-filehandles/filetest.t
 roast/S16-filehandles/io.t
 roast/S16-filehandles/io_in_for_loops.t
@@ -741,6 +743,7 @@ roast/S16-io/cwd.t
 roast/S16-io/eof.t
 roast/S16-io/getc.t
 roast/S16-io/handles-between-threads.t
+roast/S16-io/home.t
 roast/S16-io/newline.t
 roast/S16-io/note.t
 roast/S16-io/print.t
@@ -951,6 +954,8 @@ roast/S32-io/io-path-unix.t
 roast/S32-io/io-path-win.t
 roast/S32-io/io-spec-cygwin.t
 roast/S32-io/io-spec-qnx.t
+roast/S32-io/io-spec-unix.t
+roast/S32-io/io-spec-win.t
 roast/S32-io/io-special.t
 roast/S32-io/mkdir_rmdir.t
 roast/S32-io/move.t

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -744,6 +744,20 @@ impl VM {
         }
         self.locals_dirty = true;
 
+        // Save env values for function locals so we can restore them after
+        // the function returns. This prevents function-local variables from
+        // leaking into the caller's env (the positional light path does not
+        // save/restore env unlike call_compiled_function_named).
+        let saved_env_locals: Vec<(String, Option<Value>)> = cf
+            .code
+            .locals
+            .iter()
+            .map(|name| {
+                let old = self.interpreter.env().get(name).cloned();
+                (name.clone(), old)
+            })
+            .collect();
+
         let saved_stack_depth = self.stack.len();
         let let_mark = self.interpreter.let_saves_len();
 
@@ -818,6 +832,19 @@ impl VM {
         self.env_dirty = saved_env_dirty;
 
         self.interpreter.restore_readonly_vars(saved_readonly);
+
+        // Clean up function-local variables that were INTRODUCED by the function
+        // body (not present in env before the call). Variables that existed before
+        // the call must keep their current value since the function body may have
+        // modified them through side effects (e.g., pushing to a closure-captured
+        // array). Only newly introduced locals are removed to prevent them from
+        // leaking into the caller's scope.
+        for (local_name, saved_val) in &saved_env_locals {
+            if saved_val.is_none() {
+                // This local was not in env before the call — remove it
+                self.interpreter.env_mut().remove(local_name);
+            }
+        }
 
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1464,7 +1464,26 @@ impl VM {
                 // Since var_name starts with '%' and is not bound,
                 // we use Arc::make_mut (COW semantics for %-sigiled vars)
                 if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(var_name) {
-                    Arc::make_mut(hash).insert(key, val.clone());
+                    Arc::make_mut(hash).insert(key.clone(), val.clone());
+                }
+                // Sync OS environment when %*ENV is modified
+                #[cfg(not(target_family = "wasm"))]
+                if var_name == "%*ENV" {
+                    // SAFETY: mutsu is single-threaded
+                    unsafe {
+                        std::env::set_var(&key, val.to_string_value());
+                    }
+                    // Sync $*HOME when %*ENV<HOME> changes
+                    if key == "HOME" {
+                        let home_str = val.to_string_value();
+                        let home_val = self.interpreter.make_io_path_instance(&home_str);
+                        self.interpreter
+                            .env_mut()
+                            .insert("$*HOME".to_string(), home_val.clone());
+                        self.interpreter
+                            .env_mut()
+                            .insert("*HOME".to_string(), home_val);
+                    }
                 }
                 self.stack.push(val);
                 Some(Ok(()))
@@ -1475,10 +1494,28 @@ impl VM {
                 let val = self.stack.pop().unwrap();
                 let key = idx.to_string_value();
                 let mut map = std::collections::HashMap::new();
-                map.insert(key, val.clone());
+                map.insert(key.clone(), val.clone());
                 self.interpreter
                     .env_mut()
                     .insert(var_name.to_string(), Value::hash(map));
+                // Sync OS environment when %*ENV is modified
+                #[cfg(not(target_family = "wasm"))]
+                if var_name == "%*ENV" {
+                    // SAFETY: mutsu is single-threaded
+                    unsafe {
+                        std::env::set_var(&key, val.to_string_value());
+                    }
+                    if key == "HOME" {
+                        let home_str = val.to_string_value();
+                        let home_val = self.interpreter.make_io_path_instance(&home_str);
+                        self.interpreter
+                            .env_mut()
+                            .insert("$*HOME".to_string(), home_val.clone());
+                        self.interpreter
+                            .env_mut()
+                            .insert("*HOME".to_string(), home_val);
+                    }
+                }
                 self.stack.push(val);
                 Some(Ok(()))
             }


### PR DESCRIPTION
## Summary
- Fix `try_fast_hash_element_assign` to call `std::env::set_var` when `%*ENV` is modified and sync `$*HOME` when `HOME` changes, matching the slow path behavior
- Fix `call_compiled_function_positional_light` to clean up function-local variables from env after the call, preventing stale values from leaking into the caller's scope
- Add 5 previously-passing roast tests back to the whitelist

## Test plan
- [x] All 5 previously failing roast tests now pass: `S02-magicals/env.t`, `S16-io/home.t`, `S16-filehandles/filestat.t`, `S32-io/io-spec-unix.t`, `S32-io/io-spec-win.t`
- [x] `make test` passes (2 pre-existing failures in `t/overloading-operators.t` and `t/tail-function.t` are unrelated)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)