### PR TITLE
Hyper wordy postfix operator in dotted form is a method call

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -3184,20 +3184,39 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 }
             }
 
-            // User-declared postfix operator in dotted form: ».??? / >>.???
+            // User-declared postfix operator in dotted form (».??? / >>.???) is
+            // only allowed for *non-wordy* (symbolic) operators. A wordy postfix
+            // like `foo` in dotted form is a plain method call (and throws
+            // X::Method::NotFound if no such method exists), per S03:
+            // `@a».???` calls `postfix:<???>`, but `@a».foo` looks up a method.
             if modifier.is_none()
                 && let Some((full_name, consumed)) =
                     super::super::stmt::simple::match_user_declared_postfix_op(r)
             {
-                expr = Expr::HyperMethodCall {
-                    target: Box::new(expr),
-                    name: Symbol::intern(&full_name),
-                    args: Vec::new(),
-                    modifier: None,
-                    quoted: false,
-                };
-                rest = &r[consumed..];
-                continue;
+                let inner = full_name
+                    .strip_prefix("postfix:<")
+                    .and_then(|s| s.strip_suffix('>'))
+                    .unwrap_or("");
+                let is_wordy = inner
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_alphabetic() || c == '_')
+                    && inner
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+                if !is_wordy {
+                    expr = Expr::HyperMethodCall {
+                        target: Box::new(expr),
+                        name: Symbol::intern(&full_name),
+                        args: Vec::new(),
+                        modifier: None,
+                        quoted: false,
+                    };
+                    rest = &r[consumed..];
+                    continue;
+                }
+                // Wordy postfix in dotted form: fall through to method-name
+                // parsing so it dispatches as a method call.
             }
 
             // Hyper with quoted method name: ».""() / »."name"() / »."{expr}"()

--- a/t/hyper-postfix-dotted-wordy.t
+++ b/t/hyper-postfix-dotted-wordy.t
@@ -1,0 +1,32 @@
+use Test;
+
+# In a hyper postfix, a *wordy* (identifier) user-declared postfix operator may
+# be applied only in the non-dotted form (`@a»foo` / `@a>>foo`). The dotted form
+# (`@a».foo` / `@a>>.foo`) is a method call, so it throws X::Method::NotFound
+# when no such method exists. A *non-wordy* (symbolic) postfix operator works in
+# both forms. Mirrors roast/S03-metaops/hyper.t.
+
+plan 8;
+
+sub postfix:<foo>($) { 42 }
+sub postfix:<???>($) { 42 }
+
+my @a = 1 .. 3;
+
+# wordy postfix: non-dotted form applies the operator
+is-deeply (@a»foo),  [42, 42, 42], 'wordy postfix, guillemet form';
+is-deeply (@a>>foo), [42, 42, 42], 'wordy postfix, ASCII form';
+
+# wordy postfix: dotted form is a method call -> X::Method::NotFound
+throws-like { @a».foo }, X::Method::NotFound,
+    message => "No such method 'foo' for invocant of type 'Int'",
+    'wordy postfix dotted form (guillemet) throws';
+throws-like { @a>>.foo }, X::Method::NotFound,
+    message => "No such method 'foo' for invocant of type 'Int'",
+    'wordy postfix dotted form (ASCII) throws';
+
+# non-wordy (symbolic) postfix works in every form
+is-deeply (@a»???),   [42, 42, 42], 'symbolic postfix, guillemet';
+is-deeply (@a>>???),  [42, 42, 42], 'symbolic postfix, ASCII';
+is-deeply (@a».???),  [42, 42, 42], 'symbolic postfix, guillemet dotted';
+is-deeply (@a>>.???), [42, 42, 42], 'symbolic postfix, ASCII dotted';


### PR DESCRIPTION
## Problem

In a hyper postfix, a user-declared postfix operator was matched in both the non-dotted form (`@a»foo`) and the dotted form (`@a».foo`). But per S03 the dotted form is a method call:

```
sub postfix:<foo>($) { 42 }
my @a = 1..3;
@a»foo      # (42 42 42)            -- non-dotted applies the operator
@a».foo     # X::Method::NotFound   -- dotted is a method call
```

A *non-wordy* (symbolic) postfix such as `???` is still allowed in the dotted form (`@a».???`).

## Fix

Restrict the dotted-form postfix-operator match in the parser to non-wordy (symbolic) operators; a wordy (identifier) postfix falls through to normal method-name parsing, so it dispatches as a method and throws `X::Method::NotFound` with `No such method 'foo' for invocant of type 'Int'`.

## Tests

New `t/hyper-postfix-dotted-wordy.t` (8 cases): wordy postfix non-dotted applies, dotted throws (guillemet + ASCII), symbolic postfix works in all four forms. Local `roast/S03-metaops/hyper.t` failing subtests dropped from 18 to 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)