### PR TITLE
feat(vm): enforce inline where constraints on variables and on ++/--

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -384,10 +384,38 @@ located relative to CWD) — `run-roast-test.sh` now runs them with CWD=roast.
 
 ## Subset Types / Where Clauses (2 tests)
 
-Subset types with complex where clauses, and their interaction with type checking, hang or fail.
+Subset types with complex where clauses, and their interaction with type checking.
 
-- roast/S12-subset/subtypes.t (timeout)
-- roast/S02-names/is_default.t
+- roast/S12-subset/subtypes.t (no longer times out; 90/92 run, 13 failing as of
+  the inline-`where`/`++` fixes below). Inline `where` constraints on `my`
+  variables (`my $x where * > 0`, `my Int $n where { $_ %% 2 }`,
+  `my $v where &predicate`) are now desugared into anonymous subsets so they are
+  enforced on initialization AND on assignment, and `++`/`--` on a subset-typed
+  scalar re-checks the constraint (`my Even $x = 2; $x++` throws
+  X::TypeCheck::Assignment and preserves the value). Local test:
+  t/where-constraint-var.t. **Remaining failures are NOT where-clause bugs:**
+  the dominant one is closure writeback from a block/Whatever-code predicate
+  stored in a `&`-variable — `my &pm = { $wanted = $^got; True }; 42 ~~ PS`
+  updates `$wanted` the first time but a second invocation of the same captured
+  block (e.g. via a later `my $x where &pm = 42`) re-runs the body yet its write
+  to the captured `$wanted` is lost. This is the first-class container-identity /
+  closure-capture limitation (lever C, in progress), not subset-specific. The
+  same root cause blocks the signature `where &codevar` `neg arg`/`pos arg`
+  subtests (the predicate's write to the outer `$wanted` does not propagate).
+  Other independent failures: `fail()` inside a subset predicate (test 25),
+  Junction-of-types in `where` (87), read-only enforcement of the `where` topic
+  (34), and `where &var` enforcement on `|c`/slurpy params (85). Tests 91-92 also
+  fail in reference rakudo here.
+- roast/S02-names/is_default.t — **unpassable as written**: reference rakudo
+  (2022.12) fails to compile it (`===SORRY===` at line 527, `has $.v is
+  default(T)` inside a generic role). mutsu actually runs further (141/146) than
+  the reference. Its remaining real failures are the `is default(...)` trait on
+  **hashes** when the defaulted hash is stored in an array and re-bound via a
+  `for` signature (`%a is raw`): the container-keyed default (keyed by the Arc
+  pointer of the hash map) is lost across the copy/rebind, so `%a<o>` and
+  `%a.VAR.default` return `(Any)` instead of the default. Blocked on first-class
+  container identity (same root limitation), and unwhitelist­able regardless
+  because of the line-527 generic-role compile failure.
 
 ## Binding / Container Semantics (4 tests)
 

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -589,8 +589,37 @@ impl Compiler {
                 is_export,
                 export_tags,
                 custom_traits,
-                where_constraint: _,
+                where_constraint,
             } => {
+                // An inline `where` constraint on a scalar/sigilless variable
+                // (e.g. `my $x where * > 0`, `my Int $n where { $_ %% 2 }`,
+                // `my $v where &predicate`) is desugared into an anonymous subset
+                // whose base is the declared type (or `Any`) and whose predicate is
+                // the `where` expression. Reusing the subset machinery means the
+                // existing type-constraint enforcement (TypeCheck on init and on
+                // every assignment) checks the predicate for free. Collection
+                // variables (`@`/`%`) are left untouched: a `where` there applies
+                // to the whole container, which we do not yet model this way.
+                let owned_type_constraint: Option<String> = match where_constraint {
+                    Some(wc) if !name.starts_with('@') && !name.starts_with('%') => {
+                        let anon = format!("__mutsu_anon_subset_{}", self.tmp_counter);
+                        self.tmp_counter += 1;
+                        let base = type_constraint.clone().unwrap_or_else(|| "Any".to_string());
+                        let subset_stmt = Stmt::SubsetDecl {
+                            name: Symbol::intern(&anon),
+                            base,
+                            predicate: Some((**wc).clone()),
+                            version: String::new(),
+                            is_export: false,
+                            export_tags: Vec::new(),
+                        };
+                        let idx = self.code.add_stmt(subset_stmt);
+                        self.code.emit(OpCode::RegisterSubset(idx));
+                        Some(anon)
+                    }
+                    _ => type_constraint.clone(),
+                };
+                let type_constraint = &owned_type_constraint;
                 // X::Dynamic::Package: dynamic variables cannot have package-like names
                 if Self::is_dynamic_package_var(name) {
                     self.emit_dynamic_package_error(name);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -923,6 +923,7 @@ impl VM {
         }
         let val = self.normalize_incdec_source_with_type(name, val);
         let new_val = self.increment_value_smart(&val)?;
+        self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
@@ -999,6 +1000,7 @@ impl VM {
         }
         let val = self.normalize_incdec_source_with_type(name, val);
         let new_val = self.decrement_value_smart(&val)?;
+        self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1272,6 +1272,44 @@ impl VM {
         Ok(Self::increment_value(val))
     }
 
+    /// Enforce a scalar variable's declared type/subset constraint on the result
+    /// of an in-place `++`/`--`. Raku re-checks the constraint after the
+    /// mutation, so `my Even $x = 2; $x++` must throw X::TypeCheck::Assignment
+    /// (3 is not Even) and leave the variable untouched. Native int/num/str
+    /// variables wrap instead of erroring, so they are skipped, as are
+    /// container (`@`/`%`/`&`) variables whose constraint applies to elements.
+    pub(super) fn check_incdec_type_constraint(
+        &mut self,
+        name: &str,
+        new_val: &Value,
+    ) -> Result<(), RuntimeError> {
+        if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
+            return Ok(());
+        }
+        if let Some(constraint) = self.interpreter.var_type_constraint(name) {
+            if crate::runtime::native_types::is_native_int_type(&constraint)
+                || matches!(constraint.as_str(), "num" | "num32" | "num64" | "str")
+            {
+                return Ok(());
+            }
+            if !matches!(new_val, Value::Nil)
+                && !self.interpreter.type_matches_value(&constraint, new_val)
+            {
+                let display = if name.starts_with('$') {
+                    name.to_string()
+                } else {
+                    format!("${}", name)
+                };
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    &display,
+                    &constraint,
+                    new_val,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Decrement a value, calling .pred() on Instance values with custom methods.
     pub(super) fn decrement_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
         if let Value::Instance { .. } = val
@@ -1376,6 +1414,7 @@ impl VM {
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.increment_value_smart(&val)?;
         let new_val = Self::maybe_wrap_native_int(&self.interpreter, name, new_val);
+        self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
@@ -1502,6 +1541,7 @@ impl VM {
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.decrement_value_smart(&val)?;
         let new_val = Self::maybe_wrap_native_int(&self.interpreter, name, new_val);
+        self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);

--- a/t/where-constraint-var.t
+++ b/t/where-constraint-var.t
@@ -1,0 +1,69 @@
+use Test;
+
+# Inline `where` constraints on `my` variable declarations are enforced both
+# on initialization and on subsequent assignment, and `++`/`--` re-check the
+# declared subset/type constraint.
+
+plan 20;
+
+# --- Block constraint -------------------------------------------------------
+{
+    my $a where { $_ > 10 } = 50;
+    is $a, 50, 'block where: valid initializer accepted';
+    throws-like { my $b where { $_ > 10 } = 5 },
+        X::TypeCheck::Assignment, 'block where: invalid initializer dies';
+
+    my $c where { $_ %% 2 } = 4;
+    throws-like { $c = 7 }, X::TypeCheck::Assignment,
+        'block where: invalid reassignment dies';
+    is $c, 4, 'block where: value preserved after failed assignment';
+    lives-ok { $c = 8 }, 'block where: valid reassignment lives';
+    is $c, 8, 'block where: valid reassignment took effect';
+}
+
+# --- Whatever-code constraint ----------------------------------------------
+{
+    my $a where * > 100 = 200;
+    is $a, 200, 'whatever where: valid initializer accepted';
+    throws-like { my $b where * > 100 = 5 },
+        X::TypeCheck::Assignment, 'whatever where: invalid initializer dies';
+}
+
+# --- Constraint combined with a declared type ------------------------------
+{
+    my Int $a where * %% 3 = 9;
+    is $a, 9, 'typed where: valid initializer accepted';
+    throws-like { my Int $b where * %% 3 = 10 },
+        X::TypeCheck::Assignment, 'typed where: failing predicate dies';
+    throws-like { my Int $c where * %% 3 = "x" },
+        X::TypeCheck::Assignment, 'typed where: failing base type dies';
+}
+
+# --- Code-variable constraint ----------------------------------------------
+{
+    my &even = { $_ %% 2 };
+    my $a where &even = 6;
+    is $a, 6, 'code-var where: valid initializer accepted';
+    throws-like { my $b where &even = 7 },
+        X::TypeCheck::Assignment, 'code-var where: invalid initializer dies';
+}
+
+# --- ++/-- re-check a named subset constraint ------------------------------
+{
+    subset Even of Int where { $_ % 2 == 0 };
+    my Even $x = 2;
+    throws-like { $x++ }, X::TypeCheck::Assignment, 'subset var cannot be ++ed';
+    is $x, 2, 'value preserved after failed ++';
+    throws-like { $x-- }, X::TypeCheck::Assignment, 'subset var cannot be --ed';
+    is $x, 2, 'value preserved after failed --';
+}
+
+# --- ++ that lands on a valid value still works ----------------------------
+{
+    subset BigEnough of Int where { $_ >= 0 };
+    my BigEnough $n = 5;
+    lives-ok { $n++ }, 'in-range ++ lives';
+    is $n, 6, 'in-range ++ updates the value';
+    throws-like { $n = -1 }, X::TypeCheck::Assignment,
+        'out-of-range assignment still dies';
+}


### PR DESCRIPTION
## Summary

Two related subset/where-clause fixes driven by `TODO_roast/BLOCKERS.md` (Subset Types / Where Clauses), found by deep-diving `roast/S12-subset/subtypes.t`:

1. **Inline `where` constraints on `my` variables are now enforced.** A constraint like `my $x where * > 0`, `my Int $n where { $_ %% 2 }`, or `my $v where &predicate` was parsed but silently dropped at compile time. It is now desugared into an anonymous subset whose base is the declared type (or `Any`) and whose predicate is the `where` expression, so the existing type-constraint machinery checks it both on initialization and on every later assignment. Collection variables (`@`/`%`) are left untouched.

2. **`++`/`--` re-check the declared subset/type constraint.** `my Even $x = 2; $x++` previously produced an odd value silently. All four scalar inc/dec ops now run a post-mutation check that throws `X::TypeCheck::Assignment` and preserves the old value. Native `int`/`num`/`str` still wrap and are skipped.

## Impact

- `roast/S12-subset/subtypes.t`: 16 to 13 failing (of 90 run; no longer times out).
- New local test `t/where-constraint-var.t` (20 subtests).

Remaining `subtypes.t` failures are not where-clause bugs: the dominant one is closure writeback from a block/Whatever-code predicate captured in a `&`-variable, the first-class container-identity limitation already tracked separately. `BLOCKERS.md` is updated with the analysis.

## Testing

- `make test` green except the known-flaky `t/lock.t`.
- All whitelisted subset tests still pass.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)