### PR TITLE
fix: keep typed (object) hash key constraint across COW / Arc-pointer reuse

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1134,7 +1134,7 @@ pub(crate) struct CustomTypeData {
     pub(crate) is_mixin: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ContainerTypeInfo {
     pub(crate) value_type: String,
     pub(crate) key_type: Option<String>,
@@ -4613,6 +4613,46 @@ impl Interpreter {
         if let Some(value) = self.env.get(name).cloned() {
             self.register_container_type_metadata(&value, info.clone());
         }
+    }
+
+    /// Re-establish a named typed hash's Arc-pointer-keyed metadata from its
+    /// authoritative, scope-correct name-based key constraint.
+    ///
+    /// `hash_type_metadata` is keyed by the hash's `Arc` pointer, which is
+    /// reused after the hash is dropped and changes across copy-on-write. Across
+    /// block scopes (e.g. a `my %h{Int}` declared after an earlier exited
+    /// `my Int %h`) the pointer-keyed entry can intermittently go missing while
+    /// the name-based `var_hash_key_constraints` entry stays correct — making
+    /// `%h{$int} = ...` lose object-hash (`.WHICH`-keyed) semantics so the value
+    /// is stored under a stringified key and later reads return Nil. Healing the
+    /// pointer-keyed entry from the name-based constraint before each typed-hash
+    /// element assignment removes that nondeterminism. No-op for hashes without
+    /// a key constraint (the common case).
+    pub(crate) fn reconcile_hash_type_metadata_from_name(&mut self, name: &str) {
+        let Some(name_key) = self.var_hash_key_constraint(name) else {
+            return;
+        };
+        let Some(value @ Value::Hash(_)) = self.env.get(name).cloned() else {
+            return;
+        };
+        let current = self.container_type_metadata(&value);
+        if current.as_ref().and_then(|i| i.key_type.clone()) == Some(name_key.clone()) {
+            return; // already correct
+        }
+        let info = match current {
+            Some(mut i) => {
+                i.key_type = Some(name_key);
+                i
+            }
+            None => ContainerTypeInfo {
+                value_type: self
+                    .var_type_constraint(name)
+                    .unwrap_or_else(|| "Mu".to_string()),
+                key_type: Some(name_key),
+                declared_type: None,
+            },
+        };
+        self.register_container_type_metadata(&value, info);
     }
 
     fn parse_container_constraint(name: &str, raw: &str) -> ContainerTypeInfo {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1005,16 +1005,23 @@ pub struct Interpreter {
     container_defaults: HashMap<usize, Value>,
     /// Optional hash key type constraints (e.g. `%h{Str}`).
     var_hash_key_constraints: HashMap<String, String>,
-    /// Type metadata for Array values keyed by Arc pointer identity.
-    array_type_metadata: HashMap<usize, ContainerTypeInfo>,
+    /// Type metadata for Array values keyed by Arc pointer identity. A `Weak`
+    /// of the container is stored alongside so lookups can detect Arc-pointer
+    /// *reuse*: a freed container's pointer gets reallocated to an unrelated
+    /// value, and without the `Weak::ptr_eq` validation the stale metadata
+    /// would alias onto it (e.g. an `EVAL`-created list inheriting a dropped
+    /// typed array's element type and dying on a type check).
+    array_type_metadata: HashMap<usize, (std::sync::Weak<Vec<Value>>, ContainerTypeInfo)>,
     /// Type metadata for Mix values keyed by Arc pointer identity.
     mix_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Set values keyed by Arc pointer identity.
     set_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Bag values keyed by Arc pointer identity.
     bag_type_metadata: HashMap<usize, ContainerTypeInfo>,
-    /// Type metadata for Hash values keyed by Arc pointer identity.
-    hash_type_metadata: HashMap<usize, ContainerTypeInfo>,
+    /// Type metadata for Hash values keyed by Arc pointer identity. See
+    /// `array_type_metadata` for why a `Weak` is stored alongside.
+    hash_type_metadata:
+        HashMap<usize, (std::sync::Weak<HashMap<String, Value>>, ContainerTypeInfo)>,
     /// Original key objects for object hashes, keyed by Hash Arc pointer identity.
     hash_object_keys: HashMap<usize, HashMap<String, Value>>,
     /// Type metadata for instance values keyed by stable instance id.
@@ -4479,7 +4486,8 @@ impl Interpreter {
         match value {
             Value::Array(items, ..) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.array_type_metadata.insert(id, info);
+                self.array_type_metadata
+                    .insert(id, (Arc::downgrade(items), info));
             }
             Value::Mix(items, _) => {
                 let id = Arc::as_ptr(items) as usize;
@@ -4495,7 +4503,8 @@ impl Interpreter {
             }
             Value::Hash(items) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata.insert(id, info);
+                self.hash_type_metadata
+                    .insert(id, (Arc::downgrade(items), info));
             }
             Value::Instance { id, .. } => {
                 self.instance_type_metadata.insert(*id, info);
@@ -4529,7 +4538,10 @@ impl Interpreter {
         match value {
             Value::Array(items, ..) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.array_type_metadata.get(&id).cloned()
+                self.array_type_metadata
+                    .get(&id)
+                    .filter(|(weak, _)| weak.upgrade().is_some_and(|a| Arc::ptr_eq(&a, items)))
+                    .map(|(_, info)| info.clone())
             }
             Value::Mix(items, _) => {
                 let id = Arc::as_ptr(items) as usize;
@@ -4545,7 +4557,10 @@ impl Interpreter {
             }
             Value::Hash(items) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata.get(&id).cloned()
+                self.hash_type_metadata
+                    .get(&id)
+                    .filter(|(weak, _)| weak.upgrade().is_some_and(|a| Arc::ptr_eq(&a, items)))
+                    .map(|(_, info)| info.clone())
             }
             Value::Instance { id, .. } => self.instance_type_metadata.get(id).cloned(),
             Value::Mixin(inner, _) => self.container_type_metadata(inner),
@@ -4589,22 +4604,16 @@ impl Interpreter {
 
     /// Check if a hash is an object hash (has a key_type constraint).
     pub(crate) fn is_object_hash(&self, hash: &Value) -> bool {
-        if let Value::Hash(arc) = hash {
-            let id = Arc::as_ptr(arc) as usize;
-            if let Some(info) = self.hash_type_metadata.get(&id) {
-                return info.key_type.is_some();
-            }
-        }
-        false
+        // Goes through container_type_metadata so the Weak-validated lookup
+        // rejects stale entries left by Arc-pointer reuse.
+        self.container_type_metadata(hash)
+            .is_some_and(|info| info.key_type.is_some())
     }
 
     /// Get the key type constraint for an object hash, if any.
     pub(crate) fn hash_key_type(&self, hash: &Value) -> Option<String> {
-        if let Value::Hash(arc) = hash {
-            let id = Arc::as_ptr(arc) as usize;
-            if let Some(info) = self.hash_type_metadata.get(&id) {
-                return info.key_type.clone();
-            }
+        if let Some(info) = self.container_type_metadata(hash) {
+            return info.key_type;
         }
         None
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1005,23 +1005,16 @@ pub struct Interpreter {
     container_defaults: HashMap<usize, Value>,
     /// Optional hash key type constraints (e.g. `%h{Str}`).
     var_hash_key_constraints: HashMap<String, String>,
-    /// Type metadata for Array values keyed by Arc pointer identity. A `Weak`
-    /// of the container is stored alongside so lookups can detect Arc-pointer
-    /// *reuse*: a freed container's pointer gets reallocated to an unrelated
-    /// value, and without the `Weak::ptr_eq` validation the stale metadata
-    /// would alias onto it (e.g. an `EVAL`-created list inheriting a dropped
-    /// typed array's element type and dying on a type check).
-    array_type_metadata: HashMap<usize, (std::sync::Weak<Vec<Value>>, ContainerTypeInfo)>,
+    /// Type metadata for Array values keyed by Arc pointer identity.
+    array_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Mix values keyed by Arc pointer identity.
     mix_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Set values keyed by Arc pointer identity.
     set_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Bag values keyed by Arc pointer identity.
     bag_type_metadata: HashMap<usize, ContainerTypeInfo>,
-    /// Type metadata for Hash values keyed by Arc pointer identity. See
-    /// `array_type_metadata` for why a `Weak` is stored alongside.
-    hash_type_metadata:
-        HashMap<usize, (std::sync::Weak<HashMap<String, Value>>, ContainerTypeInfo)>,
+    /// Type metadata for Hash values keyed by Arc pointer identity.
+    hash_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Original key objects for object hashes, keyed by Hash Arc pointer identity.
     hash_object_keys: HashMap<usize, HashMap<String, Value>>,
     /// Type metadata for instance values keyed by stable instance id.
@@ -4486,8 +4479,7 @@ impl Interpreter {
         match value {
             Value::Array(items, ..) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.array_type_metadata
-                    .insert(id, (Arc::downgrade(items), info));
+                self.array_type_metadata.insert(id, info);
             }
             Value::Mix(items, _) => {
                 let id = Arc::as_ptr(items) as usize;
@@ -4503,8 +4495,7 @@ impl Interpreter {
             }
             Value::Hash(items) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata
-                    .insert(id, (Arc::downgrade(items), info));
+                self.hash_type_metadata.insert(id, info);
             }
             Value::Instance { id, .. } => {
                 self.instance_type_metadata.insert(*id, info);
@@ -4538,10 +4529,7 @@ impl Interpreter {
         match value {
             Value::Array(items, ..) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.array_type_metadata
-                    .get(&id)
-                    .filter(|(weak, _)| weak.upgrade().is_some_and(|a| Arc::ptr_eq(&a, items)))
-                    .map(|(_, info)| info.clone())
+                self.array_type_metadata.get(&id).cloned()
             }
             Value::Mix(items, _) => {
                 let id = Arc::as_ptr(items) as usize;
@@ -4557,10 +4545,7 @@ impl Interpreter {
             }
             Value::Hash(items) => {
                 let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata
-                    .get(&id)
-                    .filter(|(weak, _)| weak.upgrade().is_some_and(|a| Arc::ptr_eq(&a, items)))
-                    .map(|(_, info)| info.clone())
+                self.hash_type_metadata.get(&id).cloned()
             }
             Value::Instance { id, .. } => self.instance_type_metadata.get(id).cloned(),
             Value::Mixin(inner, _) => self.container_type_metadata(inner),
@@ -4604,16 +4589,22 @@ impl Interpreter {
 
     /// Check if a hash is an object hash (has a key_type constraint).
     pub(crate) fn is_object_hash(&self, hash: &Value) -> bool {
-        // Goes through container_type_metadata so the Weak-validated lookup
-        // rejects stale entries left by Arc-pointer reuse.
-        self.container_type_metadata(hash)
-            .is_some_and(|info| info.key_type.is_some())
+        if let Value::Hash(arc) = hash {
+            let id = Arc::as_ptr(arc) as usize;
+            if let Some(info) = self.hash_type_metadata.get(&id) {
+                return info.key_type.is_some();
+            }
+        }
+        false
     }
 
     /// Get the key type constraint for an object hash, if any.
     pub(crate) fn hash_key_type(&self, hash: &Value) -> Option<String> {
-        if let Some(info) = self.container_type_metadata(hash) {
-            return info.key_type;
+        if let Value::Hash(arc) = hash {
+            let id = Arc::as_ptr(arc) as usize;
+            if let Some(info) = self.hash_type_metadata.get(&id) {
+                return info.key_type.clone();
+            }
         }
         None
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2066,6 +2066,13 @@ impl VM {
         // metadata key. Reapply them on the final container so typed-array
         // hole semantics and `is default(...)` are preserved.
         let save_var_name = Self::const_str(code, name_idx).to_string();
+        // Heal the hash's Arc-pointer-keyed type metadata from its authoritative
+        // name-based key constraint before assigning, so object-hash semantics
+        // survive across copy-on-write and Arc-pointer reuse (otherwise typed
+        // `%h{$int} = ...` intermittently loses its key constraint and stores the
+        // value under a stringified key, returning Nil on later reads).
+        self.interpreter
+            .reconcile_hash_type_metadata_from_name(&save_var_name);
         let saved_type_meta_outer = self
             .interpreter
             .env()
@@ -2090,14 +2097,23 @@ impl VM {
             None
         };
         let result = self.exec_index_assign_expr_named_op_inner(code, name_idx, is_positional);
-        // Restore metadata on the post-assignment container if the
-        // identity-keyed map lost it.
+        // Restore metadata on the post-assignment container when the
+        // identity-keyed map lost it OR holds a stale entry. Copy-on-write
+        // changes the hash's Arc pointer (the metadata key), and freed pointers
+        // get reused by later allocations carrying *different* stale metadata,
+        // so a mere `.is_none()` check leaves a reused pointer's wrong entry in
+        // place — re-register whenever the current entry differs from the value
+        // saved before the assignment. Object-hash element reads (`%h{$int}`)
+        // detect their key constraint only through this pointer-keyed metadata
+        // (the read op has no variable name to fall back on), so a stale/lost
+        // entry silently degrades them to string-keyed lookups returning Nil.
         if let Some(info) = saved_type_meta_outer
             && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
             && self
                 .interpreter
                 .container_type_metadata(&container)
-                .is_none()
+                .as_ref()
+                != Some(&info)
         {
             self.interpreter
                 .register_container_type_metadata(&container, info);

--- a/t/typed-hash-keyconstraint-cow.t
+++ b/t/typed-hash-keyconstraint-cow.t
@@ -1,0 +1,39 @@
+use Test;
+
+# Regression: a typed (object) hash `my %h{Int}` must keep its key constraint
+# (and therefore .WHICH-keyed object-hash semantics) across copy-on-write and
+# across earlier exited blocks that declared a same-named hash with a different
+# constraint. The constraint lives in Arc-pointer-keyed metadata that COW and
+# Arc-pointer reuse could intermittently drop, degrading `%h{$int}` reads to
+# string-keyed lookups that returned Nil (roast S02-types/hash.t,
+# S09-typed-arrays/hashes.t, previously mislabeled "CI-load timeouts").
+
+plan 8;
+
+# An earlier exited block declares `%h` with a *different* constraint, so its
+# stale metadata is in play when the object hash below is declared.
+{
+    my Int %h;
+    %h = (a => 3, b => 7);
+    %h<foo> = 8;
+}
+
+{
+    my %h{Int};
+    is %h.keyof.^name, 'Int', 'keyof is Int after a prior differently-typed %h block';
+
+    # Failing string-key assignments (these COW the hash) must not drop the
+    # key constraint for the subsequent valid Int-key assignments.
+    dies-ok { %h<a> = 1 }, 'string key rejected';
+    dies-ok { %h<a b c> = (1, 2, 3) }, 'string key slice rejected';
+
+    %h{1} = "a";
+    is %h{1}, 'a', 'single Int-key assignment persists after COW';
+
+    %h{(2, 3, 4)} = <b c d>;
+    is %h{2}, 'b', 'Int-key slice assignment persists (key 2)';
+    is %h{4}, 'd', 'Int-key slice assignment persists (key 4)';
+
+    ok %h{2}:exists, ':exists works on the object hash';
+    is %h.keyof.^name, 'Int', 'keyof still Int after assignments';
+}


### PR DESCRIPTION
## Summary

Fixes the **intermittent** failures in `roast/S02-types/hash.t` and `roast/S09-typed-arrays/hashes.t` — long mislabeled "CI-load-sensitive timeouts" in CLAUDE.md, but actually allocation/hash-order-dependent **correctness bugs** (the tests run in ~0.07s, mutsu startup ~0ms — not a perf/timeout issue; verified by profiling).

A typed object hash `my %h{Int}` stores/reads elements by `.WHICH`. Whether a hash is an object hash is decided via type metadata keyed by the hash's `Arc` pointer (`hash_type_metadata: HashMap<usize, ContainerTypeInfo>`). That pointer changes on copy-on-write and is **reused by later allocations after the hash is dropped**, so the entry could intermittently vanish or be replaced by a *different* dead container's stale entry. The element-**read** op (`%h{$int}`) has no variable name to fall back on and relies solely on this pointer-keyed metadata, so when it went stale the read silently degraded to a string-keyed lookup and returned `Nil` for a value the (robust, name-based) **write** path had stored by `.WHICH` → `"a did the assignment work"` etc. fail.

## Fix

1. **Heal before assignment** — `reconcile_hash_type_metadata_from_name` re-establishes the pointer-keyed metadata from the authoritative, scope-correct name-based key constraint (`var_hash_key_constraints`) before a typed-hash element assignment.
2. **Overwrite stale on restore** — after the assignment, re-register the saved metadata whenever the current pointer-keyed entry *differs* from it (not only when absent); a reused pointer can carry a stale non-`None` entry the old `.is_none()` guard left in place. `ContainerTypeInfo` gains `PartialEq`.

## Validation

- `roast/S09-typed-arrays/hashes.t`: **0/500** failures (was ~0.7–1.7% before).
- `make test`: clean, no failures.
- New pin `t/typed-hash-keyconstraint-cow.t` (8 cases: keyof after a prior differently-typed `%h` block, string-key rejection, single + slice Int-key assignment persistence, `:exists`).

## Known residual (separate bug, not addressed here)

`roast/S02-types/hash.t` has a distinct, rarer (~0.2%) intermittent failure in its `my %b := %a.clone; %b<c> = 256` independence block (lines 390-396) — unrelated to this metadata fix; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)