### PR TITLE
S03 hyper func-op: write back mutated values for sigilless-rw code-refs

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -38,7 +38,19 @@
     (maybe-method), `».+`/`».*` (all-candidates).
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
-  - Current blocker: callable code-ref invocation in this file dies (`Unknown function ...: op`).
+  - Runs 1462/5076 (was 328). Hyper function-op (`$a >>[&op]<< $b`) writeback for
+    sigilless-`rw` code-refs is now implemented: scalar/array/hash operands, named
+    subs, and lexical `&op`/`&metaop` loop variables (routed through VM closure
+    dispatch so the return value + sigilless `rw` binding match a named call). See
+    `t/hyper-func-op-writeback.t`.
+  - Remaining blocker: the test's `&[op=]` assignment meta-operator code-refs
+    (`&[+=]`, `&[~=]`, ...) do NOT mutate their first argument even on a direct
+    call (`op($a, $b)` returns the right value but leaves `$a` unchanged). These
+    are `Value::Sub` named `infix:<op=>` with a plain `($arg0, $arg1)` signature,
+    so they are neither detected as writable nor do they write through. Fixing
+    this requires the synthesized assignment-metaop routine to bind its first
+    argument `rw` and assign back. Once that lands, the per-iteration `*=`/`~=`/
+    `+=` writeback assertions and the run-to-completion stop should clear.
 - [x] roast/S03-metaops/misc.t
 - [ ] roast/S03-metaops/not.t
   - 46/47 tests pass. The remaining failure is subtest 47 (chaining of !before/!after) where 2 of 12 subtests fail due to wrong expected values in the test (lines 84 and 93, marked `#?rakudo skip`). Even raku (Rakudo) fails these same tests. Cannot whitelist until roast fixes the expected values or the fudging mechanism is implemented.

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -297,11 +297,25 @@ impl Compiler {
         self.compile_expr(left);
         self.compile_expr(right);
         let name_idx = self.code.add_constant(Value::str(func_name.to_string()));
+        // When the left operand is a simple lvalue (`$a`, `@a`), the hyper
+        // function-op binds each element `rw`; a mutating code-ref (`&[+=]`,
+        // a `sub (\a,\b) { a = ... }`) must write the result back into the
+        // lvalue. Ask the VM to push the mutated left value, then store it.
+        let writeback_target: Option<String> = match left {
+            Expr::Var(name) => Some(name.clone()),
+            Expr::ArrayVar(name) => Some(format!("@{}", name)),
+            Expr::HashVar(name) => Some(format!("%{}", name)),
+            _ => None,
+        };
         self.code.emit(OpCode::HyperFuncOp {
             name_idx,
             dwim_left,
             dwim_right,
+            writeback: writeback_target.is_some(),
         });
+        if let Some(name) = writeback_target {
+            self.emit_set_named_var(&name);
+        }
     }
 
     /// Build the right-hand operand for a short-circuiting `Z` meta-op.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -760,6 +760,11 @@ pub(crate) enum OpCode {
         name_idx: u32,
         dwim_left: bool,
         dwim_right: bool,
+        /// When true, the left operand is a mutable lvalue: bind each element
+        /// `rw` so a mutating code-ref (e.g. `&[+=]`) writes back, and push the
+        /// (possibly mutated) left value on top of the result so the compiler
+        /// can store it back into the lvalue.
+        writeback: bool,
     },
 
     // -- MetaOp (Rop, Xop, Zop) --

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -12,13 +12,13 @@ mod type_registry;
 
 // Re-export public items from submodules
 pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
-pub(crate) use signature::unwrap_varref_value;
 pub(in crate::runtime) use signature::{
     bind_named_rename_sub_signature, bind_sub_signature_from_value, flatten_into_slurpy,
-    indexed_varref_from_value, make_varref_value, sigilless_alias_key, sigilless_readonly_key,
+    indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
     sub_signature_matches_value, sub_signature_target_from_remaining_args, varref_from_value,
     wrap_native_int_for_binding,
 };
+pub(crate) use signature::{make_varref_value, unwrap_varref_value};
 // Internal re-exports used by submodules via `use super::*`
 use signature::code_signature_matches_value;
 

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -152,11 +152,7 @@ pub(in crate::runtime) fn flatten_into_slurpy(values: &[Value], out: &mut Vec<Va
     }
 }
 
-pub(in crate::runtime) fn make_varref_value(
-    name: String,
-    value: Value,
-    source_index: Option<usize>,
-) -> Value {
+pub(crate) fn make_varref_value(name: String, value: Value, source_index: Option<usize>) -> Value {
     let mut named = std::collections::HashMap::new();
     named.insert("__mutsu_varref_name".to_string(), Value::str(name));
     named.insert("__mutsu_varref_value".to_string(), value);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3437,8 +3437,16 @@ impl VM {
                 name_idx,
                 dwim_left,
                 dwim_right,
+                writeback,
             } => {
-                self.exec_hyper_func_op(code, *name_idx, *dwim_left, *dwim_right, compiled_fns)?;
+                self.exec_hyper_func_op(
+                    code,
+                    *name_idx,
+                    *dwim_left,
+                    *dwim_right,
+                    *writeback,
+                    compiled_fns,
+                )?;
                 *ip += 1;
             }
 

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1116,17 +1116,54 @@ impl VM {
         name_idx: u32,
         dwim_left: bool,
         dwim_right: bool,
+        writeback: bool,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap_or(Value::Nil);
         let left = self.stack.pop().unwrap_or(Value::Nil);
         let name = Self::const_str(code, name_idx).to_string();
+        // Resolve a concrete code-ref value when `name` refers to a lexical
+        // `&name` variable (e.g. the `&op`/`&metaop` loop variables in
+        // S03-metaops/infix.t). Such calls must go through the VM closure
+        // dispatch (`vm_call_on_value`) so sigilless `rw` binding and the
+        // return value behave the same as a named-sub call; the interpreter
+        // fallback mishandles both for mutating sigilless subs.
+        let func_value: Option<Value> = {
+            let bare = name.trim_start_matches('&');
+            let mut found = None;
+            for key in [format!("&{}", bare), bare.to_string()] {
+                if let Some(v @ (Value::Sub(_) | Value::WeakSub(_))) =
+                    self.interpreter.env().get(&key)
+                {
+                    found = Some(v.clone());
+                    break;
+                }
+            }
+            found
+        };
+        // Hash operands: apply the code-ref to each value key-by-key, mirroring
+        // the dwim key-set semantics of `exec_hyper_op`.
+        if matches!(&left, Value::Hash(..)) || matches!(&right, Value::Hash(..)) {
+            return self.exec_hyper_func_op_hash(
+                left,
+                right,
+                &name,
+                func_value.as_ref(),
+                dwim_left,
+                dwim_right,
+                writeback,
+                compiled_fns,
+            );
+        }
         let both_scalar = !Self::is_listy(&left) && !Self::is_listy(&right);
         let left_list = Interpreter::value_to_list(&left);
         let right_list = Interpreter::value_to_list(&right);
         let left_len = left_list.len();
         let right_len = right_list.len();
         if left_len == 0 && right_len == 0 {
+            if writeback {
+                self.stack.push(Value::array(Vec::new()));
+            }
             self.stack.push(Value::array(Vec::new()));
             return Ok(());
         }
@@ -1145,38 +1182,254 @@ impl VM {
         } else {
             right_len
         };
+        // When the left operand is a writable lvalue and the code-ref's first
+        // parameter is bindable `rw` (sigilless `\a`, `$a is rw`, or `is raw`),
+        // pass each left element by writable reference so a mutating code-ref
+        // (e.g. `&[+=]`) writes back. We then collect the (possibly mutated)
+        // left elements and leave them on the stack for the compiler-emitted
+        // store into the lvalue.
+        let do_writeback = writeback
+            && self.hyper_func_first_param_writable(
+                &name,
+                func_value.as_ref(),
+                compiled_fns,
+                &left_list,
+                &right_list,
+            );
         // Look up the function by name (&name variable or compiled function)
         let mut results = Vec::with_capacity(result_len);
+        let mut mutated_left: Vec<Value> =
+            Vec::with_capacity(if do_writeback { result_len } else { 0 });
         for i in 0..result_len {
             let l = if left_len == 0 {
-                &Value::Int(0)
+                Value::Int(0)
             } else {
-                &left_list[i % left_len]
+                left_list[i % left_len].clone()
             };
             let r = if right_len == 0 {
                 &Value::Int(0)
             } else {
                 &right_list[i % right_len]
             };
-            let call_args = vec![l.clone(), r.clone()];
-            let result =
-                self.call_function_compiled_first(&name, call_args.clone(), compiled_fns)?;
-            results.push(result);
-        }
-        let result = if both_scalar && results.len() == 1 {
-            results.into_iter().next().unwrap()
-        } else {
-            // Preserve List kind when inputs are Lists (not Arrays)
-            let left_is_array = matches!(&left, Value::Array(_, crate::value::ArrayKind::Array));
-            let right_is_array = matches!(&right, Value::Array(_, crate::value::ArrayKind::Array));
-            if !left_is_array && !right_is_array {
-                Value::Array(std::sync::Arc::new(results), crate::value::ArrayKind::List)
+            if do_writeback {
+                let synth = format!("__mutsu_hyperfn_lv_{}", i);
+                self.interpreter.env_mut().insert(synth.clone(), l.clone());
+                let varref =
+                    crate::runtime::types::make_varref_value(synth.clone(), l.clone(), None);
+                let call_args = vec![varref, r.clone()];
+                let result = self.dispatch_hyper_func_call(
+                    &name,
+                    func_value.as_ref(),
+                    call_args,
+                    compiled_fns,
+                )?;
+                results.push(result);
+                let updated = self.interpreter.env().get(&synth).cloned().unwrap_or(l);
+                self.interpreter.env_mut().remove(&synth);
+                mutated_left.push(updated);
             } else {
-                Value::real_array(results)
+                let call_args = vec![l, r.clone()];
+                let result = self.dispatch_hyper_func_call(
+                    &name,
+                    func_value.as_ref(),
+                    call_args,
+                    compiled_fns,
+                )?;
+                results.push(result);
+            }
+        }
+        let left_is_array = matches!(&left, Value::Array(_, crate::value::ArrayKind::Array));
+        let right_is_array = matches!(&right, Value::Array(_, crate::value::ArrayKind::Array));
+        let wrap = |items: Vec<Value>| -> Value {
+            if both_scalar && items.len() == 1 {
+                items.into_iter().next().unwrap()
+            } else if !left_is_array && !right_is_array {
+                Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+            } else {
+                Value::real_array(items)
             }
         };
-        self.stack.push(result);
+        // For writeback, push the mutated-left value first (consumed by the
+        // store op) and leave the function results on top as the expression
+        // value.
+        if writeback {
+            let writeback_val = if do_writeback {
+                wrap(mutated_left)
+            } else {
+                // No mutation happened; restore the original left value so the
+                // compiler-emitted store is a harmless no-op.
+                left.clone()
+            };
+            self.stack.push(wrap(results));
+            self.stack.push(writeback_val);
+        } else {
+            self.stack.push(wrap(results));
+        }
         Ok(())
+    }
+
+    /// Hash variant of `exec_hyper_func_op`: apply a code-ref to hash values
+    /// key-by-key. Supports hash-hash (matched by key, dwim selecting the key
+    /// set) and hash-scalar broadcasting, plus `rw` write-back of the mutated
+    /// left hash for `%a >>[&metaop]<< %b`.
+    #[allow(clippy::too_many_arguments)]
+    fn exec_hyper_func_op_hash(
+        &mut self,
+        left: Value,
+        right: Value,
+        name: &str,
+        func_value: Option<&Value>,
+        dwim_left: bool,
+        dwim_right: bool,
+        writeback: bool,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<(), RuntimeError> {
+        let probe_left: Vec<Value> = match &left {
+            Value::Hash(m) => m.values().cloned().collect(),
+            other => vec![other.clone()],
+        };
+        let probe_right: Vec<Value> = match &right {
+            Value::Hash(m) => m.values().cloned().collect(),
+            other => vec![other.clone()],
+        };
+        let do_writeback = writeback
+            && matches!(&left, Value::Hash(..))
+            && self.hyper_func_first_param_writable(
+                name,
+                func_value,
+                compiled_fns,
+                &probe_left,
+                &probe_right,
+            );
+        // Determine the key set and a per-key (left, right) value source.
+        let (keys, la, ra, right_scalar) = match (&left, &right) {
+            (Value::Hash(la), Value::Hash(ra)) => {
+                let keys: Vec<String> = match (dwim_left, dwim_right) {
+                    (false, false) => {
+                        let mut ks: Vec<String> = la.keys().cloned().collect();
+                        for k in ra.keys() {
+                            if !la.contains_key(k) {
+                                ks.push(k.clone());
+                            }
+                        }
+                        ks
+                    }
+                    (true, true) => la.keys().filter(|k| ra.contains_key(*k)).cloned().collect(),
+                    (false, true) => la.keys().cloned().collect(),
+                    (true, false) => ra.keys().cloned().collect(),
+                };
+                (keys, Some(la.clone()), Some(ra.clone()), None)
+            }
+            (Value::Hash(la), _) => {
+                let keys: Vec<String> = la.keys().cloned().collect();
+                (keys, Some(la.clone()), None, Some(right.clone()))
+            }
+            (_, Value::Hash(ra)) => {
+                // scalar >>op<< %hash : broadcast left over right's keys
+                let keys: Vec<String> = ra.keys().cloned().collect();
+                (keys, None, Some(ra.clone()), None)
+            }
+            _ => unreachable!("exec_hyper_func_op_hash called without a hash operand"),
+        };
+        let identity = Value::Int(0);
+        let mut result: std::collections::HashMap<String, Value> =
+            std::collections::HashMap::with_capacity(keys.len());
+        let mut mutated: std::collections::HashMap<String, Value> =
+            std::collections::HashMap::with_capacity(if do_writeback { keys.len() } else { 0 });
+        for key in keys {
+            let l = match &la {
+                Some(m) => m.get(&key).cloned().unwrap_or_else(|| identity.clone()),
+                None => left.clone(),
+            };
+            let r = match (&ra, &right_scalar) {
+                (Some(m), _) => m.get(&key).cloned().unwrap_or_else(|| identity.clone()),
+                (None, Some(s)) => s.clone(),
+                (None, None) => identity.clone(),
+            };
+            if do_writeback {
+                let synth = format!("__mutsu_hyperfn_lvh_{}", key);
+                self.interpreter.env_mut().insert(synth.clone(), l.clone());
+                let varref =
+                    crate::runtime::types::make_varref_value(synth.clone(), l.clone(), None);
+                let call_args = vec![varref, r];
+                let v = self.dispatch_hyper_func_call(name, func_value, call_args, compiled_fns)?;
+                let updated = self.interpreter.env().get(&synth).cloned().unwrap_or(l);
+                self.interpreter.env_mut().remove(&synth);
+                result.insert(key.clone(), v);
+                mutated.insert(key, updated);
+            } else {
+                let call_args = vec![l, r];
+                let v = self.dispatch_hyper_func_call(name, func_value, call_args, compiled_fns)?;
+                result.insert(key, v);
+            }
+        }
+        let result_hash = Value::Hash(std::sync::Arc::new(result));
+        if writeback {
+            let writeback_val = if do_writeback {
+                Value::Hash(std::sync::Arc::new(mutated))
+            } else {
+                left.clone()
+            };
+            self.stack.push(result_hash);
+            self.stack.push(writeback_val);
+        } else {
+            self.stack.push(result_hash);
+        }
+        Ok(())
+    }
+
+    /// Dispatch a single per-element call of a hyper function-op. Lexical
+    /// code-refs (`func_value`) go through the VM closure dispatch; named subs
+    /// go through the compiled-first path.
+    fn dispatch_hyper_func_call(
+        &mut self,
+        name: &str,
+        func_value: Option<&Value>,
+        call_args: Vec<Value>,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<Value, RuntimeError> {
+        if let Some(fv) = func_value {
+            self.vm_call_on_value(fv.clone(), call_args, Some(compiled_fns))
+        } else {
+            self.call_function_compiled_first(name, call_args, compiled_fns)
+        }
+    }
+
+    /// Determine whether the code-ref named `name` binds its first positional
+    /// parameter in a way that can write back to the caller (sigilless raw,
+    /// `is rw`, or `is raw`). Used to decide whether a hyper function-op should
+    /// pass left elements by writable reference.
+    fn hyper_func_first_param_writable(
+        &mut self,
+        name: &str,
+        func_value: Option<&Value>,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+        left_list: &[Value],
+        right_list: &[Value],
+    ) -> bool {
+        let probe = vec![
+            left_list.first().cloned().unwrap_or(Value::Int(0)),
+            right_list.first().cloned().unwrap_or(Value::Int(0)),
+        ];
+        fn writable(pd: &crate::ast::ParamDef) -> bool {
+            pd.sigilless || pd.traits.iter().any(|t| t == "rw" || t == "raw")
+        }
+        // A code-ref held in a lexical `&name` variable: inspect its SubData.
+        let sub = match func_value {
+            Some(Value::Sub(data)) => Some(data.clone()),
+            Some(Value::WeakSub(weak)) => weak.upgrade(),
+            _ => None,
+        };
+        if let Some(data) = sub {
+            return data.param_defs.first().map(writable).unwrap_or(false);
+        }
+        if let Some(cf) = self.find_compiled_function(compiled_fns, name, &probe) {
+            return cf.param_defs.first().map(writable).unwrap_or(false);
+        }
+        if let Some(def) = self.interpreter.resolve_function_with_types(name, &probe) {
+            return def.param_defs.first().map(writable).unwrap_or(false);
+        }
+        false
     }
 
     pub(super) fn exec_meta_op(

--- a/t/hyper-func-op-writeback.t
+++ b/t/hyper-func-op-writeback.t
@@ -1,0 +1,84 @@
+use Test;
+
+# Hyper function-op (`>>[&func]<<`) with a mutating, sigilless `rw` code-ref
+# must write the mutated value back into the left lvalue, both for named subs
+# and for code-refs held in lexical `&` variables (as S03-metaops/infix.t does).
+
+plan 19;
+
+sub cst (\a, \b) { "foo" }
+sub csta(\a, \b) { a = "foo" }
+
+# --- scalar, named code-ref ---
+{
+    my $a = 1;
+    my $r = $a >>[&cst]<< 6;
+    is $r, "foo", "scalar >>[&cst]<< returns result";
+    is $a, 1, "non-mutating op leaves lvalue unchanged";
+}
+{
+    my $a = 1;
+    my $r = $a >>[&csta]<< 6;
+    is $r, "foo", "scalar >>[&csta]<< returns result";
+    is $a, "foo", "mutating op writes back to lvalue";
+}
+
+# --- scalar, lexical code-ref variable ---
+{
+    my &op = &cst;
+    my &metaop = &csta;
+    my $a = 1;
+    is ($a >>[&op]<< 6), "foo", "lexical &op returns result";
+    is $a, 1, "lexical non-mutating op leaves lvalue unchanged";
+    my $b = 1;
+    is ($b >>[&metaop]<< 6), "foo", "lexical &metaop returns result";
+    is $b, "foo", "lexical mutating op writes back";
+}
+
+# --- array ---
+{
+    my @a = 1, 2, 3;
+    my @r = @a >>[&csta]<< (6, 7, 8);
+    is-deeply @r, ["foo", "foo", "foo"], "array >>[&csta]<< returns results";
+    is-deeply @a, ["foo", "foo", "foo"], "array mutating op writes back";
+}
+{
+    my @a = 1, 2, 3;
+    my @r = @a >>[&cst]<< (6, 7, 8);
+    is-deeply @r, ["foo", "foo", "foo"], "array >>[&cst]<< returns results";
+    is-deeply @a, [1, 2, 3], "array non-mutating op leaves lvalue unchanged";
+}
+
+# --- array, lexical code-ref ---
+{
+    my &metaop = &csta;
+    my @a = 1, 2, 3;
+    my @r = @a >>[&metaop]<< (6, 7, 8);
+    is-deeply @r, ["foo", "foo", "foo"], "array lexical &metaop returns results";
+    is-deeply @a, ["foo", "foo", "foo"], "array lexical mutating op writes back";
+}
+
+# --- hash ---
+{
+    my %a = a => 1, b => 2;
+    my %b = a => 6, b => 7;
+    my %r = %a >>[&csta]<< %b;
+    is-deeply %r, {a => "foo", b => "foo"}, "hash >>[&csta]<< returns results";
+    is-deeply %a, {a => "foo", b => "foo"}, "hash mutating op writes back";
+}
+{
+    my %a = a => 1, b => 2;
+    my %b = a => 6, b => 7;
+    my %r = %a >>[&cst]<< %b;
+    is-deeply %r, {a => "foo", b => "foo"}, "hash >>[&cst]<< returns results";
+    is-deeply %a, {a => 1, b => 2}, "hash non-mutating op leaves lvalue unchanged";
+}
+
+# --- hash, lexical code-ref ---
+{
+    my &metaop = &csta;
+    my %a = a => 1, b => 2;
+    my %b = a => 6, b => 7;
+    my %r = %a >>[&metaop]<< %b;
+    is-deeply %a, {a => "foo", b => "foo"}, "hash lexical mutating op writes back";
+}


### PR DESCRIPTION
Implements write-back for the hyper function-op `$a >>[&f]<< $b` when the code-ref binds its first argument `rw` (sigilless `\a`, `is rw`, or `is raw`) and mutates it — the core pattern in roast/S03-metaops/infix.t. Previously died with 'Cannot modify an immutable value'.

## What changed
- `OpCode::HyperFuncOp` gains a `writeback` flag (set by the compiler when the left operand is a simple lvalue). The VM binds each left element through a synthetic varref so a mutating code-ref writes back, then stores the mutated values into the lvalue.
- Lexical `&op`/`&metaop` code-refs (the loop variables in infix.t) are dispatched through `vm_call_on_value` so the return value and sigilless rw binding match a named-sub call.
- Hash operands handled key-by-key (`exec_hyper_func_op_hash`) with dwim key-set semantics, including write-back of the mutated left hash.

## Impact
infix.t now runs 1462/5076 subtests (was 328). Remaining blocker (in TODO_roast/S03.md): `&[op=]` assignment meta-op code-refs don't yet mutate their first arg.

## Tests
- Adds t/hyper-func-op-writeback.t (19 cases).
- cargo test (449) green; prove t/ only the known pre-existing/flaky failures.
- No regressions in S03-metaops/{hyper,reduce,cross,zip,reverse}.t or inplace.t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)