### PR TITLE
fix: keep PredictiveIterator-backed Seq association alive across scope (tail/Numeric)

### DIFF
--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -17,6 +17,18 @@ impl Interpreter {
         }
     }
 
+    /// Look up the PredictiveIterator backing a `Seq.new(iterator)` by seq_id.
+    /// Prefers the non-scoped `predictive_seq_iters` map (survives scope), then
+    /// falls back to the legacy env key for any in-scope registrations.
+    pub(in crate::runtime) fn predictive_seq_iter_for(&self, seq_id: usize) -> Option<Value> {
+        if let Some(iter) = self.predictive_seq_iters.get(&seq_id) {
+            return Some(iter.clone());
+        }
+        self.env
+            .get(&format!("__mutsu_predictive_seq_iter::{seq_id}"))
+            .cloned()
+    }
+
     pub(in crate::runtime) fn dispatch_tail(
         &mut self,
         target: Value,
@@ -40,7 +52,7 @@ impl Interpreter {
         {
             let seq_id = std::sync::Arc::as_ptr(items) as usize;
             let key = format!("__mutsu_predictive_seq_iter::{seq_id}");
-            if let Some(iterator) = self.env.get(&key).cloned() {
+            if let Some(iterator) = self.predictive_seq_iter_for(seq_id) {
                 let iter_slot = "$mutsu_predictive_tail_iterator";
                 let saved_iter = self.env.get(iter_slot).cloned();
                 self.env.insert(iter_slot.to_string(), iterator);
@@ -114,6 +126,10 @@ impl Interpreter {
                             }
                         }
                     }
+                    // Persist the advanced iterator state in both the non-scoped
+                    // map (authoritative, survives scope) and the legacy env key.
+                    self.predictive_seq_iters
+                        .insert(seq_id, updated_iter.clone());
                     self.env.insert(key, updated_iter);
                 }
                 if let Some(prev) = saved_iter {

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -17,8 +17,7 @@ impl Interpreter {
                 // Otherwise return the element count.
                 if let Value::Seq(items) = &target {
                     let seq_id = std::sync::Arc::as_ptr(items) as usize;
-                    let iter_key = format!("__mutsu_predictive_seq_iter::{seq_id}");
-                    if let Some(iter) = self.env.get(&iter_key).cloned() {
+                    if let Some(iter) = self.predictive_seq_iter_for(seq_id) {
                         return Some(self.call_method_with_values(iter, "count-only", vec![]));
                     }
                     return Some(Ok(Value::Int(items.len() as i64)));
@@ -227,8 +226,7 @@ impl Interpreter {
                 if let Value::Seq(items) = &target {
                     // Check for PredictiveIterator-backed Seq (stored by Seq.new)
                     let seq_id = std::sync::Arc::as_ptr(items) as usize;
-                    let iter_key = format!("__mutsu_predictive_seq_iter::{seq_id}");
-                    if let Some(iter) = self.env.get(&iter_key).cloned() {
+                    if let Some(iter) = self.predictive_seq_iter_for(seq_id) {
                         // Call count-only on the PredictiveIterator
                         return Some(self.call_method_with_values(iter, "count-only", vec![]));
                     }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1020,6 +1020,9 @@ impl Interpreter {
                             let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
                             if let Value::Seq(items) = &seq {
                                 let seq_id = std::sync::Arc::as_ptr(items) as usize;
+                                // Store off the scoped env so the association
+                                // survives sub/block returns (see field docs).
+                                self.predictive_seq_iters.insert(seq_id, iterator.clone());
                                 self.env.insert(
                                     format!("__mutsu_predictive_seq_iter::{seq_id}"),
                                     iterator.clone(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -902,6 +902,12 @@ pub struct Interpreter {
     /// Used to propagate package declarations when a module is re-used.
     module_packages: HashMap<String, HashSet<String>>,
     closure_env_overrides: HashMap<u64, Env>,
+    /// PredictiveIterator backing a `Seq.new(iterator)`, keyed by the Seq's
+    /// Arc pointer (`seq_id`). Kept off the scoped `env` so the association
+    /// survives sub/block returns between Seq creation and `.tail`/`.Numeric`
+    /// (an env-keyed side table was lost on scope exit).
+    /// TODO: entries are never reclaimed; acceptable as predictive Seqs are rare.
+    predictive_seq_iters: HashMap<usize, Value>,
     protect_block_cache: ProtectBlockCache,
     private_zeroarg_method_cache: HashMap<(String, String), Option<(String, MethodDef)>>,
     module_load_stack: Vec<String>,
@@ -3043,6 +3049,7 @@ impl Interpreter {
             chain_declared_packages: HashSet::new(),
             module_packages: HashMap::new(),
             closure_env_overrides: HashMap::new(),
+            predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
@@ -5111,6 +5118,7 @@ impl Interpreter {
             chain_declared_packages: self.chain_declared_packages.clone(),
             module_packages: self.module_packages.clone(),
             closure_env_overrides: self.closure_env_overrides.clone(),
+            predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),

--- a/t/predictive-seq-tail-scope.t
+++ b/t/predictive-seq-tail-scope.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Regression: a PredictiveIterator-backed Seq created by `Seq.new(iterator)`
+# must keep its iterator association across scope boundaries, so `.tail` /
+# `.Numeric` can use the count-only path even when the Seq was built inside a
+# sub or block and consumed later in an outer scope.
+#
+# Previously the association lived in a `__mutsu_predictive_seq_iter::{id}` env
+# key that was discarded on sub/block return, so `.tail` returned Nil.
+
+plan 4;
+
+my $cls = class :: does PredictiveIterator {
+    has $!i;
+    method pull-one  { ++$!i <= 10 ?? $!i !! IterationEnd }
+    method skip-one  { ++$!i <= 10 ?? True !! False }
+    method count-only { 0 max 10 - $!i }
+};
+
+# Built and consumed at top level.
+is Seq.new($cls.new).tail, 10, 'tail count-only path at top level';
+
+# Built inside a bare block, consumed outside.
+my $s;
+{ $s = Seq.new($cls.new) }
+is $s.tail, 10, 'association survives a bare-block return';
+
+# Built inside a sub, consumed outside.
+sub make-seq { Seq.new($cls.new) }
+is make-seq.tail, 10, 'association survives a sub return';
+
+# .Numeric also uses count-only across scope.
+my $s2;
+{ $s2 = Seq.new($cls.new) }
+is $s2.Numeric, 10, '.Numeric count-only survives scope';


### PR DESCRIPTION
## Summary

`t/tail-function.t` test 4 was deterministically failing (not flaky). `Seq.new(predictive_iterator)` registered the backing iterator under a scoped-`env` key (`__mutsu_predictive_seq_iter::{seq_id}`); when the Seq was built inside a sub/block and consumed later in an outer scope (`sub mk { Seq.new: ... }; mk.tail`), that env key was discarded on scope return, so `.tail` / `.Numeric` couldn't find the iterator and returned `Nil` instead of using `count-only`.

## Fix

Store the association in a non-scoped interpreter-level map (`predictive_seq_iters: HashMap<seq_id, Value>`) that survives sub/block returns, with the legacy env key kept as a fallback. The advanced iterator state is written back to the map after `.tail` consumes it. Cloned into worker interpreters in `clone_for_thread`.

## Validation

- `t/tail-function.t` now passes fully (test 4 fixed; test 5's `$!attr` propagation also resolves — `TODO passed`).
- New pin `t/predictive-seq-tail-scope.t`: top-level / bare-block return / sub return / `.Numeric`.
- `make test` (release): no new failures vs the `main` baseline; iterator/seq/gather pins green.

Note: `t/` TAP tests are non-fatal in CI (roast whitelist is authoritative); this is a hygiene fix that turns a deterministic `t/` failure green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)