### PR TITLE
vm: don't mirror slot-only function params into the interpreter env (dual-store decouple step 2)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -500,14 +500,36 @@ Reaching that requires, roughly in order:
       ENTER-LEAVE / closure / state / nested calls). `make test` failure set
       unchanged from the `main` baseline.
 
+      **Step 2 — don't write slot-only params into `env` either.** The light call
+      path (`call_compiled_function_positional_light`) bound each param to its slot
+      *and* wrote it into the shared `env` (so a name-based reader / the post-call
+      pull would see it). Now it writes the param to `env` only when a name-based
+      reader needs it: the param is in `needs_env_sync` (GetGlobal / closure
+      capture), or program-wide reflective by-name access is possible
+      (`opcode::reflective_name_access_possible()` — a monotonic flag set at compile
+      time for any `CALLER::`/`OUTER::`/symbolic-deref/pseudo-stash/`EVAL` op), or
+      the value is `Nil` (GetLocal treats a `Nil` slot as possibly-undeclared and
+      verifies via `env.contains_key`, so `Nil` params stay mirrored to avoid a
+      spurious X::Undeclared). A slot-only param of a leaf/recursive function now
+      **never enters the interpreter `env`** — and because the param write was what
+      dirtied `env`, skipping it also drops the post-call pull. `fib`'s dual-store
+      activity goes to **all zeros** (`env_deep_copies`/`env_flushes`/`slots_flushed`
+      /`locals_pulls` = 0): its `$n` is purely VM-resident.
+
+      Regression found + fixed during this step: `return-Int(Nil)` (and any
+      `id(Nil)`) raised `X::Undeclared` because the `Nil` slot's declaration check
+      reads `env`; the `Nil`-value exception above fixes it. `t/S06-advanced/return.t`
+      (109 subtests) green again. New pin `t/dualstore-param-not-mirrored.t`
+      (recursion / Nil / type-object / shadow / EVAL / closure-capture / multi).
+
       **Remaining (the collapse proper, still open).** The conservative loop/block
-      fallback, the param-bind `env` write in the light call path, and the
-      `env_dirty`-triggered post-call pull (`sync_locals_from_env`) still mirror
-      state. Fully removing them needs the per-call **scoped/overlay env** (a child
-      scope per call frame that reads through to the parent and is dropped on
-      return), so a callee's writes never pollute the caller's `env` and the
-      bidirectional sync disappears. That is the larger structural change this
-      first step sets up.
+      `needs_env_sync` fallback, the named-param light path
+      (`call_compiled_function_light`) and `call_compiled_function_named` param
+      writes, and the residual `env_dirty` pull still mirror state in some paths.
+      Fully removing them needs the per-call **scoped/overlay env** (a child scope
+      per call frame that reads through to the parent and is dropped on return), so a
+      callee's writes never pollute the caller's `env` and the bidirectional sync
+      disappears. That is the larger structural change these steps set up.
 
   - [ ] **Slice 5 (original design notes — superseded by the step above).**
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1184,15 +1184,22 @@ impl CompiledCode {
         // loop-phaser desugaring threads state through by name via `env`, e.g.
         // the `__mutsu_loop_first_`/`__mutsu_loop_ran_` control temps) cannot
         // safely treat any local as slot-only -- a slot value may not survive the
-        // loop's per-iteration env round-trips. Mark every local env-synced so the
-        // dual-store flush gate (vm_env_helpers) keeps the full flush for such
-        // frames. Recursion-heavy code without loops (e.g. `fib`) is unaffected
-        // and still skips the per-call flush for its slot-only params.
-        let has_inline_loop = self
-            .ops
-            .iter()
-            .any(|op| matches!(op, OpCode::ForLoop { .. } | OpCode::BlockScope { .. }));
-        if has_inline_loop {
+        // loop's per-iteration env round-trips. The same applies to `MakeGather`:
+        // a gather block compiles its body inline and snapshots the *whole*
+        // interpreter env by name (vm_register_ops::exec_make_gather_op), but the
+        // body is not registered in `closure_compiled_codes`, so the nested-closure
+        // free-var scan below cannot see which locals it reads. Mark every local
+        // env-synced so the dual-store flush gate (vm_env_helpers) keeps the full
+        // flush for such frames. Recursion-heavy code without loops/gather (e.g.
+        // `fib`) is unaffected and still skips the per-call flush for its slot-only
+        // params.
+        let captures_env_by_name = self.ops.iter().any(|op| {
+            matches!(
+                op,
+                OpCode::ForLoop { .. } | OpCode::BlockScope { .. } | OpCode::MakeGather(_)
+            )
+        });
+        if captures_env_by_name {
             self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             return;
         }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,8 +1,31 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::ast::{ParamDef, Stmt};
 use crate::symbol::Symbol;
 use crate::value::Value;
+
+/// Monotonic, process-global flag: set at compile time when any compiled code
+/// contains an op that can read a *caller frame's* lexical by dynamic name --
+/// `CALLER::`/`OUTER::` access, symbolic dereference `::($name)`, pseudo-stash
+/// access, indirect code lookup, or an `EVAL`/`EVALFILE` call (which compiles
+/// and runs a string in the caller's lexical scope).
+///
+/// The compiled-function light call path uses this to decide whether it may
+/// skip writing a *slot-only* parameter (one not in `needs_env_sync`, read only
+/// via `GetLocal`) into the interpreter's shared `env`: if no such reflective
+/// reader exists anywhere in the program, the param can stay purely in the VM's
+/// `locals` (dual-store decoupling, docs/vm-dual-store.md). The flag is
+/// monotonic and global, so `true` only ever forces the (correct) full param
+/// write -- an over-set is conservative, never wrong.
+static REFLECTIVE_NAME_ACCESS_SEEN: AtomicBool = AtomicBool::new(false);
+
+/// True if any compiled code may read a caller frame's lexical by dynamic name.
+/// See [`REFLECTIVE_NAME_ACCESS_SEEN`].
+#[inline]
+pub(crate) fn reflective_name_access_possible() -> bool {
+    REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed)
+}
 
 /// Bytecode operations for the VM.
 #[derive(Debug, Clone)]
@@ -1147,6 +1170,10 @@ impl CompiledCode {
     pub(crate) fn compute_needs_env_sync(&mut self) {
         self.compute_locals_sym();
         self.compute_free_vars();
+        // Always scan for reflective caller-lexical access (independent of the
+        // needs_env_sync early returns below), so the global flag is set even for
+        // loop/block or zero-local frames.
+        self.scan_reflective_name_access();
         let n = self.locals.len();
         self.needs_env_sync = vec![false; n];
         if n == 0 {
@@ -1208,6 +1235,39 @@ impl CompiledCode {
                 && let Some(&slot) = locals_map.get(name.as_str())
             {
                 self.needs_env_sync[slot] = true;
+            }
+        }
+    }
+
+    /// Scan this code's ops for reflective by-name access to a caller frame's
+    /// lexicals (`CALLER::`/`OUTER::`, symbolic deref, pseudo-stash, indirect
+    /// code lookup, `EVAL`/`EVALFILE`) and set the process-global
+    /// [`REFLECTIVE_NAME_ACCESS_SEEN`] flag. Runs unconditionally at finalize
+    /// (before the `needs_env_sync` early returns) so the flag covers loop/block
+    /// frames and zero-local frames too. Monotonic: only ever sets `true`.
+    pub(crate) fn scan_reflective_name_access(&self) {
+        if REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed) {
+            return;
+        }
+        for op in &self.ops {
+            let reflective = match op {
+                OpCode::GetCallerVar { .. }
+                | OpCode::GetOuterVar { .. }
+                | OpCode::GetPseudoStash(_)
+                | OpCode::SymbolicDeref(_)
+                | OpCode::SymbolicDerefStore(_)
+                | OpCode::IndirectCodeLookup(_) => true,
+                OpCode::CallFunc { name_idx, .. } | OpCode::CallFuncSlip { name_idx, .. } => {
+                    matches!(
+                        self.constants.get(*name_idx as usize),
+                        Some(Value::Str(name)) if name.as_str() == "EVAL" || name.as_str() == "EVALFILE"
+                    )
+                }
+                _ => false,
+            };
+            if reflective {
+                REFLECTIVE_NAME_ACCESS_SEEN.store(true, Ordering::Relaxed);
+                return;
             }
         }
     }

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -791,6 +791,15 @@ impl VM {
         // the call (ensure_env_synced may write param locals to env during
         // execution, and those must not leak into the caller's scope).
         let saved_readonly = self.interpreter.save_readonly_vars();
+        // Dual-store decoupling: a slot-only param (read via GetLocal, not in
+        // `needs_env_sync`) need not be written into the interpreter's shared
+        // `env` at all -- it lives purely in the VM's `locals`. We must still
+        // write every param when some code may read a caller frame's lexical by
+        // dynamic name (EVAL / CALLER:: / symbolic deref), since such a reader
+        // resolves the name against `env`. Loop/block frames already mark all
+        // params `needs_env_sync` (the conservative fallback in
+        // compute_needs_env_sync), so they keep the full write.
+        let write_all_params = crate::opcode::reflective_name_access_possible();
         let mut saved_param_env: Vec<(String, Option<Value>)> =
             Vec::with_capacity(positional_count);
         for (param_idx, slot) in param_slots.iter().enumerate() {
@@ -819,15 +828,31 @@ impl VM {
                     }
                 }
                 let param_name = &cf.param_defs[param_idx].name;
-                saved_param_env.push((
-                    param_name.clone(),
-                    self.interpreter.env().get(param_name).cloned(),
-                ));
                 self.locals[*slot] = val.clone();
-                // Write params to env so sync_locals_from_env (triggered by
-                // ensure_locals_synced) doesn't clobber them with stale values
-                // from the caller's scope.
-                self.interpreter.env_mut().insert(param_name.clone(), val);
+                // Write the param into env only when a name-based reader needs it:
+                // it is referenced via a GetGlobal-family op / captured by a
+                // closure (`needs_env_sync`), or reflective access is possible
+                // anywhere in the program. Otherwise the param stays slot-only and
+                // never crosses into the interpreter's env.
+                //
+                // Exception: a `Nil`-valued param must still be written. The
+                // GetLocal handler treats a `Nil` slot as possibly-undeclared and
+                // verifies declaration via `env.contains_key(name)` (a legitimately
+                // `Nil` param would otherwise raise X::Undeclared). Nil params are
+                // rare, so this costs nothing on the hot Int-recursion path.
+                let needs_env = write_all_params
+                    || matches!(val, Value::Nil)
+                    || cf.code.needs_env_sync.get(*slot).copied().unwrap_or(true);
+                if needs_env {
+                    saved_param_env.push((
+                        param_name.clone(),
+                        self.interpreter.env().get(param_name).cloned(),
+                    ));
+                    // Write params to env so sync_locals_from_env (triggered by
+                    // ensure_locals_synced) doesn't clobber them with stale values
+                    // from the caller's scope.
+                    self.interpreter.env_mut().insert(param_name.clone(), val);
+                }
                 self.interpreter
                     .mark_readonly(&cf.param_defs[param_idx].name);
             }

--- a/t/dualstore-param-not-mirrored.t
+++ b/t/dualstore-param-not-mirrored.t
@@ -7,7 +7,7 @@ use Test;
 # lives purely in the VM's `locals`. This must not change any observable
 # behaviour.
 
-plan 14;
+plan 16;
 
 # Pure recursion: slot-only param, never mirrored into env.
 sub fib($n) { $n < 2 ?? $n !! fib($n - 1) + fib($n - 2) }
@@ -50,3 +50,10 @@ multi mtype(Int $x) { "int:$x" }
 multi mtype(Str $x) { "str:$x" }
 is mtype(7), "int:7", 'multi dispatch Int param';
 is mtype("hi"), "str:hi", 'multi dispatch Str param';
+
+# A gather block compiles its body inline and snapshots the whole env by name;
+# the param it reads ($num) must stay env-synced even though the gather body is
+# not in closure_compiled_codes (regression: S02-types/lazy-lists.t).
+sub make-lazy-list($num) { gather { take $_ for 0 ..^ $num }.lazy }
+is make-lazy-list(4).List.join(','), '0,1,2,3', 'gather body reads slot-only param via env snapshot';
+is make-lazy-list(10).first(*.is-prime), 2, 'lazy gather over param stays correct';

--- a/t/dualstore-param-not-mirrored.t
+++ b/t/dualstore-param-not-mirrored.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Decoupling pin (docs/vm-dual-store.md Slice 5 step 2, ANALYSIS.md §1.2): the
+# compiled-function light call path no longer writes a *slot-only* positional
+# param (one read via GetLocal, not in needs_env_sync, with no program-wide
+# reflective by-name access) into the interpreter's shared `env`. The param
+# lives purely in the VM's `locals`. This must not change any observable
+# behaviour.
+
+plan 14;
+
+# Pure recursion: slot-only param, never mirrored into env.
+sub fib($n) { $n < 2 ?? $n !! fib($n - 1) + fib($n - 2) }
+is fib(10), 55, 'recursive slot-only param';
+is fib(20), 6765, 'deeper recursion';
+
+# Accumulator recursion (two slot-only params).
+sub acc($n, $a) { $n == 0 ?? $a !! acc($n - 1, $a + $n) }
+is acc(100, 0), 5050, 'two-param tail-style recursion';
+
+# Nil-valued param must still be readable (GetLocal treats a Nil slot as
+# possibly-undeclared and verifies via env, so Nil params are still mirrored).
+sub id($x) { $x }
+is id(Nil).raku, 'Nil', 'Nil param read back correctly';
+is id(42), 42, 'Int param read back';
+cmp-ok id(Int), '===', Int, 'type-object param read back';
+
+# Return-type-checked sub with Nil (regression: return.t).
+sub return-Int($x --> Int) { $x }
+is return-Int(Nil), Nil, 'Nil through Int return typecheck';
+is return-Int(42), 42, 'Int through Int return typecheck';
+
+# Shadowing: a callee param must not be clobbered by a same-named outer var.
+my $n = 5;
+sub shadow($n) { $n }
+is shadow(10), 10, 'param shadows same-named outer var (no env clobber)';
+
+# Reflective access keeps params mirrored: EVAL reads the param by name.
+sub eval-param($n) { EVAL('$n + 1') }
+is eval-param(5), 6, 'EVAL reads param by name';
+
+# Closure capturing a param keeps it env-synced (needs_env_sync).
+sub make-adder($base) { -> $x { $x + $base } }
+my $add5 = make-adder(5);
+is $add5(3), 8, 'closure captures param';
+is $add5(10), 15, 'closure capture stable across calls';
+
+# Multi-dispatch on slot-only params.
+multi mtype(Int $x) { "int:$x" }
+multi mtype(Str $x) { "str:$x" }
+is mtype(7), "int:7", 'multi dispatch Int param';
+is mtype("hi"), "str:hi", 'multi dispatch Str param';


### PR DESCRIPTION
## Summary

Dual-store decoupling (`docs/vm-dual-store.md` Slice 5, ANALYSIS.md §1.2) — **not perf**: stop the compiled-function light call path from writing a *slot-only* positional param into the interpreter's shared `env`.

`call_compiled_function_positional_light` bound each param to its VM slot **and** wrote it into `env`. Now it writes to `env` only when a name-based reader needs it:

- the param is in `needs_env_sync` (GetGlobal-family op / closure capture), **or**
- program-wide reflective by-name access is possible — a new monotonic compile-time flag `opcode::reflective_name_access_possible()` set when any code has a `CALLER::`/`OUTER::` read, symbolic deref `::($n)`, pseudo-stash access, indirect code lookup, or an `EVAL`/`EVALFILE` call (these run a string in the caller's lexical scope), **or**
- the value is `Nil` — GetLocal treats a `Nil` slot as possibly-undeclared and verifies via `env.contains_key`, so `Nil` params stay mirrored to avoid a spurious `X::Undeclared`.

## Impact

A slot-only param of a leaf/recursive function **never enters the interpreter `env`**. Because the param write was also what dirtied `env`, skipping it drops the post-call pull too: **`fib`'s dual-store activity goes to all zeros** (`env_deep_copies`/`env_flushes`/`slots_flushed`/`locals_pulls` = 0) — its `$n` is purely VM-resident. Combined with step 1 (#2608, flush gating), the callee's slot-only state no longer crosses into the interpreter.

## Regression found + fixed mid-step

`return-Int(Nil)` / `id(Nil)` raised `X::Undeclared` because the `Nil`-slot declaration check reads `env`; the `Nil`-value exception above fixes it. `roast/S06-advanced/return.t` (109 subtests) green.

## Tests

- New pin `t/dualstore-param-not-mirrored.t` (14: recursion / Nil / type-object / shadow / EVAL-reads-param / closure-capture / multi-dispatch).
- `make test` failure set unchanged from the `main` baseline (`placeholder.t` t8, `tail-function.t` t4, `wrap.t`).
- S06 signature/routine/multi/advanced whitelist (40 files) green; full `make roast` to CI.

## Remaining (collapse proper)

The conservative loop/block `needs_env_sync` fallback, the named-param light path + `call_compiled_function_named` param writes, and the residual `env_dirty` pull still mirror state in some paths. Fully removing them needs the per-call **scoped/overlay env** (child scope per call frame, dropped on return). These steps set that up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)