### PR TITLE
fix: improve is default() trait support for private attrs and array/hash elements

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -110,7 +110,12 @@
 - [ ] roast/S02-names/indirect.t
   - 0/? pass. Parse error at line 16
 - [ ] roast/S02-names/is_default.t
-  - 0/? pass. Parse error at line 11
+  - 124/146 pass. Remaining blockers:
+    - Nil assignment to array/hash attribute elements not restoring default
+    - Hash/Array subtests with typed keys (%{Str:D}), :delete adverb, is raw params
+    - Missing typed exception classes: X::Parameter::Default::TypeCheck, X::TypeCheck::Attribute::Default, X::Comp::Trait::NotOnNative
+    - `is default()` type constraint validation (of Int, :D/:U)
+    - Generics with `is default(T)` in parameterized roles
 - [ ] roast/S02-names/is_dynamic.t
   - 0/28 pass. Runtime abort after 1 failure — `is dynamic` trait not supported
 - [ ] roast/S02-names/name.t

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -420,7 +420,17 @@ impl VM {
                 self.interpreter
                     .set_var_default(&format!("!{}", attr_name), def.clone());
                 self.interpreter
-                    .set_var_default(&format!(".{}", attr_name), def);
+                    .set_var_default(&format!(".{}", attr_name), def.clone());
+                // Also register for @!attr/@.attr and %!attr/%.attr so
+                // .VAR.default works on array/hash attributes.
+                self.interpreter
+                    .set_var_default(&format!("@!{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("@.{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("%!{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("%.{}", attr_name), def);
             }
         }
 
@@ -938,7 +948,15 @@ impl VM {
                 self.interpreter
                     .set_var_default(&format!("!{}", attr_name), def.clone());
                 self.interpreter
-                    .set_var_default(&format!(".{}", attr_name), def);
+                    .set_var_default(&format!(".{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("@!{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("@.{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("%!{}", attr_name), def.clone());
+                self.interpreter
+                    .set_var_default(&format!("%.{}", attr_name), def);
             }
         }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1310,7 +1310,19 @@ impl VM {
             Value::Nil
         };
         let effective = match &current {
-            Value::Nil => Value::Int(0),
+            Value::Nil => {
+                // Check if the container has an `is default(...)` value;
+                // e.g. `my @a is default(42); @a[0]++` should increment 42.
+                if let Some(def) = self.interpreter.var_default(&name) {
+                    if matches!(def, Value::Nil) {
+                        Value::Int(0)
+                    } else {
+                        def.clone()
+                    }
+                } else {
+                    Value::Int(0)
+                }
+            }
             other => other.clone(),
         };
         let effective = Self::normalize_incdec_source(effective);
@@ -3072,7 +3084,16 @@ impl VM {
             }
             let is_internal = name.starts_with("__");
             let is_special = matches!(name.as_str(), "_" | "/" | "!" | "¢");
-            if !is_internal && !is_special && !self.interpreter.env().contains_key(&name) {
+            // Private attribute locals (!attr) are populated directly from
+            // instance attributes in fast-path method calls; they may not be
+            // in the env (when skip_env_setup is active) but are still valid.
+            let is_private_attr =
+                name.starts_with('!') && name.len() > 1 && !name.starts_with("__");
+            if !is_internal
+                && !is_special
+                && !is_private_attr
+                && !self.interpreter.env().contains_key(&name)
+            {
                 return Err(RuntimeError::new(format!(
                     "X::Undeclared::Symbols: Variable '{name}' is not declared"
                 )));


### PR DESCRIPTION
## Summary
- Fix private attribute locals (`$!attr`) with Nil value throwing false "undeclared variable" errors during fast-path method execution (skip_env_setup mode)
- Fix `++`/`--` on array/hash elements with `is default()` to use the default value as base instead of 0
- Register var_default for `@!`/`@.` and `%!`/`%.` prefixed attribute names so `.VAR.default` works correctly on array/hash attributes inside methods

Improves `roast/S02-names/is_default.t` from 27/146 to 124/146 passing subtests.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `prove -e 'target/debug/mutsu' t/` all 491 tests pass
- [x] `prove -e 'target/debug/mutsu' t/is-default.t` passes
- [x] `prove -e 'target/debug/mutsu' roast/S03-operators/increment.t` passes (no regression)
- [x] `prove -e 'target/debug/mutsu' roast/S12-class/attributes.t roast/S12-class/basic.t` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)