### PR TITLE
refactor(vm): migrate roles group into shared Registry (phase ② PR-A slice 4)

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -105,7 +105,21 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   edition-2021 の `if let` 一時値スコープ罠を含め全て `let` 巻き上げ／clone-out で解消（resolution.rs の
   multi/private dispatch、methods_object の BUILD、private-zeroarg fast-path の cache 書き込みを guard 外へ）。
   全 `get_mut` ボディは registry 非再入を確認。build/clippy/make test 緑。
-- 残（フィールド別 total/writes）: roles(110)/role_parents(45)/role_candidates(21)、functions(96)/token_defs(35)。
+- **PR-A slice 4（本 PR, #2763 後）**: roles 群 7 フィールド移行（roles, user_declared_roles, role_candidates,
+  role_parents, role_hides, role_type_params, class_role_param_bindings、~200 サイト）。`RoleCandidateDef` を
+  `pub(crate)` 化（`RoleDef` は既に Debug/Clone/pub(crate)）。builtin roles seed は `Interpreter::new` の
+  registry ブロックで `registry.roles = {..}` に投入、`clone_for_thread` の 7 個別 clone 削除。**参照返却アクセサ
+  2 本**（`get_role_def -> Option<&RoleDef>`、`class_role_param_bindings -> Option<&HashMap>`）を owned 返しへ。
+  VM 側は両アクセサ経由のみ（`.is_some()`/`.map()` なので呼び出し側不変）。再入安全化: ① **read→write 同一ロック
+  deadlock を 2 件発見・修正**（registration_class.rs の role hidden フラグ→hidden_classes、role_hides→
+  hidden_defer_parents。read ガード保持中に `registry_mut()` を呼ぶ＝借用チェッカ未捕捉のデッドロック）。
+  Python ブレース対応スキャナで全 registry フィールドの read-get ボディ内 `registry_mut` を網羅検査し 0 を確認。
+  ② `&mut self` 再入を跨ぐ read ガード（`if let` scrutinee は本クレート edition2024 でもボディ全体で生存）を
+  clone-out/`let` 巻き上げで解消（methods.rs role 型punning、methods_object の new() role bindings、smart_match の
+  parametric parents、resolution の class+role メソッド表 or_else 単一ガード化）。③ 一文 2 read ガード
+  （`classes.contains_key || roles.contains_key` 3 箇所）を単一束縛ガードへ。build/clippy/make test 緑。
+  挙動不変確認（ロール合成/継承/パラメタ化/punning/conflict/`but`; Stack配列属性の Nil は main と同一の既存ギャップ）。
+- 残（フィールド別 total/writes）: functions(96)/token_defs(35)/proto_*。
 
 ## 完了の定義（②）
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -718,7 +718,7 @@ impl Interpreter {
     }
 
     pub(crate) fn is_role(&self, name: &str) -> bool {
-        self.roles.contains_key(name)
+        self.registry().roles.contains_key(name)
     }
 
     pub(crate) fn push_method_class(&mut self, class_name: String) {
@@ -897,15 +897,18 @@ impl Interpreter {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn get_role_def(&self, role_name: &str) -> Option<&super::RoleDef> {
-        self.roles.get(role_name)
+    pub(crate) fn get_role_def(&self, role_name: &str) -> Option<super::RoleDef> {
+        self.registry().roles.get(role_name).cloned()
     }
 
     pub(crate) fn class_role_param_bindings(
         &self,
         class_name: &str,
-    ) -> Option<&HashMap<String, Value>> {
-        self.class_role_param_bindings.get(class_name)
+    ) -> Option<HashMap<String, Value>> {
+        self.registry()
+            .class_role_param_bindings
+            .get(class_name)
+            .cloned()
     }
 
     /// Compile all uncompiled method bodies in a method map.
@@ -999,7 +1002,7 @@ impl Interpreter {
 
     /// Compile method bodies for a given role.
     pub(crate) fn compile_role_methods(&mut self, role_name: &str) {
-        if let Some(role_def) = self.roles.get_mut(role_name) {
+        if let Some(role_def) = self.registry_mut().roles.get_mut(role_name) {
             let attr_names: Vec<String> = role_def.attributes.iter().map(|a| a.0.clone()).collect();
             Self::compile_methods_for_map(&mut role_def.methods, role_name, &attr_names);
         }
@@ -1887,7 +1890,7 @@ impl Interpreter {
                 )))
             });
         }
-        for role_name in self.roles.keys() {
+        for role_name in self.registry().roles.keys() {
             // Skip roles hidden from package stash lookups (transitive deps)
             if package_name != "MY"
                 && package_name != "GLOBAL"

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -258,7 +258,7 @@ impl Interpreter {
             && (self.has_type(name)
                 || crate::runtime::utils::is_known_type_constraint(name)
                 || self.registry().subsets.contains_key(name)
-                || self.roles.contains_key(name))
+                || self.registry().roles.contains_key(name))
         {
             let source = match &args[0] {
                 Value::Package(sym) => Some(sym.resolve()),
@@ -773,7 +773,7 @@ impl Interpreter {
             && (self.has_type(name)
                 || crate::runtime::utils::is_known_type_constraint(name)
                 || self.registry().subsets.contains_key(name)
-                || self.roles.contains_key(name))
+                || self.registry().roles.contains_key(name))
         {
             return Ok(Value::Package(Symbol::intern(&format!("{name}(Any)"))));
         }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -35,7 +35,7 @@ impl Interpreter {
             // Walk the MRO; submethods are per-class, not inherited.
             for mro_class in &mro {
                 // Skip role entries in MRO
-                if self.roles.contains_key(mro_class)
+                if self.registry().roles.contains_key(mro_class)
                     && !self.registry().classes.contains_key(mro_class)
                 {
                     continue;
@@ -696,23 +696,24 @@ impl Interpreter {
         role_name: &str,
     ) -> Vec<ClassAttributeDef> {
         let mut attrs: Vec<ClassAttributeDef> = Vec::new();
-        if let Some(role) = self.roles.get(role_name) {
+        if let Some(role) = self.registry().roles.get(role_name) {
             attrs.extend(role.attributes.clone());
         }
-        if let Some(parent_names) = self.role_parents.get(role_name) {
+        if let Some(parent_names) = self.registry().role_parents.get(role_name) {
             let mut role_stack: Vec<String> = parent_names.clone();
             let mut visited = vec![role_name.to_string()];
             while let Some(parent_role_name) = role_stack.pop() {
                 if !visited.contains(&parent_role_name) {
                     visited.push(parent_role_name.clone());
-                    if let Some(parent_role) = self.roles.get(&parent_role_name) {
+                    if let Some(parent_role) = self.registry().roles.get(&parent_role_name) {
                         for attr in &parent_role.attributes {
                             if !attrs.iter().any(|a| a.0 == attr.0) {
                                 attrs.push(attr.clone());
                             }
                         }
                     }
-                    if let Some(grandparents) = self.role_parents.get(&parent_role_name) {
+                    if let Some(grandparents) = self.registry().role_parents.get(&parent_role_name)
+                    {
                         for gp in grandparents {
                             if !visited.contains(gp) {
                                 role_stack.push(gp.clone());
@@ -1090,7 +1091,7 @@ impl Interpreter {
         let saved_var_bindings = self.var_bindings.clone();
         let saved_readonly = self.save_readonly_vars();
         self.method_class_stack.push(owner_class.to_string());
-        let role_context = if self.roles.contains_key(owner_class) {
+        let role_context = if self.registry().roles.contains_key(owner_class) {
             Some(owner_class.to_string())
         } else {
             method_def.role_origin.clone()
@@ -1117,13 +1118,18 @@ impl Interpreter {
         // will set $_ back to self if the invocant param is named "_".
         self.env
             .insert("_".to_string(), Value::Package(Symbol::intern("Any")));
-        if let Some(role_bindings) = self.class_role_param_bindings.get(owner_class) {
-            for (name, value) in role_bindings {
-                self.env.insert(name.clone(), value.clone());
-            }
-        } else if let Some(role_bindings) = self.class_role_param_bindings.get(receiver_class_name)
-        {
-            for (name, value) in role_bindings {
+        // Clone the bindings out under a single guard, then write env (the guard
+        // borrows *self, so it must drop before mutating self.env).
+        let role_bindings = {
+            let registry = self.registry();
+            registry
+                .class_role_param_bindings
+                .get(owner_class)
+                .or_else(|| registry.class_role_param_bindings.get(receiver_class_name))
+                .cloned()
+        };
+        if let Some(role_bindings) = role_bindings {
+            for (name, value) in &role_bindings {
                 self.env.insert(name.clone(), value.clone());
             }
         }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2424,15 +2424,21 @@ impl Interpreter {
 
         // Role type-object method punning
         if method != "new" {
-            if let Value::Package(role_name) = &target
-                && let Some(role) = self.roles.get(&role_name.resolve())
-            {
-                let is_public_attr_accessor = args.is_empty()
-                    && role
-                        .attributes
-                        .iter()
-                        .any(|(attr_name, is_public, ..)| *is_public && attr_name == method);
-                if role.methods.contains_key(method) || is_public_attr_accessor {
+            if let Value::Package(role_name) = &target {
+                // Decide under the guard, then drop it before re-entering.
+                let should_dispatch = self
+                    .registry()
+                    .roles
+                    .get(&role_name.resolve())
+                    .map(|role| {
+                        let is_public_attr_accessor = args.is_empty()
+                            && role.attributes.iter().any(|(attr_name, is_public, ..)| {
+                                *is_public && attr_name == method
+                            });
+                        role.methods.contains_key(method) || is_public_attr_accessor
+                    })
+                    .unwrap_or(false);
+                if should_dispatch {
                     let instance = self.dispatch_new(target.clone(), Vec::new())?;
                     return self.call_method_with_values(instance, method, args);
                 }

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -58,7 +58,7 @@ impl Interpreter {
             ));
         }
         // Check role methods
-        if let Some(role_def) = self.roles.get(&class_name_str)
+        if let Some(role_def) = self.registry().roles.get(&class_name_str)
             && let Some(defs) = role_def.methods.get(method_name)
             && let Some(def) = defs.first()
         {
@@ -454,7 +454,7 @@ impl Interpreter {
                 let mut attrs = HashMap::new();
                 attrs.insert(
                     "composable".to_string(),
-                    Value::Bool(self.roles.contains_key(base_name)),
+                    Value::Bool(self.registry().roles.contains_key(base_name)),
                 );
                 Ok(Value::make_instance(
                     Symbol::intern("Perl6::Metamodel::Archetypes"),
@@ -814,7 +814,7 @@ impl Interpreter {
                         .trim_end_matches(')')
                         .to_string(),
                 };
-                if let Some(candidates) = self.role_candidates.get(&base_name) {
+                if let Some(candidates) = self.registry().role_candidates.get(&base_name) {
                     let values = candidates
                         .iter()
                         .enumerate()
@@ -846,7 +846,7 @@ impl Interpreter {
                         .collect::<Vec<_>>();
                     return Ok(Value::array(values));
                 }
-                if self.roles.contains_key(&base_name) {
+                if self.registry().roles.contains_key(&base_name) {
                     return Ok(Value::array(vec![Value::Package(Symbol::intern(
                         &base_name,
                     ))]));
@@ -928,7 +928,7 @@ impl Interpreter {
                 };
                 if let Some(result) = check_transitive(
                     &self.registry().class_composed_roles,
-                    &self.role_parents,
+                    &self.registry().role_parents,
                     &class_name,
                 ) {
                     return Ok(result);
@@ -938,7 +938,7 @@ impl Interpreter {
                     for cn in &mro[1..] {
                         if let Some(result) = check_transitive(
                             &self.registry().class_composed_roles,
-                            &self.role_parents,
+                            &self.registry().role_parents,
                             cn,
                         ) {
                             return Ok(result);
@@ -1128,7 +1128,7 @@ impl Interpreter {
                 .split_once('[')
                 .map(|(b, _)| b)
                 .unwrap_or(entry.as_str());
-            if self.roles.contains_key(base_entry)
+            if self.registry().roles.contains_key(base_entry)
                 && entry != "Any"
                 && entry != "Mu"
                 && entry != &class_name
@@ -1180,13 +1180,13 @@ impl Interpreter {
         result: &mut Vec<Value>,
         seen: &mut HashSet<String>,
     ) {
-        if let Some(parents) = self.role_parents.get(role_name) {
+        if let Some(parents) = self.registry().role_parents.get(role_name) {
             for parent in parents {
                 let base = parent
                     .split_once('[')
                     .map(|(b, _)| b)
                     .unwrap_or(parent.as_str());
-                if self.roles.contains_key(base) && seen.insert(base.to_string()) {
+                if self.registry().roles.contains_key(base) && seen.insert(base.to_string()) {
                     result.push(Value::Package(Symbol::intern(base)));
                     self.add_role_parents_to_mro(base, _base_mro, result, seen);
                 }
@@ -1266,13 +1266,13 @@ impl Interpreter {
     }
 
     pub(super) fn collect_hidden_roles(&self, role_name: &str, to_hide: &mut HashSet<String>) {
-        if let Some(parents) = self.role_parents.get(role_name) {
+        if let Some(parents) = self.registry().role_parents.get(role_name) {
             for parent in parents {
                 let base = parent
                     .split_once('[')
                     .map(|(b, _)| b)
                     .unwrap_or(parent.as_str());
-                if self.roles.contains_key(base) && to_hide.insert(base.to_string()) {
+                if self.registry().roles.contains_key(base) && to_hide.insert(base.to_string()) {
                     self.collect_hidden_roles(base, to_hide);
                 }
             }
@@ -1794,7 +1794,7 @@ impl Interpreter {
         include_private: bool,
         result: &mut Vec<Value>,
     ) {
-        if let Some(role_def) = self.roles.get(role_name) {
+        if let Some(role_def) = self.registry().roles.get(role_name) {
             // Add accessor methods for public attributes
             for (attr_name, is_public, ..) in &role_def.attributes {
                 if *is_public && !role_def.methods.contains_key(attr_name) {
@@ -2433,7 +2433,7 @@ impl Interpreter {
     ) -> Vec<String> {
         // If the target is a role (not a class), return its role_parents.
         // For instances (punned roles), include the role itself in the list.
-        let is_role = self.roles.contains_key(class_name)
+        let is_role = self.registry().roles.contains_key(class_name)
             && !self.registry().classes.contains_key(class_name);
         if is_role {
             let mut result = Vec::new();
@@ -2442,12 +2442,13 @@ impl Interpreter {
                 result.push(class_name.to_string());
             }
             if non_transitive {
-                if !is_instance && let Some(parents) = self.role_parents.get(class_name) {
+                if !is_instance && let Some(parents) = self.registry().role_parents.get(class_name)
+                {
                     result.extend(parents.clone());
                 }
                 return result;
             }
-            if let Some(parents) = self.role_parents.get(class_name) {
+            if let Some(parents) = self.registry().role_parents.get(class_name) {
                 let mut seen: std::collections::HashSet<String> = result.iter().cloned().collect();
                 for p in parents {
                     if seen.insert(p.clone()) {
@@ -2479,7 +2480,7 @@ impl Interpreter {
                 let mut transitive = std::collections::HashSet::new();
                 for r in &all {
                     let base = r.split_once('[').map(|(b, _)| b).unwrap_or(r.as_str());
-                    if let Some(parents) = self.role_parents.get(base) {
+                    if let Some(parents) = self.registry().role_parents.get(base) {
                         for p in parents {
                             transitive.insert(p.clone());
                             self.collect_transitive_set(p, &mut transitive);
@@ -2527,7 +2528,7 @@ impl Interpreter {
             .split_once('[')
             .map(|(b, _)| b)
             .unwrap_or(role_name);
-        if let Some(parents) = self.role_parents.get(base) {
+        if let Some(parents) = self.registry().role_parents.get(base) {
             for p in parents {
                 if result.insert(p.clone()) {
                     self.collect_transitive_set(p, result);
@@ -2546,7 +2547,7 @@ impl Interpreter {
             .split_once('[')
             .map(|(b, _)| b)
             .unwrap_or(role_name);
-        if let Some(parents) = self.role_parents.get(base) {
+        if let Some(parents) = self.registry().role_parents.get(base) {
             for p in parents {
                 if seen.insert(p.clone()) {
                     result.push(p.clone());

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -359,7 +359,7 @@ impl Interpreter {
                 continue;
             }
             // Skip role entries in MRO
-            if self.roles.contains_key(mro_class)
+            if self.registry().roles.contains_key(mro_class)
                 && !self.registry().classes.contains_key(mro_class)
             {
                 continue;
@@ -436,7 +436,7 @@ impl Interpreter {
                 continue;
             }
             // Skip role entries in MRO
-            if self.roles.contains_key(mro_class)
+            if self.registry().roles.contains_key(mro_class)
                 && !self.registry().classes.contains_key(mro_class)
             {
                 continue;

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -652,7 +652,8 @@ impl Interpreter {
         // registers so we can keep them invisible to `::()` until merged.
         let class_before: std::collections::HashSet<String> =
             self.registry().classes.keys().cloned().collect();
-        let role_before: std::collections::HashSet<String> = self.roles.keys().cloned().collect();
+        let role_before: std::collections::HashSet<String> =
+            self.registry().roles.keys().cloned().collect();
         if source_path.exists() {
             let saved = self.precomp_enabled;
             self.precomp_enabled = false;
@@ -668,7 +669,7 @@ impl Interpreter {
                 new_symbols.push(k.clone());
             }
         }
-        for k in self.roles.keys() {
+        for k in self.registry().roles.keys() {
             if !role_before.contains(k) {
                 new_symbols.push(k.clone());
             }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -628,7 +628,7 @@ impl Interpreter {
                 // isa only matches classes, not roles. If the target is a role
                 // that has NOT been punned to a class, return False (use .does
                 // for role checking).
-                if self.roles.contains_key(&target_name)
+                if self.registry().roles.contains_key(&target_name)
                     && !self.registry().classes.contains_key(&target_name)
                 {
                     return Ok(Value::Bool(false));
@@ -1266,7 +1266,7 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(name) = type_obj_name {
-                    if !self.roles.contains_key(&name) {
+                    if !self.registry().roles.contains_key(&name) {
                         return Err(RuntimeError::new(format!(
                             "X::Method::NotFound: Unknown method value dispatch (fallback disabled): {}",
                             method
@@ -1409,7 +1409,7 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(name) = num_name {
-                    if self.roles.contains_key(&name) {
+                    if self.registry().roles.contains_key(&name) {
                         Ok(Value::Int(0))
                     } else {
                         Err(RuntimeError::new(format!(

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -266,7 +266,7 @@ impl Interpreter {
             }
         };
         // Use appropriate HOW metaclass for each type kind
-        let how_name = if self.roles.contains_key(&type_name) && !type_name.contains('[')
+        let how_name = if self.registry().roles.contains_key(&type_name) && !type_name.contains('[')
             || matches!(
                 type_name.as_str(),
                 "Numeric"

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -28,7 +28,8 @@ impl Interpreter {
                     .keys()
                     .filter_map(|k| k.strip_prefix("__mutsu_role__"))
                     .any(|role_name| {
-                        self.roles
+                        self.registry()
+                            .roles
                             .get(role_name)
                             .is_some_and(|role| role.methods.contains_key(method))
                     });
@@ -37,7 +38,7 @@ impl Interpreter {
                         .keys()
                         .filter_map(|k| k.strip_prefix("__mutsu_role__"))
                         .any(|role_name| {
-                            self.roles.get(role_name).is_some_and(|role| {
+                            self.registry().roles.get(role_name).is_some_and(|role| {
                                 role.attributes
                                     .iter()
                                     .any(|(name, is_pub, ..)| name == method && *is_pub)
@@ -186,7 +187,7 @@ impl Interpreter {
                 key.strip_prefix("__mutsu_role__")
                     .map(|name| name.to_string())
             }) {
-                if let Some(role) = self.roles.get(&role_name)
+                if let Some(role) = self.registry().roles.get(&role_name)
                     && let Some(defs) = role.methods.get(&method_name)
                 {
                     for def in defs {

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -197,7 +197,7 @@ impl Interpreter {
             let Some(role_name) = key.strip_prefix("__mutsu_role__") else {
                 continue;
             };
-            if let Some(role) = self.roles.get(role_name)
+            if let Some(role) = self.registry().roles.get(role_name)
                 && role.methods.contains_key(method)
             {
                 return true;

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -240,14 +240,18 @@ impl Interpreter {
         {
             let base_name_str = base_name.resolve();
             self.ensure_role_punned_to_class(&base_name_str);
-            let mut selected_role = self.roles.get(&base_name_str).cloned();
+            let mut selected_role = self.registry().roles.get(&base_name_str).cloned();
             let mut matched_lang_version: Option<String> = None;
             let mut selected_param_names = self
+                .registry()
                 .role_type_params
                 .get(&base_name_str)
                 .cloned()
                 .unwrap_or_default();
-            if let Some(candidates) = self.role_candidates.get(&base_name_str).cloned() {
+            // Hoist clone to a `let` so the guard drops before the filter_map
+            // closure re-enters (&mut self).
+            let candidates = self.registry().role_candidates.get(&base_name_str).cloned();
+            if let Some(candidates) = candidates {
                 let mut matching: Vec<(super::RoleCandidateDef, i32, usize)> = candidates
                     .into_iter()
                     .enumerate()
@@ -2612,7 +2616,10 @@ impl Interpreter {
                     return Ok(result);
                 }
             }
-            if let Some(role) = self.roles.get(&class_name.resolve()).cloned() {
+            // Hoist clone to a `let` so the guard drops before the body re-enters
+            // (eval_block_value for attribute defaults).
+            let role = self.registry().roles.get(&class_name.resolve()).cloned();
+            if let Some(role) = role {
                 // Check for attribute conflicts detected during role composition
                 if let Some((attr_name, role_a, role_b)) = role.attribute_conflicts.first() {
                     return Err(RuntimeError::new(format!(
@@ -2635,13 +2642,20 @@ impl Interpreter {
 
                 // Collect attributes from this role and all composed parent roles
                 let mut all_attributes = role.attributes.clone();
-                if let Some(parent_names) = self.role_parents.get(&class_name.resolve()).cloned() {
+                if let Some(parent_names) = self
+                    .registry()
+                    .role_parents
+                    .get(&class_name.resolve())
+                    .cloned()
+                {
                     let mut role_stack: Vec<String> = parent_names;
                     let mut visited = vec![class_name.resolve()];
                     while let Some(parent_role_name) = role_stack.pop() {
                         if !visited.contains(&parent_role_name) {
                             visited.push(parent_role_name.clone());
-                            if let Some(parent_role) = self.roles.get(&parent_role_name).cloned() {
+                            if let Some(parent_role) =
+                                self.registry().roles.get(&parent_role_name).cloned()
+                            {
                                 for attr in &parent_role.attributes {
                                     if !all_attributes.iter().any(|a| a.0 == attr.0) {
                                         all_attributes.push(attr.clone());
@@ -2649,7 +2663,7 @@ impl Interpreter {
                                 }
                             }
                             if let Some(grandparents) =
-                                self.role_parents.get(&parent_role_name).cloned()
+                                self.registry().role_parents.get(&parent_role_name).cloned()
                             {
                                 for gp_name in &grandparents {
                                     if !visited.contains(gp_name) {
@@ -2682,6 +2696,7 @@ impl Interpreter {
                 // returns the correct value for this role's origin module.
                 let cn_str = class_name.resolve();
                 let bare_lang_ver = self
+                    .registry()
                     .role_candidates
                     .get(&cn_str)
                     .and_then(|candidates| {
@@ -2718,7 +2733,7 @@ impl Interpreter {
             }
             // Auto-pun role to class if needed (e.g., role COERCE calling self.new)
             if !self.registry().classes.contains_key(&cn_resolved)
-                && self.roles.contains_key(&cn_resolved)
+                && self.registry().roles.contains_key(&cn_resolved)
             {
                 self.ensure_role_punned_to_class(&cn_resolved);
             }
@@ -2803,14 +2818,20 @@ impl Interpreter {
                 let mut attrs = HashMap::new();
                 let mut positional_ctor_args: Vec<Value> = Vec::new();
                 let saved_default_env = self.env.clone();
-                if let Some(role_bindings) = self.class_role_param_bindings.get(class_key) {
-                    for (name, value) in role_bindings {
-                        self.env.insert(name.clone(), value.clone());
-                    }
-                } else if let Some(role_bindings) =
-                    self.class_role_param_bindings.get(&class_name.resolve())
-                {
-                    for (name, value) in role_bindings {
+                let role_bindings = {
+                    let registry = self.registry();
+                    registry
+                        .class_role_param_bindings
+                        .get(class_key)
+                        .or_else(|| {
+                            registry
+                                .class_role_param_bindings
+                                .get(&class_name.resolve())
+                        })
+                        .cloned()
+                };
+                if let Some(role_bindings) = role_bindings {
+                    for (name, value) in &role_bindings {
                         self.env.insert(name.clone(), value.clone());
                     }
                 }
@@ -2955,16 +2976,20 @@ impl Interpreter {
                 // referencing role type parameters (e.g., `has $.x = $a`) work.
                 // Also add class-qualified versions (e.g., `AP_2::a`) so that
                 // bindings resolve correctly when current_package is the class.
-                if let Some(role_bindings) = self.class_role_param_bindings.get(class_key) {
-                    for (name, value) in role_bindings {
-                        self.env.insert(name.clone(), value.clone());
-                        self.env
-                            .insert(format!("{}::{}", class_key, name), value.clone());
-                    }
-                } else if let Some(role_bindings) =
-                    self.class_role_param_bindings.get(&class_name.resolve())
-                {
-                    for (name, value) in role_bindings {
+                let role_bindings = {
+                    let registry = self.registry();
+                    registry
+                        .class_role_param_bindings
+                        .get(class_key)
+                        .or_else(|| {
+                            registry
+                                .class_role_param_bindings
+                                .get(&class_name.resolve())
+                        })
+                        .cloned()
+                };
+                if let Some(role_bindings) = role_bindings {
+                    for (name, value) in &role_bindings {
                         self.env.insert(name.clone(), value.clone());
                         self.env
                             .insert(format!("{}::{}", class_key, name), value.clone());
@@ -3174,7 +3199,7 @@ impl Interpreter {
                         continue;
                     }
                     // Skip role entries in MRO — they are handled separately below
-                    if self.roles.contains_key(mro_class)
+                    if self.registry().roles.contains_key(mro_class)
                         && !self.registry().classes.contains_key(mro_class)
                     {
                         continue;
@@ -3303,7 +3328,7 @@ impl Interpreter {
                         continue;
                     }
                     // Skip role entries in MRO
-                    if self.roles.contains_key(mro_class)
+                    if self.registry().roles.contains_key(mro_class)
                         && !self.registry().classes.contains_key(mro_class)
                     {
                         continue;
@@ -3664,7 +3689,7 @@ impl Interpreter {
         // Now filter to only roles that have the requested submethod
         let mut result = Vec::new();
         for role_name in &ordered {
-            if let Some(role_def) = self.roles.get(role_name)
+            if let Some(role_def) = self.registry().roles.get(role_name)
                 && let Some(overloads) = role_def.methods.get(method_name)
             {
                 for md in overloads {
@@ -3689,13 +3714,13 @@ impl Interpreter {
             return;
         }
         // First, expand parent roles
-        if let Some(parents) = self.role_parents.get(role_name) {
+        if let Some(parents) = self.registry().role_parents.get(role_name) {
             for parent in parents {
                 let parent_base = parent
                     .split_once('[')
                     .map(|(b, _)| b)
                     .unwrap_or(parent.as_str());
-                if self.roles.contains_key(parent_base) {
+                if self.registry().roles.contains_key(parent_base) {
                     self.expand_role_depth_first(parent_base, ordered, seen);
                 }
             }

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -102,7 +102,7 @@ impl Interpreter {
         // ambiguous. Resolution happens against the consumer's immediate roles, so an
         // indirect second concretization (reached through another role) does not count.
         if in_composed_roles
-            && self.roles.contains_key(qualifier)
+            && self.registry().roles.contains_key(qualifier)
             && self
                 .role_concretizations_at_nearest(&inst_cn_str, qualifier)
                 .len()
@@ -191,8 +191,9 @@ impl Interpreter {
             }
         }
         // Also check the role definition directly
-        let role_lookup = self.roles.get(qualifier).cloned().or_else(|| {
-            self.roles
+        let role_lookup = self.registry().roles.get(qualifier).cloned().or_else(|| {
+            self.registry()
+                .roles
                 .iter()
                 .find(|(name, _)| {
                     name.starts_with(qualifier) && name[qualifier.len()..].starts_with('[')
@@ -246,7 +247,7 @@ impl Interpreter {
         let direct_roles = |node: &str| -> Vec<String> {
             if let Some(roles) = self.registry().class_composed_roles.get(node) {
                 roles.clone()
-            } else if let Some(parents) = self.role_parents.get(node) {
+            } else if let Some(parents) = self.registry().role_parents.get(node) {
                 parents.clone()
             } else {
                 Vec::new()

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -168,7 +168,7 @@ impl Interpreter {
                     continue;
                 }
                 out.push((WalkKind::Role, base.clone()));
-                if let Some(parents) = self.role_parents.get(&base) {
+                if let Some(parents) = self.registry().role_parents.get(&base) {
                     for p in parents {
                         let p_base = p
                             .split_once('[')
@@ -226,7 +226,7 @@ impl Interpreter {
                 // Submethods on roles are not composed into the consuming
                 // class's method table, so look them up on the role's own
                 // method table first.
-                if let Some(role_def) = self.roles.get(owner)
+                if let Some(role_def) = self.registry().roles.get(owner)
                     && let Some(overloads) = role_def.methods.get(method_name)
                     && let Some(m) = overloads.iter().find(|m| !m.is_private)
                 {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -338,7 +338,7 @@ pub(crate) struct RoleDef {
 }
 
 #[derive(Debug, Clone)]
-struct RoleCandidateDef {
+pub(crate) struct RoleCandidateDef {
     type_params: Vec<String>,
     type_param_defs: Vec<ParamDef>,
     role_def: RoleDef,
@@ -884,15 +884,6 @@ pub struct Interpreter {
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
-    roles: HashMap<String, RoleDef>,
-    /// Roles explicitly declared via user code (not pre-registered builtins).
-    /// Used to detect X::Redeclaration for role->class name conflicts.
-    user_declared_roles: HashSet<String>,
-    role_candidates: HashMap<String, Vec<RoleCandidateDef>>,
-    role_parents: HashMap<String, Vec<String>>,
-    role_hides: HashMap<String, Vec<String>>,
-    role_type_params: HashMap<String, Vec<String>>,
-    class_role_param_bindings: HashMap<String, HashMap<String, Value>>,
     proto_subs: HashSet<String>,
     proto_tokens: HashSet<String>,
     proto_dispatch_stack: Vec<(String, Vec<Value>)>,
@@ -2907,127 +2898,15 @@ impl Interpreter {
                 );
                 ccr.insert("Complex".to_string(), vec!["Numeric".to_string()]);
                 ccr.insert("Str".to_string(), vec!["Stringy".to_string()]);
-                Arc::new(RwLock::new(registry))
-            },
-            roles: {
-                let mut roles = HashMap::new();
-                roles.insert(
-                    "Encoding".to_string(),
-                    RoleDef {
-                        attributes: Vec::new(),
-                        methods: HashMap::new(),
-                        is_stub_role: false,
-                        is_hidden: false,
-                        is_rw: false,
-                        captured_env: None,
-                        wildcard_handles: Vec::new(),
-                        role_id: 0,
-                        attribute_conflicts: Vec::new(),
-                        own_attribute_names: std::collections::HashSet::new(),
-                        deferred_body_stmts: Vec::new(),
-                        deferred_custom_traits: Vec::new(),
-                    },
-                );
-                roles.insert(
-                    "Iterator".to_string(),
-                    RoleDef {
-                        attributes: Vec::new(),
-                        methods: HashMap::new(),
-                        is_stub_role: false,
-                        is_hidden: false,
-                        is_rw: false,
-                        captured_env: None,
-                        wildcard_handles: Vec::new(),
-                        role_id: 0,
-                        attribute_conflicts: Vec::new(),
-                        own_attribute_names: std::collections::HashSet::new(),
-                        deferred_body_stmts: Vec::new(),
-                        deferred_custom_traits: Vec::new(),
-                    },
-                );
-                roles.insert(
-                    "PredictiveIterator".to_string(),
-                    RoleDef {
-                        attributes: Vec::new(),
-                        methods: HashMap::new(),
-                        is_stub_role: false,
-                        is_hidden: false,
-                        is_rw: false,
-                        captured_env: None,
-                        wildcard_handles: Vec::new(),
-                        role_id: 0,
-                        attribute_conflicts: Vec::new(),
-                        own_attribute_names: std::collections::HashSet::new(),
-                        deferred_body_stmts: Vec::new(),
-                        deferred_custom_traits: Vec::new(),
-                    },
-                );
-                roles.insert(
-                    "Iterable".to_string(),
-                    RoleDef {
-                        attributes: Vec::new(),
-                        methods: HashMap::new(),
-                        is_stub_role: false,
-                        is_hidden: false,
-                        is_rw: false,
-                        captured_env: None,
-                        wildcard_handles: Vec::new(),
-                        role_id: 0,
-                        attribute_conflicts: Vec::new(),
-                        own_attribute_names: std::collections::HashSet::new(),
-                        deferred_body_stmts: Vec::new(),
-                        deferred_custom_traits: Vec::new(),
-                    },
-                );
-                roles.insert(
-                    "X::Control".to_string(),
-                    RoleDef {
-                        attributes: Vec::new(),
-                        methods: HashMap::new(),
-                        is_stub_role: false,
-                        is_hidden: false,
-                        is_rw: false,
-                        captured_env: None,
-                        wildcard_handles: Vec::new(),
-                        role_id: 0,
-                        attribute_conflicts: Vec::new(),
-                        own_attribute_names: std::collections::HashSet::new(),
-                        deferred_body_stmts: Vec::new(),
-                        deferred_custom_traits: Vec::new(),
-                    },
-                );
-                // CompUnit::Repository role with required stub methods
-                {
-                    let stub_body = vec![Stmt::Expr(Expr::Call {
-                        name: Symbol::intern("__mutsu_stub_die"),
-                        args: vec![],
-                    })];
-                    let stub_method = |body: Vec<Stmt>| MethodDef {
-                        params: Vec::new(),
-                        param_defs: Vec::new(),
-                        body: std::sync::Arc::new(body),
-                        is_rw: false,
-                        is_private: false,
-                        is_multi: false,
-                        is_my: false,
-                        role_origin: None,
-                        original_role: None,
-                        return_type: None,
-                        compiled_code: None,
-                        delegation: None,
-                        is_default: false,
-                        deprecated_message: None,
-                        is_submethod: false,
-                    };
-                    let mut methods = HashMap::new();
-                    for name in ["id", "need", "load", "loaded"] {
-                        methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
-                    }
+                // Built-in role definitions (PR-A slice 4: roles now live in the
+                // shared Registry instead of an Interpreter field).
+                registry.roles = {
+                    let mut roles = HashMap::new();
                     roles.insert(
-                        "CompUnit::Repository".to_string(),
+                        "Encoding".to_string(),
                         RoleDef {
                             attributes: Vec::new(),
-                            methods,
+                            methods: HashMap::new(),
                             is_stub_role: false,
                             is_hidden: false,
                             is_rw: false,
@@ -3040,15 +2919,123 @@ impl Interpreter {
                             deferred_custom_traits: Vec::new(),
                         },
                     );
-                }
-                roles
+                    roles.insert(
+                        "Iterator".to_string(),
+                        RoleDef {
+                            attributes: Vec::new(),
+                            methods: HashMap::new(),
+                            is_stub_role: false,
+                            is_hidden: false,
+                            is_rw: false,
+                            captured_env: None,
+                            wildcard_handles: Vec::new(),
+                            role_id: 0,
+                            attribute_conflicts: Vec::new(),
+                            own_attribute_names: std::collections::HashSet::new(),
+                            deferred_body_stmts: Vec::new(),
+                            deferred_custom_traits: Vec::new(),
+                        },
+                    );
+                    roles.insert(
+                        "PredictiveIterator".to_string(),
+                        RoleDef {
+                            attributes: Vec::new(),
+                            methods: HashMap::new(),
+                            is_stub_role: false,
+                            is_hidden: false,
+                            is_rw: false,
+                            captured_env: None,
+                            wildcard_handles: Vec::new(),
+                            role_id: 0,
+                            attribute_conflicts: Vec::new(),
+                            own_attribute_names: std::collections::HashSet::new(),
+                            deferred_body_stmts: Vec::new(),
+                            deferred_custom_traits: Vec::new(),
+                        },
+                    );
+                    roles.insert(
+                        "Iterable".to_string(),
+                        RoleDef {
+                            attributes: Vec::new(),
+                            methods: HashMap::new(),
+                            is_stub_role: false,
+                            is_hidden: false,
+                            is_rw: false,
+                            captured_env: None,
+                            wildcard_handles: Vec::new(),
+                            role_id: 0,
+                            attribute_conflicts: Vec::new(),
+                            own_attribute_names: std::collections::HashSet::new(),
+                            deferred_body_stmts: Vec::new(),
+                            deferred_custom_traits: Vec::new(),
+                        },
+                    );
+                    roles.insert(
+                        "X::Control".to_string(),
+                        RoleDef {
+                            attributes: Vec::new(),
+                            methods: HashMap::new(),
+                            is_stub_role: false,
+                            is_hidden: false,
+                            is_rw: false,
+                            captured_env: None,
+                            wildcard_handles: Vec::new(),
+                            role_id: 0,
+                            attribute_conflicts: Vec::new(),
+                            own_attribute_names: std::collections::HashSet::new(),
+                            deferred_body_stmts: Vec::new(),
+                            deferred_custom_traits: Vec::new(),
+                        },
+                    );
+                    // CompUnit::Repository role with required stub methods
+                    {
+                        let stub_body = vec![Stmt::Expr(Expr::Call {
+                            name: Symbol::intern("__mutsu_stub_die"),
+                            args: vec![],
+                        })];
+                        let stub_method = |body: Vec<Stmt>| MethodDef {
+                            params: Vec::new(),
+                            param_defs: Vec::new(),
+                            body: std::sync::Arc::new(body),
+                            is_rw: false,
+                            is_private: false,
+                            is_multi: false,
+                            is_my: false,
+                            role_origin: None,
+                            original_role: None,
+                            return_type: None,
+                            compiled_code: None,
+                            delegation: None,
+                            is_default: false,
+                            deprecated_message: None,
+                            is_submethod: false,
+                        };
+                        let mut methods = HashMap::new();
+                        for name in ["id", "need", "load", "loaded"] {
+                            methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
+                        }
+                        roles.insert(
+                            "CompUnit::Repository".to_string(),
+                            RoleDef {
+                                attributes: Vec::new(),
+                                methods,
+                                is_stub_role: false,
+                                is_hidden: false,
+                                is_rw: false,
+                                captured_env: None,
+                                wildcard_handles: Vec::new(),
+                                role_id: 0,
+                                attribute_conflicts: Vec::new(),
+                                own_attribute_names: std::collections::HashSet::new(),
+                                deferred_body_stmts: Vec::new(),
+                                deferred_custom_traits: Vec::new(),
+                            },
+                        );
+                    }
+                    roles
+                };
+                Arc::new(RwLock::new(registry))
             },
-            user_declared_roles: HashSet::new(),
-            role_candidates: HashMap::new(),
-            role_parents: HashMap::new(),
-            role_hides: HashMap::new(),
-            role_type_params: HashMap::new(),
-            class_role_param_bindings: HashMap::new(),
             proto_subs: HashSet::new(),
             proto_tokens: HashSet::new(),
             proto_dispatch_stack: Vec::new(),
@@ -3481,8 +3468,10 @@ impl Interpreter {
             // classes from the package stash. This handles the case where the
             // module was first loaded transitively by a non-contributing module.
             if self.module_load_stack.is_empty() && module.contains("::") {
-                let is_contributor =
-                    self.registry().classes.contains_key(module) || self.roles.contains_key(module);
+                let is_contributor = {
+                    let registry = self.registry();
+                    registry.classes.contains_key(module) || registry.roles.contains_key(module)
+                };
                 if is_contributor {
                     self.package_stash_hidden.remove(module);
                 }
@@ -3512,7 +3501,7 @@ impl Interpreter {
         };
         self.module_load_stack.push(module.to_string());
         let class_snapshot: HashSet<String> = self.registry().classes.keys().cloned().collect();
-        let role_snapshot: HashSet<String> = self.roles.keys().cloned().collect();
+        let role_snapshot: HashSet<String> = self.registry().roles.keys().cloned().collect();
         let env_snapshot: HashSet<Symbol> = self.env.keys().copied().collect();
         let func_keys_before: HashSet<Symbol> = self.functions.keys().copied().collect();
 
@@ -3614,8 +3603,10 @@ impl Interpreter {
             //       (tracked in `chain_declared_packages` which is scoped to this load).
             // If neither condition holds, new classes/roles are hidden from X's stash.
             if let Some((namespace, _)) = module.rsplit_once("::") {
-                let module_declares_own_class =
-                    self.registry().classes.contains_key(module) || self.roles.contains_key(module);
+                let module_declares_own_class = {
+                    let registry = self.registry();
+                    registry.classes.contains_key(module) || registry.roles.contains_key(module)
+                };
                 let chain_has_package_decl = self.chain_declared_packages.contains(namespace);
                 if !module_declares_own_class && !chain_has_package_decl {
                     // Hide newly registered classes/roles from the namespace stash
@@ -3629,7 +3620,8 @@ impl Interpreter {
                             self.package_stash_hidden.insert(class_name.clone());
                         }
                     }
-                    for role_name in self.roles.keys() {
+                    let role_names: Vec<String> = self.registry().roles.keys().cloned().collect();
+                    for role_name in &role_names {
                         if !role_snapshot.contains(role_name)
                             && role_name.starts_with(namespace)
                             && role_name.get(namespace.len()..namespace.len() + 2) == Some("::")
@@ -5226,13 +5218,6 @@ impl Interpreter {
             // independent snapshot (matches prior per-field clone semantics: the
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
-            roles: self.roles.clone(),
-            user_declared_roles: self.user_declared_roles.clone(),
-            role_candidates: self.role_candidates.clone(),
-            role_parents: self.role_parents.clone(),
-            role_hides: self.role_hides.clone(),
-            role_type_params: self.role_type_params.clone(),
-            class_role_param_bindings: self.class_role_param_bindings.clone(),
             proto_subs: self.proto_subs.clone(),
             proto_tokens: self.proto_tokens.clone(),
             proto_dispatch_stack: Vec::new(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -371,12 +371,12 @@ impl Interpreter {
         let mut names = Vec::new();
         if let Some(class_def) = self.registry().classes.get(type_name) {
             names.extend(class_def.methods.keys().cloned());
-        } else if let Some(role_def) = self.roles.get(type_name) {
+        } else if let Some(role_def) = self.registry().roles.get(type_name) {
             names.extend(role_def.methods.keys().cloned());
             // Also include methods from composed roles
             if let Some(composed) = self.registry().class_composed_roles.get(type_name) {
                 for role_name in composed {
-                    if let Some(rd) = self.roles.get(role_name) {
+                    if let Some(rd) = self.registry().roles.get(role_name) {
                         for key in rd.methods.keys() {
                             if !names.contains(key) {
                                 names.push(key.clone());
@@ -427,7 +427,7 @@ impl Interpreter {
         if let Some(def) = self.registry().classes.get(constraint) {
             return 10 + def.parents.len() as i32;
         }
-        if self.roles.contains_key(constraint) {
+        if self.registry().roles.contains_key(constraint) {
             return 9;
         }
         8
@@ -495,8 +495,8 @@ impl Interpreter {
         } else {
             &parent
         };
-        let Some(candidates) = self.role_candidates.get(base_role_name).cloned() else {
-            if let Some(role) = self.roles.get(base_role_name).cloned() {
+        let Some(candidates) = self.registry().role_candidates.get(base_role_name).cloned() else {
+            if let Some(role) = self.registry().roles.get(base_role_name).cloned() {
                 return Ok(Some((role, Vec::new(), Vec::new())));
             }
             if matches!(base_role_name, "Positional" | "Associative" | "Callable") {
@@ -629,16 +629,20 @@ impl Interpreter {
         // declared inside a `unit module`/`unit class` body.
         if lookup.contains("::") {
             let bare = lookup.rsplit_once("::").map(|(_, b)| b).unwrap_or(lookup);
-            if !self.registry().classes.contains_key(lookup)
-                && !self.roles.contains_key(lookup)
-                && (self.registry().classes.contains_key(bare) || self.roles.contains_key(bare))
-            {
+            // Single guard for all four lookups (avoids stacking read guards).
+            let needs_bare = {
+                let registry = self.registry();
+                !registry.classes.contains_key(lookup)
+                    && !registry.roles.contains_key(lookup)
+                    && (registry.classes.contains_key(bare) || registry.roles.contains_key(bare))
+            };
+            if needs_bare {
                 return format!("{}{}", bare, suffix);
             }
             if let Value::Package(pkg) = self.resolve_indirect_type_name(bare) {
                 let resolved = pkg.resolve();
                 if self.registry().classes.contains_key(resolved.as_str())
-                    || self.roles.contains_key(resolved.as_str())
+                    || self.registry().roles.contains_key(resolved.as_str())
                 {
                     return format!("{}{}", resolved, suffix);
                 }
@@ -680,7 +684,7 @@ impl Interpreter {
         let prev_hidden = self.registry().hidden_classes.contains(name);
         let prev_hidden_defer = self.registry().hidden_defer_parents.get(name).cloned();
         let prev_composed_roles = self.registry().class_composed_roles.get(name).cloned();
-        let prev_role_param_bindings = self.class_role_param_bindings.get(name).cloned();
+        let prev_role_param_bindings = self.registry().class_role_param_bindings.get(name).cloned();
         // Clear `is Type` trait entries for this class (they'll be re-populated from the body).
         self.registry_mut()
             .class_attribute_is_types
@@ -714,17 +718,18 @@ impl Interpreter {
                 this.registry_mut().class_composed_roles.remove(name);
             }
             if let Some(bindings) = prev_role_param_bindings.clone() {
-                this.class_role_param_bindings
+                this.registry_mut()
+                    .class_role_param_bindings
                     .insert(name.to_string(), bindings);
             } else {
-                this.class_role_param_bindings.remove(name);
+                this.registry_mut().class_role_param_bindings.remove(name);
             }
         };
 
         // Detect X::Redeclaration when a class redefines a role in the same scope.
         // Only check user-declared roles (not pre-registered builtins like Iterator).
         // Lexical classes (`my class`) are allowed to shadow outer role names.
-        if !is_lexical && self.user_declared_roles.contains(name) {
+        if !is_lexical && self.registry().user_declared_roles.contains(name) {
             // Only report redeclaration for non-stub class bodies
             let body_non_stub: Vec<_> = body
                 .iter()
@@ -849,7 +854,7 @@ impl Interpreter {
             }
             if !self.registry().classes.contains_key(base_parent)
                 && !BUILTIN_TYPES.contains(&base_parent)
-                && !self.roles.contains_key(base_parent)
+                && !self.registry().roles.contains_key(base_parent)
                 && !self.registry().enum_types.contains_key(base_parent)
             {
                 // Use X::InvalidType for `does` parents, X::Inheritance::UnknownParent
@@ -889,7 +894,7 @@ impl Interpreter {
             // Check that `does` targets are actually roles, not classes
             if does_parents.contains(parent)
                 && self.registry().classes.contains_key(resolved_parent)
-                && !self.roles.contains_key(resolved_parent)
+                && !self.registry().roles.contains_key(resolved_parent)
                 && !BUILTIN_TYPES.contains(&resolved_parent)
             {
                 return Err(RuntimeError::new(format!(
@@ -1080,7 +1085,9 @@ impl Interpreter {
                         // Don't remove the param name itself - methods may need it
                     }
                 }
-                if let Some(parent_specs) = self.role_parents.get(base_role_name).cloned() {
+                if let Some(parent_specs) =
+                    self.registry().role_parents.get(base_role_name).cloned()
+                {
                     for parent_spec in parent_specs {
                         let resolved_parent = if let Some(v) = role_param_values.get(&parent_spec) {
                             type_value_name(v)
@@ -1110,27 +1117,28 @@ impl Interpreter {
                             .split_once('[')
                             .map(|(b, _)| b)
                             .unwrap_or(resolved_parent.as_str());
-                        if let Some(parent_role) = self.roles.get(parent_base).cloned() {
+                        if let Some(parent_role) = self.registry().roles.get(parent_base).cloned() {
                             if !composed_roles_list.contains(&resolved_parent) {
                                 composed_roles_list.push(resolved_parent.clone());
                             }
-                            let parent_type_subs: Vec<(String, String)> =
-                                if let Some(parent_tps) = self.role_type_params.get(parent_base) {
-                                    if let Some(bracket_start) = resolved_parent.find('[') {
-                                        let args_str = &resolved_parent
-                                            [bracket_start + 1..resolved_parent.len() - 1];
-                                        let args = parse_role_type_args(args_str);
-                                        parent_tps
-                                            .iter()
-                                            .zip(args.iter())
-                                            .map(|(p, a)| (p.clone(), a.clone()))
-                                            .collect()
-                                    } else {
-                                        Vec::new()
-                                    }
+                            let parent_type_subs: Vec<(String, String)> = if let Some(parent_tps) =
+                                self.registry().role_type_params.get(parent_base)
+                            {
+                                if let Some(bracket_start) = resolved_parent.find('[') {
+                                    let args_str = &resolved_parent
+                                        [bracket_start + 1..resolved_parent.len() - 1];
+                                    let args = parse_role_type_args(args_str);
+                                    parent_tps
+                                        .iter()
+                                        .zip(args.iter())
+                                        .map(|(p, a)| (p.clone(), a.clone()))
+                                        .collect()
                                 } else {
                                     Vec::new()
-                                };
+                                }
+                            } else {
+                                Vec::new()
+                            };
                             for attr in &parent_role.attributes {
                                 if !class_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
                                     class_def.attributes.push(attr.clone());
@@ -1209,7 +1217,7 @@ impl Interpreter {
                     .push(base_role_name.to_string());
             } else if does_parents.contains(parent)
                 && BUILTIN_TYPES.contains(&base_role_name)
-                && !self.roles.contains_key(base_role_name)
+                && !self.registry().roles.contains_key(base_role_name)
                 && !composed_roles_list.contains(&resolved_parent_name)
             {
                 // Built-in type used as a role via `does` (e.g., `does Numeric`,
@@ -1219,9 +1227,10 @@ impl Interpreter {
             }
         }
         if class_role_param_bindings.is_empty() {
-            self.class_role_param_bindings.remove(name);
+            self.registry_mut().class_role_param_bindings.remove(name);
         } else {
-            self.class_role_param_bindings
+            self.registry_mut()
+                .class_role_param_bindings
                 .insert(name.to_string(), class_role_param_bindings);
         }
         // Handle role punning: `is Role` creates a punned class from the role
@@ -1243,10 +1252,10 @@ impl Interpreter {
                     if !seen_roles.insert(role_name.clone()) {
                         continue;
                     }
-                    if let Some(rparents) = self.role_parents.get(&role_name).cloned() {
+                    if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.roles.contains_key(rp_base) {
+                            if self.registry().roles.contains_key(rp_base) {
                                 // It's a role - add as composed role and recurse
                                 if !punned_composed_roles.contains(&rp) {
                                     punned_composed_roles.push(rp.clone());
@@ -1283,9 +1292,14 @@ impl Interpreter {
                         .insert(base_role.to_string(), punned_composed_roles);
                 }
                 // Propagate hidden status from role to punned class
-                if let Some(role_def) = self.roles.get(base_role)
-                    && role_def.is_hidden
-                {
+                // Read the flag under the guard, drop it, then write (read->write on
+                // the same lock would deadlock).
+                let base_role_is_hidden = self
+                    .registry()
+                    .roles
+                    .get(base_role)
+                    .is_some_and(|role_def| role_def.is_hidden);
+                if base_role_is_hidden {
                     self.registry_mut()
                         .hidden_classes
                         .insert(base_role.to_string());
@@ -1327,10 +1341,10 @@ impl Interpreter {
                     if !seen_roles.insert(role_name.clone()) {
                         continue;
                     }
-                    if let Some(rparents) = self.role_parents.get(&role_name).cloned() {
+                    if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.roles.contains_key(rp_base) {
+                            if self.registry().roles.contains_key(rp_base) {
                                 // It's a sub-role, recurse
                                 role_stack.push(rp_base.to_string());
                             } else if self.registry().classes.contains_key(rp_base)
@@ -1361,7 +1375,10 @@ impl Interpreter {
                     if !seen_roles.insert(role_name.clone()) {
                         continue;
                     }
-                    if let Some(hides_list) = self.role_hides.get(&role_name).cloned() {
+                    // Hoist the clone to a `let` so the read guard drops before the
+                    // registry_mut write below (read->write on the same lock deadlocks).
+                    let hides_list = self.registry().role_hides.get(&role_name).cloned();
+                    if let Some(hides_list) = hides_list {
                         for hidden in hides_list {
                             self.registry_mut()
                                 .hidden_defer_parents
@@ -1371,10 +1388,10 @@ impl Interpreter {
                         }
                     }
                     // Recurse into sub-roles
-                    if let Some(rparents) = self.role_parents.get(&role_name).cloned() {
+                    if let Some(rparents) = self.registry().role_parents.get(&role_name).cloned() {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.roles.contains_key(rp_base) {
+                            if self.registry().roles.contains_key(rp_base) {
                                 role_stack.push(rp_base.to_string());
                             }
                         }
@@ -2096,7 +2113,7 @@ impl Interpreter {
                 }
                 Stmt::DoesDecl { name: role_name } => {
                     let role_name_str = role_name.resolve();
-                    if !self.roles.contains_key(&role_name_str)
+                    if !self.registry().roles.contains_key(&role_name_str)
                         && matches!(
                             role_name_str.as_str(),
                             "Real"
@@ -2114,9 +2131,14 @@ impl Interpreter {
                         }
                         continue;
                     }
-                    let role = self.roles.get(&role_name_str).cloned().ok_or_else(|| {
-                        RuntimeError::new(format!("Unknown role: {}", role_name_str))
-                    })?;
+                    let role = self
+                        .registry()
+                        .roles
+                        .get(&role_name_str)
+                        .cloned()
+                        .ok_or_else(|| {
+                            RuntimeError::new(format!("Unknown role: {}", role_name_str))
+                        })?;
                     if role.is_stub_role {
                         return Err(RuntimeError::typed_msg(
                             "X::Role::Parametric::NoSuchCandidate",
@@ -2166,7 +2188,9 @@ impl Interpreter {
                         class_def.mro.clear();
                     }
                     // Transfer role's own parents (from `is` declarations) to the class
-                    if let Some(rparents) = self.role_parents.get(&role_name_str).cloned() {
+                    if let Some(rparents) =
+                        self.registry().role_parents.get(&role_name_str).cloned()
+                    {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
                             if self.registry().classes.contains_key(rp_base)
@@ -2663,6 +2687,7 @@ impl Interpreter {
         if is_stub_body
             && type_params.is_empty()
             && self
+                .registry()
                 .roles
                 .get(name)
                 .is_some_and(|existing| !existing.is_stub_role)
@@ -2678,16 +2703,17 @@ impl Interpreter {
         // restore them after the parametric variant adds its own parents.
         let prev_parents = if !type_params.is_empty()
             && self
+                .registry()
                 .roles
                 .get(name)
                 .is_some_and(|existing| !existing.is_stub_role)
         {
-            self.role_parents.get(name).cloned()
+            self.registry().role_parents.get(name).cloned()
         } else {
             None
         };
-        self.role_parents.remove(name);
-        self.role_hides.remove(name);
+        self.registry_mut().role_parents.remove(name);
+        self.registry_mut().role_hides.remove(name);
         let mut role_def = RoleDef {
             attributes: Vec::new(),
             methods: HashMap::new(),
@@ -2755,13 +2781,14 @@ impl Interpreter {
                         // Record the conflict; the existing one came from a composed role.
                         // We need to figure out which role contributed it.
                         let parent_role = self
+                            .registry()
                             .role_parents
                             .get(name)
                             .and_then(|parents| {
                                 parents.iter().find(|p| {
                                     let base =
                                         p.split_once('[').map(|(b, _)| b).unwrap_or(p.as_str());
-                                    self.roles.get(base).is_some_and(|r| {
+                                    self.registry().roles.get(base).is_some_and(|r| {
                                         r.attributes.iter().any(|(n, ..)| n == &attr_name_str)
                                     })
                                 })
@@ -2802,14 +2829,16 @@ impl Interpreter {
                     let role_name_str = role_name.resolve();
                     if let Some(hidden_name) = role_name_str.strip_prefix("__mutsu_role_hides__") {
                         // Track hidden class relationship for this role
-                        self.role_hides
+                        self.registry_mut()
+                            .role_hides
                             .entry(name.to_string())
                             .or_default()
                             .push(hidden_name.to_string());
                         continue;
                     }
                     if self.registry().classes.contains_key(&role_name_str) {
-                        self.role_parents
+                        self.registry_mut()
+                            .role_parents
                             .entry(name.to_string())
                             .or_default()
                             .push(role_name_str);
@@ -2820,7 +2849,7 @@ impl Interpreter {
                         .map(|(b, _)| b)
                         .unwrap_or(role_name_str.as_str());
                     if type_params.iter().any(|tp| tp == base_role_name)
-                        || (!self.roles.contains_key(base_role_name)
+                        || (!self.registry().roles.contains_key(base_role_name)
                             && matches!(
                                 base_role_name,
                                 "Real"
@@ -2832,13 +2861,14 @@ impl Interpreter {
                                     | "Associative"
                             ))
                     {
-                        self.role_parents
+                        self.registry_mut()
+                            .role_parents
                             .entry(name.to_string())
                             .or_default()
                             .push(role_name_str);
                         continue;
                     }
-                    let role = match self.roles.get(base_role_name).cloned() {
+                    let role = match self.registry().roles.get(base_role_name).cloned() {
                         Some(r) => r,
                         None => {
                             // If trait_mod:<is> is defined and this is a lowercase name,
@@ -2867,7 +2897,8 @@ impl Interpreter {
                             "No matching candidate found for the parametric role",
                         ));
                     }
-                    self.role_parents
+                    self.registry_mut()
+                        .role_parents
                         .entry(name.to_string())
                         .or_default()
                         .push(role_name_str.clone());
@@ -2881,12 +2912,17 @@ impl Interpreter {
                             // Store the resolved param bindings so they are
                             // available when the child role is punned to a class
                             // and methods referencing role params are dispatched.
-                            let bindings = self
-                                .class_role_param_bindings
-                                .entry(name.to_string())
-                                .or_default();
-                            for (p, v) in resolved_param_names.iter().zip(resolved_values.iter()) {
-                                bindings.insert(p.clone(), v.clone());
+                            {
+                                let mut registry = self.registry_mut();
+                                let bindings = registry
+                                    .class_role_param_bindings
+                                    .entry(name.to_string())
+                                    .or_default();
+                                for (p, v) in
+                                    resolved_param_names.iter().zip(resolved_values.iter())
+                                {
+                                    bindings.insert(p.clone(), v.clone());
+                                }
                             }
                             resolved_param_names
                                 .iter()
@@ -2894,7 +2930,7 @@ impl Interpreter {
                                 .map(|(p, v)| (p.clone(), type_value_name(v)))
                                 .collect()
                         } else if let Some(parent_type_params) =
-                            self.role_type_params.get(base_role_name)
+                            self.registry().role_type_params.get(base_role_name)
                         {
                             if let Some(bracket_start) = role_name_str.find('[') {
                                 let args_str =
@@ -3156,8 +3192,14 @@ impl Interpreter {
         }
         // Capture the parents that were added during this registration
         // (these are the parents specific to this candidate).
-        let candidate_parents = self.role_parents.get(name).cloned().unwrap_or_default();
-        self.role_candidates
+        let candidate_parents = self
+            .registry()
+            .role_parents
+            .get(name)
+            .cloned()
+            .unwrap_or_default();
+        self.registry_mut()
+            .role_candidates
             .entry(name.to_string())
             .or_default()
             .push(RoleCandidateDef {
@@ -3168,22 +3210,27 @@ impl Interpreter {
                 language_version: crate::parser::current_language_version(),
             });
         if self
+            .registry()
             .roles
             .get(name)
             .is_none_or(|existing| existing.is_stub_role || type_params.is_empty())
         {
-            self.roles.insert(name.to_string(), role_def);
-            self.user_declared_roles.insert(name.to_string());
+            self.registry_mut().roles.insert(name.to_string(), role_def);
+            self.registry_mut()
+                .user_declared_roles
+                .insert(name.to_string());
         }
-        if !type_params.is_empty() && !self.role_type_params.contains_key(name) {
-            self.role_type_params
+        if !type_params.is_empty() && !self.registry().role_type_params.contains_key(name) {
+            self.registry_mut()
+                .role_type_params
                 .insert(name.to_string(), type_params.to_vec());
         }
         // When a parametric variant was registered over an existing non-parametric
         // role (forming a role group), merge the previous parents back into
         // role_parents so that role_parent_args_for can find all candidates' parents.
         if let Some(prev) = prev_parents {
-            let current = self.role_parents.entry(name.to_string()).or_default();
+            let mut registry = self.registry_mut();
+            let current = registry.role_parents.entry(name.to_string()).or_default();
             for p in prev {
                 if !current.contains(&p) {
                     current.push(p);
@@ -3377,7 +3424,7 @@ impl Interpreter {
             return;
         }
         self.clear_private_zeroarg_method_cache();
-        let role_def = match self.roles.get(role_name) {
+        let role_def = match self.registry().roles.get(role_name) {
             Some(r) => r.clone(),
             None => return,
         };
@@ -3385,12 +3432,13 @@ impl Interpreter {
         let mut all_attributes = role_def.attributes.clone();
         let mut all_methods: HashMap<String, Vec<MethodDef>> = role_def.methods.clone();
         let mut composed_roles_list = vec![role_name.to_string()];
-        if let Some(parent_names) = self.role_parents.get(role_name).cloned() {
+        if let Some(parent_names) = self.registry().role_parents.get(role_name).cloned() {
             let mut role_stack: Vec<String> = parent_names;
             while let Some(parent_role_name) = role_stack.pop() {
                 if !composed_roles_list.contains(&parent_role_name) {
                     composed_roles_list.push(parent_role_name.clone());
-                    if let Some(parent_role) = self.roles.get(&parent_role_name).cloned() {
+                    if let Some(parent_role) = self.registry().roles.get(&parent_role_name).cloned()
+                    {
                         for attr in &parent_role.attributes {
                             // ClassAttributeDef is a tuple; field 0 is the attribute name
                             if !all_attributes.iter().any(|a| a.0 == attr.0) {
@@ -3405,7 +3453,9 @@ impl Interpreter {
                         }
                     }
                     // Also recurse into grandparent roles
-                    if let Some(grandparents) = self.role_parents.get(&parent_role_name).cloned() {
+                    if let Some(grandparents) =
+                        self.registry().role_parents.get(&parent_role_name).cloned()
+                    {
                         for gp_name in &grandparents {
                             if !composed_roles_list.contains(gp_name) {
                                 role_stack.push(gp_name.clone());
@@ -3439,12 +3489,16 @@ impl Interpreter {
         // revision metadata from the matching candidate so that
         // `.^language-revision` on the pun instance returns the correct
         // revision (not the last-registered candidate's revision).
-        let candidate_lang_version = self.role_candidates.get(role_name).and_then(|candidates| {
-            candidates
-                .iter()
-                .find(|c| c.type_params.is_empty())
-                .map(|c| c.language_version.clone())
-        });
+        let candidate_lang_version =
+            self.registry()
+                .role_candidates
+                .get(role_name)
+                .and_then(|candidates| {
+                    candidates
+                        .iter()
+                        .find(|c| c.type_params.is_empty())
+                        .map(|c| c.language_version.clone())
+                });
         if let Some(version) = candidate_lang_version {
             self.store_language_revision_from_version(role_name, &version);
         }

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -532,8 +532,8 @@ impl Interpreter {
         let fq_name = format!("{}::{}", self.current_package, name);
         if self.registry().classes.contains_key(name)
             || self.registry().classes.contains_key(fq_name.as_str())
-            || self.roles.contains_key(name)
-            || self.roles.contains_key(fq_name.as_str())
+            || self.registry().roles.contains_key(name)
+            || self.registry().roles.contains_key(fq_name.as_str())
         {
             Some(Value::Package(Symbol::intern(name)))
         } else if let Some(val) = self.env.get(name) {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::value::{EnumValue, Value};
 
-use super::{ClassDef, SubsetDef};
+use super::{ClassDef, RoleCandidateDef, RoleDef, SubsetDef};
 
 /// Program declaration registry. See module docs.
 ///
@@ -81,4 +81,23 @@ pub(crate) struct Registry {
     pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
     /// Per-attribute `is DEPRECATED` message: (class, attr) -> message.
     pub(crate) class_attribute_deprecated: HashMap<(String, String), String>,
+
+    // ----- roles (PR-A slice 4) -----
+    /// User/builtin role definitions: role name -> [`RoleDef`] (methods,
+    /// attributes, deferred body, ...). Like `classes`, callers clone the
+    /// minimal projection under a short-lived guard rather than the whole def.
+    pub(crate) roles: HashMap<String, RoleDef>,
+    /// Roles explicitly declared via user code (not pre-registered builtins);
+    /// used to detect `X::Redeclaration` for role->class name conflicts.
+    pub(crate) user_declared_roles: HashSet<String>,
+    /// Parameterized role candidates: role name -> [candidate by arity/types].
+    pub(crate) role_candidates: HashMap<String, Vec<RoleCandidateDef>>,
+    /// Role inheritance: role -> [parent role specs].
+    pub(crate) role_parents: HashMap<String, Vec<String>>,
+    /// `also hides` relationships on roles: role -> [hidden names].
+    pub(crate) role_hides: HashMap<String, Vec<String>>,
+    /// Declared type parameters per parameterized role: role -> [param names].
+    pub(crate) role_type_params: HashMap<String, Vec<String>>,
+    /// Bound role type parameters per class: class -> (param name -> value).
+    pub(crate) class_role_param_bindings: HashMap<String, HashMap<String, Value>>,
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -304,7 +304,11 @@ impl Interpreter {
         invocant: Option<&Value>,
     ) -> Option<(String, MethodDef)> {
         self.dispatch_ambiguous = false;
-        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
+        let role_bindings = self
+            .registry()
+            .class_role_param_bindings
+            .get(class_name)
+            .cloned();
         let mro = self.class_mro(class_name);
         // Collect all matching multi candidates across the MRO, then pick the
         // most specific one by type hierarchy distance.
@@ -316,8 +320,8 @@ impl Interpreter {
         for cn in &mro {
             // Hoist the clone to a `let` so the registry read guard drops here,
             // before method_args_match_for_invocant re-enters (&mut self). An
-            // `if let` scrutinee would keep the temporary guard alive across the
-            // whole block (edition-2021 temporary scope).
+            // `if let` scrutinee would otherwise keep the temporary guard alive
+            // across the whole block.
             let overloads = self
                 .registry()
                 .classes
@@ -567,24 +571,33 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Vec<(String, MethodDef)> {
-        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
+        let role_bindings = self
+            .registry()
+            .class_role_param_bindings
+            .get(class_name)
+            .cloned();
         let mro = self.class_mro(class_name);
         let mut matches = Vec::new();
         for cn in &mro {
             // An MRO entry may be a regular class or a punned role used as a
             // parent (`class Foo is R1 { ... }`). Role methods are stored in
-            // `self.roles`, so fall back there when the entry is not a class.
-            let overloads = self
-                .registry()
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
-                .or_else(|| {
-                    self.roles
-                        .get(cn.as_str())
-                        .and_then(|r| r.methods.get(method_name))
-                })
-                .cloned();
+            // `self.registry().roles`, so fall back there when the entry is not a class.
+            // Single guard for both the class and role method tables; clone the
+            // matched overload Vec out so the guard drops before re-entry below.
+            let overloads = {
+                let registry = self.registry();
+                registry
+                    .classes
+                    .get(cn.as_str())
+                    .and_then(|c| c.methods.get(method_name))
+                    .or_else(|| {
+                        registry
+                            .roles
+                            .get(cn.as_str())
+                            .and_then(|r| r.methods.get(method_name))
+                    })
+                    .cloned()
+            };
             if let Some(overloads) = overloads {
                 let is_ancestor = cn != class_name;
                 for def in overloads {
@@ -693,7 +706,11 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
-        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
+        let role_bindings = self
+            .registry()
+            .class_role_param_bindings
+            .get(class_name)
+            .cloned();
         let mro = self.class_mro(class_name);
         for cn in mro {
             if cn != owner_class {
@@ -732,7 +749,11 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
-        let role_bindings = self.class_role_param_bindings.get(class_name).cloned();
+        let role_bindings = self
+            .registry()
+            .class_role_param_bindings
+            .get(class_name)
+            .cloned();
         if arg_values.is_empty()
             && let Some(cached) = self
                 .private_zeroarg_method_cache

--- a/src/runtime/seq_helpers/role_type.rs
+++ b/src/runtime/seq_helpers/role_type.rs
@@ -12,7 +12,7 @@ impl Interpreter {
             if !seen.insert(role.clone()) {
                 continue;
             }
-            if let Some(parents) = self.role_parents.get(&role) {
+            if let Some(parents) = self.registry().role_parents.get(&role) {
                 for parent in parents {
                     if parent == rhs_role {
                         return true;

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -19,12 +19,16 @@ impl Interpreter {
         role_args: &[Value],
         target_base: &str,
     ) -> Option<Vec<Value>> {
-        let candidate = self.role_candidates.get(role_name).and_then(|candidates| {
-            candidates
-                .iter()
-                .find(|c| c.type_params.len() == role_args.len())
-                .cloned()
-        })?;
+        let candidate = self
+            .registry()
+            .role_candidates
+            .get(role_name)
+            .and_then(|candidates| {
+                candidates
+                    .iter()
+                    .find(|c| c.type_params.len() == role_args.len())
+                    .cloned()
+            })?;
         let candidate_param_names = candidate.type_params;
         let param_map: HashMap<String, Value> = candidate_param_names
             .into_iter()

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1060,10 +1060,20 @@ impl Interpreter {
                 }
                 // Check if the parametric candidate's `is` parents include the RHS class.
                 // For role groups, look up the parametric candidate's parents.
-                if let Some(candidates) = self.role_candidates.get(&lhs_base_resolved)
-                    && let Some(candidate) = candidates.iter().find(|c| !c.type_params.is_empty())
-                {
-                    let mut stack: Vec<String> = candidate.parents.clone();
+                // Clone the parametric candidate's parents out under a single guard,
+                // then drop it before the loop re-enters (class_mro is &mut self).
+                let candidate_parents = {
+                    let registry = self.registry();
+                    registry
+                        .role_candidates
+                        .get(&lhs_base_resolved)
+                        .and_then(|candidates| {
+                            candidates.iter().find(|c| !c.type_params.is_empty())
+                        })
+                        .map(|candidate| candidate.parents.clone())
+                };
+                if let Some(candidate_parents) = candidate_parents {
+                    let mut stack: Vec<String> = candidate_parents;
                     let mut seen = HashSet::new();
                     while let Some(parent) = stack.pop() {
                         if !seen.insert(parent.clone()) {

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -826,17 +826,18 @@ impl Interpreter {
 
     pub(super) fn eval_eval_string(&mut self, code: &str) -> Result<Value, RuntimeError> {
         let routine_snapshot = self.snapshot_routine_registry();
-        let roles_snapshot = self.roles.clone();
-        let user_declared_roles_snapshot = std::mem::take(&mut self.user_declared_roles);
-        let role_candidates_snapshot = self.role_candidates.clone();
-        let role_type_params_snapshot = self.role_type_params.clone();
-        let role_parents_snapshot = self.role_parents.clone();
-        let role_hides_snapshot = self.role_hides.clone();
+        let roles_snapshot = self.registry().roles.clone();
+        let user_declared_roles_snapshot =
+            std::mem::take(&mut self.registry_mut().user_declared_roles);
+        let role_candidates_snapshot = self.registry().role_candidates.clone();
+        let role_type_params_snapshot = self.registry().role_type_params.clone();
+        let role_parents_snapshot = self.registry().role_parents.clone();
+        let role_hides_snapshot = self.registry().role_hides.clone();
         let classes_snapshot = self.registry().classes.clone();
         let hidden_classes_snapshot = self.registry().hidden_classes.clone();
         let hidden_defer_parents_snapshot = self.registry().hidden_defer_parents.clone();
         let class_composed_roles_snapshot = self.registry().class_composed_roles.clone();
-        let class_role_param_bindings_snapshot = self.class_role_param_bindings.clone();
+        let class_role_param_bindings_snapshot = self.registry().class_role_param_bindings.clone();
         let env_snapshot = self.env.clone();
         let saved_topic = self.env.get("_").cloned();
         let trimmed = code.trim();
@@ -941,18 +942,19 @@ impl Interpreter {
             self.env.remove("__mutsu_in_eval");
         }
         self.restore_routine_registry_eval(routine_snapshot);
-        let current_roles = self.roles.clone();
-        let current_role_candidates = self.role_candidates.clone();
-        let current_role_type_params = self.role_type_params.clone();
-        let current_role_parents = self.role_parents.clone();
-        let current_role_hides = self.role_hides.clone();
+        let current_roles = self.registry().roles.clone();
+        let current_role_candidates = self.registry().role_candidates.clone();
+        let current_role_type_params = self.registry().role_type_params.clone();
+        let current_role_parents = self.registry().role_parents.clone();
+        let current_role_hides = self.registry().role_hides.clone();
         let current_classes = self.registry().classes.clone();
         let current_hidden_classes = self.registry().hidden_classes.clone();
         let current_hidden_defer_parents = self.registry().hidden_defer_parents.clone();
         let current_class_composed_roles = self.registry().class_composed_roles.clone();
-        let current_class_role_param_bindings = self.class_role_param_bindings.clone();
+        let current_class_role_param_bindings = self.registry().class_role_param_bindings.clone();
         let current_env = self.env.clone();
         let current_type_keys: std::collections::HashSet<String> = self
+            .registry()
             .roles
             .keys()
             .chain(self.registry().classes.keys())
@@ -963,24 +965,30 @@ impl Interpreter {
             .chain(classes_snapshot.keys())
             .cloned()
             .collect();
-        self.roles = roles_snapshot;
-        self.user_declared_roles = user_declared_roles_snapshot;
-        self.role_candidates = role_candidates_snapshot;
-        self.role_type_params = role_type_params_snapshot;
-        self.role_parents = role_parents_snapshot;
-        self.role_hides = role_hides_snapshot;
+        self.registry_mut().roles = roles_snapshot;
+        self.registry_mut().user_declared_roles = user_declared_roles_snapshot;
+        self.registry_mut().role_candidates = role_candidates_snapshot;
+        self.registry_mut().role_type_params = role_type_params_snapshot;
+        self.registry_mut().role_parents = role_parents_snapshot;
+        self.registry_mut().role_hides = role_hides_snapshot;
         self.registry_mut().classes = classes_snapshot;
         self.registry_mut().hidden_classes = hidden_classes_snapshot;
         self.registry_mut().hidden_defer_parents = hidden_defer_parents_snapshot;
         self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
-        self.class_role_param_bindings = class_role_param_bindings_snapshot;
-        self.roles.extend(current_roles);
+        self.registry_mut().class_role_param_bindings = class_role_param_bindings_snapshot;
+        self.registry_mut().roles.extend(current_roles);
         // Don't extend user_declared_roles: roles declared in EVAL are EVAL-scoped
         // and should not affect the parent's redeclaration detection.
-        self.role_candidates.extend(current_role_candidates);
-        self.role_type_params.extend(current_role_type_params);
-        self.role_parents.extend(current_role_parents);
-        self.role_hides.extend(current_role_hides);
+        self.registry_mut()
+            .role_candidates
+            .extend(current_role_candidates);
+        self.registry_mut()
+            .role_type_params
+            .extend(current_role_type_params);
+        self.registry_mut()
+            .role_parents
+            .extend(current_role_parents);
+        self.registry_mut().role_hides.extend(current_role_hides);
         self.registry_mut().classes.extend(current_classes);
         self.registry_mut()
             .hidden_classes
@@ -991,7 +999,8 @@ impl Interpreter {
         self.registry_mut()
             .class_composed_roles
             .extend(current_class_composed_roles);
-        self.class_role_param_bindings
+        self.registry_mut()
+            .class_role_param_bindings
             .extend(current_class_role_param_bindings);
         for key in current_type_keys.union(&snapshot_type_keys) {
             if let Some(value) = current_env.get(key).cloned() {

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -184,12 +184,13 @@ impl Interpreter {
         nested.registry_mut().classes = self.registry().classes.clone();
         nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
         nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
-        nested.roles = self.roles.clone();
-        nested.role_candidates = self.role_candidates.clone();
-        nested.role_parents = self.role_parents.clone();
-        nested.role_hides = self.role_hides.clone();
-        nested.role_type_params = self.role_type_params.clone();
-        nested.class_role_param_bindings = self.class_role_param_bindings.clone();
+        nested.registry_mut().roles = self.registry().roles.clone();
+        nested.registry_mut().role_candidates = self.registry().role_candidates.clone();
+        nested.registry_mut().role_parents = self.registry().role_parents.clone();
+        nested.registry_mut().role_hides = self.registry().role_hides.clone();
+        nested.registry_mut().role_type_params = self.registry().role_type_params.clone();
+        nested.registry_mut().class_role_param_bindings =
+            self.registry().class_role_param_bindings.clone();
         nested.registry_mut().subsets = self.registry().subsets.clone();
         nested.registry_mut().enum_types = self.registry().enum_types.clone();
         nested.type_metadata = self.type_metadata.clone();
@@ -283,12 +284,13 @@ impl Interpreter {
         nested.registry_mut().classes = self.registry().classes.clone();
         nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
         nested.registry_mut().class_composed_roles = self.registry().class_composed_roles.clone();
-        nested.roles = self.roles.clone();
-        nested.role_candidates = self.role_candidates.clone();
-        nested.role_parents = self.role_parents.clone();
-        nested.role_hides = self.role_hides.clone();
-        nested.role_type_params = self.role_type_params.clone();
-        nested.class_role_param_bindings = self.class_role_param_bindings.clone();
+        nested.registry_mut().roles = self.registry().roles.clone();
+        nested.registry_mut().role_candidates = self.registry().role_candidates.clone();
+        nested.registry_mut().role_parents = self.registry().role_parents.clone();
+        nested.registry_mut().role_hides = self.registry().role_hides.clone();
+        nested.registry_mut().role_type_params = self.registry().role_type_params.clone();
+        nested.registry_mut().class_role_param_bindings =
+            self.registry().class_role_param_bindings.clone();
         nested.registry_mut().subsets = self.registry().subsets.clone();
         nested.registry_mut().enum_types = self.registry().enum_types.clone();
         nested.type_metadata = self.type_metadata.clone();

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -60,12 +60,13 @@ impl Interpreter {
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =
                     self.registry().class_composed_roles.clone();
-                nested.roles = self.roles.clone();
-                nested.role_candidates = self.role_candidates.clone();
-                nested.role_parents = self.role_parents.clone();
-                nested.role_hides = self.role_hides.clone();
-                nested.role_type_params = self.role_type_params.clone();
-                nested.class_role_param_bindings = self.class_role_param_bindings.clone();
+                nested.registry_mut().roles = self.registry().roles.clone();
+                nested.registry_mut().role_candidates = self.registry().role_candidates.clone();
+                nested.registry_mut().role_parents = self.registry().role_parents.clone();
+                nested.registry_mut().role_hides = self.registry().role_hides.clone();
+                nested.registry_mut().role_type_params = self.registry().role_type_params.clone();
+                nested.registry_mut().class_role_param_bindings =
+                    self.registry().class_role_param_bindings.clone();
                 nested.registry_mut().subsets = self.registry().subsets.clone();
                 nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -24,12 +24,13 @@ impl Interpreter {
         self.registry_mut().hidden_defer_parents = nested.registry().hidden_defer_parents.clone();
         self.registry_mut().class_trusts = nested.registry().class_trusts.clone();
         self.registry_mut().class_composed_roles = nested.registry().class_composed_roles.clone();
-        self.roles = nested.roles.clone();
-        self.role_candidates = nested.role_candidates.clone();
-        self.role_parents = nested.role_parents.clone();
-        self.role_hides = nested.role_hides.clone();
-        self.role_type_params = nested.role_type_params.clone();
-        self.class_role_param_bindings = nested.class_role_param_bindings.clone();
+        self.registry_mut().roles = nested.registry().roles.clone();
+        self.registry_mut().role_candidates = nested.registry().role_candidates.clone();
+        self.registry_mut().role_parents = nested.registry().role_parents.clone();
+        self.registry_mut().role_hides = nested.registry().role_hides.clone();
+        self.registry_mut().role_type_params = nested.registry().role_type_params.clone();
+        self.registry_mut().class_role_param_bindings =
+            nested.registry().class_role_param_bindings.clone();
         self.registry_mut().attribute_build_overrides =
             nested.registry().attribute_build_overrides.clone();
         self.registry_mut().subsets = nested.registry().subsets.clone();

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -48,7 +48,7 @@ impl Interpreter {
         let saved_proto_tokens = self.proto_tokens.clone();
         let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
-        let saved_roles = self.roles.clone();
+        let saved_roles = self.registry().roles.clone();
         let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
@@ -71,7 +71,7 @@ impl Interpreter {
             self.proto_tokens = saved_proto_tokens;
             self.registry_mut().classes = saved_classes;
             self.registry_mut().class_trusts = saved_class_trusts;
-            self.roles = saved_roles;
+            self.registry_mut().roles = saved_roles;
             self.registry_mut().subsets = saved_subsets;
             // Merge type_metadata: preserve entries added during the subtest
             for (key, val) in std::mem::take(&mut self.type_metadata) {
@@ -99,7 +99,7 @@ impl Interpreter {
         self.proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
-        self.roles = saved_roles;
+        self.registry_mut().roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest
         for (key, val) in std::mem::take(&mut self.type_metadata) {
@@ -146,7 +146,7 @@ impl Interpreter {
         let saved_proto_tokens = self.proto_tokens.clone();
         let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
-        let saved_roles = self.roles.clone();
+        let saved_roles = self.registry().roles.clone();
         let saved_subsets = self.registry().subsets.clone();
         let mut saved_type_metadata = self.type_metadata.clone();
         let saved_var_type_constraints = self.snapshot_var_type_constraints();
@@ -160,7 +160,7 @@ impl Interpreter {
         self.proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
-        self.roles = saved_roles;
+        self.registry_mut().roles = saved_roles;
         self.registry_mut().subsets = saved_subsets;
         // Merge type_metadata: preserve entries added during the subtest
         for (key, val) in std::mem::take(&mut self.type_metadata) {

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -36,12 +36,13 @@ impl Interpreter {
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =
                     self.registry().class_composed_roles.clone();
-                nested.roles = self.roles.clone();
-                nested.role_candidates = self.role_candidates.clone();
-                nested.role_parents = self.role_parents.clone();
-                nested.role_hides = self.role_hides.clone();
-                nested.role_type_params = self.role_type_params.clone();
-                nested.class_role_param_bindings = self.class_role_param_bindings.clone();
+                nested.registry_mut().roles = self.registry().roles.clone();
+                nested.registry_mut().role_candidates = self.registry().role_candidates.clone();
+                nested.registry_mut().role_parents = self.registry().role_parents.clone();
+                nested.registry_mut().role_hides = self.registry().role_hides.clone();
+                nested.registry_mut().role_type_params = self.registry().role_type_params.clone();
+                nested.registry_mut().class_role_param_bindings =
+                    self.registry().class_role_param_bindings.clone();
                 nested.registry_mut().subsets = self.registry().subsets.clone();
                 nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();
@@ -368,7 +369,7 @@ impl Interpreter {
                 nested.proto_subs = self.proto_subs.clone();
                 nested.proto_tokens = self.proto_tokens.clone();
                 nested.registry_mut().classes = self.registry().classes.clone();
-                nested.roles = self.roles.clone();
+                nested.registry_mut().roles = self.registry().roles.clone();
                 nested.registry_mut().subsets = self.registry().subsets.clone();
                 nested.registry_mut().enum_types = self.registry().enum_types.clone();
                 nested.type_metadata = self.type_metadata.clone();

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -366,7 +366,7 @@ impl Interpreter {
             return Ok(value);
         };
         let role_name = role_name.resolve();
-        let Some(candidates) = self.role_candidates.get(&role_name).cloned() else {
+        let Some(candidates) = self.registry().role_candidates.get(&role_name).cloned() else {
             return Ok(value);
         };
         let Some(candidate) = candidates.into_iter().find(|candidate| {

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -13,15 +13,19 @@ impl Interpreter {
                 _ => None,
             });
         if let Some(role_id) = role_id
-            && let Some(candidate) = self.role_candidates.get(role_name).and_then(|candidates| {
-                candidates
-                    .iter()
-                    .find(|candidate| candidate.role_def.role_id == role_id)
-            })
+            && let Some(candidate) =
+                self.registry()
+                    .role_candidates
+                    .get(role_name)
+                    .and_then(|candidates| {
+                        candidates
+                            .iter()
+                            .find(|candidate| candidate.role_def.role_id == role_id)
+                    })
         {
             return Some(candidate.role_def.clone());
         }
-        self.roles.get(role_name).cloned()
+        self.registry().roles.get(role_name).cloned()
     }
 
     pub(crate) fn resolve_parametric_role_runtime(
@@ -29,13 +33,17 @@ impl Interpreter {
         base_name: &str,
         type_args: &[Value],
     ) -> Option<(RoleDef, Vec<String>)> {
-        let mut selected_role = self.roles.get(base_name).cloned();
+        let mut selected_role = self.registry().roles.get(base_name).cloned();
         let mut selected_param_names = self
+            .registry()
             .role_type_params
             .get(base_name)
             .cloned()
             .unwrap_or_default();
-        if let Some(candidates) = self.role_candidates.get(base_name).cloned() {
+        // Hoist clone to a `let` so the guard drops before the filter_map closure
+        // re-enters (an if-let scrutinee guard otherwise lives through the block).
+        let candidates = self.registry().role_candidates.get(base_name).cloned();
+        if let Some(candidates) = candidates {
             let mut matching: Vec<(crate::runtime::RoleCandidateDef, i32, usize)> = candidates
                 .into_iter()
                 .enumerate()
@@ -230,20 +238,20 @@ impl Interpreter {
             Value::ParametricRole {
                 base_name,
                 type_args,
-            } if self.roles.contains_key(&base_name.resolve()) => {
+            } if self.registry().roles.contains_key(&base_name.resolve()) => {
                 Some((base_name.resolve(), type_args.clone()))
             }
-            Value::Pair(name, boxed) if self.roles.contains_key(name) => {
+            Value::Pair(name, boxed) if self.registry().roles.contains_key(name) => {
                 if let Value::Array(args, ..) = boxed.as_ref() {
                     Some((name.clone(), args.as_ref().clone()))
                 } else {
                     None
                 }
             }
-            Value::Package(name) if self.roles.contains_key(&name.resolve()) => {
+            Value::Package(name) if self.registry().roles.contains_key(&name.resolve()) => {
                 Some((name.resolve(), Vec::new()))
             }
-            Value::Str(name) if self.roles.contains_key(name.as_str()) => {
+            Value::Str(name) if self.registry().roles.contains_key(name.as_str()) => {
                 Some((name.to_string(), Vec::new()))
             }
             _ => None,
@@ -256,7 +264,7 @@ impl Interpreter {
         role_name: &str,
         role_args: &[Value],
     ) -> Result<Value, RuntimeError> {
-        let role = self.roles.get(role_name).cloned();
+        let role = self.registry().roles.get(role_name).cloned();
         if role.is_none()
             && !matches!(
                 role_name,
@@ -281,6 +289,7 @@ impl Interpreter {
             // constraints (e.g. `method hi(vartype $foo)`) can resolve the type
             // variables during dispatch.
             let param_names = self
+                .registry()
                 .role_type_params
                 .get(role_name)
                 .cloned()
@@ -296,7 +305,11 @@ impl Interpreter {
         // same name (e.g. two `my role A { }` in different scopes) produce
         // distinct mixin maps, making `===` return False for values mixed with
         // different role instances.
-        let role_id = self.roles.get(role_name).map_or(0, |r| r.role_id);
+        let role_id = self
+            .registry()
+            .roles
+            .get(role_name)
+            .map_or(0, |r| r.role_id);
         if role_id != 0 {
             mixins.insert(
                 format!("__mutsu_role_id__{}", role_name),
@@ -351,7 +364,7 @@ impl Interpreter {
         target: Value,
         role_name: &str,
     ) -> Result<Value, RuntimeError> {
-        let role = match self.roles.get(role_name).cloned() {
+        let role = match self.registry().roles.get(role_name).cloned() {
             Some(r) => r,
             None => return Ok(target),
         };

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -198,20 +198,20 @@ impl Interpreter {
     }
 
     /// Resolve a potentially qualified role name to its registered key.
-    /// If `name` is in `self.roles`, returns it as-is. Otherwise, if `name`
+    /// If `name` is in `self.registry().roles`, returns it as-is. Otherwise, if `name`
     /// contains `::`, tries the short name (after the last `::`).
     pub(in crate::runtime) fn resolve_role_key(&self, name: &str) -> Option<String> {
-        if self.roles.contains_key(name) {
+        if self.registry().roles.contains_key(name) {
             return Some(name.to_string());
         }
         if let Some(Value::Package(pkg)) = self.env.get(name) {
             let resolved = pkg.resolve();
-            if self.roles.contains_key(&resolved) {
+            if self.registry().roles.contains_key(&resolved) {
                 return Some(resolved);
             }
         }
         if let Some(short) = name.rsplit("::").next()
-            && self.roles.contains_key(short)
+            && self.registry().roles.contains_key(short)
         {
             return Some(short.to_string());
         }
@@ -685,7 +685,7 @@ impl Interpreter {
                     if Self::type_matches(effective_constraint, &role_name) {
                         return true;
                     }
-                    if let Some(rparents) = self.role_parents.get(&role_name) {
+                    if let Some(rparents) = self.registry().role_parents.get(&role_name) {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
                             if self.resolve_role_key(rp_base).is_some() {
@@ -707,27 +707,31 @@ impl Interpreter {
                 .split_once('[')
                 .map(|(b, _)| b)
                 .unwrap_or(&pkg_resolved);
-            if self.roles.contains_key(pkg_base) {
+            if self.registry().roles.contains_key(pkg_base) {
                 // For role groups, use candidate-specific parents:
                 // - Curried roles (e.g. R[Int]): use parametric candidate's parents
                 // - Bare role name: use non-parametric candidate's parents
-                let candidate_parents = self.role_candidates.get(pkg_base).and_then(|candidates| {
-                    if pkg_resolved.contains('[') {
-                        // Curried: find the parametric candidate
-                        candidates
-                            .iter()
-                            .find(|c| !c.type_params.is_empty())
-                            .map(|c| c.parents.clone())
-                    } else {
-                        // Bare: find the non-parametric candidate
-                        candidates
-                            .iter()
-                            .find(|c| c.type_params.is_empty())
-                            .map(|c| c.parents.clone())
-                    }
-                });
+                let candidate_parents =
+                    self.registry()
+                        .role_candidates
+                        .get(pkg_base)
+                        .and_then(|candidates| {
+                            if pkg_resolved.contains('[') {
+                                // Curried: find the parametric candidate
+                                candidates
+                                    .iter()
+                                    .find(|c| !c.type_params.is_empty())
+                                    .map(|c| c.parents.clone())
+                            } else {
+                                // Bare: find the non-parametric candidate
+                                candidates
+                                    .iter()
+                                    .find(|c| c.type_params.is_empty())
+                                    .map(|c| c.parents.clone())
+                            }
+                        });
                 let initial_parents = candidate_parents
-                    .or_else(|| self.role_parents.get(pkg_base).cloned())
+                    .or_else(|| self.registry().role_parents.get(pkg_base).cloned())
                     .unwrap_or_default();
                 let mut stack: Vec<String> = initial_parents;
                 let mut seen = HashSet::new();
@@ -755,7 +759,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    if let Some(rparents) = self.role_parents.get(&parent) {
+                    if let Some(rparents) = self.registry().role_parents.get(&parent) {
                         for rp in rparents {
                             stack.push(rp.clone());
                         }
@@ -815,7 +819,7 @@ impl Interpreter {
                 return true;
             }
             // Check composed roles for the instance's class (and its MRO)
-            if self.roles.contains_key(constraint) {
+            if self.registry().roles.contains_key(constraint) {
                 let mro = self.class_mro(&class_name.resolve());
                 let mut role_stack: Vec<String> = Vec::new();
                 let mut seen_roles = HashSet::new();
@@ -834,10 +838,10 @@ impl Interpreter {
                     if role_name == constraint {
                         return true;
                     }
-                    if let Some(rparents) = self.role_parents.get(&role_name) {
+                    if let Some(rparents) = self.registry().role_parents.get(&role_name) {
                         for rp in rparents {
                             let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            if self.roles.contains_key(rp_base) {
+                            if self.registry().roles.contains_key(rp_base) {
                                 role_stack.push(rp_base.to_string());
                             }
                         }

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -226,12 +226,12 @@ impl Interpreter {
     /// Check if a type name is known (either a class, role, or enum).
     pub(crate) fn has_type(&self, name: &str) -> bool {
         self.registry().classes.contains_key(name)
-            || self.roles.contains_key(name)
+            || self.registry().roles.contains_key(name)
             || self.registry().enum_types.contains_key(name)
             || self.registry().subsets.contains_key(name)
             || Self::parse_parametric_type_name(name).is_some_and(|(base, _)| {
                 self.registry().classes.contains_key(&base)
-                    || self.roles.contains_key(&base)
+                    || self.registry().roles.contains_key(&base)
                     || self.registry().enum_types.contains_key(&base)
                     || self.registry().subsets.contains_key(&base)
             })
@@ -249,11 +249,12 @@ impl Interpreter {
     }
 
     pub(crate) fn has_role(&self, name: &str) -> bool {
-        self.roles.contains_key(name)
+        self.registry().roles.contains_key(name)
     }
 
     pub(crate) fn role_has_method(&self, role_name: &str, method_name: &str) -> bool {
-        self.roles
+        self.registry()
+            .roles
             .get(role_name)
             .is_some_and(|r| r.methods.contains_key(method_name))
     }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -227,11 +227,7 @@ impl VM {
         );
 
         // Role param bindings
-        if let Some(role_bindings) = self
-            .interpreter
-            .class_role_param_bindings(owner_class)
-            .cloned()
-        {
+        if let Some(role_bindings) = self.interpreter.class_role_param_bindings(owner_class) {
             for (name, value) in &role_bindings {
                 self.interpreter
                     .env_mut()
@@ -240,7 +236,6 @@ impl VM {
         } else if let Some(role_bindings) = self
             .interpreter
             .class_role_param_bindings(receiver_class_name)
-            .cloned()
         {
             for (name, value) in &role_bindings {
                 self.interpreter


### PR DESCRIPTION
## Summary

Continues the **phase ② registry VM-ownership** migration (PLAN.md ②, design: `docs/vm-registry-ownership.md`). After slices 1–3 (enum/subset, class metadata, `classes`), this slice moves the **7 roles-group fields** off the `Interpreter` struct into the shared `Arc<RwLock<Registry>>`:

`roles`, `user_declared_roles`, `role_candidates`, `role_parents`, `role_hides`, `role_type_params`, `class_role_param_bindings` (~200 access sites).

Behavior-preserving structural refactor — CI (`make test` + `make roast`) is the safety net.

## Changes

- `RoleCandidateDef` made `pub(crate)` (`RoleDef` was already `Debug`/`Clone`/`pub(crate)`).
- Built-in roles seed `registry.roles` in `Interpreter::new`; `clone_for_thread` drops the 7 per-field clones (subsumed by the whole-`Registry` snapshot clone — per-thread independent `Arc` preserved).
- Reference-returning accessors `get_role_def() -> Option<&RoleDef>` and `class_role_param_bindings() -> Option<&HashMap>` now return owned values (a reference into a `RwLock` guard can't escape). VM call sites use `.is_some()` / `.map()`, so they are unchanged.

## Re-entrancy safety (the important part)

- **Found and fixed two read→write same-lock deadlocks the borrow checker cannot catch** (both operands borrow `&self`, so no `E0502`): in `registration_class.rs`, a read guard on `roles` / `role_hides` was held while calling `registry_mut()` to write `hidden_classes` / `hidden_defer_parents`. A Python brace-matched scan over **every** registry field now reports zero read-get bodies containing `registry_mut()`.
- `&mut self` re-entries crossing a read guard (an `if let` scrutinee guard lives through the whole consequent block) are resolved by cloning out / hoisting to a `let`: role type-object punning (`methods.rs`), `new()` role bindings (`methods_object.rs`), the parametric-role parent walk (`smart_match.rs`), and a single-guard `or_else` over the class+role method tables (`resolution.rs`).
- Three `classes.contains_key || roles.contains_key` statements (two stacked read guards) collapsed to a single bound guard.
- Every `get_mut` body audited to not re-enter the registry.

## Verification

- `cargo build` + `cargo clippy -D warnings` green.
- `make test` green (458 cargo unit tests, prove `t/`).
- All 115 whitelisted `S12-*` / `S14-*` (class/role) roast tests pass (2246 subtests).
- Role smoke test: composition, role-does-role inheritance, parameterized roles (`Container[Int]`), multi-role attributes, method-conflict resolution, punning, `but` mixin, `.^roles`. (One pre-existing gap — a punned role's `@.items` returning `Nil` — reproduces identically on `main`, so it is unrelated to this refactor.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)