### PR TITLE
parser: CORE-SETTING-REV and per-compunit $*RAKU.version; EVAL resolves use-exports

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -228,16 +228,28 @@ EVAL now passes all 30 tests in eval.t (#2513). Remaining issues are EVAL scope 
 - roast/S04-declarations/my-6e.t (EVAL scope visibility)
 - roast/S12-attributes/class.t (EVAL inside class body)
 
-## Module/Package System (6 tests)
+## Module/Package System (1 test remaining)
 
-Module versioning, import-multi semantics, CompUnit::Repository, and distribution metadata are incomplete.
+**This section was stale (verified 2026-06-05).** Most listed tests already pass
+and are whitelisted; one is unpassable as written:
 
-- roast/S11-modules/import-multi.t (X::Redeclaration in imports)
-- roast/S11-modules/versioning.t (core-revision)
-- roast/S11-repository/cur-candidates.t (error - repository queries)
-- roast/S11-repository/cur-current-distribution.t
-- roast/S11-repository/curli-install.t (C::R::Installable role)
-- roast/S19-command-line-options/01-dash-uppercase-i.t
+- roast/S11-modules/import-multi.t — **whitelisted, passes**
+- roast/S11-modules/versioning.t — **whitelisted, passes** (PR: `CORE-SETTING-REV`
+  compile-time term + `BEGIN $*RAKU.version` folding to the compunit's language
+  version + EVAL now sets parser lib paths so `use Foo; bar` resolves parenless
+  exports)
+- roast/S11-repository/cur-candidates.t — **whitelisted, passes**
+- roast/S11-repository/cur-current-distribution.t — **whitelisted, passes**
+- roast/S19-command-line-options/01-dash-uppercase-i.t — **unpassable as written**:
+  rakudo itself fails it (`@*INC` and `$*OS` no longer exist; "planned 8 tests,
+  but ran 0").
+
+**Still failing:**
+- roast/S11-repository/curli-install.t — needs a full
+  `CompUnit::Repository::Installation` implementation: `$*REPO ~~
+  CompUnit::Repository::Installable`/`::Locally` role smartmatch, `.install`,
+  `.need`, `Distribution::Hash`, `CompUnit::DependencySpecification`, and
+  `GLOBALish.WHO.merge-symbols`. Large feature; deferred.
 
 ## Multi Method / Subsignature Dispatch (2 tests remaining)
 

--- a/TODO_roast/S11.md
+++ b/TODO_roast/S11.md
@@ -25,10 +25,15 @@
 - [x] roast/S11-modules/require.t
 - [x] roast/S11-modules/runtime.t
   - 1/1 pass.
-- [ ] roast/S11-modules/versioning.t
-  - 0/9 pass. Needs the `use v6.c/d/e` version-pragma to influence
-    `$*RAKU.version`/core-revision and the Module_6c/d/e fixtures'
-    core-revision/raku-version routines (roast/packages/S11-modules/lib).
-- [ ] roast/S11-repository/cur-candidates.t
-- [ ] roast/S11-repository/cur-current-distribution.t
+- [x] roast/S11-modules/versioning.t
+  - 9/9 pass. `CORE-SETTING-REV` is folded to the compunit's language-revision
+    letter at parse time; `BEGIN $*RAKU.version`/`$*PERL.version` fold to the
+    compunit's Version. EVAL now sets parser lib paths so `use Foo; bar`
+    resolves Foo's parenless exported subs.
+- [x] roast/S11-repository/cur-candidates.t
+- [x] roast/S11-repository/cur-current-distribution.t
 - [ ] roast/S11-repository/curli-install.t
+  - Needs a full CompUnit::Repository::Installation: `$*REPO ~~
+    CompUnit::Repository::Installable`/`::Locally`, `.install`/`.need`,
+    `Distribution::Hash`, `CompUnit::DependencySpecification`,
+    `GLOBALish.WHO.merge-symbols`. Large feature; deferred.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -564,6 +564,7 @@ roast/S11-modules/rakulib.t
 roast/S11-modules/re-export.t
 roast/S11-modules/require.t
 roast/S11-modules/runtime.t
+roast/S11-modules/versioning.t
 roast/S11-repository/cur-candidates.t
 roast/S11-repository/cur-current-distribution.t
 roast/S12-attributes/augment-and-initialization.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -601,6 +601,18 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     if let Ok(r) = try_kw("NaN", Value::Num(f64::NAN)) {
         return Ok(r);
     }
+    // CORE-SETTING-REV — a compile-time constant equal to the language revision
+    // letter (c/d/e) of the current compilation unit, as set by `use v6.X`.
+    // The parser knows the active version while parsing each compunit, so we
+    // fold it to a string literal at parse time (matching Rakudo, where it is a
+    // BEGIN-time constant).
+    {
+        let ver = crate::parser::current_language_version();
+        let rev = ver.rsplit('.').next().unwrap_or("c").to_string();
+        if let Ok(r) = try_kw("CORE-SETTING-REV", Value::str(rev)) {
+            return Ok(r);
+        }
+    }
     // rand — generates a random number (term)
     if input.starts_with("rand")
         && !input[4..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1801,7 +1801,56 @@ pub(super) fn phaser_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, s) = statement(rest)?;
         (r, vec![s])
     };
+    // `BEGIN $*RAKU.version` (and `$*PERL.version`) is a compile-time constant
+    // equal to the language version of the current compilation unit. The parser
+    // knows the active `use v6.X` version, so fold it to a Version literal here.
+    // BEGIN of a pure constant has no side effects, so the phaser wrapper is
+    // dropped — the value flows through directly (e.g. as a sub's return value).
+    if kind == PhaserKind::Begin
+        && body.len() == 1
+        && let Stmt::Expr(e) = &body[0]
+        && let Some(v) = fold_compile_time_version(e)
+    {
+        return Ok((rest, Stmt::Expr(Expr::Literal(v))));
+    }
     Ok((rest, Stmt::Phaser { kind, body }))
+}
+
+/// Fold `$*RAKU.version` / `$*PERL.version` to a Version literal of the current
+/// compilation unit's language version. These reflect the `use v6.X` pragma in
+/// effect and are constant per compunit.
+fn fold_compile_time_version(expr: &Expr) -> Option<Value> {
+    let Expr::MethodCall {
+        target, name, args, ..
+    } = expr
+    else {
+        return None;
+    };
+    if !args.is_empty() || name.resolve() != "version" {
+        return None;
+    }
+    let Expr::Var(v) = &**target else {
+        return None;
+    };
+    if v != "*RAKU" && v != "*PERL" {
+        return None;
+    }
+    let ver = current_language_version();
+    let parts: Vec<crate::value::VersionPart> = ver
+        .split('.')
+        .map(|s| {
+            if let Ok(n) = s.parse::<i64>() {
+                crate::value::VersionPart::Num(n)
+            } else {
+                crate::value::VersionPart::Str(s.to_string())
+            }
+        })
+        .collect();
+    Some(Value::Version {
+        parts,
+        plus: false,
+        minus: false,
+    })
 }
 
 /// Parse `subtest` declaration.

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -10,13 +10,20 @@ impl Interpreter {
         imported_names: &[String],
     ) -> Result<Value, RuntimeError> {
         let user_sub_names = self.collect_eval_user_sub_names();
-        match crate::parser::parse_program_with_operators_and_user_subs(
+        // Make module search paths visible to the parser so that `use Foo`
+        // inside the EVAL'd code can resolve and register Foo's exported sub
+        // names (needed for parenless calls like `use Foo; bar`).
+        crate::parser::set_parser_lib_paths(self.lib_paths.clone());
+        crate::parser::set_parser_program_path(self.program_path.clone());
+        let parse_result = crate::parser::parse_program_with_operators_and_user_subs(
             src,
             op_names,
             op_assoc,
             imported_names,
             &user_sub_names,
-        ) {
+        );
+        crate::parser::clear_parser_lib_paths();
+        match parse_result {
             Ok((stmts, _)) => {
                 self.check_eval_class_redeclarations(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;


### PR DESCRIPTION
## Summary

Makes `roast/S11-modules/versioning.t` pass (9/9, now whitelisted) by treating a compilation unit's language revision as a compile-time constant, the way Rakudo does.

- **`CORE-SETTING-REV`** folds to the current compunit's language revision letter (c/d/e), derived from the active `use v6.X` pragma the parser already tracks.
- **`BEGIN $*RAKU.version` / `$*PERL.version`** fold to a `Version` literal of the compunit's language version. `BEGIN` of a pure constant has no side effects, so the phaser wrapper is dropped and the value flows through as e.g. a sub's return value. This captures the *module's* version at module-compile time, not the *caller's* version at call time (so `use v6.d; use Module_6c; raku-version` correctly yields `6.c`).
- **EVAL** now sets the parser's module search (lib) paths before parsing the EVAL'd source, so `use Foo; bar` inside `EVAL` resolves `Foo`'s exported subs and parses `bar` as a parenless call instead of an undeclared bareword.

## Stale tracking reconciled

The BLOCKERS.md "Module/Package System (6 tests)" list was stale:

- `import-multi.t`, `cur-candidates.t`, `cur-current-distribution.t` — already pass and whitelisted.
- `S19-command-line-options/01-dash-uppercase-i.t` — **unpassable**: rakudo itself fails it (`@*INC`/`$*OS` no longer exist; "planned 8 tests, but ran 0").
- `curli-install.t` — needs a full `CompUnit::Repository::Installation` (`$*REPO ~~ ::Installable/::Locally`, `.install`/`.need`, `Distribution::Hash`, `CompUnit::DependencySpecification`, `GLOBALish.WHO.merge-symbols`); stays deferred.

## Testing

- `roast/S11-modules/versioning.t` -> 9/9 PASS (added to whitelist)
- EVAL whitelist tests (S29-context/eval.t, evalfile.t, S04-phasers/in-eval.t, S06-other/main-eval.t, integration/eval-and-threads.t, S01-perl-5-integration/eval_lex.t) all still PASS
- cargo unit tests 449/0; clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)