### PR TITLE
feat(container): step 1 — escape analysis replaces the ≥2-sibling boxing proxy

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -255,3 +255,26 @@ push」に変えると、配列要素が `Value::Scalar`/`ContainerRef`/`ItemArr
     `gather.t` 38 は Phase 2 take-rw の既知未対応（非 whitelist・無関係）。
   - **範囲外（次スライス）**: 単一の脱出クロージャ（`my &f; { my $a=3; &f=sub{$a++} }` → 3,0）は 1 クロージャで
     multi に入らず未修正。`.VAR.^name` 反映 / `is rw` 3-way persistent も別スライス。
+- 2026-06-08: **step 1 = escape 解析（コンパイラ・キーストーン）= 成功**。PLAN.md §🟣「実装順序」step 1。
+  `multi_captured_mutated_locals`（「≥2 兄弟クロージャに捕捉」という proxy）を、本来の信号 **escape 解析**
+  （捕捉する子クロージャの値がフレームを脱出するか）に置換。proxy ではなく本機構にしたことで、単一脱出
+  クロージャを**構造的に**捕捉し、かつ即時呼び出し（`lives-ok {...}`/`map {...}`）は非 box のまま維持。
+  - **コンパイラ signal**: `Compiler::escaping_position`（bool）+ `with_escape(escaping, f)` save/restore ヘルパ。
+    escaping=true: 代入/`:=` RHS（`compile_assignment_rhs_for_target`）、`return`/`fail` operand、ブロック/
+    ルーチン tail（`helpers_sub_body.rs` の last-`Stmt::Expr` 3 箇所 + `mod.rs` top-level tail）、配列/ハッシュ/
+    capture リテラル要素。escaping=false（既定）: 呼び出し引数（`compile_call_arg`/`compile_method_arg` で
+    リセット＝#2746 ガード。`my @r = map {...}` のように call が脱出位置でも引数クロージャは非 box）。
+  - **データ**: `CompiledCode.closure_escapes: Vec<bool>`（`closure_compiled_codes` と添字一致）。
+    `add_closure_code(code, escapes)` が `escaping_position` を記録。`compute_free_vars` は子を enumerate して
+    `closure_escapes[i]` を見、捕捉×変異 own-local を**脱出する子に捕捉**されたら `needs_cell_locals`
+    （旧 `multi_captured_mutated_locals` をリネーム）へ。`captured_mutated_locals`（path A ループ boxing 用）は不変。
+  - **VM**: `box_captured_lexicals` の path B が `needs_cell_locals` を参照（型/`where` ガード・path A は byte-for-byte 不変）。
+  - 検証: `$f = sub{$a++}` 単一脱出（`my $f`/`&f()`）→ 3/4（旧 3/0）。兄弟 `make(); $s(42); $g()` → 42（subsume）。
+    factory `return sub{$n++}` → 0/1/0。即時呼び出し `for`/`map` → 非 box（3 / 12）。**perf カナリア
+    int.t 0.21s 維持（#2746 回帰なし）**。`make test` PASS（458 unit + 5315 prove）、clippy clean、
+    S03-binding/closure・S04-declarations/state・pointy(-rw) 等 whitelist PASS。
+  - **範囲外（別系統の事前バグ・follow-up）**: **bareword `f()` 呼び出し**は、捕捉変数が**抜けた bare block 内**
+    にある場合に凍結スナップショットを読む（`&f()` / `$f` は正しく共有セルを読むので escape 解析は正常）。
+    これは bareword sub 呼び出しの dispatch/scope-exit 経路の別バグで、step 1 の cell 共有とは独立。
+  - **次（step 2）**: needs-cell な `$` local を宣言時にセル化し、`owned_captures`/`closure_captured_state`/
+    `box_captured_lexicals` の boxing ヒューリスティック（4→1）を削除（PLAN.md 実装順序 step 2）。

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -111,21 +111,26 @@ impl Compiler {
                 self.code.patch_jump(jump_end);
             }
             Expr::ArrayLiteral(elems) => {
-                for elem in elems {
-                    self.compile_expr(elem);
-                    if Self::expr_is_scalar_var(elem) {
-                        self.code.emit(OpCode::Itemize);
+                // Elements are stored into the list -> a closure element escapes.
+                self.with_escape(true, |c| {
+                    for elem in elems {
+                        c.compile_expr(elem);
+                        if Self::expr_is_scalar_var(elem) {
+                            c.code.emit(OpCode::Itemize);
+                        }
                     }
-                }
+                });
                 self.code.emit(OpCode::MakeArray(elems.len() as u32));
             }
             Expr::BracketArray(elems, trailing_comma) => {
                 self.compile_expr_bracket_array(elems, *trailing_comma);
             }
             Expr::CaptureLiteral(items) => {
-                for item in items {
-                    self.compile_expr(item);
-                }
+                self.with_escape(true, |c| {
+                    for item in items {
+                        c.compile_expr(item);
+                    }
+                });
                 self.code.emit(OpCode::MakeCapture(items.len() as u32));
             }
             // Expression-level function call

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -374,7 +374,8 @@ impl Compiler {
         if Self::has_block_placeholders(stmts) {
             let placeholders = crate::ast::collect_placeholders_shallow(stmts);
             let compiled = self.compile_closure_body(&placeholders, &[], stmts);
-            let cc_idx = self.code.add_closure_code(compiled);
+            let esc = self.escaping_position;
+            let cc_idx = self.code.add_closure_code(compiled, esc);
             let idx = self.code.add_stmt(Stmt::Block(stmts.to_vec()));
             self.code.emit(OpCode::MakeBlockClosure(idx, Some(cc_idx)));
         } else {

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -13,7 +13,8 @@ impl Compiler {
             } else {
                 self.compile_routine_closure_body(&[], &[], body)
             };
-            let cc_idx = self.code.add_closure_code(compiled);
+            let esc = self.escaping_position;
+            let cc_idx = self.code.add_closure_code(compiled, esc);
             let idx = self.code.add_stmt(Stmt::SubDecl {
                 name: Symbol::intern(""),
                 name_expr: None,
@@ -53,7 +54,8 @@ impl Compiler {
             } else {
                 self.compile_routine_closure_body(&placeholders, &[], body)
             };
-            let cc_idx = self.code.add_closure_code(compiled);
+            let esc = self.escaping_position;
+            let cc_idx = self.code.add_closure_code(compiled, esc);
             let idx = self.code.add_stmt(Stmt::Block(body.to_vec()));
             self.code
                 .emit(OpCode::MakeAnonSub(idx, Some(cc_idx), is_block));
@@ -137,7 +139,8 @@ impl Compiler {
         if is_pointy {
             compiled.is_pointy_block = true;
         }
-        let cc_idx = self.code.add_closure_code(compiled);
+        let esc = self.escaping_position;
+        let cc_idx = self.code.add_closure_code(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {
             name: Symbol::intern(""),
             name_expr: None,
@@ -177,7 +180,8 @@ impl Compiler {
             vec![param.to_string()]
         };
         let compiled = self.compile_closure_body(&params, &[], body);
-        let cc_idx = self.code.add_closure_code(compiled);
+        let esc = self.escaping_position;
+        let cc_idx = self.code.add_closure_code(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {
             name: Symbol::intern(""),
             name_expr: None,

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -87,9 +87,10 @@ impl Compiler {
             // Push key as string constant
             let key_idx = self.code.add_constant(Value::str(key.clone()));
             self.code.emit(OpCode::LoadConst(key_idx));
-            // Push value (or True if none, for bare colonpairs like :a)
+            // Push value (or True if none, for bare colonpairs like :a). Values
+            // are stored into the hash -> a closure value escapes the frame.
             if let Some(val_expr) = val_opt {
-                self.compile_expr(val_expr);
+                self.with_escape(true, |c| c.compile_expr(val_expr));
             } else {
                 self.code.emit(OpCode::LoadTrue);
             }
@@ -290,37 +291,40 @@ impl Compiler {
 
     /// Compile BracketArray expression ([...]).
     pub(super) fn compile_expr_bracket_array(&mut self, elems: &[Expr], trailing_comma: bool) {
-        let single_with_trailing_comma = trailing_comma && elems.len() == 1;
-        if elems.len() == 1 && !single_with_trailing_comma {
-            if let Expr::ArrayLiteral(items) = &elems[0] {
-                for item in items {
-                    self.compile_expr(item);
-                }
-                self.code.emit(OpCode::MakeRealArray(items.len() as u32));
-            } else {
-                self.compile_expr(&elems[0]);
-                // When the single element is a scalar variable ($x) or explicit
-                // item context ($%h, $@a), use MakeRealArrayNoFlatten so that
-                // hash/array values held in scalars are not flattened.
-                // HashVar and ArrayVar (% and @ sigiled) SHOULD flatten.
-                let should_not_flatten = matches!(&elems[0], Expr::Var(_) | Expr::Itemize(_));
-                if should_not_flatten {
-                    self.code.emit(OpCode::MakeRealArrayNoFlatten(1));
+        // Elements are stored into the array -> a closure element escapes.
+        self.with_escape(true, |s| {
+            let single_with_trailing_comma = trailing_comma && elems.len() == 1;
+            if elems.len() == 1 && !single_with_trailing_comma {
+                if let Expr::ArrayLiteral(items) = &elems[0] {
+                    for item in items {
+                        s.compile_expr(item);
+                    }
+                    s.code.emit(OpCode::MakeRealArray(items.len() as u32));
                 } else {
-                    self.code.emit(OpCode::MakeRealArray(1));
+                    s.compile_expr(&elems[0]);
+                    // When the single element is a scalar variable ($x) or explicit
+                    // item context ($%h, $@a), use MakeRealArrayNoFlatten so that
+                    // hash/array values held in scalars are not flattened.
+                    // HashVar and ArrayVar (% and @ sigiled) SHOULD flatten.
+                    let should_not_flatten = matches!(&elems[0], Expr::Var(_) | Expr::Itemize(_));
+                    if should_not_flatten {
+                        s.code.emit(OpCode::MakeRealArrayNoFlatten(1));
+                    } else {
+                        s.code.emit(OpCode::MakeRealArray(1));
+                    }
+                }
+            } else {
+                for elem in elems {
+                    s.compile_expr(elem);
+                }
+                if single_with_trailing_comma {
+                    s.code
+                        .emit(OpCode::MakeRealArrayNoFlatten(elems.len() as u32));
+                } else {
+                    s.code.emit(OpCode::MakeRealArray(elems.len() as u32));
                 }
             }
-        } else {
-            for elem in elems {
-                self.compile_expr(elem);
-            }
-            if single_with_trailing_comma {
-                self.code
-                    .emit(OpCode::MakeRealArrayNoFlatten(elems.len() as u32));
-            } else {
-                self.code.emit(OpCode::MakeRealArray(elems.len() as u32));
-            }
-        }
+        });
     }
 
     /// Compile Index expression (target[index] or target{index}).

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -100,30 +100,35 @@ impl Compiler {
     /// Compile a method call argument. Named args (AssignExpr) are
     /// compiled as Pair values so they survive VM execution.
     pub(super) fn compile_method_arg(&mut self, arg: &Expr) {
-        if let Expr::AssignExpr { name, expr, .. } = arg {
-            // `foo(arg = 1)` in method-call argument position is treated as a named
-            // argument only for sigilless identifiers. Sigiled targets (`$x = ...`,
-            // `@x = ...`, `%x = ...`) are real assignment expressions.
-            if name.starts_with('$')
-                || name.starts_with('@')
-                || name.starts_with('%')
-                || name.starts_with('&')
-            {
-                self.compile_expr(arg);
-                if Self::needs_decont(arg) {
-                    self.code.emit(OpCode::Decont);
+        // A method argument is passed to the callee, not stored in the caller
+        // frame, so a closure argument is conservatively NON-escaping (same
+        // #2746 guard as compile_call_arg).
+        self.with_escape(false, |s| {
+            if let Expr::AssignExpr { name, expr, .. } = arg {
+                // `foo(arg = 1)` in method-call argument position is treated as a
+                // named argument only for sigilless identifiers. Sigiled targets
+                // (`$x = ...`, `@x = ...`, `%x = ...`) are real assignment exprs.
+                if name.starts_with('$')
+                    || name.starts_with('@')
+                    || name.starts_with('%')
+                    || name.starts_with('&')
+                {
+                    s.compile_expr(arg);
+                    if Self::needs_decont(arg) {
+                        s.code.emit(OpCode::Decont);
+                    }
+                } else {
+                    s.compile_expr(&Expr::Literal(Value::str(name.clone())));
+                    s.compile_expr(expr);
+                    s.code.emit(OpCode::MakePair);
                 }
             } else {
-                self.compile_expr(&Expr::Literal(Value::str(name.clone())));
-                self.compile_expr(expr);
-                self.code.emit(OpCode::MakePair);
+                s.compile_expr(arg);
+                if Self::needs_decont(arg) {
+                    s.code.emit(OpCode::Decont);
+                }
             }
-        } else {
-            self.compile_expr(arg);
-            if Self::needs_decont(arg) {
-                self.code.emit(OpCode::Decont);
-            }
-        }
+        });
     }
 
     /// Check if an expression produces an array value that needs decontainerization
@@ -155,7 +160,11 @@ impl Compiler {
     }
 
     pub(super) fn compile_call_arg(&mut self, arg: &Expr) {
-        self.compile_expr(arg);
+        // A call argument's value is passed to the callee, not stored in the
+        // caller frame, so a closure argument is conservatively NON-escaping
+        // (the #2746 guard: `map {...}` / `lives-ok {...}` must not box even when
+        // the whole call sits in an escaping position like `my @r = map {...}`).
+        self.with_escape(false, |c| c.compile_expr(arg));
         if Self::needs_decont(arg) {
             self.code.emit(OpCode::Decont);
         }

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -363,7 +363,9 @@ impl Compiler {
             if is_last {
                 match stmt {
                     Stmt::Expr(expr) => {
-                        sub_compiler.compile_expr(expr);
+                        // Tail expression becomes the routine's value (implicit
+                        // return) -> a closure here escapes the frame.
+                        sub_compiler.with_escape(true, |c| c.compile_expr(expr));
                         // Don't emit Pop — leave value on stack as implicit return
                         continue;
                     }
@@ -547,7 +549,8 @@ impl Compiler {
             for (i, stmt) in body_stmts.iter().enumerate() {
                 let is_last = i == body_stmts.len() - 1;
                 if is_last && let Stmt::Expr(expr) = stmt {
-                    sub_compiler.compile_expr(expr);
+                    // Tail expression becomes the block value -> closure escapes.
+                    sub_compiler.with_escape(true, |c| c.compile_expr(expr));
                     sub_compiler.code.emit(OpCode::SetTopic);
                     continue;
                 }
@@ -629,7 +632,8 @@ impl Compiler {
                 if is_last {
                     match stmt {
                         Stmt::Expr(expr) => {
-                            sub_compiler.compile_expr(expr);
+                            // Tail expression = implicit return -> closure escapes.
+                            sub_compiler.with_escape(true, |c| c.compile_expr(expr));
                             continue;
                         }
                         Stmt::Call { name, args } => {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -90,6 +90,15 @@ pub(crate) struct Compiler {
     pub(super) pending_index_rw_writebacks: Vec<(Expr, String, String)>,
     /// The current distribution context for $?DISTRIBUTION.
     pub(crate) current_distribution: Option<Value>,
+    /// True while compiling a sub-expression whose VALUE is stored/returned/bound
+    /// (an *escaping position*): assignment or `:=` RHS, `return`/`fail` operand,
+    /// block/routine tail, or a literal element. A closure created while this is
+    /// set has its value escape the creating frame, forcing a shared `ContainerRef`
+    /// cell for the captured-and-mutated locals it closes over (escape analysis;
+    /// see `CompiledCode::closure_escapes`). Default false = the conservative
+    /// non-escaping (immediately-invoked) classification, so call arguments and
+    /// control-construct blocks never over-box (the #2746 perf guard).
+    escaping_position: bool,
 }
 
 impl Compiler {
@@ -117,7 +126,19 @@ impl Compiler {
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
+            escaping_position: false,
         }
+    }
+
+    /// Run `f` with the escaping-position flag set to `escaping`, restoring the
+    /// previous value afterward. Used to mark which syntactic positions cause a
+    /// closure created within them to escape its frame (see `escaping_position`).
+    pub(super) fn with_escape<R>(&mut self, escaping: bool, f: impl FnOnce(&mut Self) -> R) -> R {
+        let saved = self.escaping_position;
+        self.escaping_position = escaping;
+        let r = f(self);
+        self.escaping_position = saved;
+        r
     }
 
     /// Emit a SetSourceLine opcode for the current source line, if known.
@@ -563,7 +584,8 @@ impl Compiler {
                 if is_last {
                     match stmt {
                         Stmt::Expr(expr) => {
-                            self.compile_expr(expr);
+                            // Tail expression becomes the body value -> escapes.
+                            self.with_escape(true, |c| c.compile_expr(expr));
                             self.code.emit(OpCode::SetTopic);
                             continue;
                         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -231,7 +231,10 @@ impl Compiler {
     }
 
     fn compile_assignment_rhs_for_target(&mut self, name: &str, expr: &Expr) {
-        self.compile_expr(expr);
+        // The RHS value is stored into the target, so a closure literal here
+        // escapes the creating frame (escape analysis): force a shared cell for
+        // the captured-and-mutated locals it closes over.
+        self.with_escape(true, |c| c.compile_expr(expr));
         if !name.starts_with('@')
             && !name.starts_with('%')
             && !name.starts_with('&')
@@ -1582,7 +1585,8 @@ impl Compiler {
                 self.code.emit(OpCode::Redo(label.clone()));
             }
             Stmt::Return(expr) => {
-                self.compile_expr(expr);
+                // A returned closure escapes the routine frame (escape analysis).
+                self.with_escape(true, |c| c.compile_expr(expr));
                 if self.is_routine {
                     self.code.emit(OpCode::Return);
                 } else {
@@ -1595,7 +1599,8 @@ impl Compiler {
                 self.code.emit(OpCode::Die);
             }
             Stmt::Fail(expr) => {
-                self.compile_expr(expr);
+                // A failed value is stored/propagated -> closure escapes.
+                self.with_escape(true, |c| c.compile_expr(expr));
                 self.code.emit(OpCode::Fail);
             }
             Stmt::Proceed => {
@@ -1613,7 +1618,7 @@ impl Compiler {
                 expr,
                 op: AssignOp::MatchAssign,
             } if name != "*PID" => {
-                self.compile_expr(expr);
+                self.with_escape(true, |c| c.compile_expr(expr));
                 self.code.emit(OpCode::StrCoerce);
                 self.emit_set_named_var(name);
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1040,6 +1040,15 @@ pub(crate) struct CompiledCode {
     pub(crate) our_locals: Vec<(usize, String)>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
+    /// Parallel to `closure_compiled_codes`: `closure_escapes[i]` is true if the
+    /// i-th child closure was created in an *escaping position* — its value is
+    /// stored/returned/bound (assignment or `:=` RHS, `return`/`fail` operand,
+    /// block tail, or a literal element) rather than immediately invoked (a call
+    /// argument like `lives-ok {...}` / `map {...}`, or a control-construct
+    /// block). Consumed by `compute_free_vars` to decide which captured-and-
+    /// mutated own-locals need a shared `ContainerRef` cell (escape analysis,
+    /// replacing the old `>=2 sibling closures` proxy).
+    pub(crate) closure_escapes: Vec<bool>,
     /// Whether this compiled code represents a Routine (sub/method) as opposed
     /// to a Block (bare block / pointy block).  `return` signals are caught
     /// only at routine boundaries, allowing pointy-block returns to propagate
@@ -1090,15 +1099,20 @@ pub(crate) struct CompiledCode {
     /// Declaration-only / read-only captures are excluded on purpose: boxing
     /// them is unnecessary and trips ContainerRef-unaware paths.
     pub(crate) captured_mutated_locals: Vec<Symbol>,
-    /// Subset of `captured_mutated_locals` that is captured by **two or more
-    /// distinct child closures** of this frame. These genuinely need a shared
-    /// `ContainerRef` cell so sibling closures observe each other's writes even
-    /// after the declaring frame exits (Phase 1 / lever C, non-loop case). The VM
-    /// boxes these regardless of loop context (see `box_captured_lexicals`); the
-    /// `>=2` restriction keeps boxing rare (per-closure-creation cost bounded) and
-    /// excludes the single immediately-invoked closure pattern (`lives-ok {...}`)
-    /// that caused the broad-boxing perf/correctness regression (see #2749).
-    pub(crate) multi_captured_mutated_locals: Vec<Symbol>,
+    /// Subset of `captured_mutated_locals` captured by at least one child closure
+    /// whose value **escapes** the creating frame (its `closure_escapes` bit is
+    /// set — stored/returned/bound rather than immediately invoked). These
+    /// genuinely need a shared `ContainerRef` cell so the escaping closure (and
+    /// any siblings) observe mutations even after the declaring frame exits
+    /// (Phase 1 / lever C, non-loop case). The VM boxes these regardless of loop
+    /// context (see `box_captured_lexicals`). This escape signal replaces the old
+    /// `>=2 distinct sibling closures` proxy: it both subsumes the sibling
+    /// getter+setter case (both are assigned, so both escape) AND fixes the
+    /// single escaping closure (`&f = sub {...}`) that the >=2 proxy missed —
+    /// while keeping immediately-invoked closures (`lives-ok {...}` / `map {...}`,
+    /// call args / control blocks) non-boxed, avoiding the broad-boxing
+    /// perf/correctness regression (see #2749).
+    pub(crate) needs_cell_locals: Vec<Symbol>,
     /// True if this code contains any call opcode (function/method/closure
     /// invocation). Set during `emit()`. The closure exit-writeback skip uses
     /// this as the "is this a leaf closure" test: a non-leaf closure may have a
@@ -1132,6 +1146,7 @@ impl CompiledCode {
             state_locals: Vec::new(),
             our_locals: Vec::new(),
             closure_compiled_codes: Vec::new(),
+            closure_escapes: Vec::new(),
             is_routine: false,
             source_line: None,
             is_pointy_block: false,
@@ -1142,7 +1157,7 @@ impl CompiledCode {
             free_var_syms: Vec::new(),
             free_var_writes: Vec::new(),
             captured_mutated_locals: Vec::new(),
-            multi_captured_mutated_locals: Vec::new(),
+            needs_cell_locals: Vec::new(),
             has_calls: false,
         }
     }
@@ -1453,44 +1468,39 @@ impl CompiledCode {
             }
         }
         // Own locals captured by a nested closure AND mutated -> must be boxed
-        // into a shared container at capture time. Also count how many DISTINCT
-        // child closures capture each own-local, so siblings (>=2 closures over
-        // the same local) can share one cell even in non-loop frames.
+        // into a shared container at capture time. `captured_mutated` drives the
+        // loop (path A) boxing and the VM's capture filter. `needs_cell` is the
+        // escape-analysis subset: captured-and-mutated locals closed over by at
+        // least one child closure whose value ESCAPES the frame
+        // (`closure_escapes[i]` — stored/returned/bound, not immediately
+        // invoked). This replaces the old `>=2 distinct sibling closures` proxy.
         let mut captured_mutated: std::collections::HashSet<Symbol> =
             std::collections::HashSet::new();
-        let mut child_capture_count: std::collections::HashMap<Symbol, usize> =
-            std::collections::HashMap::new();
-        for nested in &self.closure_compiled_codes {
-            // De-dup within a single child so each child counts at most once.
-            let mut seen_in_child: std::collections::HashSet<Symbol> =
-                std::collections::HashSet::new();
+        let mut needs_cell: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        for (i, nested) in self.closure_compiled_codes.iter().enumerate() {
+            let escapes = self.closure_escapes.get(i).copied().unwrap_or(false);
             for sym in &nested.free_var_syms {
-                if sym.with_str(|s| own.contains(s)) {
-                    if self_mutated.contains(sym) {
-                        captured_mutated.insert(*sym);
-                    }
-                    if seen_in_child.insert(*sym) {
-                        *child_capture_count.entry(*sym).or_insert(0) += 1;
+                if sym.with_str(|s| own.contains(s)) && self_mutated.contains(sym) {
+                    captured_mutated.insert(*sym);
+                    if escapes {
+                        needs_cell.insert(*sym);
                     }
                 }
             }
         }
-        // Sibling-shared: captured-and-mutated AND captured by >=2 child closures.
-        let multi_captured: Vec<Symbol> = captured_mutated
-            .iter()
-            .filter(|sym| child_capture_count.get(*sym).copied().unwrap_or(0) >= 2)
-            .copied()
-            .collect();
         self.free_var_syms = free.into_iter().collect();
         self.free_var_writes = free_writes.into_iter().collect();
         self.captured_mutated_locals = captured_mutated.into_iter().collect();
-        self.multi_captured_mutated_locals = multi_captured;
+        self.needs_cell_locals = needs_cell.into_iter().collect();
     }
 
-    /// Store a compiled closure body and return its index.
-    pub(crate) fn add_closure_code(&mut self, code: CompiledCode) -> u32 {
+    /// Store a compiled closure body and return its index. `escapes` records
+    /// whether the closure was created in an escaping position (see
+    /// `closure_escapes`); the two Vecs are kept index-aligned in lockstep.
+    pub(crate) fn add_closure_code(&mut self, code: CompiledCode, escapes: bool) -> u32 {
         let idx = self.closure_compiled_codes.len() as u32;
         self.closure_compiled_codes.push(Arc::new(code));
+        self.closure_escapes.push(escapes);
         idx
     }
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -239,15 +239,17 @@ impl VM {
         // broad form regressed perf and correctness, see #2749 / docs):
         //   (A) loop-body locals (`loop_local_vars`): per-iteration binding, the
         //       original lever-C path — kept byte-for-byte.
-        //   (B) `multi_captured_mutated_locals`: locals captured by >=2 distinct
-        //       sibling closures (compiler signal). These genuinely need a shared
-        //       cell even in non-loop frames (e.g. a getter+setter factory). The
-        //       >=2 restriction excludes the single immediately-invoked closure
-        //       (`lives-ok {...}`) pattern, bounding boxing cost and avoiding the
-        //       broad-boxing perf blowup.
+        //   (B) `needs_cell_locals`: locals captured by a child closure whose
+        //       value ESCAPES the creating frame (escape analysis — stored,
+        //       returned, or bound, not immediately invoked). These genuinely
+        //       need a shared cell even in non-loop frames (e.g. a getter+setter
+        //       factory, or a single `&f = sub {...}` assigned closure). The
+        //       escape signal excludes the immediately-invoked closure
+        //       (`lives-ok {...}` / `map {...}`, call args / control blocks),
+        //       bounding boxing cost and avoiding the broad-boxing perf blowup.
         // Read-only loop captures are handled by `owned_captures` (value-freeze).
         if code.captured_mutated_locals.is_empty()
-            || (self.loop_local_vars.is_empty() && code.multi_captured_mutated_locals.is_empty())
+            || (self.loop_local_vars.is_empty() && code.needs_cell_locals.is_empty())
         {
             return;
         }
@@ -255,15 +257,15 @@ impl VM {
             if !code.captured_mutated_locals.contains(sym) {
                 continue;
             }
-            let is_multi = code.multi_captured_mutated_locals.contains(sym);
+            let needs_cell = code.needs_cell_locals.contains(sym);
             let Some(idx) = sym.with_str(|s| {
                 if s.starts_with('@') || s.starts_with('%') || s.starts_with('&') {
                     return None;
                 }
                 let is_loop_local = self.loop_local_vars.iter().any(|set| set.contains(s));
                 if !is_loop_local {
-                    // Non-loop sibling path (B) only.
-                    if !is_multi {
+                    // Non-loop escaping path (B) only.
+                    if !needs_cell {
                         return None;
                     }
                     // A type/`where`-constrained scalar must keep flowing through

--- a/t/closure-container-capture.t
+++ b/t/closure-container-capture.t
@@ -6,7 +6,7 @@ use Test;
 # latter via the compiler's >=2-sibling-closure signal), while loop-body `my`
 # stays per-iteration fresh.
 
-plan 15;
+plan 19;
 
 # --- intra-iteration mutation after capture (was: frozen value) ---
 {
@@ -101,4 +101,32 @@ plan 15;
     my $c = { @a.elems };
     @a.push(4);
     is $c(), 4, 'array free variable stays reference-shared';
+}
+
+# --- escape analysis (step 1): a SINGLE closure that ESCAPES the frame (assigned
+# to an outer variable) shares the captured container, even though only one
+# closure captures it (the old >=2-sibling proxy missed this). ---
+{
+    my $f;
+    { my $a = 3; $f = sub { $a++ } }
+    is $f(), 3, 'single escaping closure: first call reads captured value';
+    is $f(), 4, 'single escaping closure: state persists through the shared cell';
+}
+
+# --- immediately-invoked closures (call arguments) are NOT boxed: the captured
+# topic/local flows through the non-escaping path. This is the #2746 perf guard;
+# here we just assert correctness is unaffected. ---
+{
+    my $sum = 0;
+    (1, 2, 3).map({ $sum += $_ });
+    is $sum, 6, 'immediately-invoked map closure mutates outer var correctly';
+}
+
+# --- a returned closure factory keeps independent per-instance state ---
+{
+    sub counter { my $n = 0; return sub { $n++ } }
+    my $a = counter();
+    my $b = counter();
+    $a(); $a();
+    is $b(), 0, 'returned closure factory: instances have independent state';
 }


### PR DESCRIPTION
## Summary

Container-identity migration (PLAN.md §🟣 第2優先, **implementation order step 1: the compiler keystone**). Replaces the `multi_captured_mutated_locals` heuristic (the "captured by ≥2 distinct sibling closures" **proxy**) with a real **escape analysis**.

A captured-and-mutated own-local needs a shared `ContainerRef` cell iff it is captured by a child closure whose value **escapes** the creating frame — stored, returned, or bound, not immediately invoked. This is the one general mechanism the architecture-first policy calls for, replacing a heuristic rather than adding one.

### What it fixes / preserves
- **Subsumes** the sibling getter+setter case (both closures are assigned → both escape → share one cell).
- **Structurally fixes** the single escaping closure: `my $f; { my $a = 3; $f = sub { $a++ } }; say $f(); say $f();` → now `3, 4` (was `3, 0`). The ≥2 proxy missed it because there is only one closure.
- **Keeps immediately-invoked closures non-boxed** (`lives-ok {...}`, `map {...}`, call args, control blocks) → avoids the #2746 broad-boxing perf blowup.

### Changes
- **Compiler** (`src/compiler/`): `Compiler::escaping_position` flag + `with_escape(escaping, f)` save/restore helper. escaping=true at assignment/`:=` RHS, `return`/`fail`, block/routine tail, array/hash/capture literal elements; escaping=false (default) is reset inside `compile_call_arg` / `compile_method_arg` so a closure argument never inherits an enclosing escaping context (the #2746 guard, e.g. `my @r = map {...}, @a`).
- **opcode** (`src/opcode.rs`): `CompiledCode.closure_escapes: Vec<bool>` (parallel to `closure_compiled_codes`), recorded by `add_closure_code`. `compute_free_vars` consumes it to build `needs_cell_locals` (renamed from `multi_captured_mutated_locals`). `captured_mutated_locals` (loop path A) unchanged.
- **VM** (`src/vm/vm_register_ops.rs`): `box_captured_lexicals` path B consults `needs_cell_locals`; the type/`where` guard and loop path (A) are byte-for-byte unchanged.

### Out of scope (separate pre-existing bug, follow-up)
Bareword `f()` calls read a frozen snapshot when the captured var lives in an **exited bare block** (`&f()` / `$f` read the shared cell correctly, so escape analysis itself is sound). This is a distinct bareword-call dispatch/scope-exit path. **step 2** will cell-ize scalars at declaration and delete the `owned_captures` / `closure_captured_state` / `box_captured_lexicals` heuristics (4 → 1).

## Verification
- Single escaping closure (`my $f`/`&f()`) → `3, 4`; sibling `make(); $s(42); $g()` → `42`; factory `return sub{$n++}` → `0,1,0`; `for`/`map` non-boxed → `3` / `12`.
- **Perf canary `roast/S32-num/int.t` stays 0.21s** (#2746 has no regression).
- `make test` PASS (458 unit + 5315 prove), `cargo clippy -- -D warnings` clean.
- Whitelisted closure roast PASS: S03-binding/closure, S04-declarations/state, S02-magicals/block, S04-blocks-and-statements/pointy(-rw).
- New cases added to `t/closure-container-capture.t` (19 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)