### PR TITLE
feat(constant): X::Redeclaration on same-scope constant redeclaration

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -22,9 +22,16 @@
     - Test 46: `constant fib := 0, 1, *+* ... *; fib[100]` — indexing a lazy
       infinite sequence (even bound to a plain `@`-var) returns Nil; deep VM
       lazy-iterator issue, unrelated to constants.
-    - Test 56: redeclaring a constant (`constant Mouse = Rat; constant Mouse =
-      Rat`) should throw X::Redeclaration; mutsu does not.
-    Difficulty: Medium
+    - Test 56: redeclaring a constant in the same lexical block now throws
+      X::Redeclaration (compile-time, with `.symbol`); inner-block shadowing is
+      still allowed. FIXED.
+    - Tests 69-72 do not run: the file aborts at test 69 on multi-candidate
+      *sharing* via a constant operator binding (`constant &infix:<comet> :=
+      &infix:<snowman>` then a new `multi infix:<comet>` candidate must also be
+      visible through `snowman`); plus tests 70-71 need the `ExportConstant`
+      module and 72 needs a regex stored in a `constant $`-sigil term.
+    Difficulty: Medium per-fix, but full whitelist blocked by the lazy-sequence
+    (46), constant-aliased qualified name (44), and multi-sharing (69) features.
 - [ ] roast/S04-declarations/implicit-parameter.t
 - [ ] roast/S04-declarations/multiple.t
   - 3/8 pass (tests 1-3). Failures: `my ($a, $b) = (1, 2)` destructuring works but `my ($a, @b)` with slurpy not supported; `my ($a, *@b)` splat syntax not implemented; `state` declarations not supported. Difficulty: Medium

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -7,6 +7,7 @@ pub(super) struct LexicalScopeSnapshot {
     dynamic_scope_all: bool,
     dynamic_scope_names: Option<std::collections::HashSet<String>>,
     constant_vars_in_scope: std::collections::HashSet<String>,
+    constant_vars_current_scope: std::collections::HashSet<String>,
 }
 
 impl Compiler {
@@ -15,10 +16,14 @@ impl Compiler {
     }
 
     pub(super) fn push_dynamic_scope_lexical(&mut self) -> LexicalScopeSnapshot {
+        // `std::mem::take` resets the current-scope constant set: the entered
+        // block starts with no constants of its own, so an inner `constant X`
+        // may legitimately shadow an outer one without being a redeclaration.
         LexicalScopeSnapshot {
             dynamic_scope_all: self.dynamic_scope_all,
             dynamic_scope_names: self.dynamic_scope_names.clone(),
             constant_vars_in_scope: self.constant_vars_in_scope.clone(),
+            constant_vars_current_scope: std::mem::take(&mut self.constant_vars_current_scope),
         }
     }
 
@@ -30,6 +35,7 @@ impl Compiler {
         // valid, so drop them from the in-scope set. Subsequent bare-word access
         // then resolves them via GetBareWord (package/global lookup).
         self.constant_vars_in_scope = saved.constant_vars_in_scope;
+        self.constant_vars_current_scope = saved.constant_vars_current_scope;
     }
 
     pub(super) fn apply_dynamic_scope_pragma(&mut self, arg: Option<&Expr>) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -73,6 +73,10 @@ pub(crate) struct Compiler {
     /// declaring block has exited, their stale local slot must not be reused —
     /// such bare-word accesses fall back to GetBareWord (package/global lookup).
     constant_vars_in_scope: std::collections::HashSet<String>,
+    /// Constants declared in the *current* lexical block only (reset on block
+    /// entry). Declaring the same constant twice in one block is an
+    /// X::Redeclaration; a shadowing declaration in an inner block is allowed.
+    constant_vars_current_scope: std::collections::HashSet<String>,
     /// Local names that are sigilless bindings (declared with `my \Foo = ...`
     /// or as a sigilless parameter).  BareWord resolution only uses GetLocal
     /// for names in this set; `$`-sigiled variables must not shadow type names.
@@ -108,6 +112,7 @@ impl Compiler {
             scalar_bind_autovivify: false,
             constant_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
+            constant_vars_current_scope: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -646,10 +646,24 @@ impl Compiler {
                 // them in `for` loops (constants have no Scalar container).
                 let is_constant_decl = custom_traits.iter().any(|(t, _)| t == "__constant");
                 if is_constant_decl {
-                    // X::Redeclaration: declaring the same constant twice in the
-                    // same lexical block is an error (shadowing in an inner block
-                    // is fine — see constant_vars_current_scope reset on entry).
-                    if !self.constant_vars_current_scope.insert(name.clone()) {
+                    // X::Redeclaration on a duplicate same-scope `constant` is only
+                    // fired when the *sigil* matches. mutsu's AST strips the `$`
+                    // from a scalar constant name, so `constant sym` (sigilless)
+                    // and `constant $sym` (scalar) both arrive here as "sym"; firing
+                    // on the bare name alone would wrongly reject that legal pair
+                    // (see roast S06-operator-overloading/sub.t). Key the
+                    // duplicate-detection set by the source sigil so only true
+                    // same-sigil redeclarations are caught.
+                    let constant_sigil = custom_traits
+                        .iter()
+                        .find(|(t, _)| t == "__constant_sigil")
+                        .and_then(|(_, e)| match e {
+                            Some(Expr::Literal(Value::Str(s))) => Some(s.to_string()),
+                            _ => None,
+                        })
+                        .unwrap_or_default();
+                    let redecl_key = format!("{}{}", constant_sigil, name);
+                    if !self.constant_vars_current_scope.insert(redecl_key) {
                         let sym = name.trim_start_matches(['$', '@', '%', '&']).to_string();
                         let mut attrs = std::collections::HashMap::new();
                         attrs.insert("symbol".to_string(), Value::str(sym));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -646,6 +646,20 @@ impl Compiler {
                 // them in `for` loops (constants have no Scalar container).
                 let is_constant_decl = custom_traits.iter().any(|(t, _)| t == "__constant");
                 if is_constant_decl {
+                    // X::Redeclaration: declaring the same constant twice in the
+                    // same lexical block is an error (shadowing in an inner block
+                    // is fine — see constant_vars_current_scope reset on entry).
+                    if !self.constant_vars_current_scope.insert(name.clone()) {
+                        let sym = name.trim_start_matches(['$', '@', '%', '&']).to_string();
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(sym));
+                        attrs.insert("what".to_string(), Value::str_from("symbol"));
+                        let err = Value::make_instance(Symbol::intern("X::Redeclaration"), attrs);
+                        let idx = self.code.add_constant(err);
+                        self.code.emit(OpCode::LoadConst(idx));
+                        self.code.emit(OpCode::Die);
+                        return;
+                    }
                     self.constant_vars.insert(name.clone());
                     self.constant_vars_in_scope.insert(name.clone());
                 }

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -45,6 +45,23 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
         register_term_symbol_from_decl_name(&n);
         (r, n)
     };
+    // Record the source sigil so the compiler can distinguish a scalar
+    // `constant $x` from a sigilless `constant x` for X::Redeclaration purposes
+    // (the VarDecl `name` strips the `$`, so both would otherwise collide).
+    let sigil_marker = match sigil {
+        b'$' => "$",
+        b'@' => "@",
+        b'%' => "%",
+        b'&' => "&",
+        _ => "",
+    };
+    let constant_traits = vec![
+        ("__constant".to_string(), None),
+        (
+            "__constant_sigil".to_string(),
+            Some(Expr::Literal(Value::str(sigil_marker.to_string()))),
+        ),
+    ];
     let (mut rest, _) = ws(rest)?;
     let mut is_export = false;
     let mut export_tags: Vec<String> = Vec::new();
@@ -116,7 +133,7 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
                 is_dynamic: false,
                 is_export,
                 export_tags: export_tags.clone(),
-                custom_traits: vec![("__constant".to_string(), None)],
+                custom_traits: constant_traits.clone(),
                 where_constraint: None,
             },
         ));
@@ -148,7 +165,7 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
                 is_dynamic: false,
                 is_export,
                 export_tags: export_tags.clone(),
-                custom_traits: vec![("__constant".to_string(), None)],
+                custom_traits: constant_traits.clone(),
                 where_constraint: None,
             },
         ));
@@ -165,7 +182,7 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
             is_dynamic: false,
             is_export,
             export_tags,
-            custom_traits: vec![("__constant".to_string(), None)],
+            custom_traits: constant_traits.clone(),
             where_constraint: None,
         },
     ))


### PR DESCRIPTION
## 概要

同一レキシカルブロック内で `constant` を二重宣言した場合、コンパイル時に **X::Redeclaration**(`.symbol` 付き)を投げるようにした(Raku 準拠)。内側ブロックでの shadowing は引き続き許可。

## 実装

`constant_vars_current_scope` セットをブロック入場時に `std::mem::take` でリセット、退場時に復元することで、同一スコープの重複のみを検出(inner-block shadowing は誤検出しない)。

## 影響

- `S04-declarations/constant.t` の test 56(`throws-like X::Redeclaration`)が通過(実行される 68 中 5→4 失敗)。
- X::Redeclaration は `S32-exceptions/misc2.t` でも必要な横断的な例外型。

## constant.t の残ブロッカー(TODO_roast/S04.md に記録)

whitelist には以下の Hard 機能が必要なため本 PR では未対応:
- bind-to-constant rebind(`baka := 23`、tests 24/26)
- constant エイリアス経由の修飾名解決(`G::c`、test 44)
- lazy 無限列の bigint インデックス(`fib[100]`、test 46)
- constant 演算子バインド経由の multi 候補共有(test 69、これが 69-72 の実行を止めている)
- `ExportConstant` モジュール(70-71)、`constant $`-sigil 内の regex(72)

## テスト

- `make test` PASS(589 files / 5141 tests、回帰なし)
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)