### PR TITLE
feat: inline grammar action dispatch for dynamic variable propagation

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1003,6 +1003,20 @@ impl Interpreter {
             Some(defs) => defs,
             None => return Ok(None),
         };
+        // For a single non-proto definition, skip LTM testing and return
+        // the pattern directly. LTM testing would prematurely reject
+        // patterns whose subrules depend on dynamic variables modified by
+        // grammar action methods (e.g. $*X changed between <first> and
+        // <second> tokens).
+        let is_proto = self.has_proto_token(name);
+        if defs.len() == 1 && !is_proto {
+            if let Some(pattern) =
+                self.eval_token_def(&defs.into_iter().next().unwrap(), arg_values)?
+            {
+                return Ok(Some(pattern));
+            }
+            return Ok(None);
+        }
         let subject = match self.env.get("_") {
             Some(Value::Str(s)) => Some(s.to_string()),
             _ => None,

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -220,7 +220,16 @@ impl Interpreter {
             "toggle" => Some(self.dispatch_toggle(target, &args)),
             "eager" if args.is_empty() => Some(self.dispatch_eager_method(target)),
             "is-lazy" if args.is_empty() => Some(Ok(self.dispatch_is_lazy_method(&target))),
-            "first" if !args.is_empty() => Some(self.dispatch_first(target, &args)),
+            "first" if !args.is_empty() => {
+                // User-defined methods take priority over builtin .first
+                if let Value::Instance { class_name, .. } = &target
+                    && self.has_user_method(&class_name.resolve(), "first")
+                {
+                    None
+                } else {
+                    Some(self.dispatch_first(target, &args))
+                }
+            }
             "first" if args.is_empty() => {
                 if let Value::Instance { class_name, .. } = &target
                     && class_name == "Supply"

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -172,11 +172,37 @@ impl Interpreter {
                 let _ = self.bind_function_args_values(&def.param_defs, &def.params, &rule_args);
             }
 
+            // Set up inline grammar actions context so that action methods fire
+            // during regex matching (not just after). This allows side effects
+            // like dynamic variable changes to propagate to subsequent tokens.
+            if let Some(ref actions_val) = actions_obj {
+                let ctx = super::regex::regex_helpers::GrammarInlineActionsCtx {
+                    actions: actions_val.clone(),
+                    interp: self.clone_for_grammar_actions(),
+                };
+                super::regex::regex_helpers::GRAMMAR_INLINE_ACTIONS.with(|slot| {
+                    *slot.borrow_mut() = Some(Box::new(ctx));
+                });
+            }
             let captures = if method == "parse" || method == "parsefile" {
                 self.regex_match_with_captures_full_from_start(&pattern, &text)
             } else {
                 self.regex_match_with_captures(&pattern, &text)
             };
+            // Sync env changes from inline actions back to main interpreter
+            if actions_obj.is_some() {
+                super::regex::regex_helpers::GRAMMAR_INLINE_ACTIONS.with(|slot| {
+                    if let Some(ctx) = slot.borrow().as_ref() {
+                        // Copy dynamic variable changes back to our env
+                        for (key, val) in ctx.interp.env.iter() {
+                            if key.starts_with("*") {
+                                self.env.insert_sym(*key, val.clone());
+                            }
+                        }
+                    }
+                    *slot.borrow_mut() = None;
+                });
+            }
             // Check for pending regex error (e.g., <sym> used outside proto regex)
             if let Some(err) = Self::take_pending_regex_error() {
                 return Err(err);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4682,6 +4682,38 @@ impl Interpreter {
             })
     }
 
+    /// Create a clone for grammar action method dispatch.
+    /// Copies definitions needed for method resolution but starts with fresh output.
+    pub(crate) fn clone_for_grammar_actions(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            functions: self.functions.clone(),
+            proto_functions: self.proto_functions.clone(),
+            token_defs: self.token_defs.clone(),
+            current_package: self.current_package.clone(),
+            var_dynamic_flags: self.var_dynamic_flags.clone(),
+            var_type_constraints: self.var_type_constraints.clone(),
+            state_vars: self.state_vars.clone(),
+            classes: self.classes.clone(),
+            cunion_classes: self.cunion_classes.clone(),
+            hidden_classes: self.hidden_classes.clone(),
+            class_stubs: self.class_stubs.clone(),
+            class_composed_roles: self.class_composed_roles.clone(),
+            class_enum_roles: self.class_enum_roles.clone(),
+            roles: self.roles.clone(),
+            role_candidates: self.role_candidates.clone(),
+            role_parents: self.role_parents.clone(),
+            role_type_params: self.role_type_params.clone(),
+            class_role_param_bindings: self.class_role_param_bindings.clone(),
+            class_subs: self.class_subs.clone(),
+            subsets: self.subsets.clone(),
+            enum_types: self.enum_types.clone(),
+            closure_env_overrides: self.closure_env_overrides.clone(),
+            loaded_modules: self.loaded_modules.clone(),
+            ..Default::default()
+        }
+    }
+
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,6 +1,6 @@
 mod regex_casefold;
 mod regex_eval;
-mod regex_helpers;
+pub(in crate::runtime) mod regex_helpers;
 mod regex_interpolate;
 mod regex_match_atom;
 mod regex_match_atom_simple;

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -4,11 +4,79 @@ use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
 use unicode_segmentation::UnicodeSegmentation;
 
+/// Context for firing grammar action methods inline during regex matching.
+/// Stored in a thread-local so that the immutable regex engine (`&self`) can
+/// trigger mutable action method calls when a named subrule match completes.
+pub(crate) struct GrammarInlineActionsCtx {
+    /// The actions object (e.g. `A.new` passed via `:actions`).
+    pub(crate) actions: Value,
+    /// A mutable interpreter used to call action methods and track env changes.
+    /// Dynamic variable changes propagate to subsequent regex interpolations.
+    pub(crate) interp: Interpreter,
+}
+
 thread_local! {
     pub(super) static PENDING_REGEX_GOAL_FAILURE: RefCell<Option<(String, usize)>> = const { RefCell::new(None) };
     /// Collects plain (non-assertion) code blocks that should be executed eagerly
     /// during regex matching, even if the overall match fails. Used by `comb` etc.
     pub(crate) static EAGER_CODE_BLOCKS: RefCell<Option<Vec<CodeBlockContext>>> = const { RefCell::new(None) };
+    /// Grammar inline actions context. When set, named subrule matches
+    /// fire their action methods immediately during regex matching, allowing
+    /// side effects (e.g. dynamic variable changes) to affect subsequent tokens.
+    pub(crate) static GRAMMAR_INLINE_ACTIONS: RefCell<Option<Box<GrammarInlineActionsCtx>>> = const { RefCell::new(None) };
+}
+
+/// Fire an inline grammar action method for a named subrule match.
+/// Returns true if an action was fired.
+pub(crate) fn fire_inline_grammar_action(
+    rule_name: &str,
+    matched: &str,
+    from: usize,
+    to: usize,
+    inner_caps: &RegexCaptures,
+) -> bool {
+    GRAMMAR_INLINE_ACTIONS.with(|slot| {
+        let mut borrow = slot.borrow_mut();
+        let Some(ctx) = borrow.as_mut() else {
+            return false;
+        };
+        let match_obj = Value::make_match_object_full_q(
+            matched.to_string(),
+            from as i64,
+            to as i64,
+            &inner_caps.positional,
+            &inner_caps.named,
+            &inner_caps.named_subcaps,
+            &inner_caps.positional_subcaps,
+            &inner_caps.positional_quantified,
+            None,
+            &inner_caps.named_quantified,
+        );
+        ctx.interp.env.insert("/".to_string(), match_obj.clone());
+        ctx.interp.env.remove("made");
+        ctx.interp.action_made = None;
+        let result =
+            ctx.interp
+                .call_method_with_values(ctx.actions.clone(), rule_name, vec![match_obj]);
+        match result {
+            Ok(_) => true,
+            Err(e) if e.is_method_not_found() => false,
+            Err(_) => false,
+        }
+    })
+}
+
+/// Look up a dynamic variable in the grammar inline actions context.
+pub(crate) fn lookup_grammar_actions_dynvar(name: &str) -> Option<Value> {
+    GRAMMAR_INLINE_ACTIONS.with(|slot| {
+        let borrow = slot.borrow();
+        let ctx = borrow.as_ref()?;
+        ctx.interp
+            .env
+            .get(name)
+            .cloned()
+            .or_else(|| ctx.interp.env.get(&format!("${name}")).cloned())
+    })
 }
 
 /// Strip combining marks from a character, returning just the base character(s).

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -345,12 +345,21 @@ impl Interpreter {
                     None
                 };
                 if let Some((name, end)) = parsed {
-                    if let Some(value) = self
-                        .env
-                        .get(&name)
-                        .cloned()
-                        .or_else(|| self.env.get(&format!("${name}")).cloned())
-                    {
+                    // For dynamic variables, check grammar actions env first
+                    let resolved = if name.starts_with('*') {
+                        super::regex_helpers::lookup_grammar_actions_dynvar(&name).or_else(|| {
+                            self.env
+                                .get(&name)
+                                .cloned()
+                                .or_else(|| self.env.get(&format!("${name}")).cloned())
+                        })
+                    } else {
+                        self.env
+                            .get(&name)
+                            .cloned()
+                            .or_else(|| self.env.get(&format!("${name}")).cloned())
+                    };
+                    if let Some(value) = resolved {
                         match value {
                             Value::Regex(pat) => out.push_str(&pat),
                             other => {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -269,6 +269,14 @@ impl Interpreter {
                                 .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                             if let Some(capture_name) = capture_name {
                                 let captured: String = chars[pos..end].iter().collect();
+                                // Fire inline grammar action for this subrule
+                                super::regex_helpers::fire_inline_grammar_action(
+                                    &spec.lookup_name,
+                                    &captured,
+                                    pos,
+                                    end,
+                                    &inner_caps,
+                                );
                                 // Store inner captures as subcaptures (nested)
                                 let mut subcap = inner_caps;
                                 subcap.matched = captured.clone();

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -439,6 +439,14 @@ impl Interpreter {
                         .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                     if let Some(capture_name) = capture_name {
                         let captured: String = chars[pos..end].iter().collect();
+                        // Fire inline grammar action for this subrule
+                        super::regex_helpers::fire_inline_grammar_action(
+                            &spec.lookup_name,
+                            &captured,
+                            pos,
+                            end,
+                            &inner_caps,
+                        );
                         // Store inner captures as subcaptures (nested)
                         let mut subcap = inner_caps;
                         subcap.matched = captured.clone();

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3397,6 +3397,21 @@ impl Interpreter {
         None
     }
 
+    /// Look up a variable, checking the grammar inline actions env first for
+    /// dynamic variables (twigil `*`). This allows action method side effects
+    /// (e.g. `$*X = 'bb'`) to propagate to subsequent regex interpolations.
+    fn lookup_regex_scalar(&self, name: &str) -> Option<Value> {
+        if name.starts_with('*')
+            && let Some(val) = super::regex::regex_helpers::lookup_grammar_actions_dynvar(name)
+        {
+            return Some(val);
+        }
+        self.env
+            .get(name)
+            .cloned()
+            .or_else(|| self.env.get(&format!("${name}")).cloned())
+    }
+
     pub(super) fn interpolate_regex_scalars(&self, pattern: &str) -> Result<String, RuntimeError> {
         let chars: Vec<char> = pattern.chars().collect();
         let mut out = String::new();
@@ -3570,12 +3585,7 @@ impl Interpreter {
                             continue;
                         }
                         let name: String = chars[name_start..j].iter().collect();
-                        let value = self
-                            .env
-                            .get(&name)
-                            .cloned()
-                            .or_else(|| self.env.get(&format!("${name}")).cloned())
-                            .unwrap_or(Value::Nil);
+                        let value = self.lookup_regex_scalar(&name).unwrap_or(Value::Nil);
                         Self::check_hash_in_regex(&value)?;
                         Self::push_value_as_regex_pattern(&value, &mut out);
                         i = j + 1;
@@ -3603,12 +3613,7 @@ impl Interpreter {
                         continue;
                     }
                     let name: String = chars[name_start..j].iter().collect();
-                    let value = self
-                        .env
-                        .get(&name)
-                        .cloned()
-                        .or_else(|| self.env.get(&format!("${name}")).cloned())
-                        .unwrap_or(Value::Nil);
+                    let value = self.lookup_regex_scalar(&name).unwrap_or(Value::Nil);
                     Self::check_hash_in_regex(&value)?;
                     Self::push_value_as_regex_pattern(&value, &mut out);
                     i = j;

--- a/t/grammar-inline-actions.t
+++ b/t/grammar-inline-actions.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 4;
+
+# Test: grammar action methods fire inline during parsing,
+# allowing dynamic variable changes to affect subsequent tokens.
+{
+    my $*X = 'aa';
+
+    grammar G {
+        regex TOP { <first> <second> }
+        token first { $*X }
+        token second { $*X }
+    }
+
+    class A {
+        method first($/) {
+            $*X = 'bb';
+        }
+        method second($/) { }
+    }
+
+    my $actions = A.new;
+    my $m = G.parse('aabb', :$actions);
+    ok $m.defined, 'grammar parse with inline action dynvar change succeeds';
+    is ~$m, 'aabb', 'full match text is correct';
+    is ~$m<first>, 'aa', 'first subrule matched aa';
+    is ~$m<second>, 'bb', 'second subrule matched bb (after dynvar change)';
+}


### PR DESCRIPTION
## Summary
- Grammar action methods now fire inline during regex matching (not just post-parse)
- Enables dynamic variable changes in actions to affect subsequent parsing
- Required for Template::Mustache delimiter change (`{{=<% %>=}}`)

## Test plan
- [x] New test `t/grammar-inline-actions.t` (4 tests)
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)