### PR TITLE
feat: implement .Numeric/.Real warnings on type objects

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -560,6 +560,21 @@ pub(super) fn dispatch(
             Some(Some(Ok(result)))
         }
         "Real" => {
+            // Calling .Real on a type object (Package) should warn and return zero
+            if let Value::Package(name) = target {
+                let type_name = name.resolve();
+                let zero = match type_name.as_str() {
+                    "Int" | "IntStr" => Value::Int(0),
+                    "Rat" | "FatRat" | "RatStr" => Value::Rat(0, 1),
+                    "Num" | "NumStr" | "Complex" | "ComplexStr" => Value::Num(0.0),
+                    _ => return Some(None),
+                };
+                let msg = format!(
+                    "Use of uninitialized value of type {} in numeric context",
+                    type_name
+                );
+                return Some(Some(Err(RuntimeError::warn_signal_with_resume(msg, zero))));
+            }
             let result = match target {
                 Value::Int(i) => Value::Int(*i),
                 Value::BigInt(_) => target.clone(),
@@ -607,6 +622,22 @@ pub(super) fn dispatch(
             Some(Some(Ok(result)))
         }
         "Numeric" => {
+            // Calling .Numeric on a type object (Package) should warn and return zero
+            if let Value::Package(name) = target {
+                let type_name = name.resolve();
+                let zero = match type_name.as_str() {
+                    "Int" | "IntStr" => Value::Int(0),
+                    "Rat" | "FatRat" | "RatStr" => Value::Rat(0, 1),
+                    "Num" | "NumStr" => Value::Num(0.0),
+                    "Complex" | "ComplexStr" => Value::Complex(0.0, 0.0),
+                    _ => return Some(None),
+                };
+                let msg = format!(
+                    "Use of uninitialized value of type {} in numeric context",
+                    type_name
+                );
+                return Some(Some(Err(RuntimeError::warn_signal_with_resume(msg, zero))));
+            }
             let result = match target {
                 Value::Int(i) => Value::Int(*i),
                 Value::BigInt(_) => target.clone(),


### PR DESCRIPTION
## Summary
- Calling `.Numeric` or `.Real` on a type object (e.g., `Int.Numeric`) now correctly issues a "Use of uninitialized value of type X in numeric context" warning and returns the appropriate zero value
- Matches Raku's behavior for built-in numeric types: Int, Num, Rat, FatRat, Complex, IntStr, NumStr, RatStr, ComplexStr
- Improves `roast/S02-literals/allomorphic.t` from ~105/119 to 115/119 passing subtests

## Remaining failures in allomorphic.t (not addressed here)
- `.ACCEPTS` subtest: `my class` scoping inside gather blocks (deeper architectural issue)
- `val Slip`: Slip expansion in builtin function arguments
- `CustomNumeric`/`CustomReal`: user-defined classes that `does Numeric`/`does Real` need role method inheritance on type objects

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `make test` passes (flaky lock.t/io-path excluded)
- [x] First 100 whitelisted roast tests pass with no regressions
- [x] `roast/S02-literals/allomorphic.t` improves from ~4 entirely failing subtests to only 4/119 individual failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)