### PR TITLE
docs: mark S32-temporal/local.t as passing

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -221,12 +221,11 @@ Pod6 formatting codes (Pod::FormattingCode type), table rendering, and trailing 
 - roast/S26-documentation/block-trailing.t
 - roast/S26-documentation/why-trailing.t
 
-## Temporal / DateTime (3 tests)
+## Temporal / DateTime (2 tests)
 
-Duration arithmetic (Inf, NaN, modulo), $*TZ dynamic variable not pre-set, and time numification.
+Duration arithmetic (Inf, NaN, modulo), and time numification.
 
 - roast/S32-temporal/DateTime-Instant-Duration.t (Duration.new(Inf/NaN), modulo)
-- roast/S32-temporal/local.t ($*TZ not defined by default)
 - roast/S32-temporal/time.t (Time::Local numification)
 
 ## Subset Types / Where Clauses (2 tests)

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -345,7 +345,7 @@
 - [ ] roast/S32-temporal/DateTime.t
 - [ ] roast/S32-temporal/greg-jd-frac-seconds.t
 - [x] roast/S32-temporal/juliandate.t
-- [ ] roast/S32-temporal/local.t
+- [x] roast/S32-temporal/local.t
 - [ ] roast/S32-temporal/time.t
 - [ ] roast/S32-trig/atan2.t
 - [ ] roast/S32-trig/cosech.t


### PR DESCRIPTION
## Summary

`roast/S32-temporal/local.t` already passes via prove (exit 0, "Result: PASS") and is already in `roast-whitelist.txt` (added in #2495, which implemented `$*TZ`, `DateTime.local`, and leap-second-aware timezone conversion).

The TODO tracking was stale:
- `TODO_roast/S32.md`: marked the checkbox `[x]`.
- `TODO_roast/BLOCKERS.md`: removed `local.t` from the Temporal / DateTime blocker list (3 -> 2 tests) and dropped the inaccurate '$*TZ not defined by default' note.

### Verification

prove -e 'target/debug/mutsu' roast/S32-temporal/local.t => Result: PASS

The 9 subtests that fail (DST-aware local timezone semantics) are marked `#?rakudo todo` and also fail under reference rakudo; mutsu correctly treats them as TODO. No code changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)