### PR TITLE
fix: resolve 7 failing tests in roast/S02-types/set.t

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -290,10 +290,19 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "hash" => match target {
             Value::Set(s, _) => {
                 let mut map = std::collections::HashMap::new();
+                let mut original_keys = std::collections::HashMap::new();
                 for k in s.iter() {
                     map.insert(k.clone(), Value::Bool(true));
+                    let typed = s.typed_key(k);
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Some(Ok(Value::hash(map)))
+                let result = Value::hash(map);
+                if !original_keys.is_empty() {
+                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Some(Ok(result))
             }
             Value::Bag(b, _) => {
                 let mut map = std::collections::HashMap::new();
@@ -345,7 +354,18 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(map) => {
-                    let keys: Vec<Value> = map.keys().map(|k| Value::hash_key_decode(k)).collect();
+                    // Check if this is a Set-derived object hash (all values are Bool(true)
+                    // and original typed keys are registered).
+                    let is_set_derived_obj_hash = !map.is_empty()
+                        && map.values().all(|v| matches!(v, Value::Bool(true)))
+                        && crate::runtime::utils::hash_original_keys_snapshot(target).is_some();
+                    let keys: Vec<Value> = if is_set_derived_obj_hash {
+                        map.keys()
+                            .map(|k| crate::runtime::utils::hash_typed_key(target, k))
+                            .collect()
+                    } else {
+                        map.keys().map(|k| Value::hash_key_decode(k)).collect()
+                    };
                     Some(Ok(Value::array(keys)))
                 }
                 Value::Pair(key, _) => {

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -618,8 +618,8 @@ pub(super) fn enrich_expected_error(
     context: &str,
     remaining_len_fallback: usize,
 ) -> PError {
-    // Preserve fatal errors with structured exceptions (e.g., X::Obsolete)
-    if err.is_fatal() && err.exception.is_some() {
+    // Preserve fatal errors (non-recoverable parse errors)
+    if err.is_fatal() {
         return err;
     }
     PError {

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2269,10 +2269,11 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
         // Object constructor shorthand: Type{ :named(...) } / Type{ key => value, ... }.
         // Treat this as Type.new(...) for package/type barewords.
         // But NOT for sigilless variables (term symbols like \h), which should use
-        // hash subscript semantics instead.
+        // hash subscript semantics instead. Also NOT for `self` which uses hash subscript.
         if rest.starts_with('{')
             && matches!(&expr, Expr::BareWord(name) if {
-                crate::parser::stmt::simple::match_user_declared_term_symbol(name).is_none()
+                name != "self"
+                && crate::parser::stmt::simple::match_user_declared_term_symbol(name).is_none()
             })
         {
             let r = &rest[1..];

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -886,19 +886,25 @@ fn or_or_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             if let Some(prev) = last_list_assoc_op
                 && prev != op
             {
-                return Err(PError::fatal(format!(
-                    "Only identical operators may be list associative; since '{}' and '{}' differ, they are non-associative and you need to clarify with parentheses",
-                    match prev {
+                {
+                    let lhs = match prev {
                         LogicalOp::Min => "min",
                         LogicalOp::Max => "max",
                         _ => unreachable!(),
-                    },
-                    match op {
+                    };
+                    let rhs = match op {
                         LogicalOp::Min => "min",
                         LogicalOp::Max => "max",
                         _ => unreachable!(),
-                    }
-                )));
+                    };
+                    return Err(syntax_exception(
+                        "X::Syntax::NonAssociative",
+                        format!(
+                            "Only identical operators may be list associative; since '{}' and '{}' differ, they are non-associative and you need to clarify with parentheses",
+                            lhs, rhs
+                        ),
+                    ));
+                }
             }
             last_list_assoc_op = Some(op);
         }

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -2369,6 +2369,25 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((r2, supply_method_call(block_body)));
     }
 
+    // set/bag/mix followed immediately by < (no whitespace) is a parse error
+    if matches!(name.as_str(), "set" | "bag" | "mix")
+        && rest.starts_with('<')
+        && std::ptr::eq(rest, r)
+    {
+        let msg = format!(
+            "Use of non-subscript brackets after \"{}\" where postfix is expected; \
+             please use whitespace before any arguments",
+            name
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+        let exception = crate::value::Value::make_instance(
+            crate::symbol::Symbol::intern("X::Syntax::Confused"),
+            attrs,
+        );
+        return Err(PError::fatal_with_exception(msg, Box::new(exception)));
+    }
+
     // Check for listop: bareword followed by space and argument (but not statement modifier)
     // e.g., shift @a, push @a, 42, etc.
     // Skip when directly followed by '.' — `func.method` is `(func()).method`,
@@ -2587,11 +2606,24 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     }
 
     // Functions that can be called with no arguments as bare words
-    if matches!(
-        name.as_str(),
-        "await" | "slip" | "set" | "bag" | "mix" | "slurp"
-    ) && is_terminator_or_dot
-    {
+    if matches!(name.as_str(), "await" | "slip" | "slurp") && is_terminator_or_dot {
+        return Ok((rest, make_call_expr(name, input, vec![])));
+    }
+
+    // set/bag/mix without arguments or parens is a parse error in Raku
+    if matches!(name.as_str(), "set" | "bag" | "mix") && is_terminator {
+        let msg = format!(
+            "Function \"{}\" may not be called without arguments \
+             (please use () or whitespace to denote arguments, \
+             or &{} to refer to the function as a noun, \
+             or use .{} if you meant to call it as a method on $_)",
+            name, name, name
+        );
+        return Err(PError::fatal(msg));
+    }
+
+    // set/bag/mix followed by '.' is a zero-arg call (method chain on result)
+    if matches!(name.as_str(), "set" | "bag" | "mix") && rest_trimmed.starts_with('.') {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -232,6 +232,9 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
         match ident::identifier_or_call(input) {
             Ok(r) => Ok(r),
             Err(err) => {
+                if err.is_fatal() {
+                    return Err(err);
+                }
                 update_best_error(&mut best_error, err, input_len);
                 Err(best_error
                     .map(|(_, err)| err)

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -405,13 +405,7 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             }
             if let Ok(parsed_assign) = super::assign::parse_assign_expr_or_comma(input) {
                 parsed_assign
-            } else if err.is_fatal()
-                && (err.exception.is_some()
-                    || err
-                        .messages
-                        .first()
-                        .is_some_and(|m| m.contains("X::Comp::Trait::Unknown")))
-            {
+            } else if err.is_fatal() {
                 return Err(err);
             } else {
                 return Err(PError {

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -403,10 +403,10 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             if err.messages.iter().any(|m| m.contains("X::Obsolete")) {
                 return Err(err);
             }
-            if let Ok(parsed_assign) = super::assign::parse_assign_expr_or_comma(input) {
-                parsed_assign
-            } else if err.is_fatal() {
+            if err.is_fatal() {
                 return Err(err);
+            } else if let Ok(parsed_assign) = super::assign::parse_assign_expr_or_comma(input) {
+                parsed_assign
             } else {
                 return Err(PError {
                     messages: merge_expected_messages(

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -7,45 +7,67 @@ impl Interpreter {
             return Err(RuntimeError::cannot_lazy_what("Set"));
         }
         let mut elems = HashSet::new();
-        match target {
-            Value::Set(_, _) => return Ok(target),
-            Value::Array(items, ..) => {
-                fn add_item(elems: &mut HashSet<String>, item: &Value) {
-                    match item {
-                        Value::Pair(k, v) => {
-                            if v.truthy() {
-                                elems.insert(k.clone());
-                            }
+        let mut original_keys: HashMap<String, Value> = HashMap::new();
+        let mut has_non_str = false;
+        fn add_item(
+            elems: &mut HashSet<String>,
+            original_keys: &mut HashMap<String, Value>,
+            has_non_str: &mut bool,
+            item: &Value,
+        ) {
+            match item {
+                Value::Pair(k, v) => {
+                    if v.truthy() {
+                        elems.insert(k.clone());
+                    }
+                }
+                Value::ValuePair(k, v) => {
+                    if v.truthy() {
+                        let str_key = k.to_string_value();
+                        if !matches!(k.as_ref(), Value::Str(_)) {
+                            *has_non_str = true;
+                            original_keys
+                                .entry(str_key.clone())
+                                .or_insert_with(|| k.as_ref().clone());
                         }
-                        Value::ValuePair(k, v) => {
-                            if v.truthy() {
-                                elems.insert(k.to_string_value());
-                            }
-                        }
-                        Value::Hash(h) => {
-                            for (k, v) in h.iter() {
-                                if v.truthy() {
-                                    elems.insert(k.clone());
-                                }
-                            }
-                        }
-                        Value::Array(inner, kind) if !kind.is_itemized() => {
-                            for inner_item in inner.iter() {
-                                add_item(elems, inner_item);
-                            }
-                        }
-                        Value::Seq(inner) | Value::Slip(inner) => {
-                            for inner_item in inner.iter() {
-                                add_item(elems, inner_item);
-                            }
-                        }
-                        _ => {
-                            elems.insert(item.to_string_value());
+                        elems.insert(str_key);
+                    }
+                }
+                Value::Hash(h) => {
+                    for (k, v) in h.iter() {
+                        if v.truthy() {
+                            elems.insert(k.clone());
                         }
                     }
                 }
+                Value::Array(inner, kind) if !kind.is_itemized() => {
+                    for inner_item in inner.iter() {
+                        add_item(elems, original_keys, has_non_str, inner_item);
+                    }
+                }
+                Value::Seq(inner) | Value::Slip(inner) => {
+                    for inner_item in inner.iter() {
+                        add_item(elems, original_keys, has_non_str, inner_item);
+                    }
+                }
+                Value::Str(_) => {
+                    elems.insert(item.to_string_value());
+                }
+                _ => {
+                    let str_key = item.to_string_value();
+                    *has_non_str = true;
+                    original_keys
+                        .entry(str_key.clone())
+                        .or_insert_with(|| item.clone());
+                    elems.insert(str_key);
+                }
+            }
+        }
+        match target {
+            Value::Set(_, _) => return Ok(target),
+            Value::Array(items, ..) => {
                 for item in items.iter() {
-                    add_item(&mut elems, item);
+                    add_item(&mut elems, &mut original_keys, &mut has_non_str, item);
                 }
             }
             Value::Hash(items) => {
@@ -72,7 +94,14 @@ impl Interpreter {
             }
             Value::ValuePair(k, v) => {
                 if v.truthy() {
-                    elems.insert(k.to_string_value());
+                    let str_key = k.to_string_value();
+                    if !matches!(k.as_ref(), Value::Str(_)) {
+                        has_non_str = true;
+                        original_keys
+                            .entry(str_key.clone())
+                            .or_insert_with(|| k.as_ref().clone());
+                    }
+                    elems.insert(str_key);
                 }
             }
             // Instance types composing Baggy: delegate to internal bag data
@@ -82,14 +111,25 @@ impl Interpreter {
             }
             other if other.is_range() => {
                 for item in Self::value_to_list(&other) {
-                    elems.insert(item.to_string_value());
+                    add_item(&mut elems, &mut original_keys, &mut has_non_str, &item);
                 }
             }
             other => {
-                elems.insert(other.to_string_value());
+                let str_key = other.to_string_value();
+                if !matches!(&other, Value::Str(_)) {
+                    has_non_str = true;
+                    original_keys
+                        .entry(str_key.clone())
+                        .or_insert_with(|| other.clone());
+                }
+                elems.insert(str_key);
             }
         }
-        Ok(Value::set(elems))
+        if has_non_str {
+            Ok(Value::set_typed(elems, original_keys))
+        } else {
+            Ok(Value::set(elems))
+        }
     }
 
     /// Check if a value is lazy/infinite and cannot be coerced to a QuantHash.
@@ -558,10 +598,19 @@ impl Interpreter {
             }
             Value::Set(s, _) => {
                 let mut map = HashMap::new();
+                let mut original_keys = HashMap::new();
                 for k in s.iter() {
                     map.insert(k.clone(), Value::Bool(true));
+                    let typed = s.typed_key(k);
+                    if !matches!(&typed, Value::Str(s) if s.as_ref() == k) {
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Ok(Value::hash(map))
+                let result = Value::hash(map);
+                if !original_keys.is_empty() {
+                    super::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Ok(result)
             }
             Value::Bag(b, _) => {
                 let mut map = HashMap::new();

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -914,6 +914,20 @@ impl Interpreter {
                     }
                 }
 
+                // If the pair value is an immutable type (Bool, Int, Num, Str, Rat)
+                // and the pair is not backed by a mutable container, throw RO error.
+                // This handles e.g. Set.pairs[0].value = 0 which should die.
+                if matches!(
+                    current_value.as_ref(),
+                    Value::Bool(_) | Value::Int(_) | Value::Num(_) | Value::Str(_) | Value::Rat(..)
+                ) {
+                    let type_name = crate::value::what_type_name(current_value.as_ref());
+                    return Err(RuntimeError::assignment_ro_typename(
+                        &type_name,
+                        &current_value.to_string_value(),
+                    ));
+                }
+
                 // Standalone pair (not derived from a hash or array): update the
                 // pair value directly by replacing the variable binding, and also
                 // propagate to any other environment bindings that hold a pair

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -914,18 +914,19 @@ impl Interpreter {
                     }
                 }
 
-                // If the pair value is an immutable type (Bool, Int, Num, Str, Rat)
-                // and the pair is not backed by a mutable container, throw RO error.
-                // This handles e.g. Set.pairs[0].value = 0 which should die.
-                if matches!(
-                    current_value.as_ref(),
-                    Value::Bool(_) | Value::Int(_) | Value::Num(_) | Value::Str(_) | Value::Rat(..)
-                ) {
-                    let type_name = crate::value::what_type_name(current_value.as_ref());
-                    return Err(RuntimeError::assignment_ro_typename(
-                        &type_name,
-                        &current_value.to_string_value(),
-                    ));
+                // If the pair value is Bool and the pair is NOT directly backed
+                // by a user-visible hash variable, the Bool is immutable.
+                // This handles Set.pairs[0].value = 0 which should die.
+                if matches!(current_value.as_ref(), Value::Bool(_)) {
+                    let has_backing_hash = target_var
+                        .is_some_and(|vn| matches!(self.env.get(vn), Some(Value::Hash(_))));
+                    if !has_backing_hash {
+                        let type_name = crate::value::what_type_name(current_value.as_ref());
+                        return Err(RuntimeError::assignment_ro_typename(
+                            &type_name,
+                            &current_value.to_string_value(),
+                        ));
+                    }
                 }
 
                 // Standalone pair (not derived from a hash or array): update the

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4646,6 +4646,31 @@ impl Interpreter {
         false
     }
 
+    /// Check if a class inherits from an immutable Setty type (Set, Bag, Mix).
+    pub(crate) fn class_inherits_from_immutable_setty(&self, name: &str) -> bool {
+        const IMMUTABLE_SETTY: &[&str] = &["Set", "Bag", "Mix"];
+        if IMMUTABLE_SETTY.contains(&name) {
+            return true;
+        }
+        let class_def = self.classes.get(name).or_else(|| {
+            self.classes
+                .iter()
+                .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
+                .map(|(_, v)| v)
+        });
+        if let Some(class_def) = class_def {
+            for parent in &class_def.parents {
+                if IMMUTABLE_SETTY.contains(&parent.as_str()) {
+                    return true;
+                }
+                if self.class_inherits_from_immutable_setty(parent) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Check if a class has scoped subs declared in its body.
     pub(crate) fn has_class_scoped_subs(&self, class_name: &str) -> bool {
         self.class_subs

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -945,6 +945,23 @@ impl Interpreter {
                         weight.is_finite() && *weight == 1.0 && set.contains(key)
                     })
             }
+            // X ~~ Set: coerce LHS to a Set (using its elements) and compare
+            (_, Value::Set(rhs_set, _))
+                if matches!(
+                    left,
+                    Value::Array(..) | Value::Seq(_) | Value::Slip(_) | Value::Bag(..)
+                ) =>
+            {
+                // Collect LHS elements as string keys (same representation as Set uses)
+                let lhs_keys: std::collections::HashSet<String> = match left {
+                    Value::Array(items, ..) | Value::Seq(items) | Value::Slip(items) => {
+                        items.iter().map(|v| v.to_string_value()).collect()
+                    }
+                    Value::Bag(b, _) => b.keys().cloned().collect(),
+                    _ => std::collections::HashSet::new(),
+                };
+                lhs_keys.len() == rhs_set.len() && lhs_keys.iter().all(|k| rhs_set.contains(k))
+            }
             // Array ~~ Hash: check if any element exists as a key in the hash
             (Value::Array(items, ..), Value::Hash(map)) => items.iter().any(|item| {
                 let key = item.to_string_value();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2239,6 +2239,8 @@ impl VM {
                 // When the container is an Instance of a Hash subclass (e.g.
                 // `class MyHash is Hash {}`), convert it to a plain Hash
                 // before element assignment so hash operations work correctly.
+                // But if it inherits from an immutable type (Set, Bag, Mix),
+                // throw X::Assignment::RO instead.
                 if let Some(Value::Instance {
                     class_name,
                     attributes,
@@ -2248,6 +2250,11 @@ impl VM {
                         .interpreter
                         .is_container_subclass(&class_name.resolve())
                 {
+                    let cn = class_name.resolve();
+                    if self.interpreter.class_inherits_from_immutable_setty(&cn) {
+                        let display = format!("{}()", cn);
+                        return Err(RuntimeError::assignment_ro_typename(&cn, &display));
+                    }
                     let hash_map: HashMap<String, Value> = HashMap::clone(&**attributes);
                     let hash_val = Value::hash(hash_map);
                     self.interpreter

--- a/t/set.t
+++ b/t/set.t
@@ -118,7 +118,7 @@ is $m.WHAT, "(Mix)", ".WHAT returns (Mix)";
 # Truthiness
 ok ?$m, "non-empty mix is truthy";
 nok ?mix(), "empty mix is falsy";
-my $m3 = mix;
+my $m3 = mix();
 nok ?$m3, "bare mix call is falsy";
 
 ok "isn't" (elem) set <I'm afraid it isn't your day>, "set listop handles apostrophes in angle words";


### PR DESCRIPTION
## Summary
- Fix all 7 previously-failing tests in `roast/S02-types/set.t` (241/248 → 246/248, 0 failures)
- Pair.value assignment throws X::Assignment::RO for immutable values
- `self{$foo}` now correctly parses as hash subscript (not .new constructor)
- Set subclass instances throw X::Assignment::RO on subscript assignment
- Seq/Array smartmatch against Set coerces LHS to set for comparison
- Set.Hash/.hash preserves typed keys (Int, List, etc.) via original-keys registry
- `set;` / `set<...>` are now parse errors per Raku spec (propagate fatal parse errors)
- Update t/set.t to use `mix()` instead of bare `mix;`

## Test plan
- [x] All 7 previously-failing tests now pass (190, 197, 200, 201-202, 215-216)
- [x] `prove -e target/debug/mutsu t/` passes (492 files, 4037 tests, only flaky t/lock.t fails)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] No regressions in t/is-rw-traits.t, t/subscript-adverbs.t, t/pairup.t, t/set.t

🤖 Generated with [Claude Code](https://claude.com/claude-code)