### PR TITLE
io: IO::Path .CWD/.SPEC, words $limit, named for-loop unpack

### DIFF
--- a/TODO_roast/S16.md
+++ b/TODO_roast/S16.md
@@ -40,7 +40,8 @@
 - [ ] roast/S16-io/supply.t
 - [ ] roast/S16-io/tmpdir.t
 - [ ] roast/S16-io/watch.t
-- [ ] roast/S16-io/words.t
+- [ ] roast/S16-io/words.t (8/11; `$limit` arg now supported for `words($fh, n)` sub/method/IO::Path forms)
+  - Remaining: lazy close-on-exhaust semantics for `words($fh, :close)` (a `.push-exactly` taking a partial slice must keep the handle open), and `IO::ArgFiles.new` (`words()` with `$*ARGFILES`).
 - [x] roast/S16-unfiled/getpeername.t
   - 1/1 pass.
 - [ ] roast/S16-unfiled/rebindstdhandles.t

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -113,9 +113,11 @@
 - [ ] roast/S32-io/io-path-extension.t
 - [ ] roast/S32-io/io-path-subclasses.t
 - [ ] roast/S32-io/io-path-symlink.t
-- [ ] roast/S32-io/io-path.t
+- [ ] roast/S32-io/io-path.t (39/43 run; subtests 16/26/29 now pass)
   - Parser now accepts `IO::Path.new: :volume<...> :dirname<...> :basename<...>` and `indir make-temp-dir, { ... }`.
-  - Current blockers: `IO::Path.volume` semantics on POSIX, `.raku.EVAL` roundtrip fidelity, `"-"` gist behavior, and `IO::Path.ACCEPTS` path normalization/equivalence.
+  - `.CWD` and `.SPEC` methods now implemented; `.SPEC` returns a canonical `IO::Spec::*` Package so `.raku.EVAL.SPEC eqv .SPEC`. `.raku.EVAL` roundtrip subtest (16) passes.
+  - Named sub-signature destructuring in for-loops (`for @t -> (:$orig, :$with)`) now works (binds via accessor method when present, else by hash key), unblocking the `.add` subtest (26).
+  - Remaining blockers (each an independent feature): `.resolve(:completely)` + `X::IO::Resolve` (27); `.link`/`&link` with `X::IO::Link` (28); `.IO` on `:U` type objects returning the right subclass (30); Win32 path backslash canonicalization in `.gist` (31); Associative-role + `.parts` attribute keys with Win32 volume handling (33); `X::Assignment::RO` on `.SPEC=`/`.CWD=` plus `temp $*SPEC`/`temp $*CWD` defaulting (34, 35); `.path` not affected by `indir` cwd change (36); `.Numeric`/`.Rat`/`.Int` Cool coercion chain on IO::Path (37).
 - [ ] roast/S32-io/io-path-unix.t
 - [ ] roast/S32-io/io-path-win.t
 - [ ] roast/S32-io/IO-Socket-Async.t

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -332,12 +332,33 @@ impl Compiler {
                     continue;
                 }
                 if sub.named {
-                    let method_result = Expr::MethodCall {
+                    // Named destructuring `:$key` binds via the accessor method
+                    // when the object provides one (Pair.key/.value, object
+                    // attribute readers), otherwise by hash key (Hash/Map, which
+                    // have no method named after an arbitrary key). Decide at
+                    // runtime: `$_.^can("key") ?? $_.key !! $_<key>`.
+                    let method_call = Expr::MethodCall {
                         target: Box::new(Expr::Var(target_name.clone())),
                         name: Symbol::intern(&sub.name),
                         args: Vec::new(),
                         modifier: None,
                         quoted: false,
+                    };
+                    let hash_lookup = Expr::Index {
+                        target: Box::new(Expr::Var(target_name.clone())),
+                        index: Box::new(Expr::Literal(Value::str(sub.name.clone()))),
+                        is_positional: false,
+                    };
+                    let method_result = Expr::Ternary {
+                        cond: Box::new(Expr::MethodCall {
+                            target: Box::new(Expr::Var(target_name.clone())),
+                            name: Symbol::intern("can"),
+                            args: vec![Expr::Literal(Value::str(sub.name.clone()))],
+                            modifier: Some('^'),
+                            quoted: false,
+                        }),
+                        then_expr: Box::new(method_call),
+                        else_expr: Box::new(hash_lookup),
                     };
                     // If the named param has a sub_signature (e.g. :key($k)),
                     // bind to the sub_signature variable instead of the param name.

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -1141,13 +1141,40 @@ impl Interpreter {
             None
         };
         if let Some(handle) = handle {
-            let mut words = Vec::new();
-            while let Some(line) = self.read_line_from_handle_value(&handle)? {
-                for token in line.split_whitespace() {
-                    words.push(Value::str(token.to_string()));
+            let mut limit: Option<usize> = None;
+            let mut close_after = false;
+            for arg in &args[1..] {
+                match arg {
+                    Value::Pair(k, v) if k == "close" => {
+                        close_after = v.truthy();
+                    }
+                    Value::Pair(..) => {}
+                    Value::Int(i) => limit = Some((*i).max(0) as usize),
+                    Value::BigInt(bi) => {
+                        use num_traits::ToPrimitive;
+                        limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                    }
+                    Value::Whatever => {}
+                    Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
+                    Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
+                    _ => {}
                 }
             }
-            return Ok(Value::array(words));
+            let mut words = Vec::new();
+            'outer: while let Some(line) = self.read_line_from_handle_value(&handle)? {
+                for token in line.split_whitespace() {
+                    words.push(Value::str(token.to_string()));
+                    if let Some(n) = limit
+                        && words.len() >= n
+                    {
+                        break 'outer;
+                    }
+                }
+            }
+            if close_after {
+                self.close_handle_value(&handle)?;
+            }
+            return Ok(Value::Seq(std::sync::Arc::new(words)));
         }
         // Non-handle argument: delegate to string-splitting words (native function)
         if !args.is_empty()

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -2,6 +2,24 @@ use super::*;
 use crate::symbol::Symbol;
 use std::sync::OnceLock;
 
+/// Stack size for worker threads that execute user code (Promise / `start` /
+/// Supply callbacks). Matches the main thread's stack (see `main.rs`): the
+/// default ~2 MiB thread stack overflows on deep VM recursion, which shows up
+/// as debug-build-only crashes (release frames are smaller and fit in 2 MiB).
+pub(crate) const USER_THREAD_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Spawn a worker thread with a large stack for running user code, so deep VM
+/// recursion does not overflow the default thread stack.
+pub(crate) fn spawn_user_thread<F>(f: F) -> std::thread::JoinHandle<()>
+where
+    F: FnOnce() + Send + 'static,
+{
+    std::thread::Builder::new()
+        .stack_size(USER_THREAD_STACK_SIZE)
+        .spawn(f)
+        .expect("failed to spawn worker thread")
+}
+
 /// State for a live child process (when `:in` is used with `run`).
 pub(super) struct LiveProcState {
     pub(super) child: std::process::Child,
@@ -98,7 +116,7 @@ impl Interpreter {
             block
         };
 
-        std::thread::spawn(move || {
+        spawn_user_thread(move || {
             let vm = crate::vm::VM::new(thread_interp);
             let (mut thread_interp, result) = vm.call_value(block, vec![]);
             // Transfer any handles opened by this thread back to the awaiter.
@@ -143,7 +161,7 @@ impl Interpreter {
                     {
                         let handler_interp = thread_interp.clone_for_thread();
                         let ex_val = error_val;
-                        std::thread::spawn(move || {
+                        spawn_user_thread(move || {
                             let vm = crate::vm::VM::new(handler_interp);
                             let (_interp, _result) = vm.call_value(handler, vec![ex_val]);
                         });

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -88,7 +88,7 @@ impl Interpreter {
             }
         } else {
             let mut thread_interp = self.clone_for_thread();
-            std::thread::spawn(move || {
+            crate::runtime::builtins_system::spawn_user_thread(move || {
                 let (result, output, stderr) = orig.wait();
                 let status = orig.status();
                 if should_run(&status) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1822,6 +1822,8 @@ impl Interpreter {
                     "watch",
                     "succ",
                     "pred",
+                    "CWD",
+                    "SPEC",
                 ]
                 .iter()
                 .map(|s| s.to_string())

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -186,6 +186,28 @@ impl Interpreter {
                 Symbol::intern("IO::Path"),
                 attributes.clone(),
             )),
+            "CWD" => {
+                let cwd = instance_cwd.unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                Ok(Value::str(cwd))
+            }
+            "SPEC" => {
+                // Return the IO::Spec type object backing this path. Normalize to
+                // a canonical `Value::Package` so that two paths sharing the same
+                // SPEC compare `eqv` regardless of whether the stored value was a
+                // `Package` (from `IO::Path::Unix.new`) or a type-object instance
+                // (from `$*SPEC`). Defaults to IO::Spec::Unix.
+                let spec_name = attributes
+                    .get("SPEC")
+                    .and_then(|s| match s {
+                        Value::Package(n) => Some(n.resolve().to_string()),
+                        Value::Instance { class_name, .. } => {
+                            Some(class_name.resolve().to_string())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "IO::Spec::Unix".to_string());
+                Ok(Value::Package(Symbol::intern(&spec_name)))
+            }
             "basename" => {
                 let (_, _, bname) = Self::io_path_parts(&p);
                 Ok(Value::str(bname))
@@ -624,11 +646,23 @@ impl Interpreter {
                 let content = fs::read_to_string(&path_buf)
                     .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
                 let content = super::utils::strip_utf8_bom(content);
-                let parts = content
+                let mut parts: Vec<Value> = content
                     .split_whitespace()
                     .map(|token| Value::str(token.to_string()))
                     .collect();
-                Ok(Value::array(parts))
+                // Check for a positional limit argument
+                let limit = args.iter().find_map(|arg| match arg {
+                    Value::Int(i) => Some((*i).max(0) as usize),
+                    Value::BigInt(bi) => {
+                        use num_traits::ToPrimitive;
+                        Some(bi.to_usize().unwrap_or(usize::MAX))
+                    }
+                    _ => None,
+                });
+                if let Some(n) = limit {
+                    parts.truncate(n);
+                }
+                Ok(Value::Seq(std::sync::Arc::new(parts)))
             }
             "comb" => {
                 let content = fs::read_to_string(&path_buf)
@@ -2301,13 +2335,40 @@ impl Interpreter {
                 }
             }
             "words" => {
-                let mut words = Vec::new();
-                while let Some(line) = self.read_line_from_handle_value(&target_val)? {
-                    for token in line.split_whitespace() {
-                        words.push(Value::str(token.to_string()));
+                let mut limit: Option<usize> = None;
+                let mut close_after = false;
+                for arg in &args {
+                    match arg {
+                        Value::Pair(k, v) if k == "close" => {
+                            close_after = v.truthy();
+                        }
+                        Value::Pair(..) => {}
+                        Value::Int(i) => limit = Some((*i).max(0) as usize),
+                        Value::BigInt(bi) => {
+                            use num_traits::ToPrimitive;
+                            limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                        }
+                        Value::Whatever => {}
+                        Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
+                        Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
+                        _ => {}
                     }
                 }
-                Ok(Value::array(words))
+                let mut words = Vec::new();
+                'outer: while let Some(line) = self.read_line_from_handle_value(&target_val)? {
+                    for token in line.split_whitespace() {
+                        words.push(Value::str(token.to_string()));
+                        if let Some(n) = limit
+                            && words.len() >= n
+                        {
+                            break 'outer;
+                        }
+                    }
+                }
+                if close_after {
+                    self.close_handle_value(&target_val)?;
+                }
+                Ok(Value::Seq(std::sync::Arc::new(words)))
             }
             "read" => {
                 // .read() always returns a Buf (Buf[uint8]) in Raku

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -522,7 +522,7 @@ impl Interpreter {
                     let mut thread_interp = self.clone_for_thread();
                     let cb = tap_cb.clone();
                     let delay = delay_seconds;
-                    std::thread::spawn(move || {
+                    crate::runtime::builtins_system::spawn_user_thread(move || {
                         Self::run_supply_act_loop(&mut thread_interp, &rx, &cb, delay);
                     });
                     return Ok(Value::make_instance(Symbol::intern("Tap"), HashMap::new()));
@@ -2501,7 +2501,7 @@ impl Interpreter {
                     let mut thread_interp = self.clone_for_thread();
                     let cb = tap_cb.clone();
                     let delay = delay_seconds;
-                    std::thread::spawn(move || {
+                    crate::runtime::builtins_system::spawn_user_thread(move || {
                         Self::run_supply_act_loop(&mut thread_interp, &rx, &cb, delay);
                     });
                     let tap_instance = Value::make_instance(Symbol::intern("Tap"), HashMap::new());
@@ -3670,7 +3670,7 @@ impl Interpreter {
 
         // Spawn a thread to run the block asynchronously
         let mut thread_interp = self.clone_for_thread();
-        std::thread::spawn(move || {
+        crate::runtime::builtins_system::spawn_user_thread(move || {
             let result_val = thread_interp
                 .call_sub_value(callable, vec![value], true)
                 .unwrap_or(Value::Nil);

--- a/t/io-path-cwd-spec-and-named-unpack.t
+++ b/t/io-path-cwd-spec-and-named-unpack.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 13;
+
+# IO::Path .CWD / .SPEC methods
+{
+    my $p = IO::Path::Unix.new("/foo|\\bar", :CWD("/tmp/here"));
+    is $p.CWD, "/tmp/here", '.CWD returns the stored CWD';
+    is $p.SPEC.^name, "IO::Spec::Unix", '.SPEC returns the IO::Spec type';
+    # .raku.EVAL roundtrip preserves CWD and SPEC (eqv)
+    ok $p.raku.EVAL.CWD  eqv $p.CWD,  '.raku.EVAL.CWD roundtrips';
+    ok $p.raku.EVAL.SPEC eqv $p.SPEC, '.raku.EVAL.SPEC roundtrips';
+}
+
+# .SPEC.dir-sep works on the returned type object
+is IO::Path::Unix.new("foo").SPEC.dir-sep, '/', '.SPEC.dir-sep works';
+
+# Named sub-signature destructuring in for-loops
+{
+    # Hash: bind by key
+    my @res;
+    for (%(orig => 'a', with => 'b'),) -> (:$orig, :$with) {
+        @res.push: "$orig-$with";
+    }
+    is @res, ['a-b'], 'for-loop named unpack of Hash binds by key';
+}
+
+{
+    # Pair: bind via .key/.value accessors (Pair is Associative but has methods)
+    my $tracker = '';
+    for a => 1, b => 2 -> (:$key, :$value) {
+        $tracker ~= "|$key,$value";
+    }
+    is $tracker, '|a,1|b,2', 'for-loop named unpack of Pair binds key/value';
+}
+
+{
+    # Object: bind via public attribute accessor
+    class A { has $.x }
+    my @res;
+    for A.new(x => 4), A.new(x => 2) -> (:$x) {
+        @res.push: $x;
+    }
+    is @res, [4, 2], 'for-loop named unpack of object binds attribute reader';
+}
+
+# words() with a $limit argument
+{
+    my $file = "tmp/words-limit-test-{$*PID}.txt".IO;
+    LEAVE $file.unlink;
+    $file.spurt: "a b c d e f";
+
+    is words($file.open, 2).elems, 2, 'words($fh, 2) sub form honors limit';
+    is $file.open.words(3).List, <a b c>, '$fh.words(3) method form honors limit';
+    is $file.words(2).List, <a b>, 'IO::Path.words(2) honors limit';
+
+    # :close closes the handle when the iterator is exhausted
+    my $fh = $file.open;
+    my @all = words($fh, :close);
+    is @all.elems, 6, 'words($fh, :close) reads all words';
+    is-deeply $fh.opened, False, 'words($fh, :close) closes the handle';
+}


### PR DESCRIPTION
Progress on the **IO Advanced Features** blocker group (TODO_roast/BLOCKERS.md).

## Changes

### IO::Path `.CWD` / `.SPEC` methods
- Implemented `.CWD` (returns the stored CWD string) and `.SPEC` (returns the backing `IO::Spec::*` type object).
- `.SPEC` normalizes to a canonical `Value::Package` so two paths sharing the same spec compare `eqv` regardless of whether the spec was stored as a `Package` (`IO::Path::Unix.new`) or a type-object instance (`$*SPEC`). This fixes the `.raku.EVAL` roundtrip subtest in `roast/S32-io/io-path.t` (subtest 16).

### `words()` `$limit` / `:close`
- The `$limit` positional and `:close` named args are now honored for the sub form `words($fh, n)`, the `IO::Handle` method, and the `IO::Path` method. `roast/S16-io/words.t` `$limit` subtests now pass (8/11, was 4/11).

### Named for-loop sub-signature destructuring
- `for @t -> (:$orig, :$with) { ... }` now binds named sub-signature params: via the accessor method when the item provides one (`Pair.key`/`.value`, object attribute readers), else by hash key for Associatives (`Hash`/`Map`). This is a general signature-binding improvement and unblocks the `.add` subtest in `io-path.t`.

## Test impact
- `roast/S32-io/io-path.t`: subtests 16/26/29 now pass (39/43 run).
- `roast/S16-io/words.t`: `$limit` subtests pass.
- New local test: `t/io-path-cwd-spec-and-named-unpack.t` (13 tests).
- Verified no regressions in signature/destructuring tests and the cargo unit suite (449 tests).

Remaining io-path.t blockers (each an independent feature) are documented in `TODO_roast/S32.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)