### PR TITLE
fix: support :k, :v, :kv, :p adverbs on min/max and add minmax.t to whitelist

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1055,6 +1055,7 @@ roast/S32-list/iterator.t
 roast/S32-list/join.t
 roast/S32-list/map.t
 roast/S32-list/map_function_return_values.t
+roast/S32-list/minmax.t
 roast/S32-list/permutations.t
 roast/S32-list/pick.t
 roast/S32-list/produce.t

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1236,21 +1236,13 @@ fn native_function_2arg(
             }
         }
         "min" => {
-            if matches!(arg1, Value::Pair(name, _) if name == "by")
-                || matches!(arg2, Value::Pair(name, _) if name == "by")
-                || matches!(arg1, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-                || matches!(arg2, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-            {
+            if is_extrema_named_pair(arg1) || is_extrema_named_pair(arg2) {
                 return None;
             }
             Some(minmax_two(arg1, arg2, false))
         }
         "max" => {
-            if matches!(arg1, Value::Pair(name, _) if name == "by")
-                || matches!(arg2, Value::Pair(name, _) if name == "by")
-                || matches!(arg1, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-                || matches!(arg2, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-            {
+            if is_extrema_named_pair(arg1) || is_extrema_named_pair(arg2) {
                 return None;
             }
             Some(minmax_two(arg1, arg2, true))
@@ -1448,16 +1440,25 @@ fn generic_range_as_bigint(v: &Value) -> Option<NumBigInt> {
     }
 }
 
+/// Check if a value is a named pair relevant to min/max/minmax dispatch
+/// (i.e. :by, :k, :v, :kv, :p) -- these need interpreter handling.
+fn is_extrema_named_pair(v: &Value) -> bool {
+    match v {
+        Value::Pair(name, _) => matches!(name.as_str(), "by" | "k" | "v" | "kv" | "p"),
+        Value::ValuePair(key, _) => {
+            matches!(key.as_ref(), Value::Str(name) if matches!(name.as_str(), "by" | "k" | "v" | "kv" | "p"))
+        }
+        _ => false,
+    }
+}
+
 fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, RuntimeError>> {
     match name {
         "min" => {
             if args.is_empty() {
                 return Some(Ok(Value::Nil));
             }
-            if args.iter().any(|arg| {
-                matches!(arg, Value::Pair(name, _) if name == "by")
-                    || matches!(arg, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-            }) {
+            if args.iter().any(is_extrema_named_pair) {
                 return None;
             }
             let mut acc = args[0].clone();
@@ -1474,10 +1475,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             if args.is_empty() {
                 return Some(Ok(Value::Nil));
             }
-            if args.iter().any(|arg| {
-                matches!(arg, Value::Pair(name, _) if name == "by")
-                    || matches!(arg, Value::ValuePair(key, _) if matches!(key.as_ref(), Value::Str(name) if name.as_str() == "by"))
-            }) {
+            if args.iter().any(is_extrema_named_pair) {
                 return None;
             }
             let mut acc = args[0].clone();

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -748,7 +748,7 @@ impl Interpreter {
         };
 
         if items.is_empty() {
-            return Ok(Value::array(vec![]));
+            return Ok(Value::Seq(std::sync::Arc::new(vec![])));
         }
 
         // Find all indices matching the extremum
@@ -766,11 +766,11 @@ impl Interpreter {
                     .iter()
                     .map(|&i| Value::Int(i as i64))
                     .collect();
-                Ok(Value::array(keys))
+                Ok(Value::Seq(std::sync::Arc::new(keys)))
             }
             "v" => {
                 let vals: Vec<Value> = matching_indices.iter().map(|&i| items[i].clone()).collect();
-                Ok(Value::array(vals))
+                Ok(Value::Seq(std::sync::Arc::new(vals)))
             }
             "kv" => {
                 let mut kvs = Vec::new();
@@ -778,14 +778,16 @@ impl Interpreter {
                     kvs.push(Value::Int(i as i64));
                     kvs.push(items[i].clone());
                 }
-                Ok(Value::array(kvs))
+                Ok(Value::Seq(std::sync::Arc::new(kvs)))
             }
             "p" => {
                 let pairs: Vec<Value> = matching_indices
                     .iter()
-                    .map(|&i| Value::Pair(i.to_string(), Box::new(items[i].clone())))
+                    .map(|&i| {
+                        Value::ValuePair(Box::new(Value::Int(i as i64)), Box::new(items[i].clone()))
+                    })
                     .collect();
-                Ok(Value::array(pairs))
+                Ok(Value::Seq(std::sync::Arc::new(pairs)))
             }
             _ => Ok(result),
         }


### PR DESCRIPTION
## Summary
- Fix native function fast path to fall through to interpreter when :k/:v/:kv/:p adverbs are present on `min()`/`max()` sub calls (both 2-arg and variadic paths)
- Fix :p adverb to produce `ValuePair` with `Int` key instead of `Pair` with `String` key (e.g. `0 => "a"` not `:0("a")`)
- Return `Seq` instead of `Array` from adverb results for `is-deeply` compatibility
- Add `roast/S32-list/minmax.t` to whitelist (all 169 tests pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-list/minmax.t` passes all 169 tests
- [x] `make test` passes (no regressions)
- [x] `make roast` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)