### PR TITLE
vm: instrument function-dispatch fallback rate (strangler step 2)

### DIFF
--- a/docs/vm-decoupling.md
+++ b/docs/vm-decoupling.md
@@ -17,11 +17,27 @@ $ MUTSU_VM_STATS=1 ./target/debug/mutsu roast/S02-types/array.t 2>&1 | grep vm-s
 [mutsu vm-stats] method-call opcodes=9 interpreter_fallbacks=2 (22.2% of opcodes)
 ```
 
-- `method-call opcodes` — explicit `.foo(...)` calls executed via the
-  `CallMethod*` opcode family (`exec_call_method_op` and its mut/dynamic variants).
-- `interpreter_fallbacks` — method executions delegated to the tree-walking
-  interpreter (`Interpreter::call_method_with_values` /
-  `call_method_mut_with_values`) from the VM.
+Two lines are printed — one for method dispatch, one for function dispatch:
+
+```
+[mutsu vm-stats] method-call opcodes=5 interpreter_fallbacks=2 (40.0% of opcodes)
+[mutsu vm-stats] function-call opcodes=198 interpreter_fallbacks=190 (96.0% of opcodes)
+```
+
+- `*-call opcodes` — explicit `.foo(...)` / `foo(...)` calls executed via the
+  `CallMethod*` opcode family (`exec_call_method_op` and its mut/dynamic
+  variants) and the `CallFunc*` family (`exec_call_func_op`,
+  `exec_call_func_slip_op`, `exec_call_on_value_op`, `exec_call_on_code_var_op`).
+- `interpreter_fallbacks` — executions delegated from the VM into the
+  interpreter: for methods, `Interpreter::call_method_with_values` /
+  `call_method_mut_with_values`; for functions, `Interpreter::call_function` /
+  `call_function_fallback`.
+
+Note on functions: `call_function` dispatches both user subs (tree-walked /
+on-the-fly compiled) *and* native-Rust builtins implemented in the interpreter
+crate. So a function "fallback" means "left the VM's compiled/native dispatch and
+entered the interpreter", which is exactly the coupling we want to remove, but it
+is not always a tree-walk.
 
 The two counters are measured at different layers, so `fallback` can exceed
 `total` for code dominated by implicit coercions (`.Str`/`.Numeric`/`.Bool`)
@@ -32,31 +48,46 @@ hyper) are included.
 The instrumentation is gated behind a single cached boolean and is a no-op when
 `MUTSU_VM_STATS` is unset.
 
-## Baseline (2026-06, PR #1 of the series)
+## Baseline (2026-06)
+
+method dispatch (PR #2571, strangler step 1):
 
 | program | method-call opcodes | interpreter fallbacks |
 |---|---|---|
-| `roast/S02-types/array.t` | 9 | 2 |
-| `roast/S32-str/sprintf.t` | 5 | 2 |
-| `await (^4).map: { start { (1..100).map(*.Str).join.chars } }` | 413 | 5 |
+| `roast/S02-types/array.t` | 9 | 2 (22%) |
+| `roast/6.d/S32-str/sprintf.t` | 5 | 2 (40%) |
+| `await (^4).map: { start { (1..100).map(*.Str).join.chars } }` | 413 | 5 (1%) |
 
-### What the baseline already tells us
+function dispatch (strangler step 2):
 
-The explicit method-call **execution** fallback rate is lower than expected:
-most heavy collection work (`push`, `map`, `grep`, `elems`, …) compiles to
-dedicated native opcodes (e.g. `ArrayPush`) that run in the VM and never reach
-the `CallMethod` path. So the dominant VM↔Interpreter coupling is **not** method
-execution delegation — it is the shared runtime *state* the VM borrows from the
-interpreter (~480 `env()`/`env_mut()` calls and the package/type/readonly state;
-see `ANALYSIS.md` §1.1–1.2).
+| program | function-call opcodes | interpreter fallbacks |
+|---|---|---|
+| `roast/S02-types/array.t` | 12 | 10 (83%) |
+| `roast/6.d/S32-str/sprintf.t` | 198 | 190 (96%) |
+| `roast/S04-statements/if.t` | 49 | 17 (35%) |
+| `fib(20)` (recursive user sub) | 21891 | 0 (0%) |
+
+### What the baseline tells us
+
+- **Method** execution fallback is *low*: most heavy collection work (`push`,
+  `map`, `grep`, `elems`, …) compiles to dedicated native opcodes (e.g.
+  `ArrayPush`) that run in the VM and never reach the `CallMethod` path.
+- **Function** execution fallback is *high* (often 80–96%): builtins and `Test`
+  functions (`is`/`ok`/`plan`/`sprintf`/`join`/…) are not in the VM's native
+  function table, so they route through `Interpreter::call_function`. Recursive
+  user subs, by contrast, compile cleanly (`fib(20)` → 0% fallback).
+
+So the two biggest decoupling levers are:
+1. the shared runtime **state** the VM borrows from the interpreter (~480
+   `env()`/`env_mut()` calls; `ANALYSIS.md` §1.1–1.2), and
+2. **function** dispatch — moving hot builtins/`Test` functions into the VM's
+   native dispatch so they stop routing through `call_function`.
 
 ## Next steps (candidate strangler targets)
 
-1. Extend instrumentation to **function** dispatch (`call_function` /
-   `call_function_fallback`) — likely a larger fallback surface than methods.
-2. Instrument the dedicated native opcodes' delegation into `builtins`/`runtime`
-   to see where execution actually lands.
-3. Begin the state-ownership work (collapse the `locals`↔`env` dual store,
+1. Move the hottest builtins / `Test` functions into the VM's
+   `try_native_function` table so they execute without `call_function`.
+2. Begin the state-ownership work (collapse the `locals`↔`env` dual store,
    `ANALYSIS.md` §1.2) so the VM stops borrowing the interpreter's env.
 
 Record each step's before/after numbers in this file so the trend is visible.

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -65,6 +65,7 @@ impl VM {
         {
             return self.compile_and_call_function_def(&def, args, compiled_fns);
         }
+        crate::vm::vm_stats::record_function_fallback();
         self.interpreter.call_function(name, args)
     }
 

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -33,6 +33,7 @@ impl VM {
         arg_sources_idx: Option<u32>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_function_dispatch();
         // Ultra-fast path: positional light-call cache for positional-only functions.
         {
             let name_str = Self::const_str(code, name_idx);
@@ -361,6 +362,7 @@ impl VM {
         slip_pos: Option<u32>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_function_dispatch();
         self.ensure_env_synced(code);
         let name = Self::const_str(code, name_idx).to_string();
         let total = regular_arity as usize + 1; // +1 for the slip value
@@ -403,6 +405,7 @@ impl VM {
             self.env_dirty = true;
         } else if self.interpreter.user_function_matches_call(&name, &args) {
             // A user-defined sub shadows a same-named builtin.
+            crate::vm::vm_stats::record_function_fallback();
             let result = self.interpreter.call_function_fallback(&name, &args)?;
             let result = self.interpreter.maybe_fetch_rw_proxy(result, true)?;
             self.stack.push(result);
@@ -429,6 +432,7 @@ impl VM {
         arg_sources_idx: Option<u32>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_function_dispatch();
         self.ensure_env_synced(code);
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
@@ -490,6 +494,7 @@ impl VM {
         arg_sources_idx: Option<u32>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_function_dispatch();
         self.ensure_env_synced(code);
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
@@ -667,12 +672,14 @@ impl VM {
                 // User-defined multi candidates take priority over builtins.
                 // Call call_function_fallback directly to bypass the builtin match
                 // in call_function, which would shadow user-defined multi subs.
+                crate::vm::vm_stats::record_function_fallback();
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function_fallback(name, &args);
                 self.interpreter.set_pending_call_arg_sources(None);
                 self.interpreter.maybe_fetch_rw_proxy(result?, true)
             } else if self.interpreter.user_function_matches_call(name, &args) {
                 // A user-defined sub shadows a same-named builtin.
+                crate::vm::vm_stats::record_function_fallback();
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function_fallback(name, &args);
                 self.interpreter.set_pending_call_arg_sources(None);
@@ -700,6 +707,7 @@ impl VM {
                 if name == "start" {
                     self.sync_env_from_locals(code);
                 }
+                crate::vm::vm_stats::record_function_fallback();
                 self.interpreter.set_pending_call_arg_sources(arg_sources);
                 let result = self.interpreter.call_function(name, args);
                 self.interpreter.set_pending_call_arg_sources(None);

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -15,6 +15,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static METHOD_TOTAL: AtomicU64 = AtomicU64::new(0);
 static METHOD_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static FUNCTION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static FUNCTION_FALLBACK: AtomicU64 = AtomicU64::new(0);
 
 /// Whether instrumentation is active. Resolved once from the environment so the
 /// hot path is a single cached boolean load when the feature is off.
@@ -40,6 +42,24 @@ pub(crate) fn record_method_fallback() {
     }
 }
 
+/// Record that an explicit function-call opcode (`foo(...)`) was executed.
+#[inline]
+pub(crate) fn record_function_dispatch() {
+    if enabled() {
+        FUNCTION_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record that a function dispatch fell back to the tree-walking interpreter
+/// (`Interpreter::call_function` / `call_function_fallback`) instead of running
+/// compiled or native code.
+#[inline]
+pub(crate) fn record_function_fallback() {
+    if enabled() {
+        FUNCTION_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Print a one-line summary of VM fallback statistics to stderr.
 ///
 /// No-op unless `MUTSU_VM_STATS` is set. Counts aggregate across worker threads
@@ -48,19 +68,30 @@ pub(crate) fn dump() {
     if !enabled() {
         return;
     }
-    let total = METHOD_TOTAL.load(Ordering::Relaxed);
-    let fallback = METHOD_FALLBACK.load(Ordering::Relaxed);
-    let pct = if total == 0 {
+    // `*_opcodes` count explicit call opcodes; `*_fallbacks` count executions
+    // delegated to the tree-walking interpreter. The two are measured at
+    // different layers, so a `fallback` count may exceed its opcode count for
+    // code dominated by calls that reach the interpreter without going through
+    // a call opcode (implicit coercions like .Str/.Numeric/.Bool for methods;
+    // Routine-value and meta-operator calls for functions).
+    let m_total = METHOD_TOTAL.load(Ordering::Relaxed);
+    let m_fallback = METHOD_FALLBACK.load(Ordering::Relaxed);
+    let m_pct = if m_total == 0 {
         0.0
     } else {
-        fallback as f64 * 100.0 / total as f64
+        m_fallback as f64 * 100.0 / m_total as f64
     };
-    // `total` counts explicit method-call opcodes; `fallback` counts method
-    // executions delegated to the tree-walking interpreter. The two are
-    // measured at different layers, so `fallback` may exceed `total` for code
-    // dominated by implicit coercion calls (.Str/.Numeric/.Bool) that reach the
-    // interpreter without going through a method-call opcode.
+    let f_total = FUNCTION_TOTAL.load(Ordering::Relaxed);
+    let f_fallback = FUNCTION_FALLBACK.load(Ordering::Relaxed);
+    let f_pct = if f_total == 0 {
+        0.0
+    } else {
+        f_fallback as f64 * 100.0 / f_total as f64
+    };
     eprintln!(
-        "[mutsu vm-stats] method-call opcodes={total} interpreter_fallbacks={fallback} ({pct:.1}% of opcodes)"
+        "[mutsu vm-stats] method-call opcodes={m_total} interpreter_fallbacks={m_fallback} ({m_pct:.1}% of opcodes)"
+    );
+    eprintln!(
+        "[mutsu vm-stats] function-call opcodes={f_total} interpreter_fallbacks={f_fallback} ({f_pct:.1}% of opcodes)"
     );
 }


### PR DESCRIPTION
**strangler step 2** ([step1 #2571](https://github.com/tokuhirom/mutsu/pull/2571) にスタック)。`MUTSU_VM_STATS` をメソッドに加えて**関数ディスパッチ**にも拡張します。

> ⚠️ base が `vm/instrument-fallback-rate` (step1) です。step1 がマージされれば自動で main に張り替わります。差分の純増分は最新コミットのみ。

## 変更
- 分母 = 関数呼び出し opcode (`exec_call_func_op` / `exec_call_func_slip_op` / `exec_call_on_value_op` / `exec_call_on_code_var_op`)
- フォールバック = `Interpreter::call_function` / `call_function_fallback` への委譲(中心の `call_function_compiled_first` フォールバック + `exec_call_func_op`・`dispatch_func_call_inner` の user-shadow/multi/final 各サイト)
- `docs/vm-decoupling.md` に関数ベースラインを追記

## 判明したこと(重要)
**関数のフォールバック率はメソッドよりはるかに高い** — 組込み・Test 関数 (`is`/`ok`/`plan`/`sprintf`/`join`) が `call_function` 経由になるため:

| program | function opcodes | fallback |
|---|---|---|
| `roast/6.d/S32-str/sprintf.t` | 198 | **190 (96%)** |
| `roast/S02-types/array.t` | 12 | 10 (83%) |
| `roast/S04-statements/if.t` | 49 | 17 (35%) |
| `fib(20)` (再帰ユーザ sub) | 21891 | **0 (0%)** |

メソッド実行はほぼコンパイル済みだが、**関数ディスパッチが本命の切り離し標的**。次ステップ: ホットな組込み/Test 関数を VM の `try_native_function` に移し `call_function` を経由しないようにする。

(注: `call_function` はユーザ sub だけでなく interpreter crate 内のネイティブ Rust 組込みも捌くため、"fallback" は「VM のネイティブ/コンパイル済みディスパッチを離れ interpreter に入った」を意味し、必ずしも tree-walk ではない。doc に明記。)

## 確認
- `MUTSU_VM_STATS` 未設定時は挙動不変。`cargo clippy -D warnings` / `cargo fmt` 通過。回帰スモーク(class.t, sprintf.t, if.t)パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)