### PR TITLE
fix: underscore-to-kebab normalization for dynamic variable names

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -124,6 +124,19 @@ impl VM {
     }
 
     pub(super) fn get_env_with_main_alias(&self, name: &str) -> Option<Value> {
+        // Raku allows underscore variants of kebab-case identifiers
+        // (e.g. $*EXECUTABLE_NAME is equivalent to $*EXECUTABLE-NAME).
+        // Try the kebab-case equivalent first if the name contains underscores.
+        if name.contains('_') {
+            let kebab = name.replace('_', "-");
+            if let Some(val) = self.get_env_with_main_alias_inner(&kebab) {
+                return Some(val);
+            }
+        }
+        self.get_env_with_main_alias_inner(name)
+    }
+
+    fn get_env_with_main_alias_inner(&self, name: &str) -> Option<Value> {
         // Atomic array CAS stores the authoritative copy under an internal key.
         // Always check it first so both thread-clone and non-clone reads
         // observe the latest CAS'd value.

--- a/t/underscore-kebab-var.t
+++ b/t/underscore-kebab-var.t
@@ -1,0 +1,15 @@
+use Test;
+
+plan 4;
+
+# Raku allows underscore variants of kebab-case identifiers
+# $*EXECUTABLE_NAME should be equivalent to $*EXECUTABLE-NAME
+
+is $*EXECUTABLE-NAME, 'mutsu', '$*EXECUTABLE-NAME works';
+is $*EXECUTABLE_NAME, 'mutsu', '$*EXECUTABLE_NAME works (underscore variant)';
+is $*EXECUTABLE_NAME, $*EXECUTABLE-NAME, 'underscore and kebab variants are equivalent';
+
+# User-defined dynamic variables with kebab-case should also be accessible
+# via underscore variant
+my $*my-var = 42;
+is $*my_var, 42, 'user-defined $*my-var accessible as $*my_var';


### PR DESCRIPTION
## Summary
- Adds underscore-to-kebab normalization in `get_env_with_main_alias` so that `$*EXECUTABLE_NAME` resolves to `$*EXECUTABLE-NAME` (and similarly for any dynamic variable)
- In Raku, identifiers with underscores are equivalent to their kebab-case variants
- Adds test covering the feature (`t/underscore-kebab-var.t`)

## Context
Investigated while working on `roast/S19-command-line-options/01-dash-uppercase-i.t`. That test cannot fully pass because it uses deprecated Pugs-era features (`$*OS`, `@*INC`, shell-style `run`) that don't exist in modern Raku. However, the underscore-to-kebab normalization is a genuine general-purpose improvement.

## Test plan
- [x] `make test` passes (489 tests, all successful)
- [x] Roast whitelisted tests pass (verified first 100)
- [x] New test `t/underscore-kebab-var.t` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)