### PR TITLE
refactor(vm): move MRO/class-lookup reads into Registry methods (phase ② PR-B slice 1)

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -134,13 +134,38 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   検出スキャナは `match/if-let self.registry_mut()` ブロック本体の registry 再アクセスも走査せよ（下記）。
   最終防衛線は make roast のタイムアウト**（make test+51823 roast サンプル緑、回帰ゼロ）。
 
+## PR-B（read 側移行）進捗
+
+- **PR-B slice 1 = MRO/クラス lookup の Registry メソッド化（本 PR）**: MRO 計算は VM の全メソッド
+  ディスパッチが叩く最ホットの registry-read。これを `impl Registry`（`src/runtime/registry.rs`）の
+  pure メソッドへ降ろした:
+  - `Registry::compute_class_mro(&self, name, stack) -> Result<Vec<String>>` — `self.classes` のみ参照
+    する純 C3 線形化。再帰は registry 内に閉じ、ユーザコード再入なし。
+  - `Registry::class_mro(&mut self, name) -> Vec<String>` — builtin 階層（Match/Capture/CompUnit…）+
+    parameterized（`Foo[Bar]`）+ `ClassDef::mro` キャッシュ参照 + compute + キャッシュ書き戻しを**単一
+    write ガード**で実施。従来 `Interpreter::class_mro` は最大 5 本の `registry()`/`registry_mut()` を
+    個別取得していたのを 1 本に集約（ホットパスの lock 取得削減）。
+  - `Registry::class_mro_cached(&self, name) -> Option<Vec<String>>` — readonly（キャッシュ or 単一要素）。
+  - `Registry::class_has_method(&mut self, name, method) -> bool` — MRO walk による method 有無判定。
+  Interpreter 側 `class_mro`/`compute_class_mro`/`class_mro_readonly`/`class_has_method` は薄い委譲
+  ラッパへ（65 + 多数の呼び出し側は無改変）。挙動不変、build/clippy/make test 緑、S12/S14 roast 緑。
+- **VM 直読みについて（調査結果）**: 現状 VM が registry フィールドを直接読むサイトは皆無で、`package_stubs`
+  の 2 write のみ（`vm.rs`）。VM の registry 系アクセスは全て `self.interpreter.<wrapper>()` 経由
+  （`type_matches_value` 40+ サイト、`class_mro` 等）。よって「VM ~15-20 read サイトを `self.registry.read()`
+  へ」は実コードと不一致＝VM への registry ハンドル追加は本 slice では不要（②非ゴールの Arc→plain 畳み込み
+  と一体で ③/④へ）。read 側移行の実体は wrapper の Registry メソッド化＝本 slice。
+- **残（PR-B 後続）**: 型マッチ（`type_matching.rs`）の「クラス MRO 経由の composed-role 推移 walk」2 ブロック
+  （L668-697 / L821-850）。pure-registry 読みだが、ゲート条件が **block1=`resolve_role_key`（Interpreter
+  名前解決）/ effective_constraint subtype 判定**、**block2=`roles.contains_key` / exact 一致**で非自明に異なり、
+  素朴な統合は推移閉包を変える恐れ。挙動不変を厳守するため別 slice で（gate を保ったまま Registry 側 closure
+  ヘルパへ抽出）。`resolve_method_with_owner_impl` の registry-read 部も同様に後続。
+
 ## 完了の定義（②）— **PR-A 完了（slice 1-5, #2760/2762/2763/2764/本PR）**
 
 `Interpreter` から宣言レジストリ全フィールドが消え `registry: Arc<RwLock<Registry>>` 1 本に。`clone_for_thread`
 のレジストリ複製は registry 全体 clone 1 行のみ（個別フィールド clone ゼロ、snapshot 不変）。VM の registry 系
-lookup は accessor 経由（多くは既に owned 返し）。**次は PR-B**（lookup/MRO/型マッチを Registry メソッド化して
-VM が `self.registry.read()` で直読み、台帳 §2 の関数 dispatch fallback 撲滅の前提を整える）→ **PR-C**
-（register_* の write-through 整理）→ ③（env/型/state 移管）。
+lookup は accessor 経由（多くは既に owned 返し）。**PR-B**（lookup/MRO/型マッチを Registry メソッド化、上記
+進捗）→ **PR-C**（register_* の write-through 整理）→ ③（env/型/state 移管）。
 
 ## 非ゴール
 

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -201,7 +201,8 @@ impl Interpreter {
     }
 
     pub(super) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
-        self.registry_mut().class_has_method(class_name, method_name)
+        self.registry_mut()
+            .class_has_method(class_name, method_name)
     }
 
     /// Check whether the class (or its MRO ancestors) has a `new` method

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -190,107 +190,18 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Compute the C3 MRO for `class_name`. Delegates to the pure-registry
+    /// [`Registry::compute_class_mro`] under a single read guard.
     pub(super) fn compute_class_mro(
         &mut self,
         class_name: &str,
         stack: &mut Vec<String>,
     ) -> Result<Vec<String>, RuntimeError> {
-        if stack.iter().any(|name| name == class_name) {
-            return Err(RuntimeError::new(format!(
-                "C3 MRO cycle detected at {}",
-                class_name
-            )));
-        }
-        if let Some(class_def) = self.registry().classes.get(class_name)
-            && !class_def.mro.is_empty()
-        {
-            return Ok(class_def.mro.clone());
-        }
-        stack.push(class_name.to_string());
-        let explicit_parents = self
-            .registry()
-            .classes
-            .get(class_name)
-            .map(|c| c.parents.clone())
-            .unwrap_or_default();
-        // If a user-defined class has no explicit parents, it implicitly
-        // inherits from Any (which in turn inherits from Mu).  This matches
-        // Raku's default class hierarchy.
-        let parents =
-            if explicit_parents.is_empty() && self.registry().classes.contains_key(class_name) {
-                vec!["Any".to_string()]
-            } else {
-                explicit_parents
-            };
-        let mut seqs: Vec<Vec<String>> = Vec::new();
-        for parent in &parents {
-            if self.registry().classes.contains_key(parent) {
-                let mro = self.compute_class_mro(parent, stack)?;
-                seqs.push(mro);
-            } else if parent == "Any" {
-                // Any implicitly inherits from Mu
-                seqs.push(vec!["Any".to_string(), "Mu".to_string()]);
-            } else if parent == "Cool" {
-                seqs.push(vec![
-                    "Cool".to_string(),
-                    "Any".to_string(),
-                    "Mu".to_string(),
-                ]);
-            } else {
-                seqs.push(vec![parent.clone()]);
-            }
-        }
-        seqs.push(parents.clone());
-        let mut result = vec![class_name.to_string()];
-        while seqs.iter().any(|s| !s.is_empty()) {
-            let mut candidate = None;
-            for seq in &seqs {
-                if seq.is_empty() {
-                    continue;
-                }
-                let head = &seq[0];
-                let mut in_tail = false;
-                for other in &seqs {
-                    if other.len() > 1 && other[1..].contains(head) {
-                        in_tail = true;
-                        break;
-                    }
-                }
-                if !in_tail {
-                    candidate = Some(head.clone());
-                    break;
-                }
-            }
-            if let Some(head) = candidate {
-                result.push(head.clone());
-                for seq in seqs.iter_mut() {
-                    if !seq.is_empty() && seq[0] == head {
-                        seq.remove(0);
-                    }
-                }
-            } else {
-                stack.pop();
-                return Err(RuntimeError::new(format!(
-                    "Inconsistent class hierarchy for {}",
-                    class_name
-                )));
-            }
-        }
-        stack.pop();
-        Ok(result)
+        self.registry().compute_class_mro(class_name, stack)
     }
 
     pub(super) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
-        let mro = self.class_mro(class_name);
-        for cn in mro {
-            if let Some(class_def) = self.registry().classes.get(&cn)
-                && (class_def.methods.contains_key(method_name)
-                    || class_def.native_methods.contains(method_name))
-            {
-                return true;
-            }
-        }
-        false
+        self.registry_mut().class_has_method(class_name, method_name)
     }
 
     /// Check whether the class (or its MRO ancestors) has a `new` method

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -186,12 +186,7 @@ impl Interpreter {
 
     /// Read-only variant of class_mro for use from non-mut helpers.
     fn class_mro_readonly(&self, class_name: &str) -> Option<Vec<String>> {
-        let registry = self.registry();
-        let class_def = registry.classes.get(class_name)?;
-        if !class_def.mro.is_empty() {
-            return Some(class_def.mro.clone());
-        }
-        Some(vec![class_name.to_string()])
+        self.registry().class_mro_cached(class_name)
     }
 
     /// Look up the "own" MethodDef for `method_name` on the given class or role.

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -231,8 +231,12 @@ impl Registry {
             let builtin_mro: Option<Vec<&str>> = match class_name {
                 "Match" => Some(vec!["Match", "Capture", "Cool", "Any", "Mu"]),
                 "Capture" => Some(vec!["Capture", "Any", "Mu"]),
-                "Distribution::Path" => Some(vec!["Distribution::Path", "Distribution", "Any", "Mu"]),
-                "Distribution::Hash" => Some(vec!["Distribution::Hash", "Distribution", "Any", "Mu"]),
+                "Distribution::Path" => {
+                    Some(vec!["Distribution::Path", "Distribution", "Any", "Mu"])
+                }
+                "Distribution::Hash" => {
+                    Some(vec!["Distribution::Hash", "Distribution", "Any", "Mu"])
+                }
                 "Distribution::Installation" => Some(vec![
                     "Distribution::Installation",
                     "Distribution",

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ast::FunctionDef;
 use crate::symbol::Symbol;
-use crate::value::{EnumValue, Value};
+use crate::value::{EnumValue, RuntimeError, Value};
 
 use super::{ClassDef, RoleCandidateDef, RoleDef, SubsetDef};
 
@@ -118,4 +118,199 @@ pub(crate) struct Registry {
     pub(crate) proto_subs: HashSet<String>,
     /// `proto token`/`proto rule` declaration markers (existence set).
     pub(crate) proto_tokens: HashSet<String>,
+}
+
+/// Structural lookups over the declaration registry (PR-B: read-side migration).
+///
+/// These methods are the single source of truth for the *registry-read* portions
+/// of class lookup / MRO computation. They consult only registry fields (no
+/// re-entry into user-code execution and no Interpreter state), so they take a
+/// plain `&self` / `&mut self` on `Registry` and the caller holds exactly one
+/// guard for the whole operation — replacing the previous chains of separate
+/// `registry()` / `registry_mut()` acquisitions on the Interpreter side.
+impl Registry {
+    /// Compute the C3 linearization (method resolution order) for `class_name`
+    /// from the registered class hierarchy. Pure read over `self.classes` —
+    /// recursion stays within the registry. Does not consult or fill the cached
+    /// `ClassDef::mro` write side; that is done by [`Registry::class_mro`].
+    pub(crate) fn compute_class_mro(
+        &self,
+        class_name: &str,
+        stack: &mut Vec<String>,
+    ) -> Result<Vec<String>, RuntimeError> {
+        if stack.iter().any(|name| name == class_name) {
+            return Err(RuntimeError::new(format!(
+                "C3 MRO cycle detected at {}",
+                class_name
+            )));
+        }
+        if let Some(class_def) = self.classes.get(class_name)
+            && !class_def.mro.is_empty()
+        {
+            return Ok(class_def.mro.clone());
+        }
+        stack.push(class_name.to_string());
+        let explicit_parents = self
+            .classes
+            .get(class_name)
+            .map(|c| c.parents.clone())
+            .unwrap_or_default();
+        // If a user-defined class has no explicit parents, it implicitly
+        // inherits from Any (which in turn inherits from Mu).  This matches
+        // Raku's default class hierarchy.
+        let parents = if explicit_parents.is_empty() && self.classes.contains_key(class_name) {
+            vec!["Any".to_string()]
+        } else {
+            explicit_parents
+        };
+        let mut seqs: Vec<Vec<String>> = Vec::new();
+        for parent in &parents {
+            if self.classes.contains_key(parent) {
+                let mro = self.compute_class_mro(parent, stack)?;
+                seqs.push(mro);
+            } else if parent == "Any" {
+                // Any implicitly inherits from Mu
+                seqs.push(vec!["Any".to_string(), "Mu".to_string()]);
+            } else if parent == "Cool" {
+                seqs.push(vec![
+                    "Cool".to_string(),
+                    "Any".to_string(),
+                    "Mu".to_string(),
+                ]);
+            } else {
+                seqs.push(vec![parent.clone()]);
+            }
+        }
+        seqs.push(parents.clone());
+        let mut result = vec![class_name.to_string()];
+        while seqs.iter().any(|s| !s.is_empty()) {
+            let mut candidate = None;
+            for seq in &seqs {
+                if seq.is_empty() {
+                    continue;
+                }
+                let head = &seq[0];
+                let mut in_tail = false;
+                for other in &seqs {
+                    if other.len() > 1 && other[1..].contains(head) {
+                        in_tail = true;
+                        break;
+                    }
+                }
+                if !in_tail {
+                    candidate = Some(head.clone());
+                    break;
+                }
+            }
+            if let Some(head) = candidate {
+                result.push(head.clone());
+                for seq in seqs.iter_mut() {
+                    if !seq.is_empty() && seq[0] == head {
+                        seq.remove(0);
+                    }
+                }
+            } else {
+                stack.pop();
+                return Err(RuntimeError::new(format!(
+                    "Inconsistent class hierarchy for {}",
+                    class_name
+                )));
+            }
+        }
+        stack.pop();
+        Ok(result)
+    }
+
+    /// Resolve the MRO for `class_name`, returning the cached `ClassDef::mro`
+    /// when present, the hardcoded hierarchy for built-in types that are not
+    /// user-defined classes, and otherwise computing + caching via
+    /// [`Registry::compute_class_mro`]. Single write guard for the whole op.
+    pub(crate) fn class_mro(&mut self, class_name: &str) -> Vec<String> {
+        // Built-in type hierarchies for types that are not user-defined classes
+        if !self.classes.contains_key(class_name) {
+            let builtin_mro: Option<Vec<&str>> = match class_name {
+                "Match" => Some(vec!["Match", "Capture", "Cool", "Any", "Mu"]),
+                "Capture" => Some(vec!["Capture", "Any", "Mu"]),
+                "Distribution::Path" => Some(vec!["Distribution::Path", "Distribution", "Any", "Mu"]),
+                "Distribution::Hash" => Some(vec!["Distribution::Hash", "Distribution", "Any", "Mu"]),
+                "Distribution::Installation" => Some(vec![
+                    "Distribution::Installation",
+                    "Distribution",
+                    "Any",
+                    "Mu",
+                ]),
+                "CompUnit::DependencySpecification" => {
+                    Some(vec!["CompUnit::DependencySpecification", "Any", "Mu"])
+                }
+                "CompUnit::Repository::FileSystem" => Some(vec![
+                    "CompUnit::Repository::FileSystem",
+                    "CompUnit::Repository",
+                    "Any",
+                    "Mu",
+                ]),
+                "CompUnit::Repository::Installation" => Some(vec![
+                    "CompUnit::Repository::Installation",
+                    "CompUnit::Repository::Installable",
+                    "CompUnit::Repository::Locally",
+                    "CompUnit::Repository",
+                    "Any",
+                    "Mu",
+                ]),
+                _ => None,
+            };
+            if let Some(mro) = builtin_mro {
+                return mro.into_iter().map(String::from).collect();
+            }
+        }
+        if !self.classes.contains_key(class_name)
+            && let Some((base, _)) = class_name.split_once('[')
+            && class_name.ends_with(']')
+            && self.classes.contains_key(base)
+        {
+            let mut mro = vec![class_name.to_string()];
+            mro.extend(self.class_mro(base));
+            return mro;
+        }
+        if let Some(class_def) = self.classes.get(class_name)
+            && !class_def.mro.is_empty()
+        {
+            return class_def.mro.clone();
+        }
+        let mut stack = Vec::new();
+        match self.compute_class_mro(class_name, &mut stack) {
+            Ok(mro) => {
+                if let Some(class_def) = self.classes.get_mut(class_name) {
+                    class_def.mro = mro.clone();
+                }
+                mro
+            }
+            Err(_) => vec![class_name.to_string()],
+        }
+    }
+
+    /// Read-only MRO lookup: the cached `ClassDef::mro` when present, otherwise a
+    /// single-element MRO `[class_name]`. Returns `None` when the class is not
+    /// registered. Used by non-`&mut` helpers that must not trigger computation.
+    pub(crate) fn class_mro_cached(&self, class_name: &str) -> Option<Vec<String>> {
+        let class_def = self.classes.get(class_name)?;
+        if !class_def.mro.is_empty() {
+            return Some(class_def.mro.clone());
+        }
+        Some(vec![class_name.to_string()])
+    }
+
+    /// Whether `class_name` (or any class in its MRO) defines `method_name`
+    /// either as a user method or a native method. Pure registry MRO walk.
+    pub(crate) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        let mro = self.class_mro(class_name);
+        for cn in mro {
+            if let Some(class_def) = self.classes.get(&cn)
+                && (class_def.methods.contains_key(method_name)
+                    || class_def.native_methods.contains(method_name))
+            {
+                return true;
+            }
+        }
+        false
+    }
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -908,71 +908,10 @@ impl Interpreter {
             .is_some_and(|caller| caller == owner_class)
     }
 
+    /// Resolve the MRO for `class_name`. Delegates to [`Registry::class_mro`],
+    /// which holds a single write guard for the whole compute-and-cache op.
     pub(super) fn class_mro(&mut self, class_name: &str) -> Vec<String> {
-        // Built-in type hierarchies for types that are not user-defined classes
-        if !self.registry().classes.contains_key(class_name) {
-            let builtin_mro: Option<Vec<&str>> = match class_name {
-                "Match" => Some(vec!["Match", "Capture", "Cool", "Any", "Mu"]),
-                "Capture" => Some(vec!["Capture", "Any", "Mu"]),
-                "Distribution::Path" => {
-                    Some(vec!["Distribution::Path", "Distribution", "Any", "Mu"])
-                }
-                "Distribution::Hash" => {
-                    Some(vec!["Distribution::Hash", "Distribution", "Any", "Mu"])
-                }
-                "Distribution::Installation" => Some(vec![
-                    "Distribution::Installation",
-                    "Distribution",
-                    "Any",
-                    "Mu",
-                ]),
-                "CompUnit::DependencySpecification" => {
-                    Some(vec!["CompUnit::DependencySpecification", "Any", "Mu"])
-                }
-                "CompUnit::Repository::FileSystem" => Some(vec![
-                    "CompUnit::Repository::FileSystem",
-                    "CompUnit::Repository",
-                    "Any",
-                    "Mu",
-                ]),
-                "CompUnit::Repository::Installation" => Some(vec![
-                    "CompUnit::Repository::Installation",
-                    "CompUnit::Repository::Installable",
-                    "CompUnit::Repository::Locally",
-                    "CompUnit::Repository",
-                    "Any",
-                    "Mu",
-                ]),
-                _ => None,
-            };
-            if let Some(mro) = builtin_mro {
-                return mro.into_iter().map(String::from).collect();
-            }
-        }
-        if !self.registry().classes.contains_key(class_name)
-            && let Some((base, _)) = class_name.split_once('[')
-            && class_name.ends_with(']')
-            && self.registry().classes.contains_key(base)
-        {
-            let mut mro = vec![class_name.to_string()];
-            mro.extend(self.class_mro(base));
-            return mro;
-        }
-        if let Some(class_def) = self.registry().classes.get(class_name)
-            && !class_def.mro.is_empty()
-        {
-            return class_def.mro.clone();
-        }
-        let mut stack = Vec::new();
-        match self.compute_class_mro(class_name, &mut stack) {
-            Ok(mro) => {
-                if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
-                    class_def.mro = mro.clone();
-                }
-                mro
-            }
-            Err(_) => vec![class_name.to_string()],
-        }
+        self.registry_mut().class_mro(class_name)
     }
 
     pub(super) fn force_lazy_list(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {


### PR DESCRIPTION
## What

Phase ② **PR-B** is the read-side migration of the VM/Interpreter decoupling: factor the registry-read portions of lookup / MRO / type-matching into methods on `Registry` itself, so the read logic lives where the data lives rather than as multi-guard chains on the Interpreter.

This first slice moves **MRO computation + class lookup** — the hottest registry read, hit by every method dispatch — onto `impl Registry` (`src/runtime/registry.rs`):

- `Registry::compute_class_mro(&self, name, stack)` — pure C3 linearization over `self.classes`; recursion stays within the registry, no user-code re-entry.
- `Registry::class_mro(&mut self, name)` — builtin hierarchies + parameterized (`Foo[Bar]`) + cached `ClassDef::mro` + compute + cache write-back, **all under a single write guard**. Previously `Interpreter::class_mro` took up to **5 separate** `registry()`/`registry_mut()` guards per call on the dispatch hot path.
- `Registry::class_mro_cached(&self, name)` — read-only (cached or single-element).
- `Registry::class_has_method(&mut self, name, method)` — MRO-walk method probe.

`Interpreter::class_mro` / `compute_class_mro` / `class_mro_readonly` / `class_has_method` become thin delegating wrappers; the 65+ call sites are untouched.

## Why

PR-A moved the registry *fields* into a shared `Registry`. PR-B moves the *read logic* onto `Registry`, collapsing the per-call lock-guard churn on the hottest path and setting up ledger §2 function-dispatch fallback removal. See `docs/vm-registry-ownership.md`.

## Scope notes

- **Behavior-invariant** structural refactor — no semantic changes.
- The VM has **no direct registry-field reads** today (only 2 `package_stubs` writes); its registry access is all via Interpreter wrappers, so no VM registry handle is added here (deferred to ③/④ alongside the Arc→plain collapse).
- The type-matching composed-role transitive walk (two blocks in `type_matching.rs` with divergent gate conditions — `resolve_role_key` vs `roles.contains_key`) is deferred to a later slice to keep this one behavior-invariant.

## Testing

- `cargo build` / `cargo clippy -- -D warnings` clean.
- `make test` green (5336 tests, 0 failures).
- S12 (class/MRO) + S14 (roles) roast green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)