### PR TITLE
signature: enforce `is required` on named params like the `!` marker

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -116,6 +116,12 @@
 - [ ] roast/S06-signature/slurpy-and-interpolation.t
 - [ ] roast/S06-signature/slurpy-blocks.t
 - [ ] roast/S06-signature/slurpy-params.t
+  - `:$n is required` is now enforced like `:$n!` (tests 28-29 pass; #TBD). The
+    file still aborts at test 30 "Testing with slurpy scalar": slurpy *scalar*
+    params (`*$f`, `*$s`) parse (slurpy=true, scalar) but are not bound — they
+    should capture the leading positional args before a `*@` slurpy. Needs
+    slurpy-scalar binding in runtime/types/binding.rs (and the VM path). Plans
+    86 tests; may have further blockers past 30.
 - [ ] roast/S06-signature/slurpy-placeholders.t
 - [ ] roast/S06-signature/sub-ref.t
 - [ ] roast/S06-signature/tree-node-parameters.t

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -454,6 +454,19 @@ fn parse_generic_suffix(input: &str) -> PResult<'_, String> {
 }
 
 pub(super) fn parse_single_param(input: &str) -> PResult<'_, ParamDef> {
+    let (rest, mut p) = parse_single_param_inner(input)?;
+    // The `is required` trait is exactly the `!` required marker; normalize it
+    // onto the canonical `required` flag (and drop the now-redundant trait) so
+    // all binding sites enforce it identically to `:$n!` — e.g. `:$n is required`
+    // must die when `n` is not passed, even alongside a `*%h` slurpy.
+    if p.traits.iter().any(|t| t == "required") {
+        p.required = true;
+        p.traits.retain(|t| t != "required");
+    }
+    Ok((rest, p))
+}
+
+fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     let mut rest = input;
     let mut named = false;
     let mut slurpy = false;

--- a/t/param-is-required.t
+++ b/t/param-is-required.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# `is required` on a named parameter is exactly the `!` required marker: the
+# call must die when the named argument is not passed, even when a slurpy `*%h`
+# could otherwise absorb named arguments.
+
+sub need-n(:$n is required) { $n }
+lives-ok { need-n(n => 5) }, ':$n is required lives when n is passed';
+is need-n(n => 5), 5, ':$n is required binds the value';
+dies-ok { need-n() }, ':$n is required dies when n is missing';
+
+# `is required` matches the `!` shorthand behaviour and message.
+sub need-bang(:$n!) { $n }
+{
+    my $msg-trait = (try { need-n(); CATCH { default { .message } } }) // $!.message;
+    my $msg-bang  = (try { need-bang(); CATCH { default { .message } } }) // $!.message;
+    is $msg-trait, $msg-bang, 'is required and ! give the same error message';
+}
+
+# A slurpy `*%h` must not satisfy a required named parameter.
+sub with-slurpy(:$n is required, *%h, *@a) { "$n {%h.elems} {@a.elems}" }
+lives-ok { with-slurpy(1, n => 20, y => 300, 4000) },
+    'required named lives when present alongside *%h/*@a';
+is with-slurpy(1, n => 20, y => 300, 4000), '20 1 2',
+    'required named binds; extras go to *%h and *@a';
+dies-ok { with-slurpy(1, x => 20, y => 300, 4000) },
+    'required named dies even when *%h could absorb the named args';
+
+# Multiple required named params.
+sub two(:$a! is required, :$b is required) { "$a$b" }
+dies-ok { two(a => 1) }, 'all required named params are enforced';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

`:$n is required` parsed the `required` trait into the parameter's trait list but never set the canonical `required` flag, so binding **ignored it** — a call missing `n` would not die, even though the equivalent `:$n!` shorthand does. A `*%h` slurpy made this especially visible: extra named args were absorbed while the required `$n` went unchecked.

```raku
sub foo(:$n is required, *%h, *@a) { }
foo(1, x => 20, 4000);   # now dies (was silently OK); foo(1, n => 20, 4000) still lives
```

## Fix

Normalize the `is required` trait onto `required = true` at a single point (a thin wrapper around `parse_single_param`), and drop the now-redundant trait so `:$n is required` is byte-for-byte equivalent to `:$n!` — same binding path, same `Required named parameter 'n' not passed` message.

## Impact

- Fixes `roast/S06-signature/slurpy-params.t` tests 28-29. (The file still aborts later at test 30, which needs slurpy **scalar** `*$f` binding — documented in `TODO_roast/S06.md`.)
- General correctness improvement for any code using `is required`.

## Tests

- New `t/param-is-required.t` (8 tests).
- All 53 signature/param `t/` tests pass; full `t/` sweep shows no new failures (only known-flaky proc-async, which passes on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)