### PR TITLE
feat(io): lazy words iterator with close-on-exhaust + IO::ArgFiles.new

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -40,7 +40,9 @@ unicode (`builtins/unicode.rs`), and Buf/OS builtins. The main engineer never
 touches these.
 
 1. **IO** (Medium): S32-io/io-handle.t, S32-io/io-path.t, S32-io/io-path-cygwin.t,
-   S32-io/lock.t, S16-io/words.t
+   S32-io/lock.t
+   (S16-io/words.t — DONE, whitelisted: lazy word iterator + close-on-exhaust +
+   `IO::ArgFiles.new`.)
 2. **Regex / Match** (Medium): S05-capture/alias.t, S05-mass/rx.t,
    S05-match/capturing-contexts.t, S05-metasyntax/angle-brackets.t,
    S05-nonstrings/basic.t
@@ -292,8 +294,8 @@ cases. `pipe.t`, `spurt.t`, `indir.t`, `child-secure.t` now pass.
   10 failing.
 - roast/S32-io/lock.t — **Medium**. `.lock`/`.unlock` throw X::Method::NotFound (file
   locking not implemented).
-- roast/S16-io/words.t — **Medium**. 8/11. Remaining: lazy close-on-exhaust for
-  `words($fh, :close)` partial slices, and `IO::ArgFiles.new`.
+- roast/S16-io/words.t — **DONE** (whitelisted). Lazy word iterator with
+  close-on-exhaust + `IO::ArgFiles.new(@files)`.
 
 ## gather/take Laziness — **Hard**
 

--- a/TODO_roast/S16.md
+++ b/TODO_roast/S16.md
@@ -40,8 +40,12 @@
 - [ ] roast/S16-io/supply.t
 - [ ] roast/S16-io/tmpdir.t
 - [ ] roast/S16-io/watch.t
-- [ ] roast/S16-io/words.t (8/11; `$limit` arg now supported for `words($fh, n)` sub/method/IO::Path forms)
-  - Remaining: lazy close-on-exhaust semantics for `words($fh, :close)` (a `.push-exactly` taking a partial slice must keep the handle open), and `IO::ArgFiles.new` (`words()` with `$*ARGFILES`).
+- [x] roast/S16-io/words.t (11/11) — lazy word iterator with close-on-exhaust
+  (`words($fh, :close)`: a `.push-exactly` partial slice keeps the handle open; a
+  full consumer closes it) via `LazyIoLines { words: true }` + per-handle
+  `pending_words`/`close_on_word_exhaust`. `IO::ArgFiles.new(@files)` reads across
+  an explicit file list (per-handle `argfiles_paths`); `words()` with no args uses
+  `$*ARGFILES`. `+`/`is-deeply`/`is-eqv` now drain a lazy IO words/lines iterator.
 - [x] roast/S16-unfiled/getpeername.t
   - 1/1 pass.
 - [ ] roast/S16-unfiled/rebindstdhandles.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -806,6 +806,7 @@ roast/S16-io/split.t
 roast/S16-io/supply.t
 roast/S16-io/tmpdir.t
 roast/S16-io/watch.t
+roast/S16-io/words.t
 roast/S16-unfiled/getpeername.t
 roast/S16-unfiled/rebindstdhandles.t
 roast/S17-channel/basic.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -525,12 +525,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     value.to_value(),
                 ])))),
                 Value::Package(_) => None, // let runtime handle (may be enum type)
-                Value::LazyIoLines { handle, .. } => {
+                Value::LazyIoLines { handle, words, .. } => {
                     // Wrap the lazy IO lines with kv flag so the for-loop can
                     // iterate lazily producing index-value pairs.
                     Some(Ok(Value::LazyIoLines {
                         handle: handle.clone(),
                         kv: true,
+                        words: *words,
                     }))
                 }
                 v if v.is_range() => Some(Ok(Value::array(positional_kv(

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -1142,6 +1142,7 @@ impl Interpreter {
                 return Ok(Value::LazyIoLines {
                     handle: Box::new(handle),
                     kv: false,
+                    words: false,
                 });
             }
             let mut lines = Vec::new();
@@ -1172,7 +1173,7 @@ impl Interpreter {
         if let Some(handle) = handle {
             let mut limit: Option<usize> = None;
             let mut close_after = false;
-            for arg in &args[1..] {
+            for arg in args.get(1..).unwrap_or(&[]) {
                 match arg {
                     Value::Pair(k, v) if k == "close" => {
                         close_after = v.truthy();
@@ -1189,15 +1190,26 @@ impl Interpreter {
                     _ => {}
                 }
             }
+            if limit.is_none() {
+                // No limit: return a lazy word iterator so a partial consumer
+                // (e.g. `words($fh, :close)[1,2]`) leaves the handle open, while a
+                // full consumer triggers close-on-exhaust when `:close` was given.
+                if close_after {
+                    self.handle_state_mut(&handle)?.close_on_word_exhaust = true;
+                }
+                return Ok(Value::LazyIoLines {
+                    handle: Box::new(handle),
+                    kv: false,
+                    words: true,
+                });
+            }
             let mut words = Vec::new();
-            'outer: while let Some(line) = self.read_line_from_handle_value(&handle)? {
-                for token in line.split_whitespace() {
-                    words.push(Value::str(token.to_string()));
-                    if let Some(n) = limit
-                        && words.len() >= n
-                    {
-                        break 'outer;
-                    }
+            'outer: while let Some(word) = self.read_word_from_handle_value(&handle)? {
+                words.push(Value::str(word));
+                if let Some(n) = limit
+                    && words.len() >= n
+                {
+                    break 'outer;
                 }
             }
             if close_after {

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -413,21 +413,27 @@ impl Interpreter {
             IoHandleTarget::ArgFiles => {
                 let seps = state.line_separators.clone();
                 let chomp = state.line_chomp;
-                if argfiles_list.is_empty() {
+                // An `IO::ArgFiles.new(@files)` handle carries its own file list;
+                // a plain `$*ARGFILES` handle falls back to the global `@*ARGS`.
+                let effective_list = match &state.argfiles_paths {
+                    Some(paths) => paths.clone(),
+                    None => argfiles_list,
+                };
+                if effective_list.is_empty() {
                     // No file args — read from stdin, using $*IN's nl-in if available
                     let (effective_seps, effective_chomp) =
                         stdin_seps.clone().unwrap_or((seps.clone(), chomp));
                     let mut stdin = std::io::stdin().lock();
                     Self::read_record_with_separators(&mut stdin, &effective_seps, effective_chomp)
                 } else {
-                    // Read from files listed in @*ARGS sequentially
+                    // Read from files listed in the effective list sequentially
                     loop {
-                        if state.argfiles_index >= argfiles_list.len() {
+                        if state.argfiles_index >= effective_list.len() {
                             return Ok(None);
                         }
                         // Open the next file if we don't have a reader
                         if state.argfiles_reader.is_none() {
-                            let path = &argfiles_list[state.argfiles_index];
+                            let path = &effective_list[state.argfiles_index];
                             if path == "-" {
                                 // `-` means read from stdin
                                 let mut stdin = std::io::stdin().lock();
@@ -485,6 +491,46 @@ impl Interpreter {
         }
     }
 
+    /// Read the next whitespace-delimited word from a handle, buffering the
+    /// leftover words of each line in `pending_words`. Returns `None` at EOF,
+    /// auto-closing the handle if `close_on_word_exhaust` was requested
+    /// (Raku's `words($fh, :close)` close-on-exhaust semantics). Because the
+    /// handle only closes when iteration actually reaches EOF, a partial
+    /// consumer (e.g. `words($fh, :close)[1,2]`) leaves the handle open.
+    pub(crate) fn read_word_from_handle_value(
+        &mut self,
+        handle_value: &Value,
+    ) -> Result<Option<String>, RuntimeError> {
+        loop {
+            if let Some(word) = self
+                .handle_state_mut(handle_value)?
+                .pending_words
+                .pop_front()
+            {
+                return Ok(Some(word));
+            }
+            match self.read_line_from_handle_value(handle_value)? {
+                Some(line) => {
+                    let words: Vec<String> =
+                        line.split_whitespace().map(|s| s.to_string()).collect();
+                    if words.is_empty() {
+                        continue;
+                    }
+                    let state = self.handle_state_mut(handle_value)?;
+                    state.pending_words.extend(words);
+                }
+                None => {
+                    let state = self.handle_state_mut(handle_value)?;
+                    let should_close = state.close_on_word_exhaust && !state.closed;
+                    if should_close {
+                        let _ = self.close_handle_value(handle_value);
+                    }
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
     pub(super) fn read_bytes_from_handle_value(
         &mut self,
         handle_value: &Value,
@@ -510,18 +556,23 @@ impl Interpreter {
                 Ok(buffer)
             }
             IoHandleTarget::ArgFiles => {
-                // Read bytes from files listed in @*ARGS sequentially
-                let argfiles_list: Vec<String> = self
-                    .env
-                    .get("@*ARGS")
-                    .and_then(|v| {
-                        if let Value::Array(items, ..) = v {
-                            Some(items.iter().map(|v| v.to_string_value()).collect())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_default();
+                // Read bytes from files listed in @*ARGS sequentially, unless the
+                // handle carries its own explicit list (`IO::ArgFiles.new(@files)`).
+                let argfiles_list: Vec<String> =
+                    match self.handle_state_mut(handle_value)?.argfiles_paths.clone() {
+                        Some(paths) => paths,
+                        None => self
+                            .env
+                            .get("@*ARGS")
+                            .and_then(|v| {
+                                if let Value::Array(items, ..) = v {
+                                    Some(items.iter().map(|v| v.to_string_value()).collect())
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or_default(),
+                    };
                 if argfiles_list.is_empty() {
                     // No file args — read from stdin
                     use std::io::Read;
@@ -1125,6 +1176,9 @@ impl Interpreter {
             utf16_detected_be: None,
             argfiles_index: 0,
             argfiles_reader: None,
+            argfiles_paths: None,
+            pending_words: std::collections::VecDeque::new(),
+            close_on_word_exhaust: false,
         };
         // For utf16 encoding in write/append mode, write BOM at start
         let enc_lower = state.encoding.to_lowercase();

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2618,6 +2618,9 @@ impl Interpreter {
             utf16_detected_be: None,
             argfiles_index: 0,
             argfiles_reader: None,
+            argfiles_paths: None,
+            pending_words: std::collections::VecDeque::new(),
+            close_on_word_exhaust: false,
         };
         self.handles.insert(id, state);
         self.make_handle_instance(id)

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -123,6 +123,9 @@ impl Interpreter {
                     utf16_detected_be: None,
                     argfiles_index: 0,
                     argfiles_reader: None,
+                    argfiles_paths: None,
+                    pending_words: std::collections::VecDeque::new(),
+                    close_on_word_exhaust: false,
                 };
                 self.handles.insert(id, state);
                 let mut attrs = HashMap::new();
@@ -166,6 +169,9 @@ impl Interpreter {
                 utf16_detected_be: None,
                 argfiles_index: 0,
                 argfiles_reader: None,
+                argfiles_paths: None,
+                pending_words: std::collections::VecDeque::new(),
+                close_on_word_exhaust: false,
             };
             self.handles.insert(id, state);
             let mut attrs = HashMap::new();
@@ -222,6 +228,9 @@ impl Interpreter {
                     utf16_detected_be: None,
                     argfiles_index: 0,
                     argfiles_reader: None,
+                    argfiles_paths: None,
+                    pending_words: std::collections::VecDeque::new(),
+                    close_on_word_exhaust: false,
                 };
                 self.handles.insert(id, state);
                 let mut attrs = HashMap::new();

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -50,6 +50,9 @@ impl Interpreter {
             utf16_detected_be: None,
             argfiles_index: 0,
             argfiles_reader: None,
+            argfiles_paths: None,
+            pending_words: std::collections::VecDeque::new(),
+            close_on_word_exhaust: false,
         };
         self.handles.insert(id, state);
         let mut attrs = HashMap::new();

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -11,6 +11,30 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
         match method {
+            "new" if matches!(target, Value::Package(name) if name == "IO::ArgFiles") => {
+                // IO::ArgFiles.new(@files): an $*ARGFILES-like handle that reads
+                // from an explicit file list rather than the global @*ARGS.
+                let paths: Vec<String> = args
+                    .iter()
+                    .filter(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+                    .flat_map(|a| match a {
+                        Value::Array(items, ..) | Value::Seq(items) => items
+                            .iter()
+                            .map(|v| v.to_string_value())
+                            .collect::<Vec<_>>(),
+                        other => vec![other.to_string_value()],
+                    })
+                    .collect();
+                let handle = self.create_handle(
+                    crate::runtime::IoHandleTarget::ArgFiles,
+                    crate::runtime::IoHandleMode::Read,
+                    None,
+                );
+                if let Ok(state) = self.handle_state_mut(&handle) {
+                    state.argfiles_paths = Some(paths);
+                }
+                Some(Ok(handle))
+            }
             "new" if matches!(target, Value::Package(name) if matches!(name.resolve().as_str(), "ObjAt" | "ValueObjAt")) =>
             {
                 let class_name = if let Value::Package(n) = target {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -556,6 +556,15 @@ pub(crate) struct IoHandleState {
     argfiles_index: usize,
     /// For ArgFiles: currently open file reader (buffered)
     argfiles_reader: Option<std::io::BufReader<fs::File>>,
+    /// For ArgFiles created via `IO::ArgFiles.new(@files)`: the explicit file
+    /// list to read from, overriding the global `@*ARGS`. None = use `@*ARGS`.
+    argfiles_paths: Option<Vec<String>>,
+    /// Buffered words not yet yielded by `read_word_from_handle_value`. A single
+    /// line read can produce many words; the leftovers live here until consumed.
+    pending_words: std::collections::VecDeque<String>,
+    /// When set, the handle is closed automatically the moment word iteration
+    /// reaches EOF (Raku's `words($fh, :close)` close-on-exhaust semantics).
+    close_on_word_exhaust: bool,
 }
 
 #[derive(Clone)]
@@ -5154,6 +5163,9 @@ impl Interpreter {
                 utf16_detected_be: handle.utf16_detected_be,
                 argfiles_index: handle.argfiles_index,
                 argfiles_reader: None, // Cannot clone BufReader; will reopen if needed
+                argfiles_paths: handle.argfiles_paths.clone(),
+                pending_words: handle.pending_words.clone(),
+                close_on_word_exhaust: handle.close_on_word_exhaust,
             };
             cloned_handles.insert(*id, cloned);
         }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2408,6 +2408,7 @@ impl Interpreter {
                     Ok(Value::LazyIoLines {
                         handle: Box::new(target_val.clone()),
                         kv: false,
+                        words: false,
                     })
                 }
             }
@@ -2431,15 +2432,26 @@ impl Interpreter {
                         _ => {}
                     }
                 }
+                if limit.is_none() {
+                    // No limit: return a lazy word iterator so a partial consumer
+                    // (e.g. `$fh.words[1,2]`) leaves the handle open, while a full
+                    // consumer triggers close-on-exhaust when `:close` was given.
+                    if close_after {
+                        self.handle_state_mut(&target_val)?.close_on_word_exhaust = true;
+                    }
+                    return Ok(Value::LazyIoLines {
+                        handle: Box::new(target_val.clone()),
+                        kv: false,
+                        words: true,
+                    });
+                }
                 let mut words = Vec::new();
-                'outer: while let Some(line) = self.read_line_from_handle_value(&target_val)? {
-                    for token in line.split_whitespace() {
-                        words.push(Value::str(token.to_string()));
-                        if let Some(n) = limit
-                            && words.len() >= n
-                        {
-                            break 'outer;
-                        }
+                'outer: while let Some(word) = self.read_word_from_handle_value(&target_val)? {
+                    words.push(Value::str(word));
+                    if let Some(n) = limit
+                        && words.len() >= n
+                    {
+                        break 'outer;
                     }
                 }
                 if close_after {

--- a/src/runtime/native_methods/socket_inet.rs
+++ b/src/runtime/native_methods/socket_inet.rs
@@ -95,6 +95,9 @@ impl Interpreter {
                     utf16_detected_be: None,
                     argfiles_index: 0,
                     argfiles_reader: None,
+                    argfiles_paths: None,
+                    pending_words: std::collections::VecDeque::new(),
+                    close_on_word_exhaust: false,
                 };
                 self.handles.insert(new_id, state);
                 let mut attrs = HashMap::new();

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1012,30 +1012,48 @@ impl Interpreter {
     }
 
     /// Force a `LazyIoLines` value into an eager array by reading all remaining
-    /// lines from the file handle.
-    pub(crate) fn force_lazy_io_lines(&mut self, handle: &Value) -> Result<Value, RuntimeError> {
-        let mut lines = Vec::new();
-        while let Some(line) = self.read_line_from_handle_value(handle)? {
-            lines.push(Value::str(line));
+    /// records from the file handle. When `words` is true the records are
+    /// whitespace-delimited words; otherwise they are lines.
+    pub(crate) fn force_lazy_io_lines(
+        &mut self,
+        handle: &Value,
+        words: bool,
+    ) -> Result<Value, RuntimeError> {
+        let mut items = Vec::new();
+        if words {
+            while let Some(word) = self.read_word_from_handle_value(handle)? {
+                items.push(Value::str(word));
+            }
+        } else {
+            while let Some(line) = self.read_line_from_handle_value(handle)? {
+                items.push(Value::str(line));
+            }
         }
-        Ok(Value::array(lines))
+        Ok(Value::array(items))
     }
 
     /// Force a `LazyIoLines` value into an eager array by reading at most `n`
-    /// lines from the file handle, leaving the rest available for subsequent reads.
+    /// records from the file handle, leaving the rest available for subsequent
+    /// reads. When `words` is true the records are words; otherwise lines.
     pub(crate) fn force_lazy_io_lines_n(
         &mut self,
         handle: &Value,
         n: usize,
+        words: bool,
     ) -> Result<Value, RuntimeError> {
-        let mut lines = Vec::new();
-        while lines.len() < n {
-            match self.read_line_from_handle_value(handle)? {
-                Some(line) => lines.push(Value::str(line)),
+        let mut items = Vec::new();
+        while items.len() < n {
+            let next = if words {
+                self.read_word_from_handle_value(handle)?
+            } else {
+                self.read_line_from_handle_value(handle)?
+            };
+            match next {
+                Some(rec) => items.push(Value::str(rec)),
                 None => break,
             }
         }
-        Ok(Value::array(lines))
+        Ok(Value::array(items))
     }
 
     pub(super) fn split_block_phasers(&self, stmts: &[Stmt]) -> SplitPhasers {

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -107,8 +107,8 @@ impl Interpreter {
                 .join(" ")),
             // A lazy IO lines iterator (e.g. `$fh.lines`) must be forced before
             // comparison so it stringifies as its contents rather than "(...)".
-            Value::LazyIoLines { handle, .. } => {
-                Ok(self.force_lazy_io_lines(handle)?.to_string_value())
+            Value::LazyIoLines { handle, words, .. } => {
+                Ok(self.force_lazy_io_lines(handle, *words)?.to_string_value())
             }
             _ => Ok(value.to_string_value()),
         }

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -289,6 +289,19 @@ impl Interpreter {
     }
 
     /// Convert Seq to List (Array) for is-deeply comparison, per Raku spec.
+    /// Drain a lazy IO words/lines iterator into an eager `Seq` so it compares
+    /// by contents (matching what `words($fh)`/`lines($fh)` conceptually yield).
+    /// Non-lazy values pass through unchanged.
+    fn force_lazy_io_to_seq(&mut self, v: Value) -> Value {
+        if let Value::LazyIoLines { handle, words, .. } = &v
+            && let Ok(forced) = self.force_lazy_io_lines(handle, *words)
+        {
+            let items = crate::runtime::utils::value_to_list(&forced);
+            return Value::Seq(std::sync::Arc::new(items));
+        }
+        v
+    }
+
     fn seq_to_list(&mut self, v: &Value) -> Value {
         match v {
             Value::Seq(items) => Value::Array(items.clone(), ArrayKind::List),
@@ -296,6 +309,17 @@ impl Interpreter {
                 Ok(items) => Value::Array(std::sync::Arc::new(items), ArrayKind::List),
                 Err(_) => v.clone(),
             },
+            // A lazy IO words/lines iterator must be drained before comparison so
+            // it compares as its contents rather than the opaque "(...)".
+            Value::LazyIoLines { handle, words, .. } => {
+                match self.force_lazy_io_lines(handle, *words) {
+                    Ok(forced) => {
+                        let items = crate::runtime::utils::value_to_list(&forced);
+                        Value::Array(std::sync::Arc::new(items), ArrayKind::List)
+                    }
+                    Err(_) => v.clone(),
+                }
+            }
             _ => v.clone(),
         }
     }
@@ -495,9 +519,11 @@ impl Interpreter {
         let got = Self::positional_value(args, 0)
             .cloned()
             .unwrap_or(Value::Nil);
+        let got = self.force_lazy_io_to_seq(got);
         let expected = Self::positional_value(args, 1)
             .cloned()
             .unwrap_or(Value::Nil);
+        let expected = self.force_lazy_io_to_seq(expected);
         let desc = Self::positional_string(args, 2);
         let ok = got.eqv(&expected);
         self.test_ok(ok, &desc, false)?;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1084,6 +1084,10 @@ pub enum Value {
     LazyIoLines {
         handle: Box<Value>,
         kv: bool,
+        /// When true, the lazy iterator yields whitespace-delimited *words*
+        /// (via `read_word_from_handle_value`) rather than lines. Used by
+        /// `words($fh)` so a partial consumer leaves the handle open.
+        words: bool,
     },
     /// A reference to a hash slot, used for autovivification in `is raw` contexts.
     /// Reading this value returns the current value at the key (or Any).

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2542,11 +2542,11 @@ impl VM {
                             self.force_lazy_list_vm(list)?;
                             self.env_dirty = true;
                         }
-                        Value::LazyIoLines { handle, .. } => {
+                        Value::LazyIoLines { handle, words, .. } => {
                             // Sinking a lazy IO lines iterator must drain the
                             // underlying handle so that side effects (read
                             // position, .eof) are observable.
-                            self.interpreter.force_lazy_io_lines(handle)?;
+                            self.interpreter.force_lazy_io_lines(handle, *words)?;
                             self.env_dirty = true;
                         }
                         _ => {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -355,7 +355,12 @@ impl VM {
 
         // Handle lazy IO lines: iterate by pulling one line at a time
         // so that $fh.tell reflects the current read position.
-        if let Value::LazyIoLines { ref handle, kv } = iterable {
+        if let Value::LazyIoLines {
+            ref handle,
+            kv,
+            words,
+        } = iterable
+        {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;
             self.exec_for_loop_lazy_io_lines(
@@ -363,6 +368,7 @@ impl VM {
                 spec,
                 handle,
                 kv,
+                words,
                 body_start,
                 loop_end,
                 compiled_fns,
@@ -1552,6 +1558,7 @@ impl VM {
         spec: &ForLoopSpec,
         handle: &Value,
         kv: bool,
+        words: bool,
         body_start: usize,
         loop_end: usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
@@ -1582,8 +1589,12 @@ impl VM {
         let mut line_index: i64 = 0;
 
         'for_loop: loop {
-            // Read the next line from the handle
-            let line = self.interpreter.read_line_from_handle_value(handle)?;
+            // Read the next record (word or line) from the handle
+            let line = if words {
+                self.interpreter.read_word_from_handle_value(handle)?
+            } else {
+                self.interpreter.read_line_from_handle_value(handle)?
+            };
             let Some(line_str) = line else {
                 break 'for_loop; // EOF
             };

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -246,8 +246,13 @@ impl VM {
     /// If the value is a `LazyIoLines`, force it into an eager array by reading
     /// all remaining lines from the file handle. Otherwise return the value as-is.
     pub(super) fn force_if_lazy_io_lines(&mut self, val: Value) -> Result<Value, RuntimeError> {
-        if let Value::LazyIoLines { ref handle, kv } = val {
-            let forced = self.interpreter.force_lazy_io_lines(handle)?;
+        if let Value::LazyIoLines {
+            ref handle,
+            kv,
+            words,
+        } = val
+        {
+            let forced = self.interpreter.force_lazy_io_lines(handle, words)?;
             if kv {
                 // Apply .kv transformation on the forced array
                 let items = crate::runtime::utils::value_to_list(&forced);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -710,6 +710,13 @@ impl VM {
             self.stack.push(result);
             return Ok(());
         }
+        // Force a lazy IO words/lines iterator so numeric coercion counts its
+        // elements (e.g. `+$fh.words` / `+$fh.lines`) rather than yielding 0.
+        let val = if matches!(&val, Value::LazyIoLines { .. }) {
+            self.force_if_lazy_io_lines(val)?
+        } else {
+            val
+        };
         // Force LazyList before numeric coercion so we can count elements.
         // If the lazy list has a known element count (e.g. n! for permutations),
         // use that directly without materializing.

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -272,7 +272,12 @@ impl VM {
             self.stack.push(target);
             return Ok(());
         }
-        if let Value::LazyIoLines { ref handle, kv } = target {
+        if let Value::LazyIoLines {
+            ref handle,
+            kv,
+            words,
+        } = target
+        {
             // Determine the maximum index requested so we only read the
             // minimum number of lines from the handle, leaving the rest
             // available for subsequent reads.
@@ -303,7 +308,7 @@ impl VM {
             };
             target = match needed {
                 Some(n) => {
-                    let forced = self.interpreter.force_lazy_io_lines_n(handle, n)?;
+                    let forced = self.interpreter.force_lazy_io_lines_n(handle, n, words)?;
                     if kv {
                         let items = crate::runtime::utils::value_to_list(&forced);
                         let mut kv_items = Vec::with_capacity(items.len() * 2);

--- a/t/words-lazy-close.t
+++ b/t/words-lazy-close.t
@@ -1,0 +1,80 @@
+use Test;
+
+# Lazy `words($fh)` / `$fh.words` with close-on-exhaust semantics, plus
+# IO::ArgFiles.new(@files). See roast/S16-io/words.t for the full spec.
+
+plan 11;
+
+my $file = $*TMPDIR.add("mutsu-words-lazy-{$*PID}.txt");
+$file.spurt("alpha beta gamma\ndelta epsilon\n");
+LEAVE { $file.unlink }
+
+# --- &words sub form ---------------------------------------------------------
+
+# Full consumption yields all words in order.
+{
+    my $fh = $file.open;
+    is-deeply words($fh).List, <alpha beta gamma delta epsilon>,
+        '&words drains all words';
+    $fh.close;
+}
+
+# `:close` with full consumption closes the handle.
+{
+    my $fh = $file.open;
+    my @res = words($fh, :close);
+    is-deeply @res.List, <alpha beta gamma delta epsilon>, ':close full read words';
+    is $fh.opened, False, ':close full read closes handle';
+}
+
+# `:close` with a partial slice leaves the handle OPEN (close-on-exhaust only).
+{
+    my $fh = $file.open;
+    my @res = words($fh, :close)[1, 2];
+    is-deeply @res.List, <beta gamma>, ':close partial slice words';
+    is $fh.opened, True, ':close partial slice keeps handle open';
+    $fh.close;
+}
+
+# A `$limit` reads exactly that many words.
+{
+    my $fh = $file.open;
+    is-deeply words($fh, 2).List, <alpha beta>, '$limit words';
+    $fh.close;
+}
+
+# --- IO::Handle.words method form -------------------------------------------
+
+{
+    my $fh = $file.open;
+    is-deeply $fh.words.List, <alpha beta gamma delta epsilon>, '.words method drains all';
+    $fh.close;
+}
+
+# Numeric coercion of the lazy iterator counts elements.
+{
+    my $fh = $file.open;
+    is +$fh.words, 5, '+$fh.words counts words';
+    $fh.close;
+}
+
+# --- IO::ArgFiles.new(@files) ------------------------------------------------
+
+my $f1 = $*TMPDIR.add("mutsu-argf1-{$*PID}.txt");
+my $f2 = $*TMPDIR.add("mutsu-argf2-{$*PID}.txt");
+$f1.spurt("foo bar");
+$f2.spurt("baz qux");
+LEAVE { $f1.unlink; $f2.unlink }
+
+{
+    my $af = IO::ArgFiles.new($f1, $f2);
+    isa-ok $af, IO::Handle, 'IO::ArgFiles.new returns a handle';
+    is-deeply $af.words.List, <foo bar baz qux>,
+        'IO::ArgFiles.new reads words across all files';
+}
+
+# words() with no args reads from $*ARGFILES.
+{
+    my $*ARGFILES = IO::ArgFiles.new($f1, $f2);
+    is-deeply words().List, <foo bar baz qux>, 'words() uses $*ARGFILES';
+}


### PR DESCRIPTION
## 概要

BLOCKERS.md の **Tier 1（完全に独立したサブシステム）** の IO タスクとして `roast/S16-io/words.t` を全通過（8/11 → 11/11）させ、whitelist に追加した。メインエンジニアが担当する VM/コンテナ周りとはファイルが重ならない IO サブシステム内の変更。

## 実装した2機能（いずれも IO サブシステムに閉じる）

### 1. lazy な `words($fh)` / `$fh.words` + close-on-exhaust

`words` は limit 無しの場合、ハンドルを即時に全読みする eager な `Seq` ではなく lazy な `LazyIoLines { words: true }` を返すようにした。

- 新ヘルパー `read_word_from_handle_value` が、各行の余った単語を per-handle の `pending_words` (VecDeque) にバッファし、EOF 到達時に `close_on_word_exhaust`（= `words($fh, :close)` で設定）が立っていればハンドルを閉じる。
- これで Raku の意味論を満たす: 部分消費（`words($fh, :close)[1,2]`）はハンドルを **開いたまま** にし、完全消費（for ループ / push-all / `.elems` / Seq 比較）は EOF まで drain して閉じる。
- for ループ・添字・sink・`+`/elems 数値化、および `is`/`is-deeply`/`is-eqv` の各経路が lazy IO words/lines を drain するよう更新。
- 副産物: 既存の `+$fh.lines` → 0 バグ（lazy lines が数値化で 0 になる）も解消し、`S32-io/io-handle.t` の "iterator-producing read methods" 部分テストが通るようになった（同ファイルの残失敗は既存の nl-out/gist ブロッカーのみ）。

### 2. `IO::ArgFiles.new(@files)`

明示的なファイルリストを横断して読む ArgFiles ハンドルを生成（per-handle `argfiles_paths` で global `@*ARGS` を上書き）。`words()` を引数なしで呼ぶと `$*ARGFILES` から読む。あわせて、`words()` を positional 引数なしで呼んだときに空スライスへ `args[1..]` で添字アクセスしてパニックする潜在バグも修正。

## テスト

- `roast/S16-io/words.t` を whitelist に追加（sorted 確認済み）
- 新規 `t/words-lazy-close.t` で lazy / close-on-exhaust / ArgFiles 挙動を pin
- `make test` green（584 files / 5073 tests）、unit tests green（456）、clippy/fmt クリーン
- whitelisted な lazy-IO テスト（lines.t / comb.t / split.t / eof.t / readchars.t）に回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)