### PR TITLE
perf: monomorphic inline cache for method resolution

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -145,6 +145,9 @@ pub(crate) struct VM {
     /// Method resolution cache: maps (class_name, method_name) to resolved
     /// (owner_class, MethodDef). Avoids repeated MRO walks for the same method.
     method_resolve_cache: HashMap<(Symbol, Symbol), Option<(String, crate::runtime::MethodDef)>>,
+    /// Monomorphic inline cache: stores the last (class, method, owner, def)
+    /// resolution result. Skips HashMap lookup for repeated same-class calls.
+    last_method_resolve: Option<(Symbol, Symbol, String, crate::runtime::MethodDef)>,
     /// Stack of sets tracking variable names declared (via SetVarDynamic) within
     /// each active BlockScope. Used during BlockScope restoration to avoid
     /// propagating block-local variable values to the outer scope.
@@ -317,6 +320,7 @@ impl VM {
             pos_light_call_cache: HashMap::new(),
             pos_light_call_cache_gen: 0,
             method_resolve_cache: HashMap::new(),
+            last_method_resolve: None,
             block_declared_vars: Vec::new(),
             pending_alias_bind_names: Vec::new(),
             otf_call_cache: HashMap::new(),

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -237,29 +237,40 @@ impl VM {
         };
         if let Some(cn) = class_name
             && let Some((owner_class, method_def)) = {
-                let cache_key = (
-                    crate::symbol::Symbol::intern(&cn),
-                    crate::symbol::Symbol::intern(method),
-                );
-                // Check cache, but skip cached results for multi-methods since
-                // multi-dispatch depends on argument types/arity.
-                let cached = self.method_resolve_cache.get(&cache_key).cloned();
-                if let Some(ref hit) = cached
-                    && let Some((_, def)) = hit
-                    && !def.is_multi
+                let class_sym = crate::symbol::Symbol::intern(&cn);
+                let method_sym = crate::symbol::Symbol::intern(method);
+                // Monomorphic inline cache: single-entry check before HashMap.
+                if let Some((cc, cm, ref co, ref cd)) = self.last_method_resolve
+                    && cc == class_sym
+                    && cm == method_sym
+                    && !cd.is_multi
                 {
-                    hit.clone()
+                    Some((co.clone(), cd.clone()))
                 } else {
-                    let resolved = self
-                        .interpreter
-                        .resolve_method_with_owner_invocant(&cn, method, &args, &target);
-                    // Only cache non-multi methods; multi-method resolution depends
-                    // on argument types and must not be cached by name alone.
-                    if resolved.as_ref().is_none_or(|(_, def)| !def.is_multi) {
-                        self.method_resolve_cache
-                            .insert(cache_key, resolved.clone());
+                    let cache_key = (class_sym, method_sym);
+                    let cached = self.method_resolve_cache.get(&cache_key).cloned();
+                    let result = if let Some(ref hit) = cached
+                        && let Some((_, def)) = hit
+                        && !def.is_multi
+                    {
+                        hit.clone()
+                    } else {
+                        let resolved = self
+                            .interpreter
+                            .resolve_method_with_owner_invocant(&cn, method, &args, &target);
+                        if resolved.as_ref().is_none_or(|(_, def)| !def.is_multi) {
+                            self.method_resolve_cache
+                                .insert(cache_key, resolved.clone());
+                        }
+                        resolved
+                    };
+                    if let Some((ref owner, ref def)) = result
+                        && !def.is_multi
+                    {
+                        self.last_method_resolve =
+                            Some((class_sym, method_sym, owner.clone(), def.clone()));
                     }
-                    resolved
+                    result
                 }
             }
         {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -315,6 +315,7 @@ impl VM {
             )?;
             self.fn_resolve_gen += 1;
             self.method_resolve_cache.clear();
+            self.last_method_resolve = None;
             if *is_export && !self.interpreter.suppress_exports {
                 self.interpreter.register_exported_sub(
                     self.interpreter.current_package().to_string(),
@@ -486,6 +487,7 @@ impl VM {
         self.interpreter.use_module_with_tags(module, &tags)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
         self.env_dirty = true;
         Ok(())
     }
@@ -512,6 +514,7 @@ impl VM {
         self.interpreter.import_module(module, &tags)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
         self.env_dirty = true;
         Ok(())
     }
@@ -525,6 +528,7 @@ impl VM {
         self.interpreter.no_module(module)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
         self.env_dirty = true;
         Ok(())
     }
@@ -538,6 +542,7 @@ impl VM {
         self.interpreter.need_module(module)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
         self.env_dirty = true;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add single-entry inline cache (`last_method_resolve`) for method resolution
- Skips HashMap lookup for repeated same-class+method calls (tight loops)
- Cache cleared alongside `method_resolve_cache` on class/role registration

bench-class ~2-4% improvement. Low risk — falls through to existing HashMap cache on miss.

## Test plan
- [x] `make test` passes
- [x] All attribute/method tests pass
- [x] No benchmark regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)