### PR TITLE
fix: improve S02-types/bag.t pass rate (247 -> 251 of 255)

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -306,17 +306,39 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             Value::Bag(b, _) => {
                 let mut map = std::collections::HashMap::new();
+                let mut original_keys = std::collections::HashMap::new();
                 for (k, v) in b.iter() {
                     map.insert(k.clone(), Value::Int(*v));
+                    let typed = b.typed_key(k);
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Some(Ok(Value::hash(map)))
+                let result = Value::hash(map);
+                if !original_keys.is_empty() {
+                    // Mark this hash as having typed keys from a Bag
+                    original_keys.insert("__mutsu_typed_key_hash__".to_string(), Value::Bool(true));
+                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Some(Ok(result))
             }
             Value::Mix(m, _) => {
                 let mut map = std::collections::HashMap::new();
+                let mut original_keys = std::collections::HashMap::new();
                 for (k, v) in m.iter() {
                     map.insert(k.clone(), Value::Num(*v));
+                    let typed = m.typed_key(k);
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Some(Ok(Value::hash(map)))
+                let result = Value::hash(map);
+                if !original_keys.is_empty() {
+                    // Mark this hash as having typed keys from a Mix
+                    original_keys.insert("__mutsu_typed_key_hash__".to_string(), Value::Bool(true));
+                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Some(Ok(result))
             }
             Value::Instance { .. } => {
                 // Instance types should fall through to accessor dispatch,
@@ -354,12 +376,19 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(map) => {
-                    // Check if this is a Set-derived object hash (all values are Bool(true)
-                    // and original typed keys are registered).
-                    let is_set_derived_obj_hash = !map.is_empty()
-                        && map.values().all(|v| matches!(v, Value::Bool(true)))
-                        && crate::runtime::utils::hash_original_keys_snapshot(target).is_some();
-                    let keys: Vec<Value> = if is_set_derived_obj_hash {
+                    // Check if this is a Set/Bag-derived object hash where keys
+                    // should be returned as their original typed values.
+                    // Set-derived: all values are Bool(true) + original keys exist.
+                    // Bag-derived: flagged with __baggy_hash marker in original keys.
+                    let original_keys = crate::runtime::utils::hash_original_keys_snapshot(target);
+                    let is_typed_key_hash = if let Some(ref orig) = original_keys {
+                        orig.contains_key("__mutsu_typed_key_hash__")
+                            || (!map.is_empty()
+                                && map.values().all(|v| matches!(v, Value::Bool(true))))
+                    } else {
+                        false
+                    };
+                    let keys: Vec<Value> = if is_typed_key_hash {
                         map.keys()
                             .map(|k| crate::runtime::utils::hash_typed_key(target, k))
                             .collect()

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -314,6 +314,18 @@ pub(crate) fn native_method_0arg(
         return native_method_0arg(inner, method_sym);
     }
 
+    // Instance with __baggy_data__: delegate Bag-like methods to the inner Bag/Set
+    // so that subclasses of Bag/Set (e.g. `my class MyBag is Bag {}`) work correctly.
+    if let Value::Instance { attributes, .. } = target
+        && let Some(inner) = attributes.get("__baggy_data__")
+        && !matches!(
+            method,
+            "WHAT" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
+        )
+    {
+        return native_method_0arg(inner, method_sym);
+    }
+
     // $!.pending returns a list of all tracked Failure values (S04 spec).
     if method == "pending" {
         let failures = crate::value::get_pending_failures();

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -320,7 +320,7 @@ pub(crate) fn native_method_0arg(
         && let Some(inner) = attributes.get("__baggy_data__")
         && !matches!(
             method,
-            "WHAT" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
+            "WHAT" | "WHICH" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
         )
     {
         return native_method_0arg(inner, method_sym);

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -650,6 +650,16 @@ pub(crate) fn native_method_1arg(
     if let Value::Scalar(inner) = target {
         return native_method_1arg(inner, method_sym, arg);
     }
+    // Instance with __baggy_data__: delegate to the inner Bag/Set for collection methods
+    if let Value::Instance { attributes, .. } = target
+        && let Some(inner) = attributes.get("__baggy_data__")
+        && !matches!(
+            method,
+            "WHAT" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
+        )
+    {
+        return native_method_1arg(inner, method_sym, arg);
+    }
     // Cool numeric coercion: when a Str calls a numeric 1-arg method, coerce to numeric first.
     // Also coerce the arg if it's a Str for numeric methods.
     {

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -655,7 +655,7 @@ pub(crate) fn native_method_1arg(
         && let Some(inner) = attributes.get("__baggy_data__")
         && !matches!(
             method,
-            "WHAT" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
+            "WHAT" | "WHICH" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
         )
     {
         return native_method_1arg(inner, method_sym, arg);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1093,11 +1093,6 @@ impl Compiler {
                     .map(|p| self.code.add_constant(Value::str(p.clone())));
                 let bind_stmts =
                     Self::build_for_bind_stmts(param, param_def.as_ref(), param_idx, params);
-                if !bind_stmts.is_empty() {
-                    let mut merged = bind_stmts;
-                    merged.extend(loop_body);
-                    loop_body = merged;
-                }
                 // Determine if this for-loop has rw params (via `<->` or `is rw` trait)
                 let has_rw = *rw_block
                     || (**param_def)
@@ -1107,6 +1102,18 @@ impl Compiler {
                 let has_copy = (**param_def)
                     .as_ref()
                     .is_some_and(|def| def.traits.iter().any(|t| t == "copy"));
+                if !bind_stmts.is_empty() {
+                    let mut merged = bind_stmts;
+                    // After binding multi-param variables, mark them readonly
+                    // (unless the block uses `<->` or `is rw`).
+                    if !has_rw && !has_copy && !params.is_empty() {
+                        for p in params {
+                            merged.push(Stmt::MarkReadonly(p.clone()));
+                        }
+                    }
+                    merged.extend(loop_body);
+                    loop_body = merged;
+                }
                 let arity = if !params.is_empty() {
                     params.len() as u32
                 } else {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2066,6 +2066,50 @@ impl Interpreter {
                             add_item(&mut counts, &mut original_keys, &mut has_non_str_keys, arg);
                         }
                     }
+                    // Type check for parameterized Bag/BagHash (e.g. Bag[Int].new(<a b c>))
+                    if let Some(ref ta) = type_args
+                        && let Some(constraint) = ta.first()
+                        && constraint.starts_with(char::is_uppercase)
+                        && constraint != "Any"
+                        && constraint != "Mu"
+                    {
+                        let items_to_check: Vec<Value> = if args.len() == 1 {
+                            let arg = &args[0];
+                            if matches!(arg, Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _))
+                            {
+                                vec![arg.clone()]
+                            } else {
+                                Self::value_to_list(arg)
+                            }
+                        } else {
+                            args.clone()
+                        };
+                        for item in &items_to_check {
+                            if !self.type_matches_value(constraint, item) {
+                                let got_type = crate::value::what_type_name(item);
+                                let got_repr = item.to_string_value();
+                                let msg = format!(
+                                    "Type check failed in binding; expected {} but got {} (\"{}\")",
+                                    constraint, got_type, got_repr,
+                                );
+                                let mut attrs = std::collections::HashMap::new();
+                                attrs.insert("message".to_string(), Value::str(msg.clone()));
+                                attrs.insert("operation".to_string(), Value::str_from("bind"));
+                                attrs.insert("got".to_string(), item.clone());
+                                attrs.insert(
+                                    "expected".to_string(),
+                                    Value::Package(Symbol::intern(constraint)),
+                                );
+                                let ex = Value::make_instance(
+                                    Symbol::intern("X::TypeCheck::Binding"),
+                                    attrs,
+                                );
+                                let mut err = RuntimeError::new(msg);
+                                err.exception = Some(Box::new(ex));
+                                return Err(err);
+                            }
+                        }
+                    }
                     return Ok(if has_non_str_keys {
                         if base_class_name == "BagHash" {
                             Value::bag_hash_typed(counts, original_keys)
@@ -3787,26 +3831,15 @@ impl Interpreter {
             // TODO: properly track the subclass type on the resulting value
             self.dispatch_new(Value::Package(Symbol::intern("Set")), args.to_vec())
         } else {
-            // Bag-like construction: flatten arrays, count occurrences
-            let mut items = Vec::new();
-            for arg in args {
-                match arg {
-                    Value::Array(elems, _) => {
-                        items.extend(elems.iter().cloned());
-                    }
-                    other => items.push(other.clone()),
-                }
-            }
-            let mut counts: HashMap<String, i64> = HashMap::new();
-            for item in &items {
-                let key = item.to_string_value();
-                *counts.entry(key).or_insert(0) += 1;
-            }
+            // Bag-like construction: delegate to dispatch_to_bag_with_what for
+            // proper handling (pairs, hashes, etc.), then wrap as an Instance
+            // so that isa-ok checks for the subclass still work.
+            let items_array = Value::array(args.to_vec());
+            let bag_value = self.dispatch_to_bag_with_what(items_array, "Bag")?;
+
+            // Store the real Bag as __baggy_data__ on an Instance of the subclass
             let mut attrs = HashMap::new();
-            attrs.insert(
-                "__baggy_data__".to_string(),
-                Value::bag_typed(counts.clone(), HashMap::new()),
-            );
+            attrs.insert("__baggy_data__".to_string(), bag_value);
             Ok(Value::make_instance(Symbol::intern(class_name), attrs))
         }
     }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -721,6 +721,17 @@ impl VM {
                     Value::Nil
                 }
             }
+            // Instance with __baggy_data__: delegate subscript to the inner Bag/Set
+            (Value::Instance { ref attributes, .. }, ref idx)
+                if attributes.contains_key("__baggy_data__") =>
+            {
+                let inner = attributes.get("__baggy_data__").unwrap().clone();
+                let idx_clone = idx.clone();
+                // Re-enter the index logic with the inner bag/set value
+                self.stack.push(inner);
+                self.stack.push(idx_clone);
+                return self.exec_index_op_with_positional(is_positional);
+            }
             (instance @ Value::Instance { .. }, Value::Str(key)) => {
                 let default = self.typed_container_default(&instance);
                 let result = self


### PR DESCRIPTION
## Summary
- Add type parameter checking for parameterized Bag[T].new() (e.g., `Bag[Int].new(<a b c>)` now throws `X::TypeCheck::Binding`)
- Fix Bag subclass construction so that `my class MyBag is Bag {}; MyBag.new(|<a b>)` properly delegates to Bag construction and exposes bag methods (keys, values, subscript) through `__baggy_data__` delegation
- Mark multi-param for loop variables as readonly after binding, fixing `for $b.kv -> \k, \v { v = 22 }` to throw as expected
- Preserve typed keys in `Bag.hash`/`Mix.hash` output using a marker flag, so non-string keys (e.g., itemized lists) are not stringified

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/bag.t` passes 251/255 (was 247/255)
- [x] `make test` passes (only pre-existing t/wrap.t failure)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)