### PR TITLE
fix: use typed exceptions for X::Assignment::RO and X::TypeCheck::Binding::Parameter

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -269,32 +269,36 @@ impl Interpreter {
                 // Immutable types (Bool, Int, Str, etc.) must die.
                 let val = args.first().cloned().unwrap_or(Value::Nil);
                 match &val {
-                    Value::Bool(b) => Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable Bool ({b})"
-                    ))),
-                    Value::Int(i) => Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable Int ({i})"
-                    ))),
-                    Value::Num(n) => Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable Num ({n})"
-                    ))),
-                    Value::Str(s) => Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable Str ({s})"
-                    ))),
-                    Value::Rat(n, d) => Err(RuntimeError::new(format!(
-                        "Cannot modify an immutable Rat ({n}/{d})"
-                    ))),
+                    Value::Bool(b) => Err(RuntimeError::assignment_ro_typename(
+                        "Bool",
+                        &format!("{b}"),
+                    )),
+                    Value::Int(i) => {
+                        Err(RuntimeError::assignment_ro_typename("Int", &format!("{i}")))
+                    }
+                    Value::Num(n) => {
+                        Err(RuntimeError::assignment_ro_typename("Num", &format!("{n}")))
+                    }
+                    Value::Str(s) => {
+                        Err(RuntimeError::assignment_ro_typename("Str", &format!("{s}")))
+                    }
+                    Value::Rat(n, d) => Err(RuntimeError::assignment_ro_typename(
+                        "Rat",
+                        &format!("{n}/{d}"),
+                    )),
                     Value::Sub(sub_def) => {
                         let sub_name = sub_def.name.resolve();
-                        Err(RuntimeError::new(format!(
-                            "Cannot modify an immutable Sub (&{sub_name})"
-                        )))
+                        Err(RuntimeError::assignment_ro_typename(
+                            "Sub",
+                            &format!("&{sub_name}"),
+                        ))
                     }
                     Value::Routine { name, .. } => {
                         let sub_name = name.resolve();
-                        Err(RuntimeError::new(format!(
-                            "Cannot modify an immutable Sub (&{sub_name})"
-                        )))
+                        Err(RuntimeError::assignment_ro_typename(
+                            "Sub",
+                            &format!("&{sub_name}"),
+                        ))
                     }
                     Value::Nil | Value::Array(..) | Value::Hash(..) => Ok(Value::Nil),
                     _ => Ok(Value::Nil),

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -156,7 +156,7 @@ pub(super) fn multidim_assign_pos(
     assert!(!indices.is_empty());
     // Unwrap any outer Scalar wrapper.
     if let Value::Scalar(_) = target {
-        return Err(RuntimeError::new("Cannot modify an immutable value"));
+        return Err(RuntimeError::assignment_ro(None));
     }
     let Value::Array(items, arr_kind) = target else {
         return Err(RuntimeError::new(
@@ -170,7 +170,7 @@ pub(super) fn multidim_assign_pos(
     if indices.len() == 1 {
         // Check for bound slot (Scalar wrapper)
         if let Some(Value::Scalar(_)) = updated.get(i) {
-            return Err(RuntimeError::new("Cannot modify an immutable value"));
+            return Err(RuntimeError::assignment_ro(None));
         }
         if i >= updated.len() {
             updated.resize(i + 1, Value::Package(Symbol::intern("Any")));
@@ -1996,7 +1996,7 @@ impl Interpreter {
                     }
                     let mut updated = items.to_vec();
                     if index < updated.len() && matches!(updated[index], Value::Scalar(_)) {
-                        return Err(RuntimeError::new("Cannot modify an immutable value"));
+                        return Err(RuntimeError::assignment_ro(None));
                     }
                     if index >= updated.len() {
                         updated.resize(index + 1, Value::Package(Symbol::intern("Any")));

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -3330,11 +3330,10 @@ impl Interpreter {
                     };
                     if is_public_accessor {
                         let current = attributes.get(method).cloned().unwrap_or(Value::Nil);
-                        return Err(RuntimeError::new(format!(
-                            "Cannot modify an immutable {} ({})",
+                        return Err(RuntimeError::assignment_ro_typename(
                             super::utils::value_type_name(&current),
-                            current.to_string_value()
-                        )));
+                            &current.to_string_value(),
+                        ));
                     }
                 }
             }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -312,12 +312,12 @@ impl VM {
                                     pd.is_invocant,
                                 ));
                             }
-                            return Err(RuntimeError::new(format!(
-                                "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected {}, got {}",
+                            return Err(RuntimeError::typecheck_binding_parameter(
                                 param_name,
                                 constraint,
-                                crate::runtime::value_type_name(&base)
-                            )));
+                                crate::runtime::value_type_name(&base),
+                                None,
+                            ));
                         }
                     }
                 }
@@ -777,7 +777,7 @@ impl VM {
             }
             if arg_idx < args.len() {
                 let val = args[arg_idx].clone();
-                if let Some(ref constraint) = pd.and_then(|pd| pd.type_constraint.as_ref())
+                if let Some(constraint) = pd.and_then(|pd| pd.type_constraint.as_ref())
                     && !self.interpreter.type_matches_value(constraint, &val)
                 {
                     // Type mismatch — fall back to slow path for proper error
@@ -787,12 +787,12 @@ impl VM {
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
                     self.interpreter.set_env(frame.saved_env);
-                    return Err(RuntimeError::new(format!(
-                        "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '{}'; expected {}, got {}",
+                    return Err(RuntimeError::typecheck_binding_parameter(
                         param_name,
                         constraint,
-                        crate::runtime::value_type_name(&val)
-                    )));
+                        crate::runtime::value_type_name(&val),
+                        None,
+                    ));
                 }
                 param_values.push((param_name, val));
                 arg_idx += 1;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1912,9 +1912,7 @@ impl VM {
                         .collect(),
                 ));
             } else {
-                return Err(RuntimeError::new(
-                    "Cannot modify an immutable Map (Map)".to_string(),
-                ));
+                return Err(RuntimeError::assignment_ro_typename("Map", "Map"));
             }
         }
         // Mix/Set/Bag: prevent auto-vivification of undefined typed variables.
@@ -3840,11 +3838,10 @@ impl VM {
                     Value::Bag(..) => "Bag",
                     _ => unreachable!(),
                 };
-                return Err(RuntimeError::new(format!(
-                    "Cannot modify an immutable {} ({})",
+                return Err(RuntimeError::assignment_ro_typename(
                     type_name,
-                    self.locals[idx].to_string_value()
-                )));
+                    &self.locals[idx].to_string_value(),
+                ));
             }
             if is_bind {
                 // `:=` binding preserves containers — skip coercion.

--- a/t/exception-types.t
+++ b/t/exception-types.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 10;
+
+# X::TypeCheck::Binding::Parameter - exact type match
+throws-like { my &f = sub (Int $x) {}; f("hello") },
+    X::TypeCheck::Binding::Parameter,
+    "binding parameter type check - exact match";
+
+# X::TypeCheck::Binding - parent type matches child exception
+throws-like { my &f = sub (Int $x) {}; f("hello") },
+    X::TypeCheck::Binding,
+    "binding type check - parent type matches";
+
+# X::TypeCheck::Binding::Parameter with attribute matchers
+throws-like { my &f = sub (Int $x) {}; f("hello") },
+    X::TypeCheck::Binding::Parameter,
+    expected => /Int/,
+    got => /Str/,
+    "binding parameter type check with attribute matchers";
+
+# X::Assignment::RO - readonly variable
+throws-like { my $x := 42; $x = 43 },
+    X::Assignment::RO,
+    "cannot assign to readonly bound variable";
+
+# X::Assignment::RO - readonly Set
+throws-like { my $s = set <a b c>; $s<d> = True },
+    X::Assignment::RO,
+    "cannot modify immutable Set";
+
+# X::Assignment::RO - readonly Bag
+throws-like { my $b = bag <a b c>; $b<d> = 1 },
+    X::Assignment::RO,
+    "cannot modify immutable Bag";
+
+# X::Assignment::RO - readonly Mix
+throws-like { my $m = mix <a b c>; $m<d> = 1.5 },
+    X::Assignment::RO,
+    "cannot modify immutable Mix";
+
+# X::TypeCheck - grandparent matches
+throws-like { my &f = sub (Int $x) {}; f("hello") },
+    X::TypeCheck,
+    "X::TypeCheck grandparent matches X::TypeCheck::Binding::Parameter";
+
+# X::Assignment::RO with message attribute
+throws-like { my $x := 42; $x = 43 },
+    X::Assignment::RO,
+    message => /Cannot/,
+    "X::Assignment::RO message attribute matches";
+
+# Exception - top-level parent matches any exception
+throws-like { my &f = sub (Int $x) {}; f("hello") },
+    Exception,
+    "Exception matches any typed exception";


### PR DESCRIPTION
## Summary
- Convert untyped `RuntimeError::new("Cannot modify an immutable ...")` calls to proper typed `RuntimeError::assignment_ro_typename()` across runtime/builtins.rs, runtime/methods.rs, runtime/methods_mut.rs, and vm/vm_var_assign_ops.rs
- Convert untyped `RuntimeError::new("X::TypeCheck::Binding::Parameter: ...")` in vm/vm_method_dispatch.rs to proper `RuntimeError::typecheck_binding_parameter()` typed exceptions
- Fix clippy warnings (unnecessary references) in the changed code paths
- Add `t/exception-types.t` with 10 tests covering `throws-like` with X::TypeCheck::Binding::Parameter, X::TypeCheck::Binding (parent type matching), X::Assignment::RO, and attribute matchers

## Test plan
- [x] `t/exception-types.t` passes all 10 tests
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)