### PR TITLE
refactor(vm): extract enum/subset registries into shared Registry cell (phase ② PR-A slice 1)

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -353,7 +353,8 @@ impl Interpreter {
         }
 
         // Check if this is a subset type
-        if let Some(subset) = self.subsets.get(spec).cloned() {
+        let subset = self.registry().subsets.get(spec).cloned();
+        if let Some(subset) = subset {
             // For subsets with coercion base types, coerce first then check predicate
             let coerced = if subset.base.contains('(') && subset.base.ends_with(')') {
                 self.enforce_coercion_return(&subset.base, value)?
@@ -465,7 +466,8 @@ impl Interpreter {
         }
 
         // For subset targets, check the where constraint
-        if let Some(subset) = self.subsets.get(base_target).cloned()
+        let subset = self.registry().subsets.get(base_target).cloned();
+        if let Some(subset) = subset
             && let Some(ref pred) = subset.predicate
         {
             let pred_clone = pred.clone();
@@ -485,7 +487,8 @@ impl Interpreter {
         value: Value,
     ) -> Result<Value, RuntimeError> {
         // If target is a subset, coerce to the subset's base type
-        if let Some(subset) = self.subsets.get(target).cloned() {
+        let subset = self.registry().subsets.get(target).cloned();
+        if let Some(subset) = subset {
             let (base, _) = super::types::strip_type_smiley(&subset.base);
             return self.try_coerce_value_for_constraint(&format!("{}()", base), value);
         }

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -229,7 +229,8 @@ impl Interpreter {
         if let Some(pattern) = self.eval_token_call_values(name, args)? {
             return Ok(Value::regex(pattern));
         }
-        if let Some(variants) = self.enum_types.get(name).cloned() {
+        let variants = self.registry().enum_types.get(name).cloned();
+        if let Some(variants) = variants {
             let Some(first) = args.first().cloned() else {
                 return Ok(Value::Nil);
             };
@@ -256,7 +257,7 @@ impl Interpreter {
         if args.len() == 1
             && (self.has_type(name)
                 || crate::runtime::utils::is_known_type_constraint(name)
-                || self.subsets.contains_key(name)
+                || self.registry().subsets.contains_key(name)
                 || self.roles.contains_key(name))
         {
             let source = match &args[0] {
@@ -771,7 +772,7 @@ impl Interpreter {
         if args.is_empty()
             && (self.has_type(name)
                 || crate::runtime::utils::is_known_type_constraint(name)
-                || self.subsets.contains_key(name)
+                || self.registry().subsets.contains_key(name)
                 || self.roles.contains_key(name))
         {
             return Ok(Value::Package(Symbol::intern(&format!("{name}(Any)"))));

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -69,7 +69,7 @@ impl Interpreter {
                 || p.type_constraint
                     .as_deref()
                     .map(Self::constraint_base_name)
-                    .map(|base| self.subsets.contains_key(base))
+                    .map(|base| self.registry().subsets.contains_key(base))
                     .unwrap_or(false)
         })
     }
@@ -269,7 +269,7 @@ impl Interpreter {
                 p.type_constraint
                     .as_deref()
                     .map(Self::constraint_base_name)
-                    .map(|base| self.subsets.contains_key(base))
+                    .map(|base| self.registry().subsets.contains_key(base))
                     .unwrap_or(false)
             })
             .count();

--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -540,12 +540,12 @@ impl Interpreter {
     /// params show `[=SubsetName]`, everything else shows `=<value>`.
     fn usage_value_placeholder(&self, pd: &ParamDef) -> String {
         if let Some(tc) = &pd.type_constraint {
-            if let Some(variants) = self.enum_types.get(tc.as_str()) {
+            if let Some(variants) = self.registry().enum_types.get(tc.as_str()) {
                 let mut names: Vec<&str> = variants.iter().map(|(k, _)| k.as_str()).collect();
                 names.sort_unstable();
                 return format!("=<{}> ({})", tc, names.join(" "));
             }
-            if self.subsets.contains_key(tc.as_str()) {
+            if self.registry().subsets.contains_key(tc.as_str()) {
                 return format!("[={}]", tc);
             }
         }
@@ -568,17 +568,22 @@ impl Interpreter {
             _ => {}
         }
         let matching: Vec<String> = self
+            .registry()
             .enum_types
             .iter()
             .filter(|(_, variants)| variants.iter().any(|(k, _)| k == &name))
             .map(|(enum_name, _)| enum_name.clone())
             .collect();
-        if matching.len() == 1
-            && let Some(variants) = self.enum_types.get(&matching[0]).cloned()
-            && let Some(enum_val) =
-                self.coerce_to_enum_variant(&matching[0], &variants, Value::str(name))
-        {
-            return enum_val;
+        if matching.len() == 1 {
+            // Hoist the registry read so the guard drops before coerce_to_enum_variant
+            // (which needs &mut self); never hold a guard across user-code re-entry.
+            let variants = self.registry().enum_types.get(&matching[0]).cloned();
+            if let Some(variants) = variants
+                && let Some(enum_val) =
+                    self.coerce_to_enum_variant(&matching[0], &variants, Value::str(name))
+            {
+                return enum_val;
+            }
         }
         arg.clone()
     }
@@ -609,7 +614,8 @@ impl Interpreter {
                 // If the parameter is typed with an enum, coerce the CLI string to
                 // the matching enum variant so type-checked binding succeeds. An
                 // unmatched string is left unchanged so dispatch can reject it.
-                if let Some(variants) = self.enum_types.get(tc).cloned()
+                let variants = self.registry().enum_types.get(tc).cloned();
+                if let Some(variants) = variants
                     && let Some(enum_val) =
                         self.coerce_to_enum_variant(tc, &variants, Value::str(s.clone()))
                 {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -656,7 +656,7 @@ impl Interpreter {
                 "pairs" | "keys" | "values" | "kv" | "antipairs" | "invert"
             )
         {
-            if let Some(variants) = self.enum_types.get(&pkg_name.resolve()) {
+            if let Some(variants) = self.registry().enum_types.get(&pkg_name.resolve()) {
                 let variants = variants.clone();
                 return self.dispatch_enum_type_collection(method, &variants);
             }

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -336,7 +336,7 @@ impl Interpreter {
                 {
                     return Ok(Self::version_from_value(value));
                 }
-                if let Some(subset) = self.subsets.get(&name) {
+                if let Some(subset) = self.registry().subsets.get(&name) {
                     return Ok(Self::version_from_value(Value::str(subset.version.clone())));
                 }
                 if invocant_name == "Grammar" {
@@ -386,19 +386,27 @@ impl Interpreter {
                 }
                 let class_resolved = class_name.resolve();
                 let other_resolved = other_name.resolve();
-                if let Some(subset) = self.subsets.get(&class_resolved) {
-                    let mut base = subset.base.clone();
+                // Clone the base out per step so the registry read guard never spans
+                // iterations (recursive read locks may deadlock).
+                if let Some(mut base) = self
+                    .registry()
+                    .subsets
+                    .get(&class_resolved)
+                    .map(|s| s.base.clone())
+                {
                     loop {
                         if base == other_resolved {
                             return Ok(Value::Bool(true));
                         }
-                        let Some(parent_subset) = self.subsets.get(&base) else {
+                        let Some(parent_base) =
+                            self.registry().subsets.get(&base).map(|s| s.base.clone())
+                        else {
                             break;
                         };
-                        if parent_subset.base == base {
+                        if parent_base == base {
                             break;
                         }
-                        base = parent_subset.base.clone();
+                        base = parent_base;
                     }
                 }
                 let mro = self.class_mro(&class_name.resolve());
@@ -961,7 +969,7 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(type_name) = type_name
-                    && let Some(variants) = self.enum_types.get(&type_name)
+                    && let Some(variants) = self.registry().enum_types.get(&type_name)
                 {
                     let values: Vec<Value> = variants
                         .iter()

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -506,7 +506,7 @@ impl Interpreter {
         let enum_name = match target {
             Value::Package(name) if name == "Bool" => Some("Bool".to_string()),
             Value::Bool(_) => Some("Bool".to_string()),
-            Value::Package(name) if self.enum_types.contains_key(&name.resolve()) => {
+            Value::Package(name) if self.registry().enum_types.contains_key(&name.resolve()) => {
                 Some(name.resolve())
             }
             Value::Enum { enum_type, .. } => Some(enum_type.resolve()),

--- a/src/runtime/methods_enum_dispatch.rs
+++ b/src/runtime/methods_enum_dispatch.rs
@@ -88,7 +88,7 @@ impl Interpreter {
                     // .pred on first element returns itself
                     return Some(Ok(target.clone()));
                 }
-                if let Some(variants) = self.enum_types.get(&enum_type.resolve())
+                if let Some(variants) = self.registry().enum_types.get(&enum_type.resolve())
                     && let Some((prev_key, prev_val)) = variants.get(index - 1)
                 {
                     return Some(Ok(Value::Enum {
@@ -102,7 +102,7 @@ impl Interpreter {
                 Some(Ok(target.clone()))
             }
             "succ" => {
-                if let Some(variants) = self.enum_types.get(&enum_type.resolve()) {
+                if let Some(variants) = self.registry().enum_types.get(&enum_type.resolve()) {
                     if let Some((next_key, next_val)) = variants.get(index + 1) {
                         return Some(Ok(Value::Enum {
                             enum_type: *enum_type,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1337,8 +1337,11 @@ impl Interpreter {
                 if pkg_name == target_name {
                     return Ok(Value::Bool(true));
                 }
-                if let Some(mut base) =
-                    self.registry().subsets.get(&pkg_name).map(|s| s.base.clone())
+                if let Some(mut base) = self
+                    .registry()
+                    .subsets
+                    .get(&pkg_name)
+                    .map(|s| s.base.clone())
                 {
                     loop {
                         if base == target_name {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -833,7 +833,7 @@ impl Interpreter {
                 && let Some(enum_names) = self.class_enum_roles.get(&class_name.resolve()).cloned()
             {
                 for enum_name in &enum_names {
-                    if let Some(variants) = self.enum_types.get(enum_name).cloned()
+                    if let Some(variants) = self.registry().enum_types.get(enum_name).cloned()
                         && variants.iter().any(|(vname, _)| vname == method)
                     {
                         // Get the stored enum value from the instance attribute
@@ -1337,18 +1337,22 @@ impl Interpreter {
                 if pkg_name == target_name {
                     return Ok(Value::Bool(true));
                 }
-                if let Some(mut base) = self.subsets.get(&pkg_name).map(|s| s.base.clone()) {
+                if let Some(mut base) =
+                    self.registry().subsets.get(&pkg_name).map(|s| s.base.clone())
+                {
                     loop {
                         if base == target_name {
                             return Ok(Value::Bool(true));
                         }
-                        let Some(parent_subset) = self.subsets.get(&base) else {
+                        let Some(parent_base) =
+                            self.registry().subsets.get(&base).map(|s| s.base.clone())
+                        else {
                             break;
                         };
-                        if parent_subset.base == base {
+                        if parent_base == base {
                             break;
                         }
-                        base = parent_subset.base.clone();
+                        base = parent_base;
                     }
                 }
                 Ok(Value::Bool(

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -285,9 +285,9 @@ impl Interpreter {
                     | "PositionalBindFailover"
             ) {
             "Perl6::Metamodel::ParametricRoleGroupHOW"
-        } else if self.enum_types.contains_key(&type_name) {
+        } else if self.registry().enum_types.contains_key(&type_name) {
             "Perl6::Metamodel::EnumHOW"
-        } else if self.subsets.contains_key(&type_name)
+        } else if self.registry().subsets.contains_key(&type_name)
             || matches!(type_name.as_str(), "UInt" | "NativeInt")
         {
             "Perl6::Metamodel::SubsetHOW"
@@ -601,7 +601,7 @@ impl Interpreter {
         };
         let type_name = type_name_owned.as_deref();
         if let Some(type_name) = type_name
-            && let Some(variants) = self.enum_types.get(type_name)
+            && let Some(variants) = self.registry().enum_types.get(type_name)
         {
             let values: Vec<Value> = variants
                 .iter()
@@ -636,7 +636,12 @@ impl Interpreter {
             ];
             Some(variants_owned.as_slice())
         } else if let Some(type_name) = type_name {
-            self.enum_types.get(type_name).map(|v| v.as_slice())
+            if let Some(v) = self.registry().enum_types.get(type_name) {
+                variants_owned = v.clone();
+                Some(variants_owned.as_slice())
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -666,7 +671,7 @@ impl Interpreter {
         target: &Value,
     ) -> Option<Result<Value, RuntimeError>> {
         if let Value::Str(type_name) = target
-            && let Some(variants) = self.enum_types.get(type_name.as_str())
+            && let Some(variants) = self.registry().enum_types.get(type_name.as_str())
         {
             let mut result = Vec::new();
             for (k, v) in variants {

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -52,7 +52,7 @@ impl Interpreter {
                     if method == key.resolve() {
                         return Some(Ok(Value::Bool(true)));
                     }
-                    if let Some(variants) = self.enum_types.get(&enum_type.resolve())
+                    if let Some(variants) = self.registry().enum_types.get(&enum_type.resolve())
                         && variants.iter().any(|(variant, _)| variant == method)
                     {
                         return Some(Ok(Value::Bool(false)));

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -216,7 +216,7 @@ impl Interpreter {
             }
         }
         if let Value::Str(ref name) = target
-            && self.enum_types.contains_key(name.as_str())
+            && self.registry().enum_types.contains_key(name.as_str())
         {
             let msg = format!(
                 "Enum '{}' is insufficiently type-like to be instantiated.  Did you mean 'class'?",

--- a/src/runtime/methods_pick_roll.rs
+++ b/src/runtime/methods_pick_roll.rs
@@ -14,12 +14,12 @@ impl Interpreter {
         }
         let enum_type_name: Option<String> = match target {
             Value::Package(type_name) => Some(type_name.resolve()),
-            Value::Str(type_name) if self.enum_types.contains_key(type_name.as_str()) => {
+            Value::Str(type_name) if self.registry().enum_types.contains_key(type_name.as_str()) => {
                 Some(type_name.to_string())
             }
             Value::Mixin(_, mixins) => mixins.values().find_map(|v| match v {
                 Value::Enum { enum_type, .. }
-                    if self.enum_types.contains_key(&enum_type.resolve()) =>
+                    if self.registry().enum_types.contains_key(&enum_type.resolve()) =>
                 {
                     Some(enum_type.resolve())
                 }
@@ -31,7 +31,7 @@ impl Interpreter {
         let pool: Option<Vec<Value>> = if type_name == "Bool" {
             Some(vec![Value::Bool(false), Value::Bool(true)])
         } else {
-            self.enum_types.get(&type_name).map(|variants| {
+            self.registry().enum_types.get(&type_name).map(|variants| {
                 variants
                     .iter()
                     .enumerate()

--- a/src/runtime/methods_pick_roll.rs
+++ b/src/runtime/methods_pick_roll.rs
@@ -14,12 +14,17 @@ impl Interpreter {
         }
         let enum_type_name: Option<String> = match target {
             Value::Package(type_name) => Some(type_name.resolve()),
-            Value::Str(type_name) if self.registry().enum_types.contains_key(type_name.as_str()) => {
+            Value::Str(type_name)
+                if self.registry().enum_types.contains_key(type_name.as_str()) =>
+            {
                 Some(type_name.to_string())
             }
             Value::Mixin(_, mixins) => mixins.values().find_map(|v| match v {
                 Value::Enum { enum_type, .. }
-                    if self.registry().enum_types.contains_key(&enum_type.resolve()) =>
+                    if self
+                        .registry()
+                        .enum_types
+                        .contains_key(&enum_type.resolve()) =>
                 {
                     Some(enum_type.resolve())
                 }

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -943,7 +943,7 @@ impl Interpreter {
                 Value::Int(i) => vec![Value::Int(i)],
                 Value::Package(ref name) => {
                     // Enum type as shape: use the number of enum variants
-                    if let Some(variants) = self.enum_types.get(&name.resolve()) {
+                    if let Some(variants) = self.registry().enum_types.get(&name.resolve()) {
                         vec![Value::Int(variants.len() as i64)]
                     } else if name == "Bool" {
                         // Bool is a builtin enum with 2 values (False, True)
@@ -967,7 +967,7 @@ impl Interpreter {
                     return Err(RuntimeError::illegal_dimension_in_shape(*f as i64));
                 }
                 Value::Package(name) => {
-                    if let Some(variants) = self.enum_types.get(&name.resolve()) {
+                    if let Some(variants) = self.registry().enum_types.get(&name.resolve()) {
                         variants.len()
                     } else if name == "Bool" {
                         2

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -202,6 +202,7 @@ pub(crate) mod regex_parse;
 mod registration;
 mod registration_class;
 mod registration_sub;
+mod registry;
 pub(crate) mod resolution;
 mod run;
 mod seq_helpers;
@@ -220,6 +221,7 @@ mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) use self::registration_class::ClassDeclModifiers;
+pub(crate) use self::registry::Registry;
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};
 
 pub(crate) use utils::*;
@@ -347,7 +349,7 @@ struct RoleCandidateDef {
 }
 
 #[derive(Debug, Clone)]
-struct SubsetDef {
+pub(crate) struct SubsetDef {
     base: String,
     predicate: Option<Expr>,
     version: String,
@@ -878,7 +880,10 @@ pub struct Interpreter {
     gather_items: Vec<Vec<Value>>,
     gather_take_limits: Vec<Option<usize>>,
     block_scope_depth: usize,
-    enum_types: HashMap<String, Vec<(String, EnumValue)>>,
+    /// Declaration registry (enums/subsets/... — migrated group-by-group, PLAN.md ②),
+    /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
+    /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
+    registry: Arc<RwLock<Registry>>,
     classes: HashMap<String, ClassDef>,
     cunion_classes: HashSet<String>,
     hidden_classes: HashSet<String>,
@@ -914,7 +919,6 @@ pub struct Interpreter {
     /// `is DEPRECATED` messages on class attributes.
     /// Maps (class_name, attr_name) to the deprecation message.
     class_attribute_deprecated: HashMap<(String, String), String>,
-    subsets: HashMap<String, SubsetDef>,
     proto_subs: HashSet<String>,
     proto_tokens: HashSet<String>,
     proto_dispatch_stack: Vec<(String, Vec<Value>)>,
@@ -2888,7 +2892,7 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: 0,
-            enum_types: HashMap::new(),
+            registry: Arc::new(RwLock::new(Registry::default())),
             classes,
             cunion_classes: HashSet::new(),
             hidden_classes: HashSet::new(),
@@ -3078,7 +3082,6 @@ impl Interpreter {
             class_attribute_defaults: HashMap::new(),
             class_attribute_is_types: HashMap::new(),
             class_attribute_deprecated: HashMap::new(),
-            subsets: HashMap::new(),
             proto_subs: HashSet::new(),
             proto_tokens: HashSet::new(),
             proto_dispatch_stack: Vec::new(),
@@ -5089,6 +5092,22 @@ impl Interpreter {
             })
     }
 
+    /// Read access to the shared declaration [`Registry`]. Returns a temporary
+    /// guard — NEVER `let`-bind it across a call that re-enters user-code
+    /// execution (`eval_block_value`/`run_block_raw`/`call_function`): `RwLock`
+    /// is not reentrant and would deadlock. Use as `self.registry().subsets...`.
+    #[inline]
+    pub(crate) fn registry(&self) -> std::sync::RwLockReadGuard<'_, Registry> {
+        self.registry.read().unwrap()
+    }
+
+    /// Write access to the shared declaration [`Registry`]. Same guard discipline
+    /// as [`Self::registry`].
+    #[inline]
+    pub(crate) fn registry_mut(&self) -> std::sync::RwLockWriteGuard<'_, Registry> {
+        self.registry.write().unwrap()
+    }
+
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`
@@ -5208,7 +5227,10 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: self.block_scope_depth,
-            enum_types: self.enum_types.clone(),
+            // Deep-clone the registry into a fresh Arc so the child thread gets an
+            // independent snapshot (matches prior per-field clone semantics: the
+            // child sees parent declarations but its own new ones don't leak back).
+            registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
             classes: self.classes.clone(),
             cunion_classes: self.cunion_classes.clone(),
             hidden_classes: self.hidden_classes.clone(),
@@ -5231,7 +5253,6 @@ impl Interpreter {
             class_attribute_defaults: self.class_attribute_defaults.clone(),
             class_attribute_is_types: self.class_attribute_is_types.clone(),
             class_attribute_deprecated: self.class_attribute_deprecated.clone(),
-            subsets: self.subsets.clone(),
             proto_subs: self.proto_subs.clone(),
             proto_tokens: self.proto_tokens.clone(),
             proto_dispatch_stack: Vec::new(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -840,7 +840,7 @@ impl Interpreter {
             if !self.classes.contains_key(base_parent)
                 && !BUILTIN_TYPES.contains(&base_parent)
                 && !self.roles.contains_key(base_parent)
-                && !self.enum_types.contains_key(base_parent)
+                && !self.registry().enum_types.contains_key(base_parent)
             {
                 // Use X::InvalidType for `does` parents, X::Inheritance::UnknownParent
                 // for `is` parents.
@@ -1187,7 +1187,7 @@ impl Interpreter {
                         }
                     }
                 }
-            } else if does_parents.contains(parent) && self.enum_types.contains_key(base_role_name)
+            } else if does_parents.contains(parent) && self.registry().enum_types.contains_key(base_role_name)
             {
                 // Enum used as a role via `does`: record it for method dispatch
                 self.class_enum_roles
@@ -3179,7 +3179,7 @@ impl Interpreter {
             }
             pred.clone()
         });
-        self.subsets.insert(
+        self.registry_mut().subsets.insert(
             name.to_string(),
             SubsetDef {
                 base: base.to_string(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1187,7 +1187,8 @@ impl Interpreter {
                         }
                     }
                 }
-            } else if does_parents.contains(parent) && self.registry().enum_types.contains_key(base_role_name)
+            } else if does_parents.contains(parent)
+                && self.registry().enum_types.contains_key(base_role_name)
             {
                 // Enum used as a role via `does`: record it for method dispatch
                 self.class_enum_roles

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -985,7 +985,7 @@ impl Interpreter {
 
         let is_anonymous = name.is_empty();
         let enum_type_name = if is_anonymous { "__ANON_ENUM__" } else { name };
-        self.enum_types
+        self.registry_mut().enum_types
             .insert(enum_type_name.to_string(), enum_variants.clone());
         if !is_anonymous {
             self.env

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -985,7 +985,8 @@ impl Interpreter {
 
         let is_anonymous = name.is_empty();
         let enum_type_name = if is_anonymous { "__ANON_ENUM__" } else { name };
-        self.registry_mut().enum_types
+        self.registry_mut()
+            .enum_types
             .insert(enum_type_name.to_string(), enum_variants.clone());
         if !is_anonymous {
             self.env

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -1,0 +1,44 @@
+//! Declaration registry shared between the VM and the Interpreter.
+//!
+//! Holds the program's *declarations* — classes, roles, enums, subsets, subs,
+//! tokens and their associated metadata. Historically these lived as ~30
+//! separate fields directly on [`Interpreter`](super::Interpreter), which trapped
+//! them inside the tree-walking interpreter: VM-native code could only reach them
+//! through `self.interpreter.<field>`. This is the "bidirectional ownership knot"
+//! that phase ② of the VM/Interpreter decoupling resolves (see PLAN.md ②).
+//!
+//! The registry is held behind `Arc<RwLock<Registry>>` so the VM and the
+//! Interpreter can reach it as *peers* rather than one owning the other. This is
+//! transitional scaffolding: the `Arc`/lock exists only because two executors
+//! share the data today. Once the Interpreter execution path is removed (PLAN.md
+//! ④/⑤), the registry collapses to a plain VM-owned field.
+//!
+//! Threading: registries are snapshot-cloned per thread (deep clone into a fresh
+//! `Arc`), matching the pre-existing `clone_for_thread` semantics — a `start {}`
+//! block sees the parent's declarations but its own new declarations do not leak
+//! back. `Value` is `Send + Sync` (all-`Arc` internals), so `Registry` is too.
+//!
+//! Lock discipline (CRITICAL): never hold a read/write guard across a call that
+//! re-enters user-code execution (`eval_block_value` / `run_block_raw` /
+//! `call_function`). `RwLock` is not reentrant, so a held guard would deadlock.
+//! Always use a *temporary* guard (`self.registry().subsets.get(..)`), never a
+//! `let`-bound guard that lives across such a call.
+
+use std::collections::HashMap;
+
+use crate::value::EnumValue;
+
+use super::SubsetDef;
+
+/// Program declaration registry. See module docs.
+///
+/// Fields are migrated here group-by-group (PLAN.md PR-A). Fields are
+/// `pub(crate)` so registry-internal runtime code can access them directly;
+/// PR-B adds typed lookup methods for the VM to call.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Registry {
+    /// `enum Name (...)` declarations: enum name -> [(variant name, value)].
+    pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
+    /// `subset Name of Base where { ... }` declarations.
+    pub(crate) subsets: HashMap<String, SubsetDef>,
+}

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1217,7 +1217,7 @@ impl Interpreter {
                     super::super::types::strip_type_smiley(&type_name_resolved);
 
                 // Enum type object smartmatch against enum values.
-                if self.enum_types.contains_key(base_type) {
+                if self.registry().enum_types.contains_key(base_type) {
                     let enum_match =
                         matches!(left, Value::Enum { enum_type, .. } if enum_type == base_type);
                     return match smiley {
@@ -1267,7 +1267,7 @@ impl Interpreter {
                 self.type_matches_value(&type_name_resolved, left)
             }
             // Backward-compatibility: enum type objects may still arrive as Str values.
-            (_, Value::Str(type_name)) if self.enum_types.contains_key(type_name.as_str()) => {
+            (_, Value::Str(type_name)) if self.registry().enum_types.contains_key(type_name.as_str()) => {
                 matches!(left, Value::Enum { enum_type, .. } if enum_type.resolve() == **type_name)
             }
             // Mu instances smartmatch only the Mu type object (Mu ~~ Mu.new is True).

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1267,7 +1267,9 @@ impl Interpreter {
                 self.type_matches_value(&type_name_resolved, left)
             }
             // Backward-compatibility: enum type objects may still arrive as Str values.
-            (_, Value::Str(type_name)) if self.registry().enum_types.contains_key(type_name.as_str()) => {
+            (_, Value::Str(type_name))
+                if self.registry().enum_types.contains_key(type_name.as_str()) =>
+            {
                 matches!(left, Value::Enum { enum_type, .. } if enum_type.resolve() == **type_name)
             }
             // Mu instances smartmatch only the Mu type object (Mu ~~ Mu.new is True).

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -190,8 +190,8 @@ impl Interpreter {
         nested.role_hides = self.role_hides.clone();
         nested.role_type_params = self.role_type_params.clone();
         nested.class_role_param_bindings = self.class_role_param_bindings.clone();
-        nested.subsets = self.subsets.clone();
-        nested.enum_types = self.enum_types.clone();
+        nested.registry_mut().subsets = self.registry().subsets.clone();
+        nested.registry_mut().enum_types = self.registry().enum_types.clone();
         nested.type_metadata = self.type_metadata.clone();
         nested.current_package = self.current_package.clone();
         nested.var_dynamic_flags = self.var_dynamic_flags.clone();
@@ -289,8 +289,8 @@ impl Interpreter {
         nested.role_hides = self.role_hides.clone();
         nested.role_type_params = self.role_type_params.clone();
         nested.class_role_param_bindings = self.class_role_param_bindings.clone();
-        nested.subsets = self.subsets.clone();
-        nested.enum_types = self.enum_types.clone();
+        nested.registry_mut().subsets = self.registry().subsets.clone();
+        nested.registry_mut().enum_types = self.registry().enum_types.clone();
         nested.type_metadata = self.type_metadata.clone();
         nested.current_package = self.current_package.clone();
         nested.var_dynamic_flags = self.var_dynamic_flags.clone();

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -65,8 +65,8 @@ impl Interpreter {
                 nested.role_hides = self.role_hides.clone();
                 nested.role_type_params = self.role_type_params.clone();
                 nested.class_role_param_bindings = self.class_role_param_bindings.clone();
-                nested.subsets = self.subsets.clone();
-                nested.enum_types = self.enum_types.clone();
+                nested.registry_mut().subsets = self.registry().subsets.clone();
+                nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();
                 nested.current_package = self.current_package.clone();
                 nested.var_dynamic_flags = self.var_dynamic_flags.clone();

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -28,7 +28,7 @@ impl Interpreter {
         self.role_type_params = nested.role_type_params.clone();
         self.class_role_param_bindings = nested.class_role_param_bindings.clone();
         self.attribute_build_overrides = nested.attribute_build_overrides.clone();
-        self.subsets = nested.subsets.clone();
+        self.registry_mut().subsets = nested.registry().subsets.clone();
         self.need_hidden_classes = nested.need_hidden_classes.clone();
     }
 

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -49,7 +49,7 @@ impl Interpreter {
         let saved_classes = self.classes.clone();
         let saved_class_trusts = self.class_trusts.clone();
         let saved_roles = self.roles.clone();
-        let saved_subsets = self.subsets.clone();
+        let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
         let run_result = self.call_sub_value(block, vec![], true);
@@ -72,7 +72,7 @@ impl Interpreter {
             self.classes = saved_classes;
             self.class_trusts = saved_class_trusts;
             self.roles = saved_roles;
-            self.subsets = saved_subsets;
+            self.registry_mut().subsets = saved_subsets;
             // Merge type_metadata: preserve entries added during the subtest
             for (key, val) in std::mem::take(&mut self.type_metadata) {
                 saved_type_metadata.entry(key).or_insert(val);
@@ -100,7 +100,7 @@ impl Interpreter {
         self.classes = saved_classes;
         self.class_trusts = saved_class_trusts;
         self.roles = saved_roles;
-        self.subsets = saved_subsets;
+        self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest
         for (key, val) in std::mem::take(&mut self.type_metadata) {
             saved_type_metadata.entry(key).or_insert(val);
@@ -147,7 +147,7 @@ impl Interpreter {
         let saved_classes = self.classes.clone();
         let saved_class_trusts = self.class_trusts.clone();
         let saved_roles = self.roles.clone();
-        let saved_subsets = self.subsets.clone();
+        let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
         self.test_fn_plan(&[Value::Int(plan)])?;
@@ -161,7 +161,7 @@ impl Interpreter {
         self.classes = saved_classes;
         self.class_trusts = saved_class_trusts;
         self.roles = saved_roles;
-        self.subsets = saved_subsets;
+        self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest
         for (key, val) in std::mem::take(&mut self.type_metadata) {
             saved_type_metadata.entry(key).or_insert(val);

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -41,8 +41,8 @@ impl Interpreter {
                 nested.role_hides = self.role_hides.clone();
                 nested.role_type_params = self.role_type_params.clone();
                 nested.class_role_param_bindings = self.class_role_param_bindings.clone();
-                nested.subsets = self.subsets.clone();
-                nested.enum_types = self.enum_types.clone();
+                nested.registry_mut().subsets = self.registry().subsets.clone();
+                nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();
                 nested.current_package = self.current_package.clone();
                 nested.suppressed_names = self.suppressed_names.clone();
@@ -368,8 +368,8 @@ impl Interpreter {
                 nested.proto_tokens = self.proto_tokens.clone();
                 nested.classes = self.classes.clone();
                 nested.roles = self.roles.clone();
-                nested.subsets = self.subsets.clone();
-                nested.enum_types = self.enum_types.clone();
+                nested.registry_mut().subsets = self.registry().subsets.clone();
+                nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();
                 for (k, v) in &self.env {
                     if !k.contains_str("::") {

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -194,7 +194,8 @@ impl Interpreter {
         {
             return Ok(coerced);
         }
-        if let Some(variants) = self.enum_types.get(base_target).cloned()
+        let variants = self.registry().enum_types.get(base_target).cloned();
+        if let Some(variants) = variants
             && let Some(enum_value) =
                 self.coerce_to_enum_variant(base_target, &variants, value.clone())
         {
@@ -302,7 +303,12 @@ impl Interpreter {
         if resolved_constraint != constraint {
             return self.try_coerce_value_for_constraint(&resolved_constraint, value);
         }
-        if let Some(subset) = self.subsets.get(resolved_constraint.as_str()).cloned()
+        let subset = self
+            .registry()
+            .subsets
+            .get(resolved_constraint.as_str())
+            .cloned();
+        if let Some(subset) = subset
             && subset.base != resolved_constraint
         {
             return self.try_coerce_value_for_constraint(&subset.base, value);

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -313,7 +313,7 @@ impl Interpreter {
                 return self.nominal_type_object_name_for_constraint(&resolved);
             }
         }
-        if let Some(subset) = self.subsets.get(&base_name) {
+        if let Some(subset) = self.registry().subsets.get(&base_name) {
             if language_version_is_6e_or_newer(&subset.version) {
                 // In v6.e, the default for a subset variable is the base type's
                 // type object (the subset's "nominalization").

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -492,7 +492,10 @@ impl Interpreter {
             };
         }
 
-        if let Some(subset) = self.subsets.get(constraint).cloned() {
+        // Drop the registry guard before the body: it evaluates the subset's `where`
+        // predicate (user code re-entry), which would deadlock under a held read lock.
+        let subset = self.registry().subsets.get(constraint).cloned();
+        if let Some(subset) = subset {
             if !self.type_matches_value(&subset.base, value) {
                 return false;
             }
@@ -641,10 +644,12 @@ impl Interpreter {
                     }
                 }
             }
-            if let Some(subset_base) = self
+            let subset_base = self
+                .registry()
                 .subsets
                 .get(&package_name.resolve())
-                .map(|subset| subset.base.clone())
+                .map(|subset| subset.base.clone());
+            if let Some(subset_base) = subset_base
                 && (constraint == package_name.resolve()
                     || self.type_matches_value(
                         constraint,

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -7,7 +7,8 @@ impl Interpreter {
             ("LittleEndian".to_string(), EnumValue::Int(1)),
             ("BigEndian".to_string(), EnumValue::Int(2)),
         ];
-        self.registry_mut().enum_types
+        self.registry_mut()
+            .enum_types
             .insert("Endian".to_string(), variants.clone());
         base.insert(Symbol::intern("Endian"), Value::str_from("Endian"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -38,7 +39,8 @@ impl Interpreter {
             ("PF_UNIX".to_string(), EnumValue::Int(3)),
             ("PF_MAX".to_string(), EnumValue::Int(4)),
         ];
-        self.registry_mut().enum_types
+        self.registry_mut()
+            .enum_types
             .insert("ProtocolFamily".to_string(), variants.clone());
         base.insert(
             Symbol::intern("ProtocolFamily"),
@@ -65,7 +67,8 @@ impl Interpreter {
             ("Same".to_string(), EnumValue::Int(0)),
             ("More".to_string(), EnumValue::Int(1)),
         ];
-        self.registry_mut().enum_types
+        self.registry_mut()
+            .enum_types
             .insert("Order".to_string(), variants.clone());
         base.insert(Symbol::intern("Order"), Value::str_from("Order"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -103,7 +106,8 @@ impl Interpreter {
             ("SIGTTIN".to_string(), EnumValue::Int(Self::sig_num(21))),
             ("SIGTTOU".to_string(), EnumValue::Int(Self::sig_num(22))),
         ];
-        self.registry_mut().enum_types
+        self.registry_mut()
+            .enum_types
             .insert("Signal".to_string(), variants.clone());
         base.insert(Symbol::intern("Signal"), Value::str_from("Signal"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -238,7 +242,8 @@ impl Interpreter {
     }
 
     pub(crate) fn has_enum_variant(&self, enum_name: &str, variant_name: &str) -> bool {
-        self.registry().enum_types
+        self.registry()
+            .enum_types
             .get(enum_name)
             .is_some_and(|variants| variants.iter().any(|(k, _)| k == variant_name))
     }
@@ -407,7 +412,11 @@ impl Interpreter {
         // Follow subset chain up to a reasonable depth to avoid cycles.
         // Clone the base out per step so the registry read guard never spans iterations.
         for _ in 0..20 {
-            let next = self.registry().subsets.get(&current).map(|s| s.base.clone());
+            let next = self
+                .registry()
+                .subsets
+                .get(&current)
+                .map(|s| s.base.clone());
             match next {
                 Some(base) => current = base,
                 None => break,

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -7,7 +7,7 @@ impl Interpreter {
             ("LittleEndian".to_string(), EnumValue::Int(1)),
             ("BigEndian".to_string(), EnumValue::Int(2)),
         ];
-        self.enum_types
+        self.registry_mut().enum_types
             .insert("Endian".to_string(), variants.clone());
         base.insert(Symbol::intern("Endian"), Value::str_from("Endian"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -38,7 +38,7 @@ impl Interpreter {
             ("PF_UNIX".to_string(), EnumValue::Int(3)),
             ("PF_MAX".to_string(), EnumValue::Int(4)),
         ];
-        self.enum_types
+        self.registry_mut().enum_types
             .insert("ProtocolFamily".to_string(), variants.clone());
         base.insert(
             Symbol::intern("ProtocolFamily"),
@@ -65,7 +65,7 @@ impl Interpreter {
             ("Same".to_string(), EnumValue::Int(0)),
             ("More".to_string(), EnumValue::Int(1)),
         ];
-        self.enum_types
+        self.registry_mut().enum_types
             .insert("Order".to_string(), variants.clone());
         base.insert(Symbol::intern("Order"), Value::str_from("Order"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -103,7 +103,7 @@ impl Interpreter {
             ("SIGTTIN".to_string(), EnumValue::Int(Self::sig_num(21))),
             ("SIGTTOU".to_string(), EnumValue::Int(Self::sig_num(22))),
         ];
-        self.enum_types
+        self.registry_mut().enum_types
             .insert("Signal".to_string(), variants.clone());
         base.insert(Symbol::intern("Signal"), Value::str_from("Signal"));
         for (index, (key, val)) in variants.iter().enumerate() {
@@ -223,22 +223,22 @@ impl Interpreter {
     pub(crate) fn has_type(&self, name: &str) -> bool {
         self.classes.contains_key(name)
             || self.roles.contains_key(name)
-            || self.enum_types.contains_key(name)
-            || self.subsets.contains_key(name)
+            || self.registry().enum_types.contains_key(name)
+            || self.registry().subsets.contains_key(name)
             || Self::parse_parametric_type_name(name).is_some_and(|(base, _)| {
                 self.classes.contains_key(&base)
                     || self.roles.contains_key(&base)
-                    || self.enum_types.contains_key(&base)
-                    || self.subsets.contains_key(&base)
+                    || self.registry().enum_types.contains_key(&base)
+                    || self.registry().subsets.contains_key(&base)
             })
     }
 
     pub(crate) fn has_enum_type(&self, name: &str) -> bool {
-        self.enum_types.contains_key(name)
+        self.registry().enum_types.contains_key(name)
     }
 
     pub(crate) fn has_enum_variant(&self, enum_name: &str, variant_name: &str) -> bool {
-        self.enum_types
+        self.registry().enum_types
             .get(enum_name)
             .is_some_and(|variants| variants.iter().any(|(k, _)| k == variant_name))
     }
@@ -261,7 +261,7 @@ impl Interpreter {
         if let Some((target, _source)) = parse_coercion_type(base_constraint) {
             return self.is_definite_constraint(target);
         }
-        if let Some(subset) = self.subsets.get(base_constraint) {
+        if let Some(subset) = self.registry().subsets.get(base_constraint) {
             if self.is_definite_constraint(&subset.base) {
                 return true;
             }
@@ -402,14 +402,15 @@ impl Interpreter {
 
     /// Resolve the ultimate base type of a constraint, following subset chains.
     /// Returns the constraint itself if it is not a subset type.
-    pub(crate) fn resolve_subset_base_type<'a>(&'a self, constraint: &'a str) -> &'a str {
-        let mut current = constraint;
-        // Follow subset chain up to a reasonable depth to avoid cycles
+    pub(crate) fn resolve_subset_base_type(&self, constraint: &str) -> String {
+        let mut current = constraint.to_string();
+        // Follow subset chain up to a reasonable depth to avoid cycles.
+        // Clone the base out per step so the registry read guard never spans iterations.
         for _ in 0..20 {
-            if let Some(subset) = self.subsets.get(current) {
-                current = &subset.base;
-            } else {
-                break;
+            let next = self.registry().subsets.get(&current).map(|s| s.base.clone());
+            match next {
+                Some(base) => current = base,
+                None => break,
             }
         }
         current

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -127,7 +127,7 @@ impl VM {
                                 return false;
                             }
                             let resolved_base = self.interpreter.resolve_subset_base_type(tc);
-                            return !matches!(resolved_base, "Mu" | "Junction");
+                            return !matches!(resolved_base.as_str(), "Mu" | "Junction");
                         }
                         return true; // No type constraint = default Any
                     }
@@ -148,7 +148,7 @@ impl VM {
                         // junction should be passed as-is to the subset's
                         // where-clause check.
                         let resolved_base = self.interpreter.resolve_subset_base_type(tc);
-                        if matches!(resolved_base, "Mu" | "Junction") {
+                        if matches!(resolved_base.as_str(), "Mu" | "Junction") {
                             return false;
                         }
                         return true;

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2440,7 +2440,7 @@ impl VM {
                 .interpreter
                 .resolve_subset_base_type(declared_constraint);
             matches!(
-                ultimate_base,
+                ultimate_base.as_str(),
                 "List"
                     | "Array"
                     | "Positional"


### PR DESCRIPTION
## Phase ② — declaration-registry VM ownership (slice 1)

Part of the VM/Interpreter decoupling (PLAN.md ②). Resolves the "bidirectional
ownership knot": declaration registries lived as fields on the tree-walking
`Interpreter`, so VM-native code could only reach them via
`self.interpreter.<field>`. This lifts them into a shared `Arc<RwLock<Registry>>`
that the VM and Interpreter hold as **peers**.

Transitional scaffolding by design: the `Arc`/lock exists only because two
executors share the data today. Once the Interpreter execution path is removed
(PLAN.md ④/⑤) the registry collapses to a plain VM-owned field — i.e. the
`Interpreter` object goes away entirely.

### This slice
Migrates the two safest, lowest-reentrancy groups (`enum_types`, `subsets`) to
establish the mechanism before the heavier groups (classes/roles/functions):

- new `src/runtime/registry.rs` — `Registry` struct + lock-discipline docs
- `Interpreter.{enum_types,subsets}` → `registry: Arc<RwLock<Registry>>` with
  `registry()` / `registry_mut()` helpers
- `clone_for_thread` deep-clones into a fresh `Arc` (snapshot-per-thread
  semantics preserved exactly)
- ~75 access sites converted; reentrancy hazards (subset `where`-predicate eval,
  subset base-chain walks) made safe by hoisting registry reads so **no guard is
  held across user-code re-entry** (`RwLock` is not reentrant → deadlock)
- `resolve_subset_base_type` returns `String` (cannot return a ref into the lock)

### Validation
Behavior-invariant. `cargo build` + `cargo clippy -- -D warnings` green;
`make test` PASS; whitelisted enum/subset/coercion roast (15 files) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)