### PR TITLE
S03-metaops/hyper.t: hyper-op precedence inheritance + recursive distribution

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -42,11 +42,16 @@
     a dwim side that is empty yields an empty result and a `*`-terminated list
     extends by copying its last real element; hyper infix called as a named
     function returns a List.
+  - Fixed (this PR): hyper-op precedence — `»+«` vs `»*«` now inherit their base
+    op's precedence (parser precedence-climbing in `concat_expr`); hyper unary
+    postfix and hyper method calls (`@a>>++`, `@a>>.abs`) now descend
+    *recursively* through nested Iterables/Hashes and write any in-place leaf
+    mutation back through every level (the "distribution for unary postfix
+    autoincr" subtests). See `t/hyper-precedence-deep.t`.
   - Remaining blockers: (1) `.deepmap`/`.nodemap` with a *mutating* block
     (`++*`, `*--`) must mutate the source leaves in place (the "hash in array
-    ++<<" / "distribution for unary postfix autoincr" subtests rely on the
-    sequential mutated state); (2) hyper-op precedence — `»+«` vs `»*«` should
-    inherit their base op's precedence (parser); (3) individual nodal methods
+    ++<<" subtests rely on the sequential mutated state — blocked on first-class
+    array-element containers); (3) individual nodal methods
     `.tree`, `.roll`, `.eager`, `.postcircumfix:<[; ]>` (multidim slice),
     `.splice` (rakudo-todo); (4) `»+=«`/`»*=»` meta-assign return value;
     (5) advanced hyper *method-call* dispatch variants in the `'method call

--- a/src/parser/expr/precedence_meta_ops.rs
+++ b/src/parser/expr/precedence_meta_ops.rs
@@ -678,6 +678,56 @@ fn try_custom_infix_at_level<'a>(
     Ok(None)
 }
 
+/// Numeric precedence ordering for a hyper operator's base op.
+/// Hyper operators inherit the precedence of the operator they are based on,
+/// so `(1,2,3) »+« (10,20,30) »*« (2,3,4)` multiplies before adding.
+fn hyper_op_prec(op: &str) -> i32 {
+    match classify_base_op(op) {
+        OpPrecedence::Multiplicative => 50,
+        OpPrecedence::Additive => 40,
+        OpPrecedence::Concatenation => 30,
+        OpPrecedence::Comparison => 20,
+        OpPrecedence::Other => 10,
+    }
+}
+
+/// Parse the right-hand side of a hyper operator, folding in any following
+/// hyper operators whose base precedence is *tighter* than `parent_prec`.
+/// This makes hyper operators honour their base operator's precedence while
+/// keeping equal-precedence chains left-associative (the outer `concat_expr`
+/// loop combines those).
+fn parse_hyper_rhs(input: &str, parent_prec: i32) -> PResult<'_, Expr> {
+    let (mut rest, mut left) = replication_expr(input)?;
+    loop {
+        let (r, _) = ws(rest)?;
+        if block_newline_terminates(input, rest, r) {
+            break;
+        }
+        if let Some((op, dwim_left, dwim_right, len)) = parse_hyper_op(r) {
+            let prec = hyper_op_prec(&op);
+            if prec <= parent_prec {
+                break;
+            }
+            let r = &r[len..];
+            let (r, _) = ws(r)?;
+            let (r, right) = parse_hyper_rhs(r, prec).map_err(|err| {
+                enrich_expected_error(err, "expected expression after hyper operator", r.len())
+            })?;
+            left = Expr::HyperOp {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+                dwim_left,
+                dwim_right,
+            };
+            rest = r;
+            continue;
+        }
+        break;
+    }
+    Ok((rest, left))
+}
+
 /// String concatenation: ~
 pub(super) fn concat_expr(input: &str) -> PResult<'_, Expr> {
     let (mut rest, mut left) = replication_expr(input)?;
@@ -709,9 +759,10 @@ pub(super) fn concat_expr(input: &str) -> PResult<'_, Expr> {
         }
         // Hyper operators: >>op<<, >>op>>, <<op<<, <<op>>
         if let Some((op, dwim_left, dwim_right, len)) = parse_hyper_op(r) {
+            let parent_prec = hyper_op_prec(&op);
             let r = &r[len..];
             let (r, _) = ws(r)?;
-            let (r, right) = replication_expr(r).map_err(|err| {
+            let (r, right) = parse_hyper_rhs(r, parent_prec).map_err(|err| {
                 enrich_expected_error(err, "expected expression after hyper operator", r.len())
             })?;
             left = Expr::HyperOp {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -295,41 +295,18 @@ impl VM {
                         method_is_nodal = true;
                     }
                     if is_iterable_item && !is_list_native_method {
-                        let sub_items = crate::runtime::value_to_list(item);
-                        let mut sub_results = Vec::with_capacity(sub_items.len());
-                        for sub_item in sub_items {
-                            let sub_val = if !skip_native {
-                                if let Some(native_result) = self.try_native_method(
-                                    &sub_item,
-                                    Symbol::intern(&method),
-                                    &item_args,
-                                ) {
-                                    native_result?
-                                } else {
-                                    let (v, _updated) = self.call_method_mut_with_temp_target(
-                                        &sub_item,
-                                        &method,
-                                        item_args.clone(),
-                                        idx,
-                                    )?;
-                                    v
-                                }
-                            } else {
-                                let (v, _updated) = self.call_method_mut_with_temp_target(
-                                    &sub_item,
-                                    &method,
-                                    item_args.clone(),
-                                    idx,
-                                )?;
-                                v
-                            };
-                            sub_results.push(sub_val);
-                        }
-                        let sub_kind = match item {
-                            Value::Array(_, kind) => *kind,
-                            _ => ArrayKind::List,
-                        };
-                        results.push(Value::Array(std::sync::Arc::new(sub_results), sub_kind));
+                        // Hyper methods descend recursively through nested
+                        // Iterables (and Hash values) down to the leaves, and
+                        // any in-place leaf mutation (e.g. `@a>>++` on nested
+                        // arrays) is written back through every level.
+                        let (sub_result, sub_mutated) = self.hyper_method_apply_recursive(
+                            item,
+                            &method,
+                            &item_args,
+                            skip_native,
+                        )?;
+                        *item = sub_mutated;
+                        results.push(sub_result);
                     } else {
                         let val = if !skip_native {
                             if let Some(native_result) =
@@ -486,6 +463,82 @@ impl VM {
         self.stack
             .push(Value::Array(std::sync::Arc::new(results), result_kind));
         Ok(())
+    }
+
+    /// Recursively apply a (non-nodal) hyper method to a value, descending into
+    /// nested Iterables and Hash values down to the leaves. Returns
+    /// `(result, mutated)`: `result` mirrors the structure with the method
+    /// return values, while `mutated` mirrors the structure with any in-place
+    /// leaf mutations (e.g. `>>++`) applied at every level so the caller can
+    /// write the changes back to the original container.
+    fn hyper_method_apply_recursive(
+        &mut self,
+        item: &Value,
+        method: &str,
+        args: &[Value],
+        skip_native: bool,
+    ) -> Result<(Value, Value), RuntimeError> {
+        match item {
+            Value::Array(elems, kind) => {
+                let mut results = Vec::with_capacity(elems.len());
+                let mut mutated = Vec::with_capacity(elems.len());
+                for sub in elems.iter() {
+                    let (r, m) =
+                        self.hyper_method_apply_recursive(sub, method, args, skip_native)?;
+                    results.push(r);
+                    mutated.push(m);
+                }
+                Ok((
+                    Value::Array(std::sync::Arc::new(results), *kind),
+                    Value::Array(std::sync::Arc::new(mutated), *kind),
+                ))
+            }
+            Value::Seq(elems) | Value::Slip(elems) => {
+                let mut results = Vec::with_capacity(elems.len());
+                let mut mutated = Vec::with_capacity(elems.len());
+                for sub in elems.iter() {
+                    let (r, m) =
+                        self.hyper_method_apply_recursive(sub, method, args, skip_native)?;
+                    results.push(r);
+                    mutated.push(m);
+                }
+                Ok((
+                    Value::Array(std::sync::Arc::new(results), ArrayKind::List),
+                    Value::Array(std::sync::Arc::new(mutated), ArrayKind::List),
+                ))
+            }
+            Value::Hash(map) => {
+                let keys: Vec<String> = map.keys().cloned().collect();
+                let mut res_map = std::collections::HashMap::with_capacity(keys.len());
+                let mut mut_map = std::collections::HashMap::with_capacity(keys.len());
+                for k in keys {
+                    let v = map.get(&k).cloned().unwrap_or(Value::Nil);
+                    let (r, m) =
+                        self.hyper_method_apply_recursive(&v, method, args, skip_native)?;
+                    res_map.insert(k.clone(), r);
+                    mut_map.insert(k, m);
+                }
+                Ok((
+                    Value::Hash(std::sync::Arc::new(res_map)),
+                    Value::Hash(std::sync::Arc::new(mut_map)),
+                ))
+            }
+            _ => {
+                // Leaf: apply the method, mirroring the non-recursive leaf path.
+                if !skip_native
+                    && let Some(native_result) =
+                        self.try_native_method(item, Symbol::intern(method), args)
+                {
+                    let v = native_result?;
+                    // Native methods do not mutate the receiver: the mutated
+                    // value is the original leaf unchanged.
+                    return Ok((v, item.clone()));
+                }
+                let (v, updated) =
+                    self.call_method_mut_with_temp_target(item, method, args.to_vec(), 0)?;
+                Ok((v, updated))
+            }
+        }
     }
 
     pub(super) fn exec_hyper_method_call_dynamic_op(

--- a/t/hyper-precedence-deep.t
+++ b/t/hyper-precedence-deep.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+# Hyper operators inherit the precedence of their base operator:
+# »*« binds tighter than »+«.
+{
+    my @r = (1, 2, 3) »+« (10, 20, 30) »*« (2, 3, 4);
+    is ~@r, '21 62 123', 'hyper »*« is tighter than »+«';
+}
+{
+    my @r = (1, 2, 3) »*« (10, 20, 30) »+« (2, 3, 4);
+    is ~@r, '12 43 94', 'hyper »*« first even when written on the left';
+}
+{
+    my @r = (1, 2, 3) »+« (10, 20, 30) »+« (100, 200, 300);
+    is ~@r, '111 222 333', 'same-precedence hyper chain is left-assoc';
+}
+{
+    my @r = (2, 3) »+« (10, 20) »*« (3, 4) »+« (1, 1);
+    is ~@r, '33 84', 'mixed hyper precedence chain';
+}
+
+# Hyper postfix ++ distributes recursively into nested arrays, mutating in place.
+{
+    my @r = [1, 2], [3, [4, 5]];
+    @r»++;
+    is ~@r, '2 3 4 5 6', 'hyper ++ distributes recursively (stringified)';
+    is-deeply @r, [[2, 3], [4, [5, 6]]], 'hyper ++ mutates nested arrays in place';
+}
+{
+    my @r = [10, 20], [30, [40, 50]];
+    @r>>--;
+    is-deeply @r, [[9, 19], [29, [39, 49]]], 'hyper -- distributes recursively (ASCII)';
+}
+
+# Hyper method call distributes recursively through nested structures.
+{
+    my @r = [-1, -2], [-3, [-4, -5]];
+    my @abs = @r>>.abs;
+    is-deeply @abs, [[1, 2], [3, [4, 5]]], 'hyper .abs distributes recursively';
+}


### PR DESCRIPTION
## Summary

Two general hyper-operator fixes from the **Hyper/Meta Operators** blocker
(`TODO_roast/BLOCKERS.md`). `roast/S03-metaops/hyper.t` goes from 15 → 12 failing
sub-subtests (tests 17, 92, 93 now pass).

### 1. Hyper operators inherit their base operator's precedence
Previously every `>>op<<` / `«op»` infix was parsed at one fixed level in
`concat_expr`, so `(1,2,3) »+« (10,20,30) »*« (2,3,4)` evaluated left-to-right
and produced `22 66 132`. Hyper operators inherit the precedence of the
operator they are based on, so `»*«` must bind tighter than `»+«`
(→ `21 62 123`). Added precedence-climbing (`parse_hyper_rhs`) keyed on the
existing `classify_base_op`, keeping equal-precedence chains left-associative.

### 2. Recursive distribution of hyper postfix / method calls
Hyper unary postfix (`@a>>++`) and hyper method calls (`@a>>.abs`) now descend
**recursively** through nested Iterables and Hash values, writing any in-place
leaf mutation back through every level. `@a>>++` on `[[1,2],[3,[4,5]]]` now
yields `[[2,3],[4,[5,6]]]` (was a no-op on nested arrays). The old one-level
manual recursion in `exec_hyper_method_call_op` is replaced by
`hyper_method_apply_recursive`, which returns both the result structure and the
mutated structure.

## Testing
- `t/hyper-precedence-deep.t` (new) — 8 assertions.
- `make test` passes (only non-hyper failures are known-flaky `t/lock.t` and a
  debug-build timeout on `t/json-tiny-compat.t`, which contains no hyper ops).
- No regressions in `S03-metaops/{infix,cross,zip}.t`, `S03-operators/arith.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)