### PR TITLE
docs: mark roast/S32-scalar/undef.t as passing

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -251,7 +251,8 @@
   - 55/55 pass. All subtests pass: defined() for type objects, undefine(), &defined reference.
 - [ ] roast/S32-scalar/perl.t
   - 5/7 pass (1-3, 5-6). `.raku`/`.perl` serialization works for simple scalars. Failures: constrained scalar serialization (4), only 6 tests reached. Difficulty: Low
-- [ ] roast/S32-scalar/undef.t
+- [x] roast/S32-scalar/undef.t
+  - 91/91 pass. Tests 20-21 are `#?rakudo todo` (definedness of undefined array/hash), expected failures that do not affect the plan.
 - [x] roast/S32-str/append.t
   - 7/7 pass.
 - [x] roast/S32-str/bool.t


### PR DESCRIPTION
## Summary

`roast/S32-scalar/undef.t` already passes fully (91/91 subtests, `prove` exits 0) and is already present in `roast-whitelist.txt` (added in #2521). However `TODO_roast/S32.md` still listed it as unchecked.

This PR updates `TODO_roast/S32.md` to mark the test as passing.

## Notes

- Tests 20 and 21 (`undefine array` / `undefine hash`) are marked `#?rakudo todo` in the test file (definedness of undefined array/hash). They are expected TODO failures and do not affect the plan count.
- No interpreter changes were needed; this is a documentation-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)