### PR TITLE
fix: .map on itemized lists and given/when return values in map callbacks

### DIFF
--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -418,7 +418,10 @@ impl Interpreter {
         let items = if crate::runtime::utils::is_shaped_array(&target) {
             crate::runtime::utils::shaped_array_leaves(&target)
         } else {
-            Self::value_to_list(&target)
+            match &target {
+                Value::Array(items, kind) if kind.is_itemized() => items.to_vec(),
+                _ => Self::value_to_list(&target),
+            }
         };
         let result = self.eval_map_over_items(args.first().cloned(), items)?;
         // .map() returns a Seq per Raku spec

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1978,9 +1978,7 @@ impl Interpreter {
                         let val = vm
                             .last_stack_value()
                             .cloned()
-                            .or_else(|| {
-                                vm.interpreter().env().get("_").cloned()
-                            })
+                            .or_else(|| vm.interpreter().env().get("_").cloned())
                             .unwrap_or(Value::Nil);
                         match val {
                             Value::Slip(elems) => result.extend(elems.iter().cloned()),
@@ -2204,9 +2202,7 @@ impl Interpreter {
                         let val = vm
                             .last_stack_value()
                             .cloned()
-                            .or_else(|| {
-                                vm.interpreter().env().get("_").cloned()
-                            })
+                            .or_else(|| vm.interpreter().env().get("_").cloned())
                             .unwrap_or(Value::Nil);
                         // Write back topic mutation if it happened
                         if arity == 1
@@ -2395,9 +2391,7 @@ impl Interpreter {
                             let pred = vm
                                 .last_stack_value()
                                 .cloned()
-                                .or_else(|| {
-                                    vm.interpreter().env().get("_").cloned()
-                                })
+                                .or_else(|| vm.interpreter().env().get("_").cloned())
                                 .unwrap_or(Value::Nil);
                             let updated_item = if arity == 1 {
                                 vm.interpreter()

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1976,10 +1976,11 @@ impl Interpreter {
                 match vm.run_reuse(&code, &compiled_fns) {
                     Ok(()) => {
                         let val = vm
-                            .interpreter()
-                            .env()
-                            .get("_")
+                            .last_stack_value()
                             .cloned()
+                            .or_else(|| {
+                                vm.interpreter().env().get("_").cloned()
+                            })
                             .unwrap_or(Value::Nil);
                         match val {
                             Value::Slip(elems) => result.extend(elems.iter().cloned()),
@@ -2201,10 +2202,11 @@ impl Interpreter {
                 match vm.run_reuse(&code, &compiled_fns) {
                     Ok(()) => {
                         let val = vm
-                            .interpreter()
-                            .env()
-                            .get("_")
+                            .last_stack_value()
                             .cloned()
+                            .or_else(|| {
+                                vm.interpreter().env().get("_").cloned()
+                            })
                             .unwrap_or(Value::Nil);
                         // Write back topic mutation if it happened
                         if arity == 1
@@ -2391,10 +2393,11 @@ impl Interpreter {
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let pred = vm
-                                .interpreter()
-                                .env()
-                                .get("_")
+                                .last_stack_value()
                                 .cloned()
+                                .or_else(|| {
+                                    vm.interpreter().env().get("_").cloned()
+                                })
                                 .unwrap_or(Value::Nil);
                             let updated_item = if arity == 1 {
                                 vm.interpreter()

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -593,6 +593,10 @@ impl VM {
         &mut self.interpreter
     }
 
+    pub(crate) fn last_stack_value(&self) -> Option<&Value> {
+        self.stack.last()
+    }
+
     /// Override the source variable used when mutating `$_` in VM execution.
     pub(crate) fn set_topic_source_var(&mut self, name: Option<String>) {
         self.topic_source_var = name;


### PR DESCRIPTION
## Summary
- `.map()` now de-containerizes itemized lists (`$(...)`) before iterating
- `eval_map_over_items` reads VM stack top (from `given/when` succeed) before falling back to `env["_"]`
- Fixes Template::Mustache section iteration where `.map(&section_format).join` produced only one result

## Test plan
- [x] `make test` passes
- [x] `(1,2,3).map(&process).list` returns `("one","two","other")` with given/when callback
- [x] `$({a=>1},{b=>2}).map(&f)` iterates over elements, not whole list
- [x] Template::Mustache basic tests: interpolation, context, comments, var, zero, triple-mustache pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)