### PR TITLE
docs: add 7 newly passing roast tests to whitelist (1220->1227)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -23,6 +23,7 @@ roast/S01-perl-5-integration/basic.t
 roast/S01-perl-5-integration/class.t
 roast/S01-perl-5-integration/context.t
 roast/S01-perl-5-integration/eval_lex.t
+roast/S01-perl-5-integration/exception_handling.t
 roast/S01-perl-5-integration/hash.t
 roast/S01-perl-5-integration/import.t
 roast/S01-perl-5-integration/isms.t
@@ -288,6 +289,7 @@ roast/S04-exceptions/fail-6e.t
 roast/S04-exceptions/fail.t
 roast/S04-exceptions/pending.t
 roast/S04-phasers/ascending-order.t
+roast/S04-phasers/begin.t
 roast/S04-phasers/check.t
 roast/S04-phasers/descending-order.t
 roast/S04-phasers/end.t
@@ -432,6 +434,7 @@ roast/S06-advanced/callsame.t
 roast/S06-advanced/dispatching.t
 roast/S06-advanced/recurse.t
 roast/S06-advanced/return.t
+roast/S06-advanced/stub.t
 roast/S06-currying/assuming-and-mmd.t
 roast/S06-currying/misc.t
 roast/S06-currying/named.t
@@ -549,11 +552,13 @@ roast/S11-modules/need.t
 roast/S11-modules/nested.t
 roast/S11-modules/rakulib.t
 roast/S11-modules/re-export.t
+roast/S11-modules/require.t
 roast/S11-modules/runtime.t
 roast/S11-repository/cur-candidates.t
 roast/S11-repository/cur-current-distribution.t
 roast/S12-attributes/augment-and-initialization.t
 roast/S12-attributes/clone.t
+roast/S12-attributes/defaults.t
 roast/S12-attributes/delegation.t
 roast/S12-attributes/inheritance.t
 roast/S12-attributes/instance.t
@@ -908,6 +913,7 @@ roast/S26-documentation/04a-input-output.t
 roast/S26-documentation/05-comment.t
 roast/S26-documentation/06-lists.t
 roast/S26-documentation/07-tables.t
+roast/S26-documentation/07a-tables.t
 roast/S26-documentation/07b-tables.t
 roast/S26-documentation/07c-tables.t
 roast/S26-documentation/08-formattingcodes.t
@@ -1171,6 +1177,7 @@ roast/S32-trig/sin.t
 roast/S32-trig/sinh.t
 roast/S32-trig/tan.t
 roast/S32-trig/tanh.t
+roast/integration/99problems-11-to-20.t
 roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t


### PR DESCRIPTION
## Summary
- Scanned all 243 non-whitelisted roast tests and found 7 that now fully pass
- Added them to `roast-whitelist.txt` (1220 -> 1227 tests)

### Newly passing tests:
| Test | Subtests | Likely enabled by |
|------|----------|-------------------|
| `roast/S01-perl-5-integration/exception_handling.t` | 3 | exception .message methods |
| `roast/S04-phasers/begin.t` | 13 | CHECK phaser fix |
| `roast/S06-advanced/stub.t` | 13 | general improvements |
| `roast/S11-modules/require.t` | 58 | module system improvements |
| `roast/S12-attributes/defaults.t` | 38 | attribute/class improvements |
| `roast/S26-documentation/07a-tables.t` | 77 | POD parsing improvements |
| `roast/integration/99problems-11-to-20.t` | 25 | general improvements |

## Test plan
- [x] Each test verified with `prove -e './target/debug/mutsu'` (exit 0, Result: PASS)
- [x] Whitelist sorted (`LC_ALL=C sort -c roast-whitelist.txt`)
- [ ] CI passes (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)