### PR TITLE
refactor(dedup): share minmax_bounds_of_value for [minmax] reduction (Category C Phase 2)

### DIFF
--- a/docs/vm-interpreter-dedup.md
+++ b/docs/vm-interpreter-dedup.md
@@ -143,8 +143,15 @@ etc.).
       normalization. Made `VM::concat_values` a state-free `pub(crate)` assoc fn
       and delegated both the VM `~` op and the reduction `~` arm to it. **1
       duplicate removed**; fixes a latent bug (`[~]` now NFC-normalizes like `~`).
-- [ ] Remaining `apply_reduction_op` bodies that reimplement vs delegate
-      (`minmax`, logic short-circuit; comparisons already use shared
-      `runtime::compare_values`).
+- [x] **`minmax`**: `apply_reduction_op`'s `minmax` arm had its own `range_bounds`
+      closure that (unlike the VM's `minmax_bounds_of_value`) did **not** recurse
+      into elements, so `[minmax] (1,5),(2,8)` etc. computed wrong bounds. Made
+      `vm_misc_ops::minmax_bounds_of_value` a `pub(crate)` fn (module exposed
+      `pub(crate)`) and delegated the arm to it. **1 duplicate removed** + bug fix
+      (`[minmax]` over nested arrays/ranges now matches raku, e.g. `0..8`, `1..9`).
+- [ ] Remaining `apply_reduction_op` bodies: logic short-circuit `&&`/`||`/`//`
+      are the reduction-only impl (the VM compiles infix short-circuit to jumps, so
+      not VM-op duplicates); comparisons already use shared `runtime::compare_values`.
+      Likely little left here.
 - [ ] Genuine-fork methods → fold into native (Category B style; depends on the
       `%`-chain block-dispatch blocker noted under Category B in PLAN.md).

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1155,41 +1155,11 @@ impl Interpreter {
                 }
             }
             "minmax" => {
-                // Helper to extract (lo, hi) from a value:
-                // - Range variants → (start, end)
-                // - Array/Seq → (min_element, max_element)
-                // - Scalar → (value, value)
-                let range_bounds = |v: &Value| -> (Value, Value) {
-                    match v {
-                        Value::Range(a, b)
-                        | Value::RangeExcl(a, b)
-                        | Value::RangeExclStart(a, b)
-                        | Value::RangeExclBoth(a, b) => (Value::Int(*a), Value::Int(*b)),
-                        Value::GenericRange { start, end, .. } => {
-                            ((**start).clone(), (**end).clone())
-                        }
-                        Value::Array(items, _) | Value::Seq(items) => {
-                            if items.is_empty() {
-                                (Value::Nil, Value::Nil)
-                            } else {
-                                let mut lo = items[0].clone();
-                                let mut hi = items[0].clone();
-                                for item in items.iter().skip(1) {
-                                    if crate::runtime::compare_values(item, &lo) < 0 {
-                                        lo = item.clone();
-                                    }
-                                    if crate::runtime::compare_values(item, &hi) > 0 {
-                                        hi = item.clone();
-                                    }
-                                }
-                                (lo, hi)
-                            }
-                        }
-                        _ => (v.clone(), v.clone()),
-                    }
-                };
-                let (left_lo, left_hi) = range_bounds(left);
-                let (right_lo, right_hi) = range_bounds(right);
+                // Extract (lo, hi) bounds from each operand via the single shared
+                // helper (handles Range / Array-Seq / scalar, recursing into
+                // elements) so this logic is not duplicated with the VM.
+                let (left_lo, left_hi) = crate::vm::vm_misc_ops::minmax_bounds_of_value(left);
+                let (right_lo, right_hi) = crate::vm::vm_misc_ops::minmax_bounds_of_value(right);
                 let lo = if crate::runtime::compare_values(&left_lo, &right_lo) <= 0 {
                     left_lo
                 } else {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -47,7 +47,7 @@ mod vm_helpers;
 mod vm_hyper_method_ops;
 mod vm_hyper_race_parallel;
 mod vm_method_dispatch;
-mod vm_misc_ops;
+pub(crate) mod vm_misc_ops;
 mod vm_native_dispatch;
 mod vm_native_map;
 mod vm_native_sort;

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -97,9 +97,12 @@ fn is_parameterized_core_type(name: &str) -> bool {
 
 /// Compute the (lo, hi) bounds of a value for use in `minmax` reduction.
 /// For scalars: returns (v, v).
-/// For arrays/lists: returns (min_element, max_element).
+/// For arrays/lists: returns (min_element, max_element), recursing into elements.
 /// For ranges: returns (start, end).
-fn minmax_bounds_of_value(v: &Value) -> (Value, Value) {
+///
+/// Single authoritative impl shared by the VM's `minmax` reduction and the
+/// interpreter's `apply_reduction_op` `minmax` arm (which delegates here).
+pub(crate) fn minmax_bounds_of_value(v: &Value) -> (Value, Value) {
     match v {
         Value::Range(a, b)
         | Value::RangeExcl(a, b)


### PR DESCRIPTION
## Summary

Category C (operator dedup) follow-up to #2719. `apply_reduction_op`'s `minmax` arm carried its own `range_bounds` closure that duplicated `vm_misc_ops::minmax_bounds_of_value` but — unlike the VM's version — did **not** recurse into elements, so `[minmax]` over nested arrays/ranges computed wrong bounds.

Expose `minmax_bounds_of_value` as a `pub(crate)` fn (and the `vm_misc_ops` module as `pub(crate)`) and delegate the reduction arm to it.

## Result

Removes the duplicate **and** fixes a bug:
- `[minmax] (1,5),(2,8),(0,3)` → `0..8` (was wrong)
- `[minmax] [3,9],[1,4]` → `1..9` (was wrong)

both now match `raku`.

## Verification

- `roast/S03-metaops/reduce.t`, `roast/S03-operators/minmax.t` pass
- `make test` PASS; `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)