### PR TITLE
vm: dispatch Test functions to their typed handler from the VM (lever A)

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -825,7 +825,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn is_builtin_function(name: &str) -> bool {
+    pub(crate) fn is_builtin_function(name: &str) -> bool {
         matches!(
             name,
             "defined"

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -128,6 +128,16 @@ impl Interpreter {
         self.test_state.is_some()
     }
 
+    /// True when a `Test` (or `Test::*`) module is loaded. This is the gate the
+    /// interpreter's `call_function_fallback` uses before dispatching a Test
+    /// function, so it is the correct precondition for the VM's native Test
+    /// dispatch too — unlike [`test_mode_active`], it is already true for the
+    /// very first test call (`plan`), before any `TestState` exists.
+    pub(crate) fn test_module_loaded(&self) -> bool {
+        self.loaded_modules.contains("Test")
+            || self.loaded_modules.iter().any(|m| m.starts_with("Test::"))
+    }
+
     /// Check if a name matches a known test function (Test or Test::Util).
     /// Used by the bare word resolver to dispatch zero-arg test function calls.
     pub(crate) fn is_test_function_name(name: &str) -> bool {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -52,6 +52,7 @@ mod vm_native_dispatch;
 mod vm_native_map;
 mod vm_native_sort;
 mod vm_native_subst;
+mod vm_native_test;
 mod vm_register_ops;
 mod vm_set_ops;
 pub(crate) mod vm_smart_match;

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -65,6 +65,10 @@ impl VM {
         {
             return self.compile_and_call_function_def(&def, args, compiled_fns);
         }
+        // Dispatch Test functions straight to their typed handler (lever A).
+        if let Some(result) = self.try_native_test_function(name, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_function_fallback(name);
         self.interpreter.call_function(name, args)
     }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -702,6 +702,9 @@ impl VM {
                 })
             {
                 self.compile_and_call_function_def(&def, args, compiled_fns)
+            } else if let Some(result) = self.try_native_test_function(name, &args) {
+                // Dispatch Test functions straight to their typed handler (lever A).
+                result
             } else {
                 // Sync VM locals to env before spawning threads so closures capture them
                 if name == "start" {

--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -1,0 +1,68 @@
+//! VM-side dispatch for `Test` / `Test::Util` functions.
+//!
+//! `is`/`ok`/`plan`/`is-deeply`/`subtest`/… are the bulk of the residual
+//! function-dispatch fallback when running the roast suite (see
+//! docs/vm-decoupling.md, lever A). They are implemented as typed Rust methods
+//! (`Interpreter::call_test_function`) rather than user AST, and are routed to
+//! the interpreter on purpose (`is_interpreter_handled_function`).
+//!
+//! Until now the VM reached them only by delegating to `Interpreter::call_function`
+//! — the generic, giant-`match` function dispatcher — which re-runs argument
+//! sanitisation and name resolution before finally landing on
+//! `call_test_function`. This routes the VM straight to the typed Test handler
+//! instead, the same "VM owns the native dispatch table" pattern already used
+//! for `sprintf` and the pure builtins.
+//!
+//! Scope note: the *bodies* of these functions are inherently interpreter
+//! coupled — they own the TAP counter/plan (`test_state`), emit TAP output, and
+//! call back into method dispatch (`.gist`/`.raku`), `EVAL`, and subprocess
+//! spawning. So this decouples the *dispatch layer*, not the bodies; moving the
+//! TAP state itself out of the interpreter is the separate lever-B work.
+//!
+//! Safety: both call sites that invoke this run *after* the VM's user-function /
+//! proto / multi-candidate / on-the-fly-compile resolution has already failed to
+//! match, so a user-defined `sub ok { … }` still shadows the Test routine (it is
+//! resolved earlier and never reaches here).
+
+use super::*;
+use crate::value::Value;
+
+impl VM {
+    /// Dispatch a `Test` module function straight to its typed handler when the
+    /// name is a known Test function and test mode is active. Returns
+    /// `Some(result)` when handled, `None` to let the caller fall back to
+    /// `Interpreter::call_function` unchanged.
+    pub(super) fn try_native_test_function(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !crate::runtime::Interpreter::is_test_function_name(name)
+            || !self.interpreter.test_module_loaded()
+        {
+            return None;
+        }
+        // Some Test names collide with core builtins (notably `run`, which is the
+        // `Proc` spawner far more often than `Test::Util::run`). The interpreter
+        // resolves the builtin first (its `call_function` match runs before the
+        // Test fallback), so never hijack a name that is also a builtin — let it
+        // take the normal path.
+        if crate::runtime::Interpreter::is_builtin_function(name) {
+            return None;
+        }
+        // Replicate the pre-dispatch setup that `Interpreter::exec_call` /
+        // `call_function` do before reaching `call_test_function`: strip the
+        // synthetic `__test_callsite_line` argument and stash it so TAP
+        // diagnostics report the right source line.
+        let (clean_args, callsite_line) = self.interpreter.sanitize_call_args(args);
+        self.interpreter.set_pending_callsite_line(callsite_line);
+        match self.interpreter.call_test_function(name, &clean_args) {
+            // Matched and handled by the typed Test dispatcher.
+            Ok(Some(value)) => Some(self.interpreter.maybe_fetch_rw_proxy(value, true)),
+            // `is_test_function_name` said yes but the dispatcher declined: fall
+            // back to the generic path so behaviour is never lost.
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}

--- a/t/test-fn-native-dispatch.t
+++ b/t/test-fn-native-dispatch.t
@@ -1,0 +1,19 @@
+use Test;
+
+# Regression guard for the VM-side Test-function dispatch
+# (src/vm/vm_native_test.rs). The VM routes Test functions straight to their
+# typed handler instead of through `call_function`. A name that is BOTH a Test
+# function and a core builtin (notably `run`, the Proc spawner, vs
+# `Test::Util::run`) must NOT be hijacked: the builtin has to keep working
+# inside a test file.
+
+plan 3;
+
+# `run` here is the builtin Proc spawner, not Test::Util::run.
+my $proc = run($*EXECUTABLE, '-e', 'print "hello-from-run"', :out);
+my $out = $proc.out.slurp;
+is $out, "hello-from-run", "builtin run is not hijacked by Test::Util::run";
+
+# Ordinary Test functions keep working alongside it.
+ok True, "ok still works after a builtin run call";
+is 2 + 2, 4, "is still works after a builtin run call";


### PR DESCRIPTION
> Stacked on #2623 (multi-arity `.map`). Base auto-retargets to `main` once #2623 merges; review only the top commit.

## Summary

`is`/`ok`/`plan`/`is-deeply`/`subtest`/… are the bulk of the residual **function-dispatch fallback** when running the roast/test suite. They are implemented as typed Rust methods (`Interpreter::call_test_function`) and routed to the interpreter on purpose (`is_interpreter_handled_function`). Until now the VM reached them only via `Interpreter::call_function` — the generic giant-`match` dispatcher — which re-sanitises args and re-resolves the name before finally landing on `call_test_function`.

`try_native_test_function` (hooked before both VM function-dispatch fallback sites — `call_function_compiled_first` and `dispatch_func_call_inner`) routes recognised Test names straight to the typed handler. Same "VM owns the native dispatch table" pattern already used for `sprintf` and the pure builtins. It replicates the only pre-dispatch setup the Test bodies depend on (stripping the synthetic `__test_callsite_line` arg and stashing it so TAP diagnostics report the right line).

## Correctness

- **Gated on `test_module_loaded()`** (a `Test`/`Test::*` is loaded) — the same precondition `call_function_fallback` uses — *not* `test_mode_active()`, which is still false for the very first call (`plan`) before any `TestState` exists.
- **Skips names that are also core builtins** (notably `run`: the `Proc` spawner, not `Test::Util::run`) — the interpreter resolves the builtin first. This was caught by the whitelisted `roast/S24-testing/line-numbers.t`, which spawns subprocesses via builtin `run` inside a test file.
- **Runs only after** user-function/proto/multi/OTF-compile resolution has failed, so a user-defined `sub ok { … }` still shadows the Test routine.

## Scope (honest framing)

This decouples the **dispatch layer**. The function *bodies* remain interpreter-coupled by nature — they own the TAP counter/plan (`test_state`), emit TAP output, and call back into method dispatch (`.gist`/`.raku`), `EVAL`, and subprocess spawning. Moving the TAP state itself out of the interpreter is the separate **lever-B** work.

## Tests

- New `t/test-fn-native-dispatch.t` guards the `run`-not-hijacked case.
- `roast/S24-testing/*` all pass (incl. the whitelisted `line-numbers.t`).
- `make test`: only the known pre-existing/flaky failures (`t/placeholder.t`, `t/tail-function.t`, `t/wrap.t`). A broad roast sample across S02–S32 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)