### PR TITLE
vm: scoped/overlay env on the compiled-method fast path (lever B, Slice 6 cont.)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -601,6 +601,35 @@ Reaching that requires, roughly in order:
         dance. Next slices: the named path merge, then method/closure/gather, then
         drop dirty tracking.
 
+        **Extension — the compiled-method fast path.** `call_compiled_method_fast`
+        installs a born-owned scoped overlay over the caller (gated on
+        `cc.closure_compiled_codes.is_empty()`) so the per-call `self` / `?CLASS` /
+        param / attr env setup writes land in a fresh empty map (`strong_count`
+        1) instead of `make_mut`-forking the inherited caller env — this removes
+        the per-method-call env deep copy the doc flagged in Slices 1/2/4c as the
+        residual bench-class cost. On return, `set_env(saved_env)`
+        (`can_skip_merge`) drops the overlay; `merge_method_env` already iterates
+        `current.iter()` (overlay-only), so it now sees exactly the method's own
+        writes (cheaper and semantically identical — the `saved.contains_key`
+        gate already restricted merges to caller-existing keys).
+
+        **The flatten placement matters (measured).** The universal
+        `flatten_scoped_env` safety guard was initially at the *top* of the
+        method-call opcodes, which collapsed the method's own overlay on the
+        first `$.attr` accessor read (a nested `CallMethodMut`) — making an
+        attribute-heavy method *slower* (~+3%) despite halving its deep copies,
+        because `flattened()` materializes the ~30-entry parent map per accessor.
+        Fix: the accessor fast path (`try_fast_accessor_read`) is a pure read that
+        touches no env, so the `flatten_scoped_env` call now sits **after** it in
+        both `exec_call_method_op` and `exec_call_method_mut_op`. An `$.attr` read
+        no longer collapses the overlay; only a genuine nested dispatch (which
+        would capture/iterate the env) flattens. Result: a 500k-iteration
+        `$obj.calc()` (`{ $.n * 2 + 1 }`) bench went **9.66s -> 7.42s (~23%)**;
+        `env_deep_copies` for a `{ 42 }` method dropped to ~0 (10001 -> 1 over
+        5000 calls). Validated: `make test` green; ~780 whitelisted
+        S02/S03/S04/S05/S06/S12/S14/S17/S32 + integration roast files green. New
+        pin `t/scoped-overlay-method.t`.
+
   - [ ] **Slice 5 (original design notes — superseded by the step above).**
 
       **The waste, measured.** `bench-fib` does **0 % function/method fallback**

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -323,7 +323,6 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
         self.ensure_env_synced(code);
-        self.flatten_scoped_env();
         // Set pending arg sources for `is rw` dispatch matching
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.interpreter
@@ -387,6 +386,12 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // Beyond the pure-read accessor fast path above, full method dispatch may
+        // capture/iterate the env; collapse a transient scoped overlay env to a
+        // flat env so the full lexical view is seen. Placed after the accessor
+        // read so a `$.attr` read inside a scoped method body does not collapse
+        // the overlay (defeating the per-method-call deep-copy elimination).
+        self.flatten_scoped_env();
         // Detect calls on undeclared type names: when a BareWord resolved to a Str
         // (because the name wasn't a known type/class), and .new() is called on it,
         // this means the user tried to instantiate a nonexistent class.

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -130,10 +130,6 @@ impl VM {
         if self.locals_dirty {
             self.ensure_env_synced(code);
         }
-        // Method dispatch may capture the env into a Sub / closure or run an
-        // interpreter fallback that iterates it; a transient scoped overlay env
-        // must be collapsed to a flat env first so the full lexical view is seen.
-        self.flatten_scoped_env();
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.interpreter
             .set_pending_call_arg_sources(arg_sources.clone());
@@ -209,7 +205,11 @@ impl VM {
             }
             return Err(RuntimeError::emit_signal(target));
         }
-        // Fast path: 0-arg attribute accessor on Instance (e.g. $obj.x)
+        // Fast path: 0-arg attribute accessor on Instance (e.g. $obj.x). This is
+        // a pure read that touches no env, so it runs safely under a scoped
+        // overlay env (the common `$.attr` read inside a scoped method body) --
+        // hence the `flatten_scoped_env` below is placed *after* it, so an
+        // accessor read does not collapse the caller's scoped overlay.
         if let Some(val) =
             self.try_fast_accessor_read(&target, method, &args, modifier_idx.is_some(), quoted)
         {
@@ -217,6 +217,11 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // Full method dispatch from here on may capture the env into a Sub /
+        // closure or run an interpreter fallback that iterates it; collapse a
+        // transient scoped overlay env to a flat env first so the full lexical
+        // view is seen.
+        self.flatten_scoped_env();
         // Junction auto-threading: thread method calls over junction values
         if let Value::Junction { kind, values } = &target
             && !matches!(

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -743,6 +743,22 @@ impl VM {
 
         self.push_light_call_frame();
         let saved_stack_depth = self.call_frames.last().unwrap().saved_stack_depth;
+        // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
+        // born-owned overlay over the caller so the `self`/`?CLASS`/param/attr
+        // env writes below land in a fresh map (strong_count 1) instead of
+        // `make_mut`-forking the inherited caller env — this removes the per-
+        // method-call env deep copy (the bench-class cost). Reads fall through to
+        // the parent; on return `set_env(saved_env)` (can_skip_merge) drops the
+        // overlay and `merge_method_env` iterates it overlay-only (the method's
+        // own writes, which is exactly what the merge needs). Gated to methods
+        // with no inner closures so no closure/thread/gather body captures or
+        // iterates the scoped env for a full lexical view.
+        let use_scoped = cc.closure_compiled_codes.is_empty();
+        if use_scoped {
+            let parent_overlay = self.interpreter.env().overlay_arc();
+            let scoped = crate::env::Env::scoped_child(parent_overlay);
+            self.interpreter.set_env(scoped);
+        }
         let saved_var_bindings = self.interpreter.take_var_bindings();
         self.interpreter.push_method_class(owner_class.to_string());
 

--- a/t/scoped-overlay-method.t
+++ b/t/scoped-overlay-method.t
@@ -1,0 +1,74 @@
+use v6;
+use Test;
+
+# Regression pin for the scoped/overlay env on the compiled-method fast path
+# (call_compiled_method_fast). See docs/vm-dual-store.md (Slice 6). A method with
+# no inner closures runs under a born-owned scoped overlay so its self/?CLASS/
+# param/attr env writes never fork the caller env; the overlay is dropped (or
+# merged overlay-only) on return. The `$.attr` accessor read is a pure read and
+# must NOT collapse the overlay.
+
+plan 16;
+
+class Point {
+    has $.x;
+    has $.y;
+    method sum() { $.x + $.y }
+    method scale($f) { Point.new(x => $.x * $f, y => $.y * $f) }
+    method bump() { $!x++; $!x }
+}
+my $p = Point.new(x => 3, y => 4);
+is $p.sum(), 7, 'method reads two attributes';
+is $p.scale(10).sum(), 70, 'method constructs + chains';
+is $p.bump(), 4, 'method mutates private attr';
+is $p.bump(), 5, 'mutation persists on the instance';
+is $p.x, 5, 'public accessor reflects mutation';
+is $p.sum(), 9, 'sum after mutation (5+4)';
+
+# method mutating a captured outer global must persist
+my $total = 0;
+class Adder { has $.n; method add() { $total += $.n; } }
+Adder.new(n => 5).add();
+Adder.new(n => 7).add();
+is $total, 12, 'method mutates captured outer global';
+
+# nested method dispatch under scoped env
+class Calc {
+    has $.base;
+    method double() { $.base * 2 }
+    method quad() { self.double() * 2 }
+}
+is Calc.new(base => 3).quad(), 12, 'nested self.method() dispatch';
+
+# method returning a closure (non-scoped path) still works
+class Maker { has $.k; method make() { my $b = $.k; -> $x { $b + $x } } }
+my &f = Maker.new(k => 100).make();
+is f(5), 105, 'closure-returning method captures attr';
+is f(10), 110, 'returned closure reusable';
+
+# inheritance + SUPER-style redispatch
+class Base { method greet() { "base" } }
+class Derived is Base { method greet() { "derived-" ~ self.Base::greet() } }
+is Derived.new.greet(), 'derived-base', 'inherited redispatch';
+
+# method with a positional param + type constraint
+class Box { has $.v; method add(Int $d) { $.v + $d } }
+is Box.new(v => 10).add(5), 15, 'method with typed positional param';
+
+# method calling a free sub (nested function call flattens scoped env)
+sub helper-fn($x) { $x * 3 }
+class User { has $.m; method use-it() { helper-fn($.m) } }
+is User.new(m => 4).use-it(), 12, 'method calling a free sub';
+
+# repeated calls on the same object are independent (no overlay leak)
+class Counter { has $.start; method val() { my $t = $.start; $t + 1 } }
+my $c = Counter.new(start => 41);
+is $c.val(), 42, 'first call';
+is $c.val(), 42, 'second call independent';
+
+# method mutating a captured array
+my @log;
+class Logger { has $.tag; method log() { @log.push($.tag); } }
+Logger.new(tag => 'a').log();
+Logger.new(tag => 'b').log();
+is @log.join(','), 'a,b', 'method mutates captured array';


### PR DESCRIPTION
Stacked on #2647.

## What

Extends the scoped/overlay env (#2647, docs/vm-dual-store.md Slice 6) to
`call_compiled_method_fast`.

## How

- Install a **born-owned scoped overlay** over the caller (gated on
  `cc.closure_compiled_codes.is_empty()`) so the per-call `self`/`?CLASS`/param/
  attr env setup writes land in a fresh empty map (`strong_count` 1) instead of
  `make_mut`-forking the inherited caller env — removing the per-method-call env
  deep copy (the residual bench-class cost from Slices 1/2/4c). On return,
  `set_env(saved_env)` (can_skip_merge) drops the overlay; `merge_method_env`
  already iterates the overlay-only `current.iter()`, so it sees exactly the
  method's own writes (cheaper, semantically identical).
- **Move the `flatten_scoped_env` safety guard** from the *top* of
  `exec_call_method_op` / `exec_call_method_mut_op` to *after* the
  `try_fast_accessor_read` fast path. A `$.attr` read is a pure read that touches
  no env, so it must not collapse the method's own overlay (which would
  materialize the ~30-entry parent map per accessor and make attribute-heavy
  methods slower). Only a genuine nested dispatch now flattens.

## Result

- 500k-iteration `$obj.calc()` (`{ $.n * 2 + 1 }`) bench **9.66s → 7.42s (~23%)**.
- `env_deep_copies` for a `{ 42 }` method: 10001 → 1 over 5000 calls.
- `make test` green; ~780 whitelisted S02/S03/S04/S05/S06/S12/S14/S17/S32 +
  integration roast files green.
- New pin `t/scoped-overlay-method.t`.

Full roast runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)