### PR TITLE
feat: implement atomic variable operation functions

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -171,6 +171,114 @@ impl Compiler {
                 arg_sources_idx: None,
             });
             return;
+        } else if name == "atomic-assign"
+            && args.len() == 2
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_store_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.compile_expr(&args[1]);
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 2,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-fetch-inc"
+            && args.len() == 1
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_post_inc_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 1,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-inc-fetch"
+            && args.len() == 1
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_pre_inc_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 1,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-fetch-dec"
+            && args.len() == 1
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_post_dec_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 1,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-dec-fetch"
+            && args.len() == 1
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_pre_dec_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 1,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-fetch-add"
+            && args.len() == 2
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_fetch_add_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.compile_expr(&args[1]);
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 2,
+                arg_sources_idx: None,
+            });
+            return;
+        } else if name == "atomic-add-fetch"
+            && args.len() == 2
+            && let Expr::Var(var_name) = &args[0]
+        {
+            let call_name_idx = self
+                .code
+                .add_constant(Value::str_from("__mutsu_atomic_add_var"));
+            let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::LoadConst(arg_idx));
+            self.compile_expr(&args[1]);
+            self.code.emit(OpCode::CallFunc {
+                name_idx: call_name_idx,
+                arity: 2,
+                arg_sources_idx: None,
+            });
+            return;
         }
         // Rewrite cas($var, ...) -> __mutsu_cas_var($var_name_str, ...)
         if name == "cas"

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -745,6 +745,7 @@ impl Interpreter {
             "__mutsu_atomic_fetch_var" => self.builtin_atomic_fetch_var(&args),
             "__mutsu_atomic_store_var" => self.builtin_atomic_store_var(&args),
             "__mutsu_atomic_add_var" => self.builtin_atomic_add_var(&args),
+            "__mutsu_atomic_fetch_add_var" => self.builtin_atomic_fetch_add_var(&args),
             "__mutsu_atomic_post_inc_var" => self.builtin_atomic_post_inc_var(&args),
             "__mutsu_atomic_pre_inc_var" => self.builtin_atomic_pre_inc_var(&args),
             "__mutsu_atomic_post_dec_var" => self.builtin_atomic_post_dec_var(&args),

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -191,6 +191,34 @@ impl Interpreter {
         Ok(next)
     }
 
+    /// Like `builtin_atomic_add_var` but returns the OLD value (before adding).
+    pub(super) fn builtin_atomic_fetch_add_var(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if args.len() < 2 {
+            return Err(RuntimeError::new(
+                "atomic-fetch-add requires variable name and increment value",
+            ));
+        }
+        let raw_name = args[0].to_string_value();
+        let name = self.canonical_atomic_var_name(&raw_name, args.first());
+        let delta = args[1].clone();
+        self.check_readonly_for_modify(&name)?;
+        let value_key = self.atomic_value_key_for_name(&name);
+        let mut shared = self.shared_vars.write().unwrap();
+        let current = self.atomic_current_value(&shared, &name, &value_key);
+        let next = crate::builtins::arith_add(current.clone(), delta)?;
+        self.env.insert(name.clone(), next.clone());
+        shared.insert(value_key.clone(), next.clone());
+        drop(shared);
+        if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+            dirty.insert(value_key);
+            dirty.insert(name);
+        }
+        Ok(current)
+    }
+
     pub(super) fn builtin_atomic_update_unit(
         &mut self,
         args: &[Value],

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -6,7 +6,18 @@ use num_bigint::BigInt as NumBigInt;
 
 /// All recognized native integer type names.
 pub(crate) const NATIVE_INT_TYPES: &[&str] = &[
-    "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "byte", "int", "uint",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "byte",
+    "int",
+    "uint",
+    "atomicint",
 ];
 
 /// Returns true if `name` is a native integer type.
@@ -30,7 +41,7 @@ pub(crate) fn native_int_bounds(type_name: &str) -> Option<(NumBigInt, NumBigInt
             NumBigInt::from(-2147483648i64),
             NumBigInt::from(2147483647i64),
         )),
-        "int64" | "int" => Some((
+        "int64" | "int" | "atomicint" => Some((
             NumBigInt::from(-9223372036854775808i64),
             NumBigInt::from(9223372036854775807i64),
         )),

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -386,6 +386,7 @@ impl VM {
                 | "byte"
                 | "int"
                 | "uint"
+                | "atomicint"
                 | "num"
                 | "num32"
                 | "num64"

--- a/t/atomic-functions.t
+++ b/t/atomic-functions.t
@@ -1,0 +1,44 @@
+use Test;
+plan 16;
+
+# full-barrier
+lives-ok { full-barrier() }, 'full-barrier lives';
+
+# atomic-fetch and atomic-assign
+{
+    my Int $x = 42;
+    is atomic-fetch($x), 42, 'atomic-fetch returns current value';
+    is atomic-assign($x, 100), 100, 'atomic-assign returns new value';
+    is atomic-fetch($x), 100, 'atomic-fetch after assign returns updated value';
+    is $x, 100, 'variable updated after atomic-assign';
+}
+
+# atomic-fetch-inc / atomic-fetch-dec
+{
+    my atomicint $x = 10;
+    is atomic-fetch-inc($x), 10, 'atomic-fetch-inc returns old value';
+    is atomic-fetch-inc($x), 11, 'atomic-fetch-inc incremented';
+    is atomic-fetch-dec($x), 12, 'atomic-fetch-dec returns old value';
+    is atomic-fetch-dec($x), 11, 'atomic-fetch-dec decremented';
+}
+
+# atomic-inc-fetch / atomic-dec-fetch
+{
+    my atomicint $x = 10;
+    is atomic-inc-fetch($x), 11, 'atomic-inc-fetch returns new value';
+    is atomic-dec-fetch($x), 10, 'atomic-dec-fetch returns new value';
+}
+
+# atomic-fetch-add / atomic-add-fetch
+{
+    my atomicint $x = 10;
+    is atomic-fetch-add($x, 5), 10, 'atomic-fetch-add returns old value';
+    is atomic-fetch($x), 15, 'value updated after atomic-fetch-add';
+    is atomic-add-fetch($x, 5), 20, 'atomic-add-fetch returns new value';
+}
+
+# atomicint is recognized as a type
+ok atomicint.Range.defined, 'atomicint.Range is defined';
+
+# type check on atomic-assign
+dies-ok { my Int $y = 42; atomic-assign($y, 'not-an-int') }, 'atomic-assign type check dies';


### PR DESCRIPTION
## Summary
- Add compiler rewrites for all standard Raku atomic variable operations: `atomic-assign`, `atomic-fetch-inc`, `atomic-inc-fetch`, `atomic-fetch-dec`, `atomic-dec-fetch`, `atomic-fetch-add`, `atomic-add-fetch`
- Add `builtin_atomic_fetch_add_var` (returns old value before adding) to complement existing `builtin_atomic_add_var` (returns new value)
- Recognize `atomicint` as a builtin type with proper int64 Range bounds

This brings `roast/S17-lowlevel/atomic.t` from 2/34 to 34/34 passing (the test is already whitelisted).

## Test plan
- [x] All 34 subtests in `roast/S17-lowlevel/atomic.t` pass
- [x] New `t/atomic-functions.t` with 16 tests covering all atomic operations
- [x] `cargo test` passes
- [x] `make test` passes (only pre-existing flaky `t/lock.t` test 10 fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)