### PR TITLE
fix: per-slot dirty tracking prevents env clobbering in ENTER/LEAVE phasers

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -285,6 +285,7 @@ roast/S04-phasers/begin.t
 roast/S04-phasers/check.t
 roast/S04-phasers/descending-order.t
 roast/S04-phasers/end.t
+roast/S04-phasers/enter-leave.t
 roast/S04-phasers/exit-in-check.t
 roast/S04-phasers/first.t
 roast/S04-phasers/in-loop.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -57,6 +57,7 @@ pub(super) struct VmCallFrame {
     pub saved_readonly: HashSet<String>,
     pub saved_env_dirty: bool,
     pub saved_locals_dirty: bool,
+    pub saved_locals_dirty_slots: Vec<bool>,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 
@@ -89,6 +90,10 @@ pub(crate) struct VM {
     /// When true, env may be stale relative to locals (simple local SetLocal skipped env write).
     /// Cleared after ensure_env_synced or sync_env_from_locals.
     locals_dirty: bool,
+    /// Per-slot dirty bitmap: tracks which specific local slots have been written
+    /// via the SetLocal fast path. Only slots marked dirty are flushed by
+    /// ensure_env_synced, preventing uninitialized locals from clobbering env values.
+    locals_dirty_slots: Vec<bool>,
     /// The instruction pointer to resume at after a .resume call in a CATCH block.
     /// Set when Die/Fail creates an exception, used by exec_try_catch_op.
     resume_ip: Option<usize>,
@@ -292,6 +297,7 @@ impl VM {
             call_frames: Vec::new(),
             env_dirty: false,
             locals_dirty: false,
+            locals_dirty_slots: Vec::new(),
             resume_ip: None,
             bind_context: false,
             rebind_context: false,
@@ -330,6 +336,7 @@ impl VM {
         }
         // Initialize local variable slots
         self.locals = vec![Value::Nil; code.locals.len()];
+        self.locals_dirty_slots = vec![false; code.locals.len()];
         for (i, name) in code.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -425,6 +425,7 @@ impl VM {
             None
         };
         let saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_dirty_slots = std::mem::take(&mut self.locals_dirty_slots);
         let saved_stack_depth = self.stack.len();
         let saved_env_dirty = self.env_dirty;
         let saved_locals_dirty = self.locals_dirty;
@@ -447,6 +448,8 @@ impl VM {
         let num_locals = cf.code.locals.len();
         self.locals.clear();
         self.locals.resize(num_locals, Value::Nil);
+        self.locals_dirty_slots.clear();
+        self.locals_dirty_slots.resize(num_locals, false);
         for (i, local_name) in cf.code.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(local_name) {
                 self.locals[i] = val.clone();
@@ -524,6 +527,7 @@ impl VM {
 
         // Restore state
         self.locals = saved_locals;
+        self.locals_dirty_slots = saved_locals_dirty_slots;
         self.env_dirty = saved_env_dirty;
         self.locals_dirty = saved_locals_dirty;
 
@@ -703,6 +707,7 @@ impl VM {
 
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_locals_dirty = self.locals_dirty;
+        let saved_locals_dirty_slots = std::mem::take(&mut self.locals_dirty_slots);
         let saved_env_dirty = self.env_dirty;
         self.locals_dirty = false;
         self.env_dirty = false;
@@ -710,6 +715,7 @@ impl VM {
         let num_locals = cf.code.locals.len();
         self.locals.clear();
         self.locals.resize(num_locals, Value::Nil);
+        self.locals_dirty_slots = vec![false; num_locals];
 
         for (i, local_name) in cf.code.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(local_name) {
@@ -734,6 +740,7 @@ impl VM {
                     self.interpreter.restore_readonly_vars(saved_readonly);
                     self.locals = saved_locals;
                     self.locals_dirty = saved_locals_dirty;
+                    self.locals_dirty_slots = saved_locals_dirty_slots;
                     self.env_dirty = saved_env_dirty;
                     return Err(RuntimeError::new(format!(
                         "Type check failed in binding ${}: expected {}, got {}",
@@ -756,7 +763,12 @@ impl VM {
                     .mark_readonly(&cf.param_defs[param_idx].name);
             }
         }
-        self.locals_dirty = true;
+        // Mark all param slots dirty so ensure_env_synced flushes them.
+        for (param_idx, slot) in param_slots.iter().enumerate() {
+            if param_idx < actual_count {
+                self.mark_local_dirty(*slot);
+            }
+        }
 
         // Save env values for function locals so we can restore them after
         // the function returns. This prevents function-local variables from
@@ -831,6 +843,7 @@ impl VM {
             if !Self::light_return_type_check(check_val, rt) {
                 self.locals = saved_locals;
                 self.locals_dirty = saved_locals_dirty;
+                self.locals_dirty_slots = saved_locals_dirty_slots;
                 self.env_dirty = saved_env_dirty;
                 self.interpreter.restore_readonly_vars(saved_readonly);
                 for (name, old_val) in saved_param_env {
@@ -853,6 +866,7 @@ impl VM {
 
         self.locals = saved_locals;
         self.locals_dirty = saved_locals_dirty;
+        self.locals_dirty_slots = saved_locals_dirty_slots;
         self.env_dirty = saved_env_dirty;
 
         self.interpreter.restore_readonly_vars(saved_readonly);
@@ -951,12 +965,14 @@ impl VM {
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_locals_dirty = self.locals_dirty;
+        let saved_locals_dirty_slots = std::mem::take(&mut self.locals_dirty_slots);
         let saved_env_dirty = self.env_dirty;
         self.locals_dirty = false;
         self.env_dirty = false;
 
         let num_locals = cf.code.locals.len();
         self.locals = vec![Value::Nil; num_locals];
+        self.locals_dirty_slots = vec![false; num_locals];
 
         // Track which env keys we modify so we can restore them.
         let mut modified_env_keys: Vec<(String, Option<Value>)> =
@@ -1059,6 +1075,7 @@ impl VM {
                 } else if pd.required {
                     self.locals = saved_locals;
                     self.locals_dirty = saved_locals_dirty;
+                    self.locals_dirty_slots = saved_locals_dirty_slots;
                     self.env_dirty = saved_env_dirty;
                     return Err(RuntimeError::new(format!(
                         "Required named parameter '{}' not passed",
@@ -1083,6 +1100,7 @@ impl VM {
                 } else if pd.required {
                     self.locals = saved_locals;
                     self.locals_dirty = saved_locals_dirty;
+                    self.locals_dirty_slots = saved_locals_dirty_slots;
                     self.env_dirty = saved_env_dirty;
                     return Err(RuntimeError::new(format!(
                         "Too few positionals passed; expected {} arguments but got {}",
@@ -1245,6 +1263,7 @@ impl VM {
         // Restore locals
         self.locals = saved_locals;
         self.locals_dirty = saved_locals_dirty;
+        self.locals_dirty_slots = saved_locals_dirty_slots;
         self.env_dirty = saved_env_dirty;
 
         // Restore readonly vars
@@ -1452,6 +1471,7 @@ impl VM {
         }
 
         self.locals = vec![Value::Nil; cf.code.locals.len()];
+        self.locals_dirty_slots = vec![false; cf.code.locals.len()];
         for (i, local_name) in cf.code.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(local_name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -528,12 +528,14 @@ impl VM {
 
         // Save/swap stack and locals for the block
         let mut saved_locals = std::mem::take(&mut self.locals);
+        let saved_locals_dirty_slots = std::mem::take(&mut self.locals_dirty_slots);
         let saved_stack = std::mem::take(&mut self.stack);
         let saved_env_dirty = self.env_dirty;
         let saved_locals_dirty = self.locals_dirty;
 
         // Initialize locals for the block
         self.locals = vec![Value::Nil; block_cc.locals.len()];
+        self.locals_dirty_slots = vec![false; block_cc.locals.len()];
         self.env_dirty = false;
         self.locals_dirty = false;
         if captured_env.is_some() {
@@ -599,6 +601,7 @@ impl VM {
 
         // Restore outer state
         self.locals = saved_locals;
+        self.locals_dirty_slots = saved_locals_dirty_slots;
         self.stack = saved_stack;
         self.env_dirty = saved_env_dirty;
         self.locals_dirty = saved_locals_dirty;

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -289,6 +289,7 @@ impl VM {
         }
 
         self.locals = vec![Value::Nil; cc.locals.len()];
+        self.locals_dirty_slots = vec![false; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(local_name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -24,6 +24,7 @@ impl VM {
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
             saved_locals_dirty: self.locals_dirty,
+            saved_locals_dirty_slots: std::mem::take(&mut self.locals_dirty_slots),
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
         };
         self.env_dirty = false;
@@ -39,6 +40,7 @@ impl VM {
             .pop()
             .expect("pop_call_frame: no frame to pop");
         self.locals = std::mem::take(&mut frame.saved_locals);
+        self.locals_dirty_slots = std::mem::take(&mut frame.saved_locals_dirty_slots);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         self.interpreter
             .restore_readonly_vars(std::mem::take(&mut frame.saved_readonly));
@@ -303,6 +305,13 @@ impl VM {
     pub(super) fn ensure_env_synced(&mut self, code: &CompiledCode) {
         if self.locals_dirty {
             for (i, name) in code.locals.iter().enumerate() {
+                // Only flush slots that have actually been written to.
+                // This prevents uninitialized locals (from later code that
+                // hasn't executed yet) from clobbering env values set by
+                // other mechanisms (e.g. for-loop parameter binding).
+                if i < self.locals_dirty_slots.len() && !self.locals_dirty_slots[i] {
+                    continue;
+                }
                 // Flush simple locals ($ vars that use the SetLocal fast path)
                 // AND bare-name params (no sigil, set by exec_direct_compiled_call).
                 // Skip topic (_), attributes (.x, !x), dynamic vars ($*x), and
@@ -312,6 +321,9 @@ impl VM {
                 }
             }
             self.locals_dirty = false;
+            for slot in self.locals_dirty_slots.iter_mut() {
+                *slot = false;
+            }
         }
     }
 
@@ -329,6 +341,15 @@ impl VM {
             && name != "_"
             && !name.contains("::")
             && !name.starts_with("__mutsu_")
+    }
+
+    /// Mark a specific local slot as dirty so ensure_env_synced will flush it.
+    #[inline(always)]
+    pub(super) fn mark_local_dirty(&mut self, idx: usize) {
+        self.locals_dirty = true;
+        if idx < self.locals_dirty_slots.len() {
+            self.locals_dirty_slots[idx] = true;
+        }
     }
 
     pub(super) fn find_local_slot(&self, code: &CompiledCode, name: &str) -> Option<usize> {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -373,6 +373,7 @@ impl VM {
 
         // Initialize locals for the compiled code
         self.locals = vec![Value::Nil; cc.locals.len()];
+        self.locals_dirty_slots = vec![false; cc.locals.len()];
         for (i, name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -357,6 +357,7 @@ impl VM {
 
         // Initialize locals from env
         self.locals = vec![Value::Nil; cc.locals.len()];
+        self.locals_dirty_slots = vec![false; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.interpreter.env().get(local_name) {
                 self.locals[i] = val.clone();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3007,21 +3007,21 @@ impl VM {
             // (unless rebinding, which replaces the ref with a new value).
             if !is_rebind && let Value::HashSlotRef { .. } = &self.locals[idx] {
                 self.locals[idx].hash_slot_write(val);
-                self.locals_dirty = true;
+                self.mark_local_dirty(idx);
                 return Ok(());
             }
             // If the current value is a DeferredHashAccess (from lazy binding),
             // autovivify the path and write the value.
             if !is_rebind && let Value::DeferredHashAccess { .. } = &self.locals[idx] {
                 self.locals[idx].deferred_hash_write(val);
-                self.locals_dirty = true;
+                self.mark_local_dirty(idx);
                 return Ok(());
             }
             // If the current value is an ArraySlotRef, write back to the parent array
             // (unless rebinding, which replaces the ref with a new value).
             if !is_rebind && let Value::ArraySlotRef { .. } = &self.locals[idx] {
                 self.locals[idx].array_slot_write(val);
-                self.locals_dirty = true;
+                self.mark_local_dirty(idx);
                 return Ok(());
             }
             if !name.starts_with('@') && !name.starts_with('%') {
@@ -3082,7 +3082,7 @@ impl VM {
                 self.interpreter
                     .set_shared_var(name, self.locals[idx].clone());
             } else {
-                self.locals_dirty = true;
+                self.mark_local_dirty(idx);
             }
             // When rebinding (`$x := expr`), remove old bind pairs and reverse aliases.
             if is_rebind {
@@ -3132,7 +3132,7 @@ impl VM {
                     self.locals[idx].clone(),
                 );
             }
-            self.locals_dirty = true;
+            self.mark_local_dirty(idx);
             return Ok(());
         }
 
@@ -3598,7 +3598,7 @@ impl VM {
             && let Value::HashSlotRef { .. } = &self.locals[idx]
         {
             self.locals[idx].hash_slot_write(val);
-            self.locals_dirty = true;
+            self.mark_local_dirty(idx);
             return Ok(());
         }
         // If the current value is a DeferredHashAccess (from lazy binding),
@@ -3608,7 +3608,7 @@ impl VM {
             && let Value::DeferredHashAccess { .. } = &self.locals[idx]
         {
             self.locals[idx].deferred_hash_write(val);
-            self.locals_dirty = true;
+            self.mark_local_dirty(idx);
             return Ok(());
         }
         // If the current value is an ArraySlotRef, write back to the parent array
@@ -3618,7 +3618,7 @@ impl VM {
             && let Value::ArraySlotRef { .. } = &self.locals[idx]
         {
             self.locals[idx].array_slot_write(val);
-            self.locals_dirty = true;
+            self.mark_local_dirty(idx);
             return Ok(());
         }
         // When binding a Proxy to a variable, update FETCH/STORE closures' captured envs
@@ -3910,7 +3910,7 @@ impl VM {
                 self.interpreter
                     .set_shared_var(name, self.locals[idx].clone());
             } else {
-                self.locals_dirty = true;
+                self.mark_local_dirty(idx);
             }
             // Track topic mutations for map rw writeback
             if name == "_" {
@@ -3919,7 +3919,7 @@ impl VM {
                     self.locals[idx].clone(),
                 );
             }
-            self.locals_dirty = true;
+            self.mark_local_dirty(idx);
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- Fixed a compiler/VM state leak where `ensure_env_synced` would flush ALL simple/bare-name locals to env, even uninitialized ones from later code that hadn't executed yet
- Added per-slot dirty bitmap (`locals_dirty_slots`) so only slots actually written via `SetLocal` are flushed to env
- This fixes `roast/S04-phasers/enter-leave.t` test 6 ("ENTER/LEAVE repeats on loop blocks") where `$x` was empty inside phasers when running the full test file

## Root cause
When a file had `my $x = 0` declared later (not yet executed), its local slot held `Nil`. The `ensure_env_synced` function would write this `Nil` to env, overwriting the for-loop's `$x` parameter that was correctly set by the VM's for-loop dispatch. ENTER/LEAVE phaser closures would then see the clobbered empty value.

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-phasers/enter-leave.t` passes (all 36 tests)
- [x] `make test` passes (485 files, 3918 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Added `roast/S04-phasers/enter-leave.t` to whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)