### PR TITLE
fix(regex): zero-width named captures for .caps/.chunks (S05-capture/caps.t)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -345,6 +345,7 @@ roast/S04-statements/until.t
 roast/S04-statements/when.t
 roast/S04-statements/while.t
 roast/S04-statements/with.t
+roast/S05-capture/caps.t
 roast/S05-capture/dot.t
 roast/S05-capture/match-object.t
 roast/S05-capture/named.t

--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -99,7 +99,7 @@ pub(super) fn match_value_to(val: &Value) -> i64 {
 /// Positional captures use `ValuePair(Int => Match)` and named captures use
 /// `Pair(Str => Match)` to preserve the Raku-visible key types.
 pub(super) fn match_caps(attributes: &HashMap<String, Value>) -> Value {
-    let mut pairs: Vec<(i64, Value)> = Vec::new();
+    let mut pairs: Vec<(i64, i64, Value)> = Vec::new();
 
     // Collect named capture positions to filter out shadowed positional captures
     let mut named_positions: Vec<(i64, i64)> = Vec::new();
@@ -123,6 +123,7 @@ pub(super) fn match_caps(attributes: &HashMap<String, Value>) -> Value {
                 if !shadowed {
                     pairs.push((
                         from,
+                        to,
                         Value::ValuePair(Box::new(Value::Int(i as i64)), Box::new(item.clone())),
                     ));
                 }
@@ -135,15 +136,18 @@ pub(super) fn match_caps(attributes: &HashMap<String, Value>) -> Value {
         for (key, val) in named.iter() {
             for item in expand_capture_items(val) {
                 let from = match_value_from(item);
-                pairs.push((from, Value::Pair(key.clone(), Box::new(item.clone()))));
+                let to = match_value_to(item);
+                pairs.push((from, to, Value::Pair(key.clone(), Box::new(item.clone()))));
             }
         }
     }
 
-    // Sort by position
-    pairs.sort_by_key(|(from, _)| *from);
+    // Sort by position. Tie-break on the end offset so a zero-width capture
+    // (e.g. an empty `%%` separator) sorts before a capture that starts at the
+    // same offset but spans further, matching Raku's match order.
+    pairs.sort_by_key(|(from, to, _)| (*from, *to));
 
-    Value::array(pairs.into_iter().map(|(_, pair)| pair).collect())
+    Value::array(pairs.into_iter().map(|(_, _, pair)| pair).collect())
 }
 
 /// Expand a capture value: if it's an Array of Matches (from quantified captures),
@@ -201,8 +205,9 @@ pub(super) fn match_chunks(attributes: &HashMap<String, Value>) -> Value {
         }
     }
 
-    // Sort by position
-    captures.sort_by_key(|(from, _, _)| *from);
+    // Sort by position; tie-break on end offset so a zero-width capture sorts
+    // before a longer capture starting at the same offset (Raku match order).
+    captures.sort_by_key(|(from, to, _)| (*from, *to));
 
     let match_from = match attributes.get("from") {
         Some(Value::Int(n)) => *n,

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -329,6 +329,24 @@ impl Interpreter {
                 .entry(name.clone())
                 .or_default()
                 .push(captured.clone());
+            // Record a minimal sub-capture carrying the exact (from, to) span so
+            // the Match object gets the right offsets even for a zero-width match
+            // (e.g. `$<delim>=<[a..z]>*` matching empty). Without this the Match
+            // builder falls back to searching for the captured text, which yields
+            // offset 0 for an empty string and breaks `.caps`/`.chunks` ordering.
+            // Only do this when no richer sub-capture already aligns with this
+            // entry, so subrule-aliased captures keep their nested structure.
+            let name_count = updated.named.get(name).map(Vec::len).unwrap_or(0);
+            let subcaps = updated.named_subcaps.entry(name.clone()).or_default();
+            if subcaps.len() < name_count {
+                subcaps.push(RegexCaptures {
+                    from,
+                    to,
+                    matched: captured.clone(),
+                    match_from: from,
+                    ..Default::default()
+                });
+            }
             // Also capture under the secondary name (e.g., original builtin class name
             // when using `$<alias>=<builtin_class>` syntax).
             if let Some(secondary) = token.secondary_named_capture.as_ref() {

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3644,16 +3644,60 @@ impl Interpreter {
                 None
             };
             let primary_named = primary_named.or_else(|| pending_builtin_named_capture.take());
-            tokens.push(RegexToken {
-                atom,
-                quant,
-                named_capture: primary_named,
-                hash_capture: pending_hash_capture.take(),
-                secondary_named_capture: secondary_named,
-                ratchet: token_ratchet,
-                frugal: token_frugal,
-                separator: token_separator,
-            });
+            let hash_capture = pending_hash_capture.take();
+            // A named capture on a *quantified* atom (`$<x>=<[a..z]>*`, `$<x>=\w+`)
+            // captures the WHOLE quantified span as a single Match (e.g. "abc"),
+            // and a zero-width match still produces an (empty) capture — matching
+            // Raku. mutsu's quantifier loop otherwise applies the named capture
+            // per-iteration (yielding `[a, b, c]`) and drops the zero-match case.
+            // Wrap the quantified atom in a non-capturing group so the named
+            // capture sits on a `quant: One` token spanning the entire run.
+            let wrap_named_quant = primary_named.is_some()
+                && hash_capture.is_none()
+                && token_separator.is_none()
+                && matches!(
+                    quant,
+                    RegexQuant::ZeroOrMore | RegexQuant::OneOrMore | RegexQuant::Repeat(..)
+                );
+            if wrap_named_quant {
+                let inner = RegexToken {
+                    atom,
+                    quant,
+                    named_capture: None,
+                    hash_capture: None,
+                    secondary_named_capture: None,
+                    ratchet: token_ratchet,
+                    frugal: token_frugal,
+                    separator: None,
+                };
+                tokens.push(RegexToken {
+                    atom: RegexAtom::Group(RegexPattern {
+                        tokens: vec![inner],
+                        anchor_start: false,
+                        anchor_end: false,
+                        ignore_case,
+                        ignore_mark,
+                    }),
+                    quant: RegexQuant::One,
+                    named_capture: primary_named,
+                    hash_capture: None,
+                    secondary_named_capture: secondary_named,
+                    ratchet: token_ratchet,
+                    frugal: token_frugal,
+                    separator: None,
+                });
+            } else {
+                tokens.push(RegexToken {
+                    atom,
+                    quant,
+                    named_capture: primary_named,
+                    hash_capture,
+                    secondary_named_capture: secondary_named,
+                    ratchet: token_ratchet,
+                    frugal: token_frugal,
+                    separator: token_separator,
+                });
+            }
         }
         let tokens = match rewrite_tilde_tokens(tokens, ignore_case, ignore_mark) {
             Ok(tokens) => tokens,


### PR DESCRIPTION
## Summary

A named capture on a **quantified** atom (`\$<delim>=<[a..z]>*`, `\$<x>=\w+`) must capture the whole quantified span as a single Match (e.g. `"abc"`), and a **zero-width** match must still produce an (empty) capture — matching Raku. mutsu previously:

1. applied the named capture **per-iteration**, yielding `[a, b, c]` instead of a single `"abc"` Match;
2. **dropped** the zero-match case entirely (so `\$<d>` was undefined); and
3. gave zero-width named captures **offset 0** (the Match builder searches for the captured text, which finds the empty string at position 0).

This broke `('XX')+ %% \$<delim>=<[a..z]>*` over `"XXXXXX"`: the three zero-width `delim` separator captures were missing from `.caps`, and `.caps`/`.chunks` ordering collapsed (`0 0 0` instead of `0 delim 0 delim 0 delim`).

## Fix

- **Parser**: wrap a named capture on a quantified atom in a non-capturing group so the named capture sits on a `quant: One` token spanning the whole run.
- **Matcher**: `apply_named_capture` records a minimal sub-capture carrying the exact `(from, to)` span, so the Match gets correct offsets even for a zero-width match (no fragile text search).
- **`.caps`/`.chunks`**: tie-break the position sort on the end offset so a zero-width capture sorts before a longer capture starting at the same offset (Raku match order).

## Result

`roast/S05-capture/caps.t` now **43/43**. Added to the whitelist. `make test` passes; no regressions in the other (still-failing) S05-capture/S05-match files (identical failure counts vs baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)