### PR TITLE
feat: implement the Format class (6.e) and Format-aware .fmt

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -197,11 +197,24 @@ WhateverCode (*) in certain contexts: dummy assignment to *, &infix:<+>(*, 42) n
 
 ## Sprintf / Format Edge Cases (2 tests)
 
-The 6.d/S32-str/sprintf*.t suites all pass now. The non-6.d sprintf.t (zprintf) has roast test bugs.
+The 6.d/S32-str/sprintf*.t suites all pass now. The non-6.d sprintf.t (zprintf) has roast test bugs. The `Format` class (6.e) is now implemented; format.t is blocked on RakuAST.
 
-**Fail (roast test bugs):**
-- roast/S32-str/sprintf.t (166/174 pass; 8 failures from buggy test expectations)
-- roast/S32-str/format.t
+**Fail (roast test bugs — cannot pass as written):**
+- roast/S32-str/sprintf.t (166/174 pass; the 8 failures, tests 71-74 and
+  101-104, have buggy expected values — `%5.2g` cases expect a `g`/`G` exponent
+  letter while the parallel `%20.2g` cases correctly expect `e`/`E`, and the
+  `%020.2g` cases expect mantissa `34.1` where the un-padded twins expect the
+  correct `3.14`. mutsu is self-consistent. See TODO_roast/S32.md.)
+
+**Blocked on RakuAST:**
+- roast/S32-str/format.t (26/49 reachable tests now pass; was 0). The Format
+  class — `Format.new`, `~~ Format`, `.arity`/`.count`/`.Callable`, `CALL-ME`,
+  stringification, and full `.fmt($format, $sep)` integration with arity-aware
+  batching and `X::Str::Sprintf::Directives::Count` — is implemented, plus
+  string interpolation of postcircumfix calls (`"$f()"`). The file aborts at
+  test 27 because `Formatter.AST` must return a `RakuAST::Node` (lines 50-52)
+  and mutsu has no RakuAST; a mid-file error aborts the remaining 23 `.fmt`
+  tests. Local coverage: t/format-class.t (40 tests).
 
 ## Unicode / Collation (6 tests)
 

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -307,6 +307,21 @@
 - [ ] roast/S32-str/flip.t
   - 10/13 pass (1-5, 7-8, 11-13). Failures: test 6 unknown, grapheme precomposed (9), grapheme without precomposed (10). Difficulty: Low (grapheme cluster awareness needed)
 - [ ] roast/S32-str/format.t
+  - 26/49 reachable tests pass (was 0). The `Format` class (6.e) is now
+    implemented: `Format.new`, `~~ Format`, `.arity`/`.count`, `.Callable`
+    (a real Sub whose `.signature` is a Signature), stringification to the
+    format, `CALL-ME` (sprintf), and full `.fmt($format, $sep)` integration
+    across List/Seq/Set/SetHash/Bag/BagHash/Mix/MixHash/Map/Hash/Pair with
+    arity-aware batching and `X::Str::Sprintf::Directives::Count` on mismatch.
+    String interpolation of postcircumfix calls (`"$f()"`, `"$f("x")"`) was
+    also added. Local coverage: t/format-class.t (40 tests, all pass).
+  - BLOCKED at test 27 on RakuAST: lines 50-52 require `Formatter::Syntax.parse`
+    (a grammar returning a Match), `Formatter.CODE` (a Callable), and
+    `Formatter.AST` returning a `RakuAST::Node`. mutsu has no RakuAST
+    infrastructure, and a mid-file runtime error aborts the whole file, so the
+    23 `.fmt` tests after line 52 are unreachable until RakuAST exists. Faking
+    `RakuAST::Node` would be a stub (forbidden), so the file cannot be
+    whitelisted without real RakuAST support.
 - [ ] roast/S32-str/gb18030-encode-decode.t
 - [ ] roast/S32-str/gb2312-encode-decode.t
 - [ ] roast/S32-str/indent.t
@@ -345,7 +360,16 @@
 - [ ] roast/S32-str/sprintf-o.t
 - [ ] roast/S32-str/sprintf-s.t
 - [ ] roast/S32-str/sprintf.t
-  - 166/174 pass. 8 failures due to buggy expected values in roast test (zprintf is unimplemented in Raku).
+  - 166/174 pass. The 8 failures (tests 71-74, 101-104) are confirmed buggy
+    expected values in the roast test, not mutsu bugs:
+    - Tests 71-74 (`%5.2g`/`%5.2G` on 3.1415e±30) expect the exponent letter to
+      be `g`/`G` (e.g. `3.14g+30`), but the parallel `%20.2g` cases (lines
+      149-152, which PASS) correctly expect `e`/`E`. mutsu is self-consistent.
+    - Tests 101-104 (`%020.2g`/`%020.2G`) expect mantissa `34.1e+30`
+      (= 3.41e31, not the 3.1415e30 input); the non-zero-padded `%20.2g` twins
+      correctly expect `3.14e+30`. Zero-padding cannot shift mantissa digits.
+    These cannot pass as written and roast is read-only, so the file cannot be
+    whitelisted. (`zprintf` is a 6.e function absent from the reference raku.)
 - [ ] roast/S32-str/sprintf-u.t
 - [ ] roast/S32-str/sprintf-x.t
 - [ ] roast/S32-str/starts-with.t

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1402,6 +1402,12 @@ pub(crate) fn native_method_1arg(
             }
         }
         "fmt" => {
+            // A Format object argument is handled by the slow-path Format dispatch
+            // (arity-aware batching, separators, X::Str::Sprintf::Directives::Count).
+            if matches!(arg, Value::Instance { class_name, .. } if class_name.resolve() == "Format")
+            {
+                return None;
+            }
             let fmt = arg.to_string_value();
             if let Value::Hash(items) = target {
                 // Hash.fmt(format): format each key-value pair, join with "\n"
@@ -2815,6 +2821,11 @@ pub(crate) fn native_method_2arg(
             }
         }
         "fmt" => {
+            // A Format object argument is handled by the slow-path Format dispatch.
+            if matches!(arg1, Value::Instance { class_name, .. } if class_name.resolve() == "Format")
+            {
+                return None;
+            }
             let fmt_str = arg1.to_string_value();
             let sep = arg2.to_string_value();
             if let Value::Hash(items) = target {

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -1404,6 +1404,55 @@ pub(super) fn process_escape_sequence<'a>(
     Ok(Some((after_escape, false)))
 }
 
+/// Try to parse a postcircumfix call on an interpolated variable: "$var()" or "$var(args)".
+/// In Raku, `"$callable(args)"` invokes the callable during interpolation. Only triggers
+/// when `(` immediately follows the variable (or its index/postcircumfix). The argument
+/// text must not contain a nested string delimiter, since the surrounding string scanner
+/// does not balance quotes inside interpolation.
+fn try_parse_interp_call(input: &str, target: Expr) -> (Expr, &str) {
+    if !input.starts_with('(') {
+        return (target, input);
+    }
+    // Find the matching close paren, respecting nesting.
+    let mut depth = 0usize;
+    let mut paren_end = None;
+    for (idx, ch) in input.char_indices() {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth == 0 {
+                paren_end = Some(idx);
+                break;
+            }
+        }
+    }
+    let Some(pe) = paren_end else {
+        return (target, input);
+    };
+    let args_str = &input[1..pe];
+    let after = &input[pe + 1..];
+    let args = if args_str.trim().is_empty() {
+        vec![]
+    } else {
+        let mut args = vec![];
+        for arg in args_str.split(',') {
+            let arg = arg.trim();
+            if let Ok((_, e)) = crate::parser::expr::expression(arg) {
+                args.push(e);
+            }
+        }
+        args
+    };
+    (
+        Expr::CallOn {
+            target: Box::new(target),
+            args,
+        },
+        after,
+    )
+}
+
 /// Try to parse a method call chain on an interpolated variable: "$var.method()" or "$var.method".
 /// Only recognizes simple identifier method names followed by `()` (no args).
 /// Try to parse a method call chain on an interpolated variable: "$var.method()" or "$var.method".
@@ -1959,6 +2008,8 @@ pub(super) fn try_interpolate_var<'a>(
             let var_rest = &rest[1..];
             let (var_rest, var_name) = parse_var_name_from_str(var_rest);
             let (expr, var_rest) = parse_postcircumfix_index(var_rest, Expr::Var(var_name));
+            // Handle postcircumfix call interpolation: "$var()" / "$var(args)"
+            let (expr, var_rest) = try_parse_interp_call(var_rest, expr);
             // Handle method call interpolation: "$var.method()" or "$var.method"
             let (expr, var_rest) = try_parse_interp_method_call(var_rest, expr);
             parts.push(expr);

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1947,25 +1947,16 @@ impl Interpreter {
             return Ok(val);
         }
 
-        // Format instance dispatch
-        if let Value::Instance {
-            class_name,
-            attributes,
-            ..
-        } = &target
-            && class_name == "Format"
+        // Format type-object / instance dispatch (new, arity, count, Callable,
+        // Str, gist, CALL-ME, ...).
+        if let Some(result) = self.dispatch_format_method(&target, method, &args) {
+            return result;
+        }
+        // <collection>.fmt($format) where $format is a Format object.
+        if method == "fmt"
+            && let Some(result) = self.dispatch_fmt_with_format(&target, &args)
         {
-            let fmt = attributes
-                .get("format")
-                .map(Value::to_string_value)
-                .unwrap_or_default();
-            match method {
-                "CALL-ME" => {
-                    return Ok(Value::str(super::sprintf::format_sprintf_args(&fmt, &args)));
-                }
-                "Str" | "gist" => return Ok(Value::str(fmt)),
-                _ => {}
-            }
+            return result;
         }
         // Match.make
         if let Value::Instance {

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -1,0 +1,297 @@
+//! The `Format` class (Raku 6.e): a `Callable` wrapper around a sprintf-style
+//! format string. `Format.new("%5s")` produces an object that stringifies to the
+//! format, is callable (`$f("foo")` -> sprintf), and integrates with `.fmt`.
+//!
+//! Authoritative semantics mirror Rakudo's `src/core.e/Format.rakumod` and the
+//! `.fmt(Format, $sep)` augmentations in `src/core.e/Fixups.rakumod`.
+
+use std::collections::HashMap;
+
+use crate::ast::{Expr, ParamDef, Stmt};
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value};
+
+use super::Interpreter;
+
+/// Build a required positional `ParamDef` with the given (sigilless) name.
+fn positional_param(name: &str) -> ParamDef {
+    ParamDef {
+        name: name.to_string(),
+        default: None,
+        multi_invocant: true,
+        required: true,
+        named: false,
+        slurpy: false,
+        double_slurpy: false,
+        onearg: false,
+        sigilless: false,
+        type_constraint: None,
+        literal_value: None,
+        sub_signature: None,
+        where_constraint: None,
+        traits: Vec::new(),
+        optional_marker: false,
+        outer_sub_signature: None,
+        code_signature: None,
+        is_invocant: false,
+        shape_constraints: None,
+    }
+}
+
+impl Interpreter {
+    /// True if `value` is a `Format` instance.
+    pub(super) fn is_format_instance(value: &Value) -> bool {
+        matches!(value, Value::Instance { class_name, .. } if class_name.resolve() == "Format")
+    }
+
+    /// Read the format string out of a `Format` instance.
+    fn format_string_of(value: &Value) -> Option<String> {
+        match value {
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name.resolve() == "Format" => Some(
+                attributes
+                    .get("format")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default(),
+            ),
+            _ => None,
+        }
+    }
+
+    /// Build the underlying `Callable` (a `Sub`) for a format string. The sub has
+    /// `count` required positional parameters and a body of `sprintf($fmt, ...)`.
+    pub(super) fn format_callable(&self, fmt: &str, count: usize) -> Value {
+        let mut params = Vec::with_capacity(count);
+        let mut param_defs = Vec::with_capacity(count);
+        let mut call_args: Vec<Expr> = Vec::with_capacity(count + 1);
+        call_args.push(Expr::Literal(Value::str(fmt.to_string())));
+        for i in 0..count {
+            let pname = format!("a{i}");
+            params.push(pname.clone());
+            param_defs.push(positional_param(&pname));
+            call_args.push(Expr::Var(pname));
+        }
+        let body = vec![Stmt::Expr(Expr::Call {
+            name: Symbol::intern("sprintf"),
+            args: call_args,
+        })];
+        Value::make_sub(
+            Symbol::intern("Formatter"),
+            Symbol::intern("format"),
+            params,
+            param_defs,
+            body,
+            false,
+            self.env.clone(),
+        )
+    }
+
+    /// Apply a format to a list of arguments, validating arity and types.
+    /// This is the `CALL-ME` behaviour and the per-batch renderer used by `.fmt`.
+    fn format_render(&self, fmt: &str, args: &[Value]) -> Result<Value, RuntimeError> {
+        super::sprintf::validate_sprintf_directives(fmt, args.len())?;
+        super::sprintf::validate_sprintf_arg_types(fmt, args)?;
+        Ok(Value::str(super::sprintf::format_sprintf_args(fmt, args)))
+    }
+
+    /// Throw `X::Str::Sprintf::Directives::Count` for an arity mismatch during `.fmt`.
+    fn format_throw_arity(fmt: &str, args_have: usize, args_used: usize) -> RuntimeError {
+        let mut attrs = HashMap::new();
+        attrs.insert("args-have".to_string(), Value::Int(args_have as i64));
+        attrs.insert("args-used".to_string(), Value::Int(args_used as i64));
+        attrs.insert("format".to_string(), Value::str(fmt.to_string()));
+        let message = format!(
+            "Your printf-style directives specify {} argument{}, but {} {} supplied",
+            args_used,
+            if args_used == 1 { "" } else { "s" },
+            if args_have < 1 {
+                "no".to_string()
+            } else {
+                args_have.to_string()
+            },
+            if args_have == 1 {
+                "argument was"
+            } else {
+                "arguments were"
+            },
+        );
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(Value::make_instance(
+            Symbol::intern("X::Str::Sprintf::Directives::Count"),
+            attrs,
+        )));
+        err
+    }
+
+    /// `Format.handle-iterator`: render a sequence of values, batching by the
+    /// format's directive count and joining with `separator`.
+    fn format_handle_iterator(
+        &self,
+        fmt: &str,
+        count: usize,
+        items: &[Value],
+        separator: &str,
+    ) -> Result<Value, RuntimeError> {
+        // No-arg format: empty input renders to "", any value is an arity error.
+        if count == 0 {
+            if items.is_empty() {
+                return Ok(Value::str(String::new()));
+            }
+            return Err(Self::format_throw_arity(fmt, 0, 1));
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        let mut idx = 0;
+        while idx < items.len() {
+            let end = (idx + count).min(items.len());
+            let batch = &items[idx..end];
+            if batch.len() < count {
+                // A non-empty short batch is an arity error.
+                return Err(Self::format_throw_arity(fmt, batch.len(), count));
+            }
+            parts.push(self.format_render(fmt, batch)?.to_string_value());
+            idx = end;
+        }
+        Ok(Value::str(parts.join(separator)))
+    }
+
+    /// Dispatch methods on a `Format` type object (`Format.new`) or instance
+    /// (`.arity`, `.count`, `.Callable`, `.Str`, `CALL-ME`, ...). Returns `None`
+    /// when the target/method is not a `Format` concern.
+    pub(super) fn dispatch_format_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        // Format.new("...")
+        if method == "new" && matches!(target, Value::Package(name) if name.resolve() == "Format") {
+            let fmt = args
+                .iter()
+                .find(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+                .map(Value::to_string_value)
+                .unwrap_or_default();
+            let mut attrs = HashMap::new();
+            attrs.insert("format".to_string(), Value::str(fmt));
+            return Some(Ok(Value::make_instance(Symbol::intern("Format"), attrs)));
+        }
+
+        let fmt = Self::format_string_of(target)?;
+        let count = super::sprintf::sprintf_directive_count(&fmt);
+        match method {
+            "Str" | "gist" | "Stringy" => Some(Ok(Value::str(fmt))),
+            "arity" | "count" => Some(Ok(Value::Int(count as i64))),
+            "Callable" => Some(Ok(self.format_callable(&fmt, count))),
+            "raku" | "perl" => Some(Ok(Value::str(format!("Format.new(\"{}\")", fmt)))),
+            "CALL-ME" => Some(self.format_render(&fmt, args)),
+            _ => None,
+        }
+    }
+
+    /// Handle `<collection>.fmt($format, $separator)` where `$format` is a `Format`.
+    /// Returns `None` when the first argument is not a `Format` instance, leaving the
+    /// regular string-based `.fmt` path untouched.
+    pub(super) fn dispatch_fmt_with_format(
+        &mut self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let format_arg = args.first()?;
+        if !Self::is_format_instance(format_arg) {
+            return None;
+        }
+        let fmt = Self::format_string_of(format_arg)?;
+        let count = super::sprintf::sprintf_directive_count(&fmt);
+
+        Some(self.fmt_with_format_inner(target, &fmt, count, args))
+    }
+
+    fn fmt_with_format_inner(
+        &mut self,
+        target: &Value,
+        fmt: &str,
+        count: usize,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        // Pair.fmt($format) -> $format($key, $value); no separator.
+        match target {
+            Value::Pair(k, v) => {
+                return self.format_render(fmt, &[Value::str(k.clone()), (**v).clone()]);
+            }
+            Value::ValuePair(k, v) => {
+                return self.format_render(fmt, &[(**k).clone(), (**v).clone()]);
+            }
+            _ => {}
+        }
+
+        // Lazy sequences cannot be formatted.
+        if Self::is_lazy_for_coerce(target) {
+            return Err(Self::cannot_lazy_fmt());
+        }
+
+        let items = self.fmt_items_for_format(target, count)?;
+        let separator = match args.get(1) {
+            Some(sep) => sep.to_string_value(),
+            None => Self::default_fmt_separator(target),
+        };
+        self.format_handle_iterator(fmt, count, &items, &separator)
+    }
+
+    /// The default separator for `.fmt(Format)`: " " for positional types, "\n"
+    /// for associative types (Set/Bag/Mix/Hash/Map).
+    fn default_fmt_separator(target: &Value) -> String {
+        match target {
+            Value::Array(..)
+            | Value::Seq(_)
+            | Value::Slip(_)
+            | Value::LazyList(_)
+            | Value::Range(_, _)
+            | Value::RangeExcl(_, _)
+            | Value::RangeExclStart(_, _)
+            | Value::RangeExclBoth(_, _)
+            | Value::GenericRange { .. } => " ".to_string(),
+            _ => "\n".to_string(),
+        }
+    }
+
+    /// Produce the sequence of values to format for a collection, following the
+    /// 6.e `.fmt` rules: positional types yield their elements; associative types
+    /// yield keys (count == 1) or flattened key/value pairs (count >= 2).
+    fn fmt_items_for_format(
+        &mut self,
+        target: &Value,
+        count: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let is_associative = matches!(
+            target,
+            Value::Hash(_) | Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _)
+        );
+        if is_associative {
+            let method = if count == 1 { "keys" } else { "kv" };
+            let result = self.call_method_with_values(target.clone(), method, Vec::new())?;
+            Ok(super::value_to_list(&result))
+        } else {
+            Ok(super::value_to_list(target))
+        }
+    }
+
+    /// `X::Cannot::Lazy` with action ".fmt".
+    fn cannot_lazy_fmt() -> RuntimeError {
+        let mut attrs = HashMap::new();
+        attrs.insert("action".to_string(), Value::str(".fmt".to_string()));
+        attrs.insert(
+            "message".to_string(),
+            Value::str("Cannot .fmt a lazy list".to_string()),
+        );
+        let mut err = RuntimeError::new("Cannot .fmt a lazy list".to_string());
+        err.exception = Some(Box::new(Value::make_instance(
+            Symbol::intern("X::Cannot::Lazy"),
+            attrs,
+        )));
+        err
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -165,6 +165,7 @@ mod methods_dispatch_match3;
 mod methods_dispatch_new;
 mod methods_distribution;
 mod methods_enum_dispatch;
+mod methods_format;
 mod methods_grammar;
 mod methods_instance_ops;
 mod methods_introspect;

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -5,7 +5,9 @@ use super::sprintf_helpers::{
     apply_float_minus_zero, apply_width, format_float_fixed, format_g, format_inf_nan,
     format_rat_fixed, normalize_sci_exponent, sign_prefix,
 };
-pub(crate) use super::sprintf_validate::{validate_sprintf_arg_types, validate_sprintf_directives};
+pub(crate) use super::sprintf_validate::{
+    sprintf_directive_count, validate_sprintf_arg_types, validate_sprintf_directives,
+};
 
 pub(crate) fn format_sprintf(fmt: &str, arg: Option<&Value>) -> String {
     match arg {

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -1,6 +1,96 @@
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 
+/// Count the number of arguments a sprintf-style format string consumes.
+/// This is the number of directives (excluding `%%`), counting `*` width/precision
+/// as additional sequential args, and using the highest positional index when
+/// `N$` positional directives are used. Used for `Format.count` / `Format.arity`.
+pub(crate) fn sprintf_directive_count(fmt: &str) -> usize {
+    let bytes = fmt.as_bytes();
+    let len = bytes.len();
+    let mut pos = 0usize;
+    let mut sequential_args = 0usize;
+    let mut max_positional = 0usize;
+    let mut uses_positional = false;
+    while pos < len {
+        if bytes[pos] != b'%' {
+            pos += 1;
+            continue;
+        }
+        pos += 1; // skip '%'
+        if pos < len && bytes[pos] == b'%' {
+            pos += 1;
+            continue;
+        }
+        // Positional argument specifier: N$
+        let mut positional_arg = None;
+        {
+            let start = pos;
+            while pos < len && bytes[pos].is_ascii_digit() {
+                pos += 1;
+            }
+            if pos > start && pos < len && bytes[pos] == b'$' {
+                let n: usize = fmt[start..pos].parse().unwrap_or(0);
+                positional_arg = Some(n);
+                uses_positional = true;
+                pos += 1;
+            } else {
+                pos = start;
+            }
+        }
+        // Flags
+        while pos < len {
+            let b = bytes[pos];
+            if b == b'-' || b == b'+' || b == b' ' || b == b'#' || b == b'0' {
+                pos += 1;
+            } else {
+                break;
+            }
+        }
+        // Width
+        if pos < len && bytes[pos] == b'*' {
+            pos += 1;
+            if positional_arg.is_none() {
+                sequential_args += 1;
+            }
+        } else {
+            while pos < len && bytes[pos].is_ascii_digit() {
+                pos += 1;
+            }
+        }
+        // Precision
+        if pos < len && bytes[pos] == b'.' {
+            pos += 1;
+            if pos < len && bytes[pos] == b'*' {
+                pos += 1;
+                if positional_arg.is_none() {
+                    sequential_args += 1;
+                }
+            } else {
+                while pos < len && bytes[pos].is_ascii_digit() {
+                    pos += 1;
+                }
+            }
+        }
+        // Conversion specifier
+        if pos < len {
+            pos += 1;
+        }
+        if let Some(p) = positional_arg {
+            if p > max_positional {
+                max_positional = p;
+            }
+        } else {
+            sequential_args += 1;
+        }
+    }
+    if uses_positional {
+        max_positional
+    } else {
+        sequential_args
+    }
+}
+
 /// Validate sprintf format directives. Throws typed exceptions for:
 /// - Unsupported directives (X::Str::Sprintf::Directives::Unsupported)
 /// - Arg count mismatch (X::Str::Sprintf::Directives::Count)

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -977,6 +977,7 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "Whatever"
             | "WhateverCode"
             | "HyperWhatever"
+            | "Format"
             | "Version"
             | "Date"
             | "DateTime"

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -349,6 +349,7 @@ impl VM {
                 | "Lock"
                 | "Semaphore"
                 | "Whatever"
+                | "Format"
                 | "Instant"
                 | "Buf"
                 | "Blob"

--- a/t/format-class.t
+++ b/t/format-class.t
@@ -1,0 +1,80 @@
+use Test;
+
+# The Format class (Raku 6.e): a Callable wrapper around a sprintf format string.
+# Mirrors the runnable (non-RakuAST) parts of roast/S32-str/format.t.
+
+plan 40;
+
+# --- argless format ---------------------------------------------------------
+my $f0 = Format.new("foo");
+isa-ok $f0, Format,                  'Format.new returns a Format';
+ok     $f0 ~~ Format,                'a Format smartmatches Format';
+isa-ok $f0.Callable, Callable,       '.Callable is a Callable';
+isa-ok $f0.Callable.signature, Signature, '.Callable.signature is a Signature';
+is     $f0.arity, 0,                 'arity of argless format';
+is     $f0.count, 0,                 'count of argless format';
+is     $f0(),     'foo',             'argless format is callable';
+is     "$f0",     'foo',             'argless format stringifies to the format';
+is     "$f0()",   'foo',             'argless format call interpolates';
+
+is     ().fmt($f0), '',              'empty list is fine for argless format';
+
+# argless format over a non-empty list throws an arity error
+my $err;
+{ <a b c>.fmt($f0); CATCH { default { $err = $_ } } }
+isa-ok $err, X::Str::Sprintf::Directives::Count, 'argless over list throws Count';
+is     $err.args-have, 0,            'args-have is 0';
+is     $err.args-used, 1,            'args-used is 1';
+is     $err.format,   'foo',         'format is foo';
+
+# --- one-arg format ---------------------------------------------------------
+my $f1 = Format.new("%5s");
+isa-ok $f1, Format,                  'one-arg Format';
+is     $f1.arity, 1,                 'arity one arg';
+is     $f1.count, 1,                 'count one arg';
+is     $f1("foo"),     '  foo',      'one-arg format is callable';
+is     "$f1",          '%5s',        'one-arg format stringifies';
+
+# --- two-arg format ---------------------------------------------------------
+my $f2 = Format.new("%5s:%5s");
+is     $f2.arity, 2,                 'arity two args';
+is     $f2.count, 2,                 'count two args';
+is     $f2("foo","bar"),     '  foo:  bar', 'two-arg format is callable';
+is     "$f2",                '%5s:%5s',     'two-arg format stringifies';
+
+# --- .fmt over collections with a one-arg format ----------------------------
+for <Set SetHash Bag BagHash Mix MixHash> -> $coercer {
+    is <a b b>."$coercer"().fmt($f1, ':'), '    a:    b' | '    b:    a',
+      "fmt on $coercer with one-arg format";
+}
+
+# --- .fmt over Set/SetHash with a two-arg (kv) format -----------------------
+for <Set SetHash> -> $coercer {
+    is <a b b>."$coercer"().fmt($f2, ','),
+      '    a: True,    b: True' | '    b: True,    a: True',
+      "fmt on $coercer with two-arg format";
+}
+
+# --- .fmt over Bag/Mix with a two-arg (kv) format ---------------------------
+for <Bag BagHash MixHash> -> $coercer {
+    is <a b b>."$coercer"().fmt($f2, ','),
+      '    a:    1,    b:    2' | '    b:    2,    a:    1',
+      "fmt on $coercer with two-arg format";
+}
+
+# --- .fmt over a Map --------------------------------------------------------
+my $map := Map.new( (a => 1, b => 2) );
+is $map.fmt($f1, ':'), '    a:    b' | '    b:    a', 'fmt on Map with one arg';
+is $map.fmt($f2, ','),
+  '    a:    1,    b:    2' | '    b:    2,    a:    1', 'fmt on Map with two args';
+
+# --- .fmt over List/Seq (positional, ordered, batched) ----------------------
+my $list := <a a b b>;
+for <List Seq> -> $coercer {
+    is $list."$coercer"().fmt($f1, ':'), '    a:    a:    b:    b',
+      "fmt on $coercer with one-arg format";
+    is $list."$coercer"().fmt($f2, ','), '    a:    a,    b:    b',
+      "fmt on $coercer with two-arg format";
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Implements Raku 6.e's **`Format`** class — a `Callable` wrapper around a sprintf-style format string — and integrates it with `.fmt`. Mirrors Rakudo's `src/core.e/Format.rakumod` and the `.fmt` augmentations in `src/core.e/Fixups.rakumod`.

This addresses the **Sprintf / Format Edge Cases** item in `TODO_roast/BLOCKERS.md`.

## What's implemented

- `Format.new("%5s")`; `Format` recognized as a type (`~~ Format`, `isa-ok`, bareword type object).
- `.arity` / `.count` (directive count), `.Callable` (a real `Sub` whose `.signature` is a `Signature`), `.Str`/`.gist` (the format string), and `CALL-ME` (validates arity/types, renders via sprintf).
- Full **`.fmt($format, $separator)`** across List/Seq/Set/SetHash/Bag/BagHash/Mix/MixHash/Map/Hash/Pair using `handle-iterator` semantics: positional types yield elements; associative types yield keys (count == 1) or flattened key/value pairs (count >= 2); arity-aware batching; arity mismatch throws `X::Str::Sprintf::Directives::Count` with `args-have`/`args-used`/`format`.
- **String interpolation of postcircumfix calls**: `"$f()"`, `"$f("x")"` (general parser win, not Format-specific).

The fast-path native `.fmt` now defers to the slow-path Format dispatch when its argument is a `Format`, leaving the string-format path untouched.

## Test results

- `roast/S32-str/format.t`: **26/49 reachable tests now pass (was 0)**. Blocked at test 27 on **RakuAST** — `Formatter.AST` must return a `RakuAST::Node` (lines 50-52), which mutsu has no infrastructure for; a mid-file runtime error aborts the remaining 23 `.fmt` tests. Faking `RakuAST::Node` would be a stub, so the file can't be whitelisted until real RakuAST support exists.
- New local test `t/format-class.t`: **40/40 pass**.
- `make roast`: 1230 files, **zero regressions**.
- `make test`: no new failures vs. main.

## Also documented

`roast/S32-str/sprintf.t`'s 8 failures (tests 71-74, 101-104) are **buggy expected values in the roast test**, not mutsu bugs. Recorded in `TODO_roast/S32.md` and `BLOCKERS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)