### PR TITLE
fix: implement proper .message methods for exception types

### DIFF
--- a/src/builtins/exception_message.rs
+++ b/src/builtins/exception_message.rs
@@ -1,0 +1,200 @@
+use crate::value::Value;
+use std::collections::HashMap;
+
+/// Construct the `.message` string for a structured exception from its class
+/// name and attribute map.  Returns `None` when the class name is not
+/// recognised (caller should fall back to the generic behaviour).
+pub fn format_exception_message(
+    class_name: &str,
+    attrs: &HashMap<String, Value>,
+) -> Option<String> {
+    match class_name {
+        "X::Str::Numeric" => {
+            let reason = attr_str(attrs, "reason");
+            let source = attr_str(attrs, "source");
+            let pos = attrs.get("pos").map(|v| v.to_f64() as usize).unwrap_or(0);
+            // Insert the ⏏ marker at position `pos` inside the source string.
+            let marked = if pos <= source.len() {
+                let mut s = String::with_capacity(source.len() + 3);
+                s.push_str(&source[..pos]);
+                s.push('\u{23CF}'); // ⏏
+                s.push_str(&source[pos..]);
+                s
+            } else {
+                format!("{}\u{23CF}", source)
+            };
+            Some(format!(
+                "Cannot convert string to number: {} in '{}' (indicated by \u{23CF})",
+                reason, marked
+            ))
+        }
+        "X::Method::NotFound" => {
+            let method = attr_str(attrs, "method");
+            let typename = attr_str(attrs, "typename");
+            Some(format!(
+                "No such method '{}' for invocant of type '{}'",
+                method, typename
+            ))
+        }
+        "X::Undeclared" => {
+            let what = attr_str_or(attrs, "what", "Variable");
+            let symbol = attr_str(attrs, "symbol");
+            let mut msg = format!("{} '{}' is not declared", what, symbol);
+            // Append suggestions if present
+            if let Some(sugg) = attrs.get("suggestions") {
+                let items = suggestion_list(sugg);
+                if !items.is_empty() {
+                    if items.len() == 1 {
+                        msg.push_str(&format!(". Did you mean '{}'?", items[0]));
+                    } else {
+                        let quoted: Vec<String> =
+                            items.iter().map(|s| format!("'{}'", s)).collect();
+                        msg.push_str(&format!(
+                            ". Did you mean any of these: {}?",
+                            quoted.join(", ")
+                        ));
+                    }
+                }
+            }
+            Some(msg)
+        }
+        "X::Cannot::Lazy" => {
+            let action = attr_str(attrs, "action");
+            Some(format!("Cannot {} a lazy list", action))
+        }
+        "X::ControlFlow::Return" => Some("Attempt to return outside of any Routine".to_string()),
+        "X::OutOfRange" => {
+            let what = attr_str_or(attrs, "what", "Argument");
+            let got = attr_str(attrs, "got");
+            let range = attr_str(attrs, "range");
+            let mut msg = format!("{} out of range. Is: {}, should be in {}", what, got, range);
+            if let Some(comment) = attrs.get("comment") {
+                let c = comment.to_string_value();
+                if !c.is_empty() {
+                    msg.push_str(&format!("; {}", c));
+                }
+            }
+            Some(msg)
+        }
+        "X::Immutable" => {
+            let typename = attr_str(attrs, "typename");
+            let method = attr_str(attrs, "method");
+            if method.is_empty() {
+                Some(format!("Cannot modify an immutable {}", typename))
+            } else {
+                Some(format!(
+                    "Cannot call '{}' on an immutable '{}'",
+                    method, typename
+                ))
+            }
+        }
+        "X::Multi::NoMatch" => {
+            let name = attr_str(attrs, "name");
+            Some(format!(
+                "Cannot resolve caller {}; none of these signatures match",
+                name
+            ))
+        }
+        "X::Multi::Ambiguous" => {
+            let name = attr_str(attrs, "name");
+            Some(format!(
+                "Ambiguous call to '{}'; these signatures all match",
+                name
+            ))
+        }
+        "X::Redeclaration" => {
+            let symbol = attr_str(attrs, "symbol");
+            let what = attr_str_or(attrs, "what", "symbol");
+            if what == "routine" {
+                Some(format!(
+                    "Redeclaration of {} '{}'. Did you mean to declare a multi-sub?",
+                    what, symbol
+                ))
+            } else {
+                Some(format!("Redeclaration of {} '{}'.", what, symbol))
+            }
+        }
+        "X::StubCode" => Some("Stub code executed".to_string()),
+        "X::Bind" => {
+            let target = attr_str(attrs, "target");
+            if target.is_empty() {
+                Some("Cannot use bind operator with this left-hand side".to_string())
+            } else {
+                Some(format!("Cannot bind to {}", target))
+            }
+        }
+        "X::Match::Bool" => {
+            let type_name = attr_str_or(attrs, "type", "");
+            Some(format!(
+                "Cannot use Bool as Matcher with '{}'. Did you mean to use $_ inside a block?",
+                type_name
+            ))
+        }
+        "X::Assignment::RO" => {
+            if let Some(val) = attrs.get("value") {
+                let type_name = value_type_label(val);
+                let val_str = val.to_string_value();
+                Some(format!(
+                    "Cannot modify an immutable {} ({})",
+                    type_name, val_str
+                ))
+            } else {
+                Some("Cannot modify an immutable value".to_string())
+            }
+        }
+        "X::NYI" => {
+            let feature = attr_str(attrs, "feature");
+            Some(format!("{} not yet implemented. Sorry.", feature))
+        }
+        "X::Signature::Placeholder" => {
+            Some("Placeholder variable cannot override an existing signature".to_string())
+        }
+        "X::IO::Closed" => {
+            let op = attr_str(attrs, "operation");
+            Some(format!("Cannot do '{}' on a closed handle", op))
+        }
+        _ => None,
+    }
+}
+
+/// Extract a string attribute, defaulting to "" if absent.
+fn attr_str(attrs: &HashMap<String, Value>, key: &str) -> String {
+    attrs
+        .get(key)
+        .map(|v| v.to_string_value())
+        .unwrap_or_default()
+}
+
+/// Extract a string attribute with a custom default.
+fn attr_str_or(attrs: &HashMap<String, Value>, key: &str, default: &str) -> String {
+    attrs
+        .get(key)
+        .map(|v| v.to_string_value())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Extract a list of suggestion strings from a Value.
+fn suggestion_list(v: &Value) -> Vec<String> {
+    match v {
+        Value::Array(items, _) => items.iter().map(|item| item.to_string_value()).collect(),
+        Value::Nil => Vec::new(),
+        other => {
+            let s = other.to_string_value();
+            if s.is_empty() { Vec::new() } else { vec![s] }
+        }
+    }
+}
+
+/// Get a human-readable type label for a value (used by X::Assignment::RO).
+fn value_type_label(v: &Value) -> String {
+    match v {
+        Value::Int(_) => "Int".to_string(),
+        Value::Num(_) => "Num".to_string(),
+        Value::Str(_) => "Str".to_string(),
+        Value::Bool(_) => "Bool".to_string(),
+        Value::Rat(_, _) => "Rat".to_string(),
+        Value::Complex(_, _) => "Complex".to_string(),
+        Value::Instance { class_name, .. } => class_name.resolve(),
+        _ => "Any".to_string(),
+    }
+}

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1141,6 +1141,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         }
                         return Some(Ok(Value::str(append_bt("Unexplained error".to_string()))));
                     }
+                    // Construct message from typed exception attributes
+                    if let Some(formatted) =
+                        crate::builtins::exception_message::format_exception_message(
+                            &cn, attributes,
+                        )
+                    {
+                        return Some(Ok(Value::str(append_bt(formatted))));
+                    }
                     return Some(Ok(Value::str(append_bt(format!("{} with no message", cn)))));
                 }
                 "Str" => {
@@ -1153,6 +1161,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     if cn == "Exception" {
                         return Some(Ok(Value::str(format!("Something went wrong in ({})", cn))));
                     }
+                    // Construct message from typed exception attributes
+                    if let Some(formatted) =
+                        crate::builtins::exception_message::format_exception_message(
+                            &cn, attributes,
+                        )
+                    {
+                        return Some(Ok(Value::str(formatted)));
+                    }
                     return Some(Ok(Value::str(format!("{} with no message", cn))));
                 }
                 "message" => {
@@ -1163,6 +1179,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         && let Some(payload) = attributes.get("payload")
                     {
                         return Some(Ok(payload.clone()));
+                    }
+                    // Construct message from typed exception attributes
+                    if let Some(formatted) =
+                        crate::builtins::exception_message::format_exception_message(
+                            &cn, attributes,
+                        )
+                    {
+                        return Some(Ok(Value::str(formatted)));
                     }
                     return Some(Ok(Value::str(String::new())));
                 }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod arith;
 pub(crate) mod collation;
+pub(crate) mod exception_message;
 mod functions;
 pub(crate) mod methods_0arg;
 mod methods_narg;

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -614,14 +614,23 @@ impl Interpreter {
                     self.class_mro(&class_name.resolve()).contains(&target_name),
                 ));
             }
-            if method == "gist"
+            if (method == "gist" || method == "message")
                 && args.is_empty()
                 && (class_name.resolve().starts_with("X::")
                     || class_name == "Exception"
                     || class_name.resolve().ends_with("Exception"))
-                && let Some(msg) = attributes.get("message")
             {
-                return Ok(Value::str(msg.to_string_value()));
+                if let Some(msg) = attributes.get("message") {
+                    return Ok(Value::str(msg.to_string_value()));
+                }
+                if let Some(formatted) =
+                    crate::builtins::exception_message::format_exception_message(
+                        &class_name.resolve(),
+                        attributes,
+                    )
+                {
+                    return Ok(Value::str(formatted));
+                }
             }
             if (method == "raku" || method == "perl")
                 && args.is_empty()

--- a/t/exception-messages.t
+++ b/t/exception-messages.t
@@ -1,0 +1,108 @@
+use Test;
+
+plan 15;
+
+# X::Method::NotFound
+{
+    try { die X::Method::NotFound.new(method => "foo", typename => "Bar") };
+    is $!.message, "No such method 'foo' for invocant of type 'Bar'",
+        "X::Method::NotFound .message";
+}
+
+# X::Str::Numeric
+{
+    try { die X::Str::Numeric.new(source => "foo", reason => "not numeric", pos => 0) };
+    ok $!.message.contains("Cannot convert string to number"),
+        "X::Str::Numeric .message contains expected prefix";
+}
+
+# X::Undeclared
+{
+    try { die X::Undeclared.new(symbol => '$foo', what => "Variable") };
+    is $!.message, "Variable '\$foo' is not declared",
+        "X::Undeclared .message";
+}
+
+# X::Cannot::Lazy
+{
+    try { die X::Cannot::Lazy.new(action => "sort") };
+    is $!.message, "Cannot sort a lazy list",
+        "X::Cannot::Lazy .message";
+}
+
+# X::ControlFlow::Return
+{
+    try { die X::ControlFlow::Return.new };
+    is $!.message, "Attempt to return outside of any Routine",
+        "X::ControlFlow::Return .message";
+}
+
+# X::OutOfRange
+{
+    try { die X::OutOfRange.new(got => 5, range => "0..3", what => "Index") };
+    is $!.message, "Index out of range. Is: 5, should be in 0..3",
+        "X::OutOfRange .message";
+}
+
+# X::Immutable (with method)
+{
+    try { die X::Immutable.new(typename => "List", method => "push") };
+    is $!.message, "Cannot call 'push' on an immutable 'List'",
+        "X::Immutable .message with method";
+}
+
+# X::Immutable (without method)
+{
+    try { die X::Immutable.new(typename => "List") };
+    is $!.message, "Cannot modify an immutable List",
+        "X::Immutable .message without method";
+}
+
+# X::Redeclaration
+{
+    try { die X::Redeclaration.new(symbol => "foo") };
+    is $!.message, "Redeclaration of symbol 'foo'.",
+        "X::Redeclaration .message";
+}
+
+# X::StubCode
+{
+    try { die X::StubCode.new };
+    is $!.message, "Stub code executed",
+        "X::StubCode .message";
+}
+
+# X::Bind
+{
+    try { die X::Bind.new };
+    is $!.message, "Cannot use bind operator with this left-hand side",
+        "X::Bind .message";
+}
+
+# X::Bind (with target)
+{
+    try { die X::Bind.new(target => "my thing") };
+    is $!.message, "Cannot bind to my thing",
+        "X::Bind .message with target";
+}
+
+# .gist includes backtrace info
+{
+    try { die X::StubCode.new };
+    ok $!.gist.contains("Stub code executed"),
+        "X::StubCode .gist contains the message";
+}
+
+# X::Multi::NoMatch
+{
+    try { die X::Multi::NoMatch.new(name => "foo") };
+    is $!.message, "Cannot resolve caller foo; none of these signatures match",
+        "X::Multi::NoMatch .message";
+}
+
+# X::Multi::Ambiguous
+{
+    try { die X::Multi::Ambiguous.new(name => "foo") };
+    is $!.message, "Ambiguous call to 'foo'; these signatures all match",
+        "X::Multi::Ambiguous .message";
+}


### PR DESCRIPTION
## Summary

- Adds a new `builtins/exception_message.rs` module with `format_exception_message()` that constructs proper error messages from exception type attributes
- Modifies `.message`, `.gist`, and `.Str` methods on exception instances to use the formatter before falling back to "X::TypeName with no message"
- Covers 17 exception types: X::Str::Numeric, X::Method::NotFound, X::Undeclared, X::Cannot::Lazy, X::ControlFlow::Return, X::OutOfRange, X::Immutable, X::Multi::NoMatch, X::Multi::Ambiguous, X::Redeclaration, X::StubCode, X::Bind, X::Match::Bool, X::Assignment::RO, X::NYI, X::Signature::Placeholder, X::IO::Closed

## Test plan

- [x] New test file `t/exception-messages.t` with 15 test cases covering all major exception types
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo test` passes
- [ ] `make test` (CI)
- [ ] `make roast` (CI)

Generated with [Claude Code](https://claude.com/claude-code)