### PR TITLE
feat: implement real TCP socket binding for IO::Socket::Async.listen

### DIFF
--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -30,7 +30,8 @@ per_file_timeout() {
       ;;
     roast/S32-io/IO-Socket-Async.t)
       # Multiple TCP socket connection tests with real network I/O.
-      echo 90
+      # Tests 10+ use encoding features that may be slower on CI.
+      echo 120
       ;;
     roast/S06-signature/named-parameters.t)
       # This test has a 1M-iteration hot loop (test 100) that takes ~8s on release builds.

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -28,6 +28,10 @@ per_file_timeout() {
       # and potentially more on slower CI machines.
       echo 60
       ;;
+    roast/S32-io/IO-Socket-Async.t)
+      # Multiple TCP socket connection tests with real network I/O.
+      echo 90
+      ;;
     roast/S06-signature/named-parameters.t)
       # This test has a 1M-iteration hot loop (test 100) that takes ~8s on release builds.
       echo 60

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,9 +487,9 @@ fn run_main() {
             interpreter.flush_all_handles();
             interpreter.flush_stderr_buffer();
             let code = interpreter.exit_code();
-            if code != 0 {
-                std::process::exit(code as i32);
-            }
+            // Always call process::exit to terminate any lingering background
+            // threads (e.g. TCP accept loops for IO::Socket::Async listeners).
+            std::process::exit(code as i32);
         }
         Err(err) => {
             print_error("Runtime error", &err, Some(&input), Some(&program_name));

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -4,6 +4,7 @@ mod encoding;
 mod proc;
 mod scheduler;
 mod socket_async;
+mod socket_async_conn;
 mod socket_helpers;
 mod socket_inet;
 pub(crate) mod state;

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -126,7 +126,9 @@ impl Interpreter {
         match method {
             "cancel" | "close" => {
                 if let Some(Value::Int(listener_id)) = attributes.get("listener-id") {
-                    close_async_listener(*listener_id as u64);
+                    let lid = *listener_id as u64;
+                    close_async_listener(lid);
+                    set_listener_closed(lid);
                 }
                 if let (Some(Value::Int(supplier_id)), Some(Value::Int(tap_id))) =
                     (attributes.get("supplier_id"), attributes.get("tap_id"))

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -1,6 +1,9 @@
 use crate::runtime::*;
 use crate::symbol::Symbol;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+
 use super::state::*;
 use super::state_supplier::*;
 
@@ -13,11 +16,11 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("IO::Socket::Async::StatusResult"), attrs)
     }
 
-    fn async_socket_kept(result: Value) -> Value {
+    pub(super) fn async_socket_kept(result: Value) -> Value {
         Self::async_socket_status_result("Kept", result, Value::Nil)
     }
 
-    fn async_socket_broken(cause: Value) -> Value {
+    pub(super) fn async_socket_broken(cause: Value) -> Value {
         Self::async_socket_status_result("Broken", Value::Nil, cause)
     }
 
@@ -187,7 +190,7 @@ impl Interpreter {
         }
     }
 
-    fn async_supplier_quit_value(&mut self, supplier_id: u64, reason: Value) {
+    pub(super) fn async_supplier_quit_value(&mut self, supplier_id: u64, reason: Value) {
         supplier_quit(supplier_id, reason.clone());
         for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
             let _ = self.call_sub_value(tap, vec![emitted], true);
@@ -254,33 +257,137 @@ impl Interpreter {
                     return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
                 }
 
-                if async_port_in_use(&host, port) {
-                    if let Some(q) = quit_cb.clone() {
-                        let mut attrs = HashMap::new();
-                        attrs.insert(
-                            "message".to_string(),
-                            Value::str_from("Address already in use"),
-                        );
-                        let ex = Value::make_instance(Symbol::intern("Exception"), attrs);
-                        let _ = self.call_sub_value(q, vec![ex], true);
+                // Bind a real TCP listener
+                let bind_addr = format!("{}:{}", host, port);
+                let tcp_listener = match std::net::TcpListener::bind(&bind_addr) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        if let Some(q) = quit_cb {
+                            let mut attrs = HashMap::new();
+                            attrs.insert(
+                                "message".to_string(),
+                                Value::str(format!("Failed to bind: {}", e)),
+                            );
+                            let ex = Value::make_instance(Symbol::intern("Exception"), attrs);
+                            let _ = self.call_sub_value(q, vec![ex], true);
+                        }
+                        return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
                     }
-                    return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
-                }
+                };
+                // Get the actual bound port (in case port was 0)
+                let actual_port = tcp_listener.local_addr().map(|a| a.port()).unwrap_or(port);
 
                 let listener_id = next_async_listener_id();
                 register_async_listener(
                     listener_id,
                     AsyncSocketListenerState {
                         host: host.clone(),
-                        port,
-                        callback,
+                        port: actual_port,
+                        callback: callback.clone(),
                         closed: false,
-                        encoding: enc,
+                        encoding: enc.clone(),
                     },
                 );
 
+                // Set up a closed flag for the accept thread
+                let closed_flag = Arc::new(AtomicBool::new(false));
+                register_listener_closed_flag(listener_id, closed_flag.clone());
+
+                // Create a supply channel so the react event loop can
+                // receive accepted connections
+                let supply_id = next_supply_id();
+                let (tx, rx) = mpsc::channel::<SupplyEvent>();
+                if let Ok(mut map) = supply_channel_map().lock() {
+                    map.insert(supply_id, rx);
+                }
+
+                // Set a short accept timeout so the thread can check
+                // the closed flag periodically
+                let _ = tcp_listener
+                    .set_nonblocking(false)
+                    .and_then(|_| tcp_listener.set_nonblocking(false));
+
+                let accept_host = host.clone();
+                let accept_enc = enc.clone();
+                // Start a background thread to accept connections
+                std::thread::spawn(move || {
+                    // Use a short timeout on accept so we can check the closed flag
+                    // TcpListener doesn't have set_timeout, so we use non-blocking + sleep
+                    let _ = tcp_listener.set_nonblocking(true);
+                    loop {
+                        if closed_flag.load(Ordering::SeqCst) {
+                            let _ = tx.send(SupplyEvent::Done);
+                            break;
+                        }
+                        match tcp_listener.accept() {
+                            Ok((stream, peer_addr)) => {
+                                let conn_id = next_async_socket_id();
+                                // Store the TcpStream globally
+                                if let Ok(cloned) = stream.try_clone() {
+                                    register_tcp_stream(conn_id, cloned);
+                                }
+
+                                let mut conn_attrs = HashMap::new();
+                                conn_attrs
+                                    .insert("conn-id".to_string(), Value::Int(conn_id as i64));
+                                conn_attrs.insert("tcp-real".to_string(), Value::Bool(true));
+                                conn_attrs.insert(
+                                    "socket-host".to_string(),
+                                    Value::str(accept_host.clone()),
+                                );
+                                conn_attrs.insert(
+                                    "socket-port".to_string(),
+                                    Value::Int(actual_port as i64),
+                                );
+                                conn_attrs.insert(
+                                    "peer-host".to_string(),
+                                    Value::str(peer_addr.ip().to_string()),
+                                );
+                                conn_attrs.insert(
+                                    "peer-port".to_string(),
+                                    Value::Int(peer_addr.port() as i64),
+                                );
+                                conn_attrs
+                                    .insert("enc".to_string(), Value::str(accept_enc.clone()));
+                                let conn_val = Value::make_instance(
+                                    Symbol::intern("IO::Socket::Async"),
+                                    conn_attrs,
+                                );
+                                if tx.send(SupplyEvent::Emit(conn_val)).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                                // No pending connection, sleep briefly
+                                std::thread::sleep(std::time::Duration::from_millis(10));
+                            }
+                            Err(_) => {
+                                // Fatal accept error, stop
+                                let _ = tx.send(SupplyEvent::Done);
+                                break;
+                            }
+                        }
+                    }
+                });
+
+                // Build a Supply instance that the react event loop can subscribe to
+                let mut supply_attrs = HashMap::new();
+                supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
+                supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+                supply_attrs.insert("live".to_string(), Value::Bool(true));
+                supply_attrs.insert("supply_id".to_string(), Value::Int(supply_id as i64));
+                let supply_val = Value::make_instance(Symbol::intern("Supply"), supply_attrs);
+
+                // If we are inside a react block, register the subscription
+                if !self.supply_emit_buffer.is_empty() {
+                    let sub = Value::array(vec![supply_val, callback]);
+                    if let Some(last) = self.supply_emit_buffer.last_mut() {
+                        last.push(sub);
+                    }
+                }
+
                 let socket_port = SharedPromise::new();
-                socket_port.keep(Value::Int(port as i64), String::new(), String::new());
+                socket_port.keep(Value::Int(actual_port as i64), String::new(), String::new());
                 let socket_host = SharedPromise::new();
                 socket_host.keep(Value::str(host), String::new(), String::new());
 
@@ -301,7 +408,7 @@ impl Interpreter {
     }
 
     /// Handle instance methods on UDP sockets (created by bind-udp / udp).
-    fn native_socket_async_udp(
+    pub(super) fn native_socket_async_udp(
         &mut self,
         attributes: &HashMap<String, Value>,
         method: &str,
@@ -436,318 +543,5 @@ impl Interpreter {
             }
         }
         Ok(())
-    }
-
-    pub(in crate::runtime) fn native_socket_async(
-        &mut self,
-        attributes: &HashMap<String, Value>,
-        method: &str,
-        args: Vec<Value>,
-    ) -> Result<Value, RuntimeError> {
-        // Dispatch to UDP handler if this is a UDP socket
-        if matches!(attributes.get("is-udp"), Some(Value::Bool(true))) {
-            return self.native_socket_async_udp(attributes, method, args);
-        }
-
-        let conn_id = attributes.get("conn-id").and_then(|v| match v {
-            Value::Int(i) => Some(*i as u64),
-            _ => None,
-        });
-
-        match method {
-            "socket-port" => Ok(attributes
-                .get("socket-port")
-                .cloned()
-                .unwrap_or(Value::Int(0))),
-            "peer-port" => Ok(attributes
-                .get("peer-port")
-                .cloned()
-                .unwrap_or(Value::Int(0))),
-            "socket-host" => Ok(attributes
-                .get("socket-host")
-                .cloned()
-                .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
-            "peer-host" => Ok(attributes
-                .get("peer-host")
-                .cloned()
-                .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
-            "close" => {
-                if let Some(id) = conn_id
-                    && let Some(state) = get_async_connection(id)
-                {
-                    update_async_connection(id, |conn| {
-                        conn.closed = true;
-                    });
-                    for sid in &state.supply_ids {
-                        self.async_supplier_done_value(*sid);
-                    }
-                    if let Some(peer_id) = state.peer_id
-                        && let Some(peer) = get_async_connection(peer_id)
-                    {
-                        update_async_connection(peer_id, |conn| {
-                            conn.peer_closed = true;
-                        });
-                        if let Some((callback, socket)) = take_deferred_accept_callback(peer_id) {
-                            let _ = self.call_sub_value(callback, vec![socket], true);
-                        }
-                        for sid in &peer.supply_ids {
-                            if let Some(supply) = get_async_supply(*sid)
-                                && !supply.is_bin
-                                && !supply.text_buffer.is_empty()
-                            {
-                                let _ = self.async_supplier_emit_value(
-                                    *sid,
-                                    Value::str(supply.text_buffer.clone()),
-                                );
-                                update_async_supply(*sid, |st| st.text_buffer.clear());
-                            }
-                            self.async_supplier_done_value(*sid);
-                        }
-                    }
-                }
-                Ok(Value::Nil)
-            }
-            "Supply" => {
-                let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
-                let is_bin = Self::named_bool(&args, "bin");
-                let supply_enc = Self::named_value(&args, "enc")
-                    .map(|v| v.to_string_value())
-                    .or_else(|| attributes.get("enc").map(Value::to_string_value))
-                    .unwrap_or_else(|| "utf-8".to_string());
-                let supply_id = next_supply_id();
-                register_async_supply(
-                    supply_id,
-                    AsyncSocketSupplyState {
-                        is_bin,
-                        encoding: supply_enc,
-                        text_buffer: String::new(),
-                        byte_buffer: Vec::new(),
-                    },
-                );
-                update_async_connection(id, |conn| conn.supply_ids.push(supply_id));
-
-                let mut initial_values: Vec<Value> = Vec::new();
-                let mut is_supplier_done = false;
-                let mut attrs = HashMap::new();
-                attrs.insert("values".to_string(), Value::array(Vec::new()));
-                attrs.insert("taps".to_string(), Value::array(Vec::new()));
-                attrs.insert("live".to_string(), Value::Bool(true));
-                attrs.insert("supplier_id".to_string(), Value::Int(supply_id as i64));
-                if let Some(conn_state) = get_async_connection(id) {
-                    is_supplier_done = conn_state.closed || conn_state.peer_closed;
-                    if !conn_state.pending_bytes.is_empty() {
-                        if is_bin {
-                            let mut battrs = HashMap::new();
-                            battrs.insert(
-                                "bytes".to_string(),
-                                Value::array(
-                                    conn_state
-                                        .pending_bytes
-                                        .iter()
-                                        .map(|b| Value::Int(*b as i64))
-                                        .collect(),
-                                ),
-                            );
-                            initial_values
-                                .push(Value::make_instance(Symbol::intern("Buf"), battrs));
-                        } else if let Some(supply) = get_async_supply(supply_id) {
-                            let decoded = if supply.encoding.eq_ignore_ascii_case("utf-8") {
-                                String::from_utf8_lossy(&conn_state.pending_bytes).to_string()
-                            } else if supply.encoding.eq_ignore_ascii_case("latin-1")
-                                || supply.encoding.eq_ignore_ascii_case("iso-8859-1")
-                            {
-                                conn_state
-                                    .pending_bytes
-                                    .iter()
-                                    .map(|b| char::from_u32(*b as u32).unwrap_or('\u{FFFD}'))
-                                    .collect()
-                            } else {
-                                self.decode_with_encoding(
-                                    &conn_state.pending_bytes,
-                                    &supply.encoding,
-                                )
-                                .unwrap_or_default()
-                            };
-                            if !decoded.is_empty() {
-                                let mut start = 0usize;
-                                for (idx, ch) in decoded.char_indices() {
-                                    if ch == '\n' {
-                                        initial_values
-                                            .push(Value::str(decoded[start..=idx].to_string()));
-                                        start = idx + ch.len_utf8();
-                                    }
-                                }
-                                let tail = decoded[start..].to_string();
-                                update_async_supply(supply_id, |st| st.text_buffer = tail);
-                            }
-                        }
-                        update_async_connection(id, |conn| conn.pending_bytes.clear());
-                    }
-                }
-                if is_supplier_done
-                    && !is_bin
-                    && let Some(supply) = get_async_supply(supply_id)
-                    && !supply.text_buffer.is_empty()
-                {
-                    initial_values.push(Value::str(supply.text_buffer.clone()));
-                    update_async_supply(supply_id, |st| st.text_buffer.clear());
-                }
-                attrs.insert("values".to_string(), Value::array(initial_values));
-                if is_supplier_done {
-                    supplier_done(supply_id);
-                    attrs.insert("supplier_done".to_string(), Value::Bool(true));
-                    attrs.insert("live".to_string(), Value::Bool(false));
-                }
-                Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
-            }
-            "write" | "print" => {
-                let promise = SharedPromise::new();
-                let result = (|| -> Result<Value, RuntimeError> {
-                    let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
-                    let state = get_async_connection(id)
-                        .ok_or_else(|| RuntimeError::new("Unknown async socket connection"))?;
-                    if state.closed {
-                        return Ok(Self::async_socket_broken(Value::str_from(
-                            "Socket is closed",
-                        )));
-                    }
-                    let peer_id = state
-                        .peer_id
-                        .ok_or_else(|| RuntimeError::new("Peer missing"))?;
-                    let peer = get_async_connection(peer_id)
-                        .ok_or_else(|| RuntimeError::new("Unknown peer connection"))?;
-
-                    let bytes = if method == "write" {
-                        args.last()
-                            .and_then(Self::extract_bytes)
-                            .unwrap_or_else(|| {
-                                args.last()
-                                    .map(Value::to_string_value)
-                                    .unwrap_or_default()
-                                    .into_bytes()
-                            })
-                    } else {
-                        let text = args
-                            .last()
-                            .map(|v| self.render_str_value(v))
-                            .unwrap_or_default();
-                        self.encode_with_encoding(&text, &state.encoding)?
-                    };
-                    if bytes.is_empty() {
-                        return Ok(Self::async_socket_kept(Value::Bool(true)));
-                    }
-                    if peer.closed {
-                        return Ok(Self::async_socket_broken(Value::str_from(
-                            "Socket is closed",
-                        )));
-                    }
-
-                    if peer.supply_ids.is_empty() {
-                        update_async_connection(peer_id, |conn| {
-                            conn.pending_bytes.extend_from_slice(&bytes);
-                        });
-                        return Ok(Self::async_socket_kept(Value::Bool(true)));
-                    }
-
-                    for sid in &peer.supply_ids {
-                        if let Some(supply) = get_async_supply(*sid) {
-                            if supply.is_bin {
-                                let mut battrs = HashMap::new();
-                                battrs.insert(
-                                    "bytes".to_string(),
-                                    Value::array(
-                                        bytes.iter().map(|b| Value::Int(*b as i64)).collect(),
-                                    ),
-                                );
-                                let buf = Value::make_instance(Symbol::intern("Buf"), battrs);
-                                let _ = self.async_supplier_emit_value(*sid, buf);
-                            } else {
-                                let mut pending = supply.byte_buffer.clone();
-                                pending.extend_from_slice(&bytes);
-                                let (decoded, remainder) = if supply
-                                    .encoding
-                                    .eq_ignore_ascii_case("utf-8")
-                                {
-                                    match std::str::from_utf8(&pending) {
-                                        Ok(s) => (s.to_string(), Vec::new()),
-                                        Err(e) => {
-                                            if e.error_len().is_none() {
-                                                let valid = &pending[..e.valid_up_to()];
-                                                let valid_decoded = std::str::from_utf8(valid)
-                                                    .unwrap_or("")
-                                                    .to_string();
-                                                (valid_decoded, pending[e.valid_up_to()..].to_vec())
-                                            } else {
-                                                self.async_supplier_quit_value(
-                                                    *sid,
-                                                    Value::str_from(
-                                                        "Malformed UTF-8 on socket Supply",
-                                                    ),
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                } else if supply.encoding.eq_ignore_ascii_case("latin-1")
-                                    || supply.encoding.eq_ignore_ascii_case("iso-8859-1")
-                                {
-                                    (
-                                        pending
-                                            .iter()
-                                            .map(|b| {
-                                                char::from_u32(*b as u32).unwrap_or('\u{FFFD}')
-                                            })
-                                            .collect(),
-                                        Vec::new(),
-                                    )
-                                } else {
-                                    match self.decode_with_encoding(&pending, &supply.encoding) {
-                                        Ok(s) => (s, Vec::new()),
-                                        Err(e) => {
-                                            self.async_supplier_quit_value(
-                                                *sid,
-                                                Value::str(e.message),
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                };
-                                let mut merged = supply.text_buffer.clone();
-                                merged.push_str(&decoded);
-                                let mut start = 0usize;
-                                for (idx, ch) in merged.char_indices() {
-                                    if ch == '\n' {
-                                        let chunk = merged[start..=idx].to_string();
-                                        let _ =
-                                            self.async_supplier_emit_value(*sid, Value::str(chunk));
-                                        start = idx + ch.len_utf8();
-                                    }
-                                }
-                                let tail = merged[start..].to_string();
-                                update_async_supply(*sid, |st| {
-                                    st.text_buffer = tail;
-                                    st.byte_buffer = remainder;
-                                });
-                            }
-                        }
-                    }
-                    Ok(Self::async_socket_kept(Value::Bool(true)))
-                })();
-
-                match result {
-                    Ok(v) => promise.keep(v, String::new(), String::new()),
-                    Err(e) => promise.keep(
-                        Self::async_socket_broken(Value::str(e.message)),
-                        String::new(),
-                        String::new(),
-                    ),
-                }
-                Ok(Value::Promise(promise))
-            }
-            _ => Err(RuntimeError::new(format!(
-                "No method '{}' on IO::Socket::Async",
-                method
-            ))),
-        }
     }
 }

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -257,21 +257,43 @@ impl Interpreter {
                     return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
                 }
 
-                // Bind a real TCP listener
+                // Bind a real TCP listener (retry briefly if port is still held
+                // by a recently-closed listener thread)
                 let bind_addr = format!("{}:{}", host, port);
-                let tcp_listener = match std::net::TcpListener::bind(&bind_addr) {
-                    Ok(l) => l,
-                    Err(e) => {
-                        if let Some(q) = quit_cb {
-                            let mut attrs = HashMap::new();
-                            attrs.insert(
-                                "message".to_string(),
-                                Value::str(format!("Failed to bind: {}", e)),
-                            );
-                            let ex = Value::make_instance(Symbol::intern("Exception"), attrs);
-                            let _ = self.call_sub_value(q, vec![ex], true);
+                let tcp_listener = {
+                    let mut last_err = None;
+                    let mut bound = None;
+                    for attempt in 0..10 {
+                        match std::net::TcpListener::bind(&bind_addr) {
+                            Ok(l) => {
+                                bound = Some(l);
+                                break;
+                            }
+                            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse && attempt < 9 => {
+                                std::thread::sleep(std::time::Duration::from_millis(20));
+                                last_err = Some(e);
+                            }
+                            Err(e) => {
+                                last_err = Some(e);
+                                break;
+                            }
                         }
-                        return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
+                    }
+                    match bound {
+                        Some(l) => l,
+                        None => {
+                            let e = last_err.unwrap();
+                            if let Some(q) = quit_cb {
+                                let mut attrs = HashMap::new();
+                                attrs.insert(
+                                    "message".to_string(),
+                                    Value::str(format!("Failed to bind: {}", e)),
+                                );
+                                let ex = Value::make_instance(Symbol::intern("Exception"), attrs);
+                                let _ = self.call_sub_value(q, vec![ex], true);
+                            }
+                            return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
+                        }
                     }
                 };
                 // Get the actual bound port (in case port was 0)

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -1,0 +1,455 @@
+use crate::runtime::*;
+use crate::symbol::Symbol;
+
+use std::sync::mpsc;
+
+use super::state::*;
+
+impl Interpreter {
+    pub(in crate::runtime) fn native_socket_async(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        // Dispatch to UDP handler if this is a UDP socket
+        if matches!(attributes.get("is-udp"), Some(Value::Bool(true))) {
+            return self.native_socket_async_udp(attributes, method, args);
+        }
+
+        // Check if this is a real TCP connection (from listener accept)
+        let is_real_tcp = matches!(attributes.get("tcp-real"), Some(Value::Bool(true)));
+
+        let conn_id = attributes.get("conn-id").and_then(|v| match v {
+            Value::Int(i) => Some(*i as u64),
+            _ => None,
+        });
+
+        match method {
+            "socket-port" => Ok(attributes
+                .get("socket-port")
+                .cloned()
+                .unwrap_or(Value::Int(0))),
+            "peer-port" => Ok(attributes
+                .get("peer-port")
+                .cloned()
+                .unwrap_or(Value::Int(0))),
+            "socket-host" => Ok(attributes
+                .get("socket-host")
+                .cloned()
+                .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
+            "peer-host" => Ok(attributes
+                .get("peer-host")
+                .cloned()
+                .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
+            "close" if is_real_tcp => {
+                if let Some(id) = conn_id {
+                    if let Some(stream) = get_tcp_stream(id)
+                        && let Ok(s) = stream.lock()
+                    {
+                        let _ = s.shutdown(std::net::Shutdown::Both);
+                    }
+                    remove_tcp_stream(id);
+                }
+                Ok(Value::Nil)
+            }
+            "close" => {
+                self.async_socket_close_in_memory(conn_id)?;
+                Ok(Value::Nil)
+            }
+            "Supply" if is_real_tcp => self.async_socket_supply_real_tcp(conn_id),
+            "Supply" => self.async_socket_supply_in_memory(conn_id, &args, attributes),
+            "write" | "print" if is_real_tcp => {
+                self.async_socket_write_real_tcp(conn_id, method, &args)
+            }
+            "write" | "print" => self.async_socket_write_in_memory(conn_id, method, &args),
+            _ => Err(RuntimeError::new(format!(
+                "No method '{}' on IO::Socket::Async",
+                method
+            ))),
+        }
+    }
+
+    fn async_socket_close_in_memory(&mut self, conn_id: Option<u64>) -> Result<(), RuntimeError> {
+        if let Some(id) = conn_id
+            && let Some(state) = get_async_connection(id)
+        {
+            update_async_connection(id, |conn| {
+                conn.closed = true;
+            });
+            for sid in &state.supply_ids {
+                self.async_supplier_done_value(*sid);
+            }
+            if let Some(peer_id) = state.peer_id
+                && let Some(peer) = get_async_connection(peer_id)
+            {
+                update_async_connection(peer_id, |conn| {
+                    conn.peer_closed = true;
+                });
+                if let Some((callback, socket)) = take_deferred_accept_callback(peer_id) {
+                    let _ = self.call_sub_value(callback, vec![socket], true);
+                }
+                for sid in &peer.supply_ids {
+                    if let Some(supply) = get_async_supply(*sid)
+                        && !supply.is_bin
+                        && !supply.text_buffer.is_empty()
+                    {
+                        let _ = self.async_supplier_emit_value(
+                            *sid,
+                            Value::str(supply.text_buffer.clone()),
+                        );
+                        update_async_supply(*sid, |st| st.text_buffer.clear());
+                    }
+                    self.async_supplier_done_value(*sid);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn async_socket_supply_real_tcp(
+        &mut self,
+        conn_id: Option<u64>,
+    ) -> Result<Value, RuntimeError> {
+        let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
+        let supply_id = next_supply_id();
+        let (tx, rx) = mpsc::channel::<SupplyEvent>();
+        if let Ok(mut map) = supply_channel_map().lock() {
+            map.insert(supply_id, rx);
+        }
+        // Start a reader thread for this connection
+        if let Some(stream_arc) = get_tcp_stream(id) {
+            let stream_clone = stream_arc.lock().ok().and_then(|s| s.try_clone().ok());
+            if let Some(mut reader) = stream_clone {
+                std::thread::spawn(move || {
+                    use std::io::Read;
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        match reader.read(&mut buf) {
+                            Ok(0) => {
+                                let _ = tx.send(SupplyEvent::Done);
+                                break;
+                            }
+                            Ok(n) => {
+                                let data = String::from_utf8_lossy(&buf[..n]).to_string();
+                                if tx.send(SupplyEvent::Emit(Value::str(data))).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => {
+                                let _ = tx.send(SupplyEvent::Done);
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        let mut attrs = HashMap::new();
+        attrs.insert("values".to_string(), Value::array(Vec::new()));
+        attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        attrs.insert("live".to_string(), Value::Bool(true));
+        attrs.insert("supply_id".to_string(), Value::Int(supply_id as i64));
+        Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
+    }
+
+    fn async_socket_supply_in_memory(
+        &mut self,
+        conn_id: Option<u64>,
+        args: &[Value],
+        attributes: &HashMap<String, Value>,
+    ) -> Result<Value, RuntimeError> {
+        let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
+        let is_bin = Self::named_bool(args, "bin");
+        let supply_enc = Self::named_value(args, "enc")
+            .map(|v| v.to_string_value())
+            .or_else(|| attributes.get("enc").map(Value::to_string_value))
+            .unwrap_or_else(|| "utf-8".to_string());
+        let supply_id = next_supply_id();
+        register_async_supply(
+            supply_id,
+            AsyncSocketSupplyState {
+                is_bin,
+                encoding: supply_enc,
+                text_buffer: String::new(),
+                byte_buffer: Vec::new(),
+            },
+        );
+        update_async_connection(id, |conn| conn.supply_ids.push(supply_id));
+
+        let mut initial_values: Vec<Value> = Vec::new();
+        let mut is_supplier_done = false;
+        let mut attrs = HashMap::new();
+        attrs.insert("values".to_string(), Value::array(Vec::new()));
+        attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        attrs.insert("live".to_string(), Value::Bool(true));
+        attrs.insert("supplier_id".to_string(), Value::Int(supply_id as i64));
+        if let Some(conn_state) = get_async_connection(id) {
+            is_supplier_done = conn_state.closed || conn_state.peer_closed;
+            if !conn_state.pending_bytes.is_empty() {
+                self.decode_pending_bytes_to_supply(
+                    &conn_state.pending_bytes,
+                    supply_id,
+                    is_bin,
+                    &mut initial_values,
+                );
+                update_async_connection(id, |conn| conn.pending_bytes.clear());
+            }
+        }
+        if is_supplier_done
+            && !is_bin
+            && let Some(supply) = get_async_supply(supply_id)
+            && !supply.text_buffer.is_empty()
+        {
+            initial_values.push(Value::str(supply.text_buffer.clone()));
+            update_async_supply(supply_id, |st| st.text_buffer.clear());
+        }
+        attrs.insert("values".to_string(), Value::array(initial_values));
+        if is_supplier_done {
+            supplier_done(supply_id);
+            attrs.insert("supplier_done".to_string(), Value::Bool(true));
+            attrs.insert("live".to_string(), Value::Bool(false));
+        }
+        Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
+    }
+
+    fn decode_pending_bytes_to_supply(
+        &mut self,
+        pending_bytes: &[u8],
+        supply_id: u64,
+        is_bin: bool,
+        initial_values: &mut Vec<Value>,
+    ) {
+        if is_bin {
+            let mut battrs = HashMap::new();
+            battrs.insert(
+                "bytes".to_string(),
+                Value::array(
+                    pending_bytes
+                        .iter()
+                        .map(|b| Value::Int(*b as i64))
+                        .collect(),
+                ),
+            );
+            initial_values.push(Value::make_instance(Symbol::intern("Buf"), battrs));
+        } else if let Some(supply) = get_async_supply(supply_id) {
+            let decoded = if supply.encoding.eq_ignore_ascii_case("utf-8") {
+                String::from_utf8_lossy(pending_bytes).to_string()
+            } else if supply.encoding.eq_ignore_ascii_case("latin-1")
+                || supply.encoding.eq_ignore_ascii_case("iso-8859-1")
+            {
+                pending_bytes
+                    .iter()
+                    .map(|b| char::from_u32(*b as u32).unwrap_or('\u{FFFD}'))
+                    .collect()
+            } else {
+                self.decode_with_encoding(pending_bytes, &supply.encoding)
+                    .unwrap_or_default()
+            };
+            if !decoded.is_empty() {
+                let mut start = 0usize;
+                for (idx, ch) in decoded.char_indices() {
+                    if ch == '\n' {
+                        initial_values.push(Value::str(decoded[start..=idx].to_string()));
+                        start = idx + ch.len_utf8();
+                    }
+                }
+                let tail = decoded[start..].to_string();
+                update_async_supply(supply_id, |st| st.text_buffer = tail);
+            }
+        }
+    }
+
+    fn async_socket_write_real_tcp(
+        &mut self,
+        conn_id: Option<u64>,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let promise = SharedPromise::new();
+        let result = (|| -> Result<Value, RuntimeError> {
+            let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
+            let stream_arc =
+                get_tcp_stream(id).ok_or_else(|| RuntimeError::new("TCP stream not found"))?;
+            let bytes = if method == "write" {
+                args.last()
+                    .and_then(Self::extract_bytes)
+                    .unwrap_or_else(|| {
+                        args.last()
+                            .map(Value::to_string_value)
+                            .unwrap_or_default()
+                            .into_bytes()
+                    })
+            } else {
+                let text = args
+                    .last()
+                    .map(|v| self.render_str_value(v))
+                    .unwrap_or_default();
+                text.into_bytes()
+            };
+            if bytes.is_empty() {
+                return Ok(Self::async_socket_kept(Value::Bool(true)));
+            }
+            let mut stream = stream_arc
+                .lock()
+                .map_err(|_| RuntimeError::new("Failed to lock TCP stream"))?;
+            use std::io::Write;
+            stream
+                .write_all(&bytes)
+                .map_err(|e| RuntimeError::new(format!("write failed: {}", e)))?;
+            stream
+                .flush()
+                .map_err(|e| RuntimeError::new(format!("flush failed: {}", e)))?;
+            Ok(Self::async_socket_kept(Value::Bool(true)))
+        })();
+        match result {
+            Ok(v) => promise.keep(v, String::new(), String::new()),
+            Err(e) => promise.keep(
+                Self::async_socket_broken(Value::str(e.message)),
+                String::new(),
+                String::new(),
+            ),
+        }
+        Ok(Value::Promise(promise))
+    }
+
+    fn async_socket_write_in_memory(
+        &mut self,
+        conn_id: Option<u64>,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let promise = SharedPromise::new();
+        let result = (|| -> Result<Value, RuntimeError> {
+            let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
+            let state = get_async_connection(id)
+                .ok_or_else(|| RuntimeError::new("Unknown async socket connection"))?;
+            if state.closed {
+                return Ok(Self::async_socket_broken(Value::str_from(
+                    "Socket is closed",
+                )));
+            }
+            let peer_id = state
+                .peer_id
+                .ok_or_else(|| RuntimeError::new("Peer missing"))?;
+            let peer = get_async_connection(peer_id)
+                .ok_or_else(|| RuntimeError::new("Unknown peer connection"))?;
+
+            let bytes = if method == "write" {
+                args.last()
+                    .and_then(Self::extract_bytes)
+                    .unwrap_or_else(|| {
+                        args.last()
+                            .map(Value::to_string_value)
+                            .unwrap_or_default()
+                            .into_bytes()
+                    })
+            } else {
+                let text = args
+                    .last()
+                    .map(|v| self.render_str_value(v))
+                    .unwrap_or_default();
+                self.encode_with_encoding(&text, &state.encoding)?
+            };
+            if bytes.is_empty() {
+                return Ok(Self::async_socket_kept(Value::Bool(true)));
+            }
+            if peer.closed {
+                return Ok(Self::async_socket_broken(Value::str_from(
+                    "Socket is closed",
+                )));
+            }
+
+            if peer.supply_ids.is_empty() {
+                update_async_connection(peer_id, |conn| {
+                    conn.pending_bytes.extend_from_slice(&bytes);
+                });
+                return Ok(Self::async_socket_kept(Value::Bool(true)));
+            }
+
+            self.deliver_bytes_to_peer_supplies(&peer.supply_ids, &bytes);
+            Ok(Self::async_socket_kept(Value::Bool(true)))
+        })();
+
+        match result {
+            Ok(v) => promise.keep(v, String::new(), String::new()),
+            Err(e) => promise.keep(
+                Self::async_socket_broken(Value::str(e.message)),
+                String::new(),
+                String::new(),
+            ),
+        }
+        Ok(Value::Promise(promise))
+    }
+
+    fn deliver_bytes_to_peer_supplies(&mut self, supply_ids: &[u64], bytes: &[u8]) {
+        for sid in supply_ids {
+            if let Some(supply) = get_async_supply(*sid) {
+                if supply.is_bin {
+                    let mut battrs = HashMap::new();
+                    battrs.insert(
+                        "bytes".to_string(),
+                        Value::array(bytes.iter().map(|b| Value::Int(*b as i64)).collect()),
+                    );
+                    let buf = Value::make_instance(Symbol::intern("Buf"), battrs);
+                    let _ = self.async_supplier_emit_value(*sid, buf);
+                } else {
+                    let mut pending = supply.byte_buffer.clone();
+                    pending.extend_from_slice(bytes);
+                    let (decoded, remainder) = if supply.encoding.eq_ignore_ascii_case("utf-8") {
+                        match std::str::from_utf8(&pending) {
+                            Ok(s) => (s.to_string(), Vec::new()),
+                            Err(e) => {
+                                if e.error_len().is_none() {
+                                    let valid = &pending[..e.valid_up_to()];
+                                    let valid_decoded =
+                                        std::str::from_utf8(valid).unwrap_or("").to_string();
+                                    (valid_decoded, pending[e.valid_up_to()..].to_vec())
+                                } else {
+                                    self.async_supplier_quit_value(
+                                        *sid,
+                                        Value::str_from("Malformed UTF-8 on socket Supply"),
+                                    );
+                                    continue;
+                                }
+                            }
+                        }
+                    } else if supply.encoding.eq_ignore_ascii_case("latin-1")
+                        || supply.encoding.eq_ignore_ascii_case("iso-8859-1")
+                    {
+                        (
+                            pending
+                                .iter()
+                                .map(|b| char::from_u32(*b as u32).unwrap_or('\u{FFFD}'))
+                                .collect(),
+                            Vec::new(),
+                        )
+                    } else {
+                        match self.decode_with_encoding(&pending, &supply.encoding) {
+                            Ok(s) => (s, Vec::new()),
+                            Err(e) => {
+                                self.async_supplier_quit_value(*sid, Value::str(e.message));
+                                continue;
+                            }
+                        }
+                    };
+                    let mut merged = supply.text_buffer.clone();
+                    merged.push_str(&decoded);
+                    let mut start = 0usize;
+                    for (idx, ch) in merged.char_indices() {
+                        if ch == '\n' {
+                            let chunk = merged[start..=idx].to_string();
+                            let _ = self.async_supplier_emit_value(*sid, Value::str(chunk));
+                            start = idx + ch.len_utf8();
+                        }
+                    }
+                    let tail = merged[start..].to_string();
+                    update_async_supply(*sid, |st| {
+                        st.text_buffer = tail;
+                        st.byte_buffer = remainder;
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -1,4 +1,5 @@
 use crate::runtime::*;
+use std::net::TcpStream;
 use std::process::ChildStdin;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -408,6 +409,7 @@ pub(in crate::runtime) fn lookup_async_listener(
     None
 }
 
+#[allow(dead_code)]
 pub(in crate::runtime) fn async_port_in_use(host: &str, port: u16) -> bool {
     if let Ok(map) = async_socket_listener_map().lock() {
         return map.values().any(|listener| {
@@ -586,4 +588,54 @@ pub(in crate::runtime) fn lookup_udp_bound_socket(
         }
     }
     None
+}
+
+/// Global map of conn-id -> TcpStream for real async TCP connections
+type TcpStreamMap = std::sync::Mutex<HashMap<u64, Arc<std::sync::Mutex<TcpStream>>>>;
+
+fn tcp_stream_map() -> &'static TcpStreamMap {
+    static MAP: OnceLock<TcpStreamMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+pub(in crate::runtime) fn register_tcp_stream(conn_id: u64, stream: TcpStream) {
+    if let Ok(mut map) = tcp_stream_map().lock() {
+        map.insert(conn_id, Arc::new(std::sync::Mutex::new(stream)));
+    }
+}
+
+pub(in crate::runtime) fn get_tcp_stream(conn_id: u64) -> Option<Arc<std::sync::Mutex<TcpStream>>> {
+    tcp_stream_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&conn_id).cloned())
+}
+
+pub(in crate::runtime) fn remove_tcp_stream(conn_id: u64) {
+    if let Ok(mut map) = tcp_stream_map().lock() {
+        map.remove(&conn_id);
+    }
+}
+
+/// Map of listener_id -> Arc<AtomicBool> for signaling listener threads to stop
+type ListenerClosedMap = std::sync::Mutex<HashMap<u64, Arc<AtomicBool>>>;
+
+fn listener_closed_map() -> &'static ListenerClosedMap {
+    static MAP: OnceLock<ListenerClosedMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+pub(in crate::runtime) fn register_listener_closed_flag(listener_id: u64, flag: Arc<AtomicBool>) {
+    if let Ok(mut map) = listener_closed_map().lock() {
+        map.insert(listener_id, flag);
+    }
+}
+
+#[allow(dead_code)]
+pub(in crate::runtime) fn set_listener_closed(listener_id: u64) {
+    if let Ok(map) = listener_closed_map().lock()
+        && let Some(flag) = map.get(&listener_id)
+    {
+        flag.store(true, Ordering::SeqCst);
+    }
 }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -158,6 +158,13 @@ impl Interpreter {
 
     /// Run the react event loop: poll all registered subscriptions
     /// until all are done.
+    /// Drain any queued react subscriptions without running the event loop.
+    /// Used when `done;` was called in the react body and we just need to
+    /// clean up without processing events.
+    pub(crate) fn run_react_event_loop_drain(&mut self) {
+        let _ = self.supply_emit_buffer.pop();
+    }
+
     pub(crate) fn run_react_event_loop(&mut self) -> Result<(), RuntimeError> {
         // Take the subscriptions collected during the react body
         let subscriptions = self.supply_emit_buffer.pop().unwrap_or_default();

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1436,8 +1436,16 @@ impl VM {
         let run_result = self.run_range(code, body_start, end, compiled_fns);
         self.stack.truncate(saved_depth);
 
-        // Run the react event loop (processes all registered subscriptions)
-        let event_result = self.interpreter.run_react_event_loop();
+        // If `done;` was called in the react body, skip the event loop —
+        // the body already signaled that no further events should be processed.
+        let body_done = matches!(&run_result, Err(e) if e.is_react_done);
+        let event_result = if body_done {
+            // Drain any queued subscriptions so they don't leak
+            self.interpreter.run_react_event_loop_drain();
+            Ok(())
+        } else {
+            self.interpreter.run_react_event_loop()
+        };
         self.sync_locals_from_env(code);
         self.env_dirty = true;
 

--- a/t/io-socket-async-listen.t
+++ b/t/io-socket-async-listen.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 4;
+
+# Test 1: Basic listen + accept + print + close via real TCP
+{
+    my $port = 19990;
+    my $done = False;
+    my $response = '';
+
+    # Start server in a thread via start {}
+    my $server-promise = start {
+        react {
+            whenever IO::Socket::Async.listen("127.0.0.1", $port) -> $conn {
+                $conn.print("HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\nHello\r\n");
+                $conn.close;
+                $done = True;
+                done;
+            }
+        }
+    };
+
+    # Give the server time to bind
+    sleep 0.5;
+
+    # Connect as a client using IO::Socket::INET
+    my $client = IO::Socket::INET.new(host => '127.0.0.1', port => $port);
+    $response = $client.recv;
+    $client.close;
+
+    ok $response.contains("Hello"), "Server sent response containing 'Hello'";
+    ok $response.contains("200 OK"), "Server sent HTTP 200 OK status";
+}
+
+# Test 2: Multiple connections
+{
+    my $port = 19991;
+    my $count = 0;
+
+    my $server-promise = start {
+        react {
+            whenever IO::Socket::Async.listen("127.0.0.1", $port) -> $conn {
+                $count++;
+                $conn.print("response $count\r\n");
+                $conn.close;
+                if $count >= 2 {
+                    done;
+                }
+            }
+        }
+    };
+
+    sleep 0.5;
+
+    my $r1 = IO::Socket::INET.new(host => '127.0.0.1', port => $port);
+    my $resp1 = $r1.recv;
+    $r1.close;
+
+    my $r2 = IO::Socket::INET.new(host => '127.0.0.1', port => $port);
+    my $resp2 = $r2.recv;
+    $r2.close;
+
+    ok $resp1.contains("response"), "First connection received response";
+    ok $resp2.contains("response"), "Second connection received response";
+}


### PR DESCRIPTION
## Summary
- `IO::Socket::Async.listen` now binds a real `TcpListener` and accepts connections in a background thread
- Each accepted connection supports `.print`, `.write`, `.close`, `.Supply` methods
- Connections dispatched through supply channels for `react { whenever ... }`
- Unblocks HTTP::Server::Tiny (server starts and accepts connections, though handler processing needs further work)

## Test plan
- [x] New test `t/io-socket-async-listen.t` (4 tests)
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)