### PR TITLE
num: pass S32-num/rat.t (Rational role, Cool .Rat coercers, Int-subclass payload)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -270,8 +270,12 @@
   - 19/89 pass (40 reached). Basic integer ** works well. Failures: `0 ** 0` edge case (7), `-1 ** 0` precedence (11), Rat exponents (13-14), Inf/NaN propagation (18, 20-25, 28-30), complex ** (34-40). Difficulty: Medium (NaN/Inf/complex propagation)
 - [ ] roast/S32-num/rand.t
   - Timeout fixed by honoring `#?rakudo skip` blocks; remaining failures are obsolete exceptions for `rand()`/`rand(3)` (`throws-like ... X::Obsolete`).
-- [ ] roast/S32-num/rat.t
-  - 61/869 pass (77 reached). Strong Rat arithmetic (+, -, *, /). Failures: `.raku` EVAL round-trip (6-9, 14-16), stringification edge cases (20), `2 / 1/3` precedence (59), many tests not reached. Difficulty: Medium-High (huge test file, many features needed)
+- [x] roast/S32-num/rat.t
+  - 869/869 pass (whitelisted). Implemented the parametric `Rational[NuT,DeT]` role
+    (prelude-injected) for `does Rational[...]`, `.so`/`.not` dispatch to user-defined
+    `Bool`, `Duration`/`Instant` and `IO::Path`/`Match`/`StrDistance` `.Rat`/`.FatRat`
+    coercion, `Nil.Rat`/`.FatRat` type-object semantics, numeric type objects numifying
+    to 0, and `Int`-subclass integer payload reads (`to_bigint`/`to_f64`).
 - [ ] roast/S32-num/real-bridge.t
 - [ ] roast/S32-num/roots.t
   - 1/55 pass. Regression: previously passed but now 51/52 tests fail (3 tests not even run).

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1107,6 +1107,7 @@ roast/S32-num/polar.t
 roast/S32-num/polymod.t
 roast/S32-num/power.t
 roast/S32-num/rand.t
+roast/S32-num/rat.t
 roast/S32-num/real-bridge.t
 roast/S32-num/roots.t
 roast/S32-num/rounders.t

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -92,6 +92,57 @@ fn tree_recursive(items: &[Value]) -> Vec<Value> {
         .collect()
 }
 
+/// Levenshtein edit distance between two strings (by Unicode scalar), used for
+/// the numeric value of a `StrDistance`.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// Real (numeric) value of a "Cool" builtin instance, used by the `.Rat`/`.FatRat`
+/// coercers: an `IO::Path` numifies via its path string, a `Match` via its
+/// matched substring, and a `StrDistance` via the edit distance between its
+/// `before`/`after` strings.
+fn cool_instance_numeric(target: &Value) -> Option<f64> {
+    let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+    else {
+        return None;
+    };
+    match class_name.resolve().as_str() {
+        "IO::Path" => target.to_string_value().trim().parse::<f64>().ok(),
+        "Match" => attributes
+            .get("str")
+            .and_then(|v| v.to_string_value().trim().parse::<f64>().ok()),
+        "StrDistance" => {
+            let before = attributes
+                .get("before")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            let after = attributes
+                .get("after")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            Some(levenshtein(&before, &after) as f64)
+        }
+        _ => None,
+    }
+}
+
 /// Convert a Value to a string for Unicode normalization.
 /// If the value is an Array of Int (Uni-like), convert codepoints to a string.
 fn uni_or_str(target: &Value) -> String {
@@ -357,7 +408,30 @@ pub(super) fn dispatch(
                     Some(Ok(make_rat(0, 1)))
                 }
             }
-            Value::Instance { .. } => None,
+            // Duration/Instant store their seconds as a Real `value`; coerce that
+            // directly so the exact Rat is preserved (e.g. Duration.new(42).Rat).
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if matches!(class_name.resolve().as_str(), "Duration" | "Instant") => {
+                match attributes.get("value") {
+                    Some(inner) => match dispatch(inner, "Rat") {
+                        Some(Some(r)) => Some(r),
+                        _ => Some(Ok(make_rat(0, 1))),
+                    },
+                    None => Some(Ok(make_rat(0, 1))),
+                }
+            }
+            Value::Instance { .. } => cool_instance_numeric(target).map(|n| {
+                if n.fract() == 0.0 && n.is_finite() {
+                    Ok(make_rat(n as i64, 1))
+                } else if n.is_finite() {
+                    Ok(crate::builtins::num_to_rat_with_epsilon(n, 1e-6))
+                } else {
+                    Ok(make_rat(0, 1))
+                }
+            }),
             Value::Package(_) => Some(Ok(make_rat(0, 1))),
             _ => {
                 let n = target.to_f64();
@@ -449,6 +523,20 @@ pub(super) fn dispatch(
                 }
             }
             Value::Package(_) => Some(Ok(Value::FatRat(0, 1))),
+            // IO::Path/Match/StrDistance numify via their Cool string/distance.
+            Value::Instance { .. } if cool_instance_numeric(target).is_some() => {
+                let n = cool_instance_numeric(target).unwrap_or(0.0);
+                if n.fract() == 0.0 && n.is_finite() {
+                    Some(Ok(Value::FatRat(n as i64, 1)))
+                } else if n.is_finite() {
+                    match crate::builtins::num_to_rat_with_epsilon(n, 1e-6) {
+                        Value::Rat(n, d) => Some(Ok(Value::FatRat(n, d))),
+                        _ => Some(Ok(Value::FatRat(0, 1))),
+                    }
+                } else {
+                    Some(Ok(Value::FatRat(0, 1)))
+                }
+            }
             _ => {
                 let n = target.to_f64();
                 if n.fract() == 0.0 && n.is_finite() {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1,7 +1,51 @@
 use super::*;
 use crate::ast::Stmt;
 
+/// Source for builtin parametric roles that are not yet representable as native
+/// `RoleDef`s. These are parsed once and prepended to programs that reference
+/// them, so they register through the ordinary RoleDecl path.
+const RATIONAL_ROLE_PRELUDE: &str = r#"
+role Rational[::NuT = Int, ::DeT = Int] does Real {
+    has NuT $.numerator = 0;
+    has DeT $.denominator = 1;
+    method new(NuT \nu = 0, DeT \de = 1) {
+        my $gcd = (nu gcd de) || 1;
+        my $n = nu div $gcd;
+        my $d = de div $gcd;
+        if $d < 0 { $n = -$n; $d = -$d; }
+        self.bless(numerator => NuT.new($n), denominator => DeT.new($d));
+    }
+    method nude { self.numerator, self.denominator }
+    method Bool { self.numerator != 0 }
+}
+"#;
+
 impl Interpreter {
+    /// Prepend builtin prelude role definitions to `stmts` when the source
+    /// references them. Currently this provides the parametric `Rational` role
+    /// for user classes written as `does Rational[...]`. The prelude is parsed
+    /// once and cached.
+    fn inject_prelude_roles(source: &str, stmts: &mut Vec<Stmt>) {
+        // Only inject when the program mentions `Rational` and does not declare
+        // its own role of that name (which would conflict).
+        if !source.contains("Rational") || source.contains("role Rational") {
+            return;
+        }
+        use std::sync::OnceLock;
+        static RATIONAL_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = RATIONAL_STMTS.get_or_init(|| {
+            crate::parse_dispatch::parse_source(RATIONAL_ROLE_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
     fn source_has_no_precompilation(code: &str) -> bool {
         code.lines().any(|line| {
             let trimmed = line.trim();
@@ -692,10 +736,14 @@ impl Interpreter {
         for warning in crate::parser::take_parse_warnings() {
             self.write_warn_to_stderr(&warning);
         }
-        let (stmts, finish_content) = parse_result?;
+        let (mut stmts, finish_content) = parse_result?;
         if let Some(content) = finish_content {
             self.env.insert("=finish".to_string(), Value::str(content));
         }
+        // Inject builtin prelude role definitions (e.g. the parametric `Rational`
+        // role) when the program references them. These are registered through the
+        // normal RoleDecl/VM path by prepending their statements to the body.
+        Self::inject_prelude_roles(&preprocessed, &mut stmts);
         let (_pre_ph, enter_ph, success_ph, failure_ph, _post_ph, body_main) =
             self.split_block_phasers(&stmts);
         // Register END phasers eagerly (before VM execution) so they run

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3069,6 +3069,14 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
         Value::Instance { attributes, .. } => {
             attributes.get("__mutsu_int_value").and_then(to_float_value)
         }
+        // A numeric type object (e.g. `Rat`, `FatRat`, `Int`) numifies to 0 in
+        // numeric context (Raku warns "Use of uninitialized value"). This makes
+        // `(Rat) == 0` true, matching Rakudo.
+        Value::Package(name) => match name.resolve().as_str() {
+            "Int" | "UInt" | "Rat" | "FatRat" | "Num" | "Rational" | "Complex" | "Numeric"
+            | "Real" | "IntStr" | "RatStr" | "NumStr" | "ComplexStr" => Some(0.0),
+            _ => None,
+        },
         _ => None,
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2948,6 +2948,14 @@ impl Value {
             } if class_name == "Instant" || class_name == "Duration" => {
                 attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0)
             }
+            // A subclass of native Int (e.g. `class Foo is Int`) carries its
+            // integer payload in the reserved `__mutsu_int_value` attribute.
+            Value::Instance { attributes, .. } if attributes.contains_key("__mutsu_int_value") => {
+                attributes
+                    .get("__mutsu_int_value")
+                    .map(|v| v.to_f64())
+                    .unwrap_or(0.0)
+            }
             // Match coerces to Numeric via its matched string
             Value::Instance {
                 class_name,
@@ -2984,6 +2992,13 @@ impl Value {
             Value::Str(s) => s
                 .parse::<NumBigInt>()
                 .unwrap_or_else(|_| NumBigInt::from(0)),
+            // A subclass of native Int (e.g. `class Foo is Int`) carries its
+            // integer payload in the reserved `__mutsu_int_value` attribute.
+            Value::Instance { attributes, .. } => attributes
+                .get("__mutsu_int_value")
+                .map(|v| v.to_bigint())
+                .unwrap_or_else(|| NumBigInt::from(0)),
+            Value::Mixin(inner, _) => inner.to_bigint(),
             _ => NumBigInt::from(0),
         }
     }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -510,7 +510,7 @@ impl VM {
             _ => {
                 // Boolifying a Failure marks it as handled
                 val.mark_failure_handled();
-                Value::Bool(val.truthy())
+                Value::Bool(self.eval_truthy(&val))
             }
         };
         self.stack.push(out);

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -386,6 +386,28 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // `.so` / `.not` on a value whose type defines a user `Bool` method must
+        // dispatch through that method (Mu.so / Mu.not are defined in terms of
+        // .Bool) rather than the native truthiness fast path.
+        if matches!(method.as_str(), "so" | "not") && args.is_empty() {
+            let user_bool_owner = match &target {
+                Value::Instance { class_name, .. } => Some(class_name.resolve()),
+                Value::Package(name) => Some(name.resolve()),
+                _ => None,
+            };
+            if let Some(cn) = user_bool_owner
+                && self
+                    .interpreter
+                    .resolve_method_with_owner(&cn, "Bool", &[])
+                    .is_some()
+            {
+                let t = self.eval_truthy(&target);
+                self.stack
+                    .push(Value::Bool(if method == "not" { !t } else { t }));
+                self.env_dirty = true;
+                return Ok(());
+            }
+        }
         // Beyond the pure-read accessor fast path above, full method dispatch may
         // capture/iterate the env; collapse a transient scoped overlay env to a
         // flat env so the full lexical view is seen. Placed after the accessor

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -217,6 +217,29 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // `.so` / `.not` on a value whose type defines a user `Bool` method must
+        // dispatch through that method (Mu.so / Mu.not are defined in terms of
+        // .Bool) rather than the native truthiness fast path, which is unaware of
+        // user-defined Bool.
+        if matches!(method, "so" | "not") && args.is_empty() {
+            let user_bool_owner = match &target {
+                Value::Instance { class_name, .. } => Some(class_name.resolve()),
+                Value::Package(name) => Some(name.resolve()),
+                _ => None,
+            };
+            if let Some(cn) = user_bool_owner
+                && self
+                    .interpreter
+                    .resolve_method_with_owner(&cn, "Bool", &[])
+                    .is_some()
+            {
+                let t = self.eval_truthy(&target);
+                self.stack
+                    .push(Value::Bool(if method == "not" { !t } else { t }));
+                self.env_dirty = true;
+                return Ok(());
+            }
+        }
         // Full method dispatch from here on may capture the env into a Sub /
         // closure or run an interpreter fallback that iterates it; collapse a
         // transient scoped overlay env to a flat env first so the full lexical
@@ -817,6 +840,16 @@ impl VM {
                         | "isa" | "does" | "can" | "^name" | "^mro" | "^pun" | "new" | "bless"
                         | "clone" | "item" | "self" | "sink" | "pending" => {
                             // Fall through to normal dispatch
+                        }
+                        // Numeric coercion on Nil (an undefined value) warns and
+                        // yields the corresponding numeric type object, e.g.
+                        // `Nil.Rat` is `(Rat)` which numifies to 0.
+                        "Rat" | "FatRat" | "Int" | "Num" | "Complex" if args.is_empty() => {
+                            let msg = "Use of Nil in numeric context".to_string();
+                            return Err(RuntimeError::warn_signal_with_resume(
+                                msg,
+                                Value::Package(Symbol::intern(method)),
+                            ));
                         }
                         _ => {
                             self.stack.push(Value::Nil);

--- a/t/rational-role.t
+++ b/t/rational-role.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 16;
+
+# Parametric Rational role: a user class can compose `does Rational[...]`.
+my class MyRat does Rational[Int, Int] {};
+
+is-deeply MyRat.new(6, 4).nude, (3, 2), 'Rational role normalizes via gcd';
+is-deeply MyRat.new(42, 0).nude, (1, 0), 'zero denominator keeps sign';
+is-deeply MyRat.new(0, 0).nude, (0, 0), 'zero/zero stays zero/zero';
+is-deeply MyRat.new(-42, 42).nude, (-1, 1), 'negative numerator reduces';
+is-deeply MyRat.new(0, 5).nude, (0, 1), 'zero numerator reduces denominator to 1';
+
+# Subclass of a Rational-composing class is still a Rational.
+my class SubRat is MyRat {};
+my $o = SubRat.new(42, 31337);
+ok $o ~~ (SubRat & MyRat & Rational), 'subclass instance smartmatches all three';
+is-deeply $o.nude, (42, 31337), 'coprime numerator/denominator unchanged';
+
+# .Bool / .so dispatch to the role-supplied Bool method.
+ok  MyRat.new(3, 5).Bool, 'nonzero numerator is True';
+nok MyRat.new(0, 5).Bool, 'zero numerator is False';
+nok MyRat.new(0, 5).so,   '.so honors user Bool';
+ok  MyRat.new(3, 5).so,   '.so honors user Bool (true)';
+nok MyRat,                'Rational type object is falsy';
+
+# Int-subclass payload: `class Foo is Int` carries its integer value, and the
+# Rational role preserves the numerator/denominator types.
+my class Foo is Int {};
+class Bar does Rational[Foo, Foo] {};
+my $b = Bar.new(Foo.new(10), Foo.new(20));
+is-deeply $b.numerator,   Foo.new(1), 'numerator keeps NuT type';
+is-deeply $b.denominator, Foo.new(2), 'denominator keeps DeT type';
+is Foo.new(10) gcd Foo.new(4), 2, 'gcd reads Int-subclass payload';
+
+# Numeric coercion of Cool builtins.
+is-deeply Duration.new(42).Rat, <42/1>, 'Duration.Rat is exact';


### PR DESCRIPTION
Makes `roast/S32-num/rat.t` fully pass (869/869, up from 865/869). Each of the four remaining subtests needed a distinct feature, all implemented as general improvements rather than test-specific hacks.

## Changes

- **Parametric `Rational[NuT,DeT]` role** (`src/runtime/run.rs`): a prelude-injected Raku role so user classes can write `does Rational[...]`. Provides a gcd-normalizing `new` (sign handling plus the `1/0`, `0/0` degenerate cases), `nude`, and `Bool`. Injected only when the program references `Rational`.
- **`.so` / `.not` / prefix `?`** (`vm_arith_ops.rs`, `vm_call_method_ops.rs`, `vm_call_method_mut_ops.rs`): now dispatch to a user-defined `Bool` method instead of the native `truthy()` fast path, matching the existing `if`-context behavior.
- **Cool `.Rat` / `.FatRat` coercers** (`dispatch_core_math.rs`): `Duration`, `Instant`, `IO::Path`, `Match`, and `StrDistance` (the last via Levenshtein distance).
- **`Int`-subclass payload reads** (`src/value/mod.rs`): `class Foo is Int` instances expose their integer payload through `to_bigint` / `to_f64` (the `__mutsu_int_value` attribute), so `gcd`, `div`, numeric coercion, and the Rational role's NuT/DeT type preservation all work.
- **`Nil.Rat` / `.FatRat` and numeric type objects** (`vm_call_method_ops.rs`, `utils.rs`): `Nil.Rat` yields the `(Rat)` type object, and numeric type objects numify to 0 in numeric context, so `(Rat) == 0` is true (matching Rakudo).

## Tests

- Adds `t/rational-role.t` (16 subtests).
- Whitelists `roast/S32-num/rat.t`.
- `roast/S32-num/rat.t` 869/869, `fatrat.t`, `comparison.t`, cargo unit tests (449), and clippy all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)