### PR TITLE
regex: memoize static-pattern parsing to fix subrule-heavy hang (S05 longest-alternative)

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -78,6 +78,30 @@
     - `<$var>` undeclared-var lookup must throw `X::Undeclared` (typed exception)
     - Reinterpret-only-one-level: `<$var>` where `$var` contains `<...>` must die
 - [ ] roast/S05-metasyntax/longest-alternative.t
+  - No longer TIMES OUT (was a hang). Root cause was not LTM but a missing
+    parse cache: `parse_regex` re-parsed the (large) `huge` token pattern on
+    every input character. The `WithHugeToken` token (~90 alternations) matched
+    against `'a' x 10000` re-parsed that ~3 KB pattern 10000 times — ~31 s for
+    that block alone, blowing the 30 s prove timeout. Fixed by memoizing the
+    parse of *static* patterns (those with no `$`/`@`/`%` interpolation sigils,
+    so their parse is a deterministic function of the source string). The whole
+    file now runs in ~3 s.
+  - Remaining failures (7 genuine + 1 `#?rakudo todo`) all require a proper LTM
+    *fate / declarative-prefix* model. mutsu's `|` currently picks the longest
+    *actual* match; the spec requires ranking alternatives by their *declarative
+    prefix* length and only then running the winning fate. Blockers:
+    - non-constant interpolated alternative must NOT count toward LTM
+      (`/ a | b | $y /` with `my $y='ab'` must match `a`, not `ab`); a constant
+      `$x` DOES count. Needs compile-time-constant tracking through interpolation.
+    - sequential alternation `||` inside `|`: only the FIRST branch participates
+      in LTM (`/ 'foo' | ['doof' || 'food'] /` must match `foo`, not `food`).
+    - implicit `<.ws>` of a `rule` is non-declarative and stops LTM
+      (`<rule>` contributes only its prefix before `<.ws>` to the fate ranking).
+    - negative lookahead does not LTM properly (this subtest is `#?rakudo todo`).
+    - `IETF::RFC_Grammar::URI` grammar fails to parse (X::Syntax::Confused) —
+      combined character-class subrule syntax `<+unreserved +sub_delims>`,
+      `<[\-+.] +uri_alpha +digit>*` not fully supported.
+    - Gproto proto-token subrule capture `$m<foo>` comes back empty.
 - [ ] roast/S05-metasyntax/lookaround.t
 - [x] roast/S05-metasyntax/null.t
   - 4/4 pass.

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -8,6 +8,24 @@ thread_local! {
     /// Thread-local storage for regex security errors that need to propagate
     /// from inside `parse_regex` (which takes `&self`) to callers that can throw.
     pub(super) static PENDING_REGEX_ERROR: RefCell<Option<RuntimeError>> = const { RefCell::new(None) };
+
+    /// Memoization cache for parsing *static* regex patterns (patterns whose
+    /// parse result does not depend on runtime state). Parsing a pattern is a
+    /// recursive-descent operation that is pure for patterns containing no
+    /// scalar/array/hash interpolation sigils (`$`, `@`, `%`); for such patterns
+    /// the parsed `RegexPattern` is a deterministic function of the source string,
+    /// so it is safe to cache and reuse across calls. This avoids re-parsing the
+    /// same (potentially large) pattern on every step of a match — e.g. a token
+    /// with dozens of alternations called once per input character.
+    static REGEX_PARSE_CACHE: RefCell<HashMap<String, RegexPattern>> = RefCell::new(HashMap::new());
+}
+
+/// A pattern is cacheable iff parsing it does not depend on runtime variable
+/// state. Interpolation (`interpolate_regex_scalars`) only substitutes when the
+/// pattern contains a `$`, `@`, or `%` sigil, so a pattern free of those parses
+/// deterministically.
+fn regex_pattern_is_static(pattern: &str) -> bool {
+    !pattern.contains(['$', '@', '%'])
 }
 
 fn single_token_pattern(token: RegexToken, ignore_case: bool, ignore_mark: bool) -> RegexPattern {
@@ -1185,6 +1203,23 @@ impl Interpreter {
     }
 
     pub(super) fn parse_regex(&self, pattern: &str) -> Option<RegexPattern> {
+        // Fast path: reuse a previously-parsed result for static patterns.
+        if regex_pattern_is_static(pattern) {
+            if let Some(cached) = REGEX_PARSE_CACHE.with(|c| c.borrow().get(pattern).cloned()) {
+                return Some(cached);
+            }
+            let parsed = self.parse_regex_uncached(pattern);
+            if let Some(ref p) = parsed {
+                REGEX_PARSE_CACHE.with(|c| {
+                    c.borrow_mut().insert(pattern.to_string(), p.clone());
+                });
+            }
+            return parsed;
+        }
+        self.parse_regex_uncached(pattern)
+    }
+
+    fn parse_regex_uncached(&self, pattern: &str) -> Option<RegexPattern> {
         fn named_lookup_is_ws(name: &str) -> bool {
             let mut raw = name.trim();
             if let Some(stripped) = raw.strip_prefix('.') {

--- a/t/regex-subrule-parse-cache.t
+++ b/t/regex-subrule-parse-cache.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Regression test: a token/subrule with many alternations, called once per
+# input character over a long string, must not be pathologically slow. Before
+# the parse-result cache, `parse_regex` re-parsed the (large) token pattern on
+# every match step, making this take tens of seconds and time out under prove.
+# See roast/S05-metasyntax/longest-alternative.t (WithHugeToken block).
+
+plan 4;
+
+{
+    my grammar Letters {
+        token TOP { <ltr>+ }
+        token ltr {
+              'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j'
+            | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't'
+            | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+        }
+    }
+
+    ok Letters.parse('a' x 5000), 'many-alternation token matches a long string';
+    is Letters.parse('hello').Str, 'hello', 'matches a normal word';
+}
+
+# Basic LTM still works (longest alternative wins).
+{
+    my $str = 'a' x 7;
+    ok $str ~~ m/aa|a|aaaa/, 'alternation matches';
+    is ~$/, 'aaaa', 'longest alternative wins regardless of order';
+}


### PR DESCRIPTION
## Summary

`roast/S05-metasyntax/longest-alternative.t` used to **time out** under prove. The hang was **not** in LTM evaluation but in **repeated parsing**: `parse_regex()` re-parses a pattern string from scratch on every call, and a subrule like `<huge>` (a token with ~90 alternations) is resolved and re-parsed *once per input character*. Matching that token against `'a' x 10000` re-parsed the ~3 KB pattern 10000 times — ~31 s for that block alone, blowing the 30 s timeout.

## Fix

Add a thread-local memoization cache for parsing **static** patterns — those with no scalar/array/hash interpolation sigils (`$`, `@`, `%`), whose parse result is therefore a deterministic function of the source string. Patterns that interpolate runtime state bypass the cache and parse exactly as before, so behavior is unchanged; only redundant re-parsing is eliminated.

Result: the whole test file now runs in **~3 s instead of timing out** (the `WithHugeToken` block alone went 31 s → 2 s, a ~15x speedup). This benefits all grammar/subrule-heavy matching, not just this test.

## Scope

The remaining 7 genuine failures in that roast file all need a proper **LTM declarative-prefix / fate** model (non-constant vars excluded from LTM, `||` first-branch-only, `<.ws>` stops LTM, combined char-class subrule syntax, proto-token captures). These are unrelated to the hang and documented in `TODO_roast/S05.md` for a follow-up, so **the file is not whitelisted yet**.

## Testing

- New regression test `t/regex-subrule-parse-cache.t` (many-alternation token over a 5000-char string; runs in 0.1 s).
- All 88 whitelisted S05 tests pass (no regression from the cache).
- `cargo test --lib`: 449 pass. `prove t/`: 572 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)