### PR TITLE
fix(compiler): propagate given value from if/with branch-final position

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -69,6 +69,15 @@ impl Compiler {
                             self.emit_nil_value();
                         }
                     }
+                    // A `given` in branch-final position must yield its value
+                    // (the Given statement leaves it on the stack), just like in
+                    // a `do {}` block (see `compile_block_inline`). This keeps
+                    // `if $c { given $v { ... } }` and statement-form `with $v {
+                    // ... }` (lowered to `if { given }`) value-producing instead
+                    // of falling through to Nil.
+                    Stmt::Given { .. } => {
+                        self.compile_stmt(stmt);
+                    }
                     _ => {
                         self.compile_stmt(stmt);
                         self.emit_nil_value();

--- a/t/if-given-value-propagation.t
+++ b/t/if-given-value-propagation.t
@@ -1,0 +1,33 @@
+use Test;
+
+# A control-flow block (`given`) in branch-final position of an `if`/`with`
+# must propagate its value outward, just like in a `do {}` block. Previously
+# `if $c { given $v { ... } }` and statement-form `with $v { ... }` (which the
+# parser lowers to `if defined($v) { given $v { ... } }`) returned Nil.
+
+plan 8;
+
+sub with_var { my $v = 5; with $v { "got-$_" } }
+is with_var(), 'got-5', 'with $var propagates block value';
+
+sub with_var_lit { my $v = 5; with $v { 99 } }
+is with_var_lit(), 99, 'with $var propagates literal body value';
+
+sub with_lit { with 5 { "lit-$_" } }
+is with_lit(), 'lit-5', 'with literal still works';
+
+sub if_given { my $v = 5; if $v { given $v { "g-$_" } } }
+is if_given(), 'g-5', 'if { given } propagates inner given value';
+
+sub if_given_lit { my $v = 5; if $v { given $v { 42 } } }
+is if_given_lit(), 42, 'if { given } propagates literal value';
+
+sub given_given { my $v = 5; given $v { given $v { "gg-$_" } } }
+is given_given(), 'gg-5', 'given { given } still works';
+
+sub if_lit { my $v = 5; if $v { "if-$v" } }
+is if_lit(), 'if-5', 'plain if value still works';
+
+# else-branch given should also propagate
+sub else_given { my $v = 5; if False { 1 } else { given $v { "e-$_" } } }
+is else_given(), 'e-5', 'else { given } propagates value';


### PR DESCRIPTION
## Summary
Fixes a general value-propagation bug: a `given` block as the last statement of an `if`/`else` branch returned `Nil` instead of its value.

This surfaced as:
- statement-form `with $v { ... }` — which the parser lowers to `if defined($v) { given $v { ... } }` — returning `Nil` when the topic is a variable. (The literal-topic `with 5 { ... }` is inlined to a `$_ =` assignment and was unaffected, which is why the bug was topic-dependent.)
- `if $c { given $v { ... } }` returning `Nil`.

### Root cause
`compile_stmts_value` (used to compute the value of an `if` branch) lacked the `Stmt::Given` branch-final arm that `compile_block_inline` (used for `do {}` blocks and sub bodies) already had, so a tail `given` fell through to the `_ => Nil` arm. Added the arm so the Given statement's value flows outward, matching `do {}` semantics.

A broader delegation to `compile_expr_do_stmt` was tried first but regressed `if … elsif … -> +@a { }` slurpy-binding (the `binding_var` form), so the fix is scoped to `Stmt::Given` only.

## Tests
- New `t/if-given-value-propagation.t` (8 cases: `with $var`, `if { given }`, `else { given }`, and the previously-working literal/given-given/plain-if cases as guards).
- `make test` → Result: PASS (5218 tests, 456 unit tests; no regressions).
- roast `S04-statements/{if,given,with,unless}.t` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)