### PR TITLE
fix: prevent premature done callback in supply blocks with whenever

### DIFF
--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -40,18 +40,18 @@ pub(in crate::runtime) use state_scheduler::{
 };
 pub(in crate::runtime) use state_supplier::{
     SupplierEmitAction, ZipAction, close_all_supplier_taps, close_supplier_channel_taps,
-    flush_supplier_batch_taps, flush_supplier_line_taps, flush_supplier_words_taps,
-    get_classify_state, get_classify_sub_supplier_ids, get_start_output_supplier_ids,
-    get_supplier_zip_state_ids, last_supplier_tap_id, register_supplier_batch_tap,
-    register_supplier_channel_tap, register_supplier_classify_tap, register_supplier_done_callback,
-    register_supplier_elems_tap, register_supplier_flat_tap, register_supplier_lines_tap,
-    register_supplier_produce_tap, register_supplier_quit_callback, register_supplier_start_tap,
-    register_supplier_tap, register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    register_supplier_words_tap, register_supplier_zip_tap, register_zip_state,
-    supplier_emit_callbacks, supplier_produce_update_acc, supplier_tap_count,
+    create_whenever_done_group, flush_supplier_batch_taps, flush_supplier_line_taps,
+    flush_supplier_words_taps, get_classify_state, get_classify_sub_supplier_ids,
+    get_start_output_supplier_ids, get_supplier_zip_state_ids, last_supplier_tap_id,
+    register_supplier_batch_tap, register_supplier_channel_tap, register_supplier_classify_tap,
+    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_flat_tap,
+    register_supplier_lines_tap, register_supplier_produce_tap, register_supplier_quit_callback,
+    register_supplier_start_tap, register_supplier_tap, register_supplier_tap_with_head_limit,
+    register_supplier_unique_tap, register_supplier_words_tap, register_supplier_zip_tap,
+    register_zip_state, supplier_emit_callbacks, supplier_produce_update_acc, supplier_tap_count,
     supplier_unique_get_seen, supplier_unique_mark_seen, take_supplier_done_callbacks,
-    take_supplier_quit_callbacks, update_classify_state, zip_buffer_value, zip_source_done,
-    zip_state_info,
+    take_supplier_quit_callbacks, update_classify_state, whenever_done_group_decrement,
+    zip_buffer_value, zip_source_done, zip_state_info,
 };
 
 use super::*;

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -52,7 +52,7 @@ impl Interpreter {
                 SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
                     let deferred_promises = supplier_done_deferred(sid2);
                     for done_cb in take_supplier_done_callbacks(sid2) {
-                        let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                        let _ = self.invoke_done_callback(done_cb);
                     }
                     for (promise, result) in deferred_promises {
                         promise.keep(result, String::new(), String::new());
@@ -155,7 +155,7 @@ impl Interpreter {
             let _ = self.call_sub_value(tap, vec![emitted], true);
         }
         for done_cb in take_supplier_done_callbacks(supplier_id) {
-            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+            let _ = self.invoke_done_callback(done_cb);
         }
     }
 
@@ -171,7 +171,7 @@ impl Interpreter {
             let _ = self.call_sub_value(quit_cb, vec![reason.clone()], true);
         }
         for done_cb in take_supplier_done_callbacks(supplier_id) {
-            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+            let _ = self.invoke_done_callback(done_cb);
         }
     }
 

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -1006,6 +1006,60 @@ pub(in crate::runtime) fn register_supplier_quit_callback(supplier_id: u64, quit
     }
 }
 
+// --- Whenever done group ---
+// Tracks a group of inner suppliers that must all complete before the
+// supply block's done callback fires.
+
+struct WheneverDoneGroup {
+    remaining: std::sync::atomic::AtomicUsize,
+    done_cb: Value,
+}
+
+type WheneverDoneGroupMap = std::sync::Mutex<HashMap<u64, std::sync::Arc<WheneverDoneGroup>>>;
+
+fn whenever_done_group_map() -> &'static WheneverDoneGroupMap {
+    static MAP: OnceLock<WheneverDoneGroupMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn next_whenever_done_group_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Create a new whenever-done group with the given number of active
+/// whenevers and a done callback. Returns the group ID.
+pub(in crate::runtime) fn create_whenever_done_group(count: usize, done_cb: Value) -> u64 {
+    let id = next_whenever_done_group_id();
+    let group = std::sync::Arc::new(WheneverDoneGroup {
+        remaining: std::sync::atomic::AtomicUsize::new(count),
+        done_cb,
+    });
+    if let Ok(mut map) = whenever_done_group_map().lock() {
+        map.insert(id, group);
+    }
+    id
+}
+
+/// Decrement the active count for a whenever-done group.
+/// Returns Some(done_cb) if the count reached zero (all whenevers done).
+pub(in crate::runtime) fn whenever_done_group_decrement(group_id: u64) -> Option<Value> {
+    if let Ok(mut map) = whenever_done_group_map().lock()
+        && let Some(group) = map.get(&group_id)
+    {
+        let prev = group
+            .remaining
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        if prev <= 1 {
+            // All whenevers done — remove the group and return the callback
+            let group = map.remove(&group_id).unwrap();
+            return Some(group.done_cb.clone());
+        }
+    }
+    None
+}
+
 /// Register a batch tap on a supplier. Values are buffered and emitted as
 /// batched lists to the downstream supplier when `:elems` count is reached.
 pub(in crate::runtime) fn register_supplier_batch_tap(

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -540,7 +540,7 @@ impl Interpreter {
 
                 // For on-demand supplies, execute the callback to produce values
                 let mut on_demand_quit: Option<Value> = None;
-                let mut has_whenever_subscriptions = false;
+                let mut done_group_marker: Option<Value> = None;
                 let values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
                     // Give the emitter a supplier_id so that when a `whenever`
                     // body calls `$emitter.emit(val)`, the value can be dispatched
@@ -577,24 +577,42 @@ impl Interpreter {
                     // [Supply, body_cb, last_cbs, quit_cbs] produced by
                     // `whenever` inside a supply block.
 
-                    // Pre-count whenever subscriptions so we can create a
-                    // done group with the correct count.
-                    let whenever_count = emitted.iter().filter(|item| {
-                        matches!(item, Value::Array(arr, ..) if arr.len() == 4
-                            && matches!(&arr[0], Value::Instance { class_name, .. } if class_name == "Supply"))
-                    }).count();
-
-                    // Create a done group if there are whenever subscriptions
-                    // and a done callback. The group tracks how many inner
-                    // suppliers must complete before done fires.
-                    let done_group_marker = if whenever_count > 0 {
-                        done_cb.as_ref().map(|df| {
-                            let group_id = create_whenever_done_group(whenever_count, df.clone());
-                            Self::make_whenever_done_group_marker(group_id)
+                    // Pre-count supplier-backed whenever subscriptions so we
+                    // can create a done group with the correct count. Only
+                    // count whenevers whose inner supply has a supplier_id,
+                    // since cold (on-demand) supplies complete synchronously
+                    // and don't participate in the done counting.
+                    let whenever_supplier_count = emitted
+                        .iter()
+                        .filter(|item| {
+                            if let Value::Array(arr, ..) = item
+                                && arr.len() == 4
+                                && let Value::Instance {
+                                    class_name,
+                                    attributes,
+                                    ..
+                                } = &arr[0]
+                                && *class_name == "Supply"
+                                && attributes.contains_key("supplier_id")
+                            {
+                                true
+                            } else {
+                                false
+                            }
                         })
-                    } else {
-                        None
-                    };
+                        .count();
+
+                    // Create a done group if there are supplier-backed
+                    // whenever subscriptions and a done callback. The group
+                    // tracks how many inner suppliers must complete before
+                    // done fires.
+                    if whenever_supplier_count > 0 {
+                        done_group_marker = done_cb.as_ref().map(|df| {
+                            let group_id =
+                                create_whenever_done_group(whenever_supplier_count, df.clone());
+                            Self::make_whenever_done_group_marker(group_id)
+                        });
+                    }
 
                     let mut plain_values = Vec::new();
                     let mut outer_tap_registered = false;
@@ -607,7 +625,6 @@ impl Interpreter {
                             // Set up a forwarding tap on the inner supply.
                             let inner_supply = &arr[0];
                             let body_cb = arr[1].clone();
-                            has_whenever_subscriptions = true;
 
                             if let Value::Instance {
                                 attributes: inner_attrs,
@@ -747,12 +764,12 @@ impl Interpreter {
                         } else {
                             register_supplier_done_callback(sid, done_fn);
                         }
-                    } else if !has_whenever_subscriptions {
-                        // Only call done immediately for on-demand supplies
-                        // without whenever subscriptions. When there are
-                        // whenever subscriptions, done is already registered
-                        // on each inner supplier and will fire when all of
-                        // them complete.
+                    } else if done_group_marker.is_none() {
+                        // Only call done immediately when there are no
+                        // supplier-backed whenever subscriptions tracking
+                        // done via the group mechanism. Cold (on-demand)
+                        // whenevers complete synchronously, so done can
+                        // fire immediately in that case.
                         let _ = self.call_sub_value(done_fn, vec![], true);
                     }
                 }
@@ -2271,7 +2288,7 @@ impl Interpreter {
                 // For on-demand supplies, execute the callback to produce values
                 let has_unique = matches!(attrs.get("unique_filter"), Some(Value::Bool(true)));
                 let mut on_demand_quit: Option<Value> = None;
-                let mut has_whenever_subscriptions = false;
+                let mut done_group_marker: Option<Value> = None;
                 let values = if let Some(on_demand_cb) = attrs.get("on_demand_callback").cloned() {
                     // Give the emitter a supplier_id so that when a `whenever`
                     // body calls `$emitter.emit(val)`, the value can be dispatched
@@ -2304,20 +2321,34 @@ impl Interpreter {
                     // Separate whenever subscription registrations from plain
                     // emitted values (same logic as immutable tap path).
 
-                    // Pre-count whenever subscriptions for done group
-                    let whenever_count = emitted.iter().filter(|item| {
-                        matches!(item, Value::Array(arr, ..) if arr.len() == 4
-                            && matches!(&arr[0], Value::Instance { class_name, .. } if class_name == "Supply"))
-                    }).count();
-
-                    let done_group_marker = if whenever_count > 0 {
-                        done_cb.as_ref().map(|df| {
-                            let group_id = create_whenever_done_group(whenever_count, df.clone());
-                            Self::make_whenever_done_group_marker(group_id)
+                    // Pre-count supplier-backed whenever subscriptions
+                    let whenever_supplier_count = emitted
+                        .iter()
+                        .filter(|item| {
+                            if let Value::Array(arr, ..) = item
+                                && arr.len() == 4
+                                && let Value::Instance {
+                                    class_name,
+                                    attributes,
+                                    ..
+                                } = &arr[0]
+                                && *class_name == "Supply"
+                                && attributes.contains_key("supplier_id")
+                            {
+                                true
+                            } else {
+                                false
+                            }
                         })
-                    } else {
-                        None
-                    };
+                        .count();
+
+                    if whenever_supplier_count > 0 {
+                        done_group_marker = done_cb.as_ref().map(|df| {
+                            let group_id =
+                                create_whenever_done_group(whenever_supplier_count, df.clone());
+                            Self::make_whenever_done_group_marker(group_id)
+                        });
+                    }
 
                     let mut plain_values = Vec::new();
                     let mut outer_tap_registered = false;
@@ -2328,7 +2359,6 @@ impl Interpreter {
                         {
                             let inner_supply = &arr[0];
                             let body_cb = arr[1].clone();
-                            has_whenever_subscriptions = true;
 
                             if let Value::Instance {
                                 attributes: inner_attrs,
@@ -2542,12 +2572,12 @@ impl Interpreter {
                         } else {
                             register_supplier_done_callback(*supplier_id as u64, done_fn);
                         }
-                    } else if !has_whenever_subscriptions {
-                        // Only call done immediately for on-demand supplies
-                        // without whenever subscriptions. When there are
-                        // whenever subscriptions, done is already registered
-                        // on each inner supplier and will fire when all of
-                        // them complete.
+                    } else if done_group_marker.is_none() {
+                        // Only call done immediately when there are no
+                        // supplier-backed whenever subscriptions tracking
+                        // done via the group mechanism. Cold (on-demand)
+                        // whenevers complete synchronously, so done can
+                        // fire immediately in that case.
                         let _ = self.call_sub_value(done_fn, vec![], true);
                     }
                 }

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -8,6 +8,35 @@ impl Interpreter {
         !matches!(callback, Value::Nil)
     }
 
+    /// Invoke a done callback. If the callback is a WheneverDoneGroup marker,
+    /// decrement the group counter and only call the real done callback when
+    /// all whenevers are done. Otherwise, call the callback directly.
+    pub(super) fn invoke_done_callback(&mut self, done_cb: Value) -> Result<(), RuntimeError> {
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = &done_cb
+            && *class_name == "__WheneverDoneGroup"
+            && let Some(Value::Int(group_id)) = attributes.get("group_id")
+        {
+            if let Some(real_done_cb) = whenever_done_group_decrement(*group_id as u64) {
+                let _ = self.call_sub_value(real_done_cb, vec![], true);
+            }
+            return Ok(());
+        }
+        let _ = self.call_sub_value(done_cb, Vec::new(), true);
+        Ok(())
+    }
+
+    /// Create a WheneverDoneGroup marker Value for registering as a done
+    /// callback on inner suppliers.
+    fn make_whenever_done_group_marker(group_id: u64) -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert("group_id".to_string(), Value::Int(group_id as i64));
+        Value::make_instance(Symbol::intern("__WheneverDoneGroup"), attrs)
+    }
+
     pub(super) fn runtime_error_from_supply_reason(reason: Value) -> RuntimeError {
         let message = reason.to_string_value();
         let mut err = RuntimeError::new(message);
@@ -511,6 +540,7 @@ impl Interpreter {
 
                 // For on-demand supplies, execute the callback to produce values
                 let mut on_demand_quit: Option<Value> = None;
+                let mut has_whenever_subscriptions = false;
                 let values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
                     // Give the emitter a supplier_id so that when a `whenever`
                     // body calls `$emitter.emit(val)`, the value can be dispatched
@@ -546,7 +576,28 @@ impl Interpreter {
                     // emitted values. A subscription registration is an Array
                     // [Supply, body_cb, last_cbs, quit_cbs] produced by
                     // `whenever` inside a supply block.
+
+                    // Pre-count whenever subscriptions so we can create a
+                    // done group with the correct count.
+                    let whenever_count = emitted.iter().filter(|item| {
+                        matches!(item, Value::Array(arr, ..) if arr.len() == 4
+                            && matches!(&arr[0], Value::Instance { class_name, .. } if class_name == "Supply"))
+                    }).count();
+
+                    // Create a done group if there are whenever subscriptions
+                    // and a done callback. The group tracks how many inner
+                    // suppliers must complete before done fires.
+                    let done_group_marker = if whenever_count > 0 {
+                        done_cb.as_ref().map(|df| {
+                            let group_id = create_whenever_done_group(whenever_count, df.clone());
+                            Self::make_whenever_done_group_marker(group_id)
+                        })
+                    } else {
+                        None
+                    };
+
                     let mut plain_values = Vec::new();
+                    let mut outer_tap_registered = false;
                     for item in emitted {
                         if let Value::Array(ref arr, ..) = item
                             && arr.len() == 4
@@ -556,6 +607,7 @@ impl Interpreter {
                             // Set up a forwarding tap on the inner supply.
                             let inner_supply = &arr[0];
                             let body_cb = arr[1].clone();
+                            has_whenever_subscriptions = true;
 
                             if let Value::Instance {
                                 attributes: inner_attrs,
@@ -572,20 +624,26 @@ impl Interpreter {
                                 // Register the outer tap callback on the emitter
                                 // so that `$emitter.emit(val)` inside the body
                                 // forwards values to the outer tap subscriber.
-                                if Self::supply_has_active_callback(&tap_cb) {
+                                // Only register once even with multiple whenevers.
+                                if !outer_tap_registered
+                                    && Self::supply_has_active_callback(&tap_cb)
+                                {
                                     register_supplier_tap(
                                         emitter_supplier_id,
                                         tap_cb.clone(),
                                         delay_seconds,
                                     );
+                                    outer_tap_registered = true;
                                 }
                                 // Register the outer quit handler on the inner
                                 // supplier so that errors propagate correctly.
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(supplier_id, qf.clone());
                                 }
-                                if let Some(ref df) = done_cb {
-                                    register_supplier_done_callback(supplier_id, df.clone());
+                                // Register done callback: use the group marker
+                                // so done only fires when ALL whenevers complete.
+                                if let Some(ref marker) = done_group_marker {
+                                    register_supplier_done_callback(supplier_id, marker.clone());
                                 }
                             } else {
                                 // Non-supplier supply: run body_cb for each
@@ -689,7 +747,12 @@ impl Interpreter {
                         } else {
                             register_supplier_done_callback(sid, done_fn);
                         }
-                    } else {
+                    } else if !has_whenever_subscriptions {
+                        // Only call done immediately for on-demand supplies
+                        // without whenever subscriptions. When there are
+                        // whenever subscriptions, done is already registered
+                        // on each inner supplier and will fire when all of
+                        // them complete.
                         let _ = self.call_sub_value(done_fn, vec![], true);
                     }
                 }
@@ -1557,7 +1620,7 @@ impl Interpreter {
                             SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
                                 let deferred_promises = supplier_done_deferred(sid2);
                                 for done_cb in take_supplier_done_callbacks(sid2) {
-                                    let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                                    let _ = self.invoke_done_callback(done_cb);
                                 }
                                 for (promise, result) in deferred_promises {
                                     promise.keep(result, String::new(), String::new());
@@ -1686,7 +1749,7 @@ impl Interpreter {
                         }
                         supplier_done(dsid);
                         for done_cb in take_supplier_done_callbacks(dsid) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                     }
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
@@ -1696,13 +1759,13 @@ impl Interpreter {
                         let _ = self.call_sub_value(tap, vec![emitted], true);
                     }
                     for done_cb in take_supplier_done_callbacks(supplier_id) {
-                        let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                        self.invoke_done_callback(done_cb)?;
                     }
                     // Propagate done to start-transform output suppliers
                     for out_sid in get_start_output_supplier_ids(supplier_id) {
                         supplier_done(out_sid);
                         for done_cb in take_supplier_done_callbacks(out_sid) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                     }
                     // Propagate done to zip output suppliers
@@ -1711,7 +1774,7 @@ impl Interpreter {
                         if matches!(action, ZipAction::AllDone) {
                             supplier_done(output_sid);
                             for done_cb in take_supplier_done_callbacks(output_sid) {
-                                let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                                let _ = self.invoke_done_callback(done_cb);
                             }
                         }
                     }
@@ -1841,7 +1904,7 @@ impl Interpreter {
                             SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
                                 let deferred_promises = supplier_done_deferred(sid2);
                                 for done_cb in take_supplier_done_callbacks(sid2) {
-                                    let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                                    let _ = self.invoke_done_callback(done_cb);
                                 }
                                 for (promise, result) in deferred_promises {
                                     promise.keep(result, String::new(), String::new());
@@ -1971,7 +2034,7 @@ impl Interpreter {
                         // Propagate done to downstream batch suppliers
                         supplier_done(dsid);
                         for done_cb in take_supplier_done_callbacks(dsid) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                     }
                     // Propagate done to classify sub-suppliers
@@ -1979,7 +2042,7 @@ impl Interpreter {
                     for sub_sid in classify_subs {
                         supplier_done(sub_sid);
                         for done_cb in take_supplier_done_callbacks(sub_sid) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                     }
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
@@ -1989,13 +2052,13 @@ impl Interpreter {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
                     for done_cb in take_supplier_done_callbacks(sid) {
-                        self.call_sub_value(done_cb, Vec::new(), true)?;
+                        self.invoke_done_callback(done_cb)?;
                     }
                     // Propagate done to start-transform output suppliers
                     for out_sid in get_start_output_supplier_ids(sid) {
                         supplier_done(out_sid);
                         for done_cb in take_supplier_done_callbacks(out_sid) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                     }
                     // Propagate done to zip output suppliers
@@ -2004,7 +2067,7 @@ impl Interpreter {
                         if matches!(action, ZipAction::AllDone) {
                             supplier_done(output_sid);
                             for done_cb in take_supplier_done_callbacks(output_sid) {
-                                let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                                let _ = self.invoke_done_callback(done_cb);
                             }
                         }
                     }
@@ -2208,6 +2271,7 @@ impl Interpreter {
                 // For on-demand supplies, execute the callback to produce values
                 let has_unique = matches!(attrs.get("unique_filter"), Some(Value::Bool(true)));
                 let mut on_demand_quit: Option<Value> = None;
+                let mut has_whenever_subscriptions = false;
                 let values = if let Some(on_demand_cb) = attrs.get("on_demand_callback").cloned() {
                     // Give the emitter a supplier_id so that when a `whenever`
                     // body calls `$emitter.emit(val)`, the value can be dispatched
@@ -2239,7 +2303,24 @@ impl Interpreter {
 
                     // Separate whenever subscription registrations from plain
                     // emitted values (same logic as immutable tap path).
+
+                    // Pre-count whenever subscriptions for done group
+                    let whenever_count = emitted.iter().filter(|item| {
+                        matches!(item, Value::Array(arr, ..) if arr.len() == 4
+                            && matches!(&arr[0], Value::Instance { class_name, .. } if class_name == "Supply"))
+                    }).count();
+
+                    let done_group_marker = if whenever_count > 0 {
+                        done_cb.as_ref().map(|df| {
+                            let group_id = create_whenever_done_group(whenever_count, df.clone());
+                            Self::make_whenever_done_group_marker(group_id)
+                        })
+                    } else {
+                        None
+                    };
+
                     let mut plain_values = Vec::new();
+                    let mut outer_tap_registered = false;
                     for item in emitted {
                         if let Value::Array(ref arr, ..) = item
                             && arr.len() == 4
@@ -2247,6 +2328,7 @@ impl Interpreter {
                         {
                             let inner_supply = &arr[0];
                             let body_cb = arr[1].clone();
+                            has_whenever_subscriptions = true;
 
                             if let Value::Instance {
                                 attributes: inner_attrs,
@@ -2259,18 +2341,24 @@ impl Interpreter {
                                 // Register the outer tap callback on the emitter
                                 // so that `$emitter.emit(val)` inside the body
                                 // forwards values to the outer tap subscriber.
-                                if Self::supply_has_active_callback(&tap_cb) {
+                                // Only register once even with multiple whenevers.
+                                if !outer_tap_registered
+                                    && Self::supply_has_active_callback(&tap_cb)
+                                {
                                     register_supplier_tap(
                                         emitter_supplier_id,
                                         tap_cb.clone(),
                                         delay_seconds,
                                     );
+                                    outer_tap_registered = true;
                                 }
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(supplier_id, qf.clone());
                                 }
-                                if let Some(ref df) = done_cb {
-                                    register_supplier_done_callback(supplier_id, df.clone());
+                                // Register done callback: use the group marker
+                                // so done only fires when ALL whenevers complete.
+                                if let Some(ref marker) = done_group_marker {
+                                    register_supplier_done_callback(supplier_id, marker.clone());
                                 }
                             } else {
                                 let empty_attrs = HashMap::new();
@@ -2454,7 +2542,12 @@ impl Interpreter {
                         } else {
                             register_supplier_done_callback(*supplier_id as u64, done_fn);
                         }
-                    } else {
+                    } else if !has_whenever_subscriptions {
+                        // Only call done immediately for on-demand supplies
+                        // without whenever subscriptions. When there are
+                        // whenever subscriptions, done is already registered
+                        // on each inner supplier and will fire when all of
+                        // them complete.
                         let _ = self.call_sub_value(done_fn, vec![], true);
                     }
                 }
@@ -2771,7 +2864,7 @@ impl Interpreter {
                     SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
                         let deferred_promises = supplier_done_deferred(sid2);
                         for done_cb in take_supplier_done_callbacks(sid2) {
-                            let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                            let _ = self.invoke_done_callback(done_cb);
                         }
                         for (promise, result) in deferred_promises {
                             promise.keep(result, String::new(), String::new());
@@ -2796,7 +2889,7 @@ impl Interpreter {
                 SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
                     let deferred_promises = supplier_done_deferred(sid2);
                     for done_cb in take_supplier_done_callbacks(sid2) {
-                        let _ = self.call_sub_value(done_cb, Vec::new(), true);
+                        let _ = self.invoke_done_callback(done_cb);
                     }
                     for (promise, result) in deferred_promises {
                         promise.keep(result, String::new(), String::new());
@@ -2944,7 +3037,7 @@ impl Interpreter {
             // Mark the inner supply as done
             supplier_done(inner_supplier_id);
             for done_cb in take_supplier_done_callbacks(inner_supplier_id) {
-                let _ = thread_interp.call_sub_value(done_cb, Vec::new(), true);
+                let _ = thread_interp.invoke_done_callback(done_cb);
             }
         });
     }


### PR DESCRIPTION
## Summary
- Fixed supply blocks with `whenever` subscriptions calling the done callback immediately on tap instead of waiting for inner suppliers to complete
- Fixed duplicate value delivery when multiple `whenever` blocks register the outer tap callback multiple times
- Implemented `WheneverDoneGroup` counting mechanism so done only fires when ALL inner suppliers are done, not just any one

These fixes resolve the timeout in `roast/S17-supply/syntax.t` (tests 1-62 now run, previously it hung at test 18 due to the premature done callback). The test still hangs at test 63 which requires `atomicint` and `Supply.interval` -- more complex concurrency features not yet implemented.

## Test plan
- [x] `make test` passes (490 tests, no regressions)
- [x] Tests 1-25 of roast/S17-supply/syntax.t pass (basic supply/whenever)
- [x] Tests 30, 38-40 now pass (multiple whenevers, done counting)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Generated with [Claude Code](https://claude.com/claude-code)