### PR TITLE
feat(parser): typed X::Syntax::Perl5Var for $& $backtick $pipe $question

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -64,9 +64,15 @@
     Still TODO in that cluster: `s///i` adverb-after, `${...}` Perl5 deref, `<>`
     readline diamond, `1 . 3` numeric-literal concat (currently reports the
     pre-existing decimal-point error instead).
+  - X::Syntax::Perl5Var partial: `$"`, `$$`, `$'`, `$\`, `$#foo`, and now `$&`,
+    `` $` ``, `$|`, `$?` throw typed X::Syntax::Perl5Var (in
+    `detect_perl5_scalar_var`). Guarded so `$&foo` (code deref), `$?FILE`
+    (compile-time var), and anonymous `$` params stay valid. Local:
+    t/perl5var-special.t. Still TODO: `$;`, `$,`, `$.`, `$@`-as-lvalue (each
+    ambiguous with anonymous-`$`-param / valid forms).
   - Remaining clusters (each its own feature; pick one per PR): X::Obsolete
     (`s///i`, `${...}`, `<>`),
-    X::Syntax::Perl5Var (`$#foo`, `$\`, `$&`, …), X::Placeholder::Mainline
+    X::Syntax::Perl5Var (`$;`, `$,`, `$.`), X::Placeholder::Mainline
     (`$^x`/`@_` at mainline), X::Redeclaration of subs/methods, X::Syntax::Confused
     /Missing, X::Comp::Group, X::Bind / X::Bind::ZenSlice, X::Does::TypeObject,
     X::Role::Initialization, X::Attribute::Package, X::Declaration::Scope,

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -1188,6 +1188,43 @@ pub(crate) fn detect_perl5_scalar_var(input: &str) -> Option<String> {
             );
         }
     }
+    // $& — Perl 5 match variable; in Raku use $/ or $<>.
+    // `$&foo` is a code-object deref (handled later), so only flag when the
+    // `&` is not the start of a routine name.
+    if let Some(after) = input.strip_prefix('&')
+        && !after.chars().next().is_some_and(is_raku_identifier_start)
+    {
+        return Some(
+            "X::Syntax::Perl5Var: Unsupported use of $& variable; in Raku please use $<>"
+                .to_string(),
+        );
+    }
+    // $` — Perl 5 prematch; in Raku use $/.prematch. A backtick never starts a
+    // valid Raku variable.
+    if input.starts_with('`') {
+        return Some(
+            "X::Syntax::Perl5Var: Unsupported use of $` variable; in Raku please use $/.prematch"
+                .to_string(),
+        );
+    }
+    // $| — Perl 5 autoflush; in Raku use the filehandle's .out-buffer attribute.
+    if input.starts_with('|') {
+        return Some(
+            "X::Syntax::Perl5Var: Unsupported use of $| variable; in Raku please use the filehandle's .out-buffer attribute"
+                .to_string(),
+        );
+    }
+    // $? — Perl 5 child error. `$?FILE`/`$?LINE`/`$?PACKAGE` etc. are valid Raku
+    // compile-time variables (a `?`-twigil before an identifier), so only flag a
+    // bare `$?`.
+    if let Some(after) = input.strip_prefix('?')
+        && !after.chars().next().is_some_and(is_raku_identifier_start)
+    {
+        return Some(
+            "X::Syntax::Perl5Var: Unsupported use of $? variable; in Raku please use $! for handling child errors also"
+                .to_string(),
+        );
+    }
     // $# followed by identifier — Perl 5 last index; in Raku use @array.end
     if let Some(after) = input.strip_prefix('#')
         && !after.is_empty()

--- a/t/perl5var-special.t
+++ b/t/perl5var-special.t
@@ -1,0 +1,21 @@
+use Test;
+plan 7;
+
+# Perl 5 special variables are unsupported in Raku and must throw
+# X::Syntax::Perl5Var (not a generic parse error).
+for '$& = 1', '$` = 1', '$| = 1', '$? = 1' -> $code {
+    throws-like $code, X::Syntax::Perl5Var, "$code throws X::Syntax::Perl5Var";
+}
+
+# Valid Raku constructs that look superficially similar must keep working:
+# - $&foo is a code-object deref
+# - $?FILE is a compile-time variable (?-twigil)
+# - an anonymous $ scalar parameter followed by punctuation
+sub foo { 42 }
+my $c = $&foo;
+is $c(), 42, '$&foo is a code-object deref, not the $& match variable';
+
+ok $?FILE.defined, '$?FILE compile-time variable still works';
+
+sub takes-anon($, $x) { $x }
+is takes-anon(1, 2), 2, 'anonymous $ scalar parameter still works';


### PR DESCRIPTION
## Problem
The Perl 5 special variables `$&` (match), `` $` `` (prematch), `$|` (autoflush),
and `$?` (child error) produced a generic `===SORRY!===` parse error instead of a
typed `X::Syntax::Perl5Var`, so `roast/S32-exceptions/misc2.t`'s
`throws-like ..., X::Syntax::Perl5Var` loop failed for these vars.

## Fix
Add detection in `detect_perl5_scalar_var` (`src/parser/primary/var.rs`), guarded
so valid look-alikes keep working:
- `$&foo` — code-object deref (only flag `$&` when not followed by an identifier)
- `$?FILE` / `$?LINE` — compile-time `?`-twigil variables (only flag bare `$?`)
- anonymous `$` scalar parameters (`sub f($, $x) {...}`) — unaffected

## Result
- `$& = 1`, `` $` = 1 ``, `$| = 1`, `$? = 1` now throw `X::Syntax::Perl5Var`;
  advances `misc2.t`'s Perl5Var cluster.
- `make test` PASS. Local coverage: `t/perl5var-special.t`.

Note: `$;`, `$,`, `$.`, and `$@`-as-lvalue are left for follow-ups — each is
ambiguous with an anonymous-`$` parameter or a valid form. Tracked in
`TODO_roast/S32.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)