### PR TITLE
chore: bump CI Rust to 1.96.0 and fix clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy, rustfmt
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown
 

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -432,10 +432,8 @@ pub(crate) fn native_method_0arg(
                     Value::Int(i)
                 } else if let Ok(f) = s.parse::<f64>() {
                     Value::Num(f)
-                } else if let Some(v) = parse_raku_int_from_str(s) {
-                    v
                 } else {
-                    return None;
+                    parse_raku_int_from_str(s)?
                 };
                 return native_method_0arg(&coerced, method_sym);
             }

--- a/src/builtins/parse_base.rs
+++ b/src/builtins/parse_base.rs
@@ -56,11 +56,9 @@ fn char_digit_value(ch: char, radix: u32) -> Option<u32> {
         (ch as u32) - ('A' as u32) + 10
     } else if ch.is_ascii_lowercase() {
         (ch as u32) - ('a' as u32) + 10
-    } else if let Some(d) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
-        // Unicode Nd character
-        d
     } else {
-        return None;
+        // Unicode Nd character
+        crate::builtins::unicode::unicode_decimal_digit_value(ch)?
     };
     if v < radix { Some(v) } else { None }
 }

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -400,12 +400,10 @@ impl Compiler {
                     then_branch,
                     else_branch,
                     ..
-                } => {
-                    if !Self::do_if_branch_supported(then_branch)
-                        || !Self::do_if_branch_supported(else_branch)
-                    {
-                        return false;
-                    }
+                } if !Self::do_if_branch_supported(then_branch)
+                    || !Self::do_if_branch_supported(else_branch) =>
+                {
+                    return false;
                 }
                 _ => {}
             }

--- a/src/parser/expr/precedence_meta_ops.rs
+++ b/src/parser/expr/precedence_meta_ops.rs
@@ -1190,11 +1190,11 @@ mod tests {
     #[test]
     fn parse_meta_op_accepts_set_union_variants() {
         assert_eq!(
-            parse_meta_op("Z(|) 2..4").map(|(m, op, len)| (m, op, len)),
+            parse_meta_op("Z(|) 2..4"),
             Some(("Z".to_string(), "(|)".to_string(), 4))
         );
         assert_eq!(
-            parse_meta_op("Z∪ 2..4").map(|(m, op, len)| (m, op, len)),
+            parse_meta_op("Z∪ 2..4"),
             Some(("Z".to_string(), "∪".to_string(), 1 + "∪".len()))
         );
     }
@@ -1202,7 +1202,7 @@ mod tests {
     #[test]
     fn parse_meta_op_accepts_not_container_identity() {
         assert_eq!(
-            parse_meta_op("X!=:= $a, $b").map(|(m, op, len)| (m, op, len)),
+            parse_meta_op("X!=:= $a, $b"),
             Some(("X".to_string(), "!=:=".to_string(), 5))
         );
     }
@@ -1210,7 +1210,7 @@ mod tests {
     #[test]
     fn parse_meta_op_accepts_container_identity() {
         assert_eq!(
-            parse_meta_op("X=:= $a, $b").map(|(m, op, len)| (m, op, len)),
+            parse_meta_op("X=:= $a, $b"),
             Some(("X".to_string(), "=:=".to_string(), 4))
         );
     }

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -313,10 +313,7 @@ fn parse_trans_adverbs(input: &str) -> Option<(&str, char, char, bool, bool, boo
     let mut complement = false;
     let mut squash = false;
 
-    loop {
-        let Some(after_colon) = rest.strip_prefix(':') else {
-            break;
-        };
+    while let Some(after_colon) = rest.strip_prefix(':') {
         let name_len = after_colon
             .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
             .unwrap_or(after_colon.len());

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1033,11 +1033,15 @@ fn find_rw_pointy_block(input: &str) -> Option<usize> {
                 // Start of block — stop scanning
                 return None;
             }
-            b'<' if depth_paren == 0 && depth_bracket == 0 && depth_angle == 0 => {
-                // Check for `<->`
-                if i + 2 < bytes.len() && bytes[i + 1] == b'-' && bytes[i + 2] == b'>' {
-                    return Some(i);
-                }
+            // Check for `<->`
+            b'<' if depth_paren == 0
+                && depth_bracket == 0
+                && depth_angle == 0
+                && i + 2 < bytes.len()
+                && bytes[i + 1] == b'-'
+                && bytes[i + 2] == b'>' =>
+            {
+                return Some(i);
             }
             _ => {}
         }

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -1474,7 +1474,7 @@ mod tests {
 
     #[test]
     fn parse_forward_sub_without_signature_is_invalid() {
-        let err = program("sub foo;").err().expect("expected parse error");
+        let err = program("sub foo;").expect_err("expected parse error");
         assert!(err.to_string().contains("X::UnitScope::Invalid"));
     }
 
@@ -1517,9 +1517,7 @@ mod tests {
 
     #[test]
     fn parse_main_semicolon_after_module_is_too_late() {
-        let err = program("module AtBeginning {}; sub MAIN;")
-            .err()
-            .expect("expected parse error");
+        let err = program("module AtBeginning {}; sub MAIN;").expect_err("expected parse error");
         assert!(err.to_string().contains("X::UnitScope::TooLate"));
     }
 

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1436,90 +1436,6 @@ fn check_io_func_followed_by_loop<'a>(name: &str, rest_after_ws: &'a str) -> PRe
     Ok((rest_after_ws, ()))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::extract_exported_names;
-    use super::{say_stmt, statement};
-    use crate::ast::{Expr, Stmt};
-
-    #[test]
-    fn extract_exported_names_fallback_handles_proto_and_kebab_case_names() {
-        let source = r#"
-proto sub is_run(|) is export {*}
-sub get_out(Str $code, :@compiler-args) is export { }
-proto doesn't-hang(|) is export {*}
-sub helper() { }
-"#;
-        let exports = extract_exported_names(source);
-        let names: Vec<String> = exports.iter().map(|e| e.name.clone()).collect();
-        assert!(names.contains(&"is_run".to_string()));
-        assert!(names.contains(&"get_out".to_string()));
-        assert!(names.contains(&"doesn't-hang".to_string()));
-        assert!(!names.contains(&"helper".to_string()));
-    }
-
-    #[test]
-    fn say_stmt_rejects_adjacent_statement_keyword_without_separator() {
-        let err = say_stmt("say and die 73266").unwrap_err();
-        assert!(
-            err.messages
-                .iter()
-                .any(|msg| msg.contains("comma or statement end after argument"))
-        );
-    }
-
-    #[test]
-    fn statement_does_not_fall_back_after_invalid_say_args() {
-        assert!(statement("say and die 73266").is_err());
-    }
-
-    #[test]
-    fn statement_rewrites_scalar_decl_before_cross_metaop() {
-        let (_, stmt) = statement("my $a = (1, 3) X (2, 4);").unwrap();
-        match stmt {
-            Stmt::Expr(Expr::MetaOp { meta, left, .. }) => {
-                assert_eq!(meta, "X");
-                match left.as_ref() {
-                    Expr::DoStmt(inner) => match inner.as_ref() {
-                        Stmt::VarDecl { name, expr, .. } => {
-                            assert_eq!(name, "a");
-                            assert!(matches!(expr, Expr::ArrayLiteral(items) if items.len() == 2));
-                        }
-                        other => panic!("expected VarDecl in DoStmt, got {other:?}"),
-                    },
-                    other => panic!("expected DoStmt on left side, got {other:?}"),
-                }
-            }
-            other => panic!("expected rewritten X meta-op statement, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn statement_keeps_array_meta_assign_as_assignment() {
-        let (_, stmt) = statement("@a [X+]= @b;").unwrap();
-        match stmt {
-            Stmt::Assign { name, expr, .. } => {
-                assert_eq!(name, "@a");
-                match expr {
-                    Expr::MetaOp {
-                        meta,
-                        op,
-                        left,
-                        right,
-                    } => {
-                        assert_eq!(meta, "X");
-                        assert_eq!(op, "+");
-                        assert!(matches!(left.as_ref(), Expr::ArrayVar(name) if name == "a"));
-                        assert!(matches!(right.as_ref(), Expr::ArrayVar(name) if name == "b"));
-                    }
-                    other => panic!("expected meta-op rhs, got {other:?}"),
-                }
-            }
-            other => panic!("expected array assignment statement, got {other:?}"),
-        }
-    }
-}
-
 /// Parse a `say` statement.
 pub(super) fn say_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("say", input).ok_or_else(|| PError::expected("say statement"))?;
@@ -2054,4 +1970,88 @@ pub(super) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
         args,
     };
     parse_statement_modifier(rest, stmt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_exported_names;
+    use super::{say_stmt, statement};
+    use crate::ast::{Expr, Stmt};
+
+    #[test]
+    fn extract_exported_names_fallback_handles_proto_and_kebab_case_names() {
+        let source = r#"
+proto sub is_run(|) is export {*}
+sub get_out(Str $code, :@compiler-args) is export { }
+proto doesn't-hang(|) is export {*}
+sub helper() { }
+"#;
+        let exports = extract_exported_names(source);
+        let names: Vec<String> = exports.iter().map(|e| e.name.clone()).collect();
+        assert!(names.contains(&"is_run".to_string()));
+        assert!(names.contains(&"get_out".to_string()));
+        assert!(names.contains(&"doesn't-hang".to_string()));
+        assert!(!names.contains(&"helper".to_string()));
+    }
+
+    #[test]
+    fn say_stmt_rejects_adjacent_statement_keyword_without_separator() {
+        let err = say_stmt("say and die 73266").unwrap_err();
+        assert!(
+            err.messages
+                .iter()
+                .any(|msg| msg.contains("comma or statement end after argument"))
+        );
+    }
+
+    #[test]
+    fn statement_does_not_fall_back_after_invalid_say_args() {
+        assert!(statement("say and die 73266").is_err());
+    }
+
+    #[test]
+    fn statement_rewrites_scalar_decl_before_cross_metaop() {
+        let (_, stmt) = statement("my $a = (1, 3) X (2, 4);").unwrap();
+        match stmt {
+            Stmt::Expr(Expr::MetaOp { meta, left, .. }) => {
+                assert_eq!(meta, "X");
+                match left.as_ref() {
+                    Expr::DoStmt(inner) => match inner.as_ref() {
+                        Stmt::VarDecl { name, expr, .. } => {
+                            assert_eq!(name, "a");
+                            assert!(matches!(expr, Expr::ArrayLiteral(items) if items.len() == 2));
+                        }
+                        other => panic!("expected VarDecl in DoStmt, got {other:?}"),
+                    },
+                    other => panic!("expected DoStmt on left side, got {other:?}"),
+                }
+            }
+            other => panic!("expected rewritten X meta-op statement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn statement_keeps_array_meta_assign_as_assignment() {
+        let (_, stmt) = statement("@a [X+]= @b;").unwrap();
+        match stmt {
+            Stmt::Assign { name, expr, .. } => {
+                assert_eq!(name, "@a");
+                match expr {
+                    Expr::MetaOp {
+                        meta,
+                        op,
+                        left,
+                        right,
+                    } => {
+                        assert_eq!(meta, "X");
+                        assert_eq!(op, "+");
+                        assert!(matches!(left.as_ref(), Expr::ArrayVar(name) if name == "a"));
+                        assert!(matches!(right.as_ref(), Expr::ArrayVar(name) if name == "b"));
+                    }
+                    other => panic!("expected meta-op rhs, got {other:?}"),
+                }
+            }
+            other => panic!("expected array assignment statement, got {other:?}"),
+        }
+    }
 }

--- a/src/runtime/methods_collection_ops/encoding_rotor_toggle.rs
+++ b/src/runtime/methods_collection_ops/encoding_rotor_toggle.rs
@@ -219,13 +219,8 @@ impl Interpreter {
                     let gap = match &gap_val {
                         Value::Int(n) => *n,
                         Value::Num(n) => *n as i64,
-                        Value::Rat(n, d) => {
-                            if *d != 0 {
-                                n / d
-                            } else {
-                                0
-                            }
-                        }
+                        Value::Rat(n, d) if *d != 0 => n / d,
+                        Value::Rat(..) => 0,
                         _ => 0,
                     };
                     rotor_specs.push(RotorSpec { count, gap });

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -575,10 +575,12 @@ impl Interpreter {
                                 return Ok(Value::str(format!("Hash[{}]", info.value_type)));
                             }
                         }
-                        Value::Array(_, kind) if kind.is_real_array() => {
-                            if info.value_type != "Any" && info.value_type != "Mu" {
-                                return Ok(Value::str(format!("Array[{}]", info.value_type)));
-                            }
+                        Value::Array(_, kind)
+                            if kind.is_real_array()
+                                && info.value_type != "Any"
+                                && info.value_type != "Mu" =>
+                        {
+                            return Ok(Value::str(format!("Array[{}]", info.value_type)));
                         }
                         _ => {}
                     }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1500,10 +1500,8 @@ impl Interpreter {
                                         version_matcher = Some(value.to_string_value());
                                     }
                                 }
-                                "api-matcher" => {
-                                    if !matches!(value.as_ref(), Value::Bool(true)) {
-                                        api_matcher = Some(value.to_string_value());
-                                    }
+                                "api-matcher" if !matches!(value.as_ref(), Value::Bool(true)) => {
+                                    api_matcher = Some(value.to_string_value());
                                 }
                                 _ => {}
                             }
@@ -3693,34 +3691,32 @@ impl Interpreter {
                         return Err(err);
                     }
                 }
-                "D" => {
-                    // :D means the value must be defined
-                    if !super::types::value_is_defined(value) {
-                        let mut ex_attrs = HashMap::new();
-                        ex_attrs.insert("name".to_string(), Value::str(format!("$!{}", attr_name)));
-                        ex_attrs.insert(
-                            "message".to_string(),
-                            Value::str(format!(
-                                "Type check failed in default value of attribute $!{}; expected {}, got {}",
-                                attr_name,
-                                self.classes.get(class_name)
-                                    .and_then(|cd| cd.attribute_types.get(attr_name))
-                                    .map(|t| format!("{}:D", t))
-                                    .unwrap_or_else(|| "Any:D".to_string()),
-                                super::value_type_name(value),
-                            )),
-                        );
-                        let ex = Value::make_instance(
-                            Symbol::intern("X::TypeCheck::Attribute::Default"),
-                            ex_attrs,
-                        );
-                        let mut err = RuntimeError::new(format!(
-                            "Type check failed in default value of attribute $!{}",
-                            attr_name
-                        ));
-                        err.exception = Some(Box::new(ex));
-                        return Err(err);
-                    }
+                // :D means the value must be defined
+                "D" if !super::types::value_is_defined(value) => {
+                    let mut ex_attrs = HashMap::new();
+                    ex_attrs.insert("name".to_string(), Value::str(format!("$!{}", attr_name)));
+                    ex_attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Type check failed in default value of attribute $!{}; expected {}, got {}",
+                            attr_name,
+                            self.classes.get(class_name)
+                                .and_then(|cd| cd.attribute_types.get(attr_name))
+                                .map(|t| format!("{}:D", t))
+                                .unwrap_or_else(|| "Any:D".to_string()),
+                            super::value_type_name(value),
+                        )),
+                    );
+                    let ex = Value::make_instance(
+                        Symbol::intern("X::TypeCheck::Attribute::Default"),
+                        ex_attrs,
+                    );
+                    let mut err = RuntimeError::new(format!(
+                        "Type check failed in default value of attribute $!{}",
+                        attr_name
+                    ));
+                    err.exception = Some(Box::new(ex));
+                    return Err(err);
                 }
                 _ => {} // "_" or anything else: no constraint
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5477,6 +5477,24 @@ impl TestState {
     }
 }
 
+impl Interpreter {
+    /// Flush all open file handle buffers. Call before process exit.
+    pub fn flush_all_handles(&mut self) {
+        for state in self.handles.values_mut() {
+            if state.closed {
+                continue;
+            }
+            if !state.out_buffer_pending.is_empty()
+                && let Some(file) = state.file.as_mut()
+            {
+                let _ = file.write_all(&state.out_buffer_pending);
+                let _ = file.flush();
+                state.out_buffer_pending.clear();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Interpreter;
@@ -5742,23 +5760,5 @@ mod tests {
                 "$target".to_string(),
             ]
         );
-    }
-}
-
-impl Interpreter {
-    /// Flush all open file handle buffers. Call before process exit.
-    pub fn flush_all_handles(&mut self) {
-        for state in self.handles.values_mut() {
-            if state.closed {
-                continue;
-            }
-            if !state.out_buffer_pending.is_empty()
-                && let Some(file) = state.file.as_mut()
-            {
-                let _ = file.write_all(&state.out_buffer_pending);
-                let _ = file.flush();
-                state.out_buffer_pending.clear();
-            }
-        }
     }
 }

--- a/src/runtime/native_methods/socket_inet.rs
+++ b/src/runtime/native_methods/socket_inet.rs
@@ -166,10 +166,8 @@ impl Interpreter {
                 for arg in &args {
                     match arg {
                         Value::Int(n) => max_chars = Some(*n as usize),
-                        Value::Pair(key, value) => {
-                            if key.as_str() == "bin" {
-                                bin_mode = value.as_ref().truthy();
-                            }
+                        Value::Pair(key, value) if key.as_str() == "bin" => {
+                            bin_mode = value.as_ref().truthy();
                         }
                         _ => {}
                     }

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -919,13 +919,7 @@ impl Interpreter {
                 j
             }
             // Backslash escape: \x
-            '\\' => {
-                if chars.len() > 1 {
-                    2
-                } else {
-                    1
-                }
-            }
+            '\\' if chars.len() > 1 => 2,
             // Single character atom
             _ => 1,
         };

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -175,13 +175,8 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                 .trim()
                 .parse::<i64>()
                 .unwrap_or_else(|_| s.trim().parse::<f64>().unwrap_or(0.0) as i64),
-            Some(Value::Bool(b)) => {
-                if *b {
-                    1
-                } else {
-                    0
-                }
-            }
+            Some(Value::Bool(true)) => 1,
+            Some(Value::Bool(false)) => 0,
             _ => 0,
         };
         let bigint_val = || match arg {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -720,11 +720,7 @@ impl VM {
         for stmt in body {
             match stmt {
                 Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } => return true,
-                Stmt::Expr(expr) => {
-                    if Self::expr_needs_interpreter(expr) {
-                        return true;
-                    }
-                }
+                Stmt::Expr(expr) if Self::expr_needs_interpreter(expr) => return true,
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary
- Bump the CI toolchain (`dtolnay/rust-toolchain`) from **1.92.0 → 1.96.0** in `.github/workflows/ci.yml` (both the `test` and `wasm-e2e` jobs) to match the local toolchain.
- Make `cargo clippy --all-targets -- -D warnings` clean under the newer 1.96 lints.

## Clippy fixes
All rewrites preserve the original logic:
- **question_mark** — collapse trailing `else { return None }` into `?`.
- **collapsible match / matchable if** — fold inner `if` conditions into match-arm guards.
- **while_let_loop** — `loop { let Some(..) = .. else { break } }` → `while let Some(..) = ..`.
- **single-branch if returning literals** — turned into dedicated match arms (`Bool(true)`/`Bool(false)`, `Rat(..) if d != 0`).
- **map_identity** — drop identity `.map(|x| x)` in tests.
- **err_expect** — `.err().expect(..)` → `.expect_err(..)`.
- **items_after_test_module** — reorder so `#[cfg(test)] mod tests` is last.

No behavioral changes. `cargo test --lib` passes (449 tests); full `make test` / `make roast` left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)