### PR TITLE
vm: instrument VM->interpreter method-dispatch fallback rate (strangler step 1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -12,6 +12,28 @@ roast ブロッカー分析は [TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md) 
 
 ---
 
+## 🔴 最優先: バイトコード VM をちゃんと治す
+
+**roast テストを1件ずつ潰すより、VM アーキテクチャの根本改修を最優先する** (ユーザー方針 2026-06-03)。
+
+mutsu の「バイトコード VM」は実態として tree-walking Interpreter の薄いフロントエンドであり、
+VM は Interpreter を共有実行状態コンテナ + フォールバック先として使っている
+([ANALYSIS.md](ANALYSIS.md) §1)。これを **strangler-fig 方式**で段階的に切り離す:
+古いフォールバックを残したまま計測し、毎 PR で「フォールバック率 X%→Y%」を可視化しながら縮める。
+進捗台帳は [docs/vm-decoupling.md](docs/vm-decoupling.md)。
+
+- [x] **計測機構の導入** (strangler step 1, PR #2571) — `MUTSU_VM_STATS=1` で VM→Interpreter の
+      メソッドディスパッチ・フォールバック率を出力。判明: 明示メソッド呼び出しの実行委譲は既に低率で、
+      支配的結合は共有状態 (env/env_mut) 側 (§1.1–1.2)。
+- [ ] **関数ディスパッチの計測**を追加 (`call_function`/`call_function_fallback` — 委譲面はメソッドより広い見込み)
+- [ ] **`locals`↔`env` 二重ストアの解消** — 単一権威ストアに統合し dirty 追跡機構を撤廃 (§1.2)
+- [ ] **クロージャに upvalue 導入** — 全フレーム env 同期を撤廃 (§1.3)
+- [ ] **env/クラスレジストリ/型検査を VM 所有データへ移し**、残存実行フォールバックを排除 (§1.1)。
+      当面は CLAUDE.md の記述を実態に合わせ、フォールバックに `// TODO: compile to bytecode` を付け負債を可視化
+- [ ] 最終: メソッド/関数フォールバック率を 0% にし、Interpreter のメソッド実行パスを削除
+
+---
+
 ## Q2 (5〜6月): パフォーマンスと Container semantics
 
 目標: **「簡単なスクリプトなら raku の代わりに使える」レベルに到達**
@@ -184,13 +206,10 @@ BLOCKERS.md の分析に基づき、インパクト順に並べたもの。
 - [ ] Hyper assignment (`@a >>+=>> 1`)
 - [ ] Triangular reduction (`[\+]`, `[\*]`, etc.)
 
-### アーキテクチャ・リファクタ (中長期 — [ANALYSIS.md](ANALYSIS.md) §1, §3)
+### アーキテクチャ・リファクタ (中長期 — [ANALYSIS.md](ANALYSIS.md) §3, §4, §6)
 
-- [ ] VM↔Interpreter の結合を解く — env/クラスレジストリ/型検査を VM 所有データへ移し、
-      残存する実行フォールバック (`call_method_with_values` 等) を排除。当面は CLAUDE.md の
-      記述を実態に合わせ、フォールバックに `// TODO: compile to bytecode` を付け負債を可視化 (§1.1)
-- [ ] locals↔env 二重ストアを単一権威ストアに統合し dirty 追跡機構を撤廃 (§1.2)
-- [ ] クロージャに upvalue を導入し全フレーム env 同期を撤廃 (§1.3)
+VM↔Interpreter の切り離し本体は冒頭の「🔴 最優先」セクション参照。以下はそれ以外の構造的負債。
+
 - [ ] 正規表現の validator/matcher 二重実装を単一パーサに統合 (§3.1)
 - [ ] `.^methods`/`.can` の型別メソッド一覧を実ディスパッチ表から導出 (§4)
 - [ ] roast fudge ロジックを核から分離 / テストの一時ファイルを `tmp/` へ / 500行超ファイルの分割 (§6)

--- a/docs/vm-decoupling.md
+++ b/docs/vm-decoupling.md
@@ -1,0 +1,62 @@
+# VM decoupling progress
+
+Goal: make the bytecode VM execute everything natively and remove its remaining
+dependence on the tree-walking `Interpreter` (see `ANALYSIS.md` section 1).
+
+We take a **strangler-fig** approach: keep the interpreter fallback paths working,
+but measure how often they are hit and shrink that number one change at a time.
+Each step should be small, shippable, and move the metric in the right direction.
+
+## Measuring fallback
+
+Run any program with `MUTSU_VM_STATS=1`; a one-line summary is printed to stderr
+at the end of the run:
+
+```
+$ MUTSU_VM_STATS=1 ./target/debug/mutsu roast/S02-types/array.t 2>&1 | grep vm-stats
+[mutsu vm-stats] method-call opcodes=9 interpreter_fallbacks=2 (22.2% of opcodes)
+```
+
+- `method-call opcodes` — explicit `.foo(...)` calls executed via the
+  `CallMethod*` opcode family (`exec_call_method_op` and its mut/dynamic variants).
+- `interpreter_fallbacks` — method executions delegated to the tree-walking
+  interpreter (`Interpreter::call_method_with_values` /
+  `call_method_mut_with_values`) from the VM.
+
+The two counters are measured at different layers, so `fallback` can exceed
+`total` for code dominated by implicit coercions (`.Str`/`.Numeric`/`.Bool`)
+that reach the interpreter without going through a method-call opcode. The
+counters are process-global atomics, so worker threads (Promise / Proc::Async /
+hyper) are included.
+
+The instrumentation is gated behind a single cached boolean and is a no-op when
+`MUTSU_VM_STATS` is unset.
+
+## Baseline (2026-06, PR #1 of the series)
+
+| program | method-call opcodes | interpreter fallbacks |
+|---|---|---|
+| `roast/S02-types/array.t` | 9 | 2 |
+| `roast/S32-str/sprintf.t` | 5 | 2 |
+| `await (^4).map: { start { (1..100).map(*.Str).join.chars } }` | 413 | 5 |
+
+### What the baseline already tells us
+
+The explicit method-call **execution** fallback rate is lower than expected:
+most heavy collection work (`push`, `map`, `grep`, `elems`, …) compiles to
+dedicated native opcodes (e.g. `ArrayPush`) that run in the VM and never reach
+the `CallMethod` path. So the dominant VM↔Interpreter coupling is **not** method
+execution delegation — it is the shared runtime *state* the VM borrows from the
+interpreter (~480 `env()`/`env_mut()` calls and the package/type/readonly state;
+see `ANALYSIS.md` §1.1–1.2).
+
+## Next steps (candidate strangler targets)
+
+1. Extend instrumentation to **function** dispatch (`call_function` /
+   `call_function_fallback`) — likely a larger fallback surface than methods.
+2. Instrument the dedicated native opcodes' delegation into `builtins`/`runtime`
+   to see where execution actually lands.
+3. Begin the state-ownership work (collapse the `locals`↔`env` dual store,
+   `ANALYSIS.md` §1.2) so the VM stops borrowing the interpreter's env.
+
+Record each step's before/after numbers in this file so the trend is visible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,14 @@ mod vm;
 pub use interpreter::Interpreter;
 pub use value::{RuntimeError, RuntimeErrorCode, Value};
 
+/// Print VM -> interpreter fallback statistics to stderr.
+///
+/// No-op unless the `MUTSU_VM_STATS` environment variable is set. Used to track
+/// progress on decoupling the bytecode VM from the tree-walking interpreter.
+pub fn dump_vm_stats() {
+    vm::vm_stats::dump();
+}
+
 /// Parse source code and return a pretty-printed AST string.
 #[allow(clippy::result_large_err)]
 pub fn dump_ast(input: &str) -> Result<String, RuntimeError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,6 +486,7 @@ fn run_main() {
             // Subtest-indented output is also flushed here.
             interpreter.flush_all_handles();
             interpreter.flush_stderr_buffer();
+            mutsu::dump_vm_stats();
             let code = interpreter.exit_code();
             // Always call process::exit to terminate any lingering background
             // threads (e.g. TCP accept loops for IO::Socket::Async listeners).
@@ -502,6 +503,7 @@ fn run_main() {
             }
             interpreter.flush_all_handles();
             interpreter.flush_stderr_buffer();
+            mutsu::dump_vm_stats();
             let code = interpreter.exit_code();
             std::process::exit(if code != 0 { code as i32 } else { 1 });
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -52,6 +52,7 @@ mod vm_native_dispatch;
 mod vm_register_ops;
 mod vm_set_ops;
 pub(crate) mod vm_smart_match;
+pub(crate) mod vm_stats;
 pub(crate) mod vm_string_regex_ops;
 mod vm_value_helpers;
 mod vm_var_assign_ops;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -118,6 +118,7 @@ impl VM {
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             if self.interpreter.is_native_method(&class, method) {
+                crate::vm::vm_stats::record_method_fallback();
                 return self
                     .interpreter
                     .call_method_with_values(target, method, args);
@@ -129,6 +130,7 @@ impl VM {
             method,
             "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"
         ) {
+            crate::vm::vm_stats::record_method_fallback();
             return self
                 .interpreter
                 .call_method_with_values(target, method, args);
@@ -224,6 +226,7 @@ impl VM {
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
+                crate::vm::vm_stats::record_method_fallback();
                 return self
                     .interpreter
                     .call_method_with_values(target, method, how_args);
@@ -350,6 +353,7 @@ impl VM {
                 }
             }
         }
+        crate::vm::vm_stats::record_method_fallback();
         self.interpreter
             .call_method_with_values(target, method, args)
     }
@@ -539,6 +543,7 @@ impl VM {
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             if self.interpreter.is_native_method(&class, method) {
+                crate::vm::vm_stats::record_method_fallback();
                 return self.interpreter.call_method_mut_with_values(
                     target_name,
                     target,
@@ -551,6 +556,7 @@ impl VM {
             method,
             "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"
         ) {
+            crate::vm::vm_stats::record_method_fallback();
             return self
                 .interpreter
                 .call_method_mut_with_values(target_name, target, method, args);
@@ -571,6 +577,7 @@ impl VM {
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
+                crate::vm::vm_stats::record_method_fallback();
                 return self
                     .interpreter
                     .call_method_with_values(target, method, how_args);
@@ -734,6 +741,7 @@ impl VM {
                 return Ok(result);
             }
         }
+        crate::vm::vm_stats::record_method_fallback();
         self.interpreter
             .call_method_mut_with_values(target_name, target, method, args)
     }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -9,6 +9,7 @@ impl VM {
         arity: u32,
         modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_method_dispatch();
         self.ensure_env_synced(code);
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
@@ -243,6 +244,7 @@ impl VM {
         target_name_idx: u32,
         modifier_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_method_dispatch();
         self.ensure_env_synced(code);
         let target_name = Self::const_str(code, target_name_idx).to_string();
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
@@ -317,6 +319,7 @@ impl VM {
         quoted: bool,
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_method_dispatch();
         self.ensure_env_synced(code);
         // Set pending arg sources for `is rw` dispatch matching
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
@@ -1166,6 +1169,7 @@ impl VM {
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));
                         // Perform the operation on the backing array
+                        crate::vm::vm_stats::record_method_fallback();
                         let result = self
                             .interpreter
                             .call_method_mut_with_values(

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -12,6 +12,7 @@ impl VM {
         quoted: bool,
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_method_dispatch();
         if self.locals_dirty {
             self.ensure_env_synced(code);
         }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -1,0 +1,66 @@
+//! Lightweight VM -> Interpreter fallback instrumentation.
+//!
+//! The bytecode VM is intended to execute everything natively, but today it
+//! still delegates a large fraction of method dispatch to the tree-walking
+//! `Interpreter` (see `ANALYSIS.md` section 1). This module counts how often
+//! that delegation happens so progress on decoupling the VM can be measured
+//! per change instead of guessed at.
+//!
+//! Disabled by default (a single relaxed atomic load guards every counter).
+//! Enable with `MUTSU_VM_STATS=1`; a one-line summary is printed to stderr at
+//! the end of the run via `crate::dump_vm_stats()`.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static METHOD_TOTAL: AtomicU64 = AtomicU64::new(0);
+static METHOD_FALLBACK: AtomicU64 = AtomicU64::new(0);
+
+/// Whether instrumentation is active. Resolved once from the environment so the
+/// hot path is a single cached boolean load when the feature is off.
+fn enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MUTSU_VM_STATS").is_some())
+}
+
+/// Record that an explicit method-call opcode (`.foo(...)`) was executed.
+#[inline]
+pub(crate) fn record_method_dispatch() {
+    if enabled() {
+        METHOD_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record that a method dispatch fell back to the tree-walking interpreter
+/// (`Interpreter::call_method_with_values`) instead of running compiled code.
+#[inline]
+pub(crate) fn record_method_fallback() {
+    if enabled() {
+        METHOD_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Print a one-line summary of VM fallback statistics to stderr.
+///
+/// No-op unless `MUTSU_VM_STATS` is set. Counts aggregate across worker threads
+/// (Promise/Proc::Async/hyper) because the counters are process-global.
+pub(crate) fn dump() {
+    if !enabled() {
+        return;
+    }
+    let total = METHOD_TOTAL.load(Ordering::Relaxed);
+    let fallback = METHOD_FALLBACK.load(Ordering::Relaxed);
+    let pct = if total == 0 {
+        0.0
+    } else {
+        fallback as f64 * 100.0 / total as f64
+    };
+    // `total` counts explicit method-call opcodes; `fallback` counts method
+    // executions delegated to the tree-walking interpreter. The two are
+    // measured at different layers, so `fallback` may exceed `total` for code
+    // dominated by implicit coercion calls (.Str/.Numeric/.Bool) that reach the
+    // interpreter without going through a method-call opcode.
+    eprintln!(
+        "[mutsu vm-stats] method-call opcodes={total} interpreter_fallbacks={fallback} ({pct:.1}% of opcodes)"
+    );
+}


### PR DESCRIPTION
バイトコード VM を tree-walking interpreter から切り離す **strangler-fig 方式**の第1歩です(PLAN.md / [ANALYSIS.md](ANALYSIS.md) §1)。「直す前にまず計測する」ため、VM→interpreter フォールバックの発生率を計測する仕組みを追加します。以降の各 PR が `フォールバック X%→Y%` を数字で示せるようになります。

## 変更内容
- **`src/vm/vm_stats.rs`** (新規): プロセスグローバルな atomic カウンタ。`MUTSU_VM_STATS` の有無を一度だけキャッシュした bool で全カウンタをガード(**未設定時は完全に no-op**)。
- 計測点:
  - 分母 = 明示的なメソッド呼び出し opcode (`exec_call_method_op` と mut/dynamic 変種)
  - フォールバック = `call_method_with_values` / `call_method_mut_with_values` への委譲(主・mut 両チョークポイント)
- `crate::dump_vm_stats()` が実行終了時に stderr へ1行サマリを出力。
- **`docs/vm-decoupling.md`** (新規): 計測方法・ベースライン・次の標的を記録(strangler の進捗台帳)。

## 使い方
\`\`\`
$ MUTSU_VM_STATS=1 ./target/debug/mutsu roast/S02-types/array.t 2>&1 | grep vm-stats
[mutsu vm-stats] method-call opcodes=9 interpreter_fallbacks=2 (22.2% of opcodes)
\`\`\`

## この時点で分かったこと
明示的メソッド呼び出しの**実行**フォールバック率はむしろ低い — `push`/`map`/`grep`/`elems` など重いコレクション操作は専用ネイティブ opcode (`ArrayPush` 等) にコンパイルされ `CallMethod` パスを通らないため。したがって VM↔Interpreter の支配的な結合は**実行委譲ではなく共有ランタイム状態**(env/env_mut 約480箇所)である(ANALYSIS §1.1–1.2)。次の標的: (1) 関数ディスパッチの計測、(2) `locals`↔`env` 二重ストアの解消。

## 確認
- `MUTSU_VM_STATS` 未設定時は挙動不変(計測は env ガードの no-op)。
- スレッド集約を確認(Promise ワーカー込みで 413 opcodes 計上)。
- `cargo clippy -- -D warnings` / `cargo fmt` 通過。whitelisted テスト(t/class.t, roast/6.d/S32-str/sprintf.t, numeric.t, comparison.t)はパス、回帰なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)