### PR TITLE
fix: Seq.new deferred iteration and consumed roundtrip

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1068,6 +1068,7 @@ roast/S32-list/repeated.t
 roast/S32-list/reverse.t
 roast/S32-list/roll.t
 roast/S32-list/rotor.t
+roast/S32-list/seq.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -299,28 +299,54 @@ impl Interpreter {
             }
             return self.call_method_with_values(*inner, method, args);
         }
-        // When Seq.new(iterator) created a deferred-iterator Seq, and .sink is called
-        // without .cache, pull from the iterator now (marks Seq as consumed).
-        if method == "sink"
-            && args.is_empty()
-            && let Value::Seq(items) = &target
+        // Seq deferred iterator handling: Seq.new(iterator) stores the iterator
+        // without pulling. When a method is called on such a Seq, materialize the
+        // items first by pulling from the iterator.
+        if let Value::Seq(items) = &target
             && crate::value::seq_has_deferred_iter(items)
-            && !crate::value::seq_is_cached(items)
         {
-            let items_arc = items.clone();
-            let iterator = crate::value::seq_take_deferred_iter(&items_arc).unwrap();
-            crate::value::seq_consume(&items_arc).ok();
-            // Pull from iterator until IterationEnd
-            let iter_val = iterator;
-            loop {
-                let val = self.call_method_with_values(iter_val.clone(), "pull-one", vec![])?;
-                if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
-                    || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
-                {
-                    break;
+            if method == "sink" && args.is_empty() && !crate::value::seq_is_cached(items) {
+                // .sink on uncached deferred Seq: pull from iterator, mark consumed.
+                let items_arc = items.clone();
+                let iterator = crate::value::seq_take_deferred_iter(&items_arc).unwrap();
+                crate::value::seq_consume(&items_arc).ok();
+                let iter_val = iterator;
+                loop {
+                    let val = self.call_method_with_values(iter_val.clone(), "pull-one", vec![])?;
+                    if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
+                        || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
+                    {
+                        break;
+                    }
+                }
+                return Ok(Value::Nil);
+            }
+            // For methods other than .cache, .sink, .raku, .perl: materialize the
+            // deferred iterator by pulling all items, then re-dispatch on the new Seq.
+            if !matches!(method, "cache" | "sink" | "raku" | "perl") {
+                let items_arc = items.clone();
+                if let Some(iterator) = crate::value::seq_take_deferred_iter(&items_arc) {
+                    let mut pulled_items = Vec::new();
+                    loop {
+                        let val =
+                            self.call_method_with_values(iterator.clone(), "pull-one", vec![])?;
+                        if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
+                            || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
+                        {
+                            break;
+                        }
+                        pulled_items.push(val);
+                    }
+                    let new_seq = Value::Seq(std::sync::Arc::new(pulled_items));
+                    // Transfer cached state from old Seq to new Seq
+                    if crate::value::seq_is_cached(&items_arc)
+                        && let Value::Seq(new_items) = &new_seq
+                    {
+                        crate::value::seq_mark_cached(new_items);
+                    }
+                    return self.call_method_with_values(new_seq, method, args);
                 }
             }
-            return Ok(Value::Nil);
         }
         // Consumed Seq guard: throw X::Seq::Consumed for iteration/coercion methods
         // when the Seq has been consumed and is not cached.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -969,43 +969,24 @@ impl Interpreter {
                         {
                             return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
                         }
-                        // Eagerly pull values from the iterator to build the Seq.
-                        // TODO: implement lazy/deferred pulling for Seq.new(iterator)
-                        // to match Raku semantics. Currently eager-pulling is needed
-                        // because many code paths (rotor, value_to_list, etc.) read
-                        // Seq items directly without handling deferred iterators.
-                        let mut items = Vec::new();
-                        let iter_slot = "$mutsu_seq_new_iterator";
-                        let saved_iter = self.env.get(iter_slot).cloned();
-                        self.env.insert(iter_slot.to_string(), iterator.clone());
-                        let mut iterations = 0usize;
-                        loop {
-                            iterations += 1;
-                            let current_iter =
-                                self.env.get(iter_slot).cloned().unwrap_or(Value::Nil);
-                            let val =
-                                self.call_method_with_values(current_iter, "pull-one", vec![])?;
-                            if iterations > 1_000 {
-                                return Err(RuntimeError::new(format!(
-                                    "Seq.new iterator did not terminate (last value: {})",
-                                    val.to_string_value()
-                                )));
-                            }
-                            if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
-                                || matches!(&val, Value::Package(name) if *name == Symbol::intern("IterationEnd"))
-                            {
-                                break;
-                            }
-                            items.push(val);
+                        // Register deferred iterator: don't pull eagerly.
+                        // Raku's Seq.new(iterator) creates a lazy Seq; pulling
+                        // happens only when the Seq is actually consumed/iterated.
+                        let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                        if let Value::Seq(items) = &seq {
+                            crate::value::seq_register_deferred_iter(items, iterator.clone());
                         }
-                        if let Some(prev) = saved_iter {
-                            self.env.insert(iter_slot.to_string(), prev);
-                        } else {
-                            self.env.remove(iter_slot);
-                        }
-                        return Ok(Value::Seq(std::sync::Arc::new(items)));
+                        return Ok(seq);
                     }
-                    return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+                    // Seq.new() with no args creates a pre-consumed Seq.
+                    // This matches Raku: Seq.new() has no iterator, so it's
+                    // immediately consumed. This is what .raku returns for
+                    // consumed Seqs ("Seq.new()") so the EVAL roundtrip works.
+                    let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                    if let Value::Seq(items) = &seq {
+                        let _ = crate::value::seq_consume(items);
+                    }
+                    return Ok(seq);
                 }
                 "Version" => {
                     let arg = args.first().cloned().unwrap_or(Value::Nil);


### PR DESCRIPTION
## Summary

- **Seq.new(iterator) now defers pulling** from the iterator instead of eagerly calling pull-one at construction time. Items are materialized on demand when a method is called on the Seq. This correctly handles `.cache` followed by `.sink` without pulling from the iterator.
- **Seq.new() (no args) creates a pre-consumed Seq**, matching Raku semantics where `Seq.new()` has no iterator and is immediately consumed. This fixes the `.raku.EVAL` roundtrip for consumed Seqs.
- Adds `roast/S32-list/seq.t` to whitelist (all 50 subtests pass, was 48/50)

## Test plan
- [x] `prove -e ./target/debug/mutsu roast/S32-list/seq.t` passes all 50 tests
- [x] `prove -e ./target/debug/mutsu roast/S32-list/rotor.t` passes (no regression from deferred iterator)
- [x] `prove -e ./target/debug/mutsu t/` shows no new failures
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` pass
- [ ] CI: `make test` and `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)