### PR TITLE
refactor(dedup): share minmax fold VM↔interpreter; VM-native .minmax incl :by (Category B)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -880,10 +880,32 @@ impl Interpreter {
             .cloned()
             .collect();
 
+        // Resolve by-block arity before borrowing self mutably for the closure.
+        let by_arity = by.as_ref().map(|b| self.extrema_callable_arity(b));
+        Self::minmax_from_values_generic(&positional, by.as_ref(), by_arity, |c, a| {
+            self.call_sub_value(c.clone(), a, true)
+        })
+    }
+
+    /// Engine-agnostic `minmax` over a list: collect candidates, fold the min and
+    /// the max (using the `:by` block — the genuine Category-B fork — through
+    /// `call`), and build the inclusive `min..max` range. Shared by the
+    /// interpreter (`builtin_minmax`) and the VM (`try_native_minmax`) so the
+    /// candidate / fold / range-build logic exists once. `by_arity` is the
+    /// resolved arity of `by` (1 = sort-key mapper, otherwise a comparator).
+    pub(crate) fn minmax_from_values_generic<F>(
+        positional: &[Value],
+        by: Option<&Value>,
+        by_arity: Option<usize>,
+        mut call: F,
+    ) -> Result<Value, RuntimeError>
+    where
+        F: FnMut(&Value, Vec<Value>) -> Result<Value, RuntimeError>,
+    {
         let mut candidates = Vec::new();
         if by.is_some() {
             // When a comparator is provided, enumerate ranges fully
-            for arg in &positional {
+            for arg in positional {
                 match arg {
                     Value::Range(..)
                     | Value::RangeExcl(..)
@@ -900,7 +922,7 @@ impl Interpreter {
                 }
             }
         } else {
-            for arg in &positional {
+            for arg in positional {
                 Self::collect_minmax_candidates(arg, &mut candidates);
             }
         }
@@ -912,35 +934,25 @@ impl Interpreter {
             ));
         }
 
-        if let Some(by_block) = &by {
-            let by_arity = self.extrema_callable_arity(by_block);
+        if let Some(by_block) = by {
+            let by_arity = by_arity.unwrap_or(2);
             let mut min_value = candidates[0].clone();
             let mut max_value = candidates[0].clone();
             for value in candidates.iter().skip(1) {
                 let cmp_min = if by_arity == 1 {
-                    let key_a = self.call_sub_value(by_block.clone(), vec![value.clone()], true)?;
-                    let key_b =
-                        self.call_sub_value(by_block.clone(), vec![min_value.clone()], true)?;
+                    let key_a = call(by_block, vec![value.clone()])?;
+                    let key_b = call(by_block, vec![min_value.clone()])?;
                     crate::runtime::compare_values(&key_a, &key_b)
                 } else {
-                    let result = self.call_sub_value(
-                        by_block.clone(),
-                        vec![value.clone(), min_value.clone()],
-                        true,
-                    )?;
+                    let result = call(by_block, vec![value.clone(), min_value.clone()])?;
                     Self::order_to_int(&result)
                 };
                 let cmp_max = if by_arity == 1 {
-                    let key_a = self.call_sub_value(by_block.clone(), vec![value.clone()], true)?;
-                    let key_b =
-                        self.call_sub_value(by_block.clone(), vec![max_value.clone()], true)?;
+                    let key_a = call(by_block, vec![value.clone()])?;
+                    let key_b = call(by_block, vec![max_value.clone()])?;
                     crate::runtime::compare_values(&key_a, &key_b)
                 } else {
-                    let result = self.call_sub_value(
-                        by_block.clone(),
-                        vec![value.clone(), max_value.clone()],
-                        true,
-                    )?;
+                    let result = call(by_block, vec![value.clone(), max_value.clone()])?;
                     Self::order_to_int(&result)
                 };
                 if cmp_min < 0 {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -388,6 +388,10 @@ impl VM {
         if let Some(result) = self.try_native_extrema(&target, method, &args) {
             return result;
         }
+        // Native `.minmax` over a plain list, including `:by` blocks.
+        if let Some(result) = self.try_native_minmax(&target, method, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -803,6 +807,10 @@ impl VM {
         }
         // Native `.min` / `.max` over a plain list, including `:by` blocks.
         if let Some(result) = self.try_native_extrema(&target, method, &args) {
+            return result;
+        }
+        // Native `.minmax` over a plain list, including `:by` blocks.
+        if let Some(result) = self.try_native_minmax(&target, method, &args) {
             return result;
         }
         crate::vm::vm_stats::record_method_fallback(method);

--- a/src/vm/vm_native_extrema.rs
+++ b/src/vm/vm_native_extrema.rs
@@ -1,19 +1,18 @@
-//! Native `.min` / `.max` in the VM.
+//! Native `.min` / `.max` / `.minmax` in the VM.
 //!
-//! `@a.min`, `@a.max`, `@a.min(*.abs)`, `@a.max({ $^a <=> $^b })`, and the
-//! `:k`/`:v`/`:kv`/`:p` adverbs over a plain eager list run entirely in the VM.
-//! The `:by` block (the genuine Category-B fork — the only part the pure-native
-//! layer cannot do) is invoked through `vm_call_on_value`, and the fold itself
-//! (flatten / failure handling / `Any`-filter / extremum selection) is the
-//! *single* shared implementation
-//! [`crate::runtime::Interpreter::extrema_from_values_generic`] — the same one
-//! the interpreter's `extrema_from_values_by` uses. This removes the `.min` /
-//! `.max` interpreter fallback for plain collections without adding a second
-//! copy of the fold.
+//! `@a.min`, `@a.max`, `@a.minmax`, their `:by` block forms (`*.abs`,
+//! `{ $^a <=> $^b }`), and the `:k`/`:v`/`:kv`/`:p` adverbs (min/max only) over a
+//! plain eager list run entirely in the VM. The `:by` block (the genuine
+//! Category-B fork — the only part the pure-native layer cannot do) is invoked
+//! through `vm_call_on_value`, and the folds themselves are the *single* shared
+//! implementations [`crate::runtime::Interpreter::extrema_from_values_generic`]
+//! and [`crate::runtime::Interpreter::minmax_from_values_generic`] — the same
+//! ones the interpreter's `extrema_from_values_by` / `builtin_minmax` use. This
+//! removes the `.min` / `.max` / `.minmax` interpreter fallback for plain
+//! collections without adding a second copy of the fold.
 //!
-//! Hash targets, `Instance`/`Supply`, `.minmax`, and any call with extra
-//! positional arguments fall back to the interpreter's `builtin_min`/`builtin_max`
-//! unchanged.
+//! Hash targets, `Instance`/`Supply`, and any call with extra positional
+//! arguments fall back to the interpreter unchanged.
 
 use super::*;
 use crate::value::{ArrayKind, Value};
@@ -102,5 +101,56 @@ impl VM {
                 Some(&adv),
             )),
         }
+    }
+
+    /// Try to run `target.minmax(...)` natively. Returns `Some(result)` when
+    /// handled in the VM, `None` to fall back unchanged.
+    pub(super) fn try_native_minmax(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "minmax" {
+            return None;
+        }
+        match target {
+            Value::Array(_, ArrayKind::Array | ArrayKind::List)
+            | Value::Seq(_)
+            | Value::Slip(_)
+            | Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => {}
+            _ => return None,
+        }
+
+        // `.minmax` takes only an optional `:by` callable (no `:k`/etc. adverbs).
+        let mut by: Option<Value> = None;
+        for arg in args {
+            match arg {
+                Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } if by.is_none() => {
+                    by = Some(arg.clone());
+                }
+                Value::Pair(name, val) if name == "by" => by = Some((**val).clone()),
+                Value::ValuePair(key, val) if matches!(key.as_ref(), Value::Str(n) if n.as_str() == "by") =>
+                {
+                    by = Some((**val).clone());
+                }
+                _ => return None,
+            }
+        }
+
+        let by_arity = by
+            .as_ref()
+            .map(|b| self.interpreter.extrema_callable_arity(b));
+        let positional = [target.clone()];
+        Some(crate::runtime::Interpreter::minmax_from_values_generic(
+            &positional,
+            by.as_ref(),
+            by_arity,
+            |c, a| self.vm_call_on_value(c.clone(), a, None),
+        ))
     }
 }


### PR DESCRIPTION
## Summary

Re-submission to **main** of the minmax migration. (The earlier #2729 was stacked on #2728's branch and its content did not reach `main` when #2728 squash-merged.)

Mirrors the min/max migration (#2728) for `minmax`. The minmax fold (candidate collection, dual min+max fold with the `:by` block, inclusive `min..max` range construction) lived **only** in the interpreter's `builtin_minmax`; the VM fell back for every `.minmax`.

Extract it into a single engine-agnostic associated function `Interpreter::minmax_from_values_generic`, parameterized over a closure that invokes the `:by` block. `builtin_minmax` becomes a thin adapter; the VM's new `try_native_minmax` passes a `vm_call_on_value` closure and is wired into both method-dispatch sites.

Hash/Instance/Supply targets and extra-positional forms fall back unchanged.

## Verification
- Behavior **identical** to the interpreter path AND to `raku` — plain, `*.abs` mapper, `{ $^a <=> $^b }` comparator, Range, empty.
- `make test` PASS; `roast/S32-list/minmax.t`, `S03-operators/minmax.t`, `S17-supply/minmax.t`, `t/minmax-failure-and-hash.t`, `t/squish-minmax.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)