### PR TITLE
docs: document open_closed.t roast test status

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -36,6 +36,7 @@
 - [ ] roast/S12-class/mro-6e.t
 - [ ] roast/S12-class/namespaced.t
 - [ ] roast/S12-class/open_closed.t
+  - 8/9 pass. Test 7 fails due to typo in the roast test itself: line 52 defines `method h {'called Qux.i'}` but line 56 expects `'called Qux.h'`. Cannot whitelist until roast is fixed upstream. raku itself also cannot run this test (missing `oo` module).
 - [ ] roast/S12-class/open.t
 - [ ] roast/S12-class/parent_attributes.t
 - [ ] roast/S12-class/rw.t


### PR DESCRIPTION
## Summary
- Document that `roast/S12-class/open_closed.t` passes 8/9 subtests in mutsu
- The single failure (test 7) is caused by a typo in the roast test itself: line 52 defines `method h {'called Qux.i'}` but line 56 expects `'called Qux.h'`
- Cannot whitelist until the roast test is fixed upstream
- `raku` itself cannot run this test (missing `oo` module)

## Test plan
- [x] Verified mutsu passes 8/9 subtests
- [x] Confirmed the failure is a roast test typo, not a mutsu bug
- [x] Updated TODO_roast/S12.md with status notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)