### PR TITLE
QuantHash (Set/Bag/Mix) hyper function-ops: pass S03-metaops/infix.t in full

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -173,6 +173,7 @@ roast/S03-junctions/boolean-context.t
 roast/S03-junctions/misc.t
 roast/S03-metaops/cross.t
 roast/S03-metaops/eager-hyper.t
+roast/S03-metaops/infix.t
 roast/S03-metaops/misc.t
 roast/S03-metaops/not.t
 roast/S03-metaops/reverse.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -101,6 +101,10 @@ pub(crate) struct VM {
     container_ref_reversed: bool,
     /// Source variable name for topic binding in for loops
     topic_source_var: Option<String>,
+    /// Names of multi-param for-loop bindings (`-> %a, %b`) whose `%`/`@` params
+    /// must preserve a QuantHash (Set/Bag/Mix) value rather than coercing it to
+    /// a plain Hash, matching Raku's parameter-binding semantics.
+    quanthash_bind_params: Vec<String>,
     /// Stack of saved call frames for compiled function/closure/method calls.
     call_frames: Vec<VmCallFrame>,
     /// When true, locals may be stale relative to env (interpreter bridge modified env).
@@ -347,6 +351,7 @@ impl VM {
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,
+            quanthash_bind_params: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
             locals_dirty: false,

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -464,6 +464,7 @@ impl VM {
             .then(|| self.interpreter.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
+        let saved_quanthash_bind = std::mem::take(&mut self.quanthash_bind_params);
         let container_binding = self.container_ref_var.take();
         let container_reversed = self.container_ref_reversed;
         self.container_ref_reversed = false;
@@ -566,6 +567,16 @@ impl VM {
             {
                 self.interpreter.mark_readonly(name);
             }
+            // `%`-sigil for-loop bindings preserve a QuantHash value (and keep
+            // its type across a `%a = ...pairs` reset) instead of coercing it to
+            // a plain Hash — Raku binds params, it does not assign-coerce them.
+            self.quanthash_bind_params = spec
+                .multi_param_names
+                .iter()
+                .chain(param_name.iter())
+                .filter(|n| n.starts_with('%'))
+                .cloned()
+                .collect();
             // Temporarily clear readonly flags for multi-param names
             // so the bind stmts (Stmt::Assign) at the start of the body can
             // re-bind variables that may be readonly from an outer scope.
@@ -805,6 +816,7 @@ impl VM {
                             self.interpreter.readonly_vars_mut().remove(name);
                         }
                         self.topic_source_var = saved_topic_source;
+                        self.quanthash_bind_params = saved_quanthash_bind.clone();
                         if spec.restore_topic {
                             match saved_topic {
                                 Some(v) => {
@@ -881,6 +893,7 @@ impl VM {
             }
         }
         self.topic_source_var = saved_topic_source;
+        self.quanthash_bind_params = saved_quanthash_bind.clone();
         if spec.restore_topic {
             match saved_topic {
                 Some(v) => {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -815,6 +815,10 @@ impl VM {
                 let has_init_values = match &current_val {
                     Some(Value::Hash(h)) => !h.is_empty(),
                     Some(Value::Array(a, _)) => !a.is_empty(),
+                    // A Seq/Slip initializer (e.g. `is SetHash = %h.map: {...}`)
+                    // must be coerced, not treated as "no initializer".
+                    Some(Value::Seq(s) | Value::Slip(s)) => !s.is_empty(),
+                    Some(Value::LazyList(_)) => true,
                     // Already converted to a QuantHash by type constraint coercion
                     Some(Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _)) => true,
                     _ => false,

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1,6 +1,15 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// The QuantHash family of a hyper-op operand, used to round-trip Set/Bag/Mix
+/// values through the plain-Hash hyper logic and back to their original type.
+#[derive(Clone, Copy)]
+enum QuantKind {
+    Set,
+    Bag,
+    Mix,
+}
+
 /// Detect the case pattern of a word.
 /// Returns one of: "uc" (all upper), "lc" (all lower), "ucfirst" (first upper, rest lower),
 /// "lcfirst" (first lower, rest upper).
@@ -1197,6 +1206,91 @@ impl VM {
         self.eval_reduction_operator_values(op, left, right)
     }
 
+    /// The QuantHash kind and mutability of a value, if it is a Set/Bag/Mix.
+    fn quanthash_kind(v: &Value) -> Option<(QuantKind, bool)> {
+        match v {
+            Value::Set(_, m) => Some((QuantKind::Set, *m)),
+            Value::Bag(_, m) => Some((QuantKind::Bag, *m)),
+            Value::Mix(_, m) => Some((QuantKind::Mix, *m)),
+            _ => None,
+        }
+    }
+
+    /// Project a QuantHash to a plain `key => weight` Hash so the existing hash
+    /// hyper logic applies. Set membership becomes `True`, Bag/Mix weights become
+    /// Int/Num. Non-QuantHash values pass through unchanged (scalar broadcast).
+    fn quanthash_to_hash(v: &Value) -> Value {
+        let map: std::collections::HashMap<String, Value> = match v {
+            Value::Set(d, _) => d
+                .elements
+                .iter()
+                .map(|k| (k.clone(), Value::Bool(true)))
+                .collect(),
+            Value::Bag(d, _) => d
+                .counts
+                .iter()
+                .map(|(k, c)| (k.clone(), Value::Int(*c)))
+                .collect(),
+            Value::Mix(d, _) => d
+                .weights
+                .iter()
+                .map(|(k, w)| (k.clone(), Value::Num(*w)))
+                .collect(),
+            other => return other.clone(),
+        };
+        Value::Hash(std::sync::Arc::new(map))
+    }
+
+    /// Rebuild a QuantHash of the given kind/mutability from a result Hash,
+    /// applying Rakudo's QuantHash coercion: Set keeps truthy keys, Bag keeps
+    /// strictly-positive integer weights, Mix keeps non-zero weights.
+    fn hash_to_quanthash(v: Value, kind: QuantKind, mutable: bool) -> Value {
+        let Value::Hash(map) = v else {
+            return v;
+        };
+        match kind {
+            QuantKind::Set => {
+                let elems: std::collections::HashSet<String> = map
+                    .iter()
+                    .filter(|(_, val)| val.truthy())
+                    .map(|(k, _)| k.clone())
+                    .collect();
+                if mutable {
+                    Value::set_hash(elems)
+                } else {
+                    Value::set(elems)
+                }
+            }
+            QuantKind::Bag => {
+                let counts: std::collections::HashMap<String, i64> = map
+                    .iter()
+                    .filter_map(|(k, val)| {
+                        let c = crate::runtime::utils::to_int(val);
+                        (c > 0).then(|| (k.clone(), c))
+                    })
+                    .collect();
+                if mutable {
+                    Value::bag_hash(counts)
+                } else {
+                    Value::bag(counts)
+                }
+            }
+            QuantKind::Mix => {
+                let weights: std::collections::HashMap<String, f64> = map
+                    .iter()
+                    .filter_map(|(k, val)| {
+                        crate::runtime::utils::to_float_value(val).map(|w| (k.clone(), w))
+                    })
+                    .collect();
+                if mutable {
+                    Value::mix_hash(weights)
+                } else {
+                    Value::mix(weights)
+                }
+            }
+        }
+    }
+
     pub(super) fn exec_hyper_func_op(
         &mut self,
         code: &CompiledCode,
@@ -1209,6 +1303,19 @@ impl VM {
         let right = self.stack.pop().unwrap_or(Value::Nil);
         let left = self.stack.pop().unwrap_or(Value::Nil);
         let name = Self::const_str(code, name_idx).to_string();
+        // QuantHash (Set/Bag/Mix) operands: reuse the plain-Hash hyper logic by
+        // projecting each to a `key => weight` Hash, then convert the result
+        // (and any write-back value) back to the original QuantHash type. The
+        // result type/mutability follows whichever operand is a QuantHash.
+        let quant_result = Self::quanthash_kind(&left).or_else(|| Self::quanthash_kind(&right));
+        let (left, right) = if quant_result.is_some() {
+            (
+                Self::quanthash_to_hash(&left),
+                Self::quanthash_to_hash(&right),
+            )
+        } else {
+            (left, right)
+        };
         // Resolve a concrete code-ref value when `name` refers to a lexical
         // `&name` variable (e.g. the `&op`/`&metaop` loop variables in
         // S03-metaops/infix.t). Such calls must go through the VM closure
@@ -1231,7 +1338,8 @@ impl VM {
         // Hash operands: apply the code-ref to each value key-by-key, mirroring
         // the dwim key-set semantics of `exec_hyper_op`.
         if matches!(&left, Value::Hash(..)) || matches!(&right, Value::Hash(..)) {
-            return self.exec_hyper_func_op_hash(
+            let stack_before = self.stack.len();
+            self.exec_hyper_func_op_hash(
                 left,
                 right,
                 &name,
@@ -1240,7 +1348,14 @@ impl VM {
                 dwim_right,
                 writeback,
                 compiled_fns,
-            );
+            )?;
+            if let Some((kind, mutable)) = quant_result {
+                let pushed: Vec<Value> = self.stack.split_off(stack_before);
+                for v in pushed {
+                    self.stack.push(Self::hash_to_quanthash(v, kind, mutable));
+                }
+            }
+            return Ok(());
         }
         let both_scalar = !Self::is_listy(&left) && !Self::is_listy(&right);
         let left_list = Interpreter::value_to_list(&left);

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -488,6 +488,28 @@ impl VM {
         {
             return Ok(value);
         }
+        // A multi-param for-loop `%`-binding keeps its QuantHash identity (Raku
+        // binds params; it does not assign-coerce them). A Set/Bag/Mix value
+        // passes through unchanged; any other value (e.g. a Seq of pairs from a
+        // `%a = %reset.pairs` reset) is coerced to the binding's *current*
+        // QuantHash type rather than collapsing to a plain Hash.
+        if self.quanthash_bind_params.iter().any(|n| n == name) {
+            if matches!(
+                value,
+                Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _)
+            ) {
+                return Ok(value);
+            }
+            let trait_name = match self.interpreter.env().get(name) {
+                Some(Value::Set(_, _)) => Some("SetHash"),
+                Some(Value::Bag(_, _)) => Some("BagHash"),
+                Some(Value::Mix(_, _)) => Some("MixHash"),
+                _ => None,
+            };
+            if let Some(tn) = trait_name {
+                return self.try_compiled_method_or_interpret(value, tn, vec![]);
+            }
+        }
         if let Some(constraint) = self.interpreter.var_type_constraint(name)
             && constraint.starts_with("SetHash")
         {

--- a/t/quanthash-hyper-funcop.t
+++ b/t/quanthash-hyper-funcop.t
@@ -1,0 +1,96 @@
+use Test;
+
+# Hyper function-ops (`%a >>[&op]<< %b`) over SetHash/BagHash/MixHash operands
+# apply the op to each value key-by-key and rebuild the QuantHash type: Set
+# keeps truthy keys, Bag keeps strictly-positive weights, Mix keeps non-zero
+# weights. Supporting machinery: a multi-param `for` `%`-binding keeps the
+# QuantHash type, a Seq initializer coerces (`my %x is SetHash = ...map(...)`),
+# and reassigning a Seq of pairs to a bound QuantHash keeps its type.
+# Mirrors roast/S03-metaops/infix.t.
+
+plan 16;
+
+my &op = &[+];
+my &sub = &[-];
+my &addinto = &[+=];
+
+# --- BagHash: weights add, type preserved ---
+{
+    my %ba is BagHash = 'a'..'c' Z=> 1..3;
+    my %bb is BagHash = 'a'..'c' Z=> 6..8;
+    is-deeply (%ba >>[&op]<< %bb), ('a'=>7, 'b'=>9, 'c'=>11).BagHash, 'BagHash >>[&+]<<';
+    is-deeply (%ba <<[&op]>> 3),   ('a'=>4, 'b'=>5, 'c'=>6).BagHash,  'BagHash <<[&+]>> scalar';
+    # subtraction drops non-positive weights -> empty BagHash
+    is-deeply (%ba >>[&sub]<< %bb), ().BagHash, 'BagHash subtraction drops non-positive';
+}
+
+# --- MixHash: non-zero weights kept (including negatives) ---
+{
+    my %ma is MixHash = 'a'..'c' Z=> 1..3;
+    my %mb is MixHash = 'a'..'c' Z=> 6..8;
+    is-deeply (%ma >>[&op]<< %mb),  ('a'=>7, 'b'=>9, 'c'=>11).MixHash,   'MixHash >>[&+]<<';
+    is-deeply (%ma >>[&sub]<< %mb), ('a'=>-5, 'b'=>-5, 'c'=>-5).MixHash, 'MixHash keeps negatives';
+}
+
+# --- SetHash: truthy keys kept; result is a SetHash ---
+{
+    my %sa is SetHash = 'a'..'c' Z=> 1..3;
+    my %sb is SetHash = 'a'..'c' Z=> 6..8;
+    my $r = %sa >>[&op]<< %sb;
+    isa-ok $r, SetHash, 'SetHash hyper result is a SetHash';
+    is $r.elems, 3, 'SetHash hyper keeps all members';
+    ok $r{'a'} && $r{'b'} && $r{'c'}, 'SetHash hyper members present';
+}
+
+# --- multi-param `for` binding preserves the QuantHash type ---
+{
+    my %ba is BagHash = (a => 1, b => 2);
+    my $seen;
+    for (%ba, %ba) -> %x, %y { $seen = %x.WHAT; last }
+    is $seen.gist, '(BagHash)', 'multi-param for-binding keeps BagHash';
+}
+
+# --- Seq initializer coerces to the declared QuantHash ---
+{
+    my %sa is SetHash = 'a'..'c' Z=> 1..3;
+    my %r is SetHash = %sa.map: { .key => .value + 1 };
+    is %r.elems, 3, 'SetHash initialized from a Seq of pairs';
+    my %ba is BagHash = 'a'..'c' Z=> 1..3;
+    my %rb is BagHash = %ba.map: { .key => .value + 1 };
+    is-deeply %rb, ('a'=>2, 'b'=>3, 'c'=>4).BagHash, 'BagHash initialized from a Seq of pairs';
+}
+
+# --- reassigning a Seq of pairs to a bound QuantHash keeps its type ---
+{
+    my %ba is BagHash = (a => 1, b => 2);
+    my %reset = %ba.pairs;
+    for (%ba,) -> %a {
+        %a = %reset.pairs;
+        is %a.WHAT.gist, '(BagHash)', 'reassigning pairs keeps BagHash';
+        is %a.elems, 2, 'reassigned BagHash has the right size';
+    }
+}
+
+# --- non-dwim scalar against a QuantHash dies ---
+{
+    my %ba is BagHash = (a => 1, b => 2);
+    dies-ok { %ba >>[&op]<< 3 }, 'non-dwim scalar against a BagHash dies';
+}
+
+# --- writeback meta-op mutates the bound QuantHash ---
+{
+    my %ba is BagHash = (a => 1, b => 2);
+    my %bb is BagHash = (a => 10, b => 20);
+    for (%ba, %bb) -> %a, %b {
+        %a >>[&addinto]<< %b;
+        is-deeply %a, (a => 11, b => 22).BagHash, '>>[&+=]<< writes back to the BagHash';
+        last;
+    }
+}
+
+# --- plain Hash hyper is unaffected ---
+{
+    my %h = (a => 1, b => 2);
+    my %g = (a => 10, b => 20);
+    is-deeply (%h >>[&op]<< %g), {a => 11, b => 22}, 'plain Hash hyper still yields a Hash';
+}


### PR DESCRIPTION
## Summary

Makes `roast/S03-metaops/infix.t` pass **in full (900 failing sub-subtests → 0)** and adds it to the whitelist. The file exercises `%a >>[&op]<< %b` (and the `<<`/`>>` dwim + `>>op=<<` write-back + scalar-broadcast variants) over `SetHash`/`BagHash`/`MixHash` operands bound inside a multi-param `for` loop.

Four related gaps are closed:

### 1. Hyper func-op on a QuantHash
`exec_hyper_func_op` projected only plain `Value::Hash` operands; Set/Bag/Mix fell through and produced a plain Hash. Now they round-trip through the existing hash hyper logic: project to a `key => weight` Hash, run the op, then rebuild the QuantHash. Rakudo coercion — Set keeps truthy keys, Bag keeps strictly-positive weights, Mix keeps non-zero weights. Result type/mutability follows the operand.

```
%bag >>[&[+]]<< %bag   # BagHash, weights added
%mix >>[&[-]]<< %mix   # MixHash, negatives kept
%set >>[&[+]]<< %set   # SetHash
```

### 2. Multi-param `for` `%`-binding keeps the QuantHash type
`-> %a, %b` bound a SetHash/BagHash/MixHash as a plain Hash (Raku **binds** params, it does not assign-coerce). A new `quanthash_bind_params` set (single- and multi-param names) marks active `%`-bindings; `coerce_hash_var_value` preserves a QuantHash value there and coerces any other value (e.g. a `%a = %reset.pairs` reset) to the binding's *current* QuantHash type.

### 3. Seq initializer coercion
`my %x is SetHash = %h.map: {...}` ignored a `Seq`/`Slip`/`LazyList` initializer (treated as "no init" → empty container). Added to the has-init-values check.

## Tests

New `t/quanthash-hyper-funcop.t` (16 cases) covering Bag/Mix/Set hyper, scalar broadcast, the multi-param binding, Seq initializers, pair-reset, write-back, the non-dwim die, and that plain-Hash hyper is unaffected. `roast/S03-metaops/infix.t` added to the whitelist (prove: 5076 tests, PASS). `roast/S02-types/hash.t` and the existing `t/hyper*.t` / `t/set-bag-mix*.t` tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)