### PR TITLE
fix: expand range indices in hash slice assignment

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -794,6 +794,7 @@ roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
 roast/S17-lowlevel/cas.t
 roast/S17-lowlevel/thread-start-join-stress.t
+roast/S17-lowlevel/thread.t
 roast/S17-procasync/basic.t
 roast/S17-procasync/bind-handles.t
 roast/S17-procasync/kill.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1594,6 +1594,10 @@ impl VM {
             Value::Array(..)
                 | Value::Junction { .. }
                 | Value::GenericRange { .. }
+                | Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
                 | Value::Nil
                 | Value::Seq(..)
                 | Value::Slip(..)
@@ -1859,10 +1863,29 @@ impl VM {
         let idx = self.stack.pop().unwrap_or(Value::Nil);
         let index_target = self.interpreter.env().get(&var_name).cloned();
         let idx = self.resolve_whatever_index_for_target(idx, index_target.as_ref());
-        // Normalize Seq/Slip index to Array for uniform handling in assignment
+        // Normalize Seq/Slip/Range index to Array for uniform handling in assignment.
+        // For hash variables, expand Range indices into individual keys so that
+        // `%h{^5} = (0 xx 5)` performs a hash slice assignment (5 separate keys)
+        // instead of treating the stringified range as a single key.
         let idx = match idx {
             Value::Seq(items) => Value::Array(items, crate::value::ArrayKind::List),
             Value::Slip(items) => Value::Array(items, crate::value::ArrayKind::List),
+            Value::Range(a, b) if var_name.starts_with('%') => {
+                let items: Vec<Value> = (a..=b).map(Value::Int).collect();
+                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+            }
+            Value::RangeExcl(a, b) if var_name.starts_with('%') => {
+                let items: Vec<Value> = (a..b).map(Value::Int).collect();
+                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+            }
+            Value::RangeExclStart(a, b) if var_name.starts_with('%') => {
+                let items: Vec<Value> = ((a + 1)..=b).map(Value::Int).collect();
+                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+            }
+            Value::RangeExclBoth(a, b) if var_name.starts_with('%') => {
+                let items: Vec<Value> = ((a + 1)..b).map(Value::Int).collect();
+                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+            }
             other => other,
         };
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);

--- a/t/hash-range-slice-assign.t
+++ b/t/hash-range-slice-assign.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 8;
+
+# Hash slice assignment with range index
+{
+    my %h;
+    %h{^3} = (0 xx 3);
+    is %h.elems, 3, '%h{^3} creates 3 entries';
+    is %h{"0"}, 0, 'key "0" has value 0';
+    is %h{"1"}, 0, 'key "1" has value 0';
+    is %h{"2"}, 0, 'key "2" has value 0';
+}
+
+# Hash slice assignment with inclusive range
+{
+    my %h;
+    %h{1..3} = (10, 20, 30);
+    is %h.elems, 3, '%h{1..3} creates 3 entries';
+    is %h{"1"}, 10, 'key "1" has value 10';
+    is %h{"2"}, 20, 'key "2" has value 20';
+    is %h{"3"}, 30, 'key "3" has value 30';
+}


### PR DESCRIPTION
## Summary
- Fix hash slice assignment with range indices (e.g., `%h{^5} = (0 xx 5)`) which was treating the range as a single stringified key instead of expanding it into individual keys
- Add Range variants to the fast-path rejection list in `try_fast_hash_element_assign` so range indices properly fall through to slice assignment handling
- Expand Range values into Array values in the index normalization step when the target is a hash variable
- Add `roast/S17-lowlevel/thread.t` to the whitelist (all 29 subtests now pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-lowlevel/thread.t` passes all 29 subtests
- [x] New local test `t/hash-range-slice-assign.t` covers `%h{^N}` and `%h{1..N}` assignment patterns
- [x] `make test` passes (only pre-existing `t/wrap.t` failure)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)