### PR TITLE
deepmap parent-aware itemization; nodemap always returns a List

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2359,9 +2359,14 @@ impl Interpreter {
             // Type objects (e.g. Array, Hash) — return as-is to avoid hanging
             Value::Package(_) => Ok(target.clone()),
             Value::Array(items, kind) => {
+                // A sublist is itemized (wrapped in a Scalar container) only when
+                // its *parent* is a List, not when the parent is a real Array.
+                // Compare Rakudo: `(1,[2,3]).deepmap(*+1)` -> `(2, $[3, 4])` but
+                // `[1,[2,3]].deepmap(*+1)` -> `[2, [3, 4]]`.
+                let child_itemize = !kind.is_real_array();
                 let mut result = Vec::new();
                 for item in items.iter() {
-                    match self.deepmap_iterate_inner(block, item, true) {
+                    match self.deepmap_iterate_inner(block, item, child_itemize) {
                         Ok(v) => result.push(v),
                         Err(e) if e.is_next => continue,
                         Err(e) => return Err(e),
@@ -2438,7 +2443,9 @@ impl Interpreter {
         target: &Value,
     ) -> Result<Value, RuntimeError> {
         match target {
-            Value::Array(items, kind) => {
+            // nodemap always returns a List, even from a real Array or a Seq.
+            // Compare Rakudo: `[2,3].nodemap(*+1).WHAT` is `List`.
+            Value::Array(items, _kind) => {
                 let mut result = Vec::new();
                 for item in items.iter() {
                     match self.call_sub_value(block.clone(), vec![item.clone()], false) {
@@ -2447,11 +2454,7 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                if kind.is_real_array() {
-                    Ok(Value::real_array(result))
-                } else {
-                    Ok(Value::array(result))
-                }
+                Ok(Value::array(result))
             }
             Value::Seq(items) => {
                 let mut result = Vec::new();
@@ -2462,7 +2465,7 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(Value::Seq(std::sync::Arc::new(result)))
+                Ok(Value::array(result))
             }
             // Single value: apply the block directly
             _ => self.call_sub_value(block.clone(), vec![target.clone()], false),

--- a/t/deepmap-nodemap-nodal.t
+++ b/t/deepmap-nodemap-nodal.t
@@ -1,0 +1,33 @@
+use Test;
+
+# .nodemap always returns a List (even from a real Array or a Seq), applying
+# the block to each top-level node without descending. .deepmap preserves the
+# container kind and itemizes a sublist only when its *parent* is a List, not
+# when the parent is a real Array. These surface as nodal hypers in
+# roast/S03-metaops/hyper.t (».nodemap / ».deepmap).
+
+plan 12;
+
+# --- nodemap returns a List ---
+is [2, 3].nodemap(* + 1).WHAT.gist, '(List)', 'nodemap from Array returns a List';
+is (1, 2).nodemap(* + 1).WHAT.gist, '(List)', 'nodemap from List returns a List';
+is (1, 2, 3).Seq.nodemap(* + 1).WHAT.gist, '(List)', 'nodemap from Seq returns a List';
+is [2, 3].nodemap(* + 1).gist, '(3 4)', 'nodemap result gist is a List';
+
+# --- nodemap is shallow: a sublist node numifies ---
+is [4, [5, 6]].nodemap(* + 1).gist, '(5 3)', 'nodemap does not descend (sublist numifies)';
+
+# --- deepmap preserves the outer Array, descends to leaves ---
+is [4, [5, 6]].deepmap(* + 1).gist, '[5 [6 7]]', 'deepmap keeps Array, nested Array not itemized';
+is [4, [5, 6]].deepmap(* + 1).raku, '[5, [6, 7]]', 'deepmap raku has no spurious $ itemizer';
+
+# --- deepmap itemization depends on the parent container ---
+is (1, [2, 3]).deepmap(* + 1).raku, '(2, $[3, 4])', 'List parent itemizes a sublist';
+is [1, [2, 3]].deepmap(* + 1).raku, '[2, [3, 4]]', 'Array parent does not itemize a sublist';
+is (1, (2, 3)).deepmap(* + 1).raku, '(2, $(3, 4))', 'List parent itemizes a nested List';
+
+# --- nodal hyper forms ---
+is ([[2, 3], [4, [5, 6]]]>>.nodemap(* + 1)).gist, '((3 4) (5 3))',
+    '».nodemap is nodal; each node mapped, result is a List';
+is ([[2, 3], [4, [5, 6]]]>>.deepmap(* + 1)).gist, '([3 4] [5 [6 7]])',
+    '».deepmap is nodal; preserves Array structure to the leaves';


### PR DESCRIPTION
## Summary

Two nodal-method fixes exercised by `roast/S03-metaops/hyper.t` (`».deepmap` / `».nodemap` subtests).

### `.nodemap` always returns a List

`[2,3].nodemap(*+1).WHAT` is `List` in Rakudo, even from a real Array or a Seq. mutsu echoed the source container kind (Array stayed Array). Now it always returns a List.

### `.deepmap` itemizes by parent container

A sublist is wrapped in a Scalar container (`$[...]` / `$(...)`) only when its **parent** is a List, not when the parent is a real Array:

```
(1,[2,3]).deepmap(*+1)   # (2, $[3, 4])   List parent -> itemized
[1,[2,3]].deepmap(*+1)   # [2, [3, 4]]    Array parent -> not itemized
```

mutsu itemized on **every** recursion, so an Array-nested sublist became an `ItemArray`. This was masked in `.raku` (which omits the `$`) but exposed in `.gist`:

```
[4,[5,6]].deepmap(*+1).gist   # before: [5 $[6 7]]   after: [5 [6 7]]
([[2,3],[4,[5,6]]]>>.deepmap(*+1)).gist
                              # before: ([3 4] [5 $[6 7]])   after: ([3 4] [5 [6 7]])
```

## Tests

New `t/deepmap-nodemap-nodal.t` (12 cases) covering return kinds, shallow vs deep descent, parent-dependent itemization, and the nodal hyper forms. `roast/S32-list/deepmap.t` still passes all 14; existing `t/map*.t` unaffected.

Advances the BLOCKERS Hyper/Meta work (`roast/S03-metaops/hyper.t` `.deepmap`/`.nodemap` nodal subtests now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)