### PR TITLE
fix: implement bidirectional container sharing for := binding

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -680,6 +680,10 @@ impl Interpreter {
         self.method_class_stack.pop();
     }
 
+    pub(crate) fn method_class_stack_top(&self) -> Option<String> {
+        self.method_class_stack.last().cloned()
+    }
+
     /// Set up a method dispatch frame for nextsame/callsame support.
     /// Returns true if a frame was pushed (caller must call pop_method_dispatch).
     /// Also pushes a samewith context unconditionally for samewith() support.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1307,20 +1307,18 @@ impl VM {
                         // find the binding.
                         self.interpreter
                             .set_our_var(name.clone(), container.clone());
-                        // Find existing qualified our_var keys that end with
-                        // "::<name>" and update them to share the ContainerRef.
-                        {
-                            let suffix = format!("::{}", name);
-                            let qualified_keys: Vec<String> = self
-                                .interpreter
-                                .our_vars_iter()
-                                .filter(|(k, _)| k.ends_with(&suffix))
-                                .map(|(k, _)| k.clone())
-                                .collect();
-                            for qk in qualified_keys {
-                                self.interpreter.set_our_var(qk.clone(), container.clone());
-                                // Also store in env so methods see the ContainerRef
-                                self.interpreter.env_mut().insert(qk, container.clone());
+                        // Update the package-qualified our_var key (e.g., "K::x"
+                        // for bare "x" in class K) so GetGlobal fallback can find
+                        // the binding. Only match the exact class from the method
+                        // class stack to avoid clobbering unrelated package vars.
+                        if let Some(method_class) = self.interpreter.method_class_stack_top() {
+                            let qualified = format!("{}::{}", method_class, name);
+                            if self.interpreter.get_our_var(&qualified).is_some() {
+                                self.interpreter
+                                    .set_our_var(qualified.clone(), container.clone());
+                                self.interpreter
+                                    .env_mut()
+                                    .insert(qualified, container.clone());
                             }
                         }
                         *ip += 1;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1300,9 +1300,29 @@ impl VM {
                                 }
                             }
                         }
-                        // Persist ContainerRef in our_vars for `our` variables
+                        // Persist ContainerRef in our_vars for `our` variables.
+                        // Store under both the bare name and any existing
+                        // package-qualified variants (e.g., "K::x" for bare "x")
+                        // so GetGlobal fallback (which uses qualified keys) can
+                        // find the binding.
                         self.interpreter
                             .set_our_var(name.clone(), container.clone());
+                        // Find existing qualified our_var keys that end with
+                        // "::<name>" and update them to share the ContainerRef.
+                        {
+                            let suffix = format!("::{}", name);
+                            let qualified_keys: Vec<String> = self
+                                .interpreter
+                                .our_vars_iter()
+                                .filter(|(k, _)| k.ends_with(&suffix))
+                                .map(|(k, _)| k.clone())
+                                .collect();
+                            for qk in qualified_keys {
+                                self.interpreter.set_our_var(qk.clone(), container.clone());
+                                // Also store in env so methods see the ContainerRef
+                                self.interpreter.env_mut().insert(qk, container.clone());
+                            }
+                        }
                         *ip += 1;
                         return Ok(());
                     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3058,6 +3058,14 @@ impl VM {
             self.stack.push(shared_val);
             return Ok(());
         }
+        // Lazy sync: if the local is not a ContainerRef but env has one
+        // (e.g., a cross-scope `:=` binding was established during a function/method
+        // call and propagated back to env but not to locals), adopt the ContainerRef.
+        if !self.locals[idx].is_container_ref()
+            && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(&name).cloned()
+        {
+            self.locals[idx] = Value::ContainerRef(arc);
+        }
         let val = self.locals[idx].clone();
         // Resolve DeferredHashAccess to its current value (Any if path doesn't exist)
         if let Value::DeferredHashAccess { .. } = &val {
@@ -3791,14 +3799,16 @@ impl VM {
             {
                 self.local_bind_pairs.push((source_idx, idx));
             }
-            // Create a shared ContainerRef only when the source variable exists in
-            // an outer call frame (cross-scope binding, e.g., method attribute binding).
-            // Same-scope bindings use the existing alias mechanism.
+            // Create a shared ContainerRef for cross-scope binding (source in
+            // outer call frame) OR same-scope rebinding (`:=` on existing vars).
+            // ContainerRef ensures bidirectional container sharing: writing to
+            // either variable updates both, matching Raku's binding semantics.
             let source_in_outer_frame = self
                 .call_frames
                 .iter()
                 .any(|f| f.saved_env.contains_key(&resolved_source));
-            if source_in_outer_frame
+            let source_in_same_scope = code.locals.iter().any(|n| n == &resolved_source);
+            if (source_in_outer_frame || (is_rebind && source_in_same_scope))
                 && !name.starts_with('@')
                 && !name.starts_with('%')
                 && !name.starts_with('&')
@@ -3858,6 +3868,16 @@ impl VM {
                 self.mark_local_dirty(idx);
                 return Ok(());
             }
+        }
+        // Lazy sync: if the local is not a ContainerRef but env has one
+        // (from a cross-scope `:=` binding), adopt the ContainerRef so the
+        // write-through below preserves shared container identity.
+        if !is_bind
+            && !is_rebind
+            && !self.locals[idx].is_container_ref()
+            && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
+        {
+            self.locals[idx] = Value::ContainerRef(arc);
         }
         // Write through ContainerRef in slow path: update inner value
         if !is_bind
@@ -4136,7 +4156,6 @@ impl VM {
         idx: u32,
     ) -> Result<(), RuntimeError> {
         let idx = idx as usize;
-
         // If the current local is a Proxy, invoke STORE instead of overwriting
         if let Value::Proxy { storer, .. } = &self.locals[idx]
             && !matches!(storer.as_ref(), Value::Nil)
@@ -4151,6 +4170,24 @@ impl VM {
         if code.simple_locals[idx] {
             let mut val = self.stack.pop().unwrap_or(Value::Nil);
             let name = &code.locals[idx];
+            // Lazy sync: if the local is not a ContainerRef but env has one
+            // (from a cross-scope `:=` binding), adopt the ContainerRef and
+            // write through it to preserve shared container identity.
+            if !self.locals[idx].is_container_ref()
+                && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
+            {
+                self.locals[idx] = Value::ContainerRef(arc);
+            }
+            if let Value::ContainerRef(arc) = &self.locals[idx] {
+                let arc = arc.clone();
+                if !name.starts_with('@') && !name.starts_with('%') {
+                    val = Self::normalize_scalar_assignment_value(val);
+                }
+                arc.lock().unwrap().clone_from(&val);
+                self.stack.push(val);
+                self.mark_local_dirty(idx);
+                return Ok(());
+            }
             if !name.starts_with('@') && !name.starts_with('%') {
                 val = Self::normalize_scalar_assignment_value(val);
             }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3061,7 +3061,16 @@ impl VM {
         // Lazy sync: if the local is not a ContainerRef but env has one
         // (e.g., a cross-scope `:=` binding was established during a function/method
         // call and propagated back to env but not to locals), adopt the ContainerRef.
+        // Skip for type objects and complex values that should not be replaced.
         if !self.locals[idx].is_container_ref()
+            && !matches!(
+                self.locals[idx],
+                Value::Package(_)
+                    | Value::Array(..)
+                    | Value::Hash(..)
+                    | Value::Sub(..)
+                    | Value::Instance { .. }
+            )
             && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(&name).cloned()
         {
             self.locals[idx] = Value::ContainerRef(arc);
@@ -3808,7 +3817,18 @@ impl VM {
                 .iter()
                 .any(|f| f.saved_env.contains_key(&resolved_source));
             let source_in_same_scope = code.locals.iter().any(|n| n == &resolved_source);
-            if (source_in_outer_frame || (is_rebind && source_in_same_scope))
+            // Only use ContainerRef for same-scope rebind when the value is a
+            // simple scalar (not a type object, array, hash, etc.)
+            let val_is_simple_scalar = !matches!(
+                val,
+                Value::Package(_)
+                    | Value::Array(..)
+                    | Value::Hash(..)
+                    | Value::Sub(..)
+                    | Value::Instance { .. }
+            );
+            if (source_in_outer_frame
+                || (is_rebind && source_in_same_scope && val_is_simple_scalar))
                 && !name.starts_with('@')
                 && !name.starts_with('%')
                 && !name.starts_with('&')
@@ -3872,9 +3892,18 @@ impl VM {
         // Lazy sync: if the local is not a ContainerRef but env has one
         // (from a cross-scope `:=` binding), adopt the ContainerRef so the
         // write-through below preserves shared container identity.
+        // Skip for type objects and complex values.
         if !is_bind
             && !is_rebind
             && !self.locals[idx].is_container_ref()
+            && !matches!(
+                self.locals[idx],
+                Value::Package(_)
+                    | Value::Array(..)
+                    | Value::Hash(..)
+                    | Value::Sub(..)
+                    | Value::Instance { .. }
+            )
             && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
         {
             self.locals[idx] = Value::ContainerRef(arc);
@@ -4173,7 +4202,16 @@ impl VM {
             // Lazy sync: if the local is not a ContainerRef but env has one
             // (from a cross-scope `:=` binding), adopt the ContainerRef and
             // write through it to preserve shared container identity.
+            // Skip for type objects and complex values.
             if !self.locals[idx].is_container_ref()
+                && !matches!(
+                    self.locals[idx],
+                    Value::Package(_)
+                        | Value::Array(..)
+                        | Value::Hash(..)
+                        | Value::Sub(..)
+                        | Value::Instance { .. }
+                )
                 && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
             {
                 self.locals[idx] = Value::ContainerRef(arc);


### PR DESCRIPTION
## Summary
- Fix `:=` (bind) operator to create proper bidirectional container sharing via ContainerRef
- Same-scope rebinding (`$a := $b`) now uses ContainerRef instead of one-way aliases
- Cross-scope binding (via method/sub calls) now properly syncs ContainerRef through lazy sync in GetLocal, SetLocal slow path, and AssignExprLocal
- Qualified `our` variable keys (e.g., `K::x`) are updated when binding bare-named vars in methods

## Test plan
- [x] `my $a = 1; my $b = 2; $a := $b; $b = 99; say $a` prints 99
- [x] Cross-scope binding via class methods works (roast S03-binding/attributes.t tests 11-12)
- [x] `make test` passes (all 492 test files)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)