### PR TITLE
perf: lightweight call frame for fast method dispatch

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -247,14 +247,11 @@ Remaining:
 - Use `Symbol` (interned string) for method names to avoid the one remaining `.to_string()` in `rewrite_method_name`
 - Skip junction check when target is `Value::Instance` (minimal impact — pattern match already fast-fails)
 
-**Step 3: Lightweight call frame for simple methods**
+**Step 3: Lightweight call frame — PARTIAL (2026-05-23)**
 
-`push_call_frame` saves: env, readonly_vars, locals, stack_depth, env_dirty, locals_dirty, locals_dirty_slots, local_bind_pairs. For simple methods, most of these are unnecessary:
-- `readonly_vars`: only needed if method uses `:=` binding
-- `local_bind_pairs`: only needed if method uses `:=` binding
-- `locals_dirty_slots`: Vec allocation per call
+Added `push_light_call_frame()` that skips cloning `readonly_vars: HashSet<String>`. The fast method dispatch path uses this since simple methods don't use `:=` binding. `VmCallFrame.saved_readonly` is now `Option<HashSet<String>>` — `pop_call_frame` only restores when `Some`.
 
-Create a `push_light_call_frame` that only saves env + locals + stack_depth.
+Remaining: `locals_dirty_slots` and `local_bind_pairs` are moved via `std::mem::take` (O(1)), so skipping them would not improve performance.
 
 ### Phase 2: Compile-time method resolution — target: method-call < 1.5x
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -56,7 +56,8 @@ pub(super) struct VmCallFrame {
     pub saved_env: Env,
     pub saved_locals: Vec<Value>,
     pub saved_stack_depth: usize,
-    pub saved_readonly: HashSet<String>,
+    /// None when using light call frame (simple methods that don't use `:=` binding).
+    pub saved_readonly: Option<HashSet<String>>,
     pub saved_env_dirty: bool,
     pub saved_locals_dirty: bool,
     pub saved_locals_dirty_slots: Vec<bool>,

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -19,7 +19,25 @@ impl VM {
     pub(super) fn push_call_frame(&mut self) {
         let frame = VmCallFrame {
             saved_env: self.interpreter.clone_env(),
-            saved_readonly: self.interpreter.save_readonly_vars(),
+            saved_readonly: Some(self.interpreter.save_readonly_vars()),
+            saved_locals: std::mem::take(&mut self.locals),
+            saved_stack_depth: self.stack.len(),
+            saved_env_dirty: self.env_dirty,
+            saved_locals_dirty: self.locals_dirty,
+            saved_locals_dirty_slots: std::mem::take(&mut self.locals_dirty_slots),
+            saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
+        };
+        self.env_dirty = false;
+        self.locals_dirty = false;
+        self.call_frames.push(frame);
+    }
+
+    /// Lightweight call frame for simple methods: skips saving readonly vars
+    /// since simple methods don't use `:=` binding.
+    pub(super) fn push_light_call_frame(&mut self) {
+        let frame = VmCallFrame {
+            saved_env: self.interpreter.clone_env(),
+            saved_readonly: None,
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
@@ -42,8 +60,9 @@ impl VM {
         self.locals = std::mem::take(&mut frame.saved_locals);
         self.locals_dirty_slots = std::mem::take(&mut frame.saved_locals_dirty_slots);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
-        self.interpreter
-            .restore_readonly_vars(std::mem::take(&mut frame.saved_readonly));
+        if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
+            self.interpreter.restore_readonly_vars(readonly);
+        }
         self.env_dirty = frame.saved_env_dirty;
         self.locals_dirty = frame.saved_locals_dirty;
         frame

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -740,7 +740,7 @@ impl VM {
             );
         }
 
-        self.push_call_frame();
+        self.push_light_call_frame();
         let saved_stack_depth = self.call_frames.last().unwrap().saved_stack_depth;
         let saved_var_bindings = self.interpreter.take_var_bindings();
         self.interpreter.push_method_class(owner_class.to_string());


### PR DESCRIPTION
## Summary

- Add `push_light_call_frame()` that skips cloning the `readonly_vars` HashSet<String>
- Simple methods on the fast dispatch path don't use `:=` binding, so readonly vars save/restore is unnecessary
- `VmCallFrame.saved_readonly` is now `Option<HashSet<String>>` — `pop_call_frame` only restores when `Some`

This is Phase 1 Step 3 from PERFORMANCE.md. The HashSet clone was a small but repeated cost on every fast-path method call.

## Test plan
- [x] `make test` passes (flaky lock.t excluded — timing-dependent concurrency test)
- [x] `cargo clippy -- -D warnings` clean
- [x] Benchmarks verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)