### PR TITLE
ci: drop release debug info in CI to speed up the build (~70s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
         run: prove -e 'timeout 30 target/debug/mutsu' t/ || echo "TAP tests had failures (non-fatal; roast is authoritative)"
 
       - name: Build (release, for roast)
+        # The repo sets `[profile.release] debug = true` for local perf
+        # profiling. CI never profiles, and full debug info bloats the binary
+        # (~250MB -> ~27MB) and slows codegen/linking by ~70s. Override it to
+        # off for CI only; Cargo.toml stays debug=true for local use.
         run: cargo build --release
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "false"
 
       - name: Roast whitelist is sorted
         run: make check-roast-whitelist


### PR DESCRIPTION
## Problem

`[profile.release] debug = true` is set in `Cargo.toml` so local `perf` profiling has symbols. But CI never profiles, and full debug info:
- bloats the release binary **~250MB -> ~27MB**
- slows codegen + linking

## Change

Override `CARGO_PROFILE_RELEASE_DEBUG=false` on the CI release build step **only**. `Cargo.toml` stays `debug = true`, so local profiling is unaffected.

## Measurement (local forced crate rebuild)

| profile | build time | binary |
|---|---|---|
| `debug=true` (current) | 4m39s (280s) | 252MB |
| `debug=false` (CI) | **3m31s (211s)** | **27MB** |

~70s (~24%) off the release build, plus a much smaller binary → cheaper cargo cache upload/download. Debug info does not affect runtime, so roast execution time is unchanged.

This stacks with #2681 (parallel roast): release build was the largest remaining step in the `test` job after that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)