### PR TITLE
feat(hash): zen-slice adverbs, X::Adverb, .name, Range-key slices

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -78,6 +78,19 @@
   - Difficulty: Very High (effectively requires implementing a compile-time error pass and
     ~30 exception types). Should be tackled incrementally per feature, not as one PR.
 - [ ] roast/S32-hash/adverbs.t
+  - 1069/1128 pass (was 823). Landed: zen-slice adverbs (`%h{}:k/:v/:kv/:p` and
+    negations/args), X::Adverb for unknown (`:foo`) and conflicting (`:k:v`)
+    subscript adverbs with correct `.what`/`.source`/`.nogo`/`.unexpected`
+    (`unexpected` is now a list; `what` is `{} slice`/`[] slice` for a pure
+    unknown-adverb zen error, `slice` when a nogo combination is present),
+    `%h.name`/`@a.name` returning the sigil'd variable name, and Range keys as
+    multi-key hash slices (`%h{"b".."c"}` and with adverbs).
+  - Remaining 59: typed-hash value-type default for a *missing* key must survive
+    rebinding — `for $%i -> %h { %h<missing>:!p }` should default to `Int` (the
+    `my Int %i` value type), but the loop variable `%h` carries no type
+    constraint and the bound Hash *value* does not carry its value-type metadata.
+    This is the first-class-container-identity limitation (value-carried type),
+    owned by the main engineer per BLOCKERS.md — not fixable from here.
 - [ ] roast/S32-hash/antipairs.t
 - [ ] roast/S32-hash/delete-adverb.t
 - [ ] roast/S32-hash/delete.t

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -55,6 +55,20 @@ impl Compiler {
             }
             _ => unreachable!(),
         };
+        // `.name` on an array/hash variable returns the sigil'd variable name
+        // (e.g. `%h.name` → "%h", `@a.name` → "@a"), matching Raku's container
+        // `.name`. (`$x.name` operates on the contained value, and `&f.name`
+        // returns the routine name, so those are left to normal dispatch.)
+        if name.resolve() == "name"
+            && args.is_empty()
+            && modifier.is_none()
+            && !quoted
+            && matches!(target, Expr::ArrayVar(_) | Expr::HashVar(_))
+        {
+            let idx = self.code.add_constant(Value::str(target_name));
+            self.code.emit(OpCode::LoadConst(idx));
+            return;
+        }
         // Fast path: @arr.push(single_expr) with no modifiers → ArrayPush opcode
         // Only for local variables (not captured closures) to avoid COW env sync issues
         if name.resolve() == "push"

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -312,6 +312,17 @@ fn try_parse_unknown_adverb(input: &str) -> Option<(&str, String)> {
 /// Determine "element access" vs "slice" from the target and index.
 /// Hash access is always "slice"; array single-element is "element access".
 fn determine_subscript_what(target: &Expr, index_expr: &Expr) -> String {
+    // A zen slice (empty subscript → Whatever index) reports the bracket kind:
+    // `{} slice` for a hash, `[] slice` for an array. This is only used when
+    // there is no `nogo` (pure unknown-adverb) error; the runtime overrides it
+    // to plain "slice" when a conflicting (nogo) combination is present.
+    if matches!(index_expr, Expr::Whatever) {
+        return if matches!(target, Expr::HashVar(_)) {
+            "{} slice".to_string()
+        } else {
+            "[] slice".to_string()
+        };
+    }
     if matches!(target, Expr::HashVar(_)) {
         return "slice".to_string();
     }
@@ -2501,10 +2512,18 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             // However, %h{}:exists and %h{}:delete need Index{Whatever} for adverb handling.
             if let Some(r) = r.strip_prefix('}') {
                 let (r_adv, _) = ws(r)?;
-                if r_adv.starts_with(":exists")
+                // `%h{}` followed by ANY subscript adverb (`:exists`/`:delete`,
+                // `:k`/`:v`/`:kv`/`:p` and their negations/args, or an unknown
+                // `:foo`) is kept as Index{Whatever} so the shared adverb-parsing
+                // loop below handles the slice semantics and X::Adverb validation.
+                // A bare `%h{}` with no adverb stays a ZenSlice.
+                let has_adverb = r_adv.starts_with(":exists")
                     || r_adv.starts_with(":!exists")
                     || r_adv.starts_with(":delete")
-                {
+                    || r_adv.starts_with(":!delete")
+                    || parse_subscript_adverb_with_expr(r_adv).is_some()
+                    || try_parse_unknown_adverb(r_adv).is_some();
+                if has_adverb {
                     // Keep as Index with Whatever so adverb processing works
                     expr = Expr::Index {
                         target: Box::new(expr),

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -678,7 +678,7 @@ impl Interpreter {
                 "__mutsu_subscript_adverb_error: missing arguments",
             ));
         }
-        let what = args[0].to_string_value();
+        let mut what = args[0].to_string_value();
         let source = args[1].to_string_value();
         let mut nogo: Vec<String> = Vec::new();
         let mut unexpected: Vec<String> = Vec::new();
@@ -690,12 +690,15 @@ impl Interpreter {
                 unexpected.push(name.to_string());
             }
         }
-        if nogo.is_empty() && !unexpected.is_empty() {
-            return Err(RuntimeError::new(format!(
-                "Unexpected adverb(s) on subscript: {}",
-                unexpected.join(", ")
-            )));
+        // A conflicting (nogo) combination is reported by the slice candidate as
+        // plain "slice"; the bracket-specific "{} slice"/"[] slice" descriptor is
+        // only used for a pure unknown-adverb error on a zen slice.
+        if !nogo.is_empty() && (what == "{} slice" || what == "[] slice") {
+            what = "slice".to_string();
         }
+        // Both the conflicting-adverb (`nogo`) and unknown-adverb (`unexpected`)
+        // cases must surface as a typed X::Adverb so `throws-like X::Adverb` and
+        // attribute matching (.what/.source/.nogo/.unexpected) work.
         Err(RuntimeError::x_adverb(&what, &source, &nogo, &unexpected))
     }
 
@@ -764,6 +767,9 @@ impl Interpreter {
 
         let mut indices = match index {
             Value::Array(items, ..) => items.to_vec(),
+            // A Range subscript on a hash is a multi-key slice (`%h{"b".."c"}:kv`),
+            // so expand it to its element keys.
+            ref r if r.is_range() => crate::runtime::utils::value_to_list(r),
             other => vec![other],
         };
         if matches!(indices.first(), Some(Value::Whatever))
@@ -828,10 +834,25 @@ impl Interpreter {
                 }
             }
             Value::Hash(map) => {
-                let default_type = var_name
-                    .as_ref()
-                    .and_then(|name| self.var_type_constraint(name))
-                    .unwrap_or_else(|| "Any".to_string());
+                // The missing-key default comes from the Hash's *value type* — read
+                // it from the container value itself (via container metadata /
+                // `is default`) so it survives rebinding (e.g. `for %i -> %h {...}`
+                // where the loop variable has no type constraint). Fall back to the
+                // declared variable's type constraint, then Any.
+                let missing_default = self
+                    .container_default(&target)
+                    .cloned()
+                    .or_else(|| {
+                        self.container_type_metadata(&target)
+                            .map(|info| Value::Package(Symbol::intern(&info.value_type)))
+                    })
+                    .or_else(|| {
+                        var_name
+                            .as_ref()
+                            .and_then(|name| self.var_type_constraint(name))
+                            .map(|t| Value::Package(Symbol::intern(&t)))
+                    })
+                    .unwrap_or_else(|| Value::Package(Symbol::intern("Any")));
                 for idx in &indices {
                     let key_str = idx.to_string_value();
                     let key =
@@ -840,7 +861,7 @@ impl Interpreter {
                     let value = map
                         .get(&key_str)
                         .cloned()
-                        .unwrap_or_else(|| Value::Package(Symbol::intern(&default_type)));
+                        .unwrap_or_else(|| missing_default.clone());
                     rows.push((key, value, exists));
                 }
             }

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -819,10 +819,17 @@ impl RuntimeError {
             "nogo".to_string(),
             Value::array(nogo.iter().map(|s| Value::str(s.to_string())).collect()),
         );
-        if !unexpected.is_empty() {
-            let unexpected_str = unexpected.join(" ");
-            attrs.insert("unexpected".to_string(), Value::str(unexpected_str));
-        }
+        // `.unexpected` is a list of the unknown adverb names (Raku returns a
+        // Seq), so smartmatch against `<foo>` / a regex over its elements works.
+        attrs.insert(
+            "unexpected".to_string(),
+            Value::array(
+                unexpected
+                    .iter()
+                    .map(|s| Value::str(s.to_string()))
+                    .collect(),
+            ),
+        );
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         Self::typed("X::Adverb", attrs)
     }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -399,6 +399,14 @@ impl VM {
         };
         // Object hash shortcut: when the target hash has a key_type constraint,
         // use .WHICH-based lookup and enforce key type checking on access.
+        // A Range used as a hash subscript is a multi-key slice: `%h{"b".."c"}`
+        // selects the keys "b","c". (For arrays a Range is a positional slice and
+        // is handled elsewhere, so only expand it for Hash targets here.)
+        let index = if matches!(&target, Value::Hash(_)) && index.is_range() {
+            Value::array(crate::runtime::utils::value_to_list(&index))
+        } else {
+            index
+        };
         if let Value::Hash(ref items) = target {
             let hash_val = Value::Hash(items.clone());
             if let Some(key_type) = self.interpreter.hash_key_type(&hash_val)

--- a/t/hash-subscript-adverbs.t
+++ b/t/hash-subscript-adverbs.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 14;
+
+my %h = a => 1, b => 2, c => 3, d => 4;
+
+# --- Zen-slice adverbs (`%h{}:adverb`) ---
+is (%h{}:k).sort,  <a b c d>,          'zen slice :k';
+is (%h{}:v).sort,  (1, 2, 3, 4),       'zen slice :v';
+is (%h{}:kv).sort, (1, 2, 3, 4, "a", "b", "c", "d"), 'zen slice :kv';
+
+# --- Range key as a multi-key hash slice ---
+is %h{"b".."c"},        (2, 3),               'range key value slice';
+is (%h{"b".."c"}:k),    <b c>,                'range key :k';
+is (%h{"b".."c"}:kv),   ("b", 2, "c", 3),     'range key :kv';
+
+# --- `.name` on array/hash variables returns the sigil'd name ---
+is %h.name, '%h', 'hash .name returns sigil name';
+my @arr = 1, 2;
+is @arr.name, '@arr', 'array .name returns sigil name';
+
+# --- X::Adverb on invalid / conflicting subscript adverbs ---
+throws-like '%h{}:foo', X::Adverb,
+    :what('{} slice'), :unexpected<foo>, 'unknown zen-slice adverb';
+throws-like '%h{}:k:v', X::Adverb,
+    :what<slice>, :nogo(<k v>), 'conflicting zen-slice adverbs';
+throws-like '%h<a>:foo', X::Adverb,
+    :unexpected<foo>, 'unknown adverb on a single-key subscript';
+throws-like '%h{}:kv:p:zip:zop', X::Adverb,
+    :nogo(<kv p>), :unexpected({ m/zip/ && m/zop/ }),
+    'multiple nogo + unexpected adverbs';
+
+# .source carries the variable name
+throws-like '%h{}:foo', X::Adverb, :source('%h'), 'X::Adverb .source is the var name';
+
+# A valid combination does not throw
+lives-ok { %h{}:kv }, 'valid zen-slice adverb does not throw';


### PR DESCRIPTION
## 概要

`S32-hash/adverbs.t` を **823→1069/1128** に前進。いずれも当該ファイルを超えて有用な、自己完結したハッシュ subscript 機能を4点実装。

## 実装

- **zen-slice adverbs**: `%h{}:k/:v/:kv/:p`(及び `:!k`/`:k($cond)` 形)が parse・評価可能に。`%h{}` の後に subscript adverb が続く場合は `Index{Whatever}` として既存の adverb 機構に流す。adverb の無い `%h{}` は ZenSlice のまま。
- **X::Adverb**: 未知(`%h{}:foo`)・競合(`%h{}:k:v`)の subscript adverb が typed X::Adverb を投げる。`.unexpected` は list 化(旧: 連結文字列)、`.what` は純粋な未知 adverb の zen エラーで `{} slice`/`[] slice`、nogo 競合時は `slice`。`.nogo`/`.source` も設定。
- **`%h.name` / `@a.name`**: sigil 付き変数名(`"%h"`, `"@a"`)を返す(Raku のコンテナ `.name`、spec で X::Adverb の `.source` に使用)。
- **Range キーのスライス**: `%h{"b".."c"}` がキー "b","c" のマルチキースライスに(通常アクセス・adverb 付き両方)。

## 残り(TODO_roast/S32.md に記録)

残り59は、typed hash の missing key 既定値が変数 rebind(`for $%i -> %h {...}`)で失われる first-class-container-identity の限界(値が value-type メタデータを持たない)。main engineer 管轄のため本 PR では未対応。

## テスト

- 新規 `t/hash-subscript-adverbs.t`(14 tests)
- `make test` PASS(588 files / 5129 tests、回帰なし)。S32-hash/{slice,keys_values,delete}, S09 typed hashes, S02 hash も PASS 確認。
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)