### PR TITLE
test: force lazy IO lines in `is` before comparison

### DIFF
--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -105,6 +105,11 @@ impl Interpreter {
                 .map(|v| v.to_string_value())
                 .collect::<Vec<_>>()
                 .join(" ")),
+            // A lazy IO lines iterator (e.g. `$fh.lines`) must be forced before
+            // comparison so it stringifies as its contents rather than "(...)".
+            Value::LazyIoLines { handle, .. } => {
+                Ok(self.force_lazy_io_lines(handle)?.to_string_value())
+            }
             _ => Ok(value.to_string_value()),
         }
     }

--- a/t/is-lazy-io-lines.t
+++ b/t/is-lazy-io-lines.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 3;
+
+# `is` must force a lazy IO lines iterator before comparing, so it stringifies
+# as its contents ("A B C") rather than the lazy gist "(...)".
+
+my $path = "tmp/is-lazy-lines-{$*PID}.txt".IO;
+LEAVE { try $path.unlink }
+
+$path.spurt("A\nB\nC\n");
+is $path.open(:r).lines, <A B C>, '.lines compares as its contents in `is`';
+
+# Changing the input line separator (nl-in) and then reading .lines.
+my $path2 = "tmp/is-lazy-lines2-{$*PID}.txt".IO;
+LEAVE { try $path2.unlink }
+$path2.spurt("A+B+C+D+");
+my $fh = $path2.open(:r);
+$fh.nl-in = "+";
+is $fh.lines, <A B C D>, '.lines honors nl-in and compares as contents';
+
+# is-deeply with the eager list form still works.
+is-deeply $path.open(:r).lines.List, ("A", "B", "C"), '.lines.List is eager';


### PR DESCRIPTION
`is $fh.lines, <A B C>` previously failed because the `is` test function stringified the lazy `LazyIoLines` value as `"(...)"` instead of forcing it to its contents. This mirrors the existing handling for `LazyList`.

## Test impact
- Fixes `roast/S32-io/io-handle.t` subtest 2 ("Changing input-line-separator works for .lines") — and more generally any `is $fh.lines, ...` comparison.
- New local test `t/is-lazy-io-lines.t` (3 tests).
- `roast/S16-io/lines.t` and `words.t` still pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)