### PR TITLE
S05 captures: conjunction merge, named-in-group subcaptures, native % separator quantifiers

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -1,9 +1,11 @@
 # S05 - grammar, interpolation, mass, metachars, modifier, transliteration
 
 - [ ] roast/S05-capture/alias.t
+  - Blocked on reverse/explicit positional capture assignment (`$1=(.) $0=(.)`, `$42=.`), package/lexical scalar capture (`$foo=(...)`), and `$<name>=@(...)` list-interpolation captures. Conjunction and named-in-group capture fixes (this PR) do not cover these aliasing forms.
 - [ ] roast/S05-capture/array-alias.t
+  - Blocked on `@<name>=(...)` array-alias captures (not implemented in the regex parser) and `@var=(...)` lexical/package array captures. Separate feature from the capture-numbering fixes here.
 - [ ] roast/S05-capture/caps.t
-  - 25/43 pass. Fails at `.caps on % separator` / `.caps on %% separator` for `(<.alpha>) +% (<.punct>)` style patterns. Mutsu's LTM-expansion approach rewrites `X +% Y` into `X (Y X)*`, which assigns new positional capture indices to the repeated atom/sep pairs instead of reusing the outer numbering. Raku assigns captures by their source position (atom=$0, sep=$1, reused across iterations). A correct fix requires either native engine support for separator quantifiers (`+%`, `*%`, `+%%`, `*%%`) via a dedicated `SeparatedRepeat` regex token, or support for explicit positional capture assignment (`$0=(...)`) so the expansion can renumber captures. Both are substantial regex-engine work.
+  - 42/43 pass (this PR). `%`/`%%` separator captures now use a native separator-quantifier path (`RegexSeparatorSpec` on `RegexToken`) that folds each side into its own capture group, matching Raku's Match layout; conjunction (`&`/`&&`) captures now merge captures from all branches and require all branches to cover the same substring. Remaining failure: test 43 (`("XX")+ %% $<delim>=<[a..z]>*`) needs a zero-width named-capture (`$<name>=atom*` matching 0 chars) to still register the named key as an empty/zero-width Match — a separate named-zero-match-slot gap.
 - [ ] roast/S05-capture/dot.t
   - 46/61 pass. Silent subrule capture leak fixed. Remaining: nested positional captures $0[0] (tests 25-28), backreferences $0 inside regex (tests 29-33), named backreferences (tests 34-39, TODO in rakudo too)
 - [ ] roast/S05-capture/hash.t
@@ -64,6 +66,7 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
+  - 56/64 pass. Remaining blockers: binding `$/` (`my $/ := 42`, tests 29-30); `(y)?`/`(z)*` zero-match needs index-stable positional capture slots so `?`→Nil and `*`→empty-list can coexist (tests 45/46 — mutsu does not reserve slots for unmatched optional captures); `%%` separator backtracking against an outer anchor (tests 53-56, where the native separator path falls back to string expansion); capture markers `<(`/`)>` in some grammar combinations (test 64).
 - [ ] roast/S05-match/make.t
 - [ ] roast/S05-match/non-capturing.t
 - [ ] roast/S05-match/positions.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -640,6 +640,21 @@ struct RegexToken {
     ratchet: bool,
     /// Frugal (non-greedy) quantifier modifier: `*?`, `+?`, `??`
     frugal: bool,
+    /// Separator for `%` / `%%` quantifiers, e.g. `<thing> +% ','`. When present,
+    /// the quantified atom is matched with `separator.atom` interleaved between
+    /// iterations. `allow_trailing` is true for `%%` (an optional trailing
+    /// separator is permitted). The separator's own captures are appended as
+    /// positional/named captures after the main atom's, matching Raku semantics.
+    separator: Option<Box<RegexSeparatorSpec>>,
+}
+
+#[derive(Clone)]
+struct RegexSeparatorSpec {
+    /// The separator sub-pattern (matched between iterations). Holding a full
+    /// pattern preserves named captures, quantifiers, and other structure of
+    /// complex separators such as `$<delim>=<[a..z]>*`.
+    pattern: RegexPattern,
+    allow_trailing: bool,
 }
 
 #[derive(Clone)]

--- a/src/runtime/regex/regex_casefold.rs
+++ b/src/runtime/regex/regex_casefold.rs
@@ -84,6 +84,16 @@ pub(super) fn casefold_pattern(pattern: &RegexPattern) -> RegexPattern {
     }
 }
 
+/// Case-fold the sub-pattern of a `%` / `%%` quantifier separator, if present.
+fn casefold_separator(sep: &Option<Box<RegexSeparatorSpec>>) -> Option<Box<RegexSeparatorSpec>> {
+    sep.as_ref().map(|s| {
+        Box::new(RegexSeparatorSpec {
+            pattern: casefold_pattern(&s.pattern),
+            allow_trailing: s.allow_trailing,
+        })
+    })
+}
+
 fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
     let folded_atom = casefold_atom(&token.atom);
     match folded_atom {
@@ -95,6 +105,7 @@ fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
             hash_capture: token.hash_capture.clone(),
             ratchet: token.ratchet,
             frugal: token.frugal,
+            separator: casefold_separator(&token.separator),
         }],
         CasefoldedAtom::Multiple(chars) => {
             // A literal that expanded to multiple chars (e.g., 'ß' -> 's','s').
@@ -109,6 +120,7 @@ fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
                     hash_capture: None,
                     ratchet: token.ratchet,
                     frugal: false,
+                    separator: None,
                 })
                 .collect();
             let group = RegexPattern {
@@ -126,6 +138,7 @@ fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
                 hash_capture: token.hash_capture.clone(),
                 ratchet: token.ratchet,
                 frugal: token.frugal,
+                separator: casefold_separator(&token.separator),
             }]
         }
     }

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -127,6 +127,12 @@ fn strip_marks_token(token: &RegexToken) -> RegexToken {
         hash_capture: token.hash_capture.clone(),
         ratchet: token.ratchet,
         frugal: token.frugal,
+        separator: token.separator.as_ref().map(|s| {
+            Box::new(RegexSeparatorSpec {
+                pattern: strip_marks_pattern(&s.pattern),
+                allow_trailing: s.allow_trailing,
+            })
+        }),
     }
 }
 
@@ -367,7 +373,11 @@ pub(super) fn merge_regex_captures(
     dst.positional_subcaps.append(&mut src.positional_subcaps);
     dst.positional_quantified
         .append(&mut src.positional_quantified);
+    dst.positional_offsets.append(&mut src.positional_offsets);
     dst.code_blocks.append(&mut src.code_blocks);
+    for (k, v) in src.hash_captures.drain() {
+        dst.hash_captures.entry(k).or_default().extend(v);
+    }
     dst
 }
 
@@ -405,7 +415,15 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
     }
     let new_entries = caps.positional.len() - base_len;
     if new_entries <= stride {
-        // Only one iteration or fewer — nothing to fold
+        // Only one iteration or fewer — nothing to fold.
+        //
+        // NOTE: a zero-iteration `*`/`+` quantified capture group should ideally
+        // reserve an empty-list slot (Raku: `(z)*` matching 0 times yields `[]`),
+        // but mutsu does not yet reserve index-stable positional capture slots
+        // for unmatched optional captures, so emitting an empty slot here would
+        // misalign indices when an earlier `(...)?` also matched zero times.
+        // TODO: reserve index-stable positional slots for all capture groups so
+        // both `(y)?`→Nil and `(z)*`→[] can coexist.
         return;
     }
     let iterations = new_entries / stride;

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -22,6 +22,26 @@ thread_local! {
 }
 
 impl Interpreter {
+    /// Try to match `branch` starting at `pos` such that it ends exactly at
+    /// `target_end`. Returns the branch's own captures (relative to an empty
+    /// baseline) on success. Used by conjunction (`&` / `&&`) matching, where
+    /// every branch must cover the same substring.
+    fn regex_match_branch_ending_at(
+        &self,
+        branch: &RegexPattern,
+        chars: &[char],
+        pos: usize,
+        target_end: usize,
+        pkg: &str,
+    ) -> Option<RegexCaptures> {
+        for (end, caps) in self.regex_match_ends_from_caps_in_pkg(branch, chars, pos, pkg) {
+            if end == target_end {
+                return Some(caps);
+            }
+        }
+        None
+    }
+
     pub(super) fn regex_match_atom_all_with_capture_in_pkg(
         &self,
         atom: &RegexAtom,
@@ -119,40 +139,38 @@ impl Interpreter {
             return groups.into_iter().flatten().collect();
         }
         if let RegexAtom::Conjunction(branches) = atom {
-            // ALL branches must match at the same position.
-            let mut longest_end = 0usize;
-            let mut longest_caps = current_caps.clone();
-            for branch in branches {
-                if let Some((end, caps)) =
-                    self.regex_match_end_from_caps_in_pkg(branch, chars, pos, pkg)
-                {
-                    if end >= longest_end {
-                        longest_end = end;
-                        longest_caps = caps;
+            // ALL branches must match the SAME substring: every branch must
+            // succeed and end at the same position. Captures from EVERY branch
+            // are merged (Raku keeps all captures from each side of `&` / `&&`),
+            // preserving written order. We try the candidate ends of the first
+            // branch and, for each, require every other branch to match exactly
+            // to that end.
+            let Some((first, rest)) = branches.split_first() else {
+                return vec![(pos, current_caps.clone())];
+            };
+            let mut out: Vec<(usize, RegexCaptures)> = Vec::new();
+            // first-branch candidates: HIGHEST-priority-first from ends fn.
+            // Build the output LOWEST-priority-first by reversing.
+            let mut first_ends = self.regex_match_ends_from_caps_in_pkg(first, chars, pos, pkg);
+            first_ends.reverse();
+            for (end, first_caps) in first_ends {
+                let mut merged = merge_regex_captures(current_caps.clone(), first_caps);
+                let mut ok = true;
+                for branch in rest {
+                    if let Some(bcaps) =
+                        self.regex_match_branch_ending_at(branch, chars, pos, end, pkg)
+                    {
+                        merged = merge_regex_captures(merged, bcaps);
+                    } else {
+                        ok = false;
+                        break;
                     }
-                } else {
-                    return Vec::new();
+                }
+                if ok {
+                    out.push((end, merged));
                 }
             }
-            let mut new_caps = current_caps.clone();
-            for (k, v) in longest_caps.named {
-                new_caps.named.entry(k).or_default().extend(v);
-            }
-            for (k, v) in longest_caps.named_subcaps {
-                new_caps.named_subcaps.entry(k).or_default().extend(v);
-            }
-            new_caps
-                .named_quantified
-                .extend(longest_caps.named_quantified);
-            new_caps.positional.append(&mut longest_caps.positional);
-            new_caps
-                .positional_subcaps
-                .append(&mut longest_caps.positional_subcaps);
-            new_caps
-                .positional_quantified
-                .append(&mut longest_caps.positional_quantified);
-            new_caps.code_blocks.append(&mut longest_caps.code_blocks);
-            return vec![(longest_end, new_caps)];
+            return out;
         }
         if let RegexAtom::Group(pattern) = atom {
             let mut out = Vec::new();
@@ -219,20 +237,11 @@ impl Interpreter {
                 let captured: String = chars[pos..end].iter().collect();
                 let mut new_caps = current_caps.clone();
                 let mut inner_caps = inner_caps;
-                // Merge inner named captures into parent
-                for (k, v) in inner_caps.named.drain() {
-                    new_caps.named.entry(k).or_default().extend(v);
-                }
-                for (k, v) in &inner_caps.named_subcaps {
-                    new_caps
-                        .named_subcaps
-                        .entry(k.clone())
-                        .or_default()
-                        .extend(v.clone());
-                }
-                new_caps
-                    .named_quantified
-                    .extend(inner_caps.named_quantified.iter().cloned());
+                // Named captures appearing inside a positional capture group belong
+                // to that group's sub-Match (`$/[0]<name>`), NOT to the parent
+                // Match's top-level named captures (`$/<name>`). They are preserved
+                // only in `positional_subcaps` below and are intentionally NOT
+                // merged into the parent `named` / `named_subcaps` maps.
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                 // Store inner captures as subcaptures of this group
                 let mut subcap = inner_caps;

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -102,37 +102,23 @@ impl Interpreter {
                 }
                 return best;
             }
-            RegexAtom::Conjunction(branches) => {
-                // ALL branches must match from the same position.
-                // The result is the longest match among the branches.
-                let mut longest_end = 0usize;
-                let mut longest_caps = current_caps.clone();
-                for branch in branches {
-                    if let Some((next, inner_caps)) =
-                        self.regex_match_end_from_caps_in_pkg(branch, chars, pos, pkg)
-                    {
-                        if next >= longest_end {
-                            longest_end = next;
-                            longest_caps = inner_caps;
-                        }
-                    } else {
-                        // If any branch fails, the whole conjunction fails
-                        return None;
-                    }
-                }
-                let mut new_caps = current_caps.clone();
-                for (k, v) in longest_caps.named {
-                    new_caps.named.entry(k).or_default().extend(v);
-                }
-                new_caps.positional.append(&mut longest_caps.positional);
-                new_caps
-                    .positional_subcaps
-                    .append(&mut longest_caps.positional_subcaps);
-                new_caps
-                    .positional_quantified
-                    .append(&mut longest_caps.positional_quantified);
-                new_caps.code_blocks.append(&mut longest_caps.code_blocks);
-                return Some((longest_end, new_caps));
+            RegexAtom::Conjunction(_) => {
+                // ALL branches must match the SAME substring (end at the same
+                // position). Captures from EVERY branch are merged (Raku keeps
+                // all captures from each side of `&` / `&&`), in written order.
+                // Delegate to the multi-end variant and take the highest-priority
+                // (longest) result.
+                return self
+                    .regex_match_atom_all_with_capture_in_pkg(
+                        atom,
+                        chars,
+                        pos,
+                        current_caps,
+                        pkg,
+                        ignore_case,
+                    )
+                    .into_iter()
+                    .next_back();
             }
             RegexAtom::SequentialAlternation(alternatives) => {
                 for alt in alternatives {
@@ -204,24 +190,11 @@ impl Interpreter {
                 {
                     let captured: String = chars[pos..end].iter().collect();
                     let mut new_caps = current_caps.clone();
-                    // Merge inner named captures into parent
-                    for (k, v) in &inner_caps.named {
-                        new_caps
-                            .named
-                            .entry(k.clone())
-                            .or_default()
-                            .extend(v.clone());
-                    }
-                    for (k, v) in &inner_caps.named_subcaps {
-                        new_caps
-                            .named_subcaps
-                            .entry(k.clone())
-                            .or_default()
-                            .extend(v.clone());
-                    }
-                    new_caps
-                        .named_quantified
-                        .extend(inner_caps.named_quantified.iter().cloned());
+                    // Named captures appearing inside a positional capture group
+                    // belong to that group's sub-Match (`$/[0]<name>`), NOT to the
+                    // parent Match's top-level named captures (`$/<name>`). They are
+                    // therefore preserved only in `positional_subcaps` below, and
+                    // are intentionally NOT merged into the parent `named` map.
                     // Store inner captures as subcaptures of this group
                     let mut subcap = inner_caps.clone();
                     subcap.matched = captured.clone();

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -51,6 +51,212 @@ impl Interpreter {
         Self::collect_named_captures_in_atom(&token.atom, &mut names);
         names
     }
+    /// Match a separator quantifier (`atom +% sep`, `atom **N..M %% sep`, ...).
+    /// The atom is matched repeatedly with `sep` interleaved between iterations.
+    /// Each side's captures are accumulated into its own folded group: the atom's
+    /// positional captures occupy the first `atom_stride` indices and the
+    /// separator's the next `sep_stride` indices, matching Raku's Match layout.
+    ///
+    /// Returns `(end, caps)` pairs in LOWEST-priority-first order (for the LIFO
+    /// matching stack): shortest match first, longest (greedy) last.
+    fn match_separated_quantifier(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        start: usize,
+        base_caps: &RegexCaptures,
+        pkg: &str,
+        pattern: &RegexPattern,
+    ) -> Vec<(usize, RegexCaptures)> {
+        let sep = token.separator.as_ref().expect("separator present");
+        let (min, max) = match &token.quant {
+            RegexQuant::OneOrMore => (1usize, None),
+            RegexQuant::ZeroOrMore => (0usize, None),
+            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
+            // `?` / exact-one don't form a separator list; treat as one.
+            _ => (1usize, Some(1usize)),
+        };
+        let atom_stride = count_capture_groups(&token.atom);
+        let sep_stride: usize = sep
+            .pattern
+            .tokens
+            .iter()
+            .map(|t| count_capture_groups(&t.atom))
+            .sum();
+        let names = Self::collect_quantified_names_for_token(token);
+
+        // Build the greedy chain of iterations. Each iteration records the atom
+        // match end and the captures produced by the atom (and, for iterations
+        // after the first, the preceding separator's captures).
+        // `atom_ends[i]` = end position after the i-th atom (0-indexed).
+        let mut atom_caps: Vec<RegexCaptures> = Vec::new();
+        let mut sep_caps: Vec<RegexCaptures> = Vec::new();
+        let mut atom_ends: Vec<usize> = Vec::new();
+
+        let empty = RegexCaptures::default();
+        // First atom.
+        let mut cur = start;
+        if let Some((end, caps)) = self.regex_match_atom_with_capture_in_pkg(
+            &token.atom,
+            chars,
+            cur,
+            &empty,
+            pkg,
+            pattern.ignore_case,
+        ) && end != cur
+        {
+            atom_caps.push(caps);
+            atom_ends.push(end);
+            cur = end;
+            // Subsequent: sep then atom.
+            loop {
+                if let Some(m) = max
+                    && atom_ends.len() >= m
+                {
+                    break;
+                }
+                let Some((sep_end, scaps)) =
+                    self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, cur, pkg)
+                else {
+                    break;
+                };
+                let Some((atom_end, acaps)) = self.regex_match_atom_with_capture_in_pkg(
+                    &token.atom,
+                    chars,
+                    sep_end,
+                    &empty,
+                    pkg,
+                    pattern.ignore_case,
+                ) else {
+                    break;
+                };
+                if atom_end == cur {
+                    break; // zero-width progress guard
+                }
+                sep_caps.push(scaps);
+                atom_caps.push(acaps);
+                atom_ends.push(atom_end);
+                cur = atom_end;
+            }
+        }
+
+        // Produce results for each valid iteration count (>= min, <= max),
+        // shortest first. Count 0 (when min==0) ends at `start`.
+        let mut results: Vec<(usize, RegexCaptures)> = Vec::new();
+        if min == 0 {
+            results.push((start, base_caps.clone()));
+        }
+        for count in 1..=atom_ends.len() {
+            if count < min {
+                continue;
+            }
+            if let Some(m) = max
+                && count > m
+            {
+                break;
+            }
+            let mut end = atom_ends[count - 1];
+            let mut caps = base_caps.clone();
+            // Optional trailing separator for `%%`. A zero-width trailing
+            // separator (e.g. `delim*` matching empty) is still a valid trailing
+            // match, so accept `sep_end >= end`.
+            let mut trailing_sep: Option<RegexCaptures> = None;
+            if sep.allow_trailing
+                && let Some((sep_end, scaps)) =
+                    self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, end, pkg)
+                && sep_end >= end
+            {
+                trailing_sep = Some(scaps);
+                end = sep_end;
+            }
+            // Assemble folded captures: atom groups first, then sep groups.
+            caps.named_quantified.extend(names.iter().cloned());
+            Self::append_separated_captures(
+                &mut caps,
+                &atom_caps[..count],
+                &sep_caps[..count.saturating_sub(1)],
+                trailing_sep.as_ref(),
+                atom_stride,
+                sep_stride,
+            );
+            results.push((end, caps));
+        }
+        results
+    }
+
+    /// Append captures from a separated quantifier into `caps`, folding each
+    /// side into its own positional/named group lists.
+    fn append_separated_captures(
+        caps: &mut RegexCaptures,
+        atom_caps: &[RegexCaptures],
+        sep_caps: &[RegexCaptures],
+        trailing_sep: Option<&RegexCaptures>,
+        atom_stride: usize,
+        sep_stride: usize,
+    ) {
+        // Positional captures: atom groups occupy the first `atom_stride` slots,
+        // separator groups the next `sep_stride`.
+        for g in 0..atom_stride {
+            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
+            let mut last_text = String::new();
+            let mut last_sub: Option<RegexCaptures> = None;
+            for ac in atom_caps {
+                if let Some(text) = ac.positional.get(g) {
+                    let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
+                    let sub = ac.positional_subcaps.get(g).cloned().flatten();
+                    list.push((text.clone(), from, to, sub.clone()));
+                    last_text = text.clone();
+                    last_sub = sub;
+                }
+            }
+            caps.positional.push(last_text);
+            caps.positional_subcaps.push(last_sub);
+            caps.positional_quantified.push(Some(list));
+            caps.positional_offsets.push((0, 0));
+        }
+        let mut all_sep: Vec<&RegexCaptures> = sep_caps.iter().collect();
+        if let Some(ts) = trailing_sep {
+            all_sep.push(ts);
+        }
+        for g in 0..sep_stride {
+            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
+            let mut last_text = String::new();
+            let mut last_sub: Option<RegexCaptures> = None;
+            for sc in &all_sep {
+                if let Some(text) = sc.positional.get(g) {
+                    let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));
+                    let sub = sc.positional_subcaps.get(g).cloned().flatten();
+                    list.push((text.clone(), from, to, sub.clone()));
+                    last_text = text.clone();
+                    last_sub = sub;
+                }
+            }
+            caps.positional.push(last_text);
+            caps.positional_subcaps.push(last_sub);
+            caps.positional_quantified.push(Some(list));
+            caps.positional_offsets.push((0, 0));
+        }
+        // Named captures: merge every iteration's named captures (as arrays).
+        for src in atom_caps.iter().chain(all_sep.iter().copied()) {
+            for (k, v) in &src.named {
+                caps.named.entry(k.clone()).or_default().extend(v.clone());
+                caps.named_quantified.insert(k.clone());
+            }
+            for (k, v) in &src.named_subcaps {
+                caps.named_subcaps
+                    .entry(k.clone())
+                    .or_default()
+                    .extend(v.clone());
+            }
+            for (k, v) in &src.hash_captures {
+                caps.hash_captures
+                    .entry(k.clone())
+                    .or_default()
+                    .extend(v.clone());
+            }
+        }
+    }
+
     pub(super) fn regex_match_end_from_caps_in_pkg(
         &self,
         pattern: &RegexPattern,
@@ -180,6 +386,21 @@ impl Interpreter {
             }
             let token = &pattern.tokens[idx];
             let pos_base = caps.positional.len();
+            // Separator quantifiers (`atom +% sep`, `atom **N..M %% sep`, ...):
+            // match the atom with the separator interleaved between iterations,
+            // accumulating each side's captures into its own (folded) group.
+            if token.separator.is_some() {
+                for (next, new_caps) in
+                    self.match_separated_quantifier(token, chars, pos, &caps, pkg, pattern)
+                {
+                    stack.push((
+                        idx + 1,
+                        next,
+                        apply_named_capture(token, pos, next, new_caps),
+                    ));
+                }
+                continue;
+            }
             match token.quant {
                 RegexQuant::One => {
                     let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -108,6 +108,7 @@ fn rewrite_tilde_tokens(
                     secondary_named_capture: None,
                     ratchet: false,
                     frugal: false,
+                    separator: None,
                 };
                 inner_tokens.push(ws_tok.clone());
                 inner_tokens.push(inner_token);
@@ -134,6 +135,7 @@ fn rewrite_tilde_tokens(
                 secondary_named_capture: None,
                 ratchet: false,
                 frugal: false,
+                separator: None,
             });
             // Skip past the inner token and any trailing ws-like tokens
             i = k + 1;
@@ -259,6 +261,7 @@ fn regex_single_quote_atom(literal: String, ignore_case: bool) -> RegexAtom {
                 secondary_named_capture: None,
                 ratchet: false,
                 frugal: false,
+                separator: None,
             })
             .collect();
         RegexAtom::Group(RegexPattern {
@@ -865,6 +868,42 @@ impl Interpreter {
     /// Split a compact regex string into the first atom and the remainder.
     /// Returns (first_atom, rest). Used to extract the single-atom separator
     /// for `%` / `%%` operators (Raku's `%` only takes a single atom).
+    /// Extract a full separator atom from the start of `s`, including an optional
+    /// `$<name>=` / `$name=` / `%<name>=` / `@<name>=` capture-alias prefix and a
+    /// trailing quantifier. Returns the matched prefix (the part to consume).
+    fn split_separator_atom(s: &str) -> String {
+        let chars: Vec<char> = s.chars().collect();
+        let mut prefix_len = 0usize;
+        // Optional sigil-alias prefix: `$<name>=`, `$name=`, `%<name>=`, `@<name>=`.
+        if let Some(&first) = chars.first()
+            && matches!(first, '$' | '%' | '@')
+        {
+            let mut j = 1;
+            if chars.get(j) == Some(&'<') {
+                // `<name>` — scan to closing '>'
+                while j < chars.len() && chars[j] != '>' {
+                    j += 1;
+                }
+                if j < chars.len() {
+                    j += 1; // consume '>'
+                }
+            } else {
+                // bare `name`
+                while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+                    j += 1;
+                }
+            }
+            // Require a trailing `=` to treat this as an alias prefix.
+            if j > 1 && chars.get(j) == Some(&'=') {
+                prefix_len = j + 1;
+            }
+        }
+        let rest: String = chars[prefix_len..].iter().collect();
+        let (atom, _) = Self::split_first_atom(&rest);
+        let prefix: String = chars[..prefix_len].iter().collect();
+        format!("{prefix}{atom}")
+    }
+
     fn split_first_atom(s: &str) -> (String, String) {
         if s.is_empty() {
             return (String::new(), String::new());
@@ -967,7 +1006,16 @@ impl Interpreter {
                 None
             };
             let is_single_atom = Self::is_single_regex_atom(atom);
-            if is_single_atom {
+            // The string-based LTM expansion (which duplicates the atom text and
+            // wraps alternations in `(...)`) renumbers captures and introduces
+            // spurious positional groups. It is only needed for the separator
+            // form `**N..M %sep`. For a plain `**N..M` whose atom contains a
+            // capture (positional `(...)` or named `<name>`), defer to the
+            // normal parser, which produces a proper `Repeat` quantifier with
+            // capture folding that preserves the Match structure.
+            let atom_has_capture =
+                Self::atom_contains_capture(atom) || Self::atom_contains_named_capture(atom);
+            if is_single_atom && (sep_mode.is_some() || !atom_has_capture) {
                 // Detect empty range (e.g. 2..1) before LTM expansion
                 let (parsed_min, parsed_max) = Self::parse_quantifier_range(count_spec);
                 if let Some(max_val) = parsed_max
@@ -1005,6 +1053,35 @@ impl Interpreter {
             // `%` takes only a single atom as separator; split off the remainder.
             let (sep_atom, sep_rest) = Self::split_first_atom(full_sep);
             let sep = Some(sep_atom.as_str());
+            // When the quantified atom or the separator contains a capture, the
+            // string-based expansion (`atom[sep atom]*`) would renumber captures
+            // and break the Match structure. Leave the `%`/`%%` text in place so
+            // the per-token parser builds a proper separator-quantifier instead.
+            //
+            // Under sigspace (`:s`), however, the string expansion correctly
+            // inserts `<ws>` matchers around the separator, which the native
+            // separator-quantifier path does not yet handle. So only defer to the
+            // native path when sigspace is NOT active.
+            //
+            // The native path also uses a greedy chain without full backtracking
+            // coordination, so it cannot correctly handle separators/atoms that
+            // require backtracking against an outer anchor — namely sequential
+            // alternation (`||`) or frugal quantifiers (`+?`/`*?`/`??`). For those
+            // we keep the string expansion (which backtracks correctly, at the
+            // cost of capture renumbering).
+            let needs_backtracking = |s: &str| -> bool {
+                s.contains("||") || s.contains("+?") || s.contains("*?") || s.contains("??")
+            };
+            if !sigspace
+                && !needs_backtracking(&atom)
+                && !needs_backtracking(&sep_atom)
+                && (Self::atom_contains_capture(&atom)
+                    || Self::atom_contains_named_capture(&atom)
+                    || Self::atom_contains_capture(&sep_atom)
+                    || Self::atom_contains_named_capture(&sep_atom))
+            {
+                return pattern.to_string();
+            }
             let use_spaced = sigspace && pattern.len() != compact.len();
             let build_with_rest = |expanded: String| -> String {
                 if sep_rest.is_empty() {
@@ -1044,6 +1121,67 @@ impl Interpreter {
             return build_with_rest(expand(&atom, "1..*", sep_mode, sep));
         }
         pattern.to_string()
+    }
+
+    /// Check whether an atom string contains a positional capture group `(...)`.
+    /// Used to guard LTM string-expansion of `**N..M`, which duplicates the atom
+    /// text and would otherwise renumber captures.
+    fn atom_contains_capture(atom: &str) -> bool {
+        let mut escaped = false;
+        let mut in_single = false;
+        let mut in_double = false;
+        for ch in atom.chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                '(' if !in_single && !in_double => return true,
+                _ => {}
+            }
+        }
+        false
+    }
+
+    /// Check whether an atom string contains a named subrule capture `<name>`
+    /// that would contribute a named entry to the Match (i.e. not a `<.foo>`,
+    /// `<?...>`, `<!...>`, character class `<[...]>`/`<+...>`/`<-...>`, or
+    /// modifier `<:...>`). Used alongside `atom_contains_capture` to guard
+    /// LTM string-expansion of `**N..M`.
+    fn atom_contains_named_capture(atom: &str) -> bool {
+        let bytes: Vec<char> = atom.chars().collect();
+        let mut i = 0;
+        let mut escaped = false;
+        let mut in_single = false;
+        let mut in_double = false;
+        while i < bytes.len() {
+            let ch = bytes[i];
+            if escaped {
+                escaped = false;
+                i += 1;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                '<' if !in_single && !in_double => {
+                    if let Some(&next) = bytes.get(i + 1) {
+                        // Capturing named subrules begin with a letter, digit,
+                        // underscore, or `&` (e.g. `<&rule>`, `<name=...>`).
+                        if next.is_alphanumeric() || next == '_' || next == '&' {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        false
     }
 
     /// Check if a string represents a single regex atom (used to guard LTM expansion).
@@ -1391,6 +1529,7 @@ impl Interpreter {
                         secondary_named_capture: None,
                         ratchet: false,
                         frugal: false,
+                        separator: None,
                     }],
                     anchor_start: false,
                     anchor_end: false,
@@ -1432,6 +1571,7 @@ impl Interpreter {
                         secondary_named_capture: None,
                         ratchet: false,
                         frugal: false,
+                        separator: None,
                     }],
                     anchor_start: false,
                     anchor_end: false,
@@ -1471,6 +1611,7 @@ impl Interpreter {
                                 secondary_named_capture: None,
                                 ratchet,
                                 frugal: false,
+                                separator: None,
                             });
                         }
                     } else {
@@ -1497,6 +1638,7 @@ impl Interpreter {
                             secondary_named_capture: None,
                             ratchet,
                             frugal: false,
+                            separator: None,
                         });
                     }
                 }
@@ -1523,6 +1665,7 @@ impl Interpreter {
                         secondary_named_capture: None,
                         ratchet,
                         frugal: false,
+                        separator: None,
                     });
                     continue;
                 } else if tokens.is_empty() {
@@ -1541,6 +1684,7 @@ impl Interpreter {
                     secondary_named_capture: None,
                     ratchet,
                     frugal: false,
+                    separator: None,
                 });
                 continue;
             }
@@ -1563,6 +1707,7 @@ impl Interpreter {
                         secondary_named_capture: None,
                         ratchet,
                         frugal: false,
+                        separator: None,
                     });
                     continue;
                 }
@@ -1598,6 +1743,7 @@ impl Interpreter {
                     secondary_named_capture: None,
                     ratchet,
                     frugal: false,
+                    separator: None,
                 });
                 continue;
             }
@@ -1676,6 +1822,7 @@ impl Interpreter {
                         secondary_named_capture: None,
                         ratchet,
                         frugal: false,
+                        separator: None,
                     });
                     continue;
                 }
@@ -1908,6 +2055,7 @@ impl Interpreter {
                                         secondary_named_capture: None,
                                         ratchet: false,
                                         frugal: false,
+                                        separator: None,
                                     });
                                 }
                                 RegexAtom::Literal(*resolved.last().unwrap())
@@ -2181,6 +2329,7 @@ impl Interpreter {
                                         secondary_named_capture: None,
                                         ratchet: false,
                                         frugal: false,
+                                        separator: None,
                                     }],
                                     anchor_start: false,
                                     anchor_end: false,
@@ -2434,6 +2583,7 @@ impl Interpreter {
                                                     secondary_named_capture: None,
                                                     ratchet: false,
                                                     frugal: false,
+                                                    separator: None,
                                                 })
                                                 .collect();
                                             RegexPattern {
@@ -2557,6 +2707,7 @@ impl Interpreter {
                                                             secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
+                                                            separator: None,
                                                         },
                                                         RegexToken {
                                                             atom: RegexAtom::CharClass(CharClass {
@@ -2573,6 +2724,7 @@ impl Interpreter {
                                                             secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
+                                                            separator: None,
                                                         },
                                                     ],
                                                     anchor_start: false,
@@ -2597,6 +2749,7 @@ impl Interpreter {
                                                     secondary_named_capture: None,
                                                     ratchet: false,
                                                     frugal: false,
+                                                    separator: None,
                                                 }],
                                                 anchor_start: false,
                                                 anchor_end: false,
@@ -2835,6 +2988,7 @@ impl Interpreter {
                                                             secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
+                                                            separator: None,
                                                         },
                                                         RegexToken {
                                                             atom: RegexAtom::CharClass(CharClass {
@@ -2851,6 +3005,7 @@ impl Interpreter {
                                                             secondary_named_capture: None,
                                                             ratchet: false,
                                                             frugal: false,
+                                                            separator: None,
                                                         },
                                                     ],
                                                     anchor_start: false,
@@ -3057,6 +3212,7 @@ impl Interpreter {
                                     secondary_named_capture: None,
                                     ratchet: false,
                                     frugal: false,
+                                    separator: None,
                                 }],
                                 anchor_start: false,
                                 anchor_end: false,
@@ -3363,6 +3519,86 @@ impl Interpreter {
             } else {
                 ratchet // inherit from pattern-level :ratchet flag
             };
+            // Handle `%` / `%%` separator quantifier modifier, e.g.
+            // `<thing>+ % ','`. Only meaningful for repeating quantifiers. The
+            // separator is a single atom (the next atom in the stream); the rest
+            // of the line is matched after the quantified group. `%%` permits an
+            // optional trailing separator.
+            let token_separator: Option<Box<RegexSeparatorSpec>> =
+                if !matches!(quant, RegexQuant::One | RegexQuant::ZeroOrOne) {
+                    // Skip whitespace before the `%`.
+                    let mut lookahead = chars.clone();
+                    while lookahead.peek().is_some_and(|c| c.is_whitespace()) {
+                        lookahead.next();
+                    }
+                    // A `%` that begins a hash-alias capture for the FOLLOWING atom
+                    // (`%<name>=...` or `%name=...`) is NOT a separator. Detect that
+                    // shape and skip separator handling so the alias parses normally.
+                    let is_hash_alias = {
+                        let mut la = lookahead.clone();
+                        if la.peek() == Some(&'%') {
+                            la.next();
+                            // Reject `%%` (always a separator marker, never an alias).
+                            if la.peek() == Some(&'%') {
+                                false
+                            } else if la.peek() == Some(&'<') {
+                                // `%<...>=` — scan to `>` then require `=`.
+                                la.next();
+                                while la.peek().is_some_and(|&c| c != '>') {
+                                    la.next();
+                                }
+                                la.next(); // '>'
+                                la.peek() == Some(&'=')
+                            } else if la.peek().is_some_and(|&c| c.is_alphabetic() || c == '_') {
+                                // `%name=` — scan identifier then require `=`.
+                                while la.peek().is_some_and(|&c| c.is_alphanumeric() || c == '_') {
+                                    la.next();
+                                }
+                                la.peek() == Some(&'=')
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    };
+                    if lookahead.peek() == Some(&'%') && !is_hash_alias {
+                        // Commit: consume up to and including the `%`/`%%`.
+                        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+                            chars.next();
+                        }
+                        chars.next(); // first '%'
+                        let allow_trailing = if chars.peek() == Some(&'%') {
+                            chars.next();
+                            true
+                        } else {
+                            false
+                        };
+                        // Skip whitespace before the separator atom.
+                        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+                            chars.next();
+                        }
+                        // Collect the separator atom text (a single atom, which may
+                        // carry a `$<name>=` / `%<name>=` / `@<name>=` alias prefix
+                        // and/or a trailing quantifier).
+                        let remaining: String = chars.clone().collect();
+                        let sep_atom_str = Self::split_separator_atom(&remaining);
+                        // Advance the main iterator past the separator atom.
+                        for _ in 0..sep_atom_str.chars().count() {
+                            chars.next();
+                        }
+                        Self::parse_regex(self, sep_atom_str.trim()).map(|pattern| {
+                            Box::new(RegexSeparatorSpec {
+                                pattern,
+                                allow_trailing,
+                            })
+                        })
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
             // When both a user alias ($<name>=) and a builtin class name are pending,
             // the alias becomes the primary capture and the builtin name becomes secondary.
             let primary_named = pending_named_capture.take();
@@ -3381,6 +3617,7 @@ impl Interpreter {
                 secondary_named_capture: secondary_named,
                 ratchet: token_ratchet,
                 frugal: token_frugal,
+                separator: token_separator,
             });
         }
         let tokens = match rewrite_tilde_tokens(tokens, ignore_case, ignore_mark) {

--- a/t/regex-separator-conjunction-captures.t
+++ b/t/regex-separator-conjunction-captures.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 14;
+
+# Helper: render .caps as 'key:value|...'
+sub ca(@x) { join '|', @x.map({ .key ~ ':' ~ .value }) }
+
+# --- Conjunction (&&, &) captures: all branches' captures are kept, and all
+#     branches must cover the same substring. ---
+
+ok 'a' ~~ m/<alpha> && a/, 'conjunction matches (alpha && a)';
+is ca($/.caps), 'alpha:a', 'conjunction keeps first-branch named capture';
+
+ok 'a' ~~ m/a && <alpha>/, 'conjunction matches (a && alpha)';
+is ca($/.caps), 'alpha:a', 'conjunction keeps last-branch named capture';
+
+ok 'a' ~~ m/<alpha> & <ident>/, 'conjunction matches (alpha & ident)';
+is ca($/.caps.sort(*.key)), 'alpha:a|ident:a', 'conjunction merges all branch captures';
+
+# A conjunction with differing match lengths fails (same-substring rule).
+nok 'abc' ~~ m/\w\w && <alpha>/, 'conjunction fails when branches differ in length';
+
+# Quantified conjunction inside a capture group: group captures, not leaked names.
+ok 'ab' ~~ m/([a|b] && <alpha>)**1..2/, 'quantified conjunction in group matches';
+is ca($/.caps), '0:a|0:b', 'quantified group conjunction yields positional captures';
+
+# --- Named captures inside a positional group are sub-captures, not top-level. ---
+ok 'a' ~~ m/(<alpha>)/, 'named capture inside positional group matches';
+is ca($/.caps), '0:a', 'named-in-group is a positional capture, not top-level named';
+
+# --- Separator quantifiers (% / %%) fold each side into its own capture group. ---
+ok 'a;b,c,' ~~ m/(<.alpha>) +% (<.punct>)/, '% separator with captures matches';
+is ca($/.caps), '0:a|1:;|0:b|1:,|0:c', '% separator folds atom/sep into separate groups';
+
+ok 'a;b,c,' ~~ m/(<.alpha>) +%% (<.punct>)/, '%% separator with captures matches';


### PR DESCRIPTION
Improves the regex capture machinery shared by the S05-capture / S05-match tests. All fixes are genuine general-purpose improvements (no test-specific hacks).

## Changes

- **Conjunction (`&` / `&&`) captures.** All branches must now cover the *same substring* (end at the same position, per spec), and captures from **every** branch are merged in written order — previously only the longest branch's captures were kept.
- **Named captures inside a positional group** (`(<alpha>)`) are now sub-captures of that group (`$/[0]<alpha>`) instead of leaking to the parent Match's top-level named captures (`$/<alpha>`).
- **`**N..M` over a capturing atom** no longer string-expands (which renumbered captures); it defers to the normal `Repeat` quantifier with proper capture folding.
- **Native `%` / `%%` separator quantifiers.** Added `RegexSeparatorSpec` on `RegexToken` plus a `match_separated_quantifier` matcher that folds each side into its own capture group, matching Raku's Match layout. String expansion is retained for sigspace and backtracking-sensitive cases (`||`, frugal quantifiers).

Also carries pre-existing worktree regex fixes (leading-null alternative `( || X )` == `( X )`; ratchet commits to highest-priority atom match).

## Impact

- `S05-capture/caps.t`: 25/43 → **42/43**.
- `capturing-contexts.t`, `alias.t`, `array-alias.t`, `hash.t` advance but remain blocked on separate features documented in `TODO_roast/S05.md`.
- No regressions across the 88 whitelisted S05 tests or the `t/` suite.

New test: `t/regex-separator-conjunction-captures.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)