### PR TITLE
fix: support CAS on instance attributes ($!attr)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -782,6 +782,7 @@ roast/S17-channel/subscription-drain-in-react.t
 roast/S17-lowlevel/atomic-ops.t
 roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
+roast/S17-lowlevel/cas.t
 roast/S17-lowlevel/thread-start-join-stress.t
 roast/S17-procasync/basic.t
 roast/S17-procasync/bind-handles.t

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -310,6 +310,16 @@ impl Compiler {
                     return;
                 }
             }
+            // For attribute variables (!attr), sync the local to env before
+            // the CAS call so the builtin can read the current value from env.
+            if var_name.starts_with('!')
+                && let Some(&slot) = self.local_map.get(var_name.as_str())
+            {
+                self.code.emit(OpCode::GetLocal(slot));
+                let sync_name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                self.code.emit(OpCode::SetGlobal(sync_name_idx));
+                self.code.emit(OpCode::Pop);
+            }
             let call_name_idx = self.code.add_constant(Value::str_from("__mutsu_cas_var"));
             let name_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(name_idx));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5041,6 +5041,15 @@ impl Interpreter {
         sv.get(key).cloned()
     }
 
+    /// Returns true if the given key is in the shared_vars_dirty set
+    /// (i.e., was modified by an atomic/CAS operation).
+    pub(crate) fn is_shared_var_dirty(&self, key: &str) -> bool {
+        self.shared_vars_dirty
+            .read()
+            .map(|d| d.contains(key))
+            .unwrap_or(false)
+    }
+
     fn mark_shared_var_dirty(&self, key: &str) {
         if self
             .shared_vars_dirty

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3001,6 +3001,16 @@ impl VM {
                 return Ok(());
             }
         }
+        // Attribute locals (!attr) modified by CAS: env holds the authoritative
+        // value since sync_locals_from_env skips !-prefixed names for performance.
+        if name.starts_with('!')
+            && self.interpreter.is_shared_var_dirty(&name)
+            && let Some(val) = self.interpreter.env().get(&name).cloned()
+        {
+            self.locals[idx] = val.clone();
+            self.stack.push(val);
+            return Ok(());
+        }
         let atomic_name = name.strip_prefix('$').unwrap_or(&name);
         let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
         // Only use the scalar atomic fast path for scalar ($) variables.


### PR DESCRIPTION
## Summary
- Fix infinite loop when using `cas($!head, $orig, $next)` on instance attributes
- Root cause: attribute locals (`!attr`) are managed exclusively via VM locals (never synced to interpreter env), but the CAS builtin reads/writes through env
- Three-part fix: compiler syncs attribute local to env before CAS call; VM GetLocal reads from env when attribute was CAS-modified; new `is_shared_var_dirty()` accessor

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-lowlevel/cas.t` passes (24/24 tests)
- [x] All existing S17 atomic/CAS whitelisted tests still pass
- [x] `make test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)