### PR TITLE
parser: fix `==>` feed into inline `my` decl + scalar-sink Array materialization

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -1724,9 +1724,15 @@ fn build_feed_expr(op: FeedOp, left: Expr, right: Expr) -> Expr {
 
 fn build_pipe_feed_expr(source: Expr, sink: Expr) -> Expr {
     match sink {
+        // Feeding into a scalar collects the feed into an Array, like an array
+        // sink: `42 ==> $x` and `(1,2,3) ==> $x` both leave `$x` as `[…]`
+        // (an Array), matching Raku (the scalar holds the materialized feed).
         Expr::Var(name) => Expr::AssignExpr {
             name,
-            expr: Box::new(source),
+            expr: Box::new(Expr::Call {
+                name: Symbol::intern("__mutsu_feed_array_assign"),
+                args: vec![source],
+            }),
             is_bind: false,
         },
         Expr::ArrayVar(name) => Expr::AssignExpr {
@@ -1778,6 +1784,54 @@ fn build_pipe_feed_expr(source: Expr, sink: Expr) -> Expr {
             name: Symbol::intern("__mutsu_feed_whatever"),
             args: vec![source],
         },
+        // Feed into an inline declaration: `... ==> my @o`. The sink parses as a
+        // `DoStmt` wrapping a `VarDecl` with a default (empty) initializer;
+        // rebuild it with the fed source as the initializer so the new variable
+        // (declared in the enclosing scope by `compile_expr_do_stmt`) receives
+        // the feed. Mirrors the bare-variable arms above (an array sink flattens
+        // the source via `__mutsu_feed_array_assign`).
+        Expr::DoStmt(stmt) if matches!(stmt.as_ref(), Stmt::VarDecl { .. }) => {
+            let Stmt::VarDecl {
+                name,
+                type_constraint,
+                is_state,
+                is_our,
+                is_dynamic,
+                is_export,
+                export_tags,
+                custom_traits,
+                where_constraint,
+                ..
+            } = *stmt
+            else {
+                unreachable!("guarded by matches! above")
+            };
+            // Array and scalar sinks materialize the feed into an Array (see the
+            // bare-variable arms above); a hash (`%`) or code (`&`) sink takes
+            // the source directly. Scalar `VarDecl` names are stored without a
+            // sigil (`my $x` -> "x"), arrays/hashes with one ("@o"/"%h").
+            let is_hash_or_code = name.starts_with('%') || name.starts_with('&');
+            let init = if is_hash_or_code {
+                source
+            } else {
+                Expr::Call {
+                    name: Symbol::intern("__mutsu_feed_array_assign"),
+                    args: vec![source],
+                }
+            };
+            Expr::DoStmt(Box::new(Stmt::VarDecl {
+                name,
+                expr: init,
+                type_constraint,
+                is_state,
+                is_our,
+                is_dynamic,
+                is_export,
+                export_tags,
+                custom_traits,
+                where_constraint,
+            }))
+        }
         other => Expr::CallOn {
             target: Box::new(other),
             args: vec![source],

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -89,8 +89,16 @@ pub(super) fn my_decl_assign_or_default(input: &str, s: MyDeclState) -> PResult<
         return handle_binding(stripped, s);
     }
 
-    // No assignment — default value
-    let (rest, _) = opt_char(rest, ';');
+    // No assignment — default value. Optionally consume a trailing `;` only in
+    // statement context. In EXPRESSION context (e.g. a feed sink
+    // `(1,2,3) ==> my @o; say @o`) the `;` terminates the *enclosing* statement
+    // and must be left for it; eating it here swallows the following statement
+    // into the expression (`say` then parses as an infix word on the feed).
+    let rest = if s.apply_modifier {
+        opt_char(rest, ';').0
+    } else {
+        rest
+    };
     let expr = default_decl_expr(
         s.is_array,
         s.is_hash,

--- a/t/feed-operators.t
+++ b/t/feed-operators.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 6;
+plan 16;
 
 {
     my @a = (1, 2);
@@ -26,3 +26,46 @@ plan 6;
 }
 
 dies-ok { my @a <== 0..Inf }, 'feeding an infinite range into an array dies';
+
+# Feed into an inline declaration `... ==> my @o` followed by another statement
+# on the same line. The terminal declaration must not swallow the `;` and the
+# following statement (regression: `my @o; say @o` parsed as `say` infix on the
+# feed, so @o stayed empty and the result printed twice).
+{
+    (1, 2, 3) ==> map({ $_ * 2 }) ==> my @o;
+    is(~@o, '2 4 6', 'feed into inline `my @o` declaration');
+}
+{
+    (1, 2, 3, 4) ==> grep({ $_ %% 2 }) ==> my @evens;
+    is(~@evens, '2 4', 'feed into inline `my @evens` with following stmt');
+}
+{
+    my $marker = 0;
+    (1, 2, 3) ==> my @xs; $marker = 42;
+    is(~@xs, '1 2 3', 'inline feed decl does not swallow the next statement');
+    is($marker, 42, 'statement after inline feed decl still runs');
+}
+{
+    # Chained feed terminating in a declaration, then an independent statement.
+    (5, 1, 3) ==> sort() ==> my @sorted;
+    my @other = 7, 8;
+    is(~@sorted, '1 3 5', 'chained feed into inline decl');
+    is(~@other, '7 8', 'declaration after chained feed is independent');
+}
+
+# Feeding into a scalar materializes the feed as an Array (matches Raku):
+# `(1,2,3) ==> $x` leaves `$x` as `[1 2 3]`, not a bare List.
+{
+    (1, 2, 3) ==> map({ $_ + 10 }) ==> my $x;
+    is($x.^name, 'Array', 'feed into inline `my $x` produces an Array');
+    is(~$x, '11 12 13', 'feed into inline `my $x` holds the materialized feed');
+}
+{
+    my $y;
+    (4, 5) ==> $y;
+    is($y.^name, 'Array', 'feed into pre-declared scalar produces an Array');
+}
+{
+    42 ==> my $z;
+    is(~$z, '42', 'feed of a single value into a scalar is a 1-element Array');
+}


### PR DESCRIPTION
## Summary

Two `==>` feed-operator correctness fixes (backlog: *Parser: 未実装演算子 — feed operators*).

### 1. Inline declaration sink swallowed the following statement

A no-initializer `my` declaration unconditionally consumed a trailing `;` (`opt_char(rest, ';')`), even when parsed in **expression** context. As a feed sink, e.g.

```raku
(1, 2, 3) ==> map({ $_ * 2 }) ==> my @o; say @o
```

the declaration ate the `;`, so `say` was then parsed as an infix word applied to the feed (`InfixFunc{say, left: feed, right: [@o]}`). Result: `@o` stayed empty and the feed value printed twice. The fix consumes the trailing `;` **only** in statement context (`apply_modifier`); in expression context it is left for the enclosing statement to terminate.

### 2. Scalar feed sink produced a List instead of an Array

Raku materializes a feed into a scalar as an **Array**: `(1,2,3) ==> $x` and `42 ==> $x` both leave `$x` as `[…]`. mutsu left a bare `List`. Both the bare-variable (`==> $x`) and inline-declaration (`==> my $x`) scalar sinks now wrap the source in `__mutsu_feed_array_assign` (the same helper the array sink uses); hash (`%`) and code (`&`) sinks are unchanged.

## Before / after

| expression | raku | mutsu before | mutsu after |
|---|---|---|---|
| `(1,2,3) ==> map({$_*2}) ==> my @o; say @o` | `[2 4 6]` | `[2 4 6][2 4 6]` (doubled, @o empty) | `[2 4 6]` |
| `42 ==> my $x; say $x` | `[42]` | `42` | `[42]` |
| `my $y; (1,2,3) ==> $y; say $y.^name` | `Array` | `List` | `Array` |

## Tests

`t/feed-operators.t` gains 10 cases (inline `my @o`/`my $x` decls, statements after a feed decl, chained feed into a decl, scalar materialization), all verified against `raku`. `make test` passes (4813 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
