### PR TITLE
refactor(container): Phase 0 PR2 — route recursive Scalar strips to descalarize

### DIFF
--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -647,9 +647,8 @@ pub(crate) fn native_method_1arg(
     let method = method_sym.resolve();
     let method = method.as_str();
 
-    if let Value::Scalar(inner) = target {
-        return native_method_1arg(inner, method_sym, arg);
-    }
+    // Scalar containers are transparent for method dispatch (no .VAR at this arity).
+    let target = target.descalarize();
     // Instance with __baggy_data__: delegate to the inner Bag/Set for collection methods
     if let Value::Instance { attributes, .. } = target
         && let Some(inner) = attributes.get("__baggy_data__")
@@ -2759,9 +2758,8 @@ pub(crate) fn native_method_2arg(
     let method = method_sym.resolve();
     let method = method.as_str();
 
-    if let Value::Scalar(inner) = target {
-        return native_method_2arg(inner, method_sym, arg1, arg2);
-    }
+    // Scalar containers are transparent for method dispatch (no .VAR at this arity).
+    let target = target.descalarize();
     if method == "flat" {
         let (depth, hammer) = if let Some(depth) = parse_flat_depth(arg1) {
             (Some(depth), is_hammer_pair(arg2))

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -247,9 +247,7 @@ impl Interpreter {
     fn multiply_bag_counts(
         value: &Value,
     ) -> Result<std::collections::HashMap<String, (i64, bool)>, RuntimeError> {
-        if let Value::Scalar(inner) = value {
-            return Self::multiply_bag_counts(inner.as_ref());
-        }
+        let value = value.descalarize();
         if Self::union_is_lazy_input(value) {
             return Err(RuntimeError::new("X::Cannot::Lazy"));
         }
@@ -334,9 +332,7 @@ impl Interpreter {
     fn multiply_mix_weights(
         value: &Value,
     ) -> Result<std::collections::HashMap<String, f64>, RuntimeError> {
-        if let Value::Scalar(inner) = value {
-            return Self::multiply_mix_weights(inner.as_ref());
-        }
+        let value = value.descalarize();
         if Self::union_is_lazy_input(value) {
             return Err(RuntimeError::new("X::Cannot::Lazy"));
         }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -485,9 +485,9 @@ pub(crate) fn version_cmp_parts(
 
 pub(crate) fn coerce_to_hash(value: Value) -> Value {
     let mix_weight_value = crate::value::mix_weight_to_value;
+    let value = value.into_descalarized();
     match value {
         Value::Hash(_) => value,
-        Value::Scalar(inner) => coerce_to_hash(*inner),
         Value::Array(items, ..) => {
             // Flatten nested Hashes into pairs before building the hash.
             // This handles `%h = %h1, %h2` where each hash should be merged.
@@ -2233,8 +2233,8 @@ pub(crate) fn parse_radix_number_body(body: &str, base: u32) -> Option<Value> {
 }
 
 pub(crate) fn coerce_to_numeric(val: Value) -> Value {
+    let val = val.into_descalarized();
     match val {
-        Value::Scalar(inner) => coerce_to_numeric(*inner),
         Value::Mixin(inner, _) => coerce_to_numeric(inner.as_ref().clone()),
         Value::Int(_)
         | Value::BigInt(_)
@@ -2380,8 +2380,8 @@ pub(crate) fn coerce_to_set(val: &Value) -> HashSet<String> {
         }
     }
 
+    let val = val.descalarize();
     match val {
-        Value::Scalar(inner) => coerce_to_set(inner),
         Value::Set(s, _) => s.elements.clone(),
         Value::Bag(b, _) => {
             let resolved = resolve_bag_tab_keys(b);
@@ -2435,8 +2435,8 @@ pub(crate) fn coerce_to_set(val: &Value) -> HashSet<String> {
 /// - Pair with falsy value → empty Set
 /// - Other scalars → Set with one element
 pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
+    let val = val.descalarize();
     match val {
-        Value::Scalar(inner) => coerce_value_to_quanthash(inner),
         Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _) => val.clone(),
         Value::Hash(h) => {
             let mut set = HashSet::new();


### PR DESCRIPTION
Phase 0 of the first-class container-identity migration, continued from #2736. **Behavior-preserving** de-duplication.

Replaces hand-rolled recursive Scalar-unwrapping in single-Scalar-arm functions with the canonical `descalarize` / `into_descalarized` helpers from #2736.

## Routed (each previously recursed via self-call or leading `if let Scalar`)
- `runtime/ops.rs`: `multiply_bag_counts`, `multiply_mix_weights`
- `runtime/utils.rs`: `coerce_to_hash`, `coerce_to_numeric`, `coerce_to_set`, `coerce_value_to_quanthash`
- `builtins/methods_narg.rs`: `native_method_1arg`, `native_method_2arg` (no `.VAR` at these arities)

## Left inline (intentionally NOT routed)
- **Single-level** strips (set add/multiply operands, `methods_narg.rs:39`, set-operator single-arg) — routing to the recursive helper would change `$($(...))` nesting semantics.
- `native_method_0arg` — has a `.VAR` guard that must observe the Scalar before stripping.
- `value/types.rs` `eqv`/`truthy`/`isa_check` — mixed Scalar+ContainerRef in one match; deferred.
- `value_type_name` — exhaustive match w/o wildcard; a leading decont would force an unreachable arm.

## Verification
- `make test` — PASS (5274)
- set/bag/mix/flatten roast plan/ran/failed counts **identical** to the pre-PR baseline (pre-existing non-whitelisted failures unchanged)
- `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)