### PR TITLE
fix: grammar parent class resolution and stack value guard in map

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -26,10 +26,56 @@ impl Compiler {
         let pkg = self.current_package.clone();
         let qualify_parent = |p: &String| -> String {
             if p.contains("::") || p.is_empty() {
-                p.clone()
-            } else {
-                format!("{}::{}", pkg, p)
+                return p.clone();
             }
+            // Well-known builtin types should not be package-qualified.
+            // "Grammar" inside a module should stay "Grammar", not become
+            // "MyModule::Grammar".
+            if matches!(
+                p.as_str(),
+                "Any"
+                    | "Cool"
+                    | "Mu"
+                    | "Grammar"
+                    | "Match"
+                    | "Int"
+                    | "Str"
+                    | "Num"
+                    | "Rat"
+                    | "Bool"
+                    | "IO"
+                    | "Exception"
+                    | "Stash"
+                    | "Array"
+                    | "Hash"
+                    | "List"
+                    | "Map"
+                    | "Set"
+                    | "Bag"
+                    | "Mix"
+                    | "Range"
+                    | "Pair"
+                    | "Regex"
+                    | "FatRat"
+                    | "Complex"
+                    | "Callable"
+                    | "Numeric"
+                    | "Real"
+                    | "Stringy"
+                    | "Positional"
+                    | "Associative"
+                    | "Proc"
+                    | "Supply"
+                    | "Supplier"
+                    | "Date"
+                    | "DateTime"
+                    | "Capture"
+                    | "Parameter"
+                    | "Signature"
+            ) {
+                return p.clone();
+            }
+            format!("{}::{}", pkg, p)
         };
         match stmt {
             Stmt::ClassDecl {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -592,6 +592,28 @@ impl Interpreter {
             (name, "")
         };
         let lookup = base.strip_prefix("::").unwrap_or(base);
+        // Well-known builtin parent types should not be resolved to a
+        // package-scoped variant (e.g. "Grammar" → "HTTP::Parser::Grammar").
+        if !lookup.contains("::")
+            && matches!(
+                lookup,
+                "Any"
+                    | "Cool"
+                    | "Mu"
+                    | "Grammar"
+                    | "Match"
+                    | "Int"
+                    | "Str"
+                    | "Num"
+                    | "Rat"
+                    | "Bool"
+                    | "IO"
+                    | "Exception"
+                    | "Stash"
+            )
+        {
+            return format!("{}{}", lookup, suffix);
+        }
         if let Value::Package(pkg) = self.resolve_indirect_type_name(lookup) {
             return format!("{}{}", pkg.resolve(), suffix);
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -594,7 +594,11 @@ impl VM {
     }
 
     pub(crate) fn last_stack_value(&self) -> Option<&Value> {
-        self.stack.last()
+        if self.stack.len() == 1 {
+            self.stack.last()
+        } else {
+            None
+        }
     }
 
     /// Override the source variable used when mutating `$_` in VM execution.

--- a/t/grammar-in-module.t
+++ b/t/grammar-in-module.t
@@ -1,0 +1,25 @@
+use Test;
+plan 2;
+
+# Test that grammar inside a class/module correctly inherits from
+# the builtin Grammar, not a package-scoped Grammar.
+
+class Foo {
+    grammar G {
+        token TOP { 'hello' }
+    }
+    method test() { G.parse('hello') }
+}
+
+ok Foo.new.test(), 'grammar inside class inherits from builtin Grammar';
+
+# Grammar inside a nested class
+class Bar {
+    class Baz {
+        grammar G2 {
+            token TOP { 'world' }
+        }
+    }
+}
+
+ok Bar::Baz::G2.parse('world'), 'grammar inside nested class works';


### PR DESCRIPTION
## Summary
- Grammar inside modules no longer errors with "unknown parent class Foo::Grammar"
- `.map` stack value guard prevents stale values from breaking export.t
- Unblocks HTTP::Parser module loading

## Test plan
- [x] New test `t/grammar-in-module.t` (2 tests)
- [x] `export.t` passes 59/59 in release build
- [x] `.map` + `given/when` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)