### PR TITLE
feat(exceptions): X::Syntax::Missing for bare constant and block-less for

### DIFF
--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1129,6 +1129,23 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
         parse_for_params(rest)?;
     let rw_block = rw_block || rw_detected;
     let (rest, _) = ws(rest)?;
+    // A `for` loop always requires a brace block. Having parsed the iterable and
+    // any pointy parameters, if no `{` follows then the block is missing
+    // (`for 1, 2` → X::Syntax::Missing, what => 'block'). Fail fatally so the
+    // statement dispatcher does not fall back to reparsing `for` as a term.
+    if !rest.starts_with('{') {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("what".to_string(), Value::str("block".to_string()));
+        attrs.insert(
+            "message".to_string(),
+            Value::str("Missing block".to_string()),
+        );
+        let ex = Value::make_instance(Symbol::intern("X::Syntax::Missing"), attrs);
+        return Err(PError::fatal_with_exception(
+            "X::Syntax::Missing: Missing block".to_string(),
+            Box::new(ex),
+        ));
+    }
     // Collect &-sigil parameter names so they can be registered as user subs
     // inside the block scope — this prevents `m()` from being misread as `m//`
     // (a regex match) when `m` is bound via `-> &m { m() }`.

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -19,9 +19,7 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws1(rest)?;
     // `constant ($a, $b) = ...` is a syntax error (X::Syntax::Missing)
     if rest.starts_with('(') {
-        return Err(PError::fatal(
-            "X::Syntax::Missing: Missing initializer on constant declaration".to_string(),
-        ));
+        return Err(missing_initializer_error());
     }
     // The name can be $var, @var, %var, &var, or bare identifier.
     let sigil = rest.as_bytes().first().copied().unwrap_or(0);
@@ -170,22 +168,19 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
             },
         ));
     }
-    let (rest, _) = opt_char(rest, ';');
-    Ok((
-        rest,
-        Stmt::VarDecl {
-            name,
-            expr: Expr::Literal(Value::Nil),
-            type_constraint: None,
-            is_state: false,
-            is_our: true,
-            is_dynamic: false,
-            is_export,
-            export_tags,
-            custom_traits: constant_traits.clone(),
-            where_constraint: None,
-        },
-    ))
+    // A `constant` with no `=`/`:=` initializer is a compile-time error
+    // (`constant foo;` → X::Syntax::Missing, what => 'initializer').
+    Err(missing_initializer_error())
+}
+
+/// X::Syntax::Missing for a `constant` declaration that has no initializer.
+fn missing_initializer_error() -> PError {
+    let msg = "X::Syntax::Missing: Missing initializer on constant declaration".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("what".to_string(), Value::str("initializer".to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Missing"), attrs);
+    PError::fatal_with_exception(msg, Box::new(ex))
 }
 
 /// Parse `subset` declaration.

--- a/t/syntax-missing.t
+++ b/t/syntax-missing.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 6;
+
+# A `for` loop with no block is X::Syntax::Missing (what => 'block').
+throws-like 'for 1, 2', X::Syntax::Missing, what => 'block',
+    'for loop without a block reports a missing block';
+throws-like 'for 1, 2 -> $x', X::Syntax::Missing, what => 'block',
+    'for loop with a pointy signature but no block reports a missing block';
+
+# A valid for loop still parses and runs.
+lives-ok { EVAL 'my @seen; for 1, 2 { @seen.push: $_ }; @seen' },
+    'a for loop with a block still parses';
+
+# A `constant` with no initializer is X::Syntax::Missing (what => 'initializer').
+throws-like 'constant foo;', X::Syntax::Missing, what => /initializer/,
+    'bare constant declaration reports a missing initializer';
+throws-like 'constant ($a, $b) = 1, 2;', X::Syntax::Missing, what => /initializer/,
+    'list-pattern constant reports a missing initializer';
+
+# A valid constant still parses and runs.
+lives-ok { EVAL 'constant foo = 42; foo' },
+    'a constant with an initializer still parses';


### PR DESCRIPTION
Two more `roast/S32-exceptions/misc2.t` clusters in the X:: campaign.

## What lands

- **`constant foo;`** (and `constant ($a, $b) = ...`) with no `=`/`:=` initializer now throws a typed **X::Syntax::Missing** (`what => 'initializer'`) instead of silently defaulting the constant to `Nil`. rakudo always rejects an initializer-less constant.
- **`for 1, 2`** (and `for ... -> $x` with no brace block) now throws a typed **X::Syntax::Missing** (`what => 'block'`). The check fires after the iterable and any pointy parameters parse, and fails fatally so the statement dispatcher does not fall back to reparsing `for` as a bareword term. Valid for-loops (`for 1,2 { }`, `for 1,2 -> $x { }`, postfix `.say for 1,2`) are unaffected.

## Tests

- New: `t/syntax-missing.t` (6 subtests, all pass).
- `make test`: PASS (607 files, 5356 tests, 0 failed).
- Whitelisted for/loop/phaser spot-checks (pointy.t, in-loop.t, …) still PASS.
- clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)