### PR TITLE
fix: callsame into punned roles, symbolic-deref operator assign, hyper infix sub names

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -47,6 +47,11 @@
 - [ ] roast/S06-operator-overloading/circumfix.t
 - [ ] roast/S06-operator-overloading/imported-subs.t
 - [ ] roast/S06-operator-overloading/infix.t
+    - Tests 1-10 pass; test 11 (`infix:<;>`) is `#?rakudo todo`.
+    - Blocker for tests 12-15: method-form operator exports (`method infix:<as>(...) is export`)
+      combined with `import` are not usable as real infix operators. `($obj as OtherClass)`
+      fails to parse ("expected statement"). Needs parser support so that an imported
+      operator-form method becomes a callable infix operator, plus `import` wiring.
 - [ ] roast/S06-operator-overloading/methods.t
 - [ ] roast/S06-operator-overloading/prefix.t
 - [ ] roast/S06-operator-overloading/semicolon.t

--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -111,6 +111,17 @@
 - [ ] roast/S12-methods/private.t
   - 13/14 pass (1-13). Failure: test 14 times out due to 10000*26=260000 private method calls being too slow (interpreter method dispatch performance). Difficulty: Hard (requires method dispatch optimization)
 - [ ] roast/S12-methods/qualified.t
+  - 4/7 subtests pass (simple, inheritance, puned role, simple parameterized role).
+  - "puned role" fixed: `callsame` now defers into a punned role parent (`class Foo is R1`)
+    by also resolving role-owned methods in `resolve_all_methods_with_owner`.
+  - Remaining failures:
+    - "run-time does" (subtest 4): runtime `self does Foo2` mixin followed by qualified
+      dispatch `self.Foo2::foo`. Even `self.Foo::foo` throws InvalidQualifier after a
+      runtime mixin. Needs runtime role mixin to extend the MRO/qualifier set.
+    - "parameterizations and inheritance" (subtest 6) and "relaxed dispatch ambiguities"
+      (subtest 7): parameterized-role concretization (`does R1[Int] does R1[Str]`),
+      `$?ROLE`/`$?CLASS`, and ambiguous-concretization detection
+      (`X::AdHoc: Ambiguous concretization lookup for R1`). Substantial parameterized-role work.
 - [ ] roast/S12-methods/submethods.t
 - [ ] roast/S12-methods/syntax.t
   - 2/15 pass (tests 1, 15). Failures: method call with empty parens `obj.doit()` (2), `.doit ()` with space (3), unspace `obj.doit\ ()` (4), colon form `obj.doit: args` (5-9), block as arg (10-12), `$.a(args)` (13-14). Difficulty: Medium-High (method call syntax variants)

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -732,6 +732,14 @@ impl Interpreter {
         op: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
+        // Hyper meta-operators called via their subroutine name, e.g.
+        // `&infix:<<<+>>>(@a, @b)` / `&infix:<»+«>(@a, @b)`. Apply the inner
+        // operator elementwise according to the dwim sides.
+        if args.len() == 2
+            && let Some((inner, dwim_left, dwim_right)) = parse_hyper_infix(op)
+        {
+            return self.apply_hyper_infix(inner, dwim_left, dwim_right, &args[0], &args[1]);
+        }
         let is_set_op = matches!(
             op,
             "(-)"
@@ -1580,4 +1588,102 @@ impl Interpreter {
             _ => TokenKind::Ident(op.to_string()),
         }
     }
+
+    /// Apply a hyper meta-operator elementwise. `inner` is the inner operator
+    /// (e.g. `+`), and `dwim_left`/`dwim_right` indicate which side may be
+    /// recycled (the pointy end of `»`/`«`).
+    fn apply_hyper_infix(
+        &mut self,
+        inner: &str,
+        dwim_left: bool,
+        dwim_right: bool,
+        left: &Value,
+        right: &Value,
+    ) -> Result<Value, RuntimeError> {
+        let left_list = Self::value_to_list(left);
+        let right_list = Self::value_to_list(right);
+        let left_len = left_list.len();
+        let right_len = right_list.len();
+        if left_len == 0 && right_len == 0 {
+            return Ok(Value::array(Vec::new()));
+        }
+        let result_len = if !dwim_left && !dwim_right {
+            if left_len != right_len {
+                return Err(RuntimeError::new(format!(
+                    "Non-dwimmy hyper operator: left has {} elements, right has {}",
+                    left_len, right_len
+                )));
+            }
+            left_len
+        } else if dwim_left && dwim_right {
+            std::cmp::max(left_len, right_len)
+        } else if dwim_right {
+            left_len
+        } else {
+            right_len
+        };
+        let mut results = Vec::with_capacity(result_len);
+        for i in 0..result_len {
+            let l = if left_len == 0 {
+                Value::Int(0)
+            } else {
+                left_list[i % left_len].clone()
+            };
+            let r = if right_len == 0 {
+                Value::Int(0)
+            } else {
+                right_list[i % right_len].clone()
+            };
+            let infix_name = format!("infix:<{}>", inner);
+            let pair_result = if let Some(v) =
+                self.resolve_function_with_types(&infix_name, &[l.clone(), r.clone()])
+            {
+                self.call_function_def(&v, &[l, r])?
+            } else {
+                Self::apply_reduction_op(inner, &l, &r)?
+            };
+            results.push(pair_result);
+        }
+        Ok(Value::real_array(results))
+    }
+}
+
+/// Parse a hyper meta-operator name into `(inner_op, dwim_left, dwim_right)`.
+/// Recognizes both ASCII (`<<`/`>>`) and Unicode (`«`/`»`) delimiters.
+///
+/// The dwimmy side (the one that may be recycled) is the one whose delimiter
+/// points "outward" away from the operator. Verified against the reference
+/// implementation:
+///   `[1,2,3] »+» [4]`  => `5 6 7`   (right dwims; result length = left)
+///   `[1] «+« [4,5,6]`  => `5 6 7`   (left dwims;  result length = right)
+///   `[1] «+» [4,5,6]`  => dwim both (result length = max)
+///   `[1] »+« [4,5,6]`  => non-dwimmy (length mismatch is an error)
+/// So: left `«`/`<<` => dwim left; right `»`/`>>` => dwim right.
+fn parse_hyper_infix(op: &str) -> Option<(&str, bool, bool)> {
+    let (after_left, dwim_left) = if let Some(rest) = op.strip_prefix("<<") {
+        (rest, true)
+    } else if let Some(rest) = op.strip_prefix('\u{00AB}') {
+        (rest, true)
+    } else if let Some(rest) = op.strip_prefix(">>") {
+        (rest, false)
+    } else if let Some(rest) = op.strip_prefix('\u{00BB}') {
+        (rest, false)
+    } else {
+        return None;
+    };
+    let (inner, dwim_right) = if let Some(rest) = after_left.strip_suffix(">>") {
+        (rest, true)
+    } else if let Some(rest) = after_left.strip_suffix('\u{00BB}') {
+        (rest, true)
+    } else if let Some(rest) = after_left.strip_suffix("<<") {
+        (rest, false)
+    } else if let Some(rest) = after_left.strip_suffix('\u{00AB}') {
+        (rest, false)
+    } else {
+        return None;
+    };
+    if inner.is_empty() {
+        return None;
+    }
+    Some((inner, dwim_left, dwim_right))
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -523,12 +523,20 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let mut matches = Vec::new();
         for cn in &mro {
-            if let Some(overloads) = self
+            // An MRO entry may be a regular class or a punned role used as a
+            // parent (`class Foo is R1 { ... }`). Role methods are stored in
+            // `self.roles`, so fall back there when the entry is not a class.
+            let overloads = self
                 .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
-                .cloned()
-            {
+                .or_else(|| {
+                    self.roles
+                        .get(cn.as_str())
+                        .and_then(|r| r.methods.get(method_name))
+                })
+                .cloned();
+            if let Some(overloads) = overloads {
                 let is_ancestor = cn != class_name;
                 for def in overloads {
                     if def.is_private {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1058,6 +1058,10 @@ impl VM {
             "$" => name.to_string(),
             "@" => format!("@{}", name),
             "%" => format!("%{}", name),
+            // Code variables (`&::("infix:<times>")`) must be stored under the
+            // `&`-sigilled name so that operator dispatch can find the closure
+            // via its `&infix:<...>` env key.
+            "&" => format!("&{}", name),
             _ => name.to_string(),
         };
         // For $ sigil (item context), take only first element if value is a list.

--- a/t/callsame-punned-role-and-hyper-infix-sub.t
+++ b/t/callsame-punned-role-and-hyper-infix-sub.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 7;
+
+# callsame defers into a punned role used as a parent (`class Foo is R1`).
+{
+    my role R1 {
+        method foo { "R1::foo" }
+    }
+    my class Foo is R1 {
+        method foo { "Foo::foo > " ~ callsame }
+    }
+    my class Bar is Foo { }
+
+    is Foo.new.foo, "Foo::foo > R1::foo", "callsame works for a punned role";
+    is Bar.new.foo, "Foo::foo > R1::foo", "callsame works for a punned role via a child class";
+}
+
+# Symbolic dereferentiation assignment to an operator code variable.
+{
+    my &infix:<times>;
+    BEGIN {
+        &::("infix:<times>") = { $^a * $^b };
+    }
+    is 3 times 5, 15, 'operator overloading using symbolic dereferentiation';
+}
+
+# Calling a hyperoperator via its &infix:<...> subroutine name (Unicode form).
+{
+    is ~(&infix:<»+«>([1,2,3],[4,5,6])), "5 7 9",
+        "hyperoperator via subroutine name";
+    is ~(&infix:<»*«>([1,2,3],[4,5,6])), "4 10 18",
+        "hyperoperator (multiply) via subroutine name";
+    # Dwimmy left side (`«` on the left) recycles the single-element list.
+    is ~(&infix:<«+«>([10],[1,2,3])), "11 12 13",
+        "dwimmy left hyperoperator recycles short side";
+}
+
+# Builtin infix via subroutine name still works.
+is &infix:<+>(2, 3), 5, "builtin infix via subroutine name";


### PR DESCRIPTION
Improves two roast tests with three general-purpose dispatch/operator fixes.

## S12-methods/qualified.t: 3/7 -> 4/7 subtests
The "puned role" subtest now passes. `callsame` inside a method whose class
uses a punned role as a parent (`class Foo is R1`) now correctly defers to the
role's method. `resolve_all_methods_with_owner` walked the MRO but only looked
methods up in `self.classes`; role methods live in `self.roles`. It now falls
back to `self.roles` for MRO entries that are punned roles, so the deferral
candidate chain used by callsame/nextsame includes role-owned methods.

## S06-operator-overloading/infix.t: 6 -> 11 tests reached
- **Test 7** (symbolic dereferentiation): `&::("infix:<times>") = { $^a * $^b }`
  now installs the operator. The `SymbolicDerefStore` op stored code variables
  without the `&` sigil, so operator dispatch (which looks up the `&infix:<...>`
  env key) never found them. The `&` sigil case now prefixes the store name.
- **Test 10** (hyperoperator via subroutine name): the Unicode pointy hyperop
  subroutine name is now callable. `call_infix_routine` detects hyper
  meta-operator delimiters, parses the dwim sides (truth-table verified against
  the reference implementation), and applies the inner operator elementwise.

Remaining blockers (recorded in `TODO_roast/S06.md` / `S12.md`):
- S12 subtest 4: runtime `does` mixin + qualified dispatch.
- S12 subtests 6-7: parameterized-role concretization, `$?ROLE`/`$?CLASS`,
  ambiguous-concretization detection.
- S06 tests 12-15: method-form operator exports usable as real infix operators
  via `import`.

## Tests
- New `t/callsame-punned-role-and-hyper-infix-sub.t` (7 subtests, all pass).
- `make test`: no new failures (lock.t / placeholder.t failures are pre-existing
  and flaky, confirmed failing on base without these changes).
- `make roast`: exit 0, 760 whitelisted files pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)