### PR TITLE
fix: initialize native type variables to zero defaults

### DIFF
--- a/scripts/roast-history.sh
+++ b/scripts/roast-history.sh
@@ -36,6 +36,10 @@ per_file_timeout() {
       # This test uses sleep 2*$_ with $_ up to 9, parallel start blocks take ~18s.
       echo 30
       ;;
+    roast/S17-promise/start.t)
+      # This test has multiple sleep 1 calls plus thread scheduling overhead.
+      echo 40
+      ;;
     *)
       echo "$TIMEOUT"
       ;;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -631,6 +631,33 @@ impl Compiler {
                     } else {
                         expr
                     };
+                    // For native types with no explicit initializer, use the
+                    // native zero/empty default so TypeCheck passes.
+                    let native_default: Option<Expr>;
+                    let rhs_expr = if matches!(rhs_expr, Expr::Literal(Value::Nil))
+                        && !name.starts_with('@')
+                        && !name.starts_with('%')
+                    {
+                        if let Some(tc) = type_constraint {
+                            if crate::runtime::native_types::is_native_int_type(tc) {
+                                native_default = Some(Expr::Literal(Value::Int(0)));
+                                native_default.as_ref().unwrap()
+                            } else if matches!(tc.as_str(), "num" | "num32" | "num64") {
+                                native_default = Some(Expr::Literal(Value::Num(0.0)));
+                                native_default.as_ref().unwrap()
+                            } else if tc == "str" {
+                                native_default =
+                                    Some(Expr::Literal(Value::Str(String::new().into())));
+                                native_default.as_ref().unwrap()
+                            } else {
+                                rhs_expr
+                            }
+                        } else {
+                            rhs_expr
+                        }
+                    } else {
+                        rhs_expr
+                    };
                     self.compile_assignment_rhs_for_target(name, rhs_expr);
                 }
                 // `constant @x = ...` should store a List, not an Array.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -631,33 +631,6 @@ impl Compiler {
                     } else {
                         expr
                     };
-                    // For native types with no explicit initializer, use the
-                    // native zero/empty default so TypeCheck passes.
-                    let native_default: Option<Expr>;
-                    let rhs_expr = if matches!(rhs_expr, Expr::Literal(Value::Nil))
-                        && !name.starts_with('@')
-                        && !name.starts_with('%')
-                    {
-                        if let Some(tc) = type_constraint {
-                            if crate::runtime::native_types::is_native_int_type(tc) {
-                                native_default = Some(Expr::Literal(Value::Int(0)));
-                                native_default.as_ref().unwrap()
-                            } else if matches!(tc.as_str(), "num" | "num32" | "num64") {
-                                native_default = Some(Expr::Literal(Value::Num(0.0)));
-                                native_default.as_ref().unwrap()
-                            } else if tc == "str" {
-                                native_default =
-                                    Some(Expr::Literal(Value::Str(String::new().into())));
-                                native_default.as_ref().unwrap()
-                            } else {
-                                rhs_expr
-                            }
-                        } else {
-                            rhs_expr
-                        }
-                    } else {
-                        rhs_expr
-                    };
                     self.compile_assignment_rhs_for_target(name, rhs_expr);
                 }
                 // `constant @x = ...` should store a List, not an Array.

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -116,6 +116,8 @@ fn typed_default_expr(type_name: &str) -> Expr {
         || base == "uint16"
         || base == "uint32"
         || base == "uint64"
+        || base == "atomicint"
+        || base == "byte"
     {
         Expr::Literal(Value::Int(0))
     } else if base == "num" || base == "num32" || base == "num64" {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1452,14 +1452,24 @@ impl VM {
                     let is_nil =
                         matches!(self.interpreter.env().get(&name), Some(Value::Nil) | None);
                     if is_nil {
-                        let type_obj = Value::Package(Symbol::intern(
-                            &self
-                                .interpreter
-                                .var_type_constraint(&name)
-                                .unwrap_or(constraint.clone()),
-                        ));
-                        self.set_env_with_main_alias(&name, type_obj.clone());
-                        self.update_local_if_exists(code, &name, &type_obj);
+                        // Native types get zero/empty defaults instead of type objects.
+                        let init_val =
+                            if crate::runtime::native_types::is_native_int_type(&constraint) {
+                                Value::Int(0)
+                            } else if matches!(constraint.as_str(), "num" | "num32" | "num64") {
+                                Value::Num(0.0)
+                            } else if constraint == "str" {
+                                Value::Str(String::new().into())
+                            } else {
+                                Value::Package(Symbol::intern(
+                                    &self
+                                        .interpreter
+                                        .var_type_constraint(&name)
+                                        .unwrap_or(constraint.clone()),
+                                ))
+                            };
+                        self.set_env_with_main_alias(&name, init_val.clone());
+                        self.update_local_if_exists(code, &name, &init_val);
                     }
                 } else if let Some(value) = self.get_env_with_main_alias(&name) {
                     let info = crate::runtime::ContainerTypeInfo {


### PR DESCRIPTION
## Summary
- Native types (`atomicint`, `int`, `int8`-`int64`, `uint8`-`uint64`, `byte`, `num`, `num32`, `num64`, `str`) now initialize to their zero/empty defaults (0, 0.0, "") instead of Nil/type objects when declared without an explicit initializer.
- Fixes `my atomicint $x; $x++` which previously failed with "Cannot unbox a type object (Nil) to atomicint".
- Adds timeout override (40s) for `roast/S17-promise/start.t` in `roast-history.sh` since it has multiple `sleep 1` calls.
- This unblocks tests 60-65 in `roast/S17-promise/start.t` (previously crashed at test 59 due to the atomicint error).

## Test plan
- [x] `my atomicint $x; $x++; say $x` outputs `1`
- [x] `my int $y; $y += 5; say $y` outputs `5`
- [x] `my num $z; say $z` outputs `0`
- [x] All 490 local tests pass (`prove -e 'target/debug/mutsu' t/`)
- [x] `roast/S17-promise/start.t` now runs 64/65 tests (was 59/65), 3 remaining failures are unrelated complex issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)