### PR TITLE
fix: handle Empty (empty Slip) in ArrayPush for typed arrays

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -144,6 +144,7 @@ roast/S02-types/stash.t
 roast/S02-types/subscripts_and_context.t
 roast/S02-types/subset-6e.t
 roast/S02-types/type.t
+roast/S02-types/undefined-types.t
 roast/S02-types/unicode.t
 roast/S02-types/version-stress.t
 roast/S02-types/version.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -137,13 +137,17 @@ impl Interpreter {
         let needs_normalize = args.iter().any(|arg| match arg {
             Value::Scalar(_) => true,
             Value::Array(_, kind) => kind.is_itemized(),
+            Value::Slip(_) => true,
             _ => false,
         });
         if !needs_normalize {
             return args;
         }
         args.into_iter()
-            .map(Self::normalize_push_unshift_arg)
+            .flat_map(|arg| match arg {
+                Value::Slip(items) => items.to_vec(),
+                other => vec![Self::normalize_push_unshift_arg(other)],
+            })
             .collect()
     }
 

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -321,6 +321,20 @@ impl VM {
         }
         let val = self.stack.pop().unwrap_or(Value::Nil);
 
+        // Empty (empty Slip) means nothing to push -- return the array as-is.
+        if let Value::Slip(ref items) = val
+            && items.is_empty()
+        {
+            let result = self
+                .interpreter
+                .env()
+                .get(target_name)
+                .cloned()
+                .unwrap_or(Value::Nil);
+            self.stack.push(result);
+            return Ok(());
+        }
+
         // Check the target exists as a simple Array in env.
         // If not (e.g., captured closure var, or non-Array), fall back to interpreter.
         let is_simple_array = self
@@ -343,18 +357,26 @@ impl VM {
             return Ok(());
         }
 
-        // Check type constraint on the array variable
+        // Check type constraint on the array variable.
+        // For Slip values, check each element individually.
         if let Some(type_name) = self
             .interpreter
             .var_type_constraint_fast(target_name)
             .map(|s| s.to_string())
-            && !self.interpreter.type_matches_value(&type_name, &val)
         {
-            return Err(RuntimeError::typecheck_assignment(
-                &type_name,
-                crate::runtime::value_type_name(&val),
-                Some(target_name),
-            ));
+            let items_to_check: Vec<&Value> = match &val {
+                Value::Slip(items) => items.iter().collect(),
+                other => vec![other],
+            };
+            for item in items_to_check {
+                if !self.interpreter.type_matches_value(&type_name, item) {
+                    return Err(RuntimeError::typecheck_assignment(
+                        &type_name,
+                        crate::runtime::value_type_name(item),
+                        Some(target_name),
+                    ));
+                }
+            }
         }
 
         // Find the local slot and drop it to allow in-place mutation


### PR DESCRIPTION
## Summary
- Fix `@a.push: Empty` on typed arrays (e.g. `my Int @a`) which was incorrectly failing with a type check error
- The VM's `ArrayPush` fast path now short-circuits empty Slips and type-checks individual Slip elements instead of the Slip container
- The interpreter's `normalize_push_unshift_args` now flattens Slip values so empty Slips produce no elements
- Adds `roast/S02-types/undefined-types.t` (49 tests) to the whitelist

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/undefined-types.t` passes (49/49)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no new regressions)

Generated with [Claude Code](https://claude.com/claude-code)