### PR TITLE
fix: BEGIN phaser ordering and non-breaking space preservation in pod tables

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -914,6 +914,7 @@ roast/S26-documentation/07c-tables.t
 roast/S26-documentation/08-formattingcodes.t
 roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t
+roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t
 roast/S26-documentation/15-numbered-alias.t
 roast/S26-documentation/block-leading-user-format.t

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -1082,13 +1082,42 @@ impl Interpreter {
             && trimmed.chars().all(|c| matches!(c, '+' | '-' | '=' | ' '))
     }
 
-    /// Normalize whitespace in a cell: collapse runs of spaces to single space.
+    /// Return true if a character is a breaking horizontal whitespace that
+    /// should be collapsed during cell normalization.  Non-breaking spaces
+    /// (U+00A0, U+202F, U+2060, U+FEFF) are intentionally excluded so that
+    /// they survive pod table processing unchanged (GH #1852).
+    fn is_breaking_hs(ch: char) -> bool {
+        matches!(
+            ch,
+            '\t'          // U+0009 CHARACTER TABULATION
+            | ' '         // U+0020 SPACE
+            | '\u{1680}'  // OGHAM SPACE MARK
+            | '\u{180E}'  // MONGOLIAN VOWEL SEPARATOR
+            | '\u{2000}'  // EN QUAD
+            | '\u{2001}'  // EM QUAD
+            | '\u{2002}'  // EN SPACE
+            | '\u{2003}'  // EM SPACE
+            | '\u{2004}'  // THREE-PER-EM SPACE
+            | '\u{2005}'  // FOUR-PER-EM SPACE
+            | '\u{2006}'  // SIX-PER-EM SPACE
+            | '\u{2007}'  // FIGURE SPACE
+            | '\u{2008}'  // PUNCTUATION SPACE
+            | '\u{2009}'  // THIN SPACE
+            | '\u{200A}'  // HAIR SPACE
+            | '\u{205F}'  // MEDIUM MATHEMATICAL SPACE
+            | '\u{3000}' // IDEOGRAPHIC SPACE
+        )
+    }
+
+    /// Normalize whitespace in a cell: collapse runs of breaking horizontal
+    /// whitespace to a single ASCII space.  Non-breaking spaces are preserved.
     fn normalize_cell(s: &str) -> String {
-        let trimmed = s.trim();
+        // Trim breaking whitespace from both ends.
+        let trimmed = s.trim_matches(Self::is_breaking_hs);
         let mut result = String::new();
         let mut prev_space = false;
         for ch in trimmed.chars() {
-            if ch == ' ' || ch == '\t' {
+            if Self::is_breaking_hs(ch) {
                 if !prev_space && !result.is_empty() {
                     result.push(' ');
                 }

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -663,7 +663,7 @@ fn reorder_at_level(
         matches!(
             s,
             Stmt::Phaser {
-                kind: PhaserKind::Check | PhaserKind::Init,
+                kind: PhaserKind::Begin | PhaserKind::Check | PhaserKind::Init,
                 ..
             }
         )
@@ -716,7 +716,14 @@ fn reorder_at_level(
             where_constraint,
         } = &stmt
         {
-            let has_init = !matches!(init_expr, Expr::Literal(crate::value::Value::Nil));
+            // A VarDecl has a real (user-supplied) initializer only when it
+            // carries the "__has_initializer" marker trait.  Without that
+            // marker the `expr` field holds only the default value for the
+            // variable's sigil (`Nil` for `$x`, empty-Array for `@arr`,
+            // empty-Hash for `%h`) and must NOT be treated as an assignment.
+            // Generating an assign from the default would silently overwrite
+            // whatever a BEGIN block stored in the same variable.
+            let has_init = custom_traits.iter().any(|(t, _)| t == "__has_initializer");
             var_decls.push(Stmt::VarDecl {
                 name: name.clone(),
                 expr: Expr::Literal(crate::value::Value::Nil),


### PR DESCRIPTION
## Summary

- Fix `has_phasers` detection in `reorder_at_level` to include `PhaserKind::Begin`, so that blocks with only a `BEGIN` phaser (no `CHECK`/`INIT`) trigger reordering
- Fix `has_init` check in phaser reordering to use `__has_initializer` marker trait instead of checking for non-Nil expr, preventing default array/hash initializers from overwriting values set by `BEGIN` blocks
- Extend `normalize_cell` in pod table processing to collapse Unicode breaking horizontal whitespace (U+1680, U+180E, U+2000–U+200A, U+205F, U+3000) while preserving non-breaking spaces (U+00A0, U+202F, U+2060, U+FEFF)

Fixes `roast/S26-documentation/12-non-breaking-space.t` (was failing with plan 1..1 instead of 1..5 in second subtest).

## Test plan

- [x] `timeout 30 prove -e 'target/debug/mutsu' roast/S26-documentation/12-non-breaking-space.t` — passes
- [x] `timeout 30 prove -e 'target/debug/mutsu' roast/S04-phasers/` — no new regressions (begin.t test 7 pre-existing)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)