### PR TITLE
perf(vm): accessor-read & native-construct env-pure (lever B Slice 6.3 stage 1b)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -871,9 +871,26 @@ Reaching that requires, roughly in order:
       | `mb_method` (`$p.g()`)  |                 10001 |     1 |
       | `mb_nested` (`self.d()`)|                 10001 |     1 |
       | `@a.elems` on a var     |                 10001 |     1 |
+      | `benchmarks/method-call`|                 20000 |     1 |
+      | `benchmarks/bench-class`|                 14001 |     2 |
+
+      **Stage 1b (same bug, other dispatch shapes).** Two more per-call
+      false-positive setters were found by measuring the real benchmarks and fixed
+      together (PR after #2689):
+      - **Fast attribute-accessor read** — `$obj.x` via `try_fast_accessor_read` in
+        both the `CallMethod` and `CallMethodMut` handlers unconditionally set
+        `env_dirty`. It is a pure read that touches no env (its own comment says so),
+        so the mark is dropped. This dominated accessor-heavy code (`bench-class`;
+        `distance-to`'s `$other.x`/`$other.y`).
+      - **Native default construction** — `Foo.new(...)` via
+        `try_native_default_construct` returned early without clearing the
+        conservative mark, yet it returns a fresh instance and writes nothing to the
+        caller env, so it is now marked pure. (This was the residual `method-call`
+        cost: `my $p2 = Point.new(...)` in the loop dirtied env and the next
+        `$p1.distance-to` receiver read paid the pull.)
 
       `make test` PASS (5093); method/OOP/closure/dynamic-var roast green. Pinned
-      by `t/method-env-dirty.t`. The flag is NOT yet deleted: the function-dispatch
+      by `t/method-env-dirty.t` (24 cases). The flag is NOT yet deleted: the function-dispatch
       half of step (1) is already precise (Slice 6.1), but steps (2) the ~36 by-name
       var/control setters and (3) the ~21 I/O + interpreter-carrier setters remain
       — (3) is gated on the interpreter-bridge removal (lever A finish / Q2). So

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -126,6 +126,9 @@ impl VM {
                 .interpreter
                 .try_native_default_construct(*class_name, &args)
         {
+            // Native construction is pure data assembly: it returns a fresh
+            // instance and writes nothing to the caller env (Slice 6.3).
+            self.method_dispatch_pure = true;
             return result;
         }
         if let Value::Instance { class_name, .. } = &target {
@@ -575,6 +578,8 @@ impl VM {
                 .interpreter
                 .try_native_default_construct(*class_name, &args)
         {
+            // Pure construction: fresh instance, no caller-env write (Slice 6.3).
+            self.method_dispatch_pure = true;
             return result;
         }
         if let Value::Instance { class_name, .. } = &target {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -379,8 +379,9 @@ impl VM {
         if let Some(val) =
             self.try_fast_accessor_read(&target, &method, &args, modifier.is_some(), quoted)
         {
+            // Pure attribute read: does not mutate the invocant (see comment
+            // above), so it does not dirty the caller's locals (Slice 6.3).
             self.stack.push(val);
-            self.env_dirty = true;
             return Ok(());
         }
         // `.so` / `.not` on a value whose type defines a user `Bool` method must

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -210,8 +210,10 @@ impl VM {
         if let Some(val) =
             self.try_fast_accessor_read(&target, method, &args, modifier_idx.is_some(), quoted)
         {
+            // Pure attribute read: touches no env (see comment above), so it does
+            // not dirty the caller's locals (Slice 6.3 — removes the per-accessor
+            // env->locals pull that dominated method-heavy code like bench-class).
             self.stack.push(val);
-            self.env_dirty = true;
             return Ok(());
         }
         // `.so` / `.not` on a value whose type defines a user `Bool` method must

--- a/t/method-env-dirty.t
+++ b/t/method-env-dirty.t
@@ -7,7 +7,7 @@ use Test;
 # reads, or that routes through the interpreter bridge must still keep the
 # caller's locals coherent. See docs/vm-dual-store.md (Slice 6.3).
 
-plan 20;
+plan 24;
 
 # --- read-only method, caller interleaves reads of its own locals ---
 class P { has $.x; method g() { return $!x + 1 } }
@@ -124,3 +124,39 @@ for 1..6 -> $i {
 }
 is @acc-arr.join(','), '1,2,3,4,5,6', 'native .push mutation visible across loop';
 is $count, 6, 'caller local intact alongside native push mutation';
+
+# --- attribute accessor read ($obj.attr) interleaved with a caller-local
+#     mutation across a loop (the fast-accessor-read pure path) ---
+class Pt { has $.v }
+my $pt = Pt.new(v => 7);
+my $accum = 0;
+my $loops = 0;
+for ^50 {
+    $accum += $pt.v;   # pure accessor read
+    $loops += 1;       # caller-local mutation must survive the read
+}
+is $accum, 350, 'accessor read value correct across loop';
+is $loops, 50, 'caller local intact alongside accessor reads';
+
+# --- `.new` constructing a fresh instance each iteration, then immediately
+#     calling a method on a *different* receiver and summing into a caller local
+#     (the native-construct pure path; mirrors benchmarks/method-call.raku) ---
+class Box { has $.n; method twice() { $!n * 2 } }
+my $base = Box.new(n => 10);
+my $total2 = 0;
+for 1..20 -> $i {
+    my $b = Box.new(n => $i);   # pure construction
+    $total2 += $base.twice() + $b.n;
+}
+is $total2, 20 * 20 + (1 + 20) * 20 / 2, 'new-in-loop + method + accessor sum correct';
+
+# --- accessor read whose result must reflect a prior same-loop mutation
+#     (ensures removing the accessor env_dirty mark did not hide a real update) ---
+class Cell { has $.val is rw }
+my $cell = Cell.new(val => 0);
+my $seen-last = -1;
+for 1..10 -> $i {
+    $cell.val = $i;        # mutate attribute
+    $seen-last = $cell.val; # accessor read must see the just-written value
+}
+is $seen-last, 10, 'accessor read reflects same-loop attribute mutation';


### PR DESCRIPTION
Follow-up to #2689. Measuring the **real** OOP benchmarks (not just the synthetic `mb_*`) after #2689 exposed two more per-call `env_dirty` false positives — the same bug as stage 1 in other dispatch shapes.

## What still pulled

| bench (10k loop)          | `locals_pulls` after #2689 |
|---------------------------|---------------------------:|
| `benchmarks/method-call`  |                      20000 |
| `benchmarks/bench-class`  |                      14001 |

Root causes:

1. **Fast attribute-accessor read** — `$obj.x` via `try_fast_accessor_read` (in both the `CallMethod` and `CallMethodMut` handlers) unconditionally set `env_dirty`, even though it is a pure read that touches no env (its own comment says exactly that). Every `$other.x` then paid an `O(caller-locals)` pull. Dominated accessor-heavy code (`bench-class`, `distance-to`).
2. **Native default construction** — `Foo.new(...)` via `try_native_default_construct` returned early *before* the purity logic, leaving the conservative `method_dispatch_pure = false`. So `my $p2 = Point.new(...)` in a loop dirtied env and the next `$p1.distance-to(...)` receiver read paid the pull.

Both are env-pure (return a value / fresh instance, write nothing to the caller env), so they no longer mark dirty.

## Result

| bench (10k loop)          | before | after |
|---------------------------|-------:|------:|
| `benchmarks/method-call`  |  20000 |     1 |
| `benchmarks/bench-class`  |  14001 |     2 |

`make test` PASS (5093). S12 class/attributes/accessor/inheritance/construction roast green. `t/method-env-dirty.t` extended to 24 cases (accessor read interleaved with caller-local mutation; new-in-loop + method; accessor read reflecting a same-loop attribute write).

Real-world OOP code (constructor in a loop + accessor reads + method calls) now does **near-zero** per-call env↔locals sync — the practical finish of the lever-B method-dispatch hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)