### PR TITLE
Improve S05-substitution/subst.t: List/Match $/ results, multi-:nth, adverb errors

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -121,6 +121,33 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
+  - 168/191 pass (was aborting at test 132 before). Remaining 23 failures span
+    several distinct features:
+  - 85, 86: `s///` / `ss///` against a string literal (`'abc' ~~ s/b/g/`) must
+    die (read-only container) — mutsu silently no-ops on a non-lvalue topic.
+  - 100, 102, 104: `:mm`/samemark with combining marks (e.g. `W̊`, `x̱`, `ý`) —
+    samemark per-character combining-mark transfer is NYI.
+  - 146-152: `.subst` `:samecase`/`:samemark` adverbs are parsed but not applied
+    in `dispatch_subst` (`_samecase` etc. are unused); `:samecase` with block
+    replacement also unimplemented.
+  - 156: `s:i($i)/.../` must throw `X::Value::Dynamic` (non-constant adverb).
+  - 159: `s///` on a read-only `$_` (method `$_` param) must die.
+  - 161, 169: empty pattern `s[] = ...` must throw `X::Syntax::Regex::NullRegex`.
+  - 162: `.subst(/(\w)/, { $m = $/[0] })` — closure mutation of an outer var is
+    discarded (subst closure env is cloned and restored, losing writeback).
+  - 181: invalid `:x` argument must throw `X::Str::Match::x` (type now
+    registered, but `.subst` does not yet validate/throw).
+  - 184, 186: `:x(1..3)` range argument to `:x` in operator/method form (opcode
+    `x_count` is a single `u32`, cannot carry a range); `.subst` does not set
+    `$/` to a List of matches for multi-match adverbs.
+  - 187-190: placeholder params (`$^a`) inside `S{...}=...` are captured by the
+    substitution's synthetic closure instead of the enclosing block.
+  - Fixed in this pass: `:g`/`:x`/multi-`:nth` now return a List of Match in `$/`
+    (single `:nth(N)` stays a Match even with `:g`); `s:g[...] = expr` with
+    captures/`$/`/`$0` on the RHS evaluated per match; multi-value `:nth(a,b)`
+    and `:nth` validation (must be >= 1 and increasing); `:overlap`/`:exhaustive`
+    rejected on substitutions with `X::Syntax::Regex::Adverb`; `ss (foo) = '...'`
+    paren-delimiter form; `S///` sets `$/`; `X::Str::Match::x` registered.
 - [ ] roast/S05-syntactic-categories/new-symbols.t
 - [x] roast/S05-transliteration/79778.t
 - [ ] roast/S05-transliteration/trans.t

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -53,6 +53,26 @@ fn regex_adverb_error(adverb: &str, message: impl Into<String>) -> PError {
     PError::fatal_with_exception(message, exception)
 }
 
+/// Reject adverbs that make no sense on a substitution. `:overlap`/`:ov` and
+/// `:exhaustive`/`:ex` are only meaningful for matching (there is no way to
+/// substitute overlapping matches), so Raku rejects them at compile time with
+/// X::Syntax::Regex::Adverb.
+fn reject_subst_only_adverbs(adverbs: &MatchAdverbs) -> Result<(), PError> {
+    if adverbs.overlap {
+        return Err(regex_adverb_error(
+            "overlap",
+            "Adverb overlap not allowed on substitution",
+        ));
+    }
+    if adverbs.exhaustive {
+        return Err(regex_adverb_error(
+            "exhaustive",
+            "Adverb exhaustive not allowed on substitution",
+        ));
+    }
+    Ok(())
+}
+
 /// Reject obsolete Perl 5 trailing regex modifiers (e.g., m/pattern/i, m/pattern/g).
 /// In Raku, adverbs come before the delimiter (:i, :g), not after.
 fn reject_trailing_p5_modifiers(rest: &str) -> Result<(), PError> {
@@ -490,17 +510,14 @@ fn build_topic_subst_compound_expr(
     })
 }
 
+/// Build a destructive `s[pattern] = expr` substitution lowered to
+/// `$_ = $_.subst(pattern, { expr })`. Used for Perl5 substitutions, whose
+/// closure replacement must bind Perl5 captures via the `.subst` method.
 fn build_topic_subst_expr(
     pattern: String,
     replacement: Expr,
     adverbs: &MatchAdverbs,
 ) -> Result<Expr, PError> {
-    if adverbs.nth.is_some() || adverbs.repeat.is_some() {
-        return Err(PError::expected(
-            "s/// replacement expression without :nth or :x",
-        ));
-    }
-
     let pattern = if adverbs.perl5 {
         pattern
     } else {
@@ -1196,11 +1213,15 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
 
     // ss/pattern/replacement/ — shorthand for s:ss/.../.../
     // Also supports adverbs: ss:g/pattern/replacement/
+    // `ss` additionally allows whitespace before a bracketing delimiter
+    // (e.g. `ss (foo) = 'bar'`), since `ss` is always a substitution.
     if let Some(after_ss) = input.strip_prefix("ss")
         && !crate::parser::stmt::simple::is_user_declared_sub("ss")
         && let Some(first_ch) = after_ss.chars().next()
         && (first_ch == ':'
-            || (!first_ch.is_alphanumeric() && first_ch != '_' && !first_ch.is_whitespace()))
+            || (!first_ch.is_alphanumeric() && first_ch != '_' && !first_ch.is_whitespace())
+            || (first_ch.is_whitespace()
+                && after_ss.trim_start().starts_with(['(', '[', '{', '<'])))
     {
         let (spec, mut adverbs) = if first_ch == ':' {
             parse_match_adverbs(after_ss)?
@@ -1210,7 +1231,11 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
         // ss implies :ss (:samespace + :sigspace)
         adverbs.samespace = true;
         adverbs.sigspace = true;
-        let spec = if first_ch == ':' { ws(spec)?.0 } else { spec };
+        let spec = if first_ch == ':' || first_ch.is_whitespace() {
+            ws(spec)?.0
+        } else {
+            spec
+        };
         if let Some(open_ch) = spec.chars().next() {
             let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
             let looks_like_method = open_ch == '.'
@@ -1218,6 +1243,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
                 && spec[2..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-');
             if is_delim && !looks_like_method {
+                reject_subst_only_adverbs(&adverbs)?;
                 let (close_ch, is_paired) = match open_ch {
                     '{' => ('}', true),
                     '[' => (']', true),
@@ -1267,6 +1293,36 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                             },
                         ));
                     }
+                    // Bracketing `ss[pattern] = replacement` assignment form.
+                    if is_paired {
+                        let (after_pat_ws, _) = ws(after_pat)?;
+                        if let Some(after_eq) = after_pat_ws.strip_prefix('=')
+                            && let Ok((rest, replacement)) = parse_subst_replacement_expr(after_eq)
+                        {
+                            let pattern = if adverbs.perl5 {
+                                pattern.to_string()
+                            } else {
+                                let p = apply_inline_match_adverbs(pattern.to_string(), &adverbs);
+                                validate_regex_pattern_or_perror(&p)?;
+                                p
+                            };
+                            return Ok((
+                                rest,
+                                Expr::Subst {
+                                    pattern,
+                                    replacement,
+                                    samecase: adverbs.samecase,
+                                    sigspace: adverbs.sigspace,
+                                    samemark: adverbs.samemark,
+                                    samespace: adverbs.samespace,
+                                    global: adverbs.global,
+                                    nth: adverbs.nth.clone(),
+                                    x: adverbs.repeat,
+                                    perl5: adverbs.perl5,
+                                },
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -1297,6 +1353,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
                 && spec[2..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-');
             if is_delim && !looks_like_method {
+                reject_subst_only_adverbs(&adverbs)?;
                 let (close_ch, is_paired) = match open_ch {
                     '{' => ('}', true),
                     '[' => (']', true),
@@ -1413,10 +1470,50 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                             ));
                         }
                         let (after_eq_ws, _) = ws(after_eq)?;
-                        let (rest, replacement) = expression(after_eq_ws)?;
+                        let (rest, replacement_expr) = expression(after_eq_ws)?;
+                        // Perl5 substitutions keep the legacy `$_ = $_.subst(...)`
+                        // lowering: the `.subst` closure path binds Perl5 captures
+                        // (`$1`, `$0`, ...) correctly per match, which the generic
+                        // Subst interpolator cannot reproduce for Perl5 regex.
+                        if adverbs.perl5 {
+                            return Ok((
+                                rest,
+                                build_topic_subst_expr(
+                                    pattern.to_string(),
+                                    replacement_expr,
+                                    &adverbs,
+                                )?,
+                            ));
+                        }
+                        // Capture the raw replacement source so the substitution
+                        // can be compiled to a `Subst` node. Compiling to `Subst`
+                        // (rather than `$_ = $_.subst(...)`) makes the expression
+                        // value the proper Match / List-of-Match result (so e.g.
+                        // `+(s:g[(\w)] = $0 x 2)` yields the match count) and sets
+                        // `$/` to a List under `:g`.
+                        let consumed = after_eq_ws.len() - rest.len();
+                        let raw_replacement = after_eq_ws[..consumed].trim().to_string();
+                        let p = apply_inline_match_adverbs(pattern.to_string(), &adverbs);
+                        validate_regex_pattern_or_perror(&p)?;
+                        let pattern = p;
+                        // Wrap the RHS expression in a `{...}` closure block so the
+                        // substitution-replacement interpolator evaluates it once per
+                        // match with `$/`, `$0`, ... bound to that match.
+                        let replacement = format!("{{{raw_replacement}}}");
                         return Ok((
                             rest,
-                            build_topic_subst_expr(pattern.to_string(), replacement, &adverbs)?,
+                            Expr::Subst {
+                                pattern,
+                                replacement,
+                                samecase: adverbs.samecase,
+                                sigspace: adverbs.sigspace,
+                                samemark: adverbs.samemark,
+                                samespace: adverbs.samespace,
+                                global: adverbs.global,
+                                nth: adverbs.nth.clone(),
+                                x: adverbs.repeat,
+                                perl5: adverbs.perl5,
+                            },
                         ));
                     }
                 }
@@ -1439,6 +1536,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
                 && spec[2..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-');
             if is_delim && !looks_like_method {
+                reject_subst_only_adverbs(&adverbs)?;
                 let (close_ch, is_paired) = match open_ch {
                     '{' => ('}', true),
                     '[' => (']', true),

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -491,6 +491,28 @@ impl Interpreter {
             .map(|ch| reverse.get(&ch).copied().unwrap_or(b'?'))
             .collect()
     }
+    /// Validate an `:nth` index list for substitution: every index must be at
+    /// least 1 and the list must be monotonically increasing. Rakudo's lazy
+    /// match iterator cannot rewind, so a non-increasing list (e.g.
+    /// `:nth(2,4,1,6)`) or a zero/negative index throws.
+    fn validate_subst_nth_list(nth_list: &[i64]) -> Result<(), RuntimeError> {
+        let mut prev: i64 = 0;
+        for &n in nth_list {
+            if n < 1 {
+                return Err(RuntimeError::new(format!(
+                    "Attempt to retrieve before :1st match -- :nth({n})"
+                )));
+            }
+            if n < prev {
+                return Err(RuntimeError::new(format!(
+                    "Attempt to fetch match #{n} after #{prev}"
+                )));
+            }
+            prev = n;
+        }
+        Ok(())
+    }
+
     pub(super) fn dispatch_subst(
         &mut self,
         target: Value,
@@ -639,15 +661,14 @@ impl Interpreter {
 
                     // Apply :nth - select specific 1-based match indices
                     if let Some(ref nth_list) = nth {
+                        Self::validate_subst_nth_list(nth_list)?;
                         let total = selected.len();
                         let mut indices: Vec<usize> = Vec::new();
                         for &n in nth_list {
-                            if n >= 1 && (n as usize) <= total {
+                            if (n as usize) <= total && !indices.contains(&(n as usize - 1)) {
                                 indices.push(n as usize - 1);
                             }
                         }
-                        indices.sort();
-                        indices.dedup();
                         let new_selected: Vec<_> = indices
                             .iter()
                             .filter_map(|&i| selected.get(i).cloned())
@@ -769,15 +790,17 @@ impl Interpreter {
                         keep.truncate(1);
                     }
                     if let Some(ref nth_list) = nth {
+                        Self::validate_subst_nth_list(nth_list)?;
                         let total = keep.len();
                         let mut selected: Vec<usize> = Vec::new();
                         for &n in nth_list {
-                            if n >= 1 && (n as usize) <= total {
-                                selected.push(keep[n as usize - 1]);
+                            if (n as usize) <= total {
+                                let chosen = keep[n as usize - 1];
+                                if !selected.contains(&chosen) {
+                                    selected.push(chosen);
+                                }
                             }
                         }
-                        selected.sort();
-                        selected.dedup();
                         keep = selected;
                     }
                     if let Some((lo, hi)) = resolve_x_count(&x_count) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2733,6 +2733,9 @@ impl Interpreter {
         // X::Str::Numeric
         register_x("X::Str::Numeric", "Exception");
 
+        // X::Str::Match::x — invalid :x argument to .subst / s///
+        register_x("X::Str::Match::x", "Exception");
+
         // X::Multi::NoMatch / X::Multi::Ambiguous
         register_x("X::Multi::NoMatch", "Exception");
         register_x("X::Multi::Ambiguous", "Exception");

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -424,7 +424,15 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let pattern = Self::const_str(code, pattern_idx).to_string();
         let raw_replacement = normalize_subst_replacement(Self::const_str(code, replacement_idx));
-        let replacement = self.interpolate_subst_replacement_with_closures(&raw_replacement);
+        // A replacement containing a `{...}` code block (e.g. from `s[...] = $0 x 2`)
+        // must be evaluated *per match*, with `$/`, `$0`, ... bound to that match.
+        // For replacements without code blocks, interpolate once up front.
+        let has_code_block = raw_replacement.contains('{');
+        let replacement = if has_code_block {
+            raw_replacement.clone()
+        } else {
+            self.interpolate_subst_replacement_with_closures(&raw_replacement)
+        };
 
         let nth_spec = nth_idx.map(|idx| Self::const_str(code, idx).to_string());
         let x_count = x_count.map(|n| n as usize);
@@ -478,17 +486,30 @@ impl VM {
                     .interpreter
                     .regex_find_first_from_with_captures(&pattern, &text, 0);
                 if let Some((start, end, captures)) = found {
-                    // Expand $0, $1, ... in the replacement with captured groups
-                    let expanded = expand_capture_refs(&replacement, &captures);
-                    let out = Self::apply_substitutions(
-                        &text,
-                        &[(start, end)],
-                        &expanded,
-                        samecase,
-                        sigspace,
-                        samemark,
-                        samespace,
-                    );
+                    let out = if has_code_block {
+                        self.apply_substitutions_dynamic(
+                            &text,
+                            &[(start, end)],
+                            &raw_replacement,
+                            std::slice::from_ref(&captures),
+                            samecase,
+                            sigspace,
+                            samemark,
+                            samespace,
+                        )
+                    } else {
+                        // Expand $0, $1, ... in the replacement with captured groups
+                        let expanded = expand_capture_refs(&replacement, &captures);
+                        Self::apply_substitutions(
+                            &text,
+                            &[(start, end)],
+                            &expanded,
+                            samecase,
+                            sigspace,
+                            samemark,
+                            samespace,
+                        )
+                    };
                     let result = Value::str(out);
                     self.interpreter
                         .env_mut()
@@ -557,7 +578,24 @@ impl VM {
                 .collect();
             (selected, captures)
         };
+        // When :g, :x, or a multi-value :nth is used, the substitution result
+        // (and $/) is a List of Match objects rather than a single Match. A bare
+        // substitution yields a single Match. A *single* :nth(N) forces a single
+        // Match even when combined with :g (e.g. `s:2nd:g/./Z/` yields a Match).
+        let single_nth = nth_spec.as_deref().is_some_and(|s| !s.contains(','));
+        let nth_is_multi = nth_spec.as_deref().is_some_and(|s| s.contains(','));
+        let result_is_list = !single_nth && (global || x_count.is_some() || nth_is_multi);
         if ranges.is_empty() {
+            if result_is_list {
+                // :g / :x with no match: result is an empty List (falsy).
+                let empty = Value::array(Vec::new());
+                self.interpreter
+                    .env_mut()
+                    .insert("/".to_string(), empty.clone());
+                self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+                self.stack.push(empty);
+                return Ok(());
+            }
             self.interpreter
                 .env_mut()
                 .insert("/".to_string(), Value::Nil);
@@ -566,7 +604,19 @@ impl VM {
             return Ok(());
         }
 
-        let out = if !per_match_captures.is_empty() {
+        let out = if has_code_block {
+            // Replacement has `{...}` code block(s): interpolate per match.
+            self.apply_substitutions_dynamic(
+                &text,
+                &ranges,
+                &raw_replacement,
+                &per_match_captures,
+                samecase,
+                sigspace,
+                samemark,
+                samespace,
+            )
+        } else if !per_match_captures.is_empty() {
             // Build output with per-match capture expansion
             Self::apply_substitutions_with_captures(
                 &text,
@@ -600,6 +650,21 @@ impl VM {
         self.interpreter
             .env_mut()
             .insert("__mutsu_rw_map_topic__".to_string(), result);
+        // For :g / :x, $/ and the substitution result are a List of Match
+        // objects; otherwise a single Match for the first (and only) range.
+        if result_is_list {
+            let matches: Vec<Value> = ranges
+                .iter()
+                .map(|(s, e)| Self::make_subst_match(&text, *s, *e))
+                .collect();
+            let list = Value::array(matches);
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), list.clone());
+            self.substitution_in_smartmatch = self.in_smartmatch_rhs;
+            self.stack.push(list);
+            return Ok(());
+        }
         // Create Match object from first match range and set $/
         let (first_start, first_end) = ranges[0];
         let match_obj = Self::make_subst_match(&text, first_start, first_end);
@@ -628,7 +693,15 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let pattern = Self::const_str(code, pattern_idx).to_string();
         let raw_replacement = normalize_subst_replacement(Self::const_str(code, replacement_idx));
-        let replacement = self.interpolate_subst_replacement_with_closures(&raw_replacement);
+        // A replacement containing a `{...}` code block (e.g. from `s[...] = $0 x 2`)
+        // must be evaluated *per match*, with `$/`, `$0`, ... bound to that match.
+        // For replacements without code blocks, interpolate once up front.
+        let has_code_block = raw_replacement.contains('{');
+        let replacement = if has_code_block {
+            raw_replacement.clone()
+        } else {
+            self.interpolate_subst_replacement_with_closures(&raw_replacement)
+        };
 
         let nth_spec = nth_idx.map(|idx| Self::const_str(code, idx).to_string());
         let x_count = x_count.map(|n| n as usize);
@@ -653,8 +726,16 @@ impl VM {
                         samemark,
                         samespace,
                     );
+                    // S/// sets $/ to the match (without mutating $_).
+                    let match_obj = Self::make_subst_match(&text, start, end);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), match_obj);
                     self.stack.push(Value::str(out));
                 } else {
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), Value::Nil);
                     self.stack.push(Value::str(text));
                 }
             } else {
@@ -662,18 +743,38 @@ impl VM {
                     .interpreter
                     .regex_find_first_from_with_captures(&pattern, &text, 0);
                 if let Some((start, end, captures)) = found {
-                    let expanded = expand_capture_refs(&replacement, &captures);
-                    let out = Self::apply_substitutions(
-                        &text,
-                        &[(start, end)],
-                        &expanded,
-                        samecase,
-                        sigspace,
-                        samemark,
-                        samespace,
-                    );
+                    let out = if has_code_block {
+                        self.apply_substitutions_dynamic(
+                            &text,
+                            &[(start, end)],
+                            &raw_replacement,
+                            std::slice::from_ref(&captures),
+                            samecase,
+                            sigspace,
+                            samemark,
+                            samespace,
+                        )
+                    } else {
+                        let expanded = expand_capture_refs(&replacement, &captures);
+                        Self::apply_substitutions(
+                            &text,
+                            &[(start, end)],
+                            &expanded,
+                            samecase,
+                            sigspace,
+                            samemark,
+                            samespace,
+                        )
+                    };
+                    let match_obj = Self::make_subst_match(&text, start, end);
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), match_obj);
                     self.stack.push(Value::str(out));
                 } else {
+                    self.interpreter
+                        .env_mut()
+                        .insert("/".to_string(), Value::Nil);
                     self.stack.push(Value::str(text));
                 }
             }
@@ -716,11 +817,33 @@ impl VM {
                 .collect();
             (selected, captures)
         };
+        // Mirror the destructive path: a single :nth(N) yields a Match; :g, :x,
+        // or a multi-value :nth yields a List of Matches in $/.
+        let single_nth = nth_spec.as_deref().is_some_and(|s| !s.contains(','));
+        let nth_is_multi = nth_spec.as_deref().is_some_and(|s| s.contains(','));
+        let result_is_list = !single_nth && (global || x_count.is_some() || nth_is_multi);
         if ranges.is_empty() {
+            let slash = if result_is_list {
+                Value::array(Vec::new())
+            } else {
+                Value::Nil
+            };
+            self.interpreter.env_mut().insert("/".to_string(), slash);
             self.stack.push(Value::str(text));
             return Ok(());
         }
-        let out = if !per_match_captures.is_empty() {
+        let out = if has_code_block {
+            self.apply_substitutions_dynamic(
+                &text,
+                &ranges,
+                &raw_replacement,
+                &per_match_captures,
+                samecase,
+                sigspace,
+                samemark,
+                samespace,
+            )
+        } else if !per_match_captures.is_empty() {
             Self::apply_substitutions_with_captures(
                 &text,
                 &ranges,
@@ -742,6 +865,22 @@ impl VM {
                 samespace,
             )
         };
+        // Set $/ to the match result (List or single Match).
+        if result_is_list {
+            let matches: Vec<Value> = ranges
+                .iter()
+                .map(|(s, e)| Self::make_subst_match(&text, *s, *e))
+                .collect();
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), Value::array(matches));
+        } else {
+            let (s, e) = ranges[0];
+            let match_obj = Self::make_subst_match(&text, s, e);
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), match_obj);
+        }
         self.stack.push(Value::str(out));
         Ok(())
     }
@@ -752,14 +891,26 @@ impl VM {
         x_count: Option<usize>,
     ) -> Result<Vec<(usize, usize)>, RuntimeError> {
         if let Some(raw) = nth_spec {
-            let n = Self::parse_subst_nth_spec(raw)?;
-            if n == 0 {
-                return Err(RuntimeError::new("Invalid :nth index (must be >= 1)"));
+            // :nth may carry a comma-separated list of 1-based indices, e.g.
+            // `:nth(1,3)`. Indices must be >= 1 and monotonically increasing.
+            let nth_list = Self::parse_subst_nth_spec(raw)?;
+            let mut selected: Vec<(usize, usize)> = Vec::new();
+            for &n in &nth_list {
+                if n <= all_matches.len() {
+                    let range = all_matches[n - 1];
+                    if !selected.contains(&range) {
+                        selected.push(range);
+                    }
+                }
             }
-            if n > all_matches.len() {
-                return Ok(Vec::new());
+            // When combined with :x(N), keep only the first N selected matches.
+            if let Some(n) = x_count {
+                if selected.len() < n {
+                    return Ok(Vec::new());
+                }
+                selected.truncate(n);
             }
-            return Ok(vec![all_matches[n - 1]]);
+            return Ok(selected);
         }
         if let Some(n) = x_count {
             if n == 0 {
@@ -773,18 +924,41 @@ impl VM {
         Ok(all_matches.first().copied().into_iter().collect())
     }
 
-    fn parse_subst_nth_spec(raw: &str) -> Result<usize, RuntimeError> {
+    /// Parse an `:nth` spec into a list of 1-based indices. Accepts a single
+    /// integer or a comma-separated list (e.g. `1,3`). Validates that every
+    /// index is >= 1 and that the list is monotonically increasing.
+    fn parse_subst_nth_spec(raw: &str) -> Result<Vec<usize>, RuntimeError> {
         let token = raw.trim();
         if token.eq_ignore_ascii_case("-Inf") {
             return Err(RuntimeError::new("Invalid :nth index (-Inf)"));
         }
-        let n = token
-            .parse::<i64>()
-            .map_err(|_| RuntimeError::new(format!("Invalid :nth index ({token})")))?;
-        if n <= 0 {
+        let mut out: Vec<usize> = Vec::new();
+        let mut prev: i64 = 0;
+        for part in token.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let n = part
+                .parse::<i64>()
+                .map_err(|_| RuntimeError::new(format!("Invalid :nth index ({part})")))?;
+            if n < 1 {
+                return Err(RuntimeError::new(format!(
+                    "Attempt to retrieve before :1st match -- :nth({n})"
+                )));
+            }
+            if n < prev {
+                return Err(RuntimeError::new(format!(
+                    "Attempt to fetch match #{n} after #{prev}"
+                )));
+            }
+            prev = n;
+            out.push(n as usize);
+        }
+        if out.is_empty() {
             return Err(RuntimeError::new(format!("Invalid :nth index ({token})")));
         }
-        Ok(n as usize)
+        Ok(out)
     }
 
     fn apply_substitutions(
@@ -879,6 +1053,120 @@ impl VM {
             prev_end_b = end_b;
         }
         out.push_str(&text[prev_end_b..]);
+        out
+    }
+
+    /// Build a substitution output when the replacement contains `{...}` code
+    /// blocks. The replacement is interpolated *per match*, with `$/`, `$0`,
+    /// `$1`, ... bound to the current match so closures like `{ $0 x 2 }` or
+    /// `{ uc($/) }` see the correct match.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_substitutions_dynamic(
+        &mut self,
+        text: &str,
+        ranges: &[(usize, usize)],
+        raw_replacement: &str,
+        per_match_captures: &[Vec<String>],
+        samecase: bool,
+        sigspace: bool,
+        samemark: bool,
+        samespace: bool,
+    ) -> String {
+        // Snapshot the env entries we overwrite so we can restore them after.
+        let saved_slash = self.interpreter.env().get("/").cloned();
+        let saved_caps: Vec<Option<Value>> = (0..10)
+            .map(|n| self.interpreter.env().get(&n.to_string()).cloned())
+            .collect();
+
+        let mut out = String::new();
+        let mut prev_end_b = 0usize;
+        for (i, (start, end)) in ranges.iter().enumerate() {
+            let start_b = runtime::char_idx_to_byte(text, *start);
+            let end_b = runtime::char_idx_to_byte(text, *end);
+            out.push_str(&text[prev_end_b..start_b]);
+            let matched_text = &text[start_b..end_b];
+
+            let caps: &[String] = per_match_captures
+                .get(i)
+                .map(|c| c.as_slice())
+                .unwrap_or(&[]);
+            // Bind `$/` to a Match object for this match, and `$0`, `$1`, ...
+            // to the positional captures.
+            let match_obj = Value::make_match_object_full(
+                matched_text.to_string(),
+                *start as i64,
+                *end as i64,
+                caps,
+                &std::collections::HashMap::new(),
+                &std::collections::HashMap::new(),
+                &[],
+                &[],
+                Some(text),
+            );
+            self.interpreter
+                .env_mut()
+                .insert("/".to_string(), match_obj);
+            for n in 0..10 {
+                if let Some(cap) = caps.get(n) {
+                    self.interpreter
+                        .env_mut()
+                        .insert(n.to_string(), Value::str(cap.clone()));
+                } else {
+                    self.interpreter.env_mut().remove(&n.to_string());
+                }
+            }
+
+            let interpolated = self.interpolate_subst_replacement_with_closures(raw_replacement);
+            let expanded = if caps.is_empty() {
+                interpolated
+            } else {
+                expand_capture_refs(&interpolated, caps)
+            };
+            let mut repl = if samecase {
+                if sigspace {
+                    samecase_per_word(&expanded, matched_text)
+                } else {
+                    crate::builtins::samecase_string(&expanded, matched_text)
+                }
+            } else if samemark {
+                if matched_text.contains(char::is_whitespace)
+                    && expanded.contains(char::is_whitespace)
+                {
+                    samemark_per_word(&expanded, matched_text)
+                } else {
+                    crate::builtins::samemark_string(&expanded, matched_text)
+                }
+            } else {
+                expanded
+            };
+            if samespace {
+                repl = samespace_replace(&repl, matched_text);
+            }
+            out.push_str(&repl);
+            prev_end_b = end_b;
+        }
+        out.push_str(&text[prev_end_b..]);
+
+        // Restore overwritten env entries (`$/` is reset to the match list/object
+        // by the caller after this returns).
+        match saved_slash {
+            Some(v) => {
+                self.interpreter.env_mut().insert("/".to_string(), v);
+            }
+            None => {
+                self.interpreter.env_mut().remove("/");
+            }
+        }
+        for (n, saved) in saved_caps.into_iter().enumerate() {
+            match saved {
+                Some(v) => {
+                    self.interpreter.env_mut().insert(n.to_string(), v);
+                }
+                None => {
+                    self.interpreter.env_mut().remove(&n.to_string());
+                }
+            }
+        }
         out
     }
 


### PR DESCRIPTION
## Summary

`roast/S05-substitution/subst.t` previously **aborted at test 132** (a fatal `Invalid :nth index` on operator-form multi-value `:nth(1,3)`). All **191 tests now run; 168 pass** (23 remaining failures are pre-existing missing features, documented in `TODO_roast/S05.md`).

### Substitution result and `$/` typing
- `:g`, `:x`, and multi-value `:nth(a,b)` now yield a **List of Match** in `$/` and as the substitution's value (so `+s:g/.../.../` is the match count). A single `:nth(N)` stays a `Match` even with `:g`.
- Empty-match `:g`/`:x` returns an empty List (falsy).
- `S///` (non-destructive) now sets `$/` like `s///`.

### Per-match dynamic replacements
- `s[...] = expr` / `S[...] = expr` with `$/`, `$0`, … or `{...}` on the RHS are interpolated **per match** (new `apply_substitutions_dynamic`), so `+(s:g[(\w)] = $0 x 2)` is `3` and the result is `aa bb cc`. Perl5 keeps the legacy `.subst`-closure lowering.

### `:nth` handling
- Operator-form `:nth` accepts a comma-separated list (`:nth(1,3)`), combinable with `:x`.
- `.subst` and operator `:nth` validate indices: must be >= 1 and monotonically increasing, else throw (`:nth(0)`, `:nth(2,4,1,6)`).

### Adverb / parsing fixes
- `:overlap`/`:exhaustive` rejected on substitutions with `X::Syntax::Regex::Adverb` (still allowed on `m//`).
- `ss (foo) = '...'` and `ss[...] = ...` now parse as a substitution.
- Registered `X::Str::Match::x`.

## Testing
- `subst.t`: 168/191 (was aborting at 132).
- All 88 whitelisted S05 tests pass (5144 subtests); no S05 regressions.
- All 29 local `t/regex-*.t` / `t/subst*.t` pass. `cargo fmt` + `clippy -D warnings` clean.

Not whitelisted (not fully passing). Remaining blockers in `TODO_roast/S05.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)