### PR TITLE
fix: remove mro-6e.t from whitelist (fails on main)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -571,7 +571,6 @@ roast/S12-class/interface-consistency.t
 roast/S12-class/lexical.t
 roast/S12-class/literal.t
 roast/S12-class/magical-vars.t
-roast/S12-class/mro-6e.t
 roast/S12-class/namespaced.t
 roast/S12-class/open.t
 roast/S12-class/parent_attributes.t


### PR DESCRIPTION
## Summary
- `roast/S12-class/mro-6e.t` was erroneously added to the whitelist
- It fails on main (rolified MRO not implemented — roles in `.^mro` output)
- Removing it to unblock other PRs blocked by this CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)