### PR TITLE
S09 native arrays: pass native-int/num/str.t and more

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -64,42 +64,31 @@ Many tests fail because mutsu doesn't throw the specific exception type the test
 - roast/S32-exceptions/misc2.t (exception attribute matching)
 - roast/S04-exceptions/exceptions-alternatives.t (3/3 failing)
 
-## Native Typed Arrays (6 tests)
+## Native Typed Arrays (3 tests — shaped only)
 
-Native typed arrays (int @a, num @a, str @a) work for most operations now.
-Several general fixes landed: `Array`/`List`/`Hash`/`Map`/`Range`/`Seq` now do
-`Cool`; `.Real` on containers returns elem count; typed-array element/slice
-assignment type-checks (`my Array @x; @x[0]=1` throws); `Positional[T]` checks
-the declared element type rather than runtime values; `returns X of Y` /
-`--> Array of Str` parameterize the return type; `my T @x .= new` targets
-`Array[T]`; comma-index slices of plain arrays-of-arrays no longer collapse to
-multidim; typed-array holes fill with the element type object (`(Int)`);
-native-array slices preserve their type; `.new` flattens Ranges; binding to a
-native element and pop/shift on empty natives behave correctly (no metadata
-loss). A separate EVAL bug — `throws-like` blocks leaking a stale `$_`/Failure
-into a later `EVAL`, which broke `my &f := EVAL 'sub f {...}'` after an empty
-`.pop` — was the abort blocking native-int/num/str past test ~159.
+Non-shaped native typed arrays (`int @a`, `num @a`, `str @a`) all pass now, along
+with the general typed-array tests. Only the *shaped* native arrays remain.
 
-**Passing now:**
-- roast/S09-typed-arrays/native.t (whitelisted)
+**Passing now (whitelisted):**
+- roast/S09-typed-arrays/native.t
+- roast/S09-typed-arrays/native-int.t
+- roast/S09-typed-arrays/native-num.t
+- roast/S09-typed-arrays/native-str.t
 - roast/S09-typed-arrays/arrays.t (84/84)
-
-**Already passing (were stale entries, whitelisted):**
 - roast/S02-types/signed-unsigned-native.t
 - roast/S02-types/multi_dimensional_array.t
 - roast/S09-multidim/XX-POS-on-dimensioned.t
 
-**Still failing (much improved, runs to completion or near it):**
-- roast/S09-typed-arrays/native-num.t (~11 failing of 510: containerized-range
-  index `@a[my $ = ^2]` numifying to a single index, left-infinite range init
-  `-Inf..0e0` not detected as lazy, `grep(:p)` Int-keyed Pair format)
-- roast/S09-typed-arrays/native-int.t (runs 1831/1840; same families plus
-  int-specific edge cases)
-- roast/S09-typed-arrays/native-str.t (runs 183/191)
-- roast/S09-typed-arrays/native-shape1-int.t (aborts ~test 101 — shaped-array
-  `.first`/`.grep` adverb handling and Arc-metadata loss on shaped ops)
-- roast/S09-typed-arrays/native-shape1-num.t (aborts ~test 101)
-- roast/S09-typed-arrays/native-shape1-str.t (aborts ~test 101)
+**Still failing — shaped native arrays (`array[T].new(:shape(n))`):**
+mutsu's shaped-array support is weak: `.map(* *= 2)` does not mutate in place,
+`@a[*-1,*-2]` slices return 0, `.raku` omits `:shape(...)`, clearing a shaped
+array (`@a = ()`) should reset to its fixed size of defaults rather than empty
+it, and `.grep`/`.values`/`.pairs` see stale (pre-mutation) values. ~33 failing
+of 101 run before the file aborts. These need real fixed-dimension array
+semantics, not the per-fix work that fixed the non-shaped suites.
+- roast/S09-typed-arrays/native-shape1-int.t
+- roast/S09-typed-arrays/native-shape1-num.t
+- roast/S09-typed-arrays/native-shape1-str.t
 
 ## Regex / Match Advanced Features (12 tests)
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -534,6 +534,9 @@ roast/S09-multidim/subs.t
 roast/S09-subscript/multidim-assignment.t
 roast/S09-typed-arrays/hashes.t
 roast/S09-typed-arrays/native-decl.t
+roast/S09-typed-arrays/native-int.t
+roast/S09-typed-arrays/native-num.t
+roast/S09-typed-arrays/native-str.t
 roast/S09-typed-arrays/native.t
 roast/S10-packages/export.t
 roast/S10-packages/joined-namespaces.t

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1577,7 +1577,11 @@ impl Interpreter {
                 };
                 let mut result = Vec::new();
                 for (i, item) in indices.iter().zip(items.iter()) {
-                    result.push(Value::Pair(i.to_string(), Box::new(item.clone())));
+                    // The key is the Int index (`3 => v`), not a Str ("3" => v).
+                    result.push(Value::ValuePair(
+                        Box::new(Value::Int(*i as i64)),
+                        Box::new(item.clone()),
+                    ));
                 }
                 Ok(Value::array(result))
             }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -328,6 +328,17 @@ impl Interpreter {
             }
             return Err(RuntimeError::emit_signal(target));
         }
+        // `.sum(:wrap)` / `.sum(:method)`: the only adverb that affects native
+        // arrays (`:wrap` selects wrapping overflow) is equivalent here; treat a
+        // named-only argument list as a plain `.sum`.
+        if method == "sum"
+            && !args.is_empty()
+            && args
+                .iter()
+                .all(|a| matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+        {
+            return self.call_method_with_values(target, "sum", Vec::new());
+        }
         // Scalar containers are transparent for method dispatch (except .item and .VAR)
         if let Value::Scalar(inner) = target {
             if method == "VAR" {

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -399,8 +399,8 @@ impl Interpreter {
                 match grep_adverb {
                     GrepAdverb::K => Ok(Value::Int(0)),
                     GrepAdverb::Kv => Ok(Value::array(vec![Value::Int(0), Value::Str(s.clone())])),
-                    GrepAdverb::P => Ok(Value::Pair(
-                        "0".to_string(),
+                    GrepAdverb::P => Ok(Value::ValuePair(
+                        Box::new(Value::Int(0)),
                         Box::new(Value::Str(s.clone())),
                     )),
                     GrepAdverb::V => Ok(Value::Str(s.clone())),

--- a/src/runtime/methods_collection_ops/mod.rs
+++ b/src/runtime/methods_collection_ops/mod.rs
@@ -79,7 +79,11 @@ impl GrepAdverb {
                 };
                 let mut result = Vec::new();
                 for (i, item) in indices.iter().zip(items.iter()) {
-                    result.push(Value::Pair(i.to_string(), Box::new(item.clone())));
+                    // The key is the Int index (`3 => v`), not a Str ("3" => v).
+                    result.push(Value::ValuePair(
+                        Box::new(Value::Int(*i as i64)),
+                        Box::new(item.clone()),
+                    ));
                 }
                 Ok(Value::array(result))
             }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -815,6 +815,21 @@ impl Interpreter {
             }
             return Ok(value);
         }
+        // Handle .head/.tail rw write-back: `@a.head = v` / `@a.tail = v`.
+        if matches!(method, "head" | "tail")
+            && method_args.is_empty()
+            && let Value::Array(ref items, ref kind) = target
+            && !items.is_empty()
+        {
+            let idx = if method == "head" { 0 } else { items.len() - 1 };
+            let mut updated = items.to_vec();
+            updated[idx] = value.clone();
+            let replacement = Value::Array(std::sync::Arc::new(updated), *kind);
+            if let Some(var_name) = target_var {
+                self.env.insert(var_name.to_string(), replacement);
+            }
+            return Ok(value);
+        }
         // Handle class-level attribute assignment (our $.x / my $.x)
         {
             let class_name_for_lookup = match &target {

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -30,6 +30,18 @@ pub(crate) fn is_native_array_element_type(name: &str) -> bool {
     is_native_int_type(name) || matches!(name, "num" | "num32" | "num64" | "str")
 }
 
+/// Map a native type to the generic family name Rakudo uses in messages such as
+/// "Cannot bind to a native <family> array" (e.g. `int8`/`int64` -> `int`,
+/// `uint16` -> `uint`, `num32` -> `num`).
+pub(crate) fn native_family_name(name: &str) -> &'static str {
+    match name {
+        "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "byte" => "uint",
+        "num" | "num32" | "num64" => "num",
+        "str" => "str",
+        _ => "int",
+    }
+}
+
 /// Returns (min, max) bounds for a native integer type as BigInt values.
 /// `byte` is an alias for `uint8`.
 /// `int` is an alias for `int64`, `uint` is an alias for `uint64`.

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3271,11 +3271,12 @@ pub(crate) fn type_check_element_typed_error(
     val: &Value,
 ) -> RuntimeError {
     let msg = type_check_element_error(var_name, expected, val);
-    let got_type = value_type_name(val);
     let display_name = format_var_name_for_error(var_name);
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("expected".to_string(), Value::str(expected.to_string()));
-    attrs.insert("got".to_string(), Value::str(got_type.to_string()));
+    // `.got` is the offending value itself (e.g. `42`), so `$!.got ~~ Int` holds,
+    // matching Rakudo's X::TypeCheck.
+    attrs.insert("got".to_string(), val.clone());
     attrs.insert("symbol".to_string(), Value::str(display_name));
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     RuntimeError::typed("X::TypeCheck::Assignment", attrs)

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -388,6 +388,13 @@ impl VM {
                 }
             }
             Value::Nil => true,
+            // A type-object hole (e.g. an `Any` gap) is acceptable for a native
+            // array: it is coerced to the array's default on store.
+            Value::Package(_)
+                if crate::runtime::native_types::is_native_array_element_type(constraint) =>
+            {
+                true
+            }
             _ => self.interpreter.type_matches_value(constraint, value),
         }
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -958,8 +958,16 @@ impl VM {
         coercion_target: &dyn Fn(&str) -> Option<String>,
         explicit_initializer: bool,
     ) -> Result<Vec<Value>, RuntimeError> {
+        let native_constraint =
+            crate::runtime::native_types::is_native_array_element_type(constraint);
         let mut coerced_items = Vec::with_capacity(items.len());
         for item in items.iter() {
+            // A type-object hole (e.g. an `Any` gap from `@a[1] = x`) assigned to a
+            // native array becomes that array's default (`0`/`0e0`/`""`).
+            if native_constraint && matches!(item, Value::Package(_)) {
+                coerced_items.push(Self::native_fill_for_constraint(Some(constraint)));
+                continue;
+            }
             if matches!(item, Value::Nil) {
                 if let Some(default) = self.interpreter.var_default(var_name) {
                     coerced_items.push(default.clone());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -962,6 +962,29 @@ impl VM {
             crate::runtime::native_types::is_native_array_element_type(constraint);
         let mut coerced_items = Vec::with_capacity(items.len());
         for item in items.iter() {
+            // A lazy/infinite Range (e.g. `-Inf..0e0`, `0e0..Inf`) cannot initialize
+            // a native array, regardless of which end is unbounded.
+            if native_constraint && crate::builtins::methods_0arg::is_value_lazy(item) {
+                return Err(RuntimeError::typed(
+                    "X::Cannot::Lazy",
+                    [
+                        (
+                            "message".to_string(),
+                            Value::str(format!(
+                                "Cannot initialize an array of {} with a lazy list",
+                                constraint
+                            )),
+                        ),
+                        ("action".to_string(), Value::str_from("initialize")),
+                        (
+                            "what".to_string(),
+                            Value::str(format!("array[{constraint}]")),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ));
+            }
             // A type-object hole (e.g. an `Any` gap from `@a[1] = x`) assigned to a
             // native array becomes that array's default (`0`/`0e0`/`""`).
             if native_constraint && matches!(item, Value::Package(_)) {
@@ -2319,7 +2342,8 @@ impl VM {
             && crate::runtime::native_types::is_native_array_element_type(&constraint)
         {
             return Err(RuntimeError::new(format!(
-                "Cannot bind to a native {constraint} array"
+                "Cannot bind to a native {} array",
+                crate::runtime::native_types::native_family_name(&constraint)
             )));
         }
         let is_bound_index = if bind_mode {
@@ -2635,6 +2659,10 @@ impl VM {
                         &idx,
                     ));
                 }
+                // Native integer arrays store the wrapped value (`-1` -> `255` in a
+                // uint8 array); the assignment expression still yields the original.
+                let native_store_val =
+                    Self::wrap_native_int_for_var(&self.interpreter, &var_name, val.clone());
                 // Resolve GenericRange with WhateverCode endpoints (e.g. @a[*-4 .. *-1] = ...)
                 let resolved_idx;
                 let idx_for_slice = if let Value::GenericRange { .. } = &idx {
@@ -2999,7 +3027,11 @@ impl VM {
                                         arr[i] = if is_self_array_ref {
                                             Self::self_array_ref_marker()
                                         } else {
-                                            val.clone()
+                                            // A native integer array stores the
+                                            // wrapped value (e.g. -1 -> 255 in a
+                                            // uint8 array), while the assignment
+                                            // expression still yields the original.
+                                            native_store_val.clone()
                                         };
                                     }
                                 }
@@ -5629,6 +5661,22 @@ impl VM {
     }
 
     /// Wrap an integer value to fit within a native integer type's range.
+    /// Wrap `val` for storage into the native-integer array named by `var_name`
+    /// (e.g. `-1` -> `255` for a `uint8` array). Returns the value unchanged when
+    /// the variable is not a native integer array or wrapping does not apply.
+    fn wrap_native_int_for_var(
+        interpreter: &crate::runtime::Interpreter,
+        var_name: &str,
+        val: Value,
+    ) -> Value {
+        if let Some(constraint) = interpreter.var_type_constraint(var_name)
+            && crate::runtime::native_types::is_native_int_type(&constraint)
+        {
+            return Self::wrap_native_int_by_constraint(&constraint, val.clone()).unwrap_or(val);
+        }
+        val
+    }
+
     /// For non-native constraints or non-integer values, returns the value unchanged.
     pub(super) fn wrap_native_int_by_constraint(
         constraint: &str,

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -191,7 +191,10 @@ impl VM {
                 "X::Delete",
                 [(
                     "message".to_string(),
-                    Value::str(format!("Cannot delete from a native {elem} array")),
+                    Value::str(format!(
+                        "Cannot delete from a native {} array",
+                        crate::runtime::native_types::native_family_name(elem)
+                    )),
                 )]
                 .into_iter()
                 .collect(),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -211,7 +211,16 @@ impl VM {
         &mut self,
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
-        let index = self.stack.pop().unwrap();
+        let mut index = self.stack.pop().unwrap();
+        // An *itemized* Range used as a subscript (`@a[my $ = ^2]`) is a single
+        // numeric index, not a slice: the contained Range numifies to its element
+        // count. (A bare Range index `@a[^2]` is still a slice.)
+        if let Value::Scalar(inner) = &index
+            && inner.is_range()
+        {
+            let n = crate::runtime::utils::value_to_list(inner).len() as i64;
+            index = Value::Int(n);
+        }
         let mut target = self.stack.pop().unwrap();
         if let Value::Junction { kind, values } = &target {
             let mut results = Vec::with_capacity(values.len());


### PR DESCRIPTION
## Summary

Builds on #2565. Makes the remaining non-shaped native typed array suites pass and whitelists them: `native-int.t`, `native-num.t`, `native-str.t`.

### Fixes
- **grep/first `:p`** produce Int-keyed pairs (`3 => v`) instead of Str-keyed.
- **X::TypeCheck::Assignment `.got`** is the offending value (so `$!.got ~~ Int`).
- **Itemized Range subscript** `@a[my $ = ^2]` is a single numeric index (the Range numifies to its element count), not a slice. A bare `@a[^2]` is still a slice.
- **Type-object holes** (an `Any` gap from `@a[1] = x`) assigned to a native array coerce to the array's default (`0`/`0e0`/`""`).
- **`.head = v` / `.tail = v`** rw write-back on arrays.
- **Native int wrapping on store**: a uint array stores the wrapped value (`-1` → `255`) while the assignment expression yields the original.
- **Lazy/infinite Range init** (`-Inf..0e0`, `0e0..Inf`) of a native array throws `X::Cannot::Lazy` (initialize) regardless of which end is unbounded.
- **Native bind/delete messages** use the generic family name (`num32`→"num", `int8`→"int", `uint8`→"uint"), matching Rakudo.
- **`.sum(:wrap)`** (named-only sum adverbs) behaves like `.sum`.

### Status
8 of the 11 BLOCKERS "Native Typed Arrays" tests now pass. Only the three *shaped* native-array suites (`native-shape1-{int,num,str}.t`) remain; they need real fixed-dimension array semantics (in-place `.map`, reset-to-defaults on clear, `:shape` in `.raku`, shaped slicing) and are tracked in BLOCKERS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)