### PR TITLE
docs: record accurate gather.t take-rw blocker (38/39 pass)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -139,9 +139,14 @@ IO::CatHandle not implemented, IO::Path subclasses (::Unix, ::Cygwin) incomplete
 
 ## gather/take Laziness (2 tests)
 
-Coroutine-based lazy gather/take implemented (#2511). range-iterator.t now passes (all 103 tests). Remaining issues: nested gathers, take-rw, and Seq laziness edge cases.
+Coroutine-based lazy gather/take implemented (#2511). range-iterator.t now passes (all 103 tests). Remaining issues: Seq laziness edge cases and take-rw container identity.
 
-- roast/S04-statements/gather.t (36/39 pass — nested gathers, take-rw, take inside m:g)
+- roast/S04-statements/gather.t (38/39 pass — only failure is test 38 take-rw
+  reference identity `@neighbors[1][1][0] =:= @spot[0][0]`. Blocked on
+  first-class array-element containers: mutsu arrays store plain Values with no
+  per-element Scalar container, so take-rw cannot preserve container identity
+  through nested indexing. See TODO_roast/S04.md for details. Nested gathers,
+  take inside m:g, and take on lists already pass.)
 - roast/S32-list/seq.t (48/50 pass — .raku.EVAL roundtrip, methods on cached Seqs)
 
 ## Hyper/Meta Operators (5 tests)

--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -75,7 +75,27 @@
   - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
 - [ ] roast/S04-statements/for_with_only_one_item.t
 - [ ] roast/S04-statements/gather.t
-  - ~3/39 pass. Failures: gathered element count (test 2), `.shift`/`.pop` on gathered list (tests 4-5), nested gather (tests 6-7), take on lists (test 8), dynamic scoping of gather (test 9), gather as statement_prefix (test 11), laziness (test 12), gather with nested while/loop (tests 13-14), decontainerization (test 18)
+  - 38/39 pass. Only remaining failure: test 38 "Got the reference equality
+    expected from take-rw" (line 291). It checks
+    `@neighbors[1][1][0] =:= @spot[0][0]` after populating `@neighbors` via
+    `eager gather for ... { take-rw @spot[i][j] }`. mutsu's `take-rw` currently
+    decontainerizes the expression (it is parsed identically to `take`, the rw
+    flag is dropped in `parser/stmt/simple.rs::take_stmt`), so the gathered value
+    is a copy, not the original container, and `=:=` returns False.
+  - BLOCKER (first-class array-element containers): a genuine fix requires
+    `take-rw EXPR` to capture the real mutable Scalar container of an indexed
+    lvalue (e.g. a shared `ContainerRef` cell vivified into `@spot[i][j]`),
+    preserve that container when it is stored into another nested array element,
+    and make `=:=` compare container identity (Arc pointer) through arbitrary
+    nesting. mutsu arrays store plain `Value`s with no per-element container, and
+    the existing `=:=` machinery for indexed elements only handles single-level
+    `var\x00idx\x00N` encoded sources via `BOUND_ARRAY_REF_SENTINEL`; nested
+    indexes fall through to `ContainerEq`, which compares decontainerized values.
+    Even plain nested binding
+    (`@n[0] := @spot[0]; @n[0][0] =:= @spot[0][0]`) returns False today,
+    confirming this is a broader missing feature (first-class element containers)
+    rather than a gather/take-specific gap. Deferred to avoid a large,
+    regression-prone VM change for a single subtest.
 - [ ] roast/S04-statements/given.t
   - ~22/54 pass. Failures: regex match object in when-clause (test 8), for+given iteration ordering (test 21), given return value (tests 26-29)
 - [ ] roast/S04-statements/goto.t


### PR DESCRIPTION
## Summary

`roast/S04-statements/gather.t` now passes **38/39** subtests. The `BLOCKERS.md` and `S04.md` notes were stale (36/39 and ~3/39). This PR updates them with the accurate current state and a precise blocker analysis.

## Investigation

The only remaining failure is **test 38** "Got the reference equality expected from take-rw" (line 291), which checks:

```raku
ok @neighbors[1][1][0] =:= @spot[0][0], 'Got the reference equality expected from take-rw';
```

after populating `@neighbors` via `eager gather for ... { take-rw @spot[i][j] }`.

mutsu's `take-rw` is parsed identically to `take` (the rw flag is dropped in `parser/stmt/simple.rs::take_stmt`), so it decontainerizes the value and `=:=` returns False.

## Why deferred

A genuine fix requires **first-class array-element Scalar containers**:
- `take-rw EXPR` must capture the real mutable container of an indexed lvalue (a shared `ContainerRef` cell), preserve it when stored into another nested array element, and `=:=` must compare container identity (Arc pointer) through arbitrary nesting.
- mutsu arrays store plain `Value`s with no per-element container; the existing indexed-element `=:=` machinery only handles single-level `var\x00idx\x00N` sources via `BOUND_ARRAY_REF_SENTINEL`, and nested indexes fall through to `ContainerEq` (decontainerized compare).
- Even plain nested binding (`@n[0] := @spot[0]; @n[0][0] =:= @spot[0][0]`) returns False today, confirming this is a broad missing feature, not gather/take-specific.

Nested gathers, take inside `m:g`, and take on lists already pass. Docs-only change; no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)