### PR TITLE
fix: Promise.then passes Promise to callback, add andthen/orelse methods

### DIFF
--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -204,7 +204,7 @@ impl Interpreter {
             .unwrap_or_else(|| "utf-8".to_string());
 
         let promise = SharedPromise::new();
-        let result = if let Some((_listener_id, listener)) =
+        if let Some((_listener_id, listener)) =
             super::super::native_methods::lookup_async_listener(&host, port)
         {
             let defer_accept = Self::callback_uses_supply_list(&listener.callback);
@@ -279,29 +279,14 @@ impl Interpreter {
                 let _ = self.call_sub_value(listener.callback, vec![server_socket], true);
             }
 
-            let mut status_attrs = HashMap::new();
-            status_attrs.insert("status".to_string(), Value::str_from("Kept"));
-            status_attrs.insert("result".to_string(), client_socket);
-            status_attrs.insert("cause".to_string(), Value::Nil);
-            Value::make_instance(
-                Symbol::intern("IO::Socket::Async::StatusResult"),
-                status_attrs,
-            )
+            // Keep the promise with the client socket directly
+            promise.keep(client_socket, String::new(), String::new());
         } else {
-            let mut status_attrs = HashMap::new();
-            status_attrs.insert("status".to_string(), Value::str_from("Broken"));
-            status_attrs.insert("result".to_string(), Value::Nil);
-            status_attrs.insert(
-                "cause".to_string(),
-                Value::str(format!("Failed to connect to '{}:{}'", host, port)),
-            );
-            Value::make_instance(
-                Symbol::intern("IO::Socket::Async::StatusResult"),
-                status_attrs,
-            )
+            // Break the promise on connection failure
+            let err_msg = format!("Failed to connect to '{}:{}'", host, port);
+            let _ = promise.try_break(Value::str(err_msg));
         };
 
-        promise.keep(result, String::new(), String::new());
         Ok(Value::Promise(promise))
     }
 

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -38,6 +38,80 @@ impl Interpreter {
         err
     }
 
+    /// Resolve a callback result into the new promise, keeping on success,
+    /// breaking on error.
+    fn resolve_promise_callback(
+        new_promise: &SharedPromise,
+        result: Result<Value, RuntimeError>,
+        output: String,
+        stderr: String,
+    ) {
+        match result {
+            Ok(v) => new_promise.keep(v, output, stderr),
+            Err(e) => {
+                let error_val = if let Some(ex) = e.exception {
+                    *ex
+                } else {
+                    Value::str(e.message)
+                };
+                new_promise.break_with(error_val, output, stderr);
+            }
+        }
+    }
+
+    /// Run a promise chaining method (.then, .andthen, .orelse).
+    /// `should_run` decides whether to invoke the callback based on the
+    /// resolved status; returns `None` to skip (propagate), `Some(true)` to
+    /// run the callback.  `propagate` produces the value to forward when
+    /// skipping.
+    fn promise_chain_method(
+        &mut self,
+        shared: &SharedPromise,
+        block: Value,
+        should_run: fn(&str) -> bool,
+        propagate_kept: bool,
+    ) -> Value {
+        let orig = shared.clone();
+        let new_promise = SharedPromise::new_with_class(shared.class_name());
+        let ret = Value::Promise(new_promise.clone());
+        if orig.is_resolved() {
+            let (result, output, stderr) = orig.wait();
+            let status = orig.status();
+            if should_run(&status) {
+                let promise_val = Value::Promise(orig.clone());
+                let cb_result = self.call_sub_value(block, vec![promise_val], true);
+                Self::resolve_promise_callback(&new_promise, cb_result, output, stderr);
+            } else if propagate_kept {
+                new_promise.keep(result, output, stderr);
+            } else {
+                new_promise.break_with(result, output, stderr);
+            }
+        } else {
+            let mut thread_interp = self.clone_for_thread();
+            std::thread::spawn(move || {
+                let (result, output, stderr) = orig.wait();
+                let status = orig.status();
+                if should_run(&status) {
+                    let promise_val = Value::Promise(orig.clone());
+                    let cb_result = thread_interp.call_sub_value(block, vec![promise_val], true);
+                    let out = std::mem::take(&mut thread_interp.output);
+                    let err = std::mem::take(&mut thread_interp.stderr_output);
+                    Self::resolve_promise_callback(
+                        &new_promise,
+                        cb_result,
+                        format!("{}{}", output, out),
+                        format!("{}{}", stderr, err),
+                    );
+                } else if propagate_kept {
+                    new_promise.keep(result, output, stderr);
+                } else {
+                    new_promise.break_with(result, output, stderr);
+                }
+            });
+        }
+        ret
+    }
+
     pub(super) fn dispatch_promise_method(
         &mut self,
         shared: &SharedPromise,
@@ -47,11 +121,12 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "result" => {
+                // Wait for the promise to resolve (blocks if Planned)
+                let (result, _, _) = shared.wait();
+                self.sync_shared_vars_to_env();
                 let status = shared.status();
                 if status == "Broken" {
                     // .result on a Broken promise throws the cause as X::AdHoc
-                    let (result, _, _) = shared.wait();
-                    self.sync_shared_vars_to_env();
                     let msg = result.to_string_value();
                     let mut attrs = HashMap::new();
                     attrs.insert("payload".to_string(), Value::str(msg.clone()));
@@ -61,9 +136,6 @@ impl Interpreter {
                     err.exception = Some(Box::new(ex));
                     Err(err)
                 } else {
-                    // Planned blocks, Kept returns value
-                    let result = shared.result_blocking();
-                    self.sync_shared_vars_to_env();
                     // Replay deferred taps for Proc::Async results
                     if let Value::Instance {
                         ref class_name,
@@ -80,54 +152,18 @@ impl Interpreter {
             "status" => Ok(Value::str(shared.status())),
             "then" => {
                 let block = args.into_iter().next().unwrap_or(Value::Nil);
-                let orig = shared.clone();
-                let new_promise = SharedPromise::new_with_class(shared.class_name());
-                let ret = Value::Promise(new_promise.clone());
-                if orig.is_resolved() {
-                    let (result, output, stderr) = orig.wait();
-                    match self.call_sub_value(block, vec![result], true) {
-                        Ok(v) => new_promise.keep(v, output, stderr),
-                        Err(e) => {
-                            let error_val = if let Some(ex) = e.exception {
-                                *ex
-                            } else {
-                                Value::str(e.message)
-                            };
-                            new_promise.break_with(error_val, output, stderr);
-                        }
-                    }
-                } else {
-                    let mut thread_interp = self.clone_for_thread();
-                    std::thread::spawn(move || {
-                        let (result, output, stderr) = orig.wait();
-                        match thread_interp.call_sub_value(block, vec![result], true) {
-                            Ok(v) => {
-                                let out = std::mem::take(&mut thread_interp.output);
-                                let err = std::mem::take(&mut thread_interp.stderr_output);
-                                new_promise.keep(
-                                    v,
-                                    format!("{}{}", output, out),
-                                    format!("{}{}", stderr, err),
-                                );
-                            }
-                            Err(e) => {
-                                let out = std::mem::take(&mut thread_interp.output);
-                                let err = std::mem::take(&mut thread_interp.stderr_output);
-                                let error_val = if let Some(ex) = e.exception {
-                                    *ex
-                                } else {
-                                    Value::str(e.message)
-                                };
-                                new_promise.break_with(
-                                    error_val,
-                                    format!("{}{}", output, out),
-                                    format!("{}{}", stderr, err),
-                                );
-                            }
-                        }
-                    });
-                }
-                Ok(ret)
+                // .then always runs the callback regardless of Kept/Broken
+                Ok(self.promise_chain_method(shared, block, |_| true, true))
+            }
+            "andthen" => {
+                let block = args.into_iter().next().unwrap_or(Value::Nil);
+                // .andthen runs callback only if Kept; propagates Broken
+                Ok(self.promise_chain_method(shared, block, |s| s == "Kept", false))
+            }
+            "orelse" => {
+                let block = args.into_iter().next().unwrap_or(Value::Nil);
+                // .orelse runs callback only if Broken; propagates Kept
+                Ok(self.promise_chain_method(shared, block, |s| s == "Broken", true))
             }
             "keep" => {
                 let value = args.into_iter().next().unwrap_or(Value::Bool(true));

--- a/t/concurrency-basic.t
+++ b/t/concurrency-basic.t
@@ -7,7 +7,8 @@ $p.keep(42);
 is $p.result, 42, 'promise result after keep';
 is $p.status, "Kept", 'promise status kept';
 
-my $p2 = $p.then(-> $x { $x + 1 });
+# .then passes the Promise itself to the callback, not the result
+my $p2 = $p.then(-> $x { $x.result + 1 });
 is $p2.result, 43, 'promise then transforms result';
 
 my $c = Channel.new();

--- a/t/concurrency-threading.t
+++ b/t/concurrency-threading.t
@@ -46,6 +46,7 @@ plan 10;
 # Test 6: Promise.then chains
 {
     my $p = start { 10 };
-    my $p2 = $p.then(-> $v { $v * 2 });
+    # .then passes the Promise itself to the callback, not the result
+    my $p2 = $p.then(-> $v { $v.result * 2 });
     is await($p2), 20, 'promise.then chains correctly';
 }


### PR DESCRIPTION
## Summary
- Fix `.then` to pass the original Promise to the callback (not the resolved value), matching Raku semantics
- Fix `.result` to properly throw on Broken promises when called before resolution (previously returned the error string instead of dying)
- Add `.andthen` and `.orelse` methods on Promise for conditional chaining
- Update local tests `t/concurrency-basic.t` and `t/concurrency-threading.t` to match correct Raku semantics
- Refactor `.then`/`.andthen`/`.orelse` to share a common helper to reduce duplication

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/concurrency-basic.t t/concurrency-threading.t` passes
- [x] `roast/S17-promise/then.t` tests 1-14 now pass (up from ~7 before)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)