### PR TITLE
Junction .gist renders eigenstates with gist when nested in a list

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -458,6 +458,16 @@ pub(super) fn dispatch(
                     }
                     Value::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     Value::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
+                    Value::Junction { kind, values } => {
+                        let kind_str = match kind {
+                            crate::value::JunctionKind::Any => "any",
+                            crate::value::JunctionKind::All => "all",
+                            crate::value::JunctionKind::One => "one",
+                            crate::value::JunctionKind::None => "none",
+                        };
+                        let elems = values.iter().map(gist_item).collect::<Vec<_>>().join(", ");
+                        format!("{}({})", kind_str, elems)
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }
@@ -496,6 +506,16 @@ pub(super) fn dispatch(
                     }
                     Value::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     Value::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
+                    Value::Junction { kind, values } => {
+                        let kind_str = match kind {
+                            crate::value::JunctionKind::Any => "any",
+                            crate::value::JunctionKind::All => "all",
+                            crate::value::JunctionKind::One => "one",
+                            crate::value::JunctionKind::None => "none",
+                        };
+                        let elems = values.iter().map(gist_item).collect::<Vec<_>>().join(", ");
+                        format!("{}({})", kind_str, elems)
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }

--- a/t/junction-gist-in-list.t
+++ b/t/junction-gist-in-list.t
@@ -1,0 +1,35 @@
+use Test;
+
+# A junction's .gist renders each eigenstate with .gist, so a nested Array
+# eigenstate keeps its brackets: `all(4, [5 6])`, not `all(4, 5 6)`. This must
+# hold even when the junction is itself an element of a List/Seq/Array being
+# gisted (e.g. the result of a nodal hyper `>>.all`). Previously the list-level
+# gist helper rendered a nested junction via .Str, dropping the brackets.
+
+plan 10;
+
+# direct junction gist (the baseline that already worked)
+is [4, [5, 6]].all.gist, 'all(4, [5 6])', 'direct .all.gist keeps nested array brackets';
+is [4, [5, 6]].any.gist, 'any(4, [5 6])', 'direct .any.gist keeps nested array brackets';
+
+# junction nested inside a List / Array / Seq
+my $j = [4, [5, 6]].all;
+is ($j,).gist, '(all(4, [5 6]))', 'junction inside a List keeps brackets';
+is [$j].gist, '[all(4, [5 6])]', 'junction inside an Array keeps brackets';
+is ($j, $j).Seq.gist, '(all(4, [5 6]) all(4, [5 6]))', 'junction inside a Seq keeps brackets';
+
+# nodal hyper `>>.all` / `>>.any` produce a List of junctions
+is ([[2, 3], [4, [5, 6]]]>>.all).gist, '(all(2, 3) all(4, [5 6]))',
+    '>>.all is nodal; nested-array eigenstate keeps brackets';
+is ([[2, 3], [4, [5, 6]]]>>.any).gist, '(any(2, 3) any(4, [5 6]))',
+    '>>.any is nodal; nested-array eigenstate keeps brackets';
+
+# mixed list of junctions with and without nested arrays
+is (any(1, [2, 3]), all(4, 5)).gist, '(any(1, [2 3]) all(4, 5))',
+    'mixed junctions render each eigenstate with gist';
+
+# nested list eigenstate renders with parens
+is all(1, (2, 3)).gist, 'all(1, (2 3))', 'nested List eigenstate renders with parens';
+
+# one/none kinds too
+is [7, [8, 9]].none.gist, 'none(7, [8 9])', 'none junction keeps nested array brackets';


### PR DESCRIPTION
## Problem

A junction's `.gist` must render each eigenstate via `.gist`, so a nested Array eigenstate keeps its brackets: `all(4, [5 6])`, not `all(4, 5 6)`.

`[4,[5,6]].all.gist` was already correct (handled by the dedicated junction-gist path in `runtime/methods.rs`). But when a junction is itself an element of a List/Seq/Array being gisted — e.g. the result of a nodal hyper `[[2,3],[4,[5,6]]]>>.all` — the list-level `gist_item` helper fell through to `to_string_value()`, which collapses a junction's eigenstates via `.Str` and drops the nested array's brackets, yielding `all(4, 5 6)`.

```
# before
([[2,3],[4,[5,6]]]>>.all).gist  =>  (all(2, 3) all(4, 5 6))   # wrong
# after / rakudo
([[2,3],[4,[5,6]]]>>.all).gist  =>  (all(2, 3) all(4, [5 6])) # correct
```

## Fix

Add a `Value::Junction` arm to both `gist_item` helpers (Array and Seq) in `dispatch_core_repr.rs` so a nested junction recurses through `gist_item` for each eigenstate, matching Rakudo.

## Tests

New `t/junction-gist-in-list.t` (10 cases): direct gist, junction inside List/Array/Seq, nodal `>>.all`/`>>.any`, mixed junctions, nested-List eigenstate, and `none`.

This advances the BLOCKERS Hyper/Meta work (`roast/S03-metaops/hyper.t` nodal `>>.all`/`>>.any`/`>>.none`/`>>.one` subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)