### PR TITLE
fix: per-candidate language revision tracking for role versioning

### DIFF
--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -783,7 +783,7 @@ impl Interpreter {
                     let values = candidates
                         .iter()
                         .enumerate()
-                        .map(|(idx, _)| {
+                        .map(|(idx, cand)| {
                             // Create Instance values with candidate index so
                             // .WHY can look up per-candidate doc comments
                             let mut attrs = std::collections::HashMap::new();
@@ -794,6 +794,17 @@ impl Interpreter {
                             attrs.insert(
                                 "__mutsu_role_base_name".to_string(),
                                 Value::str(base_name.clone()),
+                            );
+                            // Embed per-candidate language revision
+                            let revision: String =
+                                if let Some(letter) = cand.language_version.strip_prefix("6.") {
+                                    letter.chars().next().unwrap_or('c').to_string()
+                                } else {
+                                    "c".to_string()
+                                };
+                            attrs.insert(
+                                "__mutsu_language_revision".to_string(),
+                                Value::str(revision),
                             );
                             Value::make_instance(Symbol::intern(&base_name), attrs)
                         })
@@ -944,6 +955,20 @@ impl Interpreter {
                 }
             }
             "language-revision" if !args.is_empty() => {
+                // Check for per-candidate language revision embedded as an
+                // attribute (set by ^candidates for role candidate instances).
+                if let Value::Instance { attributes, .. } = &args[0]
+                    && let Some(rev) = attributes.get("__mutsu_language_revision")
+                {
+                    return Ok(rev.clone());
+                }
+                // Check for language revision in Mixin metadata (from
+                // parametric role pun instances).
+                if let Value::Mixin(_, mixins) = &args[0]
+                    && let Some(rev) = mixins.get("__mutsu_language_revision")
+                {
+                    return Ok(rev.clone());
+                }
                 let type_name = match &args[0] {
                     Value::Package(name) => name.resolve(),
                     Value::Instance { class_name, .. } => class_name.resolve(),

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -100,6 +100,7 @@ impl Interpreter {
             let base_name_str = base_name.resolve();
             self.ensure_role_punned_to_class(&base_name_str);
             let mut selected_role = self.roles.get(&base_name_str).cloned();
+            let mut matched_lang_version: Option<String> = None;
             let mut selected_param_names = self
                 .role_type_params
                 .get(&base_name_str)
@@ -181,6 +182,7 @@ impl Interpreter {
                 matching.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
                 if let Some((candidate, _, _)) = matching.into_iter().next() {
                     selected_param_names = candidate.type_params.clone();
+                    matched_lang_version = Some(candidate.language_version.clone());
                     selected_role = Some(candidate.role_def.clone());
                 }
             }
@@ -233,6 +235,20 @@ impl Interpreter {
                     mixins.insert(format!("__mutsu_attr__{}", attr_name), value);
                 }
                 self.env = saved_role_param_env;
+                // Embed language revision in mixin metadata so
+                // ^language-revision on the punned instance returns
+                // the revision of the matched candidate.
+                if let Some(ref ver) = matched_lang_version {
+                    let revision: String = if let Some(letter) = ver.strip_prefix("6.") {
+                        letter.chars().next().unwrap_or('c').to_string()
+                    } else {
+                        "c".to_string()
+                    };
+                    mixins.insert(
+                        "__mutsu_language_revision".to_string(),
+                        Value::str(revision),
+                    );
+                }
                 return Ok(Value::mixin(
                     Value::make_instance(*base_name, HashMap::new()),
                     mixins,
@@ -2522,6 +2538,36 @@ impl Interpreter {
                         Value::Nil
                     };
                     mixins.insert(format!("__mutsu_attr__{}", attr_name), value);
+                }
+                // Embed language revision from the matching candidate
+                // (no-params for bare role punning) so ^language-revision
+                // returns the correct value for this role's origin module.
+                let cn_str = class_name.resolve();
+                let bare_lang_ver = self
+                    .role_candidates
+                    .get(&cn_str)
+                    .and_then(|candidates| {
+                        candidates
+                            .iter()
+                            .find(|c| c.type_params.is_empty())
+                            .map(|c| c.language_version.clone())
+                    })
+                    .or_else(|| {
+                        self.type_metadata
+                            .get(&cn_str)
+                            .and_then(|m| m.get("language-revision"))
+                            .map(|v| format!("6.{}", v.to_string_value()))
+                    });
+                if let Some(ver) = bare_lang_ver {
+                    let revision: String = if let Some(letter) = ver.strip_prefix("6.") {
+                        letter.chars().next().unwrap_or('c').to_string()
+                    } else {
+                        "c".to_string()
+                    };
+                    mixins.insert(
+                        "__mutsu_language_revision".to_string(),
+                        Value::str(revision),
+                    );
                 }
                 return Ok(Value::mixin(
                     Value::make_instance(*class_name, HashMap::new()),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -314,6 +314,8 @@ struct RoleCandidateDef {
     role_def: RoleDef,
     /// Parent classes/roles declared via `is` on this candidate.
     parents: Vec<String>,
+    /// Language version (e.g. "6.c") captured at registration time.
+    language_version: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2850,6 +2850,7 @@ impl Interpreter {
                 type_param_defs: type_param_defs.to_vec(),
                 role_def: role_def.clone(),
                 parents: candidate_parents,
+                language_version: crate::parser::current_language_version(),
             });
         if self
             .roles
@@ -3115,6 +3116,19 @@ impl Interpreter {
         // Register the role and its composed roles
         self.class_composed_roles
             .insert(role_name.to_string(), composed_roles_list);
+        // When punning a bare role (no type params), update the language
+        // revision metadata from the matching candidate so that
+        // `.^language-revision` on the pun instance returns the correct
+        // revision (not the last-registered candidate's revision).
+        let candidate_lang_version = self.role_candidates.get(role_name).and_then(|candidates| {
+            candidates
+                .iter()
+                .find(|c| c.type_params.is_empty())
+                .map(|c| c.language_version.clone())
+        });
+        if let Some(version) = candidate_lang_version {
+            self.store_language_revision_from_version(role_name, &version);
+        }
     }
 
     /// Validate that all `$!attr` references in method bodies refer to attributes

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -52,7 +52,7 @@ impl Interpreter {
         let saved_class_trusts = self.class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.subsets.clone();
-        let saved_type_metadata = self.type_metadata.clone();
+        let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
         let run_result = self.call_sub_value(block, vec![], true);
         // If `plan skip-all` was used inside a Block callable, the error is fatal
@@ -76,6 +76,10 @@ impl Interpreter {
             self.class_trusts = saved_class_trusts;
             self.roles = saved_roles;
             self.subsets = saved_subsets;
+            // Merge type_metadata: preserve entries added during the subtest
+            for (key, val) in std::mem::take(&mut self.type_metadata) {
+                saved_type_metadata.entry(key).or_insert(val);
+            }
             self.type_metadata = saved_type_metadata;
             self.restore_var_type_constraints(saved_var_type_constraints);
             return Err(run_result.unwrap_err());
@@ -100,6 +104,10 @@ impl Interpreter {
         self.class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.subsets = saved_subsets;
+        // Merge type_metadata: preserve entries added during the subtest
+        for (key, val) in std::mem::take(&mut self.type_metadata) {
+            saved_type_metadata.entry(key).or_insert(val);
+        }
         self.type_metadata = saved_type_metadata;
         self.restore_var_type_constraints(saved_var_type_constraints);
         self.finish_subtest(ctx, &label, run_result.map(|_| ()))?;
@@ -143,7 +151,7 @@ impl Interpreter {
         let saved_class_trusts = self.class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.subsets.clone();
-        let saved_type_metadata = self.type_metadata.clone();
+        let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
         self.test_fn_plan(&[Value::Int(plan)])?;
         let run_result = self.call_sub_value(block, vec![], true);
@@ -157,6 +165,10 @@ impl Interpreter {
         self.class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.subsets = saved_subsets;
+        // Merge type_metadata: preserve entries added during the subtest
+        for (key, val) in std::mem::take(&mut self.type_metadata) {
+            saved_type_metadata.entry(key).or_insert(val);
+        }
         self.type_metadata = saved_type_metadata;
         self.restore_var_type_constraints(saved_var_type_constraints);
         self.finish_subtest(ctx, &desc, run_result.map(|_| ()))?;


### PR DESCRIPTION
## Summary
- Track language revision per role candidate so that multi-module role definitions with different `use v6.*` declarations report the correct revision via `^language-revision`
- Add `language_version` field to `RoleCandidateDef` and embed it in `^candidates` Instance attributes and role pun Mixin metadata
- Merge (rather than restore) `type_metadata` across subtests so module-loaded metadata persists

## Test plan
- [x] `roast/S14-roles/versioning.t` subtests 1-3 now pass (16 of 23 individual tests, up from 9)
- [x] Subtest 4 (Submethods) has 4 remaining failures requiring separate language-version-dependent submethod composition feature
- [x] `cargo test` passes
- [x] `make test` passes (only flaky `t/lock.t` test 10 intermittently fails)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)