### PR TITLE
chore: remove stray proc-async test scratch files and ignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bom-test-*
 tempfile*
 wip.txt
 handle-between-threads-*
+proc-async-*
 
 target-local/
 .claude/worktrees/

--- a/proc-async-bind-err.txt
+++ b/proc-async-bind-err.txt
@@ -1,1 +1,0 @@
-first line

--- a/proc-async-bind-in.txt
+++ b/proc-async-bind-in.txt
@@ -1,2 +1,0 @@
-first line
-second line

--- a/proc-async-bind-out.txt
+++ b/proc-async-bind-out.txt
@@ -1,1 +1,0 @@
-second line


### PR DESCRIPTION
## Summary
- Remove `proc-async-bind-{err,in,out}.txt` — leftover scratch output from a Proc::Async bind test that was accidentally committed to `main`.
- Add a `proc-async-*` pattern to `.gitignore` so these stop getting tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)