### PR TITLE
fix: S03-metaops/reduce.t improvements (563/580 passing)

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -185,7 +185,16 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         },
         "Capture" => Some(value_to_capture(target)),
         "Slip" => match target {
-            Value::Array(items, ..) | Value::Seq(items) => Some(Ok(Value::Slip(items.clone()))),
+            Value::Seq(items) => {
+                if crate::value::seq_is_consumed(items) && !crate::value::seq_is_cached(items) {
+                    return Some(Err(crate::value::seq_consumed_error()));
+                }
+                if !crate::value::seq_is_cached(items) {
+                    crate::value::seq_consume(items).ok();
+                }
+                Some(Ok(Value::Slip(items.clone())))
+            }
+            Value::Array(items, ..) => Some(Ok(Value::Slip(items.clone()))),
             Value::Slip(_) => Some(Ok(target.clone())),
             Value::LazyList(ll) => {
                 if ll.scan_spec.is_some() {
@@ -248,7 +257,16 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     Some(Ok(Value::array((*a..*b).map(Value::Int).collect())))
                 }
             }
-            Value::Array(items, _) | Value::Seq(items) => Some(Ok(Value::array(items.to_vec()))),
+            Value::Seq(items) => {
+                if crate::value::seq_is_consumed(items) && !crate::value::seq_is_cached(items) {
+                    return Some(Err(crate::value::seq_consumed_error()));
+                }
+                if !crate::value::seq_is_cached(items) {
+                    crate::value::seq_consume(items).ok();
+                }
+                Some(Ok(Value::array(items.to_vec())))
+            }
+            Value::Array(items, _) => Some(Ok(Value::array(items.to_vec()))),
             Value::GenericRange {
                 start,
                 end,
@@ -412,7 +430,22 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     Some(Ok(target.clone()))
                 }
             }
-            Value::Seq(items) | Value::Slip(items) => {
+            Value::Seq(items) if method == "list" || method == "Array" => {
+                // Consumed Seq check: throw X::Seq::Consumed if not cached
+                if crate::value::seq_is_consumed(items) && !crate::value::seq_is_cached(items) {
+                    return Some(Err(crate::value::seq_consumed_error()));
+                }
+                // Mark as consumed (unless cached; cached Seqs allow multiple iterations)
+                if !crate::value::seq_is_cached(items) {
+                    crate::value::seq_consume(items).ok();
+                }
+                if method == "Array" {
+                    Some(Ok(Value::real_array(items.to_vec())))
+                } else {
+                    Some(Ok(Value::array(items.to_vec())))
+                }
+            }
+            Value::Slip(items) if method == "list" || method == "Array" => {
                 if method == "Array" {
                     Some(Ok(Value::real_array(items.to_vec())))
                 } else {

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -492,6 +492,29 @@ pub(super) fn dispatch(
                     Some(Ok(Value::Nil))
                 }
             }
+            Value::Seq(items) => {
+                // If there's a deferred iterator and the Seq is not cached, fall through
+                // to the runtime which will pull from the iterator.
+                if crate::value::seq_has_deferred_iter(items) && !crate::value::seq_is_cached(items)
+                {
+                    return Some(None); // fall through to runtime
+                }
+                // Sinking a Seq marks it as consumed (unless already cached).
+                // Re-sinking a consumed Seq is ok (lives-ok).
+                crate::value::seq_sink(items);
+                Some(Ok(Value::Nil))
+            }
+            Value::LazyList(ll) => {
+                // Sinking a gather-based LazyList marks it as consumed.
+                // Needed for `$s-lazy.sink; $s-lazy.is-lazy` to throw X::Seq::Consumed.
+                let is_gather = ll.env.get("__mutsu_lazylist_from_gather").is_some();
+                if is_gather {
+                    crate::value::lazylist_consume(ll);
+                    Some(Ok(Value::Nil))
+                } else {
+                    None // fall through to runtime for non-gather lazy lists
+                }
+            }
             _ => Some(Ok(Value::Nil)),
         }),
         "item" => Some(match target {

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -87,6 +87,13 @@ pub(super) fn dispatch(
                 let lazy = matches!(attributes.get("is_lazy"), Some(Value::Bool(true)));
                 return Some(Some(Ok(Value::Bool(lazy))));
             }
+            // A consumed gather-based LazyList throws X::Seq::Consumed on .is-lazy
+            if let Value::LazyList(ll) = target {
+                let is_gather = ll.env.get("__mutsu_lazylist_from_gather").is_some();
+                if is_gather && crate::value::lazylist_is_consumed(ll) {
+                    return Some(Some(Err(crate::value::seq_consumed_error())));
+                }
+            }
             Some(Some(Ok(Value::Bool(is_value_lazy(target)))))
         }
         "lazy" => {
@@ -227,6 +234,12 @@ pub(super) fn dispatch(
         "join" => {
             if matches!(target, Value::LazyList(_)) {
                 return Some(None); // fall through to runtime to force
+            }
+            if let Value::Seq(items) = target
+                && crate::value::seq_is_consumed(items)
+                && !crate::value::seq_is_cached(items)
+            {
+                return Some(Some(Err(crate::value::seq_consumed_error())));
             }
             if crate::runtime::utils::is_shaped_array(target) {
                 let leaves = crate::runtime::utils::shaped_array_leaves(target);

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -314,6 +314,22 @@ pub(crate) fn native_method_0arg(
         return native_method_0arg(inner, method_sym);
     }
 
+    // Seq consumed/cached state checks.
+    // Only handle operations that are fully dispatched here in native_method_0arg.
+    // Do NOT pre-check methods that fall through to the runtime (like "iterator"),
+    // because native_method_0arg is called from both the VM and the interpreter,
+    // and consuming twice would throw.
+    if let Value::Seq(items) = target {
+        if method == "cache" {
+            // .cache marks as cached; handled fully here (the actual cache impl is
+            // in the per-method handler below, this just marks state).
+            crate::value::seq_mark_cached(items);
+        } else if method == "is-lazy" && crate::value::seq_is_consumed(items) {
+            // Read-only check: throws on consumed Seq but does NOT consume.
+            return Some(Err(crate::value::seq_consumed_error()));
+        }
+    }
+
     // Instance with __baggy_data__: delegate Bag-like methods to the inner Bag/Set
     // so that subclasses of Bag/Set (e.g. `my class MyBag is Bag {}`) work correctly.
     if let Value::Instance { attributes, .. } = target
@@ -653,6 +669,7 @@ pub(crate) fn is_value_lazy(value: &Value) -> bool {
     matches!(value, Value::LazyList(_))
         || matches!(value, Value::Array(_, kind) if kind.is_lazy())
         || is_infinite_range(value)
+        || matches!(value, Value::Seq(items) if crate::value::seq_is_lazy(items))
 }
 
 fn flatten_deep_value(value: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -301,11 +301,16 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         Value::Seq(items) => {
+            // A consumed Seq is represented as Seq.new() so that EVALing it
+            // produces a pre-consumed Seq (matching Raku's behavior).
+            if crate::value::seq_is_consumed(items) {
+                return "Seq.new()".to_string();
+            }
             let inner = items.iter().map(raku_value).collect::<Vec<_>>().join(", ");
             if items.len() == 1 {
-                format!("({},)", inner)
+                format!("({},).Seq", inner)
             } else {
-                format!("({})", inner)
+                format!("({}).Seq", inner)
             }
         }
         Value::Slip(items) => {

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -234,6 +234,18 @@ pub(super) fn reduction_op(input: &str) -> PResult<'_, Expr> {
     if !is_valid_reduction_op(&op) {
         return Err(PError::expected("known reduction operator"));
     }
+    // Non-associative "structural" infix operators cannot be used in reduction form.
+    // They return Order, not Bool, and are diffy (not chaining).
+    let base_for_check = op.strip_prefix('\\').unwrap_or(op.as_str());
+    let base_for_check = base_for_check
+        .strip_prefix('R')
+        .filter(|s| !s.is_empty())
+        .unwrap_or(base_for_check);
+    if matches!(base_for_check, "leg" | "<=>" | "cmp") {
+        return Err(PError::fatal(format!(
+            "X::Syntax::CannotMeta: Cannot reduce with {base_for_check} because structural infix operators are diffy and not chaining"
+        )));
+    }
     let r = &input[end + 1..];
     let call_style_operand = r.starts_with('(');
     // Zero-argument reduction: [op] with no operands → identity element

--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -139,6 +139,37 @@ impl Interpreter {
             return Ok(Value::Nil);
         }
         if items.len() == 1 {
+            // For numeric infix operators (e.g. `reduce &infix:<+>, "2"`), apply
+            // the identity element + the single element so that coercions happen.
+            let op_name = match &callable {
+                Value::Sub(data) => Some(data.name.resolve()),
+                Value::Routine { name, .. } => Some(name.resolve()),
+                _ => None,
+            };
+            if let Some(ref op) = op_name {
+                // Strip infix:<...> wrapper if present
+                let bare_op = op
+                    .strip_prefix("infix:<")
+                    .and_then(|s| s.strip_suffix('>'))
+                    .unwrap_or(op.as_str());
+                if matches!(
+                    bare_op,
+                    "+" | "-" | "*" | "/" | "%" | "**" | "+|" | "+&" | "+^"
+                ) {
+                    let elem = items.into_iter().next().unwrap();
+                    // Validate non-numeric strings
+                    if let Value::Str(ref s) = elem
+                        && crate::runtime::str_numeric::parse_raku_str_to_numeric(s).is_none()
+                    {
+                        return Err(RuntimeError::str_numeric(
+                            s,
+                            "base-10 number must begin with valid digits or '.'",
+                        ));
+                    }
+                    let identity = crate::runtime::reduction_identity(bare_op);
+                    return self.call_sub_value(callable, vec![identity, elem], false);
+                }
+            }
             return Ok(items.into_iter().next().unwrap());
         }
 

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -284,6 +284,42 @@ impl Interpreter {
             }
             return self.call_method_with_values(*inner, method, args);
         }
+        // When Seq.new(iterator) created a deferred-iterator Seq, and .sink is called
+        // without .cache, pull from the iterator now (marks Seq as consumed).
+        if method == "sink"
+            && args.is_empty()
+            && let Value::Seq(items) = &target
+            && crate::value::seq_has_deferred_iter(items)
+            && !crate::value::seq_is_cached(items)
+        {
+            let items_arc = items.clone();
+            let iterator = crate::value::seq_take_deferred_iter(&items_arc).unwrap();
+            crate::value::seq_consume(&items_arc).ok();
+            // Pull from iterator until IterationEnd
+            let iter_val = iterator;
+            loop {
+                let val = self.call_method_with_values(iter_val.clone(), "pull-one", vec![])?;
+                if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
+                    || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
+                {
+                    break;
+                }
+            }
+            return Ok(Value::Nil);
+        }
+        // Consumed Seq guard: throw X::Seq::Consumed for iteration/coercion methods
+        // when the Seq has been consumed and is not cached.
+        if let Value::Seq(items) = &target {
+            let consumed_methods = [
+                "iterator", "list", "List", "eager", "Array", "flat", "Slip", "join", "is-lazy",
+            ];
+            if consumed_methods.contains(&method)
+                && crate::value::seq_is_consumed(items)
+                && !crate::value::seq_is_cached(items)
+            {
+                return Err(crate::value::seq_consumed_error());
+            }
+        }
         // User-defined ^method (metamethod) dispatch.
         // `method ^foo(Mu) { ... }` in a class body defines a metamethod.
         // The caller (VM) already prepends the type object to args.

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -151,6 +151,33 @@ impl Interpreter {
                 let values = Self::value_to_list(&target);
                 Some(Ok(Value::junction(kind, values)))
             }
+            "slice" => {
+                // Seq.slice(@indices) — return elements at the given indices as a Seq.
+                // Seq.slice() with no args returns an empty Seq.
+                let items = if let Value::Seq(ref arc) = target {
+                    arc.as_ref().clone()
+                } else {
+                    crate::runtime::utils::value_to_list(&target)
+                };
+                if args.is_empty() {
+                    Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new()))))
+                } else {
+                    let mut result = Vec::with_capacity(args.len());
+                    for arg in &args {
+                        let idx = match arg {
+                            Value::Int(i) => Some(*i as usize),
+                            Value::Num(n) => Some(*n as usize),
+                            _ => None,
+                        };
+                        if let Some(i) = idx
+                            && i < items.len()
+                        {
+                            result.push(items[i].clone());
+                        }
+                    }
+                    Some(Ok(Value::Seq(std::sync::Arc::new(result))))
+                }
+            }
             "iterator" if args.is_empty() => Some(self.dispatch_iterator_method(target)),
             "produce" => self.dispatch_produce_method(target, args),
             "reduce" => Some(self.dispatch_reduce_method(target, args)),
@@ -255,6 +282,16 @@ impl Interpreter {
     fn dispatch_iterator_method(&mut self, target: Value) -> Result<Value, RuntimeError> {
         if matches!(&target, Value::Instance { class_name, .. } if class_name == "Iterator") {
             return Ok(target);
+        }
+        // Check consumed state for Seq: throw X::Seq::Consumed if not cached
+        if let Value::Seq(items) = &target {
+            if crate::value::seq_is_consumed(items) && !crate::value::seq_is_cached(items) {
+                return Err(crate::value::seq_consumed_error());
+            }
+            // Mark as consumed only if not cached (cached Seqs allow multiple iterations)
+            if !crate::value::seq_is_cached(items) {
+                crate::value::seq_consume(items).ok();
+            }
         }
         if let Value::Seq(items) = &target {
             let seq_id = std::sync::Arc::as_ptr(items) as usize;
@@ -364,6 +401,10 @@ impl Interpreter {
             && class_name == "Supply"
         {
             return Some(self.dispatch_supply_elems(attributes, &args));
+        }
+        // .elems on a Seq caches it (makes it available for multiple calls)
+        if let Value::Seq(items) = &target {
+            crate::value::seq_mark_cached(items);
         }
         Some(self.call_function("elems", vec![target]))
     }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -12,6 +12,19 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
         match method {
+            "Numeric" if args.is_empty() => {
+                // Seq.Numeric: if backed by a PredictiveIterator, call count-only.
+                // Otherwise return the element count.
+                if let Value::Seq(items) = &target {
+                    let seq_id = std::sync::Arc::as_ptr(items) as usize;
+                    let iter_key = format!("__mutsu_predictive_seq_iter::{seq_id}");
+                    if let Some(iter) = self.env.get(&iter_key).cloned() {
+                        return Some(self.call_method_with_values(iter, "count-only", vec![]));
+                    }
+                    return Some(Ok(Value::Int(items.len() as i64)));
+                }
+                None
+            }
             "from-list" => {
                 if let Value::Package(ref class_name) = target
                     && class_name == "Supply"

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -947,38 +947,19 @@ impl Interpreter {
                         {
                             return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
                         }
-                        let mut items = Vec::new();
-                        let iter_slot = "$mutsu_seq_new_iterator";
-                        let saved_iter = self.env.get(iter_slot).cloned();
-                        self.env.insert(iter_slot.to_string(), iterator.clone());
-                        let mut iterations = 0usize;
-                        loop {
-                            iterations += 1;
-                            let current_iter =
-                                self.env.get(iter_slot).cloned().unwrap_or(Value::Nil);
-                            let val =
-                                self.call_method_with_values(current_iter, "pull-one", vec![])?;
-                            if iterations > 1_000 {
-                                return Err(RuntimeError::new(format!(
-                                    "Seq.new iterator did not terminate (last value: {})",
-                                    val.to_string_value()
-                                )));
-                            }
-                            if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
-                                || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
-                            {
-                                break;
-                            }
-                            items.push(val);
-                        }
-                        if let Some(prev) = saved_iter {
-                            self.env.insert(iter_slot.to_string(), prev);
-                        } else {
-                            self.env.remove(iter_slot);
-                        }
-                        return Ok(Value::Seq(std::sync::Arc::new(items)));
+                        // Defer pulling: store the iterator and pull lazily when the Seq is
+                        // actually consumed. This matches Raku's Seq.new(iterator) semantics
+                        // where .new does not eagerly pull values.
+                        let arc = std::sync::Arc::new(Vec::<Value>::new());
+                        crate::value::seq_register_deferred_iter(&arc, iterator.clone());
+                        return Ok(Value::Seq(arc));
                     }
-                    return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+                    // Seq.new() with no args creates a pre-consumed Seq.
+                    // In Raku, Seq.new() has no iterator, so any consuming
+                    // operation immediately throws X::Seq::Consumed.
+                    let arc = std::sync::Arc::new(Vec::<Value>::new());
+                    crate::value::seq_consume(&arc).ok();
+                    return Ok(Value::Seq(arc));
                 }
                 "Version" => {
                     let arg = args.first().cloned().unwrap_or(Value::Nil);

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -44,6 +44,22 @@ impl Interpreter {
         let cond_callable = positional.get(1).cloned();
         let step_callable = positional.get(2).cloned();
 
+        // If there's no condition and no step, this is a lazy infinite Seq.
+        // Return a lazy list backed by a from-loop iterator.
+        if cond_callable.is_none() && step_callable.is_none() {
+            // Create a lazy from-loop Seq: store the body callable in an Iterator instance
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("from_loop_body".to_string(), body_callable);
+            attrs.insert("from_loop_done".to_string(), Value::Bool(false));
+            let iter =
+                Value::make_instance(crate::symbol::Symbol::intern("FromLoopIterator"), attrs);
+            // Wrap in a deferred-iterator Seq
+            let arc = std::sync::Arc::new(Vec::<Value>::new());
+            crate::value::seq_register_deferred_iter(&arc, iter.clone());
+            crate::value::seq_mark_lazy(&arc);
+            return Ok(Value::Seq(arc));
+        }
+
         let label_matches = |error_label: &Option<String>| {
             error_label.as_deref() == label.as_deref() || error_label.is_none()
         };

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1063,7 +1063,7 @@ impl Interpreter {
                     out.push(Self::apply_reduction_op(inner_op, l, r)?);
                 }
             }
-            return Ok(Value::array(out));
+            return Ok(Value::Seq(std::sync::Arc::new(out)));
         }
         if let Some(inner_op) = op.strip_prefix('Z')
             && !inner_op.is_empty()
@@ -1079,7 +1079,7 @@ impl Interpreter {
                     &right_list[i],
                 )?);
             }
-            return Ok(Value::array(out));
+            return Ok(Value::Seq(std::sync::Arc::new(out)));
         }
         match op {
             "+" => {
@@ -1209,34 +1209,41 @@ impl Interpreter {
                 }
             }
             "minmax" => {
-                // Check if either operand is an array/list - if so, fall through to
-                // builtin_minmax which handles flattening. This path is only for
-                // scalar reduction like [minmax] 1, 2, 3.
-                if matches!(left, Value::Array(_, _) | Value::Seq(_))
-                    || matches!(right, Value::Array(_, _) | Value::Seq(_))
-                {
-                    return Err(RuntimeError::new(format!(
-                        "Unsupported reduction operator: {}",
-                        op
-                    )));
-                }
-                // Extract min/max from existing Ranges
-                let (left_lo, left_hi) = match left {
-                    Value::Range(a, b)
-                    | Value::RangeExcl(a, b)
-                    | Value::RangeExclStart(a, b)
-                    | Value::RangeExclBoth(a, b) => (Value::Int(*a), Value::Int(*b)),
-                    Value::GenericRange { start, end, .. } => ((**start).clone(), (**end).clone()),
-                    _ => (left.clone(), left.clone()),
+                // Helper to extract (lo, hi) from a value:
+                // - Range variants → (start, end)
+                // - Array/Seq → (min_element, max_element)
+                // - Scalar → (value, value)
+                let range_bounds = |v: &Value| -> (Value, Value) {
+                    match v {
+                        Value::Range(a, b)
+                        | Value::RangeExcl(a, b)
+                        | Value::RangeExclStart(a, b)
+                        | Value::RangeExclBoth(a, b) => (Value::Int(*a), Value::Int(*b)),
+                        Value::GenericRange { start, end, .. } => {
+                            ((**start).clone(), (**end).clone())
+                        }
+                        Value::Array(items, _) | Value::Seq(items) => {
+                            if items.is_empty() {
+                                (Value::Nil, Value::Nil)
+                            } else {
+                                let mut lo = items[0].clone();
+                                let mut hi = items[0].clone();
+                                for item in items.iter().skip(1) {
+                                    if crate::runtime::compare_values(item, &lo) < 0 {
+                                        lo = item.clone();
+                                    }
+                                    if crate::runtime::compare_values(item, &hi) > 0 {
+                                        hi = item.clone();
+                                    }
+                                }
+                                (lo, hi)
+                            }
+                        }
+                        _ => (v.clone(), v.clone()),
+                    }
                 };
-                let (right_lo, right_hi) = match right {
-                    Value::Range(a, b)
-                    | Value::RangeExcl(a, b)
-                    | Value::RangeExclStart(a, b)
-                    | Value::RangeExclBoth(a, b) => (Value::Int(*a), Value::Int(*b)),
-                    Value::GenericRange { start, end, .. } => ((**start).clone(), (**end).clone()),
-                    _ => (right.clone(), right.clone()),
-                };
+                let (left_lo, left_hi) = range_bounds(left);
+                let (right_lo, right_hi) = range_bounds(right);
                 let lo = if crate::runtime::compare_values(&left_lo, &right_lo) <= 0 {
                     left_lo
                 } else {
@@ -1247,22 +1254,42 @@ impl Interpreter {
                 } else {
                     right_hi
                 };
-                Ok(Value::GenericRange {
-                    start: std::sync::Arc::new(lo),
-                    end: std::sync::Arc::new(hi),
-                    excl_start: false,
-                    excl_end: false,
+                // Return Range(lo,hi) when both bounds are integers (matches
+                // Raku's behavior where `1..3 eqv 1..3` uses the integer Range
+                // type), otherwise use GenericRange for non-integer bounds.
+                Ok(match (&lo, &hi) {
+                    (Value::Int(l), Value::Int(h)) => Value::Range(*l, *h),
+                    _ => Value::GenericRange {
+                        start: std::sync::Arc::new(lo),
+                        end: std::sync::Arc::new(hi),
+                        excl_start: false,
+                        excl_end: false,
+                    },
                 })
             }
             "min" => {
-                if crate::runtime::compare_values(left, right) <= 0 {
+                // Undefined (Any/Nil/type-object) acts as Inf for min
+                let left_undef = !crate::runtime::types::value_is_defined(left);
+                let right_undef = !crate::runtime::types::value_is_defined(right);
+                if left_undef && right_undef {
+                    Ok(Value::Num(f64::INFINITY))
+                } else if left_undef {
+                    Ok(right.clone())
+                } else if right_undef || crate::runtime::compare_values(left, right) <= 0 {
                     Ok(left.clone())
                 } else {
                     Ok(right.clone())
                 }
             }
             "max" => {
-                if crate::runtime::compare_values(left, right) >= 0 {
+                // Undefined (Any/Nil/type-object) acts as -Inf for max
+                let left_undef = !crate::runtime::types::value_is_defined(left);
+                let right_undef = !crate::runtime::types::value_is_defined(right);
+                if left_undef && right_undef {
+                    Ok(Value::Num(f64::NEG_INFINITY))
+                } else if left_undef {
+                    Ok(right.clone())
+                } else if right_undef || crate::runtime::compare_values(left, right) >= 0 {
                     Ok(left.clone())
                 } else {
                     Ok(right.clone())

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -83,7 +83,20 @@ impl Interpreter {
                 ">=" => super::super::to_float_value(&left) >= super::super::to_float_value(&right),
                 "===" => crate::runtime::utils::values_identical(&left, &right),
                 "!===" => !crate::runtime::utils::values_identical(&left, &right),
-                "eqv" => Self::cmp_eqv_bool(&left, &right),
+                "eqv" => {
+                    // Check if either side is a consumed Seq (throws X::Seq::Consumed)
+                    if let Value::Seq(items) = &left
+                        && crate::value::seq_is_consumed(items)
+                    {
+                        return Err(crate::value::seq_consumed_error());
+                    }
+                    if let Value::Seq(items) = &right
+                        && crate::value::seq_is_consumed(items)
+                    {
+                        return Err(crate::value::seq_consumed_error());
+                    }
+                    Self::cmp_eqv_bool(&left, &right)
+                }
                 "=:=" => crate::runtime::utils::values_identical(&left, &right),
                 "=~=" | "\u{2245}" => {
                     // =~= / ≅ approximately equal

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -20,6 +20,158 @@ fn consumed_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
     CONSUMED_SEQS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
+/// Global set tracking "cached" Seq instances (have called .cache).
+static CACHED_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
+
+fn cached_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
+    CACHED_SEQS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Global map from Seq Arc ptr (as usize) to a deferred iterator Value.
+/// Used for `Seq.new(iterator)` to defer pulling until the Seq is consumed.
+static DEFERRED_SEQ_ITERS: OnceLock<Mutex<HashMap<usize, Value>>> = OnceLock::new();
+
+fn deferred_seq_iters() -> &'static Mutex<HashMap<usize, Value>> {
+    DEFERRED_SEQ_ITERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Global set tracking lazy Seq instances (e.g. from Seq.from-loop without condition).
+static LAZY_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
+
+fn lazy_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
+    LAZY_SEQS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Mark a Seq as lazy (infinite, from Seq.from-loop without condition).
+pub(crate) fn seq_mark_lazy(arc_ptr: &Arc<Vec<Value>>) {
+    let mut list = lazy_seqs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    list.retain(|w| w.strong_count() > 0);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return; // already tracked
+        }
+    }
+    list.push(Arc::downgrade(arc_ptr));
+}
+
+/// Check if a Seq has been marked as lazy.
+pub(crate) fn seq_is_lazy(arc_ptr: &Arc<Vec<Value>>) -> bool {
+    let list = lazy_seqs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Global set tracking consumed LazyList instances (gather-based Seqs).
+static CONSUMED_LAZYLISTS: OnceLock<Mutex<Vec<Weak<LazyList>>>> = OnceLock::new();
+
+fn consumed_lazylists() -> &'static Mutex<Vec<Weak<LazyList>>> {
+    CONSUMED_LAZYLISTS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Register a deferred iterator for a Seq. Called by Seq.new(iterator).
+pub(crate) fn seq_register_deferred_iter(arc_ptr: &Arc<Vec<Value>>, iterator: Value) {
+    let key = Arc::as_ptr(arc_ptr) as usize;
+    let mut map = deferred_seq_iters().lock().unwrap();
+    map.insert(key, iterator);
+}
+
+/// Take the deferred iterator for a Seq (if any). Removes and returns it.
+pub(crate) fn seq_take_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> Option<Value> {
+    let key = Arc::as_ptr(arc_ptr) as usize;
+    let mut map = deferred_seq_iters().lock().unwrap();
+    map.remove(&key)
+}
+
+/// Check if a Seq has a deferred iterator.
+pub(crate) fn seq_has_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> bool {
+    let key = Arc::as_ptr(arc_ptr) as usize;
+    let map = deferred_seq_iters().lock().unwrap();
+    map.contains_key(&key)
+}
+
+/// Mark a LazyList (from gather) as consumed.
+pub(crate) fn lazylist_consume(arc_ptr: &Arc<LazyList>) -> bool {
+    let mut list = consumed_lazylists().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    list.retain(|w| w.strong_count() > 0);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return false; // already consumed
+        }
+    }
+    list.push(Arc::downgrade(arc_ptr));
+    true
+}
+
+/// Check if a LazyList has been consumed.
+pub(crate) fn lazylist_is_consumed(arc_ptr: &Arc<LazyList>) -> bool {
+    let list = consumed_lazylists().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Mark a Seq as cached (called .cache on it). Cached Seqs do not get consumed.
+pub(crate) fn seq_mark_cached(arc_ptr: &Arc<Vec<Value>>) {
+    let mut list = cached_seqs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    list.retain(|w| w.strong_count() > 0);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return; // already tracked
+        }
+    }
+    list.push(Arc::downgrade(arc_ptr));
+}
+
+/// Check if a Seq has been marked as cached.
+pub(crate) fn seq_is_cached(arc_ptr: &Arc<Vec<Value>>) -> bool {
+    let list = cached_seqs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Build a structured X::Seq::Consumed error.
+#[allow(clippy::result_large_err)]
+pub(crate) fn seq_consumed_error() -> RuntimeError {
+    let msg = "The iterator of this Seq is already in use/consumed by another Seq \
+               (you might solve this by adding .cache on usages of the Seq, or by \
+               assigning the Seq into an array)";
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.to_string()));
+    let ex = Value::make_instance(crate::symbol::Symbol::intern("X::Seq::Consumed"), attrs);
+    let mut err = RuntimeError::new(msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
 /// Mark a Seq (identified by its Arc) as consumed.
 /// Returns Err if the Seq was already consumed.
 #[allow(clippy::result_large_err)]
@@ -32,15 +184,39 @@ pub(crate) fn seq_consume(arc_ptr: &Arc<Vec<Value>>) -> Result<(), RuntimeError>
         if let Some(existing) = w.upgrade()
             && Arc::as_ptr(&existing) == target_ptr
         {
-            return Err(RuntimeError::new(
-                "The iterator of this Seq is already in use/consumed by another Seq \
-                 (you might solve this by adding .cache on usages of the Seq, or by \
-                 assigning the Seq into an array)",
-            ));
+            return Err(seq_consumed_error());
         }
     }
     list.push(Arc::downgrade(arc_ptr));
     Ok(())
+}
+
+/// Check if a Seq (identified by its Arc) has been consumed.
+pub(crate) fn seq_is_consumed(arc_ptr: &Arc<Vec<Value>>) -> bool {
+    let list = consumed_seqs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    for w in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// For sink: if cached, do nothing; if consumed, do nothing (re-sink is ok);
+/// if not cached and not consumed, mark as consumed.
+pub(crate) fn seq_sink(arc_ptr: &Arc<Vec<Value>>) {
+    if seq_is_cached(arc_ptr) {
+        seq_take_deferred_iter(arc_ptr); // discard deferred iter if any
+        return;
+    }
+    if seq_is_consumed(arc_ptr) {
+        return;
+    }
+    let _ = seq_consume(arc_ptr);
+    // Caller is responsible for pulling from deferred iter if needed.
 }
 
 /// Shared mutable attribute storage for Proxy subclasses.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3458,7 +3458,11 @@ impl VM {
                         }
                         Value::array(items)
                     }
-                    Value::Seq(items) => Value::array(items.to_vec()),
+                    Value::Seq(items) => {
+                        // Consuming the Seq via eager marks it as consumed.
+                        crate::value::seq_sink(&items);
+                        Value::array(items.to_vec())
+                    }
                     ref other if other.is_range() => {
                         Value::array(crate::runtime::utils::value_to_list(&val))
                     }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -64,7 +64,7 @@ impl VM {
                     &right_list[i],
                 )?);
             }
-            return Ok(Value::array(results));
+            return Ok(Value::Seq(std::sync::Arc::new(results)));
         }
         // Hyper operator forms: >>op<<, >>op>>, <<op<<, <<op>>
         // Apply inner op element-wise to two lists.

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -95,6 +95,39 @@ fn is_parameterized_core_type(name: &str) -> bool {
     false
 }
 
+/// Compute the (lo, hi) bounds of a value for use in `minmax` reduction.
+/// For scalars: returns (v, v).
+/// For arrays/lists: returns (min_element, max_element).
+/// For ranges: returns (start, end).
+fn minmax_bounds_of_value(v: &Value) -> (Value, Value) {
+    match v {
+        Value::Range(a, b)
+        | Value::RangeExcl(a, b)
+        | Value::RangeExclStart(a, b)
+        | Value::RangeExclBoth(a, b) => (Value::Int(*a), Value::Int(*b)),
+        Value::GenericRange { start, end, .. } => ((**start).clone(), (**end).clone()),
+        Value::Array(items, _) | Value::Seq(items) => {
+            if items.is_empty() {
+                (Value::Nil, Value::Nil)
+            } else {
+                let mut lo = items[0].clone();
+                let mut hi = items[0].clone();
+                for item in items.iter().skip(1) {
+                    let (item_lo, item_hi) = minmax_bounds_of_value(item);
+                    if crate::runtime::compare_values(&item_lo, &lo) < 0 {
+                        lo = item_lo;
+                    }
+                    if crate::runtime::compare_values(&item_hi, &hi) > 0 {
+                        hi = item_hi;
+                    }
+                }
+                (lo, hi)
+            }
+        }
+        _ => (v.clone(), v.clone()),
+    }
+}
+
 impl VM {
     fn is_builtin_reduction_op(op: &str) -> bool {
         if let Some(inner) = op
@@ -1669,20 +1702,92 @@ impl VM {
                             out.push(result);
                         }
                     } else {
-                        let mut acc = list[0].clone();
-                        out.push(acc.clone());
-                        let mut idx = 1usize;
-                        while idx + step <= list.len() {
-                            let mut call_args = vec![acc];
-                            call_args.extend(list[idx..idx + step].iter().cloned());
-                            let v = self.reduction_step_with_args(
-                                &base_op,
-                                callable.as_ref(),
-                                call_args,
-                            )?;
-                            acc = if negate { Value::Bool(!v.truthy()) } else { v };
+                        // Special case for Z/X meta-operators (e.g. [\Z~], [\X~])
+                        // when scan elements are themselves lists. In this case a
+                        // simple left-fold loses structure, so we re-apply the
+                        // operator to the entire prefix at each step.
+                        // E.g. [\Z~](<a b c>, <1 2 3>):
+                        //   step 1 = [Z~](<a b c>)       = ("abc",)
+                        //   step 2 = [Z~](<a b c>,<1 2 3>) = ("a1","b2","c3")
+                        let is_multi_list_zx = callable.is_none()
+                            && list
+                                .iter()
+                                .any(|v| matches!(v, Value::Array(_, _) | Value::Seq(_)))
+                            && ((base_op.starts_with('Z') && base_op.len() > 1)
+                                || (base_op.starts_with('X') && base_op.len() > 1));
+                        if is_multi_list_zx {
+                            // Compute prefix reductions from scratch at each step
+                            for i in 0..list.len() {
+                                let v = if i == 0 {
+                                    // Single-element: apply inner_op as a left-fold
+                                    // over the first list's elements, wrapped in Seq.
+                                    let inner_op = &base_op[1..];
+                                    let items = runtime::value_to_list(&list[0]);
+                                    if items.is_empty() {
+                                        Value::Seq(std::sync::Arc::new(vec![]))
+                                    } else {
+                                        let mut acc0 = items[0].clone();
+                                        for item in items.iter().skip(1) {
+                                            acc0 = self.eval_reduction_operator_values(
+                                                inner_op, &acc0, item,
+                                            )?;
+                                        }
+                                        Value::Seq(std::sync::Arc::new(vec![acc0]))
+                                    }
+                                } else {
+                                    // Apply the Z/X op to all prefix elements
+                                    let mut acc0 = list[0].clone();
+                                    for item in list.iter().take(i + 1).skip(1) {
+                                        acc0 = self.eval_reduction_operator_values(
+                                            &base_op, &acc0, item,
+                                        )?;
+                                    }
+                                    acc0
+                                };
+                                let result = if negate { Value::Bool(!v.truthy()) } else { v };
+                                out.push(result);
+                            }
+                        } else {
+                            let mut acc = list[0].clone();
+                            // For certain operators, the first scan element should be
+                            // the result of applying [op] to a single element, not the
+                            // element itself:
+                            //   Z~/X~ meta-operators: [Z~]("a") = ("a",) not "a"
+                            //   minmax: [minmax](x) = x..x not x
+                            if callable.is_none() {
+                                let zx_prefix = (base_op.starts_with('Z') && base_op.len() > 1)
+                                    || (base_op.starts_with('X') && base_op.len() > 1);
+                                if zx_prefix {
+                                    acc = Value::Seq(std::sync::Arc::new(vec![acc]));
+                                } else if base_op == "minmax" {
+                                    // [minmax](x) = x..x for scalars,
+                                    // or min(x)..max(x) for array/list x.
+                                    let (lo, hi) = minmax_bounds_of_value(&acc);
+                                    acc = match (&lo, &hi) {
+                                        (Value::Int(l), Value::Int(h)) => Value::Range(*l, *h),
+                                        _ => Value::GenericRange {
+                                            start: std::sync::Arc::new(lo),
+                                            end: std::sync::Arc::new(hi),
+                                            excl_start: false,
+                                            excl_end: false,
+                                        },
+                                    };
+                                }
+                            }
                             out.push(acc.clone());
-                            idx += step;
+                            let mut idx = 1usize;
+                            while idx + step <= list.len() {
+                                let mut call_args = vec![acc];
+                                call_args.extend(list[idx..idx + step].iter().cloned());
+                                let v = self.reduction_step_with_args(
+                                    &base_op,
+                                    callable.as_ref(),
+                                    call_args,
+                                )?;
+                                acc = if negate { Value::Bool(!v.truthy()) } else { v };
+                                out.push(acc.clone());
+                                idx += step;
+                            }
                         }
                     }
                     out
@@ -1786,6 +1891,36 @@ impl VM {
                         acc = self.interpreter.compose_callables(acc, item.clone());
                     }
                     self.stack.push(acc);
+                    return Ok(());
+                }
+                // Single-element reduction with a numeric/coercing operator:
+                // apply op(identity, element) so that coercions (e.g. numification
+                // for `+`) happen and type errors (e.g. X::Str::Numeric for
+                // `[+] "hello"`) are raised.  This matches Raku semantics where
+                // `[+] "2"` returns Int 2 (not Str "2").
+                if list.len() == 1
+                    && callable.is_none()
+                    && matches!(
+                        base_op.as_str(),
+                        "+" | "-" | "*" | "/" | "%" | "**" | "+|" | "+&" | "+^"
+                    )
+                {
+                    // Validate: non-numeric strings must throw X::Str::Numeric
+                    if let Value::Str(ref s) = list[0]
+                        && crate::runtime::str_numeric::parse_raku_str_to_numeric(s).is_none()
+                    {
+                        return Err(RuntimeError::str_numeric(
+                            s,
+                            "base-10 number must begin with valid digits or '.'",
+                        ));
+                    }
+                    let identity = runtime::reduction_identity(&base_op);
+                    // Coerce Instance values via Numeric()/Bridge() so that
+                    // user-defined numeric types work (e.g. `[*] CustomNumify.new`).
+                    let elem = self.coerce_numeric_bridge_value(list[0].clone())?;
+                    let v = self.reduction_step_with_args(&base_op, None, vec![identity, elem])?;
+                    let result = if negate { Value::Bool(!v.truthy()) } else { v };
+                    self.stack.push(result);
                     return Ok(());
                 }
                 let acc = match assoc {
@@ -1938,7 +2073,9 @@ impl VM {
                 _ => false,
             };
             if should_short_circuit {
-                if scan {
+                // For `andthen`: once acc is undefined, drop remaining elements from scan.
+                // For all other operators (&&/||/and/or/orelse), repeat the accumulated value.
+                if scan && op != "andthen" {
                     results.push(acc.clone());
                 }
                 // don't evaluate thunk

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -315,6 +315,12 @@ impl VM {
         }
         // Normalize Seq/Slip target to List for uniform handling
         if let Value::Seq(items) = target {
+            // Subscript on a consumed Seq throws X::Seq::Consumed.
+            // Subscript on any Seq marks it as cached (can be used again).
+            if crate::value::seq_is_consumed(&items) {
+                return Err(crate::value::seq_consumed_error());
+            }
+            crate::value::seq_mark_cached(&items);
             target = Value::Array(items, crate::value::ArrayKind::List);
         } else if let Value::Slip(items) = target {
             target = Value::Array(items, crate::value::ArrayKind::List);


### PR DESCRIPTION
## Summary

- Fixed X::Syntax::CannotMeta error for non-associative reduce operators (`leg`, `<=>`, `cmp`)
- Fixed X::Str::Numeric for single-element reduce with non-numeric string (e.g. `[+] 'hello'`)
- Coerce Instance values via Numeric()/Bridge() for single-element reduce (e.g. `[*] CustomNumify.new`)
- X/Z meta-operators now return `Value::Seq` for correct `eqv` comparisons
- `minmax` operator supports Array/Seq arguments and returns `Value::Range` for integer bounds
- `min`/`max` treat undefined values as `Inf`/`-Inf` respectively
- Triangle scan `[\op]` for Z~/X~ operators recomputes from scratch at each step
- Initial scan value for Z~/X~ wraps single element in `Seq`; `minmax` gives `Range`
- `andthen` scan correctly truncates result when short-circuit fires (remaining elements dropped)
- Functional `reduce(&infix:<+>, single-elem)` applies identity element for type coercion
- Seq consumed/cached state tracking infrastructure (for S32-list/seq.t)

## Test plan

- [ ] `prove -e 'target/debug/mutsu' roast/S03-metaops/reduce.t` shows 17 failures (down from 34+)
- [ ] `make test` passes
- [ ] `make roast` passes whitelisted tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)