### PR TITLE
fix: propagate die in supply/react as X::React::Died

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -849,6 +849,7 @@ roast/S17-supply/split.t
 roast/S17-supply/squish.t
 roast/S17-supply/start.t
 roast/S17-supply/supplier-preserving.t
+roast/S17-supply/syntax-nonblocking-await.t
 roast/S17-supply/tail.t
 roast/S17-supply/unique.t
 roast/S17-supply/wait.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -173,6 +173,7 @@ mod native_supply_methods;
 pub(crate) mod native_types;
 mod ops;
 pub(crate) mod phasers;
+mod react_died;
 mod regex;
 mod regex_parse;
 mod registration;

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -1,0 +1,188 @@
+//! Helpers for wrapping errors in `X::React::Died` when a `react` block
+//! encounters an unhandled exception from a supply.
+
+use super::subtest::ReactSubscription;
+use super::*;
+use crate::runtime::native_methods::take_supply_channel;
+use crate::symbol::Symbol;
+use std::collections::HashMap;
+
+impl Interpreter {
+    /// Wrap a `RuntimeError` in `X::React::Died`.
+    /// The resulting exception reports as `X::React::Died` and includes
+    /// the original error message and backtrace in its gist.
+    pub(crate) fn wrap_react_died(inner: RuntimeError) -> RuntimeError {
+        let original_message = inner.message.clone();
+        let backtrace_str = inner.backtrace.clone().unwrap_or_default();
+        let mut gist = format!(
+            "A react block:\n\nDied because of the exception:\n    {}",
+            original_message
+        );
+        if !backtrace_str.is_empty() {
+            gist.push_str(&format!("\n{}", backtrace_str));
+        }
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(gist.clone()));
+        attrs.insert("original-message".to_string(), Value::str(original_message));
+        if let Some(ref ex) = inner.exception {
+            attrs.insert("exception".to_string(), *ex.clone());
+        }
+        let exception = Value::make_instance(Symbol::intern("X::React::Died"), attrs);
+        let mut err = RuntimeError::new(gist);
+        err.exception = Some(Box::new(exception));
+        err
+    }
+
+    /// Wrap a `RuntimeError` in `X::React::Died` if not already wrapped.
+    pub(crate) fn wrap_react_died_if_needed(err: RuntimeError) -> RuntimeError {
+        if let Some(ref ex) = err.exception
+            && let Value::Instance { class_name, .. } = ex.as_ref()
+            && class_name.resolve() == "X::React::Died"
+        {
+            return err;
+        }
+        Self::wrap_react_died(err)
+    }
+
+    /// Check if a value is a subscription registration from `whenever` inside `supply`.
+    pub(crate) fn is_supply_subscription_registration(value: &Value) -> bool {
+        if let Value::Array(items, ..) = value
+            && items.len() >= 2
+        {
+            matches!(
+                &items[0],
+                Value::Instance { class_name, .. }
+                    if class_name == "Supply"
+                        || class_name == "Supplier"
+                        || class_name == "Supplier::Preserving"
+            ) || matches!(&items[0], Value::Promise(_) | Value::Channel(_))
+        } else {
+            false
+        }
+    }
+
+    /// Convert a subscription registration Value into a ReactSubscription.
+    /// Used when `supply { whenever ... { ... } }` creates inner subscriptions
+    /// that need to be processed by the outer react's event loop.
+    pub(crate) fn value_to_react_subscription(
+        &mut self,
+        sub_val: &Value,
+    ) -> Option<ReactSubscription> {
+        let Value::Array(items, ..) = sub_val else {
+            return None;
+        };
+        if items.len() < 2 {
+            return None;
+        }
+        let source = &items[0];
+        let callback = items[1].clone();
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = source
+        {
+            if class_name != "Supply" {
+                return None;
+            }
+            let supply_id = self.resolve_supply_channel_id_for_react(attributes);
+            let is_lines = matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
+            let head_limit = Self::extract_supply_head_limit(attributes);
+            if let Some(sid) = supply_id
+                && let Some(rx) = take_supply_channel(sid)
+            {
+                let last_cbs = items
+                    .get(2)
+                    .and_then(Self::react_value_array_items)
+                    .unwrap_or_default();
+                let quit_cbs = items
+                    .get(3)
+                    .and_then(Self::react_value_array_items)
+                    .unwrap_or_default();
+                return Some(ReactSubscription {
+                    receiver: Some(rx),
+                    supplier_id: None,
+                    supplier_next_index: 0,
+                    callback,
+                    close_callbacks: Self::extract_supply_on_close_cbs(attributes),
+                    last_callbacks: last_cbs,
+                    quit_callbacks: quit_cbs,
+                    done: false,
+                    is_lines,
+                    line_buffer: String::new(),
+                    head_limit,
+                    emit_count: 0,
+                    channel: None,
+                    promise: None,
+                });
+            }
+            if let Some(Value::Int(sid)) = attributes.get("supplier_id") {
+                let last_cbs = items
+                    .get(2)
+                    .and_then(Self::react_value_array_items)
+                    .unwrap_or_default();
+                let quit_cbs = items
+                    .get(3)
+                    .and_then(Self::react_value_array_items)
+                    .unwrap_or_default();
+                return Some(ReactSubscription {
+                    receiver: None,
+                    supplier_id: Some(*sid as u64),
+                    supplier_next_index: 0,
+                    callback,
+                    close_callbacks: Self::extract_supply_on_close_cbs(attributes),
+                    last_callbacks: last_cbs,
+                    quit_callbacks: quit_cbs,
+                    done: false,
+                    is_lines,
+                    line_buffer: String::new(),
+                    head_limit,
+                    emit_count: 0,
+                    channel: None,
+                    promise: None,
+                });
+            }
+        }
+        None
+    }
+
+    // Helpers that duplicate subtest.rs private helpers (to avoid
+    // visibility issues).
+
+    fn extract_supply_head_limit(attributes: &HashMap<String, Value>) -> Option<usize> {
+        if let Some(Value::Int(n)) = attributes.get("head_limit") {
+            Some(*n as usize)
+        } else {
+            None
+        }
+    }
+
+    fn extract_supply_on_close_cbs(attributes: &HashMap<String, Value>) -> Vec<Value> {
+        if let Some(Value::Array(callbacks, ..)) = attributes.get("on_close_callbacks") {
+            callbacks.to_vec()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn react_value_array_items(value: &Value) -> Option<Vec<Value>> {
+        if let Value::Array(items, ..) = value {
+            Some(items.to_vec())
+        } else {
+            None
+        }
+    }
+
+    fn resolve_supply_channel_id_for_react(
+        &self,
+        attributes: &HashMap<String, Value>,
+    ) -> Option<u64> {
+        if let Some(Value::Int(parent_id)) = attributes.get("parent_supply_id") {
+            return Some(*parent_id as u64);
+        }
+        if let Some(Value::Int(id)) = attributes.get("supply_id") {
+            return Some(*id as u64);
+        }
+        None
+    }
+}

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -256,13 +256,28 @@ impl Interpreter {
                             emitter_attrs.insert("done".to_string(), Value::Bool(false));
                             let emitter =
                                 Value::make_instance(Symbol::intern("Supplier"), emitter_attrs);
-                            // Execute the on-demand callback, which calls emit on the emitter
+                            // Execute the on-demand callback, which calls emit on the emitter.
+                            // If the callback dies, propagate as X::React::Died.
                             self.supply_emit_buffer.push(Vec::new());
-                            let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
+                            let od_res =
+                                self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
                             let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
-                            // Replay emitted values
+                            if let Err(od_err) = od_res
+                                && !od_err.is_react_done
+                            {
+                                return Err(Self::wrap_react_died(od_err));
+                            }
+                            // The emitted items may include subscription registrations
+                            // from `whenever` inside the supply body. Convert them to
+                            // ReactSubscriptions for the event loop.
                             for v in emitted {
-                                let _ = self.call_sub_value(callback.clone(), vec![v], true);
+                                if Self::is_supply_subscription_registration(&v) {
+                                    if let Some(rsub) = self.value_to_react_subscription(&v) {
+                                        react_subs.push(rsub);
+                                    }
+                                } else {
+                                    let _ = self.call_sub_value(callback.clone(), vec![v], true);
+                                }
                             }
                         } else {
                             // No channel, no on-demand - replay static values
@@ -437,7 +452,8 @@ impl Interpreter {
                             continue;
                         }
                         Self::run_react_close_callbacks(self, &react_subs);
-                        return Err(Self::runtime_error_from_supply_reason(error));
+                        let quit_err = Self::runtime_error_from_supply_reason(error);
+                        return Err(Self::wrap_react_died(quit_err));
                     }
                     if done {
                         if sub.is_lines && !sub.line_buffer.is_empty() {
@@ -528,7 +544,8 @@ impl Interpreter {
                         }
                         sub.done = true;
                         if !handled {
-                            return Err(Self::runtime_error_from_supply_reason(error));
+                            let ch_quit_err = Self::runtime_error_from_supply_reason(error);
+                            return Err(Self::wrap_react_died(ch_quit_err));
                         }
                     }
                     Err(mpsc::RecvTimeoutError::Timeout) => {}

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1417,7 +1417,8 @@ impl VM {
         if let Err(err) = event_result
             && !err.is_react_done
         {
-            return Err(err);
+            // Wrap in X::React::Died if not already wrapped
+            return Err(crate::runtime::Interpreter::wrap_react_died_if_needed(err));
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- When a `die` occurs inside a `supply` block or its `whenever` handler, the error is now properly wrapped in `X::React::Died` and propagated to the enclosing `react` block's CATCH handler
- Inner `whenever` subscriptions from supply blocks are forwarded to the outer react event loop as ReactSubscriptions (fixes `supply { whenever Supply.interval(...) { die ... } }` pattern)
- Quit events from suppliers and channels are wrapped in `X::React::Died`
- New `react_died.rs` module with helper functions for wrapping errors

## Test plan
- [x] `roast/S17-supply/syntax-nonblocking-await.t` passes all 9 subtests (was 5/9)
- [x] `cargo test` passes (449 tests)
- [x] `make test` passes
- [x] `make roast` passes (flaky timeout on defer-next.t is pre-existing)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)