### PR TITLE
fix: persist anonymous state variable ($) across closure calls

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -904,6 +904,9 @@ impl VM {
                             .cloned()
                             .or_else(|| self.get_env_with_main_alias(&candidate))
                     })
+                    // Anonymous state variable (`$`): fall back to persisted
+                    // state so the value survives across closure calls.
+                    .or_else(|| self.anon_state_value(name))
                     .map(Ok)
                     .unwrap_or_else(|| {
                         if name.starts_with('^') {
@@ -1474,6 +1477,9 @@ impl VM {
                 } else {
                     self.set_env_with_main_alias(&name, val.clone());
                 }
+                // Persist anonymous state variable (`$`) so it survives
+                // across closure calls (e.g. `$ ~= $_` in classify block).
+                self.sync_anon_state_value(&name, &val);
                 // Persist `our`-scoped variables so they survive block-scope
                 // restoration (which only preserves env keys that existed
                 // before the block).  `::('name')` falls back to this store.

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1387,6 +1387,8 @@ impl VM {
         }
         self.update_local_if_exists(code, &name, &val);
         self.set_env_with_main_alias(&name, val.clone());
+        // Persist anonymous state variable (`$`) across closure calls.
+        self.sync_anon_state_value(&name, &val);
         // Track topic mutations for map rw writeback: when `$_` (= "_") is
         // explicitly assigned, record the value so `eval_map_over_items_rw` can
         // read it back even after the block return value overwrites `_`.


### PR DESCRIPTION
## Summary

- Fixes the anonymous state variable `$` (e.g., `$ ~= $_`) not persisting across closure calls
- Adds `anon_state_value`/`sync_anon_state_value` to GetGlobal, SetGlobal, and AssignExpr code paths
- This fixes test 39 of roast/S32-list/classify.t (`classify({ ~($ ~= $_) })`)

## Test plan

- [x] `my $f = { ~($ ~= $_) }; $f("a"); say $f("b");` prints `ab` (was `b`)
- [x] `<a b c>.classify({ ~($ ~= $_); })` returns `{a => [a], ab => [b], abc => [c]}`
- [x] `cargo clippy -- -D warnings` passes
- [x] `make test` shows no new regressions
- [x] Pre-existing test failures (placeholder.t, wrap.t) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)