### PR TITLE
Nodal hyper methods return a List, not an Array (S03-metaops/hyper.t)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -26,6 +26,16 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
+  - ~124/159 pass (release runs further than debug; file aborts at test ~160 of
+    420). Fixed: nodal hyper methods (`>>.reverse`, `>>.sort`, `>>.elems`, etc.)
+    now return a `List` rather than an `Array`, matching Raku's gist (`(...)` vs
+    `[...]`); their computed values were already correct.
+  - Next blocker: `[[2,3],[4,[5,6]]]>>.splice(0,1)` (line 425, `#?rakudo todo`)
+    fatally errors with "No such method 'splice' for invocant of type 'Array'" —
+    `.splice` works on a named array variable but not on a bare Array value
+    (unlike `.push`/`.pop`/etc.), and the unhandled throw aborts the rest of the
+    file. Implementing `.splice` on Array values would unblock the remaining
+    ~260 tests (mostly the nodal-method block, now mostly fixed).
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
   - Current blocker: callable code-ref invocation in this file dies (`Unknown function ...: op`).

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -49,6 +49,10 @@ impl VM {
             crate::runtime::value_to_list(&target)
         };
         let mut results = Vec::with_capacity(items.len());
+        // A "nodal" hyper method (one natively defined on the list type, e.g.
+        // .reverse/.sort/.elems) operates on each node rather than recursing to
+        // leaves, and its hyper result is a List rather than an Array.
+        let mut method_is_nodal = false;
         for (idx, item) in items.iter_mut().enumerate() {
             let method = Self::rewrite_method_name(method_raw, modifier);
             // Special case: CALL-ME on callable items (from >>.(args) syntax).
@@ -273,6 +277,9 @@ impl VM {
                             | "flatmap"
                             | "pairup"
                     );
+                    if is_list_native_method {
+                        method_is_nodal = true;
+                    }
                     if is_iterable_item && !is_list_native_method {
                         let sub_items = crate::runtime::value_to_list(item);
                         let mut sub_results = Vec::with_capacity(sub_items.len());
@@ -428,9 +435,11 @@ impl VM {
             }
             _ => {}
         }
-        // Preserve the container type of the target: Array->Array, List->List
+        // Preserve the container type of the target: Array->Array, List->List.
+        // Nodal methods (applied at the node level) always yield a List, even
+        // when hypered over an Array (e.g. `[[2,3],[4,5]]>>.reverse` is a List).
         let result_kind = match &target {
-            Value::Array(_, kind) if kind.is_real_array() => ArrayKind::Array,
+            Value::Array(_, kind) if kind.is_real_array() && !method_is_nodal => ArrayKind::Array,
             _ => ArrayKind::List,
         };
         self.stack


### PR DESCRIPTION
## Summary

A **nodal** hyper method — one natively defined on the list type (`.reverse`, `.sort`, `.elems`, `.keys`, `.min`, etc.) — operates on each node rather than recursing to the leaves, and in Raku its hyper result is a `List` (gist `(...)`), whereas a non-nodal hyper method (e.g. `>>.abs`) preserves the invocant's `Array` type (gist `[...]`).

mutsu already computed the correct nodal **values**, but always wrapped the result in an `Array`, so `[[2,3],[4,[5,6]]]>>.reverse.gist` rendered as `[(3 2) ([5 6] 4)]` instead of `((3 2) ([5 6] 4))`. This tracks whether the hyper method was applied nodally and, if so, returns a `List`.

## Testing

- `roast/S03-metaops/hyper.t`: ~81 → ~124 passing of the 159 subtests reached before the file aborts. (The abort is a separate `.splice`-on-Array-value issue, documented in `TODO_roast/S03.md`.)
- `make test` and `make roast` both pass locally with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)