### PR TITLE
refactor(vm): migrate class definitions into shared Registry (phase ② PR-A slice 3)

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -91,8 +91,21 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   前の `attribute_build_overrides` clone、`has_class_scoped_subs` の二重 read を単一 let-bound guard へ。
   VM 直アクセスは `vm.rs` の `package_stubs.insert/remove` を `registry_mut()` 経由へ。build/clippy/make test
   緑、whitelist class/role/attribute roast 緑（非 whitelist の private-method 既存失敗は不変）。
-- 残（フィールド別 total/writes）: classes(178/33, 要 perf 設計)、roles(110)/role_parents(45)
-  /role_candidates(21)、functions(96)/token_defs(35)。
+- **PR-A slice 3（本 PR, #2762 後）**: `classes: HashMap<String, ClassDef>` 移行（~178 サイト）。
+  `ClassDef` を `pub(crate)` 化、Registry から `Debug` derive を除去（ClassDef/MethodDef/AST graph が非 Debug）。
+  builtin classes は `Interpreter::new` で `Registry { classes, ..default() }` に投入。`clone_for_thread` の
+  `classes.clone()` を削除（Registry 全体 clone に吸収＝snapshot 維持）。**perf 方針（#2746 の轍回避）**:
+  whole-`ClassDef` の naive clone は一切せず、ホットパス（`resolve_method_with_owner_impl`/`class_mro`/
+  `compute_class_mro`/type matching）は従来同様 targeted 投影 clone（`mro.clone()`/`methods.get(m).cloned()`）の
+  まま `registry()` ガード経由に。release microbench（病的な純メソッドディスパッチ 30万回）で **+2–4%**＝
+  遷移期 RwLock 取得コストのみ（実ワークロードでは <1%、Interpreter 撤去後に plain field へ畳めば消滅）。
+  **再入安全性**: ① `clone_for_thread` がスレッド毎に独立 Arc を生成するため lock はスレッド間非共有→単一スレッド
+  内の再帰 read は futex 実装で安全。② 真の危険＝read ガード保持中の同一ロック write（read→write 昇格 deadlock）
+  は皆無を確認（write は別オブジェクト `nested` か、guard drop 後）。③ `&mut self` 再入を跨ぐ read ガードは
+  edition-2021 の `if let` 一時値スコープ罠を含め全て `let` 巻き上げ／clone-out で解消（resolution.rs の
+  multi/private dispatch、methods_object の BUILD、private-zeroarg fast-path の cache 書き込みを guard 外へ）。
+  全 `get_mut` ボディは registry 非再入を確認。build/clippy/make test 緑。
+- 残（フィールド別 total/writes）: roles(110)/role_parents(45)/role_candidates(21)、functions(96)/token_defs(35)。
 
 ## 完了の定義（②）
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -815,7 +815,9 @@ impl Interpreter {
         method_name: &str,
         method_def: &super::MethodDef,
     ) -> Option<usize> {
-        let class_def = self.classes.get(class_name)?;
+        // No user-code re-entry here, so a let-bound guard is safe.
+        let registry = self.registry();
+        let class_def = registry.classes.get(class_name)?;
         let defs = class_def.methods.get(method_name)?;
         let target_fp = crate::ast::function_body_fingerprint(
             &method_def.params,
@@ -957,7 +959,10 @@ impl Interpreter {
         &self,
         class_name: &str,
     ) -> Option<crate::value::RuntimeError> {
-        let class_def = self.classes.get(class_name)?;
+        // No user-code re-entry here (only the static compiler check runs), so a
+        // let-bound guard is safe.
+        let registry = self.registry();
+        let class_def = registry.classes.get(class_name)?;
         for overloads in class_def.methods.values() {
             for def in overloads {
                 if let Some(err_val) =
@@ -985,7 +990,7 @@ impl Interpreter {
 
     /// Compile method bodies for a given class using the bytecode compiler.
     pub(crate) fn compile_class_methods(&mut self, class_name: &str) {
-        if let Some(class_def) = self.classes.get_mut(class_name) {
+        if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
             let attr_names: Vec<String> =
                 class_def.attributes.iter().map(|a| a.0.clone()).collect();
             Self::compile_methods_for_map(&mut class_def.methods, class_name, &attr_names);
@@ -1510,7 +1515,11 @@ impl Interpreter {
                 .functions
                 .keys()
                 .any(|k| k.resolve().starts_with(&prefix))
-            || self.classes.keys().any(|k| k.starts_with(&prefix))
+            || self
+                .registry()
+                .classes
+                .keys()
+                .any(|k| k.starts_with(&prefix))
             || self.exported_subs.contains_key(package)
             || self.exported_vars.contains_key(package)
     }
@@ -1834,7 +1843,7 @@ impl Interpreter {
                 });
         }
 
-        for class_name in self.classes.keys() {
+        for class_name in self.registry().classes.keys() {
             let class_short = class_name
                 .rsplit_once("::")
                 .map(|(_, short)| short)

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -330,7 +330,7 @@ impl Interpreter {
             "__MUTSU_UNREGISTER_CLASS__" => {
                 if let Some(name) = args.first() {
                     let class_name = name.to_string_value();
-                    self.classes.remove(&class_name);
+                    self.registry_mut().classes.remove(&class_name);
                     self.env.remove(&class_name);
                     self.suppress_name(&class_name);
                 }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -300,7 +300,7 @@ impl Interpreter {
             self.functions.keys().copied().collect();
         let before_env_keys: std::collections::HashSet<Symbol> = self.env.keys().copied().collect();
         let before_class_keys: std::collections::HashSet<String> =
-            self.classes.keys().cloned().collect();
+            self.registry().classes.keys().cloned().collect();
         if let Some(pkg) = package_hint
             && !pkg.is_empty()
         {
@@ -358,18 +358,18 @@ impl Interpreter {
             }
 
             let mut class_aliases: Vec<(String, ClassDef)> = Vec::new();
-            for (name, class_def) in &self.classes {
+            for (name, class_def) in &self.registry().classes {
                 if before_class_keys.contains(name) {
                     continue;
                 }
                 let tail = name.rsplit_once("::").map(|(_, t)| t).unwrap_or(name);
                 let alias = format!("{pkg}::{tail}");
-                if !self.classes.contains_key(&alias) {
+                if !self.registry().classes.contains_key(&alias) {
                     class_aliases.push((alias, class_def.clone()));
                 }
             }
             for (alias, class_def) in class_aliases {
-                self.classes.insert(alias, class_def);
+                self.registry_mut().classes.insert(alias, class_def);
             }
         }
 

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -25,6 +25,7 @@ impl Interpreter {
             let instance_class = item.class_name.resolve();
             // Collect the MRO so we call DESTROY on each class in order (child → parent).
             let mro: Vec<String> = self
+                .registry()
                 .classes
                 .get(&instance_class)
                 .map(|cd| cd.mro.clone())
@@ -34,14 +35,19 @@ impl Interpreter {
             // Walk the MRO; submethods are per-class, not inherited.
             for mro_class in &mro {
                 // Skip role entries in MRO
-                if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
+                if self.roles.contains_key(mro_class)
+                    && !self.registry().classes.contains_key(mro_class)
+                {
                     continue;
                 }
-                let Some(class_def) = self.classes.get(mro_class) else {
-                    continue;
+                // Clone DESTROY overloads out and drop the guard before re-entering
+                // user code (run_instance_method_resolved).
+                let destroy_overloads = match self.registry().classes.get(mro_class) {
+                    Some(class_def) => class_def.methods.get("DESTROY").cloned(),
+                    None => continue,
                 };
                 // Call class's own DESTROY submethod
-                if let Some(overloads) = class_def.methods.get("DESTROY").cloned()
+                if let Some(overloads) = destroy_overloads
                     && let Some(method_def) = overloads.into_iter().find(|def| {
                         def.is_my && !def.is_private && self.method_args_match(&[], &def.param_defs)
                     })
@@ -195,13 +201,14 @@ impl Interpreter {
                 class_name
             )));
         }
-        if let Some(class_def) = self.classes.get(class_name)
+        if let Some(class_def) = self.registry().classes.get(class_name)
             && !class_def.mro.is_empty()
         {
             return Ok(class_def.mro.clone());
         }
         stack.push(class_name.to_string());
         let explicit_parents = self
+            .registry()
             .classes
             .get(class_name)
             .map(|c| c.parents.clone())
@@ -209,14 +216,15 @@ impl Interpreter {
         // If a user-defined class has no explicit parents, it implicitly
         // inherits from Any (which in turn inherits from Mu).  This matches
         // Raku's default class hierarchy.
-        let parents = if explicit_parents.is_empty() && self.classes.contains_key(class_name) {
-            vec!["Any".to_string()]
-        } else {
-            explicit_parents
-        };
+        let parents =
+            if explicit_parents.is_empty() && self.registry().classes.contains_key(class_name) {
+                vec!["Any".to_string()]
+            } else {
+                explicit_parents
+            };
         let mut seqs: Vec<Vec<String>> = Vec::new();
         for parent in &parents {
-            if self.classes.contains_key(parent) {
+            if self.registry().classes.contains_key(parent) {
                 let mro = self.compute_class_mro(parent, stack)?;
                 seqs.push(mro);
             } else if parent == "Any" {
@@ -275,7 +283,7 @@ impl Interpreter {
     pub(super) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro {
-            if let Some(class_def) = self.classes.get(&cn)
+            if let Some(class_def) = self.registry().classes.get(&cn)
                 && (class_def.methods.contains_key(method_name)
                     || class_def.native_methods.contains(method_name))
             {
@@ -296,7 +304,7 @@ impl Interpreter {
     ) -> bool {
         let mro = self.class_mro(class_name);
         for cn in &mro {
-            let methods = match self.classes.get(cn.as_str()) {
+            let methods = match self.registry().classes.get(cn.as_str()) {
                 Some(cd) => cd.methods.get("new").cloned(),
                 None => None,
             };
@@ -466,7 +474,7 @@ impl Interpreter {
         }
         let mro = self.class_mro(class_name);
         for cn in mro {
-            if let Some(class_def) = self.classes.get(&cn)
+            if let Some(class_def) = self.registry().classes.get(&cn)
                 && class_def.native_methods.contains(method_name)
             {
                 return true;
@@ -478,7 +486,7 @@ impl Interpreter {
     pub(crate) fn has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro {
-            if let Some(class_def) = self.classes.get(&cn)
+            if let Some(class_def) = self.registry().classes.get(&cn)
                 && let Some(defs) = class_def.methods.get(method_name)
             {
                 return defs.iter().any(|d| !d.is_private);
@@ -497,7 +505,7 @@ impl Interpreter {
 
     /// Check if an attribute is buildable (can be set via .new).
     pub(crate) fn is_attribute_buildable(&self, class_name: &str, attr_name: &str) -> bool {
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             if let Some(&built) = class_def.attribute_built.get(attr_name) {
                 return built;
             }
@@ -507,7 +515,7 @@ impl Interpreter {
                 }
             }
         }
-        let mro = if let Some(cd) = self.classes.get(class_name) {
+        let mro = if let Some(cd) = self.registry().classes.get(class_name) {
             cd.mro.clone()
         } else {
             Vec::new()
@@ -516,7 +524,7 @@ impl Interpreter {
             if parent == class_name {
                 continue;
             }
-            if let Some(parent_def) = self.classes.get(parent) {
+            if let Some(parent_def) = self.registry().classes.get(parent) {
                 if let Some(&built) = parent_def.attribute_built.get(attr_name) {
                     return built;
                 }
@@ -538,7 +546,7 @@ impl Interpreter {
         attr_name: &str,
     ) -> Option<Value> {
         // Check own class first
-        if let Some(class_def) = self.classes.get(class_name)
+        if let Some(class_def) = self.registry().classes.get(class_name)
             && let Some(val) = class_def.class_level_attrs.get(attr_name)
         {
             return Some(val.clone());
@@ -549,7 +557,7 @@ impl Interpreter {
             if parent == class_name {
                 continue;
             }
-            if let Some(parent_def) = self.classes.get(parent)
+            if let Some(parent_def) = self.registry().classes.get(parent)
                 && let Some(val) = parent_def.class_level_attrs.get(attr_name)
             {
                 return Some(val.clone());
@@ -572,7 +580,7 @@ impl Interpreter {
         value: Value,
     ) -> bool {
         // Check own class first
-        if let Some(class_def) = self.classes.get_mut(class_name)
+        if let Some(class_def) = self.registry_mut().classes.get_mut(class_name)
             && class_def.class_level_attrs.contains_key(attr_name)
         {
             class_def
@@ -586,7 +594,7 @@ impl Interpreter {
             if parent == class_name {
                 continue;
             }
-            if let Some(parent_def) = self.classes.get_mut(parent)
+            if let Some(parent_def) = self.registry_mut().classes.get_mut(parent)
                 && parent_def.class_level_attrs.contains_key(attr_name)
             {
                 parent_def
@@ -603,7 +611,7 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let mut result = Vec::new();
         for cn in &mro {
-            if let Some(class_def) = self.classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 result.extend(class_def.wildcard_handles.iter().cloned());
             }
         }
@@ -619,7 +627,7 @@ impl Interpreter {
     ) {
         let mro = self.class_mro(class_name);
         for cn in &mro {
-            if let Some(class_def) = self.classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 for attr_name in &class_def.alias_attributes {
                     attrs.insert(
                         format!("__mutsu_attr_alias::{}", attr_name),
@@ -634,7 +642,7 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let mut attrs: Vec<ClassAttributeDef> = Vec::new();
         for cn in mro.iter().rev() {
-            if let Some(class_def) = self.classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 for attr in &class_def.attributes {
                     if let Some(pos) = attrs.iter().position(|(n, ..)| n == &attr.0) {
                         attrs.remove(pos);
@@ -661,7 +669,7 @@ impl Interpreter {
         // Track which attribute names appear in multiple classes (need qualified storage)
         let mut attr_counts: HashMap<String, usize> = HashMap::new();
         for cn in &mro {
-            if let Some(class_def) = self.classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 for attr in &class_def.attributes {
                     *attr_counts.entry(attr.0.clone()).or_insert(0) += 1;
                 }
@@ -669,7 +677,7 @@ impl Interpreter {
         }
         // Only include attrs that appear in multiple classes (duplicated across hierarchy)
         for cn in &mro {
-            if let Some(class_def) = self.classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn) {
                 for attr in &class_def.attributes {
                     if attr_counts.get(&attr.0).copied().unwrap_or(0) > 1 {
                         result.push((cn.clone(), attr.clone()));
@@ -729,7 +737,10 @@ impl Interpreter {
         let mut sigs = Vec::new();
         for cn in self.mro_readonly(receiver_class_name) {
             let is_ancestor = cn.as_str() != receiver_class_name;
-            let Some(class_def) = self.classes.get(cn.as_str()) else {
+            // No user-code re-entry in this loop body (pure signature-string
+            // building), so a let-bound guard is safe.
+            let registry = self.registry();
+            let Some(class_def) = registry.classes.get(cn.as_str()) else {
                 continue;
             };
             let Some(overloads) = class_def.methods.get(method_name) else {
@@ -810,7 +821,8 @@ impl Interpreter {
             // matched) from X::Method::NotFound (method does not exist at all,
             // e.g. submethod on ancestor only).
             let has_visible_method = self.class_mro(receiver_class_name).iter().any(|cn| {
-                self.classes
+                self.registry()
+                    .classes
                     .get(cn.as_str())
                     .and_then(|c| c.methods.get(method_name))
                     .is_some_and(|ovs| {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -456,7 +456,7 @@ impl Interpreter {
                 return 0;
             }
             // Use a non-mutable copy of the MRO (classes field lookup)
-            if let Some(class_def) = self.classes.get(cn.as_str()) {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for (i, ancestor) in class_def.mro.iter().enumerate() {
                     if ancestor == base {
                         return i;
@@ -475,7 +475,7 @@ impl Interpreter {
             if base == cn.as_str() {
                 return 0;
             }
-            if let Some(class_def) = self.classes.get(cn.as_str()) {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for (i, ancestor) in class_def.mro.iter().enumerate() {
                     if ancestor == base {
                         return i;

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -12,7 +12,7 @@ impl Interpreter {
             }
         };
         // Check user-defined class methods first
-        if let Some(class_def) = self.classes.get(&class_name_str)
+        if let Some(class_def) = self.registry().classes.get(&class_name_str)
             && let Some(defs) = class_def.methods.get(method_name)
             && let Some(def) = defs.first()
         {
@@ -106,7 +106,7 @@ impl Interpreter {
         // Check auto-generated accessor methods for public attributes (has $.x, has $.x is rw).
         // These are not stored in class_def.methods but are generated on-the-fly.
         // ClassAttributeDef: (attr_name, is_public, default, is_rw, is_required, sigil, where)
-        if let Some(class_def) = self.classes.get(&class_name_str) {
+        if let Some(class_def) = self.registry().classes.get(&class_name_str) {
             for (attr_name, is_public, _, is_rw, _, _, _) in &class_def.attributes {
                 if *is_public && attr_name == method_name {
                     let mut env = crate::env::Env::new();
@@ -180,7 +180,10 @@ impl Interpreter {
         method_name: &str,
         package: crate::symbol::Symbol,
     ) -> Vec<Value> {
-        let Some(class_def) = self.classes.get(class_name) else {
+        // No user-code re-entry below (pure Value construction), so a let-bound
+        // guard is safe.
+        let registry = self.registry();
+        let Some(class_def) = registry.classes.get(class_name) else {
             return Vec::new();
         };
         let Some(defs) = class_def.methods.get(method_name) else {
@@ -287,7 +290,7 @@ impl Interpreter {
             });
         }
         if let Value::Package(class_name) = invocant
-            && let Some(class_def) = self.classes.get(&class_name.resolve())
+            && let Some(class_def) = self.registry().classes.get(&class_name.resolve())
             && class_def.native_methods.contains(method_name)
         {
             return Some(Value::str(method_name.to_string()));
@@ -642,8 +645,8 @@ impl Interpreter {
                 };
                 // If the class doesn't exist yet (e.g. built-in types like Rat, Int, Str),
                 // create a stub ClassDef so methods can be added dynamically.
-                if !self.classes.contains_key(&class_name) {
-                    self.classes.insert(
+                if !self.registry().classes.contains_key(&class_name) {
+                    self.registry_mut().classes.insert(
                         class_name.clone(),
                         ClassDef {
                             parents: vec![],
@@ -660,7 +663,7 @@ impl Interpreter {
                         },
                     );
                 }
-                if let Some(class_def) = self.classes.get_mut(&class_name) {
+                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.methods.insert(method_name, vec![def]);
                 }
                 // Return Nil even if the class was not found (e.g. built-in types
@@ -702,7 +705,7 @@ impl Interpreter {
                     deprecated_message: None,
                     is_submethod: false,
                 };
-                if let Some(class_def) = self.classes.get_mut(&class_name) {
+                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.methods.entry(method_name).or_default().push(def);
                     return Ok(Value::Nil);
                 }
@@ -720,7 +723,7 @@ impl Interpreter {
                     _ => return Ok(Value::Nil),
                 };
                 let mro = self.class_mro(&class_name);
-                if let Some(class_def) = self.classes.get_mut(&class_name) {
+                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.mro = mro;
                 }
                 Ok(Value::Nil)
@@ -759,7 +762,7 @@ impl Interpreter {
                     });
                     let sigil = attr_name_raw.chars().next().unwrap_or('$');
                     // Add the attribute to the class definition
-                    if let Some(class_def) = self.classes.get_mut(&class_name) {
+                    if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                         class_def.attributes.push((
                             bare_name.clone(),
                             has_accessor, // is_public
@@ -1031,7 +1034,7 @@ impl Interpreter {
                     other => value_type_name(other).to_string(),
                 };
                 let mut table = HashMap::new();
-                if let Some(class_def) = self.classes.get(&type_name) {
+                if let Some(class_def) = self.registry().classes.get(&type_name) {
                     for (name, defs) in &class_def.methods {
                         if defs.iter().any(|d| d.is_my) {
                             table.insert(name.clone(), Value::str(name.clone()));
@@ -1053,7 +1056,7 @@ impl Interpreter {
             Value::Instance { class_name, .. } => class_name.resolve(),
             other => value_type_name(other).to_string(),
         };
-        let mut mro = if self.classes.contains_key(&class_name) {
+        let mut mro = if self.registry().classes.contains_key(&class_name) {
             self.class_mro(&class_name)
         } else {
             // Built-in type hierarchies for types that are not user-defined classes.
@@ -1375,7 +1378,7 @@ impl Interpreter {
             }
 
             // For built-in types that don't have class defs, add known methods
-            if result.is_empty() || !self.classes.contains_key(&class_name) {
+            if result.is_empty() || !self.registry().classes.contains_key(&class_name) {
                 self.collect_builtin_type_methods(&class_name, &mut result);
                 if all {
                     self.collect_builtin_type_methods("Any", &mut result);
@@ -1748,7 +1751,7 @@ impl Interpreter {
         include_private: bool,
         result: &mut Vec<Value>,
     ) {
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             // First add accessor methods for public attributes (in order)
             for (attr_name, is_public, ..) in &class_def.attributes {
                 if *is_public && !class_def.methods.contains_key(attr_name) {
@@ -1912,7 +1915,7 @@ impl Interpreter {
         self.collect_class_methods(class_name, include_private, &mut result);
 
         // Then: each parent's tree as a nested array
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             for parent in &class_def.parents {
                 let subtree = self.classhow_methods_tree(parent, include_private)?;
                 result.push(subtree);
@@ -1935,7 +1938,7 @@ impl Interpreter {
         let mro = self.classhow_mro_unhidden_names(target);
         let mut results = Vec::new();
         for cn in &mro {
-            if let Some(class_def) = self.classes.get(cn)
+            if let Some(class_def) = self.registry().classes.get(cn)
                 && let Some(defs) = class_def.methods.get(method_name)
             {
                 for def in defs.iter().filter(|def| !def.is_my || cn == &class_name) {
@@ -2044,11 +2047,11 @@ impl Interpreter {
 
     fn collect_attribute_objects(&self, class_name: &str, local_only: bool) -> Vec<Value> {
         // For Attribute itself, return BOOTSTRAPATTR instances for its well-known attributes
-        if class_name == "Attribute" && !self.classes.contains_key("Attribute") {
+        if class_name == "Attribute" && !self.registry().classes.contains_key("Attribute") {
             return Self::make_bootstrapattr_list();
         }
         if local_only {
-            if let Some(class_def) = self.classes.get(class_name) {
+            if let Some(class_def) = self.registry().classes.get(class_name) {
                 class_def
                     .attributes
                     .iter()
@@ -2058,7 +2061,7 @@ impl Interpreter {
                 Vec::new()
             }
         } else {
-            let mro = if let Some(class_def) = self.classes.get(class_name)
+            let mro = if let Some(class_def) = self.registry().classes.get(class_name)
                 && !class_def.mro.is_empty()
             {
                 class_def.mro.clone()
@@ -2071,7 +2074,7 @@ impl Interpreter {
                 if cn == "Any" || cn == "Mu" {
                     continue;
                 }
-                if let Some(cd) = self.classes.get(cn) {
+                if let Some(cd) = self.registry().classes.get(cn) {
                     for attr in &cd.attributes {
                         if seen_names.insert(attr.0.clone()) {
                             result.push(self.make_attribute_object(attr, cn));
@@ -2133,6 +2136,7 @@ impl Interpreter {
         let (ref attr_name, is_public, ref default, is_rw, _, sigil, _) = *attr;
         let full_name = format!("{}!{}", sigil, attr_name);
         let raw_type_name = self
+            .registry()
             .classes
             .get(owner)
             .and_then(|cd| cd.attribute_types.get(attr_name))
@@ -2211,7 +2215,7 @@ impl Interpreter {
     /// Build a minimal Attribute introspection object for a `has` declaration
     /// that is being processed at class-registration time, so it can be passed
     /// to a user-defined `trait_mod:<is>`. Unlike `make_attribute_object`, this
-    /// does not require the owning class to already be present in `self.classes`.
+    /// does not require the owning class to already be present in `self.registry().classes`.
     pub(crate) fn make_trait_attribute_object(
         &self,
         attr_name: &str,
@@ -2336,7 +2340,8 @@ impl Interpreter {
         let mro = self.classhow_mro_names(&args[0]);
         let parents_iter = mro.into_iter().skip(1);
         let parents: Vec<Value> = if local {
-            self.classes
+            self.registry()
+                .classes
                 .get(&class_name)
                 .map(|cd| cd.parents.clone())
                 .unwrap_or_default()
@@ -2358,6 +2363,7 @@ impl Interpreter {
 
     fn parents_tree(&mut self, class_name: &str) -> Vec<Value> {
         let direct = self
+            .registry()
             .classes
             .get(class_name)
             .map(|cd| cd.parents.clone())
@@ -2427,7 +2433,8 @@ impl Interpreter {
     ) -> Vec<String> {
         // If the target is a role (not a class), return its role_parents.
         // For instances (punned roles), include the role itself in the list.
-        let is_role = self.roles.contains_key(class_name) && !self.classes.contains_key(class_name);
+        let is_role = self.roles.contains_key(class_name)
+            && !self.registry().classes.contains_key(class_name);
         if is_role {
             let mut result = Vec::new();
             // For instances of punned roles, include the role itself first
@@ -2482,7 +2489,7 @@ impl Interpreter {
                 result.retain(|r| !transitive.contains(r));
             }
         } else {
-            let mro = if let Some(cd) = self.classes.get(class_name)
+            let mro = if let Some(cd) = self.registry().classes.get(class_name)
                 && !cd.mro.is_empty()
             {
                 cd.mro.clone()

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -304,7 +304,7 @@ impl Interpreter {
         }
         // Initialize with default attribute values
         let mut attributes = HashMap::new();
-        if self.classes.contains_key(&class_name.resolve()) {
+        if self.registry().classes.contains_key(&class_name.resolve()) {
             for (attr_name, _is_public, default, _is_rw, _, _, _) in
                 self.collect_class_attributes(&class_name.resolve())
             {
@@ -359,11 +359,14 @@ impl Interpreter {
                 continue;
             }
             // Skip role entries in MRO
-            if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
+            if self.roles.contains_key(mro_class)
+                && !self.registry().classes.contains_key(mro_class)
+            {
                 continue;
             }
             // Check if the class itself has a BUILD submethod
             let class_has_own_build = self
+                .registry()
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("BUILD"))
@@ -407,6 +410,7 @@ impl Interpreter {
             // role_origin=Some) were already called above. Regular methods
             // (is_my=false) from roles still need to go through run_instance_method.
             let has_non_submethod_build = self
+                .registry()
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("BUILD"))
@@ -432,11 +436,14 @@ impl Interpreter {
                 continue;
             }
             // Skip role entries in MRO
-            if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
+            if self.roles.contains_key(mro_class)
+                && !self.registry().classes.contains_key(mro_class)
+            {
                 continue;
             }
             // Check if the class itself has a TWEAK submethod
             let class_has_own_tweak = self
+                .registry()
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("TWEAK"))
@@ -472,6 +479,7 @@ impl Interpreter {
             // Call the class's TWEAK if it has one that wasn't already handled
             // by ordered_role_submethods_for_class. Same logic as BUILD above.
             let has_non_submethod_tweak = self
+                .registry()
                 .classes
                 .get(mro_class)
                 .and_then(|def| def.methods.get("TWEAK"))

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -651,7 +651,7 @@ impl Interpreter {
         // Load the module source in isolation: capture the classes/roles it
         // registers so we can keep them invisible to `::()` until merged.
         let class_before: std::collections::HashSet<String> =
-            self.classes.keys().cloned().collect();
+            self.registry().classes.keys().cloned().collect();
         let role_before: std::collections::HashSet<String> = self.roles.keys().cloned().collect();
         if source_path.exists() {
             let saved = self.precomp_enabled;
@@ -663,7 +663,7 @@ impl Interpreter {
             }
         }
         let mut new_symbols: Vec<String> = Vec::new();
-        for k in self.classes.keys() {
+        for k in self.registry().classes.keys() {
             if !class_before.contains(k) {
                 new_symbols.push(k.clone());
             }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -628,7 +628,8 @@ impl Interpreter {
                 // isa only matches classes, not roles. If the target is a role
                 // that has NOT been punned to a class, return False (use .does
                 // for role checking).
-                if self.roles.contains_key(&target_name) && !self.classes.contains_key(&target_name)
+                if self.roles.contains_key(&target_name)
+                    && !self.registry().classes.contains_key(&target_name)
                 {
                     return Ok(Value::Bool(false));
                 }
@@ -1377,7 +1378,7 @@ impl Interpreter {
                 Value::CustomType { repr, .. } | Value::CustomTypeInstance { repr, .. } => {
                     Ok(Value::str(repr))
                 }
-                Value::Package(name) if self.classes.contains_key(&name.resolve()) => {
+                Value::Package(name) if self.registry().classes.contains_key(&name.resolve()) => {
                     Ok(Value::str_from("P6opaque"))
                 }
                 _ => Ok(Value::str_from("P6opaque")),
@@ -1449,8 +1450,10 @@ impl Interpreter {
                     .unwrap_or_else(|| "Anon".to_string());
                 // Register an empty class definition so that .new and other
                 // class operations work on this dynamically created type.
-                if !self.classes.contains_key(&name) {
-                    self.classes.insert(name.clone(), Default::default());
+                if !self.registry().classes.contains_key(&name) {
+                    self.registry_mut()
+                        .classes
+                        .insert(name.clone(), Default::default());
                 }
                 Ok(Value::Package(Symbol::intern(&name)))
             }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -34,7 +34,7 @@ impl Interpreter {
         if cn_resolved.contains('[') || cn_resolved.contains("::") {
             return false;
         }
-        if !self.classes.contains_key(cn_resolved) {
+        if !self.registry().classes.contains_key(cn_resolved) {
             return false;
         }
         let mut has_attribute = false;
@@ -42,7 +42,11 @@ impl Interpreter {
             if cls == "Any" || cls == "Mu" || cls == "Cool" {
                 continue;
             }
-            let Some(class_def) = self.classes.get(&cls) else {
+            // Single guard for the whole eligibility check (used by both the
+            // class_def lookup and the nested parent contains_key — avoids a
+            // same-thread recursive read lock). No user-code re-entry here.
+            let registry = self.registry();
+            let Some(class_def) = registry.classes.get(&cls) else {
                 // A non-class entry in the MRO (e.g. a role) — be conservative.
                 return false;
             };
@@ -52,7 +56,7 @@ impl Interpreter {
                 && !class_def.methods.contains_key("new")
                 && class_def.native_methods.is_empty()
                 && class_def.parents.iter().all(|p| {
-                    p == "Any" || p == "Mu" || p == "Cool" || self.classes.contains_key(p)
+                    p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
                     |(_, _, _, is_required, type_constraint, sigil, where_constraint)| {
@@ -409,8 +413,10 @@ impl Interpreter {
             } else {
                 (cn_resolved.as_str(), None)
             };
-            if cn_resolved.starts_with("IO::Path::") && !self.classes.contains_key(&cn_resolved) {
-                self.classes.insert(
+            if cn_resolved.starts_with("IO::Path::")
+                && !self.registry().classes.contains_key(&cn_resolved)
+            {
+                self.registry_mut().classes.insert(
                     cn_resolved.clone(),
                     ClassDef {
                         parents: vec!["IO::Path".to_string()],
@@ -432,7 +438,7 @@ impl Interpreter {
                 let attrs = HashMap::new();
                 return Ok(Value::make_instance(Symbol::intern(&cn_resolved), attrs));
             }
-            let class_key = if self.classes.contains_key(&cn_resolved) {
+            let class_key = if self.registry().classes.contains_key(&cn_resolved) {
                 cn_resolved.as_str()
             } else {
                 base_class_name
@@ -2711,15 +2717,17 @@ impl Interpreter {
                 return self.construct_cunion_instance(&cn_resolved, &args);
             }
             // Auto-pun role to class if needed (e.g., role COERCE calling self.new)
-            if !self.classes.contains_key(&cn_resolved) && self.roles.contains_key(&cn_resolved) {
+            if !self.registry().classes.contains_key(&cn_resolved)
+                && self.roles.contains_key(&cn_resolved)
+            {
                 self.ensure_role_punned_to_class(&cn_resolved);
             }
-            if self.classes.contains_key(&cn_resolved)
+            if self.registry().classes.contains_key(&cn_resolved)
                 || type_args
                     .as_ref()
-                    .is_some_and(|_| self.classes.contains_key(base_class_name))
+                    .is_some_and(|_| self.registry().classes.contains_key(base_class_name))
             {
-                let class_key = if self.classes.contains_key(&cn_resolved) {
+                let class_key = if self.registry().classes.contains_key(&cn_resolved) {
                     cn_resolved.as_str()
                 } else {
                     base_class_name
@@ -2846,6 +2854,7 @@ impl Interpreter {
                     cn != "Any"
                         && cn != "Mu"
                         && self
+                            .registry()
                             .classes
                             .get(cn)
                             .and_then(|def| def.methods.get("BUILD"))
@@ -3065,12 +3074,13 @@ impl Interpreter {
                                 } else {
                                     let arr = Value::real_array(Vec::new());
                                     // Register element type constraint for typed array attributes
-                                    if let Some(tc) = self
+                                    let tc = self
+                                        .registry()
                                         .classes
                                         .get(class_key)
                                         .and_then(|cd| cd.attribute_types.get(&attr_name))
-                                        .cloned()
-                                    {
+                                        .cloned();
+                                    if let Some(tc) = tc {
                                         self.register_container_type_metadata(
                                             &arr,
                                             super::ContainerTypeInfo {
@@ -3100,12 +3110,13 @@ impl Interpreter {
                                 } else {
                                     let h = Value::hash(HashMap::new());
                                     // Register value type constraint for typed hash attributes
-                                    if let Some(tc) = self
+                                    let tc = self
+                                        .registry()
                                         .classes
                                         .get(class_key)
                                         .and_then(|cd| cd.attribute_types.get(&attr_name))
-                                        .cloned()
-                                    {
+                                        .cloned();
+                                    if let Some(tc) = tc {
                                         self.register_container_type_metadata(
                                             &h,
                                             super::ContainerTypeInfo {
@@ -3163,11 +3174,14 @@ impl Interpreter {
                         continue;
                     }
                     // Skip role entries in MRO — they are handled separately below
-                    if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
+                    if self.roles.contains_key(mro_class)
+                        && !self.registry().classes.contains_key(mro_class)
+                    {
                         continue;
                     }
                     // Check if the class has its own BUILD (not from a role)
                     let class_has_own_build = self
+                        .registry()
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("BUILD"))
@@ -3204,6 +3218,7 @@ impl Interpreter {
                     // by ordered_role_submethods_for_class. Role submethods (is_my=true,
                     // role_origin=Some) were already called above.
                     let has_non_submethod_build = self
+                        .registry()
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("BUILD"))
@@ -3249,6 +3264,7 @@ impl Interpreter {
                     cn != "Any"
                         && cn != "Mu"
                         && self
+                            .registry()
                             .classes
                             .get(cn)
                             .and_then(|def| def.methods.get("BUILD"))
@@ -3287,11 +3303,14 @@ impl Interpreter {
                         continue;
                     }
                     // Skip role entries in MRO
-                    if self.roles.contains_key(mro_class) && !self.classes.contains_key(mro_class) {
+                    if self.roles.contains_key(mro_class)
+                        && !self.registry().classes.contains_key(mro_class)
+                    {
                         continue;
                     }
                     // Check if the class has its own TWEAK (not from a role)
                     let class_has_own_tweak = self
+                        .registry()
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("TWEAK"))
@@ -3331,6 +3350,7 @@ impl Interpreter {
                     }
                     // Only call the class's own TWEAK (not role-composed ones).
                     let has_own_tweak = self
+                        .registry()
                         .classes
                         .get(mro_class)
                         .and_then(|def| def.methods.get("TWEAK"))
@@ -3687,7 +3707,7 @@ impl Interpreter {
     fn collect_attribute_type_constraints(&mut self, class_name: &str) -> HashMap<String, String> {
         let mut constraints = HashMap::new();
         for owner in self.class_mro(class_name) {
-            if let Some(class_def) = self.classes.get(&owner) {
+            if let Some(class_def) = self.registry().classes.get(&owner) {
                 for (attr_name, tc) in &class_def.attribute_types {
                     constraints
                         .entry(attr_name.clone())
@@ -3760,7 +3780,7 @@ impl Interpreter {
             std::collections::HashSet::new();
         let mro = self.class_mro(class_name);
         for mro_class in &mro {
-            if let Some(class_def) = self.classes.get(mro_class) {
+            if let Some(class_def) = self.registry().classes.get(mro_class) {
                 for (attr_name, smiley) in &class_def.attribute_smileys {
                     smileys
                         .entry(attr_name.clone())
@@ -3794,7 +3814,7 @@ impl Interpreter {
                             Value::str(format!(
                                 "Type check failed in default value of attribute $!{}; expected {}, got {}",
                                 attr_name,
-                                self.classes.get(class_name)
+                                self.registry().classes.get(class_name)
                                     .and_then(|cd| cd.attribute_types.get(attr_name))
                                     .map(|t| format!("{}:U", t))
                                     .unwrap_or_else(|| "Any:U".to_string()),
@@ -3822,7 +3842,7 @@ impl Interpreter {
                         Value::str(format!(
                             "Type check failed in default value of attribute $!{}; expected {}, got {}",
                             attr_name,
-                            self.classes.get(class_name)
+                            self.registry().classes.get(class_name)
                                 .and_then(|cd| cd.attribute_types.get(attr_name))
                                 .map(|t| format!("{}:D", t))
                                 .unwrap_or_else(|| "Any:D".to_string()),
@@ -3957,7 +3977,7 @@ impl Interpreter {
             "QuantHash",
         ];
         // Check the class definition's parents and MRO for Baggy/Setty
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             if class_def
                 .parents
                 .iter()
@@ -3987,7 +4007,7 @@ impl Interpreter {
     /// Determine whether a class inherits from a Set-like type (vs Bag-like).
     fn class_is_setty(&self, class_name: &str) -> bool {
         const SETTY_TYPES: &[&str] = &["Set", "SetHash"];
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             if class_def
                 .parents
                 .iter()

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -158,12 +158,14 @@ impl Interpreter {
             return Some(Ok(result));
         }
         // Fallback: find a method with matching role_origin in the instance's class.
-        if let Some(overloads) = self
+        // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
+        let overloads = self
+            .registry()
             .classes
             .get(&inst_cn_str)
             .and_then(|c| c.methods.get(actual_method))
-            .cloned()
-        {
+            .cloned();
+        if let Some(overloads) = overloads {
             for def in overloads {
                 if def.role_origin.as_deref() == Some(qualifier)
                     && !def.is_private

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1144,7 +1144,8 @@ impl Interpreter {
             // produce a dispatch error.
             let own_class = class_name.resolve();
             let method_exists = self.class_mro(&own_class).iter().any(|cn| {
-                self.classes
+                self.registry()
+                    .classes
                     .get(cn.as_str())
                     .and_then(|c| c.methods.get(method))
                     .is_some_and(|ovs| {

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -39,7 +39,7 @@ impl Interpreter {
             Value::Package(name) => name.resolve(),
             _ => return Ok(None),
         };
-        if !self.classes.contains_key(&receiver_class_name) {
+        if !self.registry().classes.contains_key(&receiver_class_name) {
             return Ok(None);
         }
 
@@ -186,7 +186,8 @@ impl Interpreter {
 
     /// Read-only variant of class_mro for use from non-mut helpers.
     fn class_mro_readonly(&self, class_name: &str) -> Option<Vec<String>> {
-        let class_def = self.classes.get(class_name)?;
+        let registry = self.registry();
+        let class_def = registry.classes.get(class_name)?;
         if !class_def.mro.is_empty() {
             return Some(class_def.mro.clone());
         }
@@ -206,7 +207,8 @@ impl Interpreter {
             WalkKind::Class => {
                 // For the receiver's own class, "own" is any candidate stored
                 // on the class with role_origin == None.
-                let class_def = self.classes.get(owner)?;
+                let registry = self.registry();
+                let class_def = registry.classes.get(owner)?;
                 let overloads = class_def.methods.get(method_name)?;
                 if owner == receiver_class {
                     overloads
@@ -232,7 +234,8 @@ impl Interpreter {
                 }
                 // Fall back to a method composed into the receiver's class
                 // table whose role origin matches this role.
-                let class_def = self.classes.get(receiver_class)?;
+                let registry = self.registry();
+                let class_def = registry.classes.get(receiver_class)?;
                 let overloads = class_def.methods.get(method_name)?;
                 overloads
                     .iter()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -284,7 +284,7 @@ impl DocComment {
 }
 
 #[derive(Clone, Default)]
-struct ClassDef {
+pub(crate) struct ClassDef {
     parents: Vec<String>,
     // (name, is_public, default, is_rw, is_required, sigil, where_constraint)
     attributes: Vec<ClassAttributeDef>,
@@ -884,7 +884,6 @@ pub struct Interpreter {
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
-    classes: HashMap<String, ClassDef>,
     roles: HashMap<String, RoleDef>,
     /// Roles explicitly declared via user code (not pre-registered builtins).
     /// Used to detect X::Redeclaration for role->class name conflicts.
@@ -2868,7 +2867,12 @@ impl Interpreter {
             gather_take_limits: Vec::new(),
             block_scope_depth: 0,
             registry: {
-                let mut registry = Registry::default();
+                // Built-in class definitions (PR-A slice 3: `classes` now lives in the
+                // shared Registry instead of an Interpreter field).
+                let mut registry = Registry {
+                    classes,
+                    ..Registry::default()
+                };
                 // Built-in class -> composed-role seeds (PR-A slice 2: class metadata
                 // now lives in the shared Registry instead of an Interpreter field).
                 let ccr = &mut registry.class_composed_roles;
@@ -2905,7 +2909,6 @@ impl Interpreter {
                 ccr.insert("Str".to_string(), vec!["Stringy".to_string()]);
                 Arc::new(RwLock::new(registry))
             },
-            classes,
             roles: {
                 let mut roles = HashMap::new();
                 roles.insert(
@@ -3426,7 +3429,7 @@ impl Interpreter {
     /// Save current function/class keys for lexical import scoping.
     pub(crate) fn push_import_scope(&mut self) {
         let func_keys: HashSet<Symbol> = self.functions.keys().copied().collect();
-        let class_keys: HashSet<String> = self.classes.keys().cloned().collect();
+        let class_keys: HashSet<String> = self.registry().classes.keys().cloned().collect();
         self.import_scope_stack.push((
             func_keys,
             class_keys,
@@ -3443,7 +3446,9 @@ impl Interpreter {
             self.import_scope_stack.pop()
         {
             self.functions.retain(|key, _| func_snapshot.contains(key));
-            self.classes.retain(|key, _| class_snapshot.contains(key));
+            self.registry_mut()
+                .classes
+                .retain(|key, _| class_snapshot.contains(key));
             self.newline_mode = newline_mode;
             self.strict_mode = strict_mode;
             self.fatal_mode = fatal_mode;
@@ -3477,7 +3482,7 @@ impl Interpreter {
             // module was first loaded transitively by a non-contributing module.
             if self.module_load_stack.is_empty() && module.contains("::") {
                 let is_contributor =
-                    self.classes.contains_key(module) || self.roles.contains_key(module);
+                    self.registry().classes.contains_key(module) || self.roles.contains_key(module);
                 if is_contributor {
                     self.package_stash_hidden.remove(module);
                 }
@@ -3506,7 +3511,7 @@ impl Interpreter {
             HashSet::new()
         };
         self.module_load_stack.push(module.to_string());
-        let class_snapshot: HashSet<String> = self.classes.keys().cloned().collect();
+        let class_snapshot: HashSet<String> = self.registry().classes.keys().cloned().collect();
         let role_snapshot: HashSet<String> = self.roles.keys().cloned().collect();
         let env_snapshot: HashSet<Symbol> = self.env.keys().copied().collect();
         let func_keys_before: HashSet<Symbol> = self.functions.keys().copied().collect();
@@ -3554,7 +3559,8 @@ impl Interpreter {
             } else {
                 module
             };
-            for class_name in self.classes.keys() {
+            let class_names: Vec<String> = self.registry().classes.keys().cloned().collect();
+            for class_name in &class_names {
                 if class_snapshot.contains(class_name) {
                     continue;
                 }
@@ -3609,11 +3615,13 @@ impl Interpreter {
             // If neither condition holds, new classes/roles are hidden from X's stash.
             if let Some((namespace, _)) = module.rsplit_once("::") {
                 let module_declares_own_class =
-                    self.classes.contains_key(module) || self.roles.contains_key(module);
+                    self.registry().classes.contains_key(module) || self.roles.contains_key(module);
                 let chain_has_package_decl = self.chain_declared_packages.contains(namespace);
                 if !module_declares_own_class && !chain_has_package_decl {
                     // Hide newly registered classes/roles from the namespace stash
-                    for class_name in self.classes.keys() {
+                    let class_names: Vec<String> =
+                        self.registry().classes.keys().cloned().collect();
+                    for class_name in &class_names {
                         if !class_snapshot.contains(class_name)
                             && class_name.starts_with(namespace)
                             && class_name.get(namespace.len()..namespace.len() + 2) == Some("::")
@@ -4066,7 +4074,7 @@ impl Interpreter {
             )));
         }
         self.module_load_stack.push(module.to_string());
-        let class_snapshot: HashSet<String> = self.classes.keys().cloned().collect();
+        let class_snapshot: HashSet<String> = self.registry().classes.keys().cloned().collect();
         let env_snapshot: HashSet<Symbol> = self.env.keys().copied().collect();
         let saved = self.suppress_exports;
         self.suppress_exports = true;
@@ -4079,7 +4087,8 @@ impl Interpreter {
             } else {
                 module.to_string()
             };
-            for class_name in self.classes.keys() {
+            let class_names: Vec<String> = self.registry().classes.keys().cloned().collect();
+            for class_name in &class_names {
                 if !class_snapshot.contains(class_name) {
                     self.need_hidden_classes.insert(class_name.clone());
                     if let Some((_, short)) = class_name.rsplit_once("::") {
@@ -4994,7 +5003,7 @@ impl Interpreter {
     }
 
     pub(crate) fn has_class(&self, name: &str) -> bool {
-        self.classes.contains_key(name)
+        self.registry().classes.contains_key(name)
     }
 
     /// Check if a class name refers to a user-defined class that inherits from
@@ -5005,14 +5014,21 @@ impl Interpreter {
             "Hash", "Array", "Map", "List", "Bag", "Set", "Mix", "BagHash", "SetHash", "MixHash",
             "Seq",
         ];
-        let class_def = self.classes.get(name).or_else(|| {
-            self.classes
-                .iter()
-                .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
-                .map(|(_, v)| v)
-        });
-        if let Some(class_def) = class_def {
-            for parent in &class_def.parents {
+        // Clone out the parents under a single guard, then recurse without holding it.
+        let parents = {
+            let reg = self.registry();
+            reg.classes
+                .get(name)
+                .or_else(|| {
+                    reg.classes
+                        .iter()
+                        .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
+                        .map(|(_, v)| v)
+                })
+                .map(|cd| cd.parents.clone())
+        };
+        if let Some(parents) = parents {
+            for parent in &parents {
                 if CONTAINER_TYPES.contains(&parent.as_str()) {
                     return true;
                 }
@@ -5030,14 +5046,21 @@ impl Interpreter {
         if IMMUTABLE_SETTY.contains(&name) {
             return true;
         }
-        let class_def = self.classes.get(name).or_else(|| {
-            self.classes
-                .iter()
-                .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
-                .map(|(_, v)| v)
-        });
-        if let Some(class_def) = class_def {
-            for parent in &class_def.parents {
+        // Clone out the parents under a single guard, then recurse without holding it.
+        let parents = {
+            let reg = self.registry();
+            reg.classes
+                .get(name)
+                .or_else(|| {
+                    reg.classes
+                        .iter()
+                        .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
+                        .map(|(_, v)| v)
+                })
+                .map(|cd| cd.parents.clone())
+        };
+        if let Some(parents) = parents {
+            for parent in &parents {
                 if IMMUTABLE_SETTY.contains(&parent.as_str()) {
                     return true;
                 }
@@ -5203,7 +5226,6 @@ impl Interpreter {
             // independent snapshot (matches prior per-field clone semantics: the
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
-            classes: self.classes.clone(),
             roles: self.roles.clone(),
             user_declared_roles: self.user_declared_roles.clone(),
             role_candidates: self.role_candidates.clone(),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -115,7 +115,10 @@ impl Interpreter {
         let mut count = 0usize;
         let mro = self.class_mro(class_name);
         for parent in mro.into_iter().skip(1) {
-            let Some(class_def) = self.classes.get(&parent) else {
+            // No user-code re-entry in this loop body (only static helpers), so a
+            // let-bound guard is safe.
+            let registry = self.registry();
+            let Some(class_def) = registry.classes.get(&parent) else {
                 continue;
             };
             let Some(defs) = class_def.methods.get(method_name) else {
@@ -494,7 +497,7 @@ impl Interpreter {
         &self,
         class_name: &str,
     ) -> Result<(), RuntimeError> {
-        let class_def = match self.classes.get(class_name) {
+        let class_def = match self.registry().classes.get(class_name) {
             Some(cd) => cd.clone(),
             None => return Ok(()),
         };

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -369,7 +369,7 @@ impl Interpreter {
     /// Collect method names from a class or role by name.
     fn collect_type_method_names(&self, type_name: &str) -> Vec<String> {
         let mut names = Vec::new();
-        if let Some(class_def) = self.classes.get(type_name) {
+        if let Some(class_def) = self.registry().classes.get(type_name) {
             names.extend(class_def.methods.keys().cloned());
         } else if let Some(role_def) = self.roles.get(type_name) {
             names.extend(role_def.methods.keys().cloned());
@@ -424,7 +424,7 @@ impl Interpreter {
         if constraint == "Any" || constraint == "Mu" {
             return 2;
         }
-        if let Some(def) = self.classes.get(constraint) {
+        if let Some(def) = self.registry().classes.get(constraint) {
             return 10 + def.parents.len() as i32;
         }
         if self.roles.contains_key(constraint) {
@@ -629,15 +629,15 @@ impl Interpreter {
         // declared inside a `unit module`/`unit class` body.
         if lookup.contains("::") {
             let bare = lookup.rsplit_once("::").map(|(_, b)| b).unwrap_or(lookup);
-            if !self.classes.contains_key(lookup)
+            if !self.registry().classes.contains_key(lookup)
                 && !self.roles.contains_key(lookup)
-                && (self.classes.contains_key(bare) || self.roles.contains_key(bare))
+                && (self.registry().classes.contains_key(bare) || self.roles.contains_key(bare))
             {
                 return format!("{}{}", bare, suffix);
             }
             if let Value::Package(pkg) = self.resolve_indirect_type_name(bare) {
                 let resolved = pkg.resolve();
-                if self.classes.contains_key(resolved.as_str())
+                if self.registry().classes.contains_key(resolved.as_str())
                     || self.roles.contains_key(resolved.as_str())
                 {
                     return format!("{}{}", resolved, suffix);
@@ -676,7 +676,7 @@ impl Interpreter {
         let does_parents = does_parents.as_slice();
         let hidden_parents: Vec<String> = hidden_parents.iter().map(|p| strip_colons(p)).collect();
         let hidden_parents = hidden_parents.as_slice();
-        let prev_class = self.classes.get(name).cloned();
+        let prev_class = self.registry().classes.get(name).cloned();
         let prev_hidden = self.registry().hidden_classes.contains(name);
         let prev_hidden_defer = self.registry().hidden_defer_parents.get(name).cloned();
         let prev_composed_roles = self.registry().class_composed_roles.get(name).cloned();
@@ -688,9 +688,11 @@ impl Interpreter {
 
         let restore_previous_state = |this: &mut Self| {
             if let Some(class_def) = prev_class.clone() {
-                this.classes.insert(name.to_string(), class_def);
+                this.registry_mut()
+                    .classes
+                    .insert(name.to_string(), class_def);
             } else {
-                this.classes.remove(name);
+                this.registry_mut().classes.remove(name);
             }
             if prev_hidden {
                 this.registry_mut().hidden_classes.insert(name.to_string());
@@ -751,7 +753,7 @@ impl Interpreter {
         // declaration), skip the stub registration to avoid overwriting the
         // real class definition.
         if is_stub_body
-            && self.classes.contains_key(name)
+            && self.registry().classes.contains_key(name)
             && !self.registry().class_stubs.contains(name)
         {
             return Ok(Vec::new());
@@ -845,7 +847,7 @@ impl Interpreter {
                     name
                 )));
             }
-            if !self.classes.contains_key(base_parent)
+            if !self.registry().classes.contains_key(base_parent)
                 && !BUILTIN_TYPES.contains(&base_parent)
                 && !self.roles.contains_key(base_parent)
                 && !self.registry().enum_types.contains_key(base_parent)
@@ -886,7 +888,7 @@ impl Interpreter {
             }
             // Check that `does` targets are actually roles, not classes
             if does_parents.contains(parent)
-                && self.classes.contains_key(resolved_parent)
+                && self.registry().classes.contains_key(resolved_parent)
                 && !self.roles.contains_key(resolved_parent)
                 && !BUILTIN_TYPES.contains(&resolved_parent)
             {
@@ -1189,7 +1191,7 @@ impl Interpreter {
                                     .or_default()
                                     .extend(composed);
                             }
-                        } else if self.classes.contains_key(parent_base)
+                        } else if self.registry().classes.contains_key(parent_base)
                             && !class_def.parents.iter().any(|p| p == &resolved_parent)
                         {
                             class_def.parents.push(resolved_parent.clone());
@@ -1229,8 +1231,8 @@ impl Interpreter {
                 .map(|(b, _)| b)
                 .unwrap_or(punned_role.as_str());
             // Create a punned class entry if one doesn't already exist
-            if !self.classes.contains_key(punned_role.as_str())
-                && !self.classes.contains_key(base_role)
+            if !self.registry().classes.contains_key(punned_role.as_str())
+                && !self.registry().classes.contains_key(base_role)
             {
                 // Collect class parents and composed roles recursively from role hierarchy
                 let mut punned_class_parents = Vec::new();
@@ -1250,7 +1252,7 @@ impl Interpreter {
                                     punned_composed_roles.push(rp.clone());
                                 }
                                 role_stack.push(rp_base.to_string());
-                            } else if self.classes.contains_key(rp_base)
+                            } else if self.registry().classes.contains_key(rp_base)
                                 && !punned_class_parents.contains(&rp)
                             {
                                 // It's a class - add as parent
@@ -1272,7 +1274,9 @@ impl Interpreter {
                     alias_attributes: HashSet::new(),
                     class_level_attrs: HashMap::new(),
                 };
-                self.classes.insert(base_role.to_string(), punned_class);
+                self.registry_mut()
+                    .classes
+                    .insert(base_role.to_string(), punned_class);
                 if !punned_composed_roles.is_empty() {
                     self.registry_mut()
                         .class_composed_roles
@@ -1293,7 +1297,7 @@ impl Interpreter {
                 }
                 // Recompute MRO for the punned class
                 let mro = self.class_mro(base_role);
-                if let Some(cd) = self.classes.get_mut(base_role) {
+                if let Some(cd) = self.registry_mut().classes.get_mut(base_role) {
                     cd.mro = mro;
                 }
             }
@@ -1329,7 +1333,7 @@ impl Interpreter {
                             if self.roles.contains_key(rp_base) {
                                 // It's a sub-role, recurse
                                 role_stack.push(rp_base.to_string());
-                            } else if self.classes.contains_key(rp_base)
+                            } else if self.registry().classes.contains_key(rp_base)
                                 && !class_def.parents.contains(&rp)
                             {
                                 class_def.parents.push(rp);
@@ -1394,10 +1398,14 @@ impl Interpreter {
         // like `A.^add_method(...)` inside the declaration can resolve `A`.
         // Clear stale method wrap chains from a previous class with the same name.
         self.method_wrap_chains.retain(|(cls, _, _), _| cls != name);
-        self.classes.insert(name.to_string(), class_def.clone());
+        self.registry_mut()
+            .classes
+            .insert(name.to_string(), class_def.clone());
         if is_stub_body {
             self.registry_mut().class_stubs.insert(name.to_string());
-            self.classes.insert(name.to_string(), class_def);
+            self.registry_mut()
+                .classes
+                .insert(name.to_string(), class_def);
             let mut stack = Vec::new();
             let _ = self.compute_class_mro(name, &mut stack)?;
             return Ok(deferred_custom_traits);
@@ -2161,7 +2169,7 @@ impl Interpreter {
                     if let Some(rparents) = self.role_parents.get(&role_name_str).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.classes.contains_key(rp_base)
+                            if self.registry().classes.contains_key(rp_base)
                                 && !class_def.parents.iter().any(|p| p == &rp)
                             {
                                 class_def.parents.push(rp.clone());
@@ -2190,7 +2198,9 @@ impl Interpreter {
                         class_def.methods.insert(alias, overloads);
                     }
                     // Also execute the statement so the code variable is set
-                    self.classes.insert(name.to_string(), class_def.clone());
+                    self.registry_mut()
+                        .classes
+                        .insert(name.to_string(), class_def.clone());
                     self.run_block_raw(std::slice::from_ref(stmt))?;
                     for outer_name in saved_env.keys() {
                         let class_scoped_name = format!("{}::{}", name, outer_name);
@@ -2198,7 +2208,7 @@ impl Interpreter {
                             self.env.insert_sym(*outer_name, updated);
                         }
                     }
-                    if let Some(updated) = self.classes.get(name).cloned() {
+                    if let Some(updated) = self.registry().classes.get(name).cloned() {
                         class_def = updated;
                     }
                 }
@@ -2221,7 +2231,9 @@ impl Interpreter {
                         Stmt::Expr(Expr::Call { name: fn_name, .. })
                             if fn_name.resolve() == "EVAL"
                     );
-                    self.classes.insert(name.to_string(), class_def.clone());
+                    self.registry_mut()
+                        .classes
+                        .insert(name.to_string(), class_def.clone());
                     let result = self.run_block_raw(std::slice::from_ref(stmt));
                     if let Err(e) = result {
                         if !is_swallowable {
@@ -2235,7 +2247,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    if let Some(updated) = self.classes.get(name).cloned() {
+                    if let Some(updated) = self.registry().classes.get(name).cloned() {
                         class_def = updated;
                     }
                 }
@@ -2256,7 +2268,9 @@ impl Interpreter {
                         .insert(fq, Value::Bool(true));
                 }
             }
-            self.classes.insert(name.to_string(), class_def.clone());
+            self.registry_mut()
+                .classes
+                .insert(name.to_string(), class_def.clone());
         }
         // Fire class-body LEAVE phasers in LIFO order now that the body scope
         // is being left. They run while the class package/env are still active
@@ -2281,7 +2295,9 @@ impl Interpreter {
             restore_previous_state(self);
             return Err(err);
         }
-        self.classes.insert(name.to_string(), class_def);
+        self.registry_mut()
+            .classes
+            .insert(name.to_string(), class_def);
         let mut stack = Vec::new();
         if let Err(err) = self.compute_class_mro(name, &mut stack) {
             restore_previous_state(self);
@@ -2300,7 +2316,7 @@ impl Interpreter {
     pub(crate) fn augment_class(&mut self, name: &str, body: &[Stmt]) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
         // Check if the class exists (user-defined or builtin)
-        let is_builtin = !self.classes.contains_key(name);
+        let is_builtin = !self.registry().classes.contains_key(name);
         if is_builtin {
             // For builtin types, create a minimal class def so we can add methods
             const BUILTIN_TYPES: &[&str] = &[
@@ -2361,7 +2377,10 @@ impl Interpreter {
                 )));
             }
             // Create a minimal entry for the builtin type
-            self.classes.entry(name.to_string()).or_default();
+            self.registry_mut()
+                .classes
+                .entry(name.to_string())
+                .or_default();
         }
 
         let saved_package = self.current_package.clone();
@@ -2455,7 +2474,7 @@ impl Interpreter {
                         deprecated_message: None,
                         is_submethod: *is_submethod,
                     };
-                    if let Some(class_def) = self.classes.get_mut(name) {
+                    if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
                         if *multi {
                             class_def
                                 .methods
@@ -2509,7 +2528,7 @@ impl Interpreter {
                     };
                     // Resolve handles before taking mutable borrow on class_def
                     let resolved = self.resolve_handle_specs_to_names(handles, &attr_var_name);
-                    if let Some(class_def) = self.classes.get_mut(name) {
+                    if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
                         class_def.attributes.push((
                             attr_name_str.clone(),
                             *is_public,
@@ -2651,7 +2670,7 @@ impl Interpreter {
             return Ok(());
         }
         // Clean up stale punned class entry for this role name.
-        self.classes.remove(name);
+        self.registry_mut().classes.remove(name);
         self.registry_mut().hidden_classes.remove(name);
         self.registry_mut().class_composed_roles.remove(name);
         // When registering a parametric variant of an existing non-parametric role
@@ -2789,7 +2808,7 @@ impl Interpreter {
                             .push(hidden_name.to_string());
                         continue;
                     }
-                    if self.classes.contains_key(&role_name_str) {
+                    if self.registry().classes.contains_key(&role_name_str) {
                         self.role_parents
                             .entry(name.to_string())
                             .or_default()
@@ -3331,7 +3350,7 @@ impl Interpreter {
         class_name: &str,
         attr_name: &str,
     ) -> Option<String> {
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             for (name, _is_public, _default, _is_rw, _, _, _) in &class_def.attributes {
                 if name == attr_name {
                     return class_def.attribute_types.get(attr_name).cloned();
@@ -3354,7 +3373,7 @@ impl Interpreter {
     /// Auto-pun a role into a class so it can be instantiated (e.g. via COERCE or new).
     /// If the role is already registered as a class, this is a no-op.
     pub(crate) fn ensure_role_punned_to_class(&mut self, role_name: &str) {
-        if self.classes.contains_key(role_name) {
+        if self.registry().classes.contains_key(role_name) {
             return;
         }
         self.clear_private_zeroarg_method_cache();
@@ -3409,7 +3428,9 @@ impl Interpreter {
             alias_attributes: HashSet::new(),
             class_level_attrs: HashMap::new(),
         };
-        self.classes.insert(role_name.to_string(), punned_class);
+        self.registry_mut()
+            .classes
+            .insert(role_name.to_string(), punned_class);
         // Register the role and its composed roles
         self.registry_mut()
             .class_composed_roles

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -530,8 +530,8 @@ impl Interpreter {
     /// Resolve a name to a type object (Package value) if the name refers to a known class or role.
     pub(crate) fn resolve_type_object(&self, name: &str) -> Option<Value> {
         let fq_name = format!("{}::{}", self.current_package, name);
-        if self.classes.contains_key(name)
-            || self.classes.contains_key(fq_name.as_str())
+        if self.registry().classes.contains_key(name)
+            || self.registry().classes.contains_key(fq_name.as_str())
             || self.roles.contains_key(name)
             || self.roles.contains_key(fq_name.as_str())
         {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -28,19 +28,29 @@ use std::collections::{HashMap, HashSet};
 
 use crate::value::{EnumValue, Value};
 
-use super::SubsetDef;
+use super::{ClassDef, SubsetDef};
 
 /// Program declaration registry. See module docs.
 ///
 /// Fields are migrated here group-by-group (PLAN.md PR-A). Fields are
 /// `pub(crate)` so registry-internal runtime code can access them directly;
 /// PR-B adds typed lookup methods for the VM to call.
-#[derive(Debug, Clone, Default)]
+///
+/// Note: no `Debug` derive — `ClassDef` (and its `MethodDef`/AST graph) is not
+/// `Debug`, and nothing needs to format the registry.
+#[derive(Clone, Default)]
 pub(crate) struct Registry {
     /// `enum Name (...)` declarations: enum name -> [(variant name, value)].
     pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
     /// `subset Name of Base where { ... }` declarations.
     pub(crate) subsets: HashMap<String, SubsetDef>,
+
+    /// User/builtin class definitions: class name -> [`ClassDef`] (parents, MRO,
+    /// methods, attributes, ...). Read on hot method-dispatch paths; callers take
+    /// short-lived `registry()` guards and clone the minimal projection they need
+    /// (e.g. `mro.clone()`, `methods.get(name).cloned()`) rather than the whole
+    /// `ClassDef`.
+    pub(crate) classes: HashMap<String, ClassDef>,
 
     // ----- class metadata (PR-A slice 2) -----
     /// Classes declared as a C `union` (native interop helper set).

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -110,7 +110,7 @@ impl Interpreter {
 
     /// Get parent class names without requiring &mut self (no MRO caching).
     pub(crate) fn class_parents_readonly(&self, class_name: &str) -> Vec<String> {
-        if let Some(class_def) = self.classes.get(class_name) {
+        if let Some(class_def) = self.registry().classes.get(class_name) {
             if !class_def.mro.is_empty() {
                 return class_def.mro.clone();
             }
@@ -314,12 +314,17 @@ impl Interpreter {
         // descendants).
         let mut submethod_blocks = false;
         for cn in &mro {
-            if let Some(overloads) = self
+            // Hoist the clone to a `let` so the registry read guard drops here,
+            // before method_args_match_for_invocant re-enters (&mut self). An
+            // `if let` scrutinee would keep the temporary guard alive across the
+            // whole block (edition-2021 temporary scope).
+            let overloads = self
+                .registry()
                 .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
-                .cloned()
-            {
+                .cloned();
+            if let Some(overloads) = overloads {
                 let any_multi = overloads.iter().any(|d| d.is_multi);
                 let mut first_visible_non_multi: Option<MethodDef> = None;
                 // Check if all overloads are submethods on an ancestor class
@@ -570,6 +575,7 @@ impl Interpreter {
             // parent (`class Foo is R1 { ... }`). Role methods are stored in
             // `self.roles`, so fall back there when the entry is not a class.
             let overloads = self
+                .registry()
                 .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
@@ -618,6 +624,7 @@ impl Interpreter {
         for cn in &mro {
             let is_ancestor = cn != class_name;
             if let Some(overloads) = self
+                .registry()
                 .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
@@ -635,7 +642,8 @@ impl Interpreter {
             return Vec::new();
         }
         let any_multi = defining_levels.iter().any(|cn| {
-            self.classes
+            self.registry()
+                .classes
                 .get(cn.as_str())
                 .and_then(|c| c.methods.get(method_name))
                 .is_some_and(|ovs| ovs.iter().any(|d| d.is_multi))
@@ -691,12 +699,14 @@ impl Interpreter {
             if cn != owner_class {
                 continue;
             }
-            if let Some(overloads) = self
+            // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
+            let overloads = self
+                .registry()
                 .classes
                 .get(&cn)
                 .and_then(|c| c.methods.get(method_name))
-                .cloned()
-            {
+                .cloned();
+            if let Some(overloads) = overloads {
                 for def in overloads {
                     if !def.is_private {
                         continue;
@@ -735,8 +745,13 @@ impl Interpreter {
         // overloads vector by scanning with a shared borrow first. This covers
         // the common case of zero-argument private method calls in tight loops.
         if arg_values.is_empty() {
-            for cn in &mro {
-                if let Some(overloads) = self
+            // Scan with a shared registry borrow (avoids cloning the whole
+            // overloads Vec — only the single matched def is cloned), find the
+            // candidate, then drop the guard before mutating the cache.
+            let mut resolved: Option<(String, MethodDef)> = None;
+            'scan: for cn in &mro {
+                let registry = self.registry();
+                if let Some(overloads) = registry
                     .classes
                     .get(cn)
                     .and_then(|c| c.methods.get(method_name))
@@ -754,12 +769,8 @@ impl Interpreter {
                             .iter()
                             .all(|p| p.is_invocant || p.traits.iter().any(|t| t == "invocant"))
                         {
-                            let resolved = Some((cn.clone(), def.clone()));
-                            self.private_zeroarg_method_cache.insert(
-                                (class_name.to_string(), method_name.to_string()),
-                                resolved.clone(),
-                            );
-                            return resolved;
+                            resolved = Some((cn.clone(), def.clone()));
+                            break 'scan;
                         }
                     }
                     // Second pass: include stubs
@@ -772,24 +783,29 @@ impl Interpreter {
                             .iter()
                             .all(|p| p.is_invocant || p.traits.iter().any(|t| t == "invocant"))
                         {
-                            let resolved = Some((cn.clone(), def.clone()));
-                            self.private_zeroarg_method_cache.insert(
-                                (class_name.to_string(), method_name.to_string()),
-                                resolved.clone(),
-                            );
-                            return resolved;
+                            resolved = Some((cn.clone(), def.clone()));
+                            break 'scan;
                         }
                     }
                 }
             }
+            if let Some(resolved) = resolved {
+                self.private_zeroarg_method_cache.insert(
+                    (class_name.to_string(), method_name.to_string()),
+                    Some(resolved.clone()),
+                );
+                return Some(resolved);
+            }
         }
         for cn in mro {
-            if let Some(overloads) = self
+            // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
+            let overloads = self
+                .registry()
                 .classes
                 .get(&cn)
                 .and_then(|c| c.methods.get(method_name))
-                .cloned()
-            {
+                .cloned();
+            if let Some(overloads) = overloads {
                 for def in &overloads {
                     if !def.is_private {
                         continue;
@@ -848,7 +864,7 @@ impl Interpreter {
 
     pub(super) fn class_mro(&mut self, class_name: &str) -> Vec<String> {
         // Built-in type hierarchies for types that are not user-defined classes
-        if !self.classes.contains_key(class_name) {
+        if !self.registry().classes.contains_key(class_name) {
             let builtin_mro: Option<Vec<&str>> = match class_name {
                 "Match" => Some(vec!["Match", "Capture", "Cool", "Any", "Mu"]),
                 "Capture" => Some(vec!["Capture", "Any", "Mu"]),
@@ -887,16 +903,16 @@ impl Interpreter {
                 return mro.into_iter().map(String::from).collect();
             }
         }
-        if !self.classes.contains_key(class_name)
+        if !self.registry().classes.contains_key(class_name)
             && let Some((base, _)) = class_name.split_once('[')
             && class_name.ends_with(']')
-            && self.classes.contains_key(base)
+            && self.registry().classes.contains_key(base)
         {
             let mut mro = vec![class_name.to_string()];
             mro.extend(self.class_mro(base));
             return mro;
         }
-        if let Some(class_def) = self.classes.get(class_name)
+        if let Some(class_def) = self.registry().classes.get(class_name)
             && !class_def.mro.is_empty()
         {
             return class_def.mro.clone();
@@ -904,7 +920,7 @@ impl Interpreter {
         let mut stack = Vec::new();
         match self.compute_class_mro(class_name, &mut stack) {
             Ok(mro) => {
-                if let Some(class_def) = self.classes.get_mut(class_name) {
+                if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
                     class_def.mro = mro.clone();
                 }
                 mro

--- a/src/runtime/seq_helpers/role_type.rs
+++ b/src/runtime/seq_helpers/role_type.rs
@@ -40,7 +40,7 @@ impl Interpreter {
                     return true;
                 }
                 // Check if l_name is a subclass of r_name
-                if let Some(class_def) = self.classes.get(&l_resolved) {
+                if let Some(class_def) = self.registry().classes.get(&l_resolved) {
                     if class_def.parents.iter().any(|p| p == &r_resolved) {
                         return true;
                     }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1236,7 +1236,10 @@ impl Interpreter {
                     // user-defined class that explicitly inherits from Mu only
                     // (e.g., `class Foo is Mu {}`) should NOT match Any.
                     // Check the actual MRO to correct this.
-                    if type_ok && base_type == "Any" && self.classes.contains_key(&*lhs_resolved) {
+                    if type_ok
+                        && base_type == "Any"
+                        && self.registry().classes.contains_key(&*lhs_resolved)
+                    {
                         let mro = self.class_mro(&lhs_resolved);
                         if !mro.iter().any(|c| c == "Any") {
                             type_ok = false;

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -81,7 +81,7 @@ impl Interpreter {
     pub(super) fn inject_eval_methods_into_class(&mut self, stmts: Vec<Stmt>) -> Vec<Stmt> {
         // Only applies when current_package is a class being defined
         let class_name = self.current_package.clone();
-        if !self.classes.contains_key(&class_name) {
+        if !self.registry().classes.contains_key(&class_name) {
             return stmts;
         }
         let mut remaining = Vec::new();
@@ -124,7 +124,7 @@ impl Interpreter {
                     deprecated_message: deprecated_message.clone(),
                     is_submethod: false,
                 };
-                if let Some(class_def) = self.classes.get_mut(&class_name) {
+                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     if *multi {
                         class_def
                             .methods
@@ -832,7 +832,7 @@ impl Interpreter {
         let role_type_params_snapshot = self.role_type_params.clone();
         let role_parents_snapshot = self.role_parents.clone();
         let role_hides_snapshot = self.role_hides.clone();
-        let classes_snapshot = self.classes.clone();
+        let classes_snapshot = self.registry().classes.clone();
         let hidden_classes_snapshot = self.registry().hidden_classes.clone();
         let hidden_defer_parents_snapshot = self.registry().hidden_defer_parents.clone();
         let class_composed_roles_snapshot = self.registry().class_composed_roles.clone();
@@ -946,7 +946,7 @@ impl Interpreter {
         let current_role_type_params = self.role_type_params.clone();
         let current_role_parents = self.role_parents.clone();
         let current_role_hides = self.role_hides.clone();
-        let current_classes = self.classes.clone();
+        let current_classes = self.registry().classes.clone();
         let current_hidden_classes = self.registry().hidden_classes.clone();
         let current_hidden_defer_parents = self.registry().hidden_defer_parents.clone();
         let current_class_composed_roles = self.registry().class_composed_roles.clone();
@@ -955,7 +955,7 @@ impl Interpreter {
         let current_type_keys: std::collections::HashSet<String> = self
             .roles
             .keys()
-            .chain(self.classes.keys())
+            .chain(self.registry().classes.keys())
             .cloned()
             .collect();
         let snapshot_type_keys: std::collections::HashSet<String> = roles_snapshot
@@ -969,7 +969,7 @@ impl Interpreter {
         self.role_type_params = role_type_params_snapshot;
         self.role_parents = role_parents_snapshot;
         self.role_hides = role_hides_snapshot;
-        self.classes = classes_snapshot;
+        self.registry_mut().classes = classes_snapshot;
         self.registry_mut().hidden_classes = hidden_classes_snapshot;
         self.registry_mut().hidden_defer_parents = hidden_defer_parents_snapshot;
         self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
@@ -981,7 +981,7 @@ impl Interpreter {
         self.role_type_params.extend(current_role_type_params);
         self.role_parents.extend(current_role_parents);
         self.role_hides.extend(current_role_hides);
-        self.classes.extend(current_classes);
+        self.registry_mut().classes.extend(current_classes);
         self.registry_mut()
             .hidden_classes
             .extend(current_hidden_classes);

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -181,7 +181,7 @@ impl Interpreter {
         }
         nested.lib_paths = self.lib_paths.clone();
         nested.program_path = self.program_path.clone();
-        nested.classes = self.classes.clone();
+        nested.registry_mut().classes = self.registry().classes.clone();
         nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
         nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
         nested.roles = self.roles.clone();
@@ -280,7 +280,7 @@ impl Interpreter {
         }
         nested.lib_paths = self.lib_paths.clone();
         nested.program_path = self.program_path.clone();
-        nested.classes = self.classes.clone();
+        nested.registry_mut().classes = self.registry().classes.clone();
         nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
         nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
         nested.roles = self.roles.clone();

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -56,7 +56,7 @@ impl Interpreter {
                 nested.token_defs = self.token_defs.clone();
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
-                nested.classes = self.classes.clone();
+                nested.registry_mut().classes = self.registry().classes.clone();
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =
                     self.registry().class_composed_roles.clone();

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -13,7 +13,7 @@ use super::*;
 impl Interpreter {
     pub(crate) fn sync_eval_definition_state(&mut self, nested: &Interpreter) {
         self.type_metadata = nested.type_metadata.clone();
-        self.classes = nested.classes.clone();
+        self.registry_mut().classes = nested.registry().classes.clone();
         // self and nested are distinct Interpreters with distinct registry Arcs,
         // so taking self's write lock and nested's read lock in one statement is
         // deadlock-free (matches the slice-1 `subsets` line below).

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -46,7 +46,7 @@ impl Interpreter {
         let saved_token_defs = self.token_defs.clone();
         let saved_proto_subs = self.proto_subs.clone();
         let saved_proto_tokens = self.proto_tokens.clone();
-        let saved_classes = self.classes.clone();
+        let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.registry().subsets.clone();
@@ -69,7 +69,7 @@ impl Interpreter {
             self.token_defs = saved_token_defs;
             self.proto_subs = saved_proto_subs;
             self.proto_tokens = saved_proto_tokens;
-            self.classes = saved_classes;
+            self.registry_mut().classes = saved_classes;
             self.registry_mut().class_trusts = saved_class_trusts;
             self.roles = saved_roles;
             self.registry_mut().subsets = saved_subsets;
@@ -97,7 +97,7 @@ impl Interpreter {
         self.token_defs = saved_token_defs;
         self.proto_subs = saved_proto_subs;
         self.proto_tokens = saved_proto_tokens;
-        self.classes = saved_classes;
+        self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;
@@ -144,7 +144,7 @@ impl Interpreter {
         let saved_token_defs = self.token_defs.clone();
         let saved_proto_subs = self.proto_subs.clone();
         let saved_proto_tokens = self.proto_tokens.clone();
-        let saved_classes = self.classes.clone();
+        let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.roles.clone();
         let saved_subsets = self.registry().subsets.clone();
@@ -158,7 +158,7 @@ impl Interpreter {
         self.token_defs = saved_token_defs;
         self.proto_subs = saved_proto_subs;
         self.proto_tokens = saved_proto_tokens;
-        self.classes = saved_classes;
+        self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
         self.roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -32,7 +32,7 @@ impl Interpreter {
                 nested.token_defs = self.token_defs.clone();
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
-                nested.classes = self.classes.clone();
+                nested.registry_mut().classes = self.registry().classes.clone();
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =
                     self.registry().class_composed_roles.clone();
@@ -159,12 +159,12 @@ impl Interpreter {
                     cls == expected_normalized
                         || cls.starts_with(&format!("{}::", expected_normalized))
                         // Check MRO: the exception's class hierarchy may include the expected type
-                        || self.classes.get(cls).is_some_and(|def| {
+                        || self.registry().classes.get(cls).is_some_and(|def| {
                             def.mro.iter().any(|parent| parent == expected_normalized)
                         })
                         // X::Comp::Group wraps compile-time errors: match any X::Comp subtype
                         || (expected_normalized == "X::Comp::Group"
-                            && self.classes.get(cls).is_some_and(|def| {
+                            && self.registry().classes.get(cls).is_some_and(|def| {
                                 def.mro.iter().any(|p| p == "X::Comp")
                             }))
                         // X::AdHoc wrapping a die'd string that encodes a type name
@@ -367,7 +367,7 @@ impl Interpreter {
                 nested.token_defs = self.token_defs.clone();
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
-                nested.classes = self.classes.clone();
+                nested.registry_mut().classes = self.registry().classes.clone();
                 nested.roles = self.roles.clone();
                 nested.registry_mut().subsets = self.registry().subsets.clone();
                 nested.registry_mut().enum_types = self.registry().enum_types.clone();
@@ -418,35 +418,35 @@ impl Interpreter {
         };
 
         // Check if the exception matches any of the provided types
-        let type_ok = match &result {
-            Ok(_) => false,
-            Err(err) => {
-                let ex_class = err.exception.as_ref().and_then(|ex| {
-                    if let Value::Instance { class_name, .. } = ex.as_ref() {
-                        Some(class_name.resolve().to_string())
-                    } else {
-                        None
-                    }
-                });
-                type_names.iter().any(|expected: &String| -> bool {
-                    if expected.is_empty() || expected == "Exception" {
-                        return true;
-                    }
-                    if let Some(cls) = &ex_class
-                        && (cls == expected
-                            || cls.starts_with(&format!("{}::", expected))
-                            || self
-                                .classes
-                                .get(cls)
-                                .is_some_and(|def| def.mro.iter().any(|parent| parent == expected)))
-                    {
-                        return true;
-                    }
-                    // Fallback: message-based matching
-                    err.message.contains(expected.as_str())
-                })
-            }
-        };
+        let type_ok =
+            match &result {
+                Ok(_) => false,
+                Err(err) => {
+                    let ex_class = err.exception.as_ref().and_then(|ex| {
+                        if let Value::Instance { class_name, .. } = ex.as_ref() {
+                            Some(class_name.resolve().to_string())
+                        } else {
+                            None
+                        }
+                    });
+                    type_names.iter().any(|expected: &String| -> bool {
+                        if expected.is_empty() || expected == "Exception" {
+                            return true;
+                        }
+                        if let Some(cls) = &ex_class
+                            && (cls == expected
+                                || cls.starts_with(&format!("{}::", expected))
+                                || self.registry().classes.get(cls).is_some_and(|def| {
+                                    def.mro.iter().any(|parent| parent == expected)
+                                }))
+                        {
+                            return true;
+                        }
+                        // Fallback: message-based matching
+                        err.message.contains(expected.as_str())
+                    })
+                }
+            };
 
         let type_display = type_names.join(", ");
 

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -219,7 +219,7 @@ impl Interpreter {
             }
             return Err(coerce_impossible_error(target, &value));
         }
-        if self.classes.contains_key(base_target) {
+        if self.registry().classes.contains_key(base_target) {
             // Wrap Pair values in a Scalar container so they are passed as
             // positional arguments to COERCE/new rather than being flattened
             // into named arguments by the method dispatch logic.

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -261,7 +261,7 @@ impl Interpreter {
             if Self::type_matches(type_name, package_base) {
                 return true;
             }
-            if let Some(class_def) = self.classes.get(package_base) {
+            if let Some(class_def) = self.registry().classes.get(package_base) {
                 return class_def
                     .parents
                     .clone()
@@ -799,7 +799,7 @@ impl Interpreter {
                 }
             }
             // Check parent classes of the instance
-            if let Some(class_def) = self.classes.get(&class_name.resolve()) {
+            if let Some(class_def) = self.registry().classes.get(&class_name.resolve()) {
                 for parent in class_def.parents.clone() {
                     if Self::type_matches(constraint, &parent) {
                         return true;

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -225,12 +225,12 @@ impl Interpreter {
 
     /// Check if a type name is known (either a class, role, or enum).
     pub(crate) fn has_type(&self, name: &str) -> bool {
-        self.classes.contains_key(name)
+        self.registry().classes.contains_key(name)
             || self.roles.contains_key(name)
             || self.registry().enum_types.contains_key(name)
             || self.registry().subsets.contains_key(name)
             || Self::parse_parametric_type_name(name).is_some_and(|(base, _)| {
-                self.classes.contains_key(&base)
+                self.registry().classes.contains_key(&base)
                     || self.roles.contains_key(&base)
                     || self.registry().enum_types.contains_key(&base)
                     || self.registry().subsets.contains_key(&base)


### PR DESCRIPTION
## Summary

Continues the **phase ② registry VM-ownership** migration (PLAN.md ②, design: `docs/vm-registry-ownership.md`). After slices 1 (#2760, enum/subset + mechanism) and 2 (#2762, class metadata), this slice moves the big one: `classes: HashMap<String, ClassDef>` off the `Interpreter` struct into the shared `Arc<RwLock<Registry>>`.

Behavior-preserving structural refactor — CI (`make test` + `make roast`) is the safety net.

## The perf-sensitive slice (avoiding the #2746 regression)

`ClassDef` is large (`methods: HashMap<String, Vec<MethodDef>>` dominates) and `classes` is read on hot method-dispatch paths. The earlier attempt regressed by cloning whole `ClassDef`s. **This slice does not.** Every hot path keeps its existing *targeted projection* clone and merely routes the read through a short-lived `registry()` guard:

- `resolve_method_with_owner_impl` → `methods.get(name).cloned()` (one overload Vec, as before)
- `class_mro` / `compute_class_mro` → `mro.clone()` (a `Vec<String>`, as before)

A **release** microbenchmark (pathological pure method dispatch, 300k iters): ~8.4s main → ~8.5–8.7s branch = **~2–4%**. That is pure transitional RwLock-acquisition cost — well under 1% on real workloads, and it vanishes when the Interpreter is removed and the registry collapses to a plain VM field (PLAN.md ④/⑤).

## Changes

- `ClassDef` made `pub(crate)`; `Registry` drops its `Debug` derive (the `ClassDef`/`MethodDef`/AST graph isn't `Debug`, and nothing formats the registry).
- Built-in classes seed `Registry { classes, ..default() }` in `Interpreter::new`; `clone_for_thread` drops `classes.clone()` (subsumed by the whole-`Registry` snapshot clone — per-thread independent `Arc` preserved).
- ~178 access sites routed through `registry()` (reads) / `registry_mut()` (writes).

## Re-entrancy safety

- **No cross-thread lock sharing**: `clone_for_thread` gives each thread its own registry `Arc`, so same-thread recursive reads on the futex `RwLock` can't deadlock against another thread's writer. The real hazard — a read guard held across a **same-lock write** (read→write upgrade) — is absent (verified: writes target a distinct `nested` interpreter or run after the guard drops).
- All `&mut self` re-entries while a read guard was live — including the **edition-2021 `if let` temporary-scope trap** — are fixed by hoisting the clone to a preceding `let` or cloning out: multi/private method dispatch (`resolution.rs`), BUILD container-type registration (`methods_object.rs`), and the private-zeroarg fast-path cache write (now after the scan guard drops).
- Every `get_mut` body was audited to not re-enter the registry.

## Verification

- `cargo build` + `cargo clippy -D warnings` green.
- `make test` green (458 cargo unit tests, prove `t/`).
- All 115 whitelisted `S12-*`/`S14-*` (class/role) roast tests pass (2246 subtests). The handful of non-whitelisted failures (`trusts.t` 4-9, `qualified.t` 6, `subtypes.t`, …) are pre-existing private-method / subset gaps, unchanged by this refactor.
- OOP smoke test: inheritance + MRO + `A::m` requalified calls, multi-dispatch, roles, private attrs/methods, `is default`, MOP, enums, 1000-iteration hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)