### PR TITLE
Improve S05 angle-brackets: regex <...> metasyntax fixes

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -63,6 +63,20 @@
   - 15/15 pass.
 - [ ] roast/S05-metachars/tilde.t
 - [ ] roast/S05-metasyntax/angle-brackets.t
+  - 51/51 of the runnable subtests pass; the run aborts at test 52 because the
+    `<$subrule>` block (lines 206-217) compiles a string containing a `{...}`
+    code block as a regex, which raises "Prohibited regex interpolation"
+    (X::SecurityPolicy). Real `raku` dies at this exact point too (no
+    MONKEY-SEE-NO-EVAL), so the file cannot reach `plan 95` without
+    implementing MONKEY-SEE-NO-EVAL-style code-string subrules. Later blocks
+    also need `<*literal>` partial-match support (line 267, `#?rakudo skip`).
+  - Fixed in this pass: char-class/Unicode-property capture aliasing
+    (`<foo=[bao]>`, `<bar=-[bao]>`, `<foo=:Letter>`, `<bar=:!Letter>`,
+    `<baz=-:Letter>`); tab as leading whitespace for `<...>` quote words;
+    apostrophes inside long subrule identifiers (`<with'hyphen>`); rejecting a
+    bare metacharacter after a subrule identifier (`<test*>`, `<test|>`,
+    `<test&>`); symbolic indirect subrule `<::($name)>`; and X::Method::NotFound
+    for an unknown subrule method (`<a aa>`).
 - [x] roast/S05-metasyntax/assertions.t
 - [ ] roast/S05-metasyntax/changed.t
 - [ ] roast/S05-metasyntax/charset.t

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -279,6 +279,26 @@ impl Interpreter {
             out
         } else if let RegexAtom::Named(name) = atom {
             let spec = Self::parse_named_regex_lookup_spec(name);
+            // Symbolic indirect subrule `<::(EXPR)>`: evaluate EXPR to obtain
+            // the rule name dynamically, then dispatch as if it were `<NAME>`.
+            // This must resolve through the same path as a literal subrule so
+            // that builtin character classes (e.g. `alpha`) and user-defined
+            // tokens both work.
+            if spec.lookup_name == "::" && spec.arg_exprs.len() == 1 {
+                let Some(val) = self.eval_regex_expr_value(&spec.arg_exprs[0], current_caps) else {
+                    return Vec::new();
+                };
+                let dyn_name = val.to_string_value();
+                let dyn_atom = RegexAtom::Named(dyn_name);
+                return self.regex_match_atom_all_with_capture_in_pkg(
+                    &dyn_atom,
+                    chars,
+                    pos,
+                    current_caps,
+                    pkg,
+                    ignore_case,
+                );
+            }
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
             } else {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -388,6 +388,24 @@ impl Interpreter {
         }
         if let RegexAtom::Named(name) = atom {
             let spec = Self::parse_named_regex_lookup_spec(name);
+            // Symbolic indirect subrule `<::(EXPR)>`: evaluate EXPR to obtain the
+            // dynamic rule name, then dispatch as if it were `<NAME>` so that
+            // builtin character classes and user-defined tokens both resolve.
+            if spec.lookup_name == "::" && spec.arg_exprs.len() == 1 {
+                let val = self.eval_regex_expr_value(&spec.arg_exprs[0], current_caps)?;
+                let dyn_atom = RegexAtom::Named(val.to_string_value());
+                return self
+                    .regex_match_atom_all_with_capture_in_pkg(
+                        &dyn_atom,
+                        chars,
+                        pos,
+                        current_caps,
+                        pkg,
+                        ignore_case,
+                    )
+                    .into_iter()
+                    .last();
+            }
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
             } else {
@@ -655,18 +673,42 @@ impl Interpreter {
             // Named rule not found — report error for valid identifier names.
             // Skip error for names containing special chars (likely parser
             // artifacts from character class syntax like `<[...]>`).
-            if !spec.silent
-                && !spec.lookup_name.is_empty()
-                && spec
-                    .lookup_name
+            //
+            // When the first character after the identifier is whitespace, the
+            // remainder is a regex argument (`<test hat>`), so the method name is
+            // just the leading identifier. Validate and report against that name.
+            let method_name = spec
+                .lookup_name
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            let is_plain_ident = !method_name.is_empty()
+                && method_name
                     .chars()
-                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ':' || c == '.')
-            {
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ':' || c == '.');
+            // If the leading identifier resolves to a known rule/token (e.g. the
+            // space form `<lit 'a'>` passes `'a'` as an argument to the defined
+            // `lit` token), it is not an unknown-method error — just a subrule
+            // call form we do not fully support yet, so fall through.
+            let leading_resolves = is_plain_ident
+                && !self
+                    .resolve_token_patterns_static_in_pkg(&method_name, pkg)
+                    .is_empty();
+            if !spec.silent && is_plain_ident && !leading_resolves {
                 super::super::regex_parse::PENDING_REGEX_ERROR.with(|e| {
-                    *e.borrow_mut() = Some(RuntimeError::new(format!(
+                    let msg = format!(
                         "No such method '{}' for invocant of type 'Match'",
-                        spec.lookup_name
-                    )));
+                        method_name
+                    );
+                    let mut err = RuntimeError::new(msg.clone());
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("message".to_string(), Value::str(msg));
+                    attrs.insert("method".to_string(), Value::str(method_name.clone()));
+                    attrs.insert("typename".to_string(), Value::str("Match".to_string()));
+                    let ex = Value::make_instance(Symbol::intern("X::Method::NotFound"), attrs);
+                    err.exception = Some(Box::new(ex));
+                    *e.borrow_mut() = Some(err);
                 });
                 return None;
             }

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2308,7 +2308,7 @@ impl Interpreter {
                             let mut brace_depth: usize = 0;
                             let mut quote: Option<char> = None;
                             let mut escaped = false;
-                            for ch in chars.by_ref() {
+                            while let Some(ch) = chars.next() {
                                 if let Some(q) = quote {
                                     name.push(ch);
                                     if escaped {
@@ -2333,7 +2333,23 @@ impl Interpreter {
                                     name.push(ch);
                                     continue;
                                 }
+                                // An apostrophe that sits between two identifier
+                                // characters is part of a Raku long identifier
+                                // (e.g. `with'hyphen`), not the start of a quoted
+                                // literal. Only treat `'` as a quote opener when it
+                                // is not flanked by word characters.
+                                let apostrophe_in_ident = ch == '\''
+                                    && name
+                                        .chars()
+                                        .last()
+                                        .is_some_and(|p| p.is_alphanumeric() || p == '_')
+                                    && chars
+                                        .peek()
+                                        .is_some_and(|n| n.is_alphanumeric() || *n == '_');
                                 match ch {
+                                    '\'' if apostrophe_in_ident => {
+                                        name.push(ch);
+                                    }
                                     '\'' | '"' if bracket_depth == 0 => {
                                         quote = Some(ch);
                                         name.push(ch);
@@ -2383,8 +2399,11 @@ impl Interpreter {
                                 }
                             }
                             // Check for word alternation: < word1 word2 ... >
-                            // Starts with a space and contains space-separated words
-                            if name.starts_with(' ') && name.ends_with(' ') {
+                            // In Raku, when the first character after `<` is
+                            // whitespace (space or tab), the contents are treated
+                            // as a list of quoted alternatives rather than a method
+                            // call. (`<a aa>` with no leading whitespace is a call.)
+                            if name.starts_with(|c: char| c.is_whitespace()) {
                                 let words: Vec<&str> = name.split_whitespace().collect();
                                 if !words.is_empty() {
                                     let alternatives: Vec<RegexPattern> = words
@@ -2431,6 +2450,44 @@ impl Interpreter {
                                     RegexAtom::ZeroWidth
                                 }
                             } else {
+                                // Handle aliasing of a char-class / Unicode-property
+                                // assertion to a named capture, e.g. `<foo=[bao]>`,
+                                // `<bar=-[bao]>`, `<foo=:Letter>`, `<bar=:!Letter>`,
+                                // `<baz=-:Letter>`. The general `<name=subrule>` aliasing
+                                // (for named rules) is resolved at match time via
+                                // parse_named_regex_lookup_spec, but char classes and
+                                // Unicode properties are parsed into dedicated atoms here,
+                                // so we strip the `ident=` prefix and record the alias as
+                                // the pending named capture before dispatching on the RHS.
+                                {
+                                    let t = name.trim();
+                                    if let Some(eq_pos) = t.find('=') {
+                                        let lhs = t[..eq_pos].trim();
+                                        let rhs = t[eq_pos + 1..].trim();
+                                        let lhs_is_ident = !lhs.is_empty()
+                                            && lhs
+                                                .chars()
+                                                .next()
+                                                .is_some_and(|c| c.is_alphabetic() || c == '_')
+                                            && lhs.chars().all(|c| {
+                                                c.is_alphanumeric()
+                                                    || c == '_'
+                                                    || c == '-'
+                                                    || c == '\''
+                                            });
+                                        let rhs_is_class_or_prop = rhs.starts_with('[')
+                                            || rhs.starts_with("-[")
+                                            || rhs.starts_with("+[")
+                                            || rhs.starts_with(':')
+                                            || rhs.starts_with("-:")
+                                            || rhs.starts_with(":!")
+                                            || rhs.starts_with("!:");
+                                        if lhs_is_ident && rhs_is_class_or_prop {
+                                            pending_named_capture = Some(lhs.to_string());
+                                            name = rhs.to_string();
+                                        }
+                                    }
+                                }
                                 // Check for Raku character class: <[...]>, <-[...]>, <+[...]>
                                 // Also handles composite: <[a..z]-[aeiou]>, <+[a..z]-[aeiou]-[y]>
                                 let trimmed = name.trim();
@@ -2556,6 +2613,12 @@ impl Interpreter {
                                             RegexAtom::Named(name)
                                         }
                                     } // close else (non-empty negated_name)
+                                } else if trimmed.starts_with("::") {
+                                    // <::($expr)> — symbolic indirect subrule. The
+                                    // double colon distinguishes it from a `<:PropName>`
+                                    // Unicode-property assertion; keep it as a Named atom
+                                    // so the dynamic name is resolved at match time.
+                                    RegexAtom::Named(name)
                                 } else if trimmed.starts_with(":!") || trimmed.starts_with("-:") {
                                     // <:!PropName> or <-:PropName> — negated Unicode property
                                     let prop_name = &trimmed[2..];
@@ -2817,6 +2880,21 @@ impl Interpreter {
                                                     PENDING_REGEX_ERROR.with(|e| {
                                                         *e.borrow_mut() =
                                                             Some(Self::make_longname_alias_error());
+                                                    });
+                                                    return None;
+                                                }
+                                                // No other characters are allowed after the
+                                                // initial identifier of a subrule assertion
+                                                // (S05). e.g. `<test*>`, `<test|>`, `<test&>`
+                                                // are malformed and must be rejected at compile
+                                                // time. Validate that the leading identifier is
+                                                // followed only by an allowed continuation
+                                                // (whitespace, `=`, `:`, `(`) or end of name.
+                                                if let Some(err) =
+                                                    Self::check_subrule_name_tail(class_name)
+                                                {
+                                                    PENDING_REGEX_ERROR.with(|e| {
+                                                        *e.borrow_mut() = Some(err);
                                                     });
                                                     return None;
                                                 }
@@ -3966,6 +4044,46 @@ impl Interpreter {
             return true;
         }
         false
+    }
+
+    /// Validate the tail of a subrule-assertion name. Per S05, no characters
+    /// other than the recognised continuations may follow the initial
+    /// identifier of a `<ident...>` subrule. Returns a malformed-regex error
+    /// when, for example, a bare regex metacharacter (`*`, `|`, `&`, ...)
+    /// immediately follows the identifier (e.g. `<test*>`).
+    pub(super) fn check_subrule_name_tail(name: &str) -> Option<RuntimeError> {
+        let mut chars = name.chars().peekable();
+        // The leading identifier must start with an alphabetic char or `_`.
+        match chars.peek() {
+            Some(c) if c.is_alphabetic() || *c == '_' => {}
+            _ => return None,
+        }
+        // Consume the (possibly long) identifier: word characters plus the
+        // intra-identifier connectors `-`, `'`, and `::` package separators.
+        while let Some(&c) = chars.peek() {
+            if c.is_alphanumeric() || c == '_' || c == '-' || c == '\'' || c == ':' {
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        // Whatever remains is the tail. An empty tail or a tail beginning with
+        // an allowed continuation is fine; anything else is malformed.
+        match chars.peek() {
+            // End of name, argument list, alias, method-args, or a passed regex.
+            None | Some('(') | Some('=') => None,
+            Some(c) if c.is_whitespace() => None,
+            Some(_) => {
+                let msg = "Unable to parse regex; couldn't find delimiter";
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("message".to_string(), Value::str(msg.to_string()));
+                let ex =
+                    Value::make_instance(Symbol::intern("X::Syntax::Regex::Unterminated"), attrs);
+                let mut err = RuntimeError::new(msg);
+                err.exception = Some(Box::new(ex));
+                Some(err)
+            }
+        }
     }
 
     /// Create an X::Syntax::Regex::Alias::LongName error.


### PR DESCRIPTION
## Summary

Fixes six independent regex `<...>` assertion features exercised by `roast/S05-metasyntax/angle-brackets.t`, taking it from **40/51 to 51/51** of the runnable subtests passing.

The file still cannot reach `plan 95`: the run aborts at test 52 on the `<$subrule>` block (lines 206-217), which compiles a string containing a `{...}` code block as a regex and raises "Prohibited regex interpolation" (X::SecurityPolicy). Real `raku` dies at the exact same point (no MONKEY-SEE-NO-EVAL), so it is not whitelisted; remaining blockers are recorded in `TODO_roast/S05.md`.

## Changes

- **Char-class / Unicode-property capture aliasing**: `<foo=[bao]>`, `<bar=-[bao]>`, `<foo=:Letter>`, `<bar=:!Letter>`, `<baz=-:Letter>`.
- **Tab as quote-words marker**: a leading tab (not just space) after `<` triggers the quoted-alternatives form.
- **Apostrophes in long subrule identifiers** (`<with'hyphen>`).
- **Reject trailing metacharacters** after a subrule identifier (`<test*>`, `<test|>`, `<test&>`).
- **Symbolic indirect subrule** `<::(EXPR)>`: evaluate EXPR to the rule name at match time and dispatch as `<NAME>`.
- **X::Method::NotFound** for an unknown subrule method (`<a aa>`), while still falling through for the space-arg form `<lit 'a'>`.

## Testing

- `roast/S05-metasyntax/angle-brackets.t`: 51 run / 0 failed (was 51 run / 11 failed).
- Whitelisted S05 regex tests all still pass — no regressions.
- `cargo clippy -- -D warnings` and `cargo fmt` clean; `t/` prove suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)