### PR TITLE
feat: implement IO::Socket::Async UDP support

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -962,6 +962,7 @@ roast/S32-hash/map.t
 roast/S32-hash/pairs.t
 roast/S32-hash/push.t
 roast/S32-hash/slice.t
+roast/S32-io/IO-Socket-Async-UDP.t
 roast/S32-io/IO-Socket-Async.t
 roast/S32-io/IO-Socket-INET-UNIX.t
 roast/S32-io/IO-Socket-INET.t

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -305,7 +305,70 @@ impl Interpreter {
         Ok(Value::Promise(promise))
     }
 
-    /// Thread.start({ block }) — spawn a real OS thread
+    /// IO::Socket::Async.bind-udp($host, $port)
+    pub(in crate::runtime) fn dispatch_socket_async_bind_udp(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let host = args
+            .first()
+            .map(Value::to_string_value)
+            .unwrap_or_else(|| "0.0.0.0".to_string());
+        let port = args
+            .get(1)
+            .map(|v| match v {
+                Value::Int(i) => *i as u16,
+                Value::Num(f) => *f as u16,
+                other => other.to_string_value().parse::<u16>().unwrap_or(0),
+            })
+            .unwrap_or(0);
+
+        if super::super::native_methods::udp_port_in_use(&host, port) {
+            return Err(RuntimeError::new(format!(
+                "Address already in use: {}:{}",
+                host, port
+            )));
+        }
+
+        let socket_id = super::super::native_methods::next_async_socket_id();
+        super::super::native_methods::register_udp_bound_socket(
+            socket_id,
+            super::super::native_methods::UdpBoundSocketState {
+                host: host.clone(),
+                port,
+                closed: false,
+                supply_ids: Vec::new(),
+            },
+        );
+
+        let mut attrs = HashMap::new();
+        attrs.insert("udp-socket-id".to_string(), Value::Int(socket_id as i64));
+        attrs.insert("socket-host".to_string(), Value::str(host));
+        attrs.insert("socket-port".to_string(), Value::Int(port as i64));
+        attrs.insert("is-udp".to_string(), Value::Bool(true));
+        Ok(Value::make_instance(
+            Symbol::intern("IO::Socket::Async"),
+            attrs,
+        ))
+    }
+
+    /// IO::Socket::Async.udp() - create an unbound UDP socket for sending
+    pub(in crate::runtime) fn dispatch_socket_async_udp(
+        &mut self,
+        _args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let socket_id = super::super::native_methods::next_async_socket_id();
+        let mut attrs = HashMap::new();
+        attrs.insert("udp-socket-id".to_string(), Value::Int(socket_id as i64));
+        attrs.insert("is-udp".to_string(), Value::Bool(true));
+        attrs.insert("is-udp-sender".to_string(), Value::Bool(true));
+        Ok(Value::make_instance(
+            Symbol::intern("IO::Socket::Async"),
+            attrs,
+        ))
+    }
+
+    /// Thread.start({ block }) -- spawn a real OS thread
     pub(in crate::runtime) fn dispatch_thread_start(
         &mut self,
         args: &[Value],

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -136,6 +136,22 @@ impl Interpreter {
                 }
                 None
             }
+            "bind-udp" => {
+                if let Value::Package(ref cn) = target
+                    && cn == "IO::Socket::Async"
+                {
+                    return Some(self.dispatch_socket_async_bind_udp(&args));
+                }
+                None
+            }
+            "udp" => {
+                if let Value::Package(ref cn) = target
+                    && cn == "IO::Socket::Async"
+                {
+                    return Some(self.dispatch_socket_async_udp(&args));
+                }
+                None
+            }
             "now" => self.dispatch_datetime_now(&target, &args),
             "Date" if args.is_empty() => {
                 if let Value::Package(ref class_name) = target {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1861,6 +1861,8 @@ impl Interpreter {
                     "peer-port",
                     "socket-host",
                     "peer-host",
+                    "print-to",
+                    "write-to",
                 ]
                 .iter()
                 .map(|s| s.to_string())

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -24,13 +24,13 @@ pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id,
 
 // Re-export pub(in crate::runtime) items accessed from sibling `runtime` modules
 pub(in crate::runtime) use state::{
-    allocate_async_listen_port, get_supply_collected_output, get_supply_taps,
+    UdpBoundSocketState, allocate_async_listen_port, get_supply_collected_output, get_supply_taps,
     lookup_async_listener, next_async_socket_id, next_supplier_id, next_supply_id, proc_stdin_map,
     register_async_connection, register_promise_combinator_sources, register_supply_tap,
-    set_supply_collected_output, supplier_done, supplier_done_deferred, supplier_emit,
-    supplier_id_from_attrs, supplier_quit, supplier_register_promise, supplier_snapshot,
-    supply_channel_map, supply_channel_map_pub, take_promise_combinator_sources,
-    update_async_connection,
+    register_udp_bound_socket, set_supply_collected_output, supplier_done, supplier_done_deferred,
+    supplier_emit, supplier_id_from_attrs, supplier_quit, supplier_register_promise,
+    supplier_snapshot, supply_channel_map, supply_channel_map_pub, take_promise_combinator_sources,
+    udp_port_in_use, update_async_connection,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -272,12 +272,155 @@ impl Interpreter {
         }
     }
 
+    /// Handle instance methods on UDP sockets (created by bind-udp / udp).
+    fn native_socket_async_udp(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let udp_id = attributes.get("udp-socket-id").and_then(|v| match v {
+            Value::Int(i) => Some(*i as u64),
+            _ => None,
+        });
+
+        match method {
+            "socket-port" => Ok(attributes
+                .get("socket-port")
+                .cloned()
+                .unwrap_or(Value::Int(0))),
+            "socket-host" => Ok(attributes
+                .get("socket-host")
+                .cloned()
+                .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
+            "close" => {
+                if let Some(id) = udp_id
+                    && let Some(state) = get_udp_bound_socket(id)
+                {
+                    update_udp_bound_socket(id, |s| s.closed = true);
+                    for sid in &state.supply_ids {
+                        self.async_supplier_done_value(*sid);
+                    }
+                }
+                Ok(Value::Nil)
+            }
+            "Supply" => {
+                let id =
+                    udp_id.ok_or_else(|| RuntimeError::new("Missing UDP socket id for Supply"))?;
+                let supply_id = next_supply_id();
+                register_async_supply(
+                    supply_id,
+                    AsyncSocketSupplyState {
+                        is_bin: false,
+                        encoding: "utf-8".to_string(),
+                        text_buffer: String::new(),
+                        byte_buffer: Vec::new(),
+                    },
+                );
+                update_udp_bound_socket(id, |s| s.supply_ids.push(supply_id));
+
+                let mut attrs = HashMap::new();
+                attrs.insert("values".to_string(), Value::array(Vec::new()));
+                attrs.insert("taps".to_string(), Value::array(Vec::new()));
+                attrs.insert("live".to_string(), Value::Bool(true));
+                attrs.insert("supplier_id".to_string(), Value::Int(supply_id as i64));
+                Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
+            }
+            "print-to" => {
+                let host = args
+                    .first()
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| "127.0.0.1".to_string());
+                let port = args
+                    .get(1)
+                    .map(|v| match v {
+                        Value::Int(i) => *i as u16,
+                        Value::Num(f) => *f as u16,
+                        other => other.to_string_value().parse::<u16>().unwrap_or(0),
+                    })
+                    .unwrap_or(0);
+                let text = args
+                    .get(2)
+                    .map(|v| self.render_str_value(v))
+                    .unwrap_or_default();
+
+                self.udp_deliver_data(&host, port, text.as_bytes())?;
+
+                let promise = SharedPromise::new();
+                promise.keep(
+                    Self::async_socket_kept(Value::Bool(true)),
+                    String::new(),
+                    String::new(),
+                );
+                Ok(Value::Promise(promise))
+            }
+            "write-to" => {
+                let host = args
+                    .first()
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| "127.0.0.1".to_string());
+                let port = args
+                    .get(1)
+                    .map(|v| match v {
+                        Value::Int(i) => *i as u16,
+                        Value::Num(f) => *f as u16,
+                        other => other.to_string_value().parse::<u16>().unwrap_or(0),
+                    })
+                    .unwrap_or(0);
+                let bytes = args
+                    .get(2)
+                    .and_then(Self::extract_bytes)
+                    .unwrap_or_else(|| {
+                        args.get(2)
+                            .map(Value::to_string_value)
+                            .unwrap_or_default()
+                            .into_bytes()
+                    });
+
+                self.udp_deliver_data(&host, port, &bytes)?;
+
+                let promise = SharedPromise::new();
+                promise.keep(
+                    Self::async_socket_kept(Value::Bool(true)),
+                    String::new(),
+                    String::new(),
+                );
+                Ok(Value::Promise(promise))
+            }
+            _ => Err(RuntimeError::new(format!(
+                "No method '{}' on IO::Socket::Async (UDP)",
+                method
+            ))),
+        }
+    }
+
+    /// Deliver UDP data to a bound socket listening on host:port.
+    fn udp_deliver_data(
+        &mut self,
+        host: &str,
+        port: u16,
+        bytes: &[u8],
+    ) -> Result<(), RuntimeError> {
+        if let Some((_id, state)) = lookup_udp_bound_socket(host, port) {
+            let text = String::from_utf8_lossy(bytes).to_string();
+            for sid in &state.supply_ids {
+                let _ = self.async_supplier_emit_value(*sid, Value::str(text.clone()));
+            }
+        }
+        Ok(())
+    }
+
     pub(in crate::runtime) fn native_socket_async(
         &mut self,
         attributes: &HashMap<String, Value>,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Dispatch to UDP handler if this is a UDP socket
+        if matches!(attributes.get("is-udp"), Some(Value::Bool(true))) {
+            return self.native_socket_async_udp(attributes, method, args);
+        }
+
         let conn_id = attributes.get("conn-id").and_then(|v| match v {
             Value::Int(i) => Some(*i as u64),
             _ => None,

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -68,6 +68,16 @@ pub(crate) struct AsyncSocketListenerState {
     pub(crate) encoding: String,
 }
 
+/// UDP bound socket state
+#[derive(Debug, Clone)]
+pub(crate) struct UdpBoundSocketState {
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) closed: bool,
+    pub(crate) supply_ids: Vec<u64>,
+}
+
+type UdpBoundSocketMap = std::sync::Mutex<HashMap<u64, UdpBoundSocketState>>;
 type AsyncSocketConnMap = std::sync::Mutex<HashMap<u64, AsyncSocketConnState>>;
 type AsyncSocketSupplyMap = std::sync::Mutex<HashMap<u64, AsyncSocketSupplyState>>;
 type AsyncSocketListenerMap = std::sync::Mutex<HashMap<u64, AsyncSocketListenerState>>;
@@ -84,6 +94,11 @@ fn async_socket_supply_map() -> &'static AsyncSocketSupplyMap {
 
 fn async_socket_listener_map() -> &'static AsyncSocketListenerMap {
     static MAP: OnceLock<AsyncSocketListenerMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn udp_bound_socket_map() -> &'static UdpBoundSocketMap {
+    static MAP: OnceLock<UdpBoundSocketMap> = OnceLock::new();
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
@@ -494,4 +509,60 @@ pub(in crate::runtime) fn take_promise_combinator_sources(
     } else {
         None
     }
+}
+
+pub(in crate::runtime) fn register_udp_bound_socket(id: u64, state: UdpBoundSocketState) {
+    if let Ok(mut map) = udp_bound_socket_map().lock() {
+        map.insert(id, state);
+    }
+}
+
+pub(in crate::runtime) fn get_udp_bound_socket(id: u64) -> Option<UdpBoundSocketState> {
+    udp_bound_socket_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&id).cloned())
+}
+
+pub(in crate::runtime) fn update_udp_bound_socket<F>(id: u64, f: F)
+where
+    F: FnOnce(&mut UdpBoundSocketState),
+{
+    if let Ok(mut map) = udp_bound_socket_map().lock()
+        && let Some(state) = map.get_mut(&id)
+    {
+        f(state);
+    }
+}
+
+pub(in crate::runtime) fn udp_port_in_use(host: &str, port: u16) -> bool {
+    if let Ok(map) = udp_bound_socket_map().lock() {
+        return map.values().any(|s| {
+            !s.closed
+                && s.port == port
+                && (s.host == host || s.host == "0.0.0.0" || host == "0.0.0.0")
+        });
+    }
+    false
+}
+
+pub(in crate::runtime) fn lookup_udp_bound_socket(
+    host: &str,
+    port: u16,
+) -> Option<(u64, UdpBoundSocketState)> {
+    if let Ok(map) = udp_bound_socket_map().lock() {
+        for (id, state) in map.iter() {
+            if state.closed || state.port != port {
+                continue;
+            }
+            if state.host == host
+                || state.host == "0.0.0.0"
+                || state.host == "::"
+                || (host == "localhost" && state.host == "127.0.0.1")
+            {
+                return Some((*id, state.clone()));
+            }
+        }
+    }
+    None
 }


### PR DESCRIPTION
## Summary
- Implement UDP socket support for `IO::Socket::Async` including `bind-udp`, `udp`, `print-to`, `write-to`, `Supply`, and `close` methods
- Add UDP bound socket state management with port reuse detection
- All 3 subtests in `roast/S32-io/IO-Socket-Async-UDP.t` now pass

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-io/IO-Socket-Async-UDP.t` passes (3/3)
- [x] `make test` passes (only pre-existing flaky `t/lock.t` failure)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `roast-whitelist.txt` sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)