### PR TITLE
refactor: replace Env Deref/DerefMut with explicit methods

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -302,53 +302,18 @@ For `can_skip_merge` methods with no closures, skip inserting `!`, `__mutsu_call
 
 The env deep clone (~12-15μs) is the dominant remaining cost. Current `Env` is `Arc<HashMap<String, Value>>` (defined in `src/env.rs` as a struct wrapping `Arc<HashMap>`, with `Deref`/`DerefMut` impls that call `Arc::make_mut` on mutation). The clone is triggered by `push_light_call_frame` bumping the Arc refcount, then `env_mut()` seeing refcount > 1.
 
-**3a. Scope chain data structure**
+**3a. Scope chain data structure — PARTIALLY COMPLETED (2026-05-24)**
 
-Replace the flat env with a linked scope chain:
-```rust
-pub struct Env {
-    local: HashMap<String, Value>,   // method-specific entries
-    parent: Option<Arc<Env>>,        // outer scope (shared, not cloned)
-}
-```
+**Completed**: API refactoring of `Env` — removed `Deref`/`DerefMut` impls and added explicit methods (`get`, `insert`, `remove`, `contains_key`, `get_mut`, `retain`, `iter`, `keys`, `values`, `values_mut`, `flatten`, `entry_or_insert`, `entry_or_insert_with`). Zero performance regression. This decouples the Env API from the internal representation, allowing future scope chain changes without touching callers.
 
-**Implementation plan** (can be parallelized across 3-4 agents):
+**Attempted and rejected**: Adding a `parent: Option<Arc<EnvParent>>` field to the Env struct for scope chain lookups. Benchmarked with three approaches:
+1. `Arc<EnvInner { local: HashMap, parent: Option<Arc<EnvInner>> }>` — 16-24% regression on bench-class/method-call due to extra indirection in every get()/insert() call
+2. `Arc<HashMap> + Option<Arc<EnvParent>>` — 10-20% regression from extra struct size (16 bytes vs 8 bytes) and parent-check branch in get()
+3. Fresh env for can_skip_merge methods — broke `test-util-test-iter-opt.t` because `overwrite_instance_bindings_by_identity` needs instance references in the env for attribute propagation
 
-1. **Agent 1: Core Env refactor** (`src/env.rs`, ~200 LOC)
-   - Replace `inner: Arc<HashMap<String, Value>>` with `local: HashMap<String, Value>` + `parent: Option<Arc<Env>>`
-   - Implement `get()` — check local first, walk parent chain
-   - Implement `insert()` — always into local
-   - Implement `contains_key()` — check local + parents
-   - Implement `iter()` — merge local entries over shadowed parent entries
-   - Implement `clone_for_method_entry()` — create a new empty scope with current env as parent (O(1))
-   - Implement `flatten()` — merge all scopes into a flat HashMap (needed for closures/debugging)
-   - Keep `ptr_eq` for the fast-path checks
-   - **Key constraint**: `get()` must be a tight loop — inline the local check, only call a `get_parent()` method on miss
+**Root cause**: Env is in the hottest possible path (every variable read/write). Even a single extra field or branch in `get()` causes measurable regression across all benchmarks. The estimated ~0.3μs overhead per method call (from PERFORMANCE.md risk analysis) was correct for individual calls, but the aggregate impact across ALL env operations (not just method dispatch) was 3-5x higher than estimated.
 
-2. **Agent 2: VM call frame adaptation** (`src/vm/vm_env_helpers.rs`, `src/vm/vm_method_dispatch.rs`)
-   - `push_light_call_frame`: Instead of `clone_env()`, use `env.clone_for_method_entry()` — creates a child scope with empty local, parent = current env
-   - `pop_call_frame`: Instead of `set_env(saved_env)`, detach the method scope and restore parent
-   - `call_compiled_method_fast`: Insert method vars (self, ?CLASS, params, etc.) into the local scope only — no deep clone needed
-   - `can_skip_merge` path: just drop the local scope (O(1))
-   - `merge_method_env`: walk the local scope entries and propagate non-local changes to parent
-
-3. **Agent 3: Interpreter env usage audit** (`src/runtime/` — ~35 files)
-   - Grep all `env()`, `env_mut()`, `env.get()`, `env.insert()`, `env.remove()`, `env.iter()`, `env.contains_key()` call sites
-   - Classify each as: (a) reads local vars — works with chain, (b) reads outer-scope vars — needs chain walk, (c) writes — needs local scope, (d) iterates — needs flatten or chain iter
-   - Most reads are for `self`, params, `$_`, `?CLASS` — all in the immediate scope
-   - Outer scope reads: `$*` dynamic vars, `&` subs, `%*ENV` — need parent chain walk
-   - Flag any patterns that assume flat env (e.g., `env.len()`, `env.keys()`)
-
-4. **Agent 4: Closure capture refactor** (`src/vm/vm_register_ops.rs`, `src/compiler/`)
-   - Closures currently capture `env.clone()` — with scope chain, they hold `Arc<Env>` (parent chain)
-   - Verify closure reads/writes work through the parent chain
-   - `may_capture_outer_vars` flag already exists — use it to skip parent chain for methods that don't create closures
-
-**Expected impact**: Method entry goes from O(100 clone) to O(6-10 insert into empty HashMap). Estimated ~12μs savings per call → method-call ~30% faster, bench-class ~25% faster.
-
-**Risk**: `env.get()` adds 1 branch (check local, then parent) per lookup. For variables in the immediate scope, this is ~1ns extra. For outer-scope lookups (rare in method bodies), add ~2-5ns per parent hop. Total overhead: ~0.3μs per method call (assuming ~300 env reads, mostly local-scope hits). Net gain: ~12μs saved − ~0.3μs overhead = ~11.7μs net improvement.
-
-**Mitigation**: If `get()` overhead is worse than expected, add a "scope depth" counter to Env. For depth 1 (most method calls), `get()` checks local then falls through to a guaranteed flat parent. LLVM can optimize this to a predictable branch.
+**Alternative approach needed**: Instead of changing the Env data structure, optimize the deep clone by reducing the env SIZE before cloning. The `skip_env_setup` optimization already reduces inserts from ~15+ to ~6. Further reducing the env size (by moving more variables to locals-only) would shrink the clone cost proportionally. See Phase 3b for the complementary approach of indexed closure captures.
 
 **3b. Closure captures as indexed slots**
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use crate::value::Value;
@@ -8,8 +7,11 @@ use crate::value::Value;
 /// Copy-on-write environment wrapper.
 ///
 /// Wraps `Arc<HashMap<String, Value>>` so that cloning is O(1) (just an Arc bump).
-/// Mutation goes through `DerefMut` which calls `Arc::make_mut`, triggering a
-/// deep clone only when the Arc is shared.
+/// Mutation goes through `Arc::make_mut`, triggering a deep clone only when
+/// the Arc is shared.
+///
+/// Previously exposed `HashMap` via `Deref`/`DerefMut`. Now uses explicit
+/// methods to allow future scope-chain extensions without changing callers.
 #[derive(Clone)]
 pub struct Env {
     inner: Arc<HashMap<String, Value>>,
@@ -27,6 +29,79 @@ impl Env {
     pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
+
+    #[inline(always)]
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.inner.get(key)
+    }
+
+    #[inline]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.inner.contains_key(key)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
+        Arc::make_mut(&mut self.inner).insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        Arc::make_mut(&mut self.inner).remove(key)
+    }
+
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
+        Arc::make_mut(&mut self.inner).get_mut(key)
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&String, &mut Value) -> bool,
+    {
+        Arc::make_mut(&mut self.inner).retain(f);
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Value> {
+        self.inner.iter()
+    }
+
+    pub fn keys(&self) -> std::collections::hash_map::Keys<'_, String, Value> {
+        self.inner.keys()
+    }
+
+    pub fn values(&self) -> std::collections::hash_map::Values<'_, String, Value> {
+        self.inner.values()
+    }
+
+    pub fn values_mut(&mut self) -> std::collections::hash_map::ValuesMut<'_, String, Value> {
+        Arc::make_mut(&mut self.inner).values_mut()
+    }
+
+    pub fn flatten(&self) -> HashMap<String, Value> {
+        (*self.inner).clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Insert only if key is not present.
+    pub fn entry_or_insert(&mut self, key: String, value: Value) {
+        if !self.inner.contains_key(&key) {
+            Arc::make_mut(&mut self.inner).insert(key, value);
+        }
+    }
+
+    /// Insert only if key is not present (lazy value).
+    pub fn entry_or_insert_with<F: FnOnce() -> Value>(&mut self, key: String, f: F) {
+        if !self.inner.contains_key(&key) {
+            Arc::make_mut(&mut self.inner).insert(key, f());
+        }
+    }
 }
 
 impl Default for Env {
@@ -40,19 +115,6 @@ impl From<HashMap<String, Value>> for Env {
         Self {
             inner: Arc::new(map),
         }
-    }
-}
-
-impl Deref for Env {
-    type Target = HashMap<String, Value>;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for Env {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        Arc::make_mut(&mut self.inner)
     }
 }
 
@@ -76,7 +138,6 @@ impl IntoIterator for Env {
     type IntoIter = std::collections::hash_map::IntoIter<String, Value>;
 
     fn into_iter(self) -> Self::IntoIter {
-        // Unwrap Arc if unique, otherwise clone the HashMap
         Arc::try_unwrap(self.inner)
             .unwrap_or_else(|arc| (*arc).clone())
             .into_iter()

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1838,8 +1838,8 @@ impl Interpreter {
         for phaser in self.end_phasers.iter_mut() {
             let captured = &mut phaser.1;
             for k in keys {
-                if captured.contains_key(*k)
-                    && let Some(v) = current_env.get(*k)
+                if captured.contains_key(k)
+                    && let Some(v) = current_env.get(k)
                 {
                     captured.insert(k.to_string(), v.clone());
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5137,12 +5137,8 @@ impl Interpreter {
         }
     }
 
-    pub(crate) fn merge_sigilless_alias_writes(
-        &self,
-        saved_env: &mut HashMap<String, Value>,
-        current_env: &HashMap<String, Value>,
-    ) {
-        for (key, alias) in current_env {
+    pub(crate) fn merge_sigilless_alias_writes(&self, saved_env: &mut Env, current_env: &Env) {
+        for (key, alias) in current_env.iter() {
             if !key.starts_with("__mutsu_sigilless_alias::") {
                 continue;
             }
@@ -5175,7 +5171,7 @@ impl Interpreter {
                 saved_env.insert(alias_name.to_string(), value);
             }
         }
-        for (key, value) in current_env {
+        for (key, value) in current_env.iter() {
             if key.starts_with("__mutsu_predictive_seq_iter::")
                 || key.starts_with("__mutsu_sigilless_alias::!")
             {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2837,7 +2837,7 @@ impl Interpreter {
             .iter()
             .any(|(_, _, default, ..)| default.is_some());
         if has_expr_default {
-            role_def.captured_env = Some((*self.env).clone());
+            role_def.captured_env = Some(self.env.flatten());
         }
         // Capture the parents that were added during this registration
         // (these are the parents specific to this candidate).

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1172,7 +1172,7 @@ impl Interpreter {
             let mut new_env = saved_env.clone();
             for (k, v) in &closure_base_env {
                 if merge_all {
-                    new_env.entry(k.clone()).or_insert(v.clone());
+                    new_env.entry_or_insert(k.clone(), v.clone());
                     continue;
                 }
                 if matches!(new_env.get(k), Some(Value::Array(..))) && matches!(v, Value::Array(..))
@@ -1641,7 +1641,7 @@ impl Interpreter {
                 .locals
                 .iter()
                 .enumerate()
-                .filter(|(_, name)| data.env.contains_key(*name))
+                .filter(|(_, name)| data.env.contains_key(name))
                 .map(|(idx, name)| (idx, name.clone()))
                 .collect();
             let mut assigned_slots = std::collections::HashSet::new();

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1074,13 +1074,9 @@ impl Interpreter {
         Value::Nil
     }
 
-    fn build_lexical_hash(
-        &self,
-        env: &HashMap<String, Value>,
-        callframe_depth: Option<usize>,
-    ) -> Value {
+    fn build_lexical_hash(&self, env: &Env, callframe_depth: Option<usize>) -> Value {
         let mut hash = HashMap::new();
-        for (k, v) in env {
+        for (k, v) in env.iter() {
             // Skip internal keys and special variables
             if k.starts_with("__") || k.starts_with('?') || k.starts_with('*') || k.starts_with('=')
             {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -142,11 +142,10 @@ impl VM {
         self.interpreter.inject_pending_callsite_line();
 
         // Merge captured environment into current env (or_insert = don't overwrite existing)
-        for (k, v) in &data.env {
+        for (k, v) in data.env.iter() {
             self.interpreter
                 .env_mut()
-                .entry(k.clone())
-                .or_insert_with(|| v.clone());
+                .entry_or_insert(k.clone(), v.clone());
         }
         // Override with persisted per-closure-instance captured variable state.
         // This ensures that each closure instance maintains independent mutable
@@ -537,7 +536,7 @@ impl VM {
             for k in captured_names.iter() {
                 let meta_key = format!("__mutsu_state_key::{}", k);
                 if let Some(Value::Str(state_key)) = self.interpreter.env().get(&meta_key).cloned()
-                    && let Some(val) = self.interpreter.env().get(*k).cloned()
+                    && let Some(val) = self.interpreter.env().get(k).cloned()
                 {
                     self.interpreter.set_state_var(state_key.to_string(), val);
                 }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1302,7 +1302,7 @@ fn writeback_attributes_from_locals(
 ///
 /// Compares original attribute values with private (`!name`) and public (`.name`)
 /// env entries, preferring public when private is unchanged and public differs.
-fn writeback_attributes(env: &HashMap<String, Value>, attributes: &mut HashMap<String, Value>) {
+fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
     for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
         if attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
             continue;

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1125,9 +1125,9 @@ impl VM {
                 // Do not shadow built-in types (e.g. `my class X::Roast::Channel`
                 // must not make the bare name `Channel` resolve to the user class).
                 if !short.is_empty() && short != qualified_name && !Self::is_builtin_type(&short) {
-                    let env = self.interpreter.env_mut();
-                    env.entry(short)
-                        .or_insert_with(|| Value::Package(Symbol::intern(&qualified_name)));
+                    self.interpreter.env_mut().entry_or_insert_with(short, || {
+                        Value::Package(Symbol::intern(&qualified_name))
+                    });
                 }
             }
             // When `my class` is used, register the class name as lexically scoped
@@ -1290,10 +1290,9 @@ impl VM {
                     .map(|(_, s)| s.to_string())
                     .unwrap_or_else(|| qualified_name.clone());
                 if !short.is_empty() && short != qualified_name {
-                    self.interpreter
-                        .env_mut()
-                        .entry(short)
-                        .or_insert_with(|| Value::Package(Symbol::intern(&qualified_name)));
+                    self.interpreter.env_mut().entry_or_insert_with(short, || {
+                        Value::Package(Symbol::intern(&qualified_name))
+                    });
                 }
             }
             self.env_dirty = true;


### PR DESCRIPTION
## Summary

- Remove `Deref<Target=HashMap>` and `DerefMut` from `Env`, replacing them with explicit methods (`get`, `insert`, `remove`, `contains_key`, `get_mut`, `retain`, `iter`, `keys`, `values`, `values_mut`, `flatten`, `entry_or_insert`, `entry_or_insert_with`)
- Internal representation remains `Arc<HashMap<String, Value>>` — zero performance regression (verified via A/B benchmarking)
- Decouples the Env API from its internal representation, enabling future scope chain optimizations without modifying callers
- Document scope chain investigation findings in PERFORMANCE.md

## Scope chain investigation

Attempted three approaches to avoid the ~12μs HashMap deep clone per method call:
1. **`Arc<EnvInner>` wrapper** — 16-24% regression from extra indirection
2. **`Arc<HashMap>` + `Option<Arc<EnvParent>>`** — 10-20% regression from larger struct and extra branch in `get()`
3. **Fresh env for can_skip_merge** — broke instance attribute propagation

Root cause: Env is in the hottest code path. Even 1 extra field or branch causes measurable regression across all benchmarks.

## Test plan

- [x] `make test` passes (490 tests, 4019 subtests)
- [x] `make roast` passes (smoke tested with 20 files)
- [x] `cargo clippy -- -D warnings` clean
- [x] A/B benchmark: bench-class/method-call/fib identical to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)