### PR TITLE
fix: make $*CWD thread-local to prevent cross-thread leakage

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -80,7 +80,7 @@
 - [ ] roast/S32-io/copy.t
 - [ ] roast/S32-io/dir.t
 - [ ] roast/S32-io/empty.txt
-- [ ] roast/S32-io/indir.t
+- [x] roast/S32-io/indir.t
 - [ ] roast/S32-io/io-cathandle.t
 - [ ] roast/S32-io/io-handle.t
 - [ ] roast/S32-io/io-path-cygwin.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -968,6 +968,7 @@ roast/S32-io/chdir-process.t
 roast/S32-io/chdir.t
 roast/S32-io/copy.t
 roast/S32-io/dir.t
+roast/S32-io/indir.t
 roast/S32-io/io-path-extension.t
 roast/S32-io/io-path-subclasses.t
 roast/S32-io/io-path-symlink.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4675,13 +4675,18 @@ impl Interpreter {
         {
             let mut sv = shared.write().unwrap();
             for (key, val) in &self.env {
-                // Skip internal variables and topic variables
+                // Skip internal variables and topic variables.
+                // Also skip $*CWD/*CWD — in Raku, dynamic variables like $*CWD
+                // are thread-local; mutations inside `start` blocks must not
+                // propagate back to the parent thread.
                 if key == "_"
                     || key == "@_"
                     || key == "/"
                     || key == "!"
                     || key == "$/"
                     || key == "$!"
+                    || key == "$*CWD"
+                    || key == "*CWD"
                     || key.starts_with("__mutsu_")
                     || key.starts_with("&")
                     || key == "?LINE"


### PR DESCRIPTION
## Summary
- Exclude `$*CWD` and `*CWD` from `shared_vars` in `clone_for_thread` so that mutations inside `start` blocks don't propagate back to the parent thread
- In Raku, dynamic variables like `$*CWD` are thread-local — this matches the expected semantics
- Adds `roast/S32-io/indir.t` to whitelist (77/77 tests now pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-io/indir.t` passes (77/77)
- [x] `make test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

���� Generated with [Claude Code](https://claude.com/claude-code)