### PR TITLE
fix: perf regression - env sync and attribute accessor fast path

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -123,6 +123,7 @@ roast/S02-types/infinity.t
 roast/S02-types/instants-and-durations.t
 roast/S02-types/int-uint.t
 roast/S02-types/is-type.t
+roast/S02-types/lazy-lists.t
 roast/S02-types/list.t
 roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
@@ -274,6 +275,8 @@ roast/S04-exception-handlers/control.t
 roast/S04-exception-handlers/top-level.t
 roast/S04-exceptions/control_across_runloop.t
 roast/S04-exceptions/fail-6e.t
+roast/S04-exceptions/fail.t
+roast/S04-exceptions/pending.t
 roast/S04-phasers/ascending-order.t
 roast/S04-phasers/begin.t
 roast/S04-phasers/check.t
@@ -969,6 +972,7 @@ roast/S32-io/socket-accept-and-working-threads.t
 roast/S32-io/socket-fail-invalid-values.t
 roast/S32-io/socket-host-port-split.t
 roast/S32-io/spurt.t
+roast/S32-io/tell.t
 roast/S32-io/utf16.t
 roast/S32-list/are.t
 roast/S32-list/batch.t

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -96,6 +96,8 @@ impl VM {
                     | "self"
                     | "clone"
                     | "return"
+                    | "handled"
+                    | "bytes"
             )
         {
             if let Some(val) = attributes.get(method.as_str()) {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -296,14 +296,14 @@ impl VM {
         }
     }
 
-    /// Sync only simple locals to env (the ones whose SetLocal fast path
-    /// skips env writes). Only runs when locals_dirty is set.
+    /// Sync all dirty locals to env. This flushes both simple-scalar locals
+    /// (whose SetLocal fast path skips env writes) AND function parameters
+    /// that were bound directly to locals by `exec_direct_compiled_call`.
+    /// Only runs when locals_dirty is set.
     pub(super) fn ensure_env_synced(&mut self, code: &CompiledCode) {
         if self.locals_dirty {
             for (i, name) in code.locals.iter().enumerate() {
-                if code.simple_locals[i] {
-                    self.set_env_with_main_alias(name, self.locals[i].clone());
-                }
+                self.set_env_with_main_alias(name, self.locals[i].clone());
             }
             self.locals_dirty = false;
         }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -296,17 +296,39 @@ impl VM {
         }
     }
 
-    /// Sync all dirty locals to env. This flushes both simple-scalar locals
-    /// (whose SetLocal fast path skips env writes) AND function parameters
-    /// that were bound directly to locals by `exec_direct_compiled_call`.
+    /// Sync dirty locals to env. Flushes simple-scalar locals (whose SetLocal
+    /// fast path skips env writes) AND bare-name function parameters that were
+    /// bound directly to locals by `exec_direct_compiled_call`.
     /// Only runs when locals_dirty is set.
     pub(super) fn ensure_env_synced(&mut self, code: &CompiledCode) {
         if self.locals_dirty {
             for (i, name) in code.locals.iter().enumerate() {
-                self.set_env_with_main_alias(name, self.locals[i].clone());
+                // Flush simple locals ($ vars that use the SetLocal fast path)
+                // AND bare-name params (no sigil, set by exec_direct_compiled_call).
+                // Skip topic (_), attributes (.x, !x), dynamic vars ($*x), and
+                // package-qualified names (Foo::bar) to avoid corrupting outer scope.
+                if code.simple_locals[i] || Self::is_bare_param_name(name) {
+                    self.set_env_with_main_alias(name, self.locals[i].clone());
+                }
             }
             self.locals_dirty = false;
         }
+    }
+
+    /// Check if a local name looks like a bare function parameter (no sigil).
+    /// These are stored by the compiler for function params like `$n` → `n`.
+    fn is_bare_param_name(name: &str) -> bool {
+        !name.is_empty()
+            && !name.starts_with('$')
+            && !name.starts_with('@')
+            && !name.starts_with('%')
+            && !name.starts_with('&')
+            && !name.starts_with('.')
+            && !name.starts_with('!')
+            && !name.starts_with('^')
+            && name != "_"
+            && !name.contains("::")
+            && !name.starts_with("__mutsu_")
     }
 
     pub(super) fn find_local_slot(&self, code: &CompiledCode, name: &str) -> Option<usize> {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -426,11 +426,9 @@ impl VM {
         // to the interpreter env. We must flush them so the merge logic below
         // can see the changes made by the gather body.
         for (i, name) in cc.locals.iter().enumerate() {
-            if cc.simple_locals[i] {
-                self.interpreter
-                    .env_mut()
-                    .insert(name.clone(), self.locals[i].clone());
-            }
+            self.interpreter
+                .env_mut()
+                .insert(name.clone(), self.locals[i].clone());
         }
 
         // Restore the outer environment, selectively merging changes from


### PR DESCRIPTION
## Summary
- Fix `ensure_env_synced` to flush ALL locals to env (not just simple_locals), fixing gather blocks inside subs that reference parameters
- Exclude `handled` from Instance attribute accessor fast path so Failure.handled correctly checks the global registry
- Exclude `bytes` from Instance attribute accessor fast path so Buf/Blob.bytes returns byte count instead of raw byte array

## Tests fixed
- roast/S02-types/lazy-lists.t (3 failures fixed: gather/take + parameter access)
- roast/S04-exceptions/fail.t (1 failure fixed: Failure.raku.EVAL roundtrip)
- roast/S04-exceptions/pending.t (3 failures fixed: Failure handled flag via .not/.defined)
- roast/S32-io/tell.t (4 failures fixed: .encode.bytes returning count vs array)

All 4 tests added to roast-whitelist.txt.

## Test plan
- [x] All 4 roast tests pass with `prove`
- [x] `make test` passes (2 pre-existing failures unchanged)
- [x] `cargo clippy -- -D warnings` clean
- [x] `roast-whitelist.txt` sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)