### PR TITLE
Hyper meta-assignment yields its value as an expression

### DIFF
--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -244,12 +244,16 @@ impl Compiler {
                 dwim_left,
                 dwim_right,
             });
-            // Assign the result back to the left-hand side variable
+            // Assign the result back to the left-hand side variable. Keep a copy
+            // on the stack (via Dup) so the hyper-assignment also yields its
+            // value as an expression, e.g. `my @r = @a »+=« (1,2,3)`.
             match left {
                 Expr::ArrayVar(name) => {
+                    self.code.emit(OpCode::Dup);
                     self.emit_set_named_var(&format!("@{}", name));
                 }
                 Expr::Var(name) => {
+                    self.code.emit(OpCode::Dup);
                     self.emit_set_named_var(name);
                 }
                 Expr::Index {

--- a/t/hyper-meta-assign-return.t
+++ b/t/hyper-meta-assign-return.t
@@ -1,0 +1,38 @@
+use Test;
+
+# A hyper meta-assignment operator (`»+=«`, `»*=»`, `»~=»`, ...) mutates its
+# left-hand lvalue *and* yields the new value as the expression result, so
+# `my @r = @a »+=« (...)` binds @r to the updated contents. Previously the
+# write-back consumed the stack value and the expression returned Any.
+# Mirrors roast/S03-metaops/hyper.t "»+=« / »*=» returns the right value".
+
+plan 8;
+
+{
+    my @array = 3, 8, 2, 9, 3, 8;
+    my @r = @array »+=« (1, 2, 3, 4, 5, 6);
+    is-deeply @r, [4, 10, 5, 13, 8, 14], '»+=« returns the right value';
+    is-deeply @array, [4, 10, 5, 13, 8, 14], '»+=« changes its lvalue';
+}
+
+{
+    my @array = 3, 8, 2, 9, 3, 8;
+    my @r = @array »*=» (1, 2, 3);
+    is-deeply @r, [3, 16, 6, 9, 6, 24], '»*=» returns the right value';
+    is-deeply @array, [3, 16, 6, 9, 6, 24], '»*=» changes its lvalue';
+}
+
+{
+    my @a = <a b c>;
+    my @r = @a »~=» <pie tart>;
+    is-deeply @r, ['apie', 'btart', 'cpie'], '»~=» returns the right value';
+    is-deeply @a, ['apie', 'btart', 'cpie'], '»~=» changes its lvalue';
+}
+
+{
+    # scalar lvalue
+    my $x = 5;
+    my $y = ($x »+=» 3);
+    is $y, 8, 'scalar hyper meta-assign returns the new value';
+    is $x, 8, 'scalar hyper meta-assign mutates the lvalue';
+}


### PR DESCRIPTION
## Problem

A hyper meta-assignment operator (`»+=«`, `»*=»`, `»~=»`, ...) over a simple Array/scalar lvalue wrote the element-wise result back to the variable correctly, but the write-back (`SetLocal`/`SetGlobal`) consumed the stack value, so the surrounding expression saw nothing:

```
my @array = 3, 8, 2, 9, 3, 8;
my @r = @array »+=« (1, 2, 3, 4, 5, 6);
say @r;       # before: [Any]   after: [4 10 5 13 8 14]
say @array;   # [4 10 5 13 8 14]  (write-back always worked)
```

## Fix

Emit a `Dup` before the write-back in the `ArrayVar` / `Var` arms of `compile_expr_hyper_op`, so the new value remains on the stack as the expression result — matching `@a += x` and Rakudo.

## Tests

New `t/hyper-meta-assign-return.t` (8 cases): `»+=«`, `»*=»`, `»~=»` on arrays plus a scalar lvalue, asserting both the returned value and the mutated lvalue. Existing `t/hyper*.t` pass unchanged; local `roast/S03-metaops/hyper.t` failing subtests dropped from 20 to 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)