### PR TITLE
Support a reduction op as the inner op of a hyper op (S03-metaops/hyper.t)

### DIFF
--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -26,6 +26,15 @@ impl VM {
         left: &Value,
         right: &Value,
     ) -> Result<Value, RuntimeError> {
+        // A reduction operator used as the inner op of a hyper op, e.g.
+        // `(1,2) >>[+]<< (100,200)`. Reducing the base op over the two operands
+        // is just the base op applied once.
+        if let Some(inner) = op.strip_prefix('[')
+            && let Some(inner_op) = inner.strip_suffix(']')
+            && !inner_op.is_empty()
+        {
+            return self.eval_reduction_operator_values(inner_op, left, right);
+        }
         if let Some(inner_op) = op.strip_prefix('R')
             && !inner_op.is_empty()
         {

--- a/t/hyper-reduction-inner-op.t
+++ b/t/hyper-reduction-inner-op.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 6;
+
+# A reduction operator used as the inner op of a hyper op applies the base op
+# to each pair (reducing a binary op over two operands is the op itself).
+is ((1, 2) >>[+]<< (100, 200)).join(','), '101,202', '>>[+]<< adds pairwise';
+is ((1, 2, 3) >>[*]<< (2, 3, 4)).join(','), '2,6,12', '>>[*]<< multiplies pairwise';
+is (('a', 'b') >>[~]<< ('x', 'y')).join(','), 'ax,by', '>>[~]<< concats pairwise';
+
+# dwim forms
+is ((1, 2, 3) >>[+]>> 10).join(','), '11,12,13', '>>[+]>> with scalar';
+is (10 <<[+]<< (1, 2, 3)).join(','), '11,12,13', '<<[+]<< with scalar';
+
+# longer list, same op
+is ((1, 2, 3, 4) >>[-]<< (1, 1, 1, 1)).join(','), '0,1,2,3', '>>[-]<< subtracts pairwise';


### PR DESCRIPTION
## Summary

`(1, 2) >>[+]<< (100, 200)` threw `Unsupported reduction operator: [+]`. Reducing a binary op over the two hyper operands is just the base op applied once, so strip the `[...]` and recurse with the inner op in `eval_reduction_operator_values`.

## Testing

- New `t/hyper-reduction-inner-op.t` (6 cases): `>>[+]<<`, `>>[*]<<`, `>>[~]<<`, dwim forms, and a longer list.
- `roast/S03-metaops/hyper.t` runs to ~389 of 420 (was ~358).
- `make roast` passes locally with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)