### PR TITLE
fix+dedup(join): single shared join_flat helper; fix join(sep, Range) ignoring separator (Category B)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -119,6 +119,34 @@ pub(crate) fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
     }
 }
 
+/// Join `rest` with `sep`, flattening with `flat`/slurpy semantics (the single
+/// shared `join` body for both `native_function("join", ..)` and the
+/// interpreter's `builtin_join`). Returns `None` when an un-realized lazy list is
+/// present, so the interpreter can force it and retry. Top-level shaped arrays
+/// join over their leaves.
+pub(crate) fn join_flat(sep: &str, rest: &[Value]) -> Option<String> {
+    let mut items = Vec::new();
+    for v in rest {
+        if let Value::LazyList(ll) = v
+            && ll.cache.lock().unwrap().is_none()
+        {
+            return None; // needs interpreter forcing
+        }
+        if crate::runtime::utils::is_shaped_array(v) {
+            items.extend(crate::runtime::utils::shaped_array_leaves(v));
+        } else {
+            flat_val(v, &mut items, true);
+        }
+    }
+    Some(
+        items
+            .iter()
+            .map(|v| v.to_str_context())
+            .collect::<Vec<_>>()
+            .join(sep),
+    )
+}
+
 // ── Built-in function dispatch ───────────────────────────────────────
 /// Try to dispatch a built-in function call.
 /// Native (interpreter-free) `sprintf` / `zprintf`.
@@ -1115,44 +1143,12 @@ fn native_function_2arg(
             let result: String = s.chars().take(keep).collect();
             Some(Ok(Value::str(result)))
         }
-        "join" => {
-            let sep = arg1.to_string_value();
-            if crate::runtime::utils::is_shaped_array(arg2) {
-                let leaves = crate::runtime::utils::shaped_array_leaves(arg2);
-                let joined = leaves
-                    .iter()
-                    .map(|v| v.to_string_value())
-                    .collect::<Vec<_>>()
-                    .join(&sep);
-                return Some(Ok(Value::str(joined)));
-            }
-            match arg2 {
-                Value::Array(items, kind) if !kind.is_itemized() => {
-                    let joined = items
-                        .iter()
-                        .map(|v| v.to_str_context())
-                        .collect::<Vec<_>>()
-                        .join(&sep);
-                    Some(Ok(Value::str(joined)))
-                }
-                Value::Seq(items) | Value::Slip(items) => {
-                    let joined = items
-                        .iter()
-                        .map(|v| v.to_str_context())
-                        .collect::<Vec<_>>()
-                        .join(&sep);
-                    Some(Ok(Value::str(joined)))
-                }
-                Value::LazyList(_) => {
-                    // Fall through to runtime to force the lazy list
-                    None
-                }
-                _ => {
-                    // Treat as single-element list (includes itemized arrays)
-                    Some(Ok(Value::str(arg2.to_str_context())))
-                }
-            }
-        }
+        // `join(sep, list)`: flatten `list` (slurpy/`flat` semantics) and join.
+        // The previous inline version ignored the separator for a `Range` arg
+        // (`join("-", 1..4)` -> "1 2 3 4"); the shared `join_flat` fixes it.
+        // Returns `None` for an un-realized lazy list -> the interpreter forces it.
+        "join" => join_flat(&arg1.to_string_value(), std::slice::from_ref(arg2))
+            .map(|joined| Ok(Value::str(joined))),
         "rotate" => {
             if let Some(shape) = crate::runtime::utils::shaped_array_shape(arg1) {
                 if shape.len() > 1 {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -78,6 +78,7 @@ pub(crate) use arith::{
     arith_add, arith_div, arith_mod, arith_mul, arith_negate, arith_pow, arith_sub,
 };
 pub(crate) use functions::flat_val;
+pub(crate) use functions::join_flat;
 pub(crate) use functions::native_function;
 pub(crate) use methods_0arg::native_method_0arg;
 pub(crate) use methods_narg::{native_method_1arg, native_method_2arg};

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1074,7 +1074,9 @@ impl Interpreter {
         // path uses. The previous inline copy here drifted from native (it had a
         // separate Range/Seq/itemized walk).
         let mut rest = Vec::with_capacity(args.len().saturating_sub(1));
-        for v in &args[1..] {
+        // `args.get(1..)` (not `&args[1..]`) so bare `join()` / `join(sep)` with no
+        // list args doesn't panic on an empty slice.
+        for v in args.get(1..).unwrap_or(&[]) {
             if let Value::LazyList(list) = v {
                 rest.push(Value::array(self.force_lazy_list(list)?));
             } else {

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1068,78 +1068,22 @@ impl Interpreter {
             .first()
             .map(|v| v.to_string_value())
             .unwrap_or_default();
-        if args.len() == 2
-            && let Some(Value::Array(items, kind)) = args.get(1)
-        {
-            if kind.is_itemized() {
-                // Itemized array: treat as single item, stringify
-                return Ok(Value::str(args[1].to_string_value()));
+        // `join(sep, *@rest)` joins the flattened rest. Force any lazy lists
+        // (join is eager over the flattened list) then run the single shared
+        // `join_flat` helper — the same one the pure `native_function("join", ..)`
+        // path uses. The previous inline copy here drifted from native (it had a
+        // separate Range/Seq/itemized walk).
+        let mut rest = Vec::with_capacity(args.len().saturating_sub(1));
+        for v in &args[1..] {
+            if let Value::LazyList(list) = v {
+                rest.push(Value::array(self.force_lazy_list(list)?));
+            } else {
+                rest.push(v.clone());
             }
-            let joined = items
-                .iter()
-                .map(|v| v.to_str_context())
-                .collect::<Vec<_>>()
-                .join(&sep);
-            return Ok(Value::str(joined));
         }
-        // Force LazyList before joining
-        if args.len() == 2
-            && let Some(Value::LazyList(list)) = args.get(1)
-        {
-            let items = self.force_lazy_list(list)?;
-            let joined = items
-                .iter()
-                .map(|v| v.to_str_context())
-                .collect::<Vec<_>>()
-                .join(&sep);
-            return Ok(Value::str(joined));
-        }
-        // Multi-arg: join(sep, item1, item2, ...)
-        // Flatten ranges and lists to their elements
-        if args.len() > 1 {
-            let mut parts = Vec::new();
-            for v in &args[1..] {
-                match v {
-                    Value::Range(start, end) => {
-                        for i in *start..=*end {
-                            parts.push(Value::Int(i).to_string_value());
-                        }
-                    }
-                    Value::RangeExcl(start, end) => {
-                        for i in *start..*end {
-                            parts.push(Value::Int(i).to_string_value());
-                        }
-                    }
-                    Value::GenericRange { .. } => {
-                        for item in crate::runtime::utils::value_to_list(v) {
-                            parts.push(item.to_str_context());
-                        }
-                    }
-                    Value::Array(items, kind) if !kind.is_itemized() => {
-                        for item in items.iter() {
-                            parts.push(item.to_str_context());
-                        }
-                    }
-                    Value::Seq(items) | Value::Slip(items) => {
-                        for item in items.as_ref() {
-                            parts.push(item.to_str_context());
-                        }
-                    }
-                    Value::LazyList(list) => {
-                        let items = self.force_lazy_list(list)?;
-                        for item in items.iter() {
-                            parts.push(item.to_str_context());
-                        }
-                    }
-                    _ => {
-                        parts.push(v.to_str_context());
-                    }
-                }
-            }
-            let joined = parts.join(&sep);
-            return Ok(Value::str(joined));
-        }
-        Ok(Value::str(String::new()))
+        Ok(Value::str(
+            crate::builtins::join_flat(&sep, &rest).unwrap_or_default(),
+        ))
     }
 
     pub(super) fn builtin_list(&self, args: &[Value]) -> Result<Value, RuntimeError> {


### PR DESCRIPTION
## Summary

Category B **lazy-fork**. `join` had two implementations — the pure 2-arg `native_function` arm and the interpreter's variadic `builtin_join` — with separate flatten walks that drifted. The native 2-arg arm fell through to a single-element `to_str_context` for a `Range`, **ignoring the separator**:

```
join("-", 1..4)   # mutsu: "1 2 3 4"   raku: "1-2-3-4"
```

Unify on a single `join_flat(sep, rest)` helper (built on the shared `flat_val`, with raku slurpy semantics + top-level shaped-array leaves + lazy-needs-forcing signalled via `None`). The native arm calls it directly; `builtin_join` forces any lazy args then calls it. The duplicate variadic walk is deleted and the Range bug fixed.

## Verification
- All 15 `join` forms (multi/list/Range/Seq/itemized/shaped/nested/lazy) match `raku`, on VM + EVAL.
- `make test` PASS; roast S32-str join tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)