### PR TITLE
ci: extend test job timeout 15 -> 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The job does two full cargo builds (debug for `prove t/`, release for
+    # roast) plus clippy, unit tests, and the ~7 min roast suite. At 15 min the
+    # job was hitting the limit and getting canceled even when every test
+    # passed (roast printing "Result: PASS" immediately before cancellation).
+    # 25 min gives headroom for a cold/partial cargo cache.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

The `test` job has been getting **canceled at the 15-minute `timeout-minutes` limit even when every test passes**, which looks like "PRs failing a lot" but is not a test regression.

Evidence from the current open PRs:
- **#2676** (regex): roast printed `Result: PASS` and `prove t/` passed, then the job was canceled with `##[error]The operation was canceled.` at **15m13s** — i.e. it hit the job timeout right as roast finished.

## Root cause

The `test` job does, in sequence:
- `cargo fmt --check` + `cargo clippy -D warnings`
- `cargo test` (unit)
- **`cargo build`** (debug, for `prove t/`)
- `prove t/`
- **`cargo build --release`** (for roast)
- `make roast` (~7 min wall)

Two full builds + clippy + unit tests + a 7-minute roast suite is ~13–15 min on a warm cache, and a cold/partial `target` cache pushes it over 15.

## Change

Raise the `test` job to `timeout-minutes: 25` for headroom. `wasm-e2e` is unaffected and stays at 15.

## Note — this does not fix the other two failures (different root causes)

- **#2675** (docs-only) failed on `roast/S16-filehandles/filestat.t` 1-3. Docs-only ⇒ not caused by the PR; passes locally 3/3 on a release build ⇒ **flaky** (file-stat timing/env). Re-trigger.
- **#2674** (lever C loop change) failed on `roast/S04-statement-modifiers/for.t` test 20 (`$_ = 'foo' for @x` rw aliasing). Passes 5/5 on a branch without the loop change ⇒ **likely a real regression from #2674's loop semantics**, needs a fix on that branch (not a re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)