### PR TITLE
vm: gate closure exit metadata write-back scans behind a monotonic flag (4c pt2c)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -427,17 +427,46 @@ Reaching that requires, roughly in order:
         S32-hash/S03-metaops files + closure pins + advent integration tests all
         green.
 
-  - [ ] **Slice 4c (part 2c) — the fork itself (deferred, low priority).** Removing
-        the per-call `make_mut` deep copy *entirely* (born-owned overlay / moving
-        the `&?BLOCK` / `__mutsu_callable_id` / param setup writes off the shared
-        env) is still open, but the profile above shows it is now worth only ~2 %,
-        so it is no longer the priority. Higher-value remaining targets in the
-        closure profile: the residual per-free-var metadata `format!`s
-        (`__mutsu_sigilless_readonly::` / `__mutsu_sigilless_alias::` /
-        `__mutsu_state_key::`), which almost always miss but whose write-sites are
-        scattered across 5+ files (so a robust monotonic gate like
-        `atomic_var_seen` needs care), and the two remaining `Symbol::starts_with`
-        prefix checks in the writeback scan.
+  - [x] **Slice 4c (part 2c) — gate the per-call sigilless/state metadata
+        write-back scans behind a monotonic flag.** Done.
+
+        **What was costing.** After part 2b the closure exit path still ran, on
+        *every* call, three per-free-var / per-env scans that almost always find
+        nothing: (1) a `format!("__mutsu_sigilless_readonly::{n}")` +
+        `format!("__mutsu_sigilless_alias::{n}")` lookup per free var, (2)
+        `merge_sigilless_alias_writes`, which scans the whole working env **twice**
+        doing `Symbol::starts_with` on every key, and (3) a
+        `format!("__mutsu_state_key::{n}")` lookup per free var. A program with no
+        sigilless variables and no state variables (the common case, incl. the
+        read-only `map`/`grep` blocks) created none of those metadata keys yet paid
+        all three scans. The profile put `format!`/`fmt::write` at ~11 % and
+        `Symbol::starts_with` at ~8.5 %.
+
+        **The robustness problem the doc flagged, solved at the choke point.** The
+        ~20 metadata-creation sites are scattered across 5+ files, so a per-site
+        monotonic gate (like `atomic_var_seen`) was error-prone. But *every* such
+        key is created via the String-keyed `Env::insert` (always a `format!`
+        result) — `insert_sym` is never used for them (verified). So a single
+        prefix check in `Env::insert` catches all creation sites regardless of
+        caller. A process-global monotonic `AtomicBool` (`env.rs
+        CLOSURE_META_KEY_SEEN`) is set there for `__mutsu_sigilless_*` /
+        `__mutsu_state_key::*` / `__mutsu_predictive_seq_iter::*`; the closure exit
+        path reads `closure_meta_keys_possible()` once and skips all three scans
+        (and the two residual `starts_with` prefix checks in the main writeback
+        loop) when it is false. The flag is global + monotonic, so an over-set only
+        ever makes the (correct) scan run — never wrong — and a program's metadata
+        lives in its own per-thread env created earlier in that thread's program
+        order, so `Relaxed` ordering suffices. Also switched the writeback scan's
+        `local_names` set from re-interning `cc.locals` per call to the
+        compile-time-precomputed `cc.locals_sym`.
+
+        **Result (release, best-of-7, interleaved): read-only closure 7.21s→5.79s
+        (~19.7 %), mutating closure 12.55s→10.55s (~15.9 %)**; `bench-fib` and
+        `bench-class` neutral (within noise). Bench output byte-identical.
+        Focused S03-binding/S04-blocks/S04-declarations(state)/S02-names/S06
+        roast set (9 files) + closure pins + the three advent integration tests
+        green. New pin `t/closure-meta-writeback-gate.t` (plain / read-only /
+        state-var-per-instance / monotonic-flag / forwarded-call-mutation).
 
 Each slice must keep `make test` + `make roast` green and report perf
 (`method-call`, `bench-class`, `bench-fib`) before/after.

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use crate::symbol::Symbol;
@@ -29,6 +30,47 @@ pub(crate) fn set_global_base(map: HashMap<Symbol, Value>) {
 #[inline(always)]
 fn global_base() -> Option<&'static HashMap<Symbol, Value>> {
     GLOBAL_BASE.get()
+}
+
+/// Monotonic, process-global flag: set the first time any closure-writeback
+/// metadata key is inserted into *any* env. These keys --
+/// `__mutsu_sigilless_readonly::*`, `__mutsu_sigilless_alias::*`,
+/// `__mutsu_state_key::*`, `__mutsu_predictive_seq_iter::*` -- drive the
+/// per-call sigilless/alias/state-var write-back scans in the closure exit path
+/// (`call_compiled_closure`). The common program never creates any of them, so
+/// the closure path consults [`closure_meta_keys_possible`] to skip those
+/// scans (and their `format!` allocations) entirely.
+///
+/// Soundness: every such key is created via the String-keyed [`Env::insert`]
+/// (always a `format!` result), so detecting them there catches *every*
+/// creation site regardless of which of the ~20 scattered callers inserts it --
+/// the robustness the per-site approach could not guarantee. The flag is
+/// monotonic and global: once `true` it stays `true`, and `true` only ever
+/// makes the (correct) scan run, so an over-set is conservative, never wrong.
+/// A program's metadata lives in its own (per-thread) env, and the creating
+/// `insert` runs earlier in that thread's program order than any closure that
+/// reads it, so `Relaxed` ordering suffices.
+static CLOSURE_META_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
+/// True if any closure-writeback metadata key may exist in some env. See
+/// [`CLOSURE_META_KEY_SEEN`].
+#[inline]
+pub(crate) fn closure_meta_keys_possible() -> bool {
+    CLOSURE_META_KEY_SEEN.load(Ordering::Relaxed)
+}
+
+/// Flip [`CLOSURE_META_KEY_SEEN`] if `key` is a closure-writeback metadata key.
+/// The outer `__mutsu_` gate keeps this ~1 byte compare for ordinary lexical
+/// names (which never start with `_`).
+#[inline]
+fn note_closure_meta_key(key: &str) {
+    if key.as_bytes().starts_with(b"__mutsu_")
+        && (key.starts_with("__mutsu_sigilless_")
+            || key.starts_with("__mutsu_state_key::")
+            || key.starts_with("__mutsu_predictive_seq_iter::"))
+    {
+        CLOSURE_META_KEY_SEEN.store(true, Ordering::Relaxed);
+    }
 }
 
 /// Copy-on-write environment wrapper.
@@ -98,6 +140,7 @@ impl Env {
 
     #[inline]
     pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
+        note_closure_meta_key(&key);
         let sym = Symbol::intern(&key);
         self.cow_mut().insert(sym, value)
     }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -608,6 +608,11 @@ impl VM {
             || has_writable_params
             || !rw_bindings.is_empty()
             || cc.has_calls;
+        // Whether any closure-writeback metadata key (sigilless readonly/alias,
+        // state-var, predictive-seq) may exist in any env. The common program
+        // creates none, so this stays false and the per-call metadata scans
+        // (and the `__mutsu_*` prefix checks below) are skipped entirely.
+        let meta_possible = crate::env::closure_meta_keys_possible();
         if needs_caller_writeback {
             let rw_sources: std::collections::HashSet<Symbol> = rw_bindings
                 .iter()
@@ -618,8 +623,10 @@ impl VM {
             // Write back captured-variable changes, but NOT the closure's own
             // parameters/locals (which live in cc.locals).  Without this filter,
             // recursive &?BLOCK calls clobber the outer frame's $n, etc.
+            // `cc.locals_sym` is `cc.locals` pre-interned at compile time, so
+            // this avoids re-interning every local on every call.
             let local_names: std::collections::HashSet<Symbol> =
-                cc.locals.iter().map(|s| Symbol::intern(s)).collect();
+                cc.locals_sym.iter().copied().collect();
             let underscore_sym = Symbol::intern("_");
             let at_underscore_sym = Symbol::intern("@_");
             for (k, v) in self.interpreter.env().iter() {
@@ -629,8 +636,9 @@ impl VM {
                     && !param_names.contains(k)
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
-                        || k.starts_with("__mutsu_predictive_seq_iter::")
-                        || k.starts_with("__mutsu_sigilless_alias::!"))
+                        || (meta_possible
+                            && (k.starts_with("__mutsu_predictive_seq_iter::")
+                                || k.starts_with("__mutsu_sigilless_alias::!"))))
                     && (!local_names.contains(k) || captured_names.contains(k))
                 {
                     // Don't leak captured-only variables to callers that don't have
@@ -648,24 +656,31 @@ impl VM {
         // modified inside the closure (e.g. `$a := $arg` where `$a` is captured).
         // Only free variables can be modified by the body, so restrict the
         // (format!-heavy) metadata scan to them instead of the whole captured env.
-        for captured_sym in &cc.free_var_syms {
-            let captured_name = captured_sym.resolve();
-            let readonly_key = format!("__mutsu_sigilless_readonly::{}", captured_name);
-            if let Some(v) = self.interpreter.env().get(&readonly_key).cloned() {
-                restored_env.insert(readonly_key, v);
+        // Skipped wholesale when no sigilless/alias/predictive metadata has ever
+        // been created (the common case) -- `meta_possible` gates the per-free-var
+        // `format!`s and the env-wide `merge_sigilless_alias_writes` scan.
+        if meta_possible {
+            for captured_sym in &cc.free_var_syms {
+                let captured_name = captured_sym.resolve();
+                let readonly_key = format!("__mutsu_sigilless_readonly::{}", captured_name);
+                if let Some(v) = self.interpreter.env().get(&readonly_key).cloned() {
+                    restored_env.insert(readonly_key, v);
+                }
+                let alias_key = format!("__mutsu_sigilless_alias::{}", captured_name);
+                if let Some(v) = self.interpreter.env().get(&alias_key).cloned() {
+                    restored_env.insert(alias_key, v);
+                }
             }
-            let alias_key = format!("__mutsu_sigilless_alias::{}", captured_name);
-            if let Some(v) = self.interpreter.env().get(&alias_key).cloned() {
-                restored_env.insert(alias_key, v);
-            }
+            self.interpreter
+                .merge_sigilless_alias_writes(&mut restored_env, self.interpreter.env());
         }
-        self.interpreter
-            .merge_sigilless_alias_writes(&mut restored_env, self.interpreter.env());
 
         // Only run the state-variable sync and cleanup when the closure
         // references captured variables that may be state vars.  This avoids the
-        // per-call overhead for simple closures in hot loops.
-        if !cc.free_var_syms.is_empty() {
+        // per-call overhead for simple closures in hot loops.  The `meta_possible`
+        // gate skips the per-free-var `format!("__mutsu_state_key::...")` lookups
+        // entirely for programs with no state variables.
+        if meta_possible && !cc.free_var_syms.is_empty() {
             // Update state variable storage when closures modify captured
             // state variables.  The metadata key "__mutsu_state_key::<name>"
             // maps the variable name to its state storage key (set by

--- a/t/closure-meta-writeback-gate.t
+++ b/t/closure-meta-writeback-gate.t
@@ -1,0 +1,61 @@
+use Test;
+
+# Regression pin for docs/vm-dual-store.md Slice 4c part 2c: the closure exit
+# path's per-call sigilless-alias / readonly / state-var writeback scans are
+# gated behind a monotonic "any closure-writeback metadata key has been
+# created" flag (env.rs CLOSURE_META_KEY_SEEN, set in Env::insert). The common
+# closure (no sigilless vars, no state vars) must skip those scans, and the
+# scans must still fire correctly once such metadata exists.
+
+plan 13;
+
+# --- Ordinary closures (flag may be false): basic capture/mutate still works.
+sub make-counter() {
+    my $n = 0;
+    my $inc = -> { $n = $n + 1; $n };
+    my @r;
+    @r.push($inc()) for ^3;
+    @r;
+}
+is make-counter(), [1, 2, 3], 'plain mutating closure captures/writes back';
+
+# Read-only closure (the hot map/grep shape) unaffected.
+my @doubled = (1, 2, 3).map({ $_ * 2 });
+is @doubled, [2, 4, 6], 'read-only map block unaffected';
+
+my @big = (1..5).grep({ $_ > 2 });
+is @big, [3, 4, 5], 'read-only grep block unaffected';
+
+# --- State variables (flips the meta flag): per-instance state persists.
+my $bump = { state $s = 0; $s = $s + 1; $s };
+is $bump(), 1, 'state var first call';
+is $bump(), 2, 'state var second call';
+is $bump(), 3, 'state var third call';
+
+# Fresh closure instance from a factory gets fresh state.
+sub make-state() { return { state $c = 0; $c = $c + 1; $c } }
+my $a = make-state();
+my $b = make-state();
+is $a(), 1, 'instance A state starts fresh';
+is $a(), 2, 'instance A state accumulates';
+is $b(), 1, 'instance B state is independent';
+
+# State array captured + mutated inside a closure.
+my $collect = { state @seen; @seen.push($^x); @seen.elems };
+is $collect(10), 1, 'state array push #1';
+is $collect(20), 2, 'state array push #2';
+
+# --- After metadata exists, ordinary closures still behave (flag is monotonic
+# so the now-always-true flag must not corrupt non-metadata closures).
+is make-counter(), [1, 2, 3], 'plain closure correct after meta flag is set';
+
+# Nested closure writes an outer captured variable through a call.
+sub outer() {
+    my $acc = 0;
+    my $add = -> $v { $acc = $acc + $v };
+    my $apply = -> $f, $x { $f($x) };   # forwards a call to a mutating closure
+    $apply($add, 5);
+    $apply($add, 7);
+    $acc;
+}
+is outer(), 12, 'nested closure mutation propagates through a forwarded call';


### PR DESCRIPTION
## Summary

Slice 4c part 2c of the VM dual-store decoupling (`docs/vm-dual-store.md`).

The closure exit path (`call_compiled_closure`) ran, on **every call**, three per-free-var / per-env scans that almost always find nothing:

1. a `format!("__mutsu_sigilless_readonly::{n}")` + `__mutsu_sigilless_alias::` lookup per free var,
2. `merge_sigilless_alias_writes`, which scans the whole working env **twice** doing `Symbol::starts_with` on every key,
3. a `format!("__mutsu_state_key::{n}")` lookup per free var.

A program with no sigilless variables and no state variables (the common case, including the read-only `map`/`grep` blocks) creates **none** of those metadata keys yet paid all three scans every call. The profile put `format!`/`fmt::write` at ~11% and `Symbol::starts_with` at ~8.5%.

## The robustness problem, solved at the choke point

The ~20 metadata-creation sites are scattered across 5+ files, so a per-site monotonic gate (like the existing `atomic_var_seen`) would be error-prone. But **every** such key is created via the String-keyed `Env::insert` (always a `format!` result) — `insert_sym` is never used for them (verified). So a single prefix check in `Env::insert` catches all creation sites regardless of caller.

A process-global monotonic `AtomicBool` (`env.rs::CLOSURE_META_KEY_SEEN`) is set there for `__mutsu_sigilless_*` / `__mutsu_state_key::*` / `__mutsu_predictive_seq_iter::*`; the closure exit path reads `closure_meta_keys_possible()` once and skips all three scans (and the two residual `starts_with` prefix checks in the main writeback loop) when false.

**Soundness:** the flag is global + monotonic, so an over-set only ever makes the (correct) scan run — never wrong. A program's metadata lives in its own per-thread env, created earlier in that thread's program order than any closure that reads it, so `Relaxed` ordering suffices.

Also switched the writeback scan's `local_names` set from re-interning `cc.locals` per call to the compile-time-precomputed `cc.locals_sym`.

## Result (release, best-of-7, interleaved)

| bench | before | after | speedup |
|---|---|---|---|
| read-only closure (heavy) | 7.21s | 5.79s | **~19.7%** |
| mutating closure (heavy) | 12.55s | 10.55s | **~15.9%** |
| bench-fib | 1.25s | 1.26s | neutral |
| bench-class | 0.61s | 0.62s | neutral |

Bench output byte-identical between before/after.

## Tests

- New pin `t/closure-meta-writeback-gate.t` (plain / read-only / state-var-per-instance / monotonic-flag-still-correct / forwarded-call-mutation).
- Focused roast set (S03-binding/closure, S04-declarations/state, S04-blocks pointy/pointy-rw/let, S02-names dynamic-scope/signature, S04-statements last/next — 9 files) green.
- Closure pins + the three advent integration tests (advent2011-day03, advent2009-day07, advent2012-day20) green.
- `make test` + `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)