### PR TITLE
fix: deep autovivification and $%h/$@a itemization

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -130,6 +130,7 @@ roast/S02-types/lazy-lists.t
 roast/S02-types/list.t
 roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
+roast/S02-types/mixed_multi_dimensional.t
 roast/S02-types/mu.t
 roast/S02-types/nan.t
 roast/S02-types/native.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -323,6 +323,9 @@ pub(crate) enum Expr {
     },
     Gather(Vec<Stmt>),
     Eager(Box<Expr>),
+    /// Item context coercion: `$%hash` or `$@array` — wraps value in Scalar container
+    /// so it won't be flattened in list context.
+    Itemize(Box<Expr>),
     Reduction {
         op: String,
         expr: Box<Expr>,
@@ -1112,7 +1115,9 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             collect_ph_expr(expr, out);
             collect_ph_expr(value, out);
         }
-        Expr::Reduction { expr, .. } | Expr::Eager(expr) => collect_ph_expr(expr, out),
+        Expr::Reduction { expr, .. } | Expr::Eager(expr) | Expr::Itemize(expr) => {
+            collect_ph_expr(expr, out)
+        }
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
         | Expr::MetaOp { left, right, .. } => {
@@ -1391,7 +1396,9 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
                 collect_ph_stmt_shallow(s, out);
             }
         }
-        Expr::Reduction { expr, .. } | Expr::Eager(expr) => collect_ph_expr_shallow(expr, out),
+        Expr::Reduction { expr, .. } | Expr::Eager(expr) | Expr::Itemize(expr) => {
+            collect_ph_expr_shallow(expr, out)
+        }
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
         | Expr::MetaOp { left, right, .. } => {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -375,6 +375,10 @@ impl Compiler {
                 self.compile_expr(inner);
                 self.code.emit(OpCode::Eager);
             }
+            Expr::Itemize(inner) => {
+                self.compile_expr(inner);
+                self.code.emit(OpCode::Itemize);
+            }
             Expr::PositionalPair(inner) => {
                 self.compile_expr(inner);
                 self.code.emit(OpCode::ContainerizePair);

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -264,6 +264,30 @@ impl Compiler {
                 name_idx,
                 is_positional: outer_positional,
             });
+        } else if let Some((name, chain)) = Self::index_assign_deep_nested_target(target) {
+            // Deep nested index assignment (3+ levels): @a[i][j][k]... = val
+            // chain contains (index_expr, is_positional) from innermost to outermost
+            // We also have the IndexAssign's own (index, outer_positional) as the final level.
+            let depth = (chain.len() + 1) as u32; // +1 for the outermost from IndexAssign
+            // Build positional flags array: innermost to outermost
+            let mut flags: Vec<Value> = chain.iter().map(|(_, p)| Value::Bool(*p)).collect();
+            flags.push(Value::Bool(outer_positional));
+            let positional_flags_idx = self.code.add_constant(Value::Array(
+                Arc::new(flags),
+                crate::value::ArrayKind::Array,
+            ));
+            // Stack order: [value, idx_outermost, ..., idx_innermost]
+            self.compile_expr(value);
+            self.compile_expr(index); // outermost
+            for (idx_expr, _) in chain.iter().rev() {
+                self.compile_expr(idx_expr);
+            }
+            let name_idx = self.code.add_constant(Value::str(name));
+            self.code.emit(OpCode::IndexAssignDeepNested {
+                name_idx,
+                depth,
+                positional_flags_idx,
+            });
         } else if let Some((name, inner_index, inner_positional)) =
             Self::index_assign_nested_target(target)
         {

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -299,6 +299,11 @@ impl Compiler {
                 self.code.emit(OpCode::MakeRealArray(items.len() as u32));
             } else {
                 self.compile_expr(&elems[0]);
+                // For scalar variables and itemized expressions, emit Itemize
+                // so MakeRealArray(1) won't flatten them via value_to_list.
+                if Self::expr_is_scalar_var(&elems[0]) || matches!(&elems[0], Expr::Itemize(_)) {
+                    self.code.emit(OpCode::Itemize);
+                }
                 self.code.emit(OpCode::MakeRealArray(1));
             }
         } else {

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -299,9 +299,12 @@ impl Compiler {
                 self.code.emit(OpCode::MakeRealArray(items.len() as u32));
             } else {
                 self.compile_expr(&elems[0]);
-                // For scalar variables and itemized expressions ($%h, $@a),
-                // use MakeRealArrayNoFlatten to prevent value_to_list flattening.
-                if Self::expr_is_scalar_var(&elems[0]) || matches!(&elems[0], Expr::Itemize(_)) {
+                // When the single element is a scalar variable ($x) or explicit
+                // item context ($%h, $@a), use MakeRealArrayNoFlatten so that
+                // hash/array values held in scalars are not flattened.
+                // HashVar and ArrayVar (% and @ sigiled) SHOULD flatten.
+                let should_not_flatten = matches!(&elems[0], Expr::Var(_) | Expr::Itemize(_));
+                if should_not_flatten {
                     self.code.emit(OpCode::MakeRealArrayNoFlatten(1));
                 } else {
                     self.code.emit(OpCode::MakeRealArray(1));

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -299,12 +299,13 @@ impl Compiler {
                 self.code.emit(OpCode::MakeRealArray(items.len() as u32));
             } else {
                 self.compile_expr(&elems[0]);
-                // For scalar variables and itemized expressions, emit Itemize
-                // so MakeRealArray(1) won't flatten them via value_to_list.
+                // For scalar variables and itemized expressions ($%h, $@a),
+                // use MakeRealArrayNoFlatten to prevent value_to_list flattening.
                 if Self::expr_is_scalar_var(&elems[0]) || matches!(&elems[0], Expr::Itemize(_)) {
-                    self.code.emit(OpCode::Itemize);
+                    self.code.emit(OpCode::MakeRealArrayNoFlatten(1));
+                } else {
+                    self.code.emit(OpCode::MakeRealArray(1));
                 }
-                self.code.emit(OpCode::MakeRealArray(1));
             }
         } else {
             for elem in elems {

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -170,6 +170,35 @@ impl Compiler {
         None
     }
 
+    /// Extract a chain of indices from arbitrarily deep nested Index nodes.
+    /// For `@a[0][1][2]` the target of IndexAssign is `Index{target: Index{target: ArrayVar("a"), [0]}, [1]}`.
+    /// This returns `(var_name, vec![(index_expr, is_positional), ...])` from innermost to outermost.
+    /// The outermost index (from IndexAssign itself) is NOT included -- caller adds it.
+    pub(super) fn index_assign_deep_nested_target(
+        target: &Expr,
+    ) -> Option<(String, Vec<(&Expr, bool)>)> {
+        let mut chain: Vec<(&Expr, bool)> = Vec::new();
+        let mut current = target;
+        while let Expr::Index {
+            target: inner_target,
+            index: inner_index,
+            is_positional: inner_is_positional,
+            ..
+        } = current
+        {
+            chain.push((inner_index, *inner_is_positional));
+            current = inner_target;
+        }
+        if chain.len() < 2 {
+            // Single level is handled by index_assign_nested_target
+            return None;
+        }
+        let name = Self::index_assign_target_name(current)?;
+        // Reverse so chain[0] is the innermost (closest to variable)
+        chain.reverse();
+        Some((name, chain))
+    }
+
     /// Hoist sub declarations: emit RegisterSub for all SubDecl statements
     /// before executing the rest of the block, so that `&name` references
     /// are available before the sub declaration appears in source order.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -525,6 +525,16 @@ pub(crate) enum OpCode {
         outer_positional: bool,
         inner_positional: bool,
     },
+    /// Deep nested index assignment (3+ levels): @a[i][j][k]... = val
+    /// Stack: [value, idx_n (outermost), idx_n-1, ..., idx_1 (innermost)]
+    /// `depth` is the total number of subscript levels.
+    /// `positional_flags_idx` is a constant index holding a Value::Array of booleans
+    /// encoding is_positional for each level from innermost to outermost.
+    IndexAssignDeepNested {
+        name_idx: u32,
+        depth: u32,
+        positional_flags_idx: u32,
+    },
     /// Generic index assignment on a stack-computed target.
     /// Stack: [target, index, value] → assigns value to target[index].
     /// Supports callframe .my hash writeback for dynamic variables.
@@ -1148,6 +1158,7 @@ impl CompiledCode {
                     | OpCode::AssignExprLocal(_)
                     | OpCode::IndexAssignExprNamed { .. }
                     | OpCode::IndexAssignExprNested { .. }
+                    | OpCode::IndexAssignDeepNested { .. }
                     | OpCode::IndexAssignGeneric
                     | OpCode::IndexAssignPseudoStashNamed { .. }
                     | OpCode::PostIncrement(_)

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -151,11 +151,12 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
             } else {
                 format!("{}{}", twigil, name)
             };
-            return if sigil == "@" {
-                Ok((rest, Expr::ArrayVar(full_name)))
+            let inner = if sigil == "@" {
+                Expr::ArrayVar(full_name)
             } else {
-                Ok((rest, Expr::HashVar(full_name)))
+                Expr::HashVar(full_name)
             };
+            return Ok((rest, Expr::Itemize(Box::new(inner))));
         }
     }
     // Handle nested scalar dereference syntax ($$x / $&f) by parsing the

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -346,6 +346,7 @@ fn expr_contains_whatever(expr: &Expr) -> bool {
         Expr::ZenSlice(inner)
         | Expr::PositionalPair(inner)
         | Expr::Eager(inner)
+        | Expr::Itemize(inner)
         | Expr::Reduction { expr: inner, .. }
         | Expr::IndirectTypeLookup(inner)
         | Expr::SymbolicDeref { expr: inner, .. } => expr_contains_whatever(inner),

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -478,6 +478,7 @@ fn lift_phasers_from_expr(
         | Expr::PositionalPair(inner)
         | Expr::ZenSlice(inner)
         | Expr::Eager(inner)
+        | Expr::Itemize(inner)
         | Expr::Reduction { expr: inner, .. }
         | Expr::IndirectCodeLookup { package: inner, .. }
         | Expr::SymbolicDeref { expr: inner, .. } => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1567,13 +1567,13 @@ impl VM {
             OpCode::Itemize => {
                 // Wrap Array/List values in their itemized (Scalar-container)
                 // variant so they are treated as single items in list context.
-                // Hash is wrapped in Scalar so it won't be flattened.
+                // Hash is already an item (not flattened in list context), so
+                // it is left unchanged.
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 let itemized = match val {
                     Value::Array(items, kind) if !kind.is_itemized() => {
                         Value::Array(items, kind.itemize())
                     }
-                    Value::Hash(h) => Value::Scalar(Box::new(Value::Hash(h))),
                     other => other,
                 };
                 self.stack.push(itemized);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1567,13 +1567,13 @@ impl VM {
             OpCode::Itemize => {
                 // Wrap Array/List values in their itemized (Scalar-container)
                 // variant so they are treated as single items in list context.
-                // Hash is already an item (not flattened in list context), so
-                // it is left unchanged.
+                // Hash is wrapped in Scalar so it won't be flattened.
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 let itemized = match val {
                     Value::Array(items, kind) if !kind.is_itemized() => {
                         Value::Array(items, kind.itemize())
                     }
+                    Value::Hash(h) => Value::Scalar(Box::new(Value::Hash(h))),
                     other => other,
                 };
                 self.stack.push(itemized);
@@ -2719,6 +2719,19 @@ impl VM {
                     *name_idx,
                     *outer_positional,
                     *inner_positional,
+                )?;
+                *ip += 1;
+            }
+            OpCode::IndexAssignDeepNested {
+                name_idx,
+                depth,
+                positional_flags_idx,
+            } => {
+                self.exec_index_assign_deep_nested_op(
+                    code,
+                    *name_idx,
+                    *depth,
+                    *positional_flags_idx,
                 )?;
                 *ip += 1;
             }

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -72,7 +72,8 @@ impl VM {
     }
 
     /// Like `exec_make_array_op` with `is_real_array=true` but never flattens
-    /// single elements. Used for bracket arrays with trailing comma (`[x,]`).
+    /// single elements. Used for bracket arrays with trailing comma (`[x,]`)
+    /// and for `[$scalar]` / `[$%h]` to prevent hash/array flattening.
     pub(super) fn exec_make_array_no_flatten_op(&mut self, n: u32) {
         let n = n as usize;
         let start = self.stack.len() - n;
@@ -81,6 +82,8 @@ impl VM {
         for val in raw {
             match val {
                 Value::Slip(items) => elems.extend(items.iter().cloned()),
+                // Nil in list context contributes nothing (same as value_to_list).
+                Value::Nil => {}
                 other => elems.push(other),
             }
         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2843,6 +2843,189 @@ impl VM {
         Ok(())
     }
 
+    /// Deep nested index assignment (3+ levels): @a[i][j][k]... = val
+    /// Stack order: [value, idx_outermost, ..., idx_innermost] (innermost on top).
+    /// positional_flags_idx is a constant index holding an array of booleans
+    /// (innermost to outermost) indicating whether each subscript is positional.
+    pub(super) fn exec_index_assign_deep_nested_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        depth: u32,
+        positional_flags_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let var_name = Self::const_str(code, name_idx).to_string();
+        let depth = depth as usize;
+
+        // Pop indices from stack: innermost first (top of stack)
+        let mut indices: Vec<String> = Vec::with_capacity(depth);
+        for _ in 0..depth {
+            let idx = self.stack.pop().unwrap_or(Value::Nil);
+            indices.push(idx.to_string_value());
+        }
+        // indices[0] = innermost, indices[depth-1] = outermost
+
+        let val = self.stack.pop().unwrap_or(Value::Nil);
+
+        // Extract positional flags from constant
+        let flags_val = code.constants[positional_flags_idx as usize].clone();
+        let positional_flags: Vec<bool> = if let Value::Array(arr, _) = &flags_val {
+            arr.iter().map(|v| matches!(v, Value::Bool(true))).collect()
+        } else {
+            vec![true; depth]
+        };
+
+        // Invalidate local cache for the variable
+        if let Some(slot) = self.find_local_slot(code, &var_name)
+            && matches!(self.locals[slot], Value::Array(..) | Value::Hash(..))
+        {
+            self.locals[slot] = Value::Nil;
+        }
+
+        // Ensure the root variable exists
+        if !self.interpreter.env().contains_key(&var_name) {
+            let init = if var_name.starts_with('@') {
+                Value::real_array(Vec::new())
+            } else if var_name.starts_with('%') {
+                Value::hash(std::collections::HashMap::new())
+            } else if positional_flags[0] {
+                Value::real_array(Vec::new())
+            } else {
+                Value::hash(std::collections::HashMap::new())
+            };
+            self.interpreter.env_mut().insert(var_name.clone(), init);
+        }
+
+        // Walk down the chain of indices, autovivifying containers as needed.
+        // We need a mutable reference to the current container at each level.
+        // Use raw pointer traversal to avoid borrow checker issues with nested mutation.
+        let root: *mut Value = self.interpreter.env_mut().get_mut(&var_name).unwrap() as *mut Value;
+
+        let mut current: *mut Value = root;
+
+        // Walk through indices[0..depth-1], autovivifying intermediate containers
+        for level in 0..depth {
+            let key = &indices[level];
+            let is_positional = positional_flags[level];
+
+            if level < depth - 1 {
+                // Intermediate level: autovivify and descend
+                let next_positional = positional_flags[level + 1];
+                unsafe {
+                    match &mut *current {
+                        Value::Array(arr_arc, _) => {
+                            if let Ok(i) = key.parse::<usize>() {
+                                let arr = Arc::make_mut(arr_arc);
+                                if i >= arr.len() {
+                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                }
+                                // Autovivify if needed
+                                let needs_viv =
+                                    !matches!(&arr[i], Value::Array(..) | Value::Hash(..));
+                                if needs_viv {
+                                    arr[i] = if next_positional {
+                                        Value::real_array(Vec::new())
+                                    } else {
+                                        Value::hash(std::collections::HashMap::new())
+                                    };
+                                }
+                                current = &mut arr[i] as *mut Value;
+                            }
+                        }
+                        Value::Hash(hash_arc) => {
+                            let hash = Arc::make_mut(hash_arc);
+                            if !hash.contains_key(key.as_str()) {
+                                let new_val = if next_positional {
+                                    Value::real_array(Vec::new())
+                                } else {
+                                    Value::hash(std::collections::HashMap::new())
+                                };
+                                hash.insert(key.clone(), new_val);
+                            }
+                            current = hash.get_mut(key.as_str()).unwrap() as *mut Value;
+                        }
+                        _ => {
+                            // Autovivify the root itself if needed
+                            if is_positional {
+                                *current = Value::real_array(Vec::new());
+                            } else {
+                                *current = Value::hash(std::collections::HashMap::new());
+                            }
+                            // Retry this level
+                            match &mut *current {
+                                Value::Array(arr_arc, _) => {
+                                    if let Ok(i) = key.parse::<usize>() {
+                                        let arr = Arc::make_mut(arr_arc);
+                                        if i >= arr.len() {
+                                            arr.resize(
+                                                i + 1,
+                                                Value::Package(Symbol::intern("Any")),
+                                            );
+                                        }
+                                        arr[i] = if next_positional {
+                                            Value::real_array(Vec::new())
+                                        } else {
+                                            Value::hash(std::collections::HashMap::new())
+                                        };
+                                        current = &mut arr[i] as *mut Value;
+                                    }
+                                }
+                                Value::Hash(hash_arc) => {
+                                    let hash = Arc::make_mut(hash_arc);
+                                    let new_val = if next_positional {
+                                        Value::real_array(Vec::new())
+                                    } else {
+                                        Value::hash(std::collections::HashMap::new())
+                                    };
+                                    hash.insert(key.clone(), new_val);
+                                    current = hash.get_mut(key.as_str()).unwrap() as *mut Value;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Final level: assign the value
+                unsafe {
+                    match &mut *current {
+                        Value::Array(arr_arc, _) => {
+                            if let Ok(i) = key.parse::<usize>() {
+                                let arr = Arc::make_mut(arr_arc);
+                                if i >= arr.len() {
+                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                }
+                                arr[i] = val.clone();
+                            }
+                        }
+                        Value::Hash(hash_arc) => {
+                            let hash = Arc::make_mut(hash_arc);
+                            hash.insert(key.clone(), val.clone());
+                        }
+                        _ => {
+                            // Autovivify at final level
+                            if is_positional {
+                                let mut arr = Vec::new();
+                                if let Ok(i) = key.parse::<usize>() {
+                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                    arr[i] = val.clone();
+                                }
+                                *current = Value::real_array(arr);
+                            } else {
+                                let mut h = std::collections::HashMap::new();
+                                h.insert(key.clone(), val.clone());
+                                *current = Value::hash(h);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.stack.push(val);
+        Ok(())
+    }
+
     /// Generic index assignment on a stack-computed target.
     /// Stack order: target (bottom), index, value (top).
     /// If the target hash has `__callframe_depth`, routes through set_caller_var.


### PR DESCRIPTION
## Summary
- Implement deep autovivification (3+ levels) for mixed multi-dimensional structures like `@a[0][0][0][0][0] = 5` and `@a[1]<two>[0]<four>[0]<six> = 6`
- Fix `$%h` / `$@a` item context: the `$` prefix on hash/array variables now correctly prevents flattening in array/list construction
- Add `roast/S02-types/mixed_multi_dimensional.t` to whitelist (77/80 pass, 3 are TODO in raku itself)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/mixed_multi_dimensional.t` passes
- [x] `make test` passes (only pre-existing flaky failures in lock.t and prompt-behavior.t)
- [x] `make roast` passes (only pre-existing flaky failure in delete-adverb.t and timeout in state.t)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)