### PR TITLE
refactor(dedup): share .first matcher scan VM↔interpreter; VM-native .first (Category B)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -202,7 +202,7 @@ mod regex_parse;
 mod registration;
 mod registration_class;
 mod registration_sub;
-mod resolution;
+pub(crate) mod resolution;
 mod run;
 mod seq_helpers;
 mod sequence;

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -2674,32 +2674,65 @@ impl Interpreter {
         list_items: &[Value],
         from_end: bool,
     ) -> Result<Option<(usize, Value)>, RuntimeError> {
-        if list_items.is_empty() {
-            return Ok(None);
-        }
-        let matcher = func;
-        let len = list_items.len();
-        for idx in 0..len {
-            let actual_idx = if from_end { len - 1 - idx } else { idx };
-            let item = list_items[actual_idx].clone();
-            let matched = if let Some(pattern) = &matcher {
-                if matches!(pattern, Value::Sub(_)) {
-                    // Pass the element positionally: a Hash-sourced `Value::Pair`
-                    // would otherwise bind as a named arg, leaving the block with
-                    // zero positionals (`%h.first({ .value > 1 })`).
-                    let call_item = crate::runtime::utils::pair_as_positional(&item);
-                    self.call_sub_value(pattern.clone(), vec![call_item], true)?
-                        .truthy()
-                } else {
-                    self.smart_match(&item, pattern)
-                }
-            } else {
-                true
-            };
-            if matched {
-                return Ok(Some((actual_idx, item)));
-            }
-        }
-        Ok(None)
+        let mut matcher = InterpFirstMatcher(self);
+        find_first_match_generic(&mut matcher, func.as_ref(), list_items, from_end)
     }
+}
+
+/// Engine-agnostic matcher for `.first` / `first`: decides whether a single
+/// element matches the pattern. The only engine-specific part is invoking a
+/// `Sub` matcher block (the genuine Category-B fork); `smart_match` for non-block
+/// patterns is the interpreter's single shared implementation. Implemented for
+/// both the interpreter ([`InterpFirstMatcher`]) and the VM (`VmFirstMatcher`),
+/// so the iteration / `:end` / `pair_as_positional` logic lives once in
+/// [`find_first_match_generic`].
+pub(crate) trait FirstMatcher {
+    fn item_matches(&mut self, pattern: &Value, item: &Value) -> Result<bool, RuntimeError>;
+}
+
+/// [`FirstMatcher`] backed by the tree-walking interpreter.
+pub(crate) struct InterpFirstMatcher<'a>(pub(crate) &'a mut Interpreter);
+
+impl FirstMatcher for InterpFirstMatcher<'_> {
+    fn item_matches(&mut self, pattern: &Value, item: &Value) -> Result<bool, RuntimeError> {
+        if matches!(pattern, Value::Sub(_)) {
+            // Pass the element positionally: a Hash-sourced `Value::Pair` would
+            // otherwise bind as a named arg, leaving the block with zero
+            // positionals (`%h.first({ .value > 1 })`).
+            let call_item = crate::runtime::utils::pair_as_positional(item);
+            Ok(self
+                .0
+                .call_sub_value(pattern.clone(), vec![call_item], true)?
+                .truthy())
+        } else {
+            Ok(self.0.smart_match(item, pattern))
+        }
+    }
+}
+
+/// Shared `.first` / `first` scan: return the first (or, with `from_end`, last)
+/// `(index, value)` whose element matches `pattern` (or any element when
+/// `pattern` is `None`). Engines supply matching through `matcher`.
+pub(crate) fn find_first_match_generic(
+    matcher: &mut dyn FirstMatcher,
+    pattern: Option<&Value>,
+    list_items: &[Value],
+    from_end: bool,
+) -> Result<Option<(usize, Value)>, RuntimeError> {
+    if list_items.is_empty() {
+        return Ok(None);
+    }
+    let len = list_items.len();
+    for idx in 0..len {
+        let actual_idx = if from_end { len - 1 - idx } else { idx };
+        let item = list_items[actual_idx].clone();
+        let matched = match pattern {
+            Some(p) => matcher.item_matches(p, &item)?,
+            None => true,
+        };
+        if matched {
+            return Ok(Some((actual_idx, item)));
+        }
+    }
+    Ok(None)
 }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -33,7 +33,7 @@ impl Interpreter {
         }
     }
 
-    pub(in crate::runtime) fn smart_match(&mut self, left: &Value, right: &Value) -> bool {
+    pub(crate) fn smart_match(&mut self, left: &Value, right: &Value) -> bool {
         match (left, right) {
             // Whatever on RHS always matches (ACCEPTS returns True for any value)
             (_, Value::Whatever) => true,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -50,6 +50,7 @@ mod vm_method_dispatch;
 pub(crate) mod vm_misc_ops;
 mod vm_native_dispatch;
 mod vm_native_extrema;
+mod vm_native_first;
 mod vm_native_map;
 mod vm_native_sort;
 mod vm_native_subst;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -392,6 +392,10 @@ impl VM {
         if let Some(result) = self.try_native_minmax(&target, method, &args) {
             return result;
         }
+        // Native `.first` over a plain list (no-adverb forms), including blocks.
+        if let Some(result) = self.try_native_first(&target, method, &args) {
+            return result;
+        }
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -811,6 +815,10 @@ impl VM {
         }
         // Native `.minmax` over a plain list, including `:by` blocks.
         if let Some(result) = self.try_native_minmax(&target, method, &args) {
+            return result;
+        }
+        // Native `.first` over a plain list (no-adverb forms), including blocks.
+        if let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
         crate::vm::vm_stats::record_method_fallback(method);

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -1,0 +1,87 @@
+//! Native `.first` in the VM (no-adverb forms).
+//!
+//! `@a.first`, `@a.first({ .foo })`, `@a.first(* > 3)`, `@a.first(/rx/)`,
+//! `%h.first({ .value > 1 })` run entirely in the VM. The `Sub` matcher block
+//! (the genuine Category-B fork) is invoked through `vm_call_on_value`; non-block
+//! patterns use the interpreter's single shared `smart_match`. The scan itself
+//! (iteration, `pair_as_positional`) is the shared
+//! [`crate::runtime::resolution::find_first_match_generic`] — the same one the
+//! interpreter's `find_first_match_over_items` uses.
+//!
+//! Anything with an adverb (`:k`/`:kv`/`:p`/`:v`/`:end`), a `Bool` matcher (which
+//! must raise `X::Match::Bool`), or a non-list target (`Supply`/`Instance`/…)
+//! falls back to the interpreter's `builtin_first` / method dispatch unchanged.
+
+use super::*;
+use crate::runtime::resolution::{FirstMatcher, find_first_match_generic};
+use crate::runtime::utils::pair_as_positional;
+use crate::value::{ArrayKind, Value};
+
+/// [`FirstMatcher`] backed by the bytecode VM.
+struct VmFirstMatcher<'a>(&'a mut VM);
+
+impl FirstMatcher for VmFirstMatcher<'_> {
+    fn item_matches(&mut self, pattern: &Value, item: &Value) -> Result<bool, RuntimeError> {
+        if matches!(pattern, Value::Sub(_)) {
+            let call_item = pair_as_positional(item);
+            Ok(self
+                .0
+                .vm_call_on_value(pattern.clone(), vec![call_item], None)?
+                .truthy())
+        } else {
+            Ok(self.0.interpreter.smart_match(item, pattern))
+        }
+    }
+}
+
+impl VM {
+    /// Try to run `target.first(...)` natively. Returns `Some(result)` when
+    /// handled in the VM, `None` to fall back unchanged.
+    pub(super) fn try_native_first(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "first" {
+            return None;
+        }
+
+        // Only plain list-like targets; `Supply`/`Instance`/… keep their own
+        // semantics -> fall back.
+        match target {
+            Value::Array(_, ArrayKind::Array | ArrayKind::List)
+            | Value::Seq(_)
+            | Value::Slip(_)
+            | Value::Hash(_)
+            | Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => {}
+            _ => return None,
+        }
+
+        // At most one positional matcher and no adverbs. Any `Pair` arg is an
+        // adverb (`:k`/`:v`/`:end`/…) handled only by the interpreter.
+        let mut func: Option<Value> = None;
+        for arg in args {
+            match arg {
+                Value::Pair(..) => return None,
+                // `Bool` matcher must raise X::Match::Bool -> let the interpreter
+                // produce the typed exception.
+                Value::Bool(_) => return None,
+                _ if func.is_none() => func = Some(arg.clone()),
+                _ => return None,
+            }
+        }
+
+        let items = crate::runtime::utils::value_to_list(target);
+        let mut matcher = VmFirstMatcher(self);
+        match find_first_match_generic(&mut matcher, func.as_ref(), &items, false) {
+            Ok(Some((_, value))) => Some(Ok(value)),
+            Ok(None) => Some(Ok(Value::Nil)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Category B continuation: collapse the duplicate `.first`/`first` matcher scan and run `.first` natively in the VM.

The matcher scan lived **only** in the interpreter's `find_first_match_over_items` (`call_sub_value` for a `Sub` block, `smart_match` otherwise), so every `@a.first({...})`, `@a.first(* > 3)`, `@a.first(/rx/)`, `%h.first({...})` fell back to the interpreter.

Extract the scan behind a `FirstMatcher` trait (the one engine-specific bit is invoking a `Sub` matcher block; `smart_match` stays the interpreter's single shared impl) + a free `find_first_match_generic` owning the iteration / `:end` / `pair_as_positional` logic. Both engines share it:

- **Interpreter** (`InterpFirstMatcher`): thin adapter.
- **VM** (`try_native_first`, new `vm_native_first.rs`, `VmFirstMatcher`): handles no-adverb `.first` over list-like targets (Array/List/Seq/Slip/Hash/Range), block via `vm_call_on_value`, non-block via `interpreter.smart_match`. Wired into both method-dispatch sites.

Adverbs (`:k`/`:kv`/`:p`/`:v`/`:end`), a `Bool` matcher (→ `X::Match::Bool`), and `Supply`/`Instance` targets fall back unchanged.

## Verification
- Behavior **identical** to the interpreter path AND `raku` — block/Whatever/regex/Hash matchers, no-match, `:end`.
- `interpreter_fallbacks=0` for a `.first`-heavy loop.
- `make test` PASS; `roast/S32-list/first*.t`, `t/first-p-adverb.t`, `t/hash-first-positional.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)