### PR TITLE
fix(vm): type-check :=-binding to a typed-hash variable

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -47,12 +47,22 @@ or aborts mid-file at the first un-thrown error. `.message` methods for 17
 exception types landed in #2532; what remains is *throwing the right type in the
 right place*, plus compile-time undeclared-symbol checking.
 
-- roast/S02-types/capture.t — **Easy**. 2/33 fail then aborts (planned 46). Needs
-  X::Cannot::Lazy from `Capture` lazy ops; an un-thrown error aborts the rest.
-- roast/S02-types/set.t — **Easy**. 1/246 fail (test 226): typechecking on a
-  Hashified `Set` iterator (`my %s := Set(...)` must reject bad-typed assignment).
-- roast/S02-types/bag.t — **Easy**. 2/255 fail: X::TypeCheck::Binding on Bag
-  coercion.
+- roast/S02-types/capture.t — **Hard**. 2/33 fail then aborts (planned 46). The
+  two failures (28-29) are NOT exception types: `$c[0]++` / `$c<a>++` on a
+  Capture built from `\($a)` must write *through* to the original scalar
+  container — first-class container identity (lever C). The later abort needs
+  X::Cannot::Lazy from `Capture` lazy ops.
+- roast/S02-types/set.t — **Hard** (remaining). Test 226 (typed-hash bind
+  type-check) is FIXED: `my Int %h := <untyped hash>` now throws
+  X::TypeCheck::Binding. The only remaining failures are the 2 not-reached tests
+  "coercion of object Hash to Set 1/2" (`:{ }.Set`), which need full object-hash
+  (`%{Mu}`) semantics — same blocker as classify/objecthash below.
+- roast/S02-types/bag.t — **Hard**. 2/255 fail. NOT exception types: test 215
+  needs Bag weights to hold values larger than i64 (`200000000000000000019`) —
+  mutsu stores `BagData` counts as `i64`, so big weights collapse to 1; a faithful
+  fix needs BigInt-capable bag weights across all set/bag/mix ops. Test 252 needs
+  Bag-union to preserve a `my class Foo is Bag` subclass type (Bag is a `Value`,
+  not a subclassable Instance).
 - roast/S02-types/baghash.t — **Medium**. 7 fail then aborts at test 270/344
   (X::TypeCheck::Binding on BagHash iterator/coercion).
 - roast/S02-types/mixhash.t — **Medium**. 4 fail then aborts at 216/295
@@ -98,9 +108,6 @@ rather than empty, and `.grep`/`.values`/`.pairs` see stale pre-mutation values.
 
 ## Regex / Match Advanced Features
 
-- roast/S05-capture/caps.t — **Easy**. 1/43 fail (test 43): `.caps`/`.chunks` drops
-  the zero-width `%`-separator captures, so the delimiter slots that should appear
-  between matches are missing (`0 0 0` instead of `0 delim 0 delim 0 delim`).
 - roast/S05-capture/alias.t — **Medium**. 14/32 fail: reverse capture (`$1` before
   `$0` textually) and mixed named/positional capture aliases yield empty strings.
 - roast/S05-capture/array-alias.t — **Hard**. 30/37 fail then aborts: named/
@@ -326,8 +333,14 @@ no per-slot `Scalar` container (first-class container identity).
   typed/object-hash edge cases; overlaps the object-hash `%{Mu}` blocker.
 - roast/S09-subscript/slice.t — **Hard**. 9/39 fail then aborts at line 310 — slices
   with infinite sequences (`@a[0..*]`); blocked on real lazy infinite sequences.
-- roast/S02-literals/allomorphic.t — **Easy**. 1/119 fail: `.ACCEPTS` on an allomorph
-  (e.g. `<42>` IntStr) doesn't smartmatch correctly.
+- roast/S02-literals/allomorphic.t — **Medium/Hard**. 1/119 fail (test 107
+  `.ACCEPTS`). Root cause is NOT ACCEPTS (that works) but same-named lexical-class
+  redeclaration: the test declares `my class IntFoo` in two separate `gather`
+  blocks; mutsu keys classes by name in a single global `self.classes` map, so the
+  second registration clobbers the first, and instances created from the first
+  dispatch `.Numeric` to the wrong (second) class. A proper fix needs per-decl
+  class identity (mirroring the existing `role_id`/`role_candidates` machinery for
+  roles), touching class storage + dispatch + `.^name` display.
 - roast/S02-types/nil.t — **Medium**. 12/65 fail then aborts (planned 67): Nil in a
   `for` loop and Nil assignment to a subset-typed var.
 - roast/S02-types/pair.t — **Medium**. 4/180 fail then aborts (planned 182): Pair

--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -264,15 +264,14 @@
 - [ ] roast/S02-types/set-iterator.t
   - 0/? pass. Parse error at line 11
 - [ ] roast/S02-types/set.t
-  - 234/248 pass (12 fail, 2 not reached). Blockers:
-    - Set stores HashSet<String>, loses original types (tests 201, 202, 233)
-    - Missing X::Assignment::RO for Set subclass (test 197)
-    - Set:U autovivification should die (test 203)
-    - Parser: `set;` without parens should error (tests 215, 216)
-    - Seq ~~ Set smartmatch parse issue (test 200)
-    - Parameterized Set[Int]: .keyof, type checking (tests 234, 235)
-    - .item.VAR.^name should return Scalar (test 238)
-    - >>.&{} on Set should return original Set (test 242)
+  - 246/248 pass, planned 248. Only remaining blocker: object-hash (`:{ }`)
+    coercion to Set ("coercion of object Hash to Set 1/2", lines 485-488). These
+    need full object-hash (`%{Mu}`, non-Str keys) semantics — the same Hard
+    blocker tracked in BLOCKERS.md. All other subtests pass.
+  - Fixed (PR): test 226 "have typechecking on a Hashifeid Set iterator" — `:=`
+    binding an untyped/coerced hash to a typed-hash variable (`my Int %h := ...`)
+    now throws X::TypeCheck::Binding, matching rakudo. Also fixed: block-final
+    `my T %h := ...` previously dropped its declared element type entirely.
 - [ ] roast/S02-types/sigils-and-types.t
   - 0/? pass. Parse error at line 78
 - [ ] roast/S02-types/signed-unsigned-native.t

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -109,6 +109,7 @@ impl Compiler {
                         name,
                         expr,
                         is_dynamic: ast_is_dynamic,
+                        type_constraint,
                         ..
                     } => {
                         // my $x = expr in block-final position: declare and return value
@@ -118,6 +119,15 @@ impl Compiler {
                             name_idx,
                             dynamic: is_dynamic,
                         });
+                        // Register the declared type constraint (e.g. `my Int %h`)
+                        // so element type-checks and `:=` bind type-checks see it,
+                        // mirroring the non-final VarDecl path. Without this a
+                        // block-final typed declaration silently loses its type.
+                        if let Some(tc) = type_constraint {
+                            let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                            self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                            self.local_types.insert(name.clone(), tc.clone());
+                        }
                         if has_mark_bind && (name.starts_with('@') || name.starts_with('%')) {
                             // Bind context for @/% variables (e.g. `my %h := :{ }`):
                             // use SetLocal with MarkBindContext and MarkVarDeclContext

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Interpreter {
-    pub(in crate::runtime) fn type_matches(constraint: &str, value_type: &str) -> bool {
+    pub(crate) fn type_matches(constraint: &str, value_type: &str) -> bool {
         if constraint == "Mu" {
             return true;
         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -460,6 +460,89 @@ impl VM {
         }
     }
 
+    /// Type-check a `:=` bind to a typed-hash variable.
+    ///
+    /// Binding (unlike assignment) does not coerce — it aliases the RHS
+    /// container directly. Raku therefore requires the RHS to *be* an
+    /// `Associative[T]` matching the variable's declared value type `T`:
+    ///
+    /// ```text
+    /// my Int %a; my Int  %b := %a;            # ok   (Int does Int)
+    /// my Int %a; my Cool %b := %a;            # ok   (Int does Cool)
+    /// my Int %h := :42foo.Set.Hash;           # dies (Hash[Any,Any])
+    /// ```
+    ///
+    /// mutsu tracks a hash's element type via `container_type_metadata`; a
+    /// plain/coerced hash has no metadata, so its value type defaults to `Mu`,
+    /// which only conforms to an `Any`/`Mu`-typed target.
+    fn check_hash_bind_value_type(
+        &mut self,
+        name: &str,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        if !name.starts_with('%') {
+            return Ok(());
+        }
+        let Some(constraint) = self.interpreter.var_type_constraint(name) else {
+            return Ok(());
+        };
+        // Only enforce for a plain value-type constraint (`my Int %h`). Skip
+        // container-trait declarations (`is Set`/`is Bag`/`is Map`/...), key-typed
+        // forms (`%h{Int}`), and the trivial Any/Mu types.
+        if constraint.contains('{')
+            || matches!(constraint.as_str(), "" | "Any" | "Mu")
+            || Self::quant_hash_trait_from_constraint(&constraint).is_some()
+            || matches!(
+                constraint.split('[').next().unwrap_or(&constraint),
+                "Set"
+                    | "SetHash"
+                    | "Bag"
+                    | "BagHash"
+                    | "Mix"
+                    | "MixHash"
+                    | "Map"
+                    | "Hash"
+                    | "Associative"
+                    | "QuantHash"
+            )
+        {
+            return Ok(());
+        }
+        // The bound container's element type (defaults to Mu when untyped).
+        let rhs_value_type = self
+            .interpreter
+            .container_type_metadata(value)
+            .map(|info| info.value_type)
+            .filter(|vt| !vt.is_empty())
+            .unwrap_or_else(|| "Mu".to_string());
+        if crate::runtime::Interpreter::type_matches(&constraint, &rhs_value_type) {
+            return Ok(());
+        }
+        let got = crate::runtime::utils::value_type_name(value);
+        let message = format!(
+            "Type check failed in binding; expected Associative[{}] but got {}",
+            constraint, got
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("got".to_string(), value.clone());
+        attrs.insert(
+            "expected".to_string(),
+            Value::Package(crate::symbol::Symbol::intern(&format!(
+                "Associative[{}]",
+                constraint
+            ))),
+        );
+        attrs.insert("symbol".to_string(), Value::str(name.to_string()));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(
+            crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+            attrs,
+        );
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(ex));
+        Err(err)
+    }
+
     pub(super) fn coerce_hash_var_value(
         &mut self,
         name: &str,
@@ -4488,7 +4571,11 @@ impl VM {
                 ));
             }
             if is_bind {
-                // `:=` binding preserves containers — skip coercion.
+                // `:=` binding preserves containers — skip coercion. But the
+                // bound container must conform to a typed-hash variable's
+                // declared value type: `my Int %h := <untyped hash>` dies
+                // because the RHS is `Hash[Any,Any]`, not `Associative[Int]`.
+                self.check_hash_bind_value_type(name, &raw_popped)?;
                 raw_popped
             } else if is_constant {
                 // `constant %x` preserves Associative containers (Hash, Bag, Set, Mix, Pair).

--- a/t/typed-hash-bind-typecheck.t
+++ b/t/typed-hash-bind-typecheck.t
@@ -1,0 +1,33 @@
+use Test;
+
+# Binding (`:=`) a hash to a typed-hash variable type-checks the container:
+# the RHS must be an `Associative[T]` matching the declared value type.
+# Assignment (`=`) coerces and is unaffected.
+
+plan 11;
+
+# An untyped/coerced hash bound to a typed hash dies.
+dies-ok { my Int %h := :42foo.Set.Hash }, 'Set.Hash bound to Int %h dies';
+dies-ok { my Int %h := { a => 1 } },       'hash literal bound to Int %h dies';
+dies-ok { my %u = (a => 1); my Int %h := %u }, 'untyped hash bound to Int %h dies';
+dies-ok { my Cool %a; my Int %b := %a },   'Cool hash bound to Int %h dies';
+
+# A matching/conforming typed hash binds successfully (covariant).
+lives-ok { my Int %a; my Int  %b := %a }, 'Int hash bound to Int %h lives';
+lives-ok { my Int %a; my Cool %b := %a }, 'Int hash bound to Cool %h lives (covariant)';
+lives-ok { my Int %a; my Any  %b := %a }, 'Int hash bound to Any %h lives';
+
+# Untyped targets accept anything.
+lives-ok { my %a; my %b := %a },          'untyped bound to untyped lives';
+lives-ok { my %h := :42foo.Set.Hash },    'Set.Hash bound to untyped %h lives';
+
+# The bound container keeps its own element type.
+{
+    my Int %a;
+    my Cool %b := %a;
+    is %b.of, Int, 'bound container keeps its declared element type';
+}
+
+# The exception is X::TypeCheck::Binding.
+throws-like { my Int %h := { a => 1 } }, X::TypeCheck::Binding,
+    'binding mismatch throws X::TypeCheck::Binding';


### PR DESCRIPTION
## Summary

Binding a hash to a typed-hash variable (`my Int %h := ...`) did not type-check the bound container. Unlike assignment, `:=` aliases the RHS directly, so Raku requires the RHS to *be* an `Associative[T]` matching the declared value type `T`:

```raku
my Int %a; my Int  %b := %a;   # ok   (Int does Int)
my Int %a; my Cool %b := %a;   # ok   (Int does Cool, covariant)
my Int %h := :42foo.Set.Hash;  # dies (Hash[Any,Any])
```

mutsu tracks a hash's element type via `container_type_metadata`; a plain/coerced hash has none, so its value type is `Mu`, which only conforms to an `Any`/`Mu`-typed target. The `SetLocal` `%`-bind branch now checks the bound container's element type against the variable's declared value type and throws `X::TypeCheck::Binding` on mismatch.

### Also fixed: block-final typed bind dropped its element type

A block-final `my T %h := ...` (the shape used inside `dies-ok { ... }`) went through the inline block-value compiler path, which ignored the declared `type_constraint` entirely (no `SetVarType` emitted). The inline path now registers the constraint like the normal `VarDecl` path, so element type-checks and the new bind check both see it.

## Roast impact

Fixes `roast/S02-types/set.t` test 226 *"have typechecking on a Hashified Set iterator"*. The file still has a separate object-hash (`:{ }.Set`) coercion blocker (tests "coercion of object Hash to Set 1/2"), so it is not yet whitelisted — recorded in `TODO_roast/S02.md`.

While investigating I found several BLOCKERS.md "Easy" entries were mislabeled and corrected their root-cause/difficulty (allomorphic.t = same-named lexical-class identity, bag.t = BigInt bag weights, capture.t = container identity; caps.t already passing/removed).

## Testing

- New `t/typed-hash-bind-typecheck.t` (11 cases, all behaviors verified against `raku`).
- `cargo test`: 450 passed.
- Full `t/` suite: 582 files / 5043 tests pass, no regressions.
- `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)