### PR TITLE
fix: lazy array for infinite range .list and Capture as parent class

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -352,28 +352,41 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             Value::Range(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(target.clone()))
+                    // Infinite range → return a lazy array so .Capture etc. throw X::Cannot::Lazy
+                    Some(Ok(Value::Array(
+                        std::sync::Arc::new(vec![]),
+                        crate::value::ArrayKind::Lazy,
+                    )))
                 } else {
                     Some(Ok(Value::array((*a..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExcl(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(target.clone()))
+                    Some(Ok(Value::Array(
+                        std::sync::Arc::new(vec![]),
+                        crate::value::ArrayKind::Lazy,
+                    )))
                 } else {
                     Some(Ok(Value::array((*a..*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclStart(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(target.clone()))
+                    Some(Ok(Value::Array(
+                        std::sync::Arc::new(vec![]),
+                        crate::value::ArrayKind::Lazy,
+                    )))
                 } else {
                     Some(Ok(Value::array((a + 1..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclBoth(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(target.clone()))
+                    Some(Ok(Value::Array(
+                        std::sync::Arc::new(vec![]),
+                        crate::value::ArrayKind::Lazy,
+                    )))
                 } else {
                     Some(Ok(Value::array((a + 1..*b).map(Value::Int).collect())))
                 }

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -352,41 +352,29 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             Value::Range(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    // Infinite range → return a lazy array so .Capture etc. throw X::Cannot::Lazy
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(vec![]),
-                        crate::value::ArrayKind::Lazy,
-                    )))
+                    // Infinite range → convert to lazy array (supports indexing + .Capture throws)
+                    Some(Ok(crate::runtime::utils::coerce_to_array(target.clone())))
                 } else {
                     Some(Ok(Value::array((*a..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExcl(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(vec![]),
-                        crate::value::ArrayKind::Lazy,
-                    )))
+                    Some(Ok(crate::runtime::utils::coerce_to_array(target.clone())))
                 } else {
                     Some(Ok(Value::array((*a..*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclStart(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(vec![]),
-                        crate::value::ArrayKind::Lazy,
-                    )))
+                    Some(Ok(crate::runtime::utils::coerce_to_array(target.clone())))
                 } else {
                     Some(Ok(Value::array((a + 1..=*b).map(Value::Int).collect())))
                 }
             }
             Value::RangeExclBoth(a, b) => {
                 if *b == i64::MAX || *a == i64::MIN {
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(vec![]),
-                        crate::value::ArrayKind::Lazy,
-                    )))
+                    Some(Ok(crate::runtime::utils::coerce_to_array(target.clone())))
                 } else {
                     Some(Ok(Value::array((a + 1..*b).map(Value::Int).collect())))
                 }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -784,6 +784,7 @@ impl Interpreter {
             "Mixy",
             "Date",
             "DateTime",
+            "Capture",
             "Grammar",
             "Parameter",
             "Proxy",
@@ -2195,6 +2196,7 @@ impl Interpreter {
                 "Order",
                 "Endian",
                 "Proc",
+                "Capture",
             ];
             if !BUILTIN_TYPES.contains(&name) {
                 return Err(RuntimeError::new(format!(


### PR DESCRIPTION
## Summary
- When `.list` is called on an infinite range (e.g., `1..*`), return a lazy array instead of the range itself. This makes `.Capture` on the result properly throw `X::Cannot::Lazy`, fixing roast `S02-types/capture.t` test 31.
- Add `Capture` to the `BUILTIN_TYPES` lists so classes can inherit from `Capture` (e.g., `class :: is Capture {}`), which was causing a runtime error that prevented tests 34-46 from executing in the capture roast test.

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/capture.t` shows test 31 now passes (was failing)
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)
- [x] Roast whitelist tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)