### PR TITLE
fix: return type smiley (:D/:U) checking for --> constraints

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -455,6 +455,7 @@ roast/S06-other/main-semicolon.t
 roast/S06-other/main-usage.t
 roast/S06-other/misc.t
 roast/S06-other/pairs-as-lvalues.t
+roast/S06-parameters/smiley.t
 roast/S06-routine-modifiers/lvalue-subroutines.t
 roast/S06-routine-modifiers/native-lvalue-subroutines.t
 roast/S06-routine-modifiers/proxy.t

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -270,18 +270,47 @@ impl Interpreter {
     }
 
     /// Create an X::TypeCheck::Return exception
-    fn throw_type_check_return(&self, got: &Value) -> RuntimeError {
+    fn throw_type_check_return(&self, expected: &str, got: &Value) -> RuntimeError {
+        let got_type = Self::display_type_name(got);
+        let got_gist = Self::display_gist(got);
         let msg = format!(
-            "Type check failed for return value; expected a type object coercion, got {}",
-            super::utils::value_type_name(got)
+            "Type check failed for return value; expected {} but got {} ({})",
+            expected, got_type, got_gist
         );
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         attrs.insert("got".to_string(), got.clone());
+        attrs.insert(
+            "expected".to_string(),
+            Value::Package(Symbol::intern(expected)),
+        );
         let exception = Value::make_instance(Symbol::intern("X::TypeCheck::Return"), attrs);
         let mut err = RuntimeError::new(msg);
         err.exception = Some(Box::new(exception));
         err
+    }
+
+    /// Get the display type name for error messages (Package shows its name)
+    fn display_type_name(value: &Value) -> String {
+        match value {
+            Value::Package(name) => name.resolve().to_string(),
+            _ => super::utils::value_type_name(value).to_string(),
+        }
+    }
+
+    /// Get a gist-like representation for error messages
+    fn display_gist(value: &Value) -> String {
+        match value {
+            Value::Package(name) => name.resolve().to_string(),
+            Value::Str(s) => format!("\"{}\"", s),
+            Value::Int(i) => i.to_string(),
+            Value::BigInt(n) => n.to_string(),
+            Value::Num(n) => format!("{}", n),
+            Value::Bool(b) => if *b { "True" } else { "False" }.to_string(),
+            Value::Rat(n, d) => format!("{}", *n as f64 / *d as f64),
+            Value::Nil => "Nil".to_string(),
+            _ => value.to_string_value(),
+        }
     }
 
     /// Create an X::Coerce::Impossible exception
@@ -326,7 +355,7 @@ impl Interpreter {
             } else {
                 // Non-coercion subset: just check the base type
                 if !self.type_matches_value(&subset.base, &value) {
-                    return Err(self.throw_type_check_return(&value));
+                    return Err(self.throw_type_check_return(spec, &value));
                 }
                 value
             };
@@ -334,7 +363,7 @@ impl Interpreter {
             if let Some(ref pred) = subset.predicate {
                 let pred_clone = pred.clone();
                 if !self.check_where_constraint(&pred_clone, &coerced) {
-                    return Err(self.throw_type_check_return(&coerced));
+                    return Err(self.throw_type_check_return(spec, &coerced));
                 }
             }
             return Ok(coerced);
@@ -347,7 +376,7 @@ impl Interpreter {
 
         // Plain type constraint (e.g., Str, Int:D)
         if !self.type_matches_value(spec, &value) {
-            return Err(self.throw_type_check_return(&value));
+            return Err(self.throw_type_check_return(spec, &value));
         }
         Ok(value)
     }
@@ -382,7 +411,7 @@ impl Interpreter {
             if !self.type_matches_value(src, &value)
                 && !self.type_matches_value(base_target, &value)
             {
-                return Err(self.throw_type_check_return(&value));
+                return Err(self.throw_type_check_return(spec, &value));
             }
         }
 

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -227,6 +227,7 @@ impl Interpreter {
             let same = existing.package == new_def.package
                 && existing.name == new_def.name
                 && existing.params == new_def.params
+                && existing.return_type == new_def.return_type
                 && format!("{:?}", existing.param_defs) == format!("{:?}", new_def.param_defs)
                 && body_debug_without_setline(&existing.body)
                     == body_debug_without_setline(&new_def.body);


### PR DESCRIPTION
## Summary
- Fixed sub re-registration ignoring return type differences, causing `:D`/`:U` smiley constraints on `-->` return types to not be enforced when a same-bodied sub was previously registered in scope
- Improved `X::TypeCheck::Return` error messages to match Raku's format: `expected Int:D but got Int (Int)` instead of generic `expected a type object coercion, got Package`
- Added `roast/S06-parameters/smiley.t` to the whitelist (39/39 tests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-parameters/smiley.t` passes all 39 tests
- [x] `make test` passes (485 files, 3918 tests)
- [x] `make roast` passes all whitelisted tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)