### PR TITLE
docs: update container semantics progress in PLAN.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -40,8 +40,13 @@
 ### Container semantics
 
 - [x] WhateverCode 複数引数 (#2232)
-- [ ] Scalar コンテナの生成・束縛が raku 互換
-- [ ] 関連 roast テストの通過率改善
+- [x] ContainerRef による `:=` バインドの共有コンテナ (#2401)
+  - `$!x := $var` 属性バインド（メソッド戻り後も維持）
+  - sigilless `has $x; $x := $var` 属性バインド
+  - post-increment/decrement の ContainerRef 対応
+- [ ] `our $x` クラス属性のバインド (attributes.t tests 11-12)
+- [ ] 多次元構造のエレメントレベルバインド (nested.t 16 failures)
+- [ ] `undefine` の aggregate 参照セマンティクス (undef.t 3 failures)
 
 ---
 

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -2,10 +2,11 @@
 
 - [ ] roast/S03-binding/arrays.t
 - [ ] roast/S03-binding/attributes.t
+  10/16 pass (3 skipped). Tests 11-12 fail: `our $x` class attribute binding requires package-level ContainerRef. Test 13 fails: `has $.scalar does Foo` role mixin on attribute declaration not implemented.
 - [ ] roast/S03-binding/closure.t
 - [ ] roast/S03-binding/hashes.t
 - [ ] roast/S03-binding/nested.t
-  42/43 pass. Test 37 fails: self-referential structure binding ($struct[1]<key><subkey>[1] := $struct[1]<key>) requires proper container model to propagate writes through nested element aliases back to parent hash entries.
+  27/43 pass. 16 failures: multidimensional structure element binding (`$abbrev := $struct[1]<key>[1]`) requires element-level Scalar containers. Changes to the original structure must propagate through the binding and vice versa.
 - [ ] roast/S03-binding/ro.t
 - [ ] roast/S03-binding/scalars.t
 - [ ] roast/S03-buf/read-int.t


### PR DESCRIPTION
## Summary
- Record ContainerRef implementation (#2401) as completed in PLAN.md
- Update TODO_roast/S03.md with current pass rates for attributes.t and nested.t
- Document remaining container semantics work items

🤖 Generated with [Claude Code](https://claude.com/claude-code)