### PR TITLE
fix: don't clobber @/% source when index-assigning the for-loop topic

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -138,6 +138,16 @@
 - [ ] roast/S32-list/categorize.t
 - [ ] roast/S32-list/classify-list.t
 - [ ] roast/S32-list/classify.t
+  - 39/40 pass. Fixed subtests 33/34: `$_[1] = $_[0] for %h.values` (index assignment
+    of the for-loop topic no longer clobbers the whole source @-array/%-hash; the
+    per-element writeback handles it). Remaining blocker: subtest 40 "classify works
+    with Junctions". When the classifier returns a Junction, Raku stores the hash keys
+    as Junction *objects* (object hash, `WHAT: Junction`) and indexing `$h{ any(...) }`
+    matches the stored Junction key by value rather than auto-threading into eigenstate
+    string lookups. mutsu stringifies the key to "any(False, False)" (`WHAT: Str`) and
+    then threads on subscript, so the lookup misses. Fixing this needs classify to build
+    an object hash preserving Junction keys, plus Junction-key hash subscript matching
+    by .WHICH instead of threading. Difficulty: High.
 - [ ] roast/S32-list/combinations.t
   - 0/33 pass. `.combinations` method not implemented at all. All tests fail. Difficulty: Medium-High (need to implement combinations algorithm)
 - [ ] roast/S32-list/create.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3043,8 +3043,16 @@ impl VM {
         }
         if let Some(updated) = self.get_env_with_main_alias(&var_name) {
             self.update_local_if_exists(code, &var_name, &updated);
+            // Write the whole topic back to its source variable only when the
+            // source is a scalar (e.g. `for $x { $_[1] = ... }`). For array/hash
+            // sources (`for @a { $_[1] = ... }`), the for-loop's own per-element
+            // writeback (write_back_for_topic_item) syncs the mutated element
+            // back at the correct index; replacing the whole container with the
+            // single topic value here would corrupt the source.
             if var_name == "_"
                 && let Some(ref source_var) = self.topic_source_var
+                && !source_var.starts_with('@')
+                && !source_var.starts_with('%')
             {
                 let source_name = source_var.clone();
                 self.set_env_with_main_alias(&source_name, updated.clone());

--- a/t/for-topic-index-mutate.t
+++ b/t/for-topic-index-mutate.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 6;
+
+# Mutating an element of the topic ($_[idx] = ...) inside a `for @arr`
+# loop must update each element in place and must NOT replace the whole
+# source array with the last iteration's topic value.
+
+{
+    my @arr = [1], [2], [3];
+    for @arr { $_[1] = 99; }
+    is-deeply @arr, [[1, 99], [2, 99], [3, 99]],
+        'for @arr { $_[1] = ... } mutates each element in place';
+}
+
+{
+    my @arr = [1], [2], [3];
+    $_[1] = 99 for @arr;
+    is-deeply @arr, [[1, 99], [2, 99], [3, 99]],
+        'statement-modifier for with $_ index mutation';
+}
+
+{
+    # Mutating values obtained via %h.values in a for loop should update
+    # the underlying hash, not corrupt the temporary array variable.
+    my %h = (a => [1], b => [2]);
+    my @v = %h.values;
+    for @v { $_[1] = 99; }
+    is-deeply %h, {a => [1, 99], b => [2, 99]},
+        'for over %h.values copy mutates underlying arrays';
+    is +@v.elems, 2, 'temporary @v keeps its element count';
+}
+
+{
+    # The classify.t pattern: $_[1] = $_[0] for %result.values
+    my %result := :{ 5 => [1], 10 => [2], 15 => [3], 20 => [4] };
+    $_[1] = $_[0] for %result.values;
+    is-deeply %result,
+        :{ 5 => [1, 1], 10 => [2, 2], 15 => [3, 3], 20 => [4, 4] },
+        'classify-style index writeback into object hash values';
+    is +%result.keys, 4, 'object hash keeps all keys after mutation';
+}


### PR DESCRIPTION
## Summary

In `for @arr { $_[1] = ... }`, mutating an element of the topic via the index-assignment path wrote the **entire** updated `$_` value back into the loop's source variable, replacing the whole array/hash with the single last-iteration topic value. This corrupted the source container:

```raku
my @arr = [1], [2], [3];
for @arr { $_[1] = 99 }
say @arr;   # was: [3 99]   (WRONG)
            # now: [[1 99] [2 99] [3 99]]  (correct)
```

The for-loop already performs correct per-element writeback via `write_back_for_topic_item`, so the whole-container writeback inside `IndexAssignExprNamed` is only needed for **scalar** sources (`for $x { $_[1] = ... }`). The fix guards that writeback against `@`/`%` sources, matching the pattern already used in the post-increment and assign-expr writeback paths.

## Roast impact

Fixes subtests 33 and 34 of `roast/S32-list/classify.t` (the `$_[1] = $_[0] for %result.values` pattern), advancing it from dying at subtest 33 to 39/40 passing.

Subtest 40 ("classify works with Junctions") remains a separate, deeper blocker: it requires classify to build an object hash preserving Junction keys as objects, plus Junction-key hash subscript matching by `.WHICH` instead of auto-threading. Recorded in `TODO_roast/S32.md`.

## Tests

Added `t/for-topic-index-mutate.t` (6 subtests) covering block-form and statement-modifier `for` topic index mutation over arrays and `%h.values`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)