### PR TITLE
refactor(sort): single shared sort_value_generic; delete dispatch_sort duplicate wrapper

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1225,7 +1225,7 @@ impl Interpreter {
             }
         }
 
-        // Build sort args for dispatch_sort
+        // Build sort args for the shared sort entry point.
         let mut sort_args: Vec<Value> = Vec::new();
         if let Some(c) = callable {
             sort_args.push(c);
@@ -1238,7 +1238,12 @@ impl Interpreter {
             return Ok(Value::array(Vec::new()));
         }
 
-        self.dispatch_sort(Value::array(items), &sort_args)
+        let mut caller = crate::runtime::methods_collection_ops::sort::InterpCaller(self);
+        crate::runtime::methods_collection_ops::sort::sort_value_generic(
+            &mut caller,
+            Value::array(items),
+            &sort_args,
+        )
     }
 
     pub(super) fn builtin_unique(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -135,6 +135,9 @@ pub(crate) trait SortCaller {
     fn call_callable(&mut self, callable: &Value, args: Vec<Value>) -> Value;
     /// Call the 0-arg method `name` on `recv` (Schwartzian key extraction).
     fn call_method(&mut self, recv: Value, name: &str) -> Value;
+    /// Resolve the arity of the sort callable (0 = none, 1 = mapper, >=2 =
+    /// comparator). Delegates to the single shared `Interpreter::sort_callable_arity`.
+    fn callable_arity(&self, callable: Option<&Value>) -> Result<usize, RuntimeError>;
 }
 
 /// [`SortCaller`] backed by the tree-walking interpreter.
@@ -158,6 +161,10 @@ impl SortCaller for InterpCaller<'_> {
         self.0
             .call_method_with_values(recv, name, vec![])
             .unwrap_or(Value::Nil)
+    }
+
+    fn callable_arity(&self, callable: Option<&Value>) -> Result<usize, RuntimeError> {
+        self.0.sort_callable_arity(callable)
     }
 }
 
@@ -475,115 +482,121 @@ impl Interpreter {
             _ => Ok(1),
         }
     }
+}
 
-    pub(crate) fn dispatch_sort(
-        &mut self,
-        target: Value,
-        args: &[Value],
-    ) -> Result<Value, RuntimeError> {
-        // Extract :k adverb and callable from args
-        let mut return_indices = false;
-        let mut callable: Option<Value> = None;
-        for arg in args {
-            match arg {
-                Value::Pair(key, val) if key == "k" => {
-                    return_indices = val.truthy();
+/// Shared `.sort` entry point — engine-agnostic argument parsing + target-shape
+/// dispatch, on top of the shared [`sort_items_generic`] / [`sort_indices_generic`]
+/// orchestration. Both engines call this with their own [`SortCaller`]:
+/// `InterpCaller` for the tree-walking interpreter (EVAL / regex carrier / `sort()`
+/// builtin / top-level `.sort` method) and `VmSortCaller` for the bytecode VM
+/// (`try_native_sort`). This removes the duplicate arg-parse + shape-dispatch
+/// wrapper that previously lived once per engine.
+///
+/// Behavior is identical to the former `Interpreter::dispatch_sort`: `:k` selects
+/// index mode, `:by` names the callable, and any other arg (including stray
+/// adverbs) is taken as the callable. Shaped multi-dim arrays sort over leaves;
+/// non-collection targets pass through unchanged. The VM gates which target shapes
+/// it accepts before calling here (Shaped / Instance / Supply still fall back).
+pub(crate) fn sort_value_generic(
+    caller: &mut dyn SortCaller,
+    target: Value,
+    args: &[Value],
+) -> Result<Value, RuntimeError> {
+    // Extract :k adverb and callable from args
+    let mut return_indices = false;
+    let mut callable: Option<Value> = None;
+    for arg in args {
+        match arg {
+            Value::Pair(key, val) if key == "k" => {
+                return_indices = val.truthy();
+            }
+            Value::Pair(key, val) if key == "by" => {
+                callable = Some(val.as_ref().clone());
+            }
+            _ => {
+                callable = Some(arg.clone());
+            }
+        }
+    }
+
+    let arity = caller.callable_arity(callable.as_ref())?;
+    let callable_ref = callable.as_ref();
+
+    match target {
+        Value::Array(ref items_arc, ref kind) => {
+            // For multi-dim shaped arrays, sort over leaves
+            let use_leaves = *kind == crate::value::ArrayKind::Shaped
+                && items_arc.iter().any(|v| matches!(v, Value::Array(..)));
+            if use_leaves {
+                let mut leaves = crate::runtime::utils::shaped_array_leaves(&target);
+                if return_indices {
+                    Ok(Value::array(sort_indices_generic(
+                        caller,
+                        &leaves,
+                        callable_ref,
+                        arity,
+                    )))
+                } else {
+                    sort_items_generic(caller, &mut leaves, callable_ref, arity);
+                    Ok(Value::Seq(Arc::new(leaves)))
                 }
-                Value::Pair(key, val) if key == "by" => {
-                    callable = Some(val.as_ref().clone());
-                }
-                _ => {
-                    callable = Some(arg.clone());
+            } else {
+                let Value::Array(mut items, ..) = target else {
+                    unreachable!()
+                };
+                let items_mut = Arc::make_mut(&mut items);
+                if return_indices {
+                    Ok(Value::array(sort_indices_generic(
+                        caller,
+                        items_mut,
+                        callable_ref,
+                        arity,
+                    )))
+                } else {
+                    sort_items_generic(caller, items_mut, callable_ref, arity);
+                    Ok(Value::Seq(Arc::new(items_mut.to_vec())))
                 }
             }
         }
-
-        let callable_arity = self.sort_callable_arity(callable.as_ref())?;
-
-        let callable_args = if let Some(c) = callable {
-            vec![c]
-        } else {
-            vec![]
-        };
-
-        let callable_ref = callable_args.first();
-
-        match target {
-            Value::Array(ref items_arc, ref kind) => {
-                // For multi-dim shaped arrays, sort over leaves
-                let use_leaves = *kind == crate::value::ArrayKind::Shaped
-                    && items_arc.iter().any(|v| matches!(v, Value::Array(..)));
-                if use_leaves {
-                    let mut leaves = crate::runtime::utils::shaped_array_leaves(&target);
-                    let mut caller = InterpCaller(self);
-                    if return_indices {
-                        let indices = sort_indices_generic(
-                            &mut caller,
-                            &leaves,
-                            callable_ref,
-                            callable_arity,
-                        );
-                        Ok(Value::array(indices))
-                    } else {
-                        sort_items_generic(&mut caller, &mut leaves, callable_ref, callable_arity);
-                        Ok(Value::Seq(Arc::new(leaves)))
-                    }
-                } else {
-                    let Value::Array(mut items, ..) = target else {
-                        unreachable!()
-                    };
-                    let items_mut = Arc::make_mut(&mut items);
-                    let mut caller = InterpCaller(self);
-                    if return_indices {
-                        let indices = sort_indices_generic(
-                            &mut caller,
-                            items_mut,
-                            callable_ref,
-                            callable_arity,
-                        );
-                        Ok(Value::array(indices))
-                    } else {
-                        sort_items_generic(&mut caller, items_mut, callable_ref, callable_arity);
-                        Ok(Value::Seq(Arc::new(items_mut.to_vec())))
-                    }
-                }
+        Value::Seq(items) | Value::Slip(items) => {
+            let mut sorted = items.as_ref().clone();
+            if return_indices {
+                Ok(Value::array(sort_indices_generic(
+                    caller,
+                    &sorted,
+                    callable_ref,
+                    arity,
+                )))
+            } else {
+                sort_items_generic(caller, &mut sorted, callable_ref, arity);
+                Ok(Value::Seq(Arc::new(sorted)))
             }
-            Value::Seq(items) | Value::Slip(items) => {
-                let mut sorted = items.as_ref().clone();
-                let mut caller = InterpCaller(self);
-                if return_indices {
-                    let indices =
-                        sort_indices_generic(&mut caller, &sorted, callable_ref, callable_arity);
-                    Ok(Value::array(indices))
-                } else {
-                    sort_items_generic(&mut caller, &mut sorted, callable_ref, callable_arity);
-                    Ok(Value::Seq(Arc::new(sorted)))
-                }
-            }
-            Value::Range(..)
-            | Value::RangeExcl(..)
-            | Value::RangeExclStart(..)
-            | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => {
-                let mut sorted = Self::value_to_list(&target);
-                let mut caller = InterpCaller(self);
-                if return_indices {
-                    let indices =
-                        sort_indices_generic(&mut caller, &sorted, callable_ref, callable_arity);
-                    Ok(Value::array(indices))
-                } else {
-                    sort_items_generic(&mut caller, &mut sorted, callable_ref, callable_arity);
-                    Ok(Value::Seq(Arc::new(sorted)))
-                }
-            }
-            Value::Hash(map) => {
-                let items: Vec<Value> = map
-                    .iter()
-                    .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
-                    .collect();
-                self.dispatch_sort(Value::array(items), args)
-            }
-            other => Ok(other),
         }
+        Value::Range(..)
+        | Value::RangeExcl(..)
+        | Value::RangeExclStart(..)
+        | Value::RangeExclBoth(..)
+        | Value::GenericRange { .. } => {
+            let mut sorted = Interpreter::value_to_list(&target);
+            if return_indices {
+                Ok(Value::array(sort_indices_generic(
+                    caller,
+                    &sorted,
+                    callable_ref,
+                    arity,
+                )))
+            } else {
+                sort_items_generic(caller, &mut sorted, callable_ref, arity);
+                Ok(Value::Seq(Arc::new(sorted)))
+            }
+        }
+        Value::Hash(map) => {
+            let items: Vec<Value> = map
+                .iter()
+                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .collect();
+            sort_value_generic(caller, Value::array(items), args)
+        }
+        other => Ok(other),
     }
 }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -598,7 +598,8 @@ impl Interpreter {
         {
             return Ok(Value::Seq(std::sync::Arc::new(vec![target])));
         }
-        self.dispatch_sort(target, &args)
+        let mut caller = crate::runtime::methods_collection_ops::sort::InterpCaller(self);
+        crate::runtime::methods_collection_ops::sort::sort_value_generic(&mut caller, target, &args)
     }
 
     /// Dispatch the "minmax" method.

--- a/src/vm/vm_native_sort.rs
+++ b/src/vm/vm_native_sort.rs
@@ -17,12 +17,9 @@
 //! `dispatch_sort` unchanged — which now shares the same orchestration.
 
 use super::*;
-use crate::runtime::methods_collection_ops::sort::{
-    SortCaller, sort_indices_generic, sort_items_generic,
-};
+use crate::runtime::methods_collection_ops::sort::{SortCaller, sort_value_generic};
 use crate::runtime::utils::pair_as_positional;
 use crate::value::{ArrayKind, Value};
-use std::sync::Arc;
 
 /// [`SortCaller`] backed by the bytecode VM.
 struct VmSortCaller<'a>(&'a mut VM);
@@ -43,6 +40,10 @@ impl SortCaller for VmSortCaller<'_> {
             .try_compiled_method_or_interpret(recv, name, vec![])
             .unwrap_or(Value::Nil)
     }
+
+    fn callable_arity(&self, callable: Option<&Value>) -> Result<usize, RuntimeError> {
+        self.0.interpreter.sort_callable_arity(callable)
+    }
 }
 
 impl VM {
@@ -61,51 +62,25 @@ impl VM {
             return None;
         }
 
-        // Collect the eager element list for the supported target shapes. Shaped
-        // multi-dim arrays (sort over leaves), Lazy, and item/scalar-wrapped
-        // arrays keep their interpreter semantics -> fall back.
-        let items: Vec<Value> = match target {
-            Value::Array(elems, ArrayKind::Array | ArrayKind::List) => elems.as_ref().clone(),
-            Value::Seq(elems) | Value::Slip(elems) => elems.as_ref().clone(),
-            Value::Range(..)
+        // Gate: only plain eager target shapes run natively. Shaped multi-dim
+        // arrays (sort over leaves), Lazy, item/scalar-wrapped arrays, and
+        // `Instance`/`Supply` keep their interpreter semantics -> fall back. The
+        // arg parsing, shape dispatch, and orchestration are then the single
+        // shared `sort_value_generic` (same code the interpreter runs).
+        match target {
+            Value::Array(_, ArrayKind::Array | ArrayKind::List)
+            | Value::Seq(_)
+            | Value::Slip(_)
+            | Value::Hash(_)
+            | Value::Range(..)
             | Value::RangeExcl(..)
             | Value::RangeExclStart(..)
             | Value::RangeExclBoth(..)
-            | Value::GenericRange { .. } => crate::runtime::Interpreter::value_to_list(target),
-            Value::Hash(map) => map
-                .iter()
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
-                .collect(),
+            | Value::GenericRange { .. } => {}
             _ => return None,
-        };
-
-        // Parse the (optional) comparator and the `:k` adverb. `:by` names the
-        // callable; any other adverb (`:kv`/`:p`/`:v`) needs the interpreter.
-        let mut callable: Option<Value> = None;
-        let mut return_indices = false;
-        for arg in args {
-            match arg {
-                Value::Pair(key, val) if key == "by" => callable = Some(val.as_ref().clone()),
-                Value::Pair(key, val) if key == "k" => return_indices = val.truthy(),
-                Value::Pair(..) => return None,
-                _ => callable = Some(arg.clone()),
-            }
         }
 
-        // Resolve arity via the shared helper (rejects explicitly 0-arity subs).
-        let arity = match self.interpreter.sort_callable_arity(callable.as_ref()) {
-            Ok(a) => a,
-            Err(e) => return Some(Err(e)),
-        };
-
-        let mut items = items;
         let mut caller = VmSortCaller(self);
-        if return_indices {
-            let indices = sort_indices_generic(&mut caller, &items, callable.as_ref(), arity);
-            Some(Ok(Value::array(indices)))
-        } else {
-            sort_items_generic(&mut caller, &mut items, callable.as_ref(), arity);
-            Some(Ok(Value::Seq(Arc::new(items))))
-        }
+        Some(sort_value_generic(&mut caller, target.clone(), args))
     }
 }


### PR DESCRIPTION
## Summary

The `.sort` **orchestration** (merge sort, Schwartzian transform, comparator inlining — `sort_items_generic` / `sort_indices_generic` + the `SortCaller` trait) was already a single shared impl. But the **wrapper** around it was still duplicated per engine:

- `Interpreter::dispatch_sort` (interp carrier: EVAL, regex blocks, the `sort()` builtin, top-level `.sort`)
- `VM::try_native_sort` (VM native path)

Each reimplemented argument parsing (`:k`/`:by`/callable), arity resolution, and target-shape → element-list dispatch — and the two had **drifted**: `dispatch_sort` took any stray adverb (`:kv`/`:p`/`:v`) as a callable, while `try_native_sort` bailed to the interpreter for them (which then ran `dispatch_sort` anyway — same net result, via a fallback).

## Change

Collapse both wrappers into one engine-agnostic `sort_value_generic(&mut dyn SortCaller, target, args)`:

- Add `SortCaller::callable_arity` so the shared wrapper resolves arity via the single `Interpreter::sort_callable_arity` regardless of engine.
- **Delete `Interpreter::dispatch_sort`**; its callers (`dispatch_sort_method`, the `sort()` builtin) build an `InterpCaller` and call the shared function.
- `try_native_sort` keeps only the target-shape **gate** (Shaped multi-dim / `Instance` / `Supply` still fall back to the interpreter) and delegates to the shared function via `VmSortCaller`. The per-engine arg-parse/shape-dispatch copy is gone, and the VM no longer bails to the interpreter for `:kv`/`:p`/`:v`.

## Behavior

Behavior-preserving — verified the prior output is unchanged across the VM, interpreter, EVAL-carrier, shaped-array fallback, and `:k`/`:kv` adverb paths. (Pre-existing non-raku quirks like `:k`→indices and `:kv`→unsorted are deliberately preserved; reconciling sort-adverb semantics with raku is a separate correctness concern, out of scope for this dedup.)

Category C Phase 3 item ① (PLAN.md).

## Tests

`t/sort-native.t`, `t/hash-first-positional.t`, whitelisted `roast/S32-list/sort.t`, and full `make test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)