### PR TITLE
fix: improve MixHash support — Rat weights, autovivification, hash keys

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -159,7 +159,7 @@ fn invert_value(target: &Value) -> Option<Value> {
         Value::Mix(items, _) => {
             for (k, weight) in items.iter() {
                 result.push(make_inverted_pair(
-                    Value::Num(*weight),
+                    crate::value::mix_weight_to_value(*weight),
                     Value::str(k.clone()),
                 ));
             }
@@ -326,7 +326,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 let mut map = std::collections::HashMap::new();
                 let mut original_keys = std::collections::HashMap::new();
                 for (k, v) in m.iter() {
-                    map.insert(k.clone(), Value::Num(*v));
+                    map.insert(k.clone(), crate::value::mix_weight_to_value(*v));
                     let typed = m.typed_key(k);
                     if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
                         original_keys.insert(k.clone(), typed);
@@ -376,10 +376,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(map) => {
-                    // Check if this is a Set/Bag-derived object hash where keys
+                    // Check if this is a Set/Bag/Mix-derived object hash where keys
                     // should be returned as their original typed values.
                     // Set-derived: all values are Bool(true) + original keys exist.
-                    // Bag-derived: flagged with __baggy_hash marker in original keys.
+                    // Bag/Mix-derived: flagged with __mutsu_typed_key_hash__ marker.
                     let original_keys = crate::runtime::utils::hash_original_keys_snapshot(target);
                     let is_typed_key_hash = if let Some(ref orig) = original_keys {
                         orig.contains_key("__mutsu_typed_key_hash__")
@@ -441,7 +441,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     b.values().map(|v| Value::Int(*v)).collect(),
                 ))),
                 Value::Mix(m, _) => Some(Ok(Value::array(
-                    m.values().map(|v| Value::Num(*v)).collect(),
+                    m.values()
+                        .map(|v| crate::value::mix_weight_to_value(*v))
+                        .collect(),
                 ))),
                 Value::Package(_) => None, // let runtime handle (may be enum type)
                 v if v.is_range() => {
@@ -504,7 +506,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     let mut kv = Vec::new();
                     for (k, v) in m.iter() {
                         kv.push(Value::str(k.clone()));
-                        kv.push(Value::Num(*v));
+                        kv.push(crate::value::mix_weight_to_value(*v));
                     }
                     Some(Ok(Value::array(kv)))
                 }
@@ -564,7 +566,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 ))),
                 Value::Mix(m, _) => Some(Ok(Value::array(
                     m.iter()
-                        .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Num(*v))))
+                        .map(|(k, v)| {
+                            Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v)))
+                        })
                         .collect(),
                 ))),
                 Value::Pair(_, _) | Value::ValuePair(_, _) => {

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -671,7 +671,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         .iter()
                         .map(|(k, v)| {
                             Value::ValuePair(
-                                Box::new(Value::Num(*v)),
+                                Box::new(crate::value::mix_weight_to_value(*v)),
                                 Box::new(Value::str(k.clone())),
                             )
                         })

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -278,7 +278,10 @@ pub(super) fn dispatch(
                         idx = items.len() - 1;
                     }
                     let (key, weight) = items.iter().nth(idx).expect("index in range");
-                    Some(Ok(Value::Pair(key.clone(), Box::new(Value::Num(*weight)))))
+                    Some(Ok(Value::Pair(
+                        key.clone(),
+                        Box::new(crate::value::mix_weight_to_value(*weight)),
+                    )))
                 }
             }
             _ => None,

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -2387,11 +2387,7 @@ pub(crate) fn native_method_1arg(
             Value::Mix(data, _) => {
                 let key = arg.to_string_value();
                 let weight = data.weights.get(&key).copied().unwrap_or(0.0);
-                if weight == weight.floor() && weight.abs() < i64::MAX as f64 {
-                    Some(Ok(Value::Int(weight as i64)))
-                } else {
-                    Some(Ok(Value::Num(weight)))
-                }
+                Some(Ok(crate::value::mix_weight_to_value(weight)))
             }
             Value::Nil => Some(Ok(Value::Package(Symbol::intern("Any")))),
             Value::Package(name) if matches!(name.resolve().as_str(), "Any" | "Mu") => {

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -654,7 +654,7 @@ impl Interpreter {
             Value::Mix(m, _) => {
                 let mut map = HashMap::new();
                 for (k, v) in m.iter() {
-                    map.insert(k.clone(), Value::Num(*v));
+                    map.insert(k.clone(), crate::value::mix_weight_to_value(*v));
                 }
                 Ok(Value::hash(map))
             }

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -453,7 +453,11 @@ impl Interpreter {
         }
     }
 
-    fn mix_add_item(weights: &mut HashMap<String, f64>, item: &Value) -> Result<(), RuntimeError> {
+    fn mix_add_item_with_keys(
+        weights: &mut HashMap<String, f64>,
+        mut original_keys: Option<&mut HashMap<String, Value>>,
+        item: &Value,
+    ) -> Result<(), RuntimeError> {
         match item {
             Value::Pair(k, v) => {
                 let w = Self::mix_pair_weight(v)?;
@@ -461,7 +465,13 @@ impl Interpreter {
             }
             Value::ValuePair(k, v) => {
                 let w = Self::mix_pair_weight(v)?;
-                *weights.entry(k.to_string_value()).or_insert(0.0) += w;
+                let str_key = k.to_string_value();
+                if let Some(ref mut orig) = original_keys
+                    && !matches!(&**k, Value::Str(_))
+                {
+                    orig.entry(str_key.clone()).or_insert_with(|| (**k).clone());
+                }
+                *weights.entry(str_key).or_insert(0.0) += w;
             }
             Value::Hash(h) => {
                 for (k, v) in h.iter() {
@@ -471,9 +481,14 @@ impl Interpreter {
                     }
                 }
             }
-            Value::Array(items, ..) | Value::Seq(items) | Value::Slip(items) => {
+            Value::Array(items, kind) if !kind.is_itemized() => {
                 for sub_item in items.iter() {
-                    Self::mix_add_item(weights, sub_item)?;
+                    Self::mix_add_item_with_keys(weights, original_keys.as_deref_mut(), sub_item)?;
+                }
+            }
+            Value::Seq(items) | Value::Slip(items) => {
+                for sub_item in items.iter() {
+                    Self::mix_add_item_with_keys(weights, original_keys.as_deref_mut(), sub_item)?;
                 }
             }
             Value::Set(s, _) => {
@@ -492,7 +507,13 @@ impl Interpreter {
                 }
             }
             _ => {
-                *weights.entry(item.to_string_value()).or_insert(0.0) += 1.0;
+                let str_key = item.to_string_value();
+                if let Some(ref mut orig) = original_keys
+                    && !matches!(item, Value::Str(_))
+                {
+                    orig.entry(str_key.clone()).or_insert_with(|| item.clone());
+                }
+                *weights.entry(str_key).or_insert(0.0) += 1.0;
             }
         }
         Ok(())
@@ -528,11 +549,12 @@ impl Interpreter {
             return Err(err);
         }
         let mut weights: HashMap<String, f64> = HashMap::new();
+        let mut original_keys: HashMap<String, Value> = HashMap::new();
         match target {
             Value::Mix(_, _) => return Ok(target),
             Value::Array(items, ..) | Value::Seq(items) | Value::Slip(items) => {
                 for item in items.iter() {
-                    Self::mix_add_item(&mut weights, item)?;
+                    Self::mix_add_item_with_keys(&mut weights, Some(&mut original_keys), item)?;
                 }
             }
             ref other @ (Value::Set(_, _)
@@ -540,7 +562,7 @@ impl Interpreter {
             | Value::Pair(..)
             | Value::ValuePair(..)
             | Value::Hash(_)) => {
-                Self::mix_add_item(&mut weights, other)?;
+                Self::mix_add_item_with_keys(&mut weights, Some(&mut original_keys), other)?;
             }
             other if other.is_range() => {
                 for item in Self::value_to_list(&other) {
@@ -548,10 +570,20 @@ impl Interpreter {
                 }
             }
             other => {
-                weights.insert(other.to_string_value(), 1.0);
+                let str_key = other.to_string_value();
+                if !matches!(&other, Value::Str(_)) {
+                    original_keys
+                        .entry(str_key.clone())
+                        .or_insert_with(|| other.clone());
+                }
+                weights.insert(str_key, 1.0);
             }
         }
-        Ok(Value::mix(weights))
+        if original_keys.is_empty() {
+            Ok(Value::mix(weights))
+        } else {
+            Ok(Value::mix_with_original_keys(weights, original_keys))
+        }
     }
 
     pub(super) fn dispatch_to_map(&self, target: Value) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_collection_ops/minmax_extrema.rs
+++ b/src/runtime/methods_collection_ops/minmax_extrema.rs
@@ -128,9 +128,15 @@ impl Interpreter {
                         if replace {
                             best_weight = Some(*weight);
                             out.clear();
-                            out.push(Value::Pair(key.clone(), Box::new(Value::Num(*weight))));
+                            out.push(Value::Pair(
+                                key.clone(),
+                                Box::new(crate::value::mix_weight_to_value(*weight)),
+                            ));
                         } else if ord == std::cmp::Ordering::Equal {
-                            out.push(Value::Pair(key.clone(), Box::new(Value::Num(*weight))));
+                            out.push(Value::Pair(
+                                key.clone(),
+                                Box::new(crate::value::mix_weight_to_value(*weight)),
+                            ));
                         }
                     }
                     Value::Seq(Arc::new(out))

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -347,11 +347,7 @@ impl Interpreter {
             let idx = (builtin_rand() * ks.len() as f64) as usize % ks.len();
             let key = ks[idx].clone();
             let weight = remaining.remove(&key).unwrap_or(0.0);
-            let weight_val = if (weight - (weight as i64 as f64)).abs() < f64::EPSILON {
-                Value::Int(weight as i64)
-            } else {
-                Value::Num(weight)
-            };
+            let weight_val = crate::value::mix_weight_to_value(weight);
             grabbed.push(Value::Pair(key, Box::new(weight_val)));
         }
         // TODO: compile to bytecode - should mutate the original variable

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2742,11 +2742,7 @@ impl Interpreter {
                 let key = ks[idx].clone();
                 let weight = remaining.remove(&key).unwrap_or(0.0);
                 if method == "grabpairs" {
-                    let weight_val = if (weight - (weight as i64 as f64)).abs() < f64::EPSILON {
-                        Value::Int(weight as i64)
-                    } else {
-                        Value::Num(weight)
-                    };
+                    let weight_val = crate::value::mix_weight_to_value(weight);
                     grabbed.push(Value::Pair(key, Box::new(weight_val)));
                 } else {
                     // grab: return the key

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1708,7 +1708,9 @@ impl Interpreter {
                 .collect(),
             Value::Mix(items, _) => items
                 .iter()
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Num(*v))))
+                .map(|(k, v)| {
+                    Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v)))
+                })
                 .collect(),
             Value::Slip(items) => items.to_vec(),
             Value::Nil => vec![],

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -92,7 +92,7 @@ impl Interpreter {
                 Vec::new(),
                 items
                     .iter()
-                    .map(|(k, v)| (k.clone(), Value::Num(*v)))
+                    .map(|(k, v)| (k.clone(), crate::value::mix_weight_to_value(*v)))
                     .collect(),
             )),
             Value::Rat(n, d) | Value::FatRat(n, d) => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1890,7 +1890,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             .collect(),
         Value::Mix(items, _) => items
             .iter()
-            .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::Num(*v))))
+            .map(|(k, v)| Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v))))
             .collect(),
         Value::Slip(items) => items.to_vec(),
         Value::Instance { attributes, .. } => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -452,13 +452,7 @@ pub(crate) fn version_cmp_parts(
 }
 
 pub(crate) fn coerce_to_hash(value: Value) -> Value {
-    let mix_weight_value = |weight: f64| {
-        if weight.is_finite() && weight.fract() == 0.0 {
-            Value::Int(weight as i64)
-        } else {
-            Value::Num(weight)
-        }
-    };
+    let mix_weight_value = crate::value::mix_weight_to_value;
     match value {
         Value::Hash(_) => value,
         Value::Scalar(inner) => coerce_to_hash(*inner),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -579,6 +579,39 @@ pub fn make_big_fat_rat(num: NumBigInt, den: NumBigInt) -> Value {
     }
 }
 
+/// Convert a Mix/MixHash weight (f64) back to a Raku Value.
+/// Returns Int for whole numbers, Rat for representable fractions, Num otherwise.
+pub fn mix_weight_to_value(w: f64) -> Value {
+    if w.is_nan() || w.is_infinite() {
+        return Value::Num(w);
+    }
+    // Check for exact integer
+    if w == (w as i64 as f64) && w.abs() < i64::MAX as f64 {
+        return Value::Int(w as i64);
+    }
+    // Try to reconstruct as Rat: use the decimal representation to find
+    // a rational number. Multiply by powers of 10 to clear the decimal.
+    // This works for values like 42.1, 1.5, 3.14 etc.
+    let s = format!("{}", w);
+    if let Some(dot_pos) = s.find('.') {
+        let decimals = s.len() - dot_pos - 1;
+        if decimals <= 15 {
+            let denom = 10i64.checked_pow(decimals as u32);
+            if let Some(d) = denom {
+                // Parse the string without the dot as numerator
+                let without_dot: String = s.chars().filter(|c| *c != '.').collect();
+                if let Ok(n) = without_dot.parse::<i64>() {
+                    // Verify round-trip: n/d as f64 == w
+                    if (n as f64 / d as f64 - w).abs() < f64::EPSILON * w.abs().max(1.0) {
+                        return make_rat(n, d);
+                    }
+                }
+            }
+        }
+    }
+    Value::Num(w)
+}
+
 /// Convert a BigInt ratio n/d to f64 with correct rounding.
 /// Uses bit-level scaling to avoid precision loss from independent to_f64() conversions.
 pub fn bigrat_to_f64(n: &NumBigInt, d: &NumBigInt) -> f64 {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -970,13 +970,7 @@ impl VM {
                         self.interpreter
                             .env_mut()
                             .insert(target_name.to_string(), new_val);
-                        let result = if old_weight == old_weight.floor()
-                            && old_weight.abs() < i64::MAX as f64
-                        {
-                            Value::Int(old_weight as i64)
-                        } else {
-                            Value::Num(old_weight)
-                        };
+                        let result = crate::value::mix_weight_to_value(old_weight);
                         self.stack.push(result);
                         self.env_dirty = true;
                         return Ok(());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -524,23 +524,28 @@ impl VM {
         }
     }
 
-    fn mix_assignment_weight(value: &Value) -> f64 {
+    fn mix_assignment_weight(value: &Value) -> Result<f64, RuntimeError> {
         match value {
-            Value::Int(i) => *i as f64,
-            Value::Num(n) => *n,
-            Value::Rat(n, d) if *d != 0 => *n as f64 / *d as f64,
-            Value::Bool(flag) => {
-                if *flag {
-                    1.0
+            Value::Int(i) => Ok(*i as f64),
+            Value::Num(n) => Ok(*n),
+            Value::Rat(n, d) if *d != 0 => Ok(*n as f64 / *d as f64),
+            Value::Bool(flag) => Ok(if *flag { 1.0 } else { 0.0 }),
+            Value::Str(s) => {
+                // Try to parse as numeric; throw X::Str::Numeric on failure
+                if let Ok(n) = s.parse::<f64>() {
+                    Ok(n)
                 } else {
-                    0.0
+                    Err(RuntimeError::str_numeric(
+                        s,
+                        "base-10 number must begin with valid digits or '.'",
+                    ))
                 }
             }
             _ => {
                 if value.truthy() {
-                    1.0
+                    Ok(1.0)
                 } else {
-                    0.0
+                    Ok(0.0)
                 }
             }
         }
@@ -1301,13 +1306,9 @@ impl VM {
                         Value::Nil
                     }
                 }
-                Value::Mix(mix, _) => mix.get(&key).map_or(Value::Int(0), |w| {
-                    if (*w - (*w as i64 as f64)).abs() < f64::EPSILON {
-                        Value::Int(*w as i64)
-                    } else {
-                        Value::Num(*w)
-                    }
-                }),
+                Value::Mix(mix, _) => mix
+                    .get(&key)
+                    .map_or(Value::Int(0), |w| Self::mix_weight_as_value(*w)),
                 Value::Set(set, _) => {
                     if set.contains(&key) {
                         Value::Bool(true)
@@ -1378,9 +1379,10 @@ impl VM {
                         if !*is_mutable {
                             return Err(RuntimeError::assignment_ro(Some("Mix")));
                         }
+                        let weight = Self::mix_assignment_weight(&new_val)?;
                         let m = Arc::make_mut(mix);
                         if new_val.truthy() {
-                            m.insert(key.clone(), Self::mix_assignment_weight(&new_val));
+                            m.insert(key.clone(), weight);
                         } else {
                             m.remove(&key);
                         }
@@ -1414,6 +1416,41 @@ impl VM {
                         }
                         true
                     }
+                    // Autovivify typed variables: `my MixHash $mh; $mh<key>++`
+                    Value::Package(sym) => {
+                        let type_name = sym.resolve();
+                        match type_name.as_str() {
+                            "MixHash" => {
+                                let mut weights = HashMap::new();
+                                let weight = Self::mix_assignment_weight(&new_val)?;
+                                if new_val.truthy() {
+                                    weights.insert(key.clone(), weight);
+                                }
+                                *container_value = Value::mix_hash(weights);
+                                true
+                            }
+                            "BagHash" => {
+                                let mut counts = HashMap::new();
+                                if let Value::Int(n) = &new_val
+                                    && *n > 0
+                                {
+                                    counts.insert(key.clone(), *n);
+                                }
+                                *container_value = Value::bag_hash(counts);
+                                true
+                            }
+                            "SetHash" => {
+                                let mut items = std::collections::HashSet::new();
+                                if new_val.truthy() {
+                                    items.insert(key.clone());
+                                }
+                                *container_value =
+                                    Value::Set(Arc::new(crate::value::SetData::new(items)), true);
+                                true
+                            }
+                            _ => false,
+                        }
+                    }
                     _ => false,
                 }
             } else {
@@ -1423,6 +1460,47 @@ impl VM {
             // Update local slot to match the modified env value
             if let Some(val) = self.interpreter.env().get(&name).cloned() {
                 self.update_local_if_exists(code, &name, &val);
+            }
+        } else {
+            // Autovivify typed containers for inc/dec on undefined variables
+            let constraint = self.interpreter.var_type_constraint(&name);
+            let effective_type = declared_type_incdec.as_deref().or(constraint.as_deref());
+            if let Some(type_name) = effective_type
+                && matches!(type_name, "MixHash" | "BagHash" | "SetHash")
+            {
+                let new_container = match type_name {
+                    "MixHash" => {
+                        let mut weights = HashMap::new();
+                        let weight = Self::mix_assignment_weight(&new_val)?;
+                        if new_val.truthy() {
+                            weights.insert(key.clone(), weight);
+                        }
+                        Value::mix_hash(weights)
+                    }
+                    "BagHash" => {
+                        let mut counts = HashMap::new();
+                        if let Value::Int(n) = &new_val
+                            && *n > 0
+                        {
+                            counts.insert(key.clone(), *n);
+                        }
+                        Value::bag_hash(counts)
+                    }
+                    "SetHash" => {
+                        let mut items = std::collections::HashSet::new();
+                        if new_val.truthy() {
+                            items.insert(key.clone());
+                        }
+                        Value::Set(Arc::new(crate::value::SetData::new(items)), true)
+                    }
+                    _ => unreachable!(),
+                };
+                self.interpreter
+                    .env_mut()
+                    .insert(name.clone(), new_container);
+                if let Some(val) = self.interpreter.env().get(&name).cloned() {
+                    self.update_local_if_exists(code, &name, &val);
+                }
             }
         }
         if return_new {
@@ -2261,6 +2339,56 @@ impl VM {
                         .env_mut()
                         .insert(var_name.clone(), hash_val);
                 }
+                // Autovivify Nil-valued typed containers (MixHash, BagHash, SetHash)
+                // before the main container dispatch so they are handled correctly.
+                {
+                    let constraint = self.interpreter.var_type_constraint(&var_name);
+                    let effective_type = declared_type.as_deref().or(constraint.as_deref());
+                    if let Some(type_name) = effective_type
+                        && matches!(type_name, "MixHash" | "BagHash" | "SetHash")
+                        && matches!(
+                            self.interpreter.env().get(&var_name),
+                            Some(Value::Nil) | Some(Value::Package(_)) | None
+                        )
+                    {
+                        let new_container = match type_name {
+                            "MixHash" => {
+                                let mut weights = HashMap::new();
+                                let weight = Self::mix_assignment_weight(&val)?;
+                                if weight != 0.0 {
+                                    weights.insert(key.clone(), weight);
+                                }
+                                Value::mix_hash(weights)
+                            }
+                            "BagHash" => {
+                                let mut counts = HashMap::new();
+                                if let Value::Int(n) = &val
+                                    && *n > 0
+                                {
+                                    counts.insert(key.clone(), *n);
+                                }
+                                Value::bag_hash(counts)
+                            }
+                            "SetHash" => {
+                                let mut items = std::collections::HashSet::new();
+                                if val.truthy() {
+                                    items.insert(key.clone());
+                                }
+                                Value::Set(Arc::new(crate::value::SetData::new(items)), true)
+                            }
+                            _ => unreachable!(),
+                        };
+                        self.interpreter
+                            .env_mut()
+                            .insert(var_name.clone(), new_container);
+                        self.stack.push(val);
+                        // Update local slot
+                        if let Some(new_val) = self.interpreter.env().get(&var_name).cloned() {
+                            self.update_local_if_exists(code, &var_name, &new_val);
+                        }
+                        return Ok(());
+                    }
+                }
                 if let Some(container) = self.interpreter.env_mut().get_mut(&var_name) {
                     match *container {
                         Value::Hash(ref mut hash) => {
@@ -2453,11 +2581,50 @@ impl VM {
                                 return Err(RuntimeError::assignment_ro(Some("Mix")));
                             }
                             let m = Arc::make_mut(mix);
-                            let weight = Self::mix_assignment_weight(&val);
+                            let weight = Self::mix_assignment_weight(&val)?;
                             if weight == 0.0 {
                                 m.remove(&key);
                             } else {
                                 m.insert(key.clone(), weight);
+                            }
+                        }
+                        // Autovivify typed containers: MixHash, BagHash, SetHash
+                        Value::Package(sym)
+                            if matches!(
+                                sym.resolve().as_str(),
+                                "MixHash" | "BagHash" | "SetHash"
+                            ) =>
+                        {
+                            let type_name = sym.resolve();
+                            match type_name.as_str() {
+                                "MixHash" => {
+                                    let mut weights = HashMap::new();
+                                    let weight = Self::mix_assignment_weight(&val)?;
+                                    if weight != 0.0 {
+                                        weights.insert(key.clone(), weight);
+                                    }
+                                    *container = Value::mix_hash(weights);
+                                }
+                                "BagHash" => {
+                                    let mut counts = HashMap::new();
+                                    if let Value::Int(n) = &val
+                                        && *n > 0
+                                    {
+                                        counts.insert(key.clone(), *n);
+                                    }
+                                    *container = Value::bag_hash(counts);
+                                }
+                                "SetHash" => {
+                                    let mut items = std::collections::HashSet::new();
+                                    if val.truthy() {
+                                        items.insert(key.clone());
+                                    }
+                                    *container = Value::Set(
+                                        Arc::new(crate::value::SetData::new(items)),
+                                        true,
+                                    );
+                                }
+                                _ => unreachable!(),
                             }
                         }
                         _ => {

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -497,10 +497,6 @@ impl VM {
     }
 
     pub(super) fn mix_weight_as_value(weight: f64) -> Value {
-        if weight.is_finite() && weight.fract() == 0.0 {
-            Value::Int(weight as i64)
-        } else {
-            Value::Num(weight)
-        }
+        crate::value::mix_weight_to_value(weight)
     }
 }


### PR DESCRIPTION
## Summary
- Add `mix_weight_to_value()` to convert f64 weights back to Rat/Int instead of always returning Num, fixing `is-deeply` comparisons with Rat literals
- Implement MixHash/BagHash/SetHash autovivification for typed variables (`my MixHash $mh; $mh<key>++` now creates the container correctly)
- Preserve original typed keys in `.hash` conversion for Mix/Bag types (non-string keys like Lists are no longer stringified)
- Fix `.MixHash` coercion to not flatten itemized lists (`$(<a b>)` treated as single key)
- Throw `X::Str::Numeric` when assigning non-numeric strings to MixHash keys

Improves `roast/S02-types/mixhash.t` from 224/237 to 228/237 passing (4 fewer failures: tests 215, 216, 228, 232).

## Test plan
- [ ] `make test` passes (no regressions in existing tests)
- [ ] `make roast` passes (no regressions in whitelisted tests)
- [ ] `roast/S02-types/mixhash.t` shows improvement (228 pass vs 224 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)