### PR TITLE
vm: nativize multi-arity .map blocks and pointy-signature blocks (lever A)

### DIFF
--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -4,11 +4,12 @@
 //! `dispatch_map_method` orchestration (see docs/vm-decoupling.md, lever A). The
 //! block *body* already runs compiled on the VM (`vm_call_on_value` ->
 //! `call_compiled_closure`); only the surrounding iteration loop lived in the
-//! interpreter. This runs that loop in the VM for the common, simple case and
-//! falls back for anything that needs the interpreter's richer orchestration
-//! (multi-arity chunking, Slip/phaser/lazy-`return` handling, `next`/`last`/
-//! `take` control flow, `.assuming`/composed blocks, non-array targets,
-//! pair-shaped elements, …).
+//! interpreter. This runs that loop in the VM for the common, simple case
+//! (including multi-arity blocks like `-> $a, $b { ... }`, which consume the
+//! source in `arity`-sized chunks) and falls back for anything that needs the
+//! interpreter's richer orchestration (Slip/phaser/lazy-`return` handling,
+//! `next`/`last`/`take` control flow, `.assuming`/composed blocks, non-array
+//! targets, pair-shaped elements, a short final chunk, …).
 //!
 //! Eligibility is intentionally conservative: when the block body contains any
 //! construct that could escape the map loop (a `return`, loop control,
@@ -94,11 +95,6 @@ impl VM {
         if requires_full_binding {
             return None;
         }
-        // Single-element-per-call only: a `-> $a, $b { }` block consumes items in
-        // chunks, which the interpreter handles.
-        if data.params.len() > 1 {
-            return None;
-        }
         // The body must not contain anything that escapes the loop (return / loop
         // control / take / emit / phaser), nor any expression form we cannot
         // prove safe.
@@ -106,10 +102,23 @@ impl VM {
             return None;
         }
 
+        // Each call consumes `arity` consecutive items. A 0-param block uses the
+        // implicit `$_` (arity 1); a multi-arity block (`-> $a, $b { }`) chunks
+        // the source. When the source length isn't a multiple of the arity the
+        // last chunk is short, which the interpreter (and raku) treat as an
+        // error ("Not enough elements" / "Too few positionals"); defer those so
+        // the error path stays in one place.
+        let arity = data.params.len().max(1);
+        if arity > 1 && !items.len().is_multiple_of(arity) {
+            return None;
+        }
+
         let block = args[0].clone();
-        let mut result: Vec<Value> = Vec::with_capacity(items.len());
-        for item in items.iter() {
-            let value = match self.vm_call_on_value(block.clone(), vec![item.clone()], None) {
+        let mut result: Vec<Value> = Vec::with_capacity(items.len() / arity + 1);
+        let mut i = 0usize;
+        while i < items.len() {
+            let chunk: Vec<Value> = items[i..i + arity].to_vec();
+            let value = match self.vm_call_on_value(block.clone(), chunk, None) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
@@ -117,6 +126,7 @@ impl VM {
                 Value::Slip(elems) => result.extend(elems.iter().cloned()),
                 v => result.push(v),
             }
+            i += arity;
         }
 
         // On a real array, mutsu's `.map` yields a List-kind array (matching the
@@ -149,6 +159,10 @@ fn stmt_is_simple(stmt: &Stmt) -> bool {
         Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
             es.iter().all(expr_is_simple)
         }
+        // A line-number marker for diagnostics; it neither escapes the loop nor
+        // mutates the topic. Pointy/`Lambda` block bodies carry these (placeholder
+        // blocks don't), so accepting them lets `-> $a { ... }` map natively too.
+        Stmt::SetLine(_) => true,
         // Self-contained nested control structures: safe as long as their bodies
         // are simple (a `last`/`next` inside them is over-conservatively rejected
         // by the leaf rules below, which is fine).

--- a/t/map-native-multiarity.t
+++ b/t/map-native-multiarity.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Exercises the VM-native `.map` fast path extended to multi-arity blocks and
+# explicit (pointy) signatures (src/vm/vm_native_map.rs). Both
+# `-> $a, $b { ... }` and the placeholder `{ $^a + $^b }` form consume the
+# source in arity-sized chunks; single-arity pointy blocks (`-> $a { ... }`),
+# which the scanner previously rejected because their bodies carry a `SetLine`
+# marker, now also run natively. Results must match the interpreter and raku.
+
+plan 13;
+
+my @a = 1, 2, 3, 4;
+
+# --- placeholder multi-arity ---
+is-deeply @a.map({ $^a + $^b }).List, (3, 7), "placeholder 2-arity sum";
+is-deeply @a.map({ $^a * $^b }).List, (2, 12), "placeholder 2-arity product";
+
+# --- pointy multi-arity ---
+is-deeply @a.map(-> $a, $b { $a + $b }).List, (3, 7), "pointy 2-arity sum";
+is-deeply @a.map(-> $a, $b { "$a-$b" }).List, ("1-2", "3-4"), "pointy 2-arity interpolation";
+
+my @six = 1, 2, 3, 4, 5, 6;
+is-deeply @six.map(-> $a, $b, $c { $a + $b + $c }).List, (6, 15), "pointy 3-arity";
+
+# --- single-arity pointy (SetLine in body) ---
+is-deeply @a.map(-> $x { $x * 10 }).List, (10, 20, 30, 40), "pointy 1-arity";
+is-deeply @a.map(-> $x { $x }).List, (1, 2, 3, 4), "pointy 1-arity identity";
+
+# --- single-arity placeholder still native ---
+is-deeply @a.map({ $_ * 2 }).List, (2, 4, 6, 8), "implicit topic 1-arity";
+is-deeply @a.map({ $^x + 1 }).List, (2, 3, 4, 5), "named placeholder 1-arity";
+
+# --- Slip flattening from a multi-arity block ---
+is-deeply @a.map(-> $a, $b { ($b, $a).Slip }).List, (2, 1, 4, 3), "multi-arity Slip swap";
+
+# --- multi-arity over a longer even list ---
+my @n = (1 .. 8).Array;
+is-deeply @n.map(-> $a, $b { $a * $b }).List, (2, 12, 30, 56), "2-arity over 8 elements";
+
+# --- combine with a downstream operation ---
+is-deeply @a.map(-> $a, $b { $a + $b }).map(* + 100).List, (103, 107), "chained map after multi-arity";
+
+# --- result is a fresh List, source unchanged ---
+{
+    @a.map(-> $a, $b { $a + $b });
+    is-deeply @a.List, (1, 2, 3, 4), "multi-arity map leaves source unchanged";
+}


### PR DESCRIPTION
> Stacked on #2622 (`.sort`). Base auto-retargets to `main` once #2622 merges; review only the top commit.

## Summary

Extends the native `.map` fast path (`vm_native_map.rs`) two ways:

### 1. Multi-arity blocks
`@a.map(-> $a, $b { ... })` and `@a.map({ $^a + $^b })` now run in the VM, consuming the source in `arity`-sized chunks via `vm_call_on_value`. A source whose length isn't a multiple of the arity has a short final chunk — an error in both the interpreter and raku — so those defer to keep the single error path in the interpreter.

### 2. Pointy / `Lambda` block bodies
`-> $a { ... }` blocks carry a leading `SetLine` marker statement that the body scanner didn't recognize, so even **single-arity** pointy blocks always fell back. `SetLine` is a diagnostics-only marker (it neither escapes the loop nor mutates the topic), so the scanner now accepts it — letting pointy blocks map natively too.

## Verified against raku

Placeholder/pointy 2- and 3-arity, Slip flattening from a multi-arity block, single-arity pointy (`-> $x { ... }`), named placeholders, and chaining all match. `t/map-native-multiarity.t` (13 assertions) exercises these; 29/30 method-calls in it run native.

## Still deferred

Pair-shaped elements and `$_`-writeback (separate follow-ups). Note: reading the topic `$_` inside an explicit-signature block yields an undefined value natively (matching raku's `Any`), where the interpreter previously bound it to the first chunk element — the native result is actually closer to raku.

## Tests

`make test`: only the known pre-existing/flaky failures (`t/placeholder.t`, `t/tail-function.t`, `t/wrap.t`). All `*map*` roast/local tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)