### PR TITLE
fix: validate signature alternates and fix Num widening for named params

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -473,6 +473,7 @@ roast/S06-signature/introspection.t
 roast/S06-signature/mixed-placeholders.t
 roast/S06-signature/multi-invocant.t
 roast/S06-signature/multidimensional.t
+roast/S06-signature/multiple-signatures.t
 roast/S06-signature/named-parameters.t
 roast/S06-signature/named-placeholders.t
 roast/S06-signature/named-renaming.t

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -838,7 +838,8 @@ pub(super) fn sub_decl_body(
         loop {
             let (r2, _) = ws(r)?;
             if !r2.starts_with('|') {
-                break r2;
+                r = r2;
+                break;
             }
             let (r3, _) = ws(&r2[1..])?;
             if !r3.starts_with('(') {
@@ -854,6 +855,23 @@ pub(super) fn sub_decl_body(
             signature_alternates.push((alt_params, alt_param_defs));
             r = r4;
         }
+        // Validate: all alternate signatures must have the same set of
+        // formal variable names as the primary signature (S13).
+        if !signature_alternates.is_empty() {
+            let mut primary_names: Vec<&str> = params.iter().map(|s| s.as_str()).collect();
+            primary_names.sort();
+            for (alt_params, _alt_defs) in &signature_alternates {
+                let mut alt_names: Vec<&str> = alt_params.iter().map(|s| s.as_str()).collect();
+                alt_names.sort();
+                if alt_names != primary_names {
+                    return Err(PError::raw(
+                        "Multis with multiple signatures must have the same set of formal variable names".to_string(),
+                        None,
+                    ));
+                }
+            }
+        }
+        r
     } else {
         rest
     };

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -407,9 +407,23 @@ impl Interpreter {
                 // Check type constraint on named param
                 if let Some(constraint) = &pd.type_constraint
                     && let Some(ref val) = arg_val
-                    && !self.type_matches_value(constraint, val)
                 {
-                    return false;
+                    let resolved_constraint = self.resolved_type_capture_name(constraint);
+                    // Apply the same numeric widening for named params as for
+                    // positional params: Int/Rat/FatRat can satisfy a Num
+                    // constraint in multi dispatch.
+                    let is_num_widening = resolved_constraint == "Num"
+                        && matches!(
+                            val,
+                            Value::Int(_)
+                                | Value::Num(_)
+                                | Value::Rat(_, _)
+                                | Value::FatRat(_, _)
+                                | Value::BigRat(_, _)
+                        );
+                    if !is_num_widening && !self.type_matches_value(&resolved_constraint, val) {
+                        return false;
+                    }
                 }
 
                 // Check where constraint on named param

--- a/t/multiple-signatures.t
+++ b/t/multiple-signatures.t
@@ -1,0 +1,52 @@
+use Test;
+plan 13;
+
+# Basic two-signature multi dispatch
+{
+    multi sub si  (Str $s, Int $i)
+                | (Int $i, Str $s) {
+        "s:$s i:$i";
+    }
+    is si("a", 3), "s:a i:3", 'two sigs dispatch (Str, Int)';
+    is si(3, "b"), "s:b i:3", 'two sigs dispatch (Int, Str)';
+}
+
+# Named parameters with Num type widening
+{
+    multi sub foo (Int $i, Num :$n) {
+        "$i $n";
+    }
+    is foo(4, :n(2.3)), '4 2.3', 'Num named param accepts Rat value';
+    is foo(4, :n(2.3e0)), '4 2.3', 'Num named param accepts Num value';
+    is foo(4, :n(42)), '4 42', 'Num named param accepts Int value';
+}
+
+# Three signatures with named params
+{
+    multi sub three  (Str $s, Int $i, Num :$n)
+                   | (Int $i, Str :$s, Num :$n)
+                   | (Num :$s, Int :$i, Str :$n) {
+        "$s $i $n";
+    }
+    is three('abc', 3, :n(2.3)), 'abc 3 2.3', 'three sigs dispatch (1)';
+    is three(4, :s<x>, :n(2.3)), 'x 4 2.3', 'three sigs dispatch (2)';
+    is three(:i(4), :s(0.2), :n('f')), '0.2 4 f', 'three sigs dispatch (3)';
+}
+
+# State variable sharing across signature alternates
+{
+    multi sub count  (Str $s, Int $i)
+                | (Int $i, Str $s) {
+        state $x = 0;
+        ++$x;
+    }
+    is count("a", 3), 1, 'state var init in multi with two sigs';
+    is count("a", 2), 2, 'state var persists';
+    is count(2, 'a'), 3, 'state var shared across alternates';
+}
+
+# Validation: different variable sets rejected
+throws-like q[ multi sub x ($x, $y) | ($x, $y, $z) { 1 }], Exception,
+    'reject different variable count';
+throws-like q[ multi sub x ($x, $y) | ($x, @y) { 1 }], Exception,
+    'reject different sigils';


### PR DESCRIPTION
## Summary
- Add parser validation that signature alternates (`|` syntax) must have the same set of formal variable names as the primary signature (S13 spec)
- Fix Num numeric widening for named parameters in multi dispatch to match positional parameter behavior (Int/Rat/FatRat can satisfy Num constraint)
- All 11 subtests of `roast/S06-signature/multiple-signatures.t` now pass (previously 2/11)

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/multiple-signatures.t` passes (13 tests covering dispatch, state vars, and validation)
- [x] `prove -e 'target/debug/mutsu' roast/S06-signature/multiple-signatures.t` passes (11 tests)
- [x] All whitelisted S06-signature roast tests pass
- [x] All whitelisted S13, S02-types, S03-operator, S32-num roast tests pass
- [x] `make test` passes
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)