### PR TITLE
feat(exporthow): X::EXPORTHOW::InvalidDirective for unknown EXPORTHOW directives

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -87,6 +87,18 @@
   - 6/37 pass (2, 4, 8, 24, 26, 36). `.WHAT` works for basic types (Array, Hash). Failures: default type detection for uninitialized variables (1, 3, 5, 9-23), typed variables (14-23), parameterized types (28-37). Difficulty: Medium-High (type object system)
 - [ ] roast/S12-meta/classhow.t
 - [ ] roast/S12-meta/exporthow.t
+  - **NOT whitelistable as written**: reference rakudo itself fails this file —
+    it passes tests 1-2 then dies at line 22 ("No such method 'tryit' for
+    invocant of type 'Perl6::Metamodel::ClassHOW'"), running only 2 of 12. The
+    file exercises EXPORTHOW SUPERSEDE/DECLARE of a custom meta-type HOW (`tryit`
+    added to ClassHOW), which current rakudo does not support.
+  - Test 1 now PASSES: loading a module with `my package EXPORTHOW { class
+    BBQ::class {} }` throws X::EXPORTHOW::InvalidDirective (directive => 'BBQ').
+    Module load validates EXPORTHOW members named `<directive>::<declarator>`
+    against the known directives {DECLARE, SUPERSEDE, COMPOSE}.
+  - Remaining (Hard, blocks whitelist regardless of mutsu): EXPORTHOW SUPERSEDE
+    of a custom meta-type HOW (the `tryit` ClassHOW method, tests 2+) — needs full
+    metamodel HOW supersession, which reference rakudo also lacks.
 - [x] roast/S12-meta/grammarhow.t
 - [ ] roast/S12-meta/primitives.t
 - [ ] roast/S12-methods/accessors.t

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -92,6 +92,42 @@ impl Interpreter {
         false
     }
 
+    /// Validate `package EXPORTHOW { ... }` directive members. An EXPORTHOW
+    /// member named `<directive>::<declarator>` must use a recognized directive
+    /// (DECLARE, SUPERSEDE, or COMPOSE); anything else is X::EXPORTHOW::InvalidDirective.
+    /// A bare member name (no `::`) is shorthand for installing a package type and
+    /// is always allowed.
+    fn validate_exporthow_directives(stmts: &[crate::ast::Stmt]) -> Result<(), RuntimeError> {
+        use crate::ast::Stmt;
+        const VALID: [&str; 3] = ["DECLARE", "SUPERSEDE", "COMPOSE"];
+        for stmt in stmts {
+            let Stmt::Package { name, body, .. } = stmt else {
+                continue;
+            };
+            if name.resolve() != "EXPORTHOW" {
+                continue;
+            }
+            for member in body {
+                let member_name = match member {
+                    Stmt::ClassDecl { name, .. } | Stmt::RoleDecl { name, .. } => name.resolve(),
+                    _ => continue,
+                };
+                if let Some((directive, _)) = member_name.split_once("::")
+                    && !VALID.contains(&directive)
+                {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("directive".to_string(), Value::str(directive.to_string()));
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!("EXPORTHOW directive '{}' is unknown", directive)),
+                    );
+                    return Err(RuntimeError::typed("X::EXPORTHOW::InvalidDirective", attrs));
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn should_skip_runtime_for_use_only_module(stmts: &[crate::ast::Stmt]) -> bool {
         if stmts.is_empty()
             || !stmts
@@ -1408,6 +1444,10 @@ impl Interpreter {
         // into the caller's language version.
         let saved_language_version = crate::parser::current_language_version();
         let (stmts, _precompiled) = self.parse_module_source(module, &source_path)?;
+        // Validate any `package EXPORTHOW { ... }` directives before running the
+        // module: a member named `<directive>::<declarator>` must use a known
+        // directive (DECLARE/SUPERSEDE/COMPOSE), else X::EXPORTHOW::InvalidDirective.
+        Self::validate_exporthow_directives(&stmts)?;
         if !Self::should_skip_runtime_for_use_only_module(&stmts) {
             // Module files should be compiled in a fresh GLOBAL scope, not
             // inheriting the caller's current_package.  Otherwise the compiler

--- a/t/exporthow-invalid-directive.t
+++ b/t/exporthow-invalid-directive.t
@@ -1,0 +1,15 @@
+use Test;
+use lib 'roast/packages/S12-meta/lib';
+
+plan 2;
+
+# A module whose EXPORTHOW package uses an unknown directive
+# (`BBQ::class`, where BBQ is not DECLARE/SUPERSEDE/COMPOSE) must throw
+# X::EXPORTHOW::InvalidDirective carrying the offending directive.
+throws-like { EVAL 'use InvalidDirective;' },
+    X::EXPORTHOW::InvalidDirective, directive => 'BBQ',
+    'invalid EXPORTHOW directive throws X::EXPORTHOW::InvalidDirective';
+
+# A plain module with no EXPORTHOW package loads without error.
+lives-ok { EVAL 'use Supersede1;' },
+    'a module without an invalid EXPORTHOW directive loads cleanly';


### PR DESCRIPTION
## 概要

`use` したモジュールが `package EXPORTHOW { ... }` を宣言し、そのメンバ名が `<directive>::<declarator>` 形式の場合、モジュールロード時に directive を既知集合 {DECLARE, SUPERSEDE, COMPOSE} と照合するようにした。未知の directive(例 `BBQ::class`)は `.directive` 属性付きの typed **X::EXPORTHOW::InvalidDirective** を投げる(Raku 準拠)。`::` を含まないメンバ名や EXPORTHOW パッケージを持たないモジュールには影響なし。

## 影響

- `S12-meta/exporthow.t` の test 1(`throws-like X::EXPORTHOW::InvalidDirective`)が通過。

## whitelist 不可の理由(TODO_roast/S12.md に記録)

reference rakudo 自身が test 2 で死ぬ(EXPORTHOW SUPERSEDE による custom meta-type HOW = `tryit` ClassHOW メソッド、現行 rakudo が持たないメタモデル機能)。ファイル全体の whitelist は不可。

## テスト

- 新規 `t/exporthow-invalid-directive.t`(2 tests)
- `make test` PASS(588 files / 5129 tests、回帰なし)
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)