### PR TITLE
refactor(vm): move method-resolution & type-match reads into Registry methods (phase ② PR-B slice 2)

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -154,11 +154,30 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   （`type_matches_value` 40+ サイト、`class_mro` 等）。よって「VM ~15-20 read サイトを `self.registry.read()`
   へ」は実コードと不一致＝VM への registry ハンドル追加は本 slice では不要（②非ゴールの Arc→plain 畳み込み
   と一体で ③/④へ）。read 側移行の実体は wrapper の Registry メソッド化＝本 slice。
-- **残（PR-B 後続）**: 型マッチ（`type_matching.rs`）の「クラス MRO 経由の composed-role 推移 walk」2 ブロック
-  （L668-697 / L821-850）。pure-registry 読みだが、ゲート条件が **block1=`resolve_role_key`（Interpreter
-  名前解決）/ effective_constraint subtype 判定**、**block2=`roles.contains_key` / exact 一致**で非自明に異なり、
-  素朴な統合は推移閉包を変える恐れ。挙動不変を厳守するため別 slice で（gate を保ったまま Registry 側 closure
-  ヘルパへ抽出）。`resolve_method_with_owner_impl` の registry-read 部も同様に後続。
+- **PR-B slice 2 = メソッド解決/型マッチの registry-read メソッド化（本 PR）**: dispatch ホットパスに散在する
+  同型の pure-registry read を `impl Registry` の owned 返しメソッドへ集約（ガード即 drop の規律を維持）:
+  - `Registry::get_method_overloads(&self, class, method) -> Option<Vec<MethodDef>>` — `classes.get(c).methods.get(m).cloned()`。
+    `resolution.rs` の同型 5 サイト（`resolve_method_with_owner_impl` のオーバーロード read、
+    `resolve_methods_per_mro_level` の read + any_multi 再チェック、private 解決 2 サイト）を変換。
+  - `Registry::get_role_param_bindings(&self, class) -> Option<HashMap<String,Value>>` — 同 4 サイト変換。
+  - `Registry::is_hidden_class` / `is_hidden_defer_parent(class, owner) -> bool`（後者は所有 set を返さず
+    述語化＝`&self`-only 呼び出し側の gratuitous clone を回避）。`should_skip_defer_method_candidate` を変換。
+  - `Registry::composed_roles_seed(&self, mro) -> Vec<String>` — composed-role 推移 walk の**シードのみ**
+    （MRO→`class_composed_roles`、push 順保持・dedup/sort 禁止＝LIFO walk の first-match-wins が load-bearing）。
+    `type_matching.rs` の Block A（Package, `resolved_constraint.is_some()`）/ Block B（Instance,
+    `roles.contains_key`）両方のシードに適用。**推移 walk 本体はインライン据え置き**: gate が
+    block A=`resolve_role_key`（env+lock 再入）/ block B=`roles.contains_key`、match が `type_matches` /
+    exact `== constraint` で非自明に異なり、`resolve_role_key` gate を Registry メソッド内（read ガード保持中）
+    から呼ぶと std `RwLock` 非再入で deadlock するため。
+  - **変換しない（意図的）**: `resolve_all_methods_with_owner` の class-OR-role `.or_else` fallback（非同型）、
+    private zero-arg fast-path（borrow 走査で matched 1 件のみ clone のホットパス最適化＝Vec 全 clone 退行回避）。
+  - **対象外（別件）**: `methods_classhow.rs`/`methods_walk.rs` の composed-role walk は構造差（VecDeque BFS vs
+    LIFO Vec、base strip タイミング差、二重 map closure）で walk 順が変わるため据え置き。`functions.get(&Symbol)`
+    lookup は周辺キー構築が `current_package`/`env` 依存のため Interpreter 側据え置き。
+  挙動不変、build/clippy/make test 緑、S12/S14（typecheck/parameterized/generic-subtyping 含む）roast 緑。
+- **残（PR-B 後続）**: `resolve_method_with_owner_impl` の残る tie-break/candidate 収集（type-distance 計算等）は
+  既に owned clone 後の純メモリ処理で registry-read は本 slice で集約済み。次は **PR-C**（register_* の
+  write-through 整理）。
 
 ## 完了の定義（②）— **PR-A 完了（slice 1-5, #2760/2762/2763/2764/本PR）**
 

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -30,7 +30,7 @@ use crate::ast::FunctionDef;
 use crate::symbol::Symbol;
 use crate::value::{EnumValue, RuntimeError, Value};
 
-use super::{ClassDef, RoleCandidateDef, RoleDef, SubsetDef};
+use super::{ClassDef, MethodDef, RoleCandidateDef, RoleDef, SubsetDef};
 
 /// Program declaration registry. See module docs.
 ///
@@ -316,5 +316,60 @@ impl Registry {
             }
         }
         false
+    }
+
+    /// The method overloads named `method_name` defined directly on `class_name`
+    /// (not inherited). Owned clone — `MethodDef` is `Arc`-backed so the clone is
+    /// O(overload count) refcount bumps, matching the prior `.cloned()` call sites.
+    pub(crate) fn get_method_overloads(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<Vec<MethodDef>> {
+        self.classes
+            .get(class_name)
+            .and_then(|c| c.methods.get(method_name))
+            .cloned()
+    }
+
+    /// Bound role type parameters for `class_name` (e.g. the `::T` -> value map
+    /// of a `class C does R[Int]`). Owned clone.
+    pub(crate) fn get_role_param_bindings(
+        &self,
+        class_name: &str,
+    ) -> Option<HashMap<String, Value>> {
+        self.class_role_param_bindings.get(class_name).cloned()
+    }
+
+    /// Whether `name` is marked `is hidden` (excluded from `.^mro` etc.).
+    pub(crate) fn is_hidden_class(&self, name: &str) -> bool {
+        self.hidden_classes.contains(name)
+    }
+
+    /// Whether `owner` is a deferred `is hidden` parent of `class`. Predicate form
+    /// (not an owned-set getter) so the `&self`-only caller keeps the guard local
+    /// and clones nothing.
+    pub(crate) fn is_hidden_defer_parent(&self, class: &str, owner: &str) -> bool {
+        self.hidden_defer_parents
+            .get(class)
+            .is_some_and(|h| h.contains(owner))
+    }
+
+    /// Seed for the composed-role transitive walk: the base names of every role
+    /// composed into any class in `mro`, in MRO-then-declaration order. The
+    /// parametric suffix is stripped (`R[Int]` -> `R`). Push order is load-bearing
+    /// — the caller consumes this LIFO via `.pop()` and relies on first-match-wins,
+    /// so this method MUST NOT dedup or sort (dedup happens during the walk).
+    pub(crate) fn composed_roles_seed(&self, mro: &[String]) -> Vec<String> {
+        let mut seed = Vec::new();
+        for cn in mro {
+            if let Some(composed) = self.class_composed_roles.get(cn.as_str()) {
+                for cr in composed {
+                    let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
+                    seed.push(base.to_string());
+                }
+            }
+        }
+        seed
     }
 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -329,11 +329,7 @@ impl Interpreter {
         invocant: Option<&Value>,
     ) -> Option<(String, MethodDef)> {
         self.dispatch_ambiguous = false;
-        let role_bindings = self
-            .registry()
-            .class_role_param_bindings
-            .get(class_name)
-            .cloned();
+        let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         // Collect all matching multi candidates across the MRO, then pick the
         // most specific one by type hierarchy distance.
@@ -349,10 +345,7 @@ impl Interpreter {
             // across the whole block.
             let overloads = self
                 .registry()
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
-                .cloned();
+                .get_method_overloads(cn.as_str(), method_name);
             if let Some(overloads) = overloads {
                 let any_multi = overloads.iter().any(|d| d.is_multi);
                 let mut first_visible_non_multi: Option<MethodDef> = None;
@@ -596,11 +589,7 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Vec<(String, MethodDef)> {
-        let role_bindings = self
-            .registry()
-            .class_role_param_bindings
-            .get(class_name)
-            .cloned();
+        let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         let mut matches = Vec::new();
         for cn in &mro {
@@ -663,10 +652,7 @@ impl Interpreter {
             let is_ancestor = cn != class_name;
             if let Some(overloads) = self
                 .registry()
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
-                .cloned()
+                .get_method_overloads(cn.as_str(), method_name)
             {
                 let has_visible = overloads
                     .iter()
@@ -681,9 +667,7 @@ impl Interpreter {
         }
         let any_multi = defining_levels.iter().any(|cn| {
             self.registry()
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
+                .get_method_overloads(cn.as_str(), method_name)
                 .is_some_and(|ovs| ovs.iter().any(|d| d.is_multi))
         });
         if !any_multi {
@@ -713,15 +697,11 @@ impl Interpreter {
         receiver_class: &str,
         candidate_owner: &str,
     ) -> bool {
-        if receiver_class != candidate_owner
-            && self.registry().hidden_classes.contains(candidate_owner)
-        {
+        if receiver_class != candidate_owner && self.registry().is_hidden_class(candidate_owner) {
             return true;
         }
         self.registry()
-            .hidden_defer_parents
-            .get(receiver_class)
-            .is_some_and(|hidden| hidden.contains(candidate_owner))
+            .is_hidden_defer_parent(receiver_class, candidate_owner)
     }
 
     pub(super) fn resolve_private_method_with_owner(
@@ -731,23 +711,14 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
-        let role_bindings = self
-            .registry()
-            .class_role_param_bindings
-            .get(class_name)
-            .cloned();
+        let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         for cn in mro {
             if cn != owner_class {
                 continue;
             }
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self
-                .registry()
-                .classes
-                .get(&cn)
-                .and_then(|c| c.methods.get(method_name))
-                .cloned();
+            let overloads = self.registry().get_method_overloads(&cn, method_name);
             if let Some(overloads) = overloads {
                 for def in overloads {
                     if !def.is_private {
@@ -774,11 +745,7 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
-        let role_bindings = self
-            .registry()
-            .class_role_param_bindings
-            .get(class_name)
-            .cloned();
+        let role_bindings = self.registry().get_role_param_bindings(class_name);
         if arg_values.is_empty()
             && let Some(cached) = self
                 .private_zeroarg_method_cache
@@ -845,12 +812,7 @@ impl Interpreter {
         }
         for cn in mro {
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self
-                .registry()
-                .classes
-                .get(&cn)
-                .and_then(|c| c.methods.get(method_name))
-                .cloned();
+            let overloads = self.registry().get_method_overloads(&cn, method_name);
             if let Some(overloads) = overloads {
                 for def in &overloads {
                     if !def.is_private {

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -667,17 +667,12 @@ impl Interpreter {
             }
             // Check transitive role composition through class_composed_roles and role_parents
             if resolved_constraint.is_some() {
-                let mut role_stack: Vec<String> = Vec::new();
+                // Seed from the registry (composed roles over the MRO); the divergent
+                // transitive walk below stays inline because its parent gate
+                // (`resolve_role_key`) re-enters the registry/env and must not run
+                // under a held guard.
+                let mut role_stack = self.registry().composed_roles_seed(&mro);
                 let mut seen_roles = HashSet::new();
-                // Collect all composed roles from the class and its parents
-                for cn in &mro {
-                    if let Some(composed) = self.registry().class_composed_roles.get(cn.as_str()) {
-                        for cr in composed {
-                            let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
-                            role_stack.push(base.to_string());
-                        }
-                    }
-                }
                 while let Some(role_name) = role_stack.pop() {
                     if !seen_roles.insert(role_name.clone()) {
                         continue;
@@ -821,16 +816,11 @@ impl Interpreter {
             // Check composed roles for the instance's class (and its MRO)
             if self.registry().roles.contains_key(constraint) {
                 let mro = self.class_mro(&class_name.resolve());
-                let mut role_stack: Vec<String> = Vec::new();
+                // Seed from the registry; the transitive walk below stays inline
+                // because its gate / match check diverge from the Package-value
+                // walk above (exact `== constraint` + `roles.contains_key` here).
+                let mut role_stack = self.registry().composed_roles_seed(&mro);
                 let mut seen_roles = HashSet::new();
-                for cn in &mro {
-                    if let Some(composed) = self.registry().class_composed_roles.get(cn.as_str()) {
-                        for cr in composed {
-                            let base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
-                            role_stack.push(base.to_string());
-                        }
-                    }
-                }
                 while let Some(role_name) = role_stack.pop() {
                     if !seen_roles.insert(role_name.clone()) {
                         continue;


### PR DESCRIPTION
## What

Phase ② **PR-B** read-side migration, continued from slice 1 (#2769, MRO). This slice factors the remaining identical-shaped pure-registry reads on the method-dispatch / type-matching hot paths onto `impl Registry`, returning **owned (cloned)** data so each caller's temporary read guard drops immediately — matching the existing manual hoist-and-drop discipline (`std::sync::RwLock` is non-reentrant).

### New `Registry` methods (`src/runtime/registry.rs`)
- `get_method_overloads(class, method) -> Option<Vec<MethodDef>>`
- `get_role_param_bindings(class) -> Option<HashMap<String, Value>>`
- `is_hidden_class(name)` / `is_hidden_defer_parent(class, owner) -> bool` — the latter is a **predicate**, not an owned-set getter, to avoid a gratuitous `HashSet` clone in a `&self`-only caller
- `composed_roles_seed(mro) -> Vec<String>` — the shared MRO→`class_composed_roles` seed for the type-match role walk; **push-order preserving, no dedup/sort** (the LIFO walk's first-match-wins is load-bearing)

### Call-site conversions
- `resolution.rs`: 5 identical `classes.get(c).methods.get(m).cloned()` overload reads + 4 `class_role_param_bindings.get(c).cloned()` reads + the hidden-class/defer-parent predicate.
- `type_matching.rs`: both composed-role walks (Block A `Value::Package`, Block B `Value::Instance`) now seed via `composed_roles_seed`. The **divergent transitive walks stay inline** — their gates (`resolve_role_key` vs `roles.contains_key`) and match checks (`type_matches` vs exact `==`) differ, and `resolve_role_key` re-enters the registry/env so it cannot run under a held guard (deadlock).

### Deliberately NOT converted (documented)
- The class-OR-role `.or_else` fallback in `resolve_all_methods_with_owner` (not identical-shaped).
- The private zero-arg fast path (borrow-scan cloning only the single matched `def` — converting would regress the documented hot-path optimization).
- `methods_classhow.rs` / `methods_walk.rs` role walks (BFS vs LIFO, differing base-strip timing).
- `functions.get(&Symbol)` lookups (key construction reads `current_package`/`env`).

## Why

PR-A moved the registry *fields* into a shared `Registry`; PR-B moves the *read logic* onto it, deduping the dispatch-path reads and setting up ledger §2 function-dispatch fallback removal. See `docs/vm-registry-ownership.md` (PR-B progress section updated).

## Testing

- `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean.
- `make test` green — 5350 tests, **0 `not ok`**.
- S12/S14 roast green locally: inheritance, composition, submethods, typecheck, parameterized-type, parameter-subtyping, generic-subtyping, mro-6e.
- Smoke: transitive role parent match (`role R2 does R1; class C does R2`) for **both** a type object (`C ~~ R1`) and an instance (`C.new ~~ R1`), private-method dispatch, multi-method dispatch.

**Behavior-invariant** structural refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)