### PR TITLE
docs: add 6.d/sprintf.t to whitelist, document zprintf test bugs

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -196,19 +196,12 @@ WhateverCode (*) in certain contexts: dummy assignment to *, &infix:<+>(*, 42) n
 - roast/S03-operators/eqv.t (eqv on references)
 - roast/S02-types/generics.t (nominalizable generic)
 
-## Sprintf / Format Edge Cases (7 tests)
+## Sprintf / Format Edge Cases (2 tests)
 
-sprintf %g/%G formatting, and the large sprintf-b/d/e/f/x test suites timeout due to sheer volume (2000+ subtests each). The format.t file seems to pass mostly.
+The 6.d/S32-str/sprintf*.t suites all pass now. The non-6.d sprintf.t (zprintf) has roast test bugs.
 
-**Timeout:**
-- roast/S32-str/sprintf-b.t (2282 tests, likely hangs mid-way)
-- roast/S32-str/sprintf-d.t (4565 tests)
-- roast/S32-str/sprintf-e.t (2282 tests)
-- roast/S32-str/sprintf-f.t (2282 tests)
-- roast/S32-str/sprintf-x.t (2282 tests)
-
-**Fail:**
-- roast/S32-str/sprintf.t (%g/%G formatting)
+**Fail (roast test bugs):**
+- roast/S32-str/sprintf.t (166/174 pass; 8 failures from buggy test expectations)
 - roast/S32-str/format.t
 
 ## Unicode / Collation (6 tests)

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -308,6 +308,7 @@
 - [ ] roast/S32-str/sprintf-o.t
 - [ ] roast/S32-str/sprintf-s.t
 - [ ] roast/S32-str/sprintf.t
+  - 166/174 pass. 8 failures due to buggy expected values in roast test (zprintf is unimplemented in Raku).
 - [ ] roast/S32-str/sprintf-u.t
 - [ ] roast/S32-str/sprintf-x.t
 - [ ] roast/S32-str/starts-with.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -13,6 +13,7 @@ roast/6.d/S32-str/sprintf-o.t
 roast/6.d/S32-str/sprintf-s.t
 roast/6.d/S32-str/sprintf-u.t
 roast/6.d/S32-str/sprintf-x.t
+roast/6.d/S32-str/sprintf.t
 roast/MISC/bug-coverage-stress.t
 roast/S01-perl-5-integration/array.t
 roast/S01-perl-5-integration/basic.t


### PR DESCRIPTION
## Summary
- Add `roast/6.d/S32-str/sprintf.t` (174 tests) to the whitelist — it passes completely
- Update BLOCKERS.md to reflect that the 6.d sprintf test suites all pass now (down from 7 blocked tests to 2)
- Document that `roast/S32-str/sprintf.t` (the zprintf v6.e.PREVIEW variant) has 8 buggy expected values that cannot be matched — zprintf is unimplemented in Raku so these expectations were never validated

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/6.d/S32-str/sprintf.t` passes (174/174)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] CI (`make test` + `make roast`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)