### PR TITLE
refactor(dedup): share min/max fold VM↔interpreter; VM-native .min/.max incl :by (Category B)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -422,7 +422,7 @@ impl Interpreter {
 
     /// Determine the arity of a callable for min/max/minmax by-block dispatch.
     /// Returns 1 for sort-key extractors, 2 for comparators.
-    fn extrema_callable_arity(&self, callable: &Value) -> usize {
+    pub(crate) fn extrema_callable_arity(&self, callable: &Value) -> usize {
         match callable {
             Value::Sub(data) => {
                 if data.params.is_empty() {
@@ -465,6 +465,30 @@ impl Interpreter {
         want_max: bool,
         by: Option<&Value>,
     ) -> Result<Value, RuntimeError> {
+        // Determine if by-block is arity-1 (sort key) or arity-2 (comparator)
+        // before borrowing self mutably for the block-call closure.
+        let by_arity = by.map(|b| self.extrema_callable_arity(b));
+        Self::extrema_from_values_generic(args, want_max, by, by_arity, |c, a| {
+            self.call_sub_value(c.clone(), a, true)
+        })
+    }
+
+    /// Engine-agnostic min/max fold over a flat list of values (the genuine
+    /// Category-B fork is the `:by` block, which each engine supplies through
+    /// `call`). Shared by the interpreter (`extrema_from_values_by`) and the VM
+    /// (`try_native_extrema`) so the flatten / failure / `Any`-filter / fold
+    /// logic exists once. `by_arity` is the resolved arity of `by`
+    /// (`extrema_callable_arity`); 1 = sort-key mapper, otherwise a comparator.
+    pub(crate) fn extrema_from_values_generic<F>(
+        args: &[Value],
+        want_max: bool,
+        by: Option<&Value>,
+        by_arity: Option<usize>,
+        mut call: F,
+    ) -> Result<Value, RuntimeError>
+    where
+        F: FnMut(&Value, Vec<Value>) -> Result<Value, RuntimeError>,
+    {
         if args.is_empty() {
             return Ok(Value::Nil);
         }
@@ -514,24 +538,17 @@ impl Interpreter {
             return Ok(args[0].clone());
         }
 
-        // Determine if by-block is arity-1 (sort key) or arity-2 (comparator)
-        let by_arity = by.map(|b| self.extrema_callable_arity(b));
-
         let mut best = filtered.remove(0);
         for value in filtered {
             let cmp = if let Some(by_block) = by {
                 if by_arity == Some(1) {
                     // Arity-1: use as sort key extractor
-                    let key_a = self.call_sub_value(by_block.clone(), vec![value.clone()], true)?;
-                    let key_b = self.call_sub_value(by_block.clone(), vec![best.clone()], true)?;
+                    let key_a = call(by_block, vec![value.clone()])?;
+                    let key_b = call(by_block, vec![best.clone()])?;
                     crate::runtime::compare_values(&key_a, &key_b)
                 } else {
                     // Arity-2: use as comparator ($^a, $^b) => Order
-                    let result = self.call_sub_value(
-                        by_block.clone(),
-                        vec![value.clone(), best.clone()],
-                        true,
-                    )?;
+                    let result = call(by_block, vec![value.clone(), best.clone()])?;
                     Self::order_to_int(&result)
                 }
             } else {
@@ -580,7 +597,7 @@ impl Interpreter {
     }
 
     /// Extract named adverbs (:k, :v, :kv, :p) from args for min/max.
-    fn extract_extrema_adverbs(args: &[Value]) -> (Option<String>, Vec<Value>) {
+    pub(crate) fn extract_extrema_adverbs(args: &[Value]) -> (Option<String>, Vec<Value>) {
         let mut adverb = None;
         let mut positional = Vec::new();
         let mut by_found = false;
@@ -690,7 +707,7 @@ impl Interpreter {
 
     /// Apply :k, :v, :kv, :p adverbs to min/max result.
     /// These return index/value/both/pair information about the extremum.
-    fn apply_extrema_adverb(
+    pub(crate) fn apply_extrema_adverb(
         &self,
         args: &[Value],
         result: Value,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -49,6 +49,7 @@ mod vm_hyper_race_parallel;
 mod vm_method_dispatch;
 pub(crate) mod vm_misc_ops;
 mod vm_native_dispatch;
+mod vm_native_extrema;
 mod vm_native_map;
 mod vm_native_sort;
 mod vm_native_subst;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -384,6 +384,10 @@ impl VM {
         if let Some(result) = self.try_native_sort(&target, method, &args) {
             return result;
         }
+        // Native `.min` / `.max` over a plain list, including `:by` blocks.
+        if let Some(result) = self.try_native_extrema(&target, method, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -795,6 +799,10 @@ impl VM {
         }
         // Native `.sort` over a plain array with no/simple comparator (lever A).
         if let Some(result) = self.try_native_sort(&target, method, &args) {
+            return result;
+        }
+        // Native `.min` / `.max` over a plain list, including `:by` blocks.
+        if let Some(result) = self.try_native_extrema(&target, method, &args) {
             return result;
         }
         crate::vm::vm_stats::record_method_fallback(method);

--- a/src/vm/vm_native_extrema.rs
+++ b/src/vm/vm_native_extrema.rs
@@ -1,0 +1,106 @@
+//! Native `.min` / `.max` in the VM.
+//!
+//! `@a.min`, `@a.max`, `@a.min(*.abs)`, `@a.max({ $^a <=> $^b })`, and the
+//! `:k`/`:v`/`:kv`/`:p` adverbs over a plain eager list run entirely in the VM.
+//! The `:by` block (the genuine Category-B fork — the only part the pure-native
+//! layer cannot do) is invoked through `vm_call_on_value`, and the fold itself
+//! (flatten / failure handling / `Any`-filter / extremum selection) is the
+//! *single* shared implementation
+//! [`crate::runtime::Interpreter::extrema_from_values_generic`] — the same one
+//! the interpreter's `extrema_from_values_by` uses. This removes the `.min` /
+//! `.max` interpreter fallback for plain collections without adding a second
+//! copy of the fold.
+//!
+//! Hash targets, `Instance`/`Supply`, `.minmax`, and any call with extra
+//! positional arguments fall back to the interpreter's `builtin_min`/`builtin_max`
+//! unchanged.
+
+use super::*;
+use crate::value::{ArrayKind, Value};
+
+impl VM {
+    /// Try to run `target.min(...)` / `target.max(...)` natively. Returns
+    /// `Some(result)` when handled in the VM, `None` to fall back unchanged.
+    ///
+    /// `.min`/`.max` yield a fresh value (no rw-view concern).
+    pub(super) fn try_native_extrema(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let want_max = match method {
+            "min" => false,
+            "max" => true,
+            _ => return None,
+        };
+
+        // Only plain eager lists. Hash sorts by key via a separate path; ranges
+        // expand; everything else (Instance/Supply/Lazy/…) keeps interpreter
+        // semantics -> fall back.
+        match target {
+            Value::Array(_, ArrayKind::Array | ArrayKind::List)
+            | Value::Seq(_)
+            | Value::Slip(_)
+            | Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => {}
+            _ => return None,
+        }
+
+        // Parse args: an optional `:by` callable (a bare Sub/Routine first arg or
+        // a `:by(...)` pair) and an optional `:k`/`:v`/`:kv`/`:p` adverb. Any
+        // other positional argument is an unusual form -> fall back.
+        let mut by: Option<Value> = None;
+        let mut adverb: Option<String> = None;
+        for arg in args {
+            match arg {
+                Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } if by.is_none() => {
+                    by = Some(arg.clone());
+                }
+                Value::Pair(name, val) if name == "by" => by = Some((**val).clone()),
+                Value::ValuePair(key, val) if matches!(key.as_ref(), Value::Str(n) if n.as_str() == "by") =>
+                {
+                    by = Some((**val).clone());
+                }
+                Value::Pair(name, val)
+                    if matches!(name.as_str(), "k" | "v" | "kv" | "p")
+                        && matches!(val.as_ref(), Value::Bool(true)) =>
+                {
+                    adverb = Some(name.clone());
+                }
+                _ => return None,
+            }
+        }
+
+        let by_arity = by
+            .as_ref()
+            .map(|b| self.interpreter.extrema_callable_arity(b));
+
+        // The generic fold flattens a single list argument, so wrap the target.
+        let positional = [target.clone()];
+        let fold = crate::runtime::Interpreter::extrema_from_values_generic(
+            &positional,
+            want_max,
+            by.as_ref(),
+            by_arity,
+            |c, a| self.vm_call_on_value(c.clone(), a, None),
+        );
+        let result = match fold {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+
+        match adverb {
+            None => Some(Ok(result)),
+            Some(adv) => Some(self.interpreter.apply_extrema_adverb(
+                &positional,
+                result,
+                want_max,
+                Some(&adv),
+            )),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Category B (PLAN.md) follow-up to the sort migration (#2727): collapse the duplicate min/max fold and decouple the VM from the interpreter for `.min`/`.max`.

The min/max fold over a flat list (flatten / failure handling / `Any`-filter / extremum selection, plus the `:by` sort-key/comparator block) lived **only** in the interpreter's `extrema_from_values_by`. The VM had no native `.min`/`.max`, so every `@a.min`, `@a.max`, `@a.min(*.abs)`, `@a.max({ $^a <=> $^b })` **fell back to the interpreter**.

This PR extracts the fold into a single engine-agnostic associated function `Interpreter::extrema_from_values_generic`, parameterized over a closure that invokes the `:by` block (the genuine Category-B fork — the only part the pure-native layer can't do). Both engines share it:

- **Interpreter** (`extrema_from_values_by`): thin adapter passing a `call_sub_value` closure.
- **VM** (`try_native_extrema`, new `vm_native_extrema.rs`): handles `.min`/`.max` over plain eager lists (Array/List/Seq/Slip/Range) including `:by` blocks (via `vm_call_on_value`) and `:k`/`:v`/`:kv`/`:p` adverbs (via the shared `apply_extrema_adverb`). Wired into both method-dispatch sites ahead of the interpreter fallback.

Hash targets, `Instance`/`Supply`, `.minmax`, and calls with extra positional args fall back to the interpreter unchanged.

## Verification
- Behavior **identical** to the interpreter path — verified VM vs `EVAL` (interpreter-carrier) parity for `:by` mappers, comparators, `:k`/`:v`/`:kv`/`:p`, and edge cases.
- `interpreter_fallbacks=0` for a min/max-heavy loop (was non-zero before).
- `make test` PASS (601 files, 5274 tests)
- `roast/S32-list/minmax.t` (whitelisted), `roast/S03-operators/minmax.t`, `t/minmax-failure-and-hash.t`, `t/squish-minmax.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)