### PR TITLE
feat(exceptions): typed X::Constructor::Positional for the default constructor

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2806,10 +2806,7 @@ impl Interpreter {
                                 if self.class_does_baggy_or_setty(&cn) {
                                     return self.construct_baggy_instance(&cn, &args);
                                 }
-                                return Err(RuntimeError::new(format!(
-                                    "Default constructor for '{}' only takes named arguments",
-                                    class_name.resolve()
-                                )));
+                                return Err(constructor_positional_error(&class_name.resolve()));
                             }
                             // Fall through to default constructor below
                         }
@@ -2921,10 +2918,7 @@ impl Interpreter {
                         .iter()
                         .any(|n| n == "Array" || n == "Int" || n == "Num" || n == "Hash");
                     if !accepts_positional {
-                        return Err(RuntimeError::new(format!(
-                            "Default constructor for '{}' only takes named arguments",
-                            class_name.resolve()
-                        )));
+                        return Err(constructor_positional_error(&class_name.resolve()));
                     }
                 }
                 // For @-sigiled attributes with shaped array declarations,
@@ -4085,4 +4079,26 @@ impl Interpreter {
             Ok(Value::make_instance(Symbol::intern(class_name), attrs))
         }
     }
+}
+
+/// Build a typed `X::Constructor::Positional` for a default constructor that
+/// was handed positional arguments (e.g. `Mu.new(1)`). The `type` attribute is
+/// the type object so the test matcher `type => Foo` accepts it.
+fn constructor_positional_error(class_name: &str) -> RuntimeError {
+    let msg = format!(
+        "Default constructor for '{}' only takes named arguments",
+        class_name
+    );
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    attrs.insert(
+        "type".to_string(),
+        Value::Package(Symbol::intern(class_name)),
+    );
+    let mut err = RuntimeError::new(msg);
+    err.exception = Some(Box::new(Value::make_instance(
+        Symbol::intern("X::Constructor::Positional"),
+        attrs,
+    )));
+    err
 }

--- a/t/constructor-positional.t
+++ b/t/constructor-positional.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 4;
+
+# The default (Mu) constructor only accepts named arguments; positional
+# arguments throw X::Constructor::Positional carrying the offending type.
+class Foo { };
+throws-like 'Mu.new(1)', X::Constructor::Positional, type => Mu,
+    'Mu.new(1) throws X::Constructor::Positional';
+throws-like 'class Foo { }; Foo.new(1, 2, 3)', X::Constructor::Positional, type => Foo,
+    'Foo.new(positionals) throws X::Constructor::Positional';
+
+# Valid named construction and positional-accepting built-ins are unaffected.
+{
+    my $f = Foo.new;
+    ok $f.defined, 'Foo.new (no args) still works';
+}
+{
+    my @a = Array.new(1, 2, 3);
+    is @a.elems, 3, 'Array.new(positionals) still works';
+}


### PR DESCRIPTION
The default (`Mu`) constructor only accepts named arguments. Handing it positional arguments (`Mu.new(1)`, `Foo.new(1, 2, 3)`) now throws a typed **X::Constructor::Positional** carrying a `type` attribute (the offending type object), so the roast matcher `type => Foo` accepts it. Previously this was an untyped ad-hoc `RuntimeError`.

Valid named construction and positional-accepting built-ins (`Array.new`, `Int.new`, …) are unaffected.

## Tests

- New: `t/constructor-positional.t` (4 subtests, all pass).
- `make test`: PASS.
- clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)