### PR TITLE
docs(container): record Phase 1 slice-1 finding (broad closure boxing reverted)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -197,3 +197,23 @@ push」に変えると、配列要素が `Value::Scalar`/`ContainerRef`/`ItemArr
   - §7 に値読み出し opcode の棚卸し表を追加（Phase 1 の設計図。`GetLocalRaw` を lvalue 読みのアンカー前例に）。
   - 挙動不変を確認: build/clippy/fmt PASS。binding/`.VAR`/`=:=`/sigilless の t/ + S03-binding roast 全 PASS。
     全 roast は CI に委譲。
+- 2026-06-08: **Phase 1 第1スライス（非ループ兄弟クロージャの broad boxing）を試行 → revert（重要な教訓）**。
+  `box_captured_lexicals` のループ限定ゲートを撤去し非ループの捕捉＋変異 `$` スカラーも `ContainerRef` 化する
+  approach を試したが、**性能・正しさの両面で under-scoped** と判明し revert。理由を記録（次スライスの設計制約）:
+  - **(1) mutation-writeback ギャップ（部分的に対処可）**: `into_deref`（PR #2742）は**読み**だけを cell 対応に
+    したが、**変異の書き戻し**は cell 非対応だった。具体的に `overwrite_instance_recursive`
+    （`runtime/methods_mut.rs`、変異メソッドの結果を instance identity で全 env 束縛へ伝播するチョークポイント）が
+    `Value::ContainerRef` の中を見ず、boxed スカラーが instance を保持して変異メソッドを受けると変異が消えた
+    （`my $x; lives-ok { $x = Obj.new }; lives-ok { $x.mutate }; $x.read` という **roast 頻出のテストヘルパ
+    パターン**。submethods.t / S24-testing / test-util 等が回帰）。`ContainerRef` arm 追加で修正可能と確認したが、
+    これは「mutation 経路を全て cell 対応にする broad audit」の入口に過ぎない。
+  - **(2) 深刻な性能回帰（approach を否定する決定打）**: broad boxing は **closure 生成毎に**捕捉＋変異の全
+    自由変数を `Arc<Mutex>` 化し env へ insert する（= env COW のディープクローン誘発）。loop-only 制限は
+    正しさだけでなく **boxing コストの上限**でもあった。撤去した結果 `roast/S32-num/int.t` が **1 秒 → 150s+
+    に激遅化**（3 ファイルを main へ戻すと 1 秒に復帰、と差分で確定）。`make test` では露見せず CI の release
+    全 roast で timeout として顕在化。
+  - **教訓 / 次スライスの設計制約**: 兄弟クロージャ共有は **escape 解析（脱出する＝返却/外部格納される
+    クロージャの捕捉だけ box。`lives-ok {…}` のような即時呼び出し引数クロージャは box しない）** で
+    boxing 対象を絞り、かつ **mutation-writeback を cell 対応化**してから入れる必要がある。素朴な
+    「ループ限定を外すだけ」は不可。これは §6「速度の担保＝エスケープ解析でコンテナを省略」の実証でもある。
+  - revert で main は clean（`#2742` の `into_deref` 地ならしのみ残す）。`int.t` は 1 秒に復帰。


### PR DESCRIPTION
## Summary

Records the finding from attempting **Phase 1 slice 1** (sibling-closure container sharing) and why it was reverted. Docs-only; no code change. main keeps only the safe `into_deref` groundwork from #2742.

## What was attempted

Broaden `box_captured_lexicals` beyond loop-body locals so non-loop sibling/escaping closures share a captured `$` scalar's `ContainerRef` cell (the target: `sub make { my $v=1; my $g={$v}; my $s=->$n{$v=$n}; return $g,$s }; my ($g,$s)=make(); $s(42); say $g()` → 42).

## Why reverted (both fatal)

1. **Correctness** — mutation-writeback through cells is unimplemented across paths. `into_deref` (#2742) made *reads* cell-aware, but `overwrite_instance_recursive` (propagates a mutating method's result to env bindings by instance identity) didn't descend into `ContainerRef`, so a boxed scalar holding an instance lost its mutation — regressing the ubiquitous test-helper pattern `my $x; lives-ok { $x = Obj.new }; lives-ok { $x.mutate }; $x.read` (submethods.t / S24-testing / test-util). Fixable, but only the entrance to a broad mutation-writeback audit.
2. **Performance (decisive)** — broad boxing allocates an `Arc<Mutex>` + env insert (→ env COW deep-clone) per closure creation; the loop-only gate also bounded that cost. Removing it made `roast/S32-num/int.t` go **~1s → 150s+** (CI timeout). Confirmed by reverting the 3 files → back to ~1s. Hidden from `make test`; surfaced only in the CI release roast.

## Constraint for the real slice

Sibling-closure sharing needs **escape analysis** (box only captures of escaping/returned closures, not immediate call-arg closures like `lives-ok {…}`) **plus** a mutation-writeback cell audit — not a naive lifting of the loop-only restriction. This is the deferred "broad ContainerRef audit" and validates §6 (escape analysis to elide containers).

Supersedes #2746 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)