### PR TITLE
feat: implement Thread class methods for S17-lowlevel/thread.t

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -420,6 +420,22 @@ impl Interpreter {
         if class_name == "IO::Path" && method_name == "comb" {
             return true;
         }
+        // Thread native methods
+        if class_name == "Thread"
+            && matches!(
+                method_name,
+                "finish"
+                    | "id"
+                    | "name"
+                    | "is-initial-thread"
+                    | "app_lifetime"
+                    | "Str"
+                    | "gist"
+                    | "WHAT"
+            )
+        {
+            return true;
+        }
         let mro = self.class_mro(class_name);
         for cn in mro {
             if let Some(class_def) = self.classes.get(&cn)

--- a/src/runtime/methods_collection_ops/mod.rs
+++ b/src/runtime/methods_collection_ops/mod.rs
@@ -91,3 +91,46 @@ static THREAD_HANDLES: std::sync::LazyLock<Mutex<HashMap<u64, std::thread::JoinH
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static NEXT_THREAD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// The OS thread ID of the initial (main) thread, captured at first access.
+static INITIAL_THREAD_ID: std::sync::LazyLock<std::thread::ThreadId> =
+    std::sync::LazyLock::new(|| std::thread::current().id());
+
+/// Returns true if the current OS thread is the initial (main) thread.
+pub(crate) fn is_initial_thread() -> bool {
+    std::thread::current().id() == *INITIAL_THREAD_ID
+}
+
+// Thread-local mutsu thread ID. Set by Thread.start for spawned threads.
+thread_local! {
+    static MUTSU_THREAD_ID: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
+}
+
+/// Set the mutsu thread ID for the current thread.
+pub(super) fn set_current_mutsu_thread_id(id: i64) {
+    MUTSU_THREAD_ID.with(|cell| cell.set(id));
+}
+
+/// Get the mutsu thread ID for the current thread.
+/// Returns 1 for the main thread, the assigned ID for spawned threads.
+pub(crate) fn current_mutsu_thread_id() -> i64 {
+    let id = MUTSU_THREAD_ID.with(|cell| cell.get());
+    if id == 0 {
+        if is_initial_thread() {
+            MUTSU_THREAD_ID.with(|cell| cell.set(1));
+            1
+        } else {
+            // Fallback for threads not started via Thread.start
+            let thread_id = std::thread::current().id();
+            let id_str = format!("{:?}", thread_id);
+            id_str
+                .chars()
+                .filter(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        }
+    } else {
+        id
+    }
+}

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -369,46 +369,83 @@ impl Interpreter {
     }
 
     /// Thread.start({ block }) -- spawn a real OS thread
+    /// Supports named params: :name("..."), :app_lifetime
     pub(in crate::runtime) fn dispatch_thread_start(
         &mut self,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
-        let block = args.first().cloned().unwrap_or(Value::Nil);
+        // Extract the block and named parameters from args
+        let mut block = Value::Nil;
+        let mut thread_name = "<anon>".to_string();
+        let mut app_lifetime = false;
+
+        for arg in args {
+            match arg {
+                Value::Pair(k, v) if k.as_str() == "name" => {
+                    thread_name = v.to_string_value();
+                }
+                Value::Pair(k, v) if k.as_str() == "app_lifetime" => {
+                    app_lifetime = v.truthy();
+                }
+                _ => {
+                    block = arg.clone();
+                }
+            }
+        }
+
         let thread_id = NEXT_THREAD_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         let mut thread_interp = self.clone_for_thread();
+        // Enable immediate stdout so thread output goes directly to stdout
+        thread_interp.set_immediate_stdout(true);
+        let mutsu_tid = thread_id as i64;
         let handle = std::thread::spawn(move || {
+            // Set the mutsu thread ID for $*THREAD.id consistency
+            super::set_current_mutsu_thread_id(mutsu_tid);
             match thread_interp.call_sub_value(block, vec![], false) {
                 Ok(_) => {}
                 Err(e) => {
                     eprintln!("Thread error: {}", e.message);
                 }
             }
-            // Flush any output from the thread
+            // Flush any remaining buffered output from the thread
             let output = std::mem::take(&mut thread_interp.output);
             if !output.is_empty() {
-                print!("{}", output);
+                use std::io::Write;
+                let _ = std::io::stdout().write_all(output.as_bytes());
+                let _ = std::io::stdout().flush();
             }
             let stderr = std::mem::take(&mut thread_interp.stderr_output);
             if !stderr.is_empty() {
-                eprint!("{}", stderr);
+                use std::io::Write;
+                let _ = std::io::stderr().write_all(stderr.as_bytes());
+                let _ = std::io::stderr().flush();
             }
         });
 
-        THREAD_HANDLES.lock().unwrap().insert(thread_id, handle);
+        if app_lifetime {
+            // For app_lifetime threads, don't store the handle -- the thread
+            // will be killed when the main thread exits
+            drop(handle);
+        } else {
+            THREAD_HANDLES.lock().unwrap().insert(thread_id, handle);
+        }
 
         let mut attrs = HashMap::new();
-        attrs.insert("thread_id".to_string(), Value::Int(thread_id as i64));
+        attrs.insert("id".to_string(), Value::Int(thread_id as i64));
+        attrs.insert("name".to_string(), Value::str(thread_name));
+        attrs.insert("app_lifetime".to_string(), Value::Bool(app_lifetime));
         Ok(Value::make_instance(Symbol::intern("Thread"), attrs))
     }
 
-    /// Thread.finish — join the thread (block until it completes)
+    /// Thread.finish -- join the thread (block until it completes)
     pub(in crate::runtime) fn dispatch_thread_finish(
         &mut self,
         attributes: &HashMap<String, Value>,
     ) -> Result<Value, RuntimeError> {
         let thread_id = attributes
-            .get("thread_id")
+            .get("id")
+            .or_else(|| attributes.get("thread_id"))
             .and_then(|v| {
                 if let Value::Int(i) = v {
                     Some(*i as u64)

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -90,6 +90,17 @@ impl Interpreter {
                 )))
             }
             "start" => self.dispatch_promise_start(&target, &args),
+            "is-initial-thread" => {
+                if matches!(&target, Value::Package(cn) if cn == "Thread")
+                    || matches!(&target, Value::Instance { class_name, .. } if class_name == "Thread")
+                {
+                    Some(Ok(Value::Bool(
+                        super::methods_collection_ops::is_initial_thread(),
+                    )))
+                } else {
+                    None
+                }
+            }
             "in" => self.dispatch_promise_in(&target, &args),
             "THREAD" => {
                 if let Value::Junction { values, .. } = &target {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -200,6 +200,9 @@ pub(crate) use self::registration_class::ClassDeclModifiers;
 
 pub(crate) use utils::*;
 
+// Re-export thread utility functions for VM access
+pub(crate) use methods_collection_ops::{current_mutsu_thread_id, is_initial_thread};
+
 use self::unicode::{check_unicode_property, check_unicode_property_with_args};
 
 pub(super) type ClassAttributeDef = (

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -410,8 +410,40 @@ impl Interpreter {
                 .or_else(|| attributes.get("thread_id"))
                 .cloned()
                 .unwrap_or(Value::Int(0))),
+            "name" => Ok(attributes
+                .get("name")
+                .cloned()
+                .unwrap_or_else(|| Value::str_from("<anon>"))),
+            "is-initial-thread" => {
+                let is_initial = attributes
+                    .get("is_initial")
+                    .map(|v| v.truthy())
+                    .unwrap_or(false);
+                Ok(Value::Bool(is_initial))
+            }
+            "app_lifetime" => Ok(attributes
+                .get("app_lifetime")
+                .cloned()
+                .unwrap_or(Value::Bool(false))),
             "WHAT" => Ok(Value::Package(crate::symbol::Symbol::intern("Thread"))),
-            "Str" | "gist" => Ok(Value::str_from("Thread")),
+            "Str" | "gist" => {
+                let id = attributes
+                    .get("id")
+                    .or_else(|| attributes.get("thread_id"))
+                    .and_then(|v| {
+                        if let Value::Int(i) = v {
+                            Some(*i)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(0);
+                let name = attributes
+                    .get("name")
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "<anon>".to_string());
+                Ok(Value::str(format!("Thread<{id}>({name})")))
+            }
             _ => Err(RuntimeError::new(format!(
                 "No method '{}' on Thread",
                 method

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -1,20 +1,16 @@
 use super::*;
+use crate::runtime::{current_mutsu_thread_id, is_initial_thread};
 use crate::symbol::Symbol;
 
 impl VM {
-    /// Create a Thread instance with the current OS thread's ID.
+    /// Create a Thread instance with the current thread's mutsu ID.
     pub(super) fn make_thread_instance() -> Value {
-        let thread_id = std::thread::current().id();
-        // Extract a numeric ID from ThreadId's Debug representation
-        let id_str = format!("{:?}", thread_id);
-        let numeric_id: i64 = id_str
-            .chars()
-            .filter(|c| c.is_ascii_digit())
-            .collect::<String>()
-            .parse()
-            .unwrap_or(0);
+        let numeric_id = current_mutsu_thread_id();
+        let is_initial = is_initial_thread();
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("id".to_string(), Value::Int(numeric_id));
+        attrs.insert("name".to_string(), Value::str_from("<anon>"));
+        attrs.insert("is_initial".to_string(), Value::Bool(is_initial));
         Value::make_instance(Symbol::intern("Thread"), attrs)
     }
 

--- a/t/thread.t
+++ b/t/thread.t
@@ -1,0 +1,77 @@
+use Test;
+
+plan 16;
+
+# Thread.is-initial-thread
+ok Thread.is-initial-thread, 'Thread.is-initial-thread is True on main thread';
+ok $*THREAD.is-initial-thread, '$*THREAD.is-initial-thread is True on main thread';
+
+# Thread.start and isa-ok
+{
+    my $t = Thread.start({ 1 });
+    isa-ok $t, Thread;
+    $t.finish;
+}
+
+# Code in thread runs, is-initial-thread is False in spawned threads
+{
+    my $t = Thread.start({
+        nok Thread.is-initial-thread, 'Thread.is-initial-thread is False in spawned thread';
+        nok $*THREAD.is-initial-thread, '$*THREAD.is-initial-thread is False in spawned thread';
+        pass "Code in thread ran";
+    });
+    $t.finish;
+    pass "Thread was finished";
+}
+
+# Thread name
+{
+    my $t = Thread.start(:name("test thread"), { 1 });
+    is $t.name, "test thread", "Thread has correct name";
+    $t.finish;
+}
+
+{
+    my $t = Thread.start({ 1 });
+    is $t.name, "<anon>", "Default thread name is <anon>";
+    $t.finish;
+}
+
+# Thread id
+{
+    my $t1 = Thread.start({ 1 });
+    my $t2 = Thread.start({ 1 });
+    isnt $t1.id, 0, "Thread has non-zero ID";
+    isnt $t1.id, $t2.id, "Different threads have different IDs";
+    $t1.finish;
+    $t2.finish;
+}
+
+# Thread Str
+{
+    my $t = Thread.start({ 1 });
+    ok $t.Str ~~ /^ Thread '<' \d+ '>' '(<anon>)' $/,
+        "Thread stringification includes id and name";
+    $t.finish;
+}
+
+# $*THREAD.id consistency
+{
+    my $tid;
+    my $t = Thread.start({ $tid = $*THREAD.id; });
+    $t.finish;
+    is $tid, $t.id, '$*THREAD.id inside thread matches $t.id';
+}
+
+# $*THREAD on main thread
+{
+    isa-ok $*THREAD, Thread, '$*THREAD is a Thread on main thread';
+    isnt $*THREAD.id, 0, 'Main thread has a non-zero ID';
+}
+
+# app_lifetime thread
+{
+    my $start = now;
+    my $alt = Thread.start({ sleep 10000 }, :app_lifetime);
+    ok now - $start < 5, "app_lifetime thread doesn't block main thread";
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive Thread class support: `is-initial-thread`, `name`, `Str`/`gist`, `app_lifetime`, consistent `$*THREAD.id` tracking
- Handle `:name` and `:app_lifetime` named parameters in `Thread.start`
- Enable immediate stdout for thread output (needed for TAP protocol)
- Register Thread methods in `is_native_method` for proper dispatch routing

Improves `roast/S17-lowlevel/thread.t` from **0/29 to 25/29** passing subtests. Remaining 4 failures are `cas` performance tests that timeout due to interpreter speed (10000 iterations x 3 threads).

## Test plan
- [x] New `t/thread.t` with 16 tests covering all Thread features
- [x] `make test` passes (488 files, 3999 tests)
- [x] Roast whitelist passes (1 pre-existing flaky spurt.t failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)