### PR TITLE
fix(regex): named capture `$<x>=(...)` must not consume a positional number

### DIFF
--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -298,29 +298,48 @@ impl Interpreter {
             }
             return results;
         }
-        let apply_named_capture =
-            |token: &RegexToken, from: usize, to: usize, caps: RegexCaptures| -> RegexCaptures {
-                let Some(name) = token.named_capture.as_ref() else {
-                    return caps;
-                };
-                let mut updated = caps;
-                let captured: String = chars[from..to].iter().collect();
+        let apply_named_capture = |token: &RegexToken,
+                                   from: usize,
+                                   to: usize,
+                                   pos_base: usize,
+                                   caps: RegexCaptures|
+         -> RegexCaptures {
+            let Some(name) = token.named_capture.as_ref() else {
+                return caps;
+            };
+            let mut updated = caps;
+            let captured: String = chars[from..to].iter().collect();
+            // A named capture group `$<x>=(...)` aliases the group to the name and
+            // does NOT consume a positional number (Raku: `/$<x>=(\w)(\d)/` makes
+            // `$<x>` the \w and `$0` the \d). When this named token's atom is itself
+            // a capturing group, it pushed a parent positional during matching;
+            // drop those entries so the following `(...)` keeps the next number.
+            // A named NON-capturing group `$<x>=[...]` leaves its inner captures'
+            // positional numbers intact (its atom is not a CaptureGroup), so this
+            // truncation correctly does not fire for it.
+            if matches!(token.atom, RegexAtom::CaptureGroup(_))
+                && updated.positional.len() > pos_base
+            {
+                updated.positional.truncate(pos_base);
+                updated.positional_subcaps.truncate(pos_base);
+                updated.positional_quantified.truncate(pos_base);
+            }
+            updated
+                .named
+                .entry(name.clone())
+                .or_default()
+                .push(captured.clone());
+            // Also capture under the secondary name (e.g., original builtin class name
+            // when using `$<alias>=<builtin_class>` syntax).
+            if let Some(secondary) = token.secondary_named_capture.as_ref() {
                 updated
                     .named
-                    .entry(name.clone())
+                    .entry(secondary.clone())
                     .or_default()
-                    .push(captured.clone());
-                // Also capture under the secondary name (e.g., original builtin class name
-                // when using `$<alias>=<builtin_class>` syntax).
-                if let Some(secondary) = token.secondary_named_capture.as_ref() {
-                    updated
-                        .named
-                        .entry(secondary.clone())
-                        .or_default()
-                        .push(captured);
-                }
-                updated
-            };
+                    .push(captured);
+            }
+            updated
+        };
         let apply_hash_capture = |token: &RegexToken,
                                   _from: usize,
                                   _to: usize,
@@ -396,7 +415,7 @@ impl Interpreter {
                     stack.push((
                         idx + 1,
                         next,
-                        apply_named_capture(token, pos, next, new_caps),
+                        apply_named_capture(token, pos, next, pos_base, new_caps),
                     ));
                 }
                 continue;
@@ -433,7 +452,7 @@ impl Interpreter {
                                 pos,
                                 next,
                                 pos_base,
-                                apply_named_capture(token, pos, next, new_caps),
+                                apply_named_capture(token, pos, next, pos_base, new_caps),
                             ),
                         ));
                     }
@@ -470,7 +489,13 @@ impl Interpreter {
                                     pos,
                                     *next,
                                     pos_base,
-                                    apply_named_capture(token, pos, *next, new_caps.clone()),
+                                    apply_named_capture(
+                                        token,
+                                        pos,
+                                        *next,
+                                        pos_base,
+                                        new_caps.clone(),
+                                    ),
                                 ),
                             ));
                         }
@@ -488,7 +513,7 @@ impl Interpreter {
                                 pos,
                                 next,
                                 pos_base,
-                                apply_named_capture(token, pos, next, new_caps),
+                                apply_named_capture(token, pos, next, pos_base, new_caps),
                             ),
                         ));
                     }
@@ -620,7 +645,7 @@ impl Interpreter {
                                 current,
                                 next,
                                 iter_pos_base,
-                                apply_named_capture(token, current, next, new_caps),
+                                apply_named_capture(token, current, next, pos_base, new_caps),
                             );
                             current_caps = new_caps.clone();
                             positions.push((next, new_caps));
@@ -799,7 +824,7 @@ impl Interpreter {
                                     pos,
                                     next,
                                     pos_base,
-                                    apply_named_capture(token, pos, next, new_caps),
+                                    apply_named_capture(token, pos, next, pos_base, new_caps),
                                 );
                                 (next, new_caps)
                             }
@@ -826,7 +851,7 @@ impl Interpreter {
                                 current,
                                 next,
                                 iter_pos_base,
-                                apply_named_capture(token, current, next, new_caps),
+                                apply_named_capture(token, current, next, pos_base, new_caps),
                             );
                             current_caps = new_caps.clone();
                             positions.push((next, new_caps));
@@ -906,7 +931,7 @@ impl Interpreter {
                                     current,
                                     next,
                                     pos_base,
-                                    apply_named_capture(token, current, next, new_caps),
+                                    apply_named_capture(token, current, next, pos_base, new_caps),
                                 );
                                 current_caps = new_caps.clone();
                                 current = next;

--- a/t/named-capture-numbering.t
+++ b/t/named-capture-numbering.t
@@ -1,0 +1,26 @@
+use Test;
+
+# A named capture group `$<x>=(...)` aliases the group to the name and does NOT
+# consume a positional capture number (Raku semantics): in `/$<x>=(\w)(\d)/`,
+# `$<x>` is the \w and `$0` is the \d. A named NON-capturing group `$<x>=[...]`
+# leaves its inner captures' positional numbers intact.
+
+plan 12;
+
+ok "a5" ~~ /$<x>=(\w)(\d)/, 'match with leading named capture';
+is ~$<x>, 'a', 'named capture $<x> is the \w';
+is ~$0,   '5', 'positional $0 is the \d (named did not consume slot 0)';
+
+ok "a5b" ~~ /$<x>=(\w)(\d)(\w)/, 'match with named + two positionals';
+is ~$<x>, 'a', '$<x> = a';
+is ~$0,   '5', '$0 = 5';
+is ~$1,   'b', '$1 = b';
+
+# named capture in the middle
+ok "ab" ~~ /(\w)$<y>=(\w)/, 'match with named capture after a positional';
+is ~$0,   'a', 'positional before named is $0';
+is ~$<y>, 'b', 'named capture after positional';
+
+# named NON-capturing group keeps inner positional numbers
+ok "a5" ~~ /$<z>=[(\w)(\d)]/, 'named non-capturing group';
+is "{~$<z>}|{~$0}|{~$1}", 'a5|a|5', 'inner captures of [...] keep $0/$1';


### PR DESCRIPTION
## Summary

In `/$<x>=(\w)(\d)/`, Raku makes `$<x>` the `\w` and `$0` the `\d` — naming a capture group aliases it to the name and removes it from positional numbering. mutsu stored it **both** as named and positional, shifting every later number:

```raku
"a5b" ~~ /$<x>=(\w)(\d)(\w)/;
# raku : $<x>=a, $0=5, $1=b
# mutsu (before): $<x>=a, $0=a, $1=5   (wrong)
# mutsu (after) : $<x>=a, $0=5, $1=b   (correct)
```

## Cause

A token with `named_capture: Some(name)` whose atom is a `CaptureGroup` pushed a parent positional during atom matching (`regex_match_capture.rs`) **and** was added to the named map by `apply_named_capture` (`regex_match_core.rs`).

## Fix

In `apply_named_capture`, when the named token's atom is a `CaptureGroup`, drop the positional entries it pushed (truncate back to the pre-token base) so the following `(...)` keeps the next number. A named **non-capturing** group `$<x>=[...]` is unaffected (its atom is not a `CaptureGroup`), so its inner captures keep their positional numbers — verified by test.

## Tests

- New pin `t/named-capture-numbering.t` (12 cases: leading/middle named captures, mixed positional+named, named non-capturing group).
- Whitelisted `S05-capture` roast (named/dot/match-object/subrule) stay green.
- Non-whitelisted alias/caps/array-alias/hash unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)