### PR TITLE
S03 hyper func-op: assignment meta-op write-back and dwim length rules

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -38,19 +38,22 @@
     (maybe-method), `».+`/`».*` (all-candidates).
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
-  - Runs 1462/5076 (was 328). Hyper function-op (`$a >>[&op]<< $b`) writeback for
-    sigilless-`rw` code-refs is now implemented: scalar/array/hash operands, named
-    subs, and lexical `&op`/`&metaop` loop variables (routed through VM closure
-    dispatch so the return value + sigilless `rw` binding match a named call). See
-    `t/hyper-func-op-writeback.t`.
-  - Remaining blocker: the test's `&[op=]` assignment meta-operator code-refs
-    (`&[+=]`, `&[~=]`, ...) do NOT mutate their first argument even on a direct
-    call (`op($a, $b)` returns the right value but leaves `$a` unchanged). These
-    are `Value::Sub` named `infix:<op=>` with a plain `($arg0, $arg1)` signature,
-    so they are neither detected as writable nor do they write through. Fixing
-    this requires the synthesized assignment-metaop routine to bind its first
-    argument `rw` and assign back. Once that lands, the per-iteration `*=`/`~=`/
-    `+=` writeback assertions and the run-to-completion stop should clear.
+  - Runs 5076/5076, 4176 pass (was 328 run / 116 pass on bare main). Implemented:
+    - Hyper function-op (`$a >>[&op]<< $b`) writeback for sigilless-`rw` code-refs:
+      scalar/array/hash operands, named subs, and lexical `&op`/`&metaop` loop
+      variables (routed through VM closure dispatch). See `t/hyper-func-op-writeback.t`.
+    - Assignment meta-operator code-refs (`&[+=]`, `&[~=]`, ...): `call_infix_routine`
+      now writes the base-op result back when the first argument is a writable
+      reference, so the hyper op (which passes a varref) mutates the lvalue.
+    - dwim length rules for the function-op: `<<op<<`/`>>op>>` die when the
+      cycled (dwim) side is longer than the fixed side; hash-vs-scalar dies unless
+      the scalar is on a dwim side; a mutating meta-op applied to a non-lvalue
+      left operand dies. See `t/hyper-metaop-writeback.t`.
+  - Remaining blocker (~900 failing): Set/Bag/Mix-valued hashes (`%a is SetHash`,
+    `BagHash`, `MixHash` in the `@int-infixes` section, lines 244-320). The hash
+    function-op only handles plain `Value::Hash`; QuantHash operands fall through
+    to the list path and produce wrong `is-deeply` results. Needs dedicated
+    Set/Bag/Mix hyper function-op handling.
 - [x] roast/S03-metaops/misc.t
 - [ ] roast/S03-metaops/not.t
   - 46/47 tests pass. The remaining failure is subtest 47 (chaining of !before/!after) where 2 of 12 subtests fail due to wrong expected values in the test (lines 84 and 93, marked `#?rakudo skip`). Even raku (Rakudo) fails these same tests. Cannot whitelist until roast fixes the expected values or the fudging mechanism is implemented.

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -812,6 +812,19 @@ impl Interpreter {
         {
             return self.apply_hyper_infix(inner, dwim_left, dwim_right, &args[0], &args[1]);
         }
+        // Assignment meta-operator called as a routine, e.g. `&[+=]` / `&[~=]`.
+        // When the left operand is a writable reference (passed by a hyper
+        // function-op or any rw caller), compute the base op and write the
+        // result back into the referenced variable, mirroring `$a op= $b`.
+        if args.len() == 2
+            && let Some(base) = assignment_metaop_base(op)
+            && let Some((source_name, inner, _)) =
+                crate::runtime::types::indexed_varref_from_value(&args[0])
+        {
+            let result = self.call_infix_routine(base, &[inner, args[1].clone()])?;
+            self.env.insert(source_name, result.clone());
+            return Ok(result);
+        }
         let is_set_op = matches!(
             op,
             "(-)"
@@ -1758,4 +1771,27 @@ fn parse_hyper_infix(op: &str) -> Option<(&str, bool, bool)> {
         return None;
     }
     Some((inner, dwim_left, dwim_right))
+}
+
+/// If `op` is an assignment meta-operator (`+=`, `~=`, `min=`, ...), return the
+/// base operator. Comparison/identity operators that merely *end* in `=` are
+/// excluded.
+fn assignment_metaop_base(op: &str) -> Option<&str> {
+    let base = op.strip_suffix('=')?;
+    if base.is_empty() {
+        return None;
+    }
+    // Exclude operators where the trailing `=` is part of the operator itself.
+    if matches!(
+        op,
+        "==" | "!=" | "<=" | ">=" | "===" | "!==" | "=:=" | "!=:=" | "<=>"
+    ) {
+        return None;
+    }
+    // A base that itself ends in `=`/`<`/`>`/`!` is a comparison-like operator
+    // (`==`, `<=`, `>=`, `!=`), not an assignment meta-op.
+    if base.ends_with(['=', '<', '>', '!']) {
+        return None;
+    }
+    Some(base)
 }

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1132,7 +1132,7 @@ impl VM {
             let bare = name.trim_start_matches('&');
             let mut found = None;
             for key in [format!("&{}", bare), bare.to_string()] {
-                if let Some(v @ (Value::Sub(_) | Value::WeakSub(_))) =
+                if let Some(v @ (Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. })) =
                     self.interpreter.env().get(&key)
                 {
                     found = Some(v.clone());
@@ -1167,19 +1167,32 @@ impl VM {
             self.stack.push(Value::array(Vec::new()));
             return Ok(());
         }
+        let length_mismatch = || {
+            RuntimeError::new(format!(
+                "Non-dwimmy hyper operator: left has {} elements, right has {}",
+                left_len, right_len
+            ))
+        };
         let result_len = if !dwim_left && !dwim_right {
             if left_len != right_len {
-                return Err(RuntimeError::new(format!(
-                    "Non-dwimmy hyper operator: left has {} elements, right has {}",
-                    left_len, right_len
-                )));
+                return Err(length_mismatch());
             }
             left_len
         } else if dwim_left && dwim_right {
             std::cmp::max(left_len, right_len)
         } else if dwim_right {
+            // Only the right side dwims: it is cycled up to the (fixed) left
+            // length, so the right must not be longer than the left.
+            if right_len > left_len {
+                return Err(length_mismatch());
+            }
             left_len
         } else {
+            // Only the left side dwims: it is cycled up to the (fixed) right
+            // length, so the left must not be longer than the right.
+            if left_len > right_len {
+                return Err(length_mismatch());
+            }
             right_len
         };
         // When the left operand is a writable lvalue and the code-ref's first
@@ -1188,14 +1201,24 @@ impl VM {
         // (e.g. `&[+=]`) writes back. We then collect the (possibly mutated)
         // left elements and leave them on the stack for the compiler-emitted
         // store into the lvalue.
-        let do_writeback = writeback
-            && self.hyper_func_first_param_writable(
-                &name,
-                func_value.as_ref(),
-                compiled_fns,
-                &left_list,
-                &right_list,
-            );
+        let func_writable = self.hyper_func_first_param_writable(
+            &name,
+            func_value.as_ref(),
+            compiled_fns,
+            &left_list,
+            &right_list,
+        );
+        // An assignment meta-op (`&[+=]`) applied to a non-lvalue left operand
+        // (a literal or literal list, e.g. `3 >>[&metaop]<< @a`) cannot write
+        // back and dies, just like `3 += 1` would. (A sigilless user sub that
+        // does not actually assign — e.g. `cst` — must NOT die here; it dies
+        // naturally only if its body assigns to the read-only bound value.)
+        if !writeback && Self::is_assign_metaop_ref(func_value.as_ref()) {
+            return Err(RuntimeError::new(
+                "Cannot modify an immutable value".to_string(),
+            ));
+        }
+        let do_writeback = writeback && func_writable;
         // Look up the function by name (&name variable or compiled function)
         let mut results = Vec::with_capacity(result_len);
         let mut mutated_left: Vec<Value> =
@@ -1292,15 +1315,24 @@ impl VM {
             Value::Hash(m) => m.values().cloned().collect(),
             other => vec![other.clone()],
         };
-        let do_writeback = writeback
-            && matches!(&left, Value::Hash(..))
-            && self.hyper_func_first_param_writable(
-                name,
-                func_value,
-                compiled_fns,
-                &probe_left,
-                &probe_right,
-            );
+        let func_writable = self.hyper_func_first_param_writable(
+            name,
+            func_value,
+            compiled_fns,
+            &probe_left,
+            &probe_right,
+        );
+        // An assignment meta-op whose left operand is not a writable hash lvalue
+        // (e.g. `3 <<[&metaop]>> %a`, where the scalar would be the mutated
+        // element) cannot write back and therefore dies.
+        if !(writeback && matches!(&left, Value::Hash(..)))
+            && Self::is_assign_metaop_ref(func_value)
+        {
+            return Err(RuntimeError::new(
+                "Cannot modify an immutable value".to_string(),
+            ));
+        }
+        let do_writeback = writeback && matches!(&left, Value::Hash(..)) && func_writable;
         // Determine the key set and a per-key (left, right) value source.
         let (keys, la, ra, right_scalar) = match (&left, &right) {
             (Value::Hash(la), Value::Hash(ra)) => {
@@ -1321,11 +1353,26 @@ impl VM {
                 (keys, Some(la.clone()), Some(ra.clone()), None)
             }
             (Value::Hash(la), _) => {
+                // `%hash OP scalar`: the scalar (right) must be on a dwim side
+                // to broadcast over the hash's keys; otherwise the lengths
+                // mismatch (N vs 1) and it is a non-dwimmy error.
+                if !dwim_right {
+                    return Err(RuntimeError::new(
+                        "Non-dwimmy hyper operator: cannot apply a hash against a non-dwim scalar"
+                            .to_string(),
+                    ));
+                }
                 let keys: Vec<String> = la.keys().cloned().collect();
                 (keys, Some(la.clone()), None, Some(right.clone()))
             }
             (_, Value::Hash(ra)) => {
-                // scalar >>op<< %hash : broadcast left over right's keys
+                // `scalar OP %hash`: the scalar (left) must be on a dwim side.
+                if !dwim_left {
+                    return Err(RuntimeError::new(
+                        "Non-dwimmy hyper operator: cannot apply a non-dwim scalar against a hash"
+                            .to_string(),
+                    ));
+                }
                 let keys: Vec<String> = ra.keys().cloned().collect();
                 (keys, None, Some(ra.clone()), None)
             }
@@ -1378,6 +1425,30 @@ impl VM {
         Ok(())
     }
 
+    /// True when the resolved code-ref is a built-in assignment meta-operator
+    /// (`&[+=]`, `&[~=]`, ...) — a `Routine` named `infix:<op=>`. Such a
+    /// routine unconditionally mutates its first argument, so applying it to a
+    /// non-lvalue is a hard error.
+    fn is_assign_metaop_ref(func_value: Option<&Value>) -> bool {
+        let Some(Value::Routine { name, .. }) = func_value else {
+            return false;
+        };
+        let Some(inner) = name
+            .resolve()
+            .strip_prefix("infix:<")
+            .and_then(|s| s.strip_suffix('>'))
+            .map(str::to_string)
+        else {
+            return false;
+        };
+        inner.ends_with('=')
+            && inner.len() > 1
+            && !matches!(
+                inner.as_str(),
+                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "=:=" | "!=:=" | "<=>"
+            )
+    }
+
     /// Dispatch a single per-element call of a hyper function-op. Lexical
     /// code-refs (`func_value`) go through the VM closure dispatch; named subs
     /// go through the compiled-first path.
@@ -1415,6 +1486,24 @@ impl VM {
             pd.sigilless || pd.traits.iter().any(|t| t == "rw" || t == "raw")
         }
         // A code-ref held in a lexical `&name` variable: inspect its SubData.
+        // An assignment meta-operator routine (`&[+=]`, `&[~=]`, ...) mutates
+        // its first argument even though its synthesized signature does not
+        // carry an `rw` marker. Detect it by name so the element is passed by
+        // writable reference.
+        if let Some(Value::Routine { name: rname, .. }) = func_value
+            && let Some(inner) = rname
+                .resolve()
+                .strip_prefix("infix:<")
+                .and_then(|s| s.strip_suffix('>'))
+            && inner.ends_with('=')
+            && inner.len() > 1
+            && !matches!(
+                inner,
+                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "=:=" | "!=:=" | "<=>"
+            )
+        {
+            return true;
+        }
         let sub = match func_value {
             Some(Value::Sub(data)) => Some(data.clone()),
             Some(Value::WeakSub(weak)) => weak.upgrade(),

--- a/t/hyper-metaop-writeback.t
+++ b/t/hyper-metaop-writeback.t
@@ -1,0 +1,84 @@
+use Test;
+
+# Hyper function-op with an *assignment meta-operator* code-ref (`&[+=]`,
+# `&[~=]`, ...) held in a lexical `&` variable writes the result back into the
+# left lvalue. A mutating meta-op applied to a non-lvalue dies, and the dwim
+# length rules are enforced. Mirrors the patterns in roast/S03-metaops/infix.t.
+
+plan 23;
+
+my &add  = &[+];
+my &cat  = &[~];
+my &addeq = &[+=];
+my &cateq = &[~=];
+
+# --- scalar assignment meta-op ---
+{
+    my $a = 1;
+    my $r = $a >>[&addeq]<< 6;
+    is $r, 7, "scalar >>[&addeq]<< returns sum";
+    is $a, 7, "scalar assignment meta-op writes back";
+}
+{
+    my $a = "h";
+    my $r = $a >>[&cateq]<< "x";
+    is $r, "hx", "lexical &[~=] returns concatenation";
+    is $a, "hx", "lexical assignment meta-op writes back";
+}
+
+# --- array assignment meta-op ---
+{
+    my @a = 1, 2, 3;
+    my @r = @a >>[&addeq]<< (6, 7, 8);
+    is-deeply @r, [7, 9, 11], "array >>[&addeq]<< returns sums";
+    is-deeply @a, [7, 9, 11], "array assignment meta-op writes back";
+}
+{
+    my @a = 1, 2, 3;
+    my @r = @a <<[&addeq]>> 3;     # scalar broadcast over array
+    is-deeply @r, [4, 5, 6], "array <<[&metaop]>> scalar broadcasts";
+    is-deeply @a, [4, 5, 6], "array broadcast meta-op writes back";
+}
+
+# --- hash assignment meta-op ---
+{
+    my %a = a => 1, b => 2;
+    my %b = a => 6, b => 7;
+    my %r = %a >>[&addeq]<< %b;
+    is-deeply %r, {a => 7, b => 9}, "hash >>[&addeq]<< returns sums";
+    is-deeply %a, {a => 7, b => 9}, "hash assignment meta-op writes back";
+}
+
+# --- dwim length rules: non-dwim array vs scalar dies ---
+{
+    my @a = 1, 2, 3;
+    dies-ok { @a >>[&add]<< 3 }, ">>op<< array vs scalar dies (non-dwim)";
+    dies-ok { @a <<[&add]<< 3 }, "<<op<< array vs scalar dies (left longer)";
+    is-deeply (@a <<[&add]>> 3), [4, 5, 6], "<<op>> broadcasts scalar (both dwim)";
+    is-deeply (@a >>[&add]>> 3), [4, 5, 6], ">>op>> broadcasts scalar (right dwim)";
+}
+
+# --- mutating meta-op on a non-lvalue dies ---
+{
+    my @a = 1, 2, 3;
+    dies-ok { 3 >>[&addeq]<< @a }, "meta-op with literal left dies (non-dwim)";
+    dies-ok { 3 <<[&addeq]>> @a }, "meta-op with literal left dies (both dwim)";
+    is-deeply (3 <<[&add]>> @a), [4, 5, 6], "plain op with literal left broadcasts";
+}
+
+# --- hash dwim/scalar rules ---
+{
+    my %a = a => 1, b => 2;
+    dies-ok { %a >>[&add]<< 3 }, "hash >>op<< scalar dies (non-dwim)";
+    is-deeply (%a <<[&add]>> 3), {a => 4, b => 5}, "hash <<op>> scalar broadcasts";
+    dies-ok { 3 >>[&add]<< %a }, "scalar >>op<< hash dies (non-dwim)";
+    is-deeply (3 <<[&add]>> %a), {a => 4, b => 5}, "scalar <<op>> hash broadcasts";
+    dies-ok { 3 <<[&addeq]>> %a }, "meta-op scalar-left over hash dies";
+}
+
+# --- mutating user sub (sigilless) on non-lvalue dies naturally ---
+{
+    sub csta(\a, \b) { a = "foo" }
+    my &cs = &csta;
+    dies-ok { 3 <<[&cs]>> (1, 2) }, "mutating sigilless sub on literal dies";
+}


### PR DESCRIPTION
Builds on #2586 to make the assignment meta-operator code-refs and dwim length semantics of `roast/S03-metaops/infix.t` work. infix.t goes from **328 run / 116 pass** (bare main) to **5076 run / 4176 pass**.

## What changed
- **`call_infix_routine`**: an assignment meta-operator (`&[+=]`, `&[~=]`, …) invoked with a writable reference as its first argument now computes the base op and writes the result back into the referenced variable, mirroring `$a op= $b`. The hyper function-op passes such a reference, so `$a >>[&metaop]<< $b` mutates the lvalue.
- **HyperFuncOp** resolves lexical `Value::Routine` code-refs (not just `Sub`s) so `&[op=]` loop variables dispatch through `vm_call_on_value`, and detects assignment-metaop routines as writable by name.
- **dwim length rules** for the function-op: `<<op<<` / `>>op>>` die when the cycled (dwim) side is longer than the fixed side; a hash against a scalar dies unless the scalar is on a dwim side; a mutating meta-op applied to a non-lvalue left operand dies (`3 >>[&metaop]<< @a`).

## Remaining infix.t gap (~900 failing)
Set/Bag/Mix-valued hashes (`%a is SetHash` etc., the `@int-infixes` section) are not yet handled by the hash function-op path; recorded in `TODO_roast/S03.md`.

## Tests
- Adds `t/hyper-metaop-writeback.t` (23 cases).
- `cargo test` (449) green; `prove t/` only the known pre-existing/flaky failures (`placeholder.t`, `tail-function.t`, `wrap.t`).
- No regressions in `S03-metaops/{hyper,reduce,cross,zip,reverse}.t` or `S03-operators/{inplace,autoincrement}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)