### PR TITLE
refactor(vm): write-through cleanup + runtime reentrancy guard (phase ② PR-C, ② complete)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -101,7 +101,8 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       （真フォールバック）/ `// CARRIER:`（反射・MOP・EVAL・メタプロ hook）で注釈し、進捗台帳
       [docs/vm-interpreter-fallback-ledger.md](docs/vm-interpreter-fallback-ledger.md) を新設。同 PR で `succ`/`pred` を
       統一 compiled-first ディスパッチへ降ろし §1 から 2 サイト消化。以後は台帳の行を消す形で進める。
-- [~] **② 宣言レジストリの VM 所有化**（設計確定: [docs/vm-registry-ownership.md](docs/vm-registry-ownership.md)）:
+- [x] **② 宣言レジストリの VM 所有化 — 完了（PR-A/B/C）**（設計: [docs/vm-registry-ownership.md](docs/vm-registry-ownership.md)）。
+      Arc<RwLock<Registry>>→plain field の最終畳み込みは Interpreter 撤去後（④/⑤）。次の戦略主作業は ③:
       `class`/`role`/`enum`/`subset`/`token`/`sub` は現在 `Register*` opcode が `interpreter.register_*_decl()` を
       呼び、レジストリ・MRO・role 合成が Interpreter 側。これらの宣言レジストリ ~30 フィールドを `Interpreter` から
       切り出し、**遷移期は `Arc<RwLock<Registry>>` 足場**（VM と Interpreter が対等に共有。`Rc<RefCell>` は
@@ -115,10 +116,14 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             から宣言レジストリが消え `clone_for_thread` は registry 全体 clone 1 行のみ（個別 clone ゼロ・snapshot 不変）。
             参照返却アクセサは owned 化。再入安全規律（read→write/write→write 同一ロック deadlock を複数発見・修正、
             Python ブレース対応スキャナ＋make roast タイムアウトで検出）を確立。詳細は docs/vm-registry-ownership.md。
-      - [ ] **PR-B（read 側）**: lookup/MRO/型マッチの registry 読み部を Registry メソッド化し、VM の read サイトを
-            `self.registry.read()` 直読みへ。台帳 §2 の関数 dispatch fallback（multi/sub 解決）撲滅の前提。
-      - [ ] **PR-C（write-through）**: `register_*_decl` の registry 書き込みを write-lock ブロックへ整理、再入跨ぎ
-            guard 無しを保証、台帳注釈更新。これで②完了→③（env/型/state 移管）へ。
+      - [x] **PR-B 完了（read 側, #2769/#2772）**: lookup/MRO/型マッチの registry 読み部を `impl Registry` の pure
+            メソッド化（`compute_class_mro`/`class_mro`/`get_method_overloads`/`composed_roles_seed` 等）。VM の
+            registry アクセスは accessor 経由（多くは owned 返し）。台帳 §2 の関数 dispatch fallback 撲滅の前提が整った。
+      - [x] **PR-C 完了（write-through）**: `register_class_decl` の連続 write/read クラスタを単一 guard ブロックへ整理
+            （prologue 5-read snapshot / `restore_previous_state` クロージャ / stub クリア）。**再入跨ぎ guard 無しを
+            実行時 guard で保証**: `registry()`/`registry_mut()` を再入検出ラッパ（debug 限定・ロックアドレスでキー付け）へ
+            差し替え、同一ロック再取得を `.read()`/`.write()` 手前で位置付き panic（サイレントデッドロックを即・明示化）。
+            台帳に②抽出/read/write-through 完了＋登録の CARRIER 性を記録。**②完了 → 次は ③（env/型/state 移管）**。
 - [ ] **③ VM が借用している Interpreter 状態を VM 所有へ移管**: env HashMap（変数ストア本体）・classes/roles/enums
       レジストリ・型検査（`type_matches_value`/`var_type_constraint`）・readonly 追跡・`let`/`temp` 復元・multi 解決・
       state 変数・`current_package`。これが移れば **interpreter ブリッジ自体が不要**になる。最大の山。

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -72,6 +72,17 @@
   単純ユーザ sub の OTF compile を追加（interpreter は終端のみ）。あわせて native-method 行を **③-blocked** に訂正
   （`native_io_*` がファイルハンドル等の interpreter 所有状態を要求するため「個別可」は誤りだった）。
 
+- **2026-06-08 (② 抽出/read/write-through 完了, #2760-2772 + 本 PR)**: 宣言レジストリの VM 所有化（phase ②）が
+  PR-A（抽出・全フィールドを `Registry` へ）→ PR-B（lookup/MRO/型マッチを `impl Registry` メソッド化）→ PR-C
+  （`register_*_decl` の write-through 整理）まで完了。一次情報は `docs/vm-registry-ownership.md`。PR-C は
+  **登録パス＝CARRIER 性**（`register_class_decl`/`register_sub_decl`/`register_enum_decl`/`register_role_decl` は
+  登録中に `eval_block_value`/`run_block_raw`/`call_function`＝クラス本体・trait ハンドラ・属性デフォルト・enum 変種値・
+  パラメタ化 role 本体を実行する＝実行トリガ）を確認し、`registry()`/`registry_mut()` を**再入検出ラッパ guard**へ
+  差し替えて「RwLock ガードを再入を跨いで保持しない」規律を **debug ビルドで実行時に強制**（同一ロック再取得を
+  ブロッキング呼び出し手前で位置付き panic、ロックアドレスでキー付けして別 registry 同時保持の正当ケースは許容）。
+  これで §2 の関数 dispatch fallback（`vm_call_func_ops.rs` multi/sub 解決, `vm_dispatch_helpers.rs` Routine）撲滅の
+  構造前提（②）が整った。残る §1/§2 は ③（state 所有移管）が前提。
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -179,12 +179,41 @@ dual-store は [vm-dual-store.md](vm-dual-store.md)。
   既に owned clone 後の純メモリ処理で registry-read は本 slice で集約済み。次は **PR-C**（register_* の
   write-through 整理）。
 
-## 完了の定義（②）— **PR-A 完了（slice 1-5, #2760/2762/2763/2764/本PR）**
+## PR-C（write-through 整理）進捗 — **②完了**
+
+- **再入跨ぎ guard 無しを *実行時* 保証（本 PR の核心）**: 従来 `registry()`/`registry_mut()` は std の
+  `RwLockReadGuard`/`RwLockWriteGuard` を直接返していたため、再入で同一ロックを再取得すると**サイレントに
+  デッドロック**し、make roast の ~13 分タイムアウトでしか捕捉できなかった。静的スキャナはコード形状の盲点が
+  あり（PR-A slice 5 の `match self.registry_mut()...{}` arm 内 write→write は借用チェッカ・スキャナ双方を
+  すり抜けて実行時ハング）。本 PR で `registry()`/`registry_mut()` を**再入検出ラッパ guard**
+  （`RegistryReadGuard`/`RegistryWriteGuard`、`src/runtime/registry.rs`）へ差し替え:
+  - debug ビルドのみ、取得直前に thread-local の保持状況を検査し、**`.read()`/`.write()` のブロッキング呼び出し
+    の手前**で位置付き panic（デッドロックする代わりに即・明示的に落ちる）。
+  - **ロックのアドレスでキー付け**（thread-global ではない）。単一スレッドが*別の*レジストリの guard を同時保持
+    する正当ケース（`self.registry_mut().classes = nested.registry().classes.clone();` ＝ self の write guard と
+    sub-interpreter `nested` の read guard。別ロックなのでデッドロックしない）を誤検出しないため。
+  - 許可/禁止行列は std `RwLock` の実デッドロック条件に一致: 同一ロックで write-while-any / read-while-write は
+    panic、read-while-read（nested read。`a().x && b().y` で両 temporary guard が文末まで生存）は許容。
+  - release は `#[cfg(debug_assertions)]` で完全に消える（ホット `registry()` read 経路に thread-local bookkeeping を
+    乗せない）。CI の release make roast はタイムアウトが最終防衛線のまま。
+  - 検証: debug バイナリで t/ + S10/S11/S12/S14/S05/S04 等 6000+ ファイル実行・**再入 panic ゼロ**（false-positive
+    無し、潜在再入バグ無し）。threading（start/promise/channel）も clean。
+- **write-through 整理（register_class_decl）**: 連続する再入無し write/read クラスタを単一 guard ブロックへ集約し
+  ロック取得回数を削減＋「この区間は guard 保持＝再入禁止」境界を構文で明示。① prologue の prev_* 5 read を
+  単一 read guard ブロックへ（全て owned/cloned）。② `restore_previous_state` ロールバッククロージャの 10 個の
+  `this.registry_mut()` を単一 write guard へ（本体に再入無し）。③ stub クリアの `class_stubs.remove` +
+  `package_stubs.remove` 連続 2 write を単一 write guard へ。上記の実行時 guard が安全性を担保（誤って read 保持中に
+  クロージャを呼べば即 panic するが、6000+ 実行で発火せず＝呼び出し点に held guard 無しを確認）。
+- **台帳注釈**: `docs/vm-interpreter-fallback-ledger.md` 進捗ログに②抽出フェーズ完了＋登録が実行をトリガする
+  CARRIER 性を記録。
+
+## 完了の定義（②）— **PR-A/B/C 完了（#2760/2762/2763/2764/2767/2769/2772/本PR）**
 
 `Interpreter` から宣言レジストリ全フィールドが消え `registry: Arc<RwLock<Registry>>` 1 本に。`clone_for_thread`
 のレジストリ複製は registry 全体 clone 1 行のみ（個別フィールド clone ゼロ、snapshot 不変）。VM の registry 系
-lookup は accessor 経由（多くは既に owned 返し）。**PR-B**（lookup/MRO/型マッチを Registry メソッド化、上記
-進捗）→ **PR-C**（register_* の write-through 整理）→ ③（env/型/state 移管）。
+lookup は accessor 経由（多くは既に owned 返し）。**PR-A**（抽出）→ **PR-B**（lookup/MRO/型マッチを Registry
+メソッド化）→ **PR-C**（register_* の write-through 整理＋再入跨ぎ guard 無しを実行時 guard で保証）まで全完了。
+**次は ③**（env/型/state 移管＝interpreter ブリッジ撤去の最大の山）。
 
 ## 非ゴール
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5084,16 +5084,20 @@ impl Interpreter {
     /// guard — NEVER `let`-bind it across a call that re-enters user-code
     /// execution (`eval_block_value`/`run_block_raw`/`call_function`): `RwLock`
     /// is not reentrant and would deadlock. Use as `self.registry().subsets...`.
+    ///
+    /// In debug builds the returned guard detects a re-entrant lock attempt on
+    /// this thread and panics with a located message instead of deadlocking (see
+    /// [`RegistryReadGuard`](crate::runtime::registry::RegistryReadGuard)).
     #[inline]
-    pub(crate) fn registry(&self) -> std::sync::RwLockReadGuard<'_, Registry> {
-        self.registry.read().unwrap()
+    pub(crate) fn registry(&self) -> crate::runtime::registry::RegistryReadGuard<'_> {
+        crate::runtime::registry::RegistryReadGuard::new(&self.registry)
     }
 
     /// Write access to the shared declaration [`Registry`]. Same guard discipline
     /// as [`Self::registry`].
     #[inline]
-    pub(crate) fn registry_mut(&self) -> std::sync::RwLockWriteGuard<'_, Registry> {
-        self.registry.write().unwrap()
+    pub(crate) fn registry_mut(&self) -> crate::runtime::registry::RegistryWriteGuard<'_> {
+        crate::runtime::registry::RegistryWriteGuard::new(&self.registry)
     }
 
     /// Create a lightweight clone of this interpreter for use in a spawned thread.

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -680,49 +680,59 @@ impl Interpreter {
         let does_parents = does_parents.as_slice();
         let hidden_parents: Vec<String> = hidden_parents.iter().map(|p| strip_colons(p)).collect();
         let hidden_parents = hidden_parents.as_slice();
-        let prev_class = self.registry().classes.get(name).cloned();
-        let prev_hidden = self.registry().hidden_classes.contains(name);
-        let prev_hidden_defer = self.registry().hidden_defer_parents.get(name).cloned();
-        let prev_composed_roles = self.registry().class_composed_roles.get(name).cloned();
-        let prev_role_param_bindings = self.registry().class_role_param_bindings.get(name).cloned();
+        // Snapshot the previous registry state for this class under a single read
+        // guard (all values are owned/cloned, no re-entry) so a redefinition can be
+        // rolled back if the new body fails.
+        let (
+            prev_class,
+            prev_hidden,
+            prev_hidden_defer,
+            prev_composed_roles,
+            prev_role_param_bindings,
+        ) = {
+            let reg = self.registry();
+            (
+                reg.classes.get(name).cloned(),
+                reg.hidden_classes.contains(name),
+                reg.hidden_defer_parents.get(name).cloned(),
+                reg.class_composed_roles.get(name).cloned(),
+                reg.class_role_param_bindings.get(name).cloned(),
+            )
+        };
         // Clear `is Type` trait entries for this class (they'll be re-populated from the body).
         self.registry_mut()
             .class_attribute_is_types
             .retain(|(cn, _), _| cn != name);
 
+        // Rollback writes are purely registry mutations with no user-code
+        // re-entry, so they take a single write guard for the whole block.
         let restore_previous_state = |this: &mut Self| {
+            let mut reg = this.registry_mut();
             if let Some(class_def) = prev_class.clone() {
-                this.registry_mut()
-                    .classes
-                    .insert(name.to_string(), class_def);
+                reg.classes.insert(name.to_string(), class_def);
             } else {
-                this.registry_mut().classes.remove(name);
+                reg.classes.remove(name);
             }
             if prev_hidden {
-                this.registry_mut().hidden_classes.insert(name.to_string());
+                reg.hidden_classes.insert(name.to_string());
             } else {
-                this.registry_mut().hidden_classes.remove(name);
+                reg.hidden_classes.remove(name);
             }
             if let Some(hidden) = prev_hidden_defer.clone() {
-                this.registry_mut()
-                    .hidden_defer_parents
-                    .insert(name.to_string(), hidden);
+                reg.hidden_defer_parents.insert(name.to_string(), hidden);
             } else {
-                this.registry_mut().hidden_defer_parents.remove(name);
+                reg.hidden_defer_parents.remove(name);
             }
             if let Some(composed) = prev_composed_roles.clone() {
-                this.registry_mut()
-                    .class_composed_roles
-                    .insert(name.to_string(), composed);
+                reg.class_composed_roles.insert(name.to_string(), composed);
             } else {
-                this.registry_mut().class_composed_roles.remove(name);
+                reg.class_composed_roles.remove(name);
             }
             if let Some(bindings) = prev_role_param_bindings.clone() {
-                this.registry_mut()
-                    .class_role_param_bindings
+                reg.class_role_param_bindings
                     .insert(name.to_string(), bindings);
             } else {
-                this.registry_mut().class_role_param_bindings.remove(name);
+                reg.class_role_param_bindings.remove(name);
             }
         };
 
@@ -1427,10 +1437,13 @@ impl Interpreter {
             let _ = self.compute_class_mro(name, &mut stack)?;
             return Ok(deferred_custom_traits);
         }
-        // Clear stub status now that the class has a real body.
-        self.registry_mut().class_stubs.remove(name);
-        // Also clear package stub status (for `package Foo { ... }; class Foo { }`)
-        self.registry_mut().package_stubs.remove(name);
+        // Clear stub status now that the class has a real body (also clears
+        // package stub status for `package Foo { ... }; class Foo { }`).
+        {
+            let mut reg = self.registry_mut();
+            reg.class_stubs.remove(name);
+            reg.package_stubs.remove(name);
+        }
         let saved_package = self.current_package.clone();
         let saved_env = self.env.clone();
         self.current_package = name.to_string();

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -373,3 +373,207 @@ impl Registry {
         seed
     }
 }
+
+// ---------------------------------------------------------------------------
+// Reentrancy-detecting guards (debug-only)
+// ---------------------------------------------------------------------------
+//
+// `Arc<RwLock<Registry>>` is a non-reentrant lock. The lock discipline (see the
+// module docs) is: never hold a read/write guard across a call that re-enters
+// user-code execution, because the re-entry will try to re-acquire the lock and
+// deadlock. Registration paths (`register_*_decl`) are the prime offenders —
+// they interleave registry writes with `eval_block_value` / `run_block_raw` /
+// `call_function` (class body statements, trait handlers, attribute defaults,
+// enum variant values, parametric role bodies), so a stray held guard silently
+// deadlocks.
+//
+// A silent deadlock is only caught by `make roast`'s ~13-min timeout, and a
+// static text scanner misses code shapes the borrow checker also misses (PR-A
+// slice 5: a `write -> write` inside a `match self.registry_mut()...{}` arm hung
+// at runtime despite passing both checks). So instead we detect re-entry at
+// runtime, in debug builds: each acquisition checks a thread-local record of the
+// guards this thread currently holds *on that same lock* and panics with a
+// located message before the would-be-deadlocking `.read()`/`.write()` call.
+//
+// The record is keyed by the lock's address, NOT just by thread: a single thread
+// legitimately holds guards on *different* registries at once — e.g.
+// `self.registry_mut().classes = nested.registry().classes.clone();` holds a
+// write guard on `self`'s registry and a read guard on a sub-interpreter's
+// (`nested`) registry simultaneously. Those are independent locks, so there is no
+// deadlock; a thread-global flag would false-positive. Only re-acquiring the
+// *same* lock deadlocks.
+//
+// The allowed/forbidden matrix (per lock) matches `std::sync::RwLock`'s actual
+// deadlock conditions:
+//   - acquiring a WRITE while ANY guard (read or write) on the same lock is held -> deadlock
+//   - acquiring a READ while a WRITE on the same lock is held                    -> deadlock
+//   - acquiring a READ while only READ guards on the same lock are held          -> tolerated
+//     (nested reads are relied upon, e.g. `a().x && b().y` keeps both temporary
+//     read guards alive to end-of-statement).
+//
+// This is `#[cfg(debug_assertions)]` only: the per-access bookkeeping would
+// otherwise tax the hot `registry()` read path (method dispatch reads MRO through
+// it). CI's release `make roast` still backstops via timeout.
+
+#[cfg(debug_assertions)]
+mod reentry_check {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        // lock address -> (outstanding read guards, write guard held?) on this thread.
+        static HELD: RefCell<HashMap<usize, (u32, bool)>> = RefCell::new(HashMap::new());
+    }
+
+    /// Called before `RwLock::read()`. Panics if this thread already holds a write
+    /// guard on the same lock (read-while-write deadlocks).
+    pub(super) fn enter_read(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            let entry = h.entry(lock).or_insert((0, false));
+            assert!(
+                !entry.1,
+                "registry(): a read guard was acquired while this thread already \
+                 holds a write guard on the same registry. RwLock<Registry> is not \
+                 reentrant; drop the write guard before re-entering. See the lock \
+                 discipline in src/runtime/registry.rs / docs/vm-registry-ownership.md.",
+            );
+            entry.0 += 1;
+        });
+    }
+
+    pub(super) fn exit_read(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            if let Some(entry) = h.get_mut(&lock) {
+                entry.0 = entry.0.saturating_sub(1);
+                if entry.0 == 0 && !entry.1 {
+                    h.remove(&lock);
+                }
+            }
+        });
+    }
+
+    /// Called before `RwLock::write()`. Panics if this thread already holds any
+    /// guard on the same lock (write-while-anything deadlocks).
+    pub(super) fn enter_write(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            let entry = h.entry(lock).or_insert((0, false));
+            assert!(
+                !entry.1,
+                "registry_mut(): a write guard was acquired while this thread \
+                 already holds a write guard on the same registry (write -> write). \
+                 RwLock<Registry> is not reentrant; consolidate into a single write \
+                 guard. See src/runtime/registry.rs / docs/vm-registry-ownership.md.",
+            );
+            assert!(
+                entry.0 == 0,
+                "registry_mut(): a write guard was acquired while this thread holds \
+                 a read guard on the same registry (read -> write upgrade). \
+                 RwLock<Registry> is not reentrant; drop the read guard first. See \
+                 src/runtime/registry.rs / docs/vm-registry-ownership.md.",
+            );
+            entry.1 = true;
+        });
+    }
+
+    pub(super) fn exit_write(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            if let Some(entry) = h.get_mut(&lock) {
+                entry.1 = false;
+                if entry.0 == 0 {
+                    h.remove(&lock);
+                }
+            }
+        });
+    }
+}
+
+/// Read guard for the shared [`Registry`]. Derefs to `Registry`; in debug builds
+/// it records the acquisition in a thread-local so a re-entrant lock attempt
+/// panics with a located message instead of silently deadlocking (see the
+/// `reentry_check` module above).
+pub(crate) struct RegistryReadGuard<'a> {
+    inner: std::sync::RwLockReadGuard<'a, Registry>,
+    #[cfg(debug_assertions)]
+    lock_id: usize,
+}
+
+impl<'a> RegistryReadGuard<'a> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<Registry>) -> Self {
+        #[cfg(debug_assertions)]
+        let lock_id = lock as *const _ as usize;
+        #[cfg(debug_assertions)]
+        reentry_check::enter_read(lock_id);
+        // Acquire only after the reentry check, so a would-be deadlock panics
+        // instead of hanging on the blocking `.read()`.
+        let inner = lock.read().unwrap();
+        Self {
+            inner,
+            #[cfg(debug_assertions)]
+            lock_id,
+        }
+    }
+}
+
+impl std::ops::Deref for RegistryReadGuard<'_> {
+    type Target = Registry;
+    #[inline]
+    fn deref(&self) -> &Registry {
+        &self.inner
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for RegistryReadGuard<'_> {
+    fn drop(&mut self) {
+        reentry_check::exit_read(self.lock_id);
+    }
+}
+
+/// Write guard for the shared [`Registry`]. Same reentry instrumentation as
+/// [`RegistryReadGuard`].
+pub(crate) struct RegistryWriteGuard<'a> {
+    inner: std::sync::RwLockWriteGuard<'a, Registry>,
+    #[cfg(debug_assertions)]
+    lock_id: usize,
+}
+
+impl<'a> RegistryWriteGuard<'a> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<Registry>) -> Self {
+        #[cfg(debug_assertions)]
+        let lock_id = lock as *const _ as usize;
+        #[cfg(debug_assertions)]
+        reentry_check::enter_write(lock_id);
+        let inner = lock.write().unwrap();
+        Self {
+            inner,
+            #[cfg(debug_assertions)]
+            lock_id,
+        }
+    }
+}
+
+impl std::ops::Deref for RegistryWriteGuard<'_> {
+    type Target = Registry;
+    #[inline]
+    fn deref(&self) -> &Registry {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for RegistryWriteGuard<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Registry {
+        &mut self.inner
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for RegistryWriteGuard<'_> {
+    fn drop(&mut self) {
+        reentry_check::exit_write(self.lock_id);
+    }
+}


### PR DESCRIPTION
Phase ② (declaration-registry VM ownership) **final slice (PR-C)**. Completes ② after PR-A (extraction, #2760/2762/2763/2764/2767) and PR-B (read-side Registry methods, #2769/2772).

## What

Tidy `register_*_decl`'s registry write paths and turn the *"never hold a registry guard across user-code re-entry"* discipline — previously a documented convention caught only by `make roast`'s ~13-min timeout, and missed by **both** the borrow checker and the static scanner (PR-A slice 5's `write -> write` inside a `match self.registry_mut(){}` arm hung at runtime despite passing both checks) — into a **runtime-enforced guarantee**.

## Runtime reentrancy guard (debug-only)

- `registry()` / `registry_mut()` now return wrapper guards (`RegistryReadGuard` / `RegistryWriteGuard`) that record the acquisition in a thread-local **before** the blocking `.read()`/`.write()`, so a re-entrant same-lock acquisition **panics with a located message instead of deadlocking**.
- **Keyed by lock address, not thread**: a single thread legitimately holds guards on *different* registries at once — e.g. `self.registry_mut().classes = nested.registry().classes.clone();` holds a write guard on `self`'s registry and a read guard on a sub-interpreter's. Only re-acquiring the *same* lock deadlocks. The allowed/forbidden matrix matches `std::sync::RwLock`: same-lock write-while-any and read-while-write panic; nested read-while-read is tolerated.
- `#[cfg(debug_assertions)]` only — the hot `registry()` read path (method dispatch reads MRO through it) takes **no** bookkeeping in release; CI's release `make roast` still backstops via timeout.
- **Validated**: 6000+ debug-build `.t`/`.raku` executions (S04/S05/S10/S11/S12/S14 + `t/`) and threading (start/promise/channel) — **zero reentry panics** (no false-positives, no latent reentry bug).

## Write-through cleanup (register_class_decl)

Consolidate reentry-free write/read clusters into single guard blocks (prologue `prev_*` 5-read snapshot; `restore_previous_state` rollback closure; stub-clear two writes), reducing lock churn and making the "guard held = no re-entry here" boundary explicit. The runtime guard verifies safety.

## Docs

Mark ② (PR-A/B/C) complete in `PLAN.md` / `docs/vm-registry-ownership.md`; annotate `docs/vm-interpreter-fallback-ledger.md` with ② completion and registration's CARRIER nature. **Next strategic work: ③ (env / type-check / state ownership migration).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)