### PR TITLE
feat(exceptions): X::Inheritance::Unsupported for inheriting from a package

### DIFF
--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -886,6 +886,29 @@ impl Interpreter {
                     deferred_custom_traits.push(resolved_parent_name.to_string());
                     continue;
                 }
+                // A name that is declared as a `package` (or module) exists but
+                // does not support inheritance: `package A {}; class B is A {}`
+                // is X::Inheritance::Unsupported, not an unknown-parent error.
+                if self.chain_declared_packages.contains(base_parent)
+                    || self
+                        .chain_declared_packages
+                        .contains(resolved_parent_name.as_str())
+                {
+                    let msg = format!(
+                        "{} does not support inheritance, so {} cannot inherit from it",
+                        resolved_parent_name, name
+                    );
+                    let mut attrs = HashMap::new();
+                    attrs.insert("child-typename".to_string(), Value::str(name.to_string()));
+                    attrs.insert(
+                        "parent".to_string(),
+                        Value::Package(crate::symbol::Symbol::intern(
+                            resolved_parent_name.as_str(),
+                        )),
+                    );
+                    attrs.insert("message".to_string(), Value::str(msg));
+                    return Err(RuntimeError::typed("X::Inheritance::Unsupported", attrs));
+                }
                 {
                     let msg = format!(
                         "class '{}' specifies unknown parent class '{}'",

--- a/t/inheritance-unsupported.t
+++ b/t/inheritance-unsupported.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 4;
+
+# Inheriting from a `package` (or module) — which exists but does not support
+# inheritance — is X::Inheritance::Unsupported, not an unknown-parent error.
+throws-like 'my package A { }; my class B is A { }', X::Inheritance::Unsupported,
+    'a class cannot inherit from a my package';
+throws-like 'package A { }; class B is A { }', X::Inheritance::Unsupported,
+    'a class cannot inherit from a package';
+
+# A genuinely undeclared parent is still an unknown-parent error.
+throws-like 'class B is NoSuchParent { }', X::Inheritance::UnknownParent,
+    'inheriting from an undeclared name is an unknown-parent error';
+
+# Ordinary class inheritance still works.
+{
+    my $r = EVAL 'class A { method m { 41 } }; class B is A { }; B.new.m';
+    is $r, 41, 'ordinary class inheritance still works';
+}


### PR DESCRIPTION
`class B is A` where `A` is a declared `package` (or module) — which exists but does not support inheritance — now throws a typed **X::Inheritance::Unsupported** ("A does not support inheritance, so B cannot inherit from it") carrying `child-typename` and `parent` attributes, instead of the misleading "unknown parent class" error.

A genuinely undeclared parent name still raises **X::Inheritance::UnknownParent**, and ordinary class inheritance is unaffected.

## Tests

- New: `t/inheritance-unsupported.t` (4 subtests, all pass).
- `make test`: PASS (610 files, 5374 tests, 0 failed).
- clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)