### PR TITLE
fix: implement in-place undefine for arrays and hashes

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -344,10 +344,16 @@ impl Compiler {
                     arg_sources_idx: None,
                 });
             } else if let Some(vname) = var_name {
-                // Push Nil and assign to the variable
-                self.code.emit(OpCode::LoadNil);
-                let name_idx = self.code.add_constant(Value::str(vname));
-                self.code.emit(OpCode::AssignExpr(name_idx));
+                // For @/% variables, clear in-place so references see the change.
+                // For scalars, assign Nil.
+                if vname.starts_with('@') || vname.starts_with('%') {
+                    let name_idx = self.code.add_constant(Value::str(vname));
+                    self.code.emit(OpCode::UndefineAggregate(name_idx));
+                } else {
+                    self.code.emit(OpCode::LoadNil);
+                    let name_idx = self.code.add_constant(Value::str(vname));
+                    self.code.emit(OpCode::AssignExpr(name_idx));
+                }
             } else if matches!(&args[0], Expr::Index { target, .. } if matches!(**target, Expr::HashVar(_) | Expr::ArrayVar(_) | Expr::Var(_)))
             {
                 // undefine %hash<key> or undefine @arr[idx] -> target[index] = Nil

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -474,6 +474,9 @@ pub(crate) enum OpCode {
     /// Tag the current value as coming from a reversed named container (for `@a.reverse` writeback)
     TagContainerRefReversed(u32),
 
+    /// Clear an aggregate variable (@/%) in-place so references see the change.
+    UndefineAggregate(u32),
+
     // -- Unary coercion --
     NumCoerce,
     StrCoerce,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2600,6 +2600,44 @@ impl VM {
                 *ip += 1;
             }
 
+            OpCode::UndefineAggregate(name_idx) => {
+                let name = Self::const_str(code, *name_idx);
+                if let Some(val) = self.get_env_with_main_alias(name) {
+                    match &val {
+                        Value::Array(arc, _) => {
+                            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                            unsafe { (*ptr).clear() };
+                        }
+                        Value::Hash(arc) => {
+                            let ptr =
+                                Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
+                            unsafe { (*ptr).clear() };
+                        }
+                        _ => {}
+                    }
+                }
+                // Also update locals if present
+                if let Some(slot) = self.find_local_slot(code, name) {
+                    match &self.locals[slot] {
+                        Value::Array(arc, _) => {
+                            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                            unsafe { (*ptr).clear() };
+                        }
+                        Value::Hash(arc) => {
+                            let ptr =
+                                Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
+                            unsafe { (*ptr).clear() };
+                        }
+                        _ => {
+                            self.locals[slot] = Value::Nil;
+                            self.mark_local_dirty(slot);
+                        }
+                    }
+                }
+                self.stack.push(Value::Nil);
+                *ip += 1;
+            }
+
             // -- Postfix operators --
             OpCode::PostIncrement(name_idx) => {
                 self.exec_post_increment_op(code, *name_idx)?;


### PR DESCRIPTION
## Summary
- Add `UndefineAggregate` opcode that clears array/hash contents in-place via unsafe Arc pointer mutation
- References to the original container see the cleared state (Raku container reference semantics)
- `undefine @ary` now correctly empties the array (was creating `[Nil]` before)

## Test plan
- [x] `undefine @ary` + reference test: `$ary_r` sees 0 elements after undefine
- [x] `undefine %hash` + reference test: `$hash_r.keys` sees 0 after undefine
- [x] Fixes roast/S32-scalar/undef.t tests 37, 38, 42
- [x] No regressions in autovivification, hash, native tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)