### PR TITLE
feat(regex): numbered capture aliases + :s propagation into alternation

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -203,8 +203,13 @@ rather than empty, and `.grep`/`.values`/`.pairs` see stale pre-mutation values.
 
 ## Regex / Match Advanced Features
 
-- roast/S05-capture/alias.t — **Medium**. 14/32 fail: reverse capture (`$1` before
-  `$0` textually) and mixed named/positional capture aliases yield empty strings.
+- roast/S05-capture/alias.t — **Medium**. Down to 1 real failure (tests 11-13 are
+  `# TODO`). Numbered scalar capture aliases (`$N=<atom>`, reverse `$1=..$0=..`,
+  arbitrary-start `$42=` with auto-numbering continuing) and `:s` sigspace
+  propagation into alternation branches are now implemented. Remaining: test 20
+  `$/<family><ident>` — a named capture alias on a group containing a subrule
+  (`$<family>=(<ident>)`) must preserve the inner `<ident>` as a nested subcap of
+  `$<family>` (capture-merge surgery; the inner named capture is dropped today).
 - roast/S05-capture/array-alias.t — **Hard**. 30/37 fail then aborts: named/
   sequential array captures (`@<foo>=...`) are largely unimplemented.
 - roast/S05-capture/hash.t — **Hard**. 30/99 fail then aborts at line 134: package/

--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -1,7 +1,14 @@
 # S05 - grammar, interpolation, mass, metachars, modifier, transliteration
 
 - [ ] roast/S05-capture/alias.t
-  - Blocked on reverse/explicit positional capture assignment (`$1=(.) $0=(.)`, `$42=.`), package/lexical scalar capture (`$foo=(...)`), and `$<name>=@(...)` list-interpolation captures. Conjunction and named-in-group capture fixes (this PR) do not cover these aliasing forms.
+  - Down to 1 real failure (tests 11-13 are `# TODO` package-variable capture).
+    Numbered scalar capture aliases `$N=<atom>` (reverse `$1=(.) $0=(.)`,
+    arbitrary-start `$42=.` with auto-numbering continuing from N+1) now route to
+    positional index N via an all-digit `named_capture` name in
+    `apply_named_capture`; `:s` sigspace now propagates into alternation branches
+    (the re-parse of each `|` arm prepends `:s`). Remaining: test 20
+    `$/<family><ident>` — `$<family>=(<ident>)` must keep the inner `<ident>` as a
+    nested subcap of `$<family>` (it is currently dropped on alias).
 - [ ] roast/S05-capture/array-alias.t
   - Blocked on `@<name>=(...)` array-alias captures (not implemented in the regex parser) and `@var=(...)` lexical/package array captures. Separate feature from the capture-numbering fixes here.
 - [ ] roast/S05-capture/caps.t

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -307,6 +307,49 @@ impl Interpreter {
             let Some(name) = token.named_capture.as_ref() else {
                 return caps;
             };
+            // Numbered scalar capture alias `$N=<atom>`: the alias name is all
+            // digits, so route the capture to positional index N (padding lower
+            // indices) and let subsequent groups continue numbering from N+1.
+            // (Named captures always start with a letter/underscore, so an
+            // all-digit name can only come from `$N=`.)
+            if let Ok(forced_idx) = name.parse::<usize>() {
+                let mut updated = caps;
+                let captured: String = chars[from..to].iter().collect();
+                // Drop the auto-positional entry a capturing group atom produced;
+                // the alias decides this capture's index explicitly.
+                if matches!(token.atom, RegexAtom::CaptureGroup(_))
+                    && updated.positional.len() > pos_base
+                {
+                    updated.positional.truncate(pos_base);
+                    updated.positional_subcaps.truncate(pos_base);
+                    updated.positional_quantified.truncate(pos_base);
+                    updated.positional_offsets.truncate(pos_base);
+                }
+                while updated.positional.len() < forced_idx {
+                    updated.positional.push(String::new());
+                    updated.positional_subcaps.push(None);
+                    updated.positional_quantified.push(None);
+                    updated.positional_offsets.push((0, 0));
+                }
+                if updated.positional.len() == forced_idx {
+                    updated.positional.push(captured);
+                    updated.positional_subcaps.push(None);
+                    updated.positional_quantified.push(None);
+                    updated.positional_offsets.push((from, to));
+                } else {
+                    updated.positional[forced_idx] = captured;
+                    if forced_idx < updated.positional_offsets.len() {
+                        updated.positional_offsets[forced_idx] = (from, to);
+                    }
+                    if forced_idx < updated.positional_subcaps.len() {
+                        updated.positional_subcaps[forced_idx] = None;
+                    }
+                    if forced_idx < updated.positional_quantified.len() {
+                        updated.positional_quantified[forced_idx] = None;
+                    }
+                }
+                return updated;
+            }
             let mut updated = caps;
             let captured: String = chars[from..to].iter().collect();
             // A named capture group `$<x>=(...)` aliases the group to the name and

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1538,12 +1538,17 @@ impl Interpreter {
                 if alt_src.is_empty() {
                     continue;
                 }
-                // Re-apply inline adverbs for each alternative
-                let alt_pat = if ignore_case && !alt_src.starts_with(":i") {
-                    format!(":i {}", alt_src)
-                } else {
-                    alt_src.to_string()
-                };
+                // Re-apply inline adverbs for each alternative. Both `:i`
+                // (ignore-case) and `:s` (sigspace) must propagate to the
+                // re-parsed sub-pattern, otherwise an alternative like `(a) (b)`
+                // loses its sigspace whitespace matchers and fails to match.
+                let mut alt_pat = alt_src.to_string();
+                if ignore_case && !alt_src.starts_with(":i") {
+                    alt_pat = format!(":i {}", alt_pat);
+                }
+                if sigspace {
+                    alt_pat = format!(":s {}", alt_pat);
+                }
                 if let Some(p) = self.parse_regex(&alt_pat) {
                     alt_patterns.push(p);
                 }
@@ -1727,11 +1732,31 @@ impl Interpreter {
                 anchor_end = true;
                 break;
             }
-            // $0, $1, ... — backreference to positional capture group
+            // $0, $1, ... — either a numbered scalar capture alias (`$0=(...)`)
+            // or a backreference to a positional capture group (`$0`).
             if c == '$' && chars.peek().is_some_and(|ch| ch.is_ascii_digit()) {
                 let mut digits = String::new();
                 while chars.peek().is_some_and(|ch| ch.is_ascii_digit()) {
                     digits.push(chars.next().unwrap());
+                }
+                // A trailing `=` (after optional whitespace) makes this a numbered
+                // capture alias: `$N=<atom>` stores the atom's capture at index N
+                // and continues auto-numbering from N+1. We reuse the
+                // `named_capture` channel with an all-digit "name", which
+                // `apply_named_capture` recognizes and routes to the positional
+                // slot instead of the named hash.
+                let mut lookahead = chars.clone();
+                while lookahead.peek().is_some_and(|ch| ch.is_whitespace()) {
+                    lookahead.next();
+                }
+                if lookahead.peek() == Some(&'=') {
+                    chars = lookahead;
+                    chars.next(); // consume '='
+                    while chars.peek().is_some_and(|ch| ch.is_whitespace()) {
+                        chars.next();
+                    }
+                    pending_named_capture = Some(digits);
+                    continue;
                 }
                 if let Ok(idx) = digits.parse::<usize>() {
                     tokens.push(RegexToken {

--- a/t/regex-numbered-alias.t
+++ b/t/regex-numbered-alias.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Numbered scalar capture aliases (`$N=<atom>`) and `:s` (sigspace) propagation
+# into alternation branches. See roast/S05-capture/alias.t.
+
+plan 16;
+
+# --- Reverse / explicit numbered aliases ------------------------------------
+
+ok "abcd" ~~ m/a $1=(.) $0=(.) d/, 'reverse numbered alias matches';
+is ~$0, 'c', '$0 captured (second group)';
+is ~$1, 'b', '$1 captured (first group)';
+
+# Numbered alias starting at an arbitrary index, with auto-numbering continuing.
+ok "foobar" ~~ m/$42=. (..) (...) /, 'alias starting at non-zero matches';
+is ~$42, 'f',   '$42 explicit';
+is ~$43, 'oo',  '$43 continues numbering';
+is ~$44, 'bar', '$44 continues numbering';
+
+# A bare `$0` (no `=`) is still a backreference, not an alias.
+ok "abab" ~~ m/(ab) $0/, 'bare $0 is a backreference';
+
+# --- :s (sigspace) propagates into alternation branches ---------------------
+
+ok "a b" ~~ m:s/(a) (b) | (c) (d)/, ':s matches first multi-token alternative';
+ok "c d" ~~ m:s/(a) (b) | (c) (d)/, ':s matches second multi-token alternative';
+nok "ab" ~~ m:s/(a) (b) | (c) (d)/, ':s requires whitespace between tokens';
+
+# Numbered aliases inside :s alternation (the alias.t pair-match shape).
+ok "foo => 22" ~~ m:s/$0=(foo) '=>' (\d+) | $1=(\d+) '<=' $0=(foo)/,
+    ':s + alias, first alternative';
+is ~$0, 'foo', 'key captured via $0=';
+is ~$1, '22',  'value captured via (\d+)';
+
+ok "22 <= foo" ~~ m:s/$0=(foo) '=>' (\d+) | $1=(\d+) '<=' $0=(foo)/,
+    ':s + alias, second alternative';
+is ~$0, 'foo', 'reverse key captured via $0=';


### PR DESCRIPTION
## 概要

BLOCKERS.md **Tier 1（regex 隔離サブシステム）** の作業。2つの自己完結した regex 修正で、`roast/S05-capture/alias.t` を 14 失敗 → 1 失敗まで削減（残り1件は別根の nested-subcap 問題、テスト 11-13 は `# TODO`）。メインエンジニアの VM/コンテナ作業とはファイルが重ならない（`runtime/regex_parse.rs` と `runtime/regex/`）。

## 修正1: 番号付きスカラーキャプチャエイリアス `$N=<atom>`

パーサが `$<数字>` の後ろの `=` を検出し、backreference ではなく**番号付きキャプチャエイリアス**として扱う（`$0=(.)`, `$1=(.)`, `$42=.`）。`named_capture` チャネルを全数字名で再利用し、`apply_named_capture` が全数字名を検出して capture を positional index N へ配置。下位インデックスをパディングするので、後続の無名グループは N+1 から連番継続（`$42=. (..) (...)` → $42/$43/$44）。逆順エイリアス（`$1=(.) $0=(.)`）や alternation 内の番号付きエイリアスも動作。`=` の無い素の `$0` は従来どおり backreference。

## 修正2: `:s`（sigspace）の alternation 分岐への伝播

top-level の `|`/`||` alternation を分割して各分岐を再パースする際、従来は `:i` のみ再適用し `:s` を落としていた。そのため `(a) (b)` のような分岐が sigspace の空白マッチャを失い `a b` にマッチしなかった。各分岐の再パース時に sigspace が有効なら `:s` を前置するよう修正。これは alias.t に限らず **alternation を使う全ての `:s` 正規表現に効く一般修正**。

## テスト

- 新規 `t/regex-numbered-alias.t` で両機能を pin（16 サブテスト）
- `make test` green（584 files / 5073 tests）、unit tests green（456）
- whitelisted な S05 roast テストは全 PASS（回帰なし）、`S05-substitution/subst.t` は既存の 23 失敗のまま変化なし
- clippy/fmt クリーン

alias.t はまだ whitelist しない（test 20 `$/<family><ident>` の nested subcap 保持が別途必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)