### PR TITLE
fix: implement X::Worry::Precedence::Range typed exception

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -30,6 +30,33 @@ fn syntax_exception(class_name: &str, message: impl Into<String>) -> PError {
     PError::fatal_with_exception(message, Box::new(exception))
 }
 
+fn worry_precedence_range(action: &str) -> PError {
+    let message = format!(
+        "To {} a range, parenthesize the whole range.\n(Or parenthesize the whole endpoint expression, if you meant that.)",
+        action
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("action".to_string(), Value::str(action.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Worry::Precedence::Range"), attrs);
+    PError::fatal_with_exception(message, Box::new(exception))
+}
+
+/// Check if the left expression of a range operator is a bare prefix `|` or `~`
+/// (not parenthesized), which creates a precedence ambiguity warning.
+/// We check the original input text rather than the AST because parentheses
+/// are transparent in the AST (`(|4)` and `|4` produce the same tree).
+fn check_range_precedence_worry(input: &str) -> Result<(), PError> {
+    let trimmed = input.trim_start();
+    if trimmed.starts_with('|') && !trimmed.starts_with("|(") {
+        return Err(worry_precedence_range("apply a Slip flattener to"));
+    }
+    if trimmed.starts_with('~') && !trimmed.starts_with("~(") {
+        return Err(worry_precedence_range("stringify"));
+    }
+    Ok(())
+}
+
 fn non_list_associative_error(lhs: &str, rhs: &str) -> PError {
     syntax_exception(
         "X::Syntax::NonListAssociative",
@@ -2607,6 +2634,7 @@ pub(super) fn range_expr(input: &str) -> PResult<'_, Expr> {
     let (r, _) = ws(rest)?;
 
     if let Some(stripped) = r.strip_prefix("^..^") {
+        check_range_precedence_worry(input)?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r).map_err(|err| {
             enrich_expected_error(err, "expected range RHS after '^..^'", r.len())
@@ -2621,6 +2649,7 @@ pub(super) fn range_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     if let Some(stripped) = r.strip_prefix("^..") {
+        check_range_precedence_worry(input)?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '^..'", r.len()))?;
@@ -2634,6 +2663,7 @@ pub(super) fn range_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     if let Some(stripped) = r.strip_prefix("..^") {
+        check_range_precedence_worry(input)?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '..^'", r.len()))?;
@@ -2647,6 +2677,7 @@ pub(super) fn range_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     if r.starts_with("..") && !r.starts_with("...") {
+        check_range_precedence_worry(input)?;
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, right) = structural_expr(r)


### PR DESCRIPTION
## Summary
- Implement `X::Worry::Precedence::Range` typed exception that detects bare prefix `|` (Slip) and `~` (stringify) operators before range operators (`..`, `^..`, `..^`, `^..^`)
- Matches Raku's behavior: `|4 .. 5` and `~4 .. 5` emit a parse error with a helpful message suggesting parenthesization
- Parenthesized forms like `|(4..5)`, `(|4)..5`, `~(4..5)`, and `(~4)..5` are accepted without warning
- Fixes 8 subtests in `roast/S03-operators/range.t` (tests 130-149)

## Test plan
- [x] `|4 .. 5` emits `X::Worry::Precedence::Range` error
- [x] `~4 .. 5` emits `X::Worry::Precedence::Range` error  
- [x] `|4 ^.. 5`, `|4 ..^ 5`, `|4 ^..^ 5` all emit the error
- [x] `|(4 .. 5)`, `(|4) .. 5`, `~(4 .. 5)`, `(~4) .. 5` work without error
- [x] Local range tests pass (`t/range-variants.t`, `t/range-method.t`, `t/range-list.t`)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)