### PR TITLE
fix: pass all roast/S32-io/pipe.t tests

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1769,11 +1769,19 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     continue;
                 }
                 // Check for colon-arg syntax: .method: arg, arg2
+                // OR adverb syntax: .method :key (space before colon means colon-pair)
+                let has_space_before_colon =
+                    r.starts_with(' ') || r.starts_with('\t') || r.starts_with('\n');
                 let (r2, _) = ws(r)?;
                 if r2.starts_with(':') && !r2.starts_with("::") {
-                    let r3 = &r2[1..];
-                    let (r3, _) = ws(r3)?;
-                    let (r3, first_arg) = expression(r3)?;
+                    // If there was space before ':', treat as adverb (colon-pair)
+                    let (r3, first_arg) = if has_space_before_colon {
+                        colonpair_expr(r2)?
+                    } else {
+                        let r3 = &r2[1..];
+                        let (r3, _) = ws(r3)?;
+                        expression(r3)?
+                    };
                     let mut args = vec![first_arg];
                     let mut r_inner = r3;
                     loop {

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -68,6 +68,10 @@ struct ProcOptions {
     in_pipe_content: Option<String>,
     bin: bool,
     win_verbatim_args: bool,
+    /// When :out is given an IO::Handle, store the handle ID to dup the fd
+    out_handle_id: Option<usize>,
+    /// When :merge is True, redirect stderr to stdout
+    merge: bool,
 }
 
 impl Interpreter {
@@ -708,6 +712,8 @@ impl Interpreter {
             in_pipe_content: None,
             bin: false,
             win_verbatim_args: false,
+            out_handle_id: None,
+            merge: false,
         };
         for value in args.iter().skip(skip) {
             if let Value::Hash(map) = value {
@@ -727,13 +733,16 @@ impl Interpreter {
                             opts.capture_err = inner.truthy();
                         }
                         "out" => {
-                            opts.capture_out = inner.truthy();
+                            Self::extract_out_option(inner, &mut opts);
                         }
                         "in" => {
                             Self::extract_in_option(inner, &mut opts);
                         }
                         "bin" => {
                             opts.bin = inner.truthy();
+                        }
+                        "merge" => {
+                            opts.merge = inner.truthy();
                         }
                         "win-verbatim-args" => {
                             opts.win_verbatim_args = inner.truthy();
@@ -746,9 +755,10 @@ impl Interpreter {
                 match key.as_str() {
                     "cwd" => opts.cwd = Some(inner.to_string_value()),
                     "err" => opts.capture_err = inner.truthy(),
-                    "out" => opts.capture_out = inner.truthy(),
+                    "out" => Self::extract_out_option(inner, &mut opts),
                     "in" => Self::extract_in_option(inner, &mut opts),
                     "bin" => opts.bin = inner.truthy(),
+                    "merge" => opts.merge = inner.truthy(),
                     "win-verbatim-args" => opts.win_verbatim_args = inner.truthy(),
                     _ => {}
                 }
@@ -791,6 +801,22 @@ impl Interpreter {
             return;
         }
         opts.capture_in = value.truthy();
+    }
+
+    fn extract_out_option(value: &Value, opts: &mut ProcOptions) {
+        // :out can be an IO::Handle (redirect stdout to that file handle)
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = value
+            && class_name.resolve() == "IO::Handle"
+            && let Some(Value::Int(id)) = attributes.get("handle")
+        {
+            opts.out_handle_id = Some(*id as usize);
+            return;
+        }
+        opts.capture_out = value.truthy();
     }
 
     #[cfg(windows)]
@@ -886,12 +912,40 @@ impl Interpreter {
         let mut cmd = Command::new(program);
         Self::apply_run_args(&mut cmd, rest_args, opts.win_verbatim_args);
 
-        if opts.capture_out {
+        // Handle :out with IO::Handle — redirect stdout to that file
+        let mut stdout_file_for_merge: Option<std::fs::File> = None;
+        if let Some(handle_id) = opts.out_handle_id {
+            let state = self
+                .handles
+                .get(&handle_id)
+                .ok_or_else(|| RuntimeError::new("Invalid IO::Handle for :out"))?;
+            let file = state
+                .file
+                .as_ref()
+                .ok_or_else(|| RuntimeError::new(":out IO::Handle has no file"))?;
+            let cloned = file
+                .try_clone()
+                .map_err(|e| RuntimeError::new(format!("Cannot dup file for :out: {e}")))?;
+            if opts.merge {
+                stdout_file_for_merge =
+                    Some(cloned.try_clone().map_err(|e| {
+                        RuntimeError::new(format!("Cannot dup file for :merge: {e}"))
+                    })?);
+            }
+            cmd.stdout(std::process::Stdio::from(cloned));
+        } else if opts.capture_out {
             cmd.stdout(std::process::Stdio::piped());
         } else {
             cmd.stdout(std::process::Stdio::null());
         }
-        if opts.capture_err {
+        if opts.merge {
+            if let Some(file) = stdout_file_for_merge {
+                cmd.stderr(std::process::Stdio::from(file));
+            } else {
+                // :merge without :out(file) — stderr goes to same pipe as stdout
+                cmd.stderr(std::process::Stdio::piped());
+            }
+        } else if opts.capture_err {
             cmd.stderr(std::process::Stdio::piped());
         } else {
             cmd.stderr(std::process::Stdio::null());

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -499,7 +499,16 @@ impl Interpreter {
             IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
                 Err(RuntimeError::new("Handle not readable"))
             }
-            IoHandleTarget::Stdin => Ok(Vec::new()),
+            IoHandleTarget::Stdin => {
+                use std::io::Read;
+                let mut stdin = std::io::stdin().lock();
+                let mut buffer = vec![0u8; count];
+                let bytes_read = stdin.read(&mut buffer).map_err(|err| {
+                    RuntimeError::new(format!("Failed to read from stdin: {}", err))
+                })?;
+                buffer.truncate(bytes_read);
+                Ok(buffer)
+            }
             IoHandleTarget::ArgFiles => {
                 // Read bytes from files listed in @*ARGS sequentially
                 let argfiles_list: Vec<String> = self
@@ -514,7 +523,15 @@ impl Interpreter {
                     })
                     .unwrap_or_default();
                 if argfiles_list.is_empty() {
-                    return Ok(Vec::new());
+                    // No file args — read from stdin
+                    use std::io::Read;
+                    let mut stdin = std::io::stdin().lock();
+                    let mut buffer = vec![0u8; count];
+                    let bytes_read = stdin.read(&mut buffer).map_err(|err| {
+                        RuntimeError::new(format!("Failed to read from stdin: {}", err))
+                    })?;
+                    buffer.truncate(bytes_read);
+                    return Ok(buffer);
                 }
                 // Re-borrow state after extracting args list
                 let state = self.handle_state_mut(handle_value)?;


### PR DESCRIPTION
## Summary

- Implement stdin byte reading in `read_bytes_from_handle_value` so bare `slurp` and `$*IN.slurp` work correctly via the byte-reading path
- Support `:out(IO::Handle)` and `:merge` options in `run`/`shell` for redirecting child stdout/stderr to file handles
- Fix method call adverb parsing: `.method :key` (space before colon) now parses `:key` as a colonpair instead of stripping the colon and treating it as a bare word -- this fixes `.open :w` failing silently

## Test plan

- [x] `prove -e './target/debug/mutsu' roast/S32-io/pipe.t` passes all 16 subtests
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make test` passes (only flaky t/lock.t test 10)
- [x] Partial `make roast` whitelist passes (50 tests verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)