### PR TITLE
refactor(dedup): finish Category A — delete remaining pure-value builtin copies

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -64,11 +64,16 @@ native_function に arm がある（必要条件）だけでは不十分 — **E
 `try_native_function` と interpreter fallback の `native_function` は**カバレッジが違う**（例: `chrs`/`ords`
 は native arm があるのに fallback 未到達 → 残す）。
 
-- [ ] **Category A — 純粋値 builtin（delete & fallthrough）**: native が authoritative。Interpreter の
+- [x] **Category A — 純粋値 builtin（delete & fallthrough）完了**: native が authoritative。Interpreter の
       `builtin_*` arm + 本体を削除し、catch-all → fallback → native_function に委譲。
-  - [x] **第1バッチ (#2714, in flight)**: `abs`/`lc`/`uc`/`tc`/`trim`/`flip`/`chr`/`ord`/`chars` の Interpreter
-        コピー削除。`chrs`/`ords`（fallback 未到達）と `words`（IO 版で別物）は対象外として残す。
-  - [ ] 残りの純粋値 builtin（docs の Category A 一覧）を同手順で。
+  - [x] **第1バッチ (#2714)**: `abs`/`lc`/`uc`/`tc`/`trim`/`flip`/`chr`/`ord`/`chars` の Interpreter
+        コピー削除。
+  - [x] **第2バッチ（Category A 完了）**: 残りの純粋値重複 `sign`/`ords`/`chrs`/`unival`/`univals` を削除。
+        `sign`/`ords` は native 1-arg が既にカバー（純粋削除）。第1バッチで「fallback 未到達」として
+        残していた `chrs`/`unival`/`univals` は、重複維持ではなく **native を到達可能化** して削除:
+        `chrs` を `native_function_variadic` へ全 arity ルーティング（+ `value_to_list` で Range/Seq 平坦化）、
+        `unival`/`univals` を `native_function_1arg` から `.unival`/`.univals` メソッド実装へ委譲。
+        VM/EVAL 両経路で raku 一致を確認。**純粋値 builtin の重複はゼロ**。`words`（IO 版で別物）は非対象。
 - [ ] **Category B — genuine fork（native に難ケースを足してから削除）**: `min`/`max`/`minmax`/`sort`/`join`/
       `first`/`flat`/`elems`/`index`/`rindex` 等。native/pure 層は comparator ブロック・lazy・junction で bail し
       Interpreter に落ちる。**比較子ブロックは VM 層で `vm_call_on_value`（`.map`/`.grep` と同じクロージャ
@@ -115,7 +120,7 @@ native_function に arm がある（必要条件）だけでは不十分 — **E
       env を任意の名前で書く唯一の存在（interpreter ブリッジ）が消えるので `env_dirty`/`ensure_locals_synced`/
       `sync_locals_from_env`/`saved_env_dirty` の dual-store 機構も削除できる（レバー B 完遂）。
 - **残フォールバック**には `// TODO: compile to bytecode` を付け負債を可視化。
-- **次の着手候補（優先順）**: Category A の残り（低リスク・delete & fallthrough）→ Category B の `%`-chain
+- **次の着手候補（優先順）**: Category A は**完了**（純粋値 builtin の重複ゼロ）。次は Category B の `%`-chain
   block-dispatch は **根本原因解決済み（#2725, `pair_as_positional`）** なので min/max/sort の native 移行 +
   `dispatch_sort`/`builtin_min/max` 削除に着手可能 → Category C Phase 3 の残（comb/substr/split 折込）→
   🟣第2優先「第一級コンテナ」（レバー C 本丸 + Q2 の Arc-pointer flaky を吸収）。

--- a/docs/vm-interpreter-dedup.md
+++ b/docs/vm-interpreter-dedup.md
@@ -63,21 +63,45 @@ the name through that fallback.
 5. `make test` + `make roast` — the interpreter copies are exercised by EVAL /
    regex / carrier paths across the suite, so the full roast run is the net.
 
-### Gotcha found in practice (`chrs` / `ords`)
+### Gotcha found in practice (`chrs` / `ords`) — and how it was resolved
 
-`chrs` and `ords` have native arms in `functions.rs`, but they are **not reached
-through `call_function_fallback`'s `native_function` call** (multi-arg /
-array-returning dispatch differs from the single-`arg` fallback table). Deleting
-their interpreter arms made `EVAL(q{chrs(72,105)})` fail with *"Unknown function:
-chrs"*. They were **kept**. Lesson: step 3 (EVAL-path verification) is mandatory;
-a native arm existing is necessary but not sufficient.
+`chrs` originally had a native arm only in `native_function_variadic` (the 4+ arg
+path), so `chrs(72,105)` (2 args) routed to `native_function_2arg`, found nothing,
+and `EVAL(q{chrs(72,105)})` failed with *"Unknown function: chrs"*. The first batch
+**kept** the interpreter copy. The right fix (Category A second batch) was **not**
+to keep the duplicate but to **make native reachable at the call's arity**: route
+`chrs` through `native_function_variadic` for all arities. `ords`, despite being
+grouped with `chrs`, was actually already reachable — it has a `native_function_1arg`
+arm and Raku's `ords` is 1-arg only — so it just needed deleting.
+
+Lesson: step 3 (EVAL-path verification) is mandatory — a native arm existing is
+necessary but not sufficient; check the **arity** the fallback will dispatch to.
+When a native arm exists at the wrong arity, prefer adding/rerouting the native arm
+(one impl) over keeping the interpreter duplicate.
 
 ## Progress
 
 - **Done (Slice 6.3 dedup, first batch)** — deleted the interpreter copies of 9
   pure value builtins, all verified equivalent through the EVAL fallback path and
   `make roast`: `abs`, `lc`, `uc`, `tc`, `trim`, `flip`, `chr`, `ord`, `chars`.
-  Kept `chrs`/`ords` (fallback-unreachable native, see gotcha).
+- **Done (Category A complete, second batch)** — the remaining pure value builtin
+  duplicates were deleted, finishing Category A. `sign` and `ords` were pure
+  deletions (native `native_function_1arg` already covered them; `ords` is 1-arg
+  only in Raku, so the single-arg fallback fully reaches it). The three that the
+  first batch had **kept** as "fallback-unreachable" were made reachable instead
+  of left duplicated:
+  - `chrs` — routed through `native_function_variadic` for *every* arity (a guard
+    at the top of `native_function`, like `sum`/`zip`), and its variadic arm now
+    flattens via `crate::runtime::utils::value_to_list` so `chrs(72..74)` /
+    `chrs((72,73,74))` keep working. Interpreter `builtin_chrs` deleted.
+  - `unival` / `univals` — added `native_function_1arg` arms that delegate to the
+    `.unival` / `.univals` method impl (`methods_0arg/dispatch_core_unicode.rs`),
+    the single source of truth. Interpreter `builtin_unival` / `builtin_univals`
+    (and the `unival_for_char` helper) deleted.
+  All verified equal through both the VM and EVAL paths against `raku`, plus the
+  whitelisted `S32-num/sign.t`, `S32-str/ords.t`, `S15-unicode-information/unival.t`,
+  `S29-conversions/ord_and_chr.t`. **No pure-value builtin duplicate remains** —
+  the next dedup work is Category B (genuine forks) / Category C (methods/arith).
 
 ## Remaining duplication (prioritized)
 

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -163,6 +163,11 @@ pub(crate) fn native_function(
     if name == "sum" {
         return native_function_variadic(name, args);
     }
+    // chrs(*@codes) is variadic; route every arity through the variadic arm so
+    // chrs(72,105) etc. are reachable (not just the 4+ arg path).
+    if name == "chrs" {
+        return native_function_variadic(name, args);
+    }
     if name == "zip" {
         if args
             .iter()
@@ -481,6 +486,10 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             }
         }
         "is-prime" => Some(super::methods_0arg::coercion::value_is_prime(arg)),
+        // unival/univals delegate to the .unival/.univals method implementation
+        // (dispatch_core_unicode) — single source of truth, no separate copy.
+        "unival" => super::methods_0arg::native_method_0arg(arg, Symbol::intern("unival")),
+        "univals" => super::methods_0arg::native_method_0arg(arg, Symbol::intern("univals")),
         "lsb" => super::methods_0arg::native_method_0arg(arg, Symbol::intern("lsb")),
         "msb" => super::methods_0arg::native_method_0arg(arg, Symbol::intern("msb")),
         "sign" => {
@@ -1557,13 +1566,10 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
                 }
             };
             for arg in args {
-                match arg {
-                    Value::Array(items, ..) => {
-                        for item in items.iter() {
-                            push_chr(&mut result, item);
-                        }
-                    }
-                    _ => push_chr(&mut result, arg),
+                // Flatten Array/Range/Seq/Slip just like the slurpy `*@codes`
+                // signature so chrs(72..74) / chrs((72,73,74)) work.
+                for item in crate::runtime::utils::value_to_list(arg) {
+                    push_chr(&mut result, &item);
                 }
             }
             Some(Ok(Value::str(result)))

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -448,7 +448,8 @@ impl Interpreter {
             "values" => self.builtin_values(&args),
             "kv" => self.builtin_kv(&args),
             "pairs" => self.builtin_pairs(&args),
-            "sign" => self.builtin_sign(&args),
+            // sign removed (Category A dedup): native_function_1arg "sign"
+            // (src/builtins/functions.rs) is authoritative via call_function_fallback.
             "val" => Ok(super::builtins_collection::builtin_val(&args)),
             "min" => self.builtin_min(&args),
             "max" => self.builtin_max(&args),
@@ -649,10 +650,10 @@ impl Interpreter {
                 let method_args = args[1..].to_vec();
                 self.call_method_with_values(target, "rindex", method_args)
             }
-            "chrs" => self.builtin_chrs(&args),
-            "ords" => self.builtin_ords(&args),
-            "unival" => self.builtin_unival(&args),
-            "univals" => self.builtin_univals(&args),
+            // chrs / ords / unival / univals removed (Category A dedup): native
+            // implementations in src/builtins/functions.rs are authoritative
+            // (chrs routed through native_function_variadic; ords/unival/univals
+            // via native_function_1arg) and reached via call_function_fallback.
             "sprintf" | "zprintf" => {
                 // If the first arg is a Junction, thread through it:
                 // call .Str on each element and concatenate.

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -341,25 +341,9 @@ impl Interpreter {
             .unwrap_or_else(|| Ok(Value::array(Vec::new())))
     }
 
-    // builtin_abs removed (Slice 6.3 dedup): native `abs` in
-    // src/builtins/functions.rs is authoritative (reached via
+    // builtin_abs / builtin_sign removed (Slice 6.3 / Category A dedup): native
+    // `abs` / `sign` in src/builtins/functions.rs are authoritative (reached via
     // call_function_fallback -> native_function).
-
-    pub(super) fn builtin_sign(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let val = args
-            .first()
-            .ok_or_else(|| RuntimeError::new("sign requires an argument"))?;
-        // Delegate to the .sign method via the native_method_0arg path
-        match crate::builtins::methods_0arg::native_method_0arg(
-            val,
-            crate::symbol::Symbol::intern("sign"),
-        ) {
-            Some(result) => result,
-            None => Err(RuntimeError::new(
-                "Cannot call sign on this value".to_string(),
-            )),
-        }
-    }
 }
 
 /// Raku `val()` builtin: convert a string into an allomorphic type.

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -2,106 +2,13 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    // chr / ord removed (Slice 6.3 dedup): native implementations in
-    // src/builtins/functions.rs are authoritative (reached via
-    // call_function_fallback -> native_function). chrs / ords are KEPT: their
-    // native arms are not reachable through the interpreter's
-    // call_function_fallback -> native_function path (multi-arg / array-returning
-    // dispatch differs from the single-arg fallback table).
-    pub(super) fn builtin_chrs(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let mut result = String::new();
-        for arg in args {
-            for item in Self::value_to_list(arg) {
-                if let Value::Int(i) = item
-                    && i >= 0
-                    && (i as u64) <= 0x10ffff
-                    && let Some(ch) = std::char::from_u32(i as u32)
-                {
-                    result.push(ch);
-                    continue;
-                }
-                result.push_str(&item.to_string_value());
-            }
-        }
-        Ok(Value::str(result))
-    }
-
-    pub(super) fn builtin_ords(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        if let Some(val) = args.first() {
-            let codes = val
-                .to_string_value()
-                .chars()
-                .map(|ch| Value::Int(ch as u32 as i64))
-                .collect();
-            return Ok(Value::array(codes));
-        }
-        Ok(Value::array(Vec::new()))
-    }
-
-    pub(super) fn builtin_unival(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let Some(arg) = args.first() else {
-            return Ok(Value::Nil);
-        };
-        // Type objects should throw an error
-        if matches!(arg, Value::Package(_) | Value::CustomType { .. }) {
-            return Err(RuntimeError::new(
-                "Cannot call unival on a type object".to_string(),
-            ));
-        }
-        let ch = match arg {
-            Value::Int(i) if *i >= 0 => {
-                let Some(ch) = char::from_u32(*i as u32) else {
-                    return Ok(Value::Num(f64::NAN));
-                };
-                ch
-            }
-            _ => {
-                let s = arg.to_string_value();
-                let Some(ch) = s.chars().next() else {
-                    return Ok(Value::Nil);
-                };
-                ch
-            }
-        };
-        Self::unival_for_char(ch)
-    }
-
-    pub(super) fn builtin_univals(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let Some(arg) = args.first() else {
-            return Ok(Value::array(Vec::new()));
-        };
-        // Type objects should throw an error
-        if matches!(arg, Value::Package(_) | Value::CustomType { .. }) {
-            return Err(RuntimeError::new(
-                "Cannot call univals on a type object".to_string(),
-            ));
-        }
-        let s = arg.to_string_value();
-        if s.is_empty() {
-            return Ok(Value::array(Vec::new()));
-        }
-        let mut result = Vec::new();
-        for ch in s.chars() {
-            result.push(Self::unival_for_char(ch)?);
-        }
-        Ok(Value::array(result))
-    }
-
-    fn unival_for_char(ch: char) -> Result<Value, RuntimeError> {
-        if let Some((n, d)) = crate::builtins::unicode::unicode_rat_value(ch) {
-            return Ok(crate::value::make_rat(n, d));
-        }
-        if let Some(n) = crate::builtins::unicode::unicode_numeric_int_value(ch) {
-            return Ok(Value::Int(n));
-        }
-        if let Some(n) = crate::builtins::unicode::unicode_decimal_digit_value(ch) {
-            return Ok(Value::Int(n as i64));
-        }
-        Ok(Value::Num(f64::NAN))
-    }
-
-    // flip / lc / uc / tc / trim / chars removed (Slice 6.3 dedup): native
-    // implementations in src/builtins/functions.rs are authoritative.
+    // chr / ord / chrs / ords / unival / univals removed (Slice 6.3 / Category A
+    // dedup): native implementations in src/builtins/functions.rs are
+    // authoritative (reached via call_function_fallback -> native_function).
+    // chrs is routed through native_function_variadic; ords/unival/univals are in
+    // native_function_1arg (unival/univals delegate to the .unival/.univals
+    // method, the single source of truth in methods_0arg/dispatch_core_unicode).
+    // flip / lc / uc / tc / trim / chars removed (Slice 6.3 dedup) — same.
     pub(super) fn builtin_sprintf(
         &self,
         args: &[Value],


### PR DESCRIPTION
## Summary

Completes **Category A** (pure value builtins: delete & fallthrough) of the
VM/Interpreter dedup effort tracked in PLAN.md / `docs/vm-interpreter-dedup.md`.
The first batch (#2714) deleted 9 duplicates; this PR removes the **last 5**, so
no pure-value builtin is implemented twice anymore.

| fn | action |
|----|--------|
| `sign` | pure deletion — `native_function_1arg "sign"` already covers it |
| `ords` | pure deletion — native 1-arg covers; Raku `ords` is 1-arg only |
| `chrs` | route through `native_function_variadic` for every arity + flatten via `value_to_list` (so `chrs(72..74)` works), then delete interpreter copy |
| `unival` / `univals` | add `native_function_1arg` arms delegating to the `.unival`/`.univals` method impl (single source of truth), then delete interpreter copies |

The 3 functions the first batch had **kept** as "fallback-unreachable" are now made
reachable (one native impl) rather than left duplicated — the right resolution of
that gotcha.

## Verification

- VM path **and** EVAL fallback path both match `raku` for: `sign`, `ords`,
  `chrs(72,105)`, `chrs(72..74)`, `chrs((72,73,74))`, `chrs([72,73])`,
  `unival("½")`, `univals("⅓⅔")`, `unival(65)`→NaN, `univals("")`→().
- Whitelisted roast pass: `S32-num/sign.t`, `S32-str/ords.t`,
  `S15-unicode-information/unival.t`, `S29-conversions/ord_and_chr.t`, `S32-str/val.t`.
- `make test` PASS (5274 tests, 0 failed); `cargo clippy -D warnings` clean (no orphaned fns).

Docs: updated `docs/vm-interpreter-dedup.md` (Category A done, gotcha corrected) and
`PLAN.md` (Category A checked off, next pointer → Category B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)