### PR TITLE
refactor(comb): move pure Int/Str split to builtins::comb, shared by both engines

### DIFF
--- a/src/builtins/comb.rs
+++ b/src/builtins/comb.rs
@@ -1,0 +1,115 @@
+//! Pure (engine-agnostic) `.comb` matchers.
+//!
+//! `.comb` splits a string by a matcher. The *pure* matcher cases — an `Int`
+//! chunk size and a fixed `Str` needle — need no interpreter state, so they live
+//! here in the native layer as the single shared implementation, reachable by
+//! both the VM (`native_method_1arg`/`native_method_2arg` -> `native_comb_method`)
+//! and the interpreter (`dispatch_comb_with_args`, which calls [`comb_pure`]
+//! instead of reimplementing the split). This follows the same layering as
+//! `builtins::split`.
+//!
+//! The `Regex` matcher (and a bare matcher reinterpreted as a regex) genuinely
+//! needs the interpreter-coupled regex engine (`regex_find_all`, code blocks,
+//! `Match` objects), so those cases stay in `runtime/` — [`comb_pure`] returns
+//! `None` for them, signalling the caller to defer.
+
+use crate::value::{RuntimeError, Value};
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Apply a `comb` limit to a result vector: `Some(n)` keeps the first `n`
+/// (and `n <= 0` yields empty); `None` keeps all.
+fn apply_limit(result: Vec<Value>, limit: Option<i64>) -> Vec<Value> {
+    match limit {
+        Some(lim) if lim <= 0 => Vec::new(),
+        Some(lim) => result.into_iter().take(lim as usize).collect(),
+        None => result,
+    }
+}
+
+/// Pure `.comb` split for the `Int` (chunk) and `Str` (fixed needle) matchers.
+///
+/// Returns `Some(items)` for those matchers (and `Some(empty)` when `limit <= 0`,
+/// matching the interpreter's early-out). Returns `None` for any other matcher
+/// (`Regex`, `Sub`, a bare value to be reinterpreted as a regex, or no matcher),
+/// signalling the caller to fall back to the interpreter's regex path.
+pub(crate) fn comb_pure(
+    text: &str,
+    matcher: Option<&Value>,
+    limit: Option<i64>,
+) -> Option<Vec<Value>> {
+    // A non-positive limit yields empty regardless of matcher (mirrors the
+    // interpreter's early return before matching).
+    if matches!(limit, Some(lim) if lim <= 0) {
+        return Some(Vec::new());
+    }
+
+    match matcher {
+        Some(Value::Int(n)) => {
+            let chunk_size = if *n <= 0 { 1usize } else { *n as usize };
+            let graphemes: Vec<&str> = text.graphemes(true).collect();
+            let result: Vec<Value> = graphemes
+                .chunks(chunk_size)
+                .map(|chunk| Value::str(chunk.concat()))
+                .collect();
+            Some(apply_limit(result, limit))
+        }
+        Some(Value::Str(needle)) => {
+            if needle.is_empty() {
+                let chars: Vec<Value> = text
+                    .graphemes(true)
+                    .map(|g| Value::str(g.to_string()))
+                    .collect();
+                return Some(apply_limit(chars, limit));
+            }
+            let mut result = Vec::new();
+            let mut offset = 0usize;
+            while offset <= text.len() {
+                if let Some(lim) = limit
+                    && result.len() >= lim as usize
+                {
+                    break;
+                }
+                let Some(pos) = text[offset..].find(needle.as_str()) else {
+                    break;
+                };
+                let start = offset + pos;
+                let end = start + needle.len();
+                result.push(Value::str(text[start..end].to_string()));
+                offset = end;
+            }
+            Some(result)
+        }
+        _ => None,
+    }
+}
+
+/// Native `.comb(...)` for the pure matcher cases. Parses the positional
+/// matcher + optional limit (the `:match` adverb only affects the regex path and
+/// is ignored here, exactly as the interpreter ignores it for `Int`/`Str`).
+/// Returns `None` to defer to the interpreter for `Regex`/`Sub`/bare matchers.
+pub(crate) fn native_comb_method(
+    target: &Value,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    let text = target.to_string_value();
+
+    // Separate positional args from the `:match` named pair (regex-only).
+    let mut positional: Vec<&Value> = Vec::new();
+    for arg in args {
+        if let Value::Pair(key, _) = arg
+            && key == "match"
+        {
+            continue;
+        }
+        positional.push(arg);
+    }
+
+    let limit: Option<i64> = if positional.len() >= 2 {
+        Some(positional[1].to_f64() as i64)
+    } else {
+        None
+    };
+    let matcher = positional.first().copied();
+
+    comb_pure(&text, matcher, limit).map(|items| Ok(Value::Seq(std::sync::Arc::new(items))))
+}

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1102,6 +1102,20 @@ pub(crate) fn native_method_1arg(
             }
             super::split::native_split_method(target, std::slice::from_ref(arg))
         }
+        "comb" => {
+            // Supply/IO targets have their own comb semantics in the interpreter.
+            if let Value::Instance { class_name, .. } = target
+                && (class_name == "Supply"
+                    || class_name == "IO::Handle"
+                    || class_name == "IO::Path"
+                    || class_name == "IO::Pipe")
+            {
+                return None;
+            }
+            // Pure Int-chunk / Str-fixed split (shared with the interpreter via
+            // builtins::comb); Regex/Sub/bare matchers return None -> interpreter.
+            super::comb::native_comb_method(target, std::slice::from_ref(arg))
+        }
         "lines" => {
             if let Value::Instance { class_name, .. } = target
                 && class_name == "Supply"
@@ -2789,6 +2803,21 @@ pub(crate) fn native_method_2arg(
             return None;
         }
         return super::split::native_split_method(target, &[arg1.clone(), arg2.clone()]);
+    }
+
+    if method == "comb" {
+        // Supply/IO targets keep their interpreter comb semantics.
+        if let Value::Instance { class_name, .. } = target
+            && (class_name == "Supply"
+                || class_name == "IO::Handle"
+                || class_name == "IO::Path"
+                || class_name == "IO::Pipe")
+        {
+            return None;
+        }
+        // `.comb(matcher, limit)`: pure Int/Str split shared with the
+        // interpreter; Regex/Sub/bare matchers return None -> interpreter.
+        return super::comb::native_comb_method(target, &[arg1.clone(), arg2.clone()]);
     }
 
     match method {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod arith;
 pub(crate) mod collation;
+pub(crate) mod comb;
 pub(crate) mod exception_message;
 mod functions;
 pub(crate) mod methods_0arg;

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -188,8 +188,6 @@ impl Interpreter {
         target: Value,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        use unicode_segmentation::UnicodeSegmentation;
-
         let text = target.to_string_value();
 
         // Separate positional args from named :match pair
@@ -224,42 +222,13 @@ impl Interpreter {
         let make_seq = |items: Vec<Value>| Value::Seq(std::sync::Arc::new(items));
 
         match matcher {
-            Some(Value::Int(n)) => {
-                let chunk_size = if *n <= 0 { 1usize } else { *n as usize };
-                let graphemes: Vec<&str> = text.graphemes(true).collect();
-                let result: Vec<Value> = graphemes
-                    .chunks(chunk_size)
-                    .map(|chunk| Value::str(chunk.concat()))
-                    .collect();
-                let result = Self::apply_limit(result, limit);
-                Some(Ok(make_seq(result)))
-            }
-            Some(Value::Str(needle)) => {
-                if needle.is_empty() {
-                    let chars: Vec<Value> = text
-                        .graphemes(true)
-                        .map(|g| Value::str(g.to_string()))
-                        .collect();
-                    let chars = Self::apply_limit(chars, limit);
-                    return Some(Ok(make_seq(chars)));
-                }
-                let mut result = Vec::new();
-                let mut offset = 0usize;
-                while offset <= text.len() {
-                    if let Some(lim) = limit
-                        && result.len() >= lim as usize
-                    {
-                        break;
-                    }
-                    let Some(pos) = text[offset..].find(needle.as_str()) else {
-                        break;
-                    };
-                    let start = offset + pos;
-                    let end = start + needle.len();
-                    result.push(Value::str(text[start..end].to_string()));
-                    offset = end;
-                }
-                Some(Ok(make_seq(result)))
+            // Pure Int-chunk / Str-fixed split: single shared impl in
+            // `builtins::comb` (also driving the native fast path). The regex
+            // engine cases below stay here because they need the interpreter.
+            Some(m @ (Value::Int(_) | Value::Str(_))) => {
+                let items = crate::builtins::comb::comb_pure(&text, Some(m), limit)
+                    .expect("comb_pure always handles Int/Str matchers");
+                Some(Ok(make_seq(items)))
             }
             Some(Value::Regex(pat)) => {
                 // Use the capturing path only when the regex contains code

--- a/t/comb-native-layer.t
+++ b/t/comb-native-layer.t
@@ -1,0 +1,40 @@
+use Test;
+
+# `.comb` Int-chunk and Str-fixed matchers are a single pure implementation in
+# builtins::comb, shared by the native fast path and the interpreter. The Regex
+# matcher stays in the interpreter (regex engine). These exercise both layers and
+# the same construct under EVAL (interpreter carrier).
+
+plan 18;
+
+# --- Int chunk matcher (native) ---
+is "aabbcc".comb(2).join('|'), 'aa|bb|cc', 'comb(Int) chunks';
+is "abcde".comb(2).join('|'), 'ab|cd|e', 'comb(Int) trailing short chunk';
+is "aabbcc".comb(2, 2).join('|'), 'aa|bb', 'comb(Int, limit)';
+is "aaa".comb(2, 0).elems, 0, 'comb(Int, 0) is empty';
+is "abc".comb(-1).join('|'), 'a|b|c', 'comb(Int<=0) is per-grapheme';
+
+# --- Str fixed matcher (native) ---
+is "abcabc".comb("bc").join('|'), 'bc|bc', 'comb(Str) fixed needle';
+is "a.b.c".comb(".").join('|'), '.|.', 'comb(Str) literal dot';
+is "hello".comb("").join('|'), 'h|e|l|l|o', 'comb("") splits graphemes';
+is "xaxax".comb("a", 1).join('|'), 'a', 'comb(Str, limit)';
+is "abc".comb("z").elems, 0, 'comb(Str) no match is empty';
+
+# --- no-arg grapheme split (native 0-arg) ---
+is "héllo".comb.elems, 5, 'comb() grapheme count';
+
+# --- Regex matcher (interpreter path) ---
+is "a1b2c3".comb(/\d/).join('|'), '1|2|3', 'comb(/rx/) single digits';
+is "foo123bar456".comb(/\d+/).join('|'), '123|456', 'comb(/rx/) digit runs';
+is "a1b2c3".comb(/\d/, 2).join('|'), '1|2', 'comb(/rx/, limit)';
+
+# --- Code matcher is rejected (interpreter path) ---
+dies-ok { "abc".comb({ $_ }) }, 'comb(Code) dies';
+
+# --- EVAL carrier (interpreter evaluates the call) ---
+is EVAL(q{"aabbcc".comb(2).join('|')}), 'aa|bb|cc', 'comb(Int) via EVAL';
+is EVAL(q{"a1b2".comb(/\d/).join('|')}), '1|2', 'comb(/rx/) via EVAL';
+
+# --- Unicode grapheme chunking (native, combining marks) ---
+is "a\c[COMBINING ACUTE ACCENT]bc".comb(1).elems, 3, 'comb(1) counts graphemes not codepoints';


### PR DESCRIPTION
## Summary

`.comb`'s **Int-chunk** and **Str-fixed-needle** matchers are pure string operations, but they lived only in the interpreter (`runtime/.../dispatch_comb_with_args`). So `"x".comb(2)` / `.comb("y")` took a VM→interpreter fallback despite needing no interpreter state — the single impl was in the wrong layer. (The 0-arg grapheme split was already native; the arg'd pure cases were stranded.)

## Change

Relocate the pure split into `src/builtins/comb.rs` as one shared `comb_pure`, following the `builtins::split` precedent:

- Native fast path gains a `comb` arm in `native_method_1arg` / `native_method_2arg` (via `native_comb_method`) for plain string targets.
- The interpreter's `dispatch_comb_with_args` now **calls** `comb_pure` for the Int/Str cases instead of reimplementing them.

This removes the VM→interpreter fallback for Int/Str comb and fixes the layering **without duplicating logic** — one implementation, in the native layer, reached by both engines. The `Regex` matcher (regex engine, code blocks, `Match` objects) and the Code-argument rejection stay in the interpreter where they genuinely belong (`comb_pure` returns `None` so the caller defers). Supply/IO targets keep their interpreter comb semantics (native arms bail for those).

Part of an architecture review under the project's "dedup over perf" principle: split was already exemplary (pure helpers in `builtins/split.rs`, reused by the interpreter for the regex case); comb/substr had their pure matchers mis-placed in the interpreter layer. This is the comb half.

Category C Phase 3 item ② (PLAN.md).

## Tests

New `t/comb-native-layer.t` (18 cases: Int/Str/limit/grapheme/regex/Code-dies/EVAL/Unicode). Whitelisted `roast/S32-str/comb.t`, `roast/S16-io/comb.t`, `roast/S17-supply/comb.t` and full `make test` pass; verified Int/Str/limit edge cases (`comb(2,0)`, `comb(-1)`, `comb("")`) against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)