### PR TITLE
fix: make &?ROUTINE transparent through bare blocks and work in named regex

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -81,6 +81,7 @@ roast/S02-magicals/env.t
 roast/S02-magicals/file_line.t
 roast/S02-magicals/pid.t
 roast/S02-magicals/progname.t
+roast/S02-magicals/sub.t
 roast/S02-magicals/subname.t
 roast/S02-names-vars/contextual.t
 roast/S02-names-vars/fmt.t

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -177,7 +177,22 @@ impl Interpreter {
                     .or_else(|| self.extract_token_regex_pattern(&name.resolve()))
                 {
                     let text = left.to_string_value();
+                    // Push routine frame so &?ROUTINE resolves inside code blocks
+                    self.routine_stack.push(super::super::RoutineFrame {
+                        package: package.resolve(),
+                        name: name.resolve(),
+                        line: None,
+                        file: None,
+                        is_method: false,
+                        is_block: false,
+                    });
                     if let Some(captures) = self.regex_match_with_captures(&pat, &text) {
+                        // Set positional captures before executing code blocks
+                        for (i, v) in captures.positional.iter().enumerate() {
+                            self.env.insert(i.to_string(), Value::str(v.clone()));
+                        }
+                        // Execute code blocks from regex for side effects
+                        self.execute_regex_code_blocks(&captures.code_blocks);
                         let match_obj = Value::make_match_object_with_captures(
                             captures.matched.clone(),
                             captures.from as i64,
@@ -186,9 +201,6 @@ impl Interpreter {
                             &captures.named,
                         );
                         self.env.insert("/".to_string(), match_obj);
-                        for (i, v) in captures.positional.iter().enumerate() {
-                            self.env.insert(i.to_string(), Value::str(v.clone()));
-                        }
                         for (k, v) in &captures.named {
                             let value = if v.len() == 1 {
                                 Value::str(v[0].clone())
@@ -197,8 +209,10 @@ impl Interpreter {
                             };
                             self.env.insert(format!("<{}>", k), value);
                         }
+                        self.routine_stack.pop();
                         return true;
                     }
+                    self.routine_stack.pop();
                     self.clear_match_state();
                     return false;
                 }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -199,7 +199,10 @@ impl VM {
         // &?ROUTINE can skip it and see the enclosing routine.
         let call_line = self.current_source_line();
         let call_file = self.current_source_file();
-        if cc.is_pointy_block {
+        if cc.is_pointy_block || data.is_bare_block {
+            // Bare blocks and pointy blocks are NOT routine boundaries.
+            // Push a marker name so &?ROUTINE skips them and finds the
+            // enclosing sub/method.
             self.interpreter.push_block_routine_with_location(
                 data.package.resolve(),
                 "<pointy-block>".to_string(),


### PR DESCRIPTION
## Summary
- Bare blocks (`{ }` closures without `sub` keyword) are now transparent to `&?ROUTINE`, preventing stack overflow when `&?ROUTINE` is used inside a closure within a sub
- Named regex/token/rule smartmatched via `&foo` now execute embedded code blocks and push a routine frame so `&?ROUTINE` resolves correctly
- Adds `roast/S02-magicals/sub.t` to whitelist (11/11 passing)

## Test plan
- [x] `timeout 30 target/debug/mutsu roast/S02-magicals/sub.t` passes all 11 subtests
- [x] `make test` passes (491 files, 4027 tests)
- [x] `make roast` passes (no new failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)