### PR TITLE
refactor(vm): route smartmatch + Routine method dispatch through unified dispatch (ledger §1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -29,8 +29,7 @@
 | `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B（共有セル所有） |
 | `vm_data_ops.rs` shaped push | shaped 配列 push | MEDIUM | shaped 次元メタ検査の VM 化 |
 | `vm_data_ops.rs` non-simple push | closure-captured / 非Array push | MEDIUM | 第一級コンテナ Phase 2（ContainerRef） |
-| `vm_smart_match.rs` key-method | smartmatch のキーメソッド抽出 | EASY-MED | ③ |
-| `vm_dispatch_helpers.rs` Routine dispatch | Routine 値の call_function/method | MEDIUM | ② レジストリ / multi 解決 |
+| ~~`vm_smart_match.rs` key-method~~ | ~~smartmatch のキーメソッド抽出~~ | — | **✅消化 (PR2)**: 統一 compiled-first へ |
 | `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |
 | `vm_register_ops.rs` react loop | `run_react_event_loop[_drain]` | HARD | lever B（async state 所有） |
 
@@ -44,6 +43,7 @@
 | `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端 | HARD | ③ |
 | `vm_var_get_ops.rs` 0-arg term | 0引数のユーザ/multi 関数 term | MEDIUM | ② |
 | `vm_var_get_ops.rs` pkg-qualified | `Module::func` を term 位置で | MEDIUM | ② |
+| `vm_dispatch_helpers.rs` Routine call_function | Routine 値の関数解決（method 部は消化済） | MEDIUM | ② レジストリ / multi 解決 |
 
 ## §C — CARRIER（撲滅対象外・文書化して残す。④で確定）
 
@@ -60,10 +60,15 @@
 
 ## 進捗ログ
 
-- **2026-06-08 (PR-1)**: ① の起点。全フォールバックを `// TODO: compile to bytecode` / `// CARRIER:` で可視化し
-  本台帳を新設。併せて EASY 撲滅 1 件: `succ`/`pred`（`vm_var_assign_ops.rs` の `increment_value_smart`/
+- **2026-06-08 (PR-1, #2755 merged)**: ① の起点。全フォールバックを `// TODO: compile to bytecode` / `// CARRIER:`
+  で可視化し本台帳を新設。併せて EASY 撲滅 1 件: `succ`/`pred`（`vm_var_assign_ops.rs` の `increment_value_smart`/
   `decrement_value_smart`）の生 `interpreter.call_method_with_values` を統一 compiled-first ディスパッチ
   `try_compiled_method_or_interpret` に差し替え（§1 から 2 サイト消化）。
+- **2026-06-08 (PR-2)**: 同手法で value-receiver の生 `call_method_with_values` をさらに 2 サイト消化 →
+  `vm_smart_match.rs` smartmatch キーメソッド、`vm_dispatch_helpers.rs` Routine の method-dispatch 分岐
+  （`&?ROUTINE.dispatcher()(self,…)`）を統一 compiled-first ディスパッチへ。ユーザ定義メソッドは compiled bytecode
+  実行になり、native/reflective のみが共有末端へ。t/smartmatch-method-dispatch.t 追加。S03-smartmatch 全 pass。
+  （補足: fat-arrow `$o ~~ (k => v)` が False を返すのは Pair 分岐到達前の別パースバグで本作業の対象外。コロンペアは正常。）
 
 ## 撲滅の順序（PLAN.md ①〜⑤ に対応）
 

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -345,8 +345,10 @@ impl VM {
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 
-        // TODO: compile to bytecode — Routine value dispatch (the call_function /
-        // call_method_with_values sites in this block). See ledger §1.
+        // TODO: compile to bytecode — Routine value dispatch (the call_function
+        // sites in this block; the method-dispatch site now routes through the
+        // unified compiled-first path). Blocked-by: VM-side function/multi
+        // resolution (ledger §2).
         // Routine: resolve to function name and dispatch
         // Keep using interpreter.call_function here because Routine values may
         // reference builtin functions (e.g. &SETTING::not resolves to Routine{name:"not"})
@@ -375,9 +377,9 @@ impl VM {
             {
                 let invocant = args[0].clone();
                 let method_args = args[1..].to_vec();
-                return self
-                    .interpreter
-                    .call_method_with_values(invocant, &name_str, method_args);
+                // Route through the VM's unified compiled-first dispatch (ledger §1):
+                // user-defined methods run as compiled bytecode, native fall back.
+                return self.try_compiled_method_or_interpret(invocant, &name_str, method_args);
             }
             return self.interpreter.call_function(&name_str, args);
         }

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -595,11 +595,12 @@ impl VM {
             )
         {
             let method_name = key.as_str();
-            // TODO: compile to bytecode — smartmatch key-method extraction (ledger §1).
-            match self
-                .interpreter
-                .call_method_with_values(left.clone(), method_name, vec![])
-            {
+            // Route the key-method call through the VM's unified compiled-first
+            // dispatch (ledger §1): user-defined methods run as compiled bytecode;
+            // only native/reflective methods bottom out at the interpreter. `left`
+            // is never an Array/Hash/Seq here (excluded above), so the native
+            // array/list fast paths inside are inert.
+            match self.try_compiled_method_or_interpret(left.clone(), method_name, Vec::new()) {
                 Ok(result) => {
                     return result.truthy() == val.truthy();
                 }

--- a/t/smartmatch-method-dispatch.t
+++ b/t/smartmatch-method-dispatch.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+# `$obj ~~ Pair` calls the method named by the pair key and compares its
+# boolean coercion with the pair value's. This exercises the VM's unified
+# compiled-first method dispatch for the smartmatch key-method path
+# (vm_smart_match.rs), using a non-accessor user-defined method.
+class N {
+    has $.n;
+    method even  { $.n %% 2 }
+    method big   { $.n > 100 }
+}
+
+my $four = N.new(n => 4);
+my $five = N.new(n => 5);
+
+ok  ($four ~~ :even(True)),  'user method via smartmatch pair: even(4) is True';
+ok  ($five ~~ :even(False)), 'user method via smartmatch pair: even(5) is False';
+ok  ($four ~~ :even),        ':even shorthand (=> True) matches even(4)';
+nok ($five ~~ :even),        ':even shorthand does not match odd(5)';
+
+my $huge = N.new(n => 9999);
+ok  ($huge ~~ :big),         'second user method (big) dispatches correctly';
+nok ($four ~~ :big),         'big(4) is False';


### PR DESCRIPTION
最終ゴール ①（PLAN.md: tree-walk フォールバック撲滅）の継続。#2755 と同じ手法で、value-receiver の生 `interpreter.call_method_with_values` を **2 サイト** VM 統一 compiled-first ディスパッチ `try_compiled_method_or_interpret` へ降ろす。

## 変更
- **`vm_smart_match.rs`**: `$obj ~~ Pair` のキーメソッド呼び（`?$obj."{k}" === ?v`）。`left` はこの分岐に届く時点で Array/Hash/Seq を除外済みなので統一エントリ内の native list 系 fast-path は不活性。`set_pending_dispatch_error` のエラー処理も保存。
- **`vm_dispatch_helpers.rs`**: Routine の `&?ROUTINE.dispatcher()(self, …)` メソッドディスパッチ（package が既知クラスのとき）。

ユーザ定義メソッドは compiled bytecode 実行になり、native/reflective のみが共有末端へ。台帳 §1 を 2 行消化（Routine の call_function サイトは §2 へ移動、VM 側 function/multi 解決待ち）。

## 検証
- `t/smartmatch-method-dispatch.t` 新規（非アクセサのユーザメソッドを `:k(v)` 経由で検証）
- roast `S03-smartmatch/*`（any-method, any-pair, any-hash-pair, 00-sanity, disorganized）全 pass
- `make test` 5327 tests PASS
- 挙動保存を git-stash 差分で確認（変更前後で出力同一）
- 補足: fat-arrow `$o ~~ (k => v)` が False を返すのは Pair 分岐到達前の別パースバグで本 PR 対象外（コロンペアは正常動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)