### PR TITLE
feat: native typed array Positional compliance, defaults, shaped :exists/:delete, whatever compound-assign

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -221,9 +221,9 @@
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t
   - 0/? pass. Parse error at line 13
-- [ ] roast/S02-types/multi_dimensional_array.t
-  - 0/? pass. Parse error at line 15
-  - Deferred: raku itself fails with "Jagged array shapes not yet implemented" at line 35, so the test cannot pass even on Rakudo. Added to too_difficult.txt.
+- [x] roast/S02-types/multi_dimensional_array.t
+  - 59/59 pass (whitelisted). Shaped multi-dimensional arrays work, including
+    native typed shaped arrays after the Native Typed Arrays work.
 - [ ] roast/S02-types/mu.t
   - 0/? pass. Parse error at line 9
 - [x] roast/S02-types/nan.t

--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -8,7 +8,9 @@
 - [ ] roast/S09-multidim/indexing.t
 - [ ] roast/S09-multidim/methods.t
 - [ ] roast/S09-multidim/subs.t
-- [ ] roast/S09-multidim/XX-POS-on-dimensioned.t
+- [x] roast/S09-multidim/XX-POS-on-dimensioned.t
+  - 69/69 pass (whitelisted). Shaped/native array bounds, :delete (X::Delete),
+    and bind restrictions work after the Native Typed Arrays work.
 - [ ] roast/S09-multidim/XX-POS-on-undimensioned.t
 - [ ] roast/S09-subscript/multidim-assignment.t
 - [ ] roast/S09-subscript/slice.t
@@ -28,9 +30,28 @@
   - Test 44: Self-referential hash assignment `(%h1 = %h1, %h2)` parsed incorrectly in `is-deeply` call context. Parser issue with parenthesized assignment as function argument.
 - [ ] roast/S09-typed-arrays/native-decl.t
 - [ ] roast/S09-typed-arrays/native-int.t
+  - Partial. Native `array[int]` type objects now do Positional/Positional[int],
+    `.of` works on parametric type objects, OOB reads return 0, and mutating
+    map (`* *= 2`) now works (whatever compound-assign currying). Remaining:
+    a deeper feature still aborts mid-file (e.g. native int wrap/coercion or
+    grep/first :p semantics) — needs follow-up.
 - [ ] roast/S09-typed-arrays/native-num.t
+  - Partial. Same Positional/.of/OOB-default/mutating-map improvements apply.
+    Native num `array[num]` Range slice-assign (`@arr[^3] = ...`) now expands
+    the range so values distribute per element.
 - [ ] roast/S09-typed-arrays/native-shape1-int.t
+  - Partial (101+ run, was 49). Shaped native `:exists` is now range-based,
+    `:delete` throws X::Delete, OOB-in-range reads return the element default,
+    and mutating map works. Tests 2/5 (`Positional[int]`) are `#?rakudo todo`.
+    Remaining failures: grep/first :p/:kv, .pairup/.antipairs, .pick/.roll,
+    .raku formatting, type-checked push/assign exceptions.
 - [ ] roast/S09-typed-arrays/native-shape1-num.t
+  - Partial (101+ run, was 49). Same shaped-array improvements as shape1-int.
 - [ ] roast/S09-typed-arrays/native-shape1-str.t
+  - Partial. Same shaped-array improvements; native str default is empty string.
 - [ ] roast/S09-typed-arrays/native-str.t
+  - Partial. Positional/.of improvements apply. Remaining: grep :p, pop/shift
+    on empty native array dies with the right X:: type, .raku formatting.
 - [ ] roast/S09-typed-arrays/native.t
+  - Blocked: even rakudo fails test 11 (`foo @a` with `Real(Cool)` coercion of
+    a native str array dies). Max reachable is 10/12; not a mutsu bug.

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -669,6 +669,16 @@ fn build_compound_assign_target_expr(target: Expr, op_name: &str, value: Expr) -
     let Some(op) = compound_assign_op_from_name(op_name) else {
         return assignment_ro_expr(target, value);
     };
+    // Bare `* op= value` curries to a WhateverCode that mutates its topic,
+    // i.e. `{ $_ op= value }`. Used for e.g. `@a.map(* *= 2)`.
+    if matches!(target, Expr::Whatever) {
+        let body = build_compound_assign_target_expr(Expr::Var("_".to_string()), op_name, value);
+        return Expr::Lambda {
+            param: "_".to_string(),
+            body: vec![crate::ast::Stmt::Expr(body)],
+            is_whatever_code: true,
+        };
+    }
     match target {
         Expr::Var(name) => Expr::AssignExpr {
             name: name.clone(),

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -805,6 +805,16 @@ pub(crate) fn build_compound_assign_expr(
         other => other,
     };
     Ok(match lhs {
+        // Bare `* op= rhs` curries to a WhateverCode that mutates its topic:
+        // `{ $_ op= rhs }`. Used for e.g. `@a.map(* *= 2)`.
+        Expr::Whatever => {
+            let body = build_compound_assign_expr(Expr::Var("_".to_string()), op, rhs)?;
+            Expr::Lambda {
+                param: "_".to_string(),
+                body: vec![crate::ast::Stmt::Expr(body)],
+                is_whatever_code: true,
+            }
+        }
         Expr::AssignExpr {
             name,
             expr,

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2723,6 +2723,29 @@ impl Interpreter {
             return Ok(Value::Package(Symbol::intern("Mu")));
         }
 
+        // .of on a parametric type object, e.g. `array[int]`, `Array[Int]`,
+        // `Positional[Int]`. Returns the element type.
+        if method == "of"
+            && args.is_empty()
+            && let Value::Package(name) = &target
+        {
+            let resolved = name.resolve();
+            if let Some(open) = resolved.find('[')
+                && resolved.ends_with(']')
+            {
+                let base = &resolved[..open];
+                if matches!(
+                    base,
+                    "array" | "Array" | "Positional" | "List" | "Seq" | "Hash" | "Map"
+                ) {
+                    let inner = &resolved[open + 1..resolved.len() - 1];
+                    // Hash[ValueType, KeyType] -> .of is the value type.
+                    let value_type = inner.split(',').next().unwrap_or(inner).trim();
+                    return Ok(Value::Package(Symbol::intern(value_type)));
+                }
+            }
+        }
+
         // .keyof on Hash
         if method == "keyof" && args.is_empty() && matches!(&target, Value::Hash(_)) {
             if let Some(info) = self.container_type_metadata(&target)

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -207,15 +207,18 @@ impl Interpreter {
                     | "Buf"
                     | "Blob"
                     | "Capture"
+                    | "array"
             )
         {
+            // The bare native `array` type (and its parameterized form
+            // `array[int]`, whose base name is `array`) does Positional.
             return true;
         }
         // Array is-a List in Raku type hierarchy
         if constraint == "List"
             && matches!(
                 value_type,
-                "Array" | "List" | "Seq" | "HyperSeq" | "RaceSeq"
+                "Array" | "List" | "Seq" | "HyperSeq" | "RaceSeq" | "array"
             )
         {
             return true;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2066,22 +2066,40 @@ impl VM {
         // For hash variables, expand Range indices into individual keys so that
         // `%h{^5} = (0 xx 5)` performs a hash slice assignment (5 separate keys)
         // instead of treating the stringified range as a single key.
+        // Native typed arrays (e.g. `array[num]`) need numeric Range slice
+        // indices expanded to an explicit index list so the slice-assign path
+        // distributes each value to a single element (rather than checking the
+        // whole RHS list against the scalar element type).
+        let array_var_is_native = !var_name.starts_with('%')
+            && matches!(index_target, Some(Value::Array(..)))
+            && (self
+                .interpreter
+                .var_type_constraint(&var_name)
+                .as_deref()
+                .is_some_and(crate::runtime::native_types::is_native_array_element_type)
+                || index_target
+                    .as_ref()
+                    .and_then(|v| self.interpreter.container_type_metadata(v))
+                    .is_some_and(|info| {
+                        crate::runtime::native_types::is_native_array_element_type(&info.value_type)
+                    }));
+        let expand_range = var_name.starts_with('%') || array_var_is_native;
         let idx = match idx {
             Value::Seq(items) => Value::Array(items, crate::value::ArrayKind::List),
             Value::Slip(items) => Value::Array(items, crate::value::ArrayKind::List),
-            Value::Range(a, b) if var_name.starts_with('%') => {
+            Value::Range(a, b) if expand_range => {
                 let items: Vec<Value> = (a..=b).map(Value::Int).collect();
                 Value::Array(Arc::new(items), crate::value::ArrayKind::List)
             }
-            Value::RangeExcl(a, b) if var_name.starts_with('%') => {
+            Value::RangeExcl(a, b) if expand_range => {
                 let items: Vec<Value> = (a..b).map(Value::Int).collect();
                 Value::Array(Arc::new(items), crate::value::ArrayKind::List)
             }
-            Value::RangeExclStart(a, b) if var_name.starts_with('%') => {
+            Value::RangeExclStart(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..=b).map(Value::Int).collect();
                 Value::Array(Arc::new(items), crate::value::ArrayKind::List)
             }
-            Value::RangeExclBoth(a, b) if var_name.starts_with('%') => {
+            Value::RangeExclBoth(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..b).map(Value::Int).collect();
                 Value::Array(Arc::new(items), crate::value::ArrayKind::List)
             }

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -181,6 +181,22 @@ impl VM {
         let _target_is_mixhash = declared_type_del.as_deref().is_some_and(|t| t == "MixHash");
         let _target_is_baghash = declared_type_del.as_deref().is_some_and(|t| t == "BagHash");
         let _target_is_sethash = declared_type_del.as_deref().is_some_and(|t| t == "SetHash");
+        // Deleting from a native typed array (e.g. `array[int]`) is illegal:
+        // native arrays have no "holes" to create. Throw X::Delete.
+        if let Some(dt) = declared_type_del.as_deref()
+            && let Some(elem) = dt.strip_prefix("array[").and_then(|s| s.strip_suffix(']'))
+            && crate::runtime::native_types::is_native_array_element_type(elem)
+        {
+            return Err(RuntimeError::typed(
+                "X::Delete",
+                [(
+                    "message".to_string(),
+                    Value::str(format!("Cannot delete from a native {elem} array")),
+                )]
+                .into_iter()
+                .collect(),
+            ));
+        }
         // Note: Bag/Set immutability checks for :delete are intentionally
         // omitted here because Bag/BagHash and Set/SetHash share the same
         // Value variants and the declared_type metadata is not always

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -528,9 +528,11 @@ impl VM {
             return Ok(());
         }
 
-        let items = match &target {
-            Value::Array(items, ..) => items.as_ref(),
-            _ => &[] as &[Value],
+        let (items, is_shaped): (&[Value], bool) = match &target {
+            Value::Array(items, kind) => {
+                (items.as_slice(), *kind == crate::value::ArrayKind::Shaped)
+            }
+            _ => (&[] as &[Value], false),
         };
 
         let is_multi = indices.len() != 1 || is_zen;
@@ -538,10 +540,16 @@ impl VM {
         if !is_multi {
             // Single index
             let i = indices[0];
-            let slot_present = i >= 0
-                && items
-                    .get(i as usize)
-                    .is_some_and(|v| !matches!(v, Value::Nil));
+            // Shaped arrays are fixed-size: any in-range index exists,
+            // regardless of whether the slot holds the (default) Nil value.
+            let slot_present = if is_shaped {
+                i >= 0 && (i as usize) < items.len()
+            } else {
+                i >= 0
+                    && items
+                        .get(i as usize)
+                        .is_some_and(|v| !matches!(v, Value::Nil))
+            };
             let is_deleted = array_var_name
                 .as_deref()
                 .is_some_and(|n| self.is_deleted_index(n, i));
@@ -580,10 +588,14 @@ impl VM {
         let pairs: Vec<(i64, bool)> = indices
             .iter()
             .map(|&i| {
-                let slot_present = i >= 0
-                    && items
-                        .get(i as usize)
-                        .is_some_and(|v| !matches!(v, Value::Nil));
+                let slot_present = if is_shaped {
+                    i >= 0 && (i as usize) < items.len()
+                } else {
+                    i >= 0
+                        && items
+                            .get(i as usize)
+                            .is_some_and(|v| !matches!(v, Value::Nil))
+                };
                 let is_deleted = array_var_name
                     .as_deref()
                     .is_some_and(|n| self.is_deleted_index(n, i));

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -460,7 +460,7 @@ impl VM {
                     return Err(RuntimeError::new(format!(
                         "Index {} for dimension 1 out of range (must be 0..{})",
                         i,
-                        items.len() - 1
+                        items.len().saturating_sub(1)
                     )));
                 } else {
                     let default =

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -164,6 +164,13 @@ impl VM {
             Some(Value::Package(name)) if name == "Any" && !matches!(default, Value::Nil) => {
                 default
             }
+            // Shaped arrays are pre-allocated with Nil placeholders; an
+            // uninitialized in-range slot reads as the element default
+            // (e.g. 0 for `array[int]`). Non-shaped arrays may legitimately
+            // hold Nil values, so this only applies to Shaped arrays.
+            Some(Value::Nil) if kind == ArrayKind::Shaped && !matches!(default, Value::Nil) => {
+                default
+            }
             Some(value) => value.clone(),
             None => default,
         }
@@ -345,6 +352,12 @@ impl VM {
             return def.clone();
         }
         if let Some(info) = self.interpreter.container_type_metadata(target) {
+            // Native typed arrays default their elements to the native type's
+            // zero value rather than the (uninstantiable) type object:
+            // int -> 0, num -> 0e0, str -> "".
+            if let Some(def) = native_element_default(&info.value_type) {
+                return def;
+            }
             Value::Package(Symbol::intern(&info.value_type))
         } else if matches!(target, Value::Hash(_)) {
             Value::Package(Symbol::intern("Any"))
@@ -779,5 +792,21 @@ impl VM {
                 map.remove(&idx.to_string_value());
             }
         }
+    }
+}
+
+/// The default ("zero") value for a native array element type.
+/// Native integer types default to 0, native floats (num/num32/num64) to 0e0,
+/// and native `str` to the empty string. Returns `None` for non-native types
+/// (e.g. `Int`, `Str`), which keep their type-object default.
+pub(super) fn native_element_default(value_type: &str) -> Option<Value> {
+    if crate::runtime::native_types::is_native_int_type(value_type) {
+        Some(Value::Int(0))
+    } else if matches!(value_type, "num" | "num32" | "num64") {
+        Some(Value::Num(0.0))
+    } else if value_type == "str" {
+        Some(Value::str_from(""))
+    } else {
+        None
     }
 }

--- a/t/native-typed-arrays.t
+++ b/t/native-typed-arrays.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 24;
+
+# array[T] type objects do Positional / Positional[T]
+ok array[int] ~~ Positional,        'array[int] type object is Positional';
+ok array[int] ~~ Positional[int],   'array[int] type object is Positional[int]';
+ok array[num] ~~ Positional,        'array[num] type object is Positional';
+ok array[str] ~~ Positional,        'array[str] type object is Positional';
+
+# .of on parametric type objects
+ok array[int].of === int,           'array[int].of is int';
+ok array[num].of === num,           'array[num].of is num';
+ok Array[Int].of === Int,           'Array[Int].of is Int';
+ok Positional[Int].of === Int,      'Positional[Int].of is Int';
+
+# instances are Positional and report .of
+my @a := array[int].new;
+ok @a ~~ Positional,                'array[int] instance is Positional';
+ok @a.of === int,                   'array[int] instance .of is int';
+
+# out-of-bounds reads on native arrays return the element default (not the type object)
+is @a[5], 0,                        'OOB read on native int array gives 0';
+my @n := array[num].new;
+is @n[5], 0e0,                      'OOB read on native num array gives 0e0';
+
+# mutating map via whatever compound-assign currying
+my @m = 1, 2, 3;
+is-deeply @m.map(* *= 2).List, (2, 4, 6), 'mutating map (* *= 2) works';
+is-deeply @m, [2, 4, 6],            'mutating map mutated the array in place';
+
+my @mi := array[int].new(10, 20, 30);
+is-deeply @mi.map(* += 5).List, (15, 25, 35), 'mutating map (* += 5) on native int array';
+
+# shaped native arrays
+my @s := array[int].new(:shape(5));
+is @s.elems, 5,                     'shaped native array has 5 elems';
+is @s[2], 0,                        'uninitialized shaped native int slot reads as 0';
+ok @s[4]:exists,                    ':exists is true for in-range index of shaped native array';
+nok @s[5]:exists,                   ':exists is false for out-of-range index';
+ok @s[0]:exists,                    ':exists is true for index 0';
+
+# :delete dies on native arrays
+dies-ok { @s[0]:delete },           ':delete dies on a native array';
+is (@s[0]:!delete), 0,              ':!delete returns the value without deleting';
+
+# native num range slice-assign distributes values per element
+my @rs := array[num].new;
+@rs[^3] = 1e0, 2e0, 3e0;
+is-deeply @rs.List, (1e0, 2e0, 3e0), 'range slice-assign distributes to native num array';
+
+# regular whatever code still works (no regression)
+is-deeply (1, 2, 3).map(* + 10).List, (11, 12, 13), 'regular whatever map still works';


### PR DESCRIPTION
Tackles the **Native Typed Arrays** blocker group (TODO_roast/BLOCKERS.md).

## What changed

Native typed arrays (\`array[int]\`, \`array[num]\`, \`array[str]\`) and their type objects now behave like proper \`Positional[T]\` containers:

- **\`array[T]\` type objects do \`Positional\` / \`Positional[T]\`** — added \`array\` to the role-relationship table in \`type_matching_static.rs\`.
- **\`.of\` on parametric type objects** (\`array[int].of\`, \`Array[Int].of\`, \`Positional[Int].of\`, \`Hash[V,K].of\`) returns the element/value type.
- **OOB reads on native arrays** return the element default (\`0\`/\`0e0\`/\`\"\"\`) instead of the uninstantiable type object (new \`native_element_default\` helper).
- **Shaped native arrays**: in-range \`:exists\` is range-based; uninitialized in-range slots read as the element default; \`:delete\` throws \`X::Delete\` (\"Cannot delete from a native <type> array\").
- **Range slice-assign** \`@arr[^3] = ...\` on native arrays expands the range so values distribute per element (matching the hash-slice behavior).
- **Parser**: bare \`* op= value\` (e.g. \`* *= 2\`) now curries to a WhateverCode \`{ \$_ op= value }\`, fixing \`@a.map(* *= 2)\` for all arrays (this was a general bug, not native-only).
- Fixed a subtract-with-overflow panic on empty shaped-array OOB access.

## Results

Fully passing now (already whitelisted): \`S02-types/multi_dimensional_array.t\` (59), \`S09-multidim/XX-POS-on-dimensioned.t\` (69).

Substantial partial progress on the native tests (e.g. \`native-int.t\` 2→159 subtests run, \`native-shape1-int.t\` 49→101 run). Remaining blockers for full passes are recorded in TODO_roast/S09.md (grep \`:p\`/\`:kv\`, \`.pairup\`/\`.antipairs\`, \`.pick\`/\`.roll\`, \`.raku\` formatting, type-checked push exceptions). \`native.t\` is capped at 10/12 even in rakudo (Real(Cool) coercion of a native str array dies upstream).

Adds \`t/native-typed-arrays.t\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)