### PR TITLE
temporal: store Duration seconds as Rational, fix Rat % BigInt modulo

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -190,15 +190,20 @@ Module versioning, import-multi semantics, CompUnit::Repository, and distributio
 - roast/S11-repository/curli-install.t (C::R::Installable role)
 - roast/S19-command-line-options/01-dash-uppercase-i.t
 
-## Multi Method / Subsignature Dispatch (5 tests)
+## Multi Method / Subsignature Dispatch (2 tests remaining)
 
-Multi method dispatch on type signatures doesn't work properly. Subsignature matching in multi dispatch is incomplete.
+**Already passing/whitelisted (this section was stale — verified 2026-06-05):**
+- roast/S06-multi/subsignature.t (whitelisted; remaining `not ok` are `# TODO`)
+- roast/S12-methods/multi.t (whitelisted, passes)
+- roast/S06-other/main.t (whitelisted, passes)
 
-- roast/S06-multi/subsignature.t
-- roast/S12-methods/multi.t (multi method on Str/Numeric signatures)
-- roast/S12-methods/qualified.t (callsame in punned roles)
-- roast/S06-operator-overloading/infix.t
-- roast/S06-other/main.t (MAIN with enum type constraints)
+**Still failing:**
+- roast/S12-methods/qualified.t (6/7; only "parameterizations and inheritance" —
+  callsame in punned roles — fails)
+- roast/S06-operator-overloading/infix.t — **unpassable as written**: rakudo
+  itself fails to compile it ("Cannot bind to '&infix:<plus>' because Code items
+  cannot be rebound" at line 40). mutsu runs further but the test relies on
+  rebinding `&infix:<...>`, which is illegal in current Raku.
 
 ## WhateverCode / Currying Edge Cases (3 tests)
 
@@ -268,12 +273,22 @@ Pod6 formatting codes (Pod::FormattingCode type), table rendering, and trailing 
 - roast/S26-documentation/block-trailing.t
 - roast/S26-documentation/why-trailing.t
 
-## Temporal / DateTime (2 tests)
+## Temporal / DateTime (DONE except an unpassable test)
 
-Duration arithmetic (Inf, NaN, modulo), and time numification.
+**Resolved (whitelisted):**
+- roast/S32-temporal/DateTime-Instant-Duration.t (68/68) — Duration now stores
+  its seconds as a Rational (so `.tai` is a Rat / does Rational), `Duration % Real`
+  returns a Duration computed with exact rational arithmetic (matching
+  `Duration.new($seconds % $real)`), and `Duration.new` defaults to `0.0` (Rat).
+  Also fixed a general `arith_mod` bug where `Rat % BigInt` (e.g. `(7/1) % (2**66)`)
+  returned 0 — rational modulo now uses big-rational parts. (#TBD)
 
-- roast/S32-temporal/DateTime-Instant-Duration.t (Duration.new(Inf/NaN), modulo)
-- roast/S32-temporal/time.t (Time::Local numification)
+**Unpassable as written (cannot be fixed):**
+- roast/S32-temporal/time.t — uses Perl 5 builtins `localtime`/`gmtime`/`times`
+  which are NOT Raku core routines (rakudo itself fails to compile this file:
+  "localtime used at lines ...; times ... Did you mean 'lines'?"), and the file
+  contains two deliberate `flunk("FIXME Time::Local should by numifiable")` calls.
+  It can never reach a passing state. Leave un-whitelisted.
 
 ## Subset Types / Where Clauses (2 tests)
 
@@ -295,7 +310,15 @@ Binding to attributes, nested binding, and container semantics (Scalar decontain
 
 categorize.t now fully passes (28/28, whitelisted). minmax.t fully passes (whitelisted, #2510). classify.t nearly passes (38/40 — 2 edge cases remaining).
 
-- roast/S32-list/classify.t (39/40 pass — only the Junction-threading subtest remains; classify with a mapper returning a Junction must thread and store values under multiple keys)
+- roast/S32-list/classify.t (39/40 pass — only the "classify works with
+  Junctions" subtest remains. NOTE (verified 2026-06-05): this is NOT a small
+  fix. When the mapper returns a Junction, rakudo's `.classify` builds an
+  **object hash** (`my Any %{Mu}`) keyed by the Junction's `.WHICH` identity
+  (any(True,False) is one key, distinct from any(False,False)), and `$h{ any(...) }`
+  retrieves by object-key identity WITHOUT autothreading the subscript. mutsu's
+  `Value::Hash` is `HashMap<String, Value>` (string keys only) with no
+  object-hash support, so this subtest is blocked on full object-hash
+  (`%{Mu}` / non-Str keyed hash) semantics, not a classify-local tweak.)
 
 ## Miscellaneous (25 tests)
 

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -417,13 +417,20 @@
 - [ ] roast/S32-temporal/baum-gregorian-data.t
 - [ ] roast/S32-temporal/calendar.t
 - [ ] roast/S32-temporal/Date.t
-- [ ] roast/S32-temporal/DateTime-Instant-Duration.t
-  - 64/68 subtests pass; remaining 4 need: does-ok Rational role check, Duration % Real dispatch, Duration.new.tai Rat storage
+- [x] roast/S32-temporal/DateTime-Instant-Duration.t
+  - 68/68 pass (whitelisted). Duration now stores its seconds as a Rational, so
+    `.tai` does Rational; `Rat ~~ Rational` / `.does(Rational)` now true;
+    `Duration % Real` returns a Duration via exact rational arithmetic; `Duration.new`
+    defaults to `0.0` (Rat). Also fixed a general `arith_mod` bug: `Rat % BigInt`
+    (e.g. `(7/1) % (2**66)`) returned 0 — rational modulo now uses big-rational parts.
 - [ ] roast/S32-temporal/DateTime.t
 - [ ] roast/S32-temporal/greg-jd-frac-seconds.t
 - [x] roast/S32-temporal/juliandate.t
 - [x] roast/S32-temporal/local.t
 - [ ] roast/S32-temporal/time.t
+  - UNPASSABLE as written: uses Perl 5 builtins `localtime`/`gmtime`/`times`
+    (not Raku core — rakudo itself fails to compile the file) and contains two
+    deliberate `flunk("FIXME Time::Local should by numifiable")` calls. Cannot pass.
 - [ ] roast/S32-trig/atan2.t
 - [ ] roast/S32-trig/cosech.t
 - [ ] roast/S32-trig/cosec.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1173,6 +1173,7 @@ roast/S32-str/val.t
 roast/S32-str/windows-1251-windows-1252-encode-decode.t
 roast/S32-str/words.t
 roast/S32-temporal/Date.t
+roast/S32-temporal/DateTime-Instant-Duration.t
 roast/S32-temporal/DateTime.t
 roast/S32-temporal/baum-gregorian-data.t
 roast/S32-temporal/calendar.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -225,6 +225,67 @@ fn instance_duration_value(value: &Value) -> Option<f64> {
     }
 }
 
+/// Return the raw stored `value` of a Duration instance (a Rational), if any.
+fn instance_duration_raw_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name == "Duration" => attributes.get("value").cloned(),
+        _ => None,
+    }
+}
+
+/// Coerce a Real value to a Rational, matching Rakudo's Duration which always
+/// stores its seconds as a Rat. Integers become exact Rats; existing rationals
+/// are kept; Inf/NaN map to the degenerate Rats `1/0`/`0/0`; floats use the
+/// standard epsilon conversion.
+pub(crate) fn real_to_rat(v: &Value) -> Value {
+    match v {
+        Value::Rat(..) | Value::BigRat(..) | Value::FatRat(..) => v.clone(),
+        Value::Int(i) => crate::value::make_rat(*i, 1),
+        Value::Bool(b) => crate::value::make_rat(*b as i64, 1),
+        // Preserve large integers exactly as a (big) Rat with denominator 1.
+        Value::BigInt(b) => crate::value::make_big_rat_arith((**b).clone(), NumBigInt::from(1)),
+        Value::Num(f) => {
+            if f.is_nan() {
+                Value::Rat(0, 0)
+            } else if f.is_infinite() {
+                if *f > 0.0 {
+                    Value::Rat(1, 0)
+                } else {
+                    Value::Rat(-1, 0)
+                }
+            } else {
+                crate::builtins::num_to_rat_with_epsilon(*f, 1e-6)
+            }
+        }
+        // Anything else (e.g. Str, allomorphs): fall back through f64.
+        _ => {
+            let f = runtime::to_float_value(v).unwrap_or(0.0);
+            if f.is_nan() {
+                Value::Rat(0, 0)
+            } else if f.is_infinite() {
+                if f > 0.0 {
+                    Value::Rat(1, 0)
+                } else {
+                    Value::Rat(-1, 0)
+                }
+            } else {
+                crate::builtins::num_to_rat_with_epsilon(f, 1e-6)
+            }
+        }
+    }
+}
+
+/// Build a Duration instance storing the given (already Rational) value.
+fn make_duration_from_value(val: Value) -> Value {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("value".to_string(), val);
+    Value::make_instance(Symbol::intern("Duration"), attrs)
+}
+
 fn instance_datetime_parts(value: &Value) -> Option<(i64, i64, i64, i64, i64, f64, i64)> {
     match value {
         Value::Instance { attributes, .. }
@@ -1008,14 +1069,15 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
 }
 
 pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError> {
-    if let Some(dur) = instance_duration_value(&left)
+    if let Some(raw) = instance_duration_raw_value(&left)
         && right.is_numeric()
     {
-        let rhs = runtime::to_float_value(&right).unwrap_or(0.0);
-        if rhs == 0.0 {
-            return Err(RuntimeError::numeric_divide_by_zero());
-        }
-        return Ok(make_duration(dur.rem_euclid(rhs)));
+        // Duration % Real => Duration. Compute with exact rational arithmetic
+        // (the same code path as a plain modulo) so the result is eqv to
+        // Duration.new($seconds % $real). arith_mod throws X::Numeric::DivideByZero
+        // when the divisor is zero.
+        let modded = arith_mod(real_to_rat(&raw), right)?;
+        return Ok(make_duration_from_value(real_to_rat(&modded)));
     }
     let (mut l, mut r) = runtime::coerce_numeric(left, right);
     // Mixed Num/Rat modulo should use floating semantics; routing through
@@ -1036,70 +1098,38 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
     {
         l = Value::Num(runtime::to_float_value(&l).unwrap_or(f64::NAN));
     }
-    if let (Some((an, ad)), Some((bn, bd))) = (runtime::to_rat_parts(&l), runtime::to_rat_parts(&r))
+    // Exact rational modulo (divisor-sign semantics) via big-rational parts so
+    // that large operands such as `(7/1) % (2**66)` are handled exactly instead
+    // of falling through to a 0 result.
+    let l_is_rat = matches!(
+        l,
+        Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigRat(_, _)
+    );
+    let r_is_rat = matches!(
+        r,
+        Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigRat(_, _)
+    );
+    if (l_is_rat || r_is_rat)
+        && let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
     {
-        if matches!(l, Value::Rat(_, _) | Value::FatRat(_, _))
-            || matches!(r, Value::Rat(_, _) | Value::FatRat(_, _))
-        {
-            if bn == 0 {
-                return Err(RuntimeError::numeric_divide_by_zero());
-            }
-            // Rational modulo with divisor-sign semantics.
-            let num = num_integer::Integer::mod_floor(&(an * bd), &(ad * bn));
-            let den = ad * bd;
-            let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
-            Ok(if has_fat_rat {
-                make_fat_rat(num, den)
-            } else {
-                crate::value::make_rat(num, den)
-            })
-        } else {
-            Ok(match (l, r) {
-                (Value::Int(_), Value::Int(0)) => {
-                    return Err(RuntimeError::numeric_divide_by_zero());
-                }
-                (Value::BigInt(_), Value::Int(0)) => {
-                    return Err(RuntimeError::numeric_divide_by_zero());
-                }
-                (Value::Int(_), Value::BigInt(b)) if b.is_zero() => {
-                    return Err(RuntimeError::numeric_divide_by_zero());
-                }
-                (Value::BigInt(_), Value::BigInt(b)) if b.is_zero() => {
-                    return Err(RuntimeError::numeric_divide_by_zero());
-                }
-                (Value::Int(a), Value::Int(b)) => {
-                    Value::Int(num_integer::Integer::mod_floor(&a, &b))
-                }
-                (Value::BigInt(a), Value::Int(b)) => {
-                    let bb = num_bigint::BigInt::from(b);
-                    Value::from_bigint(num_integer::Integer::mod_floor(a.as_ref(), &bb))
-                }
-                (Value::Int(a), Value::BigInt(b)) => {
-                    let aa = num_bigint::BigInt::from(a);
-                    Value::from_bigint(num_integer::Integer::mod_floor(&aa, b.as_ref()))
-                }
-                (Value::BigInt(a), Value::BigInt(b)) => {
-                    Value::from_bigint(num_integer::Integer::mod_floor(a.as_ref(), b.as_ref()))
-                }
-                (Value::Num(a), Value::Num(0.0)) => {
-                    return Ok(RuntimeError::divide_by_zero_failure(
-                        Some(Value::Num(a)),
-                        Some("%"),
-                    ));
-                }
-                (Value::Num(a), Value::Num(b)) => Value::Num(float_mod_floor(a, b)),
-                (ref lv, Value::Num(0.0)) => {
-                    return Ok(RuntimeError::divide_by_zero_failure(
-                        Some(lv.clone()),
-                        Some("%"),
-                    ));
-                }
-                (Value::Int(a), Value::Num(b)) => Value::Num(float_mod_floor(a as f64, b)),
-                (Value::Num(a), Value::Int(b)) => Value::Num(float_mod_floor(a, b as f64)),
-                _ => Value::Int(0),
-            })
+        if bn.is_zero() {
+            return Err(RuntimeError::numeric_divide_by_zero());
         }
-    } else {
+        let num = num_integer::Integer::mod_floor(&(&an * &bd), &(&ad * &bn));
+        let den = &ad * &bd;
+        let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
+        return Ok(if has_fat_rat {
+            // FatRat % ... stays a FatRat. make_big_fat_rat normalizes small
+            // results down to Rat, so re-tag those as FatRat.
+            match crate::value::make_big_fat_rat(num, den) {
+                Value::Rat(n, d) => Value::FatRat(n, d),
+                other => other,
+            }
+        } else {
+            crate::value::make_big_rat_arith(num, den)
+        });
+    }
+    {
         Ok(match (l, r) {
             (Value::Int(_), Value::Int(0)) => {
                 return Err(RuntimeError::numeric_divide_by_zero());

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1089,6 +1089,9 @@ impl Interpreter {
                     } else {
                         0.0
                     };
+                    // Duration stores its seconds as a Rational (matching Rakudo,
+                    // where Duration.new(...).tai is always a Rat). Infinite/NaN
+                    // arguments map to the degenerate Rats 1/0 / -1/0 / 0/0.
                     let val = if secs.is_infinite() {
                         if secs > 0.0 {
                             Value::Rat(1, 0)
@@ -1098,7 +1101,10 @@ impl Interpreter {
                     } else if secs.is_nan() {
                         Value::Rat(0, 0)
                     } else {
-                        Value::Num(secs)
+                        match args.first() {
+                            Some(v) => crate::builtins::arith::real_to_rat(v),
+                            None => crate::value::make_rat(0, 1),
+                        }
                     };
                     let mut attrs = HashMap::new();
                     attrs.insert("value".to_string(), val);

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -115,6 +115,10 @@ impl Interpreter {
         {
             return true;
         }
+        // Rational role: Rat and FatRat do Rational[Int,Int]
+        if constraint == "Rational" && matches!(value_type, "Rat" | "FatRat") {
+            return true;
+        }
         // Native integer/num types do Real and Numeric
         if constraint == "Real"
             && (crate::runtime::native_types::is_native_int_type(value_type)

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -650,6 +650,10 @@ impl Value {
                     | Value::FatRat(_, _)
                     | Value::BigRat(_, _)
             ),
+            "Rational" => matches!(
+                self,
+                Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigRat(_, _)
+            ),
             "Dateish" => matches!(
                 self,
                 Value::Instance { class_name, .. } if class_name == "Date" || class_name == "DateTime"

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -318,6 +318,11 @@ impl VM {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            // Duration % Real => Duration. Handle before numeric coercion strips
+            // the Duration wrapper down to a bare number.
+            if crate::builtins::arith::is_temporal_operand(&l) {
+                return crate::builtins::arith_mod(l, r);
+            }
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             crate::builtins::arith_mod(l, r)
         })?;


### PR DESCRIPTION
Completes the **Temporal / DateTime** blocker category.

## DateTime-Instant-Duration.t: 64/68 → 68/68 (whitelisted)

Three fixes:

1. **Rational role membership** — `Rat ~~ Rational` and `(1/2).does(Rational)` returned `False`. Added a `Rational` arm to both type-hierarchy checks (`Value::isa_check` and `Interpreter::type_matches`) so `Rat`/`FatRat` do the `Rational` role. Fixes `does-ok Duration.new(Inf/NaN).tai, Rational`.

2. **Duration stores seconds as a Rational** — matching Rakudo, where `Duration.new(...).tai` is always a `Rat`. `Duration.new` with no argument defaults to `0.0` (Rat); `Duration % Real` returns a `Duration` computed with exact rational arithmetic so it is `eqv` to `Duration.new($seconds % $real)`. `exec_mod_op` now handles temporal operands before numeric coercion strips the `Duration` wrapper. BigInt seconds are preserved exactly as a (big) Rat.

3. **General `arith_mod` bug** — `Rat % BigInt` (e.g. `(7/1) % (2**66)`) returned `0` because `to_rat_parts` overflows `i64` for big operands, dropping the rational case to a `0` fallthrough. Rational modulo now uses big-rational parts; FatRat results are re-tagged so `FatRat % x` stays a `FatRat` (keeps `fatrat.t` green).

## time.t — unpassable as written

Uses the Perl 5 builtins `localtime`/`gmtime`/`times`, which are **not** Raku core routines (rakudo itself fails to compile the file), and it contains two deliberate `flunk("FIXME Time::Local should by numifiable")` calls. Documented in `BLOCKERS.md` / `S32.md`; left un-whitelisted.

## Doc corrections (verified)

While investigating I corrected stale `BLOCKERS.md` entries: the Multi Method tests `subsignature.t`/`multi.t`/`main.t` are already whitelisted; `infix.t` is unpassable (rakudo rejects rebinding `&infix:<plus>`); `classify.t`'s remaining subtest needs full object-hash (`%{Mu}`) support, not a classify-local tweak.

## Testing

- `cargo test`: 449 pass
- 77 arithmetic-related `t/` files (679 tests): pass
- Whitelisted roast (S03-operators/S32-num/S32-temporal/S03-metaops/S02-types/S03-binding): no regressions; `fatrat.t` still passes
- `DateTime-Instant-Duration.t`: 68/68 across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)