### PR TITLE
fix: user-defined subs properly shadow same-named builtins

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -429,7 +429,6 @@ roast/S05-transliteration/with-closure.t
 roast/S06-advanced/callframe.t
 roast/S06-advanced/callsame.t
 roast/S06-advanced/dispatching.t
-roast/S06-advanced/dispatching.t
 roast/S06-advanced/recurse.t
 roast/S06-advanced/return.t
 roast/S06-advanced/stub.t
@@ -570,7 +569,6 @@ roast/S12-class/attributes-required.t
 roast/S12-class/attributes.t
 roast/S12-class/augment-supersede.t
 roast/S12-class/basic.t
-roast/S12-class/basic.t
 roast/S12-class/declaration-order.t
 roast/S12-class/extending-arrays.t
 roast/S12-class/inheritance-class-methods.t
@@ -648,7 +646,6 @@ roast/S12-traits/precomp.t
 roast/S13-overloading/fallbacks-deep.t
 roast/S13-overloading/metaoperators.t
 roast/S13-overloading/multiple-signatures.t
-roast/S13-overloading/operators.t
 roast/S13-overloading/operators.t
 roast/S13-overloading/typecasting-long.t
 roast/S13-syntax/aliasing.t
@@ -1181,6 +1178,7 @@ roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t
 roast/integration/advent2009-day04.t
 roast/integration/advent2009-day07.t
+roast/integration/advent2009-day08.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -691,6 +691,19 @@ impl Interpreter {
             .any(|k| k.resolve().starts_with(&fq_slash))
     }
 
+    /// Check if a user-defined function with the given name can accept the
+    /// given args (arity + type check). Used to decide whether a user-defined
+    /// sub should shadow a same-named builtin.
+    pub(crate) fn user_function_matches_call(&mut self, name: &str, args: &[Value]) -> bool {
+        if !self.has_function(name) && !self.has_multi_function(name) {
+            return false;
+        }
+        let Some(def) = self.resolve_function_with_types(name, args) else {
+            return false;
+        };
+        self.args_match_param_types(args, &def.param_defs)
+    }
+
     pub(super) fn malformed_return_value_compile_error() -> RuntimeError {
         let mut err = RuntimeError::new("Malformed return value");
         let mut attrs = std::collections::HashMap::new();

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -244,15 +244,22 @@ impl VM {
             self.fn_resolve_cache.clear();
             self.fn_resolve_cache_gen = self.fn_resolve_gen;
         }
-        let expected_fingerprint = self
-            .interpreter
-            .resolve_function_with_types(name, args)
-            .map(|def| {
-                crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body)
-            });
+        let resolved_def = self.interpreter.resolve_function_with_types(name, args);
+        let expected_fingerprint = resolved_def.as_ref().map(|def| {
+            crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body)
+        });
         // If runtime resolution fails, avoid reusing stale compiled cache entries.
         // This can happen across repeated EVAL calls that redefine the same routine name.
         let expected_fingerprint = expected_fingerprint?;
+        let def_arity = resolved_def
+            .as_ref()
+            .map(|def| {
+                def.param_defs
+                    .iter()
+                    .filter(|pd| !pd.named && !pd.slurpy)
+                    .count()
+            })
+            .unwrap_or(arity);
         let matches_resolved = |cf: &CompiledFunction| cf.fingerprint == expected_fingerprint;
         let pkg = self.interpreter.current_package();
         let type_sig: Vec<String> = args
@@ -390,11 +397,26 @@ impl VM {
                 }
             }
         }
+        // Fallback: when call arity differs from definition arity (e.g. optional
+        // params), try the definition's param count to find the compiled function.
+        if found_key.is_none() && def_arity != arity {
+            let key_fp = format!("{}::{}/{}#{:x}", pkg, name, def_arity, expected_fingerprint);
+            if compiled_fns.get(&key_fp).is_some_and(&matches_resolved) {
+                found_key = Some(key_fp);
+            } else if pkg != "GLOBAL" {
+                let key_fp_global =
+                    format!("GLOBAL::{}/{}#{:x}", name, def_arity, expected_fingerprint);
+                if compiled_fns
+                    .get(&key_fp_global)
+                    .is_some_and(&matches_resolved)
+                {
+                    found_key = Some(key_fp_global);
+                }
+            }
+        }
         if let Some(key) = found_key {
             // Cache the resolution result for future lookups
-            let cached_pkg = self
-                .interpreter
-                .resolve_function_with_types(name, args)
+            let cached_pkg = resolved_def
                 .map(|def| def.package.resolve())
                 .unwrap_or_else(|| self.interpreter.current_package().to_string());
             if use_cache {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -401,13 +401,7 @@ impl VM {
                 .maybe_fetch_rw_proxy(result, cf_auto_fetch)?;
             self.stack.push(result);
             self.env_dirty = true;
-        } else if (self.interpreter.has_function(&name)
-            || self.interpreter.has_multi_function(&name))
-            && self
-                .interpreter
-                .resolve_function_with_types(&name, &args)
-                .is_some()
-        {
+        } else if self.interpreter.user_function_matches_call(&name, &args) {
             // A user-defined sub shadows a same-named builtin.
             let result = self.interpreter.call_function_fallback(&name, &args)?;
             let result = self.interpreter.maybe_fetch_rw_proxy(result, true)?;
@@ -677,13 +671,7 @@ impl VM {
                 let result = self.interpreter.call_function_fallback(name, &args);
                 self.interpreter.set_pending_call_arg_sources(None);
                 self.interpreter.maybe_fetch_rw_proxy(result?, true)
-            } else if (self.interpreter.has_function(name)
-                || self.interpreter.has_multi_function(name))
-                && self
-                    .interpreter
-                    .resolve_function_with_types(name, &args)
-                    .is_some()
-            {
+            } else if self.interpreter.user_function_matches_call(name, &args) {
                 // A user-defined sub shadows a same-named builtin.
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function_fallback(name, &args);

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -25,13 +25,6 @@ impl VM {
         }
     }
 
-    pub(super) fn is_user_shadowable_builtin(name: &str) -> bool {
-        matches!(
-            name,
-            "first" | "grep" | "map" | "sort" | "reverse" | "unique" | "last" | "head" | "tail"
-        )
-    }
-
     pub(super) fn exec_call_func_op(
         &mut self,
         code: &CompiledCode,
@@ -408,8 +401,14 @@ impl VM {
                 .maybe_fetch_rw_proxy(result, cf_auto_fetch)?;
             self.stack.push(result);
             self.env_dirty = true;
-        } else if Self::is_user_shadowable_builtin(&name) && self.interpreter.has_function(&name) {
-            // A user-defined sub shadows a same-named builtin listop.
+        } else if (self.interpreter.has_function(&name)
+            || self.interpreter.has_multi_function(&name))
+            && self
+                .interpreter
+                .resolve_function_with_types(&name, &args)
+                .is_some()
+        {
+            // A user-defined sub shadows a same-named builtin.
             let result = self.interpreter.call_function_fallback(&name, &args)?;
             let result = self.interpreter.maybe_fetch_rw_proxy(result, true)?;
             self.stack.push(result);
@@ -678,11 +677,14 @@ impl VM {
                 let result = self.interpreter.call_function_fallback(name, &args);
                 self.interpreter.set_pending_call_arg_sources(None);
                 self.interpreter.maybe_fetch_rw_proxy(result?, true)
-            } else if Self::is_user_shadowable_builtin(name) && self.interpreter.has_function(name)
+            } else if (self.interpreter.has_function(name)
+                || self.interpreter.has_multi_function(name))
+                && self
+                    .interpreter
+                    .resolve_function_with_types(name, &args)
+                    .is_some()
             {
-                // A user-defined sub shadows a same-named builtin listop.
-                // Route through the interpreter fallback so the user sub is
-                // invoked rather than the builtin.
+                // A user-defined sub shadows a same-named builtin.
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function_fallback(name, &args);
                 self.interpreter.set_pending_call_arg_sources(None);


### PR DESCRIPTION
## Summary
- Generalize the hardcoded 9-function `is_user_shadowable_builtin` whitelist to allow any user-defined sub to shadow a same-named builtin
- Add `user_function_matches_call()` helper that verifies arity + type compatibility before allowing shadowing, preventing module functions (e.g. `Test::Util::run`) from incorrectly shadowing builtins with different signatures
- Add compiled function lookup fallback using definition arity (for functions with optional/default params where call-site arity differs from definition arity)

Fixes: user-defined `sub first($s, $n = 3)` now properly shadows the builtin `first` when called as `first("hello")`

Supersedes #2526.

## Test plan
- [x] `roast/integration/advent2009-day08.t` passes (enabled by this fix)
- [x] `roast/S06-other/main-usage.t` passes (48/48 — no regression from Test::Util's `run`)
- [x] `make test` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>