### PR TITLE
fix: for-loop topic element writeback no longer clobbers the aggregate

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -250,7 +250,7 @@ Binding to attributes, nested binding, and container semantics (Scalar decontain
 
 categorize.t now fully passes (28/28, whitelisted). minmax.t fully passes (whitelisted, #2510). classify.t nearly passes (38/40 — 2 edge cases remaining).
 
-- roast/S32-list/classify.t (38/40 pass — 2 edge cases remaining)
+- roast/S32-list/classify.t (39/40 pass — only the Junction-threading subtest remains; classify with a mapper returning a Junction must thread and store values under multiple keys)
 
 ## Miscellaneous (25 tests)
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3045,7 +3045,13 @@ impl VM {
             self.update_local_if_exists(code, &var_name, &updated);
             if var_name == "_"
                 && let Some(ref source_var) = self.topic_source_var
+                && !source_var.starts_with('@')
+                && !source_var.starts_with('%')
             {
+                // For @/% sources, element writeback to a per-index slot is
+                // handled by write_back_for_topic_item at the end of the loop
+                // body. Overwriting the whole container with $_ here would
+                // clobber the aggregate (e.g. `$_[1] = 9 for @a`).
                 let source_name = source_var.clone();
                 self.set_env_with_main_alias(&source_name, updated.clone());
                 self.update_local_if_exists(code, &source_name, &updated);

--- a/t/for-topic-element-writeback.t
+++ b/t/for-topic-element-writeback.t
@@ -1,0 +1,41 @@
+use Test;
+
+# Regression test: `$_[N] = ...` inside a `for @aggregate` statement modifier
+# must write back to the per-index element slot, not clobber the whole
+# aggregate with the last topic value.
+
+plan 6;
+
+{
+    my @a = ([1], [2], [3]);
+    $_[1] = 9 for @a;
+    is-deeply @a, [[1, 9], [2, 9], [3, 9]], 'topic element writeback into array of arrays';
+}
+
+{
+    my @a = ([1], [2], [3]);
+    for @a { $_[1] = 9 }
+    is-deeply @a, [[1, 9], [2, 9], [3, 9]], 'topic element writeback in block for';
+}
+
+{
+    # classify into an existing filled hash: each value array grows
+    my %r = (5 => [1], 10 => [2]);
+    my @vals = %r.values;
+    $_[1] = $_[0] for @vals;
+    is %r<5>.elems, 2, 'value array via temp grows correctly (5)';
+    is %r<10>.elems, 2, 'value array via temp grows correctly (10)';
+}
+
+{
+    # nested topic indexing keeps the aggregate intact
+    my @a = ([10, 20], [30, 40]);
+    $_[0] = $_[0] + 1 for @a;
+    is-deeply @a, [[11, 20], [31, 40]], 'increment first element of each sub-array';
+}
+
+{
+    my @a = ('a', 'b', 'c');
+    $_ = $_.uc for @a;
+    is-deeply @a, ['A', 'B', 'C'], 'plain topic writeback still works';
+}


### PR DESCRIPTION
## Summary

`\$_[N] = ...` inside a `for @aggregate` statement modifier was overwriting the **entire** source container with the whole `\$_` value, instead of writing back to the per-index element slot.

```raku
my @a = ([1], [2], [3]);
\$_[1] = 9 for @a;
say @a;   # was [3 9], now [[1 9] [2 9] [3 9]]
```

## Root cause

The element-assignment path in `exec_set_indexed_op` (`vm_var_assign_ops.rs`) unconditionally wrote the updated `\$_` back to `topic_source_var`. For `@`/`%` sources that writeback is the responsibility of `write_back_for_topic_item`, which targets `@source[idx]`. The two other topic-writeback sites already guarded against `@`/`%` sources; this site was missing the guard, so it clobbered the whole aggregate with the last topic value.

## Impact

- Advances `roast/S32-list/classify.t` from 33/40 (aborting mid-file) to 39/40. The only remaining subtest needs Junction threading in `classify` (a separate feature, noted in BLOCKERS.md).
- Adds `t/for-topic-element-writeback.t` covering array-of-arrays writeback, block-form `for`, `%hash.values` via temp, nested increment, and plain topic writeback.

## Testing

- `make test`: no new failures (pre-existing `t/placeholder.t`, `t/wrap.t` failures are unrelated and also fail on `main`).
- `make roast`: no regressions (`DateTime.t`/`spurt.t` are time/environment-flaky and fail on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)