### PR TITLE
feat(io): IO::Path::Cygwin backslash normalization + Win32 volume semantics

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -60,11 +60,10 @@ do NOT spend time here, the file cannot reach a clean pass as written.
 contained feature; estimate + concrete approach given so the next worker can start
 cold):
 
-1. **S32-io/io-path-cygwin.t** — *Medium, best next pickup.* 10 failing: IO::Path::Cygwin path
-   canonicalization (UNC `//server/share`, drive letters `A:`, backslash separators
-   in volume/dirname/basename/is-absolute). Self-contained in the Cygwin SPEC
-   (`runtime/native_io.rs` path-split helpers). No Rakudo quirk — purely a
-   string-splitting spec to implement to match `IO::Spec::Cygwin`.
+1. **S32-io/io-path-cygwin.t** — **DONE** (whitelisted). IO::Path::Cygwin now
+   normalizes backslashes to forward slashes and uses Win32-style volume /
+   absoluteness semantics (`is_cygwin_spec` + `io_path_parts_spec` in
+   `runtime/native_io.rs`; cygwin branches in absolute/relative).
 2. **S03-buf/write-int.t** — *Hard (large but mechanical).* 2530 tests; needs
    128-bit `read-int128`/`write-int128`/`-uint128` across NativeEndian/Little/Big
    plus the existing 8/16/32/64 widths. `Value` has `BigInt`; wire the `write-int*`
@@ -420,9 +419,9 @@ cases. `pipe.t`, `spurt.t`, `indir.t`, `child-secure.t` now pass.
   on `.SPEC=`/`.CWD=` + `temp $*SPEC`/`temp $*CWD` (34, 35), `.path`
   indir-independence (36), `.Numeric` Cool chain (37 — most tractable: IO::Path is
   Cool, numify via `.Str`).
-- roast/S32-io/io-path-cygwin.t — **Medium**. IO::Path::Cygwin: UNC `//server/share`,
-  drive letters `A:`, backslash separators in volume/dirname/basename/is-absolute;
-  10 failing.
+- roast/S32-io/io-path-cygwin.t — **DONE** (whitelisted). IO::Path::Cygwin: UNC
+  `//server/share`, drive letters `A:`, backslash separators in
+  volume/dirname/basename/is-absolute, plus cygwin absolute/relative.
 - roast/S32-io/lock.t — **Hard**. `.lock`/`.unlock` throw X::Method::NotFound.
   Needs **fcntl POSIX record locks** (`F_SETLK`/`F_SETLKW`, `F_RDLCK`/`F_WRLCK`),
   NOT `flock(2)` — rakudo rejects an exclusive lock on a read-only fd via fcntl

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -147,7 +147,7 @@
       returns Nil; fix that first, then re-isolate the topic source).
       23 `.print-nl`, 29 `.WRITE`, 30 `.EOF/.WRITE` all need a user-subclassable
       IO::Handle with polymorphic READ/WRITE/EOF. Substantial feature.)
-- [ ] roast/S32-io/io-path-cygwin.t
+- [x] roast/S32-io/io-path-cygwin.t
 - [ ] roast/S32-io/io-path-extension.t
 - [ ] roast/S32-io/io-path-subclasses.t
 - [ ] roast/S32-io/io-path-symlink.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1017,6 +1017,7 @@ roast/S32-io/child-secure.t
 roast/S32-io/copy.t
 roast/S32-io/dir.t
 roast/S32-io/indir.t
+roast/S32-io/io-path-cygwin.t
 roast/S32-io/io-path-extension.t
 roast/S32-io/io-path-subclasses.t
 roast/S32-io/io-path-symlink.t

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -225,11 +225,11 @@ impl Interpreter {
                 Ok(Value::Package(Symbol::intern(&spec_name)))
             }
             "basename" => {
-                let (_, _, bname) = Self::io_path_parts(&p);
+                let (_, _, bname) = Self::io_path_parts_spec(&p, attributes);
                 Ok(Value::str(bname))
             }
             "dirname" => {
-                let (_, dname, _) = Self::io_path_parts(&p);
+                let (_, dname, _) = Self::io_path_parts_spec(&p, attributes);
                 Ok(Value::str(dname))
             }
             "cleanup" => {
@@ -241,7 +241,7 @@ impl Interpreter {
                 Ok(Self::clone_io_path_with_path(attributes, normalized))
             }
             "parts" => {
-                let (volume, dirname, basename) = Self::io_path_parts(&p);
+                let (volume, dirname, basename) = Self::io_path_parts_spec(&p, attributes);
                 let mut parts = HashMap::new();
                 parts.insert("volume".to_string(), Value::str(volume));
                 parts.insert("dirname".to_string(), Value::str(dirname));
@@ -265,7 +265,11 @@ impl Interpreter {
                     ));
                 }
                 let sep = Self::io_path_sep(attributes);
-                let mut path = p.clone();
+                let mut path = if Self::is_cygwin_spec(attributes) {
+                    p.replace('\\', "/")
+                } else {
+                    p.clone()
+                };
                 for _ in 0..levels {
                     if path == "." {
                         path = "..".to_string();
@@ -449,6 +453,24 @@ impl Interpreter {
                     // Canonicalize the result
                     let cleaned = Self::canonpath_win32(&abs, false);
                     Ok(Value::str(cleaned))
+                } else if Self::is_cygwin_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    let pn = p.replace('\\', "/");
+                    let abs = if Self::io_path_is_absolute_win32(&pn) {
+                        pn
+                    } else {
+                        let bn = base.replace('\\', "/");
+                        if bn.ends_with('/') {
+                            format!("{}{}", bn, pn)
+                        } else {
+                            format!("{}/{}", bn, pn)
+                        }
+                    };
+                    Ok(Value::str(Self::canonpath_cygwin(&abs, false)))
                 } else {
                     let base = args.first().map(|v| v.to_string_value());
                     if let Some(base) = base {
@@ -477,6 +499,20 @@ impl Interpreter {
                     let rel = norm_p
                         .strip_prefix(&norm_base)
                         .and_then(|r| r.strip_prefix('\\'))
+                        .unwrap_or(&norm_p);
+                    Ok(Value::str(rel.to_string()))
+                } else if Self::is_cygwin_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    // Normalize separators for comparison (Cygwin uses forward slashes).
+                    let norm_p = p.replace('\\', "/");
+                    let norm_base = base.replace('\\', "/");
+                    let rel = norm_p
+                        .strip_prefix(&norm_base)
+                        .and_then(|r| r.strip_prefix('/'))
                         .unwrap_or(&norm_p);
                     Ok(Value::str(rel.to_string()))
                 } else {
@@ -517,12 +553,14 @@ impl Interpreter {
                 Ok(Value::make_instance(Symbol::intern("IO::Path"), new_attrs))
             }
             "volume" => {
-                let (volume, _, _) = Self::io_path_parts(&p);
+                let (volume, _, _) = Self::io_path_parts_spec(&p, attributes);
                 Ok(Value::str(volume))
             }
             "is-absolute" => {
                 let abs = if Self::is_win32_spec(attributes) {
                     Self::io_path_is_absolute_win32(&p)
+                } else if Self::is_cygwin_spec(attributes) {
+                    Self::io_path_is_absolute_win32(&p.replace('\\', "/"))
                 } else {
                     original.is_absolute()
                 };
@@ -531,6 +569,8 @@ impl Interpreter {
             "is-relative" => {
                 let abs = if Self::is_win32_spec(attributes) {
                     Self::io_path_is_absolute_win32(&p)
+                } else if Self::is_cygwin_spec(attributes) {
+                    Self::io_path_is_absolute_win32(&p.replace('\\', "/"))
                 } else {
                     original.is_absolute()
                 };
@@ -1227,6 +1267,37 @@ impl Interpreter {
                 name == "IO::Spec::Win32" || name.ends_with("Win32")
             })
             .unwrap_or(false)
+    }
+
+    /// Whether the path's SPEC is `IO::Spec::Cygwin`. Cygwin uses Win32-style
+    /// volume/absoluteness semantics (UNC, drive letters) but normalizes all
+    /// backslashes to forward slashes in its output.
+    fn is_cygwin_spec(attributes: &HashMap<String, Value>) -> bool {
+        attributes
+            .get("SPEC")
+            .map(|s| {
+                let name = match s {
+                    Value::Package(n) => n.resolve().to_string(),
+                    Value::Instance { class_name, .. } => class_name.resolve().to_string(),
+                    _ => String::new(),
+                };
+                name == "IO::Spec::Cygwin" || name.ends_with("Cygwin")
+            })
+            .unwrap_or(false)
+    }
+
+    /// Split a path into (volume, dirname, basename), honoring the Cygwin SPEC
+    /// by first converting backslashes to forward slashes (Cygwin treats `\`
+    /// and `/` interchangeably and emits forward slashes).
+    fn io_path_parts_spec(
+        path: &str,
+        attributes: &HashMap<String, Value>,
+    ) -> (String, String, String) {
+        if Self::is_cygwin_spec(attributes) {
+            Self::io_path_parts(&path.replace('\\', "/"))
+        } else {
+            Self::io_path_parts(path)
+        }
     }
 
     /// Get the directory separator based on the SPEC attribute.


### PR DESCRIPTION
## Summary
Whitelist `roast/S32-io/io-path-cygwin.t` (previously 10 failing subtests).

`IO::Spec::Cygwin` treats `\` and `/` interchangeably, emits forward slashes in its output, and shares Win32 volume/absoluteness semantics (UNC `//server/share`, drive letters `A:`). This PR implements that:

- Add `is_cygwin_spec` + `io_path_parts_spec` helpers in `runtime/native_io.rs` that convert backslashes to forward slashes before splitting, then route `volume`/`dirname`/`basename`/`parts`/`parent`/`is-absolute`/`is-relative` through them.
- Add cygwin branches to `.absolute`/`.relative` that join the base and path with forward slashes and canonicalize via `canonpath_cygwin`.
- `.Str` still restringifies to the original path verbatim (no normalization of the stored path).

## Tests
- `prove -e target/debug/mutsu roast/S32-io/io-path-cygwin.t` → PASS (58 tests; the only remaining `not ok` is the pre-existing `todo` for `resolve` NYI).
- No regression in `io-path-unix.t`, `io-path-win.t`, `io-path-subclasses.t`, `io-spec-cygwin.t`, `io-spec-unix.t`, `io-path-extension.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)