### PR TITLE
fix: lazy infinite sequences and m:g code block execution

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -198,6 +198,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                             compiled_fns: None,
                             elems_count: Some(Value::BigInt(factorial)),
                             scan_spec: None,
+                            sequence_spec: None,
                             coroutine: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
@@ -220,6 +221,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                     compiled_fns: None,
                     elems_count: Some(Value::BigInt(factorial)),
                     scan_spec: None,
+                    sequence_spec: None,
                     coroutine: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1087,6 +1087,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     compiled_fns: None,
                     elems_count: Some(Value::BigInt(factorial)),
                     scan_spec: None,
+                    sequence_spec: None,
                     coroutine: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -117,6 +117,7 @@ pub(super) fn dispatch(
                                 .scan_spec
                                 .as_ref()
                                 .map(|s| std::sync::Mutex::new(s.lock().unwrap().clone())),
+                            sequence_spec: list.sequence_spec.clone(),
                             coroutine: list
                                 .coroutine
                                 .as_ref()
@@ -162,6 +163,7 @@ pub(super) fn dispatch(
                     compiled_fns: None,
                     elems_count: None,
                     scan_spec: None,
+                    sequence_spec: None,
                     coroutine: None,
                 },
             )))))

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1497,6 +1497,7 @@ impl Interpreter {
                             .scan_spec
                             .as_ref()
                             .map(|s| std::sync::Mutex::new(s.lock().unwrap().clone())),
+                        sequence_spec: list.sequence_spec.clone(),
                         coroutine: list
                             .coroutine
                             .as_ref()

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -509,6 +509,12 @@ impl Interpreter {
                 } else {
                     non_overlapping
                 };
+                // Execute code blocks from each match for side effects
+                for cap in &selected {
+                    if !cap.code_blocks.is_empty() {
+                        self.execute_regex_code_blocks(&cap.code_blocks);
+                    }
+                }
                 self.apply_multi_regex_captures(&selected);
                 true
             }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -1330,9 +1330,40 @@ impl Interpreter {
         result.extend(extra_rhs);
         // When the endpoint is infinite (None), return a LazyList to preserve laziness
         if endpoint.is_none() && endpoint_kind.is_none() {
-            Ok(Value::LazyList(std::sync::Arc::new(
-                crate::value::LazyList::new_cached(result),
-            )))
+            // Build a SequenceSpec so the lazy list can generate more elements on demand
+            let seq_spec = match &mode {
+                SeqMode::Arithmetic(step) => {
+                    let all_int = result.iter().all(|v| matches!(v, Value::Int(_)));
+                    if all_int && *step == (*step as i64) as f64 {
+                        Some(crate::value::SequenceSpec::Arithmetic {
+                            step: *step as i64,
+                            all_int: true,
+                        })
+                    } else {
+                        Some(crate::value::SequenceSpec::Arithmetic {
+                            step: *step as i64,
+                            all_int: false,
+                        })
+                    }
+                }
+                SeqMode::GeometricRat(num, den) => Some(crate::value::SequenceSpec::GeometricRat {
+                    num: *num,
+                    den: *den,
+                }),
+                SeqMode::Geometric(ratio) => {
+                    Some(crate::value::SequenceSpec::Geometric { ratio: *ratio })
+                }
+                SeqMode::Closure => None,
+            };
+            if let Some(spec) = seq_spec {
+                Ok(Value::LazyList(std::sync::Arc::new(
+                    crate::value::LazyList::new_sequence(result, spec),
+                )))
+            } else {
+                Ok(Value::LazyList(std::sync::Arc::new(
+                    crate::value::LazyList::new_cached(result),
+                )))
+            }
         } else {
             Ok(Value::array(result))
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1111,6 +1111,23 @@ pub(crate) enum VersionPart {
     Whatever,
 }
 
+/// Specification for a lazy infinite sequence (e.g. `1...*`, `2, 4 ... *`).
+/// Stored in `LazyList` to allow on-demand element generation beyond the
+/// initially cached seed elements.
+#[derive(Debug, Clone)]
+pub(crate) enum SequenceSpec {
+    /// Arithmetic progression: next = last + step
+    Arithmetic {
+        step: i64,
+        /// Whether the seed values are all Int (enables Int-typed output)
+        all_int: bool,
+    },
+    /// Geometric progression: next = last * num / den
+    GeometricRat { num: i64, den: i64 },
+    /// Geometric progression with floating-point ratio
+    Geometric { ratio: f64 },
+}
+
 /// Specification for a lazy scan (triangle) reduction.
 /// Stored in `LazyList` to allow on-demand element computation.
 #[derive(Debug, Clone)]
@@ -1176,6 +1193,9 @@ pub(crate) struct LazyList {
     pub(crate) elems_count: Option<Value>,
     /// Scan (triangle reduce) specification for lazy on-demand computation.
     pub(crate) scan_spec: Option<Mutex<ScanSpec>>,
+    /// Sequence specification for infinite arithmetic/geometric sequences.
+    /// When present, more elements can be generated on demand beyond the cache.
+    pub(crate) sequence_spec: Option<SequenceSpec>,
     /// Suspended coroutine state for lazy gather/take.
     /// When present, the gather body can be resumed from where `take` paused it.
     pub(crate) coroutine: Option<Mutex<GatherCoroutineState>>,
@@ -1204,6 +1224,7 @@ impl Clone for LazyList {
                 .scan_spec
                 .as_ref()
                 .map(|s| Mutex::new(s.lock().unwrap().clone())),
+            sequence_spec: self.sequence_spec.clone(),
             coroutine: self
                 .coroutine
                 .as_ref()
@@ -1223,6 +1244,22 @@ impl LazyList {
             compiled_fns: None,
             elems_count: None,
             scan_spec: None,
+            sequence_spec: None,
+            coroutine: None,
+        }
+    }
+
+    /// Create an infinite sequence lazy list that can generate elements on demand.
+    pub(crate) fn new_sequence(seeds: Vec<Value>, spec: SequenceSpec) -> Self {
+        Self {
+            body: Vec::new(),
+            env: crate::env::Env::new(),
+            cache: Mutex::new(Some(seeds)),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: None,
+            sequence_spec: Some(spec),
             coroutine: None,
         }
     }
@@ -1237,6 +1274,7 @@ impl LazyList {
             compiled_fns: None,
             elems_count: None,
             scan_spec: Some(Mutex::new(spec)),
+            sequence_spec: None,
             coroutine: None,
         }
     }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -331,10 +331,10 @@ impl VM {
             }
         }
 
-        // For gather-based LazyList iterables, iterate lazily by pulling
-        // items one at a time. This avoids materializing infinite sequences.
+        // For gather-based or sequence-spec LazyList iterables, iterate lazily
+        // by pulling items one at a time. This avoids materializing infinite sequences.
         if let Value::LazyList(ref ll) = iterable
-            && ll.coroutine.is_some()
+            && (ll.coroutine.is_some() || ll.sequence_spec.is_some())
         {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -343,6 +343,13 @@ impl VM {
             return self.force_scan_lazy_list(list, 200_000);
         }
 
+        // For sequence-spec lazy lists, return current cache (infinite lists
+        // are never fully materialized)
+        if list.sequence_spec.is_some() {
+            let cache = list.cache.lock().unwrap();
+            return Ok(cache.as_ref().cloned().unwrap_or_default());
+        }
+
         // Check cache first
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);
@@ -508,6 +515,11 @@ impl VM {
             {
                 return Ok(cached[..needed].to_vec());
             }
+        }
+
+        // For sequence-spec lazy lists, generate more elements on demand
+        if let Some(ref spec) = list.sequence_spec {
+            return Self::extend_sequence_cache(list, spec, needed);
         }
 
         // Check if coroutine is finished (body completed, all elements produced)
@@ -1178,5 +1190,58 @@ impl VM {
         } else {
             val
         }
+    }
+
+    /// Extend a sequence-spec lazy list's cache to at least `needed` elements.
+    /// This generates new elements using the sequence spec (arithmetic/geometric)
+    /// without needing any VM or interpreter context.
+    fn extend_sequence_cache(
+        list: &LazyList,
+        spec: &crate::value::SequenceSpec,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let mut cache = list.cache.lock().unwrap();
+        let items = cache.get_or_insert_with(Vec::new);
+        if items.len() >= needed {
+            return Ok(items[..needed].to_vec());
+        }
+        // Generate more elements
+        while items.len() < needed {
+            let last = items.last().cloned().unwrap_or(Value::Int(0));
+            let next = match spec {
+                crate::value::SequenceSpec::Arithmetic { step, all_int } => {
+                    if *all_int {
+                        if let Value::Int(n) = last {
+                            Value::Int(n + step)
+                        } else {
+                            let n = last.to_f64();
+                            Value::Num(n + *step as f64)
+                        }
+                    } else {
+                        let n = last.to_f64();
+                        Value::Num(n + *step as f64)
+                    }
+                }
+                crate::value::SequenceSpec::GeometricRat { num, den } => {
+                    if let Value::Int(n) = last {
+                        let result = n * num;
+                        if result % den == 0 {
+                            Value::Int(result / den)
+                        } else {
+                            Value::Rat(result * num, *den)
+                        }
+                    } else {
+                        let n = last.to_f64();
+                        Value::Num(n * (*num as f64) / (*den as f64))
+                    }
+                }
+                crate::value::SequenceSpec::Geometric { ratio } => {
+                    let n = last.to_f64();
+                    Value::Num(n * ratio)
+                }
+            };
+            items.push(next);
+        }
+        Ok(items[..needed].to_vec())
     }
 }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -43,6 +43,7 @@ impl VM {
                 compiled_fns: Some(std::sync::Arc::new(compiled_fns)),
                 elems_count: None,
                 scan_spec: None,
+                sequence_spec: None,
                 coroutine: Some(std::sync::Mutex::new(crate::value::GatherCoroutineState {
                     ip: 0,
                     locals: Vec::new(),


### PR DESCRIPTION
## Summary
- Infinite sequences (e.g. `1...*`) now produce `LazyList` values with a `SequenceSpec` that enables on-demand element generation, fixing nested `gather for` over infinite sequences (gather.t test 17)
- Global regex matches (`m:g/.../`) now execute embedded code blocks for each match, not just for single matches (gather.t test 39)
- gather.t progress: 36/39 → 38/39 passing (remaining failure is test 38: take-rw container identity, which requires deep container reference semantics)

## Test plan
- [x] `prove -e 'target/debug/mutsu' roast/S04-statements/gather.t` passes 38/39 (up from 36/39)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass
- [x] `prove -e 'target/debug/mutsu' t/` passes with no new regressions
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)