### PR TITLE
fix: propagate $!attr := outer_var binding through ContainerRef for increment/decrement ops

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1062,6 +1062,7 @@ roast/S32-list/rotor.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t
+roast/S32-list/tail.t
 roast/S32-list/toggle.t
 roast/S32-list/unique.t
 roast/S32-num/abs.t

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1126,6 +1126,34 @@ impl Interpreter {
             if attr_name.contains('\0') {
                 continue;
             }
+            // Handle attribute alias metadata (from `$!attr := outer_var` bindings).
+            // e.g. "__mutsu_attr_alias::pulled" -> "pulled" means $!pulled was bound
+            // to sigilless var `pulled`. Re-establish the sigilless alias in env so
+            // that increment/decrement ops can propagate changes to the aliased var.
+            const ATTR_ALIAS_META_PREFIX: &str = "__mutsu_attr_alias::";
+            if let Some(actual_attr) = attr_name.strip_prefix(ATTR_ALIAS_META_PREFIX) {
+                if let Value::Str(source_name) = attr_val {
+                    // Set up: !attr → source_name alias (for write propagation)
+                    self.env.insert(
+                        format!("__mutsu_sigilless_alias::!{}", actual_attr),
+                        Value::str(source_name.to_string()),
+                    );
+                    self.env.insert(
+                        format!("__mutsu_sigilless_readonly::!{}", actual_attr),
+                        Value::Bool(false),
+                    );
+                    // Reverse: source_name → !attr alias
+                    self.env.insert(
+                        format!("__mutsu_sigilless_alias::{}", source_name),
+                        Value::str(format!("!{}", actual_attr)),
+                    );
+                    // Also populate source_name with current attribute value
+                    if let Some(attr_value) = attributes.get(actual_attr) {
+                        self.env.insert(source_name.to_string(), attr_value.clone());
+                    }
+                }
+                continue;
+            }
             // For private attributes, prefer the class-qualified value from
             // the method's owner class (so Parent's $!priv != Child's $!priv).
             let qualified_key = format!("{}\0{}", owner_class, attr_name);
@@ -1309,6 +1337,10 @@ impl Interpreter {
                 merged_env.insert_sym(*k, v.clone());
             }
         }
+        // Propagate sigilless attribute alias writes back to the caller's env.
+        // This handles `$!attr := outer_var` bindings: if the method modified
+        // $!attr, the change flows back to the aliased outer variable.
+        self.merge_sigilless_alias_writes(&mut merged_env, &self.env);
         // Apply `is rw` parameter writebacks so that changes to `is rw`
         // params inside the method body propagate back to the caller's
         // variables.

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -764,11 +764,45 @@ impl VM {
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
         {
+            // ContainerRef: increment through the shared arc (e.g. `$!attr := outer_var`).
+            if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                let inner = arc.lock().unwrap().clone();
+                let val = self.normalize_incdec_source_with_type(name, inner);
+                let new_val = self.increment_value_smart(&val)?;
+                arc.lock().unwrap().clone_from(&new_val);
+                self.stack.push(new_val);
+                return Ok(());
+            }
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.increment_value_smart(&val)?;
             self.locals[slot] = new_val.clone();
             self.mark_local_dirty(slot);
+            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
+            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+                if let Value::Str(n) = v {
+                    Some(n.to_string())
+                } else {
+                    None
+                }
+            });
+            let mut seen_aliases = std::collections::HashSet::new();
+            while let Some(current_alias) = alias_name {
+                if !seen_aliases.insert(current_alias.clone()) {
+                    break;
+                }
+                self.set_env_with_main_alias(&current_alias, new_val.clone());
+                self.update_local_if_exists(code, &current_alias, &new_val);
+                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
+                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                    if let Value::Str(n) = v {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                });
+            }
             self.stack.push(new_val);
             return Ok(());
         }
@@ -795,11 +829,45 @@ impl VM {
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
         {
+            // ContainerRef: decrement through the shared arc (e.g. `$!attr := outer_var`).
+            if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                let inner = arc.lock().unwrap().clone();
+                let val = self.normalize_incdec_source_with_type(name, inner);
+                let new_val = self.decrement_value_smart(&val)?;
+                arc.lock().unwrap().clone_from(&new_val);
+                self.stack.push(new_val);
+                return Ok(());
+            }
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.decrement_value_smart(&val)?;
             self.locals[slot] = new_val.clone();
             self.mark_local_dirty(slot);
+            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
+            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+                if let Value::Str(n) = v {
+                    Some(n.to_string())
+                } else {
+                    None
+                }
+            });
+            let mut seen_aliases = std::collections::HashSet::new();
+            while let Some(current_alias) = alias_name {
+                if !seen_aliases.insert(current_alias.clone()) {
+                    break;
+                }
+                self.set_env_with_main_alias(&current_alias, new_val.clone());
+                self.update_local_if_exists(code, &current_alias, &new_val);
+                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
+                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                    if let Value::Str(n) = v {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                });
+            }
             self.stack.push(new_val);
             return Ok(());
         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1117,11 +1117,45 @@ impl VM {
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
         {
+            // ContainerRef: increment through the shared arc (e.g. `$!attr := outer_var`).
+            if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                let inner = arc.lock().unwrap().clone();
+                let val = self.normalize_incdec_source_with_type(name, inner);
+                let new_val = self.increment_value_smart(&val)?;
+                arc.lock().unwrap().clone_from(&new_val);
+                self.stack.push(val);
+                return Ok(());
+            }
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.increment_value_smart(&val)?;
-            self.locals[slot] = new_val;
+            self.locals[slot] = new_val.clone();
             self.mark_local_dirty(slot);
+            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
+            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+                if let Value::Str(n) = v {
+                    Some(n.to_string())
+                } else {
+                    None
+                }
+            });
+            let mut seen_aliases = std::collections::HashSet::new();
+            while let Some(current_alias) = alias_name {
+                if !seen_aliases.insert(current_alias.clone()) {
+                    break;
+                }
+                self.set_env_with_main_alias(&current_alias, new_val.clone());
+                self.update_local_if_exists(code, &current_alias, &new_val);
+                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
+                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                    if let Value::Str(n) = v {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                });
+            }
             self.stack.push(val);
             return Ok(());
         }
@@ -1220,11 +1254,45 @@ impl VM {
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
         {
+            // ContainerRef: decrement through the shared arc (e.g. `$!attr := outer_var`).
+            if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                let inner = arc.lock().unwrap().clone();
+                let val = self.normalize_incdec_source_with_type(name, inner);
+                let new_val = self.decrement_value_smart(&val)?;
+                arc.lock().unwrap().clone_from(&new_val);
+                self.stack.push(val);
+                return Ok(());
+            }
             let raw_val = self.locals[slot].clone();
             let val = self.normalize_incdec_source_with_type(name, raw_val);
             let new_val = self.decrement_value_smart(&val)?;
-            self.locals[slot] = new_val;
+            self.locals[slot] = new_val.clone();
             self.mark_local_dirty(slot);
+            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
+            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+                if let Value::Str(n) = v {
+                    Some(n.to_string())
+                } else {
+                    None
+                }
+            });
+            let mut seen_aliases = std::collections::HashSet::new();
+            while let Some(current_alias) = alias_name {
+                if !seen_aliases.insert(current_alias.clone()) {
+                    break;
+                }
+                self.set_env_with_main_alias(&current_alias, new_val.clone());
+                self.update_local_if_exists(code, &current_alias, &new_val);
+                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
+                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                    if let Value::Str(n) = v {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                });
+            }
             self.stack.push(val);
             return Ok(());
         }


### PR DESCRIPTION
## Summary

- When `$!attr := outer_var` binds an attribute to an outer variable, the binding uses a `ContainerRef` (shared Arc) for write-through semantics
- The fast path for `!`-prefixed locals in post/pre-increment/decrement ops was bypassing ContainerRef handling, computing wrong results (returning Int(1) from `ContainerRef++`) and failing to propagate increments to the aliased outer variable
- Fix: detect `ContainerRef` in `!attr` local slots and increment/decrement through the shared Arc directly, so the outer variable sees the updated value
- Also fixes `run_instance_method_resolved` in the interpreter path to set up sigilless alias metadata from `__mutsu_attr_alias::` entries, matching the VM path behavior

## Test plan

- [x] `roast/S32-list/tail.t` — all 57 tests pass (was failing subtest 53, inner test 2: "we called .pull-one just once")
- [x] No regressions in `t/` test suite (pre-existing failures are unrelated)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)