### PR TITLE
feat: register subset and class-method `is export` for import

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -47,11 +47,20 @@
 - [ ] roast/S06-operator-overloading/circumfix.t
 - [ ] roast/S06-operator-overloading/imported-subs.t
 - [ ] roast/S06-operator-overloading/infix.t
-    - Tests 1-10 pass; test 11 (`infix:<;>`) is `#?rakudo todo`.
-    - Blocker for tests 12-15: method-form operator exports (`method infix:<as>(...) is export`)
-      combined with `import` are not usable as real infix operators. `($obj as OtherClass)`
-      fails to parse ("expected statement"). Needs parser support so that an imported
-      operator-form method becomes a callable infix operator, plus `import` wiring.
+    - NOTE: rakudo itself cannot even compile this file (line 40
+      `&infix:<plus> := { ... }` -> "Cannot bind to '&infix:<plus>' because
+      Code items cannot be rebound"; the block is `#?rakudo skip`-fudged).
+    - Tests 1-10 and 12-13 pass. Test 11 (`infix:<;>`) fails (the unfudged file
+      evaluates `3 ; 2` as `2`, not `5`); this matches a `#?rakudo todo`.
+    - `import C { method ... is export }` no longer dies with "No exports found"
+      (a class with `is export` methods is now recorded as having exports), so
+      execution reaches tests 12-15 (was 11).
+    - Remaining blocker for tests 14-15: method-form operator dispatch. `~$obj`
+      does not call `method prefix:<~>` on an instance, and the infix `as`
+      operator-form method is not usable as a real infix (`$obj as OtherClass`
+      fails to parse). Needs unary/infix dispatch to consult instance
+      operator-methods plus parser support for user-defined infix from imported
+      operator methods. This is a separate, larger feature.
 - [ ] roast/S06-operator-overloading/methods.t
 - [ ] roast/S06-operator-overloading/prefix.t
 - [ ] roast/S06-operator-overloading/semicolon.t
@@ -62,13 +71,12 @@
 - [ ] roast/S06-other/introspection.t
 - [ ] roast/S06-other/main-eval.t
 - [ ] roast/S06-other/main-semicolon.t
-- [ ] roast/S06-other/main.t
-  - 22/23 pass. Remaining blocker: subtest "MAIN can take type-constraint
-    using a subset declared in a separate scope" needs `import M;` of an
-    inline `module M { subset S is export ... }` to make the exported subset
-    visible. mutsu reports "No exports found for module: M" for inline-module
-    `import`. MAIN enum/subset coercion, `%*SUB-MAIN-OPTS<named-anywhere>`,
-    and enum auto-conversion all pass now.
+- [x] roast/S06-other/main.t
+  - 23/23 pass. The final subtest "MAIN can take type-constraint using a
+    subset declared in a separate scope" now works: an inline
+    `module M { subset S is export ... }` records the subset in the export
+    table so `import M;` succeeds and the subset type is usable as a MAIN
+    constraint.
 - [ ] roast/S06-other/main-usage.t
 - [ ] roast/S06-other/misc.t
 - [ ] roast/S06-other/pairs-as-lvalues.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -466,6 +466,7 @@ roast/S06-other/introspection.t
 roast/S06-other/main-eval.t
 roast/S06-other/main-semicolon.t
 roast/S06-other/main-usage.t
+roast/S06-other/main.t
 roast/S06-other/misc.t
 roast/S06-other/pairs-as-lvalues.t
 roast/S06-parameters/smiley.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -746,6 +746,10 @@ pub(crate) enum Stmt {
         handles: Vec<HandleSpec>,
         /// Custom `is` traits (non-builtin trait names) with optional argument expression
         custom_traits: Vec<(String, Option<Expr>)>,
+        /// `is export` on the method: when a class/role is imported, exported
+        /// methods are made available as their sub-form (e.g. operator subs).
+        is_export: bool,
+        export_tags: Vec<String>,
     },
     RoleDecl {
         name: Symbol,
@@ -776,6 +780,8 @@ pub(crate) enum Stmt {
         base: String,
         predicate: Option<Expr>,
         version: String,
+        is_export: bool,
+        export_tags: Vec<String>,
     },
     Phaser {
         kind: PhaserKind,

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -1,5 +1,5 @@
 use super::super::super::expr::expression;
-use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
+use super::super::super::helpers::{ws, ws1};
 use super::super::super::parse_result::{PError, PResult, opt_char};
 use super::super::{ident, keyword, qualified_ident, var_name};
 use super::helpers::{
@@ -177,15 +177,29 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;
     let (mut rest, _) = ws(rest)?;
+    let mut is_export = false;
+    let mut export_tags: Vec<String> = Vec::new();
     while let Some(r) = keyword("is", rest) {
         let (r, _) = ws1(r)?;
         let (r, trait_name) = ident(r)?;
-        let (r, _) = ws(r)?;
         if trait_name == "export" {
-            rest = skip_balanced_parens(r);
-            let (r2, _) = ws(rest)?;
+            is_export = true;
+            let (r2, tags) = parse_export_trait_tags(r)?;
+            if tags.is_empty() {
+                if !export_tags.iter().any(|t| t == "DEFAULT") {
+                    export_tags.push("DEFAULT".to_string());
+                }
+            } else {
+                for tag in tags {
+                    if !export_tags.iter().any(|t| t == &tag) {
+                        export_tags.push(tag);
+                    }
+                }
+            }
+            let (r2, _) = ws(r2)?;
             rest = r2;
         } else {
+            let (r, _) = ws(r)?;
             rest = r;
         }
     }
@@ -213,6 +227,8 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
             base,
             predicate,
             version: super::super::simple::current_language_version(),
+            is_export,
+            export_tags,
         },
     ))
 }

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -100,6 +100,8 @@ pub(super) fn try_keyword_dispatch(
                     base: routine_type,
                     predicate,
                     version: super::super::simple::current_language_version(),
+                    is_export: false,
+                    export_tags: Vec::new(),
                 },
             )));
         }

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -1697,6 +1697,8 @@ fn method_decl_body_with_my(
                 })
                 .cloned()
                 .collect(),
+            is_export: traits.is_export,
+            export_tags: traits.export_tags.clone(),
         },
     ))
 }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1610,6 +1610,8 @@ impl Interpreter {
                     deprecated_message,
                     handles: method_handles,
                     custom_traits: method_custom_traits,
+                    is_export: method_is_export,
+                    export_tags: method_export_tags,
                 } => {
                     self.validate_private_access_in_stmts(name, method_body)?;
                     Self::validate_attr_declared_in_class(&class_own_attrs, method_body)?;
@@ -1764,6 +1766,23 @@ impl Interpreter {
                                 .methods
                                 .insert(resolved_method_name.clone(), vec![def]);
                         }
+                    }
+                    // A method declared `is export` is recorded as an export of
+                    // the enclosing class so that `import ClassName` succeeds
+                    // (and exposes the method's sub-form name). This is mainly
+                    // used by operator methods such as `method infix:<as> is
+                    // export`, whose sub-form is importable.
+                    if *method_is_export && !self.suppress_exports {
+                        let tags = if method_export_tags.is_empty() {
+                            vec!["DEFAULT".to_string()]
+                        } else {
+                            method_export_tags.clone()
+                        };
+                        self.register_exported_var(
+                            name.to_string(),
+                            format!("&{}", resolved_method_name),
+                            tags,
+                        );
                     }
                     // Apply custom trait_mod:<is> for each non-builtin trait on methods
                     if !method_custom_traits.is_empty() {
@@ -2879,6 +2898,8 @@ impl Interpreter {
                     deprecated_message: _,
                     handles: method_handles,
                     custom_traits: _,
+                    is_export: _,
+                    export_tags: _,
                 } => {
                     // Validate that $!attr references in the method body are declared
                     // in this role (same check as for class methods).

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1391,14 +1391,38 @@ impl VM {
             base,
             predicate,
             version,
+            is_export,
+            export_tags,
         } = stmt
         {
+            let resolved_name = name.resolve();
             self.interpreter.register_subset_decl(
-                &name.resolve(),
+                &resolved_name,
                 base,
                 predicate.as_ref(),
                 version,
             );
+            // When a subset is declared `is export` inside a module, record it
+            // in the export table so `import M` (and `use M`) can find it.
+            // The subset type itself is already registered under its bare name
+            // in the global env by `register_subset_decl`, so importing only
+            // needs to make `import M` succeed (and validate export tags).
+            if *is_export && !self.interpreter.suppress_exports {
+                let (export_pkg, export_short) =
+                    if let Some((pkg, short)) = resolved_name.rsplit_once("::") {
+                        (pkg.to_string(), short.to_string())
+                    } else {
+                        (
+                            self.interpreter.current_package().to_string(),
+                            resolved_name,
+                        )
+                    };
+                self.interpreter.register_exported_var(
+                    export_pkg,
+                    export_short,
+                    export_tags.clone(),
+                );
+            }
             self.env_dirty = true;
             Ok(())
         } else {

--- a/t/module-export-import.t
+++ b/t/module-export-import.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 8;
+
+# A subset declared `is export` inside an inline module can be imported.
+{
+    module M1 { subset Even is export where * %% 2 }
+    import M1;
+    ok Even ~~ Any, 'imported subset is a known type';
+    my Even $x = 4;
+    is $x, 4, 'value matching the subset predicate is accepted';
+    is Even.^name, 'Even', 'subset type name is correct after import';
+}
+
+# A subset declared `is export(:tag)` is importable via that tag.
+{
+    module M2 { subset Small is export(:nums) where * < 10 }
+    import M2 :nums;
+    my Small $y = 3;
+    is $y, 3, 'tagged subset export imported via tag';
+}
+
+# Using a subset from an inline module as a MAIN type constraint
+# (regression for S06-other/main.t).
+{
+    module M3 { subset S is export where / 'ok' / }
+    import M3;
+    my S $s = "ok";
+    is $s, "ok", 'subset MAIN-style constraint usable after import';
+}
+
+# Importing a class that has `is export` methods must not die with
+# "No exports found" (regression for S06-operator-overloading/infix.t).
+{
+    class C1 {
+        method greet is export { "hello" }
+        method infix:<as> ($self: $to) is export { $to }
+    }
+    lives-ok { import C1 }, 'import of class with exported methods does not die';
+    my $obj = C1.new;
+    is $obj.greet, 'hello', 'exported method still callable as a normal method';
+}
+
+# Importing a class with no exports at all is still an error.
+{
+    class C2 { method plain { 1 } }
+    dies-ok { import C2 }, 'import of class without exports still dies';
+}


### PR DESCRIPTION
## Summary

Finishes the two remaining inline-module export/import blockers from S06.

### Blocker A — `roast/S06-other/main.t` (now 23/23, whitelisted)
An inline `module M { subset S is export ... }` previously discarded the export info, so `import M;` failed with `No exports found for module: M`. Subsets now carry `is_export`/`export_tags` through the AST, the parser captures them, and the VM records them in the export table on registration. The exported subset type is now importable and usable as a `MAIN` type constraint.

### Blocker B — `roast/S06-operator-overloading/infix.t` (11 → 13 subtests)
A `class` whose only exports are `is export` methods (e.g. `method infix:<as> ... is export`) caused `import SomeClass` to die with `No exports found`. Methods declared `is export` are now recorded as exports of the enclosing class, so `import` succeeds. Execution now reaches tests 12-13 (previously it aborted at test 11).

Note: `infix.t` cannot be compiled by rakudo itself (line 40 `&infix:<plus> := { ... }` rebind error; that block is `#?rakudo skip`-fudged). Tests 14-15 additionally require **method-form operator dispatch** (`~$obj` calling `method prefix:<~>`, and using an imported operator-form method as a real infix), which is a separate, larger feature recorded as a remaining blocker in `TODO_roast/S06.md`.

## Changes
- `Stmt::SubsetDecl` and `Stmt::MethodDecl` gain `is_export`/`export_tags`.
- Parser captures `is export(:tags)` on `subset` and methods.
- VM/runtime register subset and class-method exports via `register_exported_var`.
- New test `t/module-export-import.t` (8 cases).
- `roast/S06-other/main.t` added to the whitelist; `TODO_roast/S06.md` updated.

## Test results
- `roast/S06-other/main.t`: 23/23 PASS
- `roast/S06-operator-overloading/infix.t`: 12 passing subtests (was 10 before abort at test 11)
- `t/module-export-import.t`: 8/8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)