### PR TITLE
fix: stop stale captured-env snapshots clobbering live caller lexicals on wrapped/closure calls

### DIFF
--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1167,24 +1167,35 @@ impl Interpreter {
                     remaining,
                     args: sanitized_args.clone(),
                 };
-                let wrapper_id = if let Value::Sub(ref wd) = outermost {
-                    Some(wd.id)
+                let (wrapper_id, wrapper_base_env) = if let Value::Sub(ref wd) = outermost {
+                    (Some(wd.id), Some(wd.env.clone()))
                 } else {
-                    None
+                    (None, None)
                 };
                 self.wrap_dispatch_stack.push(frame);
                 let result = self.call_sub_value(outermost, sanitized_args, false);
                 self.wrap_dispatch_stack.pop();
                 // Propagate closure variable mutations from the wrapper back to
                 // the current env so captured variables (e.g. $seen = True) are
-                // visible to the caller.
+                // visible to the caller. Only write back keys the wrapper actually
+                // *changed* relative to its captured lexical snapshot: a persisted
+                // value equal to the wrapper's capture is stale (never mutated) and
+                // must not clobber the caller's live value (e.g. the `$h` that holds
+                // this very WrapHandle, captured as Nil mid-`my $h = &foo.wrap(...)`).
                 if let Some(wid) = wrapper_id
                     && let Some(persisted) = self.closure_env_overrides.get(&wid).cloned()
                 {
                     for (k, v) in persisted.iter() {
-                        if self.env.contains_key_sym(*k) {
-                            self.env.insert_sym(*k, v.clone());
+                        if !self.env.contains_key_sym(*k) {
+                            continue;
                         }
+                        let unchanged = wrapper_base_env
+                            .as_ref()
+                            .is_some_and(|base| base.get_sym(*k) == Some(v));
+                        if unchanged {
+                            continue;
+                        }
+                        self.env.insert_sym(*k, v.clone());
                     }
                 }
                 return result;
@@ -1423,6 +1434,14 @@ impl Interpreter {
             });
             self.prepare_definite_return_slot(return_spec.as_deref());
             let let_mark = self.let_saves.len();
+            // Snapshot the body-entry env so the exit writeback can tell which
+            // captured outer scalars the body actually *mutated* (and propagate
+            // only those) from those it merely captured a stale snapshot of.
+            // Without this, a callee's stale captured value (e.g. an original
+            // sub's snapshot of `$h` taken before `my $h = &foo.wrap(...)`
+            // assigned it) would clobber the caller's live value on return.
+            // Env is copy-on-write, so this clone is O(1) until the body forks it.
+            let body_entry_env = self.env.clone();
             let result = match self.eval_block_value(&data.body) {
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", data.package, data.name);
@@ -1499,19 +1518,27 @@ impl Interpreter {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
                 for (k, v) in self.env.iter() {
-                    if k != "_"
-                        && k != "@_"
-                        && !subsig_names.contains(&k.resolve())
-                        && (matches!(v, Value::Array(..))
-                            || (merged.contains_key_sym(*k)
-                                && matches!(
-                                    v,
-                                    Value::Bool(_)
-                                        | Value::Int(_)
-                                        | Value::Num(_)
-                                        | Value::Str(_)
-                                        | Value::Rat(_, _)
-                                )))
+                    if k == "_" || k == "@_" || subsig_names.contains(&k.resolve()) {
+                        continue;
+                    }
+                    if matches!(v, Value::Array(..)) {
+                        // Arrays are Arc-shared; in-place mutations are already
+                        // visible to the caller, and reassignment should propagate.
+                        merged.insert_sym(*k, v.clone());
+                    } else if merged.contains_key_sym(*k)
+                        && matches!(
+                            v,
+                            Value::Bool(_)
+                                | Value::Int(_)
+                                | Value::Num(_)
+                                | Value::Str(_)
+                                | Value::Rat(_, _)
+                        )
+                        // Only write a captured scalar back to the caller when the
+                        // body actually changed it from its body-entry value. A
+                        // value equal to the entry snapshot is a stale capture, not
+                        // a mutation, and must not clobber the caller's live value.
+                        && body_entry_env.get_sym(*k) != Some(v)
                     {
                         merged.insert_sym(*k, v.clone());
                     }

--- a/t/wrap-closure-capture.t
+++ b/t/wrap-closure-capture.t
@@ -1,0 +1,76 @@
+use Test;
+
+# Regression: wrapping a sub with a closure wrapper must not let the wrapper's
+# stale captured env snapshot clobber live caller lexicals on return, and must
+# still propagate the wrapper's genuine mutations of captured variables.
+#
+# Root cause (fixed): the interpreter's call_sub_value overlaid and wrote back a
+# sub's captured-env snapshot wholesale. The original sub, called via callsame,
+# carried a stale snapshot of `$h` (captured as Nil mid-`my $h = &foo.wrap(...)`)
+# and reverted the live WrapHandle; symmetrically, scalar mutations a wrapper made
+# to captured outer variables were lost. Both directions are exercised here.
+
+plan 8;
+
+# 1-2. The WrapHandle variable survives invoking the wrapped sub, and .restore works.
+{
+    sub qux { 42 }
+    my $h = &qux.wrap(-> { 1 + callsame });
+    is qux(), 43, 'wrapped call runs the wrapper';
+    $h.restore();
+    is qux(), 42, '$h is not clobbered by the wrapped call; .restore() works';
+}
+
+# 3. A wrapper's scalar mutation of a captured variable propagates to the caller.
+{
+    my $seen = False;
+    sub f1 { 1 }
+    &f1.wrap(-> { $seen = True; callsame });
+    f1();
+    is $seen, True, 'wrapper scalar mutation of captured var propagates';
+}
+
+# 4. Counter accumulates across multiple wrapped calls.
+{
+    my $n = 0;
+    sub f2 { 1 }
+    &f2.wrap(-> { $n++; callsame });
+    f2();
+    f2();
+    is $n, 2, 'wrapper increments a captured counter across calls';
+}
+
+# 5. Array mutation by a wrapper is visible to the caller.
+{
+    my @log;
+    sub f3 { 1 }
+    &f3.wrap(-> { @log.push("x"); callsame });
+    f3();
+    is @log.join(','), 'x', 'wrapper array mutation propagates';
+}
+
+# 6. An unrelated caller lexical is untouched by a wrapped call.
+{
+    sub f4 { 1 }
+    my $other = "keep";
+    &f4.wrap(-> { callsame });
+    f4();
+    is $other, "keep", 'unrelated caller lexical not clobbered';
+}
+
+# 7. Named-sub wrapper still works (no closure capture path).
+{
+    my $seen2 = False;
+    sub f5 { 1 }
+    sub w5 { $seen2 = True; callsame }
+    &f5.wrap(&w5);
+    f5();
+    is $seen2, True, 'named-sub wrapper mutation propagates';
+}
+
+# 8. Return value modification through callsame.
+{
+    sub greeting { "hello" }
+    &greeting.wrap(sub { callsame() ~ " world" });
+    is greeting(), "hello world", 'wrapper can modify return value';
+}


### PR DESCRIPTION
## Summary

`t/wrap.t` was deterministically failing (3/3 runs) — it is **not flaky** as the CLAUDE.md "Known flaky tests" list claims. Root-cause investigation traced it to a dual-store / closure-capture correctness bug in the interpreter's `call_sub_value`.

The interpreter overlaid and wrote back a sub's captured-env snapshot wholesale on every call. When a wrapped sub is invoked via the wrap-chain dispatch (or `callsame`), two symmetric bugs surfaced:

1. **WrapHandle destroyed.** The original sub, dispatched through `callsame`, carried a stale capture of the `$h` holding the handle (captured as `Nil` mid-`my $h = &foo.wrap(...)`). Its exit writeback reverted the caller's live `WrapHandle` to `Nil`, so a later `$h.restore()` raised `No such method 'restore' for invocant of type 'Any'`.
2. **Wrapper scalar mutations lost.** `$seen = True` / `$n++` inside a closure wrapper did not propagate — the inner sub's writeback re-imposed its stale snapshot over the change.

(Array mutations survived only incidentally because arrays are Arc-shared.)

## Fix

Propagate a captured scalar back to the caller **only when the body actually changed it**:
- `call_sub_value` snapshots the body-entry env and writes a scalar back only if it differs from entry.
- The wrap dispatch compares the wrapper's persisted env against its captured lexical base; a value equal to the capture is stale, not a mutation, and must not clobber the caller's live value.

This applies the scoped-env semantics (a callee propagates only what it mutates) to the interpreter sub-call path.

## Validation

- `t/wrap.t` now passes (16/16).
- New pin `t/wrap-closure-capture.t` (8 cases) covers both directions + named-sub wrapper + unrelated-lexical isolation.
- `make test` failure set reduced to the two unrelated pre-existing gaps (`t/placeholder.t` test 8, `t/tail-function.t` test 4); no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)