### PR TITLE
fix: qualified dispatch through run-time mixins + parametric-role ambiguity (S12 qualified.t 6/7)

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -111,17 +111,30 @@
 - [ ] roast/S12-methods/private.t
   - 13/14 pass (1-13). Failure: test 14 times out due to 10000*26=260000 private method calls being too slow (interpreter method dispatch performance). Difficulty: Hard (requires method dispatch optimization)
 - [ ] roast/S12-methods/qualified.t
-  - 4/7 subtests pass (simple, inheritance, puned role, simple parameterized role).
+  - 6/7 subtests pass (simple, inheritance, puned role, run-time does, simple
+    parameterized role, relaxed dispatch ambiguities).
   - "puned role" fixed: `callsame` now defers into a punned role parent (`class Foo is R1`)
     by also resolving role-owned methods in `resolve_all_methods_with_owner`.
-  - Remaining failures:
-    - "run-time does" (subtest 4): runtime `self does Foo2` mixin followed by qualified
-      dispatch `self.Foo2::foo`. Even `self.Foo::foo` throws InvalidQualifier after a
-      runtime mixin. Needs runtime role mixin to extend the MRO/qualifier set.
-    - "parameterizations and inheritance" (subtest 6) and "relaxed dispatch ambiguities"
-      (subtest 7): parameterized-role concretization (`does R1[Int] does R1[Str]`),
-      `$?ROLE`/`$?CLASS`, and ambiguous-concretization detection
-      (`X::AdHoc: Ambiguous concretization lookup for R1`). Substantial parameterized-role work.
+  - "run-time does" (subtest 4) fixed: added `dispatch_qualified_mixin_method` so qualified
+    calls (`self.Foo::foo`, `self.Foo1::foo`, `self.Foo2::foo`) resolve on a `Value::Mixin`
+    target. The Mixin is kept as the invocant during the qualified parent-class call so an
+    interleaved `self.Parent::m` no longer clobbers the run-time mixin (it previously went
+    through the plain-instance identity writeback and dropped the mixin).
+  - "relaxed dispatch ambiguities" (subtest 7) fixed: a parametric role composed with two
+    distinct concretizations by the nearest consumer now throws
+    `X::AdHoc: Ambiguous concretization lookup for <Role>` (see
+    `role_concretizations_at_nearest`). Also fixed a spurious
+    `X::Role::Composition::Conflict` when a role (R2) that defines a method also composes a
+    sub-role (R1) with the same-named method: the sub-role copy is no longer re-propagated
+    into the consumer as an independent candidate (registration_class.rs).
+  - Remaining failure:
+    - "parameterizations and inheritance" (subtest 6): stacks several distinct features.
+      `my class CR2 does R1[Set]` inside a role is now accepted (was rejected as our-scoped),
+      but the subtest still needs: (a) role-to-role type-parameter forwarding in role
+      application (`role R2[::T] does R1[::T]` -> "cannot use ::T in role application");
+      (b) `$?ROLE`/`$?CLASS` returning parameterized type names (e.g. `R1[Int]`, `R2[Num]`);
+      (c) relaxed qualified calls returning multiple slipped concretizations
+      (`self.R2::of-type` yielding `R2`, `R1[Bool]`, ...). Substantial parameterized-role work.
 - [ ] roast/S12-methods/submethods.t
 - [ ] roast/S12-methods/syntax.t
   - 2/15 pass (tests 1, 15). Failures: method call with empty parens `obj.doit()` (2), `.doit ()` with space (3), unspace `obj.doit\ ()` (4), colon form `obj.doit: args` (5-9), block as arg (10-12), `$.a(args)` (13-14). Difficulty: Medium-High (method call syntax variants)

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1895,6 +1895,11 @@ impl Interpreter {
             return result;
         }
 
+        // Qualified method on a runtime-mixed-in value (Value::Mixin): Class::method
+        if let Some(result) = self.dispatch_qualified_mixin_method(&target, method, args.clone()) {
+            return result;
+        }
+
         // Qualified method on non-Instance values
         if let Some(result) =
             self.dispatch_qualified_non_instance_method(&target, method, args.clone())

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -89,6 +89,23 @@ impl Interpreter {
                 actual_method, qualifier, inst_cn_str
             ))));
         }
+        // Relaxed-dispatch ambiguity: if the qualifier names a parametric role and the
+        // nearest consumer (the class itself, or a role it composes) composes that base
+        // role under two or more *distinct* concretizations, the qualified lookup is
+        // ambiguous. Resolution happens against the consumer's immediate roles, so an
+        // indirect second concretization (reached through another role) does not count.
+        if in_composed_roles
+            && self.roles.contains_key(qualifier)
+            && self
+                .role_concretizations_at_nearest(&inst_cn_str, qualifier)
+                .len()
+                > 1
+        {
+            return Some(Err(RuntimeError::new(format!(
+                "Ambiguous concretization lookup for {}",
+                qualifier
+            ))));
+        }
         // Read: look up the attribute in the qualifier class's attribute definitions
         if args.is_empty() {
             let class_attrs = self.collect_class_attributes(qualifier);
@@ -195,6 +212,207 @@ impl Interpreter {
                     self.overwrite_instance_bindings_by_identity(&inst_cn, tid, updated);
                     return Some(Ok(result));
                 }
+            }
+        }
+
+        None
+    }
+
+    /// Find the distinct concretizations of parametric role `base_role` as composed by
+    /// the *nearest* consumer reachable from `class_name`. Resolution follows the
+    /// "immediate roles" model: a breadth-first walk over consumer nodes (the class,
+    /// then each role it composes, then those roles' composed roles, ...). The first
+    /// consumer node that directly composes `base_role` determines the result; its set
+    /// of distinct concretizations (e.g. `{"R1[Int]", "R1[Str]"}`) is returned. A second
+    /// concretization reached only through a deeper role does not contribute, so it does
+    /// not create ambiguity.
+    pub(crate) fn role_concretizations_at_nearest(
+        &self,
+        class_name: &str,
+        base_role: &str,
+    ) -> std::collections::BTreeSet<String> {
+        use std::collections::{BTreeSet, VecDeque};
+        // The consumer's directly-composed roles: classes use class_composed_roles,
+        // roles use role_parents (which records `does`-composed sub-roles).
+        let direct_roles = |node: &str| -> Vec<String> {
+            if let Some(roles) = self.class_composed_roles.get(node) {
+                roles.clone()
+            } else if let Some(parents) = self.role_parents.get(node) {
+                parents.clone()
+            } else {
+                Vec::new()
+            }
+        };
+        let base_of = |full: &str| -> String {
+            full.split_once('[')
+                .map(|(b, _)| b.to_string())
+                .unwrap_or_else(|| full.to_string())
+        };
+        let mut queue: VecDeque<String> = VecDeque::new();
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        queue.push_back(class_name.to_string());
+        seen.insert(class_name.to_string());
+        while let Some(node) = queue.pop_front() {
+            let composed = direct_roles(&node);
+            let matches: BTreeSet<String> = composed
+                .iter()
+                .filter(|r| base_of(r) == base_role)
+                .cloned()
+                .collect();
+            if !matches.is_empty() {
+                // Nearest consumer found; ambiguity is decided by its own composition.
+                return matches;
+            }
+            for r in composed {
+                let rb = base_of(&r);
+                if seen.insert(rb.clone()) {
+                    queue.push_back(rb);
+                }
+            }
+        }
+        BTreeSet::new()
+    }
+
+    /// Handle qualified method names on a runtime-mixed-in value (Value::Mixin):
+    /// e.g. after `self does Foo2`, calls like `self.Foo::foo`, `self.Foo1::foo`,
+    /// `self.Foo2::foo` must still resolve through the inner instance's MRO/roles
+    /// and through roles applied at run time.
+    /// Returns Some(result) if handled, None to continue.
+    pub(super) fn dispatch_qualified_mixin_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let (qualifier, actual_method) = method.rsplit_once("::")?;
+        if method.starts_with('!') {
+            return None;
+        }
+        let Value::Mixin(inner, mixins) = target else {
+            return None;
+        };
+
+        // 1) Qualifier is a role: applied at run time on this mixin, composed on the
+        //    inner instance's class, or otherwise a known role. Dispatch directly to
+        //    that role's method, keeping the mixin as self so any run-time mixin
+        //    survives the call.
+        let inner_class = if let Value::Instance { class_name, .. } = inner.as_ref() {
+            Some(class_name.resolve())
+        } else {
+            None
+        };
+        let composed_on_inner = inner_class.as_deref().is_some_and(|cn| {
+            self.class_mro(cn).iter().any(|c| {
+                self.class_composed_roles.get(c).is_some_and(|roles| {
+                    roles.iter().any(|r| {
+                        r == qualifier
+                            || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                    })
+                })
+            })
+        });
+        let role_applied = mixins.contains_key(&format!("__mutsu_role__{qualifier}"))
+            || mixins.contains_key(qualifier)
+            || composed_on_inner;
+        if role_applied
+            && let Some(role) = self.role_def_for_mixin_role(mixins, qualifier)
+            && let Some(overloads) = role.methods.get(actual_method).cloned()
+        {
+            let role_param_bindings: Vec<(String, Value)> = mixins
+                .iter()
+                .filter_map(|(key, value)| {
+                    key.strip_prefix("__mutsu_role_param__")
+                        .map(|name| (name.to_string(), value.clone()))
+                })
+                .collect();
+            for def in overloads {
+                if def.is_private || !self.method_args_match(&args, &def.param_defs) {
+                    continue;
+                }
+                // Start from the inner instance's attributes (for compose-time
+                // roles whose state lives on the class), then layer mixin-stored
+                // role attributes on top (for run-time-applied roles).
+                let mut role_attrs: HashMap<String, Value> =
+                    if let Value::Instance { attributes, .. } = inner.as_ref() {
+                        (**attributes).clone()
+                    } else {
+                        HashMap::new()
+                    };
+                for (key, value) in mixins.iter() {
+                    if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
+                        role_attrs.insert(attr.to_string(), value.clone());
+                    }
+                }
+                let mut saved: Vec<(String, Option<Value>)> = Vec::new();
+                for (name, value) in &role_param_bindings {
+                    saved.push((name.clone(), self.env.get(name).cloned()));
+                    self.env.insert(name.clone(), value.clone());
+                }
+                let res = self.run_instance_method_resolved(
+                    qualifier,
+                    qualifier,
+                    def,
+                    role_attrs,
+                    args,
+                    Some(target.clone()),
+                );
+                for (name, prev) in saved {
+                    if let Some(prev) = prev {
+                        self.env.insert(name, prev);
+                    } else {
+                        self.env.remove(&name);
+                    }
+                }
+                return Some(res.map(|(result, _updated)| result));
+            }
+        }
+
+        // 2) Otherwise the qualifier names a class (or compose-time role) reachable
+        //    through the inner instance's MRO. Resolve and run the qualified method,
+        //    but keep the Mixin as the invocant so the run-time mixin survives the
+        //    call (a plain-instance identity writeback would drop the mixin).
+        if let Value::Instance {
+            class_name: inner_cn,
+            ..
+        } = inner.as_ref()
+        {
+            let inst_cn_str = inner_cn.resolve();
+            let inst_mro = self.class_mro(&inst_cn_str);
+            let in_mro = inst_mro.iter().any(|c| c == qualifier);
+            let in_composed_roles = !in_mro
+                && inst_mro.iter().any(|c| {
+                    self.class_composed_roles.get(c).is_some_and(|roles| {
+                        roles.iter().any(|r| {
+                            r == qualifier
+                                || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                        })
+                    })
+                });
+            if !in_mro && !in_composed_roles {
+                return Some(Err(RuntimeError::new(format!(
+                    "X::Method::InvalidQualifier: Cannot dispatch to method {} on {} because it is not inherited or done by {}",
+                    actual_method, qualifier, inst_cn_str
+                ))));
+            }
+            if let Some((_owner, def)) =
+                self.resolve_method_with_owner(qualifier, actual_method, &args)
+            {
+                // Use the inner instance's attributes so the method body can read
+                // attributes, but run with the Mixin target as the invocant.
+                let attrs_map = if let Value::Instance { attributes, .. } = inner.as_ref() {
+                    (**attributes).clone()
+                } else {
+                    HashMap::new()
+                };
+                let res = self.run_instance_method_resolved(
+                    &inst_cn_str,
+                    qualifier,
+                    def,
+                    attrs_map,
+                    args,
+                    Some(target.clone()),
+                );
+                return Some(res.map(|(result, _updated)| result));
             }
         }
 

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1132,6 +1132,20 @@ impl Interpreter {
                                 if non_my_overloads.is_empty() {
                                     continue;
                                 }
+                                // If the composing role (base_role_name, e.g. R2) defines
+                                // this method itself, it has already resolved the same-named
+                                // method it inherits from its parent role (parent_base, e.g.
+                                // R1). Do not re-propagate the parent's copy into the consumer
+                                // as an independent candidate -- doing so would create a spurious
+                                // X::Role::Composition::Conflict. The parent role's method is
+                                // still reachable via a qualified call (self.R1::method).
+                                let resolved_by_composing_role =
+                                    role.methods.get(mname).is_some_and(|defs| {
+                                        defs.iter().any(|d| d.role_origin.is_none() && !d.is_my)
+                                    });
+                                if resolved_by_composing_role {
+                                    continue;
+                                }
                                 let composed: Vec<MethodDef> = if parent_type_subs.is_empty() {
                                     non_my_overloads
                                         .into_iter()
@@ -2489,7 +2503,12 @@ impl Interpreter {
             .collect();
         for stmt in &check_body {
             let declaration = match stmt {
-                Stmt::ClassDecl { .. } => Some("class"),
+                // A `my class` inside a role is a lexically-scoped class private to the
+                // role and is allowed; only an implicitly our-scoped `class` is forbidden.
+                Stmt::ClassDecl {
+                    is_lexical: false, ..
+                } => Some("class"),
+                Stmt::ClassDecl { .. } => None,
                 Stmt::SubsetDecl { .. } => Some("subset"),
                 Stmt::EnumDecl { .. } => Some("enum"),
                 Stmt::RoleDecl { .. } => Some("role"),

--- a/t/qualified-runtime-does.t
+++ b/t/qualified-runtime-does.t
@@ -1,0 +1,78 @@
+use Test;
+
+plan 6;
+
+# Qualified method dispatch through roles applied at run time via `does`,
+# interleaved with qualified calls to compose-time roles and parent classes.
+{
+    my role Foo1 { method foo { "Foo1::foo" } }
+    my role Foo2 { method foo { "Foo2::foo" } }
+    my role Foo3 { method foo { "Foo3::foo" } }
+
+    my class Foo { method foo { "Foo::foo" } }
+
+    my class Bar is Foo does Foo1 {
+        method run {
+            my @res;
+            @res.push: "Bar::foo";
+            @res.push: self.Foo::foo;
+            @res.push: self.Foo1::foo;
+
+            self does Foo2;
+            @res.push: self.Foo::foo;
+            @res.push: self.Foo1::foo;
+            @res.push: self.Foo2::foo;
+
+            self does Foo3;
+            @res.push: self.Foo::foo;
+            @res.push: self.Foo1::foo;
+            @res.push: self.Foo2::foo;
+            @res.push: self.Foo3::foo;
+            @res
+        }
+    }
+
+    is-deeply Bar.new.run,
+        [<Bar::foo Foo::foo Foo1::foo Foo::foo Foo1::foo Foo2::foo Foo::foo Foo1::foo Foo2::foo Foo3::foo>],
+        "qualified dispatch survives interleaved run-time role mixin";
+}
+
+# A run-time mixin must persist across a qualified parent-class call.
+{
+    my role R { method tag { "R::tag" } }
+    my class P { method tag { "P::tag" } }
+    my class C is P {
+        method check {
+            self does R;
+            my $parent = self.P::tag;   # qualified parent call
+            return ($parent, self.R::tag, self.does(R));
+        }
+    }
+    my ($p, $r, $d) = C.new.check;
+    is $p, "P::tag", "qualified parent call returns parent method";
+    is $r, "R::tag", "run-time role still reachable after parent call";
+    ok $d, "object still does the run-time role after a qualified parent call";
+}
+
+# Ambiguous concretization of a parametric role composed twice in one class.
+{
+    my role R1[::T] { method of-type { "R1" } }
+    my class C1 does R1[Int] does R1[Str] {
+        method of-type { self.R1::of-type }
+    }
+    throws-like { C1.new.of-type }, X::AdHoc,
+        "ambiguous concretization in a class throws",
+        message => 'Ambiguous concretization lookup for R1';
+}
+
+# Ambiguity arising inside a composed role (resolved against immediate roles).
+{
+    my role R1[::T] { method of-type { "R1" } }
+    my role R2 does R1[Int] does R1[Bool] {
+        method of-type { self.R1::of-type }
+    }
+    my class C2 does R2 { }
+    throws-like { C2.new.of-type }, X::AdHoc,
+        "ambiguous concretization in a role throws",
+        message => 'Ambiguous concretization lookup for R1';
+}


### PR DESCRIPTION
## Summary

Advances `roast/S12-methods/qualified.t` from 4/7 to **6/7** subtests passing.

### run-time does (subtest 4)
Added `dispatch_qualified_mixin_method` so qualified method calls
(`self.Foo::foo`, `self.Foo1::foo`, `self.Foo2::foo`) resolve correctly on a
`Value::Mixin` target after a run-time `self does Role`. The Mixin is kept as the
invocant during a qualified parent-class call, so an interleaved `self.Parent::m`
no longer clobbers the run-time mixin (it previously routed through the
plain-instance identity writeback and dropped the mixin).

### relaxed dispatch ambiguities (subtest 7)
A parametric role composed with two distinct concretizations by the nearest
consumer now throws `X::AdHoc: Ambiguous concretization lookup for <Role>`
(`role_concretizations_at_nearest`, using the "immediate roles" resolution model).
Also fixed a spurious `X::Role::Composition::Conflict`: when a role (R2) that
defines a method also composes a sub-role (R1) with the same-named method, R1's
copy is no longer re-propagated into the consumer as an independent candidate
(it remains reachable via a qualified `self.R1::m` call).

### misc
Allow `my class` (lexically scoped) inside a role body; only implicitly
our-scoped classes remain forbidden.

### Remaining (subtest 6, "parameterizations and inheritance")
Still blocked on stacked parametric-role features: role-to-role type-parameter
forwarding (`role R2[::T] does R1[::T]`), `$?ROLE`/`$?CLASS` parameterized names,
and relaxed qualified calls returning multiple slipped concretizations. Documented
in TODO_roast/S12.md.

## Tests
- New `t/qualified-runtime-does.t` (6 assertions).
- `make test`: pre-existing failures only (tail-function.t #4, placeholder.t #8,
  wrap.t, and a flaky parallel io-get.t which passes standalone) -- all unrelated.
- `make roast`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)