### PR TITLE
fix: pass all 244 tests in roast/S02-types/mix.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -130,6 +130,7 @@ roast/S02-types/lazy-lists.t
 roast/S02-types/list.t
 roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
+roast/S02-types/mix.t
 roast/S02-types/mixed_multi_dimensional.t
 roast/S02-types/mu.t
 roast/S02-types/multi_dimensional_array.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -291,15 +291,19 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Set(s, _) => {
                 let mut map = std::collections::HashMap::new();
                 let mut original_keys = std::collections::HashMap::new();
+                let mut has_typed = false;
                 for k in s.iter() {
                     map.insert(k.clone(), Value::Bool(true));
                     let typed = s.typed_key(k);
                     if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
                         original_keys.insert(k.clone(), typed);
                     }
                 }
                 let result = Value::hash(map);
-                if !original_keys.is_empty() {
+                if has_typed {
+                    // Tag so .keys can distinguish setty-origin hashes
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
                     crate::runtime::utils::register_hash_original_keys(&result, original_keys);
                 }
                 Some(Ok(result))
@@ -307,17 +311,18 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Bag(b, _) => {
                 let mut map = std::collections::HashMap::new();
                 let mut original_keys = std::collections::HashMap::new();
+                let mut has_typed = false;
                 for (k, v) in b.iter() {
                     map.insert(k.clone(), Value::Int(*v));
                     let typed = b.typed_key(k);
                     if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
                         original_keys.insert(k.clone(), typed);
                     }
                 }
                 let result = Value::hash(map);
-                if !original_keys.is_empty() {
-                    // Mark this hash as having typed keys from a Bag
-                    original_keys.insert("__mutsu_typed_key_hash__".to_string(), Value::Bool(true));
+                if has_typed {
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
                     crate::runtime::utils::register_hash_original_keys(&result, original_keys);
                 }
                 Some(Ok(result))
@@ -325,17 +330,18 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Mix(m, _) => {
                 let mut map = std::collections::HashMap::new();
                 let mut original_keys = std::collections::HashMap::new();
+                let mut has_typed = false;
                 for (k, v) in m.iter() {
                     map.insert(k.clone(), crate::value::mix_weight_to_value(*v));
                     let typed = m.typed_key(k);
                     if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
                         original_keys.insert(k.clone(), typed);
                     }
                 }
                 let result = Value::hash(map);
-                if !original_keys.is_empty() {
-                    // Mark this hash as having typed keys from a Mix
-                    original_keys.insert("__mutsu_typed_key_hash__".to_string(), Value::Bool(true));
+                if has_typed {
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
                     crate::runtime::utils::register_hash_original_keys(&result, original_keys);
                 }
                 Some(Ok(result))
@@ -376,19 +382,17 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(map) => {
-                    // Check if this is a Set/Bag/Mix-derived object hash where keys
-                    // should be returned as their original typed values.
-                    // Set-derived: all values are Bool(true) + original keys exist.
-                    // Bag/Mix-derived: flagged with __mutsu_typed_key_hash__ marker.
-                    let original_keys = crate::runtime::utils::hash_original_keys_snapshot(target);
-                    let is_typed_key_hash = if let Some(ref orig) = original_keys {
-                        orig.contains_key("__mutsu_typed_key_hash__")
-                            || (!map.is_empty()
-                                && map.values().all(|v| matches!(v, Value::Bool(true))))
+                    // Use original typed keys for object hashes that were
+                    // created from Set/Bag/Mix .hash coercion and tagged
+                    // with a __setty_origin marker in original_keys.
+                    let has_setty_origin = if let Some(orig) =
+                        crate::runtime::utils::hash_original_keys_snapshot(target)
+                    {
+                        orig.contains_key("__mutsu_setty_origin")
                     } else {
                         false
                     };
-                    let keys: Vec<Value> = if is_typed_key_hash {
+                    let keys: Vec<Value> = if has_setty_origin {
                         map.keys()
                             .map(|k| crate::runtime::utils::hash_typed_key(target, k))
                             .collect()
@@ -784,7 +788,12 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Set(s, _) => Some(Ok(Value::Int(s.len() as i64))),
             Value::Bag(b, _) => Some(Ok(Value::Int(b.values().sum::<i64>()))),
             Value::Mix(m, _) => {
-                let (n, d) = f64_to_rat(m.values().sum::<f64>());
+                // Sort values before summing to ensure deterministic results
+                // regardless of HashMap iteration order, avoiding f64
+                // non-associativity issues (e.g. 1.1+1.1+3.3+3.3 vs 1.1+3.3+1.1+3.3).
+                let mut vals: Vec<f64> = m.values().copied().collect();
+                vals.sort_by(|a, b| a.total_cmp(b));
+                let (n, d) = f64_to_rat(vals.iter().sum::<f64>());
                 Some(Ok(crate::value::make_rat(n, d)))
             }
             _ => None,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -380,23 +380,37 @@ impl Compiler {
         // binding it first would clobber the source array before other params
         // can read from it.  Defer the `$_` binding to the end.
         let mut deferred_topic = None;
+        let mut sigilless_names = Vec::new();
         for (i, p) in params.iter().enumerate() {
+            // Sigilless params are prefixed with \\ by the parser.
+            let (actual_name, is_sigilless) = if let Some(name) = p.strip_prefix('\\') {
+                (name.to_string(), true)
+            } else {
+                (p.clone(), false)
+            };
             let stmt = bind_stmt(
-                p.clone(),
+                actual_name.clone(),
                 Expr::Index {
                     target: Box::new(Expr::Var("_".to_string())),
                     index: Box::new(Expr::Literal(Value::Int(i as i64))),
                     is_positional: false,
                 },
             );
-            if p == "_" {
+            if actual_name == "_" {
                 deferred_topic = Some(stmt);
             } else {
                 bind_stmts.push(stmt);
             }
+            if is_sigilless {
+                sigilless_names.push(actual_name);
+            }
         }
         if let Some(stmt) = deferred_topic {
             bind_stmts.push(stmt);
+        }
+        // Mark sigilless params as readonly (e.g. `-> \k, \v`).
+        for name in sigilless_names {
+            bind_stmts.push(Stmt::MarkSigillessReadonly(name));
         }
         bind_stmts
     }
@@ -412,10 +426,12 @@ impl Compiler {
                 Expr::HashVar(name) => Some(format!("%{}", name)),
                 _ => None,
             },
-            // Handle @a.values, @a.kv, $pair.value → source is @a / $pair
+            // Handle @a.values, @a.kv, @a.pairs, $pair.value → source is @a / $pair
             Expr::MethodCall {
                 target, name, args, ..
-            } if args.is_empty() && (*name == "values" || *name == "kv" || *name == "value") => {
+            } if args.is_empty()
+                && (*name == "values" || *name == "kv" || *name == "value" || *name == "pairs") =>
+            {
                 Self::for_iterable_source_name(target)
             }
             // Handle @a.reverse → source is @a (reversed)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1137,7 +1137,10 @@ impl Compiler {
                     .as_ref()
                     .and_then(|p| self.local_map.get(p.as_str()).copied());
                 let rw_param_names = if has_rw && !params.is_empty() {
-                    params.clone()
+                    params
+                        .iter()
+                        .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
+                        .collect()
                 } else {
                     Vec::new()
                 };
@@ -1172,7 +1175,10 @@ impl Compiler {
                     source_var_names,
                     autothread_junctions,
                     explicit_zero_params: *explicit_zero_params,
-                    multi_param_names: params.clone(),
+                    multi_param_names: params
+                        .iter()
+                        .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
+                        .collect(),
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -775,7 +775,12 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
         };
         let (r, _) = ws(r)?;
         if r.starts_with(',') {
-            let mut params = vec![first];
+            let first_param = if first_def.sigilless {
+                format!("\\{}", first)
+            } else {
+                first
+            };
+            let mut params = vec![first_param];
             let mut any_rw = rw_block || first_def.traits.iter().any(|t| t == "rw");
             let mut r = r;
             loop {
@@ -785,7 +790,13 @@ pub(super) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 if next.traits.iter().any(|t| t == "rw") {
                     any_rw = true;
                 }
-                params.push(next.name);
+                // Prefix sigilless params with \\ so the compiler can
+                // emit MarkSigillessReadonly for them.
+                if next.sigilless {
+                    params.push(format!("\\{}", next.name));
+                } else {
+                    params.push(next.name);
+                }
                 let (r2, _) = ws(r2)?;
                 if !r2.starts_with(',') {
                     r = r2;

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -493,16 +493,34 @@ impl Interpreter {
             }
             Value::Set(s, _) => {
                 for k in s.iter() {
+                    let typed = s.typed_key(k);
+                    if let Some(ref mut orig) = original_keys
+                        && !matches!(&typed, Value::Str(sv) if sv.as_ref() == k)
+                    {
+                        orig.entry(k.clone()).or_insert(typed);
+                    }
                     *weights.entry(k.clone()).or_insert(0.0) += 1.0;
                 }
             }
             Value::Bag(b, _) => {
                 for (k, v) in b.iter() {
+                    let typed = b.typed_key(k);
+                    if let Some(ref mut orig) = original_keys
+                        && !matches!(&typed, Value::Str(sv) if sv.as_ref() == k)
+                    {
+                        orig.entry(k.clone()).or_insert(typed);
+                    }
                     *weights.entry(k.clone()).or_insert(0.0) += *v as f64;
                 }
             }
             Value::Mix(m, _) => {
                 for (k, v) in m.iter() {
+                    let typed = m.typed_key(k);
+                    if let Some(ref mut orig) = original_keys
+                        && !matches!(&typed, Value::Str(sv) if sv.as_ref() == k)
+                    {
+                        orig.entry(k.clone()).or_insert(typed);
+                    }
                     *weights.entry(k.clone()).or_insert(0.0) += v;
                 }
             }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -641,6 +641,19 @@ impl Interpreter {
         method_args: Vec<Value>,
         value: Value,
     ) -> Result<Value, RuntimeError> {
+        // If the target variable is deep-readonly (e.g. $_ in a for-loop
+        // over an immutable type like Mix/Set/Bag), disallow method-based
+        // mutation such as .value = ... on pairs.
+        if let Some(var_name) = target_var {
+            let deep_key = format!("__mutsu_deep_readonly::{}", var_name);
+            if matches!(self.env.get(&deep_key), Some(Value::Bool(true))) {
+                let repr = value.to_string_value();
+                return Err(RuntimeError::assignment_ro_typename(
+                    &crate::value::what_type_name(&value),
+                    &repr,
+                ));
+            }
+        }
         // Handle AT-POS lvalue assignment: @arr.AT-POS(idx...) = v  =>  ASSIGN-POS(idx..., v)
         if method == "AT-POS" && !method_args.is_empty() && matches!(&target, Value::Array(..)) {
             let mut assign_args = method_args.clone();

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -2065,7 +2065,11 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
         Value::Set(items, _) => Value::Int(items.len() as i64),
         Value::Bag(items, _) => Value::Int(items.values().sum()),
         Value::Mix(items, _) => {
-            let total: f64 = items.values().copied().fold(0.0, std::ops::Add::add);
+            // Sort values before summing for deterministic results
+            // regardless of HashMap iteration order.
+            let mut vals: Vec<f64> = items.values().copied().collect();
+            vals.sort_by(|a, b| a.total_cmp(b));
+            let total: f64 = vals.iter().copied().fold(0.0, std::ops::Add::add);
             if total == 0.0 && items.is_empty() {
                 Value::Int(0)
             } else if (total - (total as i64 as f64)).abs() < f64::EPSILON {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -419,6 +419,24 @@ impl VM {
                 (name.clone(), val, was_readonly, sigilless_ro)
             })
             .collect();
+        // Determine if the implicit topic ($_) should be read-only.
+        // Only mark $_ readonly when iterating over a known immutable collection
+        // (Mix, Set, Bag). This blocks `.value = ...` mutations on pairs from
+        // immutable collections while keeping $_ writable for expression results,
+        // multi-param for loops, and Scalar containers holding plain values.
+        let topic_readonly =
+            !spec.is_rw && param_name.is_none() && spec.multi_param_names.is_empty() && {
+                match &container_binding {
+                    None => false,
+                    Some(name) => {
+                        if let Some(val) = self.get_env_with_main_alias(name) {
+                            matches!(val, Value::Mix(_, _) | Value::Set(_, _) | Value::Bag(_, _))
+                        } else {
+                            false
+                        }
+                    }
+                }
+            };
         let total_items = chunked_items.len();
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate() {
             self.topic_source_var = if writes_back_topic {
@@ -450,6 +468,15 @@ impl VM {
             }
             if let Some(slot) = spec.param_local {
                 self.locals[slot as usize] = item.clone();
+            }
+            // Mark implicit $_ readonly when source is immutable.
+            // Also set a deep-readonly flag so that method-lvalue
+            // assignments like .value = ... are blocked too.
+            if topic_readonly {
+                self.interpreter.mark_readonly("_");
+                self.interpreter
+                    .env_mut()
+                    .insert("__mutsu_deep_readonly::_".to_string(), Value::Bool(true));
             }
             // Mark named params readonly when not in rw mode
             if !spec.is_rw
@@ -676,6 +703,12 @@ impl VM {
                     }
                     Err(e) => {
                         // Unmark readonly before propagating error
+                        if topic_readonly {
+                            self.interpreter.unmark_readonly("_");
+                            self.interpreter
+                                .env_mut()
+                                .remove("__mutsu_deep_readonly::_");
+                        }
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
@@ -698,6 +731,13 @@ impl VM {
             if self.interpreter.is_halted() {
                 break;
             }
+        }
+        // Unmark readonly topic after loop completion
+        if topic_readonly {
+            self.interpreter.unmark_readonly("_");
+            self.interpreter
+                .env_mut()
+                .remove("__mutsu_deep_readonly::_");
         }
         // Unmark readonly params after loop completion
         if !spec.is_rw

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3596,6 +3596,11 @@ impl VM {
             // same-named variable in an outer scope.
             let deleted_key = format!("__mutsu_deleted_index::{}", name);
             self.interpreter.env_mut().remove(&deleted_key);
+            // Clear any sigilless-readonly flag inherited from an outer
+            // scope (e.g. a for-loop `\result` shouldn't block `my $result`
+            // in a called sub).
+            let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
+            self.interpreter.env_mut().remove(&readonly_key);
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it.
@@ -4220,10 +4225,15 @@ impl VM {
         }
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        if matches!(
-            self.interpreter.env().get(&readonly_key),
-            Some(Value::Bool(true))
-        ) && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
+        // Only enforce sigilless-readonly when this is NOT a new variable
+        // declaration (my $x = ...).  A `my` decl creates a fresh variable
+        // that shadows the sigilless one, so it must not be blocked.
+        if !is_vardecl
+            && matches!(
+                self.interpreter.env().get(&readonly_key),
+                Some(Value::Bool(true))
+            )
+            && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
         {
             return Err(RuntimeError::assignment_ro(None));
         }


### PR DESCRIPTION
## Summary
- Rebased version of PR #2461 on latest main (resolving conflicts from merged PRs)
- Mark `$_` as deep-readonly when iterating immutable collections (Mix/Set/Bag), blocking `.value = ...` mutations on pairs
- Track typed keys through Mix/Bag/Set `.hash` coercion with `__mutsu_setty_origin` marker (replacing `__mutsu_typed_key_hash__`)
- Sort Mix values before summing for deterministic f64 results regardless of HashMap iteration order
- Support sigilless multi-param `\` prefix in for-loop parameters (`-> \k, \v`)
- Add `.pairs` to `for_iterable_source_name` recognition
- Add `roast/S02-types/mix.t` to whitelist (244/244 tests pass)

## Test plan
- [x] `timeout 120 target/debug/mutsu roast/S02-types/mix.t` passes all 244 tests
- [x] `timeout 60 target/debug/mutsu roast/S04-statements/when.t` passes (no regressions)
- [x] `timeout 60 target/debug/mutsu roast/S04-statements/with.t` passes (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)