### PR TITLE
fix+dedup(elems): define elems($x) as $x.elems; delete drifted second copy (Category B)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -774,21 +774,12 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 })))
             }
         }
-        "elems" => match arg {
-            Value::Array(items, ..) => Some(Ok(Value::Int(items.len() as i64))),
-            Value::Hash(items) => Some(Ok(Value::Int(items.len() as i64))),
-            Value::Str(s) => Some(Ok(Value::Int(s.chars().count() as i64))),
-            Value::LazyList(_) => None,
-            Value::Instance {
-                class_name,
-                attributes,
-                ..
-            } if class_name == "Stash" => match attributes.get("symbols") {
-                Some(Value::Hash(map)) => Some(Ok(Value::Int(map.len() as i64))),
-                _ => Some(Ok(Value::Int(0))),
-            },
-            _ => Some(Ok(Value::Int(1))),
-        },
+        // `elems($x)` is defined as `$x.elems`; delegate to the single `.elems`
+        // method impl instead of a drifting second copy. The inline version here
+        // wrongly counted Str chars (raku: a Str is 1 element) and missed Seq.
+        // `native_method_0arg` returns `None` for the cases the method leaves to
+        // the interpreter (e.g. gather-sourced lazy lists), which fall through.
+        "elems" => super::methods_0arg::native_method_0arg(arg, Symbol::intern("elems")),
         "reverse" => {
             // LazyIoLines needs the interpreter to materialize — fall through
             if matches!(arg, Value::LazyIoLines { .. }) {

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -69,14 +69,12 @@ impl Interpreter {
             err.exception = Some(Box::new(ex));
             return Err(err);
         }
-        let val = &args[0];
-        Ok(match val {
-            Value::Array(items, ..) => Value::Int(items.len() as i64),
-            Value::LazyList(list) => Value::Int(self.force_lazy_list(list)?.len() as i64),
-            Value::Hash(items) => Value::Int(items.len() as i64),
-            Value::Str(s) => Value::Int(s.chars().count() as i64),
-            _ => Value::Int(1),
-        })
+        // `elems($x)` is defined as `$x.elems`; delegate to the single `.elems`
+        // method impl rather than keep a second copy that drifted (it counted Str
+        // chars instead of 1, missed Seq, and force-counted lazy lists that raku
+        // rejects with X::Cannot::Lazy). The method dispatch still forces
+        // gather-sourced lazy lists via its interpreter slow path.
+        self.call_method_with_values(args[0].clone(), "elems", vec![])
     }
 
     pub(super) fn builtin_set(&self, args: &[Value]) -> Result<Value, RuntimeError> {


### PR DESCRIPTION
## Summary

First of the Category B **lazy-forks**. `elems` had two implementations — the pure `native_function` arm and the interpreter's `builtin_elems` — that had drifted from the (correct) `.elems` method and from `raku`:

| call | before (mutsu) | raku / `.elems` method |
|------|------|------|
| `elems("hello")` | **5** (char count) | **1** (a Str is one element) |
| `elems((1,2,3).Seq)` | **1** | **3** |
| `elems(lazy)` | force-counted | **X::Cannot::Lazy** |
| `end("hello")` | **4** | **0** |

`elems($x)` is defined as `$x.elems`, so both copies now **delegate to the single `.elems` method impl**:
- native function arm → `native_method_0arg(.., "elems")`
- `builtin_elems` → `call_method_with_values(.., "elems", ..)` (still forces gather-sourced lazy lists via the method's interpreter slow path)

This removes the duplicate and fixes the bugs (the drift the dedup doctrine warns about — found while collapsing the copies).

## Verification
- VM + EVAL + `raku` agree on all cases above.
- `make test` PASS; `roast/S32-list/end.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)