### PR TITLE
fix: support bound variable declarations in expression context

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1026,6 +1026,7 @@ roast/S32-io/utf16.t
 roast/S32-list/are.t
 roast/S32-list/batch.t
 roast/S32-list/categorize-list.t
+roast/S32-list/categorize.t
 roast/S32-list/classify-list.t
 roast/S32-list/combinations.t
 roast/S32-list/create.t

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -104,9 +104,21 @@ impl Compiler {
                             name_idx,
                             dynamic: is_dynamic,
                         });
-                        self.compile_expr(expr);
-                        self.code.emit(OpCode::Dup);
-                        self.emit_set_named_var(name);
+                        if has_mark_bind && (name.starts_with('@') || name.starts_with('%')) {
+                            // Bind context for @/% variables (e.g. `my %h := :{ }`):
+                            // use SetLocal with MarkBindContext and MarkVarDeclContext
+                            // to avoid the readonly check that SetGlobal performs.
+                            self.compile_expr(expr);
+                            self.code.emit(OpCode::Dup);
+                            self.code.emit(OpCode::MarkBindContext);
+                            self.code.emit(OpCode::MarkVarDeclContext);
+                            let slot = self.alloc_local(name);
+                            self.code.emit(OpCode::SetLocal(slot));
+                        } else {
+                            self.compile_expr(expr);
+                            self.code.emit(OpCode::Dup);
+                            self.emit_set_named_var(name);
+                        }
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }


### PR DESCRIPTION
## Summary
- Fix `my %h := :{ }` / `my @a := [...]` in expression context (e.g., `:into(my %h := :{ })`)
- The compiler was using `SetGlobal` which checks readonly, causing "Cannot assign to a readonly variable" errors
- Now uses `SetLocal` with `MarkBindContext`/`MarkVarDeclContext` for bound @/% VarDecls in block-final position
- Adds `roast/S32-list/categorize.t` to whitelist (0/28 -> 28/28 passing)
- `roast/S32-list/classify.t` improves from 2/40 to 32/40 (remaining failures are unrelated: topic variable mutation, anonymous state variables, Junction hash keys)

## Test plan
- [x] `prove -e target/debug/mutsu roast/S32-list/categorize.t` passes all 28 tests
- [x] `prove -e target/release/mutsu t/` - no regressions (same pre-existing failures)
- [x] `make roast` - no regressions
- [x] `cargo test` - 449 passed
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)