### PR TITLE
feat(regex): preserve inner subcap of aliased group — whitelist S05-capture/alias.t

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -43,9 +43,10 @@ touches these.
    S32-io/lock.t
    (S16-io/words.t — DONE, whitelisted: lazy word iterator + close-on-exhaust +
    `IO::ArgFiles.new`.)
-2. **Regex / Match** (Medium): S05-capture/alias.t, S05-mass/rx.t,
-   S05-match/capturing-contexts.t, S05-metasyntax/angle-brackets.t,
-   S05-nonstrings/basic.t
+2. **Regex / Match** (Medium): S05-mass/rx.t,
+   S05-match/capturing-contexts.t, S05-metasyntax/angle-brackets.t
+   (S05-capture/alias.t — DONE, whitelisted. S05-nonstrings/basic.t — unpassable:
+   reference rakudo fails to compile it, `No such symbol 'Antelope'`.)
 3. **Buf / OS** (Medium): S03-buf/write-int.t, S29-os/system.t
 4. **Unicode** (Hard but self-contained — crate-level work): S32-str/CollationTest…,
    S15-nfg/GraphemeBreakTest-3.t
@@ -205,13 +206,11 @@ rather than empty, and `.grep`/`.values`/`.pairs` see stale pre-mutation values.
 
 ## Regex / Match Advanced Features
 
-- roast/S05-capture/alias.t — **Medium**. Down to 1 real failure (tests 11-13 are
-  `# TODO`). Numbered scalar capture aliases (`$N=<atom>`, reverse `$1=..$0=..`,
-  arbitrary-start `$42=` with auto-numbering continuing) and `:s` sigspace
-  propagation into alternation branches are now implemented. Remaining: test 20
-  `$/<family><ident>` — a named capture alias on a group containing a subrule
-  (`$<family>=(<ident>)`) must preserve the inner `<ident>` as a nested subcap of
-  `$<family>` (capture-merge surgery; the inner named capture is dropped today).
+- roast/S05-capture/alias.t — **DONE** (whitelisted; tests 11-13 are `# TODO`).
+  Numbered scalar capture aliases (`$N=<atom>`, reverse, arbitrary-start with
+  auto-numbering), `:s` sigspace propagation into alternation branches, and
+  preserving an aliased group's inner subrule capture as a nested subcap
+  (`$<family>=(<ident>)` -> `$<family><ident>`).
 - roast/S05-capture/array-alias.t — **Hard**. 30/37 fail then aborts: named/
   sequential array captures (`@<foo>=...`) are largely unimplemented.
 - roast/S05-capture/hash.t — **Hard**. 30/99 fail then aborts at line 134: package/
@@ -225,8 +224,10 @@ rather than empty, and `.grep`/`.values`/`.pairs` see stale pre-mutation values.
   a regex as a method from `<&foo()>` / `<.foo>` angle-bracket assertions (NYI).
 - roast/S05-metasyntax/longest-alternative.t — **Hard**. Timeout — LTM (longest
   token matching) over many alternatives is not implemented efficiently.
-- roast/S05-nonstrings/basic.t — **Medium**. Aborts before test 1 (ran 0/5):
-  matching a regex against a non-Str (matching coerces the subject) throws early.
+- roast/S05-nonstrings/basic.t — **unpassable as written**. Reference rakudo on
+  this box fails to compile it: `No such symbol 'Antelope'` (`<.isa(::Antelope)>`)
+  plus "Useless declaration of a has-scoped method in mainline" for the
+  mainline `regex monster {...}` declarations. Do NOT attempt.
 - roast/S05-substitution/subst.t — see Exception Types above (same file).
 
 ## Pseudo-packages / Symbol Lookup — **Hard**

--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -1,14 +1,14 @@
 # S05 - grammar, interpolation, mass, metachars, modifier, transliteration
 
-- [ ] roast/S05-capture/alias.t
-  - Down to 1 real failure (tests 11-13 are `# TODO` package-variable capture).
-    Numbered scalar capture aliases `$N=<atom>` (reverse `$1=(.) $0=(.)`,
-    arbitrary-start `$42=.` with auto-numbering continuing from N+1) now route to
+- [x] roast/S05-capture/alias.t (32/32; tests 11-13 are `# TODO`)
+  - Numbered scalar capture aliases `$N=<atom>` (reverse `$1=(.) $0=(.)`,
+    arbitrary-start `$42=.` with auto-numbering continuing from N+1) route to
     positional index N via an all-digit `named_capture` name in
-    `apply_named_capture`; `:s` sigspace now propagates into alternation branches
-    (the re-parse of each `|` arm prepends `:s`). Remaining: test 20
-    `$/<family><ident>` — `$<family>=(<ident>)` must keep the inner `<ident>` as a
-    nested subcap of `$<family>` (it is currently dropped on alias).
+    `apply_named_capture`; `:s` sigspace propagates into alternation branches (each
+    `|` arm re-parse prepends `:s`). Test 20: a named alias on a group containing a
+    subrule (`$<family>=(<ident>)`) now preserves the group's inner subcapture as
+    the alias's nested subcap (instead of truncating it away), so
+    `$<family><ident>` is reachable.
 - [ ] roast/S05-capture/array-alias.t
   - Blocked on `@<name>=(...)` array-alias captures (not implemented in the regex parser) and `@var=(...)` lexical/package array captures. Separate feature from the capture-numbering fixes here.
 - [ ] roast/S05-capture/caps.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -345,6 +345,7 @@ roast/S04-statements/until.t
 roast/S04-statements/when.t
 roast/S04-statements/while.t
 roast/S04-statements/with.t
+roast/S05-capture/alias.t
 roast/S05-capture/caps.t
 roast/S05-capture/dot.t
 roast/S05-capture/match-object.t

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -360,9 +360,15 @@ impl Interpreter {
             // A named NON-capturing group `$<x>=[...]` leaves its inner captures'
             // positional numbers intact (its atom is not a CaptureGroup), so this
             // truncation correctly does not fire for it.
+            // When aliasing a capturing group, preserve the group's own inner
+            // captures (named subrules etc.) so e.g. `$<family>=(<ident>)` keeps
+            // `$<family><ident>` accessible — otherwise truncating the group's
+            // positional entry would discard its nested subcapture.
+            let mut group_subcap: Option<RegexCaptures> = None;
             if matches!(token.atom, RegexAtom::CaptureGroup(_))
                 && updated.positional.len() > pos_base
             {
+                group_subcap = updated.positional_subcaps.get(pos_base).cloned().flatten();
                 updated.positional.truncate(pos_base);
                 updated.positional_subcaps.truncate(pos_base);
                 updated.positional_quantified.truncate(pos_base);
@@ -382,13 +388,23 @@ impl Interpreter {
             let name_count = updated.named.get(name).map(Vec::len).unwrap_or(0);
             let subcaps = updated.named_subcaps.entry(name.clone()).or_default();
             if subcaps.len() < name_count {
-                subcaps.push(RegexCaptures {
-                    from,
-                    to,
-                    matched: captured.clone(),
-                    match_from: from,
-                    ..Default::default()
-                });
+                if let Some(mut gs) = group_subcap.take() {
+                    // Keep the group's nested captures, but pin the span/text to
+                    // the aliased group's extent.
+                    gs.from = from;
+                    gs.to = to;
+                    gs.match_from = from;
+                    gs.matched = captured.clone();
+                    subcaps.push(gs);
+                } else {
+                    subcaps.push(RegexCaptures {
+                        from,
+                        to,
+                        matched: captured.clone(),
+                        match_from: from,
+                        ..Default::default()
+                    });
+                }
             }
             // Also capture under the secondary name (e.g., original builtin class name
             // when using `$<alias>=<builtin_class>` syntax).

--- a/t/regex-aliased-group-subcap.t
+++ b/t/regex-aliased-group-subcap.t
@@ -1,0 +1,16 @@
+use Test;
+
+# A named capture alias on a group that contains a subrule must preserve the
+# inner subrule capture as a nested subcapture of the alias, so
+# `$<outer><inner>` is reachable. See roast/S05-capture/alias.t test 20.
+
+plan 5;
+
+ok "Jon Lee" ~~ m:s/$<first>=(<.ident>) $<family>=(<ident>)/,
+    'aliased group with subrule matches';
+is ~$/<first>,  'Jon', '$<first> captured';
+is ~$/<family>, 'Lee', '$<family> captured';
+is ~$/<family><ident>, 'Lee',
+    'inner <ident> preserved as nested subcap of $<family>';
+is $/<family>.hash.keys.sort.join(','), 'ident',
+    '$<family> exposes exactly the nested ident key';


### PR DESCRIPTION
## 概要

`roast/S05-capture/alias.t` の最後の実失敗（test 20）を解決し、ファイルを完全 whitelist 化。#2691（番号付き alias + `:s` alternation 伝播）と合わせて alias.t が完成（テスト 11-13 は `# TODO`）。Tier 1 の regex タスク。

## 修正

subrule を含むグループに名前エイリアスを付けた場合（`$<family>=(<ident>)`）、`$<family><ident>` でアクセスできるようにグループ内側の subcapture を保持する。

従来、capturing group をエイリアスすると、後続の `(...)` が正しい番号を取れるようにグループの positional エントリを truncate していたが、これがグループの `positional_subcaps` エントリ（内側 `<ident>` の構造が入っている場所）も巻き添えで破棄し、内側キャプチャが完全に失われていた。

修正後は `apply_named_capture` が truncate 前にグループの内側 subcapture を取得し、最小限の from/to のみの subcap の代わりに、それをエイリアスの nested subcap として使う（span/text はエイリアスされたグループの範囲に固定）。`make_match_object_full` は既に `named_subcaps` を nested Match に変換するため、`$<family><ident>` が解決する。

あわせて `roast/S05-nonstrings/basic.t` が unpassable（reference rakudo 自身がコンパイル不可: `No such symbol 'Antelope'`）であることを BLOCKERS に記録。

## テスト

- 新規 `t/regex-aliased-group-subcap.t`
- `roast/S05-capture/alias.t` を whitelist に追加（32/32 PASS、sorted 確認済み）
- `make test` green（588 files / 5125 tests）、unit green（456）、whitelisted S05 全 PASS、clippy/fmt クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)