### PR TITLE
vm: replace conservative whole-frame closure env-sync with free-var set

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -243,5 +243,41 @@ Reaching that requires, roughly in order:
       (`fill(true)` whenever any closure exists) can be dropped. This is what
       actually removes the per-call `make_mut` deep copies.
 
+  - [x] **Slice 4a — drop the conservative whole-frame `needs_env_sync`.** Done.
+
+        `compute_needs_env_sync` previously did `needs_env_sync.fill(true)` (mirror
+        *every* local of the frame into `env`) the moment any closure existed in
+        the frame, "because closures may capture any outer variable via GetGlobal."
+        Since Slice 3 each `CompiledCode` knows its exact `free_var_syms` (the names
+        it, or a nested closure, reads from an enclosing scope). A local of *this*
+        frame is observable by a closure created here **iff** its name is in some
+        nested closure's `free_var_syms` — that is precisely the set
+        `ensure_env_synced` must flush before `MakeBlockClosure` snapshots the env.
+        So the `fill(true)` is replaced by marking only those locals (unioned with
+        the existing GetGlobal-family-in-this-code set). Frames with many locals but
+        few captured ones now mirror only the captured handful instead of all.
+
+        Soundness: a closure can only read an outer local by name through a compiled
+        GetGlobal-family op in its (or a nested closure's) body, which is exactly
+        what `compute_free_vars` collects; interpreter fallbacks inside the body read
+        from the full captured-env snapshot, and special names (`&?BLOCK`, `$/`,
+        dynamics) are not parent-frame locals. Verified that even `{ EVAL '$x' }`
+        capturing a slot-local `$x` from an enclosing sub still resolves correctly.
+
+        Perf: closure benches unchanged within noise (read-only ~3.0s, mutating
+        ~5.0s release — the bench closures capture nearly all their parent's
+        locals, so `fill(true)` and the precise set coincide; the win is in
+        wide-frame code). No deep-copy count change (that needs 4b/4c). `make test`
+        failure set unchanged from the `main` baseline (`t/placeholder.t`,
+        `t/tail-function.t`, `t/wrap.t` pre-existing); S04/S06 (157 files) and
+        S02/S12/S14 (241 files) whitelist green. New pin:
+        `t/closure-selective-env-sync.t`.
+
+  - [ ] **Slice 4b/4c — upvalue capture + move setup writes off the shared env.**
+        Still to do: give closures an explicit upvalue list (or scoped overlay env)
+        and move the `&?BLOCK` / `__mutsu_callable_id` / param-binding setup writes
+        off the shared global env. This is what removes the residual per-call
+        `make_mut` deep copies (Slice 3 located them at exactly those setup writes).
+
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1152,18 +1152,26 @@ impl CompiledCode {
         if n == 0 {
             return;
         }
-        // If closures exist, conservatively mark all locals as needing env sync
-        // because closures may capture any outer variable via GetGlobal.
-        if !self.closure_compiled_codes.is_empty() {
-            self.needs_env_sync.fill(true);
-            return;
-        }
         let locals_map: std::collections::HashMap<&str, usize> = self
             .locals
             .iter()
             .enumerate()
             .map(|(i, name)| (name.as_str(), i))
             .collect();
+        // A nested closure created in this frame captures the env at creation
+        // time and later reads its free variables from that snapshot by name.
+        // Any local of *this* frame that is a free variable of some nested
+        // closure must therefore be flushed to env before the capture. This
+        // replaces the old conservative `fill(true)` (which mirrored *every*
+        // local to env whenever any closure existed) with the exact set of
+        // locals a closure can actually observe.
+        for nested in &self.closure_compiled_codes {
+            for sym in &nested.free_var_syms {
+                if let Some(slot) = sym.with_str(|s| locals_map.get(s).copied()) {
+                    self.needs_env_sync[slot] = true;
+                }
+            }
+        }
         for op in &self.ops {
             let name_idx = match op {
                 OpCode::GetGlobal(idx)

--- a/t/closure-selective-env-sync.t
+++ b/t/closure-selective-env-sync.t
@@ -1,0 +1,83 @@
+use Test;
+
+# Regression pins for the precise closure env-sync analysis: a frame may hold
+# many locals while a closure created in it captures only a few. The compiler
+# must flush exactly the captured (free) variables to env before the capture,
+# no more and no less. Over-syncing was the old conservative behaviour; this
+# test guards against under-syncing (stale captures) after the precision change.
+
+plan 8;
+
+# A closure captures one of several sibling locals and mutates it; the other
+# siblings must be untouched and the mutation must be visible to the caller.
+sub selective() {
+    my $a = 1;
+    my $b = 2;
+    my $c = 3;
+    my $d = 4;
+    my $f = { $b = $b + 10 };
+    $f();
+    "$a $b $c $d";
+}
+is selective(), "1 12 3 4", "closure mutates only the captured sibling local";
+
+# A read-only closure sees the latest value of a captured local even when the
+# local is assigned after the closure is built.
+sub deferred() {
+    my $x = 1;
+    my $g = { $x };
+    $x = 99;
+    $g();
+}
+is deferred(), 99, "read-only closure sees post-build assignment to captured local";
+
+# Nested closure mutating a grandparent local through two capture levels.
+sub nested() {
+    my $n = 0;
+    my $outer = {
+        my $inner = { $n = $n + 1 };
+        $inner();
+        $inner();
+    };
+    $outer();
+    $n;
+}
+is nested(), 2, "nested closure mutates grandparent local transitively";
+
+# String interpolation of a captured local inside a closure.
+sub interp() {
+    my $name = "world";
+    my $extra = "unused";
+    my $h = { "hello $name" };
+    $h();
+}
+is interp(), "hello world", "string interpolation captures outer local";
+
+# map/grep blocks capturing an outer local that is not otherwise referenced.
+sub mapgrep() {
+    my $mul = 3;
+    (1, 2, 3).map({ $_ * $mul }).grep({ $_ > 3 }).join(",");
+}
+is mapgrep(), "6,9", "map/grep blocks capture outer local";
+
+# Each closure instance from a factory keeps independent captured state.
+sub make-counter($start) {
+    my $n = $start;
+    -> { $n = $n + 1; $n };
+}
+my $c1 = make-counter(0);
+my $c2 = make-counter(100);
+my $a1 = $c1(); my $a2 = $c1(); my $a3 = $c1();
+is "$a1,$a2,$a3", "1,2,3", "first counter has its own state";
+my $b1 = $c2(); my $b2 = $c2();
+is "$b1,$b2", "101,102", "second counter is independent";
+
+# A closure that reads a captured local but never assigns it must not leak any
+# of the parent frame's purely-local (non-captured) variables.
+sub no-leak() {
+    my $captured = 5;
+    my $only-local = 999;
+    my $r = { $captured * 2 };
+    $r();
+}
+is no-leak(), 10, "read-only closure returns captured-derived value";


### PR DESCRIPTION
## What

Slice 4a of the VM `locals`↔`env` dual-store collapse (docs/vm-dual-store.md).

`compute_needs_env_sync` previously did `needs_env_sync.fill(true)` — mirror **every** local of a frame into the env — the moment any closure existed in that frame, on the conservative assumption that a closure may capture any outer variable via `GetGlobal`.

Since the free-variable analysis (Slice 3, #2582), each `CompiledCode` knows its exact `free_var_syms`: the names it (or a nested closure) reads from an enclosing scope. A local of *this* frame is observable by a closure created here **iff** its name is in some nested closure's `free_var_syms` — precisely the set `ensure_env_synced` must flush before `MakeBlockClosure` snapshots the env. So the `fill(true)` is replaced by marking only those locals (unioned with the existing GetGlobal-family-in-this-code set).

Frames with many locals but few captured ones now mirror only the captured handful instead of all of them — dropping the conservative whole-frame writeback called out as a Slice 4 goal.

## Soundness

A closure can only read an outer local by name through a compiled GetGlobal-family op in its (or a nested closure's) body — exactly what `compute_free_vars` collects. Interpreter fallbacks inside the body read from the full captured-env snapshot, and special names (`&?BLOCK`, `$/`, dynamics) are not parent-frame locals. Verified `{ EVAL '\$x' }` capturing a slot-local `\$x` from an enclosing sub still resolves correctly.

## Perf

Closure benches unchanged within noise (read-only ~3.0s, mutating ~5.0s release): the bench closures capture nearly all their parent's locals, so `fill(true)` and the precise set coincide there; the win is in wide-frame code. No deep-copy count change — that needs Slice 4b/4c (upvalue capture + moving the `&?BLOCK`/`__mutsu_callable_id` setup writes off the shared env).

## Tests

- New pin: `t/closure-selective-env-sync.t` (8 subtests, matches `raku`).
- S04/S06 whitelist (157 files) and S02/S12/S14 whitelist (241 files) green.
- `make test` failure set unchanged from the `main` baseline (`placeholder.t`/`tail-function.t`/`wrap.t` pre-existing).

> Stacked on #2585 (base = `vm/closure-writeback-skip`). Retarget to `main` once #2585 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)