### PR TITLE
S03-operators/assign.t: lvalue-yielding assignment & [op]= reduce-meta in expressions

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -55,8 +55,15 @@
   - 0/? pass. Panic: `attempt to multiply with overflow` in `i64::pow`. Needs BigInt or checked arithmetic.
 - [x] roast/S03-operators/assign-is-not-binding.t
 - [ ] roast/S03-operators/assign.t
-  - Panic on infix routine `=` dispatch is fixed; current blocker is package/hash assignment semantics (hits `Unknown method value dispatch ... keys` and exits early).
-  - 36/302 pass.
+  - ~158/193 pass (file still aborts mid-run at test ~193 of 302). Fixed:
+    `(($c = 3) = 4)` (assignment yields its container as an lvalue), and `[op]=`
+    reduce-meta compound assignment in expression context (`@p = ($x [+]= 6)`,
+    which lowered to an unhandled "reduce" meta-op in the VM).
+  - Next blocker: `flat $::('Foo::b') = l(), l()` — `flat` combined with a
+    symbolic-deref (`$::(...)`) assignment fatally errors ("Unknown call: flat"),
+    aborting the rest of the file. Beyond that: itemization/flat interactions and
+    several list-assignment-context edge cases (tests 5, 7-8, 20-21, 26, 38,
+    47-50, 53, 55-56, ... still fail among the run subtests).
 - [ ] roast/S03-operators/autoincrement-range.t
   - 5/104 pass.
 - [ ] roast/S03-operators/autoincrement.t

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -24,6 +24,25 @@ impl Compiler {
             return;
         } else if name == "__mutsu_assign_callable_lvalue"
             && args.len() == 3
+            && let Expr::AssignExpr {
+                name: var_name,
+                is_bind: false,
+                ..
+            } = &args[0]
+        {
+            // `($c = 3) = 4`: an assignment yields the assigned container as an
+            // lvalue, so the outer assignment writes through to the same
+            // variable. Run the inner assignment for its side effect, then
+            // assign the RHS to the same variable.
+            self.compile_expr(&args[0]);
+            self.code.emit(OpCode::Pop);
+            self.compile_expr(&args[2]);
+            self.code.emit(OpCode::Dup);
+            let name_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::AssignExpr(name_idx));
+            return;
+        } else if name == "__mutsu_assign_callable_lvalue"
+            && args.len() == 3
             && let Expr::ArrayLiteral(targets) = &args[0]
             && targets.iter().all(|t| {
                 matches!(

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1126,6 +1126,10 @@ impl VM {
         let meta = Self::const_str(code, meta_idx).to_string();
         let op = Self::const_str(code, op_idx).to_string();
         let result = match meta.as_str() {
+            // `[op]=` compound assignment (e.g. `$x [+]= 6`) lowers to a "reduce"
+            // meta-op: reducing the base op over the two operands is just the base
+            // op applied once.
+            "reduce" => self.eval_reduction_operator_values(&op, &left, &right)?,
             "R" => {
                 if op == "..." || op == "...^" {
                     let exclude_end = op == "...^";


### PR DESCRIPTION
## Summary

Two fixes that unblock ~86 more subtests in `roast/S03-operators/assign.t` (it was aborting at test 107; now runs to ~193, ~158 passing):

1. **`(($c = 3) = 4)`** — a scalar assignment yields its container as an lvalue, so the outer assignment writes through to the same variable. Handled in the `__mutsu_assign_callable_lvalue` lowering when the lvalue is an `AssignExpr`: run the inner assignment for its side effect, then assign the RHS to the same variable. Previously threw "Cannot modify an immutable value" and aborted the whole file.

2. **`@p = ($x [+]= 6)`** — the `[op]=` reduce-meta compound assignment in expression context lowered to a `MetaOp` with meta `"reduce"` that the VM did not handle ("Unknown meta operator: reduce"). Reducing a binary op over two operands is just the base op applied once, so it's now evaluated as such.

## Testing

- assign.t: 107 → 193 tests run (~82 → ~158 passing).
- Local assign tests still pass: `compound-assign-ops.t`, `meta-op-assign.t`, `index-assign-expr.t`, `hyper-assign.t`, `list-assign-existing.t`, etc.
- No new `make test` failures (placeholder.t / tail-function.t pre-existing; lock.t flaky concurrency).

Remaining assign.t blockers documented in `TODO_roast/S03.md` (symbolic-deref `$::(...)` assignment with `flat`, itemization/flat interactions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)