### PR TITLE
fix: correct BagHash X::Cannot::Lazy .what and enable re-assignment

### DIFF
--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -864,7 +864,7 @@ impl Interpreter {
                 if matches!(arg0, Value::Mix(_, _)) {
                     return self.dispatch_to_mix(arg0);
                 }
-                return self.dispatch_to_bag(arg0);
+                return self.dispatch_to_bag_with_what(arg0, "Bag");
             }
             if matches!(op, "(-)" | "∖" | "(|)" | "∪" | "(&)" | "∩" | "(^)" | "⊖") {
                 return Ok(coerce_value_to_quanthash(&args[0]));

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -117,10 +117,14 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn dispatch_to_bag(&self, target: Value) -> Result<Value, RuntimeError> {
+    pub(super) fn dispatch_to_bag_with_what(
+        &self,
+        target: Value,
+        what: &str,
+    ) -> Result<Value, RuntimeError> {
         // Check for lazy/infinite inputs
         if Self::is_lazy_for_coerce(&target) {
-            return Err(RuntimeError::cannot_lazy_what("Bag"));
+            return Err(RuntimeError::cannot_lazy_what(what));
         }
         let mut counts: HashMap<String, i64> = HashMap::new();
         let mut original_keys: HashMap<String, Value> = HashMap::new();

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -40,7 +40,7 @@ impl Interpreter {
                 Some(Ok(result))
             }
             "Bag" | "BagHash" if args.is_empty() => {
-                let result = match self.dispatch_to_bag(target) {
+                let result = match self.dispatch_to_bag_with_what(target, method) {
                     Ok(r) => r,
                     Err(e) => return Some(Err(e)),
                 };
@@ -76,7 +76,7 @@ impl Interpreter {
                         }
                         // Convert items to a temporary array and use dispatch_to_bag
                         let arr = Value::array(all_items);
-                        let result = match self.dispatch_to_bag(arr) {
+                        let result = match self.dispatch_to_bag_with_what(arr, &cn) {
                             Ok(r) => r,
                             Err(e) => return Some(Err(e)),
                         };

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -222,6 +222,8 @@ impl VM {
         match base {
             "Mix" => Some("Mix"),
             "MixHash" => Some("MixHash"),
+            "Bag" => Some("Bag"),
+            "BagHash" => Some("BagHash"),
             _ => None,
         }
     }
@@ -322,7 +324,17 @@ impl VM {
         if let Some(constraint) = self.interpreter.var_type_constraint_fast(name).cloned()
             && let Some(trait_name) = Self::quant_hash_trait_from_constraint(&constraint)
         {
-            return self.try_compiled_method_or_interpret(value, trait_name, vec![]);
+            // Only coerce if the variable IS a QuantHash container (declared via `is`),
+            // not when the constraint is a value type (declared via `of`).
+            // Check: if the current value is already a QuantHash, it's an `is` trait.
+            let current = self.interpreter.env().get(name).cloned();
+            let is_quanthash_container = matches!(
+                current,
+                Some(Value::Bag(_, _) | Value::Mix(_, _) | Value::Set(_, _))
+            );
+            if is_quanthash_container {
+                return self.try_compiled_method_or_interpret(value, trait_name, vec![]);
+            }
         }
         if self.interpreter.check_readonly_for_modify(name).is_err()
             && matches!(


### PR DESCRIPTION
## Summary
- Fix `X::Cannot::Lazy` to report "BagHash" (not "Bag") in `.what` attribute when `.BagHash` coercion is called on a lazy list
- Enable re-assignment to `%h is BagHash` variables (e.g. `%h = <a b c>`) by adding Bag/BagHash to the QuantHash coercion path
- Guard against confusing `of BagHash` (value type constraint) with `is BagHash` (container trait) during assignment coercion

These fixes improve roast/S02-types/baghash.t (test 229 now passes, lazy error reporting correct). The test cannot be whitelisted yet due to remaining proxy container features needed for BagHash value iteration.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` passes (only pre-existing t/lock.t flake)
- [x] `make roast` passes (only pre-existing timeouts in defer-next.t and sprintf-d.t)
- [x] `raku -e '...'` verified for BagHash re-assignment behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)