### PR TITLE
regex: fix ratchet backtracking-control and leading-null alternatives (S05-mass/rx, recursive)

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -35,18 +35,29 @@
 - [ ] roast/S05-mass/properties-general.t
 - [x] roast/S05-mass/properties-script.t
   - 360/360 pass.
-- [ ] roast/S05-mass/recursive.t
-  - Blocker: needs semantic distinction between `|` (LTM) and `||` (ordered
-    alternation). mutsu currently collapses both to a single `Alternation`
-    variant and picks longest-match via LIFO stack ordering, so `<?> || x <&r>`
-    prefers the longer `x <&r>` branch instead of committing to the zero-width
-    first alternative. Fixing requires a new `OrderedAlternation` atom plumbed
-    through regex_parse, regex_match_atom, regex_match_atom_simple,
-    regex_match_capture, regex_helpers, and methods_grammar.
-  - Additional blocker: tests 17-20 use a left-recursive regex
-    `regex r2 { <?> | <&r2> x }` which causes a stack overflow. Requires
-    left-recursion detection/seeding in the backtracking engine.
+- [x] roast/S05-mass/recursive.t
+  - 20/20 pass. `||` ordered alternation and left-recursion seeding are now
+    implemented; the recursive/left-recursive regexes match correctly.
 - [ ] roast/S05-mass/rx.t
+  - Backtracking-control core fixed: per-token ratchet (`:`) now commits to the
+    atom's highest-priority match (first `||` alternative / longest `|`/greedy
+    match) instead of always the longest, so `( ab || abc ): de` correctly
+    fails ("no backtrack into subpattern"). Leading null `||`/`|` alternatives
+    inside `[...]`/`(...)` groups are now ignored (Raku semantics) instead of
+    introducing a spurious empty-winning branch under ratchet.
+  - Not whitelistable: rakudo itself cannot compile this file (`::` backtracking
+    control is NYI in Rakudo — it dies at compile time on line 38), so the file
+    is not fully passable upstream either.
+  - Remaining mutsu blockers (after the backtracking fix, run aborts at test 20):
+    - `<commit>` named assertion (line 93) is NYI and raises a runtime error
+      ("No such method 'commit'") that aborts the whole file. Marked
+      `#?rakudo todo '<commit> NYI'` upstream.
+    - Many later subtests use `throws-like` against specific compile-time regex
+      exception types (`X::Obsolete`, `X::Syntax::Regex::NullRegex`,
+      `X::Comp::Group`, ...) for retired metachars (`\A \Z \z \p \P \L \U \Q \G
+      \1`), null-regex diagnostics, and char-class parse errors.
+    - `::` / `:::` / `<commit>` group/rule cut semantics are not implemented
+      (currently treated as `#?rakudo skip` passes).
 - [ ] roast/S05-mass/stdrules.t
 - [ ] roast/S05-match/arrayhash.t
   - 5/9 pass. Previously passed with wrong parsing (/ treated as division). Now regex is correctly parsed but anchored regex (^ $) doesn't match correctly against array elements in smartmatch.

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -191,8 +191,14 @@ impl Interpreter {
                         pattern.ignore_case,
                     );
                     if token.ratchet {
-                        candidates
-                            .sort_by_key(|(next, c)| (*next, c.positional.len(), c.named.len()));
+                        // Ratchet (`:`) commits to the atom's highest-priority match
+                        // and forbids backtracking into it. Candidates are returned in
+                        // "lowest priority first, highest priority last" order, so the
+                        // atom's preferred match is the last element: for `||` it is the
+                        // first alternative, for `|`/greedy quantifiers it is the longest
+                        // match — both already sit last. Keep only that one. (Sorting by
+                        // length here was wrong: it picked the longest match even for `||`,
+                        // letting `( ab || abc ): de` backtrack into the group.)
                         if let Some(best) = candidates.pop() {
                             candidates = vec![best];
                         }
@@ -221,8 +227,8 @@ impl Interpreter {
                         pattern.ignore_case,
                     );
                     if token.ratchet {
-                        candidates
-                            .sort_by_key(|(next, c)| (*next, c.positional.len(), c.named.len()));
+                        // Same as the `One` case: commit to the atom's highest-priority
+                        // match (the last candidate), not the longest one.
                         if let Some(best) = candidates.pop() {
                             // Atom matched — commit to the match (no backtracking)
                             candidates = vec![best];

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2924,7 +2924,14 @@ impl Interpreter {
                     let needs_capture_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();
-                        for alt in alternatives {
+                        for (alt_idx, alt) in alternatives.iter().enumerate() {
+                            // A leading null alternative is ignored in Raku: `( || X )`
+                            // and `( | X )` behave like `( X )`. Skip a whitespace-only
+                            // first alternative so it does not contribute a spurious
+                            // empty-matching (and, under ratchet, empty-winning) branch.
+                            if alt_idx == 0 && alt.trim().is_empty() {
+                                continue;
+                            }
                             let parsed_alt = if needs_capture_scope {
                                 let mut scoped = String::new();
                                 if ignore_case {
@@ -2940,40 +2947,46 @@ impl Interpreter {
                                     scoped.push_str(":m ");
                                 }
                                 if sigspace {
-                                    scoped.push_str(&alt);
+                                    scoped.push_str(alt);
                                 } else {
                                     scoped.push_str(alt.trim_end());
                                 }
                                 self.parse_regex(&scoped)
                             } else {
-                                self.parse_regex(&alt)
+                                self.parse_regex(alt)
                             };
                             if let Some(p) = parsed_alt {
                                 alt_patterns.push(p);
                             }
                         }
-                        let group_atom = if cap_is_sequential {
-                            RegexAtom::SequentialAlternation(alt_patterns)
+                        if alt_patterns.len() == 1 {
+                            // Only one real alternative remained after dropping the
+                            // leading null: treat it as a plain (capturing) group.
+                            RegexAtom::CaptureGroup(alt_patterns.into_iter().next().unwrap())
                         } else {
-                            try_collapse_alternation_to_charclass(&alt_patterns)
-                                .unwrap_or(RegexAtom::Alternation(alt_patterns))
-                        };
-                        let group_pat = RegexPattern {
-                            tokens: vec![RegexToken {
-                                atom: group_atom,
-                                quant: RegexQuant::One,
-                                named_capture: None,
-                                hash_capture: None,
-                                secondary_named_capture: None,
-                                ratchet: false,
-                                frugal: false,
-                            }],
-                            anchor_start: false,
-                            anchor_end: false,
-                            ignore_case,
-                            ignore_mark,
-                        };
-                        RegexAtom::CaptureGroup(group_pat)
+                            let group_atom = if cap_is_sequential {
+                                RegexAtom::SequentialAlternation(alt_patterns)
+                            } else {
+                                try_collapse_alternation_to_charclass(&alt_patterns)
+                                    .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                            };
+                            let group_pat = RegexPattern {
+                                tokens: vec![RegexToken {
+                                    atom: group_atom,
+                                    quant: RegexQuant::One,
+                                    named_capture: None,
+                                    hash_capture: None,
+                                    secondary_named_capture: None,
+                                    ratchet: false,
+                                    frugal: false,
+                                }],
+                                anchor_start: false,
+                                anchor_end: false,
+                                ignore_case,
+                                ignore_mark,
+                            };
+                            RegexAtom::CaptureGroup(group_pat)
+                        }
                     } else {
                         let parsed_group = if needs_capture_scope {
                             let mut scoped = String::new();
@@ -3030,7 +3043,14 @@ impl Interpreter {
                     let needs_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();
-                        for alt in alternatives {
+                        for (alt_idx, alt) in alternatives.iter().enumerate() {
+                            // A leading null alternative is ignored in Raku: `[ || X ]`
+                            // and `[ | X ]` behave like `[ X ]`. Skip a whitespace-only
+                            // first alternative so it does not contribute a spurious
+                            // empty-matching (and, under ratchet, empty-winning) branch.
+                            if alt_idx == 0 && alt.trim().is_empty() {
+                                continue;
+                            }
                             let parsed_alt = if needs_scope {
                                 let mut scoped = String::new();
                                 if ignore_case {
@@ -3048,19 +3068,23 @@ impl Interpreter {
                                 // In sigspace mode, preserve trailing whitespace so it
                                 // becomes \s* — needed for quantified groups.
                                 if sigspace {
-                                    scoped.push_str(&alt);
+                                    scoped.push_str(alt);
                                 } else {
                                     scoped.push_str(alt.trim_end());
                                 }
                                 self.parse_regex(&scoped)
                             } else {
-                                self.parse_regex(&alt)
+                                self.parse_regex(alt)
                             };
                             if let Some(p) = parsed_alt {
                                 alt_patterns.push(p);
                             }
                         }
-                        if bracket_is_sequential {
+                        if alt_patterns.len() == 1 {
+                            // Only one real alternative remained after dropping the
+                            // leading null: treat it as a plain non-capturing group.
+                            RegexAtom::Group(alt_patterns.into_iter().next().unwrap())
+                        } else if bracket_is_sequential {
                             RegexAtom::SequentialAlternation(alt_patterns)
                         } else {
                             try_collapse_alternation_to_charclass(&alt_patterns)


### PR DESCRIPTION
## Summary

Fixes the regex backtracking-control core targeted by `roast/S05-mass/rx.t` and confirms `roast/S05-mass/recursive.t` (20/20, already whitelisted).

### Ratchet (`:` / `:ratchet`) commits to highest-priority match, not longest
The matcher implemented ratchet (no-backtrack-into-atom) by sorting candidates by length and keeping the longest. That is wrong for ordered alternation: `( ab || abc ): de` committed to `abc` (longest) instead of `ab` (first `||` alternative), so it matched when the spec requires it to fail ("no backtrack into subpattern"). Candidates are already returned in "lowest-priority-first, highest-priority-last" order, so the fix is to keep the **last** candidate rather than sort by length. Greedy ratchet (`\d+:`, `a*: a`) and LTM ratchet (`[ ab | abc ]:`) still behave correctly.

### Leading null `||`/`|` alternatives in groups are ignored
Keeping the highest-priority candidate exposed a latent bug: a leading null alternative inside a `[...]`/`(...)` group (e.g. `[ || X ]`, as grammar tokens write `token TOP { [ || [ <line> ]+ ] }`) was parsed into an empty-matching first alternative. Under ratchet that empty branch became highest-priority and won, so the group matched nothing. Raku ignores a leading null alternative; we now skip a whitespace-only first alternative in both group paths (collapsing to a plain group when one real alternative remains), matching what top-level `parse_regex` already did.

## Results
- `S05-mass/recursive.t`: 20/20 (whitelisted; TODO marked `[x]`).
- `S05-mass/rx.t`: backtracking core now correct. **Not whitelistable** — rakudo itself cannot compile this file (`::` backtracking control is NYI upstream, dies at compile on line 38), and `<commit>` / typed compile-time regex errors remain NYI in mutsu. Blockers documented in `TODO_roast/S05.md`.
- No regressions across the full S05 whitelist (5144 subtests) or the `t/` suite. Also fixes a latent issue in `S05-grammar/parse_and_parsefile-6e.t` that the ratchet change first exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)