### PR TITLE
chore: increase batch.t CI timeout to 180s

### DIFF
--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -12,8 +12,8 @@ per_file_timeout() {
   case "$test_file" in
     roast/S17-supply/batch.t)
       # This test uses sleep 5 in after-tap blocks (4 time-based subtests x2 schedulers).
-      # Even raku takes ~37s to run it. CI can be slower.
-      echo 120
+      # Even raku takes ~37s to run it. CI runners are ~3x slower.
+      echo 180
       ;;
     roast/S17-supply/unique.t)
       # This test intentionally uses multiple sleep 1 calls and needs >30s.


### PR DESCRIPTION
## Summary
- Add `roast/S17-supply/batch.t` to whitelist (newly passing after Supply improvements)
- Whitelist: 1189 → 1190

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-supply/batch.t` passes all 9 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)