### PR TITLE
feat(signature): bind slurpy scalar parameters (*$x)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -129,12 +129,20 @@
 - [ ] roast/S06-signature/slurpy-and-interpolation.t
 - [ ] roast/S06-signature/slurpy-blocks.t
 - [ ] roast/S06-signature/slurpy-params.t
-  - `:$n is required` is now enforced like `:$n!` (tests 28-29 pass; #TBD). The
-    file still aborts at test 30 "Testing with slurpy scalar": slurpy *scalar*
-    params (`*$f`, `*$s`) parse (slurpy=true, scalar) but are not bound — they
-    should capture the leading positional args before a `*@` slurpy. Needs
-    slurpy-scalar binding in runtime/types/binding.rs (and the VM path). Plans
-    86 tests; may have further blockers past 30.
+  - `:$n is required` is now enforced like `:$n!` (tests 28-29 pass).
+  - Slurpy *scalar* params (`*$f`, `*$s`) now bind: each captures the next single
+    positional arg (skipping named/Pair args), leaving the rest for a trailing
+    `*@`. Implemented in `runtime/types/binding.rs` (new branch in the
+    `pd.slurpy` chain, guarded by `!name.starts_with('@')`). Tests 30-33 now pass;
+    the file progresses 29 -> 43 of 86 run. Local coverage: t/slurpy-params.t.
+  - Remaining blockers (each its own feature, no single-PR whitelist):
+    - tests 34-35: Mu slurpy `*@a` must NOT autothread a Junction argument
+      (`slurp_obj_thread(3|4|5)` should call once); needs junction-autothread
+      suppression for slurpy params. The `multi` variant additionally aborts the
+      file with "Test failures".
+    - tests 39, 41-43 (and the `+foo`/`+@foo` blocks after): single-argument-rule
+      slurpy (`+@foo`, `+foo`) flattening of Range / nested list+arg / lazy Seq is
+      incomplete (`.elems` off).
 - [ ] roast/S06-signature/slurpy-placeholders.t
 - [ ] roast/S06-signature/sub-ref.t
 - [ ] roast/S06-signature/tree-node-parameters.t

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -414,6 +414,29 @@ impl Interpreter {
                         self.bind_param_value(&key, Value::real_array(items));
                         self.set_var_type_constraint(&key, pd.type_constraint.clone());
                     }
+                } else if !pd.name.starts_with('@') {
+                    // *$x -- slurpy scalar: captures what would otherwise be the
+                    // next element of the variadic array (S06 "List parameters").
+                    // It consumes a single positional argument; named (Pair) args
+                    // are skipped so they fall through to a *%_ slurpy. With no
+                    // positional left it binds an undefined value (slurpy is
+                    // always optional).
+                    let mut value = Value::Nil;
+                    while positional_idx < args.len() {
+                        let raw_arg = args[positional_idx].clone();
+                        positional_idx += 1;
+                        let arg = unwrap_varref_value(raw_arg);
+                        if matches!(&arg, Value::Pair(..)) {
+                            // Named arg -- leave for *%_ slurpy; keep scanning.
+                            continue;
+                        }
+                        value = arg;
+                        break;
+                    }
+                    if !pd.name.is_empty() {
+                        self.bind_param_value(&pd.name, value.clone());
+                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                    }
                 } else {
                     let mut items = Vec::new();
                     let is_raw_slurpy = pd.traits.iter().any(|t| t == "raw");

--- a/t/slurpy-params.t
+++ b/t/slurpy-params.t
@@ -1,5 +1,5 @@
 use Test;
-plan 6;
+plan 11;
 
 sub collect(*@args) {
     return @args.elems;
@@ -29,3 +29,18 @@ sub first-elems(*@args) {
     return @args[0].elems;
 }
 is first-elems($[1, 2, 3]), 3, 'itemized array stays Array inside slurpy parameter';
+
+# Slurpy scalar parameters capture the leading elements of the variadic args
+# (S06 "List parameters").
+sub s-first(*$f, *$s, *@r) { return $f }
+sub s-second(*$f, *$s, *@r) { return $s }
+sub s-rest(*$f, *$s, *@r) { return [+] @r }
+is s-first(1, 2, 3, 4, 5), 1, 'first slurpy scalar captures first positional';
+is s-second(1, 2, 3, 4, 5), 2, 'second slurpy scalar captures second positional';
+is s-rest(1, 2, 3, 4, 5), 12, 'remaining slurpy array captures the rest';
+
+sub s-undef(*$f) { return $f.defined }
+is s-undef(), False, 'slurpy scalar with no positional is undefined';
+
+sub s-named(*$f, *%h) { return "$f:%h<n>" }
+is s-named(7, n => 9), "7:9", 'slurpy scalar skips named args, *%h captures them';


### PR DESCRIPTION
## Problem
Slurpy scalar parameters (`*$f`, `*$s`) parsed (slurpy=true, scalar sigil) but
were never bound. In `bind_function_args_values` the `pd.slurpy` chain handled
only `|c` captures, `*%hash`, `**@`, and the flattening `*@` array case; a slurpy
scalar fell into the `*@` branch and bound an `@`-prefixed array, leaving the
body's `$f` undeclared (`X::Undeclared::Symbols`). `roast/S06-signature/slurpy-params.t`
aborted at test 30 ("Testing with slurpy scalar").

## Fix
Add a dedicated branch in `runtime/types/binding.rs` (guarded by
`!name.starts_with('@')`) that captures the next single positional argument,
skipping named/Pair args so they fall through to a trailing `*%`, and binds an
undefined value when no positional remains (slurpy is always optional). Matches
S06: "Slurpy scalar parameters capture what would otherwise be the first elements
of the variadic array."

## Result
- `*$f, *$s, *@r` now bind correctly (`first(1,2,3,4,5) == 1`, rest sums to 12).
- `roast/S06-signature/slurpy-params.t` progresses **29 → 43** of 86 run (tests
  30-33 now pass). Not yet whitelisted — remaining failures are separate features
  (Junction-autothread suppression on `*@`, single-arg-rule `+@`/`+foo` Range/Seq
  flattening); tracked in `TODO_roast/S06.md`.
- Local coverage added to `t/slurpy-params.t` (5 new cases).
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)