### PR TITLE
refactor(container): Phase 0 PR1 — canonical descalarize helper

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -84,7 +84,8 @@ pub(crate) enum OpCode {
     BoolBitNeg, // ?^ prefix: boolean bitwise negation
     StrBitNeg,  // ~^ prefix: string/buffer bitwise negation
     MakeSlip,   // | prefix: convert array/list to Slip for flattening
-    Decont,     // decontainerize: Array(_, true) → Array(_, false) for slurpy flattening
+    Decont,     // strip ONE level of Value::Scalar for slurpy flattening (NOT the
+    // recursive Value::descalarize; touches no ArrayKind flag — see decont family note)
     /// Itemize (containerize) an Array/List value so it behaves as a single
     /// item in list context. Emitted when `$` variable values are used inside
     /// `ArrayLiteral` or assigned to `@`/`%` targets.

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -34,9 +34,7 @@ pub(super) fn multidim_at_pos(target: &Value, indices: &[Value]) -> Value {
     let mut cur = target.clone();
     for idx in indices {
         // Transparently unwrap Scalar containers (used as "bound" markers for BIND-POS).
-        while let Value::Scalar(inner) = &cur {
-            cur = (**inner).clone();
-        }
+        cur = cur.into_descalarized();
         let Some(i) = pos_index(idx) else {
             return make_nonneg_failure();
         };
@@ -45,18 +43,13 @@ pub(super) fn multidim_at_pos(target: &Value, indices: &[Value]) -> Value {
         };
         cur = items.get(i).cloned().unwrap_or(Value::Nil);
     }
-    while let Value::Scalar(inner) = &cur {
-        cur = (**inner).clone();
-    }
-    cur
+    cur.into_descalarized()
 }
 
 pub(super) fn multidim_exists_pos(target: &Value, indices: &[Value]) -> bool {
     let mut cur = target.clone();
     for idx in indices {
-        while let Value::Scalar(inner) = &cur {
-            cur = (**inner).clone();
-        }
+        cur = cur.into_descalarized();
         let Some(i) = pos_index(idx) else {
             return false;
         };
@@ -76,9 +69,7 @@ pub(super) fn multidim_exists_pos(target: &Value, indices: &[Value]) -> bool {
 fn shaped_multidim_exists_pos(target: &Value, indices: &[Value], shape: &[usize]) -> bool {
     let mut cur = target.clone();
     for (dim_idx, idx) in indices.iter().enumerate() {
-        while let Value::Scalar(inner) = &cur {
-            cur = (**inner).clone();
-        }
+        cur = cur.into_descalarized();
         let Some(i) = pos_index(idx) else {
             return false;
         };

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -54,18 +54,11 @@ fn write_bits_into_bytes(bytes: &mut [u8], from: usize, bits: usize, value: &Big
 }
 
 impl Interpreter {
-    fn strip_scalar(value: Value) -> Value {
-        match value {
-            Value::Scalar(inner) => Self::strip_scalar(*inner),
-            other => other,
-        }
-    }
-
     fn apply_hash_assignment_entry(
         updated: &mut std::collections::HashMap<String, Value>,
         item: Value,
     ) -> bool {
-        match Self::strip_scalar(item) {
+        match item.into_descalarized() {
             Value::Pair(key, boxed) => {
                 updated.insert(key, *boxed);
                 true
@@ -86,7 +79,7 @@ impl Interpreter {
         existing_hash: std::collections::HashMap<String, Value>,
         value: Value,
     ) -> Value {
-        let normalized_value = Self::strip_scalar(value);
+        let normalized_value = value.into_descalarized();
         match normalized_value {
             Value::Pair(..) | Value::ValuePair(..) | Value::Hash(..) => {
                 let mut updated = existing_hash;
@@ -113,7 +106,7 @@ impl Interpreter {
     }
 
     fn normalize_rw_accessor_assignment(current: Option<Value>, value: Value) -> Value {
-        let current = current.map(Self::strip_scalar);
+        let current = current.map(Value::into_descalarized);
         match current {
             Some(Value::Hash(existing_hash)) => {
                 Self::normalize_hash_like_assignment((*existing_hash).clone(), value)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2366,11 +2366,33 @@ impl Value {
         Value::str(key.to_string())
     }
 
-    /// Unwrap a Scalar container, returning the inner value.
-    /// For non-Scalar values, returns self unchanged.
-    pub fn decontainerize(&self) -> &Value {
+    // --- decont family (see docs/container-identity.md §3) ---
+    // mutsu has THREE "decontainerize" operations on THREE different axes.
+    // They are intentionally NOT fused into one helper:
+    //   - Value::descalarize / into_descalarized — strips `Scalar` ($(...)), RECURSIVE
+    //   - Value::deref_container                  — reads through `ContainerRef` (:=), single cell
+    //   - ArrayKind::decontainerize               — strips `ItemList`/`ItemArray` flag (list flatten)
+    // A "full decont" that strips all three is deferred to Phase 1+; it must NOT be
+    // applied at lvalue/container-requiring sites (is-rw writeback, :=, .VAR, =:=,
+    // take-rw, autoviv slot-refs), which need the live cell or the container variant.
+
+    /// Unwrap a `Scalar` container, returning a reference to the inner value.
+    /// RECURSIVE: nested `$($(...))` are fully stripped. Non-Scalar values are
+    /// returned as-is. See the decont family note above; this is the Scalar axis only.
+    pub fn descalarize(&self) -> &Value {
         match self {
-            Value::Scalar(inner) => inner.decontainerize(),
+            Value::Scalar(inner) => inner.descalarize(),
+            other => other,
+        }
+    }
+
+    /// Owned, recursive `Scalar`-strip. Same axis/semantics as [`Value::descalarize`]
+    /// but consumes `self` and returns the inner value by value (no extra clone for
+    /// callers that already own the value). Canonical replacement for the former
+    /// `runtime::methods_mut::strip_scalar`.
+    pub fn into_descalarized(self) -> Value {
+        match self {
+            Value::Scalar(inner) => inner.into_descalarized(),
             other => other,
         }
     }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -439,6 +439,9 @@ impl VM {
     }
 
     pub(super) fn exec_decont_op(&mut self) {
+        // Strips a SINGLE level of Value::Scalar for slurpy flattening. This is
+        // intentionally non-recursive and distinct from the recursive
+        // Value::descalarize (see the decont family note in value/mod.rs §3).
         let val = self.stack.pop().unwrap();
         let new_val = match val {
             Value::Scalar(inner) => *inner,
@@ -538,13 +541,13 @@ impl VM {
             .interpreter
             .auto_fetch_proxy(&left)
             .unwrap_or(left)
-            .decontainerize()
+            .descalarize()
             .clone();
         let right = self
             .interpreter
             .auto_fetch_proxy(&right)
             .unwrap_or(right)
-            .decontainerize()
+            .descalarize()
             .clone();
         // Both junctions: thread left first, swap kinds if right is tighter
         if let (Value::Junction { kind: lk, .. }, Value::Junction { kind: rk, .. }) =

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -908,8 +908,8 @@ impl VM {
         let left = self.interpreter.auto_fetch_proxy(&left)?;
         let right = self.interpreter.auto_fetch_proxy(&right)?;
         // Decontainerize Scalar wrappers
-        let left = left.decontainerize().clone();
-        let right = right.decontainerize().clone();
+        let left = left.descalarize().clone();
+        let right = right.descalarize().clone();
         if let (
             Value::Junction {
                 kind: left_kind,


### PR DESCRIPTION
First step of the first-class container-identity migration (`docs/container-identity.md` §3, PLAN.md「🟣 第2優先: 第一級コンテナ」). **Behavior-preserving** — this is pure de-duplication, no semantic change.

## What

mutsu has three "decontainerize" operations on three different axes that were partly duplicated/ad-hoc:
- **Scalar** `$(...)` itemization wrapper — recursive strip
- **ContainerRef** `:=` shared cell — single read-through
- **ArrayKind** `ItemList`/`ItemArray` flag — list-flattening (a different *type*)

This PR consolidates the **Scalar axis** onto a single canonical helper and documents why the three axes must NOT be fused (fusing breaks the `is rw` writeback Pair classification and the `@a = $l` flattening that Phase 1 must fix).

- Rename `Value::decontainerize` → `Value::descalarize` (disambiguate from `ArrayKind::decontainerize`).
- Add owned recursive `Value::into_descalarized` + a decont-family doc block.
- Delete the duplicate recursive `Interpreter::strip_scalar`; route its callers to `into_descalarized`.
- Replace four recursive `while let Value::Scalar` loops in `methods.rs` with `into_descalarized`.
- Clarify `OpCode::Decont`/`exec_decont_op` is a single-level Scalar strip (not the recursive helper); fix the stale opcode comment.

## Verification

- `make test` — PASS (5274 tests)
- Targeted roast: `S02-types/flattening.t`, `S32-list/flat.t`, `S32-array/push.t`, `S32-hash/push.t`, `S03-metaops/reduce.t`, `S32-list/reduce.t` — all PASS
- `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)