### PR TITLE
Hyper auto-increment/decrement writes mutation back to Array/Hash

### DIFF
--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -385,6 +385,11 @@ impl Interpreter {
                 other => interp.call_function(routine, vec![other]),
             }
         }
+        // Auto-increment/decrement prefix hyper ops mutate the operand in place,
+        // so the original container variable must be written back (e.g.
+        // `--<<%h` and `--<<@a` both decrement the stored elements). Negation
+        // (`-<<`) and other non-mutating prefixes only return a new container.
+        let mutating = op == "++" || op == "--";
         // Handle hashes: apply the operation to values, preserving hash structure
         if let Value::Hash(map) = &args[1] {
             let mut result_map = std::collections::HashMap::new();
@@ -392,7 +397,24 @@ impl Interpreter {
                 let new_val = apply_hyper_prefix(self, &routine, v.clone())?;
                 result_map.insert(k.clone(), new_val);
             }
-            return Ok(Value::Hash(std::sync::Arc::new(result_map)));
+            let result = Value::Hash(std::sync::Arc::new(result_map));
+            if mutating {
+                self.overwrite_hash_bindings_by_identity(map, result.clone());
+            }
+            return Ok(result);
+        }
+        // Handle arrays: preserve the array kind and write the mutation back to
+        // the original variable for auto-increment/decrement.
+        if let Value::Array(items, kind) = &args[1] {
+            let mut results = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                results.push(apply_hyper_prefix(self, &routine, item.clone())?);
+            }
+            let result = Value::Array(std::sync::Arc::new(results), *kind);
+            if mutating {
+                self.overwrite_array_bindings_by_identity(items, result.clone());
+            }
+            return Ok(result);
         }
         let items = crate::runtime::value_to_list(&args[1]);
         let mut results = Vec::with_capacity(items.len());

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -300,7 +300,7 @@ impl Interpreter {
         Ok(out)
     }
 
-    pub(super) fn overwrite_array_bindings_by_identity(
+    pub(crate) fn overwrite_array_bindings_by_identity(
         &mut self,
         needle: &std::sync::Arc<Vec<Value>>,
         replacement: Value,
@@ -320,7 +320,7 @@ impl Interpreter {
         }
     }
 
-    fn overwrite_hash_bindings_by_identity(
+    pub(crate) fn overwrite_hash_bindings_by_identity(
         &mut self,
         needle: &std::sync::Arc<std::collections::HashMap<String, Value>>,
         replacement: Value,

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -378,6 +378,23 @@ impl VM {
             }
             self.env_dirty = true;
         }
+        // Hash target: write any in-place per-value mutation back to the
+        // original variable (e.g. `%h>>++` increments the stored values). The
+        // returned hash (built from `results` below) carries the method return
+        // values, which for postfix `++`/`--` differ from the new stored values.
+        if let Value::Hash(existing) = &target
+            && let Some(keys) = &hash_keys
+        {
+            let mut map = std::collections::HashMap::with_capacity(keys.len());
+            for (key, item) in keys.iter().zip(items.iter()) {
+                map.insert(key.clone(), item.clone());
+            }
+            self.interpreter.overwrite_hash_bindings_by_identity(
+                existing,
+                Value::Hash(std::sync::Arc::new(map)),
+            );
+            self.env_dirty = true;
+        }
         // Preserve the container type of the target for QuantHash types.
         // The items list was produced by value_to_list, which yields Pairs
         // in HashMap iteration order. Reconstruct the same type using the

--- a/t/hyper-autoincr-writeback.t
+++ b/t/hyper-autoincr-writeback.t
@@ -1,0 +1,68 @@
+use Test;
+
+# Auto-increment / auto-decrement hyper operators mutate their operand in
+# place, so the original container variable (Array or Hash) must reflect the
+# change -- for both prefix (`--<<%h`, `++<<@a`) and postfix (`%h>>++`,
+# `@a>>--`) forms. Non-mutating prefixes like negation (`-<<`) must NOT mutate.
+# Mirrors roast/S03-metaops/hyper.t "hash - correct result from --<< / >>++".
+
+plan 20;
+
+# --- prefix --<< / ++<< on a Hash: mutates in place ---
+{
+    my %a = a => 1, b => 2, c => 3;
+    my %r = --<<%a;
+    is %r<a>, 0, 'prefix --<< returns decremented values';
+    is %r<c>, 2, 'prefix --<< returns decremented values (c)';
+    is %a<a>, 0, 'prefix --<< mutates the hash in place';
+    is %a<b>, 1, 'prefix --<< mutates the hash in place (b)';
+    is %a<c>, 2, 'prefix --<< mutates the hash in place (c)';
+
+    my %s = ++<<%a;
+    is %a<a>, 1, 'prefix ++<< mutates the hash back up';
+    is %s<c>, 3, 'prefix ++<< returns incremented values';
+}
+
+# --- postfix >>++ / >>-- on a Hash: mutates in place, returns old values ---
+{
+    my %a = a => 1, b => 2, c => 3;
+    my %r = %a>>++;
+    is %r<a>, 1, 'postfix >>++ returns the old values';
+    is %a<a>, 2, 'postfix >>++ mutates the hash in place';
+    is %a<c>, 4, 'postfix >>++ mutates the hash in place (c)';
+
+    my %s = %a>>--;
+    is %s<a>, 2, 'postfix >>-- returns the old values';
+    is %a<a>, 1, 'postfix >>-- mutates the hash back down';
+}
+
+# --- prefix --<< / ++<< on an Array: mutates in place ---
+{
+    my @x = 1, 2, 3;
+    --<<@x;
+    is-deeply @x, [0, 1, 2], 'prefix --<< mutates the array in place';
+    ++<<@x;
+    is-deeply @x, [1, 2, 3], 'prefix ++<< mutates the array back up';
+}
+
+# --- postfix >>++ / >>-- on an Array: mutates in place ---
+{
+    my @y = 1, 2, 3;
+    @y>>++;
+    is-deeply @y, [2, 3, 4], 'postfix >>++ mutates the array in place';
+    @y>>--;
+    is-deeply @y, [1, 2, 3], 'postfix >>-- mutates the array back down';
+}
+
+# --- negation prefix -<< does NOT mutate ---
+{
+    my %n = a => 1, b => 2;
+    my %m = -<<%n;
+    is %n<a>, 1, 'negation -<< does not mutate the hash';
+    is %m<a>, -1, 'negation -<< returns negated values';
+
+    my @a = 1, 2, 3;
+    my @b = -<<@a;
+    is-deeply @a, [1, 2, 3], 'negation -<< does not mutate the array';
+    is-deeply @b, [-1, -2, -3], 'negation -<< returns negated values';
+}


### PR DESCRIPTION
## Problem

The hyper auto-increment / auto-decrement operators (`--<<`, `++<<`, `>>++`, `>>--`) mutate their operand in place, so the original container variable must reflect the change. Previously only the **postfix Array** form worked:

```
my @y = 1,2,3; @y>>++;  say @y;  # [2 3 4]  ✓ (already worked)
my @x = 1,2,3; --<<@x;  say @x;  # [1 2 3]  ✗ should be [0 1 2]
my %a = a=>1,b=>2;   --<<%a; say %a<a>;  # 1  ✗ should be 0
my %b = a=>1,b=>2; %b>>++;  say %b<a>;  # 1  ✗ should be 2
```

All three broken forms returned the correct *new* container but left the variable unchanged. roast/S03-metaops/hyper.t exercises this with sequentially-dependent subtests ("hash - correct result from --<<", ">>++"), so the missing write-back failed those.

## Fix

- **Prefix** (`builtin_hyper_prefix`): for the mutating ops `++`/`--`, write the result back to the original Array/Hash by `Arc` identity. Non-mutating prefixes (negation `-<<`) still only return a new container.
- **Postfix** (`exec_hyper_method_call_op`): add the Hash counterpart of the existing Array write-back, pairing the original keys with the mutated per-value items. The returned hash still carries the method *return* values (old values for postfix `++`/`--`), which differ from the stored values.
- Expose `overwrite_array_bindings_by_identity` / `overwrite_hash_bindings_by_identity` as `pub(crate)`.

## Tests

New `t/hyper-autoincr-writeback.t` (20 cases): prefix/postfix `++`/`--` on Array and Hash mutate in place; negation `-<<` does not mutate. All existing `t/hyper*.t` pass unchanged.

Advances the BLOCKERS Hyper/Meta work (`roast/S03-metaops/hyper.t` hash auto-incr/decr subtests now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)