### PR TITLE
runtime: full Match.gist with positional captures + nested-Match gist in containers

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -475,9 +475,7 @@ pub(super) fn dispatch(
                         class_name,
                         attributes,
                         ..
-                    } if class_name == "Match" => {
-                        crate::runtime::utils::match_gist(attributes, 0)
-                    }
+                    } if class_name == "Match" => crate::runtime::utils::match_gist(attributes, 0),
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }
@@ -533,9 +531,7 @@ pub(super) fn dispatch(
                         class_name,
                         attributes,
                         ..
-                    } if class_name == "Match" => {
-                        crate::runtime::utils::match_gist(attributes, 0)
-                    }
+                    } if class_name == "Match" => crate::runtime::utils::match_gist(attributes, 0),
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -468,6 +468,16 @@ pub(super) fn dispatch(
                         let elems = values.iter().map(gist_item).collect::<Vec<_>>().join(", ");
                         format!("{}({})", kind_str, elems)
                     }
+                    // A Match nested in a list/seq gist renders as its full
+                    // `Match.gist` (corner-quoted text + sub-captures), not the
+                    // bare matched string.
+                    Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } if class_name == "Match" => {
+                        crate::runtime::utils::match_gist(attributes, 0)
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }
@@ -515,6 +525,16 @@ pub(super) fn dispatch(
                         };
                         let elems = values.iter().map(gist_item).collect::<Vec<_>>().join(", ");
                         format!("{}({})", kind_str, elems)
+                    }
+                    // A Match nested in a list/seq gist renders as its full
+                    // `Match.gist` (corner-quoted text + sub-captures), not the
+                    // bare matched string.
+                    Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } if class_name == "Match" => {
+                        crate::runtime::utils::match_gist(attributes, 0)
                     }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1388,23 +1388,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(attributes.get("to").cloned().unwrap_or(Value::Int(0))));
             }
             "gist" => {
-                let matched = target.to_string_value();
-                let mut gist = format!("\u{FF62}{}\u{FF63}", matched);
-                if let Some(Value::Hash(named)) = attributes.get("named")
-                    && !named.is_empty()
-                {
-                    let mut keys: Vec<&String> = named.keys().collect();
-                    keys.sort();
-                    for key in keys {
-                        if let Some(value) = named.get(key) {
-                            gist.push_str(&format!(
-                                "\n {} => \u{FF62}{}\u{FF63}",
-                                key,
-                                value.to_string_value()
-                            ));
-                        }
-                    }
-                }
+                // Full Match gist: corner-quoted text plus positional/named
+                // sub-captures, ordered by position and nested recursively.
+                let gist = crate::runtime::utils::match_gist(attributes, 0);
                 return Some(Ok(Value::str(gist)));
             }
             "Str" => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -917,7 +917,109 @@ pub(crate) fn gist_value(value: &Value) -> String {
             let sep = if *excl_end { "..^" } else { ".." };
             format!("{}{}{}{}", prefix, gist_value(start), sep, gist_value(end))
         }
+        // A Match nested inside a container (e.g. the values of `$/.caps` or a
+        // `m:g//` result list) must still gist as `｢matched｣` plus its sub-
+        // captures, matching `Match.gist`. The generic Instance fall-through
+        // below would otherwise stringify it to the bare matched text.
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name == "Match" => match_gist(attributes, 0),
         _ => value.to_string_value(),
+    }
+}
+
+/// Render a Match's `.gist`: the corner-quoted matched text followed by its
+/// positional and named sub-captures, each on its own indented line, ordered by
+/// the capture's start position (`from`) and nested recursively. This mirrors
+/// Rakudo's `Match.gist`:
+///
+/// ```text
+/// ｢a1b2｣
+///  0 => ｢a1｣
+///   0 => ｢a｣
+///   1 => ｢1｣
+///  0 => ｢b2｣
+///   0 => ｢b｣
+///   1 => ｢2｣
+/// ```
+///
+/// A quantified capture (`(\w)+`) is a list of Match values, each emitted under
+/// the same index. `depth` controls indentation (one leading space per level).
+pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> String {
+    let matched = attributes
+        .get("str")
+        .map(|s| s.to_string_value())
+        .unwrap_or_default();
+    let mut out = format!("\u{FF62}{}\u{FF63}", matched);
+
+    // Flatten captures into (from, label, match-value) entries so a quantified
+    // capture contributes one entry per repetition, then order by match start
+    // position (named and positional interleave by position).
+    let mut entries: Vec<(i64, String, Value)> = Vec::new();
+    let push_capture = |label: &str, value: &Value, entries: &mut Vec<(i64, String, Value)>| {
+        match value {
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Match" => {
+                entries.push((match_from(attributes), label.to_string(), value.clone()));
+            }
+            // Quantified capture: a list of Match values under one index.
+            Value::Array(items, _) | Value::Seq(items) | Value::Slip(items) => {
+                for item in items.iter() {
+                    if let Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } = item
+                        && class_name == "Match"
+                    {
+                        entries.push((match_from(attributes), label.to_string(), item.clone()));
+                    }
+                }
+            }
+            _ => {}
+        }
+    };
+
+    if let Some(Value::Array(list, _)) = attributes.get("list") {
+        for (i, cap) in list.iter().enumerate() {
+            push_capture(&i.to_string(), cap, &mut entries);
+        }
+    }
+    if let Some(Value::Hash(named)) = attributes.get("named") {
+        let mut keys: Vec<&String> = named.keys().collect();
+        keys.sort();
+        for k in keys {
+            if let Some(v) = named.get(k) {
+                push_capture(k, v, &mut entries);
+            }
+        }
+    }
+    entries.sort_by_key(|(from, _, _)| *from);
+
+    let indent = " ".repeat(depth + 1);
+    for (_, label, val) in entries {
+        if let Value::Instance { attributes, .. } = &val {
+            out.push_str(&format!(
+                "\n{}{} => {}",
+                indent,
+                label,
+                match_gist(attributes, depth + 1)
+            ));
+        }
+    }
+    out
+}
+
+/// The `from` (start offset) of a Match's attributes, or 0 when absent.
+fn match_from(attributes: &HashMap<String, Value>) -> i64 {
+    match attributes.get("from") {
+        Some(Value::Int(n)) => *n,
+        _ => 0,
     }
 }
 

--- a/t/match-gist.t
+++ b/t/match-gist.t
@@ -1,0 +1,61 @@
+use Test;
+
+# Match.gist (and the gist of a Match nested inside a container) renders the
+# corner-quoted matched text plus positional/named sub-captures, ordered by
+# match position and nested recursively — matching Rakudo. Regression: nested
+# Match values (e.g. the values of `$/.caps` or a `m:g//` result list) used to
+# gist as the bare matched text, and a Match's own positional captures were not
+# shown at all.
+
+plan 9;
+
+{
+    "a1" ~~ /(\w)(\d)/;
+    is $/.gist, "｢a1｣\n 0 => ｢a｣\n 1 => ｢1｣",
+        "positional captures appear in the gist";
+}
+
+{
+    "abc" ~~ /(\w)+/;
+    is $/.gist, "｢abc｣\n 0 => ｢a｣\n 0 => ｢b｣\n 0 => ｢c｣",
+        "quantified capture repeats under the same index";
+}
+
+{
+    "a1b2" ~~ /((\w)(\d))+/;
+    is $/.gist,
+        "｢a1b2｣\n 0 => ｢a1｣\n  0 => ｢a｣\n  1 => ｢1｣\n 0 => ｢b2｣\n  0 => ｢b｣\n  1 => ｢2｣",
+        "nested captures indent one space per depth";
+}
+
+{
+    "abc123" ~~ /(\w+?)(\d+)/;
+    is $/.caps.gist, "(0 => ｢abc｣ 1 => ｢123｣)",
+        "Match values nested in .caps gist as corner-quoted text";
+    is $/.chunks.gist, "(0 => ｢abc｣ 1 => ｢123｣)",
+        ".chunks values gist as corner-quoted text";
+}
+
+{
+    my @m = "abcabc" ~~ m:g/a/;
+    is @m.map(*.gist).join(" "), "｢a｣ ｢a｣",
+        "each m:g result Match gists with corner quotes";
+}
+
+{
+    # A simple Match with no sub-captures gists as just the corner-quoted text.
+    "hello" ~~ /ell/;
+    is $/.gist, "｢ell｣", "captureless Match gist is just the matched text";
+}
+
+{
+    # The .Str of a Match is still the plain matched text (no corner quotes).
+    "hello" ~~ /ell/;
+    is $/.Str, "ell", "Match.Str is the plain matched text";
+}
+
+{
+    # gist used implicitly by `say` over a list of Matches.
+    my @m = "x1y2" ~~ m:g/<[xy]>\d/;
+    is @m.map(*.Str).gist, "(x1 y2)", "mapped Match .Str values are plain";
+}


### PR DESCRIPTION
## Summary

Fixes `Match.gist` to include **positional** captures, and makes a Match **nested inside a container** gist correctly (backlog: *Regex/Grammar — Match object `.caps`/`.chunks`*).

### Problems

1. `Match.gist` emitted only the corner-quoted matched text plus *named* captures. Positional `(...)` captures were dropped:

   ```raku
   "a1" ~~ /(\w)(\d)/; say $/;
   # was:  ｢a1｣
   # raku: ｢a1｣
   #        0 => ｢a｣
   #        1 => ｢1｣
   ```

2. A Match nested in a container (the values of `$/.caps` / `.chunks`, a `m:g//` result list) gisted as the **bare matched string**. There were three separate gist code paths — `runtime::utils::gist_value` (used by `say`), the `Array`/`Seq` `.gist` methods in `methods_0arg::dispatch_core_repr`, and `Match.gist` itself — and each fell through to `to_string_value()` for a Match, so `say $/.caps` gave `(0 => abc 1 => 123)` instead of `(0 => ｢abc｣ 1 => ｢123｣)`.

### Fix

Add one shared `runtime::utils::match_gist` that renders the corner-quoted text plus positional and named sub-captures, ordered by match start position (`from`), with quantified captures repeated under the same index and nested captures indented one space per depth — matching Rakudo. All three gist paths now call it for a `Match`.

```text
"a1b2" ~~ /((\w)(\d))+/; say $/;
｢a1b2｣
 0 => ｢a1｣
  0 => ｢a｣
  1 => ｢1｣
 0 => ｢b2｣
  0 => ｢b｣
  1 => ｢2｣
```

## Tests

`t/match-gist.t` (9 cases): positional / quantified / nested captures, `.caps`/`.chunks` and `m:g//` nested gist, captureless matches, and that `.Str` stays plain. All verified against `raku`. `make test` passes (4812 tests).

## Out of scope (noted)

`@m.gist` for a `m:g//` result Array still wraps as `(…)` instead of `[…]` — a separate array-kind nuance where the `.gist` method receiver sees the result as `List` while `say @m` reads it as `Array`. Match values inside it now corner-quote correctly; the wrap mismatch is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
