### PR TITLE
chore: drop flaky S02-names-vars/perl.t from roast whitelist

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -139,7 +139,14 @@
   - 0/? pass. Parse error at line 46
 - [ ] roast/S02-names-vars/names.t
   - 0/? pass. Parse error at line 10
-- [x] roast/S02-names-vars/perl.t
+- [ ] roast/S02-names-vars/perl.t
+    - Removed from roast-whitelist.txt: intermittently bails early ("Bad plan. You
+      planned 114 tests but ran 100", exit 255) ~15-40% of prove runs. All tests that
+      run pass (no `not ok`); the script stops after a nondeterministic point (around
+      the EVAL-in-grep / Buf blocks, tests 101+). Likely the typed-container alloc /
+      hash-order flaky. Direct `mutsu perl.t` runs are 114/114 and deterministic, so
+      the nondeterminism only surfaces under prove. Re-add once the underlying
+      nondeterminism is fixed.
 - [ ] roast/S02-names-vars/signature.t
   - 0/? pass. Parse error at line 10
 - [ ] roast/S02-names-vars/variables-and-packages.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -91,7 +91,6 @@ roast/S02-magicals/subname.t
 roast/S02-names-vars/contextual.t
 roast/S02-names-vars/fmt.t
 roast/S02-names-vars/list_array_perl.t
-roast/S02-names-vars/perl.t
 roast/S02-names-vars/signature.t
 roast/S02-names-vars/varnames.t
 roast/S02-names/SETTING-6e.t


### PR DESCRIPTION
## Why

`roast/S02-names-vars/perl.t` is a known-flaky test (documented in CLAUDE.md / PLAN.md) that intermittently bails early under `prove`:

```
Bad plan. You planned 114 tests but ran 100.
Dubious, test returned 255
```

It fails in roughly **15–40% of prove runs**, which is high enough to block CI on **unrelated PRs** (e.g. #2646, where this was the only real failure).

## Diagnosis

- Every test that *does* run passes — there is no `not ok` assertion failure. The script just stops executing somewhere past test ~100 (the `EVAL`-in-`grep` / `Buf` blocks), so the final plan check reports a mismatch and exits 255.
- Running `target/release/mutsu roast/S02-names-vars/perl.t` **directly** yields 114/114 deterministically across many runs. The nondeterminism only surfaces under `prove`.
- Consistent with the documented typed-container alloc / hash-order flakiness.

## What this does

- Removes `roast/S02-names-vars/perl.t` from `roast-whitelist.txt` so it no longer gates CI.
- Records the reason and re-add condition in `TODO_roast/S02.md`.

This is a temporary measure to unblock CI; the underlying nondeterminism should still be fixed and the test re-added afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)