### PR TITLE
fix: support does Numeric/Real on user classes and fix expr-context class role composition

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -627,7 +627,8 @@ pub(super) fn dispatch(
                 let type_name = name.resolve();
                 let zero = match type_name.as_str() {
                     "Int" | "IntStr" => Value::Int(0),
-                    "Rat" | "FatRat" | "RatStr" => Value::Rat(0, 1),
+                    "Rat" | "RatStr" => Value::Rat(0, 1),
+                    "FatRat" => Value::FatRat(0, 1),
                     "Num" | "NumStr" => Value::Num(0.0),
                     "Complex" | "ComplexStr" => Value::Complex(0.0, 0.0),
                     _ => return Some(None),

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -1600,6 +1600,7 @@ pub(super) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             } else if let Some(r2) = keyword("does", r) {
                 let (r2, _) = super::super::helpers::ws1(r2)?;
                 let (r2, role) = parse_qualified_ident_with_hyphens(r2)?;
+                parents.push(role.clone());
                 does_roles.push(role);
                 let (r2, _) = ws(r2)?;
                 r = r2;
@@ -1630,6 +1631,7 @@ pub(super) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             } else if let Some(r2) = keyword("does", r) {
                 let (r2, _) = super::super::helpers::ws1(r2)?;
                 let (r2, role) = parse_qualified_ident_with_hyphens(r2)?;
+                parents.push(role.clone());
                 does_roles.push(role);
                 let (r2, _) = ws(r2)?;
                 r = r2;
@@ -1648,11 +1650,11 @@ pub(super) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
 
     let (rest, mut body) = parse_block_body(rest)?;
     // Insert DoesDecl statements at the beginning of the body for `does` clauses
-    for role_name in does_roles.into_iter().rev() {
+    for role_name in does_roles.iter().rev() {
         body.insert(
             0,
             Stmt::DoesDecl {
-                name: Symbol::intern(&role_name),
+                name: Symbol::intern(role_name),
             },
         );
     }
@@ -1666,7 +1668,7 @@ pub(super) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             is_hidden: false,
             is_lexical: false,
             hidden_parents: Vec::new(),
-            does_parents: Vec::new(),
+            does_parents: does_roles,
             repr: None,
             body,
             language_version: crate::parser::current_language_version(),

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -302,6 +302,32 @@ impl Interpreter {
                 return Ok(result);
             }
         }
+        // .Numeric / .Real on type objects for user classes that compose those roles.
+        // In Raku, `does Numeric` / `does Real` provides a default `.Numeric` / `.Real`
+        // method on type objects: it warns about uninitialized use and calls `self.new`.
+        if matches!(method, "Numeric" | "Real")
+            && args.is_empty()
+            && let Value::Package(name) = &target
+        {
+            let type_name = name.resolve();
+            // Only handle user-defined classes (not built-in types, which are handled
+            // by the builtins fast path in dispatch_core_coerce.rs).
+            let role_name = method; // "Numeric" or "Real"
+            let composes_role = self
+                .class_composed_roles
+                .get(&type_name)
+                .is_some_and(|roles| roles.iter().any(|r| r == role_name));
+            if composes_role {
+                let msg = format!(
+                    "Use of uninitialized value of type {} in numeric context",
+                    type_name
+                );
+                // Call self.new to get the default value
+                let new_val = self.call_method_with_values(target.clone(), "new", vec![])?;
+                return Err(RuntimeError::warn_signal_with_resume(msg, new_val));
+            }
+        }
+
         // .return method: triggers a return from the enclosing sub with the invocant
         if method == "return" && args.is_empty() {
             let mut err = RuntimeError::new("return");

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -310,19 +310,19 @@ impl Interpreter {
             && let Value::Package(name) = &target
         {
             let type_name = name.resolve();
-            // Only handle user-defined classes (not built-in types, which are handled
-            // by the builtins fast path in dispatch_core_coerce.rs).
-            let role_name = method; // "Numeric" or "Real"
+            let role_name = method;
             let composes_role = self
                 .class_composed_roles
                 .get(&type_name)
                 .is_some_and(|roles| roles.iter().any(|r| r == role_name));
-            if composes_role {
+            // Only apply default handler if the class composes the role but does NOT
+            // define its own Numeric/Real method (user method should take priority).
+            let has_user_method = self.class_has_method(&type_name, method);
+            if composes_role && !has_user_method {
                 let msg = format!(
                     "Use of uninitialized value of type {} in numeric context",
                     type_name
                 );
-                // Call self.new to get the default value
                 let new_val = self.call_method_with_values(target.clone(), "new", vec![])?;
                 return Err(RuntimeError::warn_signal_with_resume(msg, new_val));
             }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1137,6 +1137,15 @@ impl Interpreter {
                     .entry(name.to_string())
                     .or_default()
                     .push(base_role_name.to_string());
+            } else if does_parents.contains(parent)
+                && BUILTIN_TYPES.contains(&base_role_name)
+                && !self.roles.contains_key(base_role_name)
+                && !composed_roles_list.contains(&resolved_parent_name)
+            {
+                // Built-in type used as a role via `does` (e.g., `does Numeric`,
+                // `does Real`): record in composed_roles_list so that role-based
+                // method dispatch (e.g., .Numeric on type objects) works correctly.
+                composed_roles_list.push(resolved_parent_name.clone());
             }
         }
         if class_role_param_bindings.is_empty() {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -248,11 +248,18 @@ impl VM {
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
         // Flatten any Slip values in the argument list (from |capture slipping)
+        // val() uses capture semantics (Mu |) — preserve Slip as a single arg.
+        let preserve_slip_entirely = name == "val";
         let preserve_empty_slip = Self::preserve_empty_slip_arg(&name);
-        let mut args = Vec::new();
-        for arg in raw_args {
-            Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
-        }
+        let args = if preserve_slip_entirely {
+            raw_args
+        } else {
+            let mut args = Vec::new();
+            for arg in raw_args {
+                Self::append_flattened_call_arg(&mut args, arg, preserve_empty_slip);
+            }
+            args
+        };
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         let arg_sources = if arg_sources.as_ref().is_some_and(|sources| {
             sources.len() != args.len()


### PR DESCRIPTION
## Summary
- Add `.Numeric`/`.Real` method dispatch for type objects of user classes that compose `Numeric`/`Real` roles (warns about uninitialized use, then calls `.new`)
- Fix expression-context class declarations (`my class Foo does R { }`) to properly pass `does_parents` to class registration, matching statement-level class behavior
- Record built-in types used as roles via `does` in `composed_roles_list` so role-based method dispatch works
- Fix `FatRat.Numeric` to return `FatRat(0,1)` instead of `Rat(0,1)`
- Preserve Slip values when calling `val()` to match Raku's capture semantics

These fixes address 3 of 4 failures in `roast/S02-literals/allomorphic.t` (tests 110, 113, 114). The remaining test 107 (.ACCEPTS) requires lexical class identity scoping which is a deeper architectural issue.

## Test plan
- [ ] `make test` passes
- [ ] `make roast` passes (no regressions in whitelisted tests)
- [ ] `roast/S02-literals/allomorphic.t` goes from 4 failures to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)