### PR TITLE
vm: Symbol-key the closure exit writeback scan (4c pt2b)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -387,20 +387,57 @@ Reaching that requires, roughly in order:
         cross-thread counter). (`roast/S17-lowlevel/lock.t` fails identically on the
         pre-change binary — pre-existing, not whitelisted.)
 
-  - [ ] **Slice 4c (part 2b) — upvalue capture + move setup writes off the shared
-        env.** Still to do: give closures an explicit upvalue list (or scoped
-        overlay env) and move the `&?BLOCK` / `__mutsu_callable_id` / param-binding
-        setup writes off the shared global env. This removes the per-call
-        `make_mut` deep copies *entirely* (Slice 3 located them at exactly those
-        setup writes; Slices 4b/4c-part1 only shrank each copy, 4c-part2a removed
-        the per-op `format!` overhead — none of them cut the deep-copy count). The
-        remaining structural cost is the full-`data.env` merge loop in
-        `call_compiled_closure` (`entry_or_insert_sym` over ~100 captured entries
-        per call); replacing it with a captured-env *fallback layer* (so `GetGlobal`
-        consults `data.env` on miss instead of merging it in) is the natural next
-        step, but it must preserve the intricate exit writeback semantics
-        (advent integration tests, recursive `&?BLOCK`, rw bindings, sigilless
-        aliases).
+  - [x] **Slice 4c (part 2b) — Symbol-key the closure exit writeback scan.** Done.
+
+        **The deep-copy count turned out not to be the prize.** A `perf` profile of
+        a mutating-closure bench on the post-part2a binary put `Env::cow_mut` (the
+        `make_mut` deep copy) at only **~2 %**. The dominant cost is **Symbol→string
+        churn (~33 %: `Symbol::starts_with` / `with_str` / `PartialEq<&str>` /
+        `intern`)** plus residual `format!` (~14 %), concentrated in the closure
+        **exit writeback scan** (`call_compiled_closure`). So neither removing the
+        per-call fork nor the merge loop is where the time is.
+
+        **Negative result recorded — the captured-env *fallback layer* does not pay
+        off.** I prototyped giving `Env` an `Arc<Env>` fallback tier so closure
+        dispatch could expose `SubData::env` by reference instead of the
+        `entry_or_insert_sym` merge loop (reads fall through; iteration stays
+        overlay-only, so the writeback semantics are provably unchanged — verified
+        green incl. the advent tests). But Slice 4b already hoisted ~110 constants
+        out of the env, so the captured overlay is now only **~30 entries**, not
+        ~100: the merge is cheap, while the fallback adds a per-call
+        `Arc::new(data.env.clone())` allocation + a read indirection. Measured net:
+        read-only closure ~5 % faster but **mutating closure ~3 % slower** — not
+        worth the blast radius to `Env`. Abandoned. (Lesson: post-4b the dual-store
+        per-call cost is small; the lever moved to the writeback machinery.)
+
+        **What shipped instead.** The exit writeback scan built its
+        param/local/rw-source membership sets as `HashSet<&str>`/`HashSet<String>`
+        and did a `with_str` (Symbol→&str resolve) on *every* working-env entry for
+        each set, plus `*k != "_"` / `*k != "@_"` `PartialEq<&str>` compares. These
+        are now `HashSet<Symbol>` (names interned once per call) and precomputed
+        sentinel `Symbol`s, so the per-entry checks compare interned `Symbol`s
+        directly (u32 + hash) with no string resolution. The scan only runs for
+        non-leaf / mutating closures (read-only leaf closures already skip it), so
+        this targets exactly the mutating-closure path.
+
+        **Result (release, best-of-9, interleaved): mutating closure 13.71s→12.43s
+        (~9.3 %)**; read-only closure, `bench-class`, `bench-fib` neutral (they do
+        not run the writeback scan). Output byte-identical. `make test` failure set
+        unchanged from the `main` baseline; 68 whitelisted S04/S06/S32-list/
+        S32-hash/S03-metaops files + closure pins + advent integration tests all
+        green.
+
+  - [ ] **Slice 4c (part 2c) — the fork itself (deferred, low priority).** Removing
+        the per-call `make_mut` deep copy *entirely* (born-owned overlay / moving
+        the `&?BLOCK` / `__mutsu_callable_id` / param setup writes off the shared
+        env) is still open, but the profile above shows it is now worth only ~2 %,
+        so it is no longer the priority. Higher-value remaining targets in the
+        closure profile: the residual per-free-var metadata `format!`s
+        (`__mutsu_sigilless_readonly::` / `__mutsu_sigilless_alias::` /
+        `__mutsu_state_key::`), which almost always miss but whose write-sites are
+        scattered across 5+ files (so a robust monotonic gate like
+        `atomic_var_seen` needs care), and the two remaining `Symbol::starts_with`
+        prefix checks in the writeback scan.
 
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -538,21 +538,25 @@ impl VM {
         // Build set of parameter names — these are strictly local to the
         // function call and must never leak back to the caller's env, even
         // when they share a name with a captured outer variable.
-        let mut param_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        // Keyed by interned Symbol so the per-entry membership checks in the
+        // writeback scan below compare Symbols directly (a u32 compare + hash)
+        // instead of resolving every env key back to a &str via `with_str` --
+        // that Symbol-to-string churn dominated the writeback profile.
+        let mut param_names: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
         for p in &data.params {
-            param_names.insert(p.as_str());
+            param_names.insert(Symbol::intern(p));
         }
         // Collect names bound by subsignature parameters (e.g. `|c(Str $x)`),
         // which are also strictly call-local and must not leak to the caller.
         let mut subsig_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for pd in &data.param_defs {
             if !pd.name.is_empty() {
-                param_names.insert(pd.name.as_str());
+                param_names.insert(Symbol::intern(&pd.name));
             }
             Interpreter::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
         }
         for name in &subsig_names {
-            param_names.insert(name.as_str());
+            param_names.insert(Symbol::intern(name));
         }
 
         // The full-env writeback below scans the entire working env (~100
@@ -605,27 +609,29 @@ impl VM {
             || !rw_bindings.is_empty()
             || cc.has_calls;
         if needs_caller_writeback {
-            let rw_sources: std::collections::HashSet<String> = rw_bindings
+            let rw_sources: std::collections::HashSet<Symbol> = rw_bindings
                 .iter()
-                .map(|(_, source)| source.clone())
+                .map(|(_, source)| Symbol::intern(source))
                 .collect();
             let captured_names: std::collections::HashSet<Symbol> =
                 data.env.keys().copied().collect();
             // Write back captured-variable changes, but NOT the closure's own
             // parameters/locals (which live in cc.locals).  Without this filter,
             // recursive &?BLOCK calls clobber the outer frame's $n, etc.
-            let local_names: std::collections::HashSet<&str> =
-                cc.locals.iter().map(|s| s.as_str()).collect();
+            let local_names: std::collections::HashSet<Symbol> =
+                cc.locals.iter().map(|s| Symbol::intern(s)).collect();
+            let underscore_sym = Symbol::intern("_");
+            let at_underscore_sym = Symbol::intern("@_");
             for (k, v) in self.interpreter.env().iter() {
-                if *k != "_"
-                    && *k != "@_"
-                    && !k.with_str(|s| rw_sources.contains(s))
-                    && !k.with_str(|s| param_names.contains(s))
+                if *k != underscore_sym
+                    && *k != at_underscore_sym
+                    && !rw_sources.contains(k)
+                    && !param_names.contains(k)
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
                         || k.starts_with("__mutsu_predictive_seq_iter::")
                         || k.starts_with("__mutsu_sigilless_alias::!"))
-                    && (!k.with_str(|s| local_names.contains(s)) || captured_names.contains(k))
+                    && (!local_names.contains(k) || captured_names.contains(k))
                 {
                     // Don't leak captured-only variables to callers that don't have
                     // them. This prevents independent closures from sharing state
@@ -679,7 +685,7 @@ impl VM {
         for local_name in cc.locals.iter() {
             if !local_name.is_empty()
                 && !data.env.contains_key(local_name)
-                && !param_names.contains(local_name.as_str())
+                && !param_names.contains(&Symbol::intern(local_name))
                 && !local_name.starts_with("__mutsu_")
             {
                 restored_env.remove(local_name);


### PR DESCRIPTION
## Summary

`docs/vm-dual-store.md` Slice 4c part 2b — the dual-store decoupling work.

**Measurement first.** A `perf` profile of a mutating-closure bench (post-part2a)
put the `make_mut` deep copy (`Env::cow_mut`) at only **~2 %** — the per-call fork
is *not* the bottleneck anymore. The dominant cost is **Symbol→string churn
(~33 %: `Symbol::starts_with` / `with_str` / `PartialEq<&str>` / `intern`)**,
concentrated in the closure **exit writeback scan**.

The scan built its param/local/rw-source membership sets as
`HashSet<&str>`/`HashSet<String>` and did a `with_str` (Symbol→&str resolve) on
**every** working-env entry for each set, plus `*k != "_"` / `*k != "@_"`
`PartialEq<&str>` compares. These are now `HashSet<Symbol>` (names interned once
per call) and precomputed sentinel `Symbol`s, so per-entry checks compare interned
`Symbol`s directly (u32 + hash), no string resolution. The scan only runs for
non-leaf / mutating closures (read-only leaf closures already skip it).

## Perf (release, best-of-9, interleaved)

| bench | before | after | speedup |
|---|---|---|---|
| mutating closure (heavy) | 13.71s | 12.43s | **~9.3 %** |
| read-only closure (heavy) | 7.07s | 7.10s | neutral (skips writeback) |
| bench-class | 0.60s | 0.61s | neutral |
| bench-fib | 1.26s | 1.24s | neutral |

Output byte-identical before/after.

## Negative result recorded (docs only)

The doc also records that a captured-env `Arc<Env>` **fallback layer** (to replace
the per-call `entry_or_insert_sym` merge loop) does **not** pay off: Slice 4b
already shrank the captured overlay to ~30 entries, so the merge is cheap while
the fallback adds a per-call `Arc::new` + read indirection (mutating closure ~3 %
slower). Abandoned — useful to know for future work.

## Tests

- `make test` failure set unchanged from the `main` baseline (`placeholder.t` t8, `tail-function.t` t4, `wrap.t`, `hyper-func-op-writeback.t` t8 — all pre-existing).
- 68 whitelisted `S04`/`S06`/`S32-list`/`S32-hash`/`S03-metaops` files all green.
- Closure pins (`closure-captured-state`, `closure-selective-env-sync`, `closure-nested-writeback`) + advent integration tests (the writeback-risk cases) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)