### PR TITLE
vm: nativize .subst over a Str with a simple pattern/replacement (lever A)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -50,6 +50,7 @@ mod vm_method_dispatch;
 mod vm_misc_ops;
 mod vm_native_dispatch;
 mod vm_native_map;
+mod vm_native_subst;
 mod vm_register_ops;
 mod vm_set_ops;
 pub(crate) mod vm_smart_match;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -371,6 +371,10 @@ impl VM {
         if let Some(result) = self.try_native_array_map(&target, method, &args) {
             return result;
         }
+        // Native `.subst` over a Str with a simple pattern/replacement (lever A).
+        if let Some(result) = self.try_native_subst(&target, method, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -770,6 +774,10 @@ impl VM {
         }
         // Native `.map` / `.grep` over a concrete array with a simple block (lever A).
         if let Some(result) = self.try_native_array_map(&target, method, &args) {
+            return result;
+        }
+        // Native `.subst` over a Str with a simple pattern/replacement (lever A).
+        if let Some(result) = self.try_native_subst(&target, method, &args) {
             return result;
         }
         crate::vm::vm_stats::record_method_fallback(method);

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -1,0 +1,177 @@
+//! Native `.subst` over a `Str` invocant with a simple pattern/replacement.
+//!
+//! `"...".subst(/pat/, "repl")` previously always fell back to the interpreter's
+//! `dispatch_subst` (see docs/vm-decoupling.md, lever A; `.subst` is the
+//! highest-frequency residual method fallback). The substitution *engine* —
+//! regex matching (`regex_find_first_from_with_captures`), `$0`/`$1` capture
+//! expansion (`expand_capture_refs`) and Match-object construction — already
+//! lives VM-side because the operator form `s/.../.../ ` compiles to
+//! `OpCode::Subst` and runs natively in `exec_subst_op`. This routes the common
+//! `.subst` *method* call through the same building blocks instead of the
+//! interpreter, falling back for anything that needs the interpreter's richer
+//! handling (closure replacements, regex-with-adverbs objects, Perl5 regex, the
+//! `:nth`/`:x`/`:c`/`:p`/`:ii`/`:mm`/`:ss` adverbs, non-`Str` invocants, …).
+//!
+//! The output is built to match `dispatch_subst` byte-for-byte (including
+//! mutsu's literal-`$0` expansion in string replacements and its `$/` policy:
+//! set on a single non-global match, left untouched on a global match, set to
+//! `Nil` on no match), so this is a pure decoupling change with no behavioral
+//! difference.
+
+use super::*;
+use crate::value::Value;
+use std::collections::HashMap;
+
+impl VM {
+    /// Try to run `target.subst(pattern, replacement, :g?)` natively. Returns
+    /// `Some(result)` when handled in the VM, `None` to fall back to the
+    /// interpreter unchanged.
+    pub(super) fn try_native_subst(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "subst" {
+            return None;
+        }
+        // Only a plain string invocant. Other Cool types stringify in the
+        // interpreter; keep the native path conservative.
+        let Value::Str(text_arc) = target else {
+            return None;
+        };
+        let text = text_arc.to_string();
+
+        // Split args into positionals and adverbs. Only `:g`/`:global` are
+        // understood here; any other adverb (`:nth`/`:x`/`:c`/`:p`/`:ii`/…)
+        // means fall back, because their selection semantics live in
+        // `dispatch_subst`.
+        let mut positional: Vec<&Value> = Vec::new();
+        let mut global = false;
+        for arg in args {
+            if let Value::Pair(key, value) = arg {
+                match key.as_str() {
+                    "g" | "global" => global = value.truthy(),
+                    _ => return None,
+                }
+            } else {
+                positional.push(arg);
+            }
+        }
+        // `.subst` takes a pattern and an optional replacement; anything else is
+        // unusual enough to defer.
+        if positional.is_empty() || positional.len() > 2 {
+            return None;
+        }
+        let pattern = positional[0];
+        let replacement_val = positional.get(1).copied();
+        // Only literal string (or absent) replacements. A closure replacement
+        // needs `eval_subst_replacement`'s block call; numbers/other values are
+        // rare enough to defer.
+        let replacement_str = match replacement_val {
+            None => String::new(),
+            Some(Value::Str(s)) => s.to_string(),
+            _ => return None,
+        };
+
+        match pattern {
+            // Plain (non-adverb, non-Perl5) regex literal: `.subst(/pat/, ...)`.
+            Value::Regex(pat) => {
+                Some(self.native_subst_regex(&text, &pat.to_string(), &replacement_str, global))
+            }
+            // Literal string pattern: pure string replacement, never touches `$/`.
+            Value::Str(pat) => {
+                let pat = pat.as_str();
+                if pat.is_empty() {
+                    // Empty-pattern semantics (match between every char) differ
+                    // from `str::replace`; let the interpreter handle it.
+                    return None;
+                }
+                let result = if global {
+                    text.replace(pat, &replacement_str)
+                } else {
+                    text.replacen(pat, &replacement_str, 1)
+                };
+                Some(Ok(Value::str(result)))
+            }
+            _ => None,
+        }
+    }
+
+    /// Native regex `.subst`. Mirrors the non-adverb path of `dispatch_subst`'s
+    /// `Value::Regex` branch.
+    fn native_subst_regex(
+        &mut self,
+        text: &str,
+        pat: &str,
+        replacement_str: &str,
+        global: bool,
+    ) -> Result<Value, RuntimeError> {
+        // Collect non-overlapping matches with their positional captures, using
+        // the same iterative walk the operator form uses in `exec_subst_op`.
+        let mut matches: Vec<(usize, usize, Vec<String>)> = Vec::new();
+        let mut pos = 0usize;
+        while let Some((start, end, caps)) = self
+            .interpreter
+            .regex_find_first_from_with_captures(pat, text, pos)
+        {
+            pos = if end > start { end } else { start + 1 };
+            matches.push((start, end, caps));
+        }
+
+        if matches.is_empty() {
+            // No match: `$/` becomes Nil and the original string is returned.
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), Value::Nil);
+            return Ok(Value::str(text.to_string()));
+        }
+
+        // A non-global `.subst` replaces only the first match and sets `$/` to
+        // that match; a global `.subst` replaces every match and leaves `$/`
+        // untouched (matching `dispatch_subst`).
+        let selected: &[(usize, usize, Vec<String>)] =
+            if global { &matches } else { &matches[..1] };
+
+        let chars: Vec<char> = text.chars().collect();
+        let mut result = String::with_capacity(text.len());
+        let mut last_end = 0usize;
+        for (start, end, caps) in selected {
+            result.extend(chars[last_end..*start].iter());
+            // Expand `$0`/`$1`/… only when the match actually captured groups,
+            // matching `eval_subst_replacement` (a literal `$0` with no capture
+            // group is kept verbatim).
+            if caps.is_empty() {
+                result.push_str(replacement_str);
+            } else {
+                result.push_str(&crate::vm::vm_string_regex_ops::expand_capture_refs(
+                    replacement_str,
+                    caps,
+                ));
+            }
+            last_end = *end;
+        }
+        result.extend(chars[last_end..].iter());
+
+        if !global {
+            let (start, end, caps) = &matches[0];
+            let matched: String = chars[*start..*end].iter().collect();
+            let match_obj = Value::make_match_object_full(
+                matched,
+                *start as i64,
+                *end as i64,
+                caps,
+                &HashMap::new(),
+                &HashMap::new(),
+                &[],
+                &[],
+                Some(text),
+            );
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), match_obj);
+        }
+
+        Ok(Value::str(result))
+    }
+}

--- a/t/subst-native.t
+++ b/t/subst-native.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Exercises the VM-native `.subst` fast path (src/vm/vm_native_subst.rs).
+# These all use a Str invocant with a plain regex/string pattern and a string
+# (or absent) replacement -- the common cases now handled in the VM instead of
+# falling back to the interpreter. Results must remain identical to the
+# interpreter path.
+
+plan 20;
+
+# --- regex pattern, single match ---
+is "aXbXc".subst(/X/, "-"), "a-bXc", "regex single replaces first match only";
+is "hello".subst(/l/, "L"), "heLlo", "regex single, first of repeated";
+is "abc".subst(/Z/, "-"), "abc", "regex no match returns original";
+is "abc".subst(/b/, ""), "ac", "regex empty replacement deletes match";
+is "abc".subst(/b/), "ac", "regex absent replacement deletes match";
+
+# --- regex pattern, global (:g) ---
+is "aXbXc".subst(/X/, "-", :g), "a-b-c", "regex :g replaces all";
+is "aaa".subst(/a/, "bb", :g), "bbbbbb", "regex :g overlapping-free expansion";
+is "abc".subst(/Z/, "-", :g), "abc", "regex :g no match returns original";
+
+# --- string pattern ---
+is "hello".subst("l", "L"), "heLlo", "string single replaces first";
+is "hello".subst("l", "L", :g), "heLLo", "string :g replaces all";
+is "a.b.c".subst(".", "-", :g), "a-b-c", "string :g treats pattern literally";
+is "abc".subst("z", "-"), "abc", "string no match returns original";
+
+# --- $/ after subst ---
+{
+    my $s = "foo123bar";
+    $s.subst(/(\d+)/, "X");
+    ok $/.defined, '$/ is set after single regex subst';
+    is $/.Str, "123", '$/ holds the matched text';
+    is $/[0].Str, "123", '$/[0] holds the first capture';
+}
+{
+    "abc".subst(/Z/, "-");
+    nok $/.defined, '$/ is Nil after a no-match subst';
+}
+
+# --- unicode (char vs byte indices) ---
+is "café".subst(/é/, "e"), "cafe", "unicode single subst";
+is "naïve café".subst(/<[éï]>/, "_", :g), "na_ve caf_", "unicode :g subst";
+
+# --- chaining returns a fresh string, invocant unchanged ---
+{
+    my $orig = "a,b,c";
+    my $new = $orig.subst(/","/, ";", :g);
+    is $new, "a;b;c", "subst returns substituted copy";
+    is $orig, "a,b,c", "subst leaves the invocant unchanged";
+}


### PR DESCRIPTION
## Summary

`.subst` is the highest-frequency residual **method fallback** — string-processing scripts call it in a loop (probe: `subst=100` fallbacks). Until now every `.subst` *method* call routed through the interpreter's `dispatch_subst`, even though the substitution *engine* already lives VM-side: the **operator** form `s/.../.../ ` compiles to `OpCode::Subst` and runs natively in `exec_subst_op` using `regex_find_first_from_with_captures`, `expand_capture_refs`, and the VM Match-object builder.

This PR adds `try_native_subst` (hooked before both method-dispatch fallback sites in `vm_call_method_compiled.rs`) that routes the common case through those same building blocks instead of the interpreter.

## Scope (eligibility)

Handled natively:
- `Str` invocant
- plain `Value::Regex` or literal `Value::Str` pattern
- string (or absent) replacement
- optional `:g`/`:global`

Falls back (unchanged) for: closure replacements, `RegexWithAdverbs` objects, Perl5 regex, the `:nth`/`:x`/`:c`/`:p`/`:ii`/`:mm`/`:ss` adverbs, empty-string patterns, and non-`Str` invocants.

## Behavioral fidelity

Output is built to match `dispatch_subst` byte-for-byte, including:
- mutsu's literal-`$0` expansion in string replacements (only when the match captured groups);
- the `$/` policy: set (with positional captures) on a single non-global match, left untouched on a global match, set to `Nil` on no match.

This is a **pure decoupling** change — no behavioral difference vs the interpreter path.

## Impact

`tmp/probe_methods.raku` subst method-fallback **100 → 0**.

## Tests

- New `t/subst-native.t` (20 assertions, all raku-compliant — verified against `raku` as the oracle).
- Existing subst tests pass: `t/ss-substitution.t`, `t/subst-backrefs.t`, `t/regex-capture-markers-and-subst-modifier.t`, `roast/S05-substitution/{subst,match,67222}.t`.
- `make test`: only the known pre-existing/flaky failures (`t/placeholder.t`, `t/tail-function.t`, `t/wrap.t`) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)