### PR TITLE
vm: hoist immutable magic/dynamic-var defaults into the shared env base tier (4c pt1)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -309,14 +309,48 @@ Reaching that requires, roughly in order:
         regression). 791-file enum/closure/integration whitelist green. New pin
         `t/builtin-enum-base-tier.t` (bare/qualified/closure/thread/shadow).
 
-  - [ ] **Slice 4c — upvalue capture + move setup writes off the shared env.**
-        Still to do: give closures an explicit upvalue list (or scoped overlay env)
-        and move the `&?BLOCK` / `__mutsu_callable_id` / param-binding setup writes
-        off the shared global env. This removes the per-call `make_mut` deep copies
-        *entirely* (Slice 3 located them at exactly those setup writes; Slice 4b only
-        shrank each copy, it did not cut the count). A natural extension of 4b is to
-        also hoist the remaining immutable dynamic/magic-var defaults into the base
-        tier so the overlay shrinks further.
+  - [x] **Slice 4c (part 1) — hoist the immutable dynamic/magic-var defaults into
+        the base tier.** Done (the "natural extension of 4b" below).
+
+        A per-call env probe after 4b showed the ~49-entry overlay still carried
+        ~20 *immutable* process-constant magic/dynamic vars: `$*VM`/`*VM`/`?VM`,
+        `*PERL`/`?PERL`, `*RAKU`/`?RAKU`, `*KERNEL`/`?KERNEL`, `*DISTRO`/`?DISTRO`,
+        `$*EXECUTABLE`(`-NAME`), `$*SPEC`, `*PID`, `*TZ`, `*INIT-INSTANT`. These are
+        set once at interpreter start and never reassigned/removed by normal
+        programs, yet every per-frame env clone+fork copied all of them.
+
+        **What shipped.** `Interpreter::new` now moves this fixed allowlist
+        (`IMMUTABLE_BASE_DYNAMICS`) out of `self.env` and into the shared
+        [`GLOBAL_BASE`] tier (alongside the 4b enum constants) before
+        `set_global_base`. Reads fall back to the base via `Env::get`/`get_sym`; a
+        rare write is promoted into the overlay by `Env::get_mut`; a `my $*VM`
+        shadow writes the overlay and reverts on scope exit. The base stays
+        invisible to `iter`/`keys`/`len`/`remove`, so the block-exit writeback scan,
+        `clone_for_thread`'s env iteration, and the handle-id scan are all
+        unaffected (none of these vars are handles or mutable dynamics).
+        *Mutable* dynamics (`$*OUT`, `$*ERR`, `$*IN`, `$*CWD`, `$*TMPDIR`, `$*HOME`,
+        `%*ENV`, `@*ARGS`, `$*SCHEDULER`, `$*REPO`, `$*ARGFILES`) intentionally stay
+        in the overlay.
+
+        **Result.** The per-call deep copy now forks a ~29-entry overlay instead of
+        ~49 (the *count* is still unchanged — that needs part 2). Release benches
+        (best-of-5, interleaved): **read-only closure 1.30s→1.11s (~1.17x),
+        mutating closure 2.15s→1.66s (~1.30x), 30k read-only closure 9.44s→8.07s
+        (~1.17x); `bench-class` neutral** (its methods take the
+        `skip_env_setup` light path, which already avoids the big-env fork). Bench
+        output byte-identical between baseline and change. `make test` failure set
+        unchanged from the `main` baseline (`placeholder.t` t8, `tail-function.t`
+        t4, `wrap.t`, `hyper-func-op-writeback.t` t8 all pre-existing). New pin
+        `t/base-tier-magic-vars.t` (read / underscore alias / sub / block / closure
+        / shadow / thread visibility).
+
+  - [ ] **Slice 4c (part 2) — upvalue capture + move setup writes off the shared
+        env.** Still to do: give closures an explicit upvalue list (or scoped
+        overlay env) and move the `&?BLOCK` / `__mutsu_callable_id` / param-binding
+        setup writes off the shared global env. This removes the per-call
+        `make_mut` deep copies *entirely* (Slice 3 located them at exactly those
+        setup writes; Slices 4b/4c-part1 only shrank each copy, they did not cut the
+        count).
 
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1161,6 +1161,33 @@ impl Default for Interpreter {
     }
 }
 
+/// Immutable process-constant magic/dynamic variables hoisted into the shared
+/// env base tier (see `Interpreter::new`). These hold the same value for the
+/// whole process and are never reassigned/removed by normal programs, so they
+/// need not live in every per-frame env overlay (docs/vm-dual-store.md 4c).
+const IMMUTABLE_BASE_DYNAMICS: &[&str] = &[
+    "*PID",
+    "*TZ",
+    "*INIT-INSTANT",
+    "$*VM",
+    "*VM",
+    "?VM",
+    "*PERL",
+    "?PERL",
+    "*RAKU",
+    "?RAKU",
+    "*KERNEL",
+    "?KERNEL",
+    "*DISTRO",
+    "?DISTRO",
+    "$*EXECUTABLE",
+    "*EXECUTABLE",
+    "$*EXECUTABLE-NAME",
+    "*EXECUTABLE-NAME",
+    "$*SPEC",
+    "*SPEC",
+];
+
 impl Interpreter {
     /// Take any pending regex security error from the thread-local store.
     pub(crate) fn take_pending_regex_error() -> Option<RuntimeError> {
@@ -3087,6 +3114,20 @@ impl Interpreter {
         interpreter.init_endian_enum(&mut enum_base);
         interpreter.init_protocol_family_enum(&mut enum_base);
         interpreter.init_signal_enum(&mut enum_base);
+        // Hoist the immutable process-constant magic/dynamic vars out of every
+        // per-frame env overlay into the shared base tier (docs/vm-dual-store.md
+        // 4c "natural extension"). These are set once at interpreter start and
+        // never reassigned/removed by normal programs; reads fall back to the
+        // base tier, and a rare write is promoted into the overlay by
+        // `Env::get_mut`, so semantics are preserved while the per-call deep
+        // copy forks a smaller overlay. Mutable dynamics ($*OUT, $*CWD, %*ENV,
+        // @*ARGS, $*SCHEDULER, $*REPO, handles, ...) intentionally stay in the
+        // overlay.
+        for key in IMMUTABLE_BASE_DYNAMICS {
+            if let Some(v) = interpreter.env.remove(key) {
+                enum_base.insert(Symbol::intern(key), v);
+            }
+        }
         crate::env::set_global_base(enum_base);
         interpreter.env.insert("Any".to_string(), Value::Nil);
         // Set up $*REPO as a default CompUnit::Repository::FileSystem instance

--- a/t/base-tier-magic-vars.t
+++ b/t/base-tier-magic-vars.t
@@ -1,0 +1,50 @@
+use Test;
+
+# Regression pin for docs/vm-dual-store.md Slice 4c: the immutable
+# process-constant magic/dynamic variables ($*VM, $*KERNEL, $*EXECUTABLE,
+# $*SPEC, $*PID, ...) are hoisted into the shared env base tier instead of
+# living in every per-frame env overlay. Reads must still resolve, the
+# kebab/underscore alias must work, the values must be visible inside subs,
+# blocks, closures and threads, and a `my $*FOO` shadow inside a block must
+# not leak out.
+
+plan 14;
+
+# Basic reads resolve through the base tier.
+ok $*VM.defined,             '$*VM is defined';
+ok $*KERNEL.defined,         '$*KERNEL is defined';
+ok $*DISTRO.defined,         '$*DISTRO is defined';
+ok $*EXECUTABLE.defined,     '$*EXECUTABLE is defined';
+ok $*EXECUTABLE-NAME.defined,'$*EXECUTABLE-NAME is defined';
+ok $*SPEC.defined,           '$*SPEC is defined';
+ok $*PID ~~ Int,             '$*PID is an Int';
+
+# Underscore alias for the kebab-case name.
+is $*EXECUTABLE_NAME, $*EXECUTABLE-NAME, '$*EXECUTABLE_NAME aliases $*EXECUTABLE-NAME';
+
+# Visible inside a sub (a per-frame env that no longer carries these entries).
+sub reads-vm() { $*VM.^name }
+is reads-vm(), $*VM.^name, '$*VM visible inside a sub';
+
+# Visible inside a nested block.
+{
+    ok $*KERNEL.defined, '$*KERNEL visible inside a block';
+}
+
+# Visible inside a closure that does not capture it directly.
+my $c = { $*SPEC.^name };
+is $c(), $*SPEC.^name, '$*SPEC visible inside a closure';
+
+# A dynamic-scope shadow (a base-tier var promoted into a local overlay) must
+# take effect for its scope and not leak to the enclosing scope. Done inside a
+# sub to avoid the unrelated read-then-redeclare postdeclaration limitation.
+sub shadows-vm() {
+    my $*VM = 42;
+    $*VM;
+}
+is shadows-vm(), 42, '$*VM shadowable via my $*VM';
+isnt $*VM, 42, '$*VM unaffected outside the shadowing sub';
+
+# Visible across a thread boundary (thread env falls back to the base tier).
+my $p = start { $*KERNEL.^name }
+is await($p), $*KERNEL.^name, '$*KERNEL visible inside a thread';


### PR DESCRIPTION
## Summary

Slice 4c "natural extension" from `docs/vm-dual-store.md` — the dual-store
decoupling work.

After Slice 4b, the ~49-entry per-frame env overlay still carried ~20 **immutable
process-constant** magic/dynamic vars (`$*VM`/`*VM`/`?VM`, `*PERL`/`?PERL`,
`*RAKU`/`?RAKU`, `*KERNEL`/`?KERNEL`, `*DISTRO`/`?DISTRO`, `$*EXECUTABLE`(`-NAME`),
`$*SPEC`, `*PID`, `*TZ`, `*INIT-INSTANT`). They are set once at interpreter start
and never reassigned/removed by normal programs, yet every per-call env clone+fork
copied all of them.

`Interpreter::new` now moves a fixed allowlist (`IMMUTABLE_BASE_DYNAMICS`) out of
`self.env` into the shared `GLOBAL_BASE` tier (alongside the 4b enum constants)
before `set_global_base`. Reads fall back to the base via `Env::get`; a rare write
is promoted into the overlay by `Env::get_mut`; a `my $*VM` shadow writes the
overlay and reverts on scope exit. The base stays invisible to
`iter`/`keys`/`len`/`remove`, so the block-exit writeback scan,
`clone_for_thread`'s env iteration, and the handle-id scan are unaffected.

**Mutable** dynamics (`$*OUT`, `$*ERR`, `$*IN`, `$*CWD`, `$*TMPDIR`, `$*HOME`,
`%*ENV`, `@*ARGS`, `$*SCHEDULER`, `$*REPO`, `$*ARGFILES`) intentionally stay in the
overlay.

## Perf (release, best-of-5, interleaved)

| bench | baseline | change | speedup |
|---|---|---|---|
| read-only closure | 1.30s | 1.11s | ~1.17× |
| mutating closure | 2.15s | 1.66s | ~1.30× |
| 30k read-only closure | 9.44s | 8.07s | ~1.17× |
| bench-class | 0.61s | 0.62s | neutral (light method path) |

Per-call overlay fork shrinks from ~49 to ~29 entries. The deep-copy *count* is
unchanged — cutting it to zero needs 4c part 2 (upvalue capture / scoped env).
Bench output byte-identical between baseline and change.

## Tests

- New pin `t/base-tier-magic-vars.t` (read / underscore alias / sub / block /
  closure / shadow / thread visibility).
- `make test` failure set unchanged from the `main` baseline (`placeholder.t` t8,
  `tail-function.t` t4, `wrap.t`, `hyper-func-op-writeback.t` t8 — all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)