### PR TITLE
fix: Supplier reuse after done/quit and Tap.close return value

### DIFF
--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -29,8 +29,8 @@ pub(in crate::runtime) use state::{
     register_async_connection, register_promise_combinator_sources, register_supply_tap,
     register_udp_bound_socket, set_supply_collected_output, supplier_done, supplier_done_deferred,
     supplier_emit, supplier_id_from_attrs, supplier_quit, supplier_register_promise,
-    supplier_snapshot, supply_channel_map, supply_channel_map_pub, take_promise_combinator_sources,
-    udp_port_in_use, update_async_connection,
+    supplier_reset, supplier_snapshot, supply_channel_map, supply_channel_map_pub,
+    take_promise_combinator_sources, udp_port_in_use, update_async_connection,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;
@@ -38,14 +38,14 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, ZipAction, close_supplier_channel_taps, flush_supplier_batch_taps,
-    flush_supplier_line_taps, flush_supplier_words_taps, get_classify_state,
-    get_classify_sub_supplier_ids, get_start_output_supplier_ids, get_supplier_zip_state_ids,
-    last_supplier_tap_id, register_supplier_batch_tap, register_supplier_channel_tap,
-    register_supplier_classify_tap, register_supplier_done_callback, register_supplier_elems_tap,
-    register_supplier_flat_tap, register_supplier_lines_tap, register_supplier_produce_tap,
-    register_supplier_quit_callback, register_supplier_start_tap, register_supplier_tap,
-    register_supplier_tap_with_head_limit, register_supplier_unique_tap,
+    SupplierEmitAction, ZipAction, close_all_supplier_taps, close_supplier_channel_taps,
+    flush_supplier_batch_taps, flush_supplier_line_taps, flush_supplier_words_taps,
+    get_classify_state, get_classify_sub_supplier_ids, get_start_output_supplier_ids,
+    get_supplier_zip_state_ids, last_supplier_tap_id, register_supplier_batch_tap,
+    register_supplier_channel_tap, register_supplier_classify_tap, register_supplier_done_callback,
+    register_supplier_elems_tap, register_supplier_flat_tap, register_supplier_lines_tap,
+    register_supplier_produce_tap, register_supplier_quit_callback, register_supplier_start_tap,
+    register_supplier_tap, register_supplier_tap_with_head_limit, register_supplier_unique_tap,
     register_supplier_words_tap, register_supplier_zip_tap, register_zip_state,
     supplier_emit_callbacks, supplier_produce_update_acc, supplier_tap_count,
     supplier_unique_get_seen, supplier_unique_mark_seen, take_supplier_done_callbacks,

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -133,7 +133,7 @@ impl Interpreter {
                 {
                     close_supplier_tap(*supplier_id as u64, *tap_id as u64);
                 }
-                Ok(Value::Nil)
+                Ok(Value::Bool(true))
             }
             "socket-port" => Ok(attributes
                 .get("socket-port")

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -320,6 +320,17 @@ pub(in crate::runtime) fn supplier_quit(supplier_id: u64, reason: Value) {
     }
 }
 
+/// Reset the supplier state after done/quit so it can be reused.
+pub(in crate::runtime) fn supplier_reset(supplier_id: u64) {
+    if let Ok(mut map) = supplier_state_map().lock()
+        && let Some(state) = map.get_mut(&supplier_id)
+    {
+        state.done = false;
+        state.quit_reason = None;
+        state.emitted.clear();
+    }
+}
+
 pub(in crate::runtime) fn next_supply_id() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     COUNTER.fetch_add(1, Ordering::Relaxed)

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -133,6 +133,19 @@ pub(in crate::runtime) fn close_supplier_tap(supplier_id: u64, tap_id: u64) {
     }
 }
 
+/// Close all taps on the given supplier so they stop receiving emits.
+pub(in crate::runtime) fn close_all_supplier_taps(supplier_id: u64) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get_mut(&supplier_id)
+    {
+        for tap in subs.taps.iter_mut() {
+            tap.closed = true;
+        }
+        subs.done_callbacks.clear();
+        subs.quit_callbacks.clear();
+    }
+}
+
 /// Return the id of the most recently registered tap on the given supplier,
 /// if any. Used by `tap` to build a Tap handle that can be closed.
 pub(in crate::runtime) fn last_supplier_tap_id(supplier_id: u64) -> Option<u64> {

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1715,6 +1715,8 @@ impl Interpreter {
                             }
                         }
                     }
+                    close_all_supplier_taps(supplier_id);
+                    supplier_reset(supplier_id);
                 }
                 Ok(Value::Nil)
             }
@@ -1738,9 +1740,9 @@ impl Interpreter {
                             self.call_supply_quit_handler(quit_cb, reason.clone())?;
                         }
                     }
-                    for done_cb in take_supplier_done_callbacks(supplier_id) {
-                        self.call_sub_value(done_cb, Vec::new(), true)?;
-                    }
+                    let _ = take_supplier_done_callbacks(supplier_id);
+                    close_all_supplier_taps(supplier_id);
+                    supplier_reset(supplier_id);
                 }
                 Ok(Value::Nil)
             }
@@ -2006,7 +2008,11 @@ impl Interpreter {
                             }
                         }
                     }
+                    close_all_supplier_taps(sid);
+                    supplier_reset(sid);
                 }
+                attrs.insert("done".to_string(), Value::Bool(false));
+                attrs.remove("emitted");
                 Ok((Value::Nil, attrs))
             }
             "quit" => {
@@ -2031,10 +2037,13 @@ impl Interpreter {
                     for quit_cb in take_supplier_quit_callbacks(sid) {
                         self.call_supply_quit_handler(quit_cb, reason.clone())?;
                     }
-                    for done_cb in take_supplier_done_callbacks(sid) {
-                        self.call_sub_value(done_cb, Vec::new(), true)?;
-                    }
+                    let _ = take_supplier_done_callbacks(sid);
+                    close_all_supplier_taps(sid);
+                    supplier_reset(sid);
                 }
+                attrs.insert("done".to_string(), Value::Bool(false));
+                attrs.remove("quit_reason");
+                attrs.remove("emitted");
                 Ok((Value::Nil, attrs))
             }
             _ => Err(RuntimeError::new(format!(


### PR DESCRIPTION
## Summary
- After `Supplier.done()` or `.quit()`, reset the supplier state and close all existing taps so the supplier can accept new taps and emits. This matches Raku semantics where done/quit only affect taps that were active at the time.
- `Tap.close` now returns `True` instead of `Nil`.
- `Supplier.quit()` no longer fires done callbacks (only quit callbacks).

Fixes 20 of 24 failing subtests in `roast/S17-supply/basic.t` (from 56/80 to 76/80 passing).

## Test plan
- [x] `roast/S17-supply/basic.t` passes 76/80 subtests (up from 56/80)
- [ ] `make test` passes (CI will verify)
- [ ] `make roast` passes (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)