### PR TITLE
vm: gate per-read atomic check + typed closure-capture store (4c pt2a)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -344,13 +344,63 @@ Reaching that requires, roughly in order:
         `t/base-tier-magic-vars.t` (read / underscore alias / sub / block / closure
         / shadow / thread visibility).
 
-  - [ ] **Slice 4c (part 2) — upvalue capture + move setup writes off the shared
+  - [x] **Slice 4c (part 2a) — kill the per-read/per-call `format!` on the hot
+        variable-read and closure-call paths.** Done.
+
+        **Measurement first (the deep-copy count was a red herring at this scale).**
+        A `perf` profile of a closure-heavy bench showed `Env::cow_mut` (the
+        `make_mut` deep copy) is now negligible; the dominant runtime cost is
+        per-op string/format/Symbol churn. Two hot `format!` sources:
+        1. **`exec_get_global` / the `GetLocal` shared-read path run an atomic-var
+           check on *every* variable read**: a `format!("__mutsu_atomic_name::{n}")`
+           plus *two* `var_type_constraint` calls (each itself a
+           `format!("__mutsu_type::{n}")` + env lookup). Closures read their free
+           vars via `GetGlobal`, and recursion (`fib`) reads its param constantly,
+           so this is on the critical path of essentially all variable-read-heavy
+           code — yet atomics are exotic.
+        2. **The closure capture-state persist/load** keyed state by
+           `format!("__mutsu_closure_cap::{id}::{name}")` (String) in the shared
+           `state_vars` map, allocating + string-hashing per free var per call.
+
+        **What shipped.**
+        * A monotonic `Interpreter::atomic_var_seen` flag, set when any `atomicint`
+          constraint is registered (`set_var_type_constraint`) or atomic storage is
+          created (`atomic_value_key_for_name`), and inherited across thread clones
+          (atomics are shared via `shared_vars`). The two hot atomic-read checks are
+          gated behind it, so a program with no atomics skips the whole check
+          (`format!` + constraint lookups) on every read. All three trigger
+          conditions of the check are covered by the two flag-set sites, so the gate
+          can never hide a real atomic.
+        * A dedicated typed store `closure_captured_state: HashMap<(u64, Symbol),
+          Value>` replaces the formatted-String `__mutsu_closure_cap::` keys,
+          removing the per-call `format!` + String hashing from closure capture
+          persistence.
+
+        **Result (release, best-of-7, interleaved).** **`bench-fib` 1.56s→1.23s
+        (~21%)** (every recursive call reads its param), **read-only closure
+        8.05s→7.06s (~12%)**, **mutating closure 15.20s→14.18s (~7%)**, `bench-class`
+        ~3%. Bench output byte-identical. `make test` failure set unchanged from the
+        `main` baseline (`placeholder.t` t8, `tail-function.t` t4, `wrap.t`,
+        `hyper-func-op-writeback.t` t8). Atomic semantics verified: whitelisted
+        `roast/S17-lowlevel/atomic.t` + `atomic-ops.t` (62 subtests) green; new pin
+        `t/atomic-read-gate.t` (ordinary/closure reads + atomic inc/fetch/assign +
+        cross-thread counter). (`roast/S17-lowlevel/lock.t` fails identically on the
+        pre-change binary — pre-existing, not whitelisted.)
+
+  - [ ] **Slice 4c (part 2b) — upvalue capture + move setup writes off the shared
         env.** Still to do: give closures an explicit upvalue list (or scoped
         overlay env) and move the `&?BLOCK` / `__mutsu_callable_id` / param-binding
         setup writes off the shared global env. This removes the per-call
         `make_mut` deep copies *entirely* (Slice 3 located them at exactly those
-        setup writes; Slices 4b/4c-part1 only shrank each copy, they did not cut the
-        count).
+        setup writes; Slices 4b/4c-part1 only shrank each copy, 4c-part2a removed
+        the per-op `format!` overhead — none of them cut the deep-copy count). The
+        remaining structural cost is the full-`data.env` merge loop in
+        `call_compiled_closure` (`entry_or_insert_sym` over ~100 captured entries
+        per call); replacing it with a captured-env *fallback layer* (so `GetGlobal`
+        consults `data.env` on miss instead of merging it in) is the natural next
+        step, but it must preserve the intricate exit writeback semantics
+        (advent integration tests, recursive `&?BLOCK`, rw bindings, sigilless
+        aliases).
 
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -663,6 +663,16 @@ impl Interpreter {
         self.state_vars.insert(key, value);
     }
 
+    /// Read per-closure-instance captured-variable state (hot closure-call path).
+    pub(crate) fn get_closure_captured_state(&self, id: u64, name: Symbol) -> Option<&Value> {
+        self.closure_captured_state.get(&(id, name))
+    }
+
+    /// Persist per-closure-instance captured-variable state (hot closure-call path).
+    pub(crate) fn set_closure_captured_state(&mut self, id: u64, name: Symbol, value: Value) {
+        self.closure_captured_state.insert((id, name), value);
+    }
+
     pub(crate) fn current_once_scope(&self) -> Option<u64> {
         // When inside a closure call, __mutsu_callable_id identifies the
         // specific closure clone.  This must take priority over the

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -84,6 +84,7 @@ impl Interpreter {
     }
 
     pub(super) fn atomic_value_key_for_name(&mut self, name: &str) -> String {
+        self.mark_atomic_var_seen();
         let name_key = Self::atomic_shared_name_key(name);
         if let Some(Value::Str(existing)) = self.env.get(&name_key) {
             return existing.to_string();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -957,6 +957,13 @@ pub struct Interpreter {
     /// preserves env keys that existed before the block).
     our_vars: HashMap<String, Value>,
     state_vars: HashMap<String, Value>,
+    /// Per-closure-instance captured-variable state, keyed by
+    /// (closure instance id, captured variable Symbol). This is the hot
+    /// closure-call persistence store (loaded/saved on every closure call for
+    /// its free variables); a typed key avoids the per-call
+    /// `format!("__mutsu_closure_cap::{id}::{name}")` String allocation and the
+    /// String hashing that dominated the closure dispatch profile.
+    closure_captured_state: HashMap<(u64, Symbol), Value>,
     once_values: HashMap<String, Value>,
     once_scope_stack: Vec<u64>,
     next_once_scope_id: u64,
@@ -977,6 +984,14 @@ pub struct Interpreter {
     pub(crate) attributes_pragma: String,
     /// Variable type constraints used to enforce typed re-assignment across closures.
     var_type_constraints: HashMap<String, String>,
+    /// Monotonic flag: set once any `atomicint` variable / atomic storage has been
+    /// registered in this interpreter (or inherited from a parent thread). The
+    /// per-`GetGlobal`/`GetLocal` atomic-variable check is expensive (a `format!`
+    /// plus two `var_type_constraint` lookups, each itself a `format!`), yet
+    /// atomics are exotic; when this flag is clear the entire check is skipped,
+    /// which removes that cost from the hot variable-read path. Never cleared, so
+    /// a program that stops using an atomic still resolves correctly.
+    atomic_var_seen: bool,
     /// Variable default values set by `is default(...)` trait.
     var_defaults: HashMap<String, Value>,
     /// Container element defaults for arrays/hashes with `is default(...)`,
@@ -3047,6 +3062,7 @@ impl Interpreter {
             fatal_mode: false,
             our_vars: HashMap::new(),
             state_vars: HashMap::new(),
+            closure_captured_state: HashMap::new(),
             once_values: HashMap::new(),
             once_scope_stack: Vec::new(),
             next_once_scope_id: 1,
@@ -3056,6 +3072,7 @@ impl Interpreter {
             variables_pragma: String::new(),
             attributes_pragma: String::new(),
             var_type_constraints: HashMap::new(),
+            atomic_var_seen: false,
             var_defaults: HashMap::new(),
             container_defaults: HashMap::new(),
             var_hash_key_constraints: HashMap::new(),
@@ -4244,6 +4261,9 @@ impl Interpreter {
         let meta_key = format!("__mutsu_type::{}", key);
         if let Some(constraint) = constraint {
             let info = Self::parse_container_constraint(name, &constraint);
+            if info.value_type == "atomicint" || constraint.contains("atomicint") {
+                self.atomic_var_seen = true;
+            }
             self.var_type_constraints
                 .insert(key.clone(), info.value_type.clone());
             self.env
@@ -4290,6 +4310,20 @@ impl Interpreter {
     /// fast path for simple scalar variables where the env-based constraint is never set.
     pub(crate) fn var_type_constraint_fast(&self, name: &str) -> Option<&String> {
         self.var_type_constraints.get(name)
+    }
+
+    /// Whether any `atomicint`/atomic-storage variable has ever been registered
+    /// (monotonic). When false, the hot variable-read path can skip the entire
+    /// atomic-variable check (which otherwise costs `format!`s and constraint
+    /// lookups on every `GetGlobal`/`GetLocal`).
+    #[inline(always)]
+    pub(crate) fn atomic_var_seen(&self) -> bool {
+        self.atomic_var_seen
+    }
+
+    /// Mark that an atomic variable / atomic storage has been registered.
+    pub(crate) fn mark_atomic_var_seen(&mut self) {
+        self.atomic_var_seen = true;
     }
 
     /// Set the default value for a variable declared with `is default(...)`.
@@ -5096,6 +5130,10 @@ impl Interpreter {
             fatal_mode: self.fatal_mode,
             our_vars: HashMap::new(),
             state_vars: HashMap::new(),
+            // Mirror state_vars: a thread clone starts with no persisted
+            // closure captured state (falls back to the captured-env initial
+            // values), exactly as before this store existed.
+            closure_captured_state: HashMap::new(),
             once_values: self.once_values.clone(),
             once_scope_stack: Vec::new(),
             next_once_scope_id: self.next_once_scope_id,
@@ -5105,6 +5143,10 @@ impl Interpreter {
             variables_pragma: self.variables_pragma.clone(),
             attributes_pragma: self.attributes_pragma.clone(),
             var_type_constraints: self.var_type_constraints.clone(),
+            // Inherit monotonically: if the parent ever registered an atomic var,
+            // the child (which shares the atomic storage via shared_vars) must keep
+            // running the atomic-variable read check.
+            atomic_var_seen: self.atomic_var_seen,
             var_defaults: self.var_defaults.clone(),
             container_defaults: self.container_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -792,21 +792,27 @@ impl VM {
                     *ip += 1;
                     return Ok(());
                 }
-                let atomic_name = name.strip_prefix('$').unwrap_or(name);
-                let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
-                let is_atomic_int = self.interpreter.var_type_constraint(name).as_deref()
-                    == Some("atomicint")
-                    || self.interpreter.var_type_constraint(atomic_name).as_deref()
+                // Atomic-variable read: only possible once some `atomicint`/atomic
+                // storage has been registered. Skip the whole check (a `format!`
+                // plus two `var_type_constraint` lookups) on the hot read path when
+                // no atomics exist, which is the overwhelmingly common case.
+                if self.interpreter.atomic_var_seen() {
+                    let atomic_name = name.strip_prefix('$').unwrap_or(name);
+                    let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
+                    let is_atomic_int = self.interpreter.var_type_constraint(name).as_deref()
                         == Some("atomicint")
-                    || self.interpreter.get_shared_var(&atomic_name_key).is_some();
-                if is_atomic_int {
-                    let fetched = self.interpreter.call_function(
-                        "__mutsu_atomic_fetch_var",
-                        vec![Value::str(atomic_name.to_string())],
-                    )?;
-                    self.stack.push(fetched);
-                    *ip += 1;
-                    return Ok(());
+                        || self.interpreter.var_type_constraint(atomic_name).as_deref()
+                            == Some("atomicint")
+                        || self.interpreter.get_shared_var(&atomic_name_key).is_some();
+                    if is_atomic_int {
+                        let fetched = self.interpreter.call_function(
+                            "__mutsu_atomic_fetch_var",
+                            vec![Value::str(atomic_name.to_string())],
+                        )?;
+                        self.stack.push(fetched);
+                        *ip += 1;
+                        return Ok(());
+                    }
                 }
                 let val = self
                     .get_env_with_main_alias(name)

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -192,9 +192,8 @@ impl VM {
             .free_var_syms
             .iter()
             .filter_map(|k| {
-                let persist_key = format!("__mutsu_closure_cap::{}::{}", data.id, k);
                 self.interpreter
-                    .get_state_var(&persist_key)
+                    .get_closure_captured_state(data.id, *k)
                     .map(|val| (*k, val.clone()))
             })
             .collect();
@@ -524,8 +523,8 @@ impl VM {
         // the body, so only those need persisting.
         for k in &cc.free_var_syms {
             if let Some(val) = self.interpreter.env().get_sym(*k).cloned() {
-                let persist_key = format!("__mutsu_closure_cap::{}::{}", data.id, k);
-                self.interpreter.set_state_var(persist_key, val);
+                self.interpreter
+                    .set_closure_captured_state(data.id, *k, val);
             }
         }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3935,23 +3935,28 @@ impl VM {
             self.stack.push(val);
             return Ok(());
         }
-        let atomic_name = name.strip_prefix('$').unwrap_or(&name);
-        let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
-        // Only use the scalar atomic fast path for scalar ($) variables.
-        // Array (@) variables with `atomicint` constraint are element-wise
-        // atomic and should go through the normal array read path.
-        let is_atomic_int = !name.starts_with('@')
-            && (self.interpreter.var_type_constraint(&name).as_deref() == Some("atomicint")
-                || self.interpreter.var_type_constraint(atomic_name).as_deref()
-                    == Some("atomicint")
-                || self.interpreter.get_shared_var(&atomic_name_key).is_some());
-        if is_atomic_int {
-            let fetched = self
-                .interpreter
-                .builtin_atomic_fetch_var(&[Value::str(atomic_name.to_string())])?;
-            self.locals[idx] = fetched.clone();
-            self.stack.push(fetched);
-            return Ok(());
+        // Atomic-variable read: skip entirely (a `format!` plus two
+        // `var_type_constraint` lookups) when no atomic storage has ever been
+        // registered — the common case on this hot local-read path.
+        if self.interpreter.atomic_var_seen() {
+            let atomic_name = name.strip_prefix('$').unwrap_or(&name);
+            let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
+            // Only use the scalar atomic fast path for scalar ($) variables.
+            // Array (@) variables with `atomicint` constraint are element-wise
+            // atomic and should go through the normal array read path.
+            let is_atomic_int = !name.starts_with('@')
+                && (self.interpreter.var_type_constraint(&name).as_deref() == Some("atomicint")
+                    || self.interpreter.var_type_constraint(atomic_name).as_deref()
+                        == Some("atomicint")
+                    || self.interpreter.get_shared_var(&atomic_name_key).is_some());
+            if is_atomic_int {
+                let fetched = self
+                    .interpreter
+                    .builtin_atomic_fetch_var(&[Value::str(atomic_name.to_string())])?;
+                self.locals[idx] = fetched.clone();
+                self.stack.push(fetched);
+                return Ok(());
+            }
         }
         // Atomic array CAS stores the authoritative array under an internal
         // shared key.  Check it first so reads pick up the latest CAS'd value.

--- a/t/atomic-read-gate.t
+++ b/t/atomic-read-gate.t
@@ -1,0 +1,45 @@
+use Test;
+
+# Regression pin for docs/vm-dual-store.md Slice 4c part 2: the per-read atomic
+# variable check in GetGlobal/GetLocal is gated behind a monotonic
+# "an atomic var has been registered" flag, so ordinary variable reads no longer
+# pay the atomic-name `format!` + constraint lookups. This must not change
+# observable atomic semantics, and ordinary (non-atomic) reads must still work.
+
+plan 10;
+
+# Ordinary scalar reads (the gated-off common case) are unaffected.
+my $x = 10;
+my $y = $x + 5;
+is $y, 15, 'ordinary scalar read unaffected by the gate';
+
+# Reads inside a closure (free-variable GetGlobal — the hot path the gate
+# optimizes) still resolve.
+my $base = 100;
+my $f = -> $n { $n + $base };
+is $f(7), 107, 'closure free-variable read unaffected';
+
+# Atomic scalar: increment / add / fetch still work once an atomic is declared
+# (declaration flips the gate on).
+my atomicint $a = 0;
+$a⚛++;
+$a⚛++;
+is $a, 2, 'atomicint post-increment works';
+is atomic-fetch-inc($a), 2, 'atomic-fetch-inc returns value before increment';
+is $a, 3, 'atomic-fetch-inc incremented the value';
+atomic-assign($a, 13);
+is $a, 13, 'atomic-assign works';
+is atomic-fetch($a), 13, 'atomic-fetch returns current value';
+
+# Ordinary variables declared after an atomic still read correctly (the gate is
+# monotonic, so the check now runs for every read but must not misfire on a
+# non-atomic name).
+my $z = 42;
+is $z, 42, 'non-atomic read correct after an atomic exists';
+is $f(1), 101, 'closure still correct after an atomic exists';
+
+# Atomic shared across threads (the cross-thread shared-storage check path).
+my atomicint $counter = 0;
+my @p = (^4).map({ start { $counter⚛++ for ^250 } });
+await @p;
+is $counter, 1000, 'atomic counter correct across threads';


### PR DESCRIPTION
## Summary

`docs/vm-dual-store.md` Slice 4c part 2a — the dual-store decoupling work.

A `perf` profile of closure-heavy code (after 4b/4c-pt1) showed the `make_mut`
deep copy is now negligible; the dominant cost is **per-op `format!`/`Symbol`
churn**. This PR removes two hot `format!` sources:

### 1. Atomic-variable check on every variable read

`exec_get_global` and the `GetLocal` shared-read path ran an atomic-var check on
**every** read: `format!("__mutsu_atomic_name::{n}")` + two `var_type_constraint`
calls (each itself a `format!("__mutsu_type::{n}")` + env lookup). Closures read
their free vars via `GetGlobal`, and recursion reads its param constantly, so
this sits on the critical path of essentially all variable-read-heavy code — yet
atomics are exotic.

Now gated behind a monotonic `Interpreter::atomic_var_seen` flag, set when an
`atomicint` constraint is registered or atomic storage is created, and inherited
across thread clones (atomics are shared via `shared_vars`). All three trigger
conditions of the check are covered by the two flag-set sites, so the gate can
never hide a real atomic.

### 2. Closure capture-state persistence

Replaced the formatted-String `__mutsu_closure_cap::{id}::{name}` keys (alloc +
string hash per free var per call) with a dedicated typed store
`closure_captured_state: HashMap<(u64, Symbol), Value>`.

## Perf (release, best-of-7, interleaved)

| bench | before | after | speedup |
|---|---|---|---|
| bench-fib | 1.56s | 1.23s | **~21%** |
| read-only closure (heavy) | 8.05s | 7.06s | ~12% |
| mutating closure (heavy) | 15.20s | 14.18s | ~7% |
| bench-class | 0.62s | 0.60s | ~3% |

Bench output byte-identical before/after.

## Tests

- New pin `t/atomic-read-gate.t` (ordinary + closure reads, atomic inc/fetch/assign, cross-thread atomic counter).
- Atomic semantics: whitelisted `roast/S17-lowlevel/atomic.t` + `atomic-ops.t` (62 subtests) green.
- `make test` failure set unchanged from the `main` baseline (`placeholder.t` t8, `tail-function.t` t4, `wrap.t`, `hyper-func-op-writeback.t` t8 — all pre-existing). `roast/S17-lowlevel/lock.t` fails identically on the pre-change binary (pre-existing, not whitelisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)