### PR TITLE
fix: skip too-many-positionals check in .assuming on multi-dispatch wrapper Subs

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -431,6 +431,7 @@ roast/S06-advanced/dispatching.t
 roast/S06-advanced/recurse.t
 roast/S06-advanced/return.t
 roast/S06-advanced/stub.t
+roast/S06-currying/assuming-and-mmd.t
 roast/S06-currying/misc.t
 roast/S06-currying/named.t
 roast/S06-currying/positional.t

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -457,6 +457,11 @@ impl Interpreter {
                     }
                 }
                 // Check too many positionals (skip if there's a slurpy or capture param)
+                // Also skip for multi-dispatch wrapper Subs where actual arity
+                // depends on which candidate is selected at call time.
+                let is_multi_dispatch = next.env.contains_key("__mutsu_multi_dispatch_name")
+                    || next.env.contains_key("__mutsu_multi_dispatch_candidates")
+                    || next.env.contains_key("__mutsu_routine_name");
                 let has_slurpy = next.param_defs.iter().any(|pd| {
                     pd.slurpy
                         || pd.double_slurpy
@@ -474,7 +479,10 @@ impl Interpreter {
                     .iter()
                     .filter(|v| !is_placeholder(v))
                     .count();
-                if !has_slurpy && non_placeholder_count > positional_param_count {
+                if !is_multi_dispatch
+                    && !has_slurpy
+                    && non_placeholder_count > positional_param_count
+                {
                     let mut ex_attrs = std::collections::HashMap::new();
                     ex_attrs.insert(
                         "payload".to_string(),


### PR DESCRIPTION
## Summary
- Fixed `.assuming()` on multi-dispatch wrapper Subs incorrectly returning a Failure mixin for "Too many positionals passed" when the wrapper Sub has empty `param_defs`
- The actual arity of a multi-dispatch wrapper depends on which candidate is selected at call time, so the too-many-positionals check must be skipped
- Added `roast/S06-currying/assuming-and-mmd.t` to the whitelist (all 11 tests now pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S06-currying/assuming-and-mmd.t` passes all 11 tests
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass
- [ ] CI (`make test` + `make roast`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)