### PR TITLE
chore: add atomic.t to roast whitelist

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -780,6 +780,7 @@ roast/S17-channel/basic.t
 roast/S17-channel/stress.t
 roast/S17-channel/subscription-drain-in-react.t
 roast/S17-lowlevel/atomic-ops.t
+roast/S17-lowlevel/atomic.t
 roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
 roast/S17-lowlevel/cas.t


### PR DESCRIPTION
## Summary
- Add `roast/S17-lowlevel/atomic.t` (34 tests) to whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-lowlevel/atomic.t` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)