### PR TITLE
feat: implement typed exceptions for throws-like matching

### DIFF
--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -70,8 +70,10 @@ impl Interpreter {
             if matches!(value, Value::Nil) {
                 value = Value::Package(Symbol::intern(&constraint));
             } else if !self.type_matches_value(&constraint, &value) {
-                return Err(RuntimeError::new(
-                    crate::runtime::utils::type_check_assignment_error(name, &constraint, &value),
+                return Err(crate::runtime::utils::type_check_assignment_typed_error(
+                    name,
+                    &constraint,
+                    &value,
                 ));
             }
             if !matches!(value, Value::Nil | Value::Package(_)) {

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -538,11 +538,28 @@ impl Interpreter {
         let has_type_captures = param_defs
             .iter()
             .any(|pd| pd.name.starts_with("::") || pd.name == "__type_capture__");
-        let is_type_only_mismatch = err.exception.is_none()
+        let is_binding_param_exception = err.exception.as_ref().is_some_and(|ex| {
+            if let Value::Instance { class_name, .. } = ex.as_ref() {
+                class_name.resolve() == "X::TypeCheck::Binding::Parameter"
+            } else {
+                false
+            }
+        });
+        let is_type_only_mismatch = (is_binding_param_exception
+            || (err.exception.is_none()
+                && err
+                    .message
+                    .contains("X::TypeCheck::Binding::Parameter: Type check failed")))
             && !has_type_captures
-            && err
-                .message
-                .contains("X::TypeCheck::Binding::Parameter: Type check failed")
+            // Only convert when ALL typed parameters are simple scalar types.
+            // Sigiled parameters (@, %, &) have container-level type constraints
+            // that should remain as binding errors.
+            && !param_defs.iter().any(|pd| {
+                pd.type_constraint.is_some()
+                    && (pd.name.starts_with('@')
+                        || pd.name.starts_with('%')
+                        || pd.name.starts_with('&'))
+            })
             && param_defs.iter().any(|pd| {
                 pd.type_constraint.as_ref().is_some_and(|tc| {
                     matches!(
@@ -580,7 +597,9 @@ impl Interpreter {
                     )
                 })
             });
-        if (is_arity_error || is_type_only_mismatch) && err.exception.is_none() {
+        if (is_arity_error || is_type_only_mismatch)
+            && (err.exception.is_none() || is_binding_param_exception)
+        {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert("message".to_string(), Value::str(enhanced_msg.clone()));
             attrs.insert("objname".to_string(), Value::str(func_name.to_string()));

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1059,12 +1059,12 @@ impl Interpreter {
                                     pd.is_invocant,
                                 ));
                             }
-                            return Err(RuntimeError::new(format!(
-                                "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected {}, got {}",
+                            return Err(RuntimeError::typecheck_binding_parameter(
                                 param_name,
                                 constraint,
-                                super::value_type_name(&base)
-                            )));
+                                super::value_type_name(&base),
+                                None,
+                            ));
                         }
                     }
                 }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1160,9 +1160,16 @@ impl Interpreter {
                 self.env = saved_env;
                 self.restore_readonly_vars(saved_readonly);
                 // Convert binding type-check errors to X::TypeCheck::Argument for proto calls
-                if e.message
-                    .contains("X::TypeCheck::Binding::Parameter: Type check failed")
-                {
+                let is_binding_param = e.exception.as_ref().is_some_and(|ex| {
+                    if let Value::Instance { class_name, .. } = ex.as_ref() {
+                        class_name.resolve() == "X::TypeCheck::Binding::Parameter"
+                    } else {
+                        false
+                    }
+                }) || e
+                    .message
+                    .contains("X::TypeCheck::Binding::Parameter: Type check failed");
+                if is_binding_param {
                     let type_names: Vec<String> = args
                         .iter()
                         .filter(|a| !matches!(a, Value::Pair(..)))

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1797,12 +1797,10 @@ impl Interpreter {
                             })
                         && !self.type_matches_value(&constraint, value)
                     {
-                        return Err(RuntimeError::new(
-                            crate::runtime::utils::type_check_element_error(
-                                &var_name,
-                                &constraint,
-                                value,
-                            ),
+                        return Err(crate::runtime::utils::type_check_element_typed_error(
+                            &var_name,
+                            &constraint,
+                            value,
                         ));
                     }
 

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1271,13 +1271,11 @@ impl Interpreter {
                     && !self.type_matches_value(&type_constraint, &value)
                     && !self.is_container_subclass(&type_constraint)
                 {
-                    return Err(RuntimeError::new(format!(
-                        "Type check failed in assignment to $!{}; expected {}, got {} ({})",
-                        method,
-                        type_constraint,
+                    return Err(RuntimeError::typecheck_assignment(
+                        &type_constraint,
                         super::utils::value_type_name(&value),
-                        value.to_string_value()
-                    )));
+                        Some(&format!("$!{}", method)),
+                    ));
                 }
                 // Element-level type check for @ attributes (e.g. `has @.a of int`)
                 if attr_sigil == '@'

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4396,8 +4396,10 @@ impl Interpreter {
         if let Some(constraint) = self.var_type_constraint(var_name) {
             for val in values {
                 if !matches!(val, Value::Nil) && !self.type_matches_value(&constraint, val) {
-                    return Err(RuntimeError::new(
-                        crate::runtime::utils::type_check_element_error(var_name, &constraint, val),
+                    return Err(crate::runtime::utils::type_check_element_typed_error(
+                        var_name,
+                        &constraint,
+                        val,
                     ));
                 }
             }
@@ -4417,17 +4419,9 @@ impl Interpreter {
             if constraint != "Mu" && constraint != "Any" {
                 for val in values {
                     if !matches!(val, Value::Nil) && !self.type_matches_value(constraint, val) {
-                        let msg =
-                            crate::runtime::utils::type_check_element_error("@_", constraint, val);
-                        let mut err = RuntimeError::new(msg.clone());
-                        let mut attrs = std::collections::HashMap::new();
-                        attrs.insert("message".to_string(), Value::str(msg));
-                        let ex = Value::make_instance(
-                            crate::symbol::Symbol::intern("X::TypeCheck::Assignment"),
-                            attrs,
-                        );
-                        err.exception = Some(Box::new(ex));
-                        return Err(err);
+                        return Err(crate::runtime::utils::type_check_element_typed_error(
+                            "@_", constraint, val,
+                        ));
                     }
                 }
             }

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -127,25 +127,28 @@ impl Interpreter {
                 } else if positional_idx < positional_args.len() {
                     let value = positional_args[positional_idx].clone();
                     if param.starts_with("&^") && !self.type_matches_value("Callable", &value) {
-                        return Err(RuntimeError::new(format!(
-                            "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Callable, got {}",
+                        return Err(RuntimeError::typecheck_binding_parameter(
                             param,
-                            crate::runtime::value_type_name(&value)
-                        )));
+                            "Callable",
+                            crate::runtime::value_type_name(&value),
+                            None,
+                        ));
                     }
                     if param.starts_with("@^") && !self.type_matches_value("Positional", &value) {
-                        return Err(RuntimeError::new(format!(
-                            "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Positional, got {}",
+                        return Err(RuntimeError::typecheck_binding_parameter(
                             param,
-                            crate::runtime::value_type_name(&value)
-                        )));
+                            "Positional",
+                            crate::runtime::value_type_name(&value),
+                            None,
+                        ));
                     }
                     if param.starts_with("%^") && !self.type_matches_value("Associative", &value) {
-                        return Err(RuntimeError::new(format!(
-                            "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected Associative, got {}",
+                        return Err(RuntimeError::typecheck_binding_parameter(
                             param,
-                            crate::runtime::value_type_name(&value)
-                        )));
+                            "Associative",
+                            crate::runtime::value_type_name(&value),
+                            None,
+                        ));
                     }
                     self.bind_param_value(param, value);
                     positional_idx += 1;
@@ -921,13 +924,16 @@ impl Interpreter {
                             } else {
                                 pd.name.clone()
                             };
-                            return Err(RuntimeError::new(format!(
-                                "{}: Type check failed for {}: expected {}, got {}",
-                                type_error_kind,
-                                display_name,
-                                resolved_constraint,
-                                crate::runtime::value_type_name(&value)
-                            )));
+                            let got = crate::runtime::value_type_name(&value);
+                            return Err(RuntimeError::typecheck_binding_parameter(
+                                &display_name,
+                                &resolved_constraint,
+                                got,
+                                Some(format!(
+                                    "{}: Type check failed for {}: expected {}, got {}",
+                                    type_error_kind, display_name, resolved_constraint, got
+                                )),
+                            ));
                         } else {
                             value = self
                                 .try_coerce_value_for_constraint(&resolved_constraint, value)

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -298,27 +298,29 @@ pub(in crate::runtime) fn bind_named_rename_sub_signature(
         if let Some(tc) = &sub_pd.type_constraint
             && !interpreter.type_matches_value(tc, value)
         {
-            return Err(RuntimeError::new(format!(
-                "Type check failed in binding to parameter '{}'; expected {}, got {}",
+            return Err(RuntimeError::typecheck_binding_parameter(
                 bind_name,
                 tc,
-                crate::runtime::value_type_name(value)
-            )));
+                crate::runtime::value_type_name(value),
+                None,
+            ));
         }
         // Sigil-based type check: %param requires Associative, @param requires Positional
         if bind_name.starts_with('%') && !matches!(value, Value::Hash(..)) {
-            return Err(RuntimeError::new(format!(
-                "Type check failed in binding to parameter '{}'; expected Associative, got {}",
+            return Err(RuntimeError::typecheck_binding_parameter(
                 bind_name,
-                crate::runtime::value_type_name(value)
-            )));
+                "Associative",
+                crate::runtime::value_type_name(value),
+                None,
+            ));
         }
         if bind_name.starts_with('@') && !matches!(value, Value::Array(..) | Value::Nil) {
-            return Err(RuntimeError::new(format!(
-                "Type check failed in binding to parameter '{}'; expected Positional, got {}",
+            return Err(RuntimeError::typecheck_binding_parameter(
                 bind_name,
-                crate::runtime::value_type_name(value)
-            )));
+                "Positional",
+                crate::runtime::value_type_name(value),
+                None,
+            ));
         }
         interpreter.bind_param_value(bind_name, value.clone());
         interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3160,6 +3160,24 @@ pub(crate) fn type_check_assignment_error(var_name: &str, expected: &str, val: &
     }
 }
 
+/// Build a structured X::TypeCheck::Assignment RuntimeError.
+/// This creates a proper exception object that `throws-like` can match.
+pub(crate) fn type_check_assignment_typed_error(
+    var_name: &str,
+    expected: &str,
+    val: &Value,
+) -> RuntimeError {
+    let msg = type_check_assignment_error(var_name, expected, val);
+    let got_type = value_type_name(val);
+    let display_name = format_var_name_for_error(var_name);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+    attrs.insert("got".to_string(), Value::str(got_type.to_string()));
+    attrs.insert("symbol".to_string(), Value::str(display_name));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    RuntimeError::typed("X::TypeCheck::Assignment", attrs)
+}
+
 /// Build the standard X::TypeCheck::Assignment error for array/hash elements:
 /// `Type check failed for an element of @a; expected Int but got Str ("hi")`
 pub(crate) fn type_check_element_error(var_name: &str, expected: &str, val: &Value) -> String {
@@ -3177,4 +3195,21 @@ pub(crate) fn type_check_element_error(var_name: &str, expected: &str, val: &Val
             display_name, expected, got_type, repr
         )
     }
+}
+
+/// Build a structured X::TypeCheck::Assignment RuntimeError for element type checks.
+pub(crate) fn type_check_element_typed_error(
+    var_name: &str,
+    expected: &str,
+    val: &Value,
+) -> RuntimeError {
+    let msg = type_check_element_error(var_name, expected, val);
+    let got_type = value_type_name(val);
+    let display_name = format_var_name_for_error(var_name);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+    attrs.insert("got".to_string(), Value::str(got_type.to_string()));
+    attrs.insert("symbol".to_string(), Value::str(display_name));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    RuntimeError::typed("X::TypeCheck::Assignment", attrs)
 }

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -739,6 +739,27 @@ impl RuntimeError {
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         Self::typed("X::Bind", attrs)
     }
+
+    /// X::TypeCheck::Binding::Parameter - Type check failed in binding to parameter
+    pub(crate) fn typecheck_binding_parameter(
+        param: &str,
+        expected: &str,
+        got: &str,
+        message: Option<String>,
+    ) -> Self {
+        let msg = message.unwrap_or_else(|| {
+            format!(
+                "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected {}, got {}",
+                param, expected, got
+            )
+        });
+        let mut attrs = HashMap::new();
+        attrs.insert("parameter".to_string(), Value::str(param.to_string()));
+        attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+        attrs.insert("got".to_string(), Value::str(got.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::TypeCheck::Binding::Parameter", attrs)
+    }
 }
 
 #[cfg(test)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1206,8 +1206,10 @@ impl VM {
                         {
                             return Err(err);
                         }
-                        return Err(RuntimeError::new(
-                            runtime::utils::type_check_assignment_error(&name, &constraint, &val),
+                        return Err(runtime::utils::type_check_assignment_typed_error(
+                            &name,
+                            &constraint,
+                            &val,
                         ));
                     }
                     if !matches!(val, Value::Nil) {

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -749,12 +749,19 @@ impl VM {
                     self.locals_dirty = saved_locals_dirty;
                     self.locals_dirty_slots = saved_locals_dirty_slots;
                     self.env_dirty = saved_env_dirty;
-                    return Err(RuntimeError::new(format!(
-                        "Type check failed in binding ${}: expected {}, got {}",
-                        cf.param_defs[param_idx].name,
-                        tc,
-                        runtime::value_type_name(&val)
-                    )));
+                    {
+                        let param_name = &cf.param_defs[param_idx].name;
+                        let got = runtime::value_type_name(&val);
+                        let msg = format!(
+                            "Type check failed in binding ${}: expected {}, got {}",
+                            param_name, tc, got
+                        );
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("expected".to_string(), Value::str(tc.to_string()));
+                        attrs.insert("got".to_string(), Value::str(got.to_string()));
+                        attrs.insert("message".to_string(), Value::str(msg.clone()));
+                        return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+                    }
                 }
                 let param_name = &cf.param_defs[param_idx].name;
                 saved_param_env.push((

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -851,10 +851,9 @@ impl VM {
                             if let Some(ref typed_val) = coerced {
                                 if !self.interpreter.type_matches_value(constraint, typed_val) {
                                     let got_type = crate::value::what_type_name(typed_val);
-                                    return Err(RuntimeError::new(format!(
-                                        "Type check failed in binding; expected {} but got {} (\"{}\")",
-                                        constraint, got_type, key
-                                    )));
+                                    return Err(RuntimeError::typecheck_binding_parameter(
+                                        key, constraint, &got_type, None,
+                                    ));
                                 }
                                 typed_keys.insert(key.clone(), typed_val.clone());
                             } else {
@@ -862,10 +861,9 @@ impl VM {
                                 let key_val = Value::str(key.clone());
                                 if !self.interpreter.type_matches_value(constraint, &key_val) {
                                     let got_type = crate::value::what_type_name(&key_val);
-                                    return Err(RuntimeError::new(format!(
-                                        "Type check failed in binding; expected {} but got {} (\"{}\")",
-                                        constraint, got_type, key
-                                    )));
+                                    return Err(RuntimeError::typecheck_binding_parameter(
+                                        key, constraint, &got_type, None,
+                                    ));
                                 }
                             }
                         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -710,11 +710,11 @@ impl VM {
                         .interpreter
                         .type_matches_value(&target_type, &key_as_typed_value)
                     {
-                        return Err(RuntimeError::new(runtime::utils::type_check_element_error(
+                        return Err(runtime::utils::type_check_element_typed_error(
                             var_name,
                             constraint,
                             &Value::str(key.clone()),
-                        )));
+                        ));
                     }
                     key.clone()
                 } else {
@@ -727,8 +727,8 @@ impl VM {
                         } else if explicit_initializer
                             && self.interpreter.is_definite_constraint(constraint)
                         {
-                            return Err(RuntimeError::new(
-                                runtime::utils::type_check_element_error(var_name, constraint, val),
+                            return Err(runtime::utils::type_check_element_typed_error(
+                                var_name, constraint, val,
                             ));
                         } else {
                             val.clone()
@@ -743,8 +743,8 @@ impl VM {
                                 .try_coerce_value_for_constraint(constraint, val.clone())?
                         };
                         if !self.interpreter.type_matches_value(&target_type, &coerced) {
-                            return Err(RuntimeError::new(
-                                runtime::utils::type_check_element_error(var_name, constraint, val),
+                            return Err(runtime::utils::type_check_element_typed_error(
+                                var_name, constraint, val,
                             ));
                         }
                         coerced
@@ -783,9 +783,9 @@ impl VM {
                 } else if explicit_initializer
                     && self.interpreter.is_definite_constraint(constraint)
                 {
-                    return Err(RuntimeError::new(runtime::utils::type_check_element_error(
+                    return Err(runtime::utils::type_check_element_typed_error(
                         var_name, constraint, item,
-                    )));
+                    ));
                 } else {
                     coerced_items.push(item.clone());
                 }
@@ -835,9 +835,9 @@ impl VM {
                     .try_coerce_value_for_constraint(constraint, item.clone())?
             };
             if !self.interpreter.type_matches_value(&target_type, &coerced) {
-                return Err(RuntimeError::new(runtime::utils::type_check_element_error(
+                return Err(runtime::utils::type_check_element_typed_error(
                     var_name, constraint, item,
-                )));
+                ));
             }
             coerced_items.push(coerced);
         }
@@ -2015,8 +2015,10 @@ impl VM {
                         if !matches!(v, Value::Nil)
                             && !self.interpreter.type_matches_value(&constraint, v)
                         {
-                            return Err(RuntimeError::new(
-                                runtime::utils::type_check_element_error(&var_name, &constraint, v),
+                            return Err(runtime::utils::type_check_element_typed_error(
+                                &var_name,
+                                &constraint,
+                                v,
                             ));
                         }
                     }
@@ -2025,12 +2027,10 @@ impl VM {
                 if let Some(key_constraint) = self.interpreter.var_hash_key_constraint(&var_name) {
                     for key in keys.iter() {
                         if !self.interpreter.type_matches_value(&key_constraint, key) {
-                            return Err(RuntimeError::new(
-                                runtime::utils::type_check_element_error(
-                                    &var_name,
-                                    &key_constraint,
-                                    key,
-                                ),
+                            return Err(runtime::utils::type_check_element_typed_error(
+                                &var_name,
+                                &key_constraint,
+                                key,
                             ));
                         }
                     }
@@ -2086,11 +2086,11 @@ impl VM {
                     )
                     && !self.interpreter.is_container_subclass(&constraint)
                 {
-                    return Err(RuntimeError::new(runtime::utils::type_check_element_error(
+                    return Err(runtime::utils::type_check_element_typed_error(
                         &var_name,
                         &constraint,
                         &val,
-                    )));
+                    ));
                 }
                 // Check key type constraint for single-key hash element assignment
                 if var_name.starts_with('%')
@@ -2098,11 +2098,11 @@ impl VM {
                         self.interpreter.var_hash_key_constraint(&var_name)
                     && !self.interpreter.type_matches_value(&key_constraint, &idx)
                 {
-                    return Err(RuntimeError::new(runtime::utils::type_check_element_error(
+                    return Err(runtime::utils::type_check_element_typed_error(
                         &var_name,
                         &key_constraint,
                         &idx,
-                    )));
+                    ));
                 }
                 // Resolve GenericRange with WhateverCode endpoints (e.g. @a[*-4 .. *-1] = ...)
                 let resolved_idx;
@@ -2624,12 +2624,10 @@ impl VM {
                         val = Value::Package(Symbol::intern(&nominal));
                     }
                 } else if !self.interpreter.type_matches_value(&constraint, &val) {
-                    return Err(RuntimeError::new(
-                        runtime::utils::type_check_assignment_error(
-                            &resolved_name,
-                            &constraint,
-                            &val,
-                        ),
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        &resolved_name,
+                        &constraint,
+                        &val,
                     ));
                 }
                 if !matches!(val, Value::Nil | Value::Package(_)) {
@@ -3214,8 +3212,10 @@ impl VM {
                 if matches!(val, Value::Nil) && self.interpreter.is_definite_constraint(&constraint)
                 {
                     if has_explicit_initializer {
-                        return Err(RuntimeError::new(
-                            runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                        return Err(runtime::utils::type_check_assignment_typed_error(
+                            name,
+                            &constraint,
+                            &val,
                         ));
                     }
                     return Err(RuntimeError::new(format!(
@@ -3226,8 +3226,10 @@ impl VM {
                 if !matches!(val, Value::Nil)
                     && !self.interpreter.type_matches_value(&constraint, &val)
                 {
-                    return Err(RuntimeError::new(
-                        runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        name,
+                        &constraint,
+                        &val,
                     ));
                 }
                 let val = if !matches!(val, Value::Nil) {
@@ -3342,8 +3344,10 @@ impl VM {
                 && matches!(raw_popped, Value::Nil)
                 && let Some(constraint) = self.interpreter.var_type_constraint(name)
             {
-                return Err(RuntimeError::new(
-                    runtime::utils::type_check_assignment_error(name, &constraint, &Value::Nil),
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    name,
+                    &constraint,
+                    &Value::Nil,
                 ));
             }
             // Prevent re-initialization of immutable containers (Mix, Set, Bag)
@@ -3384,8 +3388,10 @@ impl VM {
                 && matches!(raw_popped, Value::Nil)
                 && let Some(constraint) = self.interpreter.var_type_constraint(name)
             {
-                return Err(RuntimeError::new(
-                    runtime::utils::type_check_assignment_error(name, &constraint, &Value::Nil),
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    name,
+                    &constraint,
+                    &Value::Nil,
                 ));
             }
             let mut assigned = if is_constant {
@@ -3687,8 +3693,10 @@ impl VM {
         {
             if matches!(val, Value::Nil) && self.interpreter.is_definite_constraint(&constraint) {
                 if has_explicit_initializer {
-                    return Err(RuntimeError::new(
-                        runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        name,
+                        &constraint,
+                        &val,
                     ));
                 }
                 return Err(RuntimeError::new(format!(
@@ -3698,8 +3706,10 @@ impl VM {
             }
             if !matches!(val, Value::Nil) && !self.interpreter.type_matches_value(&constraint, &val)
             {
-                return Err(RuntimeError::new(
-                    runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    name,
+                    &constraint,
+                    &val,
                 ));
             }
             if !matches!(val, Value::Nil) {
@@ -4140,8 +4150,10 @@ impl VM {
                         Value::Package(Symbol::intern(&nominal))
                     }
                 } else if !self.interpreter.type_matches_value(&constraint, &val) {
-                    return Err(RuntimeError::new(
-                        runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        name,
+                        &constraint,
+                        &val,
                     ));
                 } else if !matches!(val, Value::Nil | Value::Package(_)) {
                     self.interpreter
@@ -4241,8 +4253,10 @@ impl VM {
                     val = Value::Package(Symbol::intern(&nominal));
                 }
             } else if !self.interpreter.type_matches_value(&constraint, &val) {
-                return Err(RuntimeError::new(
-                    runtime::utils::type_check_assignment_error(name, &constraint, &val),
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    name,
+                    &constraint,
+                    &val,
                 ));
             }
             if !matches!(val, Value::Nil | Value::Package(_)) {

--- a/t/typed-exceptions.t
+++ b/t/typed-exceptions.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 8;
+
+# X::TypeCheck::Assignment - thrown on typed variable assignment failure
+throws-like { my Int $x = "hello" }, X::TypeCheck::Assignment,
+    "typed variable assignment throws X::TypeCheck::Assignment";
+
+# X::TypeCheck::Assignment for array elements
+throws-like { my Int @a; @a[0] = "hi" }, X::TypeCheck::Assignment,
+    "typed array element assignment throws X::TypeCheck::Assignment";
+
+# X::TypeCheck::Argument - thrown when calling a sub with wrong argument types
+throws-like { sub f(Int $x) {}; f("hi") }, X::TypeCheck::Argument,
+    "calling sub with wrong type throws X::TypeCheck::Argument";
+
+# X::TypeCheck (parent type) should match X::TypeCheck::Argument
+throws-like { sub f(Int $x) {}; f("hi") }, X::TypeCheck,
+    "parent type X::TypeCheck matches Argument subtype";
+
+# X::Assignment::RO - thrown when assigning to a readonly value
+throws-like { sub f($x) { $x = 5 }; f(42) }, X::Assignment::RO,
+    "assignment to readonly parameter throws X::Assignment::RO";
+
+# X::TypeCheck should match X::TypeCheck::Assignment (parent type)
+throws-like { my Int $x = "hello" }, X::TypeCheck,
+    "parent type X::TypeCheck matches Assignment subtype";
+
+# Named attribute matchers
+throws-like { my Int $x = "hello" }, X::TypeCheck::Assignment,
+    message => /expected.*Int/,
+    "attribute matcher on exception message works";
+
+# Multiple typed parameters - first mismatch fails
+throws-like { sub g(Str $a, Int $b) {}; g(42, "hi") }, X::TypeCheck::Argument,
+    "multiple params: wrong arg type throws X::TypeCheck::Argument";


### PR DESCRIPTION
## Summary
- Add structured exception objects for `X::TypeCheck::Assignment` and `X::TypeCheck::Binding::Parameter` so that `throws-like` tests can match specific exception types via `.isa` checks
- Replace plain `RuntimeError::new(string)` calls with proper typed constructors that set the `.exception` field
- This unblocks 22+ roast tests that use `throws-like` with specific exception types (see TODO_roast/BLOCKERS.md)

## Test plan
- [x] `t/typed-exceptions.t` — 8 tests covering all three exception types and parent-type matching
- [x] `make test` passes (Result: PASS)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)