### PR TITLE
perf: pre-compute attribute slot indices for method exit writeback

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -102,7 +102,7 @@ Both hash insert and delete fast paths now handle `Arc::strong_count == 2` by te
 | **env deep clone + batched inserts** | **~15μs** | **Arc::make_mut + all special vars + attrs in one hold** |
 | Direct locals init | ~2μs | Populate from source data (attrs, params, special vars) |
 | **Bytecode execution** | **~1μs** | The actual method body |
-| Cleanup (can_skip_merge) | ~5μs | Writeback attrs from locals, restore env |
+| Cleanup (can_skip_merge) | ~3μs | Writeback attrs via pre-computed slot indices, restore env |
 | Cleanup (non-can_skip_merge) | ~10μs | Sync locals→env, merge, writeback |
 | **Total** | **~40μs** | **Down from ~54μs (26% faster)** |
 
@@ -132,6 +132,11 @@ Potential improvements:
 - Specialize compiled code for known-Int arguments
 
 ## Optimization History
+
+### 2026-05-23: Pre-compute attribute slot indices for method exit writeback
+- **Change**: Add `AttrSlots` struct to `CompiledCode` that pre-computes local slot indices for each attribute (private, public, array, hash variants) at compile time. `writeback_attributes_from_locals` uses these pre-computed indices instead of 6 × N_attrs linear searches with `format!()` allocations per method exit. Also eliminate env round-trip in `call_compiled_method_fast`'s `can_skip_merge` path — attribute writeback goes directly from locals to attributes.
+- **Effect**: method-call ~4% faster, bench-class ~3% faster
+- **Value**: Eliminates O(6 × N_attrs × N_locals) string comparisons and 6 × N_attrs `format!()` allocations per method exit. For a class with 3 attributes and 10 locals, this saves ~18 heap allocations and ~90 string comparisons per method call.
 
 ### 2026-05-23: Avoid String allocation and skip wrap chain check
 - **Change**: Two optimizations: (1) Use `Cow<str>` in `rewrite_method_name` for `exec_call_method_op` — avoids a String allocation on every method call when no modifier (`^`/`!`) is present (the common case). The method name stays as a borrowed `&str` from the constant pool. (2) Add `has_any_wrap_chains()` early return in `check_method_wrap_chain` — skip the expensive `find_method_candidate_index` (which computes AST fingerprints) and `get_method_wrap_chain` when no wrap chains exist.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -955,6 +955,22 @@ pub(crate) struct CompiledCode {
     /// that are NOT method-local (attributes, params, special vars).
     /// When true, the fast method path cannot use a fresh env.
     pub(crate) may_capture_outer_vars: bool,
+    /// Pre-computed attribute slot mapping for fast writeback on method exit.
+    /// Each entry: (attr_name, private_slot, public_slot, arr_private, arr_public, hash_private, hash_public).
+    /// Slots are `None` if not found in `locals`. Avoids 6 × N_attrs linear searches.
+    pub(crate) attr_slots: Vec<AttrSlots>,
+}
+
+/// Pre-computed local slot indices for a single attribute.
+#[derive(Debug, Clone)]
+pub(crate) struct AttrSlots {
+    pub(crate) attr_name: String,
+    pub(crate) private: Option<usize>,
+    pub(crate) public: Option<usize>,
+    pub(crate) arr_private: Option<usize>,
+    pub(crate) arr_public: Option<usize>,
+    pub(crate) hash_private: Option<usize>,
+    pub(crate) hash_public: Option<usize>,
 }
 
 impl CompiledCode {
@@ -973,6 +989,26 @@ impl CompiledCode {
             is_pointy_block: false,
             has_env_writes: false,
             may_capture_outer_vars: false,
+            attr_slots: Vec::new(),
+        }
+    }
+
+    pub(crate) fn compute_attr_slots(&mut self, attr_names: &[String]) {
+        self.attr_slots.clear();
+        for attr_name in attr_names {
+            let find = |prefix: &str| -> Option<usize> {
+                let key = format!("{}{}", prefix, attr_name);
+                self.locals.iter().rposition(|n| *n == key)
+            };
+            self.attr_slots.push(AttrSlots {
+                attr_name: attr_name.clone(),
+                private: find("!"),
+                public: find("."),
+                arr_private: find("@!"),
+                arr_public: find("@."),
+                hash_private: find("%!"),
+                hash_public: find("%."),
+            });
         }
     }
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -854,22 +854,19 @@ impl Interpreter {
     fn compile_methods_for_map(
         methods: &mut HashMap<String, Vec<super::MethodDef>>,
         package_name: &str,
+        attr_names: &[String],
     ) {
         let mut to_compile = Vec::new();
         for (method_name, overloads) in methods.iter() {
             for (idx, def) in overloads.iter().enumerate() {
                 if def.compiled_code.is_none() && !def.body.is_empty() {
                     let mut compiler = crate::compiler::Compiler::new();
-                    // For $?PACKAGE: use the original role name if this method
-                    // was composed from a role, otherwise use the class/package name.
                     let method_package = def
                         .original_role
                         .as_deref()
                         .or(def.role_origin.as_deref())
                         .unwrap_or(package_name);
                     compiler.set_current_package(method_package.to_string());
-                    // Pre-allocate "self" and "__ANON_STATE__" as locals so that
-                    // $.attr and $!attr can use GetLocal instead of GetGlobal.
                     let mut method_params = vec!["self".to_string(), "__ANON_STATE__".to_string()];
                     method_params.extend(def.params.iter().cloned());
                     let mut cc = compiler.compile_routine_closure_body(
@@ -878,6 +875,7 @@ impl Interpreter {
                         &def.body,
                     );
                     cc.compute_may_capture_outer_vars();
+                    cc.compute_attr_slots(attr_names);
                     to_compile.push((method_name.clone(), idx, std::sync::Arc::new(cc)));
                 }
             }
@@ -926,14 +924,17 @@ impl Interpreter {
     /// Compile method bodies for a given class using the bytecode compiler.
     pub(crate) fn compile_class_methods(&mut self, class_name: &str) {
         if let Some(class_def) = self.classes.get_mut(class_name) {
-            Self::compile_methods_for_map(&mut class_def.methods, class_name);
+            let attr_names: Vec<String> =
+                class_def.attributes.iter().map(|a| a.0.clone()).collect();
+            Self::compile_methods_for_map(&mut class_def.methods, class_name, &attr_names);
         }
     }
 
     /// Compile method bodies for a given role.
     pub(crate) fn compile_role_methods(&mut self, role_name: &str) {
         if let Some(role_def) = self.roles.get_mut(role_name) {
-            Self::compile_methods_for_map(&mut role_def.methods, role_name);
+            let attr_names: Vec<String> = role_def.attributes.iter().map(|a| a.0.clone()).collect();
+            Self::compile_methods_for_map(&mut role_def.methods, role_name, &attr_names);
         }
     }
 

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -565,17 +565,8 @@ impl VM {
         }
 
         if can_skip_merge {
-            // Sync only attribute-related locals to env for writeback.
-            // Full locals→env sync is unnecessary since we skip the merge,
-            // but attribute values must be written back for instance updates.
-            for (i, local_name) in cc.locals.iter().enumerate() {
-                if local_name.starts_with('.') || local_name.starts_with('!') {
-                    self.interpreter
-                        .env_mut()
-                        .insert(local_name.clone(), self.locals[i].clone());
-                }
-            }
-            writeback_attributes(self.interpreter.env(), &mut attributes);
+            // Write back attributes directly from locals (skip env round-trip).
+            writeback_attributes_from_locals(cc, &self.locals, &mut attributes, owner_class);
 
             let method_var_bindings = self.interpreter.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -1150,81 +1141,129 @@ fn writeback_attributes_from_locals(
     attributes: &mut HashMap<String, Value>,
     owner_class: &str,
 ) {
-    for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
-        if attr_name.starts_with(ATTR_ALIAS_META_PREFIX) || attr_name.contains('\0') {
-            continue;
-        }
-        let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
+    // Fast path: use pre-computed slot indices when available
+    if !cc.attr_slots.is_empty() {
+        for slots in &cc.attr_slots {
+            let original = attributes
+                .get(&slots.attr_name)
+                .cloned()
+                .unwrap_or(Value::Nil);
+            let private_val = slots.private.map(|i| &locals[i]);
+            let public_val = slots.public.map(|i| &locals[i]);
+            let arr_private_val = slots.arr_private.map(|i| &locals[i]);
+            let arr_public_val = slots.arr_public.map(|i| &locals[i]);
+            let hash_private_val = slots.hash_private.map(|i| &locals[i]);
+            let hash_public_val = slots.hash_public.map(|i| &locals[i]);
 
-        let private_key = format!("!{}", attr_name);
-        let public_key = format!(".{}", attr_name);
-        let private_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &private_key)
-            .map(|i| locals[i].clone());
-        let public_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &public_key)
-            .map(|i| locals[i].clone());
+            if let (Some(priv_val), Some(pub_val)) = (arr_private_val, arr_public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
+                }
+                continue;
+            }
+            if let (Some(priv_val), Some(pub_val)) = (hash_private_val, hash_public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
+                }
+                continue;
+            }
+            if let (Some(priv_val), Some(pub_val)) = (private_val, public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
+                }
+                continue;
+            }
+            if let Some(val) = arr_private_val.or(hash_private_val).or(private_val) {
+                attributes.insert(slots.attr_name.clone(), val.clone());
+                continue;
+            }
+            if let Some(val) = arr_public_val.or(hash_public_val).or(public_val) {
+                attributes.insert(slots.attr_name.clone(), val.clone());
+            }
+        }
+    } else {
+        // Fallback: linear search (for methods compiled without attr info)
+        for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
+            if attr_name.starts_with(ATTR_ALIAS_META_PREFIX) || attr_name.contains('\0') {
+                continue;
+            }
+            let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
 
-        // Also check array/hash variants
-        let arr_private_key = format!("@!{}", attr_name);
-        let arr_public_key = format!("@.{}", attr_name);
-        let hash_private_key = format!("%!{}", attr_name);
-        let hash_public_key = format!("%.{}", attr_name);
-        let arr_private_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &arr_private_key)
-            .map(|i| locals[i].clone());
-        let arr_public_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &arr_public_key)
-            .map(|i| locals[i].clone());
-        let hash_private_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &hash_private_key)
-            .map(|i| locals[i].clone());
-        let hash_public_val = cc
-            .locals
-            .iter()
-            .rposition(|n| n == &hash_public_key)
-            .map(|i| locals[i].clone());
+            let private_key = format!("!{}", attr_name);
+            let public_key = format!(".{}", attr_name);
+            let private_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &private_key)
+                .map(|i| locals[i].clone());
+            let public_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &public_key)
+                .map(|i| locals[i].clone());
 
-        if let (Some(priv_val), Some(pub_val)) = (&arr_private_val, &arr_public_val) {
-            if *priv_val == original && *pub_val != original {
-                attributes.insert(attr_name.clone(), pub_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), priv_val.clone());
+            let arr_private_key = format!("@!{}", attr_name);
+            let arr_public_key = format!("@.{}", attr_name);
+            let hash_private_key = format!("%!{}", attr_name);
+            let hash_public_key = format!("%.{}", attr_name);
+            let arr_private_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &arr_private_key)
+                .map(|i| locals[i].clone());
+            let arr_public_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &arr_public_key)
+                .map(|i| locals[i].clone());
+            let hash_private_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &hash_private_key)
+                .map(|i| locals[i].clone());
+            let hash_public_val = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &hash_public_key)
+                .map(|i| locals[i].clone());
+
+            if let (Some(priv_val), Some(pub_val)) = (&arr_private_val, &arr_public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(attr_name.clone(), priv_val.clone());
+                }
+                continue;
             }
-            continue;
-        }
-        if let (Some(priv_val), Some(pub_val)) = (&hash_private_val, &hash_public_val) {
-            if *priv_val == original && *pub_val != original {
-                attributes.insert(attr_name.clone(), pub_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), priv_val.clone());
+            if let (Some(priv_val), Some(pub_val)) = (&hash_private_val, &hash_public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(attr_name.clone(), priv_val.clone());
+                }
+                continue;
             }
-            continue;
-        }
-        if let (Some(priv_val), Some(pub_val)) = (&private_val, &public_val) {
-            if *priv_val == original && *pub_val != original {
-                attributes.insert(attr_name.clone(), pub_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), priv_val.clone());
+            if let (Some(priv_val), Some(pub_val)) = (&private_val, &public_val) {
+                if *priv_val == original && *pub_val != original {
+                    attributes.insert(attr_name.clone(), pub_val.clone());
+                } else {
+                    attributes.insert(attr_name.clone(), priv_val.clone());
+                }
+                continue;
             }
-            continue;
-        }
-        if let Some(val) = arr_private_val.or(hash_private_val).or(private_val) {
-            attributes.insert(attr_name.clone(), val);
-            continue;
-        }
-        if let Some(val) = arr_public_val.or(hash_public_val).or(public_val) {
-            attributes.insert(attr_name, val);
+            if let Some(val) = arr_private_val.or(hash_private_val).or(private_val) {
+                attributes.insert(attr_name.clone(), val);
+                continue;
+            }
+            if let Some(val) = arr_public_val.or(hash_public_val).or(public_val) {
+                attributes.insert(attr_name, val);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Pre-compute attribute-to-local-slot mappings at compile time (`AttrSlots` struct on `CompiledCode`), eliminating 6 × N_attrs linear searches and `format!()` allocations per method exit
- Eliminate env round-trip in `call_compiled_method_fast`'s `can_skip_merge` path — attribute writeback goes directly from locals to attributes instead of locals → env → attributes
- Falls back to existing linear search for methods compiled without attribute info

## Test plan
- [x] `make test` passes (490 files, 4019 tests)
- [x] All 46 whitelisted S12 class/method/role roast tests pass (717 subtests)
- [x] Benchmarks show ~3-4% improvement on method-call and bench-class

🤖 Generated with [Claude Code](https://claude.com/claude-code)