### PR TITLE
feat(vm): flatten `@a = $bound` for scalars bound (`:=`) to a Positional

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -211,13 +211,12 @@ Coroutine-based lazy gather/take implemented (#2511). range-iterator.t now passe
   take inside m:g, and take on lists already pass.)
 - roast/S32-list/seq.t (48/50 pass — .raku.EVAL roundtrip, methods on cached Seqs)
 
-## Hyper/Meta Operators (5 tests)
+## Hyper/Meta Operators (4 tests)
 
-Hyper operators (>>op<<) with assignment forms, reduce operator edge cases ([,], [min], [^^]), and hyper method dispatch on complex structures.
+Hyper operators (>>op<<) with assignment forms and hyper method dispatch on complex structures.
 
 - roast/S03-metaops/hyper.t (timeout - >>op<< with assignment)
 - roast/S03-metaops/infix.t (>>~=<< assignment forms)
-- roast/S03-metaops/reduce.t ([=:=], [,], [min], [^^])
 - roast/S03-operators/inplace.t (.= on class instantiation)
 - roast/S03-operators/assign.t (assignment as function, list assignment)
 

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -79,17 +79,19 @@
 - [x] roast/S03-metaops/misc.t
 - [ ] roast/S03-metaops/not.t
   - 46/47 tests pass. The remaining failure is subtest 47 (chaining of !before/!after) where 2 of 12 subtests fail due to wrong expected values in the test (lines 84 and 93, marked `#?rakudo skip`). Even raku (Rakudo) fails these same tests. Cannot whitelist until roast fixes the expected values or the fudging mechanism is implemented.
-- [ ] roast/S03-metaops/reduce.t
-  - 579/580 pass. Fixed: custom `is assoc<chain>` infixes in `[op]` reductions,
+- [x] roast/S03-metaops/reduce.t
+  - 580/580 pass. Fixed: custom `is assoc<chain>` infixes in `[op]` reductions,
     `[Z&&]`/`[Z||]`/`[Zand]`/`[Zor]` short-circuit thunk distribution (per-element
     thunks; was eagerly evaluating side effects), `[=]` right-associative
     assignment reduce, `[=:=]`/`[!=:=]` container-identity reductions (rewritten
-    to pairwise `&&`-chains preserving container identity). Remaining failure:
-    test 62 `[,] produces a uncontainerized List`. The negative-number allomorph
-    half is now fixed (`<-3>` is IntStr / `<-3.5>` is RatStr, #TBD). The remaining
-    blocker is `@a = $list` not flattening a `:=`-bound List: `$list := <...>`
-    holds a real List, but assigning it to `@a` keeps it as a single element
-    (raku flattens it) — a core `:=`/itemization issue, not a meta-op problem.
+    to pairwise `&&`-chains preserving container identity). The last failure
+    (test 62 `[,] produces a uncontainerized List`) was actually `@a = $list`
+    not flattening a `:=`-bound List: a scalar bound to a Positional is NOT a
+    Scalar container, so `@a = $bound` must flatten, not itemize. Fixed by
+    tagging scalar `:=` binds with an internal `__scalar_bind` trait; SetLocal
+    records a decontainerize marker (`__mutsu_bound_decont::<name>`) for
+    Positional binds, and the new `ItemizeVar` opcode (replacing `Itemize` for
+    `@a = $var`) skips itemization when that marker is present.
 - [ ] roast/S03-metaops/reverse.t
 - [ ] roast/S03-metaops/zip.t
   - 20/77 pass. Remaining blockers: [Z+] reduction with join (parser precedence for reduction ops consuming remaining args), Z, list associativity (parser), Z+= meta-assignment, Z= assignment, is-lazy on Z result (needs lazy Seq), throws-like for Z. syntax errors, &infix:<Z+> function refs, Zxx/Zand/Z&&/Zor/Z||/Zandthen/Zorelse thunking, itemization in Z

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -176,6 +176,7 @@ roast/S03-metaops/eager-hyper.t
 roast/S03-metaops/infix.t
 roast/S03-metaops/misc.t
 roast/S03-metaops/not.t
+roast/S03-metaops/reduce.t
 roast/S03-metaops/reverse.t
 roast/S03-metaops/zip.t
 roast/S03-operators/adverbial-modifiers.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -241,9 +241,14 @@ impl Compiler {
         }
         // When assigning a `$` scalar variable to an `@` target, itemize
         // the value so it is treated as a single item (not flattened).
-        // Sigilless variables (BareWord) are not itemized.
-        if name.starts_with('@') && matches!(expr, Expr::Var(_)) {
-            self.code.emit(OpCode::Itemize);
+        // Sigilless variables (BareWord) are not itemized. A scalar bound
+        // (`:=`) to a Positional is NOT a container, so use the var-aware
+        // opcode which skips itemization for bound scalars.
+        if name.starts_with('@')
+            && let Expr::Var(var_name) = expr
+        {
+            let name_idx = self.code.add_constant(Value::str(var_name.clone()));
+            self.code.emit(OpCode::ItemizeVar(name_idx));
         }
     }
 
@@ -710,6 +715,12 @@ impl Compiler {
                 // resetting to Nil. This makes `our $x = 3; ... our $x`
                 // preserve the value 3 in the redeclaration.
                 let is_our_redecl_nil = *is_our && matches!(expr, Expr::Literal(Value::Nil));
+                // A scalar `:=` bind to a Positional makes the scalar a
+                // non-container alias; record it so SetLocal can mark it
+                // decontainerized (so `@a = $bound` flattens, not itemizes).
+                // The parser tags such binds with the internal `__scalar_bind`
+                // trait.
+                let scalar_bind_decont = custom_traits.iter().any(|(t, _)| t == "__scalar_bind");
                 if is_our_redecl_nil {
                     let qualified = self.qualify_variable_name(name);
                     let idx = self.code.add_constant(Value::str(qualified));
@@ -822,6 +833,9 @@ impl Compiler {
                         });
                     if has_quant_hash_trait {
                         self.code.emit(OpCode::MarkBindContext);
+                    }
+                    if scalar_bind_decont {
+                        self.code.emit(OpCode::MarkScalarBindContext);
                     }
                     self.code.emit(OpCode::SetLocal(slot));
                     if *is_our {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -89,6 +89,11 @@ pub(crate) enum OpCode {
     /// item in list context. Emitted when `$` variable values are used inside
     /// `ArrayLiteral` or assigned to `@`/`%` targets.
     Itemize,
+    /// Like `Itemize`, but skips itemization when the named scalar variable is
+    /// bound (`:=`) to a Positional value. A bound scalar is NOT a Scalar
+    /// container, so `@a = $bound` must flatten (matching Raku). The argument is
+    /// the constant-pool index of the variable name. Emitted for `@a = $var`.
+    ItemizeVar(u32),
     /// Wrap the top-of-stack value in a Value::Scalar container.
     /// Used for `my $ = expr` (anonymous scalar) in argument position,
     /// so the anonymous container is preserved in immutable List contexts.
@@ -103,6 +108,9 @@ pub(crate) enum OpCode {
     WrapVarRef(u32),
     /// Signal that the next SetLocal is a `:=` bind (preserve container type for `@` vars).
     MarkBindContext,
+    /// Signal that the next SetLocal binds a `$` scalar to a Positional value via
+    /// `:=`, so it must be recorded as decontainerized (so `@a = $bound` flattens).
+    MarkScalarBindContext,
     /// Signal that the next SetLocal is a `:=` rebind (not a VarDecl).
     /// Triggers cleanup of old bind pairs and reverse aliases.
     MarkRebindContext,

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -552,6 +552,17 @@ fn handle_binding(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         !s.is_array && !bound_name.starts_with('%') && super::scalar_binding_rhs_is_readonly(&expr);
     let bind_to_var = matches!(expr, Expr::Var(_));
     let bind_to_index = matches!(expr, Expr::Index { .. });
+    // A `$` scalar bound (`:=`) to a value is NOT a Scalar container, so
+    // `@a = $bound` must flatten a Positional value rather than itemize it.
+    // Mark the VarDecl with an internal trait the compiler reads to emit
+    // MarkScalarBindContext (instead of wrapping in a SyntheticBlock, which
+    // would change the value when the bind is used as an expression).
+    let is_scalar_bind =
+        !s.is_array && !bound_name.starts_with('%') && !bound_name.starts_with('&');
+    let mut custom_traits = s.custom_traits.clone();
+    if is_scalar_bind {
+        custom_traits.push(("__scalar_bind".to_string(), None));
+    }
     let stmt = Stmt::VarDecl {
         name: s.name,
         expr,
@@ -561,7 +572,7 @@ fn handle_binding(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         is_dynamic: s.has_dynamic_trait,
         is_export: s.has_export_trait,
         export_tags: s.export_tags.clone(),
-        custom_traits: s.custom_traits.clone(),
+        custom_traits,
         where_constraint: s.where_constraint.clone(),
     };
     let stmt = if s.is_array || bound_name.starts_with('%') {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -128,6 +128,15 @@ pub(crate) struct VM {
     resume_ip: Option<usize>,
     /// When true, the next SetLocal is a `:=` bind (preserves container type for `@` vars).
     bind_context: bool,
+    /// When true, the next SetLocal binds a `$` scalar to a Positional via `:=` and
+    /// must record the scalar as decontainerized. Independent of `bind_context` so
+    /// scalar binds keep their existing (fast-path) store routing.
+    scalar_bind_context: bool,
+    /// True once any scalar has been bound (`:=`) to a Positional value, marking
+    /// it as decontainerized in the env (`__mutsu_bound_decont::$name`). Guards the
+    /// (otherwise hot) marker-clearing in scalar assignment so the common case
+    /// (no such binds) stays zero-cost.
+    bound_decont_active: bool,
     /// When true, the next SetLocal is a `:=` rebind (not VarDecl).
     /// Used to trigger cleanup of old bind pairs and reverse aliases.
     rebind_context: bool,
@@ -382,6 +391,8 @@ impl VM {
             env_dirty: false,
             resume_ip: None,
             bind_context: false,
+            scalar_bind_context: false,
+            bound_decont_active: false,
             rebind_context: false,
             constant_context: false,
             explicit_initializer_context: false,
@@ -1806,6 +1817,35 @@ impl VM {
                 self.stack.push(itemized);
                 *ip += 1;
             }
+            OpCode::ItemizeVar(name_idx) => {
+                // Itemize a scalar variable's value for `@a = $var`, UNLESS the
+                // scalar was bound (`:=`) to a Positional. A bound scalar is not
+                // a Scalar container, so its value must flatten on `@`-assignment.
+                let val = self.stack.pop().unwrap_or(Value::Nil);
+                let is_bound_decont = if self.bound_decont_active {
+                    let var_name = match &code.constants[*name_idx as usize] {
+                        Value::Str(s) => s.as_str(),
+                        _ => "",
+                    };
+                    let key = format!("__mutsu_bound_decont::{}", var_name);
+                    matches!(self.interpreter.env().get(&key), Some(Value::Bool(true)))
+                } else {
+                    false
+                };
+                let result = if is_bound_decont {
+                    val
+                } else {
+                    match val {
+                        Value::Array(items, kind) if !kind.is_itemized() => {
+                            Value::Array(items, kind.itemize())
+                        }
+                        Value::Seq(items) => Value::Scalar(Box::new(Value::Seq(items))),
+                        other => other,
+                    }
+                };
+                self.stack.push(result);
+                *ip += 1;
+            }
             OpCode::WrapScalar => {
                 // Wrap the top-of-stack value in a Value::Scalar container.
                 // Used for `my $ = expr` (anonymous scalar) in argument position
@@ -1837,6 +1877,10 @@ impl VM {
             }
             OpCode::MarkBindContext => {
                 self.bind_context = true;
+                *ip += 1;
+            }
+            OpCode::MarkScalarBindContext => {
+                self.scalar_bind_context = true;
                 *ip += 1;
             }
             OpCode::MarkRebindContext => {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -763,6 +763,41 @@ impl VM {
         })
     }
 
+    /// Track whether a scalar variable is bound (`:=`) to a Positional value.
+    /// A bound scalar is NOT a Scalar container, so `@a = $bound` must flatten
+    /// rather than itemize. The `ItemizeVar` opcode reads this marker. Plain
+    /// assignment to a scalar clears any stale marker (guarded by
+    /// `bound_decont_active` so the common no-bind case stays cheap).
+    pub(super) fn update_bound_decont_marker(&mut self, name: &str, is_bind: bool, val: &Value) {
+        // Scalar local names carry no sigil (e.g. "y"); `@`/`%`/`&` vars do.
+        if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
+            return;
+        }
+        if is_bind {
+            let is_positional = match val {
+                Value::Array(_, k) => !k.is_itemized(),
+                Value::Seq(_)
+                | Value::Slip(_)
+                | Value::LazyList(_)
+                | Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..) => true,
+                _ => false,
+            };
+            if is_positional {
+                let key = format!("__mutsu_bound_decont::{}", name);
+                self.interpreter.env_mut().insert(key, Value::Bool(true));
+                self.bound_decont_active = true;
+                return;
+            }
+        }
+        if self.bound_decont_active {
+            let key = format!("__mutsu_bound_decont::{}", name);
+            self.interpreter.env_mut().remove(&key);
+        }
+    }
+
     pub(super) fn normalize_scalar_assignment_value(val: Value) -> Value {
         let is_nilish = |v: &Value| match v {
             Value::Nil => true,
@@ -4166,11 +4201,22 @@ impl VM {
         let is_constant = self.constant_context;
         let has_explicit_initializer = self.explicit_initializer_context;
         let is_vardecl = self.vardecl_context;
+        let scalar_bind = self.scalar_bind_context;
         self.bind_context = false;
+        self.scalar_bind_context = false;
         self.rebind_context = false;
         self.constant_context = false;
         self.explicit_initializer_context = false;
         self.vardecl_context = false;
+        // Record/clear the decontainerize marker for `$` scalars. A scalar bound
+        // (`:=`) to a Positional is not a Scalar container, so `@a = $bound` must
+        // flatten (the `ItemizeVar` opcode reads this marker). Plain assignment
+        // re-containerizes, clearing any stale marker. Done before the fast/slow
+        // split so both paths are covered. `raw_popped` is only borrowed.
+        {
+            let name = &code.locals[idx];
+            self.update_bound_decont_marker(name, scalar_bind || is_bind, &raw_popped);
+        }
         // A redeclaration (`my @a` in a new scope) must not inherit the
         // `is default(...)` trait from an earlier same-named variable,
         // since var_defaults is keyed only by name. Drop any stale entry;


### PR DESCRIPTION
## Summary

A `$` scalar **bound** (`:=`) to a Positional value is NOT a Scalar container, so assigning it to an `@` variable must **flatten** it (matching Raku), whereas an **assigned** (`=`) scalar containerizes its value and stays a single element. Previously mutsu itemized every `@a = $var` unconditionally, so a `:=`-bound List collapsed into one element:

```raku
my $list := <5 -3 7 0 1 -9>;   # not containerized
my @array = $list;             # mutsu: 1 elem; raku: 6 elems
is-deeply ([,] @array), $list; # was: ($(5,-3,7,0,1,-9),)  now: (5,-3,7,0,1,-9)
```

## Fix

- **Parser** tags scalar `:=` binds with an internal `__scalar_bind` trait (no AST/structure change, so binds used as expressions — e.g. `isa-ok (my $ib := Foo.new), Foo` — are unaffected).
- **Compiler** emits `MarkScalarBindContext` before the bind's `SetLocal`.
- **SetLocal** records a decontainerize marker (`__mutsu_bound_decont::<name>`) for Positional binds and clears it on plain assignment (guarded by a `bound_decont_active` flag so the no-bind common case stays cheap).
- New **`ItemizeVar`** opcode (replaces `Itemize` for `@a = $var`) skips itemization when the source scalar carries that marker.

## Result

This was the last failing subtest (test 62, `[,] produces a uncontainerized List`) in **roast/S03-metaops/reduce.t**, now **580/580**. Added to the whitelist; `make test` (cargo + t/) and `make roast` both pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)