### PR TITLE
fix: grammar tokens override builtin char class names in subrule resolution

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2712,73 +2712,102 @@ impl Interpreter {
                                         } else {
                                             (trimmed, false)
                                         };
-                                    // Check for named character classes
-                                    match class_name {
-                                        "alpha" | "upper" | "lower" | "digit" | "xdigit"
-                                        | "space" | "alnum" | "blank" | "cntrl" | "punct"
-                                        | "graph" | "print" => {
-                                            // Set builtin named capture so $<alpha>, $<digit>, etc. work
-                                            // (only for non-dot calls)
-                                            if !is_dot_call {
-                                                pending_builtin_named_capture =
-                                                    Some(class_name.to_string());
+                                    // If this name matches a builtin char class but
+                                    // the current grammar defines a token with the
+                                    // same name, the grammar token takes precedence.
+                                    let is_builtin_name = matches!(
+                                        class_name,
+                                        "alpha"
+                                            | "upper"
+                                            | "lower"
+                                            | "digit"
+                                            | "xdigit"
+                                            | "space"
+                                            | "alnum"
+                                            | "blank"
+                                            | "cntrl"
+                                            | "punct"
+                                            | "graph"
+                                            | "print"
+                                            | "ident"
+                                    );
+                                    let grammar_overrides_builtin = is_builtin_name
+                                        && !self.current_package.is_empty()
+                                        && self.resolve_token_defs(class_name).is_some();
+                                    if grammar_overrides_builtin {
+                                        RegexAtom::Named(name)
+                                    } else {
+                                        // Check for named character classes
+                                        match class_name {
+                                            "alpha" | "upper" | "lower" | "digit" | "xdigit"
+                                            | "space" | "alnum" | "blank" | "cntrl" | "punct"
+                                            | "graph" | "print" => {
+                                                // Set builtin named capture so $<alpha>, $<digit>, etc. work
+                                                // (only for non-dot calls)
+                                                if !is_dot_call {
+                                                    pending_builtin_named_capture =
+                                                        Some(class_name.to_string());
+                                                }
+                                                RegexAtom::CharClass(CharClass {
+                                                    items: vec![ClassItem::NamedBuiltin(
+                                                        class_name.to_string(),
+                                                    )],
+                                                    negated: false,
+                                                })
                                             }
-                                            RegexAtom::CharClass(CharClass {
-                                                items: vec![ClassItem::NamedBuiltin(
-                                                    class_name.to_string(),
-                                                )],
-                                                negated: false,
-                                            })
-                                        }
-                                        "ident" => {
-                                            // <ident> = <alpha> <alnum>*
-                                            if !is_dot_call {
-                                                pending_builtin_named_capture =
-                                                    Some("ident".to_string());
+                                            "ident" => {
+                                                // <ident> = <alpha> <alnum>*
+                                                if !is_dot_call {
+                                                    pending_builtin_named_capture =
+                                                        Some("ident".to_string());
+                                                }
+                                                RegexAtom::Group(RegexPattern {
+                                                    tokens: vec![
+                                                        RegexToken {
+                                                            atom: RegexAtom::CharClass(CharClass {
+                                                                items: vec![
+                                                                    ClassItem::NamedBuiltin(
+                                                                        "alpha".to_string(),
+                                                                    ),
+                                                                ],
+                                                                negated: false,
+                                                            }),
+                                                            quant: RegexQuant::One,
+                                                            named_capture: None,
+                                                            hash_capture: None,
+                                                            secondary_named_capture: None,
+                                                            ratchet: false,
+                                                            frugal: false,
+                                                        },
+                                                        RegexToken {
+                                                            atom: RegexAtom::CharClass(CharClass {
+                                                                items: vec![
+                                                                    ClassItem::NamedBuiltin(
+                                                                        "alnum".to_string(),
+                                                                    ),
+                                                                ],
+                                                                negated: false,
+                                                            }),
+                                                            quant: RegexQuant::ZeroOrMore,
+                                                            named_capture: None,
+                                                            hash_capture: None,
+                                                            secondary_named_capture: None,
+                                                            ratchet: false,
+                                                            frugal: false,
+                                                        },
+                                                    ],
+                                                    anchor_start: false,
+                                                    anchor_end: false,
+                                                    ignore_case,
+                                                    ignore_mark,
+                                                })
                                             }
-                                            RegexAtom::Group(RegexPattern {
-                                                tokens: vec![
-                                                    RegexToken {
-                                                        atom: RegexAtom::CharClass(CharClass {
-                                                            items: vec![ClassItem::NamedBuiltin(
-                                                                "alpha".to_string(),
-                                                            )],
-                                                            negated: false,
-                                                        }),
-                                                        quant: RegexQuant::One,
-                                                        named_capture: None,
-                                                        hash_capture: None,
-                                                        secondary_named_capture: None,
-                                                        ratchet: false,
-                                                        frugal: false,
-                                                    },
-                                                    RegexToken {
-                                                        atom: RegexAtom::CharClass(CharClass {
-                                                            items: vec![ClassItem::NamedBuiltin(
-                                                                "alnum".to_string(),
-                                                            )],
-                                                            negated: false,
-                                                        }),
-                                                        quant: RegexQuant::ZeroOrMore,
-                                                        named_capture: None,
-                                                        hash_capture: None,
-                                                        secondary_named_capture: None,
-                                                        ratchet: false,
-                                                        frugal: false,
-                                                    },
-                                                ],
-                                                anchor_start: false,
-                                                anchor_end: false,
-                                                ignore_case,
-                                                ignore_mark,
-                                            })
-                                        }
-                                        _ => {
-                                            // <sym> / <.sym> can only be used in a proto regex
-                                            // with :sym<> adverb — it should have been replaced
-                                            // by instantiate_token_pattern before reaching here
-                                            if class_name == "sym" {
-                                                PENDING_REGEX_ERROR.with(|e| {
+                                            _ => {
+                                                // <sym> / <.sym> can only be used in a proto regex
+                                                // with :sym<> adverb — it should have been replaced
+                                                // by instantiate_token_pattern before reaching here
+                                                if class_name == "sym" {
+                                                    PENDING_REGEX_ERROR.with(|e| {
                                                     let msg = "Can only use \"<sym>\" token in a proto regex";
                                                     let mut err = RuntimeError::new(msg);
                                                     let mut attrs = std::collections::HashMap::new();
@@ -2787,19 +2816,20 @@ impl Interpreter {
                                                     err.exception = Some(Box::new(ex));
                                                     *e.borrow_mut() = Some(err);
                                                 });
-                                                return None;
+                                                    return None;
+                                                }
+                                                // Check for longname aliases
+                                                if trimmed.contains("::") && trimmed.contains('=') {
+                                                    PENDING_REGEX_ERROR.with(|e| {
+                                                        *e.borrow_mut() =
+                                                            Some(Self::make_longname_alias_error());
+                                                    });
+                                                    return None;
+                                                }
+                                                RegexAtom::Named(name)
                                             }
-                                            // Check for longname aliases
-                                            if trimmed.contains("::") && trimmed.contains('=') {
-                                                PENDING_REGEX_ERROR.with(|e| {
-                                                    *e.borrow_mut() =
-                                                        Some(Self::make_longname_alias_error());
-                                                });
-                                                return None;
-                                            }
-                                            RegexAtom::Named(name)
                                         }
-                                    }
+                                    } // close else of grammar_overrides_builtin
                                 }
                             } // close word-alternation else
                         } // close else for code assertion special case

--- a/t/grammar-builtin-override.t
+++ b/t/grammar-builtin-override.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 6;
+
+# Grammar tokens with names that shadow built-in character classes
+# should take precedence over the built-in when used as subrules.
+
+# Test: grammar defines its own "ident" token (shadows builtin <ident>)
+grammar G {
+    token ident { <+ graph - punct> <+ graph - [\<\>\{\}\[\]&=%$]>* }
+    token name { <ident> }
+}
+
+# Direct call should work
+my $r1 = G.parse("bar-x", :rule<ident>);
+ok $r1.defined, "direct call to custom ident matches";
+is ~$r1, "bar-x", "direct ident matches full 'bar-x'";
+
+# As subrule should also work (grammar's ident, not builtin)
+my $r2 = G.subparse("bar-x", :rule<name>);
+ok $r2.defined, "subrule call to custom ident matches";
+is ~$r2, "bar-x", "subrule ident matches full 'bar-x'";
+
+# Verify the built-in ident still works in non-grammar context
+ok "foo123" ~~ /<ident>/, "builtin <ident> still works outside grammar";
+is $/.Str, "foo123", "builtin <ident> matches correctly";


### PR DESCRIPTION
## Summary
- When a grammar defines a token with the same name as a builtin character class (e.g., `ident`, `alpha`, `digit`), the grammar's token now correctly takes precedence when referenced as a subrule inside another token.
- Previously, `<ident>` inside a grammar token was always resolved as the builtin `<alpha> <alnum>*` pattern, even if the grammar defined its own `ident` token with different rules.
- Added test `t/grammar-builtin-override.t` covering direct calls, subrule calls, and non-grammar builtin usage.

## Test plan
- [x] `prove -e 'target/release/mutsu' t/grammar-builtin-override.t` passes
- [x] All grammar roast tests pass (`prove -e 'target/release/mutsu' roast/S05-grammar/*.t`)
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)
- [x] Builtin `<ident>` still works correctly outside grammar context

🤖 Generated with [Claude Code](https://claude.com/claude-code)