### PR TITLE
feat(signature): X::Parameter::WrongOrder for misordered parameters

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -50,6 +50,20 @@
 - [ ] roast/S32-encoding/encoder.t
 - [ ] roast/S32-encoding/registry.t
 - [ ] roast/S32-exceptions/misc2.t
+  - **Hard, multi-PR campaign** (reference rakudo fails only 1 of 265). mutsu
+    runs 241/265 (aborts at 241), 131 failing — each failing `throws-like` needs
+    a distinct compile-time exception type thrown at the right place. Landed so
+    far: X::Parameter::WrongOrder (`misplaced`/`after`) for required/optional
+    positional after an optional, named, or variadic parameter.
+  - Remaining clusters (each its own feature; pick one per PR): X::Obsolete
+    (`qr//`, `.` concat, `foreach`, C-style `for`, `undef`, `<>`),
+    X::Syntax::Perl5Var (`$#foo`, `$\`, `$&`, …), X::Placeholder::Mainline
+    (`$^x`/`@_` at mainline), X::Redeclaration of subs/methods, X::Syntax::Confused
+    /Missing, X::Comp::Group, X::Bind / X::Bind::ZenSlice, X::Does::TypeObject,
+    X::Role::Initialization, X::Attribute::Package, X::Declaration::Scope,
+    X::Syntax::Variable::Twigil/Reserved/NoSelf, X::Augment::NoSuchType,
+    X::Mixin::NotComposable, X::Constructor::Positional, X::Phaser::PrePost, … and
+    the abort at test 241 (X::Multi::NoMatch / X::Syntax::Adverb throws-like).
 - [ ] roast/S32-exceptions/misc.t
   - 42/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -146,6 +146,8 @@ fn default_type_matches_constraint(
 
 pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PError> {
     let mut saw_optional_positional = false;
+    let mut saw_named = false;
+    let mut saw_variadic = false;
     for pd in params {
         // Reject $? twigil parameters (compile-time variables like $?VERSION, $?FILE)
         // but allow $! (error variable / attribute twigil) since $! is a valid param name
@@ -183,15 +185,64 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
                 default_type, constraint
             )));
         }
-        if pd.named || pd.slurpy {
+        // Parameter ordering: a positional parameter may not appear after an
+        // optional positional, a named, or a variadic (slurpy) parameter.
+        // X::Parameter::WrongOrder reports which kind is `misplaced` and the kind
+        // it was placed `after`.
+        if pd.named {
+            saw_named = true;
+            continue;
+        }
+        if pd.slurpy || pd.double_slurpy || pd.onearg {
+            saw_variadic = true;
             continue;
         }
         let is_optional_positional = pd.optional_marker || pd.default.is_some();
-        if saw_optional_positional && !is_optional_positional {
-            return Err(PError::fatal(
-                "X::Parameter::WrongOrder: required positional parameters must come before optional positional parameters"
-                    .to_string(),
-            ));
+        // The `after` kind: most restrictive preceding blocker wins.
+        let after = if saw_variadic {
+            Some("variadic")
+        } else if saw_named {
+            Some("named")
+        } else if !is_optional_positional && saw_optional_positional {
+            Some("optional")
+        } else {
+            None
+        };
+        // An optional positional is only misplaced after a named/variadic param
+        // (two optionals in a row are fine).
+        let blocked = if is_optional_positional {
+            saw_variadic || saw_named
+        } else {
+            after.is_some()
+        };
+        if blocked {
+            let after = after.unwrap_or("optional");
+            let misplaced = if is_optional_positional {
+                "optional positional"
+            } else {
+                "required"
+            };
+            let display = format!("${}", pd.name);
+            let msg = format!(
+                "Cannot put {} parameter {} after {} parameters",
+                misplaced, display, after
+            );
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "misplaced".to_string(),
+                crate::value::Value::str(misplaced.to_string()),
+            );
+            attrs.insert(
+                "after".to_string(),
+                crate::value::Value::str(after.to_string()),
+            );
+            attrs.insert("parameter".to_string(), crate::value::Value::str(display));
+            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Parameter::WrongOrder"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(msg, Box::new(ex)));
         }
         if is_optional_positional {
             saw_optional_positional = true;

--- a/t/parameter-wrong-order.t
+++ b/t/parameter-wrong-order.t
@@ -1,0 +1,26 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 9;
+
+# X::Parameter::WrongOrder: a positional parameter may not follow an optional,
+# named, or variadic parameter. `.misplaced` / `.after` describe the conflict.
+throws-like 'sub f($a?, $b) { }', X::Parameter::WrongOrder,
+    misplaced => 'required', after => 'optional',
+    'required after optional positional';
+throws-like 'sub f(*@a, $b) { }', X::Parameter::WrongOrder,
+    misplaced => 'required', after => 'variadic',
+    'required after variadic';
+throws-like 'sub f(*@a, $b?) { }', X::Parameter::WrongOrder,
+    misplaced => 'optional positional', after => 'variadic',
+    'optional positional after variadic';
+throws-like 'sub f(:$a, $b) { }', X::Parameter::WrongOrder,
+    misplaced => 'required', after => 'named',
+    'required after named';
+
+# Legitimate signatures must NOT throw.
+lives-ok { EVAL 'sub a($x, $y?) { }' },     'required then optional is fine';
+lives-ok { EVAL 'sub b($x?, $y?) { }' },    'optional then optional is fine';
+lives-ok { EVAL 'sub c($x, *@rest) { }' },  'positional then slurpy is fine';
+lives-ok { EVAL 'sub d($x, :$named) { }' }, 'positional then named is fine';
+lives-ok { EVAL 'sub e($x?, :$n) { }' },    'optional then named is fine';


### PR DESCRIPTION
## 概要

optional positional / named / variadic(slurpy)パラメータの後に positional パラメータを置いた場合、typed **X::Parameter::WrongOrder**(`.misplaced` = `required`/`optional positional`、`.after` = `optional`/`named`/`variadic`)を投げるようにした(Raku 準拠)。従来は required-after-optional のみ、かつ untyped な generic エラーだった。

正当な順序(required→optional、optional→optional、positional→slurpy、positional/optional→named)は影響なし。

## 影響

`S32-exceptions/misc2.t` の例外型キャンペーンの第一弾(同ファイルは ~40 種の compile-time 例外型が必要; 134→131 失敗)。

## misc2.t は Hard な multi-PR キャンペーン(TODO_roast/S32.md に記録)

reference rakudo は 265 中 1 失敗のみ。残りクラスタ(各々が独立した機能、1 PR ずつ): X::Obsolete、X::Syntax::Perl5Var、X::Placeholder::Mainline、X::Redeclaration(sub/method)、X::Syntax::Confused/Missing、X::Bind、X::Does::TypeObject 等、及び test 241 の abort。

## テスト

- 新規 `t/parameter-wrong-order.t`(9 tests)
- `make test` PASS(591 files / 5159 tests、回帰なし)
- `cargo clippy -- -D warnings` / `cargo fmt` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)