### PR TITLE
fix: reject private attribute twigil (!) outside class for @!/%! vars

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -119,6 +119,7 @@
 - [ ] roast/S12-subset/subtypes.t
 - [ ] roast/S12-subset/type-subset.t
 - [ ] roast/S12-traits/basic.t
+  - 1/9 pass. NOT in raku's spectest.data (raku itself fails this test). Tests 2-4 require obsolete `trait_auxiliary:<is>` feature for variable role mixins. Tests 5-8 (class role composition) would pass but EVAL on line 32 kills the program before reaching them. Test 9 (throws-like '%!P' outside class) now works with the NoSelf fix but can't run due to earlier abort.
 - [ ] roast/S12-traits/parameterized.t
 - [ ] roast/S12-traits/precomp.t
   - Regressed: now correctly errors on unknown custom trait 'is customtrait' because trait_mod:<is> from imported module isn't available during sub registration in the client module

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -895,6 +895,17 @@ impl VM {
             }
             OpCode::GetArrayVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
+                // Reject @!attr (private attribute twigil) when no self is available
+                if let Some(bare) = name.strip_prefix("@!")
+                    && !bare.is_empty()
+                    && bare.as_bytes()[0].is_ascii_alphabetic()
+                    && self.get_env_with_main_alias("self").is_none()
+                {
+                    return Err(RuntimeError::new(format!(
+                        "X::Syntax::NoSelf: Variable {} used where no 'self' is available",
+                        name
+                    )));
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| self.get_local_by_bare_name(code, name))
@@ -927,6 +938,17 @@ impl VM {
             }
             OpCode::GetHashVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
+                // Reject %!attr (private attribute twigil) when no self is available
+                if let Some(bare) = name.strip_prefix("%!")
+                    && !bare.is_empty()
+                    && bare.as_bytes()[0].is_ascii_alphabetic()
+                    && self.get_env_with_main_alias("self").is_none()
+                {
+                    return Err(RuntimeError::new(format!(
+                        "X::Syntax::NoSelf: Variable {} used where no 'self' is available",
+                        name
+                    )));
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| self.get_local_by_bare_name(code, name))
@@ -979,6 +1001,26 @@ impl VM {
                     Value::Str(s) => s.to_string(),
                     _ => unreachable!("SetGlobal name must be a string constant"),
                 };
+                // Reject private attribute twigil (!) assignment when no self is available
+                {
+                    let bare = name.trim_start_matches(['$', '@', '%', '&']);
+                    if bare.starts_with('!')
+                        && bare.len() > 1
+                        && bare.as_bytes()[1].is_ascii_alphabetic()
+                        && self.get_env_with_main_alias("self").is_none()
+                    {
+                        // Reconstruct the display name with sigil
+                        let display = if name.starts_with('!') {
+                            format!("${}", name)
+                        } else {
+                            name.clone()
+                        };
+                        return Err(RuntimeError::new(format!(
+                            "X::Syntax::NoSelf: Variable {} used where no 'self' is available",
+                            display
+                        )));
+                    }
+                }
                 if self.interpreter.strict_mode
                     && !name.contains("::")
                     && !self.interpreter.env().contains_key(&name)


### PR DESCRIPTION
## Summary
- Extend the existing `$!attr` NoSelf check in the VM to also cover `@!attr` and `%!attr` variables
- When `@!` or `%!` twigil variables are accessed (GetArrayVar, GetHashVar) or assigned (SetGlobal) outside a class/role method context where no `self` is available, throw `X::Syntax::NoSelf`
- Update TODO_roast/S12.md with analysis of roast/S12-traits/basic.t blockers (test is NOT in raku's spectest.data -- raku itself can't pass it due to obsolete `trait_auxiliary` feature)

## Test plan
- [x] `%!P = 1` outside class throws `X::Syntax::NoSelf`
- [x] `$!x = 1` outside class throws `X::Syntax::NoSelf` (pre-existing)
- [x] `@!arr` outside class throws `X::Syntax::NoSelf`
- [x] `throws-like ' %!P = 1; 1', Exception` works correctly
- [x] Class attributes (`$!x`, `@!items`, `%!data`) inside methods still work
- [x] `make test` passes (3923 tests)
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)