### PR TITLE
Hyper method/postfix on a hash, and hash<->scalar hyper ops (S03-metaops/hyper.t)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -26,12 +26,14 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
-  - Runs to ~236 of 420. Fixed: nodal hyper methods return a `List` not an
-    `Array`; `.splice` on a bare Array value; hyper ops on two hashes
-    (`%a >>+<< %b`, key-set selected by dwim arrows).
-  - Next blocker: hyper unary postfix with a *custom* operator on a hash
-    (`%a>>!` where `sub postfix:<!>`) — `Too few positionals passed` because the
-    hash value isn't passed to the postfix sub; aborts the rest of the file.
+  - ~267 pass, runs to ~358 of 420. Fixed: nodal hyper methods return a `List`;
+    `.splice` on a bare Array value; hyper ops on two hashes (`%a >>+<< %b`);
+    hyper method/custom-postfix on a hash applies to each value preserving keys
+    (`%h>>.uc`, `%a>>!`); hyper op between a hash and a scalar (`%a >>*>> 4`).
+  - Next blocker: hyper meta-assignment write-back on a list of scalars
+    (`($a,$b,$c) »~=» <pie tart>` should mutate `$a`/`$b`/`$c`), and `>>[+]<<`
+    (a reduction op used as the inner hyper op). Both are the same
+    hyper-meta-assignment feature tracked under infix.t.
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
   - Current blocker: callable code-ref invocation in this file dies (`Unknown function ...: op`).

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -32,8 +32,23 @@ impl VM {
         if let Value::Seq(ref arc) = target {
             crate::value::seq_consume(arc)?;
         }
+        // Hyper method/postfix on a Hash applies to each *value*, preserving the
+        // keys: `%h>>.uc` and `%h>>!` yield a Hash, not a list of pairs.
+        let hash_keys: Option<Vec<String>> = if let Value::Hash(map) = &target {
+            Some(map.keys().cloned().collect())
+        } else {
+            None
+        };
         // For Buf/Blob instances, expand to individual byte values for hyper dispatch
-        let mut items = if let Value::Instance {
+        let mut items = if let Some(keys) = &hash_keys {
+            if let Value::Hash(map) = &target {
+                keys.iter()
+                    .map(|k| map.get(k).cloned().unwrap_or(Value::Nil))
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        } else if let Value::Instance {
             class_name,
             attributes,
             ..
@@ -434,6 +449,16 @@ impl VM {
                 return Ok(());
             }
             _ => {}
+        }
+        // Hash target: rebuild a Hash pairing the original keys with the
+        // per-value results.
+        if let Some(keys) = hash_keys {
+            let mut map = std::collections::HashMap::with_capacity(keys.len());
+            for (key, value) in keys.into_iter().zip(results) {
+                map.insert(key, value);
+            }
+            self.stack.push(Value::Hash(std::sync::Arc::new(map)));
+            return Ok(());
         }
         // Preserve the container type of the target: Array->Array, List->List.
         // Nodal methods (applied at the node level) always yield a List, even

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1011,6 +1011,34 @@ impl VM {
             self.stack.push(Value::Hash(std::sync::Arc::new(result)));
             return Ok(());
         }
+        // Hyper op between a hash and a scalar: apply the op to each value with
+        // the scalar broadcast over every key (`%h >>*>> 4`, `2 <<**<< %h`).
+        if let Value::Hash(map) = &left
+            && !Self::is_listy(&right)
+        {
+            let map = map.clone();
+            let scalar = right.clone();
+            let mut result = std::collections::HashMap::with_capacity(map.len());
+            for (key, value) in map.iter() {
+                let v = self.eval_reduction_operator_values(&op, value, &scalar)?;
+                result.insert(key.clone(), v);
+            }
+            self.stack.push(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(());
+        }
+        if let Value::Hash(map) = &right
+            && !Self::is_listy(&left)
+        {
+            let map = map.clone();
+            let scalar = left.clone();
+            let mut result = std::collections::HashMap::with_capacity(map.len());
+            for (key, value) in map.iter() {
+                let v = self.eval_reduction_operator_values(&op, &scalar, value)?;
+                result.insert(key.clone(), v);
+            }
+            self.stack.push(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(());
+        }
         let both_scalar = !Self::is_listy(&left) && !Self::is_listy(&right);
         let left_list = Interpreter::value_to_list(&left);
         let right_list = Interpreter::value_to_list(&right);

--- a/t/hyper-hash-method-scalar.t
+++ b/t/hyper-hash-method-scalar.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 14;
+
+# Hyper method on a hash applies to each value, preserving keys
+{
+    my %h = a => 'x', b => 'y';
+    my %r = %h>>.uc;
+    is %r<a>, 'X', '>>.uc on hash value a';
+    is %r<b>, 'Y', '>>.uc on hash value b';
+    is +%r, 2, '>>.uc keeps key count';
+}
+
+# Hyper custom postfix on a hash
+{
+    sub postfix:<!>($n) { [*] 1..$n }
+    my %a = a => 1, b => 2, c => 3;
+    my %r = %a>>!;
+    is %r<a>, 1, '>>! a';
+    is %r<b>, 2, '>>! b';
+    is %r<c>, 6, '>>! c';
+    is +%r, 3, '>>! key count';
+}
+
+# Hyper op between a hash and a scalar (scalar broadcast over keys)
+{
+    my %a = a => 1, b => 2, c => 3;
+    my %r = %a >>*>> 4;
+    is %r<a>, 4, 'hash >>*>> scalar a';
+    is %r<b>, 8, 'hash >>*>> scalar b';
+    is %r<c>, 12, 'hash >>*>> scalar c';
+}
+
+{
+    my %a = a => 1, b => 2, c => 3;
+    my %r = 2 <<**<< %a;
+    is %r<a>, 2, 'scalar <<**<< hash a';
+    is %r<b>, 4, 'scalar <<**<< hash b';
+    is %r<c>, 8, 'scalar <<**<< hash c';
+    is +%r, 3, 'scalar-hash key count';
+}


### PR DESCRIPTION
## Summary

Two more hash hyper cases on top of #2576:

- **Hyper method / custom postfix on a hash** applies to each *value* and rebuilds a `Hash` with the same keys: `%h>>.uc` yields `{:a("X"), :b("Y")}`, and `%a>>!` (with `sub postfix:<!>`) applies `!` to each value. Previously `value_to_list` turned the hash into Pairs and the method ran on the pairs, producing a list.
- **Hyper op between a hash and a scalar** broadcasts the scalar over every key: `%a >>*>> 4` and `2 <<**<< %a` now yield a `Hash`.

## Testing

- New `t/hyper-hash-method-scalar.t` (14 cases).
- `roast/S03-metaops/hyper.t` now reaches ~358 of 420 (~267 passing, up from ~124 at the start of this hyper.t work). The remaining blocker is hyper meta-assignment write-back (same feature as infix.t).
- `make test` and `make roast` both pass locally with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)