### PR TITLE
fix: improve native typed array support (S09-typed-arrays/native.t 4->10 pass)

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2223,6 +2223,38 @@ impl Interpreter {
                             _ => 0,
                         },
                     };
+                    // Check for lazy values in splice replacement args
+                    // when the target is a native typed array
+                    if let Some(constraint) = self.var_type_constraint(&key)
+                        && crate::runtime::native_types::is_native_array_element_type(&constraint)
+                    {
+                        for arg in args.iter().skip(2) {
+                            let has_lazy = match arg {
+                                Value::Array(items, _) => items
+                                    .iter()
+                                    .any(crate::builtins::methods_0arg::is_value_lazy),
+                                other => crate::builtins::methods_0arg::is_value_lazy(other),
+                            };
+                            if has_lazy {
+                                let declared = format!("array[{}]", constraint);
+                                return Err(RuntimeError::typed(
+                                    "X::Cannot::Lazy",
+                                    [
+                                        (
+                                            "message".to_string(),
+                                            Value::str(format!(
+                                                "Cannot splice a lazy list into a {}",
+                                                declared
+                                            )),
+                                        ),
+                                        ("action".to_string(), Value::str_from("splice")),
+                                    ]
+                                    .into_iter()
+                                    .collect(),
+                                ));
+                            }
+                        }
+                    }
                     let mut resolved_args = args.clone();
                     // Resolve callable for offset (arg 0) with array length
                     if let Some(arg @ (Value::Sub(..) | Value::WeakSub(..))) = args.first()

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -606,6 +606,12 @@ impl Interpreter {
                     return Ok(Value::make_instance(*class_name, attrs));
                 }
                 "Array" | "List" | "Positional" | "array" => {
+                    // native `array` requires a type parameter (e.g. array[int].new)
+                    if base_class_name == "array" && type_args.is_none() {
+                        return Err(RuntimeError::new(
+                            "Must use a native array with a type parameter (e.g. array[int].new)",
+                        ));
+                    }
                     if let Some(dims) = self.shaped_dims_from_new_args(&args) {
                         // Check for :data argument to populate the shaped array
                         let data = args.iter().find_map(|arg| match arg {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1900,6 +1900,25 @@ impl VM {
         if var_name.is_some_and(|name| name.starts_with('%')) {
             return Ok(());
         }
+        // Lazy values cannot be stored in native typed arrays
+        if var_name.is_some_and(|name| name.starts_with('@'))
+            && crate::runtime::native_types::is_native_array_element_type(base_constraint)
+            && crate::builtins::methods_0arg::is_value_lazy(&value)
+        {
+            let declared = format!("array[{}]", base_constraint);
+            return Err(RuntimeError::typed(
+                "X::Cannot::Lazy",
+                [
+                    (
+                        "message".to_string(),
+                        Value::str(format!("Cannot store a lazy list onto a {}", declared)),
+                    ),
+                    ("action".to_string(), Value::str_from("store")),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+        }
         if var_name.is_some_and(|name| name.starts_with('@'))
             && matches!(&value, Value::Array(..) | Value::Seq(_))
         {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5,6 +5,23 @@ use std::sync::Arc;
 use unicode_normalization::UnicodeNormalization;
 
 impl VM {
+    /// Return the default fill value for a native type constraint.
+    /// For `int`/`uint` variants returns `Value::Int(0)`,
+    /// for `num` variants returns `Value::Num(0.0)`,
+    /// for `str` returns `Value::str("")`,
+    /// otherwise returns `Value::Package("Any")`.
+    fn native_fill_for_constraint(constraint: Option<&str>) -> Value {
+        match constraint {
+            Some(
+                "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
+                | "uint32" | "uint64" | "byte" | "atomicint",
+            ) => Value::Int(0),
+            Some("num" | "num32" | "num64") => Value::Num(0.0),
+            Some("str") => Value::str(String::new()),
+            _ => Value::Package(Symbol::intern("Any")),
+        }
+    }
+
     pub(super) fn delegated_mixin_attr_key(
         &self,
         mixins: &std::collections::HashMap<String, Value>,
@@ -686,6 +703,24 @@ impl VM {
             && let Some(constraint) = self.interpreter.var_type_constraint(var_name)
             && let Value::Array(items, kind) = value
         {
+            // Native typed arrays cannot store lazy sequences
+            if kind.is_lazy()
+                && crate::runtime::native_types::is_native_array_element_type(&constraint)
+            {
+                let declared = format!("array[{}]", constraint);
+                return Err(RuntimeError::typed(
+                    "X::Cannot::Lazy",
+                    [
+                        (
+                            "message".to_string(),
+                            Value::str(format!("Cannot store a lazy list onto a {}", declared)),
+                        ),
+                        ("action".to_string(), Value::str_from("store")),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ));
+            }
             let coerced_items = self.coerce_typed_array_elements(
                 var_name,
                 &constraint,
@@ -851,6 +886,8 @@ impl VM {
                     var_name, constraint, item,
                 ));
             }
+            // Wrap/check native integer overflow for native typed arrays
+            let coerced = Self::wrap_native_int_by_constraint(&target_type, coerced)?;
             coerced_items.push(coerced);
         }
         Ok(coerced_items)
@@ -1712,6 +1749,12 @@ impl VM {
             .as_deref()
             .unwrap_or(&original_var_name)
             .to_string();
+        // Pre-compute fill value for native typed arrays (e.g. int->0, num->0e0, str->"")
+        // Must be done before mutable borrows to avoid borrow conflicts.
+        let native_fill = {
+            let tc = self.interpreter.var_type_constraint(&var_name);
+            Self::native_fill_for_constraint(tc.as_deref())
+        };
         // Capture the old Arc pointer before any mutation so the post-mutation
         // sync code can distinguish stale COW copies from unrelated containers.
         let old_container_arc_ptr: Option<usize> =
@@ -1957,7 +2000,8 @@ impl VM {
                     {
                         let arr = Arc::make_mut(items);
                         if idx_usize >= arr.len() {
-                            arr.resize(idx_usize + 1, Value::Package(Symbol::intern("Any")));
+                            let fill = native_fill.clone();
+                            arr.resize(idx_usize + 1, fill);
                         }
                         arr[idx_usize] = v;
                     }
@@ -2009,7 +2053,8 @@ impl VM {
                         if let Value::Array(items, ..) = container {
                             let arr = Arc::make_mut(items);
                             if max_idx >= arr.len() {
-                                arr.resize(max_idx + 1, Value::Package(Symbol::intern("Any")));
+                                let fill = native_fill.clone();
+                                arr.resize(max_idx + 1, fill);
                             }
                         }
                         // Assign each value to the corresponding index
@@ -2363,7 +2408,8 @@ impl VM {
                                         Arc::make_mut(items)
                                     };
                                     if i >= arr.len() {
-                                        arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                        let fill = native_fill.clone();
+                                        arr.resize(i + 1, fill);
                                     }
                                     if bind_mode
                                         && let Some(Some(source_name)) = bind_sources.first()
@@ -2682,6 +2728,10 @@ impl VM {
         inner_positional: bool,
     ) -> Result<(), RuntimeError> {
         let var_name = Self::const_str(code, name_idx).to_string();
+        let native_fill = {
+            let tc = self.interpreter.var_type_constraint(&var_name);
+            Self::native_fill_for_constraint(tc.as_deref())
+        };
         let inner_idx = self.stack.pop().unwrap_or(Value::Nil);
         let outer_idx = self.stack.pop().unwrap_or(Value::Nil);
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);
@@ -2751,7 +2801,8 @@ impl VM {
         {
             let arr = Arc::make_mut(outer_arr);
             if inner_i >= arr.len() {
-                arr.resize(inner_i + 1, Value::Package(Symbol::intern("Any")));
+                let fill = native_fill.clone();
+                arr.resize(inner_i + 1, fill);
             }
             // Autovivify the slot if it's not already a container.
             let needs_viv = !matches!(&arr[inner_i], Value::Array(..) | Value::Hash(..));
@@ -2779,7 +2830,8 @@ impl VM {
                         } else {
                             let inner = Arc::make_mut(inner_arr);
                             if j >= inner.len() {
-                                inner.resize(j + 1, Value::Package(Symbol::intern("Any")));
+                                let fill = native_fill.clone();
+                                inner.resize(j + 1, fill);
                             }
                             inner[j] = val.clone();
                         }
@@ -2874,6 +2926,10 @@ impl VM {
         positional_flags_idx: u32,
     ) -> Result<(), RuntimeError> {
         let var_name = Self::const_str(code, name_idx).to_string();
+        let native_fill = {
+            let tc = self.interpreter.var_type_constraint(&var_name);
+            Self::native_fill_for_constraint(tc.as_deref())
+        };
         let depth = depth as usize;
 
         // Pop indices from stack: innermost first (top of stack)
@@ -2936,7 +2992,8 @@ impl VM {
                             if let Ok(i) = key.parse::<usize>() {
                                 let arr = Arc::make_mut(arr_arc);
                                 if i >= arr.len() {
-                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                    let fill = native_fill.clone();
+                                    arr.resize(i + 1, fill);
                                 }
                                 // Autovivify if needed
                                 let needs_viv =
@@ -3012,7 +3069,8 @@ impl VM {
                             if let Ok(i) = key.parse::<usize>() {
                                 let arr = Arc::make_mut(arr_arc);
                                 if i >= arr.len() {
-                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                    let fill = native_fill.clone();
+                                    arr.resize(i + 1, fill);
                                 }
                                 arr[i] = val.clone();
                             }
@@ -3026,7 +3084,8 @@ impl VM {
                             if is_positional {
                                 let mut arr = Vec::new();
                                 if let Ok(i) = key.parse::<usize>() {
-                                    arr.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                                    let fill = native_fill.clone();
+                                    arr.resize(i + 1, fill);
                                     arr[i] = val.clone();
                                 }
                                 *current = Value::real_array(arr);
@@ -3633,6 +3692,33 @@ impl VM {
                     &constraint,
                     &Value::Nil,
                 ));
+            }
+            // Native typed arrays cannot store lazy sequences — check before
+            // eager evaluation so the error is raised even if the sequence is
+            // infinite.
+            if let Some(constraint) = self.interpreter.var_type_constraint(name)
+                && crate::runtime::native_types::is_native_array_element_type(&constraint)
+            {
+                let is_lazy_value = match &raw_popped {
+                    Value::Array(_, kind) => kind.is_lazy(),
+                    Value::LazyList(_) | Value::LazyIoLines { .. } => true,
+                    _ => false,
+                };
+                if is_lazy_value {
+                    let declared = format!("array[{}]", constraint);
+                    return Err(RuntimeError::typed(
+                        "X::Cannot::Lazy",
+                        [
+                            (
+                                "message".to_string(),
+                                Value::str(format!("Cannot store a lazy list onto a {}", declared)),
+                            ),
+                            ("action".to_string(), Value::str_from("store")),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ));
+                }
             }
             let mut assigned = if is_constant {
                 // `constant @x` stores a List, not an Array.


### PR DESCRIPTION
## Summary
- Require type parameter for bare `array.new` (dies without one, matching Raku spec)
- Fill native array gaps with type-appropriate defaults (0 for int, 0e0 for num, "" for str) instead of `Any` when extending via index assignment
- Check native integer overflow when coercing typed array elements (e.g. `my int @a = 1, 2**65` now throws)
- Detect lazy sequences during native array assignment and splice, throwing `X::Cannot::Lazy` instead of type mismatch errors
- Improves `roast/S09-typed-arrays/native.t` from 4/10 to 10/10 passing (tests 11-12 also fail in Rakudo)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S09-typed-arrays/native.t` shows 10/10 pass
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)
- [x] Whitelisted roast tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)