### PR TITLE
fix: enforce readonly on constant declarations

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -927,6 +927,11 @@ impl Compiler {
                     let tc_idx = self.code.add_constant(Value::str(tc.clone()));
                     self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
                 }
+                // Mark constant variables as readonly so that subsequent
+                // assignments are rejected at runtime.
+                if is_constant_decl {
+                    self.code.emit(OpCode::MarkVarReadonly(name_idx));
+                }
             }
             Stmt::Assign {
                 name,

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -17,6 +17,12 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
     let rest =
         keyword("constant", input).ok_or_else(|| PError::expected("constant declaration"))?;
     let (rest, _) = ws1(rest)?;
+    // `constant ($a, $b) = ...` is a syntax error (X::Syntax::Missing)
+    if rest.starts_with('(') {
+        return Err(PError::fatal(
+            "X::Syntax::Missing: Missing initializer on constant declaration".to_string(),
+        ));
+    }
     // The name can be $var, @var, %var, &var, or bare identifier.
     let sigil = rest.as_bytes().first().copied().unwrap_or(0);
     let (rest, name) = if let Some(r) = rest.strip_prefix('\\') {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1110,8 +1110,22 @@ impl VM {
                 {
                     return Err(self.strict_undeclared_error(&name));
                 }
-                // Check readonly variables (e.g., $*USAGE)
-                self.interpreter.check_readonly_for_modify(&name)?;
+                // Check readonly variables (e.g., $*USAGE).
+                // Skip readonly check for SetGlobalRaw which is used for constant
+                // declarations — the constant will be re-marked readonly after this.
+                if !raw_mode {
+                    self.interpreter.check_readonly_for_modify(&name)?;
+                } else {
+                    // Clear any previous readonly marking so this constant
+                    // redeclaration can proceed (e.g., `constant sym` followed
+                    // by `constant $sym` which share the same env name).
+                    let bare = name
+                        .rsplit("::")
+                        .next()
+                        .unwrap_or(&name)
+                        .trim_start_matches(['$', '@', '%', '&']);
+                    self.interpreter.unmark_readonly(bare);
+                }
                 // Prevent re-assignment of immutable containers (Mix, Set, Bag)
                 // Only when the variable has an explicit immutable type constraint
                 // (e.g., `my %h is Mix`), not for regular scalar variables holding

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3695,9 +3695,6 @@ impl VM {
             // in a called sub).
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
             self.interpreter.env_mut().remove(&readonly_key);
-            // Clear any readonly marking from a previous constant declaration
-            // with the same name so the new declaration can proceed.
-            self.interpreter.unmark_readonly(name);
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3695,6 +3695,9 @@ impl VM {
             // in a called sub).
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
             self.interpreter.env_mut().remove(&readonly_key);
+            // Clear any readonly marking from a previous constant declaration
+            // with the same name so the new declaration can proceed.
+            self.interpreter.unmark_readonly(name);
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it.

--- a/t/constant-readonly.t
+++ b/t/constant-readonly.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+# Sigilless constant
+{
+    constant foo = 42;
+    is foo, 42, 'sigilless constant works';
+    dies-ok { foo = 3 }, 'cannot reassign sigilless constant';
+}
+
+# Sigiled constant
+{
+    constant $bar = 42;
+    is $bar, 42, 'sigiled constant works';
+    dies-ok { $bar = 2 }, 'cannot reassign sigiled constant';
+}
+
+# Array constant
+{
+    constant @arr = 1, 2, 3;
+    is @arr.elems, 3, 'array constant has correct elements';
+}
+
+# Hash constant
+{
+    constant %h = a => 1, b => 2;
+    is %h<a>, 1, 'hash constant works';
+}
+
+# constant ($a, $b) = ... should be a parse error
+{
+    throws-like 'constant ($a, $b) = (3, 4)', X::Syntax::Missing,
+        'constant list destructuring is a syntax error';
+}
+
+# Constant in try block should still be readonly
+{
+    constant grtz = 42;
+    try { grtz = 23 };
+    is grtz, 42, 'constant unchanged after failed try assignment';
+}


### PR DESCRIPTION
## Summary
- Mark constant variables as readonly after declaration by emitting `MarkVarReadonly` in the compiler, so assignments to constants throw `X::Assignment::RO` at runtime
- Reject `constant ($a, $b) = ...` syntax at parse time with `X::Syntax::Missing`, matching Raku behavior
- Added `t/constant-readonly.t` with 8 tests covering sigilless/sigiled constants, array/hash constants, parse error for list destructuring, and readonly enforcement across try blocks

Fixes 3 subtests in `roast/S04-declarations/constant.t` (tests 2, 6, 7), improving from 11/19 to 14/19 passing.

## Test plan
- [x] `prove -e 'target/debug/mutsu' t/constant-readonly.t` passes all 8 tests
- [x] `prove -e 'target/debug/mutsu' roast/S04-declarations/constant.t` shows 14/19 passing (was 11/19)
- [x] `make test` shows no new regressions (pre-existing failures in placeholder.t and wrap.t)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)