### PR TITLE
fix: pass all 178 subtests in roast/S16-io/lines.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -764,6 +764,7 @@ roast/S16-io/eof.t
 roast/S16-io/getc.t
 roast/S16-io/handles-between-threads.t
 roast/S16-io/home.t
+roast/S16-io/lines.t
 roast/S16-io/newline.t
 roast/S16-io/note.t
 roast/S16-io/print.t

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -1084,18 +1084,27 @@ impl Interpreter {
             .cloned()
             .or_else(|| self.default_input_handle());
         if let Some(handle) = handle {
-            let limit = args.get(1).and_then(|arg| match arg {
-                Value::Int(i) => Some((*i).max(0) as usize),
-                Value::BigInt(bi) => {
-                    use num_traits::ToPrimitive;
-                    Some(bi.to_usize().unwrap_or(usize::MAX))
+            let mut limit: Option<usize> = None;
+            let mut close_after = false;
+            let extra_args = if args.len() > 1 { &args[1..] } else { &[] };
+            for arg in extra_args {
+                match arg {
+                    Value::Pair(k, v) if k == "close" => {
+                        close_after = v.truthy();
+                    }
+                    Value::Pair(..) => {}
+                    Value::Int(i) => limit = Some((*i).max(0) as usize),
+                    Value::BigInt(bi) => {
+                        use num_traits::ToPrimitive;
+                        limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                    }
+                    Value::Whatever => {}
+                    Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
+                    Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
+                    Value::Rat(n, d) if *d == 0 && *n > 0 => {}
+                    _ => {}
                 }
-                Value::Whatever => None,
-                Value::Num(f) if f.is_infinite() && f.is_sign_positive() => None,
-                Value::Num(f) if *f >= 0.0 => Some(*f as usize),
-                Value::Rat(n, d) if *d == 0 && *n > 0 => None,
-                _ => None,
-            });
+            }
             if limit.is_none() {
                 // No limit: return a lazy IO lines iterator so that
                 // consumers (e.g. for-loop) can read on demand.
@@ -1115,7 +1124,10 @@ impl Interpreter {
                     break;
                 }
             }
-            return Ok(Value::array(lines));
+            if close_after {
+                self.close_handle_value(&handle)?;
+            }
+            return Ok(Value::Seq(std::sync::Arc::new(lines)));
         }
         Ok(Value::array(Vec::new()))
     }

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -51,6 +51,51 @@ impl Interpreter {
         }
     }
 
+    /// Split a string into lines using the given line separators and chomp
+    /// setting.  Used by IO::Path.lines to honour :nl-in / :!chomp.
+    pub(super) fn split_content_by_separators(
+        content: &str,
+        separators: &[Vec<u8>],
+        chomp: bool,
+    ) -> Vec<Value> {
+        let bytes = content.as_bytes();
+        let mut result = Vec::new();
+        let mut pos = 0;
+        while pos < bytes.len() {
+            // Scan for the next separator starting from current position
+            let mut found: Option<(usize, usize)> = None; // (offset, sep_len)
+            'outer: for i in pos..bytes.len() {
+                for sep in separators {
+                    if bytes[i..].starts_with(sep) {
+                        found = Some((i, sep.len()));
+                        break 'outer;
+                    }
+                }
+            }
+            match found {
+                Some((offset, sep_len)) => {
+                    if chomp {
+                        let line = &bytes[pos..offset];
+                        result.push(Value::str(String::from_utf8_lossy(line).to_string()));
+                    } else {
+                        let line = &bytes[pos..offset + sep_len];
+                        result.push(Value::str(String::from_utf8_lossy(line).to_string()));
+                    }
+                    pos = offset + sep_len;
+                }
+                None => {
+                    // Remaining text (no trailing separator)
+                    let line = &bytes[pos..];
+                    if !line.is_empty() {
+                        result.push(Value::str(String::from_utf8_lossy(line).to_string()));
+                    }
+                    break;
+                }
+            }
+        }
+        result
+    }
+
     pub(super) fn handle_id_from_value(value: &Value) -> Option<usize> {
         if let Value::Instance {
             class_name,

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -601,11 +601,24 @@ impl Interpreter {
                 let content = fs::read_to_string(&path_buf)
                     .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
                 let content = super::utils::strip_utf8_bom(content);
-                let parts = content
-                    .lines()
-                    .map(|line| Value::str(line.to_string()))
-                    .collect();
-                Ok(Value::array(parts))
+
+                // Parse nl-in / chomp named args
+                let (_, _, _, _, chomp, nl_in, _, _, _, _) = self.parse_io_flags_values(&args);
+                let mut parts = Self::split_content_by_separators(&content, &nl_in, chomp);
+
+                // Check for a positional limit argument
+                let limit = args.iter().find_map(|arg| match arg {
+                    Value::Int(i) => Some((*i).max(0) as usize),
+                    Value::BigInt(bi) => {
+                        use num_traits::ToPrimitive;
+                        Some(bi.to_usize().unwrap_or(usize::MAX))
+                    }
+                    _ => None,
+                });
+                if let Some(n) = limit {
+                    parts.truncate(n);
+                }
+                Ok(Value::Seq(std::sync::Arc::new(parts)))
             }
             "words" => {
                 let content = fs::read_to_string(&path_buf)
@@ -2236,24 +2249,34 @@ impl Interpreter {
                 ))
             }
             "lines" => {
-                let limit = args.first().and_then(|arg| match arg {
-                    Value::Int(i) => Some((*i).max(0) as usize),
-                    Value::BigInt(bi) => {
-                        use num_traits::ToPrimitive;
-                        Some(bi.to_usize().unwrap_or(usize::MAX))
+                let mut limit: Option<usize> = None;
+                let mut close_after = false;
+                for arg in &args {
+                    match arg {
+                        Value::Pair(k, v) if k == "close" => {
+                            close_after = v.truthy();
+                        }
+                        Value::Pair(..) => {}
+                        Value::Int(i) => limit = Some((*i).max(0) as usize),
+                        Value::BigInt(bi) => {
+                            use num_traits::ToPrimitive;
+                            limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                        }
+                        Value::Whatever => {}
+                        Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
+                        Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
+                        Value::Rat(n, d) if *d == 0 && *n > 0 => {}
+                        Value::Rat(n, d) if *d != 0 => {
+                            limit = Some(((*n as f64 / *d as f64) as i64).max(0) as usize);
+                        }
+                        Value::Complex(re, im) if *im == 0.0 && *re >= 0.0 => {
+                            limit = Some(*re as usize);
+                        }
+                        _ => {}
                     }
-                    Value::Whatever => None,
-                    Value::Num(f) if f.is_infinite() && f.is_sign_positive() => None,
-                    Value::Num(f) if *f >= 0.0 => Some(*f as usize),
-                    Value::Rat(n, d) if *d == 0 && *n > 0 => None,
-                    Value::Rat(n, d) if *d != 0 => {
-                        Some(((*n as f64 / *d as f64) as i64).max(0) as usize)
-                    }
-                    Value::Complex(re, im) if *im == 0.0 && *re >= 0.0 => Some(*re as usize),
-                    _ => None,
-                });
+                }
                 if limit.is_some() {
-                    // Bounded: read eagerly
+                    // Bounded: read eagerly, return Seq
                     let mut lines = Vec::new();
                     while let Some(line) = self.read_line_from_handle_value(&target_val)? {
                         lines.push(Value::str(line));
@@ -2263,7 +2286,10 @@ impl Interpreter {
                             break;
                         }
                     }
-                    Ok(Value::array(lines))
+                    if close_after {
+                        self.close_handle_value(&target_val)?;
+                    }
+                    Ok(Value::Seq(std::sync::Arc::new(lines)))
                 } else {
                     // No limit: return a lazy IO lines iterator so that
                     // consumers (e.g. for-loop) can read on demand and

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -944,6 +944,23 @@ impl Interpreter {
         Ok(Value::array(lines))
     }
 
+    /// Force a `LazyIoLines` value into an eager array by reading at most `n`
+    /// lines from the file handle, leaving the rest available for subsequent reads.
+    pub(crate) fn force_lazy_io_lines_n(
+        &mut self,
+        handle: &Value,
+        n: usize,
+    ) -> Result<Value, RuntimeError> {
+        let mut lines = Vec::new();
+        while lines.len() < n {
+            match self.read_line_from_handle_value(handle)? {
+                Some(line) => lines.push(Value::str(line)),
+                None => break,
+            }
+        }
+        Ok(Value::array(lines))
+    }
+
     pub(super) fn split_block_phasers(&self, stmts: &[Stmt]) -> SplitPhasers {
         let mut pre_ph = Vec::new();
         let mut enter_ph = Vec::new();

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -466,6 +466,10 @@ impl VM {
                     ll.cache.lock().unwrap().clone().unwrap_or_default()
                 }
             }
+            Value::LazyIoLines { .. } => match self.force_if_lazy_io_lines(val) {
+                Ok(forced) => crate::runtime::utils::value_to_list(&forced),
+                Err(_) => vec![],
+            },
             Value::Range(..)
             | Value::RangeExcl(..)
             | Value::RangeExclStart(..)

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -225,8 +225,52 @@ impl VM {
             self.stack.push(target);
             return Ok(());
         }
-        if let Value::LazyIoLines { .. } = target {
-            target = self.force_if_lazy_io_lines(target)?;
+        if let Value::LazyIoLines { ref handle, kv } = target {
+            // Determine the maximum index requested so we only read the
+            // minimum number of lines from the handle, leaving the rest
+            // available for subsequent reads.
+            let needed = match &index {
+                Value::Int(i) if *i >= 0 => Some((*i as usize).saturating_add(1)),
+                // Array index like [1,2] — find max element
+                Value::Array(items, _) => {
+                    let mut max_idx: Option<usize> = None;
+                    let mut has_negative = false;
+                    for item in items.iter() {
+                        match item {
+                            Value::Int(i) if *i >= 0 => {
+                                let u = *i as usize;
+                                max_idx = Some(max_idx.map_or(u, |m: usize| m.max(u)));
+                            }
+                            _ => {
+                                has_negative = true;
+                            }
+                        }
+                    }
+                    if has_negative {
+                        None // negative/whatever index — must read all
+                    } else {
+                        max_idx.map(|m| m.saturating_add(1))
+                    }
+                }
+                _ => None, // Whatever (*-1) or unknown — read all
+            };
+            target = match needed {
+                Some(n) => {
+                    let forced = self.interpreter.force_lazy_io_lines_n(handle, n)?;
+                    if kv {
+                        let items = crate::runtime::utils::value_to_list(&forced);
+                        let mut kv_items = Vec::with_capacity(items.len() * 2);
+                        for (i, v) in items.iter().enumerate() {
+                            kv_items.push(Value::Int(i as i64));
+                            kv_items.push(v.clone());
+                        }
+                        Value::array(kv_items)
+                    } else {
+                        forced
+                    }
+                }
+                None => self.force_if_lazy_io_lines(target)?,
+            };
         }
         if let Value::LazyList(ref ll) = target {
             let forced = if ll.scan_spec.is_some() {


### PR DESCRIPTION
## Summary
- Fix `|$handle.lines` (MakeSlip) to properly flatten LazyIoLines into slip items
- Make `$handle.lines[1,2]` read only the needed lines from the handle, leaving the rest available for subsequent `$handle.lines` calls (partial indexing)
- Add `:nl-in` and `:!chomp` support to `IO::Path.lines` via custom separator splitting
- Add `:close` support to `IO::Handle.lines` and `&lines()` to close the handle after reading
- Return `Seq` (not `Array`) from bounded `IO::Handle.lines($limit)` and `IO::Path.lines`

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S16-io/lines.t` passes all 178 subtests
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass
- [x] `prove -e 'target/debug/mutsu' t/` passes (only pre-existing flaky `t/lock.t` failure)
- [ ] CI (`make test` + `make roast`) passes

Generated with [Claude Code](https://claude.com/claude-code)