### PR TITLE
refactor(substr): collapse four native substr slice copies into one shared helper

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1219,17 +1219,7 @@ fn native_function_2arg(
             if matches!(arg1, Value::Junction { .. }) || matches!(arg2, Value::Junction { .. }) {
                 return None;
             }
-            let start = match arg2 {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None, // negative: let runtime handle
-                _ => return None,
-            };
-            let s = arg1.to_string_value();
-            let chars: Vec<char> = s.chars().collect();
-            if start > chars.len() {
-                return None; // out-of-range: let runtime handle (returns Failure)
-            }
-            Some(Ok(Value::str(chars[start..].iter().collect())))
+            super::substr::native_substr_slice(&arg1.to_string_value(), arg2, None)
         }
         "samemark" => {
             let target = arg1.to_string_value();
@@ -1442,23 +1432,7 @@ fn native_function_3arg(
             {
                 return None;
             }
-            let start = match arg2 {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None, // negative: let runtime handle
-                _ => return None,
-            };
-            let len = match arg3 {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None,
-                _ => return None,
-            };
-            let s = arg1.to_string_value();
-            let chars: Vec<char> = s.chars().collect();
-            if start > chars.len() {
-                return None; // out-of-range: let runtime handle (returns Failure)
-            }
-            let end = (start + len).min(chars.len());
-            Some(Ok(Value::str(chars[start..end].iter().collect())))
+            super::substr::native_substr_slice(&arg1.to_string_value(), arg2, Some(arg3))
         }
         _ => None,
     }

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1024,19 +1024,7 @@ pub(crate) fn native_method_1arg(
                 None => Some(Ok(Value::Nil)),
             }
         }
-        "substr" => {
-            let start = match arg {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None, // negative: let runtime handle
-                _ => return None,
-            };
-            let s = target.to_string_value();
-            let chars: Vec<char> = s.chars().collect();
-            if start > chars.len() {
-                return None; // out-of-range: let runtime handle (returns Failure)
-            }
-            Some(Ok(Value::str(chars[start..].iter().collect())))
-        }
+        "substr" => super::substr::native_substr_slice(&target.to_string_value(), arg, None),
         "indent" => {
             let s = target.to_string_value();
             let (result, warning) = str_indent(&s, arg);
@@ -2924,25 +2912,7 @@ pub(crate) fn native_method_2arg(
                 )))
             }
         }
-        "substr" => {
-            let start = match arg1 {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None, // negative: let runtime handle
-                _ => return None,
-            };
-            let len = match arg2 {
-                Value::Int(i) if *i >= 0 => *i as usize,
-                Value::Int(_) => return None,
-                _ => return None,
-            };
-            let s = target.to_string_value();
-            let chars: Vec<char> = s.chars().collect();
-            if start > chars.len() {
-                return None; // out-of-range: let runtime handle (returns Failure)
-            }
-            let end = (start + len).min(chars.len());
-            Some(Ok(Value::str(chars[start..end].iter().collect())))
-        }
+        "substr" => super::substr::native_substr_slice(&target.to_string_value(), arg1, Some(arg2)),
         "base" => {
             let radix = match arg1 {
                 Value::Int(r) if (2..=36).contains(r) => *r as u32,

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod primality;
 pub(crate) mod rng;
 pub(crate) mod split;
 pub(crate) mod str_increment;
+pub(crate) mod substr;
 pub(crate) mod transliterate;
 pub(crate) mod unicode;
 pub(crate) mod unicode_numval_table;

--- a/src/builtins/substr.rs
+++ b/src/builtins/substr.rs
@@ -1,0 +1,52 @@
+//! Pure (engine-agnostic) `substr` fast-path slice.
+//!
+//! The simple `substr` case — a non-negative integer start with an optional
+//! non-negative integer length — is a pure character slice. It was copied four
+//! times across the native layer (`native_method_1arg`/`native_method_2arg` for
+//! the `.substr` method, and the 2-/3-arg `substr` function in
+//! `builtins::functions`). This collapses those copies into one shared
+//! [`native_substr_slice`].
+//!
+//! Anything that needs interpreter state — a negative / `WhateverCode` start or
+//! length (`substr(*-3, *-1)`), a `Range` argument (`substr(2..5)`), or an
+//! out-of-range start (which must produce a `Failure` wrapping `X::OutOfRange`)
+//! — stays in the interpreter's `dispatch_substr`. This helper returns `None`
+//! for all of those so the caller defers, exactly as the four copies did.
+
+use crate::value::{RuntimeError, Value};
+
+/// Pure `substr` slice for a non-negative integer `start` and optional
+/// non-negative integer `len`. Returns `None` (defer to the interpreter) when
+/// `start`/`len` is negative or non-`Int`, or when `start` is past the end (the
+/// interpreter then returns a `Failure`).
+pub(crate) fn native_substr_slice(
+    text: &str,
+    start: &Value,
+    len: Option<&Value>,
+) -> Option<Result<Value, RuntimeError>> {
+    let start = match start {
+        Value::Int(i) if *i >= 0 => *i as usize,
+        Value::Int(_) => return None, // negative: let the interpreter handle
+        _ => return None,
+    };
+    let len = match len {
+        Some(Value::Int(i)) if *i >= 0 => Some(*i as usize),
+        Some(Value::Int(_)) => return None, // negative length
+        Some(_) => return None,             // WhateverCode / Num / etc.
+        None => None,
+    };
+
+    let chars: Vec<char> = text.chars().collect();
+    if start > chars.len() {
+        return None; // out-of-range: the interpreter returns a Failure
+    }
+
+    let slice: String = match len {
+        Some(l) => {
+            let end = (start + l).min(chars.len());
+            chars[start..end].iter().collect()
+        }
+        None => chars[start..].iter().collect(),
+    };
+    Some(Ok(Value::str(slice)))
+}

--- a/t/substr-native-layer.t
+++ b/t/substr-native-layer.t
@@ -1,0 +1,35 @@
+use Test;
+
+# The simple `substr` slice (non-negative Int start, optional non-negative Int
+# length) is a single pure helper in builtins::substr, shared by the four native
+# call sites (the .substr method 1-/2-arg, and the substr() function 2-/3-arg).
+# Negative / WhateverCode / Range starts and lengths, and out-of-range starts
+# (which return a Failure), stay in the interpreter's dispatch_substr.
+
+plan 16;
+
+# --- native fast path: method form ---
+is "hello world".substr(6), 'world', '.substr(start)';
+is "hello world".substr(0, 5), 'hello', '.substr(start, len)';
+is "hello".substr(2), 'llo', '.substr(start) mid';
+is "hello".substr(1, 2), 'el', '.substr(start, len) mid';
+is "hello".substr(5), '', '.substr(len) at end is empty';
+is "hello".substr(2, 100), 'llo', '.substr length past end clamps';
+
+# --- native fast path: function form ---
+is substr("hello world", 6), 'world', 'substr(str, start)';
+is substr("hello world", 0, 5), 'hello', 'substr(str, start, len)';
+
+# --- interpreter-coupled cases still work ---
+is "hello".substr(*-3), 'llo', '.substr(*-3) WhateverCode start';
+is "hello".substr(1, *-1), 'ell', '.substr(1, *-1) WhateverCode length';
+is "hello".substr(2..4), 'llo', '.substr(Range)';
+is "hello".substr(-2), 'lo', '.substr(negative start)';
+nok "abc".substr(10).defined, '.substr past end returns undefined (Failure)';
+
+# --- EVAL carrier (interpreter evaluates the call) ---
+is EVAL(q{"hello world".substr(6)}), 'world', 'simple substr via EVAL';
+is EVAL(q{"hello".substr(*-3)}), 'llo', 'WhateverCode substr via EVAL';
+
+# --- Unicode: char (not byte) indexing ---
+is "héllo".substr(1, 1), 'é', '.substr indexes by character';


### PR DESCRIPTION
## Summary

The simple `substr` slice — a non-negative integer start with an optional non-negative integer length — was copied **four times** across the native layer: `native_method_1arg` / `native_method_2arg` (the `.substr` method) and the 2-/3-arg `substr` function in `builtins::functions`. Each parsed a non-negative `Int` start (deferring on negative/non-`Int`), an optional non-negative `Int` length, collected chars, bounds-checked, and sliced — identical logic four times.

## Change

Collapse them into one pure `builtins::substr::native_substr_slice(text, start, len)`. All four native call sites delegate to it (the function form keeps its `Junction` guards).

The interpreter's `dispatch_substr` stays as the single owner of the cases that genuinely need it: a negative / `WhateverCode` start or length (`substr(*-3, *-1)`), a `Range` argument (`substr(2..5)`), and out-of-range starts (which return a `Failure` wrapping `X::OutOfRange`).

## Why this shape (vs the comb relocation)

Unlike `comb` — where a substantial **pure** algorithm (Int-chunk / Str-needle split) was stranded in the interpreter and got relocated down to `builtins::comb` — `substr`'s interpreter-side logic is *position resolution* that is genuinely interpreter-coupled: a `WhateverCode` start or length calls `eval_call_on_value`, and out-of-range produces a `Failure` exception. There is no pure algorithm to relocate from the interpreter. The real duplication for `substr` was the **four native copies** of the trivial slice, which this collapses to one.

Part of the same architecture review under the project's "dedup over perf" principle. Category C Phase 3 item ② (PLAN.md).

## Tests

New `t/substr-native-layer.t` (16 cases: method/function fast paths, WhateverCode/Range/negative/out-of-range interpreter cases, EVAL carrier, Unicode char indexing). Whitelisted `roast/S32-str/substr.t` and full `make test` pass; verified all forms against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)