### PR TITLE
fix: expose infix/prefix/postfix operators to EVAL parser

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -689,8 +689,8 @@ impl Interpreter {
     /// infix, term) work through runtime dispatch without parser pre-registration.
     pub(crate) fn collect_operator_sub_names(&self) -> Vec<String> {
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        // Include circumfix/postcircumfix operators defined in any loaded
-        // module so EVAL parser can still recognize their delimiter syntax.
+        // Include all user-defined operators (infix, prefix, postfix,
+        // circumfix, postcircumfix) so the EVAL parser can recognize them.
         for key in self.functions.keys() {
             let key_s = key.resolve();
             let name = if let Some(pos) = key_s.rfind("::") {
@@ -698,12 +698,22 @@ impl Interpreter {
             } else {
                 key_s.as_str()
             };
-            if name.starts_with("circumfix:") || name.starts_with("postcircumfix:") {
+            if name.starts_with("circumfix:")
+                || name.starts_with("postcircumfix:")
+                || name.starts_with("infix:")
+                || name.starts_with("prefix:")
+                || name.starts_with("postfix:")
+            {
                 seen.insert(name.to_string());
             }
         }
         for key in self.env.keys() {
-            if key.starts_with("circumfix:") || key.starts_with("postcircumfix:") {
+            if key.starts_with("circumfix:")
+                || key.starts_with("postcircumfix:")
+                || key.starts_with("infix:")
+                || key.starts_with("prefix:")
+                || key.starts_with("postfix:")
+            {
                 seen.insert(key.resolve());
             }
         }


### PR DESCRIPTION
## Summary
- Fixed `collect_operator_sub_names()` to expose user-defined `infix:`, `prefix:`, and `postfix:` operators to the EVAL parser, not just `circumfix:` and `postcircumfix:`.
- This fixes a bug where `EVAL('1 ++ 2')` would fail with a compile error when `sub infix:<++>` was defined in the enclosing scope.
- Improves `roast/S02-lexical-conventions/unspace.t` from running 54/110 tests to running all 110 tests (100 passing, 10 failing due to unrelated issues like invocant colon syntax and postfix/infix ambiguity detection).

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (only pre-existing flaky `t/lock.t` race condition)
- [x] `make roast` passes (all whitelisted tests still pass)
- [x] Verified `sub infix:<++>($x, $y) { 42 }; say EVAL('1 ++ 2')` now outputs 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)