### PR TITLE
fix: constant our-scoping, sub-call parens, and try-handled Failure reuse

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -7,7 +7,24 @@
 - [ ] roast/S04-blocks-and-statements/temp.t
 - [ ] roast/S04-declarations/constant-6.d.t
 - [ ] roast/S04-declarations/constant.t
-  - 18/72 pass. Panic fixed (UTF-8 boundary in try_meta_op). Failures: sigiled constants (5-6), constant reassignment checks, our/my scoping, hash/array constants, type constraint enforcement. Difficulty: Medium
+  - 63/72 pass (60 ok + 3 TODO). Fixed: `foo0()` parens always dispatch to the
+    sub even when a same-named constant exists; `our`-scoped constants declared
+    in an inner block are now visible in the outer scope and inside EVAL
+    (resolved via the package `our_vars` store); a `try` that yields a soft
+    Failure now marks it handled so later numeric use does not re-throw (this
+    last fix unblocked tests 20-72 that previously aborted the whole run).
+    Remaining failures, each a distinct prerequisite:
+    - Tests 24, 26: `constant baka := 23` (rebinding a term/constant via `:=`)
+      should be a compile-time error ("Cannot bind to '...' because it is a term
+      and terms cannot be rebound"); mutsu currently silently ignores the bind.
+    - Test 44: enum-variant access through a constant type alias (`G::c` where
+      `my constant G = F::B`) does not parse.
+    - Test 46: `constant fib := 0, 1, *+* ... *; fib[100]` — indexing a lazy
+      infinite sequence (even bound to a plain `@`-var) returns Nil; deep VM
+      lazy-iterator issue, unrelated to constants.
+    - Test 56: redeclaring a constant (`constant Mouse = Rat; constant Mouse =
+      Rat`) should throw X::Redeclaration; mutsu does not.
+    Difficulty: Medium
 - [ ] roast/S04-declarations/implicit-parameter.t
 - [ ] roast/S04-declarations/multiple.t
   - 3/8 pass (tests 1-3). Failures: `my ($a, $b) = (1, 2)` destructuring works but `my ($a, @b)` with slurpy not supported; `my ($a, *@b)` splat syntax not implemented; `state` declarations not supported. Difficulty: Medium

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -67,12 +67,14 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         self.code.emit(OpCode::GetBareWord(name_idx));
                     } else if self.sigilless_locals.contains(name.as_str())
-                        || self.constant_vars.contains(name.as_str())
+                        || self.constant_vars_in_scope.contains(name.as_str())
                         || name == "self"
                         || name == "__ANON_STATE__"
                     {
-                        // Sigilless bindings and constants: the bare word IS the
-                        // variable, so read directly from the local slot.
+                        // Sigilless bindings and in-scope constants: the bare word
+                        // IS the variable, so read directly from the local slot.
+                        // (Out-of-scope constants fall through to GetBareWord, which
+                        // resolves them as `our`-scoped package globals.)
                         self.code.emit(OpCode::GetLocal(slot));
                     } else {
                         // The local is a `$`-sigiled variable — a bare word with the

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -1,23 +1,35 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// Snapshot of the compiler's lexical-scope-sensitive state, saved on block
+/// entry and restored on block exit.
+pub(super) struct LexicalScopeSnapshot {
+    dynamic_scope_all: bool,
+    dynamic_scope_names: Option<std::collections::HashSet<String>>,
+    constant_vars_in_scope: std::collections::HashSet<String>,
+}
+
 impl Compiler {
     fn normalize_dynamic_scope_name(name: &str) -> String {
         name.trim_start_matches(['$', '@', '%', '&']).to_string()
     }
 
-    pub(super) fn push_dynamic_scope_lexical(
-        &mut self,
-    ) -> (bool, Option<std::collections::HashSet<String>>) {
-        (self.dynamic_scope_all, self.dynamic_scope_names.clone())
+    pub(super) fn push_dynamic_scope_lexical(&mut self) -> LexicalScopeSnapshot {
+        LexicalScopeSnapshot {
+            dynamic_scope_all: self.dynamic_scope_all,
+            dynamic_scope_names: self.dynamic_scope_names.clone(),
+            constant_vars_in_scope: self.constant_vars_in_scope.clone(),
+        }
     }
 
-    pub(super) fn pop_dynamic_scope_lexical(
-        &mut self,
-        saved: (bool, Option<std::collections::HashSet<String>>),
-    ) {
-        self.dynamic_scope_all = saved.0;
-        self.dynamic_scope_names = saved.1;
+    pub(super) fn pop_dynamic_scope_lexical(&mut self, saved: LexicalScopeSnapshot) {
+        self.dynamic_scope_all = saved.dynamic_scope_all;
+        self.dynamic_scope_names = saved.dynamic_scope_names;
+        // Constants declared inside the exiting block are `our`-scoped: they stay
+        // installed in the package, but their lexical local slot is no longer
+        // valid, so drop them from the in-scope set. Subsequent bare-word access
+        // then resolves them via GetBareWord (package/global lookup).
+        self.constant_vars_in_scope = saved.constant_vars_in_scope;
     }
 
     pub(super) fn apply_dynamic_scope_pragma(&mut self, arg: Option<&Expr>) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -68,6 +68,11 @@ pub(crate) struct Compiler {
     scalar_bind_autovivify: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
+    /// Subset of `constant_vars` whose declaring lexical block is still open.
+    /// Constants are `our`-scoped (installed in the package), so once their
+    /// declaring block has exited, their stale local slot must not be reused —
+    /// such bare-word accesses fall back to GetBareWord (package/global lookup).
+    constant_vars_in_scope: std::collections::HashSet<String>,
     /// Local names that are sigilless bindings (declared with `my \Foo = ...`
     /// or as a sigilless parameter).  BareWord resolution only uses GetLocal
     /// for names in this set; `$`-sigiled variables must not shadow type names.
@@ -102,6 +107,7 @@ impl Compiler {
             bind_vardecl: false,
             scalar_bind_autovivify: false,
             constant_vars: std::collections::HashSet::new(),
+            constant_vars_in_scope: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -613,6 +613,7 @@ impl Compiler {
                 let is_constant_decl = custom_traits.iter().any(|(t, _)| t == "__constant");
                 if is_constant_decl {
                     self.constant_vars.insert(name.clone());
+                    self.constant_vars_in_scope.insert(name.clone());
                 }
                 // X::ParametricConstant: typed @/% constants are forbidden
                 if is_constant_decl

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -313,7 +313,14 @@ pub(super) fn declared_term_symbol(input: &str) -> PResult<'_, Expr> {
     {
         // If the declared callable is immediately followed by `(`, defer to
         // identifier_or_call so `name(...)` parses as a single call expression.
-        if callable && input[consumed_len..].starts_with('(') {
+        //
+        // The same applies to a non-callable term (e.g. a sigilless `constant`)
+        // whose name also names a user-declared sub: parens always indicate a
+        // sub call, so `name()` must dispatch to the sub rather than evaluate
+        // the constant term and call its value.
+        if input[consumed_len..].starts_with('(')
+            && (callable || crate::parser::stmt::simple::is_user_declared_sub(&name))
+        {
             return Err(PError::expected("declared term symbol"));
         }
         let expr = if callable {

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -642,6 +642,9 @@ impl Interpreter {
                     || self.has_function(name)
                     || self.has_multi_function(name)
                     || self.env().contains_key(name)
+                    // `our`-scoped constants/variables installed in the package
+                    // survive in `our_vars` even after their lexical block exits.
+                    || self.get_our_var(name).is_some()
                     || local_classes.contains(name.as_str())
                     || declared.contains(name.as_str())
                     || crate::vm::VM::is_builtin_type(name)

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -204,6 +204,15 @@ impl Interpreter {
             }
             nested.env.insert_sym(*k, v.clone());
         }
+        // Propagate `our`-scoped variables/constants (installed in the package
+        // store) so the evaluated snippet can resolve them as bare words.
+        let our_vars: Vec<(String, Value)> = self
+            .our_vars_iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        for (k, v) in our_vars {
+            nested.set_our_var(k, v);
+        }
         let eval_result = nested.eval_eval_string(&code);
         let ok = eval_result.is_ok();
         let eval_err_msg = match &eval_result {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2182,6 +2182,15 @@ impl VM {
                     .env_mut()
                     .insert("!".to_string(), Value::Nil);
                 self.interpreter.discard_let_saves(let_mark);
+                // A `try` that completes normally but yields a soft Failure value
+                // (e.g. the result of an expression that returned a Failure rather
+                // than throwing) handles that Failure: its value is now "caught",
+                // so subsequent uses must not re-throw the stored exception.
+                if let Some(top) = self.stack.last()
+                    && matches!(top, Value::Instance { class_name, .. } if class_name == "Failure")
+                {
+                    top.mark_failure_handled();
+                }
                 *ip = end;
                 Ok(())
             }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -274,6 +274,10 @@ impl VM {
                 Value::Rat(n, d)
             } else if let Some(val) = crate::builtins::unicode::unicode_numeric_int_value(ch) {
                 Value::Int(val)
+            } else if let Some(our_val) = self.interpreter.get_our_var(name).cloned() {
+                // Single-character `our`-scoped constant declared in an inner
+                // block (see the multi-char case below for rationale).
+                our_val
             } else {
                 Value::str(name.to_string())
             }
@@ -290,6 +294,13 @@ impl VM {
                 attrs,
             )));
             return Err(err);
+        } else if let Some(our_val) = self.interpreter.get_our_var(name).cloned() {
+            // `our`-scoped constants (and `our` variables) declared in an inner
+            // block survive block-scope restoration in the package store
+            // (`our_vars`) even though the lexical env entry was discarded.
+            // Resolve the bare word to that persisted package value rather than
+            // treating it as an undeclared bareword string.
+            our_val
         } else {
             Value::str(name.to_string())
         };

--- a/t/constant.t
+++ b/t/constant.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 17;
 
 # Basic constant declarations
 constant $a = 42;
@@ -28,3 +28,29 @@ is "foo".IO.parent.Str, ".", 'parent of "foo"';
 is "foo".IO.parent(2).Str, "..", 'parent(2) of "foo"';
 is "a/b/c".IO.parent(3).Str, ".", 'parent(3) of "a/b/c"';
 is "a/b/c".IO.parent(4).Str, "..", 'parent(4) of "a/b/c"';
+
+# A bare constant shadows a same-named sub, but parens always call the sub.
+{
+    sub foo0 { "OH NOES" };
+    constant foo0 = 5;
+    is foo0,   5,         'bare constant wins against same-named sub';
+    is foo0(), 'OH NOES', 'parens always indicate a sub call';
+}
+
+# Constants are `our`-scoped: a constant declared in an inner block is visible
+# in the enclosing scope and inside EVAL.
+{
+    {
+        constant foo2 = 42;
+    }
+    is foo2, 42, 'inner-block constant visible in outer scope';
+    ok (EVAL 'foo2 == 42'), 'inner-block constant visible inside EVAL';
+}
+
+# A `try` whose expression yields a soft Failure handles it: later numeric use
+# returns False (uninitialized) instead of re-throwing the stored exception.
+{
+    constant @arr = [1, 2, 3];
+    constant $oob = try @arr[10];
+    ok !($oob == 99), 'try-handled Failure does not re-throw on numeric use';
+}


### PR DESCRIPTION
Advances `roast/S04-declarations/constant.t` from aborting at test 19 to **63/72 passing** (60 ok + 3 expected TODO).

## Fixes

1. **Sub-call parens win over a same-named constant.** `name()` always dispatches to a `sub name` even when a sigilless `constant name` shadows it. The parser now defers a non-callable term to the call path when it is immediately followed by `(` and the name is also a user-declared sub. (constant.t test 4)

2. **`our`-scoped constants are visible after their declaring block.** A `constant` declared in an inner block is now resolvable in the enclosing scope and inside `EVAL`. The compiler tracks which constants are still lexically in scope (saved/restored at block boundaries) and falls back to `GetBareWord` once the block exits; `GetBareWord`, the EVAL undeclared-name check, and `eval-lives-ok` now resolve such constants from the package `our_vars` store, which survives block-scope env restoration. (constant.t test 8)

3. **`try`-handled soft Failures no longer re-throw.** A `try` that completes normally but yields a `Failure` value now marks that Failure handled, so later numeric (or other) use coerces it as undefined instead of re-throwing the stored exception. This unblocked tests 20-72, which previously aborted the whole run with a fatal "Test failures".

## Tests

`t/constant.t` gains 5 cases covering all three fixes. `make test` and `make roast` pass locally (the known pre-existing build-cache-contaminated local tests `t/placeholder.t`, `t/tail-function.t`, `t/wrap.t` are unrelated to these changes and pass under a clean CI build).

## Remaining constant.t failures

Recorded in `TODO_roast/S04.md`, each a distinct prerequisite: `:=` rebinding of a constant term, enum-variant access through a constant type alias (`G::c`), lazy infinite-sequence indexing (`fib[100]`), and `X::Redeclaration` on duplicate constant declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)