### PR TITLE
S03 Set/Bag/Mix coercion: list-context flatten (don't flatten nested arrays)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -26,7 +26,7 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
-  - ~306 pass (116 sub-subtest fails, was 154), runs to ~408 of 420. Fixed:
+  - ~312 pass (110 sub-subtest fails, was 154), runs to ~408 of 420. Fixed:
     nodal hyper methods return a `List`; `.splice` on a bare Array value; hyper
     ops on two hashes and hash<->scalar; hyper method/custom-postfix on a hash;
     hyper meta-assignment write-back on a list of scalars; reduction op as inner
@@ -34,11 +34,15 @@
     callables (`&prefix:<-«>`, `&postfix:<»i>`); `X::HyperOp::Infinite` when an
     infinite/lazy operand determines the result length (with `side` attribute)
     and `X::HyperOp::NonDWIM` (with `left-elems`/`right-elems`) for length
-    mismatch.
+    mismatch; `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash` nodal
+    coercion no longer flattens nested arrays (Set/Bag/Mix coercion uses
+    list-context flattening: a List `(...)` invocant flattens, an Array `[...]`
+    invocant keeps each element whole).
   - Remaining blockers: (1) hyper-op precedence — `»+«` vs `»*«` should inherit
-    their base op's precedence (parser); (2) `.all`/`.any`/`.Bag`/`.Set` etc.
-    nodal method dispatch; (3) multidimensional array distribution for binary
-    infix; (4) advanced hyper *method-call* dispatch variants in the
+    their base op's precedence (parser); (2) `.all`/`.any`/`.none`/`.one` nodal
+    junction dispatch (hyper passes the element decontainerized); (3)
+    multidimensional array distribution for binary infix; (4) advanced hyper
+    *method-call* dispatch variants in the
     `'method call variants respect nodality'` and `'hyper method calls
     string/var method names'` subtests — `».""()` (string method name), `».&`
     (sub as method), `».$` (var holding method), `».::` (qualified), `».?`

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -9,11 +9,17 @@ impl Interpreter {
         let mut elems = HashSet::new();
         let mut original_keys: HashMap<String, Value> = HashMap::new();
         let mut has_non_str = false;
+        // `flatten` is true when this item sits in a list-context-flattening
+        // position (an element of a List `(...)` invocant): nested Lists/Arrays/
+        // Seqs/Hashes spill their contents. It is false for elements of an Array
+        // `[...]` invocant, where each element is taken whole (matches Raku:
+        // `[1,[2,3]].Set` has two elements, but `(1,[2,3]).Set` has three).
         fn add_item(
             elems: &mut HashSet<String>,
             original_keys: &mut HashMap<String, Value>,
             has_non_str: &mut bool,
             item: &Value,
+            flatten: bool,
         ) {
             match item {
                 Value::Pair(k, v) => {
@@ -33,21 +39,21 @@ impl Interpreter {
                         elems.insert(str_key);
                     }
                 }
-                Value::Hash(h) => {
+                Value::Hash(h) if flatten => {
                     for (k, v) in h.iter() {
                         if v.truthy() {
                             elems.insert(k.clone());
                         }
                     }
                 }
-                Value::Array(inner, kind) if !kind.is_itemized() => {
+                Value::Array(inner, kind) if flatten && !kind.is_itemized() => {
                     for inner_item in inner.iter() {
-                        add_item(elems, original_keys, has_non_str, inner_item);
+                        add_item(elems, original_keys, has_non_str, inner_item, true);
                     }
                 }
-                Value::Seq(inner) | Value::Slip(inner) => {
+                Value::Seq(inner) | Value::Slip(inner) if flatten => {
                     for inner_item in inner.iter() {
-                        add_item(elems, original_keys, has_non_str, inner_item);
+                        add_item(elems, original_keys, has_non_str, inner_item, true);
                     }
                 }
                 Value::Str(_) => {
@@ -65,9 +71,27 @@ impl Interpreter {
         }
         match target {
             Value::Set(_, _) => return Ok(target),
+            // A List `(...)` invocant flattens its elements in list context; an
+            // Array `[...]` (or itemized) invocant takes each element whole.
+            Value::Array(items, crate::value::ArrayKind::List) => {
+                for item in items.iter() {
+                    add_item(&mut elems, &mut original_keys, &mut has_non_str, item, true);
+                }
+            }
             Value::Array(items, ..) => {
                 for item in items.iter() {
-                    add_item(&mut elems, &mut original_keys, &mut has_non_str, item);
+                    add_item(
+                        &mut elems,
+                        &mut original_keys,
+                        &mut has_non_str,
+                        item,
+                        false,
+                    );
+                }
+            }
+            Value::Seq(items) | Value::Slip(items) => {
+                for item in items.iter() {
+                    add_item(&mut elems, &mut original_keys, &mut has_non_str, item, true);
                 }
             }
             Value::Hash(items) => {
@@ -111,7 +135,13 @@ impl Interpreter {
             }
             other if other.is_range() => {
                 for item in Self::value_to_list(&other) {
-                    add_item(&mut elems, &mut original_keys, &mut has_non_str, &item);
+                    add_item(
+                        &mut elems,
+                        &mut original_keys,
+                        &mut has_non_str,
+                        &item,
+                        false,
+                    );
                 }
             }
             other => {
@@ -242,23 +272,31 @@ impl Interpreter {
             Ok(())
         }
 
-        /// Flatten items from a value into the bag, recursing into arrays and hashes.
+        /// Flatten items from a value into the bag. `flatten` is true when the
+        /// value sits in a list-context-flattening position (an element of a
+        /// List `(...)` invocant): nested non-itemized arrays, seqs, hashes and
+        /// quant-hashes spill. When false (an element of an Array `[...]`
+        /// invocant) the value is taken whole as a single key (matches Raku:
+        /// `[1,[2,3]].Bag` has two keys, `(1,[2,3]).Bag` has three).
         fn flatten_into(
             counts: &mut HashMap<String, i64>,
             original_keys: &mut HashMap<String, Value>,
             has_non_str_keys: &mut bool,
             value: &Value,
+            flatten: bool,
         ) -> Result<(), RuntimeError> {
             match value {
-                Value::Array(_, kind) if kind.is_itemized() => {
-                    add_item(counts, original_keys, has_non_str_keys, value)?;
-                }
-                Value::Array(items, ..) => {
+                Value::Array(items, kind) if flatten && !kind.is_itemized() => {
                     for item in items.iter() {
-                        add_item(counts, original_keys, has_non_str_keys, item)?;
+                        flatten_into(counts, original_keys, has_non_str_keys, item, true)?;
                     }
                 }
-                Value::Hash(h) => {
+                Value::Seq(items) | Value::Slip(items) if flatten => {
+                    for item in items.iter() {
+                        flatten_into(counts, original_keys, has_non_str_keys, item, true)?;
+                    }
+                }
+                Value::Hash(h) if flatten => {
                     for (k, v) in h.iter() {
                         let weight = pair_weight(v)?;
                         if weight > 0 {
@@ -266,17 +304,17 @@ impl Interpreter {
                         }
                     }
                 }
-                Value::Set(s, _) => {
+                Value::Set(s, _) if flatten => {
                     for k in s.iter() {
                         counts.insert(k.clone(), 1);
                     }
                 }
-                Value::Mix(m, _) => {
+                Value::Mix(m, _) if flatten => {
                     for (k, v) in m.iter() {
                         counts.insert(k.clone(), *v as i64);
                     }
                 }
-                Value::Bag(b, _) => {
+                Value::Bag(b, _) if flatten => {
                     for (k, v) in b.iter() {
                         *counts.entry(k.clone()).or_insert(0) += *v;
                     }
@@ -310,6 +348,30 @@ impl Interpreter {
                     *counts.entry(str_key).or_insert(0) += 1;
                 }
             }
+            // A List `(...)` invocant flattens its elements in list context; an
+            // Array `[...]` (or itemized) invocant takes each element whole.
+            Value::Array(ref items, crate::value::ArrayKind::List) | Value::Seq(ref items) => {
+                for item in items.iter() {
+                    flatten_into(
+                        &mut counts,
+                        &mut original_keys,
+                        &mut has_non_str_keys,
+                        item,
+                        true,
+                    )?;
+                }
+            }
+            Value::Array(ref items, _) => {
+                for item in items.iter() {
+                    flatten_into(
+                        &mut counts,
+                        &mut original_keys,
+                        &mut has_non_str_keys,
+                        item,
+                        false,
+                    )?;
+                }
+            }
             _ => {
                 // Flatten the target into a list and process each item.
                 // This handles tuples/lists like (@a, %x).Bag where arrays
@@ -325,7 +387,13 @@ impl Interpreter {
                     )?;
                 } else {
                     for item in &items {
-                        flatten_into(&mut counts, &mut original_keys, &mut has_non_str_keys, item)?;
+                        flatten_into(
+                            &mut counts,
+                            &mut original_keys,
+                            &mut has_non_str_keys,
+                            item,
+                            true,
+                        )?;
                     }
                 }
             }
@@ -457,6 +525,7 @@ impl Interpreter {
         weights: &mut HashMap<String, f64>,
         mut original_keys: Option<&mut HashMap<String, Value>>,
         item: &Value,
+        flatten: bool,
     ) -> Result<(), RuntimeError> {
         match item {
             Value::Pair(k, v) => {
@@ -473,7 +542,7 @@ impl Interpreter {
                 }
                 *weights.entry(str_key).or_insert(0.0) += w;
             }
-            Value::Hash(h) => {
+            Value::Hash(h) if flatten => {
                 for (k, v) in h.iter() {
                     let w = Self::mix_pair_weight(v)?;
                     if w != 0.0 {
@@ -481,17 +550,30 @@ impl Interpreter {
                     }
                 }
             }
-            Value::Array(items, kind) if !kind.is_itemized() => {
+            // A nested non-itemized array / seq flattens one level in
+            // list-context (List `(...)` invocant); an Array `[...]` invocant
+            // element (flatten == false) is kept whole.
+            Value::Array(items, kind) if flatten && !kind.is_itemized() => {
                 for sub_item in items.iter() {
-                    Self::mix_add_item_with_keys(weights, original_keys.as_deref_mut(), sub_item)?;
+                    Self::mix_add_item_with_keys(
+                        weights,
+                        original_keys.as_deref_mut(),
+                        sub_item,
+                        true,
+                    )?;
                 }
             }
-            Value::Seq(items) | Value::Slip(items) => {
+            Value::Seq(items) | Value::Slip(items) if flatten => {
                 for sub_item in items.iter() {
-                    Self::mix_add_item_with_keys(weights, original_keys.as_deref_mut(), sub_item)?;
+                    Self::mix_add_item_with_keys(
+                        weights,
+                        original_keys.as_deref_mut(),
+                        sub_item,
+                        true,
+                    )?;
                 }
             }
-            Value::Set(s, _) => {
+            Value::Set(s, _) if flatten => {
                 for k in s.iter() {
                     let typed = s.typed_key(k);
                     if let Some(ref mut orig) = original_keys
@@ -502,7 +584,7 @@ impl Interpreter {
                     *weights.entry(k.clone()).or_insert(0.0) += 1.0;
                 }
             }
-            Value::Bag(b, _) => {
+            Value::Bag(b, _) if flatten => {
                 for (k, v) in b.iter() {
                     let typed = b.typed_key(k);
                     if let Some(ref mut orig) = original_keys
@@ -513,7 +595,7 @@ impl Interpreter {
                     *weights.entry(k.clone()).or_insert(0.0) += *v as f64;
                 }
             }
-            Value::Mix(m, _) => {
+            Value::Mix(m, _) if flatten => {
                 for (k, v) in m.iter() {
                     let typed = m.typed_key(k);
                     if let Some(ref mut orig) = original_keys
@@ -570,9 +652,28 @@ impl Interpreter {
         let mut original_keys: HashMap<String, Value> = HashMap::new();
         match target {
             Value::Mix(_, _) => return Ok(target),
-            Value::Array(items, ..) | Value::Seq(items) | Value::Slip(items) => {
+            // A List `(...)` invocant flattens its elements in list context; an
+            // Array `[...]` (or itemized) invocant takes each element whole.
+            Value::Array(items, crate::value::ArrayKind::List)
+            | Value::Seq(items)
+            | Value::Slip(items) => {
                 for item in items.iter() {
-                    Self::mix_add_item_with_keys(&mut weights, Some(&mut original_keys), item)?;
+                    Self::mix_add_item_with_keys(
+                        &mut weights,
+                        Some(&mut original_keys),
+                        item,
+                        true,
+                    )?;
+                }
+            }
+            Value::Array(items, ..) => {
+                for item in items.iter() {
+                    Self::mix_add_item_with_keys(
+                        &mut weights,
+                        Some(&mut original_keys),
+                        item,
+                        false,
+                    )?;
                 }
             }
             ref other @ (Value::Set(_, _)
@@ -580,7 +681,7 @@ impl Interpreter {
             | Value::Pair(..)
             | Value::ValuePair(..)
             | Value::Hash(_)) => {
-                Self::mix_add_item_with_keys(&mut weights, Some(&mut original_keys), other)?;
+                Self::mix_add_item_with_keys(&mut weights, Some(&mut original_keys), other, true)?;
             }
             other if other.is_range() => {
                 for item in Self::value_to_list(&other) {

--- a/t/set-bag-mix-nested-array.t
+++ b/t/set-bag-mix-nested-array.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Set/Bag/Mix coercion uses list-context flattening: a List `(...)` invocant
+# flattens its elements (recursively, Lists are transparent), but an Array
+# `[...]` (or itemized) invocant takes each element whole. A nested Array is
+# therefore a single element, but a nested List flattens. Mirrors the rules
+# exercised by roast/S02-types/{set,bag,mix}.t and the nodal `».Set`/`».Bag`/
+# `».Mix` subtests in roast/S03-metaops/hyper.t.
+
+plan 14;
+
+# --- Array invocant: elements taken whole (nested array NOT flattened) ---
+is [1, [2, 3]].Set.elems, 2, '[1,[2,3]].Set keeps nested array as one element';
+is [4, [5, 6]].Bag.elems, 2, '[4,[5,6]].Bag keeps nested array as one key';
+is [4, [5, 6]].Mix.elems, 2, '[4,[5,6]].Mix keeps nested array as one key';
+is [1, (2, 3)].Set.elems, 2, '[1,(2,3)].Set keeps nested list as one element (array invocant)';
+is [1, [2, [3, 4]]].Set.elems, 2, 'array invocant does not flatten at any depth';
+
+# --- List invocant: elements flattened (Lists recursively, Arrays one level) ---
+is (1, [2, 3]).Set.elems, 3, '(1,[2,3]).Set flattens nested array';
+is ((1, 2), 3).Set.elems, 3, '((1,2),3).Set flattens nested list';
+is (1, (2, (3, 4))).Set.elems, 4, 'list invocant flattens nested lists recursively';
+my @a = 1, 2, 3;
+is (@a, 9).Set.elems, 4, '(@a, 9).Set flattens the @-array';
+is [@a, 9].Set.elems, 2, '[@a, 9].Set keeps the @-array whole';
+
+# --- the nested array survives as a real Array key (gist shows brackets) ---
+is-deeply [4, [5, 6]].Set.keys.sort, (4, [5, 6]), 'nested array is a Set key, not flattened';
+is ([4, [5, 6]].Bag.keys.sort).gist, '(4 [5 6])', 'Bag key gist shows the array brackets';
+
+# --- hyper distributes the coercion per node (Array invocants) ---
+is ([[2, 3], [4, [5, 6]]]».Set».keys».sort).gist, '((2 3) (4 [5 6]))',
+    '».Set is nodal: each node coerced, nested array kept';
+is ([[2, 3], [4, [5, 6]]]».Bag».keys».sort).gist, '((2 3) (4 [5 6]))',
+    '».Bag is nodal with nested array preserved';


### PR DESCRIPTION
## Problem

`.Set`/`.Bag`/`.Mix` (and the `*Hash` variants) flattened *every* nested non-itemized array when building the quant-hash. `[4,[5,6]].Bag` wrongly produced **three** keys (4, 5, 6) instead of **two** (4 and the array `[5,6]`):

```
[4, [5, 6]].Bag.keys.elems   # mutsu: 3   raku: 2
```

## Fix

Raku's coercion uses **list-context flattening**, which depends on the *outer* container, not the element type:

| invocant | behavior | example |
|----------|----------|---------|
| List `(...)` / Seq / Slip | flatten elements (Lists recursively, Arrays one level) | `(1,[2,3]).Set` → 3, `(@a,9).Set` flattens `@a`, `(1,(2,(3,4))).Set` → 4 |
| Array `[...]` / itemized | each element taken whole | `[1,[2,3]].Set` → 2, `[@a,9].Set` keeps `@a` |

A `flatten` flag is threaded through `add_item` (Set), `flatten_into` (Bag) and `mix_add_item_with_keys` (Mix): `true` for elements of a List invocant (spill nested arrays/seqs/hashes/quant-hashes), `false` for elements of an Array invocant. The top-level match distinguishes `ArrayKind::List` from the other array kinds.

## Tests

- Fixes the 6 `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash` "is nodal" sub-subtests in `roast/S03-metaops/hyper.t` (154 → 110 failing).
- The `.Set/.Bag/.Mix works on List` subtests in `roast/S02-types/{set,bag,mix}.t` still pass (List invocant still flattens) — verified `set.t` ok 172, `bag.t` ok 171, `mix.t` ok 157.
- New `t/set-bag-mix-nested-array.t` (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)