### PR TITLE
feat(vm): block-local `my` scope for if/else branches (lever C Slice 3b)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -73,17 +73,25 @@ news/2026-06.md 参照。残タスク:
       の `.=`、isa-ok、subset 型オブジェクト代入、submethod state、Mix 不変性 — 「値検査サイトに ContainerRef が
       漏れる」共通根）。全 lvalue/型/dispatch 経路の deref 監査が要る＝専用の複数 PR。`t/closure-container-capture.t`
       の非ループ兄弟 2 ケースは `todo`。
-- [ ] **Slice 3b（残）: `if`/`else` ボディローカル `my` の clobber**（`my $x=99; if c { my $x=5 }; say $x` が
-      raku `99`、mutsu は `5`）。`if`/`else` を BlockScope（全 env 復元）でラップする案は**ブランチ内からの `:=`
-      束縛を巻き戻す**回帰（`roast/S03-sequence/exhaustive.t` 27 subtest 失敗）を生む。正解＝loop と同じ
-      shadow-only 復元を `if` ブランチにも効かせる軽量機構（`Push/PopBlockLocalScope` opcode で
-      `loop_local_saved_env` を流用、全 env 復元はしない）。`t/block-local-my-scope.t` の if/else は todo。別 PR。
+- [x] **Slice 3b: `if`/`unless`/`else` ボディローカル `my` の clobber**（`my $x=99; if c { my $x=5 }; say $x` が
+      raku `99`、mutsu は `5`）を根治。新 opcode **`BlockLocalScope { body_end }`** を追加し、block-local `my` を
+      直接宣言するブランチをこれでラップ。VM ハンドラ（`exec_block_local_scope_op`）はループ本体と同じ
+      `push_loop_local_scope`/`pop_loop_local_scope`（**shadow-only 復元**）でボディを 1 回実行する。当初試した
+      BlockScope（完全 env 復元）案は**ブランチ内から外側変数への `:=` 束縛を巻き戻す**回帰を生むため不採用
+      （shadow-only は `my` 宣言した shadow 名のみ復元し `:=` は触らない）。コンパイラは
+      `branch_declares_block_local`（直下 + `SyntheticBlock` の `my`、state/our/dynamic を除外）で判定。
+      ループ本体扱いになるので if-branch-local のクロージャ捕捉（owned_captures/box）も正しくなる
+      （`if True { my $cx=5; $c={$cx} }` → `$c()`=5, 外側 `$cx`=1）。pin `t/block-local-my-scope.t`（24件）。詳細は news/2026-06.md。
 
 ### 最終ゴール
 - [ ] メソッド/関数フォールバック率を 0%（Test/EVAL 等の本質的例外を除く）にし、Interpreter のメソッド/関数
       実行パスを削除。残フォールバックには `// TODO: compile to bytecode` を付け負債を可視化。
-- **次の着手候補（優先順）**: B の Slice 6.3 残り（regex pull → 残 by-name op → carrier、最後に `env_dirty` 削除）
-  → C の非ループ一般コンテナ捕捉 ／ if-else body-local `my`（Slice 3b）→ 🟣第2優先「第一級コンテナ」Phase 0。
+
+**レバー A は終着**（全項目 `[x]`）。**レバー C も境界の明確なスライス（1/2/2b/3/3b）は全て完了**し、残るのは
+**非ループ一般コンテナ捕捉**（上の延期項目）のみ ＝ これは素朴な box では deref 未対応経路を広く踏むため、
+🟣第2優先「第一級コンテナ」**Phase 1（スカラーの第一級コンテナ化）に吸収**して解く（PLAN 末尾参照）。
+**次の着手候補（優先順）:** B の Slice 6.3 残り（regex `~~` pull は完了 → 残 by-name op → carrier、最後に
+`env_dirty` 削除）→ 🟣第2優先「第一級コンテナ」Phase 0（decont チョークポイント整備）→ Phase 1（= レバー C 本丸を内包）。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -154,10 +154,20 @@ VM slot を占有 + `sync_env_from_locals` が毎呼び出し前に全 slot を 
   採用: ループ本体で既存外側束縛を shadow した `my` 名のみ宣言時に外側値を `loop_local_saved_env` へ記録し、
   ループ脱出で env＋共有スロットに復元。ループ**条件**の `my`（`... until COND` 文末修飾含む）は enclosing-scoped
   なので `loop_cond_active` で除外（`iterator-regressions.t` 回帰回避）。pin `t/block-local-my-scope.t`。
-  残: (1) `if`/`else` ボディの同 clobber は別 PR（当初 BlockScope ラップを試みたが、ブランチ内から外側変数への
-  `:=` 束縛を巻き戻し `S03-sequence/exhaustive.t` を 27 失敗させたため撤回 — loop と同じ shadow-only 復元を
-  `if` に効かせる block-local-scope opcode が要る）。(2) 外側束縛が無い純粋 leak の post-loop 読み（raku 未宣言
+  残: (1) → **Slice 3b で解決（下記）**。(2) 外側束縛が無い純粋 leak の post-loop 読み（raku 未宣言
   エラー）は mutsu では undefined 値（strict-vars 未実装で全体的に未強制、実害なし）。
+
+- **Slice 3b（`if`/`unless`/`else` ボディローカル `my` の clobber 根治）**: `my $x=99; if c { my $x=5 }; say $x` が
+  raku `99` のところ mutsu `5` になっていたバグを修正。新 opcode **`BlockLocalScope { body_end }`** を追加し、
+  block-local `my` を直接宣言するブランチ（`branch_declares_block_local` で判定 — 直下 + `SyntheticBlock` 内の
+  `my`、state/our/dynamic は除外）をこれでラップ。VM ハンドラ `exec_block_local_scope_op` はループ本体と同じ
+  `push_loop_local_scope`/`pop_loop_local_scope`（**shadow-only 復元**）でボディを 1 回実行する。Slice 3 で試して
+  撤回した BlockScope（完全 env 復元）案はブランチ内の `:=`（外側変数への束縛）を巻き戻すため不採用 — shadow-only
+  は `my` 宣言した shadow 名のみ復元し `:=` には触れないので `S03-sequence/exhaustive.t` 回帰が起きない。ブランチが
+  ループ本体扱いになるので if-branch-local のクロージャ捕捉（owned_captures / box-on-capture）も同時に正しくなる
+  （`if True { my $cx=5; $c={$cx} }` → `$c()`=5・外側 `$cx`=1）。pin `t/block-local-my-scope.t`（19→24件）。
+  これで**レバー C の境界の明確なスライス（1/2/2b/3/3b）は全て完了**。残るのは非ループ一般コンテナ捕捉のみで、
+  これは🟣第2優先「第一級コンテナ」Phase 1 に吸収して解く。
 
 ## `run`/`shell`/`Proc` の整備（`roast/S29-os/system.t` 全通過, whitelist 追加）
 

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -198,6 +198,42 @@ impl Compiler {
         stmts.iter().any(stmt_rebinds_topic)
     }
 
+    /// Returns true if a branch body declares a block-local `my` variable
+    /// directly in its top-level statement list. Such a declaration shadows an
+    /// enclosing same-named binding and, without scoping, would *clobber* it
+    /// (`my $x=99; if c { my $x=5 }; say $x` would wrongly print `5`). When true,
+    /// the `if`/`unless`/`else` branch is wrapped in a `BlockLocalScope` so the
+    /// loop bodies' shadow-only restore re-exposes the outer binding on exit.
+    ///
+    /// Descends into `SyntheticBlock` (the parser's inlined wrapper for
+    /// destructuring `my ($a, $b) = ...`, which is NOT a separate scope) but not
+    /// into nested `Block`/`if`/loops/subs, which introduce their own scopes.
+    /// `state`/`our`/dynamic declarations are excluded: they are not plain
+    /// lexical shadows and have their own scoping/restore rules.
+    pub(super) fn branch_declares_block_local(stmts: &[Stmt]) -> bool {
+        stmts.iter().any(|s| match s {
+            Stmt::VarDecl {
+                is_state,
+                is_our,
+                is_dynamic,
+                ..
+            } => !*is_state && !*is_our && !*is_dynamic,
+            Stmt::SyntheticBlock(inner) => Self::branch_declares_block_local(inner),
+            _ => false,
+        })
+    }
+
+    /// Compile an `if`/`unless`/`else` branch body wrapped in a `BlockLocalScope`
+    /// opcode (see `branch_declares_block_local`). The opcode runs the body once
+    /// under the loop bodies' shadow-only restore, fixing the body-local `my`
+    /// clobber without the full env restore of `BlockScope` (which would revert a
+    /// `:=` binding the branch makes to an outer variable).
+    pub(super) fn compile_block_local_branch(&mut self, stmts: &[Stmt]) {
+        let idx = self.code.emit(OpCode::BlockLocalScope { body_end: 0 });
+        self.compile_body_with_implicit_try(stmts);
+        self.code.patch_block_local_body_end(idx);
+    }
+
     /// Compile a block body, automatically wrapping in implicit try if it contains
     /// CATCH or CONTROL blocks. This should be used for any block context (bare blocks,
     /// if branches, loop bodies, sub bodies) to ensure CATCH/CONTROL are not silently ignored.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1126,6 +1126,8 @@ impl Compiler {
                 }
                 if Self::body_mutates_topic(then_branch) {
                     self.compile_stmt(&Stmt::Block(then_branch.clone()));
+                } else if Self::branch_declares_block_local(then_branch) {
+                    self.compile_block_local_branch(then_branch);
                 } else {
                     self.compile_body_with_implicit_try(then_branch);
                 }
@@ -1146,6 +1148,8 @@ impl Compiler {
                         self.compile_stmt(&else_branch[0]);
                     } else if Self::body_mutates_topic(else_branch) {
                         self.compile_stmt(&Stmt::Block(else_branch.clone()));
+                    } else if Self::branch_declares_block_local(else_branch) {
+                        self.compile_block_local_branch(else_branch);
                     } else {
                         self.compile_body_with_implicit_try(else_branch);
                     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -416,6 +416,18 @@ pub(crate) enum OpCode {
         post_start: u32,
         end: u32,
     },
+    /// Lightweight block scope for an `if`/`unless`/`else` branch body that
+    /// declares a block-local `my`. Unlike `BlockScope` (which does a full
+    /// env+locals save/restore and would revert `:=` bindings the branch makes
+    /// to *outer* variables), this only applies the loop bodies' *shadow-only*
+    /// restore: a body-local `my $x` that shadows an enclosing same-named
+    /// binding is recorded at declaration and the outer value is restored on
+    /// exit. Names bound with `:=` to an outer var (not `my`-declared in the
+    /// branch) are never recorded, so they survive. Runs the body in
+    /// `ip+1 .. body_end`.
+    BlockLocalScope {
+        body_end: u32,
+    },
     /// Check the top-of-stack value; if falsy, throw X::Phaser::PrePost.
     /// `is_pre` distinguishes PRE (true) from POST (false).
     CheckPhaser {
@@ -1226,7 +1238,10 @@ impl CompiledCode {
         let captures_env_by_name = self.ops.iter().any(|op| {
             matches!(
                 op,
-                OpCode::ForLoop { .. } | OpCode::BlockScope { .. } | OpCode::MakeGather(_)
+                OpCode::ForLoop { .. }
+                    | OpCode::BlockScope { .. }
+                    | OpCode::BlockLocalScope { .. }
+                    | OpCode::MakeGather(_)
             )
         });
         if captures_env_by_name {
@@ -1497,6 +1512,7 @@ impl CompiledCode {
                     | OpCode::HyperMethodCall { .. }
                     | OpCode::HyperMethodCallDynamic { .. }
                     | OpCode::BlockScope { .. }
+                    | OpCode::BlockLocalScope { .. }
                     | OpCode::RegisterSub(_)
                     | OpCode::RegisterClass(_)
                     | OpCode::RegisterRole(_)
@@ -1555,6 +1571,14 @@ impl CompiledCode {
             OpCode::RepeatLoop { body_end, .. } => *body_end = target,
             OpCode::BlockScope { end, .. } => *end = target,
             _ => panic!("patch_loop_end on non-loop opcode"),
+        }
+    }
+
+    pub(crate) fn patch_block_local_body_end(&mut self, idx: usize) {
+        let target = self.ops.len() as u32;
+        match &mut self.ops[idx] {
+            OpCode::BlockLocalScope { body_end } => *body_end = target,
+            _ => panic!("patch_block_local_body_end on non-BlockLocalScope opcode"),
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3712,6 +3712,9 @@ impl VM {
                     compiled_fns,
                 )?;
             }
+            OpCode::BlockLocalScope { body_end } => {
+                self.exec_block_local_scope_op(code, *body_end, ip, compiled_fns)?;
+            }
             OpCode::CheckPhaser { is_pre } => {
                 self.exec_check_phaser_op(*is_pre)?;
                 *ip += 1;

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -145,6 +145,34 @@ impl VM {
         }
     }
 
+    /// Run an `if`/`unless`/`else` branch body that declares a block-local `my`
+    /// under the loop bodies' shadow-only restore (see `push_loop_local_scope` /
+    /// `pop_loop_local_scope`). This fixes the body-local `my` *clobber*
+    /// (`my $x=99; if c { my $x=5 }; say $x` must print `99`, not `5`) without
+    /// the full env restore of `BlockScope` — which would also revert a `:=`
+    /// binding the branch makes to an *outer* variable (the regression that sent
+    /// the if/else case to Slice 3b). The branch runs once, so reusing the
+    /// per-iteration `owned_captures`/box-on-capture machinery is harmless and
+    /// keeps closure capture of the branch-local correct.
+    pub(super) fn exec_block_local_scope_op(
+        &mut self,
+        code: &CompiledCode,
+        body_end: u32,
+        ip: &mut usize,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<(), RuntimeError> {
+        let body_start = *ip + 1;
+        let body_end = body_end as usize;
+        self.push_loop_local_scope();
+        let res = self.run_range(code, body_start, body_end, compiled_fns);
+        // Restore shadowed outer bindings on every exit path (including errors
+        // such as `next`/`last`/`return`/exceptions) so the scope stays balanced.
+        self.pop_loop_local_scope(code);
+        res?;
+        *ip = body_end;
+        Ok(())
+    }
+
     pub(super) fn exec_while_loop_op(
         &mut self,
         code: &CompiledCode,

--- a/t/block-local-my-scope.t
+++ b/t/block-local-my-scope.t
@@ -4,7 +4,7 @@ use Test;
 # An inner `my $x` shadowing an outer `$x` must NOT clobber the outer slot,
 # and the name must not leak out of the block (Slice 3 of lever C / PLAN.md).
 
-plan 19;
+plan 24;
 
 # --- for loop body: shadow must not clobber outer ---
 {
@@ -29,14 +29,13 @@ plan 19;
 }
 
 # --- if body: shadow must not clobber outer ---
-# NOTE: `if`/`else` bodies are compiled inline without a runtime loop scope, so
-# the loop_local_saved_env restore does not apply. Fixing the if-body clobber
-# needs a dedicated block-local-scope mechanism (a BlockScope wrap reverts `:=`
-# bindings to outer vars made inside the branch). Deferred — tracked as todo.
+# `if`/`unless`/`else` branches that declare a block-local `my` are wrapped in a
+# BlockLocalScope opcode (Slice 3b): the loop bodies' shadow-only restore
+# re-exposes the outer binding on exit, without the full env restore of a
+# BlockScope (which would revert `:=` bindings made to outer vars in the branch).
 {
     my $x = 99;
     if True { my $x = 5 }
-    todo 'if-body my clobber needs a block-local-scope mechanism (see PLAN.md)';
     is $x, 99, 'if-body my does not clobber outer $x';
 }
 
@@ -44,8 +43,37 @@ plan 19;
 {
     my $x = 99;
     if False { } else { my $x = 5 }
-    todo 'else-body my clobber needs a block-local-scope mechanism (see PLAN.md)';
     is $x, 99, 'else-body my does not clobber outer $x';
+}
+
+# --- unless body: shadow must not clobber outer ---
+{
+    my $x = 99;
+    unless False { my $x = 5 }
+    is $x, 99, 'unless-body my does not clobber outer $x';
+}
+
+# --- if/else both branches declare a shadow ---
+{
+    my $x = 99;
+    if True { my $x = 1 } else { my $x = 2 }
+    is $x, 99, 'if/else both-branch my does not clobber outer $x';
+}
+
+# --- a `:=` binding to an outer var inside an if-branch must survive ---
+{
+    my $r;
+    if True { my @rr = 10, 20, 30; $r := @rr[0] }
+    is $r, 10, 'if-branch := binding to outer var survives BlockLocalScope';
+}
+
+# --- closure capturing an if-branch-local must see its frozen value ---
+{
+    my $cx = 1;
+    my $c;
+    if True { my $cx = 5; $c = { $cx } }
+    is $c.(), 5, 'closure captures if-branch-local value';
+    is $cx, 1, 'if-branch-local does not clobber outer captured name';
 }
 
 # --- nested blocks ---


### PR DESCRIPTION
## Summary

Completes lever C Slice 3b: a `my $x` declared directly in an `if`/`unless`/`else` branch no longer clobbers an enclosing same-named binding.

```raku
my $x = 99; if True { my $x = 5 }; say $x;   # was 5, now 99 (raku: 99)
```

### Root cause
if/else branches compile **inline**, so the loop bodies' shadow-only restore (`loop_local_saved_env`, lever C Slice 3) never applied. The branch-local `my $x` wrote through the name-keyed dual-store env to both `env["x"]` and the shared outer slot.

### Fix
New lightweight opcode **`BlockLocalScope { body_end }`**:
- Compiler wraps a branch that declares a block-local `my` (`branch_declares_block_local` — direct + `SyntheticBlock` `my`, excluding `state`/`our`/dynamic) in this opcode.
- VM handler `exec_block_local_scope_op` runs the body **once** under the same `push_loop_local_scope`/`pop_loop_local_scope` the loops use → only names that genuinely shadow an outer binding are restored on exit.

This deliberately avoids the full env restore of `BlockScope` (tried + reverted in Slice 3): a full restore reverts a `:=` binding the branch makes to an **outer** variable (the `S03-sequence/exhaustive.t` regression). Shadow-only restore touches only `my`-declared shadow names, never `:=` bindings.

Bonus: because the branch now runs as a loop-body scope, closure capture of a branch-local is also correct (owned_captures / box-on-capture):

```raku
my $cx=1; my $c; if True { my $cx=5; $c={$cx} }; $c();  # 5, outer $cx stays 1
```

### Tests
- pin `t/block-local-my-scope.t` 19 → 24 (un-todo the if/else cases; add unless, both-branch, `:=`-survival, closure-capture cases).
- `cargo test` (456), full `prove t/` (5134), broad roast spot-check (control flow / mix / submethods / kv / pairs / subset / attributes / cas / closure-over-parameters) all green locally. `cargo clippy -D warnings` clean.

Completes the bounded lever C slices (1/2/2b/3/3b). The only remaining lever C item (non-loop general container capture) is subsumed into the first-class container Phase 1 (see PLAN.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)