### PR TITLE
fix: skip angle brackets and bracket groups in LTM separator check

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -634,6 +634,46 @@ impl Interpreter {
                 i += 1;
                 continue;
             }
+            // Skip <...> angle brackets — % inside assertions/character classes
+            // is not a separator
+            if !in_single && !in_double && ch == '<' {
+                i += 1;
+                let mut angle_depth = 1u32;
+                while i < chars_vec.len() && angle_depth > 0 {
+                    let c = chars_vec[i];
+                    if c == '\\' {
+                        i += 2; // skip escaped char
+                        continue;
+                    }
+                    if c == '<' {
+                        angle_depth += 1;
+                    } else if c == '>' {
+                        angle_depth -= 1;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            // Skip [...] bracket groups — % inside bracket character classes
+            // is not a separator
+            if !in_single && !in_double && ch == '[' {
+                i += 1;
+                let mut bracket_depth = 1u32;
+                while i < chars_vec.len() && bracket_depth > 0 {
+                    let c = chars_vec[i];
+                    if c == '\\' {
+                        i += 2; // skip escaped char
+                        continue;
+                    }
+                    if c == '[' {
+                        bracket_depth += 1;
+                    } else if c == ']' {
+                        bracket_depth -= 1;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
             if !in_single && !in_double && ch == '%' {
                 // Check if this is hash aliasing: %<name>= or %ident=
                 let mut j = i + 1;

--- a/t/regex-charclass-escapes.t
+++ b/t/regex-charclass-escapes.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 6;
+
+# Backslash-escaped brackets inside character classes
+nok 'a' ~~ / <[\<\>]> /, 'letter does not match escaped angle bracket char class';
+ok '<' ~~ / <[\<\>]> /, 'literal < matches backslash-escaped char class';
+ok '>' ~~ / <[\<\>]> /, 'literal > matches backslash-escaped char class';
+
+# Complex character class with multiple escaped brackets and special chars
+ok 'a' ~~ / <+ graph - [\<\>\{\}\[\]&=%$]> /, 'graph minus escaped-bracket char class matches letter';
+nok '<' ~~ / <+ graph - [\<\>\{\}\[\]&=%$]> /, 'graph minus escaped-bracket char class rejects <';
+nok '%' ~~ / <+ graph - [\<\>\{\}\[\]&=%$]> /, 'graph minus escaped-bracket char class rejects %';


### PR DESCRIPTION
## Summary
- Fixed `has_unquoted_ltm_separator` in `regex_parse.rs` to skip `<...>` angle brackets and `[...]` bracket groups when checking for `%` LTM separators
- The `%` character inside character classes like `<+ graph - [\<\>\{\}\[\]&=%$]>` was being misidentified as an LTM separator, causing the regex pattern to be mangled by LTM expansion
- Added backslash-escape handling in both skip loops so `\<`, `\>`, `\[`, `\]` don't affect bracket depth tracking

## Test plan
- [x] Added `t/regex-charclass-escapes.t` with 6 tests covering backslash-escaped brackets in character classes
- [x] Verified `say 'a' ~~ / <+ graph - [\<\>\{\}\[\]&=%$]> /` outputs `｢a｣` (was: runtime error)
- [x] Verified grammar token with same pattern works correctly
- [x] `make test` passes (only pre-existing `wrap.t` failure)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)