### PR TITLE
refactor(vm): migrate class metadata into shared Registry (phase ② PR-A slice 2)

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -79,8 +79,19 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   `registry()`/`registry_mut()` ヘルパ、`clone_for_thread` 配線（snapshot 維持）、~75 サイト変換、
   再入ハザード（subset `where` 評価/ base-chain walk）をガード巻き上げで安全化、`resolve_subset_base_type`
   は `String` 返しへ。build/clippy/make test 緑、whitelist enum/subset/coercion 15 件 PASS。
-- 残（フィールド別 total/writes）: classes(178/33, 要 perf 設計)、class メタ群（class_composed_roles 37 等、
-  VM 直アクセスは `vm.rs` の `package_stubs.insert/remove` のみ。他はメソッド経由）、roles(110)/role_parents(45)
+- **PR-A slice 2（本 PR）**: class メタ群 14 フィールド移行（cunion_classes, hidden_classes, class_stubs,
+  package_stubs, hidden_defer_parents, class_trusts, class_how_values, class_composed_roles, class_enum_roles,
+  class_subs, attribute_build_overrides, class_attribute_defaults, class_attribute_is_types,
+  class_attribute_deprecated）。read=`registry()`/write=`registry_mut()` へ ~130 サイト変換。
+  `clone_for_thread` の 14 行個別 clone を削除（Registry 全体 clone に吸収）。`class_composed_roles` の
+  builtin seed は `Interpreter::new` で `Registry::default()` に投入。参照返却アクセサ 3 本
+  （`class_composed_roles`/`class_attribute_default`/`class_attribute_deprecated`）を owned 返し
+  （`.cloned()`）へ変更し VM/runtime 呼び出し側を追従（ガードへの参照を返せないため）。再入ハザードを
+  ガード巻き上げで安全化: `collect_transitive_roles` 前の `class_composed_roles` clone、`call_sub_value`
+  前の `attribute_build_overrides` clone、`has_class_scoped_subs` の二重 read を単一 let-bound guard へ。
+  VM 直アクセスは `vm.rs` の `package_stubs.insert/remove` を `registry_mut()` 経由へ。build/clippy/make test
+  緑、whitelist class/role/attribute roast 緑（非 whitelist の private-method 既存失敗は不変）。
+- 残（フィールド別 total/writes）: classes(178/33, 要 perf 設計)、roles(110)/role_parents(45)
   /role_candidates(21)、functions(96)/token_defs(35)。
 
 ## 完了の定義（②）

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -887,8 +887,11 @@ impl Interpreter {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn class_composed_roles(&self, class_name: &str) -> Option<&Vec<String>> {
-        self.class_composed_roles.get(class_name)
+    pub(crate) fn class_composed_roles(&self, class_name: &str) -> Option<Vec<String>> {
+        self.registry()
+            .class_composed_roles
+            .get(class_name)
+            .cloned()
     }
 
     #[allow(dead_code)]

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -279,7 +279,6 @@ impl Interpreter {
                 // Check class_attribute_default for instance attributes
                 let class_default = if let Value::Instance { class_name, .. } = &target {
                     self.class_attribute_default(&class_name.resolve(), &method)
-                        .cloned()
                 } else {
                     None
                 };

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -464,7 +464,7 @@ impl Interpreter {
                 }
             }
             // Check composed roles
-            if let Some(roles) = self.class_composed_roles.get(cn.as_str())
+            if let Some(roles) = self.registry().class_composed_roles.get(cn.as_str())
                 && roles.iter().any(|r| r == base)
             {
                 return 1;
@@ -482,7 +482,7 @@ impl Interpreter {
                     }
                 }
             }
-            if let Some(roles) = self.class_composed_roles.get(cn.as_str())
+            if let Some(roles) = self.registry().class_composed_roles.get(cn.as_str())
                 && roles.iter().any(|r| r == base)
             {
                 return 1;

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -428,6 +428,7 @@ impl Interpreter {
             let type_name = name.resolve();
             let role_name = method;
             let composes_role = self
+                .registry()
                 .class_composed_roles
                 .get(&type_name)
                 .is_some_and(|roles| roles.iter().any(|r| r == role_name));

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -923,17 +923,21 @@ impl Interpreter {
                     }
                     None
                 };
-                if let Some(result) =
-                    check_transitive(&self.class_composed_roles, &self.role_parents, &class_name)
-                {
+                if let Some(result) = check_transitive(
+                    &self.registry().class_composed_roles,
+                    &self.role_parents,
+                    &class_name,
+                ) {
                     return Ok(result);
                 }
                 if !local_only {
                     let mro = self.class_mro(&class_name);
                     for cn in &mro[1..] {
-                        if let Some(result) =
-                            check_transitive(&self.class_composed_roles, &self.role_parents, cn)
-                        {
+                        if let Some(result) = check_transitive(
+                            &self.registry().class_composed_roles,
+                            &self.role_parents,
+                            cn,
+                        ) {
                             return Ok(result);
                         }
                     }
@@ -1138,6 +1142,7 @@ impl Interpreter {
                     result.push(Value::Package(Symbol::intern(entry)));
                     // Insert composed roles for this class
                     let composed = self
+                        .registry()
                         .class_composed_roles
                         .get(entry)
                         .cloned()
@@ -1196,6 +1201,7 @@ impl Interpreter {
         };
         // Collect hidden parent names for this class
         let hidden_parents: HashSet<String> = self
+            .registry()
             .hidden_defer_parents
             .get(&class_name)
             .cloned()
@@ -1205,7 +1211,7 @@ impl Interpreter {
         for hp in &hidden_parents {
             hidden_set.insert(hp.clone());
         }
-        for hc in &self.hidden_classes {
+        for hc in &self.registry().hidden_classes {
             hidden_set.insert(hc.clone());
         }
         if hidden_set.is_empty() {
@@ -1222,8 +1228,16 @@ impl Interpreter {
                 .unwrap_or(hidden.as_str());
             to_hide.insert(hidden_base.to_string());
             // Also hide roles composed by the hidden class (try both full and base name)
-            let composed_full = self.class_composed_roles.get(hidden.as_str()).cloned();
-            let composed_base = self.class_composed_roles.get(hidden_base).cloned();
+            let composed_full = self
+                .registry()
+                .class_composed_roles
+                .get(hidden.as_str())
+                .cloned();
+            let composed_base = self
+                .registry()
+                .class_composed_roles
+                .get(hidden_base)
+                .cloned();
             let composed = composed_full.or(composed_base).unwrap_or_default();
             for role in &composed {
                 let base = role
@@ -1271,6 +1285,7 @@ impl Interpreter {
         };
         let mro = self.classhow_mro_names(invocant);
         let hidden_parents: HashSet<String> = self
+            .registry()
             .hidden_defer_parents
             .get(&class_name)
             .cloned()
@@ -1279,7 +1294,7 @@ impl Interpreter {
         for hp in &hidden_parents {
             hidden_set.insert(hp.clone());
         }
-        for hc in &self.hidden_classes {
+        for hc in &self.registry().hidden_classes {
             hidden_set.insert(hc.clone());
         }
         if hidden_set.is_empty() {
@@ -2443,7 +2458,7 @@ impl Interpreter {
         let mut result = Vec::new();
         let mut seen = std::collections::HashSet::new();
         if local_only || non_transitive {
-            if let Some(roles) = self.class_composed_roles.get(class_name) {
+            if let Some(roles) = self.registry().class_composed_roles.get(class_name) {
                 for r in roles {
                     if seen.insert(r.clone()) {
                         result.push(r.clone());
@@ -2478,8 +2493,12 @@ impl Interpreter {
                 if cn == "Any" || cn == "Mu" {
                     continue;
                 }
-                if let Some(roles) = self.class_composed_roles.get(cn) {
-                    for r in roles {
+                // Clone out before the recursive call so no registry read guard is
+                // held across `collect_transitive_roles` (avoids a same-thread
+                // recursive read lock).
+                let roles = self.registry().class_composed_roles.get(cn).cloned();
+                if let Some(roles) = roles {
+                    for r in &roles {
                         if seen.insert(r.clone()) {
                             result.push(r.clone());
                         }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -30,11 +30,13 @@ impl Interpreter {
                 let (pm_name, resolved) =
                     if let Some((owner_class, pm_name)) = private_rest.split_once("::") {
                         let caller_allowed = caller_class.as_deref() == Some(owner_class)
-                            || self.class_trusts.get(owner_class).is_some_and(|trusted| {
-                                caller_class
-                                    .as_ref()
-                                    .is_some_and(|caller| trusted.contains(caller))
-                            });
+                            || self.registry().class_trusts.get(owner_class).is_some_and(
+                                |trusted| {
+                                    caller_class
+                                        .as_ref()
+                                        .is_some_and(|caller| trusted.contains(caller))
+                                },
+                            );
                         if !caller_allowed {
                             return Err(make_private_permission_error(pm_name, owner_class));
                         }
@@ -60,6 +62,7 @@ impl Interpreter {
                 if let Some((resolved_owner, method_def)) = resolved {
                     let caller_allowed = caller_class.as_deref() == Some(resolved_owner.as_str())
                         || self
+                            .registry()
                             .class_trusts
                             .get(&resolved_owner)
                             .is_some_and(|trusted| {
@@ -217,7 +220,8 @@ impl Interpreter {
                                 "Attribute.set_build missing owner or attribute name",
                             ));
                         }
-                        self.attribute_build_overrides
+                        self.registry_mut()
+                            .attribute_build_overrides
                             .insert((owner, attr_name), build);
                         return Ok(target.clone());
                     }
@@ -794,7 +798,7 @@ impl Interpreter {
                 if class_attrs.is_empty() {
                     if let Some(val) = attributes.get(method) {
                         // Check for deprecated attribute accessor
-                        if let Some(msg) = self.class_attribute_deprecated(&cn, method).cloned() {
+                        if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                             self.check_deprecation_for_method(method, &cn, &msg);
                         }
                         return Ok(val.clone());
@@ -803,8 +807,7 @@ impl Interpreter {
                     for (attr_name, is_public, _, _, _, sigil, _) in &class_attrs {
                         if *is_public && attr_name == method {
                             // Check for deprecated attribute accessor
-                            if let Some(msg) = self.class_attribute_deprecated(&cn, method).cloned()
-                            {
+                            if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                                 self.check_deprecation_for_method(method, &cn, &msg);
                             }
                             let val = attributes.get(method).cloned().unwrap_or(Value::Nil);
@@ -830,7 +833,11 @@ impl Interpreter {
             }
             // Enum-as-role dispatch: if the class `does` an enum, check variant methods
             if args.is_empty()
-                && let Some(enum_names) = self.class_enum_roles.get(&class_name.resolve()).cloned()
+                && let Some(enum_names) = self
+                    .registry()
+                    .class_enum_roles
+                    .get(&class_name.resolve())
+                    .cloned()
             {
                 for enum_name in &enum_names {
                     if let Some(variants) = self.registry().enum_types.get(enum_name).cloned()
@@ -1016,12 +1023,15 @@ impl Interpreter {
                 let (pm_name, resolved) = if let Some((owner_class, pm_name)) =
                     private_rest.split_once("::")
                 {
-                    let caller_allowed = caller_class.as_deref() == Some(owner_class)
-                        || self.class_trusts.get(owner_class).is_some_and(|trusted| {
-                            caller_class
-                                .as_ref()
-                                .is_some_and(|caller| trusted.contains(caller))
-                        });
+                    let caller_allowed =
+                        caller_class.as_deref() == Some(owner_class)
+                            || self.registry().class_trusts.get(owner_class).is_some_and(
+                                |trusted| {
+                                    caller_class
+                                        .as_ref()
+                                        .is_some_and(|caller| trusted.contains(caller))
+                                },
+                            );
                     if !caller_allowed {
                         return Err(make_private_permission_error(pm_name, owner_class));
                     }
@@ -1043,6 +1053,7 @@ impl Interpreter {
                 if let Some((resolved_owner, method_def)) = resolved {
                     let caller_allowed = caller_class.as_deref() == Some(resolved_owner.as_str())
                         || self
+                            .registry()
                             .class_trusts
                             .get(&resolved_owner)
                             .is_some_and(|trusted| {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -234,7 +234,7 @@ impl Interpreter {
             _ => None,
         };
         if let Some(ref name) = how_lookup_name
-            && let Some(how_val) = self.class_how_values.get(name)
+            && let Some(how_val) = self.registry().class_how_values.get(name)
         {
             return Ok(how_val.clone());
         }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1158,11 +1158,15 @@ impl Interpreter {
                     (class_name.resolve(), private_rest.to_string())
                 };
             let caller_allowed = caller_class.as_deref() == Some(owner_class.as_str())
-                || self.class_trusts.get(&owner_class).is_some_and(|trusted| {
-                    caller_class
-                        .as_ref()
-                        .is_some_and(|caller| trusted.contains(caller))
-                });
+                || self
+                    .registry()
+                    .class_trusts
+                    .get(&owner_class)
+                    .is_some_and(|trusted| {
+                        caller_class
+                            .as_ref()
+                            .is_some_and(|caller| trusted.contains(caller))
+                    });
             if !caller_allowed {
                 return Err(RuntimeError::new(format!(
                     "X::Method::Private::Permission: Cannot call private method '{}' on {} because it does not trust {}",
@@ -1225,8 +1229,7 @@ impl Interpreter {
                     // When Nil is assigned to an attribute with `is default(...)`,
                     // restore the default value instead of setting Nil.
                     if matches!(assigned_value, Value::Nil)
-                        && let Some(def) =
-                            self.class_attribute_default(qualifier, &attr_name).cloned()
+                        && let Some(def) = self.class_attribute_default(qualifier, &attr_name)
                     {
                         assigned_value = def;
                     }
@@ -1278,9 +1281,7 @@ impl Interpreter {
                     // When Nil is assigned to an attribute with `is default(...)`,
                     // restore the default value instead of setting Nil.
                     if matches!(assigned_value, Value::Nil)
-                        && let Some(def) = self
-                            .class_attribute_default(qualifier, actual_method)
-                            .cloned()
+                        && let Some(def) = self.class_attribute_default(qualifier, actual_method)
                     {
                         assigned_value = def;
                     }
@@ -1498,9 +1499,7 @@ impl Interpreter {
                 // When Nil is assigned to an attribute with `is default(...)`,
                 // restore the default value instead of setting Nil.
                 if matches!(assigned_value, Value::Nil)
-                    && let Some(def) = self
-                        .class_attribute_default(&class_name.resolve(), method)
-                        .cloned()
+                    && let Some(def) = self.class_attribute_default(&class_name.resolve(), method)
                 {
                     assigned_value = def;
                 }
@@ -1643,9 +1642,7 @@ impl Interpreter {
             // When Nil is assigned to an attribute with `is default(...)`,
             // restore the default value instead of setting Nil.
             if matches!(assigned_value, Value::Nil)
-                && let Some(def) = self
-                    .class_attribute_default(&class_name.resolve(), &attr_name)
-                    .cloned()
+                && let Some(def) = self.class_attribute_default(&class_name.resolve(), &attr_name)
             {
                 assigned_value = def;
             }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2707,7 +2707,7 @@ impl Interpreter {
                 ));
             }
             // CUnion repr classes use byte-overlay construction
-            if self.cunion_classes.contains(&cn_resolved) {
+            if self.registry().cunion_classes.contains(&cn_resolved) {
                 return self.construct_cunion_instance(&cn_resolved, &args);
             }
             // Auto-pun role to class if needed (e.g., role COERCE calling self.new)
@@ -2967,11 +2967,14 @@ impl Interpreter {
                     if attrs.contains_key(&attr_name) {
                         continue;
                     }
-                    let val = if let Some(build_override) = self
+                    // Clone the override out and drop the registry guard before
+                    // call_sub_value re-enters user code (RwLock is not reentrant).
+                    let build_override = self
+                        .registry()
                         .attribute_build_overrides
                         .get(&(class_key.to_string(), attr_name.clone()))
-                        .cloned()
-                    {
+                        .cloned();
+                    let val = if let Some(build_override) = build_override {
                         let val = self.call_sub_value(build_override, Vec::new(), false)?;
                         Self::coerce_attr_value_by_sigil(val, sigil)
                     } else if let Some(expr) = default {
@@ -3024,6 +3027,7 @@ impl Interpreter {
                             '@' => {
                                 // Check for `is Type` trait (e.g. `has @.a is Buf`)
                                 let is_type = self
+                                    .registry()
                                     .class_attribute_is_types
                                     .get(&(class_key.to_string(), attr_name.clone()))
                                     .cloned();
@@ -3082,6 +3086,7 @@ impl Interpreter {
                             '%' => {
                                 // Check for `is Type` trait (e.g. `has %.h is BagHash`)
                                 let is_type = self
+                                    .registry()
                                     .class_attribute_is_types
                                     .get(&(class_key.to_string(), attr_name.clone()))
                                     .cloned();
@@ -3395,6 +3400,7 @@ impl Interpreter {
                         } else {
                             // Check for `is Type` trait on this attribute
                             let is_type_val = self
+                                .registry()
                                 .class_attribute_is_types
                                 .get(&(declaring_class.clone(), attr_name.clone()))
                                 .cloned();
@@ -3610,7 +3616,7 @@ impl Interpreter {
         class_name: &str,
         method_name: &str,
     ) -> Vec<(String, MethodDef)> {
-        let composed = match self.class_composed_roles.get(class_name) {
+        let composed = match self.registry().class_composed_roles.get(class_name) {
             Some(roles) => roles.clone(),
             None => return Vec::new(),
         };
@@ -3968,7 +3974,7 @@ impl Interpreter {
             }
         }
         // Also check composed roles
-        if let Some(roles) = self.class_composed_roles.get(class_name)
+        if let Some(roles) = self.registry().class_composed_roles.get(class_name)
             && roles
                 .iter()
                 .any(|r| SETTY_BAGGY_TYPES.contains(&r.as_str()))
@@ -3997,7 +4003,7 @@ impl Interpreter {
                 return true;
             }
         }
-        if let Some(roles) = self.class_composed_roles.get(class_name)
+        if let Some(roles) = self.registry().class_composed_roles.get(class_name)
             && roles
                 .iter()
                 .any(|r| r == "Setty" || r == "Set" || r == "SetHash")

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -24,11 +24,15 @@ impl Interpreter {
                 .cloned()
                 .or_else(|| Some(self.current_package().to_string()));
             let caller_allowed = caller_class.as_deref() == Some(owner_class)
-                || self.class_trusts.get(owner_class).is_some_and(|trusted| {
-                    caller_class
-                        .as_ref()
-                        .is_some_and(|caller| trusted.contains(caller))
-                });
+                || self
+                    .registry()
+                    .class_trusts
+                    .get(owner_class)
+                    .is_some_and(|trusted| {
+                        caller_class
+                            .as_ref()
+                            .is_some_and(|caller| trusted.contains(caller))
+                    });
             if !caller_allowed {
                 return Some(Err(make_private_permission_error(
                     private_name,
@@ -73,12 +77,15 @@ impl Interpreter {
         let in_mro = inst_mro.iter().any(|c| c == qualifier);
         let in_composed_roles = if !in_mro {
             inst_mro.iter().any(|c| {
-                self.class_composed_roles.get(c).is_some_and(|roles| {
-                    roles.iter().any(|r| {
-                        r == qualifier
-                            || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                self.registry()
+                    .class_composed_roles
+                    .get(c)
+                    .is_some_and(|roles| {
+                        roles.iter().any(|r| {
+                            r == qualifier
+                                || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                        })
                     })
-                })
             })
         } else {
             false
@@ -235,7 +242,7 @@ impl Interpreter {
         // The consumer's directly-composed roles: classes use class_composed_roles,
         // roles use role_parents (which records `does`-composed sub-roles).
         let direct_roles = |node: &str| -> Vec<String> {
-            if let Some(roles) = self.class_composed_roles.get(node) {
+            if let Some(roles) = self.registry().class_composed_roles.get(node) {
                 roles.clone()
             } else if let Some(parents) = self.role_parents.get(node) {
                 parents.clone()
@@ -303,12 +310,15 @@ impl Interpreter {
         };
         let composed_on_inner = inner_class.as_deref().is_some_and(|cn| {
             self.class_mro(cn).iter().any(|c| {
-                self.class_composed_roles.get(c).is_some_and(|roles| {
-                    roles.iter().any(|r| {
-                        r == qualifier
-                            || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                self.registry()
+                    .class_composed_roles
+                    .get(c)
+                    .is_some_and(|roles| {
+                        roles.iter().any(|r| {
+                            r == qualifier
+                                || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                        })
                     })
-                })
             })
         });
         let role_applied = mixins.contains_key(&format!("__mutsu_role__{qualifier}"))
@@ -381,12 +391,16 @@ impl Interpreter {
             let in_mro = inst_mro.iter().any(|c| c == qualifier);
             let in_composed_roles = !in_mro
                 && inst_mro.iter().any(|c| {
-                    self.class_composed_roles.get(c).is_some_and(|roles| {
-                        roles.iter().any(|r| {
-                            r == qualifier
-                                || r.starts_with(qualifier) && r[qualifier.len()..].starts_with('[')
+                    self.registry()
+                        .class_composed_roles
+                        .get(c)
+                        .is_some_and(|roles| {
+                            roles.iter().any(|r| {
+                                r == qualifier
+                                    || r.starts_with(qualifier)
+                                        && r[qualifier.len()..].starts_with('[')
+                            })
                         })
-                    })
                 });
             if !in_mro && !in_composed_roles {
                 return Some(Err(RuntimeError::new(format!(

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1073,6 +1073,7 @@ impl Interpreter {
                         .or_else(|| Some(self.current_package().to_string()));
                     let caller_allowed = caller_class.as_deref() == Some(resolved_owner.as_str())
                         || self
+                            .registry()
                             .class_trusts
                             .get(&resolved_owner)
                             .is_some_and(|trusted| {

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -153,6 +153,7 @@ impl Interpreter {
             }
             // BFS over composed roles for this class.
             let initial: Vec<String> = self
+                .registry()
                 .class_composed_roles
                 .get(cn)
                 .cloned()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -885,18 +885,6 @@ pub struct Interpreter {
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
     classes: HashMap<String, ClassDef>,
-    cunion_classes: HashSet<String>,
-    hidden_classes: HashSet<String>,
-    /// Classes that were declared as stubs (`class Foo { ... }`).
-    class_stubs: HashSet<String>,
-    /// Packages/modules that were declared as stubs (`module Foo { ... }`).
-    pub(crate) package_stubs: HashSet<String>,
-    hidden_defer_parents: HashMap<String, HashSet<String>>,
-    class_trusts: HashMap<String, HashSet<String>>,
-    /// Persistent HOW meta-objects per class/role, used for `$c.HOW does Role` persistence
-    pub(crate) class_how_values: HashMap<String, Value>,
-    class_composed_roles: HashMap<String, Vec<String>>, // class -> roles composed via `does`
-    class_enum_roles: HashMap<String, Vec<String>>,     // class -> enums composed via `does`
     roles: HashMap<String, RoleDef>,
     /// Roles explicitly declared via user code (not pre-registered builtins).
     /// Used to detect X::Redeclaration for role->class name conflicts.
@@ -906,19 +894,6 @@ pub struct Interpreter {
     role_hides: HashMap<String, Vec<String>>,
     role_type_params: HashMap<String, Vec<String>>,
     class_role_param_bindings: HashMap<String, HashMap<String, Value>>,
-    /// Private subs declared in class bodies, keyed by class name.
-    /// Maps class_name -> { "&sub_name" -> Value }.
-    class_subs: HashMap<String, HashMap<String, Value>>,
-    attribute_build_overrides: HashMap<(String, String), Value>,
-    /// Evaluated `is default(...)` values for class attributes.
-    /// Maps (class_name, attr_name) to the default value that should be restored when Nil is assigned.
-    class_attribute_defaults: HashMap<(String, String), Value>,
-    /// `is Type` traits on `@`/`%` class attributes (e.g. `has @.a is Buf`, `has %.h is BagHash`).
-    /// Maps (class_name, attr_name) to the type name.
-    class_attribute_is_types: HashMap<(String, String), String>,
-    /// `is DEPRECATED` messages on class attributes.
-    /// Maps (class_name, attr_name) to the deprecation message.
-    class_attribute_deprecated: HashMap<(String, String), String>,
     proto_subs: HashSet<String>,
     proto_tokens: HashSet<String>,
     proto_dispatch_stack: Vec<(String, Vec<Value>)>,
@@ -2892,17 +2867,11 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: 0,
-            registry: Arc::new(RwLock::new(Registry::default())),
-            classes,
-            cunion_classes: HashSet::new(),
-            hidden_classes: HashSet::new(),
-            class_stubs: HashSet::new(),
-            package_stubs: HashSet::new(),
-            hidden_defer_parents: HashMap::new(),
-            class_trusts: HashMap::new(),
-            class_how_values: HashMap::new(),
-            class_composed_roles: {
-                let mut ccr = HashMap::new();
+            registry: {
+                let mut registry = Registry::default();
+                // Built-in class -> composed-role seeds (PR-A slice 2: class metadata
+                // now lives in the shared Registry instead of an Interpreter field).
+                let ccr = &mut registry.class_composed_roles;
                 ccr.insert(
                     "CompUnit::Repository::FileSystem".to_string(),
                     vec!["CompUnit::Repository".to_string()],
@@ -2934,9 +2903,9 @@ impl Interpreter {
                 );
                 ccr.insert("Complex".to_string(), vec!["Numeric".to_string()]);
                 ccr.insert("Str".to_string(), vec!["Stringy".to_string()]);
-                ccr
+                Arc::new(RwLock::new(registry))
             },
-            class_enum_roles: HashMap::new(),
+            classes,
             roles: {
                 let mut roles = HashMap::new();
                 roles.insert(
@@ -3077,11 +3046,6 @@ impl Interpreter {
             role_hides: HashMap::new(),
             role_type_params: HashMap::new(),
             class_role_param_bindings: HashMap::new(),
-            class_subs: HashMap::new(),
-            attribute_build_overrides: HashMap::new(),
-            class_attribute_defaults: HashMap::new(),
-            class_attribute_is_types: HashMap::new(),
-            class_attribute_deprecated: HashMap::new(),
             proto_subs: HashSet::new(),
             proto_tokens: HashSet::new(),
             proto_dispatch_stack: Vec::new(),
@@ -4471,9 +4435,11 @@ impl Interpreter {
         &self,
         class_name: &str,
         attr_name: &str,
-    ) -> Option<&Value> {
-        self.class_attribute_defaults
+    ) -> Option<Value> {
+        self.registry()
+            .class_attribute_defaults
             .get(&(class_name.to_string(), attr_name.to_string()))
+            .cloned()
     }
 
     /// Get the `is DEPRECATED` message for a class attribute accessor.
@@ -4481,9 +4447,11 @@ impl Interpreter {
         &self,
         class_name: &str,
         attr_name: &str,
-    ) -> Option<&String> {
-        self.class_attribute_deprecated
+    ) -> Option<String> {
+        self.registry()
+            .class_attribute_deprecated
             .get(&(class_name.to_string(), attr_name.to_string()))
+            .cloned()
     }
 
     /// Set the element default for a container (Array/Hash) by Arc pointer identity.
@@ -5083,10 +5051,14 @@ impl Interpreter {
 
     /// Check if a class has scoped subs declared in its body.
     pub(crate) fn has_class_scoped_subs(&self, class_name: &str) -> bool {
-        self.class_subs
+        // Single guard for both reads (no user-code re-entry here, so let-binding
+        // is safe and avoids a same-thread recursive read lock).
+        let registry = self.registry();
+        registry
+            .class_subs
             .get(class_name)
             .is_some_and(|subs| !subs.is_empty())
-            || self.class_subs.keys().any(|k| {
+            || registry.class_subs.keys().any(|k| {
                 k.ends_with(&format!("::{}", class_name))
                     || class_name.ends_with(&format!("::{}", k))
             })
@@ -5232,15 +5204,6 @@ impl Interpreter {
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
             classes: self.classes.clone(),
-            cunion_classes: self.cunion_classes.clone(),
-            hidden_classes: self.hidden_classes.clone(),
-            class_stubs: self.class_stubs.clone(),
-            package_stubs: self.package_stubs.clone(),
-            hidden_defer_parents: self.hidden_defer_parents.clone(),
-            class_trusts: self.class_trusts.clone(),
-            class_how_values: self.class_how_values.clone(),
-            class_composed_roles: self.class_composed_roles.clone(),
-            class_enum_roles: self.class_enum_roles.clone(),
             roles: self.roles.clone(),
             user_declared_roles: self.user_declared_roles.clone(),
             role_candidates: self.role_candidates.clone(),
@@ -5248,11 +5211,6 @@ impl Interpreter {
             role_hides: self.role_hides.clone(),
             role_type_params: self.role_type_params.clone(),
             class_role_param_bindings: self.class_role_param_bindings.clone(),
-            class_subs: self.class_subs.clone(),
-            attribute_build_overrides: self.attribute_build_overrides.clone(),
-            class_attribute_defaults: self.class_attribute_defaults.clone(),
-            class_attribute_is_types: self.class_attribute_is_types.clone(),
-            class_attribute_deprecated: self.class_attribute_deprecated.clone(),
             proto_subs: self.proto_subs.clone(),
             proto_tokens: self.proto_tokens.clone(),
             proto_dispatch_stack: Vec::new(),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -371,6 +371,7 @@ impl Interpreter {
                     && let Some((owner_class, _)) = name.resolve().split_once("::")
                     && owner_class != caller_class
                     && !self
+                        .registry()
                         .class_trusts
                         .get(owner_class)
                         .is_some_and(|trusted| trusted.contains(caller_class))

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -374,7 +374,7 @@ impl Interpreter {
         } else if let Some(role_def) = self.roles.get(type_name) {
             names.extend(role_def.methods.keys().cloned());
             // Also include methods from composed roles
-            if let Some(composed) = self.class_composed_roles.get(type_name) {
+            if let Some(composed) = self.registry().class_composed_roles.get(type_name) {
                 for role_name in composed {
                     if let Some(rd) = self.roles.get(role_name) {
                         for key in rd.methods.keys() {
@@ -677,12 +677,13 @@ impl Interpreter {
         let hidden_parents: Vec<String> = hidden_parents.iter().map(|p| strip_colons(p)).collect();
         let hidden_parents = hidden_parents.as_slice();
         let prev_class = self.classes.get(name).cloned();
-        let prev_hidden = self.hidden_classes.contains(name);
-        let prev_hidden_defer = self.hidden_defer_parents.get(name).cloned();
-        let prev_composed_roles = self.class_composed_roles.get(name).cloned();
+        let prev_hidden = self.registry().hidden_classes.contains(name);
+        let prev_hidden_defer = self.registry().hidden_defer_parents.get(name).cloned();
+        let prev_composed_roles = self.registry().class_composed_roles.get(name).cloned();
         let prev_role_param_bindings = self.class_role_param_bindings.get(name).cloned();
         // Clear `is Type` trait entries for this class (they'll be re-populated from the body).
-        self.class_attribute_is_types
+        self.registry_mut()
+            .class_attribute_is_types
             .retain(|(cn, _), _| cn != name);
 
         let restore_previous_state = |this: &mut Self| {
@@ -692,19 +693,23 @@ impl Interpreter {
                 this.classes.remove(name);
             }
             if prev_hidden {
-                this.hidden_classes.insert(name.to_string());
+                this.registry_mut().hidden_classes.insert(name.to_string());
             } else {
-                this.hidden_classes.remove(name);
+                this.registry_mut().hidden_classes.remove(name);
             }
             if let Some(hidden) = prev_hidden_defer.clone() {
-                this.hidden_defer_parents.insert(name.to_string(), hidden);
+                this.registry_mut()
+                    .hidden_defer_parents
+                    .insert(name.to_string(), hidden);
             } else {
-                this.hidden_defer_parents.remove(name);
+                this.registry_mut().hidden_defer_parents.remove(name);
             }
             if let Some(composed) = prev_composed_roles.clone() {
-                this.class_composed_roles.insert(name.to_string(), composed);
+                this.registry_mut()
+                    .class_composed_roles
+                    .insert(name.to_string(), composed);
             } else {
-                this.class_composed_roles.remove(name);
+                this.registry_mut().class_composed_roles.remove(name);
             }
             if let Some(bindings) = prev_role_param_bindings.clone() {
                 this.class_role_param_bindings
@@ -745,7 +750,10 @@ impl Interpreter {
         // NOT a stub (i.e., it was already filled in by a hoisted real
         // declaration), skip the stub registration to avoid overwriting the
         // real class definition.
-        if is_stub_body && self.classes.contains_key(name) && !self.class_stubs.contains(name) {
+        if is_stub_body
+            && self.classes.contains_key(name)
+            && !self.registry().class_stubs.contains(name)
+        {
             return Ok(Vec::new());
         }
 
@@ -888,7 +896,7 @@ impl Interpreter {
                 )));
             }
             // Check if parent is a stub (not yet composed)
-            if self.class_stubs.contains(resolved_parent) {
+            if self.registry().class_stubs.contains(resolved_parent) {
                 let message = format!(
                     "'{}' cannot inherit from '{}' because '{}' isn't composed yet (maybe it is stubbed)",
                     name, resolved_parent, resolved_parent
@@ -924,14 +932,15 @@ impl Interpreter {
             class_level_attrs: HashMap::new(),
         };
         if is_hidden {
-            self.hidden_classes.insert(name.to_string());
+            self.registry_mut().hidden_classes.insert(name.to_string());
         } else {
-            self.hidden_classes.remove(name);
+            self.registry_mut().hidden_classes.remove(name);
         }
         if hidden_parents.is_empty() {
-            self.hidden_defer_parents.remove(name);
+            self.registry_mut().hidden_defer_parents.remove(name);
         } else {
-            self.hidden_defer_parents
+            self.registry_mut()
+                .hidden_defer_parents
                 .insert(name.to_string(), hidden_parents.iter().cloned().collect());
         }
         // Compose roles listed in the parents (from "does Role" or "is Role" in class header)
@@ -1191,7 +1200,8 @@ impl Interpreter {
                 && self.registry().enum_types.contains_key(base_role_name)
             {
                 // Enum used as a role via `does`: record it for method dispatch
-                self.class_enum_roles
+                self.registry_mut()
+                    .class_enum_roles
                     .entry(name.to_string())
                     .or_default()
                     .push(base_role_name.to_string());
@@ -1264,17 +1274,22 @@ impl Interpreter {
                 };
                 self.classes.insert(base_role.to_string(), punned_class);
                 if !punned_composed_roles.is_empty() {
-                    self.class_composed_roles
+                    self.registry_mut()
+                        .class_composed_roles
                         .insert(base_role.to_string(), punned_composed_roles);
                 }
                 // Propagate hidden status from role to punned class
                 if let Some(role_def) = self.roles.get(base_role)
                     && role_def.is_hidden
                 {
-                    self.hidden_classes.insert(base_role.to_string());
+                    self.registry_mut()
+                        .hidden_classes
+                        .insert(base_role.to_string());
                 }
                 if hidden_punned_role_bases.contains(base_role) {
-                    self.hidden_classes.insert(base_role.to_string());
+                    self.registry_mut()
+                        .hidden_classes
+                        .insert(base_role.to_string());
                 }
                 // Recompute MRO for the punned class
                 let mro = self.class_mro(base_role);
@@ -1283,11 +1298,13 @@ impl Interpreter {
                 }
             }
             if hidden_punned_role_bases.contains(base_role) {
-                self.hidden_classes.insert(base_role.to_string());
+                self.registry_mut()
+                    .hidden_classes
+                    .insert(base_role.to_string());
             }
         }
         // Clear stale composed roles from previous registration
-        self.class_composed_roles.remove(name);
+        self.registry_mut().class_composed_roles.remove(name);
         if !composed_roles_list.is_empty() {
             // Propagate role parent classes to the class (recursively through sub-roles)
             // When a role `R is C1` is composed into a class, C1 becomes a parent
@@ -1321,7 +1338,8 @@ impl Interpreter {
                     }
                 }
             }
-            self.class_composed_roles
+            self.registry_mut()
+                .class_composed_roles
                 .insert(name.to_string(), composed_roles_list.clone());
             // Propagate `hides` from composed roles (and sub-roles) to the class
             {
@@ -1341,7 +1359,8 @@ impl Interpreter {
                     }
                     if let Some(hides_list) = self.role_hides.get(&role_name).cloned() {
                         for hidden in hides_list {
-                            self.hidden_defer_parents
+                            self.registry_mut()
+                                .hidden_defer_parents
                                 .entry(name.to_string())
                                 .or_default()
                                 .insert(hidden);
@@ -1364,7 +1383,8 @@ impl Interpreter {
                 name: trusted_class,
             } = stmt
             {
-                self.class_trusts
+                self.registry_mut()
+                    .class_trusts
                     .entry(name.to_string())
                     .or_default()
                     .insert(trusted_class.resolve());
@@ -1376,16 +1396,16 @@ impl Interpreter {
         self.method_wrap_chains.retain(|(cls, _, _), _| cls != name);
         self.classes.insert(name.to_string(), class_def.clone());
         if is_stub_body {
-            self.class_stubs.insert(name.to_string());
+            self.registry_mut().class_stubs.insert(name.to_string());
             self.classes.insert(name.to_string(), class_def);
             let mut stack = Vec::new();
             let _ = self.compute_class_mro(name, &mut stack)?;
             return Ok(deferred_custom_traits);
         }
         // Clear stub status now that the class has a real body.
-        self.class_stubs.remove(name);
+        self.registry_mut().class_stubs.remove(name);
         // Also clear package stub status (for `package Foo { ... }; class Foo { }`)
-        self.package_stubs.remove(name);
+        self.registry_mut().package_stubs.remove(name);
         let saved_package = self.current_package.clone();
         let saved_env = self.env.clone();
         self.current_package = name.to_string();
@@ -1573,7 +1593,8 @@ impl Interpreter {
                                     return Err(runtime_err);
                                 }
                             }
-                            self.class_attribute_defaults
+                            self.registry_mut()
+                                .class_attribute_defaults
                                 .insert((name.to_string(), attr_name_str.clone()), val);
                         }
                     } else if default.is_some() {
@@ -1603,11 +1624,13 @@ impl Interpreter {
                             .insert(attr_name_str.clone(), *built);
                     }
                     if let Some(it) = is_type {
-                        self.class_attribute_is_types
+                        self.registry_mut()
+                            .class_attribute_is_types
                             .insert((name.to_string(), attr_name_str.clone()), it.clone());
                     }
                     if let Some(dm) = deprecated_message {
-                        self.class_attribute_deprecated
+                        self.registry_mut()
+                            .class_attribute_deprecated
                             .insert((name.to_string(), attr_name_str.clone()), dm.clone());
                     }
                     let attr_var_name = if *is_public {
@@ -2150,7 +2173,8 @@ impl Interpreter {
                 Stmt::TrustsDecl {
                     name: trusted_class,
                 } => {
-                    self.class_trusts
+                    self.registry_mut()
+                        .class_trusts
                         .entry(name.to_string())
                         .or_default()
                         .insert(trusted_class.resolve());
@@ -2225,7 +2249,8 @@ impl Interpreter {
                 if self.functions.contains_key(&Symbol::intern(&fq))
                     && !saved_functions_keys.contains(&fq)
                 {
-                    self.class_subs
+                    self.registry_mut()
+                        .class_subs
                         .entry(name.to_string())
                         .or_default()
                         .insert(fq, Value::Bool(true));
@@ -2627,8 +2652,8 @@ impl Interpreter {
         }
         // Clean up stale punned class entry for this role name.
         self.classes.remove(name);
-        self.hidden_classes.remove(name);
-        self.class_composed_roles.remove(name);
+        self.registry_mut().hidden_classes.remove(name);
+        self.registry_mut().class_composed_roles.remove(name);
         // When registering a parametric variant of an existing non-parametric role
         // (forming a role group), save the non-parametric role's parents so we can
         // restore them after the parametric variant adds its own parents.
@@ -3194,7 +3219,7 @@ impl Interpreter {
 
     pub(crate) fn register_cunion_class(&mut self, name: &str) {
         self.clear_private_zeroarg_method_cache();
-        self.cunion_classes.insert(name.to_string());
+        self.registry_mut().cunion_classes.insert(name.to_string());
     }
 
     /// Construct a CUnion instance: all native-int fields share the same
@@ -3386,7 +3411,8 @@ impl Interpreter {
         };
         self.classes.insert(role_name.to_string(), punned_class);
         // Register the role and its composed roles
-        self.class_composed_roles
+        self.registry_mut()
+            .class_composed_roles
             .insert(role_name.to_string(), composed_roles_list);
         // When punning a bare role (no type params), update the language
         // revision metadata from the matching candidate so that

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -24,9 +24,9 @@
 //! Always use a *temporary* guard (`self.registry().subsets.get(..)`), never a
 //! `let`-bound guard that lives across such a call.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use crate::value::EnumValue;
+use crate::value::{EnumValue, Value};
 
 use super::SubsetDef;
 
@@ -41,4 +41,34 @@ pub(crate) struct Registry {
     pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
     /// `subset Name of Base where { ... }` declarations.
     pub(crate) subsets: HashMap<String, SubsetDef>,
+
+    // ----- class metadata (PR-A slice 2) -----
+    /// Classes declared as a C `union` (native interop helper set).
+    pub(crate) cunion_classes: HashSet<String>,
+    /// Classes marked `is hidden` (excluded from `.^mro` etc.).
+    pub(crate) hidden_classes: HashSet<String>,
+    /// Forward-declared class stubs (`class Foo { ... }` declared later).
+    pub(crate) class_stubs: HashSet<String>,
+    /// Forward-declared package stubs.
+    pub(crate) package_stubs: HashSet<String>,
+    /// `is hidden` parents deferred until the parent is fully declared.
+    pub(crate) hidden_defer_parents: HashMap<String, HashSet<String>>,
+    /// `trusts` relationships: class -> set of trusted classes.
+    pub(crate) class_trusts: HashMap<String, HashSet<String>>,
+    /// Per-class metaclass (`HOW`) value override.
+    pub(crate) class_how_values: HashMap<String, Value>,
+    /// Roles composed into each class: class -> [role names].
+    pub(crate) class_composed_roles: HashMap<String, Vec<String>>,
+    /// Roles implicitly composed by enums: enum -> [role names].
+    pub(crate) class_enum_roles: HashMap<String, Vec<String>>,
+    /// Subs declared inside a class body: class -> (sub name -> value).
+    pub(crate) class_subs: HashMap<String, HashMap<String, Value>>,
+    /// Per-attribute `BUILD` override: (class, attr) -> builder value.
+    pub(crate) attribute_build_overrides: HashMap<(String, String), Value>,
+    /// Per-attribute default value: (class, attr) -> default value.
+    pub(crate) class_attribute_defaults: HashMap<(String, String), Value>,
+    /// Per-attribute declared type: (class, attr) -> type name.
+    pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
+    /// Per-attribute `is DEPRECATED` message: (class, attr) -> message.
+    pub(crate) class_attribute_deprecated: HashMap<(String, String), String>,
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -667,10 +667,13 @@ impl Interpreter {
         receiver_class: &str,
         candidate_owner: &str,
     ) -> bool {
-        if receiver_class != candidate_owner && self.hidden_classes.contains(candidate_owner) {
+        if receiver_class != candidate_owner
+            && self.registry().hidden_classes.contains(candidate_owner)
+        {
             return true;
         }
-        self.hidden_defer_parents
+        self.registry()
+            .hidden_defer_parents
             .get(receiver_class)
             .is_some_and(|hidden| hidden.contains(candidate_owner))
     }

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1722,10 +1722,10 @@ impl Interpreter {
     /// Throws X::Package::Stubbed if any stubs remain.
     pub(crate) fn check_unresolved_stubs(&self) -> Result<(), RuntimeError> {
         let mut unresolved: Vec<String> = Vec::new();
-        for name in &self.class_stubs {
+        for name in &self.registry().class_stubs {
             unresolved.push(name.clone());
         }
-        for name in &self.package_stubs {
+        for name in &self.registry().package_stubs {
             unresolved.push(name.clone());
         }
         if unresolved.is_empty() {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1081,7 +1081,7 @@ impl Interpreter {
                             return true;
                         }
                         // Check composed roles of parent class
-                        if let Some(composed) = self.class_composed_roles.get(&parent) {
+                        if let Some(composed) = self.registry().class_composed_roles.get(&parent) {
                             for cr in composed {
                                 let cr_base =
                                     cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -833,9 +833,9 @@ impl Interpreter {
         let role_parents_snapshot = self.role_parents.clone();
         let role_hides_snapshot = self.role_hides.clone();
         let classes_snapshot = self.classes.clone();
-        let hidden_classes_snapshot = self.hidden_classes.clone();
-        let hidden_defer_parents_snapshot = self.hidden_defer_parents.clone();
-        let class_composed_roles_snapshot = self.class_composed_roles.clone();
+        let hidden_classes_snapshot = self.registry().hidden_classes.clone();
+        let hidden_defer_parents_snapshot = self.registry().hidden_defer_parents.clone();
+        let class_composed_roles_snapshot = self.registry().class_composed_roles.clone();
         let class_role_param_bindings_snapshot = self.class_role_param_bindings.clone();
         let env_snapshot = self.env.clone();
         let saved_topic = self.env.get("_").cloned();
@@ -947,9 +947,9 @@ impl Interpreter {
         let current_role_parents = self.role_parents.clone();
         let current_role_hides = self.role_hides.clone();
         let current_classes = self.classes.clone();
-        let current_hidden_classes = self.hidden_classes.clone();
-        let current_hidden_defer_parents = self.hidden_defer_parents.clone();
-        let current_class_composed_roles = self.class_composed_roles.clone();
+        let current_hidden_classes = self.registry().hidden_classes.clone();
+        let current_hidden_defer_parents = self.registry().hidden_defer_parents.clone();
+        let current_class_composed_roles = self.registry().class_composed_roles.clone();
         let current_class_role_param_bindings = self.class_role_param_bindings.clone();
         let current_env = self.env.clone();
         let current_type_keys: std::collections::HashSet<String> = self
@@ -970,9 +970,9 @@ impl Interpreter {
         self.role_parents = role_parents_snapshot;
         self.role_hides = role_hides_snapshot;
         self.classes = classes_snapshot;
-        self.hidden_classes = hidden_classes_snapshot;
-        self.hidden_defer_parents = hidden_defer_parents_snapshot;
-        self.class_composed_roles = class_composed_roles_snapshot;
+        self.registry_mut().hidden_classes = hidden_classes_snapshot;
+        self.registry_mut().hidden_defer_parents = hidden_defer_parents_snapshot;
+        self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
         self.class_role_param_bindings = class_role_param_bindings_snapshot;
         self.roles.extend(current_roles);
         // Don't extend user_declared_roles: roles declared in EVAL are EVAL-scoped
@@ -982,10 +982,14 @@ impl Interpreter {
         self.role_parents.extend(current_role_parents);
         self.role_hides.extend(current_role_hides);
         self.classes.extend(current_classes);
-        self.hidden_classes.extend(current_hidden_classes);
-        self.hidden_defer_parents
+        self.registry_mut()
+            .hidden_classes
+            .extend(current_hidden_classes);
+        self.registry_mut()
+            .hidden_defer_parents
             .extend(current_hidden_defer_parents);
-        self.class_composed_roles
+        self.registry_mut()
+            .class_composed_roles
             .extend(current_class_composed_roles);
         self.class_role_param_bindings
             .extend(current_class_role_param_bindings);

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -182,8 +182,8 @@ impl Interpreter {
         nested.lib_paths = self.lib_paths.clone();
         nested.program_path = self.program_path.clone();
         nested.classes = self.classes.clone();
-        nested.class_trusts = self.class_trusts.clone();
-        nested.class_composed_roles = self.class_composed_roles.clone();
+        nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
+        nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
         nested.roles = self.roles.clone();
         nested.role_candidates = self.role_candidates.clone();
         nested.role_parents = self.role_parents.clone();
@@ -281,8 +281,8 @@ impl Interpreter {
         nested.lib_paths = self.lib_paths.clone();
         nested.program_path = self.program_path.clone();
         nested.classes = self.classes.clone();
-        nested.class_trusts = self.class_trusts.clone();
-        nested.class_composed_roles = self.class_composed_roles.clone();
+        nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
+        nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
         nested.roles = self.roles.clone();
         nested.role_candidates = self.role_candidates.clone();
         nested.role_parents = self.role_parents.clone();

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -57,8 +57,9 @@ impl Interpreter {
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
                 nested.classes = self.classes.clone();
-                nested.class_trusts = self.class_trusts.clone();
-                nested.class_composed_roles = self.class_composed_roles.clone();
+                nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
+                nested.registry_mut().class_composed_roles =
+                    self.registry().class_composed_roles.clone();
                 nested.roles = self.roles.clone();
                 nested.role_candidates = self.role_candidates.clone();
                 nested.role_parents = self.role_parents.clone();

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -14,20 +14,24 @@ impl Interpreter {
     pub(crate) fn sync_eval_definition_state(&mut self, nested: &Interpreter) {
         self.type_metadata = nested.type_metadata.clone();
         self.classes = nested.classes.clone();
-        self.cunion_classes = nested.cunion_classes.clone();
-        self.hidden_classes = nested.hidden_classes.clone();
-        self.class_stubs = nested.class_stubs.clone();
-        self.package_stubs = nested.package_stubs.clone();
-        self.hidden_defer_parents = nested.hidden_defer_parents.clone();
-        self.class_trusts = nested.class_trusts.clone();
-        self.class_composed_roles = nested.class_composed_roles.clone();
+        // self and nested are distinct Interpreters with distinct registry Arcs,
+        // so taking self's write lock and nested's read lock in one statement is
+        // deadlock-free (matches the slice-1 `subsets` line below).
+        self.registry_mut().cunion_classes = nested.registry().cunion_classes.clone();
+        self.registry_mut().hidden_classes = nested.registry().hidden_classes.clone();
+        self.registry_mut().class_stubs = nested.registry().class_stubs.clone();
+        self.registry_mut().package_stubs = nested.registry().package_stubs.clone();
+        self.registry_mut().hidden_defer_parents = nested.registry().hidden_defer_parents.clone();
+        self.registry_mut().class_trusts = nested.registry().class_trusts.clone();
+        self.registry_mut().class_composed_roles = nested.registry().class_composed_roles.clone();
         self.roles = nested.roles.clone();
         self.role_candidates = nested.role_candidates.clone();
         self.role_parents = nested.role_parents.clone();
         self.role_hides = nested.role_hides.clone();
         self.role_type_params = nested.role_type_params.clone();
         self.class_role_param_bindings = nested.class_role_param_bindings.clone();
-        self.attribute_build_overrides = nested.attribute_build_overrides.clone();
+        self.registry_mut().attribute_build_overrides =
+            nested.registry().attribute_build_overrides.clone();
         self.registry_mut().subsets = nested.registry().subsets.clone();
         self.need_hidden_classes = nested.need_hidden_classes.clone();
     }

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -47,7 +47,7 @@ impl Interpreter {
         let saved_proto_subs = self.proto_subs.clone();
         let saved_proto_tokens = self.proto_tokens.clone();
         let saved_classes = self.classes.clone();
-        let saved_class_trusts = self.class_trusts.clone();
+        let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
@@ -70,7 +70,7 @@ impl Interpreter {
             self.proto_subs = saved_proto_subs;
             self.proto_tokens = saved_proto_tokens;
             self.classes = saved_classes;
-            self.class_trusts = saved_class_trusts;
+            self.registry_mut().class_trusts = saved_class_trusts;
             self.roles = saved_roles;
             self.registry_mut().subsets = saved_subsets;
             // Merge type_metadata: preserve entries added during the subtest
@@ -98,7 +98,7 @@ impl Interpreter {
         self.proto_subs = saved_proto_subs;
         self.proto_tokens = saved_proto_tokens;
         self.classes = saved_classes;
-        self.class_trusts = saved_class_trusts;
+        self.registry_mut().class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest
@@ -145,7 +145,7 @@ impl Interpreter {
         let saved_proto_subs = self.proto_subs.clone();
         let saved_proto_tokens = self.proto_tokens.clone();
         let saved_classes = self.classes.clone();
-        let saved_class_trusts = self.class_trusts.clone();
+        let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
@@ -159,7 +159,7 @@ impl Interpreter {
         self.proto_subs = saved_proto_subs;
         self.proto_tokens = saved_proto_tokens;
         self.classes = saved_classes;
-        self.class_trusts = saved_class_trusts;
+        self.registry_mut().class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -33,8 +33,9 @@ impl Interpreter {
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
                 nested.classes = self.classes.clone();
-                nested.class_trusts = self.class_trusts.clone();
-                nested.class_composed_roles = self.class_composed_roles.clone();
+                nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
+                nested.registry_mut().class_composed_roles =
+                    self.registry().class_composed_roles.clone();
                 nested.roles = self.roles.clone();
                 nested.role_candidates = self.role_candidates.clone();
                 nested.role_parents = self.role_parents.clone();

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -162,7 +162,9 @@ impl Interpreter {
             // Persist HOW mixin: if the left is a HOW meta-object, store the
             // composed result so future `.HOW` calls return the mixed-in value.
             if let Some(how_target) = Self::how_target_from_value(&left) {
-                self.class_how_values.insert(how_target, result.clone());
+                self.registry_mut()
+                    .class_how_values
+                    .insert(how_target, result.clone());
             }
             return Ok(result);
         }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -671,7 +671,7 @@ impl Interpreter {
                 let mut seen_roles = HashSet::new();
                 // Collect all composed roles from the class and its parents
                 for cn in &mro {
-                    if let Some(composed) = self.class_composed_roles.get(cn.as_str()) {
+                    if let Some(composed) = self.registry().class_composed_roles.get(cn.as_str()) {
                         for cr in composed {
                             let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
                             role_stack.push(base.to_string());
@@ -747,7 +747,7 @@ impl Interpreter {
                         return true;
                     }
                     // Also check composed roles of the parent class
-                    if let Some(composed) = self.class_composed_roles.get(&parent) {
+                    if let Some(composed) = self.registry().class_composed_roles.get(&parent) {
                         for cr in composed {
                             let cr_base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
                             if Self::type_matches(effective_constraint, cr_base) {
@@ -820,7 +820,7 @@ impl Interpreter {
                 let mut role_stack: Vec<String> = Vec::new();
                 let mut seen_roles = HashSet::new();
                 for cn in &mro {
-                    if let Some(composed) = self.class_composed_roles.get(cn.as_str()) {
+                    if let Some(composed) = self.registry().class_composed_roles.get(cn.as_str()) {
                         for cr in composed {
                             let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
                             role_stack.push(base.to_string());

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3527,12 +3527,12 @@ impl VM {
             }
             OpCode::RegisterPackageStub { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.interpreter.package_stubs.insert(name);
+                self.interpreter.registry_mut().package_stubs.insert(name);
                 *ip += 1;
             }
             OpCode::ClearPackageStub { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.interpreter.package_stubs.remove(&name);
+                self.interpreter.registry_mut().package_stubs.remove(&name);
                 *ip += 1;
             }
 

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -102,11 +102,7 @@ impl VM {
         match val {
             Some(v) => {
                 let out = v.clone();
-                if let Some(msg) = self
-                    .interpreter
-                    .class_attribute_deprecated(&cn, method)
-                    .cloned()
-                {
+                if let Some(msg) = self.interpreter.class_attribute_deprecated(&cn, method) {
                     self.interpreter
                         .check_deprecation_for_method(method, &cn, &msg);
                 }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -427,8 +427,7 @@ impl VM {
                 .or_else(|| {
                     self.interpreter
                         .class_attribute_default(receiver_class_name, attr_name)
-                })
-                .cloned();
+                });
             if let Some(def) = default_val {
                 // Register for $!attr and $.attr variable names
                 self.interpreter
@@ -980,8 +979,7 @@ impl VM {
                 .or_else(|| {
                     self.interpreter
                         .class_attribute_default(receiver_class_name, attr_name)
-                })
-                .cloned();
+                });
             if let Some(def) = default_val {
                 self.interpreter
                     .set_var_default(&format!("!{}", attr_name), def.clone());


### PR DESCRIPTION
## Summary

Continues the **phase ② registry VM-ownership** strangler-fig migration (PLAN.md ②, design: `docs/vm-registry-ownership.md`). Following slice 1 (#2760, which established the `Registry` cell + `registry()`/`registry_mut()` helpers + snapshot `clone_for_thread` wiring), this slice moves the **14 class-metadata fields** off the `Interpreter` struct into the shared `Arc<RwLock<Registry>>`.

Behavior-preserving structural refactor — no logic/perf changes (the `classes` hot-path perf design comes in a later slice).

## Fields migrated

`cunion_classes`, `hidden_classes`, `class_stubs`, `package_stubs`, `hidden_defer_parents`, `class_trusts`, `class_how_values`, `class_composed_roles`, `class_enum_roles`, `class_subs`, `attribute_build_overrides`, `class_attribute_defaults`, `class_attribute_is_types`, `class_attribute_deprecated`.

## Changes

- **~130 access sites** routed through `registry()` (reads) / `registry_mut()` (writes).
- `clone_for_thread` drops its 14 per-field clones — subsumed by the whole-`Registry` snapshot clone wired in slice 1. Built-in `class_composed_roles` seeds now populate `Registry::default()` inside `Interpreter::new`.
- **Reference-returning accessors** (`class_composed_roles`, `class_attribute_default`, `class_attribute_deprecated`) now return owned values — a reference into a `RwLockReadGuard` can't escape the accessor — and all VM/runtime call sites follow suit.
- **Re-entrancy hazards lifted** by cloning out before user-code re-entry (RwLock is non-reentrant; same-thread recursive read can deadlock): `collect_transitive_roles` (clone `class_composed_roles` first), `call_sub_value` in attribute BUILD (clone `attribute_build_overrides` first), and `has_class_scoped_subs` (single let-bound guard for its two reads).
- **VM direct access**: `vm.rs` `package_stubs.insert/remove` now go through `registry_mut()`; all other VM sites reach these fields via accessor methods, so only the method bodies changed.

## Verification

- `cargo build` + `cargo clippy -D warnings` green.
- `make test` green (458 cargo unit tests, prove `t/` suite).
- Targeted class/role/attribute roast suites (`S12-class`, `S12-methods`, `S12-attributes`, `S14-roles`) green for whitelisted tests; the few non-whitelisted failures (`trusts.t` 4-9 etc.) are pre-existing private-method gaps unrelated to this refactor (the trust *check* itself — tests 1-3 — passes).
- Thread snapshot semantics verified: a class declared inside `start {}` does not leak to the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)