### PR TITLE
fix: capture leftover named args into %_ for placeholder subs

### DIFF
--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -226,11 +226,17 @@ impl Interpreter {
                 "@_".to_string(),
                 Value::array(positional_args[positional_idx..].to_vec()),
             );
-            // Insert %_ if explicitly listed in params, or if named placeholders ($:Name)
-            // are present (leftover named args should be captured in %_).
-            // WhateverCode closures use this legacy path with params like ["_"], and should
-            // NOT overwrite the caller's %_ hash in the environment.
-            if params.iter().any(|p| p == "%_" || p.starts_with(':')) {
+            // Insert %_ if explicitly listed in params, if named placeholders
+            // ($:Name) are present, or if the sub uses any `^`-twigil placeholder
+            // ($^a / @^arr / %^h / &^cb): such a sub also exposes the implicit
+            // %_ slurpy, so leftover named args must be captured there (mirrors
+            // the unconditional @_ capture above).
+            // WhateverCode closures use this legacy path with params like ["_"]
+            // (no `^`), and must NOT overwrite the caller's %_ hash.
+            if params
+                .iter()
+                .any(|p| p == "%_" || p.starts_with(':') || p.contains('^'))
+            {
                 let mut leftover_named = std::collections::HashMap::new();
                 for (key, val) in named_args {
                     if !consumed_named.contains(&key) {


### PR DESCRIPTION
## Summary

`t/placeholder.t` test 8 was deterministically failing (not flaky). A sub whose signature is auto-generated from `^`-twigil placeholders (`$^a` / `@^arr` / `%^h` / `&^cb`) also exposes the implicit `%_` slurpy, so leftover named arguments must be captured there — just as `@_` already captures leftover positionals. The legacy placeholder-binding path only populated `%_` when `params` literally contained `"%_"` or a `:name` placeholder, so:

```raku
sub mixed { [@_[0]//Nil, %_<y>//Nil, @^arr.elems, %^h<z>, &^cb()] }
mixed([10,20], {40}, {:z(30)}, 99, :x(2), :y(50))
# was: Nil   now: [99 50 2 30 40]  (matches raku)
```

left `%_<y>` undefined.

## Fix

Extend the `%_`-capture condition in `bind_function_args_values` to also fire when any param carries a `^` twigil (a real placeholder sub), mirroring the unconditional `@_` capture. WhateverCode closures (params like `["_"]`, no `^`) are unaffected and still must not clobber the caller's `%_`.

## Validation

- `t/placeholder.t` now passes fully (test 8 fixed).
- WhateverCode (`* + 1`), map/grep blocks, and closure/signature pins all green.
- `make test` (release): no new failures vs the `main` baseline.

Note: `t/` TAP tests are non-fatal in CI (roast whitelist is authoritative); this turns a deterministic `t/` failure green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)