### PR TITLE
fix: implement hyper-assign operators and flat laziness propagation

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -56,7 +56,7 @@ pub(super) fn dispatch(
                 Some(Ok(Value::Seq(Arc::new(result))))
             }
             other if is_infinite_range(other) => Some(Ok(other.clone())),
-            Value::LazyList(_) => None, // fall through to runtime to force
+            Value::LazyList(_) => Some(Ok(target.clone())), // flat of a lazy list is still lazy
             _ => {
                 let mut result = Vec::new();
                 flatten_deep_value(target, &mut result, false);

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -209,14 +209,60 @@ impl Compiler {
         dwim_left: bool,
         dwim_right: bool,
     ) {
-        self.compile_expr(left);
-        self.compile_expr(right);
-        let op_idx = self.code.add_constant(Value::str(op.to_string()));
-        self.code.emit(OpCode::HyperOp {
-            op_idx,
-            dwim_left,
-            dwim_right,
-        });
+        // Detect assignment hyper-ops (e.g. >>+=>>, >>~=>>)
+        // These need to compute with the base op and then assign back.
+        let is_assign_op = op.ends_with('=')
+            && op.len() > 1
+            && !matches!(op, "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>");
+        if is_assign_op {
+            let base_op = &op[..op.len() - 1];
+            self.compile_expr(left);
+            self.compile_expr(right);
+            let op_idx = self.code.add_constant(Value::str(base_op.to_string()));
+            self.code.emit(OpCode::HyperOp {
+                op_idx,
+                dwim_left,
+                dwim_right,
+            });
+            // Assign the result back to the left-hand side variable
+            match left {
+                Expr::ArrayVar(name) => {
+                    self.emit_set_named_var(&format!("@{}", name));
+                }
+                Expr::Var(name) => {
+                    self.emit_set_named_var(name);
+                }
+                Expr::Index {
+                    target,
+                    index,
+                    is_positional,
+                } => {
+                    // For slice hyper-assign like @a[0..2] >>~=>> "x",
+                    // compile an IndexAssign to write the hyper result back.
+                    if let Some(name) = Self::index_assign_target_name(target) {
+                        self.compile_expr(index);
+                        let name_idx = self.code.add_constant(Value::str(name));
+                        self.code.emit(OpCode::IndexAssignExprNamed {
+                            name_idx,
+                            is_positional: *is_positional,
+                        });
+                    }
+                    // For complex targets without a simple name, leave result on stack.
+                }
+                _ => {
+                    // For other complex lvalues, leave the result on the stack.
+                }
+            }
+        } else {
+            self.compile_expr(left);
+            self.compile_expr(right);
+            let op_idx = self.code.add_constant(Value::str(op.to_string()));
+            self.code.emit(OpCode::HyperOp {
+                op_idx,
+                dwim_left,
+                dwim_right,
+            });
+        }
     }
 
     /// Compile HyperFuncOp (>>[&func]<<).

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -272,6 +272,14 @@ impl VM {
         if args.iter().any(|a| matches!(a, Value::LazyList(_))) {
             let name = name_sym.resolve();
             if matches!(name.as_str(), "flat" | "eager") {
+                // For `flat`, if the single argument is lazy, preserve laziness
+                // by returning the lazy list directly (flat of a lazy list is still lazy).
+                if name.as_str() == "flat"
+                    && args.len() == 1
+                    && matches!(&args[0], Value::LazyList(_))
+                {
+                    return Some(Ok(args[0].clone()));
+                }
                 let mut forced_args = Vec::with_capacity(args.len());
                 for arg in args {
                     if let Value::LazyList(ll) = arg {

--- a/t/hyper-assign.t
+++ b/t/hyper-assign.t
@@ -1,0 +1,55 @@
+use Test;
+plan 10;
+
+# Basic hyper-assign on array variable
+{
+    my @a = 1, 2, 3;
+    @a >>+=>> 10;
+    is @a.join(","), "11,12,13", '>>+=>> adds to each element';
+}
+
+{
+    my @a = <a b c>;
+    @a >>~=>> "x";
+    is @a.join(","), "ax,bx,cx", '>>~=>> concatenates to each element';
+}
+
+{
+    my @a = 10, 20, 30;
+    @a >>-=>> 5;
+    is @a.join(","), "5,15,25", '>>-=>> subtracts from each element';
+}
+
+{
+    my @a = 2, 4, 6;
+    @a >>*=>> 3;
+    is @a.join(","), "6,12,18", '>>*=>> multiplies each element';
+}
+
+# Hyper-assign on array slice
+{
+    my @a = <a b c d>;
+    @a[0, 1] >>~=>> "x";
+    is @a.join(","), "ax,bx,c,d", '>>~=>> on slice modifies only sliced elements';
+}
+
+{
+    my @a = <a b c>;
+    @a[0 ..^ *-1] >>~=>> "y";
+    is @a.join(","), "ay,by,c", '>>~=>> with WhateverCode slice works';
+}
+
+# Verify comparison ops are NOT treated as assign
+{
+    my @a = 1, 2, 3;
+    my @b = 2, 2, 2;
+    my @r = @a >>==>> @b;
+    is @r.join(","), "False,True,False", '>>==>> is comparison, not assign';
+    is @a.join(","), "1,2,3", 'original array unchanged after >>==>>';
+}
+
+# flat preserves laziness
+{
+    is-deeply (42 xx *).flat.is-lazy, True, '(lazy).flat.is-lazy is True';
+    is-deeply (42 xx 1).flat.is-lazy, False, '(finite).flat.is-lazy is False';
+}


### PR DESCRIPTION
## Summary
- Implement `>>op=>>` hyper meta-operators with assignment (e.g. `>>+=>>`, `>>~=>>`) that modify the left-hand array or slice in place. Previously these computed results but never stored them back to the variable.
- Fix `flat()` to preserve laziness when called on lazy lists, so `(42 xx *).flat.is-lazy` correctly returns `True` instead of trying to eagerly force an infinite list.
- Supports both simple array targets (`@a >>+=>> 1`) and slice targets (`@a[0 ..^ *-1] >>~=>> "x"`).

## Test plan
- [x] New `t/hyper-assign.t` covers: basic hyper-assign ops (`+=`, `~=`, `-=`, `*=`), slice targets, and verifies comparison ops (`==`) are not mistakenly treated as assignment
- [x] `make test` passes (all 491 test files)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)