### PR TITLE
fix: improve pseudo-package support (::, MY.WHO, indirect ::($name))

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -125,7 +125,7 @@
 - [ ] roast/S02-names/pseudo-6d.t
   - 0/? pass. Parse error at line 145
 - [ ] roast/S02-names/pseudo-6e.t
-  - 0/? pass. Parse error at line 16
+  - 77/136 pass (136/202 run). Blockers: CALLER:: in inline blocks crashes, CALLERS/OUTERS/LEXICAL/DYNAMIC stash traversal not implemented, binding via root (::<$x> := $y), X::NoSuchSymbol exception type, `is dynamic` trait for CALLERS visibility, `use lib` for GH3104_6d module, CORE::v6c/v6d/v6e namespaces. Note: raku itself fails to parse this test due to $? twigil constants.
 - [ ] roast/S02-names/SETTING-6e.t
   - 0/? pass. Parse error at line 10
 - [ ] roast/S02-names/strict.t

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -797,7 +797,19 @@ pub(super) fn hash_var(input: &str) -> PResult<'_, Expr> {
 pub(crate) fn is_pseudo_package(name: &str) -> bool {
     matches!(
         name,
-        "SETTING" | "CALLER" | "OUTER" | "CORE" | "GLOBAL" | "MY" | "OUR" | "DYNAMIC" | "UNIT"
+        "SETTING"
+            | "CALLER"
+            | "CALLERS"
+            | "OUTER"
+            | "OUTERS"
+            | "CORE"
+            | "GLOBAL"
+            | "MY"
+            | "OUR"
+            | "DYNAMIC"
+            | "UNIT"
+            | "LEXICAL"
+            | "CLIENT"
     )
 }
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1458,6 +1458,26 @@ impl Interpreter {
         None
     }
 
+    /// Check if a name is a known pseudo-package (MY, OUTER, CORE, etc.)
+    pub(crate) fn is_pseudo_package_name(name: &str) -> bool {
+        matches!(
+            name,
+            "SETTING"
+                | "CALLER"
+                | "CALLERS"
+                | "OUTER"
+                | "OUTERS"
+                | "CORE"
+                | "GLOBAL"
+                | "MY"
+                | "OUR"
+                | "DYNAMIC"
+                | "UNIT"
+                | "LEXICAL"
+                | "CLIENT"
+        )
+    }
+
     fn no_such_symbol_failure(name: &str) -> Value {
         let mut ex_attrs = HashMap::new();
         ex_attrs.insert(
@@ -1474,6 +1494,11 @@ impl Interpreter {
     pub(crate) fn resolve_indirect_type_name(&self, name: &str) -> Value {
         if name.is_empty() {
             return Self::no_such_symbol_failure(name);
+        }
+        // Pseudo-package names like MY, CORE, OUTER, CALLER, etc. should
+        // resolve to Package values so that .WHO can produce the stash.
+        if Self::is_pseudo_package_name(name) {
+            return Value::Package(Symbol::intern(name));
         }
         if let Some(code_name) = name.strip_prefix('&') {
             let val = self.resolve_code_var(code_name);

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -437,6 +437,20 @@ impl VM {
             return Ok(());
         }
 
+        // .WHO on pseudo-package Package values: build the stash in the VM
+        // where we have access to locals (which the interpreter doesn't have).
+        if method == "WHO"
+            && args.is_empty()
+            && matches!(&target, Value::Package(name) if Self::is_pseudo_package_bare(&name.resolve()))
+        {
+            if let Value::Package(pkg_name) = &target {
+                let stash = self.build_pseudo_stash(code, &pkg_name.resolve());
+                self.stack.push(stash);
+            }
+            self.env_dirty = true;
+            return Ok(());
+        }
+
         // Fast path for Lock::Async.protect — execute block inline in current VM
         if method == "protect"
             && args.len() == 1

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -567,6 +567,19 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // .WHO on pseudo-package Package values: build the stash in the VM
+        // where we have access to locals (which the interpreter doesn't have).
+        if method == "WHO"
+            && args.is_empty()
+            && matches!(&target, Value::Package(name) if Self::is_pseudo_package_bare(&name.resolve()))
+        {
+            if let Value::Package(pkg_name) = &target {
+                let stash = self.build_pseudo_stash(code, &pkg_name.resolve());
+                self.stack.push(stash);
+            }
+            self.env_dirty = true;
+            return Ok(());
+        }
         // Unhandled Failure explosion: calling a non-Failure method on an unhandled
         // Failure should throw the stored exception (Raku behavior).
         if let Value::Instance { class_name, .. } = &target

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -266,6 +266,11 @@ impl VM {
         err
     }
 
+    /// Check if a bare word is a pseudo-package name (MY, OUTER, CORE, etc.)
+    pub(crate) fn is_pseudo_package_bare(name: &str) -> bool {
+        crate::runtime::Interpreter::is_pseudo_package_name(name)
+    }
+
     pub(crate) fn is_builtin_type(name: &str) -> bool {
         matches!(
             name,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4378,6 +4378,7 @@ impl VM {
         }
         if let Some(package) = name.strip_suffix("::")
             && package != "MY"
+            && !package.is_empty()
         {
             self.stack
                 .push(self.interpreter.package_stash_value(package));
@@ -4401,6 +4402,51 @@ impl VM {
             entries.entry(display_key).or_insert_with(|| val.clone());
         }
         self.stack.push(Value::Hash(Arc::new(entries)));
+    }
+
+    /// Build a pseudo-stash hash for a given pseudo-package name.
+    /// Used by .WHO dispatch on pseudo-package Package values.
+    pub(super) fn build_pseudo_stash(&mut self, code: &CompiledCode, name: &str) -> Value {
+        if name == "OUTER" {
+            let mut entries: HashMap<String, Value> = HashMap::new();
+            for (key, val) in self.interpreter.env().iter() {
+                let key_str = key.resolve();
+                if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+                    continue;
+                }
+                let display_key = Self::add_sigil_prefix(&key_str);
+                entries.insert(display_key, val.clone());
+            }
+            return Value::Hash(Arc::new(entries));
+        }
+        if name == "OUR" {
+            let mut entries: HashMap<String, Value> = HashMap::new();
+            for (key, val) in self.interpreter.our_vars_iter() {
+                let display_key = Self::add_sigil_prefix(key);
+                entries.insert(display_key, val.clone());
+            }
+            return Value::Hash(Arc::new(entries));
+        }
+        if name != "MY" && name != "LEXICAL" {
+            return self.interpreter.package_stash_value(name);
+        }
+        // MY / LEXICAL: collect locals + env
+        self.ensure_locals_synced(code);
+        let mut entries: HashMap<String, Value> = HashMap::new();
+        for (i, var_name) in code.locals.iter().enumerate() {
+            let val = self.locals[i].clone();
+            let key = Self::add_sigil_prefix(var_name);
+            entries.insert(key, val);
+        }
+        for (key, val) in self.interpreter.env().iter() {
+            let key_str = key.resolve();
+            if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+                continue;
+            }
+            let display_key = Self::add_sigil_prefix(&key_str);
+            entries.entry(display_key).or_insert_with(|| val.clone());
+        }
+        Value::Hash(Arc::new(entries))
     }
 
     /// Add a sigil prefix to a variable name for display in pseudo-stash.

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -80,6 +80,10 @@ impl VM {
             Value::Num(f64::INFINITY)
         } else if name == "Empty" {
             Value::Slip(std::sync::Arc::new(vec![]))
+        } else if Self::is_pseudo_package_bare(name) {
+            // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to
+            // Package values so that .WHO/.WHAT etc. work correctly.
+            Value::Package(Symbol::intern(name))
         } else if let Some(v) = self.interpreter.env().get(name) {
             if matches!(v, Value::Enum { .. } | Value::Nil)
                 || matches!(v, Value::Package(pkg) if pkg.resolve() != name)


### PR DESCRIPTION
## Summary

- Fix root `::` stash access (`::<$x>`) by treating empty package name as MY-like stash
- Resolve pseudo-package names (MY, CORE, OUTER, CALLER, etc.) to Package values in indirect type lookup (`::("MY")`) and bare word resolution (`MY.WHO`)
- Intercept `.WHO` on pseudo-package Package values in both `CallMethod` and `CallMethodMut` VM paths, building the stash with proper access to VM locals
- Add CALLERS, OUTERS, LEXICAL, CLIENT to the pseudo-package name list

This improves `roast/S02-names/pseudo-6e.t` from 14/22 passing to 77/136 (test still exits early due to unimplemented features like CALLER:: in inline blocks).

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All local tests pass (`prove -e 'target/debug/mutsu' t/`)
- [x] Roast whitelist tests pass (no regressions)
- [x] Verified `::<$x>`, `MY.WHO.<$x>`, `::("MY").WHO.<$x>` all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)