### PR TITLE
fix: temp undefine($var) restores default value correctly

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1101,6 +1101,7 @@ roast/S32-num/stringify.t
 roast/S32-num/unpolar.t
 roast/S32-scalar/defined.t
 roast/S32-scalar/perl.t
+roast/S32-scalar/undef.t
 roast/S32-str/Collation.t
 roast/S32-str/append.t
 roast/S32-str/bool.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -776,6 +776,7 @@ pub(crate) enum Stmt {
         index: Option<Box<Expr>>,
         value: Option<Box<Expr>>,
         is_temp: bool,
+        undefine_first: bool,
     },
     TempMethodAssign {
         var_name: String,

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -43,6 +43,7 @@ impl Compiler {
                 is_our,
                 is_dynamic: ast_is_dynamic,
                 type_constraint,
+                custom_traits,
                 ..
             } => {
                 let is_dynamic = *ast_is_dynamic || self.var_is_dynamic(name);
@@ -156,6 +157,24 @@ impl Compiler {
                 if name == "__ANON_STATE__" && type_constraint.is_none() {
                     self.code.emit(OpCode::WrapScalar);
                 }
+                // Apply custom traits (e.g. `is default(...)`) that were
+                // captured by `..` in the original pattern. Without this,
+                // chained declarations like `my $b = my $d is default(42) = "foo"`
+                // would lose the default trait on the inner variable.
+                for (trait_name, trait_arg) in custom_traits {
+                    if trait_name.starts_with("__") {
+                        continue;
+                    }
+                    if let Some(arg) = trait_arg {
+                        self.compile_expr(arg);
+                    }
+                    let trait_name_idx = self.code.add_constant(Value::str(trait_name.clone()));
+                    self.code.emit(OpCode::ApplyVarTrait {
+                        name_idx,
+                        trait_name_idx,
+                        has_arg: trait_arg.is_some(),
+                    });
+                }
             }
             Stmt::Expr(inner_expr) => {
                 self.compile_expr(inner_expr);
@@ -261,6 +280,7 @@ impl Compiler {
                 index: _,
                 value: _,
                 is_temp: _,
+                undefine_first: _,
             } => {
                 // Compile the temp/let statement, then push the variable as result.
                 // This handles `(temp @a)` / `(temp $x = 42)` in expression position.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -358,6 +358,7 @@ impl Compiler {
                         index: None,
                         value: None,
                         is_temp: true,
+                        undefine_first: false,
                     };
                     self.compile_stmt(&let_stmt);
                     // Then undefine the variable (assign Any type object)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2177,7 +2177,15 @@ impl Compiler {
                 index,
                 value,
                 is_temp,
+                undefine_first,
             } => {
+                // If undefine_first is set, assign Nil to the variable before saving.
+                // This makes LetSave capture the undefined state, so on scope exit
+                // the variable is restored to undefined (and its default value applies).
+                if *undefine_first {
+                    self.compile_expr(&Expr::Literal(Value::Nil));
+                    self.emit_set_named_var(name);
+                }
                 // Emit LetSave: saves current value of the variable
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
                 let has_index = index.is_some();

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1571,6 +1571,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: Some(Box::new(idx_expr)),
                     value: Some(Box::new(val_expr)),
                     is_temp: false,
+                    undefine_first: false,
                 },
             );
         }
@@ -1581,6 +1582,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: Some(Box::new(idx_expr)),
                 value: None,
                 is_temp: false,
+                undefine_first: false,
             },
         );
     }
@@ -1604,6 +1606,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: Some(Box::new(key_expr)),
                     value: Some(Box::new(val_expr)),
                     is_temp: false,
+                    undefine_first: false,
                 },
             );
         }
@@ -1614,6 +1617,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: Some(Box::new(key_expr)),
                 value: None,
                 is_temp: false,
+                undefine_first: false,
             },
         );
     }
@@ -1630,6 +1634,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: None,
                 value: Some(Box::new(val_expr)),
                 is_temp: false,
+                undefine_first: false,
             },
         );
     }
@@ -1642,6 +1647,7 @@ pub(super) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
             index: None,
             value: None,
             is_temp: false,
+            undefine_first: false,
         },
     )
 }
@@ -1727,13 +1733,12 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
             }
         };
         // With assignment: temp undefine($d) = "baz"
-        // Semantics: save $d with temp, then assign "baz" to it.
-        // (undefine step is implicit — temp save + assign is sufficient)
+        // Semantics: undefine $d first, then temp saves the undefined state,
+        // then assign "baz". On scope exit, temp restores to undefined.
         if var_rest.starts_with('=') && !var_rest.starts_with("==") {
             let rhs_rest = &var_rest[1..];
             let (rhs_rest, _) = ws(rhs_rest)?;
             let (rhs_rest, rhs_expr) = expression(rhs_rest)?;
-            // Emit as `temp $var = rhs` — saves current value, assigns new one
             return parse_statement_modifier(
                 rhs_rest,
                 Stmt::Let {
@@ -1741,6 +1746,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: None,
                     value: Some(Box::new(rhs_expr)),
                     is_temp: true,
+                    undefine_first: true,
                 },
             );
         }
@@ -1780,6 +1786,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: None,
                     value: Some(Box::new(val_expr)),
                     is_temp: true,
+                    undefine_first: false,
                 },
             );
         }
@@ -1791,6 +1798,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: None,
                 value: None,
                 is_temp: true,
+                undefine_first: false,
             },
         );
     }
@@ -1844,6 +1852,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: Some(Box::new(idx_expr)),
                     value: Some(Box::new(val_expr)),
                     is_temp: true,
+                    undefine_first: false,
                 },
             );
         }
@@ -1854,6 +1863,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: Some(Box::new(idx_expr)),
                 value: None,
                 is_temp: true,
+                undefine_first: false,
             },
         );
     }
@@ -1877,6 +1887,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                     index: Some(Box::new(key_expr)),
                     value: Some(Box::new(val_expr)),
                     is_temp: true,
+                    undefine_first: false,
                 },
             );
         }
@@ -1887,6 +1898,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: Some(Box::new(key_expr)),
                 value: None,
                 is_temp: true,
+                undefine_first: false,
             },
         );
     }
@@ -1903,6 +1915,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
                 index: None,
                 value: Some(Box::new(val_expr)),
                 is_temp: true,
+                undefine_first: false,
             },
         );
     }
@@ -1914,6 +1927,7 @@ pub(super) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
             index: None,
             value: None,
             is_temp: true,
+            undefine_first: false,
         },
     )
 }

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -2006,11 +2006,22 @@ impl Interpreter {
         self.let_saves.len()
     }
 
+    /// Resolve the value to restore, applying `is default(...)` when restoring Nil.
+    fn resolve_restore_value(&self, name: &str, val: &Value) -> Value {
+        if matches!(val, Value::Nil)
+            && let Some(default) = self.var_defaults.get(name)
+        {
+            return default.clone();
+        }
+        val.clone()
+    }
+
     /// Restore all variables from let_saves starting at `mark`, then truncate.
     pub(crate) fn restore_let_saves(&mut self, mark: usize) {
         for i in (mark..self.let_saves.len()).rev() {
             let (name, old_val, _is_temp) = self.let_saves[i].clone();
-            self.env.insert(name, old_val);
+            let restored = self.resolve_restore_value(&name, &old_val);
+            self.env.insert(name, restored);
         }
         self.let_saves.truncate(mark);
     }
@@ -2018,12 +2029,21 @@ impl Interpreter {
     /// On successful block exit: restore `temp` saves, discard `let` saves.
     /// For `let`, only restore if the block returned an unsuccessful value.
     pub(crate) fn resolve_let_saves_on_success(&mut self, mark: usize, success: bool) {
-        for i in (mark..self.let_saves.len()).rev() {
-            let (ref name, ref old_val, is_temp) = self.let_saves[i];
-            // temp: always restore; let: restore only if block was unsuccessful
-            if is_temp || !success {
-                self.env.insert(name.clone(), old_val.clone());
-            }
+        // Collect restore actions first to avoid borrow conflicts.
+        let restores: Vec<(String, Value)> = (mark..self.let_saves.len())
+            .rev()
+            .filter_map(|i| {
+                let (ref name, ref old_val, is_temp) = self.let_saves[i];
+                if is_temp || !success {
+                    Some((name.clone(), old_val.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for (name, old_val) in restores {
+            let restored = self.resolve_restore_value(&name, &old_val);
+            self.env.insert(name, restored);
         }
         self.let_saves.truncate(mark);
     }


### PR DESCRIPTION
## Summary
- Fix `temp undefine($d) = "baz"` to correctly undefine the variable before temp saves its value, so on scope exit the `is default(...)` value (e.g. 42) is restored instead of the pre-undefine value
- Fix VarDecl in expression position (chained `my $b = my $d is default(42) = "foo"`) to process custom traits like `is default(...)` which were previously silently dropped
- Add roast/S32-scalar/undef.t to whitelist (all 91 tests now pass)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S32-scalar/undef.t` -- all 91 tests pass (was 90/91)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass
- [x] `make test` -- no new regressions (pre-existing failures only)
- [ ] `make roast` -- CI will verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)