### PR TITLE
feat(subst): X::Assignment::RO for s///|tr/// on a matching string literal

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,10 +196,13 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 168/191 pass (was aborting at test 132 before). Remaining 23 failures span
-    several distinct features:
-  - 85, 86: `s///` / `ss///` against a string literal (`'abc' ~~ s/b/g/`) must
-    die (read-only container) — mutsu silently no-ops on a non-lvalue topic.
+  - 170/191 pass. **NOT whitelistable as written**: reference rakudo itself
+    fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
+    file cannot reach a clean pass. Remaining mutsu failures span several distinct
+    (mostly regex-internal) features:
+  - 85, 86 (FIXED): `s///` / `ss///` against a *matching* string literal
+    (`'abc' ~~ s/b/g/`) now throws X::Assignment::RO; a non-matching attempt stays
+    a no-op. (SmartMatchExpr carries an `lhs_is_literal` flag.)
   - 100, 102, 104: `:mm`/samemark with combining marks (e.g. `W̊`, `x̱`, `ý`) —
     samemark per-character combining-mark transfer is NYI.
   - 146-152: `.subst` `:samecase`/`:samemark` adverbs are parsed but not applied

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -264,12 +264,14 @@ impl Compiler {
                     _ => None,
                 };
                 let rhs_is_match_regex = matches!(right, Expr::MatchRegex(_));
+                let lhs_is_literal = matches!(left, Expr::Literal(_));
                 self.compile_expr(left);
                 let sm_idx = self.code.emit(OpCode::SmartMatchExpr {
                     rhs_end: 0,
                     negate: matches!(op, TokenKind::BangTilde),
                     lhs_var,
                     rhs_is_match_regex,
+                    lhs_is_literal,
                 });
                 // When RHS is m/regex/, unwrap to the regex value since
                 // SmartMatchExpr already handles the matching against LHS

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -264,7 +264,18 @@ impl Compiler {
                     _ => None,
                 };
                 let rhs_is_match_regex = matches!(right, Expr::MatchRegex(_));
-                let lhs_is_literal = matches!(left, Expr::Literal(_));
+                // Only a *destructive* `s///` / `tr///` against a literal LHS is an
+                // X::Assignment::RO. Non-destructive `S///` / `TR///` return a copy
+                // and never write back, so `1 ~~ TR/\#//` must not throw.
+                let rhs_is_destructive = matches!(right, Expr::Subst { .. })
+                    || matches!(
+                        right,
+                        Expr::Transliterate {
+                            non_destructive: false,
+                            ..
+                        }
+                    );
+                let lhs_is_literal = rhs_is_destructive && matches!(left, Expr::Literal(_));
                 self.compile_expr(left);
                 let sm_idx = self.code.emit(OpCode::SmartMatchExpr {
                     rhs_end: 0,

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -519,6 +519,8 @@ impl Compiler {
             // Standalone m// (not in ~~ context) returns Nil on failure, not False.
             // Setting this to false makes smart_match_op return $/ (Nil) on failure.
             rhs_is_match_regex: false,
+            // LHS here is `$_`, a writable container.
+            lhs_is_literal: false,
         });
         // RHS: load the regex constant
         let idx = self.code.add_constant(v.clone());

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -192,6 +192,9 @@ pub(crate) enum OpCode {
         /// True when RHS was originally `m//` (MatchRegex), which affects
         /// failure return value: `m//` failure returns False, bare `//` returns Nil.
         rhs_is_match_regex: bool,
+        /// True when the LHS is a literal (non-lvalue). A destructive `s///`/`tr///`
+        /// that matches against a literal must throw X::Assignment::RO.
+        lhs_is_literal: bool,
     },
     /// Scalarize a multi-match regex result: Nil -> 0, Positional -> elems, Match -> 1.
     ScalarizeRegexMatchResult,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2062,6 +2062,7 @@ impl VM {
                 negate,
                 lhs_var,
                 rhs_is_match_regex,
+                lhs_is_literal,
             } => {
                 self.exec_smart_match_expr_op(
                     code,
@@ -2070,6 +2071,7 @@ impl VM {
                     *negate,
                     lhs_var,
                     *rhs_is_match_regex,
+                    *lhs_is_literal,
                     compiled_fns,
                 )?;
             }

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1189,6 +1189,7 @@ impl VM {
         negate: bool,
         lhs_var: &Option<String>,
         rhs_is_match_regex: bool,
+        lhs_is_literal: bool,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let left = self.stack.pop().unwrap();
@@ -1218,6 +1219,19 @@ impl VM {
         self.substitution_in_smartmatch = false;
         rhs_run?;
         let right = self.stack.pop().unwrap_or(Value::Nil);
+        // A destructive `s///`/`tr///` that actually matched against a string
+        // literal has no writable container to update, so Raku throws
+        // X::Assignment::RO (e.g. `'abc' ~~ s/b/g/`). A non-matching attempt is
+        // a no-op and does not throw.
+        if lhs_is_literal && (was_substitution || was_transliterate) && right.truthy() {
+            // Restore the topic before propagating the error.
+            if let Some(v) = saved_topic {
+                self.interpreter.env_mut().insert("_".to_string(), v);
+            } else {
+                self.interpreter.env_mut().remove("_");
+            }
+            return Err(RuntimeError::assignment_ro(Some("Str")));
+        }
         if let Some(var_name) = lhs_var {
             let modified_topic = self
                 .interpreter

--- a/t/subst-readonly-literal.t
+++ b/t/subst-readonly-literal.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 5;
+
+# A destructive s/// that matches a string literal has no writable container,
+# so it must throw X::Assignment::RO (Raku behavior).
+dies-ok { 'abc' ~~ s/b/g/ }, 's/// on a matching string literal dies';
+throws-like { 'abc' ~~ s/b/g/ }, X::Assignment::RO,
+    's/// on a string literal throws X::Assignment::RO';
+
+# A non-matching s/// on a literal is a no-op and must NOT throw.
+lives-ok { 'xyz' ~~ s/b/g/ }, 'non-matching s/// on a literal does not throw';
+
+# Substitution on a real variable still works and writes back.
+{
+    my $x = 'abc';
+    $x ~~ s/b/X/;
+    is $x, 'aXc', 's/// writes back to a variable';
+}
+
+# tr/// on a matching string literal also dies.
+dies-ok { 'abc' ~~ tr/b/X/ }, 'tr/// on a matching string literal dies';


### PR DESCRIPTION
## 概要

文字列リテラルを LHS とする破壊的 `s///` / `tr///` は書き込み先コンテナを持たないため、**マッチした場合**に X::Assignment::RO を投げるようにした(`'abc' ~~ s/b/g/`、Raku 準拠)。非マッチ時は従来通り no-op、変数への置換は引き続き writeback する。SmartMatchExpr に `lhs_is_literal` フラグを追加して非lvalue topic を検出。

## 影響

- `S05-substitution/subst.t` の test 85, 86 が通過。
- X::Assignment::RO on immutable は `S32-exceptions/misc2.t` の前提でもある。

## subst.t が whitelist 不可の理由(TODO_roast/S05.md に記録)

reference rakudo 自身が test 157, 170 で失敗。残りの mutsu 失敗は regex 内部機能(`:mm`/samemark、`:samecase` 適用、非定数 `:i` の X::Value::Dynamic、X::Syntax::Regex::NullRegex)。

## テスト

- 新規 `t/subst-readonly-literal.t`(5 tests)
- `make test` PASS(590 files / 5141 tests、回帰なし)。smartmatch/match/trans roast も PASS 確認。
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)