### PR TITLE
Hyper-op dwim: empty side yields empty; `*`-terminated list pads with last element

### DIFF
--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1110,37 +1110,64 @@ impl VM {
         // At least one side is a (non-hash) Iterable: distribute element-wise,
         // recursing so nested Iterables/Hashes are handled at every depth.
         if Self::is_listy(left) || Self::is_listy(right) {
-            let left_list = Interpreter::value_to_list(left);
-            let right_list = Interpreter::value_to_list(right);
+            let mut left_list = Interpreter::value_to_list(left);
+            let mut right_list = Interpreter::value_to_list(right);
+            // A list literal ending in `*` (Whatever) is "infinitely extensible
+            // by copying its last real element". Strip the trailing Whatever;
+            // such a side adapts to the other side's length (like a dwim side)
+            // but pads with its last real element instead of cycling.
+            let left_ext = matches!(left_list.last(), Some(Value::Whatever));
+            let right_ext = matches!(right_list.last(), Some(Value::Whatever));
+            if left_ext {
+                left_list.pop();
+            }
+            if right_ext {
+                right_list.pop();
+            }
             let left_len = left_list.len();
             let right_len = right_list.len();
-            if left_len == 0 && right_len == 0 {
+            // A side determines the result length only when it neither dwims nor
+            // is `*`-extensible.
+            let left_fixed = !dwim_left && !left_ext;
+            let right_fixed = !dwim_right && !right_ext;
+            // A non-dwimmy, non-extensible hyper requires equal lengths.
+            if left_fixed && right_fixed && left_len != right_len {
+                return Err(Self::hyperop_nondwim_error(left_len, right_len));
+            }
+            // An empty operand cannot be cycled or padded to fill a dwim side, so
+            // any empty side yields an empty result (`True »+» ()` is `()`, not a
+            // `0`-padded `(1,)`). The fixed-length mismatch above already covers
+            // the case where the empty side must raise X::HyperOp::NonDWIM.
+            if left_len == 0 || right_len == 0 {
                 return Ok(Value::array(Vec::new()));
             }
-            let result_len = if !dwim_left && !dwim_right {
-                if left_len != right_len {
-                    return Err(Self::hyperop_nondwim_error(left_len, right_len));
-                }
+            let result_len = if left_fixed {
                 left_len
-            } else if dwim_left && dwim_right {
-                std::cmp::max(left_len, right_len)
-            } else if dwim_right {
-                left_len
-            } else {
+            } else if right_fixed {
                 right_len
+            } else {
+                std::cmp::max(left_len, right_len)
+            };
+            // A `*`-extensible side pads with its last real element; an ordinary
+            // dwim side cycles from the start.
+            let l_index = |i: usize| {
+                if left_ext {
+                    i.min(left_len - 1)
+                } else {
+                    i % left_len
+                }
+            };
+            let r_index = |i: usize| {
+                if right_ext {
+                    i.min(right_len - 1)
+                } else {
+                    i % right_len
+                }
             };
             let mut results = Vec::with_capacity(result_len);
             for i in 0..result_len {
-                let l = if left_len == 0 {
-                    &Value::Int(0)
-                } else {
-                    &left_list[i % left_len]
-                };
-                let r = if right_len == 0 {
-                    &Value::Int(0)
-                } else {
-                    &right_list[i % right_len]
-                };
+                let l = &left_list[l_index(i)];
+                let r = &right_list[r_index(i)];
                 results.push(self.hyper_op_pair(op, l, r, dwim_left, dwim_right)?);
             }
             // Preserve List kind when inputs are Lists (not Arrays)

--- a/t/hyper-op-dwim-empty-star.t
+++ b/t/hyper-op-dwim-empty-star.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Two refinements to hyper-op dwim length semantics:
+#   1. A dwim (cycling) side that is empty cannot be filled, so any empty
+#      operand makes a dwimmy hyper return an empty list (not a 0-padded one).
+#      A non-dwimmy length mismatch still throws X::HyperOp::NonDWIM.
+#   2. A list ending in `*` (Whatever) is "infinitely extensible by copying its
+#      last real element": it adapts to the other side's length, padding with
+#      its last real element instead of cycling.
+# Mirrors roast/S03-metaops/hyper.t.
+
+plan 16;
+
+# --- empty operand against a dwim side -> empty ---
+is (True «+« ()).gist, '()', 'left-dwim, empty RHS -> empty';
+is (True »+» ()).gist, '()', 'right-dwim, empty RHS -> empty';
+is (True «+» ()).gist, '()', 'both-dwim, empty RHS -> empty';
+is (() «+« True).gist, '()', 'left-dwim, empty LHS -> empty';
+is (() »+» True).gist, '()', 'right-dwim, empty LHS -> empty';
+my @a = <a b c d e>;
+is (@a «+« ()).elems, 0, 'dwim against empty list -> empty (list operand)';
+is (() «+» @a).elems, 0, 'empty dwim list against a list -> empty';
+
+# --- non-dwim against empty still throws X::HyperOp::NonDWIM ---
+throws-like { True »+« () }, X::HyperOp::NonDWIM,
+    left-elems => 1, right-elems => 0, 'non-dwim against empty RHS throws';
+throws-like { () »+« True }, X::HyperOp::NonDWIM,
+    left-elems => 0, right-elems => 1, 'non-dwim against empty LHS throws';
+
+# --- `*`-terminated list extends by copying its last real element ---
+is ~(<A B C D E> »~» (1, 2, 3, *)), 'A1 B2 C3 D3 E3',
+    'right-dwim: `*` list pads with last real element';
+is ~(<A B C D E> «~» (1, 2, 3, *)), 'A1 B2 C3 D3 E3',
+    'both-dwim: `*` list pads with last real element';
+is ~((1, 2, 3, *) «~« <A B C D E>), '1A 2B 3C 3D 3E',
+    'left-dwim: `*` list pads with last real element';
+is ~((1, 2, 3, *) «~» <A B C D E>), '1A 2B 3C 3D 3E',
+    'both-dwim: `*` list on the left pads';
+is ~((1, 2, *) «~» (4, 5, *)), '14 25',
+    'both `*` lists: result length is the longer real prefix';
+
+# --- ordinary cycling dwim is unaffected ---
+is ((1, 2, 3, 4) <<+>> (10, 20)).gist, '(11 22 13 24)', 'shorter dwim side still cycles';
+is ((1, 2, 3) >>+>> (10, 20, 30)).gist, '(11 22 33)', 'equal lengths unaffected';

--- a/t/hyper.t
+++ b/t/hyper.t
@@ -61,14 +61,15 @@ is @r11.join(" "), "11 22 13 24 15", '<<+>> shorter cycles to match longer';
 my @r12 = @y <<+>> @x;
 is @r12.join(" "), "11 22 13 24 15", '<<+>> commutative behavior';
 
-# empty arrays
+# empty arrays: a dwim side that is empty cannot be cycled/padded, so the
+# result is empty (matches Rakudo and roast/S03-metaops/hyper.t).
 my @empty;
 my @nonempty = 1, 2, 3;
 my @r13 = @empty <<+>> @nonempty;
-is @r13.join(" "), "1 2 3", '<<+>> empty left with nonempty right';
+is @r13.elems, 0, '<<+>> empty left with nonempty right yields empty';
 
 my @r14 = @nonempty <<+>> @empty;
-is @r14.join(" "), "1 2 3", '<<+>> nonempty left with empty right';
+is @r14.elems, 0, '<<+>> nonempty left with empty right yields empty';
 
 # chaining hyper operators
 my @c1 = 1, 2, 3;


### PR DESCRIPTION
## Summary

Two refinements to the dwim length semantics of binary hyper ops, both exercised by `roast/S03-metaops/hyper.t`.

### 1. Empty dwim side -> empty result

A dwim (cycling) side that is empty cannot be filled, so any empty operand makes a dwimmy hyper return an empty list rather than padding the other side with the operator identity:

```
True »+» ()    # before: (1,)   after: ()
() «+» @a      # before: 0-padded   after: ()
```

A non-dwimmy length mismatch still raises `X::HyperOp::NonDWIM` (e.g. `True »+« ()` with `left-elems => 1, right-elems => 0`).

### 2. `*`-terminated list is infinitely extensible

A list literal ending in `*` (Whatever) extends by copying its last real element. It adapts to the other side's length (like a dwim side) but pads with its last real element instead of cycling:

```
<A B C D E> »~» (1, 2, 3, *)   # A1 B2 C3 D3 E3
(1, 2, 3, *) «~« <A B C D E>   # 1A 2B 3C 3D 3E
(1, 2, *) «~» (4, 5, *)        # 14 25  (longer real prefix)
```

## Implementation

Reworked the listy branch of `hyper_op_pair` around a `fixed` notion — a side determines the result length only when it neither dwims nor is `*`-extensible — with per-side index closures (cycle vs pad-last).

## Tests

New `t/hyper-op-dwim-empty-star.t` (16 cases). Local `t/hyper.t` tests 13/14 asserted the old 0-padding behavior for empty dwim operands and were updated to match Rakudo/roast (empty -> empty). Local `roast/S03-metaops/hyper.t` failing subtests dropped from 38 to 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)