### PR TITLE
fix(dispatch): type unknown-function call errors as X::Undeclared::Symbols

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -7,13 +7,26 @@
 - [ ] roast/S06-advanced/dispatching.t
   - 4/8 subtests pass (subtests 1, 4-skip, 5-skip, 7-skip, 8 pass). Subtests 2-3 fail: callwith/callsame wrapper dispatch not fully working. Subtest 6 fails: nextsame dispatch chain broken when multi method calls another method.
 - [ ] roast/S06-advanced/lexical-subs.t
-  - 8/13 pass. Remaining failures require multiple independent features:
-    (1) test 2: throws-like EVAL'd undeclared-symbol check for lexically shadowed sub (X::Undeclared::Symbols).
-    (2) test 6: `&infix:<@@>` as parameter must shadow same-named package infix op — fix needs extending to the infix dispatch path (runtime::builtins_operators / vm::vm_string_regex_ops call_infix_fallback).
-    (3) test 9: `my sub a { }` inside an inner block leaks into outer scope; lexical-sub scoping doesn't get popped when block ends.
-    (4) test 10: `package Foo { sub f { } }` entries are visible as `Foo::f` even without scoping modifiers; packaged subs should not be globally reachable.
-    (5) test 11: duplicate `sub a { }; sub a { }` at same scope should throw X::Redeclaration.
-    Moved to too_difficult.txt because each failure is its own non-trivial feature; see PR for partial fix (lexical `&foo` parameter precedence).
+  - 8/13 pass. Calling an unknown `foo()` (with parens) now throws a properly
+    *typed* X::Undeclared::Symbols (was a generic string-message error) — helps
+    misc2.t and any `CATCH { when X::Undeclared::Symbols }`. Remaining failures
+    each require an independent feature:
+    (1) test 2: bareword `g` (no parens) referencing an undeclared routine must
+        throw X::Undeclared::Symbols. mutsu treats unknown lowercase barewords as
+        Str; needs compile-time undeclared-routine detection (broad parser blast
+        radius).
+    (2) tests 4/6: `&foo` / `&infix:<@@>` parameter must shadow a same-named
+        package sub/op when called by name. **Blocked on the VM call cache**
+        (`pos_light_call_cache`/`light_call_cache` are keyed by name and ignore a
+        lexical `&name` binding once the package sub has been called once). This is
+        VM-dispatch internals — owned by the main engineer per BLOCKERS.md; do not
+        patch from a sub-engineer branch.
+    (3) test 9: `my sub a { }` in an inner block leaks into the outer scope.
+    (4) test 10: `package Foo { sub f { } }` subs reachable as `Foo::f` without a
+        scoping modifier.
+    (5) test 11: duplicate `sub a { }; sub a { }` should throw X::Redeclaration —
+        mutsu's `register_sub_decl` treats two identical empty-body decls as an
+        idempotent hoist re-registration and silently allows it.
 - [ ] roast/S06-advanced/recurse.t
   - 0/? pass. Stack overflow crash. Recursive sub calls cause unbounded stack growth. Difficulty: Medium (need stack depth limit or tail-call optimization)
 - [ ] roast/S06-advanced/return_function.t

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -566,8 +566,8 @@ impl Interpreter {
                 return self.eval_call_on_value(callable, args);
             }
         }
-        Err(RuntimeError::new(format!(
-            "X::Undeclared::Symbols: Unknown function: {}",
+        Err(RuntimeError::undeclared_symbols(format!(
+            "Unknown function: {}",
             full_name
         )))
     }

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -793,8 +793,8 @@ impl Interpreter {
             return self.call_function(short_name, args.to_vec());
         }
 
-        Err(RuntimeError::new(format!(
-            "X::Undeclared::Symbols: Unknown function: {}",
+        Err(RuntimeError::undeclared_symbols(format!(
+            "Unknown function: {}",
             name
         )))
     }


### PR DESCRIPTION
## 概要

未定義ルーチンを括弧付きで呼んだ場合(`foo()`)、これまで「メッセージ文字列がクラス名で始まるだけの汎用 RuntimeError」だったものを、**正しく型付けされた X::Undeclared::Symbols** 例外として投げるようにした。これにより `CATCH { when X::Undeclared::Symbols {...} }` や `try`/`$!.^name` で捕捉可能になる(Raku 準拠)。

## 実装

stale な文字列プレフィックス付きメッセージを生成していた2箇所(`runtime/accessors.rs`、`runtime/builtins_operators.rs`)を `RuntimeError::undeclared_symbols(...)` 経由の typed 例外に変更。旧メッセージ literal `"X::Undeclared::Symbols: Unknown function:"` に依存するコードは無し。

## 影響

- `S06-advanced/lexical-subs.t` 関連、かつ `S32-exceptions/misc2.t` の前提となる横断的な例外型の修正。

## lexical-subs.t の残ブロッカー(TODO_roast/S06.md に記録)

- bareword 未定義検出(parser 広域影響)
- `&foo` パラメータのパッケージ sub 優先 — **VM call cache の問題で main engineer 管轄**(BLOCKERS.md の指示により sub-engineer ブランチからは触らない)
- inner-block の lexical-sub リーク
- 同一空 body sub の X::Redeclaration

## テスト

- `make test` PASS(588 files / 5129 tests、回帰なし)
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)