### PR TITLE
fix: preserve typed keys in Set/Bag/Mix .Hash coercion

### DIFF
--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -649,32 +649,59 @@ impl Interpreter {
             Value::Set(s, _) => {
                 let mut map = HashMap::new();
                 let mut original_keys = HashMap::new();
+                let mut has_typed = false;
                 for k in s.iter() {
                     map.insert(k.clone(), Value::Bool(true));
                     let typed = s.typed_key(k);
-                    if !matches!(&typed, Value::Str(s) if s.as_ref() == k) {
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
                         original_keys.insert(k.clone(), typed);
                     }
                 }
                 let result = Value::hash(map);
-                if !original_keys.is_empty() {
+                if has_typed {
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
                     super::utils::register_hash_original_keys(&result, original_keys);
                 }
                 Ok(result)
             }
             Value::Bag(b, _) => {
                 let mut map = HashMap::new();
+                let mut original_keys = HashMap::new();
+                let mut has_typed = false;
                 for (k, v) in b.iter() {
                     map.insert(k.clone(), Value::Int(*v));
+                    let typed = b.typed_key(k);
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Ok(Value::hash(map))
+                let result = Value::hash(map);
+                if has_typed {
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
+                    super::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Ok(result)
             }
             Value::Mix(m, _) => {
                 let mut map = HashMap::new();
+                let mut original_keys = HashMap::new();
+                let mut has_typed = false;
                 for (k, v) in m.iter() {
                     map.insert(k.clone(), crate::value::mix_weight_to_value(*v));
+                    let typed = m.typed_key(k);
+                    if !matches!(&typed, Value::Str(sv) if sv.as_ref() == k) {
+                        has_typed = true;
+                        original_keys.insert(k.clone(), typed);
+                    }
                 }
-                Ok(Value::hash(map))
+                let result = Value::hash(map);
+                if has_typed {
+                    original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
+                    super::utils::register_hash_original_keys(&result, original_keys);
+                }
+                Ok(result)
             }
             Value::Instance {
                 ref class_name,

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -562,24 +562,60 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         }
         Value::Set(items, _) => {
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
+            let mut has_typed = false;
             for key in items.iter() {
                 map.insert(key.clone(), Value::Bool(true));
+                let typed = items.typed_key(key);
+                if !matches!(&typed, Value::Str(sv) if sv.as_ref() == key) {
+                    has_typed = true;
+                    original_keys.insert(key.clone(), typed);
+                }
             }
-            Value::hash(map)
+            let result = Value::hash(map);
+            if has_typed {
+                original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
+                register_hash_original_keys(&result, original_keys);
+            }
+            result
         }
         Value::Bag(items, _) => {
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
+            let mut has_typed = false;
             for (key, count) in items.iter() {
                 map.insert(key.clone(), Value::Int(*count));
+                let typed = items.typed_key(key);
+                if !matches!(&typed, Value::Str(sv) if sv.as_ref() == key) {
+                    has_typed = true;
+                    original_keys.insert(key.clone(), typed);
+                }
             }
-            Value::hash(map)
+            let result = Value::hash(map);
+            if has_typed {
+                original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
+                register_hash_original_keys(&result, original_keys);
+            }
+            result
         }
         Value::Mix(items, _) => {
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
+            let mut has_typed = false;
             for (key, weight) in items.iter() {
                 map.insert(key.clone(), mix_weight_value(*weight));
+                let typed = items.typed_key(key);
+                if !matches!(&typed, Value::Str(sv) if sv.as_ref() == key) {
+                    has_typed = true;
+                    original_keys.insert(key.clone(), typed);
+                }
             }
-            Value::hash(map)
+            let result = Value::hash(map);
+            if has_typed {
+                original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
+                register_hash_original_keys(&result, original_keys);
+            }
+            result
         }
         Value::Range(a, b) => {
             let items: Vec<Value> = (a..=b).map(Value::Int).collect();


### PR DESCRIPTION
## Summary
- Fix `dispatch_to_hash()` (used by `.Hash`) for Set/Bag/Mix to preserve original typed keys
- Fix `coerce_to_hash()` for the same types (used by type coercion path)  
- Both now add the `__mutsu_setty_origin` marker, matching the existing `.hash` (lowercase) implementation in `collection.rs`

**Before:** `set(42).Hash.keys[0].WHAT` → `(Str)`  
**After:** `set(42).Hash.keys[0].WHAT` → `(Int)`

Fixes 1 additional subtest in `roast/S02-types/set.t` (test 201: "make sure set.Hash returns objects").

## Test plan
- [x] `set(42).Hash.keys[0].WHAT` returns `(Int)` instead of `(Str)`
- [x] `bag(42).Hash.keys[0].WHAT` returns `(Int)` instead of `(Str)` 
- [x] No regressions in `roast/S02-types/set.t`, `roast/S02-types/bag.t`
- [ ] `make test` passes
- [ ] `make roast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)