### PR TITLE
Hash .gist joins nested pairs with ", " (comma-space)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -454,7 +454,7 @@ pub(super) fn dispatch(
                             .iter()
                             .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
                             .collect();
-                        format!("{{{}}}", parts.join(" "))
+                        format!("{{{}}}", parts.join(", "))
                     }
                     Value::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     Value::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
@@ -502,7 +502,7 @@ pub(super) fn dispatch(
                             .iter()
                             .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
                             .collect();
-                        format!("{{{}}}", parts.join(" "))
+                        format!("{{{}}}", parts.join(", "))
                     }
                     Value::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     Value::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),

--- a/t/hash-gist-nested-comma.t
+++ b/t/hash-gist-nested-comma.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A Hash's .gist separates pairs with ", " (comma-space). This already held
+# for a top-level hash, but when a Hash is nested inside a List/Array/Seq/Hash
+# being gisted, the inner gist helper joined pairs with a bare space. A
+# multi-pair nested hash therefore rendered `{a => 1 b => 2}` instead of
+# `{a => 1, b => 2}`. This surfaces in nodal hypers like `>>.classify` /
+# `>>.categorize` (roast/S03-metaops/hyper.t).
+
+plan 8;
+
+# top-level (already correct)
+is {a => 1, b => 2, c => 3}.gist, '{a => 1, b => 2, c => 3}', 'top-level hash gist uses comma';
+
+# hash nested in an Array / List / Seq
+is [{a => 1, b => 2}, {c => 3, d => 4}].gist,
+    '[{a => 1, b => 2} {c => 3, d => 4}]', 'hashes inside an Array keep commas';
+is ({a => 1, b => 2},).gist, '({a => 1, b => 2})', 'hash inside a List keeps commas';
+is ({a => 1, b => 2}, {c => 3}).Seq.gist,
+    '({a => 1, b => 2} {c => 3})', 'hashes inside a Seq keep commas';
+
+# hash nested inside a hash value
+is {x => {a => 1, b => 2}}.gist, '{x => {a => 1, b => 2}}', 'nested hash value keeps commas';
+
+# single-pair nested hash: no separator needed (regression guard)
+is [{a => 1}, {b => 2}].gist, '[{a => 1} {b => 2}]', 'single-pair nested hashes unchanged';
+
+# nodal hyper that produces a List of Hashes
+is ([[2, 3], [4, [5, 6]]]>>.classify(* %% 2)).gist,
+    '({False => [3], True => [2]} {True => [4 [5 6]]})',
+    '>>.classify nodal result renders hash pairs with commas';
+is ([[2, 3], [4, 5]]>>.categorize(* %% 2)).gist,
+    '({False => [3], True => [2]} {False => [5], True => [4]})',
+    '>>.categorize nodal result renders hash pairs with commas';


### PR DESCRIPTION
## Problem

A Hash's `.gist` separates pairs with `, ` (comma-space). This already held for a top-level hash, but when a Hash is nested inside a List/Array/Seq/Hash being gisted, the inner `gist_item` helper joined pairs with a bare space:

```
{a => 1, b => 2}.gist          # {a => 1, b => 2}   ✓
[{a => 1, b => 2}].gist        # [{a => 1 b => 2}]  ✗ should be [{a => 1, b => 2}]
```

This surfaces in nodal hypers that yield a list of hashes — `>>.classify`, `>>.categorize`, `>>.hash` in roast/S03-metaops/hyper.t:

```
([[2,3],[4,[5,6]]]>>.classify(* %% 2)).gist
# before: ({False => [3] True => [2]} {True => [4 [5 6]]})
# after:  ({False => [3], True => [2]} {True => [4 [5 6]]})   # matches Rakudo
```

## Fix

Change the Hash arm of `gist_item` (used by both the Array and Seq gist helpers) to `parts.join(", ")`. Single-pair hashes emit no separator, so they're unaffected.

## Tests

New `t/hash-gist-nested-comma.t` (8 cases): hashes nested in Array/List/Seq/Hash, single-pair regression guard, and nodal `>>.classify` / `>>.categorize`.

Advances the BLOCKERS Hyper/Meta work (`roast/S03-metaops/hyper.t` `.classify`/`.categorize` nodal subtests now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)