### PR TITLE
fix(proc): pass all of roast/S29-os/system.t (run/shell/Proc)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -364,5 +364,3 @@ no per-slot `Scalar` container (first-class container identity).
   slurpy params in block signatures throw at setup.
 - roast/S32-list/skip.t — **Medium**. Plan mismatch: planned 55, ran 206 (the file
   loops more than planned, so subtest counting/laziness is off); 29 fail.
-- roast/S29-os/system.t — **Medium**. Aborts at test 3 (planned 41): `shell`/`run`
-  exit-code -1 (command-not-found) handling.

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -145,6 +145,30 @@ VM slot を占有 + `sync_env_from_locals` が毎呼び出し前に全 slot を 
   `if` に効かせる block-local-scope opcode が要る）。(2) 外側束縛が無い純粋 leak の post-loop 読み（raku 未宣言
   エラー）は mutsu では undefined 値（strict-vars 未実装で全体的に未強制、実害なし）。
 
+## `run`/`shell`/`Proc` の整備（`roast/S29-os/system.t` 全通過, whitelist 追加）
+
+`roast/S29-os/system.t`（41 tests）が test 3 で abort していたのを全 41 通過まで修正。根因は
+**ユニットモジュールの非エクスポート `our sub` が `GLOBAL::` に漏れてコアビルトインを隠す**ことだった
+（`Test::Util` の非エクスポート `our sub run` がコアの `run` Proc spawner を masking し、
+`run($*EXECUTABLE, ...)` が test-util 版にディスパッチされていた）。モジュールロード後に、
+ホイストで漏れた「非エクスポートかつビルトイン衝突する `GLOBAL::name`」を除去する一般的な修正を実装。
+あわせて以下を実装:
+
+- **`X::Proc::Unsuccessful` の OS エラー報告**: spawn 失敗（command-not-found, exit code -1）時に
+  Proc へ os-error を記録し、メッセージへ `OS error = ...` を付加（test 18）。
+- **`throws-like` の Junction マッチャ対応**: `message => /"a"/ & /"b"/` のような all/any/one/none
+  Junction を `.message` などの属性マッチで評価できるようにした（test 18）。
+- **`run`/`shell` の `$*CWD` デフォルト**: `:cwd` 未指定時に動的 `$*CWD`（`indir` が設定）を子プロセスの
+  作業ディレクトリに使う（test 34）。
+- **`:$env` の Pair 形式対応**: `extract_proc_options` の Pair 分岐に `env` を追加（test 35）。
+- **`IO::Pipe.split`**: パイプ内容を読んでから split するよう、narg/包括 split ハンドラで `IO::Pipe` を
+  スキップ（従来は `"IO::Pipe()"` に文字列化されていた、test 38）。
+- **パイプ `.close` が親 Proc を返す（identity 保持）**: `proc_by_pid_map` を追加し、live/`proc-pid` パイプの
+  `.close` が `=== $p` となる所有 Proc を返す（test 37, `S32-io/pipe.t` の test 3 も同要件）。なお live
+  （未確定）Proc は placeholder exitcode -1 を持つため sink で throw しないようガード。
+- **`Proc.spawn`/`.shell`/`.run` の mutating メソッド**: コマンドを再実行し pid/exitcode を更新。
+  spawn 失敗（pid 0）では pid を更新しない rakudo 準拠の挙動（test 39）。
+
 ## 次の計画
 
 詳細は [PLAN.md](../PLAN.md) 🔴 最優先セクション参照。次の本丸は **per-call scoped/overlay env**

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -961,6 +961,7 @@ roast/S29-context/exit.t
 roast/S29-context/sleep.t
 roast/S29-conversions/hash.t
 roast/S29-conversions/ord_and_chr.t
+roast/S29-os/system.t
 roast/S32-array/bool.t
 roast/S32-array/create.t
 roast/S32-array/delete-adverb-native.t

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1089,7 +1089,9 @@ pub(crate) fn native_method_1arg(
         }
         "split" => {
             if let Value::Instance { class_name, .. } = target
-                && (class_name == "Supply" || class_name == "IO::Handle")
+                && (class_name == "Supply"
+                    || class_name == "IO::Handle"
+                    || class_name == "IO::Pipe")
             {
                 return None;
             }
@@ -2779,7 +2781,7 @@ pub(crate) fn native_method_2arg(
 
     if method == "split" {
         if let Value::Instance { class_name, .. } = target
-            && (class_name == "Supply" || class_name == "IO::Handle")
+            && (class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe")
         {
             return None;
         }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -75,6 +75,16 @@ pub(crate) fn pipe_proc_map() -> &'static PipeProcMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
+/// Maps a child PID to the owning Proc instance, so that `.in`/`.out`/`.err`
+/// pipes (which carry the PID, not a pipe-id) can return the exact parent Proc
+/// from `.close` — preserving object identity for `$p.out.close === $p`.
+type ProcByPidMap = std::sync::Mutex<HashMap<i64, Value>>;
+
+pub(crate) fn proc_by_pid_map() -> &'static ProcByPidMap {
+    static MAP: OnceLock<ProcByPidMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
 /// Options extracted from named arguments for run/shell.
 struct ProcOptions {
     cwd: Option<String>,
@@ -806,6 +816,13 @@ impl Interpreter {
             if let Value::Pair(key, inner) = value {
                 match key.as_str() {
                     "cwd" => opts.cwd = Some(inner.to_string_value()),
+                    "env" => {
+                        if let Value::Hash(env_map) = inner.as_ref() {
+                            for (ek, ev) in env_map.iter() {
+                                opts.env.insert(ek.clone(), ev.to_string_value());
+                            }
+                        }
+                    }
                     "err" => opts.capture_err = inner.truthy(),
                     "out" => Self::extract_out_option(inner, &mut opts),
                     "in" => Self::extract_in_option(inner, &mut opts),
@@ -958,7 +975,12 @@ impl Interpreter {
 
         // Build the command tuple for .command attribute
         let command_val = Value::array(positional.iter().map(|s| Value::str(s.clone())).collect());
-        let opts_cwd = opts.cwd.clone();
+        // run() defaults the child's working directory to the dynamic $*CWD
+        // (set by `indir`), not the interpreter process's actual cwd.
+        let opts_cwd = opts
+            .cwd
+            .clone()
+            .or_else(|| self.get_dynamic_string("$*CWD"));
         let opts_env = opts.env.clone();
 
         let mut cmd = Command::new(program);
@@ -1075,7 +1097,11 @@ impl Interpreter {
                     if opts.bin {
                         attrs.insert("bin".to_string(), Value::Bool(true));
                     }
-                    return Ok(Value::make_instance(Symbol::intern("Proc"), attrs));
+                    let proc = Value::make_instance(Symbol::intern("Proc"), attrs);
+                    if let Ok(mut map) = proc_by_pid_map().lock() {
+                        map.insert(pid, proc.clone());
+                    }
+                    return Ok(proc);
                 }
 
                 let captured_out = if opts.capture_out {
@@ -1129,7 +1155,8 @@ impl Interpreter {
                     )),
                 }
             }
-            Err(_err) => {
+            Err(err) => {
+                let os_error = err.to_string();
                 // Fallback for cases where $*EXECUTABLE is passed as an IO::Path-ish value
                 // that stringifies ambiguously. Retry with current_exe.
                 if first_arg_io_path || program == "$*EXECUTABLE" || program.ends_with("mutsu") {
@@ -1210,15 +1237,27 @@ impl Interpreter {
                         }
                     }
                 }
-                Ok(Self::make_proc_instance(
+                let mut proc = Self::make_proc_instance(
                     -1,
                     0,
                     0,
                     command_val,
                     opts.capture_err.then(String::new),
                     opts.capture_out.then(String::new),
-                ))
+                );
+                Self::attach_proc_os_error(&mut proc, &os_error);
+                Ok(proc)
             }
+        }
+    }
+
+    /// Record the OS-level spawn error on a failed Proc so that
+    /// `X::Proc::Unsuccessful.message` can report it (e.g. command-not-found
+    /// produces "exit code: -1, ... OS error = No such file or directory").
+    fn attach_proc_os_error(proc: &mut Value, os_error: &str) {
+        if let Value::Instance { attributes, .. } = proc {
+            let attrs = std::sync::Arc::make_mut(attributes);
+            attrs.insert("os-error".to_string(), Value::str(os_error.to_string()));
         }
     }
 
@@ -1263,7 +1302,13 @@ impl Interpreter {
             command.stderr(std::process::Stdio::null());
         }
 
-        if let Some(cwd) = opts.cwd {
+        // shell() defaults the child's working directory to the dynamic $*CWD
+        // (set by `indir`), matching run().
+        if let Some(cwd) = opts
+            .cwd
+            .clone()
+            .or_else(|| self.get_dynamic_string("$*CWD"))
+        {
             command.current_dir(cwd);
         }
         for (k, v) in opts.env {

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -419,7 +419,10 @@ impl Interpreter {
                 Some(Value::Int(i)) => *i,
                 _ => 0,
             };
-            if exitcode != 0 {
+            // A still-"live" Proc (from `run(:in, ...)`) carries a placeholder
+            // exitcode of -1 until it is finalized; sinking it must not throw.
+            let is_live = matches!(attributes.get("live"), Some(Value::Bool(true)));
+            if exitcode != 0 && !is_live {
                 let signal = match attributes.get("signal") {
                     Some(Value::Int(i)) => *i,
                     _ => 0,
@@ -428,10 +431,22 @@ impl Interpreter {
                     .get("command")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
-                let msg = format!(
-                    "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {})",
-                    command, exitcode, signal
-                );
+                // A command that could not be spawned (exit code -1) reports the
+                // underlying OS error, matching rakudo's X::Proc::Unsuccessful.
+                let os_error = attributes
+                    .get("os-error")
+                    .map(|v| v.to_string_value())
+                    .filter(|s| !s.is_empty());
+                let msg = match &os_error {
+                    Some(oe) => format!(
+                        "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {}, OS error = {})",
+                        command, exitcode, signal, oe
+                    ),
+                    None => format!(
+                        "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {})",
+                        command, exitcode, signal
+                    ),
+                };
                 let mut ex_attrs = std::collections::HashMap::new();
                 ex_attrs.insert("message".to_string(), Value::str(msg.clone()));
                 ex_attrs.insert("proc".to_string(), val);

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2721,10 +2721,10 @@ impl Interpreter {
         }
 
         // Comprehensive split handler
-        // Skip for Supply (handled by Supply pipeline) and IO::Handle
-        // (handled by native_io_handle which slurps the file first).
+        // Skip for Supply (handled by Supply pipeline) and IO::Handle/IO::Pipe
+        // (handled by native IO dispatch which reads the content first).
         if method == "split"
-            && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle")
+            && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe")
             && !matches!(&target, Value::Package(name) if name.resolve().starts_with("IO::Spec"))
         {
             return self.handle_split_method(target, args);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1606,7 +1606,7 @@ impl Interpreter {
                 methods: HashMap::new(),
                 native_methods: [
                     "exitcode", "signal", "command", "pid", "err", "out", "in", "Numeric", "Int",
-                    "Bool", "Str", "gist",
+                    "Bool", "Str", "gist", "spawn", "shell", "run",
                 ]
                 .iter()
                 .map(|s| s.to_string())
@@ -3754,6 +3754,54 @@ impl Interpreter {
                 .collect();
             for k in non_exported_op_globals {
                 self.functions.remove(&k);
+            }
+
+            // Remove GLOBAL:: sub aliases that were leaked by sub hoisting during
+            // this module load, are NOT exported, and shadow a core builtin.
+            // A `unit module X` declares `our sub foo` under `X::foo`, but mutsu's
+            // hoist pre-pass registers the body under `GLOBAL::foo` (the runtime
+            // package is not switched by the compile-time `unit` declaration). For
+            // a non-exported sub whose name matches a core builtin, that GLOBAL
+            // alias wrongly masks the builtin in the caller's scope (e.g.
+            // Test::Util's non-exported `our sub run` was hiding the core `run`
+            // Proc spawner). Such a sub is reachable from the caller only as a bare
+            // name — which Raku does not allow for a non-exported `our sub` — so we
+            // drop the leaked alias. Gating on builtin collision keeps the change
+            // safe: non-colliding helpers stay in GLOBAL so the module's own
+            // (GLOBAL-package) bodies can still call them.
+            {
+                let mut exported_names: HashSet<String> = HashSet::new();
+                for source in ["GLOBAL", module] {
+                    if let Some(subs) = self.exported_subs.get(source) {
+                        for name in subs.keys() {
+                            exported_names.insert(name.clone());
+                        }
+                    }
+                }
+                if let Some(subs) = self.unit_module_exported_subs.get(module) {
+                    for name in subs.keys() {
+                        exported_names.insert(name.clone());
+                    }
+                }
+                let leaked_globals: Vec<Symbol> = self
+                    .functions
+                    .keys()
+                    .filter(|k| {
+                        if func_keys_before.contains(k) {
+                            return false;
+                        }
+                        let ks = k.resolve();
+                        let Some(name) = ks.strip_prefix("GLOBAL::") else {
+                            return false;
+                        };
+                        let base = name.split('/').next().unwrap_or(name);
+                        !exported_names.contains(base) && Self::is_builtin_function(base)
+                    })
+                    .copied()
+                    .collect();
+                for k in leaked_globals {
+                    self.functions.remove(&k);
+                }
             }
 
             self.loaded_modules.insert(module.to_string());

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2990,6 +2990,12 @@ impl Interpreter {
                     {
                         *guard = None; // Drop the ChildStdin
                     }
+                    // `.close` on a Proc pipe returns the owning Proc.
+                    if let Ok(map) = super::builtins_system::proc_by_pid_map().lock()
+                        && let Some(proc) = map.get(pid)
+                    {
+                        return Ok(proc.clone());
+                    }
                     return Ok(Value::Bool(true));
                 }
                 _ => {}
@@ -3096,6 +3102,12 @@ impl Interpreter {
                 }
                 "close" => {
                     let _ = finalize_and_get_content();
+                    // `.close` on a Proc pipe returns the owning Proc.
+                    if let Ok(map) = super::builtins_system::proc_by_pid_map().lock()
+                        && let Some(proc) = map.get(live_pid)
+                    {
+                        return Ok(proc.clone());
+                    }
                     return Ok(Value::Bool(true));
                 }
                 "encoding" => return Ok(Value::str("utf8".to_string())),

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -259,6 +259,7 @@ impl Interpreter {
                 | "Channel"
                 | "Supply"
                 | "Supplier"
+                | "Proc"
                 | "Proc::Async"
                 | "Encoding::Decoder"
                 | "ThreadPoolScheduler"
@@ -273,6 +274,7 @@ impl Interpreter {
                         | "Channel"
                         | "Supply"
                         | "Supplier"
+                        | "Proc"
                         | "Proc::Async"
                         | "Encoding::Decoder"
                         | "ThreadPoolScheduler"
@@ -281,6 +283,7 @@ impl Interpreter {
             })
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
+            "Proc" => self.native_proc_mut(attributes, method, args),
             "Promise" => self.native_promise_mut(attributes, method, args),
             "Channel" => self.native_channel_mut(attributes, method, args),
             "Supply" => self.native_supply_mut(attributes, method, args),

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -4,6 +4,62 @@ use crate::symbol::Symbol;
 use super::state::proc_stdin_map;
 
 impl Interpreter {
+    /// Mutating Proc methods (`.spawn`, `.run`, `.shell`) re-run a command and
+    /// update the Proc's state in place. They return Bool (success) — never the
+    /// Proc itself — so using them in sink context does not throw
+    /// X::Proc::Unsuccessful. Per rakudo, a failed *spawn* (could not start the
+    /// program at all) leaves the previous `.pid` untouched, whereas `shell`
+    /// always starts a shell, so its `.pid` updates even for a missing command.
+    pub(in crate::runtime) fn native_proc_mut(
+        &mut self,
+        attributes: HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        let new_proc = match method {
+            "spawn" | "run" => self.builtin_run(&args)?,
+            "shell" => self.builtin_shell(&args)?,
+            _ => {
+                return Err(RuntimeError::new(format!(
+                    "No native mutable method '{}' on 'Proc'",
+                    method
+                )));
+            }
+        };
+        let Value::Instance {
+            attributes: new_attrs,
+            ..
+        } = &new_proc
+        else {
+            return Ok((Value::Bool(false), attributes));
+        };
+        let new_pid = match new_attrs.get("pid") {
+            Some(Value::Int(p)) => *p,
+            _ => 0,
+        };
+        let exitcode = match new_attrs.get("exitcode") {
+            Some(Value::Int(c)) => *c,
+            _ => -1,
+        };
+        let mut updated = attributes;
+        // A pid of 0 means the program could not be spawned at all; keep the
+        // previous pid in that case (matches rakudo's `.spawn` semantics).
+        if new_pid != 0 {
+            for key in ["pid", "command", "out", "err"] {
+                if let Some(v) = new_attrs.get(key) {
+                    updated.insert(key.to_string(), v.clone());
+                }
+            }
+        }
+        if let Some(v) = new_attrs.get("exitcode") {
+            updated.insert("exitcode".to_string(), v.clone());
+        }
+        if let Some(v) = new_attrs.get("signal") {
+            updated.insert("signal".to_string(), v.clone());
+        }
+        Ok((Value::Bool(exitcode == 0), updated))
+    }
+
     // --- Proc::Async immutable ---
 
     pub(in crate::runtime) fn native_proc_async(

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -170,7 +170,7 @@ impl Interpreter {
                 | "throws-like-any"
                 | "fails-like"
                 | "is_run"
-                | "run"
+                | "Test::Util::run"
                 | "get_out"
                 | "use-ok"
                 | "does-ok"
@@ -233,7 +233,7 @@ impl Interpreter {
             "throws-like-any" => self.test_fn_throws_like_any(args).map(Some),
             "fails-like" => self.test_fn_fails_like(args).map(Some),
             "is_run" => self.test_fn_is_run(args).map(Some),
-            "run" | "Test::Util::run" => self.test_fn_run(args).map(Some),
+            "Test::Util::run" => self.test_fn_run(args).map(Some),
             "get_out" => self.test_fn_get_out(args).map(Some),
             "use-ok" => self.test_fn_use_ok(args).map(Some),
             "does-ok" => self.test_fn_does_ok(args).map(Some),

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -247,29 +247,7 @@ impl Interpreter {
                         String::new()
                     }
                 });
-            let matched = match expected_val {
-                Value::Whatever => true, // * matches anything
-                Value::Regex(pattern) => self
-                    .regex_match_with_captures(pattern, &actual_str)
-                    .is_some(),
-                Value::Sub(_) | Value::Routine { .. } => {
-                    // Smart-match: call the block with the actual value as topic
-                    let call_arg = actual_val.clone().unwrap_or(Value::Nil);
-                    match self.call_sub_value(expected_val.clone(), vec![call_arg], false) {
-                        Ok(result_val) => result_val.truthy(),
-                        Err(_) => false,
-                    }
-                }
-                Value::Package(type_name) => {
-                    // Type object matcher: check if actual_val isa the type
-                    if let Some(ref actual) = actual_val {
-                        crate::value::types::what_type_name(actual) == type_name.resolve()
-                    } else {
-                        false
-                    }
-                }
-                _ => actual_str == expected_val.to_string_value(),
-            };
+            let matched = self.matcher_accepts(expected_val, &actual_str, actual_val.as_ref());
             let expected_display = match expected_val {
                 Value::Regex(pattern) => format!("/{}/", pattern),
                 Value::Sub(_) | Value::Routine { .. } => expected_val.to_string_value(),
@@ -297,6 +275,45 @@ impl Interpreter {
             },
         )?;
         Ok(Value::Bool(type_ok))
+    }
+
+    /// Smart-match a `throws-like` attribute matcher against the actual value.
+    /// Handles Whatever, Regex, Callable, type-object and Junction matchers
+    /// (e.g. `message => /"a"/ & /"b"/`), falling back to string equality.
+    fn matcher_accepts(
+        &mut self,
+        matcher: &Value,
+        actual_str: &str,
+        actual_val: Option<&Value>,
+    ) -> bool {
+        match matcher {
+            Value::Whatever => true,
+            Value::Regex(pattern) => self
+                .regex_match_with_captures(pattern, actual_str)
+                .is_some(),
+            Value::Sub(_) | Value::Routine { .. } => {
+                let call_arg = actual_val.cloned().unwrap_or(Value::Nil);
+                match self.call_sub_value(matcher.clone(), vec![call_arg], false) {
+                    Ok(result_val) => result_val.truthy(),
+                    Err(_) => false,
+                }
+            }
+            Value::Package(type_name) => actual_val.is_some_and(|actual| {
+                crate::value::types::what_type_name(actual) == type_name.resolve()
+            }),
+            Value::Junction { kind, values } => {
+                let mut matches = values
+                    .iter()
+                    .map(|v| self.matcher_accepts(v, actual_str, actual_val));
+                match kind {
+                    crate::value::JunctionKind::All => matches.all(|m| m),
+                    crate::value::JunctionKind::Any => matches.any(|m| m),
+                    crate::value::JunctionKind::None => !matches.any(|m| m),
+                    crate::value::JunctionKind::One => matches.filter(|m| *m).count() == 1,
+                }
+            }
+            _ => actual_str == matcher.to_string_value(),
+        }
     }
 
     /// `throws-like-any($code, @ex_type, $reason?, *%matcher)`

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2568,7 +2568,12 @@ impl VM {
                                     Some(Value::Int(i)) => *i,
                                     _ => 0,
                                 };
-                                if exitcode != 0 {
+                                // A still-"live" Proc (from `run(:in, ...)`)
+                                // carries a placeholder exitcode of -1 until it
+                                // is finalized; sinking it must not throw.
+                                let is_live =
+                                    matches!(attributes.get("live"), Some(Value::Bool(true)));
+                                if exitcode != 0 && !is_live {
                                     let signal = match attributes.get("signal") {
                                         Some(Value::Int(i)) => *i,
                                         _ => 0,
@@ -2577,10 +2582,23 @@ impl VM {
                                         .get("command")
                                         .map(|v| v.to_string_value())
                                         .unwrap_or_default();
-                                    let msg = format!(
-                                        "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {})",
-                                        command, exitcode, signal
-                                    );
+                                    // When the command could not be spawned at all
+                                    // (exit code -1), rakudo reports the underlying
+                                    // OS error in the message.
+                                    let os_error = attributes
+                                        .get("os-error")
+                                        .map(|v| v.to_string_value())
+                                        .filter(|s| !s.is_empty());
+                                    let msg = match &os_error {
+                                        Some(oe) => format!(
+                                            "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {}, OS error = {})",
+                                            command, exitcode, signal, oe
+                                        ),
+                                        None => format!(
+                                            "The spawned command '{}' exited unsuccessfully (exit code: {}, signal: {})",
+                                            command, exitcode, signal
+                                        ),
+                                    };
                                     let mut ex_attrs = std::collections::HashMap::new();
                                     ex_attrs.insert("message".to_string(), Value::str(msg.clone()));
                                     ex_attrs.insert("proc".to_string(), val);


### PR DESCRIPTION
## What

Makes `roast/S29-os/system.t` pass all 41 tests and adds it to the whitelist.

The file aborted at test 3 because **Test::Util's non-exported `our sub run` leaked into `GLOBAL::` via module-load sub-hoisting and masked the core `run` Proc spawner**, so `run($*EXECUTABLE, ...)` dispatched to the test helper (which writes its first arg to a temp file and runs it). After loading a module, we now drop leaked, non-exported `GLOBAL::name` aliases that collide with a core builtin — a general fix, not a special case.

On top of that, the remaining Proc surface the test exercises:

- **X::Proc::Unsuccessful OS error** — a failed spawn (exit code -1) records the OS error and the message includes `OS error = ...` (test 18).
- **throws-like Junction matchers** — `message => /"a"/ & /"b"/` (all/any/one/none) now evaluated on attribute matchers (test 18).
- **`$*CWD` default for run/shell** — without `:cwd`, the child uses the dynamic `$*CWD` set by `indir` (test 34).
- **`:$env` Pair form** — handled in `extract_proc_options` (test 35).
- **`IO::Pipe.split`** — reads pipe content first instead of stringifying to `"IO::Pipe()"` (test 38).
- **pipe `.close` returns the owning Proc** (identity preserved, `$p.out.close === $p`), via a pid→Proc map; a still-live Proc no longer throws on sink (test 37; also `S32-io/pipe.t` test 3).
- **`Proc.spawn`/`.shell`/`.run` mutating methods** — re-run a command and update pid/exitcode; a failed spawn leaves pid untouched (test 39).

## Test

- `roast/S29-os/system.t` → 41/41 (exit 0), whitelisted.
- `roast/S32-io/pipe.t` → still 16/16 (regression guard for the pipe `.close` / sink change).
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)