### PR TITLE
fix: block access to my-scoped subs via package-qualified calls

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -523,6 +523,7 @@ roast/S10-packages/joined-namespaces.t
 roast/S10-packages/nested-use.t
 roast/S10-packages/precompilation.t
 roast/S10-packages/require-and-use.t
+roast/S10-packages/scope.t
 roast/S10-packages/use-with-class.t
 roast/S11-compunit/compunit-dependencyspecification.t
 roast/S11-compunit/compunit-repository.t

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -638,6 +638,17 @@ impl Interpreter {
             .count();
         if name.contains("::") {
             if let Some(def) = self.functions.get(&Symbol::intern(name)).cloned() {
+                // Block access to my-scoped (non-our) package items from outside
+                // their declaring package.
+                if self.is_my_scoped_package_item(name)
+                    && let Some((pkg_prefix, _)) = name.rsplit_once("::")
+                    && pkg_prefix != self.current_package
+                    && !self
+                        .current_package
+                        .starts_with(&format!("{}::", pkg_prefix))
+                {
+                    return None;
+                }
                 return Some(def);
             }
             let prefix = format!("{}/{arity}:", name);
@@ -660,7 +671,16 @@ impl Interpreter {
                 return Some(def);
             }
             if let Some(def) = self.functions.get(&Symbol::intern(name)).cloned() {
-                return Some(def);
+                if !self.is_my_scoped_package_item(name) {
+                    return Some(def);
+                } else if let Some((pkg_prefix, _)) = name.rsplit_once("::")
+                    && (pkg_prefix == self.current_package
+                        || self
+                            .current_package
+                            .starts_with(&format!("{}::", pkg_prefix)))
+                {
+                    return Some(def);
+                }
             }
             // Try qualifying with the current package prefix when the
             // prefix package is visible in the current scope (i.e., exists


### PR DESCRIPTION
## Summary
- In Raku, only `our`-scoped subs should be accessible via `Package::sub_name()` syntax. Subs declared without `our` are lexically scoped and should not be visible from outside their package.
- Adds checks in `resolve_function_with_types` to respect the `my_scoped_package_items` set when resolving package-qualified function calls, returning `None` when the caller is outside the declaring package.
- Adds `roast/S10-packages/scope.t` to the whitelist (24/24 pass).

## Test plan
- [x] `roast/S10-packages/scope.t` passes all 24 subtests
- [x] `make test` passes (490 files, no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)