### PR TITLE
feat(parser): X::Obsolete for Perl 5 `.` string concatenation

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -55,12 +55,17 @@
     a distinct compile-time exception type thrown at the right place. Landed so
     far: X::Parameter::WrongOrder (`misplaced`/`after`) for required/optional
     positional after an optional, named, or variadic parameter.
-  - X::Obsolete partial: `foreach`, C-style `for (;;)`, and bare `undef` now
-    throw structured X::Obsolete (with `old`/`replacement` attrs). Still TODO in
-    that cluster: `.` concat (`"a" . "b"`, `$a . $b`), `s///i` adverb-after,
-    `${...}` Perl5 deref, `<>` readline diamond.
+  - X::Obsolete partial: `foreach`, C-style `for (;;)`, bare `undef`, and now the
+    Perl 5 `.` string-concatenation operator (`"a" . "b"`, `$a . $b`,
+    `@a . "x"`) throw X::Obsolete. The `.`-concat detection lives in the postfix
+    parser: a dot followed by whitespace and then a non-method-name term (string
+    literal / sigiled variable / digit) is the obsolete concat; `$x . uc`
+    (method) and `$x.$name` (indirect) are unaffected. Local: t/obsolete-dot-concat.t.
+    Still TODO in that cluster: `s///i` adverb-after, `${...}` Perl5 deref, `<>`
+    readline diamond, `1 . 3` numeric-literal concat (currently reports the
+    pre-existing decimal-point error instead).
   - Remaining clusters (each its own feature; pick one per PR): X::Obsolete
-    (`.` concat, `s///i`, `${...}`, `<>`),
+    (`s///i`, `${...}`, `<>`),
     X::Syntax::Perl5Var (`$#foo`, `$\`, `$&`, …), X::Placeholder::Mainline
     (`$^x`/`@_` at mainline), X::Redeclaration of subs/methods, X::Syntax::Confused
     /Missing, X::Comp::Group, X::Bind / X::Bind::ZenSlice, X::Does::TypeObject,

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1563,6 +1563,23 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             .to_string(),
                     ));
                 }
+                // Perl 5 string concatenation: `$a . $b`, `"a" . "b"`, `1 . 3`.
+                // A method call may have whitespace before its name (`$x . uc`),
+                // but only when the name is an identifier. When the dot is
+                // followed by whitespace and then a *term* that can never be a
+                // method name -- a string literal, a number, or a sigiled
+                // variable -- it is the obsolete Perl 5 `.` concatenation
+                // operator. (Indirect method calls like `$x.$name` have no space
+                // after the dot, so they are unaffected.)
+                if trimmed.starts_with(['"', '\'', '$', '@', '%'])
+                    || trimmed.starts_with(|c: char| c.is_ascii_digit())
+                {
+                    return Err(PError::fatal(
+                        "X::Obsolete: Unsupported use of . to concatenate strings; \
+                         in Raku please use ~"
+                            .to_string(),
+                    ));
+                }
             }
             expr = auto_invoke_bareword_method_target(expr);
             let r = &rest[1..];

--- a/t/obsolete-dot-concat.t
+++ b/t/obsolete-dot-concat.t
@@ -1,0 +1,24 @@
+use Test;
+plan 9;
+
+# Perl 5's `.` string-concatenation operator is obsolete in Raku (use `~`).
+# A method call may have whitespace before the name (`$x . uc`), but a dot
+# followed by whitespace and then a term that can never be a method name
+# (string literal, number, or sigiled variable) is the obsolete concat.
+
+for '"a" . "b"', 'my ($a, $b); $a . $b', 'my $a = 1; $a . 2',
+    'my @a; @a . "x"', 'my %h; %h . "x"'
+    -> $code {
+    throws-like $code, X::Obsolete, "$code throws X::Obsolete";
+}
+
+# Valid method calls (with or without space before the dot, and indirect
+# method calls without a space after the dot) must keep working.
+is ("x" . uc), "X", 'space before dot + identifier is a method call';
+is ("hello".chars), 5, 'no-space method call still works';
+
+my $a = "abc";
+is ($a.uc), "ABC", 'indirect-free method call works';
+
+# `..` range is not affected by the obsolete-concat detection.
+is (1 .. 3).elems, 3, 'range operator unaffected';


### PR DESCRIPTION
## Problem
`"a" . "b"`, `$a . $b`, `@a . "x"` use Perl 5's `.` string-concatenation operator,
which is obsolete in Raku (use `~`). mutsu produced confusing errors instead of a
typed `X::Obsolete` ("expected ... after quoted method name" / "No such method ''"),
so `roast/S32-exceptions/misc2.t`'s `throws-like ..., X::Obsolete` checks for these
forms failed.

## Fix
In the postfix parser (`postfix_expr_loop`), when a dot is followed by whitespace
and then a term that can never be a method name — a string literal (`"`/`'`), a
sigiled variable (`$`/`@`/`%`), or a digit — emit `X::Obsolete: Unsupported use of
. to concatenate strings; in Raku please use ~`.

Safe against valid method calls:
- `$x . uc` (space before the name, identifier) — still a method call (raku allows this).
- `$x.$name` (indirect, no space after the dot) — unaffected.
- `..` / `...` / `.=` — excluded.

## Result
- `"a" . "b"` and `$a . $b` now throw `X::Obsolete`; advances `misc2.t`'s
  `.`-concat cluster.
- `make test` PASS; spot-checked method/concat-heavy whitelisted roast files
  (S32-str/concatenation, S03-operators/*, S02-literals/quoting, S05-substitution/match,
  S12-methods/*) — all PASS.
- Local coverage: `t/obsolete-dot-concat.t`.

Note: `1 . 3` (numeric *literal* target) still reports the pre-existing
decimal-point error rather than X::Obsolete; left as-is to avoid touching the
decimal-parsing path. Tracked in `TODO_roast/S32.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)