### PR TITLE
Fix [op] reduction edge cases in S03-metaops/reduce.t (17->1)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -33,6 +33,15 @@
 - [ ] roast/S03-metaops/not.t
   - 46/47 tests pass. The remaining failure is subtest 47 (chaining of !before/!after) where 2 of 12 subtests fail due to wrong expected values in the test (lines 84 and 93, marked `#?rakudo skip`). Even raku (Rakudo) fails these same tests. Cannot whitelist until roast fixes the expected values or the fudging mechanism is implemented.
 - [ ] roast/S03-metaops/reduce.t
+  - 579/580 pass. Fixed: custom `is assoc<chain>` infixes in `[op]` reductions,
+    `[Z&&]`/`[Z||]`/`[Zand]`/`[Zor]` short-circuit thunk distribution (per-element
+    thunks; was eagerly evaluating side effects), `[=]` right-associative
+    assignment reduce, `[=:=]`/`[!=:=]` container-identity reductions (rewritten
+    to pairwise `&&`-chains preserving container identity). Remaining failure:
+    test 62 `[,] produces a uncontainerized List` — needs `@a = $list` to flatten
+    a `:=`-bound List (mutsu keeps it as one element) plus negative-number
+    allomorph parsing in `<...>` word quotes (`<-3>` should be IntStr, mutsu makes
+    it Str). Both are core list/itemization issues unrelated to meta-ops.
 - [ ] roast/S03-metaops/reverse.t
 - [ ] roast/S03-metaops/zip.t
   - 20/77 pass. Remaining blockers: [Z+] reduction with join (parser precedence for reduction ops consuming remaining args), Z, list associativity (parser), Z+= meta-assignment, Z= assignment, is-lazy on Z result (needs lazy Seq), throws-like for Z. syntax errors, &infix:<Z+> function refs, Zxx/Zand/Z&&/Zor/Z||/Zandthen/Zorelse thunking, itemization in Z

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -347,6 +347,95 @@ impl Compiler {
                 // inline with short-circuit bytecode to preserve lazy evaluation semantics.
                 let base_op = op.strip_prefix('\\').unwrap_or(op.as_str());
                 let is_scan = op.starts_with('\\');
+                // `[Z&&]` / `[Z||]` / `[Zand]` / `[Zor]` etc. reduce a list of
+                // lists by left-folding the binary short-circuiting `Z` meta-op,
+                // which thunks its right operand. Rewrite into a left-nested
+                // MetaOp tree so the per-element thunking is preserved.
+                if !is_scan
+                    && let Some(zop) = base_op.strip_prefix('Z')
+                    && matches!(zop, "and" | "&&" | "or" | "||" | "andthen" | "orelse")
+                    && let Expr::ArrayLiteral(items) = expr.as_ref()
+                    && items.len() >= 2
+                {
+                    let mut iter = items.iter();
+                    let mut acc = iter.next().unwrap().clone();
+                    for item in iter {
+                        acc = Expr::MetaOp {
+                            meta: "Z".to_string(),
+                            op: zop.to_string(),
+                            left: Box::new(acc),
+                            right: Box::new(item.clone()),
+                        };
+                    }
+                    self.compile_expr(&acc);
+                    return;
+                }
+                // `[=:=]` / `[!=:=]` are chain-associative container-identity
+                // reductions. The binary `=:=` operator resolves container
+                // identity from the operand expressions (variable names / index
+                // sources), which is lost once operands are evaluated into a
+                // value list. Rewrite into a conjunction of pairwise binary
+                // comparisons so identity is preserved.
+                if !is_scan
+                    && matches!(base_op, "=:=" | "!=:=")
+                    && let Expr::ArrayLiteral(items) = expr.as_ref()
+                    && items.len() >= 2
+                {
+                    let negate = base_op == "!=:=";
+                    let mut acc: Option<Expr> = None;
+                    for pair in items.windows(2) {
+                        // `=:=` resolves container identity from the operand
+                        // expressions; `!=:=` is parsed as `!(... =:= ...)`.
+                        let mut cmp = Expr::Binary {
+                            left: Box::new(pair[0].clone()),
+                            op: TokenKind::Ident("=:=".to_string()),
+                            right: Box::new(pair[1].clone()),
+                        };
+                        if negate {
+                            cmp = Expr::Unary {
+                                op: TokenKind::Bang,
+                                expr: Box::new(cmp),
+                            };
+                        }
+                        acc = Some(match acc {
+                            None => cmp,
+                            Some(prev) => Expr::Binary {
+                                left: Box::new(prev),
+                                op: TokenKind::AndAnd,
+                                right: Box::new(cmp),
+                            },
+                        });
+                    }
+                    // Each `=:=` / `!=:=` yields a Bool, so the &&-chain result
+                    // is already a Bool (no further coercion needed).
+                    let combined = acc.unwrap();
+                    self.compile_expr(&combined);
+                    return;
+                }
+                // `[=] $a, $b, $c, 42` is a right-associative assignment reduce:
+                // `$a = ($b = ($c = 42))`. Rewrite into nested assignments so the
+                // values are written back through the variable containers.
+                if !is_scan
+                    && base_op == "="
+                    && let Expr::ArrayLiteral(items) = expr.as_ref()
+                    && items.len() >= 2
+                    && items[..items.len() - 1]
+                        .iter()
+                        .all(|e| matches!(e, Expr::Var(_)))
+                {
+                    let mut acc = items.last().unwrap().clone();
+                    for target in items[..items.len() - 1].iter().rev() {
+                        if let Expr::Var(name) = target {
+                            acc = Expr::AssignExpr {
+                                name: name.clone(),
+                                expr: Box::new(acc),
+                                is_bind: false,
+                            };
+                        }
+                    }
+                    self.compile_expr(&acc);
+                    return;
+                }
                 if matches!(
                     base_op,
                     "&&" | "||" | "and" | "or" | "//" | "andthen" | "orelse" | "^^" | "xor"

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -284,6 +284,29 @@ impl Compiler {
         });
     }
 
+    /// Build the right-hand operand for a short-circuiting `Z` meta-op.
+    ///
+    /// For a literal list `(a, b, c)` we produce an array of per-element 0-arg
+    /// thunks so each element's side effects only fire when the operator needs
+    /// it. For any other expression we pass it through as a value (it is already
+    /// evaluated once, like a normal infix operand), and the runtime treats
+    /// non-thunk entries as plain values.
+    fn zip_shortcircuit_rhs_thunks(right: &Expr) -> Expr {
+        if let Expr::ArrayLiteral(items) = right {
+            let thunks = items
+                .iter()
+                .map(|item| Expr::AnonSub {
+                    body: vec![Stmt::Expr(item.clone())],
+                    is_rw: false,
+                    is_block: true,
+                })
+                .collect();
+            Expr::ArrayLiteral(thunks)
+        } else {
+            right.clone()
+        }
+    }
+
     /// Compile MetaOp (Rop, Xop, Zop).
     pub(super) fn compile_expr_meta_op(&mut self, meta: &str, op: &str, left: &Expr, right: &Expr) {
         if meta == "X" && matches!(op, "and" | "&&" | "or" | "||" | "andthen" | "orelse") {
@@ -316,15 +339,34 @@ impl Compiler {
             self.compile_expr(&rewritten);
             return;
         }
-        // Z with short-circuit operators: thunk the right side
-        if meta == "Z" && matches!(op, "and" | "&&" | "or" | "||" | "andthen" | "orelse") {
+        // Z with short-circuit operators: thunk each right-hand element so its
+        // side effects only fire when the operator actually needs the right
+        // operand. When the right side is a literal list we can thunk per
+        // element; otherwise we pass the pre-evaluated value directly.
+        if meta == "Z" && matches!(op, "and" | "&&" | "or" | "||") {
+            let thunks = Self::zip_shortcircuit_rhs_thunks(right);
+            let rewritten = Expr::Call {
+                name: Symbol::intern("__mutsu_zip_shortcircuit"),
+                args: vec![
+                    Expr::Literal(Value::str(op.to_string())),
+                    left.clone(),
+                    thunks,
+                ],
+            };
+            self.compile_expr(&rewritten);
+            return;
+        }
+        // Zandthen / Zorelse topicalize the right operand with the left value, so
+        // they keep a single whole-list thunk (per-element wrapping would create
+        // an implicit `$_` block parameter that shadows the topic).
+        if meta == "Z" && matches!(op, "andthen" | "orelse") {
             let thunked = Expr::AnonSub {
                 body: vec![Stmt::Expr(right.clone())],
                 is_rw: false,
                 is_block: true,
             };
             let rewritten = Expr::Call {
-                name: Symbol::intern("__mutsu_zip_shortcircuit"),
+                name: Symbol::intern("__mutsu_zip_shortcircuit_topic"),
                 args: vec![
                     Expr::Literal(Value::str(op.to_string())),
                     left.clone(),

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -214,6 +214,7 @@ impl Interpreter {
             "__mutsu_andthen_finalize" => self.builtin_andthen_finalize(&args),
             "__mutsu_cross_shortcircuit" => self.builtin_cross_shortcircuit(&args),
             "__mutsu_zip_shortcircuit" => self.builtin_zip_shortcircuit(&args),
+            "__mutsu_zip_shortcircuit_topic" => self.builtin_zip_shortcircuit_topic(&args),
             "__mutsu_zip_xx" => self.builtin_zip_xx(&args),
             "__mutsu_bind_index_value" => Ok(Value::Pair(
                 "__mutsu_bind_index_value".to_string(),

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -208,15 +208,19 @@ impl Interpreter {
     }
 
     /// Zip with short-circuit semantics for and/&&/or/||/andthen/orelse.
-    /// Args: [op_name, left_list, right_thunk]
-    /// The right thunk is only evaluated per-element when the operator needs it.
+    /// Args: [op_name, left_list, right_thunks]
+    /// `right_thunks` is a list with one entry per right-hand element. Each entry
+    /// is either a 0-arg thunk (from a literal list, so side effects only fire
+    /// when the operator actually needs the right operand) or a plain value (from
+    /// a pre-evaluated right operand). Zip is 1:1, so element `i` of the left list
+    /// pairs with thunk `i`.
     pub(super) fn builtin_zip_shortcircuit(
         &mut self,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         if args.len() != 3 {
             return Err(RuntimeError::new(
-                "__mutsu_zip_shortcircuit expects op, lhs, thunk",
+                "__mutsu_zip_shortcircuit expects op, lhs, thunks",
             ));
         }
         let op = args[0].to_string_value();
@@ -231,9 +235,11 @@ impl Interpreter {
                 list
             }
         };
-        let thunk = args[2].clone();
-        let mut out = Vec::new();
-        for left in left_values {
+        let right_thunks = crate::runtime::value_to_list(&args[2]);
+        let len = left_values.len().min(right_thunks.len());
+        let mut out = Vec::with_capacity(len);
+        for i in 0..len {
+            let left = left_values[i].clone();
             let needs_rhs = match op.as_str() {
                 "and" | "&&" => left.truthy(),
                 "or" | "||" => !left.truthy(),
@@ -245,10 +251,14 @@ impl Interpreter {
                 out.push(left);
                 continue;
             }
-            let rhs_value = if op == "andthen" || op == "orelse" {
+            let entry = right_thunks[i].clone();
+            // A plain value (not a thunk) is used as-is; a thunk is evaluated now.
+            let rhs_value = if !matches!(entry, Value::Sub(_)) {
+                entry
+            } else if op == "andthen" || op == "orelse" {
                 let saved_topic = self.env.get("_").cloned();
                 self.env.insert("_".to_string(), left.clone());
-                let result = self.eval_call_on_value(thunk.clone(), Vec::new());
+                let result = self.eval_call_on_value(entry, Vec::new());
                 match saved_topic {
                     Some(value) => {
                         self.env.insert("_".to_string(), value);
@@ -259,12 +269,65 @@ impl Interpreter {
                 }
                 result?
             } else {
-                self.eval_call_on_value(thunk.clone(), Vec::new())?
+                self.eval_call_on_value(entry, Vec::new())?
             };
-            // The thunk returns a list; zip pairs elements 1:1
+            out.push(rhs_value);
+        }
+        Ok(Value::array(out))
+    }
+
+    /// Zip with short-circuit semantics for `andthen`/`orelse`, which topicalize
+    /// the right operand with the corresponding left value. Args: [op, lhs,
+    /// whole_list_thunk]. The right operand is a single thunk over the whole
+    /// list so that referencing `$_` inside resolves to the topic we set rather
+    /// than an implicit block parameter.
+    pub(super) fn builtin_zip_shortcircuit_topic(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if args.len() != 3 {
+            return Err(RuntimeError::new(
+                "__mutsu_zip_shortcircuit_topic expects op, lhs, thunk",
+            ));
+        }
+        let op = args[0].to_string_value();
+        let left_values = if matches!(args[1], Value::Nil) {
+            vec![Value::Nil]
+        } else {
+            let list = crate::runtime::value_to_list(&args[1]);
+            if list.is_empty() {
+                vec![args[1].clone()]
+            } else {
+                list
+            }
+        };
+        let thunk = args[2].clone();
+        let mut out = Vec::new();
+        for (i, left) in left_values.iter().enumerate() {
+            let needs_rhs = match op.as_str() {
+                "andthen" => crate::runtime::types::value_is_defined(left),
+                "orelse" => !crate::runtime::types::value_is_defined(left),
+                _ => false,
+            };
+            if !needs_rhs {
+                out.push(left.clone());
+                continue;
+            }
+            let saved_topic = self.env.get("_").cloned();
+            self.env.insert("_".to_string(), left.clone());
+            let result = self.eval_call_on_value(thunk.clone(), Vec::new());
+            match saved_topic {
+                Some(value) => {
+                    self.env.insert("_".to_string(), value);
+                }
+                None => {
+                    self.env.remove("_");
+                }
+            }
+            let rhs_value = result?;
+            // The thunk returns the whole right list; pick element i (zip is 1:1).
             let rhs_items = crate::runtime::value_to_list(&rhs_value);
-            // Take the first element from the thunked result (zip is 1:1)
-            out.push(rhs_items.into_iter().next().unwrap_or(Value::Nil));
+            out.push(rhs_items.into_iter().nth(i).unwrap_or(Value::Nil));
         }
         Ok(Value::array(out))
     }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1955,7 +1955,11 @@ impl VM {
         if list.is_empty() {
             self.stack.push(runtime::reduction_identity(&base_op));
         } else {
-            let is_comparison = runtime::is_chain_comparison_op(&base_op);
+            // Chain-associative operators (built-in comparisons and user-defined
+            // `is assoc<chain>` infixes) reduce as a conjunction of pairwise
+            // applications, not a left-fold.
+            let is_comparison =
+                runtime::is_chain_comparison_op(&base_op) || matches!(assoc, ReductionAssoc::Chain);
             if is_comparison {
                 let mut result = true;
                 for i in 0..list.len() - 1 {


### PR DESCRIPTION
## Summary

Fixes most of the failing subtests in `roast/S03-metaops/reduce.t` (17 → 1 failing).

### Fixed

- **Custom `is assoc<chain>` infixes** (e.g. `[eog]`) now reduce as a conjunction of pairwise applications instead of a left-fold.
- **`[Z&&]` / `[Z||]` / `[Zand]` / `[Zor]` short-circuit thunk distribution**: right-hand list elements are now thunked per element, so their side effects fire only when the operator needs the right operand (previously eager). The binary `A Z&& B` form also no longer evaluates the wrong/duplicate RHS element.
- **`[=]` right-associative assignment reduce** (`[=] $a, $b, $c, 42`) now writes the value back through each variable container.
- **`[=:=]` / `[!=:=]` container-identity reductions** are rewritten into a pairwise `&&`-chain of binary comparisons so container identity is preserved.

Zandthen/Zorelse keep a single whole-list thunk to preserve `$_` topicalization (covered by `zip.t`, which still passes).

### Remaining

`reduce.t` test 62 (`[,] produces a uncontainerized List`) needs `@a = $list` to flatten a `:=`-bound List plus negative-number allomorph parsing in `<...>` word quotes — both core list/itemization issues unrelated to meta-ops, documented in `TODO_roast/S03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)