### PR TITLE
Alias $_ to topic var in statement-form 'with'; fix block-final 'if' value

### DIFF
--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -57,6 +57,20 @@ impl Compiler {
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }
+                    // An `if`/`unless` in block-final position should yield its
+                    // taken branch's value (like `do if ...`), not Nil. This
+                    // matters e.g. for `do { if $c { ... } }` and statement-form
+                    // `with`/`without` (lowered to an `if`) used as expressions.
+                    Stmt::If {
+                        cond,
+                        then_branch,
+                        else_branch,
+                        binding_var,
+                    } if binding_var.is_none() => {
+                        self.compile_do_if_expr(cond, then_branch, else_branch);
+                        self.pop_dynamic_scope_lexical(saved);
+                        return;
+                    }
                     Stmt::Whenever { supply, .. } => {
                         // `do whenever ...` should produce the created Tap in expression context.
                         self.compile_stmt(stmt);

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -393,9 +393,13 @@ impl Compiler {
         if Self::has_phasers(stmts) {
             return false;
         }
-        for stmt in stmts {
+        let last = stmts.len().saturating_sub(1);
+        for (i, stmt) in stmts.iter().enumerate() {
             match stmt {
-                Stmt::Given { .. } => return false,
+                // A `given` in final position is handled by compile_block_inline
+                // (it leaves the block value on the stack); only a non-final
+                // `given` is unsupported here.
+                Stmt::Given { .. } if i != last => return false,
                 Stmt::If {
                     then_branch,
                     else_branch,

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -2104,6 +2104,13 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // read-only so that mutating ops like tr/// throw X::Assignment::RO.
     // Encoding the read-only flag in the value itself avoids leaking marker
     // variables across exception boundaries.
+    // When the topic is a plain variable and there is no pointy parameter, run
+    // the body under a `given` so `$_` aliases that variable (matching `given`'s
+    // semantics). This lets in-place mutations through `$_` (e.g. `.=uc`,
+    // `$_ = ...`) write back to the original container, while `$_` stays writable
+    // exactly as in `given`. The `.defined` condition is still evaluated
+    // separately via `$tmp`.
+    let use_given_alias = param_name.is_none() && matches!(&cond_expr, Expr::Var(_));
     let topic_assign = if let Expr::Literal(lit) = &cond_expr {
         let mut overrides = std::collections::HashMap::new();
         overrides.insert("__mutsu_topic_ro__".to_string(), Value::Bool(true));
@@ -2116,7 +2123,11 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     } else {
         topicalize(&tmp_var)
     };
-    let mut with_body = vec![topic_assign];
+    let mut with_body = if use_given_alias {
+        Vec::new()
+    } else {
+        vec![topic_assign]
+    };
     // If a named parameter was given (-> $param), also assign it
     if let Some(ref pname) = param_name {
         // Check if this is a sub-signature destructuring (e.g. -> ($x) or -> (Int() $x is copy))
@@ -2228,7 +2239,14 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             });
         }
     }
-    with_body.extend(body);
+    if use_given_alias {
+        with_body = vec![Stmt::Given {
+            topic: cond_expr.clone(),
+            body,
+        }];
+    } else {
+        with_body.extend(body);
+    }
 
     // Build the condition as (my $tmp = cond_expr).defined() (or
     // !(my $tmp = cond_expr).defined() for without). The DoStmt(VarDecl)


### PR DESCRIPTION
## Summary

Two related correctness fixes around topicalization and block values:

1. **`with VAR { ... }` aliases `$_` to the topic variable** (like `given`) when the topic is a plain variable with no pointy parameter. In-place mutations through `$_` now write back to the original container — e.g. `with $a { .=uc }` and `with $a { $_ = ... }`. Previously `$_` held a copy, so the mutation was lost.

2. **An `if`/`unless` in block-final position yields its taken branch's value** instead of `Nil`:
   - `compile_block_inline` had no final-position arm for `Stmt::If`, so `do { if $c { ... } }` returned `Nil`.
   - `do_if_branch_supported` rejected branches whose final statement is a `given`, so `do with $v { ... }` (lowered to an `if` whose branch is a `given`) also returned `Nil`.

   Both now propagate the branch value.

## Testing

- `roast/S04-statements/with.t`, `given.t` still pass; `t/with-without.t`, `t/orwith.t`, `t/topic-bind-conditions.t`, `t/samewith.t` pass.
- Covers the Scalar `.= with implied $_` case in `roast/S03-operators/inplace.t`.
- No new `make test` failures (placeholder.t / tail-function.t / wrap.t already fail on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)