### PR TITLE
docs: phase ② (registry VM ownership) design + PLAN.md update

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -101,9 +101,19 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       （真フォールバック）/ `// CARRIER:`（反射・MOP・EVAL・メタプロ hook）で注釈し、進捗台帳
       [docs/vm-interpreter-fallback-ledger.md](docs/vm-interpreter-fallback-ledger.md) を新設。同 PR で `succ`/`pred` を
       統一 compiled-first ディスパッチへ降ろし §1 から 2 サイト消化。以後は台帳の行を消す形で進める。
-- [ ] **② 宣言の実行を VM 所有レジストリへ**: `class`/`role`/`enum`/`subset`/`token`/`sub`/`method` は現在
-      `Register*` opcode が `interpreter.register_*_decl()` を呼び、クラスシステム・MRO・role 合成が Interpreter 側。
-      これらのレジストリを VM 所有データへ移す（②は③の前提）。
+- [~] **② 宣言レジストリの VM 所有化**（設計確定: [docs/vm-registry-ownership.md](docs/vm-registry-ownership.md)）:
+      `class`/`role`/`enum`/`subset`/`token`/`sub` は現在 `Register*` opcode が `interpreter.register_*_decl()` を
+      呼び、レジストリ・MRO・role 合成が Interpreter 側。これらの宣言レジストリ ~30 フィールドを `Interpreter` から
+      切り出し、**遷移期は `Arc<RwLock<Registry>>` 足場**（VM と Interpreter が対等に共有。`Rc<RefCell>` は
+      `Interpreter` がスレッド境界を越えるため不可）で持ち上げる。**エンドステート＝Interpreter 撤去後（④/⑤）に
+      plain な VM フィールドへ畳む**（＝ Interpreter オブジェクト消滅）。登録は登録中にユーザコードへ再入する
+      （trait ハンドラ / 属性デフォルト / クラス本体）ため、**RwLock ガードを再入を跨いで保持しない**規律が肝。
+      `clone_for_thread` のスナップショット意味論は厳守（挙動不変）。②は③の前提。
+      - [x] **PR-A slice 1（#2760）**: 機構確立 + `enum_types`/`subsets` 移行（`src/runtime/registry.rs` 新設、
+            `registry()`/`registry_mut()` ヘルパ、~75 サイト変換、再入ハザードをガード巻き上げで安全化）。
+      - [ ] **PR-A 残**: classes（178 サイト・ホット経路・大きい `ClassDef` なので naive clone を避け Registry
+            アクセサで最小データ返却）/ class メタ群 / roles 群 / functions・subs・tokens（移行後 `clone_for_thread`
+            1 行化）。→ **PR-B**（lookup を Registry メソッド化・VM 直読み）→ **PR-C**（register_* write-through 整理）。
 - [ ] **③ VM が借用している Interpreter 状態を VM 所有へ移管**: env HashMap（変数ストア本体）・classes/roles/enums
       レジストリ・型検査（`type_matches_value`/`var_type_constraint`）・readonly 追跡・`let`/`temp` 復元・multi 解決・
       state 変数・`current_package`。これが移れば **interpreter ブリッジ自体が不要**になる。最大の山。

--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -1,0 +1,96 @@
+# ② 宣言レジストリの VM 所有化（構造リファクタ設計）
+
+[PLAN.md](../PLAN.md) の最終ゴール「tree-walking Interpreter 実行パス撤去 → dual-store 削除」の
+**ステップ②**。①（個別フォールバック撲滅）は安いサイトが枯渇し、残りは構造的ブロッカー（②/③）前提。
+本書は②の確定設計。一次台帳は [vm-interpreter-fallback-ledger.md](vm-interpreter-fallback-ledger.md)、
+dual-store は [vm-dual-store.md](vm-dual-store.md)。
+
+## 解くべき問題: 双方向所有ノット
+
+- `VM` は `interpreter: Interpreter` を**値で所有**（`src/vm.rs`）。
+- `Interpreter` は VM への参照を持たないが、**共有実行状態（env・宣言レジストリ・型システム）を独占保持**。
+  VM ネイティブコードはそれらに `self.interpreter.<field>` 経由でしか触れない。
+- 実行制御は `Interpreter.run_block_raw → VM::new(self) → vm.run() → (interp,result) を返す → *self=interp`
+  で **VM↔Interpreter を ping-pong**。状態は Interpreter に「閉じ込められて」いる。
+
+②＝この閉じ込められた状態のうち**宣言レジストリ**（class/role/enum/subset/sub/token + 関連メタ ~30
+フィールド）を、VM と Interpreter が対等に触れる場所へ持ち上げる。③（env/型/state 移管）の前提であり、
+台帳 §2 の関数 dispatch フォールバック（multi/sub 解決）撲滅の前提でもある。
+
+## 設計を縛る制約（調査で確定）
+
+1. **`Value` は `Send + Sync`**（`src/value/mod.rs` でコンパイル時 assert、内部は全て `Arc`）。
+   `Interpreter` 自体が `std::thread::spawn` のクロージャへ move される（`spawn_user_thread<F: Send>`）。
+   → **`Rc<RefCell>` は Send 違反で不可。** interior-mutable 共有は `Arc<RwLock>`/`Arc<Mutex>` 一択。
+2. **レジストリは現在スレッドごとに deep-clone（スナップショット）**（`clone_for_thread`、書き戻し無し）。
+   → ②は**この意味論を厳守**（`start {}` 内宣言は親へ漏れない／親の宣言は子から見える）。
+3. **登録処理は登録中にユーザコードへ再入する**。`register_class_decl`/`register_sub_decl`/
+   `register_enum_decl` は `eval_block_value`/`run_block_raw`/`call_function("trait_mod:<is>")` を登録の
+   最中に呼び、クラス本体文・BEGIN phaser・trait ハンドラ・属性デフォルト・enum 変種値・パラメタ化 role
+   本体を実行する。その再入コードは registry を**再帰読み書き**し得る。
+   → `&mut Registry` を関数全体で借用する「plain field + &mut」案は遷移期に**借用エラー**で破綻。
+   ping-pong で registry が VM↔Interpreter を往復する点も合わせ、**遷移期は共有ハンドル一択**。
+
+## 決定（ユーザー方針 2026-06-08）
+
+- **エンドステート = VM 単独所有の plain field**（Interpreter オブジェクト消滅後）。これが確定の方向。
+- **遷移期の表現 = `Arc<RwLock<Registry>>` 足場**。Interpreter が保持し各 VM へハンドル複製。
+  ③/④で Interpreter 実行パスと ping-pong を撤去した時点で **plain な VM フィールドへ畳む**
+  （Arc/lock が要るのは「2者が共有するから」だけ。所有者が1者になれば自然消滅）。
+- **規律（重要）**: RwLock ガードを**再入を跨いで保持しない**（短い critical section で acquire→読み書き→
+  drop、`eval_block_value`/`run_block_raw`/`call_function` の前に必ず drop）。RwLock は非再入なので必須。
+- **スコープ = 構造リファクタのみ（挙動不変）**。台帳 §2 fallback の実消化は ② 完了後の別 PR。
+
+## `Registry` 構造体（`src/runtime/registry.rs`）
+
+`Interpreter` から `Registry` へ移す宣言レジストリ群（論理グループ）:
+
+- **Functions/Subs**: functions, our_scoped_functions, proto_functions, proto_subs, token_defs, proto_tokens
+- **Classes**: classes, cunion_classes, hidden_classes, class_stubs, package_stubs, hidden_defer_parents,
+  class_trusts, class_how_values, class_composed_roles, class_enum_roles, class_subs,
+  attribute_build_overrides, class_attribute_defaults, class_attribute_is_types, class_attribute_deprecated
+- **Roles**: roles, user_declared_roles, role_candidates, role_parents, role_hides, role_type_params,
+  class_role_param_bindings
+- **Enums**: enum_types — **Subsets**: subsets
+
+保持・複製: `Interpreter.registry: Arc<RwLock<Registry>>` + `registry()`/`registry_mut()` ヘルパ。
+`clone_for_thread` は `Arc::new(RwLock::new(self.registry.read().clone()))` で中身 deep-clone
+（スナップショット意味論を厳守）。全フィールド移行後、現在 ~30 行の個別 `.clone()` が 1 行に畳まれる。
+
+**境界（②に含めない）**: `type_metadata`/`array_type_metadata` 等の `Arc::as_ptr` keyed 副テーブル
+（🟣第一級コンテナ案件）、env/型検査本体/readonly/let/state/current_package（=③）。
+
+## 移行手順（strangler-fig、各 PR は挙動不変・CI が安全網）
+
+- **PR-A（抽出）**: フィールド群を Registry へ移し全アクセスを lock 経由へ。グループ単位の増分:
+  1. enum/subset（最小・再入浅い、機構確立）
+  2. class メタ群（小型・clone-cheap）
+  3. classes（ホット経路・大きい `ClassDef`。**naive clone 回避**＝Registry アクセサで最小データを返す）
+  4. roles 群（perf 敏感）
+  5. functions/subs/tokens（移行後 `clone_for_thread` 1 行化）
+- **PR-B（read 側移行）**: lookup/MRO/型マッチの registry 読み部を Registry メソッド化、VM の ~15-20 read
+  サイトを `self.registry.read()` へ。③/§2 dispatch 撲滅の前提が整う。
+- **PR-C（write-through 整理）**: register_*_decl の registry 書き込みを write-lock ブロックへ整理、
+  再入跨ぎ guard 無しを保証、台帳注釈更新（登録が実行をトリガする CARRIER）。
+
+## 進捗
+
+- **PR-A slice 1（#2760）**: 機構確立 + enum/subset 移行。`src/runtime/registry.rs` 新設、
+  `registry()`/`registry_mut()` ヘルパ、`clone_for_thread` 配線（snapshot 維持）、~75 サイト変換、
+  再入ハザード（subset `where` 評価/ base-chain walk）をガード巻き上げで安全化、`resolve_subset_base_type`
+  は `String` 返しへ。build/clippy/make test 緑、whitelist enum/subset/coercion 15 件 PASS。
+- 残（フィールド別 total/writes）: classes(178/33, 要 perf 設計)、class メタ群（class_composed_roles 37 等、
+  VM 直アクセスは `vm.rs` の `package_stubs.insert/remove` のみ。他はメソッド経由）、roles(110)/role_parents(45)
+  /role_candidates(21)、functions(96)/token_defs(35)。
+
+## 完了の定義（②）
+
+`Interpreter` から宣言レジストリ ~30 フィールドが消え `registry: Arc<RwLock<Registry>>` 1 本に。VM の
+registry 系 lookup が `self.registry.read()` 経由へ。`clone_for_thread` のレジストリ複製が 1 行化（snapshot
+不変）。台帳の §2 前提「②レジストリ」を満たした旨を更新。③（env/型/state 移管）と §2 撲滅へ進める状態。
+
+## 非ゴール
+
+env/型/state 移管（③）、登録の完全 VM ネイティブ化（③/④後）、台帳 §1/§2 の実消化（②完了後の別 PR）、
+`type_metadata` の Arc-ptr keying 解消（🟣第一級コンテナ）、Arc<RwLock>→plain field の最終畳み込み
+（Interpreter 撤去後＝④/⑤）、スレッド間 registry の真共有（スナップショット廃止、PLAN §8.3 の concurrency）。


### PR DESCRIPTION
Documents the design for **PLAN.md ②** (declaration-registry VM ownership), the
next structural step in the VM/Interpreter decoupling, so future development has
a durable reference.

### Adds `docs/vm-registry-ownership.md`
- The **bidirectional ownership knot**: VM owns `Interpreter`, but the Interpreter
  holds all the shared state (registries), so VM-native code can only reach them
  via `self.interpreter.<field>`.
- Constraints that shape the design: `Value: Send+Sync` (so `Rc<RefCell>` is out —
  the Interpreter crosses thread boundaries), registries are snapshot-cloned per
  thread, and registration **re-enters user code mid-call** (trait handlers,
  attribute defaults, class bodies).
- **Decision**: transitional `Arc<RwLock<Registry>>` handle shared by VM and
  Interpreter as peers → collapses to a plain VM-owned field once the Interpreter
  execution path is removed (i.e. the `Interpreter` object goes away). Lock
  discipline: never hold a guard across user-code re-entry (RwLock is not reentrant).
- Migration order PR-A (group-by-group) / PR-B (read-side) / PR-C (write-through).

### Updates `PLAN.md`
Marks ② as in-progress `[~]` with the design summary, a link to the new doc, and
the slice-1 (#2760, enum/subset) + remaining-groups breakdown.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)