### PR TITLE
runtime: trailing declarator #= carries callable type to $=pod WHEREFORE

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -394,15 +394,30 @@ located relative to CWD) — `run-roast-test.sh` now runs them with CWD=roast.
   bundled Unicode version doesn't implement these UAX-29 rules for Unicode 17.0.
   Needs GB9c/GB11 post-processing or a crate upgrade.)
 
-## Pod / Documentation (4 tests)
+## Pod / Documentation (1 test remaining)
 
-Pod6 formatting codes (Pod::FormattingCode type), table rendering, and trailing declarator docs.
+**Resolved (whitelisted):**
+- roast/S26-documentation/07-tables.t — already passing/whitelisted (stale entry)
+- roast/S26-documentation/08-formattingcodes.t — already passing/whitelisted (stale entry)
+- roast/S26-documentation/block-trailing.t — **whitelisted, passes (50/50)**. A
+  standalone trailing declarator comment (`#=` on its own line after the
+  declaration) now carries the declaration's callable-type / proto / return-type
+  metadata into `$=pod`, so `$=pod[i].WHEREFORE.^name` is the correct type
+  (Method/Submethod/Routine/`Sub+{Callable[Str]}`) instead of a generic `Sub`.
+  Fix in `src/runtime/io.rs` (the `#=`-on-own-line path threads
+  `callable_type_override`/`is_proto`/`return_type` from `last_declarant`).
+  Local test: t/declarator-trailing-wherefore.t.
+- roast/S26-documentation/why-trailing.t — **whitelisted, passes (54/54)** (same fix).
 
-- roast/S26-documentation/07-tables.t
-- roast/S26-documentation/08-formattingcodes.t (Pod::FormattingCode)
-- roast/S26-documentation/12-non-breaking-space.t
-- roast/S26-documentation/block-trailing.t
-- roast/S26-documentation/why-trailing.t
+**Still failing:**
+- roast/S26-documentation/12-non-breaking-space.t — NOT a Pod issue. Subtest 2
+  plans `$nbchar-count + 1` where `my $nbchar-count = @nbchars.elems` is read at
+  the top of the file but `@nbchars` is populated by a `BEGIN {}` block at the
+  *end* of the file. rakudo runs the textually-later `BEGIN` at compile time
+  (before the top-level `my` initialization), so `$nbchar-count` is 4; mutsu runs
+  `BEGIN` at its textual position, so it reads 0 and the subtest plan collapses to
+  `1..1`. Blocked on **compile-time BEGIN-phaser execution / hoisting** ordering,
+  not on Pod table rendering.
 
 ## Temporal / DateTime (DONE except an unpassable test)
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -934,12 +934,14 @@ roast/S26-documentation/14-defn.t
 roast/S26-documentation/15-numbered-alias.t
 roast/S26-documentation/block-leading-user-format.t
 roast/S26-documentation/block-leading.t
+roast/S26-documentation/block-trailing.t
 roast/S26-documentation/module-comment.t
 roast/S26-documentation/multiline-leading.t
 roast/S26-documentation/multiline-trailing.t
 roast/S26-documentation/wacky.t
 roast/S26-documentation/why-both.t
 roast/S26-documentation/why-leading.t
+roast/S26-documentation/why-trailing.t
 roast/S28-named-variables/cwd.t
 roast/S28-named-variables/init-instant.t
 roast/S28-named-variables/slangs.t

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -3250,7 +3250,16 @@ impl Interpreter {
         self.doc_comment_list.clear();
         let mut pending_leading: Option<String> = None;
         // The last declaration that can receive trailing #= comments
-        let mut last_declarant: Option<(String, super::DocDeclKind, u32)> = None;
+        // (doc_key, kind, decl_line, callable_type_override, is_proto, return_type)
+        #[allow(clippy::type_complexity)]
+        let mut last_declarant: Option<(
+            String,
+            super::DocDeclKind,
+            u32,
+            Option<&'static str>,
+            bool,
+            Option<String>,
+        )> = None;
         // Track the current class scope for method doc keys
         let mut current_class: Option<String> = None;
         // Stack of class scopes for nested classes
@@ -3860,7 +3869,14 @@ impl Interpreter {
             // Trailing doc comment (#=) on its own line
             if let Some((text, next_idx, _is_block)) = parse_doc_comment(&lines, idx, "#=") {
                 if !text.is_empty()
-                    && let Some((ref name, ref kind, decl_line)) = last_declarant
+                    && let Some((
+                        ref name,
+                        ref kind,
+                        decl_line,
+                        callable_type_ovr,
+                        is_proto,
+                        ref return_type,
+                    )) = last_declarant
                 {
                     let entry =
                         self.doc_comments
@@ -3871,6 +3887,22 @@ impl Interpreter {
                                 ..Default::default()
                             });
                     entry.trailing = append_doc_text(entry.trailing.take(), &text);
+                    // Carry the declaration's callable type / proto / return type
+                    // so a standalone trailing #= produces the correct WHEREFORE
+                    // type in $=pod (e.g. Method/Submethod/Routine, not Sub).
+                    if entry.callable_type_override.is_none()
+                        && let Some(ct) = callable_type_ovr
+                    {
+                        entry.callable_type_override = Some(ct.to_string());
+                    }
+                    if is_proto {
+                        entry.is_proto = true;
+                    }
+                    if entry.return_type.is_none()
+                        && let Some(rt) = return_type
+                    {
+                        entry.return_type = Some(rt.clone());
+                    }
                     // Ensure source_line is set so proximity matching works
                     if entry.source_line.is_none() {
                         entry.source_line = Some(decl_line);
@@ -4039,6 +4071,24 @@ impl Interpreter {
                 let leading = pending_leading.take();
                 let has_leading = leading.is_some();
                 let has_inline_trailing = inline_trailing.is_some();
+                // Extract return type for "anon Type sub {}" patterns. Computed
+                // unconditionally so a standalone trailing #= (which attaches via
+                // last_declarant) can carry the return type into $=pod.
+                let return_type_ovr: Option<String> = if name == "&<anon>" {
+                    check_line.find("anon ").and_then(|anon_pos| {
+                        let after_anon = &check_line[anon_pos + 5..];
+                        after_anon.find("sub").and_then(|sub_pos| {
+                            let type_part = after_anon[..sub_pos].trim();
+                            if type_part.is_empty() {
+                                None
+                            } else {
+                                Some(type_part.to_string())
+                            }
+                        })
+                    })
+                } else {
+                    None
+                };
                 // Only create doc_comments entry if there's actual doc content
                 if has_leading || has_inline_trailing {
                     let entry =
@@ -4062,21 +4112,21 @@ impl Interpreter {
                     if let Some(ref trail) = inline_trailing {
                         entry.trailing = append_doc_text(entry.trailing.take(), trail);
                     }
-                    // Extract return type for "anon Type sub {}" patterns
-                    if name == "&<anon>"
-                        && let Some(anon_pos) = check_line.find("anon ")
+                    if entry.return_type.is_none()
+                        && let Some(ref rt) = return_type_ovr
                     {
-                        let after_anon = &check_line[anon_pos + 5..];
-                        if let Some(sub_pos) = after_anon.find("sub") {
-                            let type_part = after_anon[..sub_pos].trim();
-                            if !type_part.is_empty() {
-                                entry.return_type = Some(type_part.to_string());
-                            }
-                        }
+                        entry.return_type = Some(rt.clone());
                     }
                 }
                 // Always set last_declarant so trailing #= on the next line can attach
-                last_declarant = Some((doc_key, kind.clone(), (idx + 1) as u32));
+                last_declarant = Some((
+                    doc_key,
+                    kind.clone(),
+                    (idx + 1) as u32,
+                    callable_type_ovr,
+                    dispatch == DispatchPrefix::Proto,
+                    return_type_ovr,
+                ));
                 // Track the current function for parameter scoping
                 if kind == super::DocDeclKind::Sub {
                     current_sub = Some(name.clone());
@@ -4143,7 +4193,14 @@ impl Interpreter {
                     }
                 }
                 // Set last_declarant so trailing #= on the next line can attach
-                last_declarant = Some((param_key, super::DocDeclKind::Param, (idx + 1) as u32));
+                last_declarant = Some((
+                    param_key,
+                    super::DocDeclKind::Param,
+                    (idx + 1) as u32,
+                    None,
+                    false,
+                    None,
+                ));
             } else {
                 // Not a recognized declaration — discard pending leading
                 pending_leading = None;

--- a/t/declarator-trailing-wherefore.t
+++ b/t/declarator-trailing-wherefore.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Regression: a standalone trailing declarator comment (#= on its own line)
+# must produce the correct WHEREFORE type in $=pod for methods, submethods,
+# protos and anon subs with return types -- not a generic "Sub".
+# Previously the callable type / proto / return-type metadata was dropped when
+# the #= comment lived on a line after the declaration.
+
+plan 7;
+
+class Sheep {
+    method roar { 'roar!' }
+    #={not too scary}
+}
+is $=pod[0].WHEREFORE.^name, 'Method', 'method trailing #= -> Method WHEREFORE';
+
+class C {
+    submethod BUILD
+    #={Bob}
+    { }
+}
+is $=pod[1].WHEREFORE.^name, 'Submethod', 'submethod trailing #= -> Submethod WHEREFORE';
+
+proto sub foo() { }
+#={solo}
+is $=pod[2].WHEREFORE.^name, 'Routine', 'proto sub trailing #= -> Routine WHEREFORE';
+
+my $anon-sub = anon Str sub {};
+#={Anonymous}
+is $=pod[3].WHEREFORE.^name, 'Sub+{Callable[Str]}',
+    'anon Str sub trailing #= -> Sub+{Callable[Str]} WHEREFORE';
+
+# The pod entry and the declarand's .WHY are the same logical declarator.
+is ~$=pod[0], 'not too scary', 'method trailing contents';
+is $=pod[0].WHEREFORE.^name, Sheep.^find_method('roar').^name,
+    '$=pod WHEREFORE name matches the method';
+
+# A plain sub with no comment has no WHY.
+sub routine {}
+is &routine.WHY.defined, False, 'undocumented sub has no WHY';


### PR DESCRIPTION
## What

A standalone trailing declarator comment (`#=` on its own line *after* a declaration) produced the wrong `WHEREFORE` type in `$=pod`.

`$=pod[i].WHEREFORE.^name` for a method / submethod / proto / `anon Type sub` came out as a generic `Sub` instead of `Method` / `Submethod` / `Routine` / `Sub+{Callable[Str]}`.

## Why

When a `#=` comment lives on the line *after* the declaration, the doc-comment entry is created lazily via `last_declarant`. That tuple only carried `(name, kind, line)`, dropping the declaration's `callable_type_override`, `is_proto`, and `return_type`. Inline trailing comments (same line) kept the metadata; own-line ones lost it.

## Fix

Thread `callable_type_override` / `is_proto` / `return_type` through `last_declarant` and apply them in the own-line `#=` path (`src/runtime/io.rs`). `return_type` is now extracted unconditionally at declaration time so it survives when the entry is created later.

## Tests

- roast/S26-documentation/block-trailing.t — 50/50 (whitelisted)
- roast/S26-documentation/why-trailing.t — 54/54 (whitelisted)
- New: t/declarator-trailing-wherefore.t

(`12-non-breaking-space.t` remains blocked on a separate issue — compile-time BEGIN-phaser hoisting, not Pod; noted in BLOCKERS.md.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)