### PR TITLE
runtime: give user-code worker threads a large stack (fix debug-only stack overflow)

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -2,6 +2,24 @@ use super::*;
 use crate::symbol::Symbol;
 use std::sync::OnceLock;
 
+/// Stack size for worker threads that execute user code (Promise / `start` /
+/// Supply callbacks). Matches the main thread's stack (see `main.rs`): the
+/// default ~2 MiB thread stack overflows on deep VM recursion, which shows up
+/// as debug-build-only crashes (release frames are smaller and fit in 2 MiB).
+pub(crate) const USER_THREAD_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Spawn a worker thread with a large stack for running user code, so deep VM
+/// recursion does not overflow the default thread stack.
+pub(crate) fn spawn_user_thread<F>(f: F) -> std::thread::JoinHandle<()>
+where
+    F: FnOnce() + Send + 'static,
+{
+    std::thread::Builder::new()
+        .stack_size(USER_THREAD_STACK_SIZE)
+        .spawn(f)
+        .expect("failed to spawn worker thread")
+}
+
 /// State for a live child process (when `:in` is used with `run`).
 pub(super) struct LiveProcState {
     pub(super) child: std::process::Child,
@@ -98,7 +116,7 @@ impl Interpreter {
             block
         };
 
-        std::thread::spawn(move || {
+        spawn_user_thread(move || {
             let vm = crate::vm::VM::new(thread_interp);
             let (mut thread_interp, result) = vm.call_value(block, vec![]);
             // Transfer any handles opened by this thread back to the awaiter.
@@ -143,7 +161,7 @@ impl Interpreter {
                     {
                         let handler_interp = thread_interp.clone_for_thread();
                         let ex_val = error_val;
-                        std::thread::spawn(move || {
+                        spawn_user_thread(move || {
                             let vm = crate::vm::VM::new(handler_interp);
                             let (_interp, _result) = vm.call_value(handler, vec![ex_val]);
                         });

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -88,7 +88,7 @@ impl Interpreter {
             }
         } else {
             let mut thread_interp = self.clone_for_thread();
-            std::thread::spawn(move || {
+            crate::runtime::builtins_system::spawn_user_thread(move || {
                 let (result, output, stderr) = orig.wait();
                 let status = orig.status();
                 if should_run(&status) {

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -522,7 +522,7 @@ impl Interpreter {
                     let mut thread_interp = self.clone_for_thread();
                     let cb = tap_cb.clone();
                     let delay = delay_seconds;
-                    std::thread::spawn(move || {
+                    crate::runtime::builtins_system::spawn_user_thread(move || {
                         Self::run_supply_act_loop(&mut thread_interp, &rx, &cb, delay);
                     });
                     return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
@@ -2501,7 +2501,7 @@ impl Interpreter {
                     let mut thread_interp = self.clone_for_thread();
                     let cb = tap_cb.clone();
                     let delay = delay_seconds;
-                    std::thread::spawn(move || {
+                    crate::runtime::builtins_system::spawn_user_thread(move || {
                         Self::run_supply_act_loop(&mut thread_interp, &rx, &cb, delay);
                     });
                     let tap_instance = Value::make_instance(Symbol::intern("Tap"), HashMap::new());
@@ -3670,7 +3670,7 @@ impl Interpreter {
 
         // Spawn a thread to run the block asynchronously
         let mut thread_interp = self.clone_for_thread();
-        std::thread::spawn(move || {
+        crate::runtime::builtins_system::spawn_user_thread(move || {
             let result_val = thread_interp
                 .call_sub_value(callable, vec![value], true)
                 .unwrap_or(Value::Nil);


### PR DESCRIPTION
## Summary

`start {}` blocks, `Promise.then` callbacks, and Supply `start`/tap loops run user code on threads spawned via the default `std::thread::spawn`, which gives only the ~2 MiB default stack. mutsu's per-call VM recursion is stack-heavy, so deep call chains overflowed that stack and aborted the process — but **only in debug builds** (release frames are smaller and fit in 2 MiB).

That is why `roast/S12-construction/destruction.t` (`await start { loop { Foo.new; Child.new ... } }`) passed in release CI yet aborted with `thread '<unknown>' has overflowed its stack` under a local debug build.

## Fix

The main thread already runs on a 32 MiB stack (`main.rs`). Add a `spawn_user_thread` helper (32 MiB, matching main) and route the thread spawns that execute user code through it:

- `spawn_callable_promise` (`start {}`) and its uncaught-handler thread
- `Promise.then` callback thread
- Supply `run_start_call_in_thread` and the two `run_supply_act_loop` tap loops

Worker threads now match the main thread's recursion capacity instead of overflowing at ~1/16th of it.

## Verification

- `roast/S12-construction/destruction.t` now passes under a **debug** build (5/5 runs); previously it aborted with a stack overflow. It already passed in release.
- All whitelisted `S17-*` concurrency tests still pass; normal `start`/`await`/Supply behavior is unchanged (output verified against `raku`).
- The change only increases worker-thread stack size, so it cannot introduce new failures.

Note: this is a debug-build robustness fix. CI runs the release build (where the 2 MiB stack already sufficed), so the win is for local debug development; `destruction.t` remains the spec-level guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)