### PR TITLE
refactor(vm): visualize Interpreter fallbacks (ledger) + route succ/pred through unified dispatch

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -97,7 +97,10 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       ＝生きた Instance/Buf/Failure メソッド fork）、`run_instance_method`（`class.rs` ＝ユーザー定義クラスメソッド）、
       `call_function`/`call_function_fallback`（`vm_call_func_ops.rs`/`vm_call_dispatch.rs`）、`run_react_event_loop` を
       VM ネイティブ実行に置換。**残すフォールバックには規約どおり `// TODO: compile to bytecode` を付与**（現状 VM ツリー
-      に 0 件 ＝ 負債が不可視。まず可視化する）。
+      に 0 件 ＝ 負債が不可視。まず可視化する）。**可視化済み（2026-06-08）**: 全サイトを `// TODO: compile to bytecode`
+      （真フォールバック）/ `// CARRIER:`（反射・MOP・EVAL・メタプロ hook）で注釈し、進捗台帳
+      [docs/vm-interpreter-fallback-ledger.md](docs/vm-interpreter-fallback-ledger.md) を新設。同 PR で `succ`/`pred` を
+      統一 compiled-first ディスパッチへ降ろし §1 から 2 サイト消化。以後は台帳の行を消す形で進める。
 - [ ] **② 宣言の実行を VM 所有レジストリへ**: `class`/`role`/`enum`/`subset`/`token`/`sub`/`method` は現在
       `Register*` opcode が `interpreter.register_*_decl()` を呼び、クラスシステム・MRO・role 合成が Interpreter 側。
       これらのレジストリを VM 所有データへ移す（②は③の前提）。

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -1,0 +1,75 @@
+# VM → Interpreter フォールバック台帳
+
+最終ゴール「tree-walking Interpreter 実行パスの撤去 → dual-store 削除」（[PLAN.md](../PLAN.md) ①〜⑤）の
+**進捗台帳**。VM (`src/vm/`) が今も Interpreter (`src/runtime/`) に委譲しているサイトを 1 箇所ずつ列挙し、
+撲滅のたびに行を消す。関連: [vm-interpreter-dedup.md](vm-interpreter-dedup.md)（重複削除）、
+[vm-dual-store.md](vm-dual-store.md)（locals↔env）、[vm-decoupling.md](vm-decoupling.md)（dispatch）。
+
+## 用語
+
+- **真フォールバック** = 本来 bytecode で実行すべきだが今は tree-walk Interpreter に委譲しているもの。
+  コードに `// TODO: compile to bytecode` を付与。これらを撲滅するのが ①。
+- **CARRIER** = 撲滅対象ではない本質的委譲（reflection / MOP / EVAL サブ VM / メタプロ hook / mode 状態）。
+  Interpreter が共有レジストリ・実行状態を所有するための参照であって tree-walk ではない（④ で「分離 or 明示」）。
+  コードに `// CARRIER:` を付与。③で env/レジストリ所有が VM に移れば単なる共有参照になる。
+
+可視化の現状: `grep -rn "TODO: compile to bytecode" src/vm/` = 18 マーカー、`grep -rn "// CARRIER:" src/vm/` = 8 マーカー。
+（1 マーカーが近接する複数サイトを束ねる箇所あり。下表が正準。）
+
+## §1 — メソッドディスパッチの真フォールバック（`call_method_with_values` / `_mut_`）
+
+| file:line | 受け手 / メソッド | 難易度 | ブロッカー / 依存 |
+|---|---|---|---|
+| `vm_call_method_compiled.rs` native-method (非mut) | Instance の native(Rust)メソッド | MEDIUM | native メソッドを VM から直接呼ぶ経路。lever A 系 |
+| `vm_call_method_compiled.rs` catch-all (非mut) | generic Instance/Buf/Failure メソッド | HARD | ③ state 所有移管（残る主 tree-walk） |
+| `vm_call_method_compiled.rs` native-method (mut) | 同上 mut | MEDIUM | 同上 |
+| `vm_call_method_compiled.rs` catch-all (mut) | 同上 mut | HARD | ③ |
+| `vm_call_method_mut_ops.rs` catch-all | generic mut メソッド | HARD | ③ |
+| `vm_call_method_mut_ops.rs` array-backed instance | `is Array` storage の push/pop/shift | MEDIUM | 第一級コンテナ Phase 2 |
+| `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B（共有セル所有） |
+| `vm_data_ops.rs` shaped push | shaped 配列 push | MEDIUM | shaped 次元メタ検査の VM 化 |
+| `vm_data_ops.rs` non-simple push | closure-captured / 非Array push | MEDIUM | 第一級コンテナ Phase 2（ContainerRef） |
+| `vm_smart_match.rs` key-method | smartmatch のキーメソッド抽出 | EASY-MED | ③ |
+| `vm_dispatch_helpers.rs` Routine dispatch | Routine 値の call_function/method | MEDIUM | ② レジストリ / multi 解決 |
+| `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |
+| `vm_register_ops.rs` react loop | `run_react_event_loop[_drain]` | HARD | lever B（async state 所有） |
+
+## §2 — 関数ディスパッチの真フォールバック（`call_function` / `call_function_fallback`）
+
+| file:line | 文脈 | 難易度 | ブロッカー / 依存 |
+|---|---|---|---|
+| `vm_call_func_ops.rs` builtin-shadow | builtin を上書きするユーザ sub | MEDIUM | ② |
+| `vm_call_func_ops.rs` multi-dispatch | ユーザ multi 候補優先 | HARD | VM 側 multi-candidate 解決 |
+| `vm_call_func_ops.rs` final else | EVAL 以外の tree-walk 関数 | HARD | ③（else 分岐のみ真フォールバック。carrier は別） |
+| `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端 | HARD | ③ |
+| `vm_var_get_ops.rs` 0-arg term | 0引数のユーザ/multi 関数 term | MEDIUM | ② |
+| `vm_var_get_ops.rs` pkg-qualified | `Module::func` を term 位置で | MEDIUM | ② |
+
+## §C — CARRIER（撲滅対象外・文書化して残す。④で確定）
+
+| file:line | 種別 | 理由 |
+|---|---|---|
+| `vm_call_method_compiled.rs` pseudo-method (非mut/mut) | MOP reflection | DEFINITE/WHAT/WHO/HOW/WHY/WHICH/WHERE/VAR は反射、bytecode 形なし |
+| `vm_call_method_compiled.rs` ^metamethod (非mut/mut) | MOP | `Foo.^bar` メタメソッドは MOP 所有 |
+| `vm_register_ops.rs` `.VAR` + `trait_mod:<is>` | コンテナ反射 + メタプロ hook | `.VAR` 反射 + ユーザ trait ハンドラ |
+| `vm_register_ops.rs` `trait_mod:<is>` 各サイト | メタプロ hook | sub/型/変数への is トレイト適用（複数箇所） |
+| `vm_var_get_ops.rs` pseudo-package | 反射スコープ解決 | `SETTING::`/`OUTER::`/`CALLER::`/`DYNAMIC::` |
+| `vm_var_get_ops.rs` test-function | mode 状態 | `make-temp-dir` 等の Test ハーネス dispatch |
+| `vm_var_get_ops.rs` call-chain | MOP dispatch stack | `callsame`/`nextsame`/`callwith`/`nextwith`/`nextcallee`/`lastcall` |
+| `vm_call_func_ops.rs` / `vm_call_dispatch.rs` carrier 分岐 | EVAL サブ VM | `EVAL`/`EVALFILE` は compile→サブ VM 実行。`is_interpreter_carrier_function` で runtime 判定済み |
+
+## 進捗ログ
+
+- **2026-06-08 (PR-1)**: ① の起点。全フォールバックを `// TODO: compile to bytecode` / `// CARRIER:` で可視化し
+  本台帳を新設。併せて EASY 撲滅 1 件: `succ`/`pred`（`vm_var_assign_ops.rs` の `increment_value_smart`/
+  `decrement_value_smart`）の生 `interpreter.call_method_with_values` を統一 compiled-first ディスパッチ
+  `try_compiled_method_or_interpret` に差し替え（§1 から 2 サイト消化）。
+
+## 撲滅の順序（PLAN.md ①〜⑤ に対応）
+
+1. EASY/MEDIUM な §1/§2 の個別撲滅（native-method 直呼び、Routine dispatch、0-arg/pkg-qualified term、
+   array-backed instance — うち container 依存は Phase 2 と合流）。
+2. ② 宣言レジストリ（class/role/enum/subset/sub/token）の VM 所有化。
+3. ③ env/型検査/readonly/let の VM 所有移管（最大の山。catch-all 群はここで消える）。
+4. ④ §C carrier の最終確定（所有が VM に移れば単なる共有参照）。
+5. ⑤ `env_dirty`/`saved_env_dirty`/`ensure_locals_synced`/`sync_locals_from_env` 削除。

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -69,6 +69,8 @@ impl VM {
         if let Some(result) = self.try_native_test_function(name, &args) {
             return result;
         }
+        // CARRIER (EVAL/pseudo-package) vs TODO: compile to bytecode (else branch =
+        // true tree-walk function fallback). See ledger §2/§C.
         if Self::is_interpreter_carrier_function(name) {
             crate::vm::vm_stats::record_function_carrier(name);
         } else {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -412,6 +412,7 @@ impl VM {
             // Slice 6.3 step 2: precise env_dirty from the named-call merge.
         } else if self.interpreter.user_function_matches_call(&name, &args) {
             // A user-defined sub shadows a same-named builtin.
+            // TODO: compile to bytecode — builtin-shadowing user sub fork (ledger §2).
             crate::vm::vm_stats::record_function_fallback(&name);
             let result = self.interpreter.call_function_fallback(&name, &args)?;
             let result = self.interpreter.maybe_fetch_rw_proxy(result, true)?;
@@ -693,6 +694,8 @@ impl VM {
                     // User-defined multi candidates take priority over builtins.
                     // Call call_function_fallback directly to bypass the builtin match
                     // in call_function, which would shadow user-defined multi subs.
+                    // TODO: compile to bytecode — multi-dispatch sub fork, blocked-by:
+                    // VM-side multi-candidate resolution (ledger §2).
                     crate::vm::vm_stats::record_function_fallback(name);
                     self.interpreter.set_pending_call_arg_sources(arg_sources);
                     let result = self.interpreter.call_function_fallback(name, &args);
@@ -733,6 +736,9 @@ impl VM {
                     // EVAL/EVALFILE compile to bytecode and run on a sub-VM, and
                     // pseudo-package reads are reflective env lookups: the
                     // interpreter is a carrier here, not a tree-walk fallback.
+                    // CARRIER (is_interpreter_carrier_function) vs TODO: compile to
+                    // bytecode (else branch = true tree-walk function fallback). The
+                    // record_* split already tracks this at runtime. See ledger §2/§C.
                     if Self::is_interpreter_carrier_function(name) {
                         crate::vm::vm_stats::record_function_carrier(name);
                     } else {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -221,6 +221,7 @@ impl VM {
         self.interpreter
             .env_mut()
             .insert(temp_name.clone(), item.clone());
+        // TODO: compile to bytecode — hyper method call over a temp-bound item (ledger §1).
         let result =
             self.interpreter
                 .call_method_mut_with_values(&temp_name, item.clone(), method, args)?;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -159,12 +159,14 @@ impl VM {
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             if self.interpreter.is_native_method(&class, method) {
+                // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self
                     .interpreter
                     .call_method_with_values(target, method, args);
             }
         }
+        // CARRIER: MOP pseudo-methods (reflection; no bytecode form). See ledger §C.
         // Pseudo-methods must always go through the interpreter which handles
         // them specially — never intercept via the compiled fast path.
         if matches!(
@@ -267,6 +269,7 @@ impl VM {
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
+                // CARRIER: user-defined ^metamethod dispatch (MOP). See ledger §C.
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self
                     .interpreter
@@ -421,6 +424,8 @@ impl VM {
         if let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
+        // TODO: compile to bytecode — generic Instance/Buf/Failure method fork,
+        // the primary remaining tree-walk method dispatch (ledger §1).
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
@@ -622,6 +627,7 @@ impl VM {
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             if self.interpreter.is_native_method(&class, method) {
+                // TODO: compile to bytecode — Instance native-method fork, mut (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self.interpreter.call_method_mut_with_values(
                     target_name,
@@ -635,6 +641,7 @@ impl VM {
             method,
             "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"
         ) {
+            // CARRIER: MOP pseudo-methods, mut (reflection). See ledger §C.
             crate::vm::vm_stats::record_method_fallback(method);
             return self
                 .interpreter
@@ -656,6 +663,7 @@ impl VM {
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
+                // CARRIER: user-defined ^metamethod dispatch, mut (MOP). See ledger §C.
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self
                     .interpreter
@@ -846,6 +854,7 @@ impl VM {
         if let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
+        // TODO: compile to bytecode — generic Instance/Buf/Failure method fork, mut (ledger §1).
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_mut_with_values(target_name, target, method, args)

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -300,6 +300,7 @@ impl VM {
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)?
         } else {
+            // TODO: compile to bytecode — generic mut method fork (ledger §1).
             self.interpreter
                 .call_method_mut_with_values(&target_name, target, &method, args)?
         };
@@ -1209,6 +1210,8 @@ impl VM {
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));
                         // Perform the operation on the backing array
+                        // TODO: compile to bytecode — Array-backed instance method
+                        // (push/pop/shift on `is Array` storage). See ledger §1.
                         crate::vm::vm_stats::record_method_fallback(&method);
                         let result = self
                             .interpreter

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -329,6 +329,8 @@ impl VM {
         target_name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let target_name = Self::const_str(code, target_name_idx);
+        // TODO: compile to bytecode — shared-array push, blocked-by: lever B
+        // (threaded shared-cell ownership). See ledger §1.
         // Fall back to interpreter for shared arrays (threaded context)
         if self.interpreter.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::Nil);
@@ -345,6 +347,8 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
+        // TODO: compile to bytecode — shaped-array push, blocked-by: shaped
+        // dimension metadata check in VM. See ledger §1.
         // Check for shaped arrays — must fall back to interpreter
         // (push is illegal on fixed-dimension arrays)
         if let Some(Value::Array(_, kind)) = self.interpreter.env().get(target_name)
@@ -380,6 +384,9 @@ impl VM {
             return Ok(());
         }
 
+        // TODO: compile to bytecode — non-simple-target push, blocked-by:
+        // first-class container identity Phase 2 (closure-captured ContainerRef
+        // arrays). See ledger §1.
         // Check the target exists as a simple Array in env.
         // If not (e.g., captured closure var, or non-Array), fall back to interpreter.
         let is_simple_array = self

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -345,6 +345,8 @@ impl VM {
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 
+        // TODO: compile to bytecode — Routine value dispatch (the call_function /
+        // call_method_with_values sites in this block). See ledger §1.
         // Routine: resolve to function name and dispatch
         // Keep using interpreter.call_function here because Routine values may
         // reference builtin functions (e.g. &SETTING::not resolves to Routine{name:"not"})

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1153,6 +1153,8 @@ impl VM {
             .get(name)
             .cloned()
             .unwrap_or(Value::Nil);
+        // CARRIER: `.VAR` pseudo-method + `trait_mod:<is>` metaprogramming hook
+        // (reflective container object + user trait handler). See ledger §C.
         let var_obj = self
             .interpreter
             .call_method_mut_with_values(name, target, "VAR", vec![])?;
@@ -1644,6 +1646,8 @@ impl VM {
         // If `done;` was called in the react body, skip the event loop —
         // the body already signaled that no further events should be processed.
         let body_done = matches!(&run_result, Err(e) if e.is_react_done);
+        // TODO: compile to bytecode — react/supply event loop, blocked-by: async
+        // state ownership (lever B). See ledger §1.
         let event_result = if body_done {
             // Drain any queued subscriptions so they don't leak
             self.interpreter.run_react_event_loop_drain();

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -595,6 +595,7 @@ impl VM {
             )
         {
             let method_name = key.as_str();
+            // TODO: compile to bytecode — smartmatch key-method extraction (ledger §1).
             match self
                 .interpreter
                 .call_method_with_values(left.clone(), method_name, vec![])

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1380,10 +1380,12 @@ impl VM {
 
     /// Increment a value, calling .succ() on Instance values with custom methods.
     pub(super) fn increment_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
+        // Route user-defined `.succ` through the VM's unified compiled-first
+        // dispatch (same entry point `.Str` interpolation already uses) instead
+        // of a raw interpreter tree-walk — one method-dispatch path, not two.
         if let Value::Instance { .. } = val
             && let Ok(result) =
-                self.interpreter
-                    .call_method_with_values(val.clone(), "succ", vec![])
+                self.try_compiled_method_or_interpret(val.clone(), "succ", Vec::new())
         {
             return Ok(result);
         }
@@ -1430,10 +1432,12 @@ impl VM {
 
     /// Decrement a value, calling .pred() on Instance values with custom methods.
     pub(super) fn decrement_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
+        // Route user-defined `.pred` through the VM's unified compiled-first
+        // dispatch (see increment_value_smart) instead of a raw interpreter
+        // tree-walk — one method-dispatch path, not two.
         if let Value::Instance { .. } = val
             && let Ok(result) =
-                self.interpreter
-                    .call_method_with_values(val.clone(), "pred", vec![])
+                self.try_compiled_method_or_interpret(val.clone(), "pred", Vec::new())
         {
             return Ok(result);
         }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -130,8 +130,8 @@ impl VM {
                 && !name.starts_with('%')
                 && matches!(v, Value::Routine { .. } | Value::Sub(_) | Value::WeakSub(_))
             {
-                // Pseudo-package names (SETTING::, OUTER::, CALLER::) need interpreter's
-                // special resolution logic, so use call_function directly for those.
+                // CARRIER: pseudo-package names (SETTING::, OUTER::, CALLER::) need
+                // the interpreter's reflective scope resolution. See ledger §C.
                 // For regular qualified names, try compiled dispatch first.
                 let result = if self.is_interpreter_handled_function(name) {
                     self.interpreter.call_function(name, Vec::new())?
@@ -187,6 +187,7 @@ impl VM {
             // should go through the normal function resolution path.
             && name.contains('-')
         {
+            // CARRIER: Test-framework function dispatch (test-mode state). See ledger §C.
             let result = self.interpreter.call_function(name, Vec::new())?;
             self.env_dirty = true;
             result
@@ -203,6 +204,7 @@ impl VM {
             {
                 native_result?
             } else {
+                // TODO: compile to bytecode — 0-arg user/multi function term fork (ledger §2).
                 let result = self.interpreter.call_function(name, Vec::new())?;
                 self.env_dirty = true;
                 result
@@ -214,6 +216,7 @@ impl VM {
             || name == "nextcallee"
             || name == "lastcall"
         {
+            // CARRIER: call-chain introspection (interpreter MOP dispatch stack). See ledger §C.
             let result = self.interpreter.call_function(name, Vec::new())?;
             self.env_dirty = true;
             result
@@ -236,6 +239,7 @@ impl VM {
             if let Some((_pkg, short)) = name.rsplit_once("::")
                 && self.interpreter.has_function(&format!("GLOBAL::{}", short))
             {
+                // TODO: compile to bytecode — package-qualified function term fork (ledger §2).
                 let result = self.interpreter.call_function(name, Vec::new())?;
                 self.env_dirty = true;
                 result

--- a/t/succ-pred-instance.t
+++ b/t/succ-pred-instance.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 6;
+
+# User-defined .succ / .pred on a class should be invoked by ++ / --.
+# This exercises the VM's unified compiled-first method dispatch for the
+# increment/decrement smart paths (increment_value_smart/decrement_value_smart).
+class Counter {
+    has $.n;
+    method succ { Counter.new(n => $.n + 1) }
+    method pred { Counter.new(n => $.n - 1) }
+}
+
+my $c = Counter.new(n => 5);
+$c++;
+is $c.n, 6, 'postfix ++ calls user-defined .succ';
+$c--;
+$c--;
+is $c.n, 4, 'postfix -- calls user-defined .pred twice';
+
+my $d = Counter.new(n => 10);
+++$d;
+is $d.n, 11, 'prefix ++ calls user-defined .succ';
+--$d;
+is $d.n, 10, 'prefix -- calls user-defined .pred';
+
+# Chained custom succ keeps returning fresh instances.
+my $e = Counter.new(n => 0);
+$e++ for ^3;
+is $e.n, 3, 'repeated ++ accumulates via .succ';
+
+# Mixed direction nets out correctly through succ/pred.
+my $f = Counter.new(n => 100);
+$f++; $f--; $f++;
+is $f.n, 101, 'mixed ++/-- net result via succ/pred';


### PR DESCRIPTION
最終ゴール「tree-walking Interpreter 実行パスの撤去 → dual-store 削除」（PLAN.md ①〜⑤）の **着手 PR**。

## 背景
調査で判明: VM ツリーに `// TODO: compile to bytecode` が **0 件** ＝ 残存する真の tree-walk フォールバックが完全に不可視だった。PLAN.md ① 自身が「まず可視化する」と明記している。

## 変更
- **可視化（メイン・挙動不変）**: 全 VM→Interpreter 委譲サイトに注釈を付与。
  - `// TODO: compile to bytecode` … 本来 bytecode 化すべき真フォールバック（18 マーカー）
  - `// CARRIER:` … 反射 / MOP / EVAL サブVM / メタプロ hook / mode 状態 ＝ 撲滅対象でない本質的委譲（8 マーカー）
- **進捗台帳新設** `docs/vm-interpreter-fallback-ledger.md`: 全サイトを §1 メソッド dispatch / §2 関数 dispatch / §C carrier に分類し、撲滅難易度・ブロッカー・依存ステップを表で列挙。以後 ① はこの台帳の行を消す形で進める。
- **EASY 撲滅 1 件（dedup・結果不変）**: ユーザ定義 `.succ`/`.pred`（`increment_value_smart`/`decrement_value_smart`）の生 `interpreter.call_method_with_values` を、VM の統一 compiled-first ディスパッチ `try_compiled_method_or_interpret`（同経路を `.Str` 補間が既に採用）へ差し替え。「1 操作 = 1 ディスパッチ経路」。§1 から 2 サイト消化。

> 誠実性メモ: 事前に「EASY」候補とした非単純配列 push / multi-dispatch / pkg 修飾は、実コード上は第一級コンテナ Phase 2 / VM 側 multi 解決が前提のため今 PR では撲滅せず TODO 注釈に留めた。

## 検証
- `cargo build` / `cargo clippy` クリーン
- `t/succ-pred-instance.t` 新規（カスタム succ/pred を ++/-- 経由で検証）
- roast `S03-operators/{autoincrement,autoincrement-range,increment}.t` + `S03-sequence/{nonnumeric,exhaustive}.t` 計 392 tests pass
- EVAL 経路同値（`EVAL(q{...$x++...})` が raku と一致）
- 全体は CI に委譲

🤖 Generated with [Claude Code](https://claude.com/claude-code)