### PR TITLE
fix: pass all 59 tests in S02-types/multi_dimensional_array.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -132,6 +132,7 @@ roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
 roast/S02-types/mixed_multi_dimensional.t
 roast/S02-types/mu.t
+roast/S02-types/multi_dimensional_array.t
 roast/S02-types/nan.t
 roast/S02-types/native.t
 roast/S02-types/nested_arrays.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1013,6 +1013,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     }
                 }
             }
+            // Scalar .sum returns the numeric value of the invocant
+            Value::Int(_) | Value::Num(_) | Value::Rat(..) | Value::BigInt(_) => {
+                Some(Ok(target.clone()))
+            }
             _ => None,
         },
         "squish" => match target {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -244,10 +244,11 @@ impl Compiler {
             // Multi-dimensional indexing: @a[$x;$y;$z]
             Expr::MultiDimIndex { target, dimensions } => {
                 self.compile_expr(target);
-                self.compile_expr(&Expr::ArrayLiteral(dimensions.clone()));
-                self.code.emit(OpCode::Index {
-                    is_positional: false,
-                });
+                for dim in dimensions {
+                    self.compile_expr(dim);
+                }
+                self.code
+                    .emit(OpCode::MultiDimIndex(dimensions.len() as u32));
             }
             // Hash hyperslice: %hash{**}:adverb
             Expr::HyperSlice { target, adverb } => {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1119,9 +1119,13 @@ impl VM {
                         }
                     })
                 });
+            // Only preserve the old shape if the new value is NOT already shaped
+            let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)
+                .is_some()
+                || matches!(&assigned, Value::Array(_, crate::value::ArrayKind::Shaped));
             if let Some(ref shape) = current_shape {
                 // For 1D shaped arrays, rebuild with the same shape
-                if shape.len() == 1 {
+                if shape.len() == 1 && !assigned_has_own_shape {
                     let items = runtime::value_to_list(&assigned);
                     let item_count = items.len();
                     let mut shaped_items: Vec<Value> = items.into_iter().take(shape[0]).collect();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1738,11 +1738,11 @@ impl VM {
         let idx = self.stack.pop().unwrap_or(Value::Nil);
         let index_target = self.interpreter.env().get(&var_name).cloned();
         let idx = self.resolve_whatever_index_for_target(idx, index_target.as_ref());
-        // Normalize Seq index to Array for uniform handling in assignment
-        let idx = if let Value::Seq(items) = idx {
-            Value::Array(items, crate::value::ArrayKind::List)
-        } else {
-            idx
+        // Normalize Seq/Slip index to Array for uniform handling in assignment
+        let idx = match idx {
+            Value::Seq(items) => Value::Array(items, crate::value::ArrayKind::List),
+            Value::Slip(items) => Value::Array(items, crate::value::ArrayKind::List),
+            other => other,
         };
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);
         let (val, bind_mode, bind_sources) = match raw_val {
@@ -3845,9 +3845,14 @@ impl VM {
                     }
                 }
             };
-            // Preserve shaped array property on re-assignment
+            // Preserve shaped array property on re-assignment, but only if the
+            // new value is NOT already a shaped array (e.g. from Array.new(:shape(...)))
+            let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)
+                .is_some()
+                || matches!(&assigned, Value::Array(_, crate::value::ArrayKind::Shaped));
             if let Some(shape) = crate::runtime::utils::shaped_array_shape(&self.locals[idx])
                 && shape.len() == 1
+                && !assigned_has_own_shape
             {
                 let items = runtime::value_to_list(&assigned);
                 let item_count = items.len();

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -12,9 +12,91 @@ impl VM {
         dims.reverse();
         let target = self.stack.pop().unwrap_or(Value::Nil);
 
+        // For shaped arrays, check bounds before reading
+        let is_shaped = crate::runtime::utils::is_shaped_array(&target);
+        if is_shaped {
+            self.check_shaped_array_bounds(&target, &dims, 0)?;
+        }
+
         let result = self.multi_dim_index_read(&target, &dims)?;
         self.stack.push(result);
         Ok(())
+    }
+
+    /// Check that all scalar indices are within bounds for a shaped array.
+    /// `dim_offset` tracks the 1-based dimension number for error messages.
+    fn check_shaped_array_bounds(
+        &self,
+        target: &Value,
+        dims: &[Value],
+        dim_offset: usize,
+    ) -> Result<(), RuntimeError> {
+        if dims.is_empty() {
+            return Ok(());
+        }
+        let dim = &dims[0];
+        let rest = &dims[1..];
+
+        match dim {
+            Value::Whatever => {
+                // * iterates all elements — no bounds check needed at this level,
+                // but recurse into each element for remaining dimensions
+                if let Value::Array(items, ..) = target {
+                    for item in items.iter() {
+                        self.check_shaped_array_bounds(item, rest, dim_offset + 1)?;
+                    }
+                }
+                Ok(())
+            }
+            Value::Array(indices, ..) => {
+                // Multiple indices — check each one
+                let items = match target {
+                    Value::Array(items, ..) => items,
+                    _ => return Ok(()),
+                };
+                for idx in indices.iter() {
+                    if let Some(i) = Self::index_to_usize(idx) {
+                        if i >= items.len() {
+                            return Err(RuntimeError::new(format!(
+                                "Index {} for dimension {} out of range (must be 0..{})",
+                                i,
+                                dim_offset + 1,
+                                items.len() - 1
+                            )));
+                        }
+                        self.check_shaped_array_bounds(&items[i], rest, dim_offset + 1)?;
+                    }
+                }
+                Ok(())
+            }
+            _ => {
+                // Scalar index
+                let resolved = if let Value::Rat(n, d) = dim {
+                    Some(Value::Int(*n / *d))
+                } else if let Value::Num(f) = dim {
+                    Some(Value::Int(*f as i64))
+                } else {
+                    None
+                };
+                let idx = resolved.as_ref().unwrap_or(dim);
+                if let Some(i) = Self::index_to_usize(idx) {
+                    let items = match target {
+                        Value::Array(items, ..) => items,
+                        _ => return Ok(()),
+                    };
+                    if i >= items.len() {
+                        return Err(RuntimeError::new(format!(
+                            "Index {} for dimension {} out of range (must be 0..{})",
+                            i,
+                            dim_offset + 1,
+                            items.len() - 1
+                        )));
+                    }
+                    self.check_shaped_array_bounds(&items[i], rest, dim_offset + 1)?;
+                }
+                Ok(())
+            }
+        }
     }
 
     /// Read a value from a nested array using multi-dimensional indices.


### PR DESCRIPTION
## Summary
- Compile `MultiDimIndex` AST nodes to `OpCode::MultiDimIndex` instead of flattening to array literal + Index, enabling proper `$a[1;0]` and `$a[0,1;2]` multi-dimensional indexing
- Add `.sum` for scalar numeric types (Int, Num, Rat, BigInt) returning the invocant, matching Raku semantics
- Fix shaped array re-declaration in loops: preserve the new shape from `Array.new(:shape(...))` instead of forcing the old shape
- Normalize `Slip` values to `Array` in index assignment for `@md.AT-POS(|$k) = value` on shaped arrays
- Add `roast/S02-types/multi_dimensional_array.t` to whitelist (all 59 tests pass, 55 non-skipped)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S02-types/multi_dimensional_array.t` passes (59/59)
- [x] `cargo clippy -- -D warnings` clean
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)