### PR TITLE
perf: fast path for anonymous state scalar (`$`) assignment

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1005,7 +1005,12 @@ impl Compiler {
                 let name_idx = self
                     .code
                     .add_constant(Value::str(effective_name.to_string()));
-                if !matches!(op, AssignOp::Bind) {
+                // The anonymous state scalar (`$`, compiled as `__ANON_STATE__`)
+                // can never be readonly via the sigilless-binding mechanism, and
+                // SetGlobal performs its own readonly_vars check, so the extra
+                // CheckReadOnly op (which allocates a `__mutsu_sigilless_readonly::`
+                // lookup key on every assignment) is pure overhead here.
+                if !matches!(op, AssignOp::Bind) && effective_name != "__ANON_STATE__" {
                     self.code.emit(OpCode::CheckReadOnly(name_idx));
                 }
                 if matches!(op, AssignOp::Bind) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1149,10 +1149,47 @@ impl VM {
                 if is_rebind {
                     self.rebind_context = false;
                 }
-                let name = match &code.constants[*name_idx as usize] {
-                    Value::Str(s) => s.to_string(),
+                let name_str = match &code.constants[*name_idx as usize] {
+                    Value::Str(s) => s.as_str(),
                     _ => unreachable!("SetGlobal name must be a string constant"),
                 };
+                // Fast path for the anonymous state scalar (`$` and `$.` desugaring).
+                // `__ANON_STATE__` is a synthetic internal name that can never be a
+                // private attribute, package/class, sigilless-bound alias, or strict-
+                // undeclared symbol, so the heavy general store path below (including
+                // the O(env) reverse-alias scan, shared-var sync, and our-var store)
+                // is unnecessary. This is extremely hot in tight loops assigning to `$`.
+                // The remaining special cases (typed/readonly anon scalar, fatal-mode
+                // Failure explosion, `:=` container write-through, capture RHS) are
+                // excluded by the guards and fall through to the general path.
+                if name_str == "__ANON_STATE__"
+                    && !raw_mode
+                    && !is_rebind
+                    && !self.interpreter.fatal_mode
+                    && self
+                        .interpreter
+                        .var_type_constraint_fast(name_str)
+                        .is_none()
+                    && !self.interpreter.is_readonly(name_str)
+                    && !matches!(self.stack.last(), Some(Value::Capture { .. }))
+                    && !matches!(
+                        self.interpreter.env().get(name_str),
+                        Some(Value::ContainerRef(_))
+                    )
+                {
+                    let val = self.stack.pop().unwrap_or(Value::Nil);
+                    // Preserve `$` state persistence across closure calls.
+                    self.sync_anon_state_value("__ANON_STATE__", &val);
+                    let sym = Symbol::intern("__ANON_STATE__");
+                    if let Some(slot) = self.interpreter.env_mut().get_mut_sym(sym) {
+                        *slot = val;
+                    } else {
+                        self.interpreter.env_mut().insert_sym(sym, val);
+                    }
+                    *ip += 1;
+                    return Ok(());
+                }
+                let name = name_str.to_string();
                 // Reject private attribute twigil (!) assignment when no self is available
                 {
                     let bare = name.trim_start_matches(['$', '@', '%', '&']);


### PR DESCRIPTION
## Summary
Assigning to the anonymous state scalar `$` (compiled as `__ANON_STATE__`) went through the full generic `SetGlobal` store path. On **every** write that path does several `format!` + `Symbol::intern` allocations (type-constraint, sigilless-readonly, sigilless-alias meta-key lookups) plus an **O(env) reverse-alias scan**, a shared-var sync, and an our-var store — none of which can ever apply to the synthetic `__ANON_STATE__` name.

This adds a tightly-guarded fast path in `SetGlobal` for `__ANON_STATE__`, and stops emitting the redundant `CheckReadOnly` op for it in the compiler.

## Guards (fall through to the unchanged general path otherwise)
The fast path only triggers when the assignment is not raw/rebind, not fatal-mode, has no type constraint, is not readonly, the RHS is not a `Capture`, and the existing slot is not a `ContainerRef` (`:=` write-through). State persistence is preserved via `sync_anon_state_value`.

## Benchmark — `S04-declarations/state.t` hot loop (`for ^2000000 { $ = foo }`)
| case | before | after |
|---|---|---|
| `$ = 42` | 4s | 0s |
| sub-with-state body | 7s | 4s |
| **full state.t** | **~13s** | **~4s** |

raku runs the full test in ~1.3s; this closes most of the gap.

## Correctness
- Anonymous-state semantics preserved: persistence across closure calls (`{ $++ }` → `012`), typed `my Int $` still type-checks. Verified against `raku`.
- `cargo test --lib`: 449 pass.
- The only two `t/` subtest failures after this change (`placeholder.t` #8 — `%_` named capture; `tail-function.t` #4 — PredictiveIterator) **fail identically on a clean baseline build without this change**, i.e. pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)