### PR TITLE
feat: RAKU_EXCEPTIONS_HANDLER=JSON exception handler

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -25,8 +25,8 @@
 - [ ] roast/S04-exception-handlers/top-level.t
 - [ ] roast/S04-exceptions/control_across_runloop.t
   - 0/1 pass. Test uses `sub foo($x = last) { $x }` where `last` is used as a default parameter value that should propagate as a control exception to the enclosing `for` loop. Requires X::ControlFlow exception propagation across call boundaries. Difficulty: Medium-High
-- [ ] roast/S04-exceptions/exceptions-alternatives.t
-  - Was passing trivially (hash `{ :1status, :err(...) }` parsed as block, expectations not tested). With correct colon-pair hash parsing, expectations are now properly checked. Fails because tests require EVAL, MONKEY-SEE-NO-EVAL, %*ENV<RAKU_EXCEPTIONS_HANDLER>="JSON", and complex grammar-based JSON parsing.
+- [x] roast/S04-exceptions/exceptions-alternatives.t
+  - Implemented the `RAKU_EXCEPTIONS_HANDLER=JSON` exception handler: uncaught exceptions are serialized to JSON (`{"<Class>":{...}}`) both at the top level (`main.rs`) and for the in-process `is_run` nested interpreter (`extract_run_output`). Added `X::CompUnit::UnsatisfiedDependency` (with a `specification` attribute) for missing modules in `use`/`require`.
 - [ ] roast/S04-exceptions/fail-6e.t
 - [ ] roast/S04-exceptions/fail.t
 - [ ] roast/S04-exceptions/pending.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -285,6 +285,7 @@ roast/S04-exception-handlers/catch.t
 roast/S04-exception-handlers/control.t
 roast/S04-exception-handlers/top-level.t
 roast/S04-exceptions/control_across_runloop.t
+roast/S04-exceptions/exceptions-alternatives.t
 roast/S04-exceptions/fail-6e.t
 roast/S04-exceptions/fail.t
 roast/S04-exceptions/pending.t

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,7 +492,14 @@ fn run_main() {
             std::process::exit(code as i32);
         }
         Err(err) => {
-            print_error("Runtime error", &err, Some(&input), Some(&program_name));
+            // When `%*ENV<RAKU_EXCEPTIONS_HANDLER>` selects the JSON handler,
+            // print uncaught exceptions as a JSON document instead of the
+            // human-readable backtrace.
+            if interpreter.exceptions_handler().as_deref() == Some("JSON") {
+                eprintln!("{}", err.to_json_exception());
+            } else {
+                print_error("Runtime error", &err, Some(&input), Some(&program_name));
+            }
             interpreter.flush_all_handles();
             interpreter.flush_stderr_buffer();
             let code = interpreter.exit_code();

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -253,7 +253,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let path = self
             .resolve_require_file_path(file)
-            .ok_or_else(|| RuntimeError::new(format!("Module not found: {}", file)))?;
+            .ok_or_else(|| RuntimeError::unsatisfied_dependency(file))?;
 
         // Try loading from precompilation cache
         let stmts = if self.precomp_enabled {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3444,7 +3444,7 @@ impl Interpreter {
             // Missing helper modules remain non-fatal for compatibility.
             match self.load_module(module) {
                 Ok(()) => Ok(()),
-                Err(err) if err.message.starts_with("Module not found:") => Ok(()),
+                Err(err) if err.is_unsatisfied_dependency() => Ok(()),
                 Err(err) => Err(err),
             }
         } else {
@@ -4043,6 +4043,21 @@ impl Interpreter {
 
     pub fn exit_code(&self) -> i64 {
         self.exit_code
+    }
+
+    /// Return the value of `%*ENV<RAKU_EXCEPTIONS_HANDLER>`, if set.
+    /// This selects the format used to print uncaught exceptions (e.g. "JSON").
+    pub fn exceptions_handler(&self) -> Option<String> {
+        let env_hash = self.env.get("%*ENV")?;
+        if let Value::Hash(map) = env_hash
+            && let Some(v) = map.get("RAKU_EXCEPTIONS_HANDLER")
+        {
+            let s = v.to_string_value();
+            if !s.is_empty() {
+                return Some(s);
+            }
+        }
+        None
     }
 
     pub(crate) fn is_halted(&self) -> bool {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1330,7 +1330,7 @@ impl Interpreter {
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
         let (source_path, _inst_dist_json) = self
             .resolve_module_path(module)
-            .ok_or_else(|| RuntimeError::new(format!("Module not found: {}", module)))?;
+            .ok_or_else(|| RuntimeError::unsatisfied_dependency(module))?;
         // Track operator subs exported by this module so EVAL can see them.
         if let Ok(source) = fs::read_to_string(&source_path) {
             for name in Self::extract_module_exported_operator_names(&source) {

--- a/src/runtime/test_functions/subprocess.rs
+++ b/src/runtime/test_functions/subprocess.rs
@@ -346,11 +346,20 @@ impl Interpreter {
                 let (stdout_only, tap_err) = Self::split_tap_output_streams(&combined);
                 let mut err = stderr_content;
                 err.push_str(&tap_err);
-                if !e.message.is_empty() {
+                // When the nested program selected the JSON exceptions handler
+                // (via %*ENV<RAKU_EXCEPTIONS_HANDLER>="JSON"), serialize the
+                // uncaught exception as JSON, matching how the standalone
+                // process prints it.
+                let printed = if nested.exceptions_handler().as_deref() == Some("JSON") {
+                    e.to_json_exception()
+                } else {
+                    e.message.clone()
+                };
+                if !printed.is_empty() {
                     if !err.is_empty() && !err.ends_with('\n') {
                         err.push('\n');
                     }
-                    err.push_str(&e.message);
+                    err.push_str(&printed);
                     err.push('\n');
                 }
                 let s = if nested.exit_code != 0 {

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -106,6 +106,16 @@ impl RuntimeError {
         }
     }
 
+    /// Check if this error represents an X::CompUnit::UnsatisfiedDependency error.
+    pub(crate) fn is_unsatisfied_dependency(&self) -> bool {
+        if let Some(ref ex) = self.exception
+            && let Value::Instance { class_name, .. } = ex.as_ref()
+        {
+            return class_name.resolve() == "X::CompUnit::UnsatisfiedDependency";
+        }
+        false
+    }
+
     /// Check if this error represents a method-not-found error.
     pub(crate) fn is_method_not_found(&self) -> bool {
         if let Some(ref ex) = self.exception
@@ -522,6 +532,15 @@ impl RuntimeError {
         Self::typed_msg("X::Undeclared::Symbols", message)
     }
 
+    /// X::CompUnit::UnsatisfiedDependency - a required module could not be found.
+    pub(crate) fn unsatisfied_dependency(module: &str) -> Self {
+        let msg = format!("Could not find {} in:\n    (module repositories)", module);
+        let mut attrs = HashMap::new();
+        attrs.insert("specification".to_string(), Value::str(module.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg));
+        Self::typed("X::CompUnit::UnsatisfiedDependency", attrs)
+    }
+
     /// X::Redeclaration - Redeclared symbol
     #[allow(dead_code)]
     pub(crate) fn redeclaration(what: &str, name: &str) -> Self {
@@ -814,6 +833,111 @@ impl RuntimeError {
         attrs.insert("got".to_string(), Value::str(got.to_string()));
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         Self::typed("X::TypeCheck::Binding::Parameter", attrs)
+    }
+
+    /// Serialize this error as a JSON document of the form
+    /// `{"<ClassName>":{<attr>:<value>, ...}}`.
+    ///
+    /// This is the format used by the `RAKU_EXCEPTIONS_HANDLER=JSON`
+    /// environment-variable exception handler. The object always contains a
+    /// `message` key (null when the exception has no message attribute).
+    pub fn to_json_exception(&self) -> String {
+        let (class_name, attrs): (String, HashMap<String, Value>) = match &self.exception {
+            Some(boxed) => match boxed.as_ref() {
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } => (
+                    class_name.resolve(),
+                    attributes
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                ),
+                other => ("X::AdHoc".to_string(), {
+                    let mut m = HashMap::new();
+                    m.insert("message".to_string(), Value::str(other.to_string_value()));
+                    m
+                }),
+            },
+            None => ("X::AdHoc".to_string(), {
+                let mut m = HashMap::new();
+                m.insert("message".to_string(), Value::str(self.message.clone()));
+                m
+            }),
+        };
+
+        // Emit attributes in a stable order: `message` first, then the rest
+        // sorted by name. Always include `message` (null if absent).
+        let mut keys: Vec<&String> = attrs.keys().collect();
+        keys.sort();
+        let mut parts: Vec<String> = Vec::new();
+        parts.push(format!(
+            "\"message\":{}",
+            match attrs.get("message") {
+                Some(v) => json_value(v),
+                None => "null".to_string(),
+            }
+        ));
+        for k in keys {
+            if k == "message" {
+                continue;
+            }
+            parts.push(format!("{}:{}", json_string(k), json_value(&attrs[k])));
+        }
+
+        format!("{{{}:{{{}}}}}", json_string(&class_name), parts.join(","))
+    }
+}
+
+/// Encode a Rust string as a JSON string literal (with surrounding quotes).
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Encode a runtime Value as a JSON value for the exception handler.
+fn json_value(v: &Value) -> String {
+    match v {
+        Value::Nil => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Int(n) => n.to_string(),
+        Value::Num(f) => {
+            if f.is_finite() {
+                f.to_string()
+            } else {
+                "null".to_string()
+            }
+        }
+        Value::Str(s) => json_string(s),
+        Value::Array(items, _) => {
+            let elems: Vec<String> = items.iter().map(json_value).collect();
+            format!("[{}]", elems.join(","))
+        }
+        Value::Hash(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let pairs: Vec<String> = keys
+                .iter()
+                .map(|k| format!("{}:{}", json_string(k), json_value(&map[*k])))
+                .collect();
+            format!("{{{}}}", pairs.join(","))
+        }
+        other => json_string(&other.to_string_value()),
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the `RAKU_EXCEPTIONS_HANDLER=JSON` environment-variable exception handler. When `%*ENV<RAKU_EXCEPTIONS_HANDLER>` is set to `"JSON"`, uncaught exceptions are serialized as a JSON document (`{"<Class>":{...}}`) instead of the human-readable backtrace.

The handler is honored in two places:
- **Top level** (`main.rs`): standalone `mutsu` process prints JSON to stderr on an uncaught exception.
- **In-process `is_run`** (`extract_run_output`): the nested interpreter used by `Test::Util`'s `is_run` also produces the JSON form, so subprocess captures match.

Also adds `X::CompUnit::UnsatisfiedDependency` (carrying a `specification` attribute) for missing modules referenced by `use`/`require`, replacing the ad-hoc `"Module not found"` message. The `is_unsatisfied_dependency()` helper replaces the old message-prefix check.

## Test

Passes `roast/S04-exceptions/exceptions-alternatives.t` (3/3), now added to the whitelist:
- exception without a `message` method → `{"X::Foo":{"message":null}}`
- `X::Undeclared::Symbols`
- missing module → JSON `X::CompUnit::UnsatisfiedDependency` with `specification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)