### PR TITLE
fix: pass roast/S32-list/seq.t (all 50 tests)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1062,7 +1062,6 @@ roast/S32-list/repeated.t
 roast/S32-list/reverse.t
 roast/S32-list/roll.t
 roast/S32-list/rotor.t
-roast/S32-list/seq.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1062,6 +1062,7 @@ roast/S32-list/repeated.t
 roast/S32-list/reverse.t
 roast/S32-list/roll.t
 roast/S32-list/rotor.t
+roast/S32-list/seq.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -452,6 +452,8 @@ pub(crate) enum ForMode {
     Normal,
     Race,
     Hyper,
+    /// `lazy for` — loop body executes lazily (not until Seq is consumed)
+    Lazy,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -577,6 +577,10 @@ pub fn raku_value(v: &Value) -> String {
             let end_sep = if *excl_end { "^" } else { "" };
             format!("{}{}{}{}", start_repr, start_sep, end_sep, end_repr)
         }
+        Value::Scalar(inner) => {
+            // $(expr) — itemized container. Render as $(<inner_raku>).
+            format!("$({})", raku_value(inner))
+        }
         Value::Capture { positional, named } => {
             let mut parts = Vec::new();
             for v in positional {

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -167,6 +167,25 @@ impl Compiler {
                 params,
                 body,
                 label,
+                mode,
+                ..
+            } if *mode == crate::ast::ForMode::Lazy => {
+                self.compile_lazy_for_expr(
+                    iterable,
+                    param,
+                    param_def.as_ref(),
+                    params,
+                    body,
+                    label,
+                );
+            }
+            Stmt::For {
+                iterable,
+                param,
+                param_def,
+                params,
+                body,
+                label,
                 ..
             } => {
                 self.compile_do_for_expr(iterable, param, param_def.as_ref(), params, body, label);

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -259,6 +259,54 @@ impl Compiler {
         self.code.patch_loop_end(loop_idx);
     }
 
+    /// Compile `lazy for` expression: lower to `gather { for @items -> $param { take do { body } } }`.
+    /// This defers execution of the body until the resulting Seq is consumed.
+    pub(super) fn compile_lazy_for_expr(
+        &mut self,
+        iterable: &Expr,
+        param: &Option<String>,
+        param_def: &Option<crate::ast::ParamDef>,
+        params: &[String],
+        body: &[Stmt],
+        label: &Option<String>,
+    ) {
+        use crate::ast::{Expr as AExpr, Stmt as AStmt};
+        // Build `take <last_expr>` body: replace the last expression with `take <expr>`
+        // and wrap the body in a for loop inside a gather block.
+        let take_body: Vec<AStmt> = {
+            let mut stmts = body.to_vec();
+            // Replace last expression statement with `take(expr)`
+            let last_idx = stmts.iter().rposition(|s| !matches!(s, AStmt::SetLine(_)));
+            if let Some(idx) = last_idx {
+                if let AStmt::Expr(expr) = stmts[idx].clone() {
+                    stmts[idx] = AStmt::Take(expr);
+                } else {
+                    // Wrap non-expr last stmt in Take(Nil) since we need a take
+                    stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil)));
+                }
+            } else {
+                stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil)));
+            }
+            stmts
+        };
+        // Build inner for loop with the take body
+        let inner_for = AStmt::For {
+            iterable: iterable.clone(),
+            param: param.clone(),
+            param_def: Box::new(param_def.clone()),
+            params: params.to_vec(),
+            body: take_body,
+            label: label.clone(),
+            mode: crate::ast::ForMode::Normal,
+            rw_block: false,
+            explicit_zero_params: false,
+        };
+        // Build gather block wrapping the for loop
+        let gather_body = vec![inner_for];
+        let gather_expr = AExpr::Gather(gather_body);
+        self.compile_expr(&gather_expr);
+    }
+
     /// Compile `do while` / `do until` expression: collect each iteration value.
     pub(super) fn compile_do_while_expr(
         &mut self,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1213,7 +1213,10 @@ impl Compiler {
                     arity,
                     collect: false,
                     restore_topic,
-                    threaded: *mode != crate::ast::ForMode::Normal,
+                    threaded: matches!(
+                        *mode,
+                        crate::ast::ForMode::Race | crate::ast::ForMode::Hyper
+                    ),
                     // is_rw: param is writable (don't mark readonly)
                     is_rw: has_rw || has_copy,
                     // do_writeback: actually write back modifications to source container

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1237,9 +1237,15 @@ pub(super) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
     // lazy prefix: wrap inner expression with .lazy method call
     // `lazy` is a statement prefix — it wraps the full following expression
     // (including infix operators like `..`), not just the next prefix term.
+    // Special case: `lazy for ...` compiles the for loop with ForMode::Lazy
+    // so the body does not execute until the resulting Seq is consumed.
     if input.starts_with("lazy") && !is_ident_char(input.as_bytes().get(4).copied()) {
         let r = &input[4..];
         let (r, _) = ws(r)?;
+        // Try to parse as `lazy for ...` first
+        if let Ok((r2, stmt)) = super::super::stmt::lazy_for_stmt_pub(r) {
+            return Ok((r2, Expr::DoStmt(Box::new(stmt))));
+        }
         let (r, expr) = expression_no_sequence(r)?;
         return Ok((
             r,

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -987,6 +987,11 @@ pub(super) fn hyper_for_stmt(input: &str) -> PResult<'_, Stmt> {
     for_stmt_with_mode(rest, crate::ast::ForMode::Hyper)
 }
 
+/// Parse `for ...` with Lazy mode (input starts at `for`, not `lazy`).
+pub(super) fn lazy_for_body(input: &str) -> PResult<'_, Stmt> {
+    for_stmt_with_mode(input, crate::ast::ForMode::Lazy)
+}
+
 /// Scan for `<->` (rw pointy block) in the input, returning its byte offset.
 /// This must handle nesting to avoid matching inside strings, brackets, etc.
 fn find_rw_pointy_block(input: &str) -> Option<usize> {

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -365,6 +365,12 @@ pub(super) fn for_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::for_stmt(input)
 }
 
+/// Public accessor for `lazy for` statement parser (used by primary.rs for `lazy for` expressions).
+/// Input should start at `for` (not `lazy`).
+pub(super) fn lazy_for_stmt_pub(input: &str) -> PResult<'_, Stmt> {
+    control::lazy_for_body(input)
+}
+
 /// Public accessor for `if` statement parser (used by primary.rs for `if` expressions).
 pub(super) fn if_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::if_stmt(input)

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -733,6 +733,23 @@ impl Interpreter {
                         return Ok(Value::array(vec![Value::str(method_name)]));
                     }
                 }
+                // pull-one on a temporary iterator (no variable): read from items at current index.
+                // Since the iterator is a temporary, index is always 0 or whatever is in attrs.
+                "pull-one" if args.is_empty() => {
+                    let items = match attributes.get("items") {
+                        Some(Value::Array(values, ..)) => values.to_vec(),
+                        _ => Vec::new(),
+                    };
+                    let index = match attributes.get("index") {
+                        Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                        _ => 0,
+                    };
+                    if index < items.len() {
+                        return Ok(items[index].clone());
+                    } else {
+                        return Ok(Value::str_from("IterationEnd"));
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -50,6 +50,65 @@ impl Interpreter {
             self.env
                 .insert("@_".to_string(), Value::array(plain_args.clone()));
         }
+        // Single-argument rule: when exactly one positional arg is a Seq/List
+        // and the function expects multiple positional params, flatten the Seq/List
+        // into individual positional args.
+        let filtered_args: Vec<Value> = {
+            let positional_count = filtered_args
+                .iter()
+                .filter(|a| !matches!(unwrap_varref_value((*a).clone()), Value::Pair(..)))
+                .count();
+            let required_positional_count = param_defs
+                .iter()
+                .filter(|pd| {
+                    !pd.named
+                        && !pd.slurpy
+                        && !pd.double_slurpy
+                        && !pd.onearg
+                        && !pd.optional_marker
+                        && !pd.name.is_empty()
+                        && !pd.name.starts_with(':')
+                        && !pd.is_invocant
+                        && pd.default.is_none()
+                })
+                .count();
+            if positional_count == 1 && required_positional_count >= 2 {
+                // Check if the single positional arg is a Seq or non-itemized Array/List
+                let single_pos = filtered_args
+                    .iter()
+                    .find(|a| !matches!(unwrap_varref_value((*a).clone()), Value::Pair(..)));
+                let named_args: Vec<Value> = filtered_args
+                    .iter()
+                    .filter(|a| matches!(unwrap_varref_value((*a).clone()), Value::Pair(..)))
+                    .cloned()
+                    .collect();
+                if let Some(single) = single_pos {
+                    let unwrapped = unwrap_varref_value(single.clone());
+                    match unwrapped {
+                        Value::Seq(items) => {
+                            let mut expanded = items.to_vec();
+                            expanded.extend(named_args);
+                            expanded
+                        }
+                        Value::Array(items, kind) if !kind.is_itemized() => {
+                            let mut expanded = items.to_vec();
+                            expanded.extend(named_args);
+                            expanded
+                        }
+                        Value::Slip(items) => {
+                            let mut expanded = items.to_vec();
+                            expanded.extend(named_args);
+                            expanded
+                        }
+                        _ => filtered_args,
+                    }
+                } else {
+                    filtered_args
+                }
+            } else {
+                filtered_args
+            }
+        };
         let args = filtered_args.as_slice();
         let arg_sources = self.take_pending_call_arg_sources();
         let mut rw_bindings = Vec::new();


### PR DESCRIPTION
## Summary

- Implement `Value::Scalar` handler in `raku_repr.rs` for `$(expr)` itemization (fixes test 36)
- Add `pull-one` support on temporary Iterator instances in non-mut method dispatch path (fixes test 39)
- Implement `lazy for` as `ForMode::Lazy` in AST/parser/compiler, lowered to `gather { for ... { take ... } }` (fixes test 42)
- Add single-argument rule: when a Seq/List is the sole arg to a function expecting 2+ required positionals, expand it (fixes test 33 subtest 2)

## Test plan

- `prove -e 'target/debug/mutsu' roast/S32-list/seq.t` — all 50 tests pass
- Local test suite: only pre-existing failures (json-tiny-compat.t timeout, wrap.t plan mismatch)
- No new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)