### PR TITLE
parser+vm: let a user-declared type shadow a built-in term constant

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -528,6 +528,16 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     // Try each keyword, ensuring it's not followed by alphanumeric (word boundary)
     // Also reject if followed by `(` to prevent treating e() as a constant
     let try_kw = |kw: &str, val: Value| -> PResult<'_, Expr> {
+        // A user-declared type of the same name shadows the built-in term
+        // constant (e.g. `class Empty {}` makes `Empty` refer to the class,
+        // not the empty Slip); let it fall through to identifier parsing.
+        // `Inf`/`NaN` are numeric literals in Raku and are NOT shadowable, so
+        // they keep their constant value even when a like-named type exists.
+        if !matches!(kw, "Inf" | "-Inf" | "NaN")
+            && crate::parser::stmt::simple::is_user_declared_type(kw)
+        {
+            return Err(PError::expected("user-declared type shadows keyword"));
+        }
         let (rest, _) = parse_tag(input, kw)?;
         // Check word boundary (superscript digits are NOT word chars)
         if let Some(c) = rest.chars().next()

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -78,7 +78,10 @@ impl VM {
             Value::Num(f64::NAN)
         } else if name == "Inf" {
             Value::Num(f64::INFINITY)
-        } else if name == "Empty" {
+        } else if name == "Empty" && !self.interpreter.has_type(name) {
+            // A user-declared type named `Empty` shadows the empty-Slip term
+            // (it is resolved to a Package by the `has_type` branch below).
+            // `Inf`/`NaN` are numeric literals and are not shadowable.
             Value::Slip(std::sync::Arc::new(vec![]))
         } else if Self::is_pseudo_package_bare(name) {
             // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to

--- a/t/user-type-shadows-term.t
+++ b/t/user-type-shadows-term.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# A user-declared type shadows a built-in *term constant* of the same name
+# (Empty, True, False, Nil, Any). Raku resolves the lexically-declared type.
+# Numeric literals (Inf, NaN) are NOT shadowable and keep their value.
+
+plan 7;
+
+# Unshadowed built-in terms still behave as constants
+is (1, 2, Empty, 3).elems, 3, 'unshadowed Empty is the empty Slip';
+ok Inf > 1e308, 'unshadowed Inf is infinity';
+ok NaN != NaN, 'unshadowed NaN is not-a-number';
+
+# A user class named Empty shadows the term
+{
+    class Empty { has $.v; }
+    my $e = Empty.new(v => 5);
+    is $e.v, 5, 'class Empty shadows the Empty term (construct)';
+    is $e.^name, 'Empty', 'class Empty shadows the Empty term (^name)';
+}
+
+# Inf / NaN are numeric literals: a like-named class does NOT shadow them
+{
+    class Inf { method answer { 42 } }
+    ok Inf > 1e308, 'Inf stays a numeric literal even with class Inf declared';
+}
+
+# A user class named Nil shadows the Nil term
+{
+    class Nil { method greet { 'hi' } }
+    is Nil.greet, 'hi', 'class Nil shadows the Nil term';
+}


### PR DESCRIPTION
## Summary

`class Empty {}` (or `Nil`/`True`/`False`/`Any`) should make that name refer to the user-declared type, but mutsu kept resolving it to the built-in term constant. `Empty.new` failed with `X::Method::NotFound: Unknown method value dispatch (fallback disabled): new` because `Empty` resolved to the empty `Slip`, not the class.

### Root cause

The parser's `keyword_literal` eagerly rewrites the bareword `Empty` to `Expr::Literal(Slip([]))` at parse time, so the receiver was a `Slip` before the VM ever saw a class. (A normally-named empty class like `class Blank {}` already worked — only the reserved term names collided.)

### Fix

- **Parser** (`primary/ident.rs`): the parser already tracks declared type names via `is_user_declared_type`. Guard the `keyword_literal` constant rewrites with it — when a like-named type is in scope, fall through to identifier parsing so the name resolves to the type.
- **VM** (`vm_var_get_ops.rs`): guard the `Empty` bareword fast path with `has_type`, so once the parser lets `Empty` through as an identifier it resolves to the `Package` rather than re-deriving the empty `Slip`.

`Inf`/`NaN` are **numeric literals** in Raku and are **not** shadowable, so they are excluded from the guard. Verified against Rakudo:

| term | shadowable by a user type? |
|---|---|
| `Empty`, `Nil`, `True`, `False`, `Any` | yes |
| `Inf`, `NaN` | no (numeric literals) |

## Tests

New `t/user-type-shadows-term.t` (7 subtests): unshadowed `Empty`/`Inf`/`NaN` keep their constant behavior; `class Empty`/`class Nil` shadow the term; `class Inf` does **not** shadow the numeric literal. Output verified identical to `raku`.

(`class Any`/`class Mu` additionally hit an unrelated implicit-parent MRO-cycle limitation and are out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)