### PR TITLE
fix: regex * % separator captures

### DIFF
--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -24,6 +24,9 @@ impl Interpreter {
                     for (k, v) in inner_caps.named_subcaps.drain() {
                         new_caps.named_subcaps.entry(k).or_default().extend(v);
                     }
+                    new_caps
+                        .named_quantified
+                        .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps
                         .positional_subcaps
@@ -54,6 +57,9 @@ impl Interpreter {
                     for (k, v) in inner_caps.named_subcaps.drain() {
                         new_caps.named_subcaps.entry(k).or_default().extend(v);
                     }
+                    new_caps
+                        .named_quantified
+                        .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps
                         .positional_subcaps
@@ -91,6 +97,9 @@ impl Interpreter {
             for (k, v) in longest_caps.named_subcaps {
                 new_caps.named_subcaps.entry(k).or_default().extend(v);
             }
+            new_caps
+                .named_quantified
+                .extend(longest_caps.named_quantified);
             new_caps.positional.append(&mut longest_caps.positional);
             new_caps
                 .positional_subcaps

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1090,7 +1090,7 @@ impl Interpreter {
                 out.push_str(&format!("{sws}{sep}{sws}{atom}"));
             }
             if trailing && allow_trailing_sep {
-                out.push_str(&format!("({sws}{sep})?"));
+                out.push_str(&format!("[{sws}{sep}]?"));
             }
             out
         };
@@ -1107,13 +1107,13 @@ impl Interpreter {
                         format!("({})", alts.join("|"))
                     }
                 }
-                None => format!("{}({sp}{atom})*", repeat_atom(min)),
+                None => format!("{}[{sp}{atom}]*", repeat_atom(min)),
             };
         }
 
         if max.is_none() && min == 1 && atom.ends_with('?') && !sep.is_empty() {
             if allow_trailing_sep {
-                return format!("{atom}({sws}{sep})?");
+                return format!("{atom}[{sws}{sep}]?");
             }
             return atom.to_string();
         }
@@ -1130,19 +1130,19 @@ impl Interpreter {
             }
             None => {
                 if min == 0 {
-                    // 0..* with separator: [atom(sep atom)*]?
-                    let mut inner = format!("{atom}({sws}{sep}{sws}{atom})*");
+                    // 0..* with separator: [atom[sep atom]*]?
+                    let mut inner = format!("{atom}[{sws}{sep}{sws}{atom}]*");
                     if allow_trailing_sep {
-                        inner.push_str(&format!("({sws}{sep})?"));
+                        inner.push_str(&format!("[{sws}{sep}]?"));
                     }
                     format!("[{inner}]?")
                 } else {
                     // Use inner without trailing sep — the trailing sep is
                     // added after the unbounded repetition group below.
                     let mut out = build_exact_list_inner(min, false);
-                    out.push_str(&format!("({sws}{sep}{sws}{atom})*"));
+                    out.push_str(&format!("[{sws}{sep}{sws}{atom}]*"));
                     if allow_trailing_sep {
-                        out.push_str(&format!("({sws}{sep})?"));
+                        out.push_str(&format!("[{sws}{sep}]?"));
                     }
                     out
                 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2468,14 +2468,14 @@ impl Value {
                 if vals.len() == 1 && !caps.named_quantified.contains(key) {
                     sub_named.insert(key.clone(), vals[0].clone());
                 } else {
-                    sub_named.insert(key.clone(), Value::array(vals));
+                    sub_named.insert(key.clone(), Value::real_array(vals));
                 }
             }
             // For quantified named captures that matched zero times, insert empty arrays
             for qname in &caps.named_quantified {
                 sub_named
                     .entry(qname.clone())
-                    .or_insert_with(|| Value::array(Vec::new()));
+                    .or_insert_with(|| Value::real_array(Vec::new()));
             }
             let mut attrs = HashMap::new();
             attrs.insert("str".to_string(), Value::str(caps.matched.clone()));
@@ -2565,14 +2565,14 @@ impl Value {
             if vals.len() == 1 && !named_quantified.contains(key) {
                 named_caps_map.insert(key.clone(), vals[0].clone());
             } else {
-                named_caps_map.insert(key.clone(), Value::array(vals));
+                named_caps_map.insert(key.clone(), Value::real_array(vals));
             }
         }
         // For quantified named captures that matched zero times, insert empty arrays
         for qname in named_quantified {
             named_caps_map
                 .entry(qname.clone())
-                .or_insert_with(|| Value::array(Vec::new()));
+                .or_insert_with(|| Value::real_array(Vec::new()));
         }
         attrs.insert("named".to_string(), Value::hash(named_caps_map));
         Value::make_instance(Symbol::intern("Match"), attrs)

--- a/t/regex-sep-quantifier-captures.t
+++ b/t/regex-sep-quantifier-captures.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# Bug 1: Named captures from subrules with * % should be arrays
+{
+    grammar G1 {
+        token ident { \w+ }
+        token name { <ident> * % '.' }
+    }
+
+    my $m = G1.parse("bar", rule => 'name');
+    is $m<ident>.WHAT.raku, 'Array', 'single match: named capture is Array';
+    is $m<ident>.elems, 1, 'single match: one element in array';
+
+    my $m2 = G1.parse("foo.bar", rule => 'name');
+    is $m2<ident>.WHAT.raku, 'Array', 'multi match: named capture is Array';
+    is $m2<ident>.elems, 2, 'multi match: two elements in array';
+}
+
+# Bug 2: Separator in * % should not leak into positional captures
+{
+    grammar G2 {
+        token ident { \w+ }
+        token name { [<ident> * % '.' | ('.')] }
+    }
+
+    my $m = G2.parse("bar", rule => 'name');
+    is $m[0].defined, False, 'single match: $0 is undefined (first branch matched)';
+    is $m<ident>.WHAT.raku, 'Array', 'single match with alternation: named capture is Array';
+
+    my $m2 = G2.parse("foo.bar", rule => 'name');
+    is $m2[0].defined, False, 'multi match: $0 is undefined (separator not captured)';
+    is $m2<ident>.elems, 2, 'multi match with alternation: two elements';
+}


### PR DESCRIPTION
## Summary
- Fix named captures from subrules with `* %` separator quantifier not collecting into Arrays (Bug 1)
- Fix separator in `* %` leaking into positional captures `$0` (Bug 2)

### Changes:
- **LTM expansion** (`regex_parse.rs`): Use `[...]` (non-capturing groups) instead of `(...)` (capturing groups) for separator repetition patterns in the `build_ltm_expansion_inner` function
- **named_quantified propagation** (`regex_match_atom.rs`): Propagate `named_quantified` through `Alternation`, `SequentialAlternation`, and `Conjunction` atom matching
- **Array type** (`value/mod.rs`): Use `Value::real_array()` (ArrayKind::Array) instead of `Value::array()` (ArrayKind::List) for quantified named captures in match objects

### Test:
- Added `t/regex-sep-quantifier-captures.t` with 8 tests covering both bugs

## Test plan
- [x] `t/regex-sep-quantifier-captures.t` passes (8/8 tests)
- [x] All 30 grammar/regex tests pass (`t/grammar-*.t t/regex-*.t`)
- [x] Verified with `raku` reference implementation
- [x] Template::Mustache 01-basic.t improves (4/9 passing)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)