### PR TITLE
Hyper meta-assignment over a list of lvalues writes back (S03-metaops/hyper.t)

### DIFF
--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -214,6 +214,26 @@ impl Compiler {
         let is_assign_op = op.ends_with('=')
             && op.len() > 1
             && !matches!(op, "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>");
+        // Hyper meta-assignment over a literal list of lvalues, e.g.
+        // `($a, $b, $c) »~=» <pie tart>`: compute the element-wise result with
+        // the base op, then distribute it back to each lvalue via the regular
+        // list-assignment machinery so each scalar is mutated.
+        if is_assign_op && matches!(left, Expr::ArrayLiteral(_)) {
+            let base_op = op[..op.len() - 1].to_string();
+            let value_expr = Expr::HyperOp {
+                op: base_op,
+                left: Box::new(left.clone()),
+                right: Box::new(right.clone()),
+                dwim_left,
+                dwim_right,
+            };
+            let assign_call = Expr::Call {
+                name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![left.clone(), Expr::ArrayLiteral(vec![]), value_expr],
+            };
+            self.compile_expr(&assign_call);
+            return;
+        }
         if is_assign_op {
             let base_op = &op[..op.len() - 1];
             self.compile_expr(left);

--- a/t/hyper-meta-assign-list.t
+++ b/t/hyper-meta-assign-list.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 10;
+
+# Hyper meta-assignment over a literal list of scalar lvalues mutates each one.
+{
+    my $a = 'apple';
+    my $b = 'blueberry';
+    my $c = 'cherry';
+    my @r = (($a, $b, $c) »~=» <pie tart>);
+    is @r.join(','), 'applepie,blueberrytart,cherrypie', 'returns the new values';
+    is $a, 'applepie', '$a mutated';
+    is $b, 'blueberrytart', '$b mutated';
+    is $c, 'cherrypie', '$c mutated (rhs cycled)';
+}
+
+{
+    my $x = 1;
+    my $y = 2;
+    my $z = 3;
+    ($x, $y, $z) »+=» (10, 20, 30);
+    is $x, 11, '+= a';
+    is $y, 22, '+= b';
+    is $z, 33, '+= c';
+}
+
+{
+    my $a = 2;
+    my $b = 3;
+    ($a, $b) »*=» 5;
+    is $a, 10, '*= scalar broadcast a';
+    is $b, 15, '*= scalar broadcast b';
+}
+
+{
+    my @arr = 1, 2, 3;
+    @arr »+=» 100;
+    is @arr.join(','), '101,102,103', 'hyper += on array elements';
+}


### PR DESCRIPTION
## Summary

`($a, $b, $c) »~=» <pie tart>` computed the right element-wise values but discarded them — the result wasn't written back to `$a`/`$b`/`$c` because the hyper-assign compiler only handled a single `Var`/`ArrayVar`/`Index` lvalue, not a literal list of them.

When the left operand of a hyper meta-assignment is an `ArrayLiteral`, this computes the element-wise result with the base op and distributes it back to each lvalue via the regular list-assignment lowering (`__mutsu_assign_callable_lvalue`), so every scalar is mutated and the new values are returned.

## Testing

- New `t/hyper-meta-assign-list.t` (10 cases): `»~=»`, `»+=»`, scalar-broadcast `»*=» 5`, and array-element `@arr »+=» 100`.
- `make roast` passes with no regressions; `t/` shows only the pre-existing placeholder.t / tail-function.t failures.
- Unblocks the `»~=»` / `»+=»` scalar-list writeback block in `roast/S03-metaops/hyper.t` (reached once the hash-hyper fixes in #2578 land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)