### PR TITLE
value: distinguish allomorphs in Set eqv

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -209,8 +209,21 @@ Module versioning, import-multi semantics, CompUnit::Repository, and distributio
 
 WhateverCode (*) in certain contexts: dummy assignment to *, &infix:<+>(*, 42) not making a closure, and multi-* expressions.
 
-- roast/S02-types/whatever.t
-- roast/S03-operators/eqv.t (eqv on references)
+- roast/S02-types/whatever.t (33 distinct failing WhateverCode features: dummy
+  `*` assignment, `&infix:<+>(*,42)` closure, X+/Z+ metaop currying with Whatever,
+  `*++`, rw params, container preservation, compile-time WhateverCode, regex
+  whatever curry — not a single root cause)
+- roast/S03-operators/eqv.t — 62/64 (the 12/17/36/37 `# TODO huh?` failures also
+  fail in rakudo). Set allomorph eqv is now fixed (`set(<42>) eqv set(42)` is
+  False; see t/set-eqv-allomorph.t). Two subtests remain:
+    - "Setty eqv Setty": needs `Set eqv SetHash` to be False (test 165). mutsu's
+      `eqv` deliberately ignores Set/SetHash mutability because the set operators
+      `(|)`/`(&)`/etc. don't reliably return a SetHash; comparing the flag would
+      regress S03-operators/set_*.t. Blocked on set-operator mutability tracking.
+    - "Throws/lives in lazy cases": `eqv` must throw X::Cannot::Lazy for two
+      same-type lazy iterables. Blocked on real lazy infinite sequences — mutsu
+      materializes `1…∞` into a finite (~33-element) list, so it has no lazy
+      iterables to detect.
 - roast/S02-types/generics.t (nominalizable generic)
 
 ## Sprintf / Format Edge Cases (2 tests)

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -125,11 +125,36 @@ impl Value {
             // Rat/FatRat: structural equality (n == n, d == d), including NaN (0/0)
             (Value::Rat(n1, d1), Value::Rat(n2, d2))
             | (Value::FatRat(n1, d1), Value::FatRat(n2, d2)) => n1 == n2 && d1 == d2,
+            // Sets: eqv must distinguish elements that share a string key but
+            // differ in type — specifically an allomorph (e.g. the IntStr <42>)
+            // from a plain value (Int 42), which rakudo separates by `.WHICH`.
+            // We compare the allomorph kind of each typed element rather than a
+            // full type-strict eqv, because mutsu does not always retain a Set
+            // element's exact numeric type (a Rat element can fall back to its
+            // Str key), and a full eqv would wrongly split two equal Rat sets.
+            // NOTE: mutability (Set vs SetHash) is intentionally NOT compared
+            // here — mutsu's set operators do not yet reliably preserve SetHash
+            // mutability through `(|)`/`(&)` etc., and comparing it would
+            // spuriously split results that only differ in that flag. The
+            // remaining Set-vs-SetHash eqv distinction (eqv.t test 165) is
+            // tracked in BLOCKERS.md.
+            (Value::Set(a, _), Value::Set(b, _)) => {
+                fn allomorph_kind(v: &Value) -> Option<String> {
+                    match v {
+                        Value::Mixin(inner, mixins) => allomorph_type_name(inner, mixins),
+                        _ => None,
+                    }
+                }
+                a.elements.len() == b.elements.len()
+                    && a.elements.iter().all(|k| {
+                        b.elements.contains(k)
+                            && allomorph_kind(&a.typed_key(k)) == allomorph_kind(&b.typed_key(k))
+                    })
+            }
             (Value::Int(_), Value::Int(_))
             | (Value::Str(_), Value::Str(_))
             | (Value::Bool(_), Value::Bool(_))
             | (Value::BigRat(_, _), Value::BigRat(_, _))
-            | (Value::Set(_, _), Value::Set(_, _))
             | (Value::Bag(_, _), Value::Bag(_, _))
             | (Value::Mix(_, _), Value::Mix(_, _))
             | (Value::Enum { .. }, Value::Enum { .. })

--- a/t/set-eqv-allomorph.t
+++ b/t/set-eqv-allomorph.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `eqv` on Sets is type-strict for allomorphs: a Set holding the IntStr
+# allomorph <42> is NOT eqv to a Set holding the plain Int 42, even though both
+# share the string key "42". (See roast/S03-operators/eqv.t, "Setty eqv Setty".)
+
+plan 8;
+
+is-deeply set(<42>) eqv set( 42 ), False, 'IntStr does not eqv Int';
+is-deeply set(<42>) eqv set('42'), False, 'IntStr does not eqv Str';
+is-deeply set( 42 ) eqv set(<42>), False, 'Int does not eqv IntStr';
+is-deeply set('42') eqv set(<42>), False, 'Str does not eqv IntStr';
+is-deeply set(<42>) eqv set(<42>), True,  'IntStr does eqv IntStr';
+
+# Non-allomorph elements that share a string key remain eqv regardless of how
+# the type was tracked internally.
+is-deeply set(1, 2)   eqv set(1, 2),   True, 'identical Int sets eqv';
+is-deeply set(1.1, 2.1) eqv set(1.1, 2.1), True, 'identical Rat sets eqv';
+
+# A RatStr allomorph (string key "1.5") is distinct from the plain Rat 1.5.
+is-deeply set(<1.5>) eqv set(1.5), False, 'RatStr does not eqv Rat';


### PR DESCRIPTION
`eqv` on Sets compared only the string element keys, so a Set holding the IntStr allomorph `<42>` compared `eqv` to a Set holding the plain Int `42` (both have key `"42"`). rakudo separates them by `.WHICH`.

This compares the **allomorph kind** of each typed element so allomorph-vs-plain sets are distinguished, while plain elements that share a string key stay `eqv`:

```raku
set(<42>) eqv set(42)    # now False (was True)
set(<42>) eqv set(<42>)  # True
set(1, 2) eqv set(1, 2)  # True
```

### Why allomorph-kind only (not full type-strict eqv)

mutsu does not always retain a Set element's exact numeric type — a `Rat` element can fall back to its `Str` key. A full type-strict `eqv` would wrongly split two equal `Rat` sets (regressed `S32-list/roll.t` in testing). Comparing just the allomorph kind fixes the tested cases without that regression.

Set/SetHash **mutability** is likewise left out of the comparison: the set operators `(|)`/`(&)`/etc. don't reliably return a `SetHash`, so comparing the flag regressed `S03-operators/set_*.t`. That (eqv.t test 165) and the lazy-`eqv` `X::Cannot::Lazy` case (blocked on real lazy infinite sequences — mutsu materializes `1…∞` into a finite list) are the remaining `eqv.t` blockers, now documented in `BLOCKERS.md`.

### Testing

- New `t/set-eqv-allomorph.t` (8 tests)
- No regressions across whitelisted `setbagmix`/`S02-types/set,bag,mix`/`S32-set`/`S32-list`/`S03-junctions`/`S03-operators/set_*` tests; `roll.t` stays green
- `cargo test`: 449 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)