### PR TITLE
fix: role submethod composition and module package scoping

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -667,6 +667,7 @@ roast/S14-roles/rw.t
 roast/S14-roles/stubs.t
 roast/S14-roles/submethods-6e.t
 roast/S14-roles/typecheck.t
+roast/S14-roles/versioning.t
 roast/S14-traits/package.t
 roast/S14-traits/variables.t
 roast/S15-literals/identifiers.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -657,6 +657,8 @@ pub(crate) enum Stmt {
         language_version: String,
         /// Custom `is` traits with optional arguments, dispatched via `trait_mod:<is>`
         custom_traits: Vec<(String, Option<Expr>)>,
+        /// Whether this class was declared with `unit class` (file-scoped body)
+        is_unit: bool,
     },
     HasDecl {
         name: Symbol,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -90,6 +90,7 @@ impl Compiler {
                 body,
                 language_version,
                 custom_traits,
+                is_unit,
                 ..
             } => {
                 let new_parents: Vec<String> = parents.iter().map(&qualify_parent).collect();
@@ -108,6 +109,7 @@ impl Compiler {
                     body: body.clone(),
                     language_version: language_version.clone(),
                     custom_traits: custom_traits.clone(),
+                    is_unit: *is_unit,
                 }
             }
             Stmt::RoleDecl {

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -1673,6 +1673,7 @@ pub(super) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             body,
             language_version: crate::parser::current_language_version(),
             custom_traits: Vec::new(),
+            is_unit: false,
         })),
     ))
 }

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -861,6 +861,7 @@ pub(crate) fn anon_class_decl(input: &str) -> PResult<'_, Stmt> {
         body,
         language_version: super::simple::current_language_version(),
         custom_traits: Vec::new(),
+        is_unit: false,
     };
     // Emit the class registration followed by unregistering the name from the scope
     let unregister = Stmt::Expr(Expr::Call {
@@ -1074,6 +1075,7 @@ pub(super) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         body,
         language_version: super::simple::current_language_version(),
         custom_traits,
+        is_unit: false,
     };
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {
@@ -1659,6 +1661,7 @@ pub(super) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
             body,
             language_version: super::simple::current_language_version(),
             custom_traits: Vec::new(),
+            is_unit: false,
         },
     ))
 }
@@ -1797,6 +1800,7 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 body: Vec::new(),
                 language_version: super::simple::current_language_version(),
                 custom_traits: Vec::new(),
+                is_unit: true,
             },
         ));
     }
@@ -1876,6 +1880,7 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 body: Vec::new(),
                 language_version: super::simple::current_language_version(),
                 custom_traits: Vec::new(),
+                is_unit: true,
             },
         ));
     }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -94,6 +94,11 @@ impl Interpreter {
         class_def: &ClassDef,
     ) -> Result<(), RuntimeError> {
         for (method_name, defs) in &class_def.methods {
+            // Submethods (like BUILD, TWEAK) from multiple roles do not conflict —
+            // they are accumulated and all called during construction. Skip them.
+            if defs.iter().all(|d| d.is_submethod) {
+                continue;
+            }
             // Check non-multi methods
             let non_multi: Vec<&MethodDef> = defs
                 .iter()

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -315,7 +315,21 @@ impl Interpreter {
         }
         // Run BUILD/TWEAK submethods in MRO order (base-first)
         let mro = self.class_mro(&class_name.resolve());
-        let is_6e = crate::parser::current_language_version().starts_with("6.e");
+        // Determine the class's language revision for submethod dispatch rules.
+        let class_lang_rev = self
+            .type_metadata
+            .get(&class_name.resolve())
+            .and_then(|m| m.get("language-revision"))
+            .map(|v| v.to_string_value())
+            .unwrap_or_else(|| {
+                let version = crate::parser::current_language_version();
+                if let Some(rest) = version.strip_prefix("6.") {
+                    rest.chars().next().unwrap_or('c').to_string()
+                } else {
+                    "c".to_string()
+                }
+            });
+        let class_is_6e = class_lang_rev != "c";
         for mro_class in mro.iter().rev() {
             if mro_class == "Any" || mro_class == "Mu" {
                 continue;
@@ -324,27 +338,61 @@ impl Interpreter {
             if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
                 continue;
             }
-            // Under v6.e+, call BUILD submethods from composed roles first
-            if is_6e {
-                let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
-                for (role_name, method_def) in role_order {
-                    let (_v, updated) = self.run_instance_method_resolved(
-                        &class_name.resolve(),
-                        &role_name,
-                        method_def,
-                        attributes.clone(),
-                        Vec::new(),
-                        Some(Value::make_instance(class_name, attributes.clone())),
-                    )?;
-                    attributes = updated;
-                }
-            }
-            let has_build = self
+            // Check if the class itself has a BUILD submethod
+            let class_has_own_build = self
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("BUILD"))
-                .is_some();
-            if has_build {
+                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                .unwrap_or(false);
+            // Call BUILD submethods from composed roles.
+            // Rules:
+            // - Always call role BUILD submethods (both 6.c and 6.e classes)
+            // - In 6.c: if class has own BUILD, skip role submethods from same
+            //   revision (6.c), but still call submethods from other revisions (6.e+)
+            // - In 6.e+: always call all role submethods regardless
+            let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
+            for (role_name, method_def) in role_order {
+                // Determine the role's language revision
+                let role_base = role_name
+                    .split_once('[')
+                    .map(|(b, _)| b)
+                    .unwrap_or(&role_name);
+                let role_lang_rev = self
+                    .type_metadata
+                    .get(role_base)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "c".to_string());
+                // In 6.c class with own BUILD: skip 6.c role submethods
+                if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
+                    continue;
+                }
+                let (_v, updated) = self.run_instance_method_resolved(
+                    &class_name.resolve(),
+                    &role_name,
+                    method_def,
+                    attributes.clone(),
+                    Vec::new(),
+                    Some(Value::make_instance(class_name, attributes.clone())),
+                )?;
+                attributes = updated;
+            }
+            // Call the class's BUILD if it has one that wasn't already handled
+            // by ordered_role_submethods_for_class. Role submethods (is_my=true,
+            // role_origin=Some) were already called above. Regular methods
+            // (is_my=false) from roles still need to go through run_instance_method.
+            let has_non_submethod_build = self
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get("BUILD"))
+                .map(|overloads| {
+                    overloads
+                        .iter()
+                        .any(|md| md.role_origin.is_none() || !md.is_my)
+                })
+                .unwrap_or(false);
+            if has_non_submethod_build {
                 let (_v, updated) = self.run_instance_method(
                     mro_class,
                     attributes.clone(),
@@ -363,27 +411,53 @@ impl Interpreter {
             if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
                 continue;
             }
-            // Under v6.e+, call TWEAK submethods from composed roles first
-            if is_6e {
-                let role_order = self.ordered_role_submethods_for_class(mro_class, "TWEAK");
-                for (role_name, method_def) in role_order {
-                    let (_v, updated) = self.run_instance_method_resolved(
-                        &class_name.resolve(),
-                        &role_name,
-                        method_def,
-                        attributes.clone(),
-                        Vec::new(),
-                        Some(Value::make_instance(class_name, attributes.clone())),
-                    )?;
-                    attributes = updated;
-                }
-            }
-            let has_tweak = self
+            // Check if the class itself has a TWEAK submethod
+            let class_has_own_tweak = self
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("TWEAK"))
-                .is_some();
-            if has_tweak {
+                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                .unwrap_or(false);
+            // Call TWEAK submethods from composed roles (same rules as BUILD)
+            let role_order = self.ordered_role_submethods_for_class(mro_class, "TWEAK");
+            for (role_name, method_def) in role_order {
+                let role_base = role_name
+                    .split_once('[')
+                    .map(|(b, _)| b)
+                    .unwrap_or(&role_name);
+                let role_lang_rev = self
+                    .type_metadata
+                    .get(role_base)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "c".to_string());
+                // In 6.c class with own TWEAK: skip 6.c role submethods
+                if !class_is_6e && class_has_own_tweak && role_lang_rev == "c" {
+                    continue;
+                }
+                let (_v, updated) = self.run_instance_method_resolved(
+                    &class_name.resolve(),
+                    &role_name,
+                    method_def,
+                    attributes.clone(),
+                    Vec::new(),
+                    Some(Value::make_instance(class_name, attributes.clone())),
+                )?;
+                attributes = updated;
+            }
+            // Call the class's TWEAK if it has one that wasn't already handled
+            // by ordered_role_submethods_for_class. Same logic as BUILD above.
+            let has_non_submethod_tweak = self
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get("TWEAK"))
+                .map(|overloads| {
+                    overloads
+                        .iter()
+                        .any(|md| md.role_origin.is_none() || !md.is_my)
+                })
+                .unwrap_or(false);
+            if has_non_submethod_tweak {
                 let (_v, updated) = self.run_instance_method(
                     mro_class,
                     attributes.clone(),

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3036,7 +3036,21 @@ impl Interpreter {
                 // Under v6.e.PREVIEW+, role submethods are also called
                 // (roles' BUILD/TWEAK before the class's own).
                 let mro = self.class_mro(class_key);
-                let is_6e = crate::parser::current_language_version().starts_with("6.e");
+                // Determine the class's language revision for submethod dispatch rules.
+                let class_lang_rev = self
+                    .type_metadata
+                    .get(&class_name.resolve())
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| {
+                        let version = crate::parser::current_language_version();
+                        if let Some(rest) = version.strip_prefix("6.") {
+                            rest.chars().next().unwrap_or('c').to_string()
+                        } else {
+                            "c".to_string()
+                        }
+                    });
+                let class_is_6e = class_lang_rev != "c";
                 for mro_class in mro.iter().rev() {
                     if mro_class == "Any" || mro_class == "Mu" {
                         continue;
@@ -3045,27 +3059,54 @@ impl Interpreter {
                     if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
                         continue;
                     }
-                    // Under v6.e+, call BUILD submethods from composed roles first
-                    if is_6e {
-                        let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
-                        for (role_name, method_def) in role_order {
-                            let (_v, updated) = self.run_instance_method_resolved(
-                                &class_name.resolve(),
-                                &role_name,
-                                method_def,
-                                attrs.clone(),
-                                args.clone(),
-                                Some(Value::make_instance(*class_name, attrs.clone())),
-                            )?;
-                            attrs = updated;
-                        }
-                    }
-                    let has_build = self
+                    // Check if the class has its own BUILD (not from a role)
+                    let class_has_own_build = self
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("BUILD"))
-                        .is_some();
-                    if has_build {
+                        .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                        .unwrap_or(false);
+                    // Call BUILD submethods from composed roles
+                    let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
+                    for (role_name, method_def) in role_order {
+                        let role_base = role_name
+                            .split_once('[')
+                            .map(|(b, _)| b)
+                            .unwrap_or(&role_name);
+                        let role_lang_rev = self
+                            .type_metadata
+                            .get(role_base)
+                            .and_then(|m| m.get("language-revision"))
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_else(|| "c".to_string());
+                        // In 6.c class with own BUILD: skip 6.c role submethods
+                        if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
+                            continue;
+                        }
+                        let (_v, updated) = self.run_instance_method_resolved(
+                            &class_name.resolve(),
+                            &role_name,
+                            method_def,
+                            attrs.clone(),
+                            args.clone(),
+                            Some(Value::make_instance(*class_name, attrs.clone())),
+                        )?;
+                        attrs = updated;
+                    }
+                    // Call the class's BUILD if it has one that wasn't already handled
+                    // by ordered_role_submethods_for_class. Role submethods (is_my=true,
+                    // role_origin=Some) were already called above.
+                    let has_non_submethod_build = self
+                        .classes
+                        .get(mro_class)
+                        .and_then(|def| def.methods.get("BUILD"))
+                        .map(|overloads| {
+                            overloads
+                                .iter()
+                                .any(|md| md.role_origin.is_none() || !md.is_my)
+                        })
+                        .unwrap_or(false);
+                    if has_non_submethod_build {
                         match self.run_instance_method(
                             mro_class,
                             attrs.clone(),
@@ -3107,14 +3148,13 @@ impl Interpreter {
                             .is_some()
                 });
                 // Also check role BUILD submethods for required attribute enforcement
-                let any_role_build = is_6e
-                    && mro.iter().any(|cn| {
-                        cn != "Any"
-                            && cn != "Mu"
-                            && !self
-                                .ordered_role_submethods_for_class(cn, "BUILD")
-                                .is_empty()
-                    });
+                let any_role_build = mro.iter().any(|cn| {
+                    cn != "Any"
+                        && cn != "Mu"
+                        && !self
+                            .ordered_role_submethods_for_class(cn, "BUILD")
+                            .is_empty()
+                });
                 if any_build || any_role_build {
                     for (attr_name, _is_public, _default, _is_rw, is_required, _sigil, _) in
                         &class_attrs_info
@@ -3143,32 +3183,57 @@ impl Interpreter {
                     if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
                         continue;
                     }
-                    // Under v6.e+, call TWEAK submethods from composed roles first
-                    if is_6e {
-                        let role_order = self.ordered_role_submethods_for_class(mro_class, "TWEAK");
-                        for (role_name, method_def) in role_order {
-                            let (_v, updated) = self.run_instance_method_resolved(
-                                &class_name.resolve(),
-                                &role_name,
-                                method_def,
-                                attrs.clone(),
-                                args.clone(),
-                                Some(Value::make_instance(*class_name, attrs.clone())),
-                            )?;
-                            attrs = updated;
-                            self.enforce_attribute_where_constraints(
-                                class_key,
-                                &class_attrs_info,
-                                &attrs,
-                            )?;
-                        }
-                    }
-                    let has_tweak = self
+                    // Check if the class has its own TWEAK (not from a role)
+                    let class_has_own_tweak = self
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("TWEAK"))
-                        .is_some();
-                    if has_tweak {
+                        .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                        .unwrap_or(false);
+                    // Call TWEAK submethods from composed roles (same rules as BUILD)
+                    let role_order = self.ordered_role_submethods_for_class(mro_class, "TWEAK");
+                    for (role_name, method_def) in role_order {
+                        let role_base = role_name
+                            .split_once('[')
+                            .map(|(b, _)| b)
+                            .unwrap_or(&role_name);
+                        let role_lang_rev = self
+                            .type_metadata
+                            .get(role_base)
+                            .and_then(|m| m.get("language-revision"))
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_else(|| "c".to_string());
+                        // In 6.c class with own TWEAK: skip 6.c role submethods
+                        if !class_is_6e && class_has_own_tweak && role_lang_rev == "c" {
+                            continue;
+                        }
+                        let (_v, updated) = self.run_instance_method_resolved(
+                            &class_name.resolve(),
+                            &role_name,
+                            method_def,
+                            attrs.clone(),
+                            args.clone(),
+                            Some(Value::make_instance(*class_name, attrs.clone())),
+                        )?;
+                        attrs = updated;
+                        self.enforce_attribute_where_constraints(
+                            class_key,
+                            &class_attrs_info,
+                            &attrs,
+                        )?;
+                    }
+                    // Only call the class's own TWEAK (not role-composed ones).
+                    let has_own_tweak = self
+                        .classes
+                        .get(mro_class)
+                        .and_then(|def| def.methods.get("TWEAK"))
+                        .map(|overloads| {
+                            overloads
+                                .iter()
+                                .any(|md| md.role_origin.is_none() || !md.is_my)
+                        })
+                        .unwrap_or(false);
+                    if has_own_tweak {
                         let (_v, updated) = self.run_instance_method(
                             mro_class,
                             attrs.clone(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -165,6 +165,9 @@ pub(crate) struct ClassDeclModifiers<'a> {
     pub(crate) is_lexical: bool,
     pub(crate) hidden_parents: &'a [String],
     pub(crate) does_parents: &'a [String],
+    /// Language version of the class being declared (e.g. "6.c", "6.d", "6.e").
+    /// Used to determine whether submethods from composed roles should be included.
+    pub(crate) language_version: &'a str,
 }
 
 fn parse_role_type_args(input: &str) -> Vec<String> {
@@ -661,7 +664,9 @@ impl Interpreter {
             is_lexical,
             hidden_parents,
             does_parents,
+            language_version: class_language_version,
         } = modifiers;
+        let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
         // `is ::Foo` means the same as `is Foo` in Raku.
         let strip_colons = |s: &str| s.strip_prefix("::").unwrap_or(s).to_string();
@@ -965,6 +970,17 @@ impl Interpreter {
                     }
                 }
                 composed_roles_list.push(resolved_parent_name.clone());
+                // Look up the role's language revision for submethod composition rules.
+                let role_lang_rev = self
+                    .type_metadata
+                    .get(base_role_name)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "c".to_string());
+                // Submethods from roles are only composed when the class is 6.c
+                // AND the role is also 6.c. In 6.d+, submethods are never composed
+                // from roles.
+                let compose_submethods = class_lang_rev == "c" && role_lang_rev == "c";
                 // Collect type parameter substitutions for method type constraints.
                 let type_subs: Vec<(String, String)> = role_param_names
                     .iter()
@@ -982,8 +998,12 @@ impl Interpreter {
                 for (mname, overloads) in &role.methods {
                     // Skip methods declared with `my` scope -- they are role-private
                     // and should not be composed into consuming classes.
-                    let non_my_overloads: Vec<&MethodDef> =
-                        overloads.iter().filter(|md| !md.is_my).collect();
+                    // Submethods (is_submethod=true) ARE composed only when both
+                    // the class and role share 6.c language revision.
+                    let non_my_overloads: Vec<&MethodDef> = overloads
+                        .iter()
+                        .filter(|md| !md.is_my || (md.is_submethod && compose_submethods))
+                        .collect();
                     if non_my_overloads.is_empty() {
                         continue;
                     }
@@ -2006,6 +2026,15 @@ impl Interpreter {
                             "No matching candidate found for the parametric role",
                         ));
                     }
+                    // Look up the role's language revision for submethod composition rules.
+                    let role_lang_rev_does = self
+                        .type_metadata
+                        .get(&role_name_str)
+                        .and_then(|m| m.get("language-revision"))
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| "c".to_string());
+                    let compose_submethods_does =
+                        class_lang_rev == "c" && role_lang_rev_does == "c";
                     for attr in &role.attributes {
                         if !class_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
                             class_def.attributes.push(attr.clone());
@@ -2014,7 +2043,7 @@ impl Interpreter {
                     for (mname, overloads) in role.methods {
                         let composed: Vec<MethodDef> = overloads
                             .into_iter()
-                            .filter(|md| !md.is_my)
+                            .filter(|md| !md.is_my || (md.is_submethod && compose_submethods_does))
                             .map(|mut md| {
                                 if md.original_role.is_none() {
                                     md.original_role = md.role_origin.clone();
@@ -2771,8 +2800,12 @@ impl Interpreter {
                     }
                     for (mname, overloads) in role.methods {
                         // Skip methods declared with `my` scope -- role-private
-                        let non_my_overloads: Vec<MethodDef> =
-                            overloads.into_iter().filter(|md| !md.is_my).collect();
+                        // Submethods (is_submethod=true) ARE composed even though
+                        // they have is_my=true.
+                        let non_my_overloads: Vec<MethodDef> = overloads
+                            .into_iter()
+                            .filter(|md| !md.is_my || md.is_submethod)
+                            .collect();
                         if non_my_overloads.is_empty() {
                             continue;
                         }

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -167,10 +167,10 @@ impl Interpreter {
     /// If the first non-Use/non-Package statement is a `unit class Foo;` (ClassDecl with empty
     /// body), merge all subsequent method/sub declarations into the class body.
     pub(super) fn merge_unit_class(stmts: Vec<Stmt>) -> Vec<Stmt> {
-        // Find the index of a ClassDecl with empty body
-        let class_idx = stmts
-            .iter()
-            .position(|s| matches!(s, Stmt::ClassDecl { body, .. } if body.is_empty()));
+        // Find the index of a unit ClassDecl with empty body (from `unit class Foo;`)
+        let class_idx = stmts.iter().position(
+            |s| matches!(s, Stmt::ClassDecl { body, is_unit: true, .. } if body.is_empty()),
+        );
         if let Some(idx) = class_idx {
             let mut result: Vec<Stmt> = stmts[..idx].to_vec();
             if let Stmt::ClassDecl {
@@ -186,6 +186,7 @@ impl Interpreter {
                 body: _,
                 language_version,
                 custom_traits,
+                ..
             } = &stmts[idx]
             {
                 let body: Vec<Stmt> = stmts[idx + 1..].to_vec();
@@ -202,6 +203,7 @@ impl Interpreter {
                     body,
                     language_version: language_version.clone(),
                     custom_traits: custom_traits.clone(),
+                    is_unit: true,
                 });
             }
             result

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1028,6 +1028,7 @@ impl VM {
             body,
             language_version,
             custom_traits,
+            ..
         } = stmt
         {
             let resolved_name = if let Some(expr) = name_expr {
@@ -1067,6 +1068,7 @@ impl VM {
                     is_lexical: *is_lexical,
                     hidden_parents,
                     does_parents,
+                    language_version,
                 },
                 body,
             )?;


### PR DESCRIPTION
## Summary
- Fix role submethod composition with language-revision-aware rules (6.c submethods only composed into 6.c classes)
- Fix BUILD/TWEAK submethod dispatch from roles during object construction for all language revisions
- Fix `merge_unit_class` incorrectly absorbing subsequent module-level statements into empty-body regular classes by adding `is_unit` to ClassDecl AST
- Fix role submethod conflict detection (submethods from multiple roles no longer conflict)
- Add `roast/S14-roles/versioning.t` to whitelist (all 4 subtests, 23 individual tests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S14-roles/versioning.t` passes
- [x] `prove -e 'target/debug/mutsu' roast/S12-construction/TWEAK.t` passes (regression check)
- [x] `make test` passes (no regressions except pre-existing t/lock.t and t/wrap.t)
- [x] `make roast` passes (no regressions except pre-existing roast/S32-io/spurt.t)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)