### PR TITLE
refactor(vm): share is_plain_eager_list; mark Category B done (recap + PLAN.md)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -74,10 +74,9 @@ native_function に arm がある（必要条件）だけでは不十分 — **E
         `chrs` を `native_function_variadic` へ全 arity ルーティング（+ `value_to_list` で Range/Seq 平坦化）、
         `unival`/`univals` を `native_function_1arg` から `.unival`/`.univals` メソッド実装へ委譲。
         VM/EVAL 両経路で raku 一致を確認。**純粋値 builtin の重複はゼロ**。`words`（IO 版で別物）は非対象。
-- [~] **Category B — genuine fork（native に難ケースを足してから削除）**: `min`/`max`/`minmax`/`sort`/`join`/
-      `first`/`flat`/`elems`/`index`/`rindex` 等。native/pure 層は comparator ブロック・lazy・junction で bail し
-      Interpreter に落ちる。**比較子ブロックは VM 層で `vm_call_on_value`（`.map`/`.grep` と同じクロージャ
-      dispatch）で呼べる**ので、VM 層に完全実装を置いて Interpreter コピーを削除する。
+- [x] **Category B — genuine fork（native に難ケースを足してから削除）＝ 完了**:
+      `min`/`max`/`minmax`/`sort`/`join`/`first`/`flat`/`elems`/`reverse`。native/pure 層が comparator ブロック・
+      lazy で bail し Interpreter に落ちていた重複を全て解消した。**2 種類の fork を別々の手法で潰した**:
   - **ブロック系 fork（comparator/mapper/matcher ブロック）= 完了**。共通パターン: オーケストレーション
     （fold/sort/scan 本体）を engine 非依存の単一実装に抽出し、**ブロック呼び出しだけ**を VM
     (`vm_call_on_value`) / interpreter (`call_sub_value` / `eval_call_on_value`) のクロージャ（trait）で差し替え。
@@ -89,10 +88,16 @@ native_function に arm がある（必要条件）だけでは不十分 — **E
     - [x] **minmax (#2730)**: `minmax_from_values_generic` 抽出。VM が `.minmax`（`:by` 込み）を native 化。
     - [x] **first (#2731)**: `find_first_match_generic` + `FirstMatcher` trait 抽出。VM が `.first`（block/regex/
           smartmatch matcher、Hash 要素は `pair_as_positional`）を native 化。adverb/Bool-matcher は fallback。
-  - **残: lazy-fork（`join`/`flat`/`elems`/`reverse`）**。これらは comparator ブロックではなく **lazy 強制が
-    native にできない**のが fork 原因。native 版と interpreter 版が itemized array / Stash / variadic で
-    **微妙に drift**（dedup doc 警告の実例）しているため、単純な「lazy 強制 → native 委譲」では挙動が変わる。
-    drift を 1 件ずつ reconcile（どちらが raku 正かを確認）してから委譲する慎重な per-item 作業が必要。
+  - **lazy-fork（`elems`/`flat`/`join`/`reverse`）= 完了**。fork 原因は comparator ブロックではなく **lazy 強制／
+    多態が native と interpreter で別実装になっていた**こと。drift を 1 件ずつ raku で確認しながら **単一の正しい
+    実装へ委譲**し、その過程で **drift 由来の潜在バグを多数発見・修正**（dedup doc 警告の実証）:
+    - [x] **elems (#2733)**: `elems($x)` = `$x.elems` として `.elems` メソッドへ委譲。`elems("hello")` 5→1、
+          `elems(Seq)` 1→3、`elems(lazy)` を `X::Cannot::Lazy` に、`end("hello")` 4→0 修正。
+    - [x] **flat (#2734)**: 単一 `flat_val` に統一（`flat_into` 削除）。`flat(1,[2,[3,4]],…)` の nested array
+          over-flatten を修正（List vs Array の段数セマンティクスを正しく適用）。
+    - [x] **join (#2735)**: 単一 `join_flat`（`flat_val` 基盤）に統一。`join("-",1..4)` がセパレータを無視する
+          バグを修正（slurpy + shaped leaves + lazy 強制）。`join()` 無引数の panic も修正。
+    - [x] **reverse (#2739)**: 単一 native `reverse` へ委譲。`reverse()` 無引数 `Nil`→`()`、Range/Slip/shaped 修正。
   - **対象外**: `index`/`rindex` は interpreter コピーが存在せず既に native のみ。
   - ✅ **sort 移行の落とし穴 — 根本原因が判明（2026-06-07, #2725）**: 「`%h.sort({block})` → expected 2 got 0」
     の正体は **`Value::Pair` vs `Value::ValuePair` の束縛差**。mutsu は呼び出し側の名前付き引数を `Value::Pair`
@@ -135,12 +140,13 @@ native_function に arm がある（必要条件）だけでは不十分 — **E
       env を任意の名前で書く唯一の存在（interpreter ブリッジ）が消えるので `env_dirty`/`ensure_locals_synced`/
       `sync_locals_from_env`/`saved_env_dirty` の dual-store 機構も削除できる（レバー B 完遂）。
 - **残フォールバック**には `// TODO: compile to bytecode` を付け負債を可視化。
-- **次の着手候補（優先順）**: Category A 完了（純粋値 builtin の重複ゼロ）。Category B の**ブロック系 fork
-  （sort/min/max/minmax/first）は完了**（#2727/#2728/#2730/#2731、上記参照）。次は Category B の残り
-  **lazy-fork（join/flat/elems/reverse）の drift reconcile → 委譲** → Category C Phase 3 の残（comb/substr/split
-  折込）→ 🟣第2優先「第一級コンテナ」（レバー C 本丸 + Q2 の Arc-pointer flaky を吸収）。
+- **次の着手候補（優先順）**: Category A 完了・**Category B 完了**（ブロック系 sort/min/max/minmax/first
+  #2727/#2728/#2730/#2731 ＋ lazy-fork elems/flat/join/reverse #2733/#2734/#2735/#2739、上記参照）。
+  次は **Category C Phase 3 の残**（`comb`(正規表現 matcher)/`substr`/`split`(named args) の native 折込、
+  pointy/`*.code` matcher の `.first`）→ 🟣第2優先「第一級コンテナ」（レバー C 本丸 + Q2 の Arc-pointer flaky を吸収）。
   - 教訓: 「重複削除」を始めると**潜在バグが芋づる式に出る**（`[%] 2**70` 精度・`[~]` NFC・`[minmax]` ネスト・
-    `%h.first` の named 束縛は全て dedup 作業中に発見・修正）。重複は drift してバグの温床になる実例。
+    `%h.first` の named 束縛・`elems("hello")`・`flat` over-flatten・`join(sep,Range)` セパレータ無視・
+    `reverse()`=Nil は全て dedup 作業中に発見・修正）。重複は drift してバグの温床になる実例。
 
 ---
 

--- a/docs/vm-interpreter-dedup.md
+++ b/docs/vm-interpreter-dedup.md
@@ -110,12 +110,25 @@ and `src/runtime/builtins*.rs`, plus method and operator duplication.
 
 - **Category A — pure value builtins, delete-and-fallthrough** (low risk; the
   above batch + any stragglers). Each needs the EVAL-path check.
-- **Category B — genuine forks** (need real consolidation, not a delete):
-  `min`/`max`/`sort`/`reverse`/`join`/`flat`/`first`/`elems`/`index`/`rindex`.
-  The native copy bails (returns `None`) on hard cases (a comparator block, a
-  `LazyList`, junction threading) and the interpreter copy handles them. To
-  collapse these, the native side must learn the hard cases first, *then* the
-  interpreter copy can be deleted. Multi-PR.
+- **Category B — genuine forks — DONE**
+  (#2727/#2728/#2730/#2731/#2733/#2734/#2735/#2739). Two distinct fork shapes,
+  collapsed by two methods:
+  - *Block forks* (`sort`/`min`/`max`/`minmax`/`first`): the native copy bailed on
+    a comparator/mapper/matcher block. Fixed by extracting the orchestration
+    (`sort_items_generic`, `extrema_from_values_generic`,
+    `minmax_from_values_generic`, `find_first_match_generic`) into one
+    engine-agnostic implementation and swapping only the block invocation through a
+    closure/trait (`SortCaller`, `FirstMatcher`, `vm_call_on_value` /
+    `call_sub_value`). The VM runs them natively (`interpreter_fallbacks=0`); the
+    interpreter copy is now a thin adapter.
+  - *Lazy forks* (`elems`/`flat`/`join`/`reverse`): the fork was lazy-forcing /
+    polymorphism re-implemented in both layers, and the two copies had **drifted**.
+    Collapsed to one correct implementation (delegate `elems`→`.elems` method,
+    `flat`/`join`→shared `flat_val`/`join_flat`, `reverse`→native), reconciling each
+    drift against `raku` — which surfaced and fixed several latent bugs
+    (`elems("hello")` 5→1, `flat` nested over-flatten, `join(sep, Range)` ignoring
+    the separator, `reverse()` `Nil`→`()`).
+  - `index`/`rindex` had no interpreter copy (already native-only).
 - **Category C — methods** duplicated across `src/builtins/methods_*` (native
   fast path) and `src/runtime/methods.rs` / `methods_mut.rs` (slow path), and
   operator/arith/coercion logic across `src/builtins/arith.rs` /

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 impl VM {
+    /// A plain, eager, list-like target — `Array`/`List`, `Seq`, `Slip`, or any
+    /// `Range`. These are the shapes the native `.sort` / `.min` / `.max` /
+    /// `.minmax` / `.first` paths handle without falling back to the interpreter
+    /// (`Shaped`/`Lazy`/itemized arrays, `Instance`/`Supply`, etc. do not).
+    /// `Hash` is intentionally excluded — callers that also accept it
+    /// (`.sort` / `.first`) test for it separately.
+    pub(super) fn is_plain_eager_list(target: &crate::value::Value) -> bool {
+        use crate::value::{ArrayKind, Value};
+        matches!(
+            target,
+            Value::Array(_, ArrayKind::Array | ArrayKind::List)
+                | Value::Seq(_)
+                | Value::Slip(_)
+                | Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::GenericRange { .. }
+        )
+    }
+
     /// Strip hyper operator delimiters (>>...<<, >>...>>, <<...<<, <<...>>)
     /// and their Unicode variants, returning the inner operator if found.
     fn strip_hyper_delimiters_str(s: &str) -> Option<&str> {

--- a/src/vm/vm_native_extrema.rs
+++ b/src/vm/vm_native_extrema.rs
@@ -15,7 +15,7 @@
 //! arguments fall back to the interpreter unchanged.
 
 use super::*;
-use crate::value::{ArrayKind, Value};
+use crate::value::Value;
 
 impl VM {
     /// Try to run `target.min(...)` / `target.max(...)` natively. Returns
@@ -34,19 +34,10 @@ impl VM {
             _ => return None,
         };
 
-        // Only plain eager lists. Hash sorts by key via a separate path; ranges
-        // expand; everything else (Instance/Supply/Lazy/…) keeps interpreter
-        // semantics -> fall back.
-        match target {
-            Value::Array(_, ArrayKind::Array | ArrayKind::List)
-            | Value::Seq(_)
-            | Value::Slip(_)
-            | Value::Range(..)
-            | Value::RangeExcl(..)
-            | Value::RangeExclStart(..)
-            | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => {}
-            _ => return None,
+        // Only plain eager lists; everything else (Hash/Instance/Supply/Lazy/…)
+        // keeps interpreter semantics -> fall back.
+        if !Self::is_plain_eager_list(target) {
+            return None;
         }
 
         // Parse args: an optional `:by` callable (a bare Sub/Routine first arg or
@@ -114,16 +105,8 @@ impl VM {
         if method != "minmax" {
             return None;
         }
-        match target {
-            Value::Array(_, ArrayKind::Array | ArrayKind::List)
-            | Value::Seq(_)
-            | Value::Slip(_)
-            | Value::Range(..)
-            | Value::RangeExcl(..)
-            | Value::RangeExclStart(..)
-            | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => {}
-            _ => return None,
+        if !Self::is_plain_eager_list(target) {
+            return None;
         }
 
         // `.minmax` takes only an optional `:by` callable (no `:k`/etc. adverbs).

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -15,7 +15,7 @@
 use super::*;
 use crate::runtime::resolution::{FirstMatcher, find_first_match_generic};
 use crate::runtime::utils::pair_as_positional;
-use crate::value::{ArrayKind, Value};
+use crate::value::Value;
 
 /// [`FirstMatcher`] backed by the bytecode VM.
 struct VmFirstMatcher<'a>(&'a mut VM);
@@ -47,19 +47,10 @@ impl VM {
             return None;
         }
 
-        // Only plain list-like targets; `Supply`/`Instance`/… keep their own
-        // semantics -> fall back.
-        match target {
-            Value::Array(_, ArrayKind::Array | ArrayKind::List)
-            | Value::Seq(_)
-            | Value::Slip(_)
-            | Value::Hash(_)
-            | Value::Range(..)
-            | Value::RangeExcl(..)
-            | Value::RangeExclStart(..)
-            | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => {}
-            _ => return None,
+        // Plain list-like targets plus `Hash` (`.first` iterates its pairs);
+        // `Supply`/`Instance`/… keep their own semantics -> fall back.
+        if !Self::is_plain_eager_list(target) && !matches!(target, Value::Hash(_)) {
+            return None;
         }
 
         // At most one positional matcher and no adverbs. Any `Pair` arg is an


### PR DESCRIPTION
## Summary

Holistic cleanup after completing Category B, plus the ledger update.

**Refactor:** the native `.min`/`.max`/`.minmax`/`.first` helpers each repeated the same "plain eager list-like target" shape match (Array/List, Seq, Slip, Range variants). Extracted to a single `VM::is_plain_eager_list` predicate; the three gate-only sites use it directly and `.first` ORs in `Hash`. (`.sort` keeps its inline match — it materializes items per shape rather than just gating.)

**Docs:** PLAN.md + docs/vm-interpreter-dedup.md now record **Category B as complete**:
- *Block forks* (sort #2727 / min·max #2728 / minmax #2730 / first #2731): collapsed via a shared engine-agnostic orchestration with the block invocation swapped through a closure/trait. VM runs them natively (`interpreter_fallbacks=0`).
- *Lazy forks* (elems #2733 / flat #2734 / join #2735 / reverse #2739): collapsed to one correct impl, reconciling drift against `raku` and fixing the latent bugs found along the way (`elems("hello")` 5→1, `flat` nested over-flatten, `join(sep, Range)` ignoring the separator, `reverse()` `Nil`→`()`).
- `index`/`rindex`: no interpreter copy (already native-only).

## Verification
- `make test` PASS; native `.min`/`.max`/`.minmax`/`.first`/`.sort` + `%h.first` sanity-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)