### PR TITLE
vm: shrink closure capture-state work from O(env) to free variables (2.3-3x closure speedup)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -147,9 +147,63 @@ Reaching that requires, roughly in order:
       (`opcode.rs:1175`), so most non-leaf methods are not `can_skip_merge`.
       (Pre-existing, unrelated: `t/tail-function.t` test 4 fails in *debug*
       builds on `main` too — a release-only PredictiveIterator path.)
-- [ ] **Slice 3 — closure upvalues.** Capture free variables explicitly so
-      closures stop reading parent `env`; drop the conservative whole-frame
-      `needs_env_sync`.
+- [x] **Slice 3 — shrink closure capture-state work to free variables.** Done.
+
+      **Measurement first (the headline was *not* deep copies).** A closure-heavy
+      micro-benchmark (5000× a factory sub that builds a closure and calls it 20×,
+      = 105000 closure calls) runs in **~15 s** and `MUTSU_VM_STATS` reports ~2
+      `env_deep_copies` per closure call. But a `perf` profile showed `Env::cow_mut`
+      (the deep copy) is only **1.3 %** of runtime. The real cost is the
+      **per-call O(captured-env) work**: every closure call iterates the *entire*
+      captured env (~110 entries, because `MakeBlockClosure` captures
+      `self.env.clone()` = the whole outer env) in several loops —
+      `cap_overrides`, the state persist loop, the readonly/alias writeback, and
+      the state-key sync — each doing a `format!("__mutsu_closure_cap::{id}::{k}")`
+      (or similar) per entry. Profile hotspots: `Symbol::intern` 9.3 %, hashing
+      ~14 %, `format!`/`Display` ~10 %. ~550 `format!` allocations **per closure
+      call**.
+
+      **Backtraces** (gated `MUTSU_DEEPCOPY_BT` in `Env::cow_mut`) further showed
+      the residual deep copies come from the `&?BLOCK` setup insert and the
+      param-binding env write — both feeding cross-cutting interpreter features
+      (`last`/`next` target resolution, `&?ROUTINE`, regex `$/`) that read
+      `__mutsu_callable_id` / `&?BLOCK` from `env` *by name* even when the body
+      text never mentions them. So those env writes **cannot** be made conditional
+      or removed piecemeal — confirming the deep-copy count itself only falls with
+      the full scoped/overlay-env refactor (Slice 4+).
+
+      **What shipped instead — restrict the per-call loops to free variables.**
+      Only a closure's *free* variables (names its body, or a nested closure's
+      body, references from an enclosing scope) can be mutated by it, so only those
+      carry per-instance captured state. `CompiledCode` now precomputes
+      `free_var_syms` (GetGlobal-family operand names not in its own locals, unioned
+      with nested closures' already-computed `free_var_syms`). `call_compiled_closure`
+      iterates `cc.free_var_syms` (a handful of names) instead of `data.env.keys()`
+      (~110) for `cap_overrides`, the state persist loop, the readonly/alias
+      writeback, and the state-key sync. The captured-env *merge* keeps copying the
+      full env (a foreign-scope caller may need any captured lexical for an
+      interpreter fallback) but now keys by the interned `Symbol` directly
+      (`Env::entry_or_insert_sym`) instead of `resolve()`+re-intern. The exit
+      locals→env flush now writes back only captured locals (frame-local closure
+      locals are discarded on env restore anyway).
+
+      Capture semantics are unchanged: `data.env` still holds the full snapshot
+      for fallback reads; only the *state-persistence* loops are narrowed, which is
+      sound because non-free captured names can't be mutated by the body.
+
+      **Result:** closure-heavy bench **~15 s → ~5 s (read-only closure, ~3×)** and
+      **~15 s → ~6.5 s (mutating closure, ~2.3×)**, output identical to `raku`.
+      `env_deep_copies` is unchanged (expected — this slice removes O(env) hashing/
+      formatting, not the make_mut copies). `make test` failure set unchanged from
+      the `main` baseline (`t/wrap.t`, `t/placeholder.t`, `t/tail-function.t`
+      pre-existing). New regression pin: `t/closure-captured-state.t`.
+
+- [ ] **Slice 4 — closure upvalues / scoped env.** Capture free variables into an
+      explicit upvalue list (or a scoped overlay env) so closures stop reading the
+      parent `env` by name, the `&?BLOCK` / `__mutsu_callable_id` setup writes move
+      off the shared global env, and the conservative whole-frame `needs_env_sync`
+      (`fill(true)` whenever any closure exists) can be dropped. This is what
+      actually removes the per-call `make_mut` deep copies.
 
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/env.rs
+++ b/src/env.rs
@@ -139,6 +139,15 @@ impl Env {
         }
     }
 
+    /// Insert only if key is not present, keyed directly by an interned Symbol.
+    /// Avoids the `resolve()` (Symbol -> String) + re-intern round trip that
+    /// `entry_or_insert` pays when the caller already holds a Symbol.
+    pub fn entry_or_insert_sym(&mut self, key: Symbol, value: Value) {
+        if !self.inner.contains_key(&key) {
+            self.cow_mut().insert(key, value);
+        }
+    }
+
     /// Insert only if key is not present (lazy value).
     pub fn entry_or_insert_with<F: FnOnce() -> Value>(&mut self, key: String, f: F) {
         let sym = Symbol::intern(&key);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1004,6 +1004,14 @@ pub(crate) struct CompiledCode {
     /// Locals that are only accessed via GetLocal don't need env sync,
     /// reducing env size and clone cost.
     pub(crate) needs_env_sync: Vec<bool>,
+    /// Free variables this code (and its nested closures) reference from an
+    /// enclosing scope: names used via GetGlobal-family ops that are not this
+    /// code's own locals. For a closure body this is the set of captured
+    /// lexicals whose per-instance mutable state actually matters, so the
+    /// closure-call path can persist/restore only these instead of iterating
+    /// the entire (~100-entry) captured env. Empty until `compute_free_vars`
+    /// runs (during `compute_needs_env_sync`).
+    pub(crate) free_var_syms: Vec<Symbol>,
 }
 
 /// Pre-computed local slot indices for a single attribute.
@@ -1037,6 +1045,7 @@ impl CompiledCode {
             may_capture_outer_vars: false,
             attr_slots: Vec::new(),
             needs_env_sync: Vec::new(),
+            free_var_syms: Vec::new(),
         }
     }
 
@@ -1124,6 +1133,7 @@ impl CompiledCode {
     /// which reduces env size and makes method call env clones cheaper.
     pub(crate) fn compute_needs_env_sync(&mut self) {
         self.compute_locals_sym();
+        self.compute_free_vars();
         let n = self.locals.len();
         self.needs_env_sync = vec![false; n];
         if n == 0 {
@@ -1162,6 +1172,51 @@ impl CompiledCode {
                 self.needs_env_sync[slot] = true;
             }
         }
+    }
+
+    /// The constant-pool index naming the variable an op reads/writes by name,
+    /// for the GetGlobal-family opcodes that resolve against the env.
+    fn op_name_const_idx(op: &OpCode) -> Option<u32> {
+        match op {
+            OpCode::GetGlobal(idx)
+            | OpCode::SetGlobal(idx)
+            | OpCode::SetGlobalRaw(idx)
+            | OpCode::PostIncrement(idx)
+            | OpCode::PostDecrement(idx)
+            | OpCode::PreIncrement(idx)
+            | OpCode::PreDecrement(idx)
+            | OpCode::GetArrayVar(idx)
+            | OpCode::GetHashVar(idx)
+            | OpCode::AssignExpr(idx) => Some(*idx),
+            _ => None,
+        }
+    }
+
+    /// Compute `free_var_syms`: the names this code references from an enclosing
+    /// scope (GetGlobal-family ops whose name is not one of this code's own
+    /// locals), unioned with the free variables of nested closures that are not
+    /// resolved by this code's locals. Nested closures have already had their
+    /// own `free_var_syms` computed (they are finalized before being embedded),
+    /// so they are folded in directly without re-walking their ops.
+    pub(crate) fn compute_free_vars(&mut self) {
+        let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
+        let mut free: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        for op in &self.ops {
+            if let Some(idx) = Self::op_name_const_idx(op)
+                && let Some(Value::Str(name)) = self.constants.get(idx as usize)
+                && !own.contains(name.as_str())
+            {
+                free.insert(Symbol::intern(name));
+            }
+        }
+        for nested in &self.closure_compiled_codes {
+            for sym in &nested.free_var_syms {
+                if !sym.with_str(|s| own.contains(s)) {
+                    free.insert(*sym);
+                }
+            }
+        }
+        self.free_var_syms = free.into_iter().collect();
     }
 
     /// Store a compiled closure body and return its index.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -172,19 +172,25 @@ impl VM {
 
         self.interpreter.inject_pending_callsite_line();
 
-        // Merge captured environment into current env (or_insert = don't overwrite existing)
+        // Merge captured environment into current env (or_insert = don't overwrite existing).
+        // Key directly by the captured Symbol to avoid a resolve()+re-intern per entry.
         for (k, v) in data.env.iter() {
             self.interpreter
                 .env_mut()
-                .entry_or_insert(k.resolve(), v.clone());
+                .entry_or_insert_sym(*k, v.clone());
         }
         // Override with persisted per-closure-instance captured variable state.
         // This ensures that each closure instance maintains independent mutable
         // state across calls (e.g. two closures from the same factory each get
         // their own copy of captured variables).
-        let cap_overrides: Vec<(Symbol, Value)> = data
-            .env
-            .keys()
+        //
+        // Only the closure's free variables can be mutated by its body, so only
+        // those carry per-instance state. Iterating `cc.free_var_syms` (a handful
+        // of names) instead of the whole captured env (~100 names) avoids that
+        // many `format!` allocations and state-var lookups per call.
+        let cap_overrides: Vec<(Symbol, Value)> = cc
+            .free_var_syms
+            .iter()
             .filter_map(|k| {
                 let persist_key = format!("__mutsu_closure_cap::{}::{}", data.id, k);
                 self.interpreter
@@ -475,9 +481,16 @@ impl VM {
             self.sync_locals_from_env(cc);
         }
 
-        // Sync locals back to env so captured variable changes are visible
+        // Sync locals back to env so captured variable changes are visible.
+        // Only captured variables that also occupy a local slot need this: a
+        // non-captured local is strictly frame-local and is discarded when the
+        // env is restored to `saved_env` below, while a captured variable not in
+        // a slot is mutated through the env directly (SetGlobal). Restricting the
+        // writeback to captured locals avoids an O(env) copy-on-write deep copy
+        // per call for the common read-only closure (which has no captured
+        // locals to flush at all).
         for (i, local_name) in cc.locals.iter().enumerate() {
-            if !local_name.is_empty() {
+            if !local_name.is_empty() && data.env.contains_key(local_name) {
                 self.interpreter
                     .env_mut()
                     .insert(local_name.clone(), self.locals[i].clone());
@@ -486,7 +499,9 @@ impl VM {
 
         // Persist captured variable state so this closure instance retains
         // its own mutable state across calls (independent from other closures).
-        for k in data.env.keys() {
+        // Mirror of `cap_overrides` above: only free variables can be mutated by
+        // the body, so only those need persisting.
+        for k in &cc.free_var_syms {
             if let Some(val) = self.interpreter.env().get_sym(*k).cloned() {
                 let persist_key = format!("__mutsu_closure_cap::{}::{}", data.id, k);
                 self.interpreter.set_state_var(persist_key, val);
@@ -552,7 +567,9 @@ impl VM {
         }
         // Write back readonly/alias metadata for captured variables that were
         // modified inside the closure (e.g. `$a := $arg` where `$a` is captured).
-        for captured_sym in &captured_names {
+        // Only free variables can be modified by the body, so restrict the
+        // (format!-heavy) metadata scan to them instead of the whole captured env.
+        for captured_sym in &cc.free_var_syms {
             let captured_name = captured_sym.resolve();
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", captured_name);
             if let Some(v) = self.interpreter.env().get(&readonly_key).cloned() {
@@ -566,15 +583,15 @@ impl VM {
         self.interpreter
             .merge_sigilless_alias_writes(&mut restored_env, self.interpreter.env());
 
-        // Only run the state-variable sync and cleanup when there are
-        // captured variables that reference state keys.  This avoids the
+        // Only run the state-variable sync and cleanup when the closure
+        // references captured variables that may be state vars.  This avoids the
         // per-call overhead for simple closures in hot loops.
-        if !captured_names.is_empty() {
+        if !cc.free_var_syms.is_empty() {
             // Update state variable storage when closures modify captured
             // state variables.  The metadata key "__mutsu_state_key::<name>"
             // maps the variable name to its state storage key (set by
             // StateVarInit in the declaring scope).
-            for k in captured_names.iter() {
+            for k in &cc.free_var_syms {
                 let meta_key = format!("__mutsu_state_key::{}", k);
                 if let Some(Value::Str(state_key)) = self.interpreter.env().get(&meta_key).cloned()
                     && let Some(val) = self.interpreter.env().get_sym(*k).cloned()

--- a/t/closure-captured-state.t
+++ b/t/closure-captured-state.t
@@ -1,0 +1,49 @@
+use Test;
+
+# Closures only persist/restore their *free* variables (the ones their body
+# actually references). These tests pin the observable behavior of that
+# per-instance captured-state machinery so the free-variable optimization in
+# call_compiled_closure cannot regress it.
+
+plan 10;
+
+# Two closures from the same factory keep independent mutable captured state.
+sub make-counter() {
+    my $n = 0;
+    return -> { $n++; $n };
+}
+my $a = make-counter();
+my $b = make-counter();
+is $a(), 1, 'first counter starts at 1';
+is $a(), 2, 'first counter increments';
+is $b(), 1, 'second counter is independent';
+is $a(), 3, 'first counter unaffected by second';
+is $b(), 2, 'second counter increments independently';
+
+# A `state` variable inside a closure persists per-instance across calls.
+my $c = -> { state $s = 0; $s = $s + 10; $s };
+is $c(), 10, 'state var first call';
+is $c(), 20, 'state var persists across calls';
+is $c(), 30, 'state var keeps accumulating';
+
+# A closure mutating a captured variable is visible to the enclosing scope.
+sub outer() {
+    my $x = 100;
+    my $bump = -> { $x = $x + 5 };
+    $bump();
+    $bump();
+    $x;
+}
+is outer(), 110, 'captured variable mutation visible to enclosing scope';
+
+# A nested closure capturing a grandparent lexical mutates it through both levels.
+sub grand() {
+    my $g = 1;
+    my $mid = -> {
+        my $inner = -> { $g = $g * 2; $g };
+        $inner(); $inner();
+    };
+    $mid();
+    $g;
+}
+is grand(), 4, 'nested closure mutates grandparent lexical';


### PR DESCRIPTION
## Summary

Slice 3 of the VM dual-store decoupling work (`docs/vm-dual-store.md`). This makes closure-heavy code **2.3–3× faster** by shrinking per-call closure capture-state bookkeeping from O(captured-env) to O(free-variables).

## Root cause (measured, not guessed)

A closure-heavy micro-benchmark (105000 closure calls) ran in **~15 s**. `MUTSU_VM_STATS` reported ~2 env deep copies per call — but a `perf` profile showed `Env::cow_mut` (the deep copy) is only **1.3 %** of runtime. The real cost is the **per-call O(captured-env) work**: every closure call iterates the *entire* captured env (~110 entries, because `MakeBlockClosure` captures `self.env.clone()` = the whole outer env) in several loops — `cap_overrides`, the state persist loop, the readonly/alias writeback, and the state-key sync — each doing a `format!("__mutsu_closure_cap::{id}::{k}")`-style allocation per entry.

Profile hotspots: `Symbol::intern` 9.3 %, hashing ~14 %, `format!`/`Display` ~10 %. ~550 `format!` allocations **per closure call**.

## Fix

Only a closure's **free variables** (names its body — or a nested closure's body — references from an enclosing scope) can be mutated by it, so only those carry per-instance captured state.

- `CompiledCode` precomputes `free_var_syms` (GetGlobal-family operand names not in its own locals, unioned with nested closures' already-computed `free_var_syms`).
- `call_compiled_closure` iterates `cc.free_var_syms` instead of `data.env.keys()` for `cap_overrides`, state persist, readonly/alias writeback, and state-key sync.
- The full-env merge is kept (a foreign-scope caller may need any captured lexical for an interpreter fallback) but now keys by interned `Symbol` directly (`Env::entry_or_insert_sym`) instead of `resolve()`+re-intern.
- The exit locals→env flush writes back only captured locals (frame-local closure locals are discarded on env restore anyway).

Capture **semantics are unchanged**: `data.env` still holds the full snapshot for fallback reads; only the *state-persistence* loops are narrowed, which is sound because non-free captured names can't be mutated by the body.

## Results

| benchmark | before | after |
|---|---|---|
| read-only closure (105k calls) | ~15 s | **~5 s (3×)** |
| mutating closure (105k calls) | ~15 s | **~6.5 s (2.3×)** |

Output identical to `raku`. `env_deep_copies` unchanged (this slice removes O(env) hashing/formatting, not the `make_mut` copies — those need the scoped-env refactor, tracked as Slice 4).

## Tests

- New regression pin: `t/closure-captured-state.t` (factory-closure independent state, per-instance `state` vars, captured-var mutation visible to enclosing scope, nested-closure grandparent capture).
- `make test` failure set unchanged from the `main` baseline (`t/wrap.t`, `t/placeholder.t`, `t/tail-function.t` are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
