### PR TITLE
fix: END phaser env handling for closures and EVAL contexts

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -288,6 +288,7 @@ roast/S04-phasers/end.t
 roast/S04-phasers/enter-leave.t
 roast/S04-phasers/exit-in-check.t
 roast/S04-phasers/first.t
+roast/S04-phasers/in-eval.t
 roast/S04-phasers/in-loop.t
 roast/S04-phasers/init.t
 roast/S04-phasers/interpolate.t

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1755,6 +1755,46 @@ impl Interpreter {
         self.end_phasers.push((body, captured_env));
     }
 
+    /// Return the number of currently registered END phasers.
+    pub(crate) fn end_phaser_count(&self) -> usize {
+        self.end_phasers.len()
+    }
+
+    /// Update captured envs for END phasers registered since `start_idx`
+    /// with the current values from the given env.  This ensures that END
+    /// phasers see final variable values rather than stale copies captured
+    /// at registration time (e.g., inside closures or block scopes).
+    pub(crate) fn update_end_phaser_envs(&mut self, start_idx: usize, current_env: &Env) {
+        for phaser in self.end_phasers[start_idx..].iter_mut() {
+            let captured = &mut phaser.1;
+            for (k, v) in current_env {
+                if captured.contains_key(k) {
+                    captured.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+
+    /// Update captured envs of ALL END phasers, but only for the specified
+    /// variable names.  Used after closure calls to propagate changes to
+    /// captured variables without overwriting unrelated variables.
+    pub(crate) fn update_end_phaser_envs_for_keys(
+        &mut self,
+        keys: &std::collections::HashSet<&str>,
+        current_env: &Env,
+    ) {
+        for phaser in self.end_phasers.iter_mut() {
+            let captured = &mut phaser.1;
+            for k in keys {
+                if captured.contains_key(*k)
+                    && let Some(v) = current_env.get(*k)
+                {
+                    captured.insert(k.to_string(), v.clone());
+                }
+            }
+        }
+    }
+
     /// Register an END phaser site_id. Returns true if this is the first
     /// registration (phaser should be pushed), false if already registered.
     pub(crate) fn register_end_phaser_site(&mut self, site_id: u64) -> bool {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -867,17 +867,42 @@ impl Interpreter {
             // Clear halted flag so END phasers can execute even after exit()
             self.halted = false;
             let phasers = self.end_phasers.clone();
+            // Save the env state before any END phasers run.  This lets us
+            // distinguish between variables set by prior END phasers (which
+            // should propagate) and stale captured values (which should not
+            // override live values).
+            let original_env = self.env.clone();
             for (body, captured_env) in phasers.iter().rev() {
                 // Track which keys are being added from captured env
                 // (not already present) so we can remove them after.
                 let mut overlay_keys: Vec<String> = Vec::new();
-                // Overlay captured lexical env on top of current env
-                // so both globals and captured lexicals are visible
+                // Overlay captured lexical env on top of current env.
+                // For keys already in the current env, only overlay if the
+                // key was NOT in the original env (meaning it was injected
+                // by a prior END phaser's overlay, not a live program
+                // variable).  This preserves live values and prior-END
+                // modifications while still providing access to captured
+                // lexicals from dead scopes.
                 for (k, v) in captured_env {
                     if !self.env.contains_key(k) {
                         overlay_keys.push(k.clone());
+                        self.env.insert(k.clone(), v.clone());
+                    } else if let Some(orig_v) = original_env.get(k) {
+                        // Key exists in both current and original env.
+                        // Overlay with captured value only if the captured
+                        // value differs from the original — this indicates
+                        // the captured value comes from a different lexical
+                        // scope (e.g. { my $a = 42; END { ... } }).
+                        if v != orig_v {
+                            self.env.insert(k.clone(), v.clone());
+                        }
+                        // If captured == original, it's the same variable —
+                        // keep the current (possibly mutated) value.
+                    } else {
+                        // Key was added by a prior END phaser's overlay.
+                        // Override with this phaser's captured value.
+                        self.env.insert(k.clone(), v.clone());
                     }
-                    self.env.insert(k.clone(), v.clone());
                 }
                 self.run_block(body)?;
                 // Remove only the overlay keys (captured lexicals not in

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -558,6 +558,19 @@ impl VM {
 
         *self.interpreter.env_mut() = restored_env;
 
+        // After a closure returns, update captured envs of END phasers for
+        // variables that the closure captures (and may have modified).  This
+        // ensures END phasers see the final values rather than stale copies.
+        // Only update keys matching the closure's captured variable names to
+        // avoid overwriting unrelated captured lexicals in other END phasers.
+        if self.interpreter.end_phaser_count() > 0 && !data.env.is_empty() {
+            let captured_names: std::collections::HashSet<&str> =
+                data.env.keys().map(|s| s.as_str()).collect();
+            let current = self.interpreter.env().clone();
+            self.interpreter
+                .update_end_phaser_envs_for_keys(&captured_names, &current);
+        }
+
         let return_spec = data.env.get("__mutsu_return_type").and_then(|v| match v {
             Value::Str(s) => Some(s.to_string()),
             _ => None,

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2166,6 +2166,7 @@ impl VM {
         self.interpreter.push_enum_scope();
         let stack_base = self.stack.len();
         let topic_before = self.last_topic_value.clone();
+        let end_phaser_count_before = self.interpreter.end_phaser_count();
         // If ENTER died, skip the body but still run LEAVE phasers
         let mut body_result = if let Err(e) = enter_result {
             Err(e)
@@ -2271,6 +2272,14 @@ impl VM {
         let block_declared = self.block_declared_vars.pop().unwrap_or_default();
 
         self.ensure_env_synced(code);
+        // Update captured envs of END phasers registered during this block
+        // so they see the final values of block-scoped variables (which will
+        // be removed from env when the block scope is restored below).
+        if self.interpreter.end_phaser_count() > end_phaser_count_before {
+            let current = self.interpreter.env().clone();
+            self.interpreter
+                .update_end_phaser_envs(end_phaser_count_before, &current);
+        }
         let current_env = self.interpreter.env().clone();
         let mut restored_env = saved_env.clone();
         for (k, v) in current_env {


### PR DESCRIPTION
## Summary
- Fix END phasers seeing stale captured variable values when registered inside closures called after EVAL
- After closure calls, update END phaser captured envs for the closure's captured variables
- At BlockScope exit, update END phaser captured envs with final block-scoped variable values
- Smarter overlay logic in `finish()`: only override existing values when captured value differs from original (indicating a different lexical scope), preserving live mutations from prior END phasers
- Adds `roast/S04-phasers/in-eval.t` to whitelist (35 tests)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-phasers/in-eval.t` passes (35/35)
- [x] `prove -e 'target/debug/mutsu' roast/S04-phasers/end.t` passes (no regression)
- [x] All 17 whitelisted S04-phasers roast tests pass
- [x] `make test` passes (485 files, 3965 tests)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)