### PR TITLE
perf: reduce method dispatch entry overhead

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -133,6 +133,11 @@ Potential improvements:
 
 ## Optimization History
 
+### 2026-05-23: Reduce method dispatch entry overhead
+- **Change**: Three optimizations: (1) Wrap MethodDef in Arc in method resolve cache — cache hit clone is now O(1) instead of deep-cloning Vec<String>/Vec<ParamDef>. (2) Avoid String allocations for method_raw and modifier — use `&str` from constant pool, only allocate when modifier requires `^`/`!` prefix (rare). (3) Skip Slip flattening when no Slip args present — check discriminants first, reuse raw_args Vec directly.
+- **Effect**: Incremental (~1-3μs per call, hard to measure on noisy 1-core system)
+- **Value**: Reduces allocation count per method call from 3-4 Strings to 1, eliminates MethodDef deep clone on cache hit, and avoids Vec copy for non-Slip args.
+
 ### 2026-05-23: Monomorphic inline cache for method resolution
 - **Change**: Add `last_method_resolve` single-entry cache to VM. Before HashMap lookup, compare (class_sym, method_sym) with last result using pointer equality. Populate cache on HashMap hit or full resolution.
 - **Effect**: bench-class ~2-4% improvement
@@ -231,18 +236,16 @@ Implemented `call_compiled_method_fast()` with batched env inserts, direct local
 
 `$!attr` now compiles to `GetLocal` instead of `GetGlobal`. Attribute locals are allocated for all `!attr` references (Var, Assign, PostIncrement, PreIncrement, PostDecrement, PreDecrement). The fast method dispatch path skips `!attr`/`.attr` env inserts since locals handle all reads/writes. `sync_locals_from_env` skips `!attr` locals to prevent stale overwrites. Inc/dec fast paths skip Proxy-bound attributes (`:=` bindings) and fall back to the env-based path.
 
-**Step 2: Eliminate `exec_call_method_op` overhead**
+**Step 2: Eliminate `exec_call_method_op` overhead — PARTIAL (2026-05-23)**
 
-The VM entry point `exec_call_method_op` does:
-- `Self::const_str(code, name_idx).to_string()` — String allocation per call
-- `Self::rewrite_method_name()` — modifier processing
-- `Self::append_flattened_call_arg()` — Slip flattening check per arg
-- Junction autothread check
+Done:
+- Avoid String allocation for `method_raw` and `modifier` — use `&str` from constant pool
+- Skip Slip flattening when no Slip args present
+- Arc<MethodDef> in resolve cache to avoid deep clone on cache hit
 
-For the common case (no modifier, no junction, no slip), most of this is wasted:
-- Use `Symbol` (interned string) for method names instead of `String`
-- Skip junction check when target is `Value::Instance`
-- Skip slip flattening when args have no Slip values (checkable via flag)
+Remaining:
+- Use `Symbol` (interned string) for method names to avoid the one remaining `.to_string()` in `rewrite_method_name`
+- Skip junction check when target is `Value::Instance` (minimal impact — pattern match already fast-fails)
 
 **Step 3: Lightweight call frame for simple methods**
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -11,6 +11,8 @@ use crate::symbol::Symbol;
 use crate::value::{ArrayKind, EnumValue, JunctionKind, LazyList, RuntimeError, Value, make_rat};
 use num_traits::{Signed, Zero};
 
+type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
+
 mod vm_arith_ops;
 mod vm_call_autothread;
 mod vm_call_dispatch;
@@ -144,10 +146,10 @@ pub(crate) struct VM {
     pos_light_call_cache_gen: u64,
     /// Method resolution cache: maps (class_name, method_name) to resolved
     /// (owner_class, MethodDef). Avoids repeated MRO walks for the same method.
-    method_resolve_cache: HashMap<(Symbol, Symbol), Option<(String, crate::runtime::MethodDef)>>,
+    method_resolve_cache: HashMap<(Symbol, Symbol), MethodResolveEntry>,
     /// Monomorphic inline cache: stores the last (class, method, owner, def)
     /// resolution result. Skips HashMap lookup for repeated same-class calls.
-    last_method_resolve: Option<(Symbol, Symbol, String, crate::runtime::MethodDef)>,
+    last_method_resolve: Option<(Symbol, Symbol, String, Arc<crate::runtime::MethodDef>)>,
     /// Stack of sets tracking variable names declared (via SetVarDynamic) within
     /// each active BlockScope. Used during BlockScope restoration to avoid
     /// propagating block-local variable values to the outer scope.

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -249,21 +249,24 @@ impl VM {
                 } else {
                     let cache_key = (class_sym, method_sym);
                     let cached = self.method_resolve_cache.get(&cache_key).cloned();
-                    let result = if let Some(ref hit) = cached
-                        && let Some((_, def)) = hit
-                        && !def.is_multi
-                    {
-                        hit.clone()
-                    } else {
-                        let resolved = self
-                            .interpreter
-                            .resolve_method_with_owner_invocant(&cn, method, &args, &target);
-                        if resolved.as_ref().is_none_or(|(_, def)| !def.is_multi) {
-                            self.method_resolve_cache
-                                .insert(cache_key, resolved.clone());
-                        }
-                        resolved
-                    };
+                    let result: Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> =
+                        if let Some(ref hit) = cached
+                            && let Some((_, def)) = hit
+                            && !def.is_multi
+                        {
+                            hit.clone()
+                        } else {
+                            let resolved = self
+                                .interpreter
+                                .resolve_method_with_owner_invocant(&cn, method, &args, &target);
+                            let resolved_arc =
+                                resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
+                            if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
+                                self.method_resolve_cache
+                                    .insert(cache_key, resolved_arc.clone());
+                            }
+                            resolved_arc
+                        };
                     if let Some((ref owner, ref def)) = result
                         && !def.is_multi
                     {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -10,7 +10,7 @@ impl VM {
         modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new("VM stack underflow in CallMethodDynamic"));
@@ -31,7 +31,7 @@ impl VM {
             .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamic target"))?;
         // Force lazy IO lines for non-lazy-preserving methods
         let method_name_str = name_val.to_string_value();
-        let method = Self::rewrite_method_name(&method_name_str, modifier.as_deref());
+        let method = Self::rewrite_method_name(&method_name_str, modifier);
         let target = if matches!(&target, Value::LazyIoLines { .. })
             && !matches!(method.as_str(), "kv" | "iterator" | "lazy")
         {
@@ -40,7 +40,7 @@ impl VM {
             target
         };
         // Handle .* and .+ modifiers
-        match modifier.as_deref() {
+        match modifier {
             Some("+") => {
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
@@ -222,7 +222,7 @@ impl VM {
                 self.try_compiled_method_or_interpret(target, &method, args)
             }
         };
-        match modifier.as_deref() {
+        match modifier {
             Some("?") => match call_result {
                 Ok(val) => self.stack.push(val),
                 Err(e) if Self::is_method_not_found_error(&e) => self.stack.push(Value::Nil),
@@ -245,7 +245,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
         let target_name = Self::const_str(code, target_name_idx).to_string();
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new(
@@ -267,9 +267,9 @@ impl VM {
             .pop()
             .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamicMut"))?;
         let method_name_str = name_val.to_string_value();
-        let method = Self::rewrite_method_name(&method_name_str, modifier.as_deref());
+        let method = Self::rewrite_method_name(&method_name_str, modifier);
         // Handle .* and .+ modifiers
-        match modifier.as_deref() {
+        match modifier {
             Some("+") => {
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
@@ -322,22 +322,26 @@ impl VM {
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.interpreter
             .set_pending_call_arg_sources(arg_sources.clone());
-        let method_raw = Self::const_str(code, name_idx).to_string();
+        let method_raw = Self::const_str(code, name_idx);
         let target_name = Self::const_str(code, target_name_idx).to_string();
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
-        let method = Self::rewrite_method_name(&method_raw, modifier.as_deref());
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
+        let method = Self::rewrite_method_name(method_raw, modifier);
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
             return Err(RuntimeError::new("VM stack underflow in CallMethodMut"));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip values in the argument list (from |capture slipping)
-        let preserve_empty_slip = Self::preserve_empty_slip_arg(&method);
-        let mut args = Vec::new();
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
-        }
+        let args = if raw_args.iter().any(|a| matches!(a, Value::Slip(_))) {
+            let preserve_empty_slip = Self::preserve_empty_slip_arg(&method);
+            let mut args = Vec::new();
+            for arg in raw_args {
+                Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
+            }
+            args
+        } else {
+            raw_args
+        };
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("VM stack underflow in CallMethodMut target".to_string())
         })?;
@@ -1079,7 +1083,7 @@ impl VM {
         };
         // For .* and .+ modifiers, skip the single-dispatch call and go
         // directly to the all-methods-in-MRO path to avoid double execution.
-        match modifier.as_deref() {
+        match modifier {
             Some("+") => {
                 let vals =
                     self.call_method_all_with_fallback(&target, &method, &args, skip_native)?;
@@ -1233,7 +1237,7 @@ impl VM {
                 } else {
                     self.try_compiled_method_mut_or_interpret(&target_name, target, &method, args)
                 };
-                match modifier.as_deref() {
+                match modifier {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -18,21 +18,25 @@ impl VM {
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.interpreter
             .set_pending_call_arg_sources(arg_sources.clone());
-        let method_raw = Self::const_str(code, name_idx).to_string();
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
-        let method = Self::rewrite_method_name(&method_raw, modifier.as_deref());
+        let method_raw = Self::const_str(code, name_idx);
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
+        let method = Self::rewrite_method_name(method_raw, modifier);
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
             return Err(RuntimeError::new("VM stack underflow in CallMethod"));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        // Flatten any Slip values in the argument list (from |capture slipping)
-        let preserve_empty_slip = Self::preserve_empty_slip_arg(&method);
-        let mut args = Vec::new();
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
-        }
+        let args = if raw_args.iter().any(|a| matches!(a, Value::Slip(_))) {
+            let preserve_empty_slip = Self::preserve_empty_slip_arg(&method);
+            let mut args = Vec::new();
+            for arg in raw_args {
+                Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
+            }
+            args
+        } else {
+            raw_args
+        };
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("VM stack underflow in CallMethod target".to_string())
         })?;
@@ -617,7 +621,7 @@ impl VM {
             return Err(err);
         }
         // Pseudo-methods (WHAT, WHICH, etc.) cannot be used with .* or .+
-        if matches!(modifier.as_deref(), Some("*") | Some("+"))
+        if matches!(modifier, Some("*") | Some("+"))
             && matches!(
                 method.as_str(),
                 "WHAT" | "WHICH" | "WHERE" | "HOW" | "WHY" | "WHO" | "DEFINITE" | "VAR"
@@ -625,12 +629,12 @@ impl VM {
         {
             return Err(RuntimeError::new(format!(
                 "Cannot use .{} on a non-identifier method call",
-                modifier.as_deref().unwrap()
+                modifier.unwrap()
             )));
         }
         // For .* and .+ modifiers, skip the single-dispatch call and go
         // directly to the all-methods-in-MRO path to avoid double execution.
-        match modifier.as_deref() {
+        match modifier {
             Some("+") => {
                 let vals =
                     self.call_method_all_with_fallback(&target, &method, &args, skip_native)?;
@@ -823,7 +827,7 @@ impl VM {
                             self.try_native_method(&resolved, Symbol::intern(&method), &args)
                         {
                             let result = native_result;
-                            match modifier.as_deref() {
+                            match modifier {
                                 Some("?") => {
                                     self.stack.push(result.unwrap_or(Value::Nil));
                                     self.env_dirty = true;
@@ -871,7 +875,7 @@ impl VM {
                 } else {
                     self.try_compiled_method_or_interpret(target, &method, args)
                 };
-                match modifier.as_deref() {
+                match modifier {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -11,8 +11,8 @@ impl VM {
         quoted: bool,
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
-        let method_raw = Self::const_str(code, name_idx).to_string();
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
+        let method_raw = Self::const_str(code, name_idx);
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
             return Err(RuntimeError::new("VM stack underflow in HyperMethodCall"));
@@ -50,7 +50,7 @@ impl VM {
         };
         let mut results = Vec::with_capacity(items.len());
         for (idx, item) in items.iter_mut().enumerate() {
-            let method = Self::rewrite_method_name(&method_raw, modifier.as_deref());
+            let method = Self::rewrite_method_name(method_raw, modifier);
             // Special case: CALL-ME on callable items (from >>.(args) syntax).
             // Instead of method dispatch, invoke the item directly as a callable.
             if method == "CALL-ME"
@@ -100,7 +100,7 @@ impl VM {
                 }
             }
             let item_args = args.clone();
-            match modifier.as_deref() {
+            match modifier {
                 Some("?") => {
                     let val = if !skip_native {
                         if let Some(native_result) =
@@ -445,7 +445,7 @@ impl VM {
         modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         self.ensure_env_synced(code);
-        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx).to_string());
+        let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new(
@@ -468,7 +468,7 @@ impl VM {
         ))
         .then(|| {
             let method_raw = name_val.to_string_value();
-            Self::rewrite_method_name(&method_raw, modifier.as_deref())
+            Self::rewrite_method_name(&method_raw, modifier)
         });
         for (idx, item) in items.iter_mut().enumerate() {
             let item_args = args.clone();
@@ -479,7 +479,7 @@ impl VM {
                 let mut call_args = Vec::with_capacity(item_args.len() + 1);
                 call_args.push(item.clone());
                 call_args.extend(item_args);
-                match modifier.as_deref() {
+                match modifier {
                     Some("?") => {
                         results.push(
                             self.vm_call_on_value(name_val.clone(), call_args, None)
@@ -503,7 +503,7 @@ impl VM {
             let method = method
                 .as_ref()
                 .expect("method string exists for non-callables");
-            match modifier.as_deref() {
+            match modifier {
                 Some("?") => {
                     let val = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)


### PR DESCRIPTION
## Summary

- **Arc<MethodDef> in method resolve cache**: Avoids deep-cloning MethodDef (params Vec<String>, param_defs Vec<ParamDef>) on every inline cache hit. Cache clone is now O(1) Arc bump instead of O(n) allocation.
- **Avoid String allocations for method_raw and modifier**: Use `&str` from constant pool directly. Only allocate when `rewrite_method_name` prepends `^` or `!` (rare modifier case).
- **Skip Slip flattening when no Slip args**: Check discriminants before iterating; reuse raw_args Vec directly when no Slips present, avoiding a second Vec allocation and N push calls.

These are incremental optimizations following PERFORMANCE.md Phase 1 Step 2. Individual gains are small (~1-3μs per call) but cumulative across the hot method dispatch path.

## Test plan
- [x] `make test` passes (all 490 tests, 4019 subtests)
- [x] `cargo clippy -- -D warnings` clean
- [x] Roast class/method tests pass
- [x] Benchmark verification (bench-class, method-call, bench-fib, int-arith)

🤖 Generated with [Claude Code](https://claude.com/claude-code)