### PR TITLE
fix: role mixin attribute defaults and trait_mod does writeback

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -909,6 +909,11 @@ pub struct Interpreter {
     /// throwing X::Coerce::Impossible. Set during the RHS evaluation of `does`
     /// so that `$x does Role("arg")` works as a role application.
     pub(crate) in_does_rhs: bool,
+    /// When set, `does` on a routine parameter inside trait_mod:<is> will
+    /// store the resulting Mixin value for writeback to the outer scope.
+    pub(crate) trait_mod_writeback_key: Option<String>,
+    /// The captured Mixin value from a trait_mod `does` writeback.
+    pub(crate) trait_mod_writeback_value: Option<Value>,
     /// When true, hash indexing with a missing key autovivifies (creates an
     /// empty Hash entry and returns it).  Set during reduce with `is raw`
     /// callbacks so that container semantics are preserved.
@@ -2971,6 +2976,8 @@ impl Interpreter {
             suppress_exports: false,
             in_lvalue_assignment: false,
             in_does_rhs: false,
+            trait_mod_writeback_key: None,
+            trait_mod_writeback_value: None,
             hash_autovivify: false,
             newline_mode: NewlineMode::Lf,
             import_scope_stack: Vec::new(),
@@ -4860,6 +4867,8 @@ impl Interpreter {
             suppress_exports: false,
             in_lvalue_assignment: false,
             in_does_rhs: false,
+            trait_mod_writeback_key: None,
+            trait_mod_writeback_value: None,
             hash_autovivify: false,
             newline_mode: self.newline_mode,
             import_scope_stack: Vec::new(),

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -440,6 +440,9 @@ impl Interpreter {
                 // pass the type object as a positional argument.
                 let type_obj = self.resolve_type_object(trait_name);
                 let mut args = vec![sub_val];
+                // Set up writeback so `$r does Role` inside trait_mod propagates
+                // the Mixin back to `&name` in the outer scope.
+                self.trait_mod_writeback_key = Some(format!("&{}", name));
                 let call_result = if let Some(type_val) = type_obj {
                     args.push(type_val);
                     if let Some(arg_val) = trait_arg_val {
@@ -455,10 +458,18 @@ impl Interpreter {
                     args.push(named_val);
                     self.call_function("trait_mod:<is>", args)
                 };
-                if let Ok(result) = call_result
+                self.trait_mod_writeback_key = None;
+                // Check if the trait_mod returned a Mixin or if the
+                // trait_mod modified the routine parameter via `$r does Role`.
+                // The writeback mechanism captures the Mixin from DoesVar
+                // inside the trait_mod and propagates it back to &name.
+                let code_var_key = format!("&{}", name);
+                if let Ok(ref result) = call_result
                     && matches!(result, Value::Mixin(..))
                 {
-                    self.env.insert(format!("&{}", name), result);
+                    self.env.insert(code_var_key, result.clone());
+                } else if let Some(mixin_val) = self.trait_mod_writeback_value.take() {
+                    self.env.insert(code_var_key, mixin_val);
                 }
             }
         }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -316,7 +316,7 @@ impl Interpreter {
             } else {
                 None
             };
-            for (idx, (attr_name, _is_public, default_expr, _, _, _, _)) in
+            for (idx, (attr_name, _is_public, default_expr, _, _, sigil, _)) in
                 role.attributes.iter().enumerate()
             {
                 let value = if let Some(arg) = role_args.get(idx) {
@@ -324,7 +324,12 @@ impl Interpreter {
                 } else if let Some(default_expr) = default_expr {
                     self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?
                 } else {
-                    Value::Nil
+                    // Default value based on sigil: @ -> [], % -> {}, $ -> Nil
+                    match sigil {
+                        '@' => Value::real_array(Vec::new()),
+                        '%' => Value::Hash(std::sync::Arc::new(HashMap::new())),
+                        _ => Value::Nil,
+                    }
                 };
                 mixins.insert(format!("__mutsu_attr__{}", attr_name), value);
             }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -1088,6 +1088,11 @@ impl VM {
         let result = self.vm_does_values(left, right)?;
         // Sync back: BUILD submethods may have modified closure variables.
         self.sync_locals_from_env(code);
+        // Capture Mixin value for trait_mod writeback (same as DoesVar path)
+        if matches!(&result, Value::Mixin(..)) && self.interpreter.trait_mod_writeback_key.is_some()
+        {
+            self.interpreter.trait_mod_writeback_value = Some(result.clone());
+        }
         self.stack.push(result);
         Ok(())
     }
@@ -1110,6 +1115,14 @@ impl VM {
             .env_mut()
             .insert(name.clone(), updated.clone());
         self.update_local_if_exists(code, &name, &updated);
+        // Capture Mixin value for trait_mod writeback: when `$r does Role`
+        // runs inside a trait_mod:<is>, the Mixin needs to propagate back
+        // to the outer scope's `&name` variable.
+        if matches!(&updated, Value::Mixin(..))
+            && self.interpreter.trait_mod_writeback_key.is_some()
+        {
+            self.interpreter.trait_mod_writeback_value = Some(updated.clone());
+        }
         self.stack.push(updated);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Initialize mixin attributes with sigil-appropriate defaults when composing roles via `does`: `@`-sigil attributes get `[]`, `%`-sigil get `{}` (instead of `Nil` for all)
- Add writeback mechanism so `$r does Role` inside `trait_mod:<is>` propagates the Mixin back to `&name` in the outer scope
- Improves `roast/S14-traits/routines.t` from 15/17 passing (test 16 still needs mixin attribute container mutation semantics)

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings` pass
- [x] `make test` shows no new regressions (t/wrap.t failure is pre-existing on main)
- [x] `roast/S14-traits/routines.t` passes 15/17 tests (test 10 is TODO, test 16 needs deeper mixin mutation support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)