### PR TITLE
fix+dedup(flat): single shared flat helper; fix nested-array over-flattening (Category B)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -73,7 +73,13 @@ fn is_infinite_range(value: &Value) -> bool {
 /// (their elements are exposed). Elements coming from a List/Seq context
 /// pass `true`; elements coming from inside an Array pass `false`
 /// (because `[...]` itemizes its contents in Raku).
-fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
+/// Flatten `v` into `out`. Single shared `flat` helper for both the pure
+/// `native_function("flat", ..)` path and the interpreter's `builtin_flat`
+/// (which wraps its args in a `List` and calls this). `flatten_arrays`
+/// distinguishes List context (flatten `[...]` children one level) from Array
+/// context (preserve nested `[...]`), matching raku — the interpreter's old
+/// `flat_into` lacked this and over-flattened nested arrays in `flat(a, b, c)`.
+pub(crate) fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
     match v {
         // Lists, Seqs, and Slips are always flattened; their children
         // inherit flatten_arrays=true since Lists don't itemize.
@@ -91,6 +97,17 @@ fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
         }
         // Itemized containers — don't descend
         Value::Array(_, kind) if kind.is_itemized() => out.push(v.clone()),
+        // Already-realized lazy lists flatten their cached items; an un-forced
+        // lazy list stays opaque (we don't force here).
+        Value::LazyList(ll) => {
+            if let Some(cached) = ll.cache.lock().unwrap().clone() {
+                for item in &cached {
+                    flat_val(item, out, flatten_arrays);
+                }
+            } else {
+                out.push(v.clone());
+            }
+        }
         Value::Range(..)
         | Value::RangeExcl(..)
         | Value::RangeExclStart(..)

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -77,6 +77,7 @@ pub(crate) fn chomp_one(s: &str) -> String {
 pub(crate) use arith::{
     arith_add, arith_div, arith_mod, arith_mul, arith_negate, arith_pow, arith_sub,
 };
+pub(crate) use functions::flat_val;
 pub(crate) use functions::native_function;
 pub(crate) use methods_0arg::native_method_0arg;
 pub(crate) use methods_narg::{native_method_1arg, native_method_2arg};

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1166,41 +1166,18 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_flat(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // `flat(a, b, c)` flattens the argument *list*, so wrap the args in a
+        // `List` and run the single shared `flat` helper (the same one the pure
+        // `native_function("flat", ..)` path uses). The previous `flat_into`
+        // copy unconditionally flattened nested `[...]`, which over-flattened
+        // `flat(1, [2, [3, 4]], (5, 6))` (raku keeps the inner `[3 4]`).
+        let list = Value::Array(
+            std::sync::Arc::new(args.to_vec()),
+            crate::value::ArrayKind::List,
+        );
         let mut result = Vec::new();
-        for arg in args {
-            Self::flat_into(arg, &mut result);
-        }
+        crate::builtins::flat_val(&list, &mut result, true);
         Ok(Value::Seq(std::sync::Arc::new(result)))
-    }
-
-    pub(crate) fn flat_into(val: &Value, out: &mut Vec<Value>) {
-        match val {
-            Value::Array(items, kind) if kind.is_itemized() => {
-                out.push(Value::Array(std::sync::Arc::clone(items), *kind))
-            }
-            Value::Array(items, ..) | Value::Slip(items) | Value::Seq(items) => {
-                for item in items.iter() {
-                    Self::flat_into(item, out);
-                }
-            }
-            Value::LazyList(ll) => {
-                if let Some(cached) = ll.cache.lock().unwrap().clone() {
-                    for item in &cached {
-                        Self::flat_into(item, out);
-                    }
-                } else {
-                    out.push(val.clone());
-                }
-            }
-            Value::Range(..)
-            | Value::RangeExcl(..)
-            | Value::RangeExclStart(..)
-            | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => {
-                out.extend(Self::value_to_list(val));
-            }
-            other => out.push(other.clone()),
-        }
     }
 
     pub(super) fn builtin_slip(&self, args: &[Value]) -> Result<Value, RuntimeError> {


### PR DESCRIPTION
## Summary

Category B **lazy-fork**. `flat` had two flatten helpers — the pure `flat_val` (`native_function`, single arg) and the interpreter's `flat_into` (`builtin_flat`, multi arg) — with **different nesting semantics**. The dispatch (single→`flat_val`, multi→`flat_into`) masked the divergence, but `flat_into` lacked `flat_val`'s List-vs-Array distinction and over-flattened nested arrays:

```
flat(1, [2, [3, 4]], (5, 6))   # mutsu: (1 2 3 4 5 6)   raku: (1 2 [3 4] 5 6)
```

Unify on the single `flat_val` (now `pub(crate)`, with `flat_into`'s LazyList-cache arm folded in). `builtin_flat` wraps its args in a `List` and calls it — matching raku's "flatten the argument list" semantics — and `flat_into` is deleted. Fixes the over-flatten bug and removes the duplicate (another drift found while collapsing copies).

## Verification
- All 15 `flat` forms (single/multi/nested/itemized/Range/Seq/lazy) match `raku`, on VM + EVAL.
- `make test` PASS; `roast/S32-list/flat.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)