### PR TITLE
refactor(vm): route cold term-position function fallbacks through unified dispatch (ledger §2)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -20,9 +20,9 @@
 
 | file:line | 受け手 / メソッド | 難易度 | ブロッカー / 依存 |
 |---|---|---|---|
-| `vm_call_method_compiled.rs` native-method (非mut) | Instance の native(Rust)メソッド | MEDIUM | native メソッドを VM から直接呼ぶ経路。lever A 系 |
+| `vm_call_method_compiled.rs` native-method (非mut) | IO::Pipe/IO::Handle 等の組み込みクラスメソッド | HARD | ③（実装 `native_io_*` がファイルハンドル等の interpreter 所有状態を要求。当初「個別可」は誤り） |
 | `vm_call_method_compiled.rs` catch-all (非mut) | generic Instance/Buf/Failure メソッド | HARD | ③ state 所有移管（残る主 tree-walk） |
-| `vm_call_method_compiled.rs` native-method (mut) | 同上 mut | MEDIUM | 同上 |
+| `vm_call_method_compiled.rs` native-method (mut) | 同上 mut | HARD | ③（同上） |
 | `vm_call_method_compiled.rs` catch-all (mut) | 同上 mut | HARD | ③ |
 | `vm_call_method_mut_ops.rs` catch-all | generic mut メソッド | HARD | ③ |
 | `vm_call_method_mut_ops.rs` array-backed instance | `is Array` storage の push/pop/shift | MEDIUM | 第一級コンテナ Phase 2 |
@@ -37,12 +37,10 @@
 
 | file:line | 文脈 | 難易度 | ブロッカー / 依存 |
 |---|---|---|---|
-| `vm_call_func_ops.rs` builtin-shadow | builtin を上書きするユーザ sub | MEDIUM | ② |
-| `vm_call_func_ops.rs` multi-dispatch | ユーザ multi 候補優先 | HARD | VM 側 multi-candidate 解決 |
-| `vm_call_func_ops.rs` final else | EVAL 以外の tree-walk 関数 | HARD | ③（else 分岐のみ真フォールバック。carrier は別） |
+| ~~`vm_var_get_ops.rs` 0-arg term~~ | ~~0引数のユーザ/multi 関数 term~~ | — | **✅消化 (PR3)**: cold fallback を統一 compiled-first へ（OTF compile 追加） |
+| ~~`vm_var_get_ops.rs` pkg-qualified~~ | ~~`Module::func` を term 位置で~~ | — | **✅消化 (PR3)**: 同上 |
+| `vm_call_func_ops.rs` builtin-shadow / multi-dispatch / final else | `call_function_fallback` 直呼び等 | HARD | ② レジストリ / VM 側 multi 解決 / ③ |
 | `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端 | HARD | ③ |
-| `vm_var_get_ops.rs` 0-arg term | 0引数のユーザ/multi 関数 term | MEDIUM | ② |
-| `vm_var_get_ops.rs` pkg-qualified | `Module::func` を term 位置で | MEDIUM | ② |
 | `vm_dispatch_helpers.rs` Routine call_function | Routine 値の関数解決（method 部は消化済） | MEDIUM | ② レジストリ / multi 解決 |
 
 ## §C — CARRIER（撲滅対象外・文書化して残す。④で確定）
@@ -69,12 +67,23 @@
   （`&?ROUTINE.dispatcher()(self,…)`）を統一 compiled-first ディスパッチへ。ユーザ定義メソッドは compiled bytecode
   実行になり、native/reflective のみが共有末端へ。t/smartmatch-method-dispatch.t 追加。S03-smartmatch 全 pass。
   （補足: fat-arrow `$o ~~ (k => v)` が False を返すのは Pair 分岐到達前の別パースバグで本作業の対象外。コロンペアは正常。）
+- **2026-06-08 (PR-3)**: §2 の cold な term 位置フォールバック 2 件（`vm_var_get_ops.rs` の 0-arg term /
+  pkg-qualified）を生 `interpreter.call_function` から統一エントリ `call_function_compiled_first` へ寄せ、
+  単純ユーザ sub の OTF compile を追加（interpreter は終端のみ）。あわせて native-method 行を **③-blocked** に訂正
+  （`native_io_*` がファイルハンドル等の interpreter 所有状態を要求するため「個別可」は誤りだった）。
+
+### 重要な現状認識（2026-06-08, PR-3 時点）
+**「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
+すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、
+個別の routing では消えない。とくに §1 の catch-all 群（残る主 tree-walk）と native-method（IO 系）は **③** が、
+mut 系 push/hyper/array-backed は **Phase 2** が、shared push/react は **lever B** が前提。
+**次の実質的進捗は ② または ③ の構造リファクタであり、設計を要する**（VM が `interpreter: Interpreter` を所有
+しつつ interpreter 側も同 state で tree-walk する双方向所有を解く必要がある）。
 
 ## 撲滅の順序（PLAN.md ①〜⑤ に対応）
 
-1. EASY/MEDIUM な §1/§2 の個別撲滅（native-method 直呼び、Routine dispatch、0-arg/pkg-qualified term、
-   array-backed instance — うち container 依存は Phase 2 と合流）。
+1. ~~EASY/MEDIUM な §1/§2 の個別撲滅~~ — **枯渇（PR-1〜3 で消化）**。残りは下記の構造ブロッカー前提。
 2. ② 宣言レジストリ（class/role/enum/subset/sub/token）の VM 所有化。
-3. ③ env/型検査/readonly/let の VM 所有移管（最大の山。catch-all 群はここで消える）。
+3. ③ env/型検査/readonly/let の VM 所有移管（最大の山。catch-all 群・native-method はここで消える）。
 4. ④ §C carrier の最終確定（所有が VM に移れば単なる共有参照）。
 5. ⑤ `env_dirty`/`saved_env_dirty`/`ensure_locals_synced`/`sync_locals_from_env` 削除。

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -204,8 +204,11 @@ impl VM {
             {
                 native_result?
             } else {
-                // TODO: compile to bytecode — 0-arg user/multi function term fork (ledger §2).
-                let result = self.interpreter.call_function(name, Vec::new())?;
+                // Route the cold 0-arg term fallback through the VM's unified
+                // compiled-first function dispatch (ledger §2): this adds OTF
+                // compilation of simple user subs; the interpreter remains only as
+                // the terminal fallback inside call_function_compiled_first.
+                let result = self.call_function_compiled_first(name, Vec::new(), compiled_fns)?;
                 self.env_dirty = true;
                 result
             }
@@ -239,8 +242,10 @@ impl VM {
             if let Some((_pkg, short)) = name.rsplit_once("::")
                 && self.interpreter.has_function(&format!("GLOBAL::{}", short))
             {
-                // TODO: compile to bytecode — package-qualified function term fork (ledger §2).
-                let result = self.interpreter.call_function(name, Vec::new())?;
+                // Route the package-qualified term fork through the VM's unified
+                // compiled-first function dispatch (ledger §2): interpreter remains
+                // only as the terminal fallback.
+                let result = self.call_function_compiled_first(name, Vec::new(), compiled_fns)?;
                 self.env_dirty = true;
                 result
             } else if let Some((pkg_prefix, last_seg)) = name.rsplit_once("::")


### PR DESCRIPTION
最終ゴール ①（PLAN.md: tree-walk フォールバック撲滅）の継続。

## 変更
- **`vm_var_get_ops.rs`**: term 位置の cold な関数フォールバック 2 件（0-arg ユーザ/multi term、pkg-qualified `Module::func` term）を生 `interpreter.call_function` から VM 統一エントリ `call_function_compiled_first` へ。単純ユーザ sub の OTF compile が加わり、interpreter は終端のみに。`env_dirty` は保守的に true 維持（精度の後退なし）。
- **台帳訂正**: native-method fork（`vm_call_method_compiled.rs`）を **③-blocked** に修正。`is_native_method` は IO::Pipe/IO::Handle 等の組み込みクラスのメソッドで、実装 `native_io_*` がファイルハンドル等の interpreter 所有 IO 状態を要求するため、state 所有移管なしには nativize 不可（当初の「個別可」は誤り）。

## 重要な現状認識（台帳に記録）
**「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇。** 残る §1/§2 のフォールバックは全て構造ブロッカー（② 宣言レジストリ / ③ state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提。次の実質的進捗は **②/③ の構造リファクタ**で、設計を要する（VM が `interpreter: Interpreter` を所有しつつ interpreter 側も同 state で tree-walk する双方向所有を解く必要）。

## 検証
- `make test` 5327 tests PASS
- 挙動保存（`call_function_compiled_first` は `interpreter.call_function` を終端フォールバックに持つ）
- build / clippy クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)