### PR TITLE
docs: document S05-nonstrings/basic.t as blocked (obsolete spec)

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -118,6 +118,22 @@
 - [ ] roast/S05-modifier/samemark.t
 - [ ] roast/S05-modifier/sigspace.t
 - [ ] roast/S05-nonstrings/basic.t
+    - BLOCKED (obsolete spec): relies on the early-Perl-6 "match regex against
+      non-strings" feature (streams/arrays) that was never implemented in Rakudo
+      and removed from the language. Cannot be made to pass without test-specific
+      hacks that contradict modern Raku semantics. Confirmed against Rakudo
+      v2022.12, which also fails to compile/run this file:
+      - `cat $fh.lines` — `cat` is an undeclared routine in modern Raku (removed).
+      - `$stream ~~ /<cheese>/` — matching a rule against a stream is unsupported.
+      - `@array ~~ /<canine>/` with `<.isa(Dog)>` — matching a rule against array
+        elements via `<.isa(...)>` is unsupported (Rakudo: "No such method
+        'canine' for invocant of type 'Match'").
+      - `<.isa(::Antelope)>` — `::Antelope` is an undefined symbol; Rakudo errors
+        with "No such symbol 'Antelope'".
+      - `is(+(@names>>.match($arrr)), 2, ...)` — expects 2 under obsolete semantics
+        where `+` summed the boolean truth of a list of Match objects; modern Raku
+        (and mutsu) returns 4 (`.elems` of the result list).
+      Not whitelisted; would require implementing removed language semantics.
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t


### PR DESCRIPTION
## Summary

`roast/S05-nonstrings/basic.t` plans 5 tests but runs 0 (it dies during execution before any assertion). Investigation shows the test relies on the early-Perl-6 "match a regex against non-strings" feature — matching rules against **streams** (`cat $fh.lines`) and **array elements** (`<.isa(Dog)>`). This feature was specced in S05 but never implemented in Rakudo and has since been removed from the language.

This test is **not passable by any modern Raku implementation**. Confirmed against reference Rakudo v2022.12, which also fails to compile/run the file:

- `cat $fh.lines` — `cat` is an undeclared routine in modern Raku (removed).
- `$stream ~~ /<cheese>/` — matching a rule against a stream is unsupported.
- `@array ~~ /<canine>/` with `<.isa(Dog)>` — matching a rule against array elements is unsupported (Rakudo: `No such method 'canine' for invocant of type 'Match'`).
- `<.isa(::Antelope)>` — `::Antelope` is undefined (Rakudo: `No such symbol 'Antelope'`).
- `is(+(@names>>.match($arrr)), 2, ...)` — expects `2` under obsolete semantics where `+` summed the boolean truth of a list of `Match` objects; modern Raku (and mutsu) returns `4` (the `.elems` of the result list).

Making this pass would require implementing removed language semantics or test-specific hacks that contradict modern Raku — both forbidden by the project rules. Therefore this PR documents it as a blocker in `TODO_roast/S05.md` and does **not** whitelist it.

## Changes

- `TODO_roast/S05.md`: detailed blocker note for `roast/S05-nonstrings/basic.t`.

No interpreter code changes; no whitelist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)