### PR TITLE
refactor(vm): migrate functions/subs/tokens into shared Registry (phase ② PR-A final slice)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -109,11 +109,16 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       plain な VM フィールドへ畳む**（＝ Interpreter オブジェクト消滅）。登録は登録中にユーザコードへ再入する
       （trait ハンドラ / 属性デフォルト / クラス本体）ため、**RwLock ガードを再入を跨いで保持しない**規律が肝。
       `clone_for_thread` のスナップショット意味論は厳守（挙動不変）。②は③の前提。
-      - [x] **PR-A slice 1（#2760）**: 機構確立 + `enum_types`/`subsets` 移行（`src/runtime/registry.rs` 新設、
-            `registry()`/`registry_mut()` ヘルパ、~75 サイト変換、再入ハザードをガード巻き上げで安全化）。
-      - [ ] **PR-A 残**: classes（178 サイト・ホット経路・大きい `ClassDef` なので naive clone を避け Registry
-            アクセサで最小データ返却）/ class メタ群 / roles 群 / functions・subs・tokens（移行後 `clone_for_thread`
-            1 行化）。→ **PR-B**（lookup を Registry メソッド化・VM 直読み）→ **PR-C**（register_* write-through 整理）。
+      - [x] **PR-A 完了（抽出フェーズ, #2760/2762/2763/2764/2767）**: 全宣言レジストリを `Registry` へ移行。
+            slice 1 enum/subset（機構確立）→ 2 class メタ群 → 3 classes（ホット経路・targeted 投影 clone 維持、
+            naive whole-clone 回避で perf 回帰なし）→ 4 roles 群 → 5 functions/subs/tokens。**結果**: `Interpreter`
+            から宣言レジストリが消え `clone_for_thread` は registry 全体 clone 1 行のみ（個別 clone ゼロ・snapshot 不変）。
+            参照返却アクセサは owned 化。再入安全規律（read→write/write→write 同一ロック deadlock を複数発見・修正、
+            Python ブレース対応スキャナ＋make roast タイムアウトで検出）を確立。詳細は docs/vm-registry-ownership.md。
+      - [ ] **PR-B（read 側）**: lookup/MRO/型マッチの registry 読み部を Registry メソッド化し、VM の read サイトを
+            `self.registry.read()` 直読みへ。台帳 §2 の関数 dispatch fallback（multi/sub 解決）撲滅の前提。
+      - [ ] **PR-C（write-through）**: `register_*_decl` の registry 書き込みを write-lock ブロックへ整理、再入跨ぎ
+            guard 無しを保証、台帳注釈更新。これで②完了→③（env/型/state 移管）へ。
 - [ ] **③ VM が借用している Interpreter 状態を VM 所有へ移管**: env HashMap（変数ストア本体）・classes/roles/enums
       レジストリ・型検査（`type_matches_value`/`var_type_constraint`）・readonly 追跡・`let`/`temp` 復元・multi 解決・
       state 変数・`current_package`。これが移れば **interpreter ブリッジ自体が不要**になる。最大の山。

--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -119,13 +119,28 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   parametric parents、resolution の class+role メソッド表 or_else 単一ガード化）。③ 一文 2 read ガード
   （`classes.contains_key || roles.contains_key` 3 箇所）を単一束縛ガードへ。build/clippy/make test 緑。
   挙動不変確認（ロール合成/継承/パラメタ化/punning/conflict/`but`; Stack配列属性の Nil は main と同一の既存ギャップ）。
-- 残（フィールド別 total/writes）: functions(96)/token_defs(35)/proto_*。
+- **PR-A slice 5 = PR-A 最終（本 PR, #2764 後）**: functions/subs/tokens 群 6 フィールド移行（functions,
+  our_scoped_functions, proto_functions, token_defs, proto_subs, proto_tokens）。`FunctionDef` は既に
+  Debug/Clone/pub(crate)。builtin seed 無し（全ユーザ定義）。**これで宣言レジストリが全て Registry に入り、
+  `clone_for_thread` の個別フィールド clone がゼロ＝registry 全体 clone 1 本のみ**（②の完了の定義を達成）。VM 直
+  アクセス無し。snapshot_routine_registry は単一 read ガード化、restore は read（our_scoped 収集）→guard drop→
+  write の 2 段に分離。regex/grammar サブインタプリタ構築の struct リテラル 9 箇所（`Interpreter { functions:..,
+  token_defs:.., ..Default }`）は `copy_decl_registry_into(&mut interp)` ヘルパへ（別 Arc 間 snapshot コピー）。
+  **★重大: write→write 同一ロック deadlock を発見・修正**: `match self.registry_mut().functions.entry(k) {
+  Occupied => { ... self.registry_mut().functions.entry(k2) ... } }` ＝外側 write ガード保持中に arm 内で再度
+  `registry_mut()`。**借用チェッカは別 `registry_mut()` 呼び出しを別借用と見るため未捕捉**で、**スキャナでも当初
+  見逃し→multi sub 宣言が実行時ハング**（スモークテストで顕在化）。`insert_multi_overload` ヘルパ（単一 write
+  ガードで base→`__m{N}` fallback）に統合。**教訓: read→write だけでなく write→write/write→read も危険。
+  検出スキャナは `match/if-let self.registry_mut()` ブロック本体の registry 再アクセスも走査せよ（下記）。
+  最終防衛線は make roast のタイムアウト**（make test+51823 roast サンプル緑、回帰ゼロ）。
 
-## 完了の定義（②）
+## 完了の定義（②）— **PR-A 完了（slice 1-5, #2760/2762/2763/2764/本PR）**
 
-`Interpreter` から宣言レジストリ ~30 フィールドが消え `registry: Arc<RwLock<Registry>>` 1 本に。VM の
-registry 系 lookup が `self.registry.read()` 経由へ。`clone_for_thread` のレジストリ複製が 1 行化（snapshot
-不変）。台帳の §2 前提「②レジストリ」を満たした旨を更新。③（env/型/state 移管）と §2 撲滅へ進める状態。
+`Interpreter` から宣言レジストリ全フィールドが消え `registry: Arc<RwLock<Registry>>` 1 本に。`clone_for_thread`
+のレジストリ複製は registry 全体 clone 1 行のみ（個別フィールド clone ゼロ、snapshot 不変）。VM の registry 系
+lookup は accessor 経由（多くは既に owned 返し）。**次は PR-B**（lookup/MRO/型マッチを Registry メソッド化して
+VM が `self.registry.read()` で直読み、台帳 §2 の関数 dispatch fallback 撲滅の前提を整える）→ **PR-C**
+（register_* の write-through 整理）→ ③（env/型/state 移管）。
 
 ## 非ゴール
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1118,12 +1118,14 @@ impl Interpreter {
         let def = self.resolve_function(lookup_name).or_else(|| {
             if has_packages {
                 let fq = format!("{}::{}", self.current_package, lookup_name);
-                self.our_scoped_functions
+                self.registry()
+                    .our_scoped_functions
                     .get(&Symbol::intern(&fq))
                     .cloned()
                     .or_else(|| {
                         let global_fq = format!("GLOBAL::{}", lookup_name);
-                        self.our_scoped_functions
+                        self.registry()
+                            .our_scoped_functions
                             .get(&Symbol::intern(&global_fq))
                             .cloned()
                     })
@@ -1135,7 +1137,7 @@ impl Interpreter {
             // Check if there are multi-dispatch variants (stored with arity/type suffixes)
             let prefix_local = format!("{}::{}/", self.current_package, lookup_name);
             let prefix_global = format!("GLOBAL::{}/", lookup_name);
-            self.functions.keys().any(|k| {
+            self.registry().functions.keys().any(|k| {
                 let ks = k.resolve();
                 ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
             })
@@ -1515,6 +1517,7 @@ impl Interpreter {
         let prefix = format!("{package}::");
         self.env.keys().any(|k| k.starts_with(&prefix))
             || self
+                .registry()
                 .functions
                 .keys()
                 .any(|k| k.resolve().starts_with(&prefix))
@@ -1823,7 +1826,7 @@ impl Interpreter {
             }
         }
 
-        for (key, def) in &self.functions {
+        for (key, def) in &self.registry().functions {
             let key_s = key.resolve();
             let Some(rest) = Self::stash_member_tail(&key_s, &package_name) else {
                 continue;
@@ -1987,13 +1990,15 @@ impl Interpreter {
     }
 
     pub(crate) fn snapshot_routine_registry(&self) -> RoutineRegistrySnapshot {
+        // Single guard for all six reads (avoids stacking read guards).
+        let registry = self.registry();
         (
-            self.functions.clone(),
-            self.proto_functions.clone(),
-            self.token_defs.clone(),
-            self.proto_subs.clone(),
-            self.proto_tokens.clone(),
-            self.our_scoped_functions.keys().copied().collect(),
+            registry.functions.clone(),
+            registry.proto_functions.clone(),
+            registry.token_defs.clone(),
+            registry.proto_subs.clone(),
+            registry.proto_tokens.clone(),
+            registry.our_scoped_functions.keys().copied().collect(),
         )
     }
 
@@ -2017,36 +2022,42 @@ impl Interpreter {
         // of our_scoped_functions keys that existed at snapshot time.
         let current_pkg = self.current_package.clone();
         let mut new_our: Vec<(Symbol, FunctionDef)> = Vec::new();
-        for (key, def) in &self.our_scoped_functions {
-            if functions.contains_key(key) {
-                continue;
-            }
-            let def_pkg = def.package.resolve();
-            // Always preserve same-package subs (original behavior).
-            if def_pkg == current_pkg {
-                new_our.push((*key, def.clone()));
-                continue;
-            }
-            // Also preserve subs that were newly added to our_scoped_functions
-            // during this block (i.e. their key was not in the snapshot). This
-            // covers nested `package Foo { our sub bar {} }` blocks. Subs from
-            // module loading (`use Foo`) are typically already in the snapshot
-            // by the time the block is restored, so they are not preserved here.
-            if !our_scoped_keys.contains(key) {
-                new_our.push((*key, def.clone()));
+        // Collect under a read guard, which drops before the writes below
+        // (read->write on the same lock would deadlock).
+        {
+            let registry = self.registry();
+            for (key, def) in &registry.our_scoped_functions {
+                if functions.contains_key(key) {
+                    continue;
+                }
+                let def_pkg = def.package.resolve();
+                // Always preserve same-package subs (original behavior).
+                if def_pkg == current_pkg {
+                    new_our.push((*key, def.clone()));
+                    continue;
+                }
+                // Also preserve subs that were newly added to our_scoped_functions
+                // during this block (i.e. their key was not in the snapshot). This
+                // covers nested `package Foo { our sub bar {} }` blocks. Subs from
+                // module loading (`use Foo`) are typically already in the snapshot
+                // by the time the block is restored, so they are not preserved here.
+                if !our_scoped_keys.contains(key) {
+                    new_our.push((*key, def.clone()));
+                }
             }
         }
-        self.functions = functions;
-        self.proto_functions = proto_functions;
-        self.token_defs = token_defs;
-        self.proto_subs = proto_subs;
-        self.proto_tokens = proto_tokens;
+        let mut registry = self.registry_mut();
+        registry.functions = functions;
+        registry.proto_functions = proto_functions;
+        registry.token_defs = token_defs;
+        registry.proto_subs = proto_subs;
+        registry.proto_tokens = proto_tokens;
         // Re-apply only newly added our-scoped functions so they survive block scope exit.
         // In EVAL context, our-scoped functions should NOT leak into the outer lexical
         // scope — they remain accessible only via OUR:: pseudo-package resolution.
         if !is_eval {
             for (key, def) in new_our {
-                self.functions.insert(key, def);
+                registry.functions.insert(key, def);
             }
         }
     }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -297,7 +297,7 @@ impl Interpreter {
         };
         let saved_package = self.current_package.clone();
         let before_function_keys: std::collections::HashSet<Symbol> =
-            self.functions.keys().copied().collect();
+            self.registry().functions.keys().copied().collect();
         let before_env_keys: std::collections::HashSet<Symbol> = self.env.keys().copied().collect();
         let before_class_keys: std::collections::HashSet<String> =
             self.registry().classes.keys().cloned().collect();
@@ -313,13 +313,16 @@ impl Interpreter {
         // A `sub MAIN` defined in a required module is NOT the program's MAIN
         // and must not be auto-dispatched at program end. Remove any top-level
         // MAIN routines that this module introduced.
-        Self::remove_leaked_main_routines(&mut self.functions, &before_function_keys);
+        Self::remove_leaked_main_routines(
+            &mut self.registry_mut().functions,
+            &before_function_keys,
+        );
 
         if let Some(pkg) = package_hint
             && !pkg.is_empty()
         {
             let mut fn_aliases: Vec<(Symbol, FunctionDef)> = Vec::new();
-            for (name, def) in &self.functions {
+            for (name, def) in &self.registry().functions {
                 if before_function_keys.contains(name) {
                     continue;
                 }
@@ -330,12 +333,12 @@ impl Interpreter {
                 }
                 let alias = format!("{pkg}::{tail}");
                 let alias_sym = Symbol::intern(&alias);
-                if !self.functions.contains_key(&alias_sym) {
+                if !self.registry().functions.contains_key(&alias_sym) {
                     fn_aliases.push((alias_sym, def.clone()));
                 }
             }
             for (alias, def) in fn_aliases {
-                self.functions.insert(alias, def);
+                self.registry_mut().functions.insert(alias, def);
             }
 
             let mut env_aliases: Vec<(String, Value)> = Vec::new();
@@ -419,6 +422,7 @@ impl Interpreter {
             let target_prefix = format!("GLOBAL::{name}/");
             let mut found = false;
             let function_entries: Vec<(Symbol, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter_map(|(k, v)| {
@@ -438,10 +442,11 @@ impl Interpreter {
                 })
                 .collect();
             for (k, v) in function_entries {
-                self.functions.insert(k, v);
+                self.registry_mut().functions.insert(k, v);
             }
             return found
                 || self
+                    .registry()
                     .functions
                     .contains_key(&Symbol::intern(&format!("GLOBAL::{name}")));
         }
@@ -487,7 +492,10 @@ impl Interpreter {
             return true;
         }
         if let Some(value) = self.env.get(&source_single).cloned() {
-            if self.functions.contains_key(&Symbol::intern(&source_single))
+            if self
+                .registry()
+                .functions
+                .contains_key(&Symbol::intern(&source_single))
                 && matches!(value, Value::Int(_))
             {
                 return false;
@@ -592,6 +600,7 @@ impl Interpreter {
             let prefix = format!("{module}::");
             if self.loaded_modules.contains(module)
                 && !self
+                    .registry()
                     .functions
                     .keys()
                     .any(|k| k.resolve().starts_with(&prefix))

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -636,18 +636,26 @@ impl Interpreter {
     ) -> Option<FunctionDef> {
         if name.contains("::") {
             let multi_key = format!("{}/{}", name, arity);
-            if let Some(def) = self.functions.get(&Symbol::intern(&multi_key)) {
+            if let Some(def) = self.registry().functions.get(&Symbol::intern(&multi_key)) {
                 return Some(def.clone());
             }
-            return self.functions.get(&Symbol::intern(name)).cloned();
+            return self
+                .registry()
+                .functions
+                .get(&Symbol::intern(name))
+                .cloned();
         }
         // Try multi-dispatch with arity first
         let multi_local = format!("{}::{}/{}", self.current_package, name, arity);
-        if let Some(def) = self.functions.get(&Symbol::intern(&multi_local)) {
+        if let Some(def) = self.registry().functions.get(&Symbol::intern(&multi_local)) {
             return Some(def.clone());
         }
         let multi_global = format!("GLOBAL::{}/{}", name, arity);
-        if let Some(def) = self.functions.get(&Symbol::intern(&multi_global)) {
+        if let Some(def) = self
+            .registry()
+            .functions
+            .get(&Symbol::intern(&multi_global))
+        {
             return Some(def.clone());
         }
         // Fall back to regular lookup
@@ -665,7 +673,12 @@ impl Interpreter {
             .filter(|v| !matches!(v, Value::Pair(..)))
             .count();
         if name.contains("::") {
-            if let Some(def) = self.functions.get(&Symbol::intern(name)).cloned() {
+            if let Some(def) = self
+                .registry()
+                .functions
+                .get(&Symbol::intern(name))
+                .cloned()
+            {
                 // Block access to my-scoped (non-our) package items from outside
                 // their declaring package.
                 if self.is_my_scoped_package_item(name)
@@ -684,6 +697,7 @@ impl Interpreter {
             let untyped_key_sym = Symbol::intern(&untyped_key);
             let untyped_m_prefix = format!("{}__m", untyped_key);
             let mut candidates: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(key, _)| {
@@ -705,6 +719,7 @@ impl Interpreter {
             // separately (across all arities under `name/`) and dispatch on them.
             let subsig_prefix = format!("{}/", name);
             let mut subsig_candidates: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(key, def)| {
@@ -721,7 +736,12 @@ impl Interpreter {
                     return Some(def);
                 }
             }
-            if let Some(def) = self.functions.get(&Symbol::intern(name)).cloned() {
+            if let Some(def) = self
+                .registry()
+                .functions
+                .get(&Symbol::intern(name))
+                .cloned()
+            {
                 if !self.is_my_scoped_package_item(name) {
                     return Some(def);
                 } else if let Some((pkg_prefix, _)) = name.rsplit_once("::")
@@ -752,7 +772,12 @@ impl Interpreter {
                 };
                 if prefix_visible {
                     let qualified = format!("{}::{}", self.current_package, name);
-                    if let Some(def) = self.functions.get(&Symbol::intern(&qualified)).cloned() {
+                    if let Some(def) = self
+                        .registry()
+                        .functions
+                        .get(&Symbol::intern(&qualified))
+                        .cloned()
+                    {
                         return Some(def);
                     }
                     let q_prefix = format!("{qualified}/{arity}:");
@@ -760,6 +785,7 @@ impl Interpreter {
                     let q_untyped_key_sym = Symbol::intern(&q_untyped_key);
                     let q_untyped_m_prefix = format!("{}__m", q_untyped_key);
                     let mut q_candidates: Vec<(String, FunctionDef)> = self
+                        .registry()
                         .functions
                         .iter()
                         .filter(|(key, _)| {
@@ -781,11 +807,21 @@ impl Interpreter {
             return None;
         }
         let exact_local = format!("{}::{}", self.current_package, name);
-        if let Some(def) = self.functions.get(&Symbol::intern(&exact_local)).cloned() {
+        if let Some(def) = self
+            .registry()
+            .functions
+            .get(&Symbol::intern(&exact_local))
+            .cloned()
+        {
             return Some(def);
         }
         let exact_global = format!("GLOBAL::{}", name);
-        if let Some(def) = self.functions.get(&Symbol::intern(&exact_global)).cloned() {
+        if let Some(def) = self
+            .registry()
+            .functions
+            .get(&Symbol::intern(&exact_global))
+            .cloned()
+        {
             return Some(def);
         }
         let prefix_local = format!("{}::{}/{}:", self.current_package, name, arity);
@@ -796,6 +832,7 @@ impl Interpreter {
         ];
         let mut found_multi_candidates = false;
         let mut candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(key, _)| {
@@ -808,6 +845,7 @@ impl Interpreter {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
             let more: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
@@ -829,6 +867,7 @@ impl Interpreter {
             format!("GLOBAL::{}/", name),
         ];
         let mut optional_candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(k, def)| {
@@ -868,6 +907,7 @@ impl Interpreter {
             format!("GLOBAL::{}/", name),
         ];
         let mut slurpy_candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(k, def)| {
@@ -895,6 +935,7 @@ impl Interpreter {
             format!("GLOBAL::{name}/"),
         ];
         let mut any_arity_candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(k, _)| {
@@ -940,6 +981,7 @@ impl Interpreter {
             format!("GLOBAL::{}/{}:", name, arity),
         ] {
             let candidates: Vec<FunctionDef> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(key, _)| key.resolve().starts_with(&prefix_base))
@@ -961,6 +1003,7 @@ impl Interpreter {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
             let mut candidates: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
@@ -994,6 +1037,7 @@ impl Interpreter {
             format!("GLOBAL::{}/", name),
         ];
         let mut slurpy_candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(k, def)| {
@@ -1034,6 +1078,7 @@ impl Interpreter {
         let mut seen_fps = Vec::new();
         for prefix in &prefixes {
             let candidates: Vec<FunctionDef> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| k.resolve().starts_with(prefix.as_str()))
@@ -1168,13 +1213,15 @@ impl Interpreter {
 
     pub(crate) fn has_proto(&self, name: &str) -> bool {
         if name.contains("::") {
-            return self.proto_subs.contains(name);
+            return self.registry().proto_subs.contains(name);
         }
         let local = format!("{}::{}", self.current_package, name);
-        if self.proto_subs.contains(&local) {
+        if self.registry().proto_subs.contains(&local) {
             return true;
         }
-        self.proto_subs.contains(&format!("GLOBAL::{}", name))
+        self.registry()
+            .proto_subs
+            .contains(&format!("GLOBAL::{}", name))
     }
 
     /// Check if any multi candidates exist for this function name (any arity).
@@ -1183,7 +1230,7 @@ impl Interpreter {
             format!("{}::{}/", self.current_package, name),
             format!("GLOBAL::{}/", name),
         ];
-        self.functions.keys().any(|k| {
+        self.registry().functions.keys().any(|k| {
             let ks = k.resolve();
             prefixes.iter().any(|p| ks.starts_with(p))
         })
@@ -1209,13 +1256,18 @@ impl Interpreter {
 
     pub(super) fn resolve_proto_function(&self, name: &str) -> Option<FunctionDef> {
         if name.contains("::") {
-            return self.proto_functions.get(&Symbol::intern(name)).cloned();
+            return self
+                .registry()
+                .proto_functions
+                .get(&Symbol::intern(name))
+                .cloned();
         }
         let local = format!("{}::{}", self.current_package, name);
-        if let Some(def) = self.proto_functions.get(&Symbol::intern(&local)) {
+        if let Some(def) = self.registry().proto_functions.get(&Symbol::intern(&local)) {
             return Some(def.clone());
         }
-        self.proto_functions
+        self.registry()
+            .proto_functions
             .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
             .cloned()
     }
@@ -1431,6 +1483,7 @@ impl Interpreter {
         ];
         // Collect all candidates (typed + generic) like resolve_function_with_types
         let mut candidates: Vec<(String, FunctionDef)> = self
+            .registry()
             .functions
             .iter()
             .filter(|(key, _)| {
@@ -1443,6 +1496,7 @@ impl Interpreter {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
             let more: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
@@ -1498,6 +1552,7 @@ impl Interpreter {
             let untyped_key_sym = Symbol::intern(&untyped_key);
             let untyped_m_prefix = format!("{}__m", untyped_key);
             let mut candidates: Vec<(String, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter(|(key, _)| {
@@ -1537,7 +1592,7 @@ impl Interpreter {
         let global_prefix = format!("GLOBAL::{}/", name);
         let bare_prefix = format!("{}/", name);
         let mut seen_sigs = std::collections::HashSet::new();
-        for (key, def) in &self.functions {
+        for (key, def) in &self.registry().functions {
             let ks = key.resolve();
             if !ks.starts_with(&local_prefix)
                 && !ks.starts_with(&global_prefix)

--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -192,7 +192,7 @@ impl Interpreter {
             }
             p
         };
-        for (key, def) in &self.functions {
+        for (key, def) in &self.registry().functions {
             let ks = key.resolve();
             if prefixes.iter().any(|prefix| ks.starts_with(prefix)) {
                 let fp =

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -128,7 +128,7 @@ impl Interpreter {
         }
         // Check grammar token/rule/regex definitions
         let token_key = format!("{}::{}", class_name_str, method_name);
-        if let Some(defs) = self.token_defs.get(&Symbol::intern(&token_key))
+        if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(&token_key))
             && !defs.is_empty()
         {
             return Some(Value::Routine {
@@ -1310,7 +1310,8 @@ impl Interpreter {
 
     pub(super) fn package_looks_like_grammar(&self, package_name: &str) -> bool {
         let prefix = format!("{package_name}::");
-        self.token_defs
+        self.registry()
+            .token_defs
             .keys()
             .any(|key| key.resolve().starts_with(&prefix))
     }

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -709,7 +709,7 @@ impl Interpreter {
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
         let mut multi_idx = 0usize;
-        for (key, def) in &self.functions {
+        for (key, def) in &self.registry().functions {
             let key_s = key.resolve();
             if key_s == exact_local
                 || key_s == exact_global

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -842,17 +842,12 @@ pub struct Interpreter {
     /// Tracks whether any output was emitted (useful when immediate_stdout
     /// skips the buffer).
     output_emitted: bool,
-    functions: HashMap<Symbol, FunctionDef>,
-    /// Functions declared with `our` scope that should persist across block boundaries.
-    our_scoped_functions: HashMap<Symbol, FunctionDef>,
     operator_assoc: HashMap<String, String>,
     /// Operator sub names (infix:<..>, prefix:<..>, etc.) that have been
     /// imported into the current lexical scope via `use Module`. Used to
     /// preseed the parser when EVAL is called so that imported operators
     /// remain visible, but non-exported operators from loaded modules do not.
     pub(crate) imported_operator_names: HashSet<String>,
-    proto_functions: HashMap<Symbol, FunctionDef>,
-    token_defs: HashMap<Symbol, Vec<FunctionDef>>,
     lib_paths: Vec<String>,
     handles: HashMap<usize, IoHandleState>,
     next_handle_id: usize,
@@ -884,8 +879,6 @@ pub struct Interpreter {
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
-    proto_subs: HashSet<String>,
-    proto_tokens: HashSet<String>,
     proto_dispatch_stack: Vec<(String, Vec<Value>)>,
     pending_dispatch_error: Option<RuntimeError>,
     end_phasers: Vec<(Vec<Stmt>, Env)>,
@@ -2830,12 +2823,8 @@ impl Interpreter {
             nested_mode: false,
             immediate_stdout: false,
             output_emitted: false,
-            functions: HashMap::new(),
-            our_scoped_functions: HashMap::new(),
             operator_assoc: HashMap::new(),
             imported_operator_names: HashSet::new(),
-            proto_functions: HashMap::new(),
-            token_defs: HashMap::new(),
             lib_paths: Vec::new(),
             handles: HashMap::new(),
             next_handle_id: 1,
@@ -3036,8 +3025,6 @@ impl Interpreter {
                 };
                 Arc::new(RwLock::new(registry))
             },
-            proto_subs: HashSet::new(),
-            proto_tokens: HashSet::new(),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,
             end_phasers: Vec::new(),
@@ -3415,7 +3402,7 @@ impl Interpreter {
 
     /// Save current function/class keys for lexical import scoping.
     pub(crate) fn push_import_scope(&mut self) {
-        let func_keys: HashSet<Symbol> = self.functions.keys().copied().collect();
+        let func_keys: HashSet<Symbol> = self.registry().functions.keys().copied().collect();
         let class_keys: HashSet<String> = self.registry().classes.keys().cloned().collect();
         self.import_scope_stack.push((
             func_keys,
@@ -3432,7 +3419,9 @@ impl Interpreter {
         if let Some((func_snapshot, class_snapshot, newline_mode, strict_mode, fatal_mode)) =
             self.import_scope_stack.pop()
         {
-            self.functions.retain(|key, _| func_snapshot.contains(key));
+            self.registry_mut()
+                .functions
+                .retain(|key, _| func_snapshot.contains(key));
             self.registry_mut()
                 .classes
                 .retain(|key, _| class_snapshot.contains(key));
@@ -3503,7 +3492,7 @@ impl Interpreter {
         let class_snapshot: HashSet<String> = self.registry().classes.keys().cloned().collect();
         let role_snapshot: HashSet<String> = self.registry().roles.keys().cloned().collect();
         let env_snapshot: HashSet<Symbol> = self.env.keys().copied().collect();
-        let func_keys_before: HashSet<Symbol> = self.functions.keys().copied().collect();
+        let func_keys_before: HashSet<Symbol> = self.registry().functions.keys().copied().collect();
 
         let result = if module == "Test"
             || matches!(
@@ -3668,11 +3657,12 @@ impl Interpreter {
                             // This export should NOT be imported — remove from GLOBAL
                             let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
                             if !func_keys_before.contains(&global_key) {
-                                self.functions.remove(&global_key);
+                                self.registry_mut().functions.remove(&global_key);
                             }
                             // Also remove multi-dispatch variants
                             let prefix = format!("GLOBAL::{}/", name);
                             let multi_keys: Vec<Symbol> = self
+                                .registry()
                                 .functions
                                 .keys()
                                 .filter(|k| {
@@ -3682,7 +3672,7 @@ impl Interpreter {
                                 .copied()
                                 .collect();
                             for mk in multi_keys {
-                                self.functions.remove(&mk);
+                                self.registry_mut().functions.remove(&mk);
                             }
                         }
                     }
@@ -3711,6 +3701,7 @@ impl Interpreter {
                 }
             }
             let non_exported_op_globals: Vec<Symbol> = self
+                .registry()
                 .functions
                 .keys()
                 .filter(|k| {
@@ -3729,7 +3720,7 @@ impl Interpreter {
                 .copied()
                 .collect();
             for k in non_exported_op_globals {
-                self.functions.remove(&k);
+                self.registry_mut().functions.remove(&k);
             }
 
             // Remove GLOBAL:: sub aliases that were leaked by sub hoisting during
@@ -3760,6 +3751,7 @@ impl Interpreter {
                     }
                 }
                 let leaked_globals: Vec<Symbol> = self
+                    .registry()
                     .functions
                     .keys()
                     .filter(|k| {
@@ -3776,7 +3768,7 @@ impl Interpreter {
                     .copied()
                     .collect();
                 for k in leaked_globals {
-                    self.functions.remove(&k);
+                    self.registry_mut().functions.remove(&k);
                 }
             }
 
@@ -3812,27 +3804,34 @@ impl Interpreter {
         // Package::EXPORT::TAG::name resolve via normal function lookup.
         let fq_key = format!("{}::{}", package, name);
         let fq_sym = crate::symbol::Symbol::intern(&fq_key);
-        if let Some(def) = self.functions.get(&fq_sym).cloned() {
+        // Hoist the clone to a `let` so the read guard drops before the
+        // registry_mut writes below (read->write on the same lock deadlocks).
+        let def = self.registry().functions.get(&fq_sym).cloned();
+        if let Some(def) = def {
             for tag in &tags {
                 // Bare EXPORT::TAG::name (accessible from the same package)
                 let bare_export = format!("EXPORT::{}::{}", tag, name);
-                self.functions
+                self.registry_mut()
+                    .functions
                     .entry(crate::symbol::Symbol::intern(&bare_export))
                     .or_insert_with(|| def.clone());
                 // Fully-qualified Package::EXPORT::TAG::name
                 let pkg_export = format!("{}::EXPORT::{}::{}", package, tag, name);
-                self.functions
+                self.registry_mut()
+                    .functions
                     .entry(crate::symbol::Symbol::intern(&pkg_export))
                     .or_insert_with(|| def.clone());
             }
             // Always register under EXPORT::ALL::name
             if !tags.contains(&"ALL".to_string()) {
                 let bare_all = format!("EXPORT::ALL::{}", name);
-                self.functions
+                self.registry_mut()
+                    .functions
                     .entry(crate::symbol::Symbol::intern(&bare_all))
                     .or_insert_with(|| def.clone());
                 let pkg_all = format!("{}::EXPORT::ALL::{}", package, name);
-                self.functions
+                self.registry_mut()
+                    .functions
                     .entry(crate::symbol::Symbol::intern(&pkg_all))
                     .or_insert_with(|| def);
             }
@@ -3979,6 +3978,7 @@ impl Interpreter {
             let target_prefix = format!("{target_pkg}::{name}/");
 
             let function_entries: Vec<(Symbol, FunctionDef)> = self
+                .registry()
                 .functions
                 .iter()
                 .filter_map(|(k, v)| {
@@ -3996,10 +3996,11 @@ impl Interpreter {
                 })
                 .collect();
             for (k, v) in function_entries {
-                self.functions.insert(k, v);
+                self.registry_mut().functions.insert(k, v);
             }
 
             let proto_entries: Vec<(Symbol, FunctionDef)> = self
+                .registry()
                 .proto_functions
                 .iter()
                 .filter_map(|(k, v)| {
@@ -4011,7 +4012,7 @@ impl Interpreter {
                 })
                 .collect();
             for (k, v) in proto_entries {
-                self.proto_functions.insert(k, v);
+                self.registry_mut().proto_functions.insert(k, v);
             }
 
             // If this exported sub carried a trait-modified value (e.g. a role
@@ -5187,12 +5188,8 @@ impl Interpreter {
             nested_mode: self.nested_mode,
             immediate_stdout: false,
             output_emitted: false,
-            functions: self.functions.clone(),
-            our_scoped_functions: self.our_scoped_functions.clone(),
             operator_assoc: self.operator_assoc.clone(),
             imported_operator_names: self.imported_operator_names.clone(),
-            proto_functions: self.proto_functions.clone(),
-            token_defs: self.token_defs.clone(),
             lib_paths: self.lib_paths.clone(),
             handles: cloned_handles,
             next_handle_id: self.next_handle_id,
@@ -5218,8 +5215,6 @@ impl Interpreter {
             // independent snapshot (matches prior per-field clone semantics: the
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
-            proto_subs: self.proto_subs.clone(),
-            proto_tokens: self.proto_tokens.clone(),
             proto_dispatch_stack: Vec::new(),
             pending_dispatch_error: None,
             end_phasers: Vec::new(),

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -3,6 +3,25 @@ use super::regex_helpers::{CaseFoldIter, matches_named_builtin};
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Copy the declaration registry (functions / proto_functions / token_defs)
+    /// from `self` into a freshly-built sub-interpreter used for regex/grammar
+    /// evaluation. `self` and `target` have distinct registry `Arc`s, so this is
+    /// a snapshot copy (matches the prior per-field clone in the struct literal).
+    pub(crate) fn copy_decl_registry_into(&self, target: &mut Interpreter) {
+        let (functions, proto_functions, token_defs) = {
+            let src = self.registry();
+            (
+                src.functions.clone(),
+                src.proto_functions.clone(),
+                src.token_defs.clone(),
+            )
+        };
+        let mut dst = target.registry_mut();
+        dst.functions = functions;
+        dst.proto_functions = proto_functions;
+        dst.token_defs = token_defs;
+    }
+
     /// Evaluate a closure interpolation `<{ code }>` inside a regex.
     /// Returns the regex pattern string to match against.
     pub(super) fn eval_regex_closure_interpolation(
@@ -21,11 +40,10 @@ impl Interpreter {
         let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
         let mut interp = Interpreter {
             env,
-            functions: self.functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: self.current_package.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {
             Ok(v) => v,
             Err(e) => e.return_value?,
@@ -107,11 +125,10 @@ impl Interpreter {
         // Evaluate the code in a fresh interpreter with this env
         let mut interp = Interpreter {
             env,
-            functions: self.functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: self.current_package.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         match interp.eval_block_value(&stmts) {
             Ok(val) => val.truthy(),
             Err(_) => false,
@@ -153,11 +170,10 @@ impl Interpreter {
         let env = self.make_regex_eval_env(caps);
         let mut interp = Interpreter {
             env,
-            functions: self.functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: self.current_package.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {
             Ok(v) => v,
             Err(_) => return None,

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -342,10 +342,10 @@ impl Interpreter {
                 if let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&source) {
                     let mut interp = Interpreter {
                         env: self.env.clone(),
-                        functions: self.functions.clone(),
                         current_package: self.current_package.clone(),
                         ..Default::default()
                     };
+                    self.copy_decl_registry_into(&mut interp);
                     let _ = interp.eval_block_value(&stmts);
                     let mut new_caps = current_caps.clone();
                     for (k, v) in &interp.env {
@@ -393,15 +393,13 @@ impl Interpreter {
                     let tail_text: String = tail.iter().collect();
                     let mut interp = Interpreter {
                         env: self.env.clone(),
-                        functions: self.functions.clone(),
-                        proto_functions: self.proto_functions.clone(),
-                        token_defs: self.token_defs.clone(),
                         current_package: sub_pkg.clone(),
                         var_dynamic_flags: self.var_dynamic_flags.clone(),
                         var_type_constraints: self.var_type_constraints.clone(),
                         state_vars: self.state_vars.clone(),
                         ..Default::default()
                     };
+                    self.copy_decl_registry_into(&mut interp);
                     if let Some(mut inner_caps) =
                         interp.regex_match_with_captures(&sub_pat, &tail_text)
                     {

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -419,15 +419,13 @@ impl Interpreter {
     ) -> Option<usize> {
         let mut interp = Interpreter {
             env: self.env.clone(),
-            functions: self.functions.clone(),
-            proto_functions: self.proto_functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: pkg.to_string(),
             var_dynamic_flags: self.var_dynamic_flags.clone(),
             var_type_constraints: self.var_type_constraints.clone(),
             state_vars: self.state_vars.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         interp.regex_match_len_at_start(pattern, text)
     }
 }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -357,7 +357,7 @@ impl Interpreter {
 
         let mut restore_always: HashMap<String, Option<Value>> = HashMap::new();
         let mut restore_on_fail: HashMap<String, Option<Value>> = HashMap::new();
-        let saved_token_defs = self.token_defs.clone();
+        let saved_token_defs = self.registry().token_defs.clone();
 
         for (decl_name, stmt_src) in declarators {
             let before_env = self.env.clone();
@@ -409,13 +409,13 @@ impl Interpreter {
             if !handled_state_postfix && !handled_direct_assign {
                 let eval_src = stmt_src.clone();
                 let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&eval_src) else {
-                    self.token_defs = saved_token_defs;
+                    self.registry_mut().token_defs = saved_token_defs;
                     self.restore_env_entries(restore_always);
                     self.restore_env_entries(restore_on_fail);
                     return None;
                 };
                 if self.eval_block_value(&stmts).is_err() {
-                    self.token_defs = saved_token_defs;
+                    self.registry_mut().token_defs = saved_token_defs;
                     self.restore_env_entries(restore_always);
                     self.restore_env_entries(restore_on_fail);
                     return None;
@@ -450,7 +450,7 @@ impl Interpreter {
 
         let result = self.regex_match_with_captures_core(&remaining_pattern, text);
         let matched = result.is_some();
-        self.token_defs = saved_token_defs;
+        self.registry_mut().token_defs = saved_token_defs;
         self.restore_env_entries(restore_always);
         if !matched {
             self.restore_env_entries(restore_on_fail);

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -153,7 +153,7 @@ impl Interpreter {
         out: &mut Vec<(String, String, Option<String>)>,
     ) {
         let exact_key = format!("{scope}::{name}");
-        if let Some(defs) = self.token_defs.get(&Symbol::intern(&exact_key)) {
+        if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(&exact_key)) {
             for def in defs {
                 if let Some(p) = Self::token_pattern_from_def(def) {
                     out.push((p, def.package.resolve(), None));
@@ -163,6 +163,7 @@ impl Interpreter {
         let sym_prefix_angle = format!("{scope}::{name}:sym<");
         let sym_prefix_french = format!("{scope}::{name}:sym\u{ab}");
         let mut sym_keys: Vec<String> = self
+            .registry()
             .token_defs
             .keys()
             .map(|key| key.resolve())
@@ -171,7 +172,7 @@ impl Interpreter {
         sym_keys.sort();
         for key in &sym_keys {
             let sym_val = Self::extract_sym_adverb(key);
-            if let Some(defs) = self.token_defs.get(&Symbol::intern(key)) {
+            if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                 for def in defs {
                     if let Some(p) = Self::token_pattern_from_def(def) {
                         out.push((p, def.package.resolve(), sym_val.clone()));
@@ -476,12 +477,10 @@ impl Interpreter {
         let (stmts, _) = crate::parse_dispatch::parse_source(&source).ok()?;
         let mut interp = Interpreter {
             env: self.make_regex_eval_env(caps),
-            functions: self.functions.clone(),
-            proto_functions: self.proto_functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: self.current_package.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         match interp.eval_block_value(&stmts) {
             Ok(v) => Some(v),
             Err(e) => e.return_value,

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -6,12 +6,13 @@ impl Interpreter {
     pub(super) fn resolve_token_defs_in_pkg(&self, name: &str, pkg: &str) -> Vec<FunctionDef> {
         let mut out = Vec::new();
         if name.contains("::") {
-            if let Some(defs) = self.token_defs.get(&Symbol::intern(name)) {
+            if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(name)) {
                 out.extend(defs.clone());
             }
             let sym_prefix_angle = format!("{name}:sym<");
             let sym_prefix_french = format!("{name}:sym\u{ab}");
             let mut sym_keys: Vec<String> = self
+                .registry()
                 .token_defs
                 .keys()
                 .map(|key| key.resolve())
@@ -21,7 +22,7 @@ impl Interpreter {
                 .collect();
             sym_keys.sort();
             for key in &sym_keys {
-                if let Some(defs) = self.token_defs.get(&Symbol::intern(key)) {
+                if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                     out.extend(defs.clone());
                 }
             }
@@ -66,12 +67,10 @@ impl Interpreter {
         for def in self.resolve_token_defs_in_pkg(name, pkg) {
             let mut interp = Interpreter {
                 env: self.env.clone(),
-                functions: self.functions.clone(),
-                proto_functions: self.proto_functions.clone(),
-                token_defs: self.token_defs.clone(),
                 current_package: def.package.resolve(),
                 ..Default::default()
             };
+            self.copy_decl_registry_into(&mut interp);
             let saved_env = interp.env.clone();
             if interp
                 .bind_function_args_values(&def.param_defs, &def.params, arg_values)

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -5947,11 +5947,10 @@ impl Interpreter {
         };
         let mut interp = Interpreter {
             env: self.env.clone(),
-            functions: self.functions.clone(),
-            token_defs: self.token_defs.clone(),
             current_package: self.current_package.clone(),
             ..Default::default()
         };
+        self.copy_decl_registry_into(&mut interp);
         match interp.eval_block_value(&stmts) {
             Ok(v) => v,
             Err(e) => e.return_value.unwrap_or(Value::Nil),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -679,8 +679,11 @@ impl Interpreter {
 
     pub(crate) fn has_declared_function(&self, name: &str) -> bool {
         let fq = format!("{}::{}", self.current_package, name);
-        self.functions.contains_key(&Symbol::intern(&fq))
-            || self.functions.contains_key(&Symbol::intern(name))
+        self.registry().functions.contains_key(&Symbol::intern(&fq))
+            || self
+                .registry()
+                .functions
+                .contains_key(&Symbol::intern(name))
     }
 
     pub(crate) fn is_implicit_zero_arg_builtin(name: &str) -> bool {
@@ -690,7 +693,8 @@ impl Interpreter {
     /// Check if a multi-dispatched function with the given name exists (any arity).
     pub(crate) fn has_multi_function(&self, name: &str) -> bool {
         let fq_slash = format!("{}::{}/", self.current_package, name);
-        self.functions
+        self.registry()
+            .functions
             .keys()
             .any(|k| k.resolve().starts_with(&fq_slash))
     }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1466,8 +1466,12 @@ impl Interpreter {
                 class_own_attrs.insert(attr_name.resolve());
             }
         }
-        let saved_functions_keys: HashSet<String> =
-            self.functions.keys().map(|k| k.resolve()).collect();
+        let saved_functions_keys: HashSet<String> = self
+            .registry()
+            .functions
+            .keys()
+            .map(|k| k.resolve())
+            .collect();
         // LEAVE phasers declared at class-body scope (e.g. via
         // `my $x will leave { ... }`) must fire when the class body is left,
         // i.e. once all body statements have been processed. Collect them here
@@ -2027,7 +2031,8 @@ impl Interpreter {
                             is_default: *is_default_candidate,
                             deprecated_message: None,
                         };
-                        self.functions
+                        self.registry_mut()
+                            .functions
                             .insert(Symbol::intern(&qualified_name), func_def);
                     }
                     // `my method` registers as a lexically-scoped function
@@ -2101,11 +2106,13 @@ impl Interpreter {
                             deprecated_message: None,
                         };
                         // Register under the short name (lexical scope)
-                        self.functions
+                        self.registry_mut()
+                            .functions
                             .insert(Symbol::intern(&resolved_method_name), func_def.clone());
                         // Also register under the qualified name for consistency
                         let qualified_name = format!("{}::{}", name, resolved_method_name);
-                        self.functions
+                        self.registry_mut()
+                            .functions
                             .insert(Symbol::intern(&qualified_name), func_def);
                         // Mark as my-scoped so it doesn't appear in the package stash
                         self.mark_my_scoped_package_item(qualified_name);
@@ -2282,7 +2289,7 @@ impl Interpreter {
             // registered via MethodDecl and stored in the class methods table).
             if let Stmt::SubDecl { name: sub_name, .. } = stmt {
                 let fq = format!("{}::{}", name, sub_name);
-                if self.functions.contains_key(&Symbol::intern(&fq))
+                if self.registry().functions.contains_key(&Symbol::intern(&fq))
                     && !saved_functions_keys.contains(&fq)
                 {
                     self.registry_mut()

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -61,6 +61,34 @@ fn string_increment(s: &str) -> String {
 }
 
 impl Interpreter {
+    /// Insert a multi-overload `def` into the function registry under `base_key`,
+    /// falling back to the first free `base_key__m{N}` suffix when `base_key` is
+    /// already taken. Uses a SINGLE write guard for all probes — the previous
+    /// `match self.registry_mut().functions.entry(..) { Occupied => self.registry_mut()... }`
+    /// shape acquired a second write lock inside the arm and deadlocked (the
+    /// borrow checker cannot see it because each `registry_mut()` is a fresh guard).
+    fn insert_multi_overload(&mut self, base_key: &str, def: FunctionDef) {
+        let mut registry = self.registry_mut();
+        let funcs = &mut registry.functions;
+        if let std::collections::hash_map::Entry::Vacant(entry) =
+            funcs.entry(Symbol::intern(base_key))
+        {
+            entry.insert(def);
+            return;
+        }
+        let mut idx = 1usize;
+        loop {
+            let key = format!("{}__m{}", base_key, idx);
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                funcs.entry(Symbol::intern(&key))
+            {
+                entry.insert(def);
+                return;
+            }
+            idx += 1;
+        }
+    }
+
     fn default_check_constraint_base(constraint: &str) -> &str {
         let mut end = constraint.len();
         for (idx, ch) in constraint.char_indices() {
@@ -207,7 +235,7 @@ impl Interpreter {
         });
         if multi {
             let single_key = format!("{}::{}", self.current_package, name);
-            if is_our_scoped && !self.proto_subs.contains(&single_key) {
+            if is_our_scoped && !self.registry().proto_subs.contains(&single_key) {
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert(
                     "message".to_string(),
@@ -236,12 +264,13 @@ impl Interpreter {
         let single_key = format!("{}::{}", self.current_package, name);
         let multi_prefix = format!("{}::{}/", self.current_package, name);
         let single_key_sym = Symbol::intern(&single_key);
-        let has_single = self.functions.contains_key(&single_key_sym);
+        let has_single = self.registry().functions.contains_key(&single_key_sym);
         let has_multi = self
+            .registry()
             .functions
             .keys()
             .any(|k| k.resolve().starts_with(&multi_prefix));
-        let has_proto = self.proto_subs.contains(&single_key);
+        let has_proto = self.registry().proto_subs.contains(&single_key);
         let allow_lexical_shadow = (self.block_scope_depth > 0 || is_lexical_hoist)
             && !matches!(self.env.get("__mutsu_in_eval"), Some(Value::Bool(true)))
             && !matches!(
@@ -268,7 +297,10 @@ impl Interpreter {
             }
         }
         let has_user_custom_traits = custom_traits.iter().any(|(t, _)| !t.starts_with("__"));
-        if let Some(existing) = self.functions.get(&single_key_sym) {
+        // Clone the existing def out so the guard drops before mutating self.env
+        // (registration cold path, so the FunctionDef clone is cheap enough).
+        let existing = self.registry().functions.get(&single_key_sym).cloned();
+        if let Some(existing) = existing {
             let same = existing.package == new_def.package
                 && existing.name == new_def.name
                 && existing.params == new_def.params
@@ -306,6 +338,7 @@ impl Interpreter {
             }
         }
         let existing_is_stub = self
+            .registry()
             .functions
             .get(&single_key_sym)
             .is_some_and(|existing| Self::is_stub_routine_body(&existing.body));
@@ -330,7 +363,7 @@ impl Interpreter {
         if !multi && allow_lexical_shadow && !is_our_scoped {
             let lexical_single = format!("{}::{}", self.current_package, name);
             let lexical_multi_prefix = format!("{}::{}/", self.current_package, name);
-            self.functions.retain(|key, _| {
+            self.registry_mut().functions.retain(|key, _| {
                 let resolved = key.resolve();
                 resolved != lexical_single && !resolved.starts_with(&lexical_multi_prefix)
             });
@@ -372,59 +405,34 @@ impl Interpreter {
                     arity,
                     type_sig.join(",")
                 );
-                match self.functions.entry(Symbol::intern(&typed_fq)) {
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        entry.insert(def.clone());
-                    }
-                    std::collections::hash_map::Entry::Occupied(_) => {
-                        let mut idx = 1usize;
-                        loop {
-                            let key = format!("{}__m{}", typed_fq, idx);
-                            if let std::collections::hash_map::Entry::Vacant(entry) =
-                                self.functions.entry(Symbol::intern(&key))
-                            {
-                                entry.insert(def.clone());
-                                break;
-                            }
-                            idx += 1;
-                        }
-                    }
-                }
+                self.insert_multi_overload(&typed_fq, def.clone());
             }
             let fq = format!("{}::{}/{}", self.current_package, name, arity);
             if !has_types || name == "trait_mod:<is>" {
-                match self.functions.entry(Symbol::intern(&fq)) {
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        entry.insert(def);
-                    }
-                    std::collections::hash_map::Entry::Occupied(_) => {
-                        let mut idx = 1usize;
-                        loop {
-                            let key = format!("{}__m{}", fq, idx);
-                            if let std::collections::hash_map::Entry::Vacant(entry) =
-                                self.functions.entry(Symbol::intern(&key))
-                            {
-                                entry.insert(def);
-                                break;
-                            }
-                            idx += 1;
-                        }
-                    }
-                }
+                self.insert_multi_overload(&fq, def);
             } else {
-                self.functions.entry(Symbol::intern(&fq)).or_insert(def);
+                self.registry_mut()
+                    .functions
+                    .entry(Symbol::intern(&fq))
+                    .or_insert(def);
             }
         } else {
             let fq = format!("{}::{}", self.current_package, name);
-            self.functions.insert(Symbol::intern(&fq), def);
+            self.registry_mut()
+                .functions
+                .insert(Symbol::intern(&fq), def);
         }
         // If this is an our-scoped sub, also store it in the persistent our_scoped_functions
         // so it survives block scope restoration.
         if is_our_scoped {
             let fq = format!("{}::{}", self.current_package, name);
-            if let Some(f) = self.functions.get(&Symbol::intern(&fq)) {
-                self.our_scoped_functions
-                    .insert(Symbol::intern(&fq), f.clone());
+            // Clone out before the registry_mut write (read->write on the same
+            // lock would deadlock).
+            let f = self.registry().functions.get(&Symbol::intern(&fq)).cloned();
+            if let Some(f) = f {
+                self.registry_mut()
+                    .our_scoped_functions
+                    .insert(Symbol::intern(&fq), f);
             }
         }
         // If this is NOT our-scoped and we're inside a non-GLOBAL package,
@@ -582,20 +590,24 @@ impl Interpreter {
         body: &[Stmt],
     ) -> Result<(), RuntimeError> {
         let key = format!("{}::{}", self.current_package, name);
-        if self.functions.contains_key(&Symbol::intern(&key)) {
+        if self
+            .registry()
+            .functions
+            .contains_key(&Symbol::intern(&key))
+        {
             return Err(RuntimeError::redeclaration_routine(name));
         }
-        if self.proto_subs.contains(&key) {
+        if self.registry().proto_subs.contains(&key) {
             return Err(RuntimeError::redeclaration_routine(name));
         }
         let prefix = format!("{key}/");
-        self.functions.retain(|existing, _| {
+        self.registry_mut().functions.retain(|existing, _| {
             let resolved = existing.resolve();
             resolved != key && !resolved.starts_with(&prefix)
         });
-        self.proto_subs.insert(key);
+        self.registry_mut().proto_subs.insert(key);
         let fq = format!("{}::{}", self.current_package, name);
-        self.proto_functions.insert(
+        self.registry_mut().proto_functions.insert(
             Symbol::intern(&fq),
             FunctionDef {
                 package: Symbol::intern(&self.current_package),
@@ -713,18 +725,19 @@ impl Interpreter {
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
         let multi_prefix = format!("GLOBAL::{}/", name);
-        let has_single = self.functions.contains_key(&single_key_sym);
+        let has_single = self.registry().functions.contains_key(&single_key_sym);
         let has_multi = self
+            .registry()
             .functions
             .keys()
             .any(|k| k.resolve().starts_with(&multi_prefix));
-        let has_proto = self.proto_subs.contains(&single_key);
+        let has_proto = self.registry().proto_subs.contains(&single_key);
         if let Some(assoc) = associativity {
             self.operator_assoc.insert(name.to_string(), assoc.clone());
             self.operator_assoc
                 .insert(format!("GLOBAL::{}", name), assoc.clone());
         }
-        if let Some(existing) = self.functions.get(&single_key_sym) {
+        if let Some(existing) = self.registry().functions.get(&single_key_sym) {
             let same = existing.package == def.package
                 && existing.name == def.name
                 && existing.params == def.params
@@ -743,6 +756,7 @@ impl Interpreter {
             }
         }
         let existing_is_stub = self
+            .registry()
             .functions
             .get(&single_key_sym)
             .is_some_and(|existing| Self::is_stub_routine_body(&existing.body));
@@ -766,31 +780,18 @@ impl Interpreter {
             let has_types = type_sig.iter().any(|t| *t != "Any");
             if has_types {
                 let typed_fq = format!("GLOBAL::{}/{}:{}", name, arity, type_sig.join(","));
-                self.functions
+                self.registry_mut()
+                    .functions
                     .insert(Symbol::intern(&typed_fq), def.clone());
             }
             let fq = format!("GLOBAL::{}/{}", name, arity);
             if !has_types {
-                match self.functions.entry(Symbol::intern(&fq)) {
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        entry.insert(def);
-                    }
-                    std::collections::hash_map::Entry::Occupied(_) => {
-                        let mut idx = 1usize;
-                        loop {
-                            let key = format!("{}__m{}", fq, idx);
-                            if let std::collections::hash_map::Entry::Vacant(entry) =
-                                self.functions.entry(Symbol::intern(&key))
-                            {
-                                entry.insert(def);
-                                break;
-                            }
-                            idx += 1;
-                        }
-                    }
-                }
+                self.insert_multi_overload(&fq, def);
             } else {
-                self.functions.entry(Symbol::intern(&fq)).or_insert(def);
+                self.registry_mut()
+                    .functions
+                    .entry(Symbol::intern(&fq))
+                    .or_insert(def);
             }
         } else {
             if has_multi && !has_proto && !supersede {
@@ -800,7 +801,9 @@ impl Interpreter {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
             let fq = format!("GLOBAL::{}", name);
-            self.functions.insert(Symbol::intern(&fq), def);
+            self.registry_mut()
+                .functions
+                .insert(Symbol::intern(&fq), def);
         }
         let callable_key = format!("__mutsu_callable_id::GLOBAL::{}", name);
         self.env.insert(
@@ -819,10 +822,14 @@ impl Interpreter {
         body: &[Stmt],
     ) -> Result<(), RuntimeError> {
         let key = format!("GLOBAL::{}", name);
-        if self.functions.contains_key(&Symbol::intern(&key)) {
+        if self
+            .registry()
+            .functions
+            .contains_key(&Symbol::intern(&key))
+        {
             return Err(RuntimeError::redeclaration_routine(name));
         }
-        if self.proto_subs.contains(&key) {
+        if self.registry().proto_subs.contains(&key) {
             // A proto with this name is already visible in GLOBAL. This happens
             // when `is export` on a GLOBAL proto hits both local/global paths,
             // or when an outer (mainline) `proto sub` of the same name already
@@ -832,8 +839,8 @@ impl Interpreter {
             // be a spurious redeclaration error, so skip it.
             return Ok(());
         }
-        self.proto_subs.insert(key.clone());
-        self.proto_functions.insert(
+        self.registry_mut().proto_subs.insert(key.clone());
+        self.registry_mut().proto_functions.insert(
             Symbol::intern(&key),
             FunctionDef {
                 package: Symbol::intern("GLOBAL"),
@@ -856,7 +863,7 @@ impl Interpreter {
 
     pub(crate) fn register_proto_token_decl(&mut self, name: &str) {
         let key = format!("{}::{}", self.current_package, name);
-        self.proto_tokens.insert(key);
+        self.registry_mut().proto_tokens.insert(key);
     }
 
     pub(crate) fn register_enum_decl(

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -26,6 +26,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::ast::FunctionDef;
+use crate::symbol::Symbol;
 use crate::value::{EnumValue, Value};
 
 use super::{ClassDef, RoleCandidateDef, RoleDef, SubsetDef};
@@ -100,4 +102,20 @@ pub(crate) struct Registry {
     pub(crate) role_type_params: HashMap<String, Vec<String>>,
     /// Bound role type parameters per class: class -> (param name -> value).
     pub(crate) class_role_param_bindings: HashMap<String, HashMap<String, Value>>,
+
+    // ----- functions / subs / tokens (PR-A slice 5, final PR-A slice) -----
+    /// User-defined subs: fully-qualified name -> [`FunctionDef`]. Read on the
+    /// sub/multi-dispatch hot path; callers clone the matched `FunctionDef`
+    /// (already the prior behavior) under a short-lived guard.
+    pub(crate) functions: HashMap<Symbol, FunctionDef>,
+    /// `our`-scoped subs that persist across block boundaries.
+    pub(crate) our_scoped_functions: HashMap<Symbol, FunctionDef>,
+    /// `proto sub` markers (multi proto stubs): name -> proto `FunctionDef`.
+    pub(crate) proto_functions: HashMap<Symbol, FunctionDef>,
+    /// Grammar token/rule definitions: name -> [overloads].
+    pub(crate) token_defs: HashMap<Symbol, Vec<FunctionDef>>,
+    /// `proto sub` declaration markers (existence set).
+    pub(crate) proto_subs: HashSet<String>,
+    /// `proto token`/`proto rule` declaration markers (existence set).
+    pub(crate) proto_tokens: HashSet<String>,
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -37,7 +37,12 @@ impl Interpreter {
     pub(super) fn resolve_function(&self, name: &str) -> Option<FunctionDef> {
         if name.contains("::") {
             // Try direct lookup first
-            if let Some(def) = self.functions.get(&Symbol::intern(name)).cloned() {
+            if let Some(def) = self
+                .registry()
+                .functions
+                .get(&Symbol::intern(name))
+                .cloned()
+            {
                 return Some(def);
             }
             // If not found, try qualifying with the current package prefix
@@ -54,7 +59,12 @@ impl Interpreter {
                 };
                 if prefix_visible {
                     let qualified = format!("{}::{}", self.current_package, name);
-                    if let Some(def) = self.functions.get(&Symbol::intern(&qualified)).cloned() {
+                    if let Some(def) = self
+                        .registry()
+                        .functions
+                        .get(&Symbol::intern(&qualified))
+                        .cloned()
+                    {
                         return Some(def);
                     }
                 }
@@ -62,11 +72,13 @@ impl Interpreter {
             return None;
         }
         let local = format!("{}::{}", self.current_package, name);
-        self.functions
+        self.registry()
+            .functions
             .get(&Symbol::intern(&local))
             .cloned()
             .or_else(|| {
-                self.functions
+                self.registry()
+                    .functions
                     .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
                     .cloned()
             })
@@ -75,9 +87,13 @@ impl Interpreter {
     pub(super) fn insert_token_def(&mut self, name: &str, def: FunctionDef, multi: bool) {
         let key = Symbol::intern(&format!("{}::{}", self.current_package, name));
         if multi {
-            self.token_defs.entry(key).or_default().push(def);
+            self.registry_mut()
+                .token_defs
+                .entry(key)
+                .or_default()
+                .push(def);
         } else {
-            self.token_defs.insert(key, vec![def]);
+            self.registry_mut().token_defs.insert(key, vec![def]);
         }
     }
 
@@ -89,12 +105,13 @@ impl Interpreter {
         defs: &mut Vec<FunctionDef>,
     ) {
         let exact_key = format!("{scope}::{name}");
-        if let Some(exact) = self.token_defs.get(&Symbol::intern(&exact_key)) {
+        if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(&exact_key)) {
             defs.extend(exact.clone());
         }
         let sym_prefix_angle = format!("{scope}::{name}:sym<");
         let sym_prefix_french = format!("{scope}::{name}:sym\u{ab}");
         let mut sym_keys: Vec<String> = self
+            .registry()
             .token_defs
             .keys()
             .map(|key| key.resolve())
@@ -102,7 +119,7 @@ impl Interpreter {
             .collect();
         sym_keys.sort();
         for key in &sym_keys {
-            if let Some(sym_defs) = self.token_defs.get(&Symbol::intern(key)) {
+            if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                 defs.extend(sym_defs.clone());
             }
         }
@@ -139,12 +156,13 @@ impl Interpreter {
     pub(crate) fn resolve_token_defs(&self, name: &str) -> Option<Vec<FunctionDef>> {
         if name.contains("::") {
             let mut defs = Vec::new();
-            if let Some(exact) = self.token_defs.get(&Symbol::intern(name)) {
+            if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(name)) {
                 defs.extend(exact.clone());
             }
             let sym_prefix_angle = format!("{name}:sym<");
             let sym_prefix_french = format!("{name}:sym\u{ab}");
             let mut sym_keys: Vec<String> = self
+                .registry()
                 .token_defs
                 .keys()
                 .map(|key| key.resolve())
@@ -154,7 +172,7 @@ impl Interpreter {
                 .collect();
             sym_keys.sort();
             for key in &sym_keys {
-                if let Some(sym_defs) = self.token_defs.get(&Symbol::intern(key)) {
+                if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                     defs.extend(sym_defs.clone());
                 }
             }
@@ -194,7 +212,7 @@ impl Interpreter {
 
     pub(crate) fn has_proto_token(&self, name: &str) -> bool {
         if name.contains("::") {
-            if self.proto_tokens.contains(name) {
+            if self.registry().proto_tokens.contains(name) {
                 return true;
             }
             // Walk MRO for qualified names
@@ -206,6 +224,7 @@ impl Interpreter {
                         continue;
                     }
                     if self
+                        .registry()
                         .proto_tokens
                         .contains(&format!("{ancestor}::{token_name}"))
                     {
@@ -217,11 +236,17 @@ impl Interpreter {
         }
         // Check current package MRO
         for scope in self.mro_readonly(&self.current_package) {
-            if self.proto_tokens.contains(&format!("{scope}::{name}")) {
+            if self
+                .registry()
+                .proto_tokens
+                .contains(&format!("{scope}::{name}"))
+            {
                 return true;
             }
         }
-        self.proto_tokens.contains(&format!("GLOBAL::{}", name))
+        self.registry()
+            .proto_tokens
+            .contains(&format!("GLOBAL::{}", name))
     }
 
     pub(super) fn resolve_method(
@@ -1773,9 +1798,9 @@ impl Interpreter {
             return Ok(Value::Nil);
         }
         let let_mark = self.let_saves_len();
-        let saved_functions = self.functions.clone();
-        let saved_proto_subs = self.proto_subs.clone();
-        let saved_proto_functions = self.proto_functions.clone();
+        let saved_functions = self.registry().functions.clone();
+        let saved_proto_subs = self.registry().proto_subs.clone();
+        let saved_proto_functions = self.registry().proto_functions.clone();
         let saved_operator_assoc = self.operator_assoc.clone();
         let saved_code_env: std::collections::HashMap<Symbol, Value> = self
             .env
@@ -1826,9 +1851,9 @@ impl Interpreter {
         };
         self.block_scope_depth = self.block_scope_depth.saturating_sub(1);
         // Sub/proto declarations in block scope are lexical; restore registries on block exit.
-        self.functions = saved_functions;
-        self.proto_subs = saved_proto_subs;
-        self.proto_functions = saved_proto_functions;
+        self.registry_mut().functions = saved_functions;
+        self.registry_mut().proto_subs = saved_proto_subs;
+        self.registry_mut().proto_functions = saved_proto_functions;
         self.operator_assoc = saved_operator_assoc;
         self.env
             .retain(|k, _| !(k.starts_with("&") || k.starts_with("__mutsu_callable_id::")));

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1467,7 +1467,7 @@ impl Interpreter {
                 false
             };
             let before_function_keys: std::collections::HashSet<crate::symbol::Symbol> =
-                self.functions.keys().copied().collect();
+                self.registry().functions.keys().copied().collect();
             let result = self.run_block(&stmts);
             if pushed_unit {
                 self.unit_module_loading_stack.pop();
@@ -1476,7 +1476,10 @@ impl Interpreter {
             result?;
             // A `sub MAIN` defined in a used module is NOT the program's MAIN
             // and must not be auto-dispatched at program end.
-            Self::remove_leaked_main_routines(&mut self.functions, &before_function_keys);
+            Self::remove_leaked_main_routines(
+                &mut self.registry_mut().functions,
+                &before_function_keys,
+            );
         }
         crate::parser::set_current_language_version(&saved_language_version);
         self.current_distribution = saved_distribution;

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -75,7 +75,7 @@ impl Interpreter {
         let mut fixed_arity = 0usize;
         let mut slurpy_min: Option<usize> = None;
 
-        for (key, def) in &self.functions {
+        for (key, def) in &self.registry().functions {
             let key_s = key.resolve();
             let loose_match = key_s.contains(&format!("::{name}/"));
             if !key_s.starts_with(&local_prefix)
@@ -125,7 +125,7 @@ impl Interpreter {
         let name = name.strip_prefix('&').unwrap_or(name);
         let local_prefix = format!("{package}::{name}/");
         let global_prefix = format!("GLOBAL::{name}/");
-        self.functions.keys().any(|key| {
+        self.registry().functions.keys().any(|key| {
             let ks = key.resolve();
             ks.starts_with(&local_prefix)
                 || ks.starts_with(&global_prefix)

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -708,7 +708,7 @@ impl Interpreter {
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         // Include all user-defined operators (infix, prefix, postfix,
         // circumfix, postcircumfix) so the EVAL parser can recognize them.
-        for key in self.functions.keys() {
+        for key in self.registry().functions.keys() {
             let key_s = key.resolve();
             let name = if let Some(pos) = key_s.rfind("::") {
                 &key_s[pos + 2..]
@@ -807,7 +807,7 @@ impl Interpreter {
     /// the `first` listop builtin) to parse correctly as `first().uc`.
     pub(crate) fn collect_eval_user_sub_names(&self) -> Vec<String> {
         let mut names: Vec<String> = Vec::new();
-        for key in self.functions.keys() {
+        for key in self.registry().functions.keys() {
             let key_s = key.resolve();
             let short = if let Some(pos) = key_s.rfind("::") {
                 &key_s[pos + 2..]

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -51,11 +51,11 @@ impl Interpreter {
                     nested.set_pid(pid.saturating_add(1));
                 }
                 nested.lib_paths = self.lib_paths.clone();
-                nested.functions = self.functions.clone();
-                nested.proto_functions = self.proto_functions.clone();
-                nested.token_defs = self.token_defs.clone();
-                nested.proto_subs = self.proto_subs.clone();
-                nested.proto_tokens = self.proto_tokens.clone();
+                nested.registry_mut().functions = self.registry().functions.clone();
+                nested.registry_mut().proto_functions = self.registry().proto_functions.clone();
+                nested.registry_mut().token_defs = self.registry().token_defs.clone();
+                nested.registry_mut().proto_subs = self.registry().proto_subs.clone();
+                nested.registry_mut().proto_tokens = self.registry().proto_tokens.clone();
                 nested.registry_mut().classes = self.registry().classes.clone();
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -41,11 +41,11 @@ impl Interpreter {
         // Override the default (true) set by begin_subtest
         self.tap.set_subtest_callable_is_sub_last(callable_is_sub);
         let saved_env = self.env.clone();
-        let saved_functions = self.functions.clone();
-        let saved_proto_functions = self.proto_functions.clone();
-        let saved_token_defs = self.token_defs.clone();
-        let saved_proto_subs = self.proto_subs.clone();
-        let saved_proto_tokens = self.proto_tokens.clone();
+        let saved_functions = self.registry().functions.clone();
+        let saved_proto_functions = self.registry().proto_functions.clone();
+        let saved_token_defs = self.registry().token_defs.clone();
+        let saved_proto_subs = self.registry().proto_subs.clone();
+        let saved_proto_tokens = self.registry().proto_tokens.clone();
         let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.registry().roles.clone();
@@ -64,11 +64,11 @@ impl Interpreter {
             self.halted = ctx.parent_halted;
             self.tap.end_subtest();
             self.env = saved_env;
-            self.functions = saved_functions;
-            self.proto_functions = saved_proto_functions;
-            self.token_defs = saved_token_defs;
-            self.proto_subs = saved_proto_subs;
-            self.proto_tokens = saved_proto_tokens;
+            self.registry_mut().functions = saved_functions;
+            self.registry_mut().proto_functions = saved_proto_functions;
+            self.registry_mut().token_defs = saved_token_defs;
+            self.registry_mut().proto_subs = saved_proto_subs;
+            self.registry_mut().proto_tokens = saved_proto_tokens;
             self.registry_mut().classes = saved_classes;
             self.registry_mut().class_trusts = saved_class_trusts;
             self.registry_mut().roles = saved_roles;
@@ -92,11 +92,11 @@ impl Interpreter {
             }
         }
         self.env = merged_env;
-        self.functions = saved_functions;
-        self.proto_functions = saved_proto_functions;
-        self.token_defs = saved_token_defs;
-        self.proto_subs = saved_proto_subs;
-        self.proto_tokens = saved_proto_tokens;
+        self.registry_mut().functions = saved_functions;
+        self.registry_mut().proto_functions = saved_proto_functions;
+        self.registry_mut().token_defs = saved_token_defs;
+        self.registry_mut().proto_subs = saved_proto_subs;
+        self.registry_mut().proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
         self.registry_mut().roles = saved_roles;
@@ -139,11 +139,11 @@ impl Interpreter {
         let desc = desc_key.to_string_value();
         let ctx = self.begin_subtest();
         let saved_env = self.env.clone();
-        let saved_functions = self.functions.clone();
-        let saved_proto_functions = self.proto_functions.clone();
-        let saved_token_defs = self.token_defs.clone();
-        let saved_proto_subs = self.proto_subs.clone();
-        let saved_proto_tokens = self.proto_tokens.clone();
+        let saved_functions = self.registry().functions.clone();
+        let saved_proto_functions = self.registry().proto_functions.clone();
+        let saved_token_defs = self.registry().token_defs.clone();
+        let saved_proto_subs = self.registry().proto_subs.clone();
+        let saved_proto_tokens = self.registry().proto_tokens.clone();
         let saved_classes = self.registry().classes.clone();
         let saved_class_trusts = self.registry().class_trusts.clone();
         let saved_roles = self.registry().roles.clone();
@@ -153,11 +153,11 @@ impl Interpreter {
         self.test_fn_plan(&[Value::Int(plan)])?;
         let run_result = self.call_sub_value(block, vec![], true);
         self.env = saved_env;
-        self.functions = saved_functions;
-        self.proto_functions = saved_proto_functions;
-        self.token_defs = saved_token_defs;
-        self.proto_subs = saved_proto_subs;
-        self.proto_tokens = saved_proto_tokens;
+        self.registry_mut().functions = saved_functions;
+        self.registry_mut().proto_functions = saved_proto_functions;
+        self.registry_mut().token_defs = saved_token_defs;
+        self.registry_mut().proto_subs = saved_proto_subs;
+        self.registry_mut().proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;
         self.registry_mut().class_trusts = saved_class_trusts;
         self.registry_mut().roles = saved_roles;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -27,11 +27,11 @@ impl Interpreter {
                 }
                 nested.lib_paths = self.lib_paths.clone();
                 nested.program_path = self.program_path.clone();
-                nested.functions = self.functions.clone();
-                nested.proto_functions = self.proto_functions.clone();
-                nested.token_defs = self.token_defs.clone();
-                nested.proto_subs = self.proto_subs.clone();
-                nested.proto_tokens = self.proto_tokens.clone();
+                nested.registry_mut().functions = self.registry().functions.clone();
+                nested.registry_mut().proto_functions = self.registry().proto_functions.clone();
+                nested.registry_mut().token_defs = self.registry().token_defs.clone();
+                nested.registry_mut().proto_subs = self.registry().proto_subs.clone();
+                nested.registry_mut().proto_tokens = self.registry().proto_tokens.clone();
                 nested.registry_mut().classes = self.registry().classes.clone();
                 nested.registry_mut().class_trusts = self.registry().class_trusts.clone();
                 nested.registry_mut().class_composed_roles =
@@ -363,11 +363,11 @@ impl Interpreter {
                 nested.strict_mode = self.strict_mode;
                 nested.lib_paths = self.lib_paths.clone();
                 nested.program_path = self.program_path.clone();
-                nested.functions = self.functions.clone();
-                nested.proto_functions = self.proto_functions.clone();
-                nested.token_defs = self.token_defs.clone();
-                nested.proto_subs = self.proto_subs.clone();
-                nested.proto_tokens = self.proto_tokens.clone();
+                nested.registry_mut().functions = self.registry().functions.clone();
+                nested.registry_mut().proto_functions = self.registry().proto_functions.clone();
+                nested.registry_mut().token_defs = self.registry().token_defs.clone();
+                nested.registry_mut().proto_subs = self.registry().proto_subs.clone();
+                nested.registry_mut().proto_tokens = self.registry().proto_tokens.clone();
                 nested.registry_mut().classes = self.registry().classes.clone();
                 nested.registry_mut().roles = self.registry().roles.clone();
                 nested.registry_mut().subsets = self.registry().subsets.clone();


### PR DESCRIPTION
## Summary

Completes **PR-A** of the phase ② registry VM-ownership migration (PLAN.md ②, design: `docs/vm-registry-ownership.md`). After slices 1–4 (enum/subset, class metadata, `classes`, roles), this final slice moves the **6 function/sub/token declaration registries** into the shared `Arc<RwLock<Registry>>`:

`functions`, `our_scoped_functions`, `proto_functions`, `token_defs`, `proto_subs`, `proto_tokens`.

**With this slice every declaration registry lives in `Registry`**, so `clone_for_thread` no longer clones any individual registry field — only the whole-`Registry` snapshot clone remains. That is the "definition of done" for ②'s extraction phase.

## Changes

- `FunctionDef` was already `Debug`/`Clone`/`pub(crate)`; no builtin seeding (all user-defined). No VM-side direct access.
- `snapshot_routine_registry` takes a single read guard; `restore_*` splits into a read phase (collect surviving `our`-scoped subs) that drops its guard before the write phase.
- The 9 regex/grammar sub-interpreter struct literals (`Interpreter { functions, token_defs, .. }`) now call a `copy_decl_registry_into(&mut interp)` helper (distinct registry `Arc`s → snapshot copy, matching prior clone semantics).

## Deadlock fix (the important part)

`match self.registry_mut().functions.entry(k) { Occupied => { ... self.registry_mut().functions.entry(k2) ... } }` acquired a **second write lock inside the match arm while the scrutinee's write guard was still held** — a **write→write self-deadlock the borrow checker cannot catch** (each `registry_mut()` is a fresh guard). This hung multi-sub registration at runtime; it was caught by a smoke test, not the static scan. Consolidated into an `insert_multi_overload` helper that uses a single write guard for the base-key and `__m{N}` fallback probes.

Lesson recorded in the design doc: scan `match` / `if let self.registry_mut()` blocks for re-entrant registry access too, not just read→write — and `make roast`'s timeout is the comprehensive safety net for deadlocks.

## Verification

- `cargo build` + `cargo clippy -D warnings` green.
- `make test` green (458 cargo unit tests, prove `t/`).
- 51823 whitelisted `S05`/`S06`/`S12`/`S14`/`S32` roast subtests pass. (The only 2 failures — `gb2312`/`shiftjis` encoding tests — reproduce identically on `main`; they are pre-existing and environment-dependent, unrelated to this refactor.)
- Smoke tests correct: recursion, multi-dispatch, `proto`, `our`-scoped sub persistence across blocks, nested-sub closure, grammar token parsing, regex `<?{...}>` code assertion (sub-interpreter), operator overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)