### PR TITLE
parser: signed numeric words in `<...>` produce allomorphs, not Str

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -80,10 +80,11 @@
     thunks; was eagerly evaluating side effects), `[=]` right-associative
     assignment reduce, `[=:=]`/`[!=:=]` container-identity reductions (rewritten
     to pairwise `&&`-chains preserving container identity). Remaining failure:
-    test 62 `[,] produces a uncontainerized List` — needs `@a = $list` to flatten
-    a `:=`-bound List (mutsu keeps it as one element) plus negative-number
-    allomorph parsing in `<...>` word quotes (`<-3>` should be IntStr, mutsu makes
-    it Str). Both are core list/itemization issues unrelated to meta-ops.
+    test 62 `[,] produces a uncontainerized List`. The negative-number allomorph
+    half is now fixed (`<-3>` is IntStr / `<-3.5>` is RatStr, #TBD). The remaining
+    blocker is `@a = $list` not flattening a `:=`-bound List: `$list := <...>`
+    holds a real List, but assigning it to `@a` keeps it as a single element
+    (raku flattens it) — a core `:=`/itemization issue, not a meta-op problem.
 - [ ] roast/S03-metaops/reverse.t
 - [ ] roast/S03-metaops/zip.t
   - 20/77 pass. Remaining blockers: [Z+] reduction with join (parser precedence for reduction ops consuming remaining args), Z, list associativity (parser), Z+= meta-assignment, Z= assignment, is-lazy on Z result (needs lazy Seq), throws-like for Z. syntax errors, &infix:<Z+> function refs, Zxx/Zand/Z&&/Zor/Z||/Zandthen/Zorelse thunking, itemization in Z

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -1396,28 +1396,56 @@ fn angle_word_value_impl(word: &str, fraction_allomorphic: bool) -> Value {
     if let Some(complex) = parse_angle_complex(parse_word) {
         return make_allomorphic_value(complex, word);
     }
-    if let Ok((rest, expr)) = super::number::integer(parse_word)
+    // The plain integer/decimal/Num parsers accept only unsigned digits (the
+    // sign is normally a prefix operator), so a leading `+`/`-` is stripped here
+    // and reapplied to the parsed value. This makes `<-3>` an IntStr and
+    // `<-3.5>` a RatStr, matching Raku (rather than a bare Str). The allomorphic
+    // Str component keeps the original signed spelling.
+    let (negate, num_word) = match parse_word.strip_prefix('-') {
+        Some(rest) if !rest.is_empty() => (true, rest),
+        _ => (false, parse_word.strip_prefix('+').unwrap_or(parse_word)),
+    };
+    let apply = |val: Value| -> Value {
+        let val = if negate {
+            negate_angle_numeric(val)
+        } else {
+            val
+        };
+        make_allomorphic_value(val, word)
+    };
+    if let Ok((rest, Expr::Literal(val))) = super::number::integer(num_word)
         && rest.is_empty()
-        && let Expr::Literal(val) = expr
     {
-        return make_allomorphic_value(val, word);
+        return apply(val);
     }
-    if let Ok((rest, expr)) = super::number::decimal(parse_word)
+    if let Ok((rest, Expr::Literal(val))) = super::number::decimal(num_word)
         && rest.is_empty()
-        && let Expr::Literal(val) = expr
     {
-        return make_allomorphic_value(val, word);
+        return apply(val);
     }
-    if let Ok((rest, expr)) = super::number::dot_decimal(parse_word)
+    if let Ok((rest, Expr::Literal(val))) = super::number::dot_decimal(num_word)
         && rest.is_empty()
-        && let Expr::Literal(val) = expr
     {
-        return make_allomorphic_value(val, word);
+        return apply(val);
     }
-    if let Some(val) = parse_angle_num(parse_word) {
-        return make_allomorphic_value(val, word);
+    if let Some(val) = parse_angle_num(num_word) {
+        return apply(val);
     }
     Value::str(word.to_string())
+}
+
+/// Negate a numeric Value produced by the unsigned angle-word number parsers.
+/// Non-numeric values are returned unchanged (the caller only passes numerics).
+fn negate_angle_numeric(val: Value) -> Value {
+    match val {
+        Value::Int(n) => Value::Int(-n),
+        Value::BigInt(n) => Value::BigInt(std::sync::Arc::new(-(&*n))),
+        Value::Num(n) => Value::Num(-n),
+        Value::Rat(n, d) => Value::Rat(-n, d),
+        Value::FatRat(n, d) => Value::FatRat(-n, d),
+        Value::BigRat(n, d) => Value::BigRat(-n, d),
+        other => other,
+    }
 }
 
 fn make_allomorphic_value(val: Value, word: &str) -> Value {

--- a/t/angle-word-signed-allomorph.t
+++ b/t/angle-word-signed-allomorph.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 15;
+
+# Negative (and explicitly positive) numeric words in <...> must produce
+# allomorphs (IntStr/RatStr/NumStr), not bare Str — matching positive words.
+
+isa-ok <-3>,    IntStr, '<-3> is IntStr';
+isa-ok <3>,     IntStr, '<3> is IntStr';
+isa-ok <+7>,    IntStr, '<+7> is IntStr';
+isa-ok <-3.5>,  RatStr, '<-3.5> is RatStr';
+isa-ok <3.5>,   RatStr, '<3.5> is RatStr';
+isa-ok <-1.2e3>, NumStr, '<-1.2e3> is NumStr';
+
+# Numeric value is correct and negative.
+is <-3> + 0,    -3,   '<-3> numifies to -3';
+is <-3.5> + 0,  -3.5, '<-3.5> numifies to -3.5';
+is <+7> + 0,    7,    '<+7> numifies to 7';
+
+# Str component keeps the original signed spelling.
+is <-3>.Str,   '-3',   '<-3>.Str keeps the sign';
+is <-3.5>.Str, '-3.5', '<-3.5>.Str keeps the sign';
+
+# Smartmatches against both the numeric type and Str.
+ok <-3> ~~ Int, '<-3> smartmatches Int';
+ok <-3> ~~ Str, '<-3> smartmatches Str';
+
+# In a word list, all elements are allomorphs.
+my @a = <5 -3 7 -9>;
+ok @a.all ~~ IntStr, 'all words in <5 -3 7 -9> are IntStr';
+is @a[1], -3, 'negative element value is correct';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

`<-3>` and `<-3.5>` parsed as plain `Str` instead of `IntStr`/`RatStr` — the angle-word numeric parsers (integer/decimal/dot_decimal/Num) accept only unsigned digits, so a leading `-`/`+` made the word fall through to a bare string. Positive words like `<5>` already became allomorphs.

```raku
say <-3>.WHAT;     # was (Str), now (IntStr)
say <-3.5>.WHAT;   # was (Str), now (RatStr)
say <5 -3 7>.raku; # was (5, "-3", 7) — a Int/Str mix; now all IntStr allomorphs
```

## Fix

Strip a leading sign in `angle_word_value_impl`, parse the unsigned body with the existing number parsers, and reapply the sign to the numeric value (`negate_angle_numeric` covers Int/BigInt/Num/Rat/FatRat/BigRat). The allomorphic `Str` component keeps the original signed spelling, so `<-3>.Str` is still `"-3"` and it smartmatches both `Int` and `Str`.

## Impact

- General correctness fix for any `<-N>` / `<-N.M>` word.
- Advances `roast/S03-metaops/reduce.t` test 62 and `S02-literals/allomorphic.t` (both still need a separate fix to fully pass — `:=`-bound List flattening / custom-subclass `.ACCEPTS` — documented in `TODO_roast/S03.md`).

## Tests

- New `t/angle-word-signed-allomorph.t` (15 tests).
- `cargo test` (449 unit) pass; full `t/` sweep shows no new failures (only known-flaky proc-async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)