### PR TITLE
Support .splice on a bare Array value (S03-metaops/hyper.t)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -30,12 +30,11 @@
     420). Fixed: nodal hyper methods (`>>.reverse`, `>>.sort`, `>>.elems`, etc.)
     now return a `List` rather than an `Array`, matching Raku's gist (`(...)` vs
     `[...]`); their computed values were already correct.
-  - Next blocker: `[[2,3],[4,[5,6]]]>>.splice(0,1)` (line 425, `#?rakudo todo`)
-    fatally errors with "No such method 'splice' for invocant of type 'Array'" —
-    `.splice` works on a named array variable but not on a bare Array value
-    (unlike `.push`/`.pop`/etc.), and the unhandled throw aborts the rest of the
-    file. Implementing `.splice` on Array values would unblock the remaining
-    ~260 tests (mostly the nodal-method block, now mostly fixed).
+  - `.splice` now works on a bare Array value (returns the removed elements as
+    an Array), so the file runs to ~180. Next blocker: hash hyper ops like
+    `my %r = %a >>+<< %b` throw "Odd number of elements found where hash
+    initializer expected" — the hyper hash result isn't a clean list of pairs,
+    so assigning it to `%r` fails and aborts the rest of the file.
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
   - Current blocker: callable code-ref invocation in this file dies (`Unknown function ...: op`).

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1000,7 +1000,7 @@ impl Interpreter {
         // Mutating array methods on Value::Array (non-container path)
         if matches!(
             method,
-            "push" | "pop" | "shift" | "unshift" | "append" | "prepend"
+            "push" | "pop" | "shift" | "unshift" | "append" | "prepend" | "splice"
         ) && matches!(&target, Value::Array(_, kind) if kind.is_real_array())
         {
             // Check element type constraints from container metadata (e.g., typed attribute arrays)

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -292,6 +292,46 @@ impl Interpreter {
                 }
                 Ok(Value::Array(Arc::new(items), kind))
             }
+            "splice" => {
+                // On a bare Array value (not a named variable) there is no
+                // container to write back to, so return the removed elements as
+                // a List, matching `@a.splice(...)`'s return value.
+                let len = items.len();
+                let resolve = |v: &Value| -> i64 {
+                    match v {
+                        Value::Int(i) => *i,
+                        Value::Whatever => len as i64,
+                        Value::Num(n) => *n as i64,
+                        Value::Str(s) => s.parse::<i64>().unwrap_or(0),
+                        Value::Mixin(inner, _) => match inner.as_ref() {
+                            Value::Int(i) => *i,
+                            _ => 0,
+                        },
+                        _ => 0,
+                    }
+                };
+                let start = (args.first().map(&resolve).unwrap_or(0).max(0) as usize).min(len);
+                let count = args
+                    .get(1)
+                    .map(&resolve)
+                    .unwrap_or((len - start) as i64)
+                    .max(0) as usize;
+                let end = (start + count).min(len);
+                let removed: Vec<Value> = items.drain(start..end).collect();
+                let mut replacement: Vec<Value> = Vec::new();
+                for arg in args.iter().skip(2) {
+                    match arg {
+                        Value::Array(arr, ..) | Value::Seq(arr) | Value::Slip(arr) => {
+                            replacement.extend(arr.iter().cloned())
+                        }
+                        other => replacement.push(other.clone()),
+                    }
+                }
+                for (i, item) in replacement.into_iter().enumerate() {
+                    items.insert(start + i, item);
+                }
+                Ok(Value::real_array(removed))
+            }
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
## Summary

`.splice` was only handled when the invocant was a named `@`-variable; calling it on a bare Array value — e.g. `[1,2,3].splice(0,1)` or via hyper `[[2,3],[4,5]]>>.splice(0,1)` — threw `No such method 'splice' for invocant of type 'Array'`, which aborted `roast/S03-metaops/hyper.t` mid-file.

This routes `splice` through the same non-container value path as `push`/`pop`/`shift`/`unshift`/`append`/`prepend` (`array_mutate_copy`), returning the removed elements as an `Array` to match `@a.splice(...)`.

## Testing

- `[1,2,3].splice(0,1)` now returns `[1]` (Array), matching Rakudo; named-variable splice is unchanged (`@a.splice(...)` still routes through the container path).
- `roast/S03-metaops/hyper.t` now runs to ~180 (was ~160).
- `make test` and `make roast` both pass locally with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)