### PR TITLE
ci: run roast suite in parallel with prove -j4 (~3x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,14 @@ jobs:
           git checkout -- roast/
 
       - name: Roast tests (make roast)
-        run: prove -e 'scripts/run-roast-test.sh' $(cat roast-whitelist.txt)
+        # -j4 matches the GitHub ubuntu-latest core count. The roast suite is
+        # dominated by sleep/timer-bound S17 concurrency tests that leave the
+        # CPU idle; running them in parallel overlaps that idle time with the
+        # CPU-bound tests and cuts wall-clock roughly 3x (~7.5min -> ~2.5min).
+        # Do not oversubscribe past the core count: the S17 scheduler/promise
+        # tests assert on real wall-clock scheduling and flake under CPU
+        # starvation.
+        run: prove -j4 -e 'scripts/run-roast-test.sh' $(cat roast-whitelist.txt)
         env:
           MUTSU_BIN: target/release/mutsu
 

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,20 @@
 CARGO_TARGET_DIR ?= target
 MUTSU_BIN ?= $(CARGO_TARGET_DIR)/release/mutsu
 
+# Parallelism for the roast suite. CI runners (GitHub ubuntu-latest) have 4
+# cores, so -j4 is the default. Going higher oversubscribes the CPU and makes
+# the timing-sensitive S17 concurrency tests (scheduler/promise/supply) flake
+# on their wall-clock assertions, so do not raise this above the core count.
+# Override locally with `make roast PROVE_JOBS=8` if you know your box can take it.
+PROVE_JOBS ?= 4
+
 test:
 	@mkdir -p tmp
 	(cargo build && cargo test && cargo build --release && prove -e '$(MUTSU_BIN)' t/) 2>&1 | tee tmp/make-test.log
 
 roast:
 	@mkdir -p tmp
-	(cargo build --release && MUTSU_BIN=$(MUTSU_BIN) prove -e 'scripts/run-roast-test.sh' $(shell cat roast-whitelist.txt)) 2>&1 | tee tmp/make-roast.log
+	(cargo build --release && MUTSU_BIN=$(MUTSU_BIN) prove -j$(PROVE_JOBS) -e 'scripts/run-roast-test.sh' $(shell cat roast-whitelist.txt)) 2>&1 | tee tmp/make-roast.log
 
 check-roast-whitelist:
 	LC_ALL=C sort -c roast-whitelist.txt


### PR DESCRIPTION
## Problem

`make roast` and the CI roast step ran `prove` with **no `-j` flag**, executing all 1251 whitelisted files **serially**. The slowest files are all sleep/timer-bound `S17` concurrency tests that leave the CPU idle while waiting:

| file | serial time |
|---|---|
| `S17-supply/unique.t` | 26s |
| `S17-scheduler/every.t` | 24s |
| `S29-context/sleep.t` / `S17-scheduler/at.t` / `in.t` / `S17-promise/allof.t` / `S17-supply/throttle.t` | ~18s each |

Serial execution serializes all that idle wall-clock time across the whole run.

## Change

Run `prove -j4` (matching the GitHub `ubuntu-latest` core count) in both the Makefile and CI.

## Measurements (local, full whitelist)

| mode | wall clock | speedup |
|---|---|---|
| serial (before) | 445s (7m24s) | 1.0x |
| **`-j4`** | **138s (2m18s)** | **3.2x** |
| `-j8` | 96s | 4.6x — but `thread.t` timed out |

`-j4` produced **no new failures** vs serial (only the pre-existing known flakies: a stale-temp-file `spurt.t` and the `Failed:0` plan-count flakies in `smiley.t` / `wacky.t` / `CollationTest`).

## Why not oversubscribe

The `S17` scheduler/promise tests assert on **real wall-clock scheduling** and flake under CPU starvation — `-j8` reintroduced a `thread.t` timeout. So `-j` is pinned to the core count. `Makefile` exposes `PROVE_JOBS` (default 4) for local override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)