### PR TITLE
feat: implement $?DISTRIBUTION support and Distribution.meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +406,7 @@ dependencies = [
  "rustc-hash",
  "rustyline",
  "serde",
+ "serde_json",
  "unicode-normalization",
  "unicode-segmentation",
  "unicode_names2",
@@ -734,6 +741,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1136,3 +1156,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 rustc-hash = "2.1.1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 bincode = "1"
 icu_collator = "2.1"
 icu_collator_data = "2.1"

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1043,6 +1043,28 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
+    // Distribution methods: meta, Str, gist, defined
+    if let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+        && class_name == "Distribution"
+    {
+        match method {
+            "meta" => {
+                return Some(Ok(attributes.get("$!meta").cloned().unwrap_or(
+                    Value::Hash(std::sync::Arc::new(std::collections::HashMap::new())),
+                )));
+            }
+            "Str" | "gist" => {
+                return Some(Ok(Value::str(format!("Distribution<{}>", class_name))));
+            }
+            "defined" => return Some(Ok(Value::Bool(true))),
+            _ => {}
+        }
+    }
+
     // Exception/X:: methods: gist, Str, message
     if let Value::Instance {
         class_name,

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -462,9 +462,10 @@ impl Compiler {
             let idx = self.code.add_constant(Value::str(slang_name.to_string()));
             self.code.emit(OpCode::LoadConst(idx));
         }
-        // $?DISTRIBUTION is Nil outside of a distribution context
+        // $?DISTRIBUTION resolves to the current distribution context, or Nil
         else if name == "?DISTRIBUTION" {
-            let idx = self.code.add_constant(Value::Nil);
+            let dist = self.current_distribution.clone().unwrap_or(Value::Nil);
+            let idx = self.code.add_constant(dist);
             self.code.emit(OpCode::LoadConst(idx));
         }
         // Compile-time package/module variables

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -103,6 +103,8 @@ impl Compiler {
         // Propagate last_source_line so the sub body knows which line
         // the sub was defined at (for backtraces).
         sub_compiler.last_source_line = self.last_source_line;
+        // Propagate distribution context so $?DISTRIBUTION works inside subs
+        sub_compiler.current_distribution = self.current_distribution.clone();
         let arity = param_defs
             .iter()
             .filter(|p| !p.named && (!p.slurpy || p.name == "_capture"))

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -79,6 +79,8 @@ pub(crate) struct Compiler {
     /// we need to write the temp variable value back to the original hash/array slot.
     /// Each entry is (original Index Expr, temp variable name).
     pub(super) pending_index_rw_writebacks: Vec<(Expr, String, String)>,
+    /// The current distribution context for $?DISTRIBUTION.
+    pub(crate) current_distribution: Option<Value>,
 }
 
 impl Compiler {
@@ -103,6 +105,7 @@ impl Compiler {
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
+            current_distribution: None,
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -873,6 +873,11 @@ pub struct Interpreter {
     protect_block_cache: ProtectBlockCache,
     private_zeroarg_method_cache: HashMap<(String, String), Option<(String, MethodDef)>>,
     module_load_stack: Vec<String>,
+    /// The current distribution context ($?DISTRIBUTION).
+    pub(crate) current_distribution: Option<Value>,
+    /// Maps package names to their distribution context.
+    /// Populated during module loading so OTF compilation can resolve $?DISTRIBUTION.
+    pub(crate) package_distributions: HashMap<String, Value>,
     /// Exported subroutine symbols by package and export tag.
     exported_subs: HashMap<String, HashMap<String, HashSet<String>>>,
     /// Exported variable/constant symbols by package and export tag.
@@ -2877,6 +2882,8 @@ impl Interpreter {
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
+            current_distribution: None,
+            package_distributions: HashMap::new(),
             exported_subs: HashMap::new(),
             exported_vars: HashMap::new(),
             unit_module_exported_subs: HashMap::new(),
@@ -4736,6 +4743,8 @@ impl Interpreter {
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
+            current_distribution: self.current_distribution.clone(),
+            package_distributions: self.package_distributions.clone(),
             exported_subs: self.exported_subs.clone(),
             exported_vars: self.exported_vars.clone(),
             unit_module_exported_subs: self.unit_module_exported_subs.clone(),

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1474,6 +1474,12 @@ impl Interpreter {
             self.current_package.clone()
         };
         compiler.set_current_package(scope);
+        // Resolve distribution context for $?DISTRIBUTION
+        compiler.current_distribution = self.current_distribution.clone().or_else(|| {
+            self.package_distributions
+                .get(&self.current_package)
+                .cloned()
+        });
         let (code, compiled_fns) = compiler.compile(body);
         self.block_scope_depth += 1;
         let result = self.run_compiled_block(&code, &compiled_fns);

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1211,10 +1211,10 @@ impl Interpreter {
         let mut dir = source_path.parent()?;
         for _ in 0..4 {
             let meta_path = dir.join("META6.json");
-            if meta_path.exists() {
-                if let Ok(content) = fs::read_to_string(&meta_path) {
-                    return Self::build_distribution_from_meta(&content);
-                }
+            if meta_path.exists()
+                && let Ok(content) = fs::read_to_string(&meta_path)
+            {
+                return Self::build_distribution_from_meta(&content);
             }
             dir = dir.parent()?;
         }
@@ -1267,12 +1267,12 @@ impl Interpreter {
                 let path = entry.path();
                 if path.is_file() {
                     for ext in &extensions {
-                        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                            if name.ends_with(ext) {
-                                let module_name = name[..name.len() - ext.len()].replace('/', "::");
-                                let relative = format!("lib/{}", name);
-                                provides.insert(module_name, Value::str(relative));
-                            }
+                        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                            && let Some(stem) = name.strip_suffix(ext)
+                        {
+                            let module_name = stem.replace('/', "::");
+                            let relative = format!("lib/{}", name);
+                            provides.insert(module_name, Value::str(relative));
                         }
                     }
                 }
@@ -1286,11 +1286,11 @@ impl Interpreter {
         if let Ok(entries) = std::fs::read_dir(resources_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_file() {
-                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        let key = format!("resources/{}", name);
-                        files.insert(key.clone(), Value::str(key));
-                    }
+                if path.is_file()
+                    && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                {
+                    let key = format!("resources/{}", name);
+                    files.insert(key.clone(), Value::str(key));
                 }
             }
         }

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -853,6 +853,14 @@ impl Interpreter {
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
         compiler.set_current_package(self.current_package.clone());
+        // Resolve distribution context: prefer the current one, then look up
+        // by the current package name in case we're running a function body
+        // from a module that had a distribution.
+        compiler.current_distribution = self.current_distribution.clone().or_else(|| {
+            self.package_distributions
+                .get(&self.current_package)
+                .cloned()
+        });
         let (code, compiled_fns) = compiler.compile(stmts);
         let interp = std::mem::take(self);
         let vm = crate::vm::VM::new(interp);
@@ -1149,6 +1157,20 @@ impl Interpreter {
                 self.imported_operator_names.insert(name);
             }
         }
+        // Detect distribution context (META6.json) for $?DISTRIBUTION.
+        let saved_distribution = self.current_distribution.clone();
+        if let Some(dist) = Self::detect_distribution(&source_path) {
+            self.current_distribution = Some(dist.clone());
+            // Record the distribution for the module's package name
+            // so OTF compilation can resolve $?DISTRIBUTION later.
+            self.package_distributions
+                .insert(module.to_string(), dist.clone());
+            // Also record under the current runtime package (typically GLOBAL
+            // for unit modules) since the interpreter's current_package may not
+            // match the module name during function body evaluation.
+            self.package_distributions
+                .insert(self.current_package.clone(), dist);
+        }
         // Save and restore the language version around module loading.
         // Each module may set its own `use v6.*` which should not leak
         // into the caller's language version.
@@ -1180,7 +1202,136 @@ impl Interpreter {
             result?;
         }
         crate::parser::set_current_language_version(&saved_language_version);
+        self.current_distribution = saved_distribution;
         Ok(())
+    }
+
+    /// Detect a distribution (META6.json) for the given module source path.
+    fn detect_distribution(source_path: &Path) -> Option<Value> {
+        let mut dir = source_path.parent()?;
+        for _ in 0..4 {
+            let meta_path = dir.join("META6.json");
+            if meta_path.exists() {
+                if let Ok(content) = fs::read_to_string(&meta_path) {
+                    return Self::build_distribution_from_meta(&content);
+                }
+            }
+            dir = dir.parent()?;
+        }
+        // No META6.json found; build a minimal auto-generated distribution
+        let lib_dir = source_path.parent()?;
+        Some(Self::build_distribution_from_lib_dir(lib_dir))
+    }
+
+    fn build_distribution_from_meta(json_content: &str) -> Option<Value> {
+        let meta_hash = Self::parse_meta6_json(json_content)?;
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "$!meta".to_string(),
+            Value::Hash(std::sync::Arc::new(meta_hash)),
+        );
+        Some(Value::make_instance_without_destroy(
+            crate::symbol::Symbol::intern("Distribution"),
+            attrs,
+        ))
+    }
+
+    fn build_distribution_from_lib_dir(lib_dir: &Path) -> Value {
+        let mut meta = HashMap::new();
+        let lib_path = lib_dir.to_string_lossy().to_string();
+        meta.insert("name".to_string(), Value::str(lib_path));
+        meta.insert("ver".to_string(), Value::str("*".to_string()));
+        meta.insert("api".to_string(), Value::str("*".to_string()));
+        meta.insert("auth".to_string(), Value::str(String::new()));
+        let provides = Self::scan_lib_provides(lib_dir);
+        meta.insert("provides".to_string(), provides);
+        let resources_dir = lib_dir.parent().map(|p| p.join("resources"));
+        let resources = if let Some(ref rd) = resources_dir
+            && rd.exists()
+        {
+            Self::scan_resources(rd)
+        } else {
+            Value::Hash(std::sync::Arc::new(HashMap::new()))
+        };
+        meta.insert("resources".to_string(), resources);
+        let mut attrs = HashMap::new();
+        attrs.insert("$!meta".to_string(), Value::Hash(std::sync::Arc::new(meta)));
+        Value::make_instance_without_destroy(crate::symbol::Symbol::intern("Distribution"), attrs)
+    }
+
+    fn scan_lib_provides(lib_dir: &Path) -> Value {
+        let mut provides = HashMap::new();
+        let extensions = [".rakumod", ".pm6", ".pm"];
+        if let Ok(entries) = std::fs::read_dir(lib_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    for ext in &extensions {
+                        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                            if name.ends_with(ext) {
+                                let module_name = name[..name.len() - ext.len()].replace('/', "::");
+                                let relative = format!("lib/{}", name);
+                                provides.insert(module_name, Value::str(relative));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Value::Hash(std::sync::Arc::new(provides))
+    }
+
+    fn scan_resources(resources_dir: &Path) -> Value {
+        let mut files = HashMap::new();
+        if let Ok(entries) = std::fs::read_dir(resources_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        let key = format!("resources/{}", name);
+                        files.insert(key.clone(), Value::str(key));
+                    }
+                }
+            }
+        }
+        Value::Hash(std::sync::Arc::new(files))
+    }
+
+    fn parse_meta6_json(content: &str) -> Option<HashMap<String, Value>> {
+        let json: serde_json::Value = serde_json::from_str(content).ok()?;
+        let obj = json.as_object()?;
+        let mut meta = HashMap::new();
+        for (key, val) in obj {
+            meta.insert(key.clone(), Self::json_to_value(val));
+        }
+        Some(meta)
+    }
+
+    fn json_to_value(val: &serde_json::Value) -> Value {
+        match val {
+            serde_json::Value::Null => Value::Nil,
+            serde_json::Value::Bool(b) => Value::Bool(*b),
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Value::Int(i)
+                } else if let Some(f) = n.as_f64() {
+                    Value::Num(f)
+                } else {
+                    Value::str(n.to_string())
+                }
+            }
+            serde_json::Value::String(s) => Value::str(s.clone()),
+            serde_json::Value::Array(arr) => {
+                Value::array(arr.iter().map(Self::json_to_value).collect())
+            }
+            serde_json::Value::Object(obj) => {
+                let mut map = HashMap::new();
+                for (k, v) in obj {
+                    map.insert(k.clone(), Self::json_to_value(v));
+                }
+                Value::Hash(std::sync::Arc::new(map))
+            }
+        }
     }
 
     /// Check for unresolved package/class stubs at program end.

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -107,6 +107,13 @@ impl VM {
                 if !pkg.is_empty() && pkg != "GLOBAL" {
                     compiler.set_current_package(pkg.to_string());
                 }
+                // Resolve $?DISTRIBUTION from the function's defining package
+                compiler.current_distribution = self
+                    .interpreter
+                    .package_distributions
+                    .get(&pkg)
+                    .cloned()
+                    .or_else(|| self.interpreter.current_distribution.clone());
                 compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
             };
             let deprecated_info = def.deprecated_message.as_ref().map(|msg| {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -681,13 +681,6 @@ impl VM {
                         && !pd.name.starts_with('&')
                 })
             {
-                // On-the-fly compile: compile the function definition to
-                // bytecode and execute via the VM, avoiding the slow
-                // tree-walking interpreter path. The compiled result is
-                // cached in otf_compile_cache for subsequent calls.
-                // Skip functions with class/role declarations or complex
-                // parameter signatures as they need the full interpreter
-                // path for correct behavior.
                 self.compile_and_call_function_def(&def, args, compiled_fns)
             } else {
                 // Sync VM locals to env before spawning threads so closures capture them

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -224,17 +224,27 @@ impl VM {
                     sym, pkg,
                 )));
             }
-            // Strip pseudo-package prefixes (OUR::, GLOBAL::, MY::, etc.)
-            // and resolve to the bare type name if it exists.
-            let bare = Interpreter::strip_pseudo_packages(name);
-            if bare != name
-                && (self.interpreter.has_type(bare)
-                    || Self::is_builtin_type(bare)
-                    || Self::is_type_with_smiley(bare, &self.interpreter))
+            // Try resolving as a package-qualified function call (e.g.
+            // `Module::func` used as a term without parens).
+            if let Some((_pkg, short)) = name.rsplit_once("::")
+                && self.interpreter.has_function(&format!("GLOBAL::{}", short))
             {
-                Value::Package(Symbol::intern(Self::resolve_type_alias(bare)))
+                let result = self.interpreter.call_function(name, Vec::new())?;
+                self.env_dirty = true;
+                result
             } else {
-                Value::Package(Symbol::intern(name))
+                // Strip pseudo-package prefixes (OUR::, GLOBAL::, MY::, etc.)
+                // and resolve to the bare type name if it exists.
+                let bare = Interpreter::strip_pseudo_packages(name);
+                if bare != name
+                    && (self.interpreter.has_type(bare)
+                        || Self::is_builtin_type(bare)
+                        || Self::is_type_with_smiley(bare, &self.interpreter))
+                {
+                    Value::Package(Symbol::intern(Self::resolve_type_alias(bare)))
+                } else {
+                    Value::Package(Symbol::intern(name))
+                }
             }
         } else if name.chars().count() == 1 {
             // Single unicode character — check for vulgar fractions etc.

--- a/t/distribution.t
+++ b/t/distribution.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 5;
+
+# $?DISTRIBUTION should be Nil at the top level (no distribution context)
+nok $?DISTRIBUTION.defined, '$?DISTRIBUTION is not defined at top level';
+
+# Test with a module that has META6.json
+{
+    use lib 'roast/packages/CurrentDistributionOne/lib';
+    use CurrentDistributionOne;
+    my $d = CurrentDistributionOne::distribution();
+    ok $d.defined, 'CurrentDistributionOne::distribution() returns defined value';
+    ok $d.meta.defined, '.meta returns defined value';
+    ok $d.meta{"provides"}.defined, '.meta{"provides"} is defined';
+    ok $d.meta{"provides"}{"CurrentDistributionOne"}.defined, '.meta{"provides"}{"CurrentDistributionOne"} is defined';
+}


### PR DESCRIPTION
## Summary
- Implement compile-time `$?DISTRIBUTION` variable that resolves to distribution metadata when code is compiled within a module loaded from a lib path with META6.json
- Add `Distribution` class with `.meta` method returning the metadata hash
- Fix package-qualified bare function calls (`Module::func.method`) to resolve as function calls when the name matches a registered function
- Auto-generate minimal distribution metadata for lib dirs without META6.json

## Changes
- **Cargo.toml**: Add `serde_json` dependency for parsing META6.json
- **Compiler**: Add `current_distribution` field, propagate through sub body compilation
- **Runtime**: Detect META6.json during module loading, store distribution context per-package
- **VM**: Resolve package-qualified bare words as function calls when appropriate
- **Builtins**: Add `Distribution` instance methods (`.meta`, `.defined`, `.Str`)

## Test plan
- [x] `t/distribution.t` - local test for $?DISTRIBUTION basics
- [x] `roast/S11-repository/cur-current-distribution.t` subtests 1-2 pass (6/9 subtests)
- [x] `make test` passes (only pre-existing flaky Lock::Async test failure)
- [x] `make roast` passes (all 1184 whitelisted tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)