### PR TITLE
fix: perf regression in method dispatch, param binding, and env merge

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -123,6 +123,7 @@ roast/S02-types/infinity.t
 roast/S02-types/instants-and-durations.t
 roast/S02-types/int-uint.t
 roast/S02-types/is-type.t
+roast/S02-types/lazy-lists.t
 roast/S02-types/list.t
 roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
@@ -157,6 +158,7 @@ roast/S03-buf/read-write-bits.t
 roast/S03-buf/write-num.t
 roast/S03-feeds/basic.t
 roast/S03-junctions/associative.t
+roast/S03-junctions/autothreading.t
 roast/S03-junctions/boolean-context.t
 roast/S03-junctions/misc.t
 roast/S03-metaops/cross.t
@@ -414,7 +416,9 @@ roast/S05-transliteration/trans.t
 roast/S05-transliteration/with-closure.t
 roast/S06-advanced/callframe.t
 roast/S06-advanced/callsame.t
+roast/S06-advanced/dispatching.t
 roast/S06-advanced/recurse.t
+roast/S06-advanced/return.t
 roast/S06-advanced/stub.t
 roast/S06-currying/assuming-and-mmd.t
 roast/S06-currying/misc.t
@@ -543,6 +547,7 @@ roast/S12-attributes/undeclared.t
 roast/S12-class/anonymous.t
 roast/S12-class/attributes-required.t
 roast/S12-class/augment-supersede.t
+roast/S12-class/basic.t
 roast/S12-class/declaration-order.t
 roast/S12-class/extending-arrays.t
 roast/S12-class/inheritance-class-methods.t
@@ -619,6 +624,8 @@ roast/S12-traits/precomp.t
 roast/S13-overloading/fallbacks-deep.t
 roast/S13-overloading/metaoperators.t
 roast/S13-overloading/multiple-signatures.t
+roast/S13-overloading/operators.t
+roast/S13-overloading/typecasting-long.t
 roast/S13-syntax/aliasing.t
 roast/S13-type-casting/methods.t
 roast/S14-roles/anonymous.t
@@ -724,6 +731,7 @@ roast/S15-unicode-information/uniprop.t
 roast/S15-unicode-information/unival.t
 roast/S16-filehandles/argfiles.t
 roast/S16-filehandles/chmod.t
+roast/S16-filehandles/filestat.t
 roast/S16-filehandles/filetest.t
 roast/S16-filehandles/io.t
 roast/S16-filehandles/io_in_for_loops.t
@@ -1012,6 +1020,7 @@ roast/S32-list/rotor.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t
+roast/S32-list/tail.t
 roast/S32-list/toggle.t
 roast/S32-list/unique.t
 roast/S32-num/abs.t

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -995,6 +995,12 @@ impl CompiledCode {
                     | OpCode::CallFuncSlip { .. }
                     | OpCode::ExecCall { .. }
                     | OpCode::ExecCallPairs { .. }
+                    | OpCode::CallMethod { .. }
+                    | OpCode::CallMethodMut { .. }
+                    | OpCode::CallMethodDynamic { .. }
+                    | OpCode::CallMethodDynamicMut { .. }
+                    | OpCode::HyperMethodCall { .. }
+                    | OpCode::HyperMethodCallDynamic { .. }
                     | OpCode::RegisterSub(_)
                     | OpCode::RegisterClass(_)
                     | OpCode::RegisterRole(_)

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -719,7 +719,12 @@ impl VM {
 
         // Bind params to locals only (skip env writes for performance).
         // The env will be synced lazily via ensure_env_synced if needed.
+        // Save old env values for param names so we can restore them after
+        // the call (ensure_env_synced may write param locals to env during
+        // execution, and those must not leak into the caller's scope).
         let saved_readonly = self.interpreter.save_readonly_vars();
+        let mut saved_param_env: Vec<(String, Option<Value>)> =
+            Vec::with_capacity(positional_count);
         for (param_idx, slot) in param_slots.iter().enumerate() {
             if param_idx < actual_count {
                 let val = crate::runtime::types::unwrap_varref_value(args[param_idx].clone());
@@ -737,7 +742,16 @@ impl VM {
                         runtime::value_type_name(&val)
                     )));
                 }
-                self.locals[*slot] = val;
+                let param_name = &cf.param_defs[param_idx].name;
+                saved_param_env.push((
+                    param_name.clone(),
+                    self.interpreter.env().get(param_name).cloned(),
+                ));
+                self.locals[*slot] = val.clone();
+                // Write params to env so sync_locals_from_env (triggered by
+                // ensure_locals_synced) doesn't clobber them with stale values
+                // from the caller's scope.
+                self.interpreter.env_mut().insert(param_name.clone(), val);
                 self.interpreter
                     .mark_readonly(&cf.param_defs[param_idx].name);
             }
@@ -805,6 +819,16 @@ impl VM {
                 self.locals_dirty = saved_locals_dirty;
                 self.env_dirty = saved_env_dirty;
                 self.interpreter.restore_readonly_vars(saved_readonly);
+                for (name, old_val) in saved_param_env {
+                    match old_val {
+                        Some(v) => {
+                            self.interpreter.env_mut().insert(name, v);
+                        }
+                        None => {
+                            self.interpreter.env_mut().remove(&name);
+                        }
+                    }
+                }
                 return Err(RuntimeError::new(format!(
                     "Type check failed for return value; expected {}, got {}",
                     rt,
@@ -818,6 +842,18 @@ impl VM {
         self.env_dirty = saved_env_dirty;
 
         self.interpreter.restore_readonly_vars(saved_readonly);
+        // Restore caller's env values for param names that may have leaked
+        // into env via ensure_env_synced during the function body execution.
+        for (name, old_val) in saved_param_env {
+            match old_val {
+                Some(v) => {
+                    self.interpreter.env_mut().insert(name, v);
+                }
+                None => {
+                    self.interpreter.env_mut().remove(&name);
+                }
+            }
+        }
 
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -194,14 +194,24 @@ impl VM {
                     crate::symbol::Symbol::intern(&cn),
                     crate::symbol::Symbol::intern(method),
                 );
-                if let Some(cached) = self.method_resolve_cache.get(&cache_key) {
-                    cached.clone()
+                // Check cache, but skip cached results for multi-methods since
+                // multi-dispatch depends on argument types/arity.
+                let cached = self.method_resolve_cache.get(&cache_key).cloned();
+                if let Some(ref hit) = cached
+                    && let Some((_, def)) = hit
+                    && !def.is_multi
+                {
+                    hit.clone()
                 } else {
                     let resolved = self
                         .interpreter
                         .resolve_method_with_owner_invocant(&cn, method, &args, &target);
-                    self.method_resolve_cache
-                        .insert(cache_key, resolved.clone());
+                    // Only cache non-multi methods; multi-method resolution depends
+                    // on argument types and must not be cached by name alone.
+                    if resolved.as_ref().is_none_or(|(_, def)| !def.is_multi) {
+                        self.method_resolve_cache
+                            .insert(cache_key, resolved.clone());
+                    }
                     resolved
                 }
             }


### PR DESCRIPTION
## Summary
- Fix method resolution cache returning wrong candidates for multi-methods (cached by name only, ignoring arg types)
- Fix positional light call path not writing params to env, causing stale value clobbering and false "undeclared" errors for Nil params
- Fix `has_env_writes` flag missing CallMethod/HyperMethodCall opcodes, causing dynamic variable changes to be discarded by `can_skip_merge`

Restores 9 roast tests to the whitelist (1159 -> 1168):
- S02-types/lazy-lists.t
- S03-junctions/autothreading.t (81 subtests)
- S06-advanced/dispatching.t
- S06-advanced/return.t (14 subtests)
- S12-class/basic.t
- S13-overloading/operators.t
- S13-overloading/typecasting-long.t (29 subtests)
- S16-filehandles/filestat.t
- S32-list/tail.t

## Test plan
- [x] All 3 target roast tests pass (autothreading.t, typecasting-long.t, return.t)
- [x] `make test` passes (485 files, 3918 tests)
- [x] `make roast` passes (1168 files)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)