### PR TITLE
fix: propagate ContainerRef on has $x attribute binding

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1319,6 +1319,23 @@ impl VM {
                         self.interpreter
                             .env_mut()
                             .insert(resolved_source.clone(), container.clone());
+                        // If the target is an attribute alias (`has $x` makes `x`
+                        // an alias for `!x`), also store the ContainerRef under
+                        // the private attribute key so writeback picks it up when
+                        // the method returns. Check via the reverse alias:
+                        // `__mutsu_sigilless_alias::!x` → `"x"`.
+                        {
+                            let reverse_key = format!("__mutsu_sigilless_alias::!{}", name);
+                            if let Some(Value::Str(ref target)) =
+                                self.interpreter.env().get(&reverse_key).cloned()
+                                && target.as_str() == name
+                            {
+                                let priv_key = format!("!{}", name);
+                                self.interpreter
+                                    .env_mut()
+                                    .insert(priv_key, container.clone());
+                            }
+                        }
                         // When rebinding to a new source, the old alias target
                         // keeps its existing value/ContainerRef — we only break
                         // the alias, we do NOT propagate the new ContainerRef to

--- a/t/has-attr-binding.t
+++ b/t/has-attr-binding.t
@@ -1,0 +1,34 @@
+use Test;
+plan 6;
+
+# Test binding on `has $x` (attribute without twigil) aliases
+{
+    my $var = 42;
+    my class Klass {
+        has $x;
+        method bind { $x := $var }
+        method get_x { $x }
+        method set_x ($new_x) { $x = $new_x }
+    }
+
+    my $obj = Klass.new;
+    $obj.bind();
+
+    is $obj.get_x, 42, 'binding has $x attribute reads bound value';
+    $var = 23;
+    is $obj.get_x, 23, 'binding has $x attribute tracks changes to source';
+    $obj.set_x(19);
+    is $var, 19, 'binding has $x attribute propagates writes back to source';
+}
+
+# Test binding on `has $.x` ($!x) instance attribute
+{
+    my $var = 100;
+    my class Klass2 { has $.x; method bind { $!x := $var } }
+
+    my $obj = Klass2.new;
+    lives-ok { $obj.bind() }, 'binding $!x instance attribute lives';
+    is $obj.x, 100, 'binding $!x reads bound value';
+    $var = 200;
+    is $obj.x, 200, 'binding $!x tracks source changes';
+}


### PR DESCRIPTION
## Summary
- Fix `has $x` (no-twigil) attribute binding inside methods: when `$x := $var` is executed, the `ContainerRef` is now also stored under the private attribute key `!x`, so attribute writeback correctly preserves the binding across method calls.
- This fixes roast/S03-binding/attributes.t tests 4-6 (Klass2 private instance attribute binding).
- Addresses PLAN.md "Container semantics" item for attribute binding.

## Test plan
- [x] New test `t/has-attr-binding.t` with 6 assertions covering `has $x` and `has $.x` binding scenarios
- [x] `prove -e './target/debug/mutsu' roast/S03-binding/attributes.t` passes tests 1-12 (13-16 are unrelated mixin issues)
- [x] `make test` passes (pre-existing flaky failures in lock.t, placeholder.t, wrap.t)
- [x] `make roast` passes (pre-existing timeout in sprintf-d.t)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)