### PR TITLE
fix(phasers): correct phaser order for will-trait blocks + class-body will leave

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -40,9 +40,16 @@
 - [x] roast/S04-declarations/smiley.t
 - [ ] roast/S04-declarations/state.t
   - 46/46 pass (test 38 is a rakudo TODO which is expected to fail). Cannot whitelist: test 42 (2M function calls in lives-ok) takes ~20s CPU in release, which risks exceeding 30s wall-clock timeout under load.
-- [ ] roast/S04-declarations/will.t
-  - `CHECK`/`INIT` phaser parsing now avoids immediate `Unknown call: CHECK` abort.
-  - Current status: runs 15/19 tests, with remaining failures in `will` trait behavior and missing full phaser semantics.
+- [x] roast/S04-declarations/will.t
+  - Whitelisted. Two fixes: (1) phaser reordering treated a block as
+    "transparent" when its only var declarations were nested in
+    `SyntheticBlock`s produced by `will <phaser>` traits, which lifted the
+    block's CHECK phasers out (running them forward and before the block's
+    BEGINs); `stmt_declares_var` now detects nested decls so such blocks are
+    reordered in place (BEGIN forward, CHECK reverse). (2) class-body LEAVE
+    phasers (`my $x will leave { ... }`) are now collected during class
+    registration and fired LIFO when the body scope is left. Tests 5/7/13
+    remain `# TODO` (will post NYI, declared-var-not-visible-in-block).
 - [ ] roast/S04-exception-handlers/catch.t
   - 2/33 pass (1, 5). Only 5 reached; crashes with unhandled "blah" exception. CATCH in sub works, but CATCH in try/closure/do-block doesn't properly suppress exceptions. Difficulty: Medium-High
 - [ ] roast/S04-exception-handlers/control.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -283,6 +283,7 @@ roast/S04-declarations/multiple.t
 roast/S04-declarations/our.t
 roast/S04-declarations/smiley.t
 roast/S04-declarations/state.t
+roast/S04-declarations/will.t
 roast/S04-exception-handlers/catch.t
 roast/S04-exception-handlers/control.t
 roast/S04-exception-handlers/top-level.t

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -177,7 +177,16 @@ fn lift_phasers_from_stmt(
     match stmt {
         // Transparent blocks: extract BEGIN/INIT/CHECK phasers
         Stmt::Block(body) => {
-            let has_var_decls = body.iter().any(|s| matches!(s, Stmt::VarDecl { .. }));
+            // A block counts as "transparent" only when it declares no
+            // variables. `will <phaser>` traits wrap their declaration in a
+            // `SyntheticBlock([VarDecl, Phaser])` (see wrap_with_will_leave),
+            // so a direct-child scan for `VarDecl` would miss them and wrongly
+            // treat the block as transparent — which lifts the block's CHECK
+            // phasers out (running them forward and before the block's BEGINs)
+            // while leaving the `will`-trait phasers nested. Detect VarDecls
+            // nested in SyntheticBlocks too so such blocks are reordered in
+            // place (BEGIN forward, CHECK reverse) instead of being lifted.
+            let has_var_decls = body.iter().any(stmt_declares_var);
             if !has_var_decls {
                 // Extract BEGIN/INIT/CHECK from this block
                 extract_phasers_from_stmts(body, begin, check, init);
@@ -790,6 +799,16 @@ fn reorder_at_level(
     }
     stmts.extend(extra_init);
     stmts.extend(rest);
+}
+
+/// True if a statement declares a variable, either directly (`VarDecl`) or
+/// nested inside a `SyntheticBlock` (as produced by `will <phaser>` traits).
+fn stmt_declares_var(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::VarDecl { .. } => true,
+        Stmt::SyntheticBlock(inner) => inner.iter().any(stmt_declares_var),
+        _ => false,
+    }
 }
 
 fn stmt_has_phaser_expr(stmt: &Stmt) -> bool {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1422,8 +1422,19 @@ impl Interpreter {
         }
         let saved_functions_keys: HashSet<String> =
             self.functions.keys().map(|k| k.resolve()).collect();
+        // LEAVE phasers declared at class-body scope (e.g. via
+        // `my $x will leave { ... }`) must fire when the class body is left,
+        // i.e. once all body statements have been processed. Collect them here
+        // and run them (LIFO) after the loop instead of executing them inline.
+        let mut class_leave_phasers: Vec<Vec<Stmt>> = Vec::new();
         for stmt in flattened_body {
             match stmt {
+                Stmt::Phaser {
+                    kind: PhaserKind::Leave,
+                    body,
+                } => {
+                    class_leave_phasers.push(body.clone());
+                }
                 Stmt::HasDecl {
                     name: attr_name,
                     is_public,
@@ -2220,6 +2231,20 @@ impl Interpreter {
                 }
             }
             self.classes.insert(name.to_string(), class_def.clone());
+        }
+        // Fire class-body LEAVE phasers in LIFO order now that the body scope
+        // is being left. They run while the class package/env are still active
+        // so their bodies can see body-scoped variables; writes to outer
+        // variables persist because the class-body env is not rolled back on
+        // the success path.
+        for body in class_leave_phasers.iter().rev() {
+            self.run_block_raw(body)?;
+            for outer_name in saved_env.keys() {
+                let class_scoped_name = format!("{}::{}", name, outer_name);
+                if let Some(updated) = self.env.get(&class_scoped_name).cloned() {
+                    self.env.insert_sym(*outer_name, updated);
+                }
+            }
         }
         self.current_package = saved_package;
         if let Err(err) = self.resolve_class_stub_requirements(name, &mut class_def) {


### PR DESCRIPTION
Whitelists `roast/S04-declarations/will.t`.

## Problem
Two distinct phaser bugs:

1. **`will`-trait block phaser order.** `my \$b will begin { ... }` parses into a
   `SyntheticBlock([VarDecl, Phaser])`. The phaser-reordering pass decided whether
   a block was "transparent" (and thus had its CHECK/INIT phasers lifted to the
   parent scope) by scanning only for *direct-child* `VarDecl`s. A block whose only
   declarations came from `will` traits was therefore misclassified as transparent:
   its CHECK phasers were lifted out and ran forward and *before* its BEGINs, while
   the `will`-trait phasers stayed nested and ran later — producing `fdabce` instead
   of `abcdef` for the spec's begin/check ordering test.

2. **Class-body `will leave`.** `class A { my \$x will leave { ... } }` never fired
   the LEAVE phaser, because a class body has no normal block scope-exit path.

## Fix
1. `stmt_declares_var` now also detects `VarDecl`s nested in `SyntheticBlock`s, so
   `will`-trait blocks are reordered in place (BEGIN forward, CHECK reverse) instead
   of being lifted.
2. Class-body LEAVE phasers are collected during class registration and fired LIFO
   when the body scope is left, with outer-variable writes propagated.

## Verification
- `prove -e target/debug/mutsu roast/S04-declarations/will.t` → PASS (tests 5/7/13
  remain `# TODO`).
- `make test` PASS; spot-checked whitelisted S04-phasers/*, S12-class/*,
  S04-declarations/* — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)