### PR TITLE
fix: support nested structure element binding in IndexAutovivifyLazy

### DIFF
--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -144,6 +144,13 @@ impl VM {
                     self.stack.push(Value::Nil);
                 }
             }
+            // When resolved is an Array (from a HashSlotRef or ArraySlotRef), create
+            // an ArraySlotRef so nested binding like `$struct[1]<key><subkey>[1]` works.
+            Value::Array(..) => {
+                self.stack.push(resolved);
+                self.stack.push(index);
+                return self.exec_index_autovivify_op();
+            }
             // When the target is a HashSlotRef pointing to a non-existent key
             // (resolved to Any/Nil), in lazy mode create a DeferredHashAccess
             // that will autovivify on write.


### PR DESCRIPTION
## Summary
- When `HashSlotRef` resolves to an `Array` value during lazy autovivify, create `ArraySlotRef` instead of `DeferredHashAccess`
- Enables `$abbrev := $struct[1]<key><subkey>[1]` — changes through either side propagate

## Test plan
- [x] Nested binding: `$struct[1]<key><subkey>[1]` read/write through binding works
- [x] Fixes 11 of 16 failures in roast/S03-binding/nested.t (16 → 5 failures)
- [x] No regressions in autovivification, hash tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)