### PR TITLE
fix: handle cross-type circular references in .raku representation

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -954,6 +954,7 @@ roast/S32-array/exists-adverb.t
 roast/S32-array/keys_values.t
 roast/S32-array/kv.t
 roast/S32-array/pairs.t
+roast/S32-array/perl.t
 roast/S32-array/pop.t
 roast/S32-array/push.t
 roast/S32-array/rotate.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -294,39 +294,151 @@ impl VM {
         }
     }
 
+    /// Check if a value contains a reference to the given array Arc pointer,
+    /// either directly or nested inside hash values.
+    /// `seen_hashes` tracks hash Arc pointers already visited to avoid infinite
+    /// recursion on self-referencing hashes.
+    fn value_contains_array_ref(v: &Value, old_ptr: usize, seen_hashes: &mut Vec<usize>) -> bool {
+        match v {
+            Value::Array(inner_arc, _) => Arc::as_ptr(inner_arc) as usize == old_ptr,
+            Value::Hash(map) => {
+                let hash_ptr = Arc::as_ptr(map) as usize;
+                if seen_hashes.contains(&hash_ptr) {
+                    return false;
+                }
+                seen_hashes.push(hash_ptr);
+                let result = map
+                    .values()
+                    .any(|hv| Self::value_contains_array_ref(hv, old_ptr, seen_hashes));
+                seen_hashes.pop();
+                result
+            }
+            _ => false,
+        }
+    }
+
+    /// Replace old array Arc references with the new array Arc, recursively
+    /// traversing into hash values. Preserves hash self-references when
+    /// cloning hash maps.
+    /// `seen_hashes` tracks hash Arc pointers already visited to avoid infinite
+    /// recursion on self-referencing hashes.
+    fn replace_array_refs_in_value(
+        v: &mut Value,
+        old_ptr: usize,
+        new_array: &Arc<Vec<Value>>,
+        kind: ArrayKind,
+        seen_hashes: &mut Vec<usize>,
+    ) {
+        match v {
+            Value::Array(inner_arc, _) if Arc::as_ptr(inner_arc) as usize == old_ptr => {
+                *v = Value::Array(new_array.clone(), kind);
+            }
+            Value::Hash(map) => {
+                let hash_ptr = Arc::as_ptr(map) as usize;
+                if seen_hashes.contains(&hash_ptr) {
+                    return;
+                }
+                seen_hashes.push(hash_ptr);
+                // Check if any values in this hash contain the old array ref
+                let needs_fixup = map.values().any(|hv| {
+                    Self::value_contains_array_ref(hv, old_ptr, &mut seen_hashes.clone())
+                });
+                if needs_fixup {
+                    // Clone the map, but track self-referencing hash keys so we
+                    // can preserve the circular hash structure in the new Arc.
+                    let mut new_map = HashMap::new();
+                    let mut self_ref_keys = Vec::new();
+                    for (k, hv) in map.iter() {
+                        if let Value::Hash(inner_arc) = hv
+                            && Arc::as_ptr(inner_arc) as usize == hash_ptr
+                        {
+                            self_ref_keys.push(k.clone());
+                            new_map.insert(k.clone(), Value::Nil);
+                        } else {
+                            new_map.insert(k.clone(), hv.clone());
+                        }
+                    }
+                    let new_hash_arc = Arc::new(new_map);
+                    let new_hash_ptr = Arc::as_ptr(&new_hash_arc) as usize;
+                    // Mark the new hash as seen so recursive calls don't
+                    // re-enter it via self-referencing values.
+                    seen_hashes.push(new_hash_ptr);
+                    // SAFETY: We just created new_hash_arc and hold the only ref.
+                    let map_ptr = Arc::as_ptr(&new_hash_arc) as *mut HashMap<String, Value>;
+                    unsafe {
+                        for key in &self_ref_keys {
+                            (*map_ptr).insert(key.clone(), Value::Hash(new_hash_arc.clone()));
+                        }
+                        for hv in (*map_ptr).values_mut() {
+                            Self::replace_array_refs_in_value(
+                                hv,
+                                old_ptr,
+                                new_array,
+                                kind,
+                                seen_hashes,
+                            );
+                        }
+                    }
+                    seen_hashes.pop();
+                    *map = new_hash_arc;
+                }
+                seen_hashes.pop();
+            }
+            _ => {}
+        }
+    }
+
     /// Fix up circular references in array assignment.
     /// When `@a = 42, @a`, the RHS contains a reference to the old array.
     /// Replace that reference with the new array to create a circular structure.
+    /// Also handles cross-type cycles like `@b = %h, @b` where `%h` contains `@b`.
     pub(super) fn fixup_circular_array_refs(new_val: &mut Value, old_ptr: &Option<usize>) {
         let Some(old_ptr) = old_ptr else { return };
         if let Value::Array(new_arc, kind) = new_val {
-            let has_old_ref = new_arc.iter().any(|v| match v {
-                Value::Array(inner_arc, _) => Arc::as_ptr(inner_arc) as usize == *old_ptr,
-                _ => false,
-            });
+            let mut seen_hashes = Vec::new();
+            let has_old_ref = new_arc
+                .iter()
+                .any(|v| Self::value_contains_array_ref(v, *old_ptr, &mut seen_hashes));
             if !has_old_ref {
                 return;
             }
             // Build a new items list, replacing old-array references with Nil placeholders
             let mut new_items: Vec<Value> = Vec::with_capacity(new_arc.len());
             let mut circular_indices = Vec::new();
+            let mut hash_fixup_indices = Vec::new();
             for (i, v) in new_arc.iter().enumerate() {
                 if let Value::Array(inner_arc, _) = v
                     && Arc::as_ptr(inner_arc) as usize == *old_ptr
                 {
                     circular_indices.push(i);
                     new_items.push(Value::Nil); // placeholder
+                } else if matches!(v, Value::Hash(_)) {
+                    let mut seen = Vec::new();
+                    if Self::value_contains_array_ref(v, *old_ptr, &mut seen) {
+                        hash_fixup_indices.push(i);
+                    }
+                    new_items.push(v.clone());
                 } else {
                     new_items.push(v.clone());
                 }
             }
             let result_arc = Arc::new(new_items);
             let items_ptr = Arc::as_ptr(&result_arc) as *mut Vec<Value>;
-            for idx in &circular_indices {
-                // SAFETY: We just created result_arc and hold the only reference,
-                // so no other thread can access it.
-                unsafe {
+            // SAFETY: We just created result_arc and hold the only reference,
+            // so no other thread can access it.
+            unsafe {
+                for idx in &circular_indices {
                     (&mut *items_ptr)[*idx] = Value::Array(result_arc.clone(), *kind);
+                }
+                for idx in &hash_fixup_indices {
+                    let mut seen = Vec::new();
+                    Self::replace_array_refs_in_value(
+                        &mut (&mut *items_ptr)[*idx],
+                        *old_ptr,
+                        &result_arc,
+                        *kind,
+                        &mut seen,
+                    );
                 }
             }
             *new_arc = result_arc;


### PR DESCRIPTION
## Summary
- Fix cross-type circular reference detection in `fixup_circular_array_refs` for array assignment
- When `@b = %h, @b, 42` where `%h` contains a reference to `@b`, the old `@b` reference inside `%h` is now correctly replaced with the new array Arc
- Preserves hash self-references when cloning hash maps during the fixup process
- Adds `roast/S32-array/perl.t` to the whitelist (all 9 tests now pass, was 8/9)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-array/perl.t` passes all 9 tests
- [x] `make test` shows no regressions
- [x] `make roast` shows no regressions
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)