### PR TITLE
fix: .emit method on values in supply blocks and tap arity checking

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -276,6 +276,21 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // .emit on any value: push to the supply emit buffer if inside a
+        // supply block, otherwise raise CX::Emit like the `emit` sub.
+        if method == "emit"
+            && args.is_empty()
+            && !matches!(
+                &target,
+                Value::Instance { class_name, .. } if class_name == "Supplier"
+            )
+        {
+            if let Some(buf) = self.supply_emit_buffer.last_mut() {
+                buf.push(target);
+                return Ok(Value::Nil);
+            }
+            return Err(RuntimeError::emit_signal(target));
+        }
         // Scalar containers are transparent for method dispatch (except .item and .VAR)
         if let Value::Scalar(inner) = target {
             if method == "VAR" {

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1211,6 +1211,11 @@ impl Interpreter {
                 let left_args = Self::composed_result_to_args(right_result, left_expects_single);
                 return self.call_sub_value(left, left_args, false);
             }
+            // Reject arguments for blocks with explicitly empty signatures
+            // (e.g. `-> { ... }` which takes 0 parameters).
+            if data.empty_sig && !call_args.is_empty() {
+                return Err(Self::reject_args_for_empty_sig(&call_args));
+            }
             let saved_env = self.env.clone();
             let saved_readonly = self.save_readonly_vars();
             if let Some(line) = self.test_pending_callsite_line {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -57,6 +57,24 @@ impl VM {
             err.return_value = Some(target);
             return Err(err);
         }
+        // .emit on any value: push to supply emit buffer if inside a supply
+        // block, otherwise raise CX::Emit. Skip for Supplier instances (they
+        // have their own emit method).
+        if method == "emit"
+            && args.is_empty()
+            && !matches!(
+                &target,
+                Value::Instance { class_name, .. } if class_name == "Supplier"
+            )
+        {
+            if let Some(buf) = self.interpreter.supply_emit_buffer.last_mut() {
+                buf.push(target);
+                self.stack.push(Value::Nil);
+                self.env_dirty = true;
+                return Ok(());
+            }
+            return Err(RuntimeError::emit_signal(target));
+        }
         // Fast path: 0-arg attribute accessor on Instance (e.g. $obj.x)
         if args.is_empty()
             && modifier_idx.is_none()

--- a/t/emit-method.t
+++ b/t/emit-method.t
@@ -1,0 +1,31 @@
+use Test;
+plan 5;
+
+# .emit as a method on values inside supply blocks
+{
+    my $s = supply { "foo".emit; 42 .emit; 0.5.emit };
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got[0], "foo", ".emit on Str works";
+    is @got[1], 42, ".emit on Int works";
+    is @got[2], 0.5, ".emit on Rat works";
+}
+
+# .emit with for loop (topic variable)
+{
+    my $s = supply { .emit for "a", "b", "c" };
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got.join(","), "a,b,c", ".emit in for loop works";
+}
+
+# .emit inside react/whenever/supply
+{
+    my @got;
+    react {
+        whenever supply { .emit for 1, 2, 3 } {
+            @got.push($_);
+        }
+    }
+    is @got.join(","), "1,2,3", ".emit in react/whenever/supply works";
+}


### PR DESCRIPTION
## Summary
- Implement `.emit` as a method on all values for supply blocks. Inside a supply context, `value.emit` pushes the invocant to the supply emit buffer (e.g., `"foo".emit` or `.emit for 1, 2, 3`). Outside supply context, raises CX::Emit.
- Add `empty_sig` arity check in `call_sub_value` so blocks with explicitly empty signatures (`-> { ... }`) reject arguments, fixing `.tap(-> { say 'hi' })` on Supply.interval.
- Adds `roast/S17-supply/basic.t` to the whitelist (all 80 subtests pass).

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S17-supply/basic.t` passes all 80 tests
- [x] `t/emit-method.t` covers .emit on Str/Int/Rat, .emit in for loops, and react/whenever/supply
- [x] All existing supply roast tests still pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)