### PR TITLE
vm: nativize .sort over a plain array (no/simple comparator) (lever A)

### DIFF
--- a/src/runtime/methods_collection_ops/mod.rs
+++ b/src/runtime/methods_collection_ops/mod.rs
@@ -5,7 +5,7 @@ mod grep;
 mod minmax_extrema;
 mod socket_inet_proc;
 mod socket_thread;
-mod sort;
+pub(crate) mod sort;
 mod tail_rotate;
 mod unique_squish;
 

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::ast::{Expr, Stmt};
 use crate::token_kind::TokenKind;
 
-fn inline_numeric_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
+pub(crate) fn inline_numeric_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
     match (a, b) {
         (Value::Int(x), Value::Int(y)) => x.cmp(y),
         (Value::Num(x), Value::Num(y)) => x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
@@ -120,7 +120,7 @@ fn detect_method_cmp_block(data: &crate::value::SubData) -> Option<(String, bool
     }
 }
 
-fn detect_simple_cmp_block(data: &crate::value::SubData) -> Option<(bool, bool)> {
+pub(crate) fn detect_simple_cmp_block(data: &crate::value::SubData) -> Option<(bool, bool)> {
     if data.params.len() < 2 {
         return None;
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -158,7 +158,7 @@ mod methods;
 mod methods_call_helpers;
 mod methods_classhow;
 mod methods_collection;
-mod methods_collection_ops;
+pub(crate) mod methods_collection_ops;
 mod methods_dispatch_match;
 mod methods_dispatch_match2;
 mod methods_dispatch_match3;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -50,6 +50,7 @@ mod vm_method_dispatch;
 mod vm_misc_ops;
 mod vm_native_dispatch;
 mod vm_native_map;
+mod vm_native_sort;
 mod vm_native_subst;
 mod vm_register_ops;
 mod vm_set_ops;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -375,6 +375,10 @@ impl VM {
         if let Some(result) = self.try_native_subst(&target, method, &args) {
             return result;
         }
+        // Native `.sort` over a plain array with no/simple comparator (lever A).
+        if let Some(result) = self.try_native_sort(&target, method, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -778,6 +782,10 @@ impl VM {
         }
         // Native `.subst` over a Str with a simple pattern/replacement (lever A).
         if let Some(result) = self.try_native_subst(&target, method, &args) {
+            return result;
+        }
+        // Native `.sort` over a plain array with no/simple comparator (lever A).
+        if let Some(result) = self.try_native_sort(&target, method, &args) {
             return result;
         }
         crate::vm::vm_stats::record_method_fallback(method);

--- a/src/vm/vm_native_sort.rs
+++ b/src/vm/vm_native_sort.rs
@@ -1,0 +1,88 @@
+//! Native `.sort` over a concrete array, for the no-comparator and
+//! simple-comparator-block cases.
+//!
+//! `@a.sort` and `@a.sort({ $^a <=> $^b })` previously always fell back to the
+//! interpreter's `dispatch_sort` (see docs/vm-decoupling.md, lever A). Those two
+//! forms — by far the most common — need no user-code call at all: the
+//! no-comparator sort uses the canonical `compare_values`, and a simple
+//! `{ $^a <=> $^b }` / `{ $^b <=> $^a }` / `cmp` block is recognized by
+//! `detect_simple_cmp_block` and compared inline. Running them in the VM keeps
+//! them fully native (no perf regression — the interpreter already avoided the
+//! block call here) and removes the `.sort` method fallback for these cases.
+//!
+//! Everything that genuinely needs the interpreter's richer orchestration —
+//! general comparator/mapper blocks (`{ $^a.foo <=> $^b.foo }`, `*.abs`, a
+//! Routine, …), the `:k`/`:kv`/`:p`/`:v` adverbs, and non-plain targets
+//! (Shaped/Lazy/ItemArray arrays, Seq, Range, Hash) — falls back unchanged.
+
+use super::*;
+use crate::runtime::methods_collection_ops::sort::{detect_simple_cmp_block, inline_numeric_cmp};
+use crate::runtime::utils::compare_values;
+use crate::value::{ArrayKind, Value};
+
+impl VM {
+    /// Try to run `target.sort(...)` natively. Returns `Some(result)` when
+    /// handled in the VM, `None` to fall back to the interpreter unchanged.
+    ///
+    /// `.sort` has no rw-view concern (it always yields a fresh `Seq`), so a
+    /// freshly-built sorted array is a faithful result.
+    pub(super) fn try_native_sort(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "sort" {
+            return None;
+        }
+        // Only a plain, eager, single-level array. `List`/`Array` both sort into
+        // a `Seq`; `Shaped` sorts over leaves, `Lazy` must stay lazy, and
+        // item/scalar-wrapped arrays have their own semantics — all fall back.
+        let items_arc = match target {
+            Value::Array(items, ArrayKind::Array | ArrayKind::List) => items.clone(),
+            _ => return None,
+        };
+
+        // Parse the (optional) comparator. Mirror `dispatch_sort`'s arg handling
+        // for the subset we support: a single positional/`:by` callable, no
+        // index-returning adverbs.
+        let mut callable: Option<&Value> = None;
+        for arg in args {
+            match arg {
+                Value::Pair(key, val) if key == "by" => callable = Some(val),
+                // `:k`/`:kv`/`:p`/`:v` (return indices/pairs) and any other
+                // adverb need the interpreter.
+                Value::Pair(..) => return None,
+                _ => callable = Some(arg),
+            }
+        }
+
+        let mut items = items_arc.as_ref().clone();
+        match callable {
+            // `@a.sort` — canonical comparison.
+            None => items.sort_by(|a, b| compare_values(a, b).cmp(&0)),
+            // `@a.sort({ $^a <=> $^b })` and friends — inline comparison when the
+            // block is a simple two-variable `<=>`/`cmp`. Any richer block (a
+            // method-keyed comparator, a 1-arity mapper, …) returns `None` here
+            // and falls back.
+            Some(Value::Sub(data)) => {
+                if data.empty_sig {
+                    return None;
+                }
+                let (reverse, is_string_cmp) = detect_simple_cmp_block(data)?;
+                items.sort_by(|a, b| {
+                    let (l, r) = if reverse { (b, a) } else { (a, b) };
+                    if is_string_cmp {
+                        l.to_str_context().cmp(&r.to_str_context())
+                    } else {
+                        inline_numeric_cmp(l, r)
+                    }
+                });
+            }
+            // Routine / WhateverCode / anything else — fall back.
+            Some(_) => return None,
+        }
+
+        Some(Ok(Value::Seq(std::sync::Arc::new(items))))
+    }
+}

--- a/t/sort-native.t
+++ b/t/sort-native.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Exercises the VM-native `.sort` fast path (src/vm/vm_native_sort.rs): the
+# no-comparator sort and simple `{ $^a <=> $^b }` / `cmp` comparator blocks now
+# run in the VM instead of falling back to the interpreter. Results (including
+# sort stability) must remain identical.
+
+plan 16;
+
+# --- no comparator ---
+is-deeply (3, 1, 2).sort.List, (1, 2, 3), "Int sort, no comparator";
+is-deeply <c a b>.sort.List, <a b c>.List, "Str sort, no comparator";
+is-deeply (3, 1.5, 2, 0.5).sort.List, (0.5, 1.5, 2, 3), "mixed Int/Rat sort";
+is-deeply [5, 3, 8, 1].sort.List, (1, 3, 5, 8), "Array (square-bracket) sort";
+is-deeply ().sort.List, ().List, "empty sort";
+is-deeply (42,).sort.List, (42,), "single-element sort";
+
+# --- simple numeric comparator block ---
+is-deeply (3, 1, 4, 1, 5).sort({ $^a <=> $^b }).List, (1, 1, 3, 4, 5), "ascending numeric comparator";
+is-deeply (3, 1, 4, 1, 5).sort({ $^b <=> $^a }).List, (5, 4, 3, 1, 1), "descending numeric comparator";
+
+# --- simple string comparator block ---
+is-deeply <banana apple cherry>.sort({ $^a cmp $^b }).List, <apple banana cherry>.List, "ascending cmp";
+is-deeply <banana apple cherry>.sort({ $^b cmp $^a }).List, <cherry banana apple>.List, "descending cmp";
+
+# --- stability: equal keys preserve input order ---
+{
+    my @p = [1, 'a'], [2, 'b'], [1, 'c'], [2, 'd'], [1, 'e'];
+    my @sorted = @p.sort({ $^a[0] <=> $^b[0] });
+    is-deeply @sorted.map(*[1]).List, <a c e b d>.List, "sort is stable for equal keys";
+}
+
+# --- negative numbers ---
+is-deeply (-3, 5, -1, 0, 2).sort.List, (-3, -1, 0, 2, 5), "sort with negatives";
+is-deeply (-3, 5, -1, 0, 2).sort({ $^b <=> $^a }).List, (5, 2, 0, -1, -3), "descending with negatives";
+
+# --- returns a Seq, leaves the source unchanged ---
+{
+    my @orig = 3, 1, 2;
+    my @s = @orig.sort;
+    is-deeply @s.List, (1, 2, 3), "sort result is sorted";
+    is-deeply @orig.List, (3, 1, 2), "sort leaves the source array unchanged";
+}
+
+# --- chaining onto sort ---
+is-deeply (3, 1, 2).sort.reverse.List, (3, 2, 1), "sort then reverse";


### PR DESCRIPTION
> Stacked on #2621 (`.subst`). Base will auto-retarget to `main` once #2621 merges; review only the top commit here.

## Summary

`@a.sort` and `@a.sort({ $^a <=> $^b })` previously routed through the interpreter's `dispatch_sort`. These two forms — by far the most common — need **no user-code call at all**: the no-comparator sort uses the canonical `compare_values`, and a simple `{ $^a <=> $^b }` / `{ $^b <=> $^a }` / `cmp` block is already recognized by `detect_simple_cmp_block` and compared inline.

`try_native_sort` (hooked before both method-dispatch fallback sites) runs those cases in the VM:

- plain `ArrayKind::Array`/`List` target (yields a `Seq`)
- no comparator → `compare_values`
- a `Value::Sub` matching `detect_simple_cmp_block` → inline numeric/string comparison (with the reverse and `cmp` variants)

## Why it's perf-neutral

The interpreter **already** avoided the block call for exactly these patterns (its own fast paths), so moving them to the VM changes no work — it only removes the `.sort` method-dispatch fallback. Rust's stable `sort_by` matches the interpreter's stable merge sort, including equal-key ordering (verified).

## Falls back unchanged

Method-keyed comparators (`{ $^a.foo <=> $^b.foo }`), 1-arity mappers (`*.abs`), Routine comparators, the `:k`/`:kv`/`:p`/`:v` adverbs, and `Shaped`/`Lazy`/`Item*`/`Seq`/`Range`/`Hash` targets.

## Shared logic

`detect_simple_cmp_block` and `inline_numeric_cmp` are made `pub(crate)` (modules re-exported) so the VM reuses the interpreter's detection rather than duplicating it.

## Tests

- New `t/sort-native.t` (16 assertions, raku-verified, incl. stability & negatives).
- `roast/S32-list/sort.t` (74), `roast/S17-supply/sort.t`, `roast/S04-statements/map-and-sort-in-for.t` all pass.
- `make test`: only the known pre-existing/flaky failures (`t/placeholder.t`, `t/tail-function.t`, `t/wrap.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)