### PR TITLE
Hyper ops on two hashes combine values key-by-key (S03-metaops/hyper.t)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -26,15 +26,12 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
-  - ~124/159 pass (release runs further than debug; file aborts at test ~160 of
-    420). Fixed: nodal hyper methods (`>>.reverse`, `>>.sort`, `>>.elems`, etc.)
-    now return a `List` rather than an `Array`, matching Raku's gist (`(...)` vs
-    `[...]`); their computed values were already correct.
-  - `.splice` now works on a bare Array value (returns the removed elements as
-    an Array), so the file runs to ~180. Next blocker: hash hyper ops like
-    `my %r = %a >>+<< %b` throw "Odd number of elements found where hash
-    initializer expected" — the hyper hash result isn't a clean list of pairs,
-    so assigning it to `%r` fails and aborts the rest of the file.
+  - Runs to ~236 of 420. Fixed: nodal hyper methods return a `List` not an
+    `Array`; `.splice` on a bare Array value; hyper ops on two hashes
+    (`%a >>+<< %b`, key-set selected by dwim arrows).
+  - Next blocker: hyper unary postfix with a *custom* operator on a hash
+    (`%a>>!` where `sub postfix:<!>`) — `Too few positionals passed` because the
+    hash value isn't passed to the postfix sub; aborts the rest of the file.
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
   - Current blocker: callable code-ref invocation in this file dies (`Unknown function ...: op`).

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -975,6 +975,42 @@ impl VM {
         let right = self.stack.pop().unwrap_or(Value::Nil);
         let left = self.stack.pop().unwrap_or(Value::Nil);
         let op = Self::const_str(code, op_idx).to_string();
+        // Hyper op on two hashes: combine values key-by-key, with the dwim arrows
+        // selecting the resulting key set. A missing value on either side uses the
+        // operator's identity element (e.g. 0 for `+`).
+        if let (Value::Hash(la), Value::Hash(ra)) = (&left, &right) {
+            let la = la.clone();
+            let ra = ra.clone();
+            // Key set by dwim direction:
+            //   >>op<<  (neither dwims)  -> union
+            //   <<op>>  (both dwim)      -> intersection
+            //   >>op>>  (right dwims)    -> left's keys
+            //   <<op<<  (left dwims)     -> right's keys
+            let keys: Vec<String> = match (dwim_left, dwim_right) {
+                (false, false) => {
+                    let mut ks: Vec<String> = la.keys().cloned().collect();
+                    for k in ra.keys() {
+                        if !la.contains_key(k) {
+                            ks.push(k.clone());
+                        }
+                    }
+                    ks
+                }
+                (true, true) => la.keys().filter(|k| ra.contains_key(*k)).cloned().collect(),
+                (false, true) => la.keys().cloned().collect(),
+                (true, false) => ra.keys().cloned().collect(),
+            };
+            let identity = runtime::reduction_identity(&op);
+            let mut result = std::collections::HashMap::with_capacity(keys.len());
+            for key in keys {
+                let l = la.get(&key).unwrap_or(&identity).clone();
+                let r = ra.get(&key).unwrap_or(&identity).clone();
+                let v = self.eval_reduction_operator_values(&op, &l, &r)?;
+                result.insert(key, v);
+            }
+            self.stack.push(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(());
+        }
         let both_scalar = !Self::is_listy(&left) && !Self::is_listy(&right);
         let left_list = Interpreter::value_to_list(&left);
         let right_list = Interpreter::value_to_list(&right);

--- a/t/hyper-hash-ops.t
+++ b/t/hyper-hash-ops.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 19;
+
+my %a = a => 1, b => 2, c => 3;
+my %b = a => 5, b => 6, c => 7;
+my %c = a => 1, b => 2;
+my %d = a => 5, b => 6;
+
+# >>op<< : union of keys, missing side uses identity (0 for +)
+{
+    my %r = %a >>+<< %b;
+    is +%r, 3, '>>+<< same keys: count';
+    is %r<a>, 6, '>>+<< a';
+    is %r<b>, 8, '>>+<< b';
+    is %r<c>, 10, '>>+<< c';
+}
+
+{
+    my %r = %c >>+<< %b;
+    is +%r, 3, '>>+<< union: count';
+    is %r<c>, 7, '>>+<< union: missing-left uses 0';
+}
+
+# <<op>> : intersection of keys
+{
+    my %r = %a <<+>> %d;
+    is +%r, 2, '<<+>> intersection: count';
+    is %r<a>, 6, '<<+>> a';
+    is %r<b>, 8, '<<+>> b';
+}
+
+# >>op>> : left operand's keys
+{
+    my %r = %a >>+>> %c;
+    is +%r, 3, '>>+>> left keys: count';
+    is %r<a>, 2, '>>+>> a';
+    is %r<c>, 3, '>>+>> missing-right uses 0';
+}
+
+# <<op<< : right operand's keys
+{
+    my %r = %c <<+<< %a;
+    is +%r, 3, '<<+<< right keys: count';
+    is %r<a>, 2, '<<+<< a';
+    is %r<c>, 3, '<<+<< missing-left uses 0';
+}
+
+# Other operators
+{
+    my %r = %a >>*<< %b;
+    is %r<a>, 5, '>>*<< a';
+    is %r<b>, 12, '>>*<< b';
+}
+
+{
+    my %x = a => 'foo', b => 'bar';
+    my %y = a => '1', b => '2';
+    my %r = %x >>~<< %y;
+    is %r<a>, 'foo1', '>>~<< string concat a';
+    is %r<b>, 'bar2', '>>~<< string concat b';
+}


### PR DESCRIPTION
## Summary

`%a >>+<< %b` and friends were flattening both hashes to value lists and zipping them, producing nonsense like `(0, 0, 0)` instead of a `Hash`. This handles the two-hash case directly in the hyper-op VM handler: combine the values for each key with the infix op, using the operator's identity element (e.g. `0` for `+`) when a key is present on only one side.

The dwim arrows select the resulting key set:

| Form | Key set |
|------|---------|
| `>>op<<` (neither dwims) | union of keys |
| `<<op>>` (both dwim) | intersection of keys |
| `>>op>>` (right dwims) | left operand's keys |
| `<<op<<` (left dwims) | right operand's keys |

## Testing

- New `t/hyper-hash-ops.t` (19 cases) covering all four arrow forms, identity-fill for missing keys, and `+`/`*`/`~` operators.
- `roast/S03-metaops/hyper.t` runs further (the hash-hyper block, ~tests 200–236, now passes; combined with the `.splice` fix in #2575 the file reaches ~236).
- `make test` and `make roast` both pass locally with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)