### PR TITLE
Hyper infix as a named function returns a List, like the operator form

### DIFF
--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1729,7 +1729,19 @@ impl Interpreter {
             };
             results.push(pair_result);
         }
-        Ok(Value::real_array(results))
+        // Preserve List kind when the inputs are Lists (not real Arrays), so the
+        // function form `infix:<»+«>((1,2,3),(4,5,6))` returns a List just like
+        // the operator form `(1,2,3) »+« (4,5,6)`.
+        let left_is_array = matches!(left, Value::Array(_, crate::value::ArrayKind::Array));
+        let right_is_array = matches!(right, Value::Array(_, crate::value::ArrayKind::Array));
+        if !left_is_array && !right_is_array {
+            Ok(Value::Array(
+                std::sync::Arc::new(results),
+                crate::value::ArrayKind::List,
+            ))
+        } else {
+            Ok(Value::real_array(results))
+        }
     }
 }
 

--- a/t/hyper-infix-autogen-list.t
+++ b/t/hyper-infix-autogen-list.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A hyper infix operator invoked as a named function -- `infix:<»+«>(a, b)`,
+# `&infix:<»+«>(a, b)`, or `&[»+«](a, b)` -- must return the same value as the
+# operator form `a »+« b`, including the List container kind when the operands
+# are Lists (not real Arrays). Previously the function form returned an Array,
+# so `is-deeply` against a List literal failed. Mirrors the "can autogen"
+# subtests in roast/S03-metaops/hyper.t.
+
+plan 14;
+
+# operator form is the reference
+is-deeply ((1, 2, 3) »+« (4, 5, 6)), (5, 7, 9), 'operator form returns a List';
+
+# named function form
+is-deeply infix:<»+«>((1, 2, 3), (4, 5, 6)), (5, 7, 9), 'infix:<»+«> as function';
+is-deeply infix:<»+»>((1, 2, 3), 1),         (2, 3, 4), 'infix:<»+»> right-dwim scalar';
+is-deeply infix:<«+«>(1, (4, 5, 6)),         (5, 6, 7), 'infix:<«+«> left-dwim scalar';
+is-deeply infix:<«+»>((1, 2), (4, 5, 6)),    (5, 7, 7), 'infix:<«+»> both-dwim extend';
+
+# &-sigil form
+is-deeply &infix:<»+«>((1, 2, 3), (4, 5, 6)), (5, 7, 9), '&infix:<»+«>';
+is-deeply &infix:<»+»>((1, 2, 3), 1),         (2, 3, 4), '&infix:<»+»>';
+is-deeply &infix:<«+«>(1, (4, 5, 6)),         (5, 6, 7), '&infix:<«+«>';
+is-deeply &infix:<«+»>((1, 2), (4, 5, 6)),    (5, 7, 7), '&infix:<«+»>';
+
+# &[...] form
+is-deeply &[»+«]((1, 2, 3), (4, 5, 6)), (5, 7, 9), '&[»+«]';
+is-deeply &[»+»]((1, 2, 3), 1),         (2, 3, 4), '&[»+»]';
+is-deeply &[«+«](1, (4, 5, 6)),         (5, 6, 7), '&[«+«]';
+
+# prefix / postfix hyper function forms (gist comparison)
+is prefix:<-«>((2, 3, 4)).gist,    '(-2 -3 -4)',        'prefix:<-«> as function';
+is &postfix:<»i>((2, 3, 4)).gist,  '(0+2i 0+3i 0+4i)',  '&postfix:<»i> as function';


### PR DESCRIPTION
## Problem

Calling a hyper operator by name returned a real Array instead of a List, so `is-deeply` against a List literal failed even though the values matched:

```
infix:<»+«>((1,2,3),(4,5,6))   # before: [5, 7, 9]  (Array)   after: (5, 7, 9)  (List)
(1,2,3) »+« (4,5,6)            # operator form already returned a List
```

This affects the `infix:<…>(…)`, `&infix:<…>(…)`, and `&[…](…)` forms (the "can autogen" subtests in `roast/S03-metaops/hyper.t`).

## Fix

In `apply_hyper_infix`, preserve List kind when both operands are Lists (not real Arrays), matching the operator form and the VM's `hyper_op_pair`.

## Tests

New `t/hyper-infix-autogen-list.t` (14 cases): operator-form reference plus the `infix:<…>` / `&infix:<…>` / `&[…]` function forms and prefix/postfix hyper function forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)