### PR TITLE
fix: implement undefine rw semantics and temp+undefine combinations

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -324,8 +324,47 @@ impl Compiler {
             });
             return;
         }
-        // Rewrite undefine($var) -> $var = Nil (assign Nil to the variable)
+        // Rewrite undefine($var) -> $var = Any (assign type object to the variable)
         if name == "undefine" && args.len() == 1 {
+            // Handle `undefine temp $var` — parsed as undefine(temp($var))
+            // Emit: LetSave (temp), then $var = Any
+            if let Expr::Call {
+                name: inner_name,
+                args: inner_args,
+            } = &args[0]
+                && inner_name.resolve() == "temp"
+                && inner_args.len() == 1
+            {
+                let inner_var = match &inner_args[0] {
+                    Expr::Var(n) => Some(n.clone()),
+                    Expr::ArrayVar(n) => Some(format!("@{}", n)),
+                    Expr::HashVar(n) => Some(format!("%{}", n)),
+                    _ => None,
+                };
+                if let Some(vname) = inner_var {
+                    // Compile: temp $var (LetSave)
+                    let let_stmt = Stmt::Let {
+                        name: vname.clone(),
+                        index: None,
+                        value: None,
+                        is_temp: true,
+                    };
+                    self.compile_stmt(&let_stmt);
+                    // Then undefine the variable (assign Any type object)
+                    if vname.starts_with('@') || vname.starts_with('%') {
+                        let name_idx = self.code.add_constant(Value::str(vname));
+                        self.code.emit(OpCode::UndefineAggregate(name_idx));
+                    } else {
+                        let any_idx = self
+                            .code
+                            .add_constant(Value::Package(crate::symbol::Symbol::intern("Any")));
+                        self.code.emit(OpCode::LoadConst(any_idx));
+                        let name_idx = self.code.add_constant(Value::str(vname));
+                        self.code.emit(OpCode::AssignExpr(name_idx));
+                    }
+                    return;
+                }
+            }
             let var_name = match &args[0] {
                 Expr::Var(n) => Some(n.clone()),
                 Expr::ArrayVar(n) => Some(format!("@{}", n)),
@@ -345,12 +384,15 @@ impl Compiler {
                 });
             } else if let Some(vname) = var_name {
                 // For @/% variables, clear in-place so references see the change.
-                // For scalars, assign Nil.
+                // For scalars, assign the type object Any (undefined but not Nil).
                 if vname.starts_with('@') || vname.starts_with('%') {
                     let name_idx = self.code.add_constant(Value::str(vname));
                     self.code.emit(OpCode::UndefineAggregate(name_idx));
                 } else {
-                    self.code.emit(OpCode::LoadNil);
+                    let any_idx = self
+                        .code
+                        .add_constant(Value::Package(crate::symbol::Symbol::intern("Any")));
+                    self.code.emit(OpCode::LoadConst(any_idx));
                     let name_idx = self.code.add_constant(Value::str(vname));
                     self.code.emit(OpCode::AssignExpr(name_idx));
                 }

--- a/src/compiler/helpers_stmt_analysis.rs
+++ b/src/compiler/helpers_stmt_analysis.rs
@@ -109,7 +109,22 @@ impl Compiler {
         match expr {
             Expr::DoBlock { body, .. } => Self::has_let_deep(body),
             Expr::Try { body, .. } => Self::has_let_deep(body),
-            Expr::Call { args, .. } => args.iter().any(Self::expr_has_let_deep),
+            // Detect `undefine temp $var`: Call("undefine", [Call("temp", ...)])
+            // The compiler expands this to LetSave + assign, so the enclosing block
+            // needs LetBlock wrapping for proper save/restore.
+            Expr::Call { name, args, .. } => {
+                if name.resolve() == "undefine"
+                    && args.len() == 1
+                    && matches!(
+                        &args[0],
+                        Expr::Call { name: inner, .. }
+                            if inner.resolve() == "temp"
+                    )
+                {
+                    return true;
+                }
+                args.iter().any(Self::expr_has_let_deep)
+            }
             Expr::MethodCall { args, target, .. }
             | Expr::DynamicMethodCall { args, target, .. }
             | Expr::HyperMethodCall { args, target, .. }

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1619,6 +1619,36 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
     )
 }
 
+/// Parse a variable from `undefine(...)` or `undefine $var` inside a `temp` context.
+fn parse_temp_undefine_var(input: &str) -> Result<(&str, String), PError> {
+    if let Some(inner) = input.strip_prefix('(') {
+        let (inner, _) = ws(inner)?;
+        let s = inner.chars().next().unwrap_or(' ');
+        if s == '$' || s == '@' || s == '%' {
+            let after_s = &inner[1..];
+            let (after_id, id) = super::ident(after_s)?;
+            let (after_id, _) = ws(after_id)?;
+            let after_id = after_id
+                .strip_prefix(')')
+                .ok_or_else(|| PError::expected("closing paren"))?;
+            let full = if s == '$' { id } else { format!("{}{}", s, id) };
+            Ok((after_id, full))
+        } else {
+            Err(PError::expected("variable after undefine("))
+        }
+    } else {
+        let s = input.chars().next().unwrap_or(' ');
+        if s == '$' || s == '@' || s == '%' {
+            let after_s = &input[1..];
+            let (after_id, id) = super::ident(after_s)?;
+            let full = if s == '$' { id } else { format!("{}{}", s, id) };
+            Ok((after_id, full))
+        } else {
+            Err(PError::expected("variable after undefine"))
+        }
+    }
+}
+
 /// Parse `temp` statement — same semantics as `let` (save/restore at scope exit).
 pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("temp", input).ok_or_else(|| PError::expected("temp statement"))?;
@@ -1650,6 +1680,51 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                 },
             );
         }
+    }
+    // temp undefine($var) [= value]:
+    // With assignment: temp saves $d, undefine, assign "baz"; restore at scope exit.
+    // Without assignment: just undefine (temp on return value is a no-op).
+    if let Some(after_undef) = rest.strip_prefix("undefine")
+        && (after_undef.starts_with('(') || after_undef.starts_with(' '))
+    {
+        let (after_undef, _) = ws(after_undef)?;
+        let (var_rest, var_name) = parse_temp_undefine_var(after_undef)?;
+        let (var_rest, _) = ws(var_rest)?;
+        let make_var_expr = |vn: &str| -> Expr {
+            if let Some(stripped) = vn.strip_prefix('@') {
+                Expr::ArrayVar(stripped.to_string())
+            } else if let Some(stripped) = vn.strip_prefix('%') {
+                Expr::HashVar(stripped.to_string())
+            } else {
+                Expr::Var(vn.to_string())
+            }
+        };
+        // With assignment: temp undefine($d) = "baz"
+        // Semantics: save $d with temp, then assign "baz" to it.
+        // (undefine step is implicit — temp save + assign is sufficient)
+        if var_rest.starts_with('=') && !var_rest.starts_with("==") {
+            let rhs_rest = &var_rest[1..];
+            let (rhs_rest, _) = ws(rhs_rest)?;
+            let (rhs_rest, rhs_expr) = expression(rhs_rest)?;
+            // Emit as `temp $var = rhs` — saves current value, assigns new one
+            return parse_statement_modifier(
+                rhs_rest,
+                Stmt::Let {
+                    name: var_name.clone(),
+                    index: None,
+                    value: Some(Box::new(rhs_expr)),
+                    is_temp: true,
+                },
+            );
+        }
+        // Bare: temp undefine($c) — just undefine (no temp wrapping)
+        return parse_statement_modifier(
+            var_rest,
+            Stmt::Expr(Expr::Call {
+                name: crate::symbol::Symbol::intern("undefine"),
+                args: vec![make_var_expr(&var_name)],
+            }),
+        );
     }
     // Parse sigil + optional twigil + var name
     let sigil = rest

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -263,7 +263,7 @@ impl Interpreter {
             "__mutsu_words_atom" => self.builtin_words_atom(&args),
             "__mutsu_qw_result" => Ok(args.first().cloned().unwrap_or(Value::Nil)),
             "__mutsu_unknown_backslash_escape" => self.builtin_unknown_backslash_escape(&args),
-            "undefine" => Ok(Value::Nil),
+            "undefine" => Ok(Value::Package(crate::symbol::Symbol::intern("Any"))),
             "__mutsu_undefine_rvalue" => {
                 // Called when undefine receives a non-variable expression.
                 // Immutable types (Bool, Int, Str, etc.) must die.

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -222,6 +222,27 @@ impl Interpreter {
             return Ok(value);
         }
 
+        // undefine($var) = value: undefine the variable, then assign value to it.
+        // `undefine` is rw — it returns the container after clearing it.
+        if name == "undefine" && call_args.len() == 1 {
+            let target = &call_args[0];
+            let var_name = {
+                let mut found = None;
+                for (k, v) in self.env.iter() {
+                    if crate::runtime::values_identical(v, target) && !k.starts_with("__") {
+                        found = Some(k.resolve());
+                        break;
+                    }
+                }
+                found
+            };
+            if let Some(vname) = var_name {
+                self.env.insert(vname.clone(), value.clone());
+                return Ok(value);
+            }
+            return Ok(value);
+        }
+
         // substr-rw as a function: substr-rw($str, from, len) = $value
         if name == "substr-rw" && !call_args.is_empty() {
             let target = call_args[0].clone();


### PR DESCRIPTION
## Summary
- Implement `undefine($var) = value` rw semantics (undefine returns the container for assignment)
- Handle `undefine temp $var` by emitting LetSave + undefine (proper scope save/restore)
- Handle `temp undefine($var)` and `temp undefine($var) = value` parser patterns
- Change `undefine` to assign `Any` type object instead of `Nil` (matches Raku behavior)
- Add `undefine(temp(...))` pattern detection to LetBlock scope analysis

Improves `roast/S32-scalar/undef.t` from 84/91 to 90/91 tests passing.
The remaining test 91 requires `is default` trait interaction with `temp` restore (separate feature).

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-scalar/undef.t` shows 90/91 pass (1 real failure)
- [x] `make test` passes (only pre-existing flaky t/lock.t failure)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)