### PR TITLE
fix: proto regex frugal quantifier and word list backslash escapes

### DIFF
--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -249,9 +249,18 @@ impl Interpreter {
                 let mut out = Vec::new();
                 for (sub_pat, sub_pkg, sym_key) in candidates {
                     if let Some(parsed) = self.parse_regex(&sub_pat) {
-                        for (inner_end, inner_caps) in
-                            self.regex_match_ends_from_caps_in_pkg(&parsed, &tail, 0, &sub_pkg)
-                        {
+                        let all_matches =
+                            self.regex_match_ends_from_caps_in_pkg(&parsed, &tail, 0, &sub_pkg);
+                        // For proto regex candidates, take only the first (preferred) match.
+                        // Frugal quantifiers produce the shortest match first; greedy produce
+                        // the longest first. Taking only the first prevents LTM from
+                        // stretching a frugal candidate's match to the maximum.
+                        let matches_to_use: Vec<_> = if sym_key.is_some() {
+                            all_matches.into_iter().take(1).collect()
+                        } else {
+                            all_matches
+                        };
+                        for (inner_end, inner_caps) in matches_to_use {
                             let end = pos + inner_end;
                             let mut new_caps = current_caps.clone();
                             let capture_name = spec

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2286,14 +2286,15 @@ impl Interpreter {
                                     }
                                     continue;
                                 }
-                                // Handle backslash escapes inside bracket classes:
-                                // \[ and \] should not affect bracket_depth, etc.
+                                // Handle backslash escapes: \< and \> should not
+                                // affect angle_depth, \[ and \] should not affect
+                                // bracket_depth, etc.
                                 if escaped {
                                     escaped = false;
                                     name.push(ch);
                                     continue;
                                 }
-                                if ch == '\\' && bracket_depth > 0 {
+                                if ch == '\\' {
                                     escaped = true;
                                     name.push(ch);
                                     continue;
@@ -2355,9 +2356,24 @@ impl Interpreter {
                                     let alternatives: Vec<RegexPattern> = words
                                         .iter()
                                         .map(|w| {
-                                            let toks: Vec<RegexToken> = w
-                                                .chars()
-                                                .map(|ch| RegexToken {
+                                            // Unescape backslash sequences: \< → <, \> → >, etc.
+                                            let mut word_chars: Vec<char> = Vec::new();
+                                            let mut wchars = w.chars().peekable();
+                                            while let Some(wch) = wchars.next() {
+                                                if wch == '\\' {
+                                                    if let Some(&next) = wchars.peek() {
+                                                        word_chars.push(next);
+                                                        wchars.next();
+                                                    } else {
+                                                        word_chars.push(wch);
+                                                    }
+                                                } else {
+                                                    word_chars.push(wch);
+                                                }
+                                            }
+                                            let toks: Vec<RegexToken> = word_chars
+                                                .iter()
+                                                .map(|&ch| RegexToken {
                                                     atom: RegexAtom::Literal(ch),
                                                     quant: RegexQuant::One,
                                                     named_capture: None,
@@ -3478,6 +3494,15 @@ impl Interpreter {
                 i += 1;
                 while i < chars.len() && depth > 0 {
                     let c = chars[i];
+                    if c == '\\' {
+                        out.push(c);
+                        i += 1;
+                        if i < chars.len() {
+                            out.push(chars[i]);
+                            i += 1;
+                        }
+                        continue;
+                    }
                     if c == '<' {
                         depth += 1;
                     } else if c == '>' {


### PR DESCRIPTION
## Summary
- Proto regex candidates now return only their first (preferred) match, fixing frugal quantifiers like `(\N*?)` in section tags
- Word list backslash escapes (`< # ^ / \< $ >`) now correctly unescape `\<` to literal `<`
- Template::Mustache basic tests: 6/9 passing (remaining 3 need delimiter change support and character class fix)

## Test plan
- [x] `make test` passes
- [x] Grammar roast tests pass (protoregex, action-stubs, parse_and_parsefile, regex, charset, signatures)
- [x] Template::Mustache: interpolation, context precedence, comments, var substitution, zero digit, triple-mustache all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)