### PR TITLE
fix: preserve $_ binding alias across block scope exit

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -75,6 +75,7 @@ roast/S02-magicals/USER.t
 roast/S02-magicals/VM.t
 roast/S02-magicals/args.t
 roast/S02-magicals/block.t
+roast/S02-magicals/dollar-underscore.t
 roast/S02-magicals/dollar_bang.t
 roast/S02-magicals/env.t
 roast/S02-magicals/file_line.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1245,14 +1245,6 @@ impl VM {
                         };
                         resolved_source = next.to_string();
                     }
-                    // Save old alias target before overwriting (for ContainerRef propagation)
-                    let old_alias_target = self.interpreter.env().get(&alias_key).and_then(|v| {
-                        if let Value::Str(s) = v {
-                            Some(s.to_string())
-                        } else {
-                            None
-                        }
-                    });
                     self.interpreter
                         .env_mut()
                         .insert(alias_key.clone(), Value::str(resolved_source.clone()));
@@ -1282,19 +1274,10 @@ impl VM {
                         self.interpreter
                             .env_mut()
                             .insert(resolved_source.clone(), container.clone());
-                        // Also update the aliased attribute local if present (e.g., !x for sigilless x)
-                        if let Some(alias_target) = &old_alias_target {
-                            self.interpreter
-                                .env_mut()
-                                .insert(alias_target.to_string(), container.clone());
-                            // Update the matching local slot
-                            if let Some(alias_idx) =
-                                code.locals.iter().rposition(|n| n == alias_target.as_str())
-                            {
-                                self.locals[alias_idx] = container.clone();
-                                self.mark_local_dirty(alias_idx);
-                            }
-                        }
+                        // When rebinding to a new source, the old alias target
+                        // keeps its existing value/ContainerRef — we only break
+                        // the alias, we do NOT propagate the new ContainerRef to
+                        // the old target.
                         // Update source local if present
                         if let Some(source_idx) =
                             code.locals.iter().rposition(|n| n == &resolved_source)

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2336,8 +2336,9 @@ impl VM {
             }
             if saved_env.contains_key_sym(k) {
                 // Lexical topic is block-scoped; don't write inner `$_` back
-                // to the outer scope on block exit.
-                if k == "_" {
+                // to the outer scope on block exit. Also preserve the alias
+                // metadata for `$_` so that `:=` bindings survive block exit.
+                if k == "_" || k == "__mutsu_sigilless_alias::_" {
                     continue;
                 }
                 // Dynamic variables (e.g. $*VAR) are scoped to the block:


### PR DESCRIPTION
## Summary
- When rebinding `$_` to a new variable while it was previously bound to another (e.g., `$_ := $d; $_ := $c`), the old alias target (`$d`) no longer gets overwritten with the new ContainerRef
- BlockScope env restoration now preserves `__mutsu_sigilless_alias::_` alongside `$_` itself, so binding metadata survives block exit
- Adds `roast/S02-magicals/dollar-underscore.t` to the whitelist (all 23 subtests pass)

## Test plan
- [x] `prove -e './target/debug/mutsu' roast/S02-magicals/dollar-underscore.t` passes all 23 subtests
- [x] All S02/S03 whitelisted roast tests still pass
- [x] `make test` passes (only pre-existing flaky t/lock.t race condition)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)