### PR TITLE
perf(vm): eliminate per-method-call env→locals pull (lever B Slice 6.3 stage 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,10 @@ Running the entire roast suite locally is wasteful and slow — **let CI run the
 - CI runs `make test` and `make roast` on a clean machine with the **release build** (`cargo build --release`, `MUTSU_BIN=target/release/mutsu`). Local debug builds are much slower, so a local timeout on a heavy test does not necessarily indicate a real failure — confirm with a release build (`target/release/mutsu`) before assuming a regression, and otherwise trust CI's verdict.
 - Push the branch and rely on CI for the comprehensive roast result rather than running the whole suite locally.
 
+### Use the DEBUG build to iterate on `MUTSU_VM_STATS` counters — release is for wall-clock only
+
+The `MUTSU_VM_STATS=1` dual-store counters (`locals_pulls`, `env_flushes`, `env_deep_copies`, `clone_env`, ...) are **deterministic and independent of the optimization level** — they count VM events, not time. So when tuning a perf/decoupling change against those counters, **iterate with the debug build** (`cargo build`, ~30-70s) and read the counters off `target/debug/mutsu`; the numbers are identical to release. Reserve the slow `cargo build --release` (which here also emits debuginfo and can take 10-15 min) for the **final wall-clock measurement** only. Do NOT default to release just because the task is perf-related — that wastes ~10× the build time per iteration for byte-identical counter output.
+
 ## Checking `make test` / `make roast` results
 
 `make test` and `make roast` automatically save their full output to log files via `tee`:

--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -845,25 +845,71 @@ Reaching that requires, roughly in order:
         and the `saved_env_dirty` frame field. Metric: `MUTSU_VM_STATS=1`
         `locals_pulls` → 0 on `mb_method`/`mb_nested` with output unchanged.
 
+      **Stage 1 — DONE (the per-method-call pull is gone).** The method-dispatch
+      half of step (1) is implemented: the blanket post-dispatch `env_dirty = true`
+      in the `CallMethod` / `CallMethodMut` opcodes is replaced by a precise
+      `method_dispatch_pure` flag (VM field, default `false` = conservative). The
+      opcode marks env dirty only when the dispatch was *not* proven pure, so a
+      missed signal can only cost a redundant pull, never a stale read. Purity is
+      reported by the compiled-method paths (skip-merge / unchanged-env = pure;
+      merge = pure iff it actually changed a caller-observable value) and by the
+      native dispatch tail (a native method returns a value without writing the
+      receiver back → env-pure). `merge_method_env` now returns a *precise*
+      changed-flag using two O(1) refinements so a nested call's overlay flatten
+      (which copies every parent lexical/global into the callee overlay) no longer
+      trips it: `cheaply_unchanged` (Arc-ptr / scalar equality skips value-identical
+      copies like `%*ENV`) and `could_name_caller_local` (a key that can never be a
+      caller local slot — `?LINE`/`?FILE`, pod `=...`, `*`-dynamics, `__mutsu_`
+      plumbing — never obliges a pull; `?LINE` differs between caller and
+      method-body lines and used to re-dirty env on every multi-line nested call).
+
+      Measured (`MUTSU_VM_STATS=1`, counters are opt-level-independent — iterate on
+      the debug build):
+
+      | bench (10k loop)        | `locals_pulls` before | after |
+      |-------------------------|----------------------:|------:|
+      | `mb_method` (`$p.g()`)  |                 10001 |     1 |
+      | `mb_nested` (`self.d()`)|                 10001 |     1 |
+      | `@a.elems` on a var     |                 10001 |     1 |
+
+      `make test` PASS (5093); method/OOP/closure/dynamic-var roast green. Pinned
+      by `t/method-env-dirty.t`. The flag is NOT yet deleted: the function-dispatch
+      half of step (1) is already precise (Slice 6.1), but steps (2) the ~36 by-name
+      var/control setters and (3) the ~21 I/O + interpreter-carrier setters remain
+      — (3) is gated on the interpreter-bridge removal (lever A finish / Q2). So
+      `env_dirty` survives only as the rare interpreter-bridge safety net; the hot
+      per-call pull — the actual lever-B cost — is eliminated.
+
 ### Remaining method-call dual-store costs (measured 2026-06-07)
 
 `MUTSU_VM_STATS=1` on the method/OOP benches isolates the two costs that survive
 after the overlay conversion (Slices 6.0–6.2). Both are structural, not
 quick-fixable in isolation:
 
-1. **Per-method-call `locals_pulls` (= the `env_dirty` flag, Slice 6.3).**
-   `tmp/mb_method.raku` (`$p.g()` in a 10k loop) → `locals_pulls=10000`. The
-   method-call opcode unconditionally sets `env_dirty=true` after dispatch (e.g.
-   `vm_call_method_mut_ops.rs` ~line 1305), forcing an O(caller-locals)
-   `sync_locals_from_env` every call. **Attempted fix that FAILED (reverted):**
-   snapshot the caller env overlay Arc before dispatch and only set `env_dirty`
-   when it changed (mirroring the function-side Slice 6.1). It backfired — the
-   extra `Arc` ref held across the call raised the overlay refcount and *induced*
-   a `make_mut` deep copy every call (`env_deep_copies` 1→10001) while the
-   caller env Arc changes on every call anyway (overlay merge/restore allocates a
-   new Arc), so `env_changed` was always true and `locals_pulls` did not drop.
-   Conclusion: this is genuinely Slice 6.3 / interpreter-decoupling territory,
-   not a localized opcode tweak.
+1. **Per-method-call `locals_pulls` (= the `env_dirty` flag, Slice 6.3). — FIXED
+   (Slice 6.3 stage 1).** `tmp/mb_method.raku` (`$p.g()` in a 10k loop) →
+   `locals_pulls` dropped from **10000 → 1**; `mb_nested` and `@a.elems` on a var
+   likewise 10001 → 1. The method-call opcode used to set `env_dirty=true`
+   unconditionally after dispatch (e.g. `vm_call_method_mut_ops.rs` ~line 1305),
+   forcing an O(caller-locals) `sync_locals_from_env` on the caller's next
+   `GetLocal`, every call.
+
+   **Earlier attempt that FAILED (instructive, do not repeat):** snapshot the
+   caller env overlay `Arc` before dispatch and only set `env_dirty` when it
+   changed. It backfired — the extra `Arc` ref held across the call raised the
+   overlay refcount and *induced* a `make_mut` deep copy every call
+   (`env_deep_copies` 1→10001), and the caller env Arc changes on every call
+   anyway (overlay merge/restore allocates a new Arc), so `env_changed` was always
+   true and `locals_pulls` did not drop.
+
+   **What worked:** do not snapshot/compare the whole env. Instead let the
+   compiled-method paths *report* purity through a `method_dispatch_pure` VM flag
+   (default `false`, so the opcode falls back to the conservative mark), and make
+   `merge_method_env` compute a *precise* changed-flag with O(1) per-key checks
+   (`cheaply_unchanged` Arc-ptr/scalar equality + `could_name_caller_local` name
+   filter) so the nested-call overlay flatten and the per-line `?LINE` churn no
+   longer trip it. No held `Arc`, no induced deep copy (`env_deep_copies` stays
+   1). See PLAN.md lever C / the Slice 6.3 stage-1 entry above.
 
 2. **Per-*nested*-method-call O(env) deep copy. — FIXED (multi-tier overlay).**
    `tmp/mb_nested.raku` (`method f() { self.d() }`) → `env_deep_copies` dropped

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -123,6 +123,15 @@ pub(crate) struct VM {
     /// When true, locals may be stale relative to env (interpreter bridge modified env).
     /// Cleared after sync_locals_from_env or pop_call_frame.
     env_dirty: bool,
+    /// Set by a compiled method dispatch to report whether it left the caller's
+    /// local slots coherent (Slice 6.3). `true` means the call provably wrote
+    /// nothing the caller can observe in its slots (a read-only / no-merge method
+    /// or a merge that propagated nothing), so the CallMethod/CallMethodMut
+    /// opcode skips its env_dirty mark and the caller avoids a per-call env->locals
+    /// pull. Defaults to `false` (conservative) for every non-compiled path
+    /// (native fallback, interpreter bridge, blocks) so a missed signal can only
+    /// cost a redundant pull, never a stale read.
+    method_dispatch_pure: bool,
     /// The instruction pointer to resume at after a .resume call in a CATCH block.
     /// Set when Die/Fail creates an exception, used by exec_try_catch_op.
     resume_ip: Option<usize>,
@@ -404,6 +413,7 @@ impl VM {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
+            method_dispatch_pure: false,
             resume_ip: None,
             bind_context: false,
             scalar_bind_context: false,

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1260,6 +1260,9 @@ impl VM {
                 // (should be Any), so absorbing here would break methods like
                 // .end, .elems, etc. on uninitialized containers.
                 // The CallMethod path has the Nil absorber for direct Nil.method calls.
+                // Slice 6.3: assume the dispatch dirties the caller env; only a
+                // proven-pure compiled method path clears this.
+                self.method_dispatch_pure = false;
                 let call_result = if !skip_native {
                     // Resolve hash sentinel entries (bound variable refs, self-refs)
                     // before passing to native methods that iterate hash values.
@@ -1276,6 +1279,12 @@ impl VM {
                     if let Some(native_result) =
                         self.try_native_method(dispatch_target, Symbol::intern(&method), &args)
                     {
+                        // A native method reaching this tail returns a value and
+                        // does not write the receiver back into env (mutating
+                        // array/hash natives are handled by the dedicated
+                        // writeback branches above and return early). So it is
+                        // env-pure w.r.t. the caller -> no per-call locals pull.
+                        self.method_dispatch_pure = true;
                         native_result
                     } else {
                         self.try_compiled_method_mut_or_interpret(
@@ -1288,21 +1297,30 @@ impl VM {
                 } else {
                     self.try_compiled_method_mut_or_interpret(&target_name, target, &method, args)
                 };
+                // Slice 6.3: mark env dirty only when the dispatch was not a
+                // proven-pure compiled method call.
+                let mark_dirty = !self.method_dispatch_pure;
                 match modifier {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);
-                            self.env_dirty = true;
+                            if mark_dirty {
+                                self.env_dirty = true;
+                            }
                         }
                         Err(e) if Self::is_method_not_found_error(&e) => {
                             self.stack.push(Value::Nil);
-                            self.env_dirty = true;
+                            if mark_dirty {
+                                self.env_dirty = true;
+                            }
                         }
                         Err(e) => return Err(e),
                     },
                     _ => {
                         self.stack.push(call_result?);
-                        self.env_dirty = true;
+                        if mark_dirty {
+                            self.env_dirty = true;
+                        }
                     }
                 }
             }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -904,10 +904,16 @@ impl VM {
                 // any variable. This handles cases like [1,2,3].shift where there
                 // is no variable to mutate. The CallMethodMut path handles variable
                 // targets separately.
+                // Slice 6.3: assume the dispatch dirties the caller env; only a
+                // proven-pure compiled method path clears this (sets it true),
+                // letting the opcode tail skip the env_dirty mark + per-call pull.
+                self.method_dispatch_pure = false;
                 let call_result = if matches!(method, "shift" | "pop")
                     && args.is_empty()
                     && matches!(&target, Value::Array(_, kind) if kind.is_real_array())
                 {
+                    // Native array read on a by-value target: env-pure.
+                    self.method_dispatch_pure = true;
                     if let Value::Array(_, kind) = &target
                         && kind.is_lazy()
                     {
@@ -965,10 +971,14 @@ impl VM {
                                     }
                                 })
                                 .collect();
+                            // Pure array transform: env-pure.
+                            self.method_dispatch_pure = true;
                             Ok(Value::Slip(std::sync::Arc::new(converted)))
                         } else if let Some(native_result) =
                             self.try_native_method(&target, Symbol::intern(method), &args)
                         {
+                            // Native method on a by-value (read) target: env-pure.
+                            self.method_dispatch_pure = true;
                             native_result
                         } else {
                             self.try_compiled_method_or_interpret(target, method, args)
@@ -976,6 +986,8 @@ impl VM {
                     } else if let Some(native_result) =
                         self.try_native_method(&target, Symbol::intern(method), &args)
                     {
+                        // Native method on a by-value (read) target: env-pure.
+                        self.method_dispatch_pure = true;
                         native_result
                     } else {
                         self.try_compiled_method_or_interpret(target, method, args)
@@ -983,21 +995,30 @@ impl VM {
                 } else {
                     self.try_compiled_method_or_interpret(target, method, args)
                 };
+                // Slice 6.3: mark env dirty only when the dispatch was not a
+                // proven-pure compiled method call.
+                let mark_dirty = !self.method_dispatch_pure;
                 match modifier {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);
-                            self.env_dirty = true;
+                            if mark_dirty {
+                                self.env_dirty = true;
+                            }
                         }
                         Err(e) if Self::is_method_not_found_error(&e) => {
                             self.stack.push(Value::Nil);
-                            self.env_dirty = true;
+                            if mark_dirty {
+                                self.env_dirty = true;
+                            }
                         }
                         Err(e) => return Err(e),
                     },
                     _ => {
                         self.stack.push(call_result?);
-                        self.env_dirty = true;
+                        if mark_dirty {
+                            self.env_dirty = true;
+                        }
                     }
                 }
                 // Wrap map/grep results back into HyperSeq/RaceSeq

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -664,7 +664,15 @@ impl VM {
             // mutate the caller env in place without a deep copy.
             let frame = self.pop_call_frame();
             let current_env = self.interpreter.take_env();
-            let mut merged_env = merge_method_env(frame.saved_env, current_env, &method_local_keys);
+            let (mut merged_env, wrote_caller) =
+                merge_method_env(frame.saved_env, current_env, &method_local_keys);
+            // Precise dirty signal (Slice 6.3): the caller only needs an
+            // env->locals re-sync when this method actually merged a
+            // caller-visible write (captured-outer var, global, &sub) or wrote
+            // back an `is rw` param. A method that merged nothing leaves the
+            // caller's slots coherent -> stays "pure" so the opcode skips the
+            // env_dirty mark (no per-call locals pull).
+            self.method_dispatch_pure = !wrote_caller && rw_writeback.is_empty();
 
             for (source_name, val) in &rw_writeback {
                 merged_env.insert(source_name.clone(), val.clone());
@@ -684,6 +692,8 @@ impl VM {
         }
 
         if can_skip_merge {
+            // No env writes possible -> the caller's slots stay coherent (pure).
+            self.method_dispatch_pure = true;
             self.interpreter.set_current_package(saved_package);
             let frame = self.pop_call_frame();
             *self.interpreter.env_mut() = frame.saved_env;
@@ -1114,7 +1124,9 @@ impl VM {
         self.interpreter.set_current_package(saved_package);
 
         if can_skip_merge {
-            // No env writes possible — just restore saved env
+            // No env writes possible — just restore saved env (pure: caller
+            // slots stay coherent, opcode skips the env_dirty mark).
+            self.method_dispatch_pure = true;
             let frame = self.pop_call_frame();
             self.interpreter.set_env(frame.saved_env);
         } else {
@@ -1123,6 +1135,8 @@ impl VM {
             // into the saved env before restoring.
             let frame = self.pop_call_frame();
             if self.interpreter.env().ptr_eq(&frame.saved_env) {
+                // Env object unchanged -> nothing merged back (pure).
+                self.method_dispatch_pure = true;
                 self.interpreter.set_env(frame.saved_env);
             } else {
                 // Build method_local_keys set (keys that should NOT leak to caller)
@@ -1155,7 +1169,11 @@ impl VM {
                 // Own both envs (frame already popped above; take the live callee
                 // env) so the merge mutates the caller env in place, no deep copy.
                 let current_env = self.interpreter.take_env();
-                let merged = merge_method_env(frame.saved_env, current_env, &method_local_keys);
+                let (merged, wrote_caller) =
+                    merge_method_env(frame.saved_env, current_env, &method_local_keys);
+                // Precise dirty signal (Slice 6.3): re-sync the caller's locals
+                // only when the method merged a caller-visible write.
+                self.method_dispatch_pure = !wrote_caller;
                 self.interpreter.set_env(merged);
             }
         }
@@ -1414,11 +1432,49 @@ fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
     }
 }
 
-/// Merge method env back into the saved (caller) env.
-///
-/// Carries forward values for keys that existed in the saved env, plus any
-/// dynamic/global keys (`&`-prefixed, `__mutsu_method_value::`-prefixed).
-/// Merge the method frame's caller-visible writes back into the caller env.
+/// True if `name` could be the name of a caller compiled-local slot (and so a
+/// change to it could make a caller slot stale). Excludes names that are never
+/// stored as a local slot — compile-time/location vars (`?...`), pod (`=...`),
+/// dynamic and pseudo-global names (anything containing `*`, e.g. `$*OUT`,
+/// `*PERL`), and `__mutsu_` internal plumbing. Used by `merge_method_env` to keep
+/// the env_dirty signal precise. Conservative: an ordinary lexical (`$x`, `@y`,
+/// bare param, `!attr`) returns true so it is always re-synced when it changes.
+fn could_name_caller_local(name: &str) -> bool {
+    !(name.starts_with('?')
+        || name.starts_with('=')
+        || name.contains('*')
+        || name.starts_with("__mutsu_"))
+}
+
+/// O(1), conservative "is this value provably unchanged?" check used by
+/// `merge_method_env` to avoid flipping `env_dirty` for value-identical copies
+/// (e.g. globals pulled in by a nested call's overlay flatten). Returns `true`
+/// only when equality is cheap to prove: Arc-pointer identity for the heap
+/// container/string types, value compare for the immutable scalars, and id
+/// compare for instances. Any case it cannot cheaply prove returns `false`, so
+/// the caller treats it as a possible change (a redundant pull at worst).
+fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
+    match (old, new) {
+        (Value::Int(a), Value::Int(b)) => a == b,
+        (Value::Num(a), Value::Num(b)) => a.to_bits() == b.to_bits(),
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        (Value::Rat(an, ad), Value::Rat(bn, bd)) => an == bn && ad == bd,
+        (Value::Package(a), Value::Package(b)) => a == b,
+        (Value::Nil, Value::Nil) => true,
+        (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b),
+        (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
+        (Value::Hash(a), Value::Hash(b)) => Arc::ptr_eq(a, b),
+        (Value::Instance { id: a, .. }, Value::Instance { id: b, .. }) => a == b,
+        _ => false,
+    }
+}
+
+/// Merge the callee method frame's caller-visible overlay writes back into the
+/// saved caller env. Returns the merged env and a flag that is `true` iff the
+/// merge changed a value that could alias a caller compiled-local slot — the
+/// precise signal (Slice 6.3) that the caller must re-sync its locals. A method
+/// whose merge changed no such value leaves the caller's slots coherent, so no
+/// env->locals pull is needed.
 ///
 /// Takes ownership of both `saved` (the caller env) and `current` (the callee's
 /// scoped overlay env). The callee's overlay is collected into a small `writes`
@@ -1429,7 +1485,11 @@ fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
 /// per-nested-call O(env) cost measured in PR #2683. `saved` is consumed (the
 /// caller discards it in favor of the returned env), so mutating it directly is
 /// safe and avoids the extra `saved.clone()`.
-fn merge_method_env(mut saved: Env, current: Env, method_local_keys: &HashSet<String>) -> Env {
+fn merge_method_env(
+    mut saved: Env,
+    current: Env,
+    method_local_keys: &HashSet<String>,
+) -> (Env, bool) {
     let writes: Vec<(Symbol, Value)> = current
         .overlay_iter()
         .filter_map(|(k, v)| {
@@ -1447,8 +1507,34 @@ fn merge_method_env(mut saved: Env, current: Env, method_local_keys: &HashSet<St
         })
         .collect();
     drop(current);
+    // Precise dirty signal (Slice 6.3): a merged write only obliges the caller to
+    // re-pull its local slots if it actually *changes* a value the caller can see.
+    // A nested method call flattens the scoped overlay, which copies every parent
+    // lexical/global (`@*ARGS`, `%*ENV`, `?LINE`, type names, ...) into the callee
+    // overlay; those copies are kept by the merge but are value-identical to the
+    // caller's, so they must not flip env_dirty. `cheaply_unchanged` proves
+    // equality in O(1) (Arc-ptr identity for containers/Str, scalar compare for
+    // immutables); anything it cannot prove unchanged counts as dirty
+    // (conservative -> at worst a redundant pull, never a stale read).
+    let wrote = writes.iter().any(|(k, v)| {
+        // Only a key that can name a caller compiled-local slot obliges a pull:
+        // `sync_locals_from_env` iterates exactly `code.locals`. Compile-time
+        // location vars (`?LINE`/`?FILE`/`?CLASS`...), pod (`=...`), dynamic /
+        // global names (`$*...`, `*PERL`, ...) and `__mutsu_` plumbing are never
+        // local slots, so a change to them never makes a caller slot stale. This
+        // matters because `?LINE` legitimately differs between the caller line
+        // and the method-body line, which would otherwise flip env_dirty on every
+        // multi-line nested method call.
+        if !k.with_str(could_name_caller_local) {
+            return false;
+        }
+        match saved.get_sym(*k) {
+            Some(old) => !cheaply_unchanged(old, v),
+            None => true,
+        }
+    });
     for (k, v) in writes {
         saved.insert_sym(k, v);
     }
-    saved
+    (saved, wrote)
 }

--- a/t/method-env-dirty.t
+++ b/t/method-env-dirty.t
@@ -1,0 +1,126 @@
+use v6;
+use Test;
+
+# Regression pin for Slice 6.3: gating the blanket per-method-call env_dirty=true.
+# A pure (read-only) compiled method call must do zero env->locals re-sync, but a
+# method that mutates a captured-outer variable, an attribute the caller then
+# reads, or that routes through the interpreter bridge must still keep the
+# caller's locals coherent. See docs/vm-dual-store.md (Slice 6.3).
+
+plan 20;
+
+# --- read-only method, caller interleaves reads of its own locals ---
+class P { has $.x; method g() { return $!x + 1 } }
+my $p = P.new(x => 5);
+my $s = 0;
+my $own = 0;
+for ^100 {
+    $s += $p.g();
+    $own += 1;
+}
+is $s, 600, 'read-only method result correct across loop';
+is $own, 100, 'caller local untouched by read-only method calls';
+
+# --- method mutating its own attribute; caller reads attr after ---
+class Counter { has $.n is rw; method bump() { $!n++ } }
+my $c = Counter.new(n => 0);
+$c.bump(); $c.bump(); $c.bump();
+is $c.n, 3, 'attribute mutation via method visible to caller';
+
+# --- method mutating a captured-outer scalar ---
+my $outer = 0;
+class Pusher { method go() { $outer += 10 } }
+my $pu = Pusher.new;
+$pu.go(); $pu.go();
+is $outer, 20, 'captured-outer scalar mutation via method propagates';
+
+# --- method mutating a captured-outer array/hash ---
+my @log;
+class Logger { method add($x) { @log.push($x) } }
+my $lg = Logger.new;
+$lg.add('a'); $lg.add('b'); $lg.add('c');
+is @log.join(','), 'a,b,c', 'captured-outer array mutation via method propagates';
+
+my %seen;
+class Marker { method mark($k) { %seen{$k} = True } }
+my $mk = Marker.new;
+$mk.mark('x'); $mk.mark('y');
+is %seen.keys.sort.join(','), 'x,y', 'captured-outer hash mutation via method propagates';
+
+# --- interleaved: caller local read between a mutating method and its result ---
+my $acc = 0;
+my $tally = 0;
+class Adder { has $.step; method add() { $acc += $!step; return $!step } }
+my $ad = Adder.new(step => 3);
+for ^5 {
+    $tally += $ad.add();
+}
+is $acc, 15, 'interleaved captured-outer mutation across method-call loop';
+is $tally, 15, 'method return value correct across loop';
+
+# --- nested method calls: inner mutates captured outer, outer reads ---
+my $deep = 0;
+class Nest {
+    method inner() { $deep++ }
+    method outer() { self.inner(); self.inner() }
+}
+my $ne = Nest.new;
+$ne.outer(); $ne.outer();
+is $deep, 4, 'nested method calls propagate captured mutation';
+
+# --- pure method call after a mutation: caller must not read stale local ---
+my $state = 100;
+class Mutator { method mutate() { $state = 200 } }
+class Pure { method calc($n) { $n * 2 } }
+my $mu = Mutator.new;
+my $pr = Pure.new;
+$mu.mutate();
+my $r = $pr.calc(5);
+is $state, 200, 'outer mutation visible after an interleaved pure method call';
+is $r, 10, 'pure method call result correct';
+
+# --- native-mutating method on a captured outer array ---
+my @arr = 1, 2, 3;
+class Sorter { method sortit() { @arr = @arr.reverse } }
+my $so = Sorter.new;
+$so.sortit();
+is @arr.join(','), '3,2,1', 'method reassigning captured-outer array propagates';
+
+# --- method returning a value used to index a caller local ---
+class Idx { method pick() { 2 } }
+my @data = 10, 20, 30, 40;
+my $id = Idx.new;
+my $picked = @data[$id.pick()];
+is $picked, 30, 'method result usable as caller-local index';
+
+# --- attribute mutation then immediate read in same expression chain ---
+class Bank { has $.bal is rw; method deposit($a) { $!bal += $a; return $!bal } }
+my $bk = Bank.new(bal => 0);
+my $b1 = $bk.deposit(50);
+my $b2 = $bk.deposit(25);
+is $b1, 50, 'first deposit returns running balance';
+is $b2, 75, 'second deposit returns running balance';
+is $bk.bal, 75, 'final balance via accessor matches';
+
+# --- native read method (.elems) on a variable receiver, interleaved with a
+#     caller-local read across a loop (the CallMethodMut native-read pure case) ---
+my @nums = 10, 20, 30;
+my $sum-elems = 0;
+my $iters = 0;
+for ^50 {
+    $sum-elems += @nums.elems;
+    $iters += 1;
+}
+is $sum-elems, 150, 'native .elems read on variable correct across loop';
+is $iters, 50, 'caller local untouched by native-read method calls';
+
+# --- mutating-native (.push) on a variable interleaved with reading another
+#     caller local: the mutation must be visible and the other local intact ---
+my @acc-arr;
+my $count = 0;
+for 1..6 -> $i {
+    @acc-arr.push($i);
+    $count += 1;
+}
+is @acc-arr.join(','), '1,2,3,4,5,6', 'native .push mutation visible across loop';
+is $count, 6, 'caller local intact alongside native push mutation';


### PR DESCRIPTION
Continues from #2686 (the Slice 6.3 prep doc — included here as the base commit) and executes its **stage 1**: removing the per-method-call `env_dirty` false-positive, the dominant remaining lever-B dual-store cost.

## Problem

Every compiled method call unconditionally set `env_dirty = true` after dispatch. That forced an `O(caller-locals)` `sync_locals_from_env` pull on the caller's very next `GetLocal` — **on every method call** — even though, with scoped-overlay isolation (Slices 6.0–6.2), a read-only method (or one whose merge propagated nothing observable) leaves the caller's local slots perfectly coherent.

A previously-attempted fix (snapshot the caller env `Arc`, compare after) backfired: the held `Arc` ref induced an `Arc::make_mut` deep copy every call. See the doc for details.

## Fix

Report purity instead of comparing the env:

- New VM flag `method_dispatch_pure`, **default `false`** (conservative). The `CallMethod` / `CallMethodMut` opcodes mark env dirty only when the dispatch was *not* proven pure — so a missed signal can only cost a redundant pull, **never a stale read**.
- Compiled-method paths set it precisely: skip-merge / unchanged-env = pure; merge = pure iff `merge_method_env` actually changed a caller-observable value.
- `merge_method_env` returns a precise changed-flag, with two O(1) refinements so a nested call's overlay *flatten* (which copies every parent lexical/global into the callee overlay) no longer trips it:
  - `cheaply_unchanged` — Arc-ptr / scalar equality skips value-identical copies (`%*ENV`, globals, …).
  - `could_name_caller_local` — `?LINE`/`?FILE`, pod `=…`, `*`-dynamics and `__mutsu_` plumbing can never be a caller local slot, so they never oblige a pull. (`?LINE` legitimately differs between caller and method-body lines and used to re-dirty env on every multi-line nested call.)
- Native methods reaching the dispatch tail return a value without writing the receiver back → env-pure.

## Results

`MUTSU_VM_STATS=1` (counters are opt-level-independent):

| bench (10k loop)         | `locals_pulls` before | after |
|--------------------------|----------------------:|------:|
| `mb_method` (`$p.g()`)   |                 10001 |     1 |
| `mb_nested` (`self.d()`) |                 10001 |     1 |
| `@a.elems` on a variable |                 10001 |     1 |

`make test` PASS (5093 tests); method / OOP / closure / dynamic-var (`?LINE`, `$!`, `$_`) roast green.

Pinned by **`t/method-env-dirty.t`** (20 cases: read-only, attribute mutation, captured-outer scalar/array/hash, nested, native read/mutate, interleaved caller-local reads).

## Scope / what remains

The `env_dirty` flag is **not deleted** — that needs the remaining setters (step 2: ~36 by-name var/control ops via reverse write-through; step 3: ~21 I/O + interpreter-carrier marks, gated on interpreter-bridge removal / lever A). After this PR, `env_dirty` survives only as the rare interpreter-bridge safety net; the hot per-call pull — the actual lever-B cost — is gone.

Supersedes #2686 (its doc is included as the base commit of this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)