### PR TITLE
fix: mixin improvements for roast S14-roles/mixin-6e.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -658,6 +658,7 @@ roast/S14-roles/crony.t
 roast/S14-roles/generic-subtyping.t
 roast/S14-roles/instantiation.t
 roast/S14-roles/lexical.t
+roast/S14-roles/mixin-6e.t
 roast/S14-roles/namespaced.t
 roast/S14-roles/parameter-subtyping.t
 roast/S14-roles/parameterized-basic.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -395,6 +395,11 @@ pub(crate) fn native_method_0arg(
                 _ => {}
             }
         }
+        // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
+        // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.
+        if let Some(mixin_val) = mixins.get(method) {
+            return Some(Ok(mixin_val.clone()));
+        }
         return native_method_0arg(inner, method_sym);
     }
     // Cool numeric coercion: when a Str calls a numeric method, coerce to numeric first.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -8,6 +8,22 @@ impl Compiler {
         op: &TokenKind,
         right: &Expr,
     ) {
+        // Special handling for `but` with a literal tuple RHS:
+        // `True but (1, "x")` compiles as multiple ButMixinTupleElem operations
+        // (one per element), generating per-element type methods with conflict
+        // checking.
+        if matches!(op, TokenKind::Ident(name) if name == "but")
+            && let Expr::ArrayLiteral(elems) = right
+            && elems.len() > 1
+        {
+            self.compile_expr(left);
+            for elem in elems {
+                self.compile_expr(elem);
+                self.code.emit(OpCode::ButMixinTupleElem);
+            }
+            return;
+        }
+
         // Iteratively flatten left-recursive Binary chains for simple opcodes
         // to avoid stack overflow on deeply nested expressions like
         // "a" ~ "b" ~ "c" ~ ... (300+ operands).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -183,6 +183,9 @@ pub(crate) enum OpCode {
 
     // -- Mixin --
     ButMixin,
+    /// Like ButMixin but checks for duplicate type conflicts (used for
+    /// per-element tuple expansion: `True but (1, "x")`).
+    ButMixinTupleElem,
     // -- Type check --
     Isa,
     Does,

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1461,6 +1461,7 @@ pub(super) fn role_decl(input: &str) -> PResult<'_, Stmt> {
 
     let (rest, mut body) = match block(rest) {
         Ok(ok) => ok,
+        Err(e) if e.is_fatal() => return Err(e),
         Err(_) => consume_raw_braced_body(rest)?,
     };
     // Handle `also is rw;` in the role body

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -211,6 +211,38 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
 
     let (rest, name) = if sigil == b'$' || is_array || is_hash || is_code {
         let (r, n) = var_name(rest)?;
+        // Reject `!` twigil in `my` scope: `my $!foo` is invalid
+        if n.starts_with('!') {
+            let scope_name = if is_state {
+                "state"
+            } else if is_our {
+                "our"
+            } else {
+                "my"
+            };
+            let message = format!(
+                "X::Syntax::Variable::Twigil: Cannot use a '!' twigil on a '{} ' variable.",
+                scope_name
+            );
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "message".to_string(),
+                crate::value::Value::str(message.clone()),
+            );
+            attrs.insert(
+                "twigil".to_string(),
+                crate::value::Value::str("!".to_string()),
+            );
+            attrs.insert(
+                "scope".to_string(),
+                crate::value::Value::str(scope_name.to_string()),
+            );
+            let exception = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Variable::Twigil"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(message, Box::new(exception)));
+        }
         (r, format!("{}{}", prefix, n))
     } else {
         return Err(PError::fatal(

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -211,8 +211,9 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
 
     let (rest, name) = if sigil == b'$' || is_array || is_hash || is_code {
         let (r, n) = var_name(rest)?;
-        // Reject `!` twigil in `my` scope: `my $!foo` is invalid
-        if n.starts_with('!') {
+        // Reject `!` twigil in `my` scope: `my $!foo` is invalid.
+        // But `my $!` (bare special variable) is allowed.
+        if n.starts_with('!') && n.len() > 1 {
             let scope_name = if is_state {
                 "state"
             } else if is_our {

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -1300,9 +1300,23 @@ impl Interpreter {
 
         let mut result = Vec::new();
 
+        // Extract mixin role names from the invocant for runtime role method collection
+        let mixin_role_names: Vec<String> = if let Value::Mixin(_, mixins) = invocant {
+            mixins
+                .keys()
+                .filter_map(|key| key.strip_prefix("__mutsu_role__").map(String::from))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         if local {
             // Only methods defined directly on this class
             self.collect_class_methods(&class_name, private, &mut result);
+            // Also include methods from runtime-mixed-in roles
+            for role_name in &mixin_role_names {
+                self.collect_role_methods(role_name, private, &mut result);
+            }
         } else {
             // Walk MRO (already includes the class itself)
             let mro = self.class_mro(&class_name);
@@ -1710,6 +1724,37 @@ impl Interpreter {
             // Also include native (built-in) methods
             for native_name in &class_def.native_methods {
                 let method_obj = self.make_native_method_object(native_name);
+                result.push(method_obj);
+            }
+        }
+    }
+
+    /// Collect methods from a runtime-mixed-in role definition.
+    pub(super) fn collect_role_methods(
+        &self,
+        role_name: &str,
+        include_private: bool,
+        result: &mut Vec<Value>,
+    ) {
+        if let Some(role_def) = self.roles.get(role_name) {
+            // Add accessor methods for public attributes
+            for (attr_name, is_public, ..) in &role_def.attributes {
+                if *is_public && !role_def.methods.contains_key(attr_name) {
+                    result.push(self.make_native_method_object(attr_name));
+                }
+            }
+            // Add explicit methods
+            for (method_name, overloads) in &role_def.methods {
+                if overloads.is_empty() {
+                    continue;
+                }
+                let first = &overloads[0];
+                if first.is_private && !include_private {
+                    continue;
+                }
+                let is_multi = overloads.len() > 1;
+                let return_type = first.return_type.clone();
+                let method_obj = self.make_method_object(method_name, first, is_multi, return_type);
                 result.push(method_obj);
             }
         }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -341,9 +341,9 @@ impl Interpreter {
         Ok(Value::mixin(inner, mixins))
     }
 
-    /// Call BUILD submethods from a role after mixin composition.
-    /// In Raku 6.e, when `$obj does Role`, the BUILD submethods of the role
-    /// are invoked on the resulting object.
+    /// Call BUILD and TWEAK submethods from a role after mixin composition.
+    /// In Raku 6.e, when `$obj does Role` or `$obj but Role`, the BUILD and
+    /// TWEAK submethods of the role are invoked on the resulting object.
     fn call_role_build_submethods(
         &mut self,
         target: Value,
@@ -353,37 +353,85 @@ impl Interpreter {
             Some(r) => r,
             None => return Ok(target),
         };
-        let build_methods = role.methods.get("BUILD").cloned();
-        if let Some(overloads) = build_methods {
-            for def in overloads {
-                // is_my is set to true for submethods in role method registration
-                if def.is_my {
-                    // Temporarily merge the role's captured environment so that
-                    // closure variables from the role definition scope are accessible
-                    // and modifications propagate back to the original scope.
-                    if let Some(captured) = &role.captured_env {
-                        for (k, v) in captured {
-                            if !self.env.contains_key(k) {
-                                self.env.insert(k.clone(), v.clone());
-                            }
-                        }
+        let mut current_target = target;
+        // Run BUILD first, then TWEAK (same order as class construction)
+        for submethod_name in &["BUILD", "TWEAK"] {
+            let methods = role.methods.get(*submethod_name).cloned();
+            if let Some(overloads) = methods {
+                for def in overloads {
+                    // is_my is set to true for submethods in role method registration
+                    if def.is_my {
+                        current_target = self.run_role_submethod(current_target, &role, &def)?;
+                        break;
                     }
-                    // Set self for the BUILD body
-                    let saved_self = self.env.get("self").cloned();
-                    self.env.insert("self".to_string(), target.clone());
-                    // Execute BUILD body directly in current scope so closure
-                    // variable mutations propagate to the outer scope.
-                    let _result = self.eval_block_value(&def.body)?;
-                    // Restore self
-                    if let Some(prev) = saved_self {
-                        self.env.insert("self".to_string(), prev);
-                    } else {
-                        self.env.remove("self");
-                    }
-                    break;
                 }
             }
         }
-        Ok(target)
+        Ok(current_target)
+    }
+
+    /// Run a single BUILD or TWEAK submethod from a role on a mixin value,
+    /// properly propagating attribute modifications back to the mixin map.
+    fn run_role_submethod(
+        &mut self,
+        target: Value,
+        role: &RoleDef,
+        def: &crate::runtime::MethodDef,
+    ) -> Result<Value, RuntimeError> {
+        // Temporarily merge the role's captured environment so that
+        // closure variables from the role definition scope are accessible
+        // and modifications propagate back to the original scope.
+        if let Some(captured) = &role.captured_env {
+            for (k, v) in captured {
+                if !self.env.contains_key(k) {
+                    self.env.insert(k.clone(), v.clone());
+                }
+            }
+        }
+        // Set up private attribute env vars from mixin attributes
+        // so that `$!foo = 42` works inside BUILD/TWEAK
+        let attr_names: Vec<String> = role
+            .attributes
+            .iter()
+            .map(|(name, ..)| name.clone())
+            .collect();
+        if let Value::Mixin(_, ref mixins) = target {
+            for attr_name in &attr_names {
+                let key = format!("__mutsu_attr__{}", attr_name);
+                if let Some(val) = mixins.get(&key) {
+                    self.env.insert(format!("!{}", attr_name), val.clone());
+                }
+            }
+        }
+        // Set self for the body
+        let saved_self = self.env.get("self").cloned();
+        self.env.insert("self".to_string(), target.clone());
+        // Execute body directly in current scope so closure
+        // variable mutations propagate to the outer scope.
+        let _result = self.eval_block_value(&def.body)?;
+        // Read back modified attribute values from env into the mixin map
+        let updated_target = if let Value::Mixin(inner, existing_mixins) = target {
+            let mut mixins = (*existing_mixins).clone();
+            for attr_name in &attr_names {
+                let env_key = format!("!{}", attr_name);
+                if let Some(val) = self.env.get(&env_key) {
+                    mixins.insert(format!("__mutsu_attr__{}", attr_name), val.clone());
+                }
+            }
+            // Clean up env vars
+            for attr_name in &attr_names {
+                self.env.remove(&format!("!{}", attr_name));
+            }
+            Value::mixin((*inner).clone(), mixins)
+        } else {
+            target
+        };
+        // Restore self
+        if let Some(prev) = saved_self {
+            self.env.insert("self".to_string(), prev);
+        } else {
+            self.env.remove("self");
+        }
+        Ok(updated_target)
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1869,6 +1869,10 @@ impl VM {
                 self.exec_but_mixin_op()?;
                 *ip += 1;
             }
+            OpCode::ButMixinTupleElem => {
+                self.exec_but_mixin_tuple_elem_op()?;
+                *ip += 1;
+            }
             OpCode::Isa => {
                 self.exec_isa_op();
                 *ip += 1;

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -992,26 +992,69 @@ impl VM {
             self.stack.push(composed?);
             return Ok(());
         }
-        let result = Self::apply_but_mixin(left, right);
+        let result = Self::apply_but_mixin(left, right)?;
         self.stack.push(result);
         Ok(())
     }
 
-    /// Apply a `but`-style mixin: wrap the left value with the right value
-    /// keyed by its type name.
-    fn apply_but_mixin(left: Value, right: Value) -> Value {
-        // Determine the mixin type from the right-hand value
-        let mixin_type = match &right {
+    /// Apply a `but` mixin for a single element from a tuple expansion,
+    /// with duplicate type conflict checking.
+    pub(super) fn exec_but_mixin_tuple_elem_op(&mut self) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let mixin_type = Self::mixin_type_for_value(&right);
+        // Check for duplicate type conflict
+        if let Value::Mixin(_, ref existing) = left
+            && existing.contains_key(&mixin_type)
+        {
+            return Err(RuntimeError::new(format!(
+                "Method '{}' must be resolved by class {}+{{}} because it exists in multiple roles",
+                mixin_type,
+                crate::runtime::utils::value_type_name(&left)
+            )));
+        }
+        let result = Self::apply_single_mixin(left, mixin_type, right);
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// Determine the mixin type name for a value (used by `but` operator).
+    fn mixin_type_for_value(val: &Value) -> String {
+        match val {
             Value::Bool(_) => "Bool".to_string(),
             Value::Int(_) | Value::BigInt(_) => "Int".to_string(),
             Value::Num(_) => "Num".to_string(),
             Value::Str(_) => "Str".to_string(),
+            Value::Rat(..) | Value::FatRat(..) | Value::BigRat(..) => "Rat".to_string(),
+            Value::Complex(..) => "Complex".to_string(),
             Value::Package(name) => name.resolve(),
             Value::Enum { enum_type, .. } => enum_type.resolve(),
             Value::Instance { class_name, .. } => class_name.resolve(),
             _ => "Any".to_string(),
-        };
-        // If left is already a Mixin, add to existing mixins
+        }
+    }
+
+    /// Apply a `but`-style mixin: wrap the left value with the right value
+    /// keyed by its type name.
+    fn apply_but_mixin(left: Value, right: Value) -> Result<Value, RuntimeError> {
+        // Handle Array RHS: `True but [1, 2]` generates a single "Array" mixin
+        if let Value::Array(_, kind) = &right {
+            if kind.is_real_array() {
+                return Ok(Self::apply_single_mixin(left, "Array".to_string(), right));
+            }
+            // List values from method calls like .list -> "List" mixin
+            return Ok(Self::apply_single_mixin(left, "List".to_string(), right));
+        }
+        if matches!(&right, Value::Seq(_)) {
+            return Ok(Self::apply_single_mixin(left, "List".to_string(), right));
+        }
+
+        let mixin_type = Self::mixin_type_for_value(&right);
+        Ok(Self::apply_single_mixin(left, mixin_type, right))
+    }
+
+    /// Apply a single mixin with the given type name.
+    fn apply_single_mixin(left: Value, mixin_type: String, right: Value) -> Value {
         match left {
             Value::Mixin(inner, existing_mixins) => {
                 let mut mixins = (*existing_mixins).clone();
@@ -1053,7 +1096,7 @@ impl VM {
         }
         // When the RHS is an enum value, `does` acts as a mixin (like `but`).
         if matches!(&right, Value::Enum { .. }) {
-            return Ok(Self::apply_but_mixin(left, right));
+            return Self::apply_but_mixin(left, right);
         }
         // When the RHS is a concrete value (Str, Int, Bool, etc.), `does` acts
         // as a mutating mixin — it overrides the corresponding type method.
@@ -1067,12 +1110,12 @@ impl VM {
                 | Value::Bool(_)
                 | Value::Rat(..)
         ) {
-            return Ok(Self::apply_but_mixin(left, right));
+            return Self::apply_but_mixin(left, right);
         }
         // When the RHS is an Instance, mix it in so that calling .$ClassName
         // on the result returns that instance.
         if matches!(&right, Value::Instance { .. }) {
-            return Ok(Self::apply_but_mixin(left, right));
+            return Self::apply_but_mixin(left, right);
         }
         // Pure check: does the value conform to the named role/type?
         let role_name = right.to_string_value();


### PR DESCRIPTION
## Summary
- Passes all 36 subtests in `roast/S14-roles/mixin-6e.t` (previously 8 failures)
- `but` with tuple RHS now creates per-element type mixins with conflict detection
- `but` with array/list RHS creates proper Array/List mixins
- TWEAK submethod invoked during role mixin, with attribute writeback
- `^methods(:local)` includes runtime-mixed-in role methods
- `my $!foo` now rejected with structured `X::Syntax::Variable::Twigil` exception
- Fatal parse errors propagate from role body blocks

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S14-roles/mixin-6e.t` passes (36/36)
- [x] `make test` passes (wrap.t failure is pre-existing)
- [x] Whitelisted roast tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)