### PR TITLE
fix: use interior mutation for nested array writes

### DIFF
--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1293,9 +1293,7 @@ impl Interpreter {
             // Seq → List when used as xx LHS (Raku caches/listifies Seq on repeat)
             Value::Seq(items) => Ok(Value::array(items.as_ref().clone())),
             // xx thunks the LHS: each repetition must be an independent copy
-            Value::Array(items, kind) => {
-                Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind))
-            }
+            Value::Array(items, kind) => Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind)),
             Value::Hash(map) => Ok(Value::Hash(Arc::new(map.as_ref().clone()))),
             _ => Ok(left.clone()),
         }

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1292,6 +1292,11 @@ impl Interpreter {
             }
             // Seq → List when used as xx LHS (Raku caches/listifies Seq on repeat)
             Value::Seq(items) => Ok(Value::array(items.as_ref().clone())),
+            // xx thunks the LHS: each repetition must be an independent copy
+            Value::Array(items, kind) => {
+                Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind))
+            }
+            Value::Hash(map) => Ok(Value::Hash(Arc::new(map.as_ref().clone()))),
             _ => Ok(left.clone()),
         }
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2691,6 +2691,13 @@ impl VM {
         // value (here "42"). `outer_key` is the outermost subscript value
         // (here "23" or "key"). We autovivify the missing entry at
         // `inner_i` based on `outer_positional`.
+        // Drop the locals copy first so the Arc refcount is 1 (avoids
+        // unnecessary cloning in Arc::make_mut).
+        if let Some(slot) = self.find_local_slot(code, &var_name)
+            && matches!(self.locals[slot], Value::Array(..))
+        {
+            self.locals[slot] = Value::Nil;
+        }
         if let Some(Value::Array(outer_arr, _kind)) = self.interpreter.env_mut().get_mut(&var_name)
             && let Ok(inner_i) = inner_key.parse::<usize>()
         {
@@ -2710,16 +2717,37 @@ impl VM {
             match &mut arr[inner_i] {
                 Value::Array(inner_arr, _) => {
                     if let Ok(j) = outer_key.parse::<usize>() {
-                        let inner = Arc::make_mut(inner_arr);
-                        if j >= inner.len() {
-                            inner.resize(j + 1, Value::Package(Symbol::intern("Any")));
+                        // Use interior mutation when the inner array is shared
+                        // (e.g., by an ArraySlotRef from := binding).
+                        if Arc::strong_count(inner_arr) > 1 {
+                            let ptr = Arc::as_ptr(inner_arr) as *mut Vec<Value>;
+                            unsafe {
+                                let v = &mut *ptr;
+                                while v.len() <= j {
+                                    v.push(Value::Nil);
+                                }
+                                v[j] = val.clone();
+                            }
+                        } else {
+                            let inner = Arc::make_mut(inner_arr);
+                            if j >= inner.len() {
+                                inner.resize(j + 1, Value::Package(Symbol::intern("Any")));
+                            }
+                            inner[j] = val.clone();
                         }
-                        inner[j] = val.clone();
                     }
                 }
                 Value::Hash(inner_hash) => {
-                    let h = Arc::make_mut(inner_hash);
-                    h.insert(outer_key.clone(), val.clone());
+                    if Arc::strong_count(inner_hash) > 1 {
+                        let ptr = Arc::as_ptr(inner_hash)
+                            as *mut std::collections::HashMap<String, Value>;
+                        unsafe {
+                            (&mut *ptr).insert(outer_key.clone(), val.clone());
+                        }
+                    } else {
+                        let h = Arc::make_mut(inner_hash);
+                        h.insert(outer_key.clone(), val.clone());
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary
- Drop local array copy before env access to reduce Arc refcount
- Use unsafe interior mutation for inner arrays/hashes when shared (Arc strong_count > 1)
- Prevents Arc::make_mut COW from breaking ArraySlotRef bindings

## Test plan
- [x] `@outer[1][0] = 99` propagates through `$x := @outer[1][0]` binding
- [x] No regressions in autovivification, hash tests
- [x] nested.t: same 5 remaining failures (subtree redefinition — deep arch issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)