### PR TITLE
fix: improve unspace parsing for degenerate form and invocant-colon syntax

### DIFF
--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -1918,16 +1918,17 @@ mod tests {
 
     #[test]
     fn parse_listop_block_then_colon_args() {
+        // In Raku, `map { block }: @list` is invocant-colon syntax:
+        // it means `{ block }.map(@list)`, i.e., a method call on the block.
         let (rest, expr) = expression("map { $_ * 2 }: @list").unwrap();
         assert_eq!(rest, "");
         match expr {
-            Expr::Call { name, args } => {
+            Expr::MethodCall { name, args, .. } => {
                 assert_eq!(name, "map");
-                assert_eq!(args.len(), 2);
-                assert!(matches!(args[0], Expr::AnonSub { .. }));
-                assert!(matches!(args[1], Expr::ArrayVar(ref n) if n.as_str() == "list"));
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Expr::ArrayVar(ref n) if n.as_str() == "list"));
             }
-            _ => panic!("expected call expression"),
+            _ => panic!("expected method call expression"),
         }
     }
 

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -2143,9 +2143,10 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok(parsed);
     }
 
-    // Check if followed by `(` for function call
-    if rest.starts_with('(') {
-        let (rest, _) = parse_char(rest, '(')?;
+    // Check if followed by `(` for function call (including degenerate unspace: `foo\(42)`)
+    let rest_unspaced = consume_unspace(rest);
+    if rest_unspaced.starts_with('(') {
+        let (rest, _) = parse_char(rest_unspaced, '(')?;
         let (rest, _) = ws(rest)?;
         // Try invocant colon syntax: foo($obj:) or foo($obj: $a, $b)
         // Parse first arg, then check for ':'
@@ -2306,26 +2307,50 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             ));
         }
         let (r3, _) = ws(r2)?;
-        if let Some(r3) = r3.strip_prefix(',').or_else(|| r3.strip_prefix(':')) {
-            // Consume comma and remaining args
+        // Also consume unspace before separator: `{ block }\ : args`
+        let r3_unspaced = consume_unspace(r3);
+        let is_comma = r3_unspaced.starts_with(',');
+        let is_colon = r3_unspaced.starts_with(':') && !r3_unspaced.starts_with("::");
+        if is_comma || is_colon {
+            let r3 = &r3_unspaced[1..];
             let (r3, _) = ws(r3)?;
-            let mut args = vec![make_anon_sub(block_body)];
+            let block_expr = make_anon_sub(block_body);
+            let mut method_args = Vec::new();
             let (mut r3, first_arg) = expression(r3)?;
-            args.push(first_arg);
+            method_args.push(first_arg);
             loop {
                 let (r4, _) = ws(r3)?;
                 if !r4.starts_with(',') {
-                    return Ok((r3, make_call_expr(name, input, args)));
+                    break;
                 }
                 let r4 = &r4[1..];
                 let (r4, _) = ws(r4)?;
                 if r4.starts_with(';') || r4.is_empty() || r4.starts_with('}') {
-                    return Ok((r4, make_call_expr(name, input, args)));
+                    r3 = r4;
+                    break;
                 }
                 let (r4, next_arg) = expression(r4)?;
-                args.push(next_arg);
+                method_args.push(next_arg);
                 r3 = r4;
             }
+            if is_colon {
+                // Invocant colon: `name { block }: args` → `{ block }.name(args)`
+                let sym_name = Symbol::intern(&name);
+                return Ok((
+                    r3,
+                    Expr::MethodCall {
+                        target: Box::new(block_expr),
+                        name: sym_name,
+                        args: method_args,
+                        modifier: None,
+                        quoted: false,
+                    },
+                ));
+            }
+            // Comma separator: `name { block }, args` → `name(block, args)`
+            let mut args = vec![block_expr];
+            args.extend(method_args);
+            return Ok((r3, make_call_expr(name, input, args)));
         }
         // Block without trailing comma — return as separate expressions
         // Fall through to BareWord


### PR DESCRIPTION
## Summary
- Handle degenerate unspace before parenthesized function calls (e.g., `abs\(42)`) so it correctly parses as `abs(42)` instead of postcircumfix on a bareword
- Correctly parse `name { block }: args` as invocant-colon syntax (MethodCall on the block), matching Raku semantics
- Support unspace before block separators: `{ block }\ : args` and `{ block }\ , args`

## Test plan
- [x] `cargo test` passes (449 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `prove -e target/debug/mutsu t/` passes
- [x] Roast whitelist tests pass
- [x] `abs\(42)` returns 42 (was Nil)
- [x] `A::foo\(42)` works (degenerate unspace with longname)
- [x] `xyzzy { @^x }: 1, 2, 3` parses as MethodCall (invocant-colon)

Generated with [Claude Code](https://claude.com/claude-code)