### PR TITLE
feat(exceptions): X::Syntax::Reserved for the () shape syntax in declarations

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -81,15 +81,32 @@
     checks live in `check_eval_class_redeclarations` (EVAL/throws-like pre-check
     path); the double-return-type check is parse-time (`parser/stmt/sub.rs` and
     `parser/stmt/decl/my_decl_dispatch.rs`). Local: t/eval-routine-redeclaration.t.
-  - Remaining clusters (each its own feature; pick one per PR): X::Obsolete
-    (`s///i`, `${...}`, `<>`),
-    X::Syntax::Perl5Var (`$;`, `$,`, `$.`), X::Placeholder::Mainline
-    (`$^x`/`@_` at mainline), X::Redeclaration of subs/methods, X::Syntax::Confused
-    /Missing, X::Comp::Group, X::Bind / X::Bind::ZenSlice, X::Does::TypeObject,
-    X::Role::Initialization, X::Attribute::Package, X::Declaration::Scope,
-    X::Syntax::Variable::Twigil/Reserved/NoSelf, X::Augment::NoSuchType,
-    X::Mixin::NotComposable, X::Constructor::Positional, X::Phaser::PrePost, … and
-    the abort at test 241 (X::Multi::NoMatch / X::Syntax::Adverb throws-like).
+  - More clusters DONE (2026-06-08, PRs #2770/#2771/#2773/#2774/#2776/#2777),
+    126→105 failing:
+    - X::Syntax::Missing: `constant foo;` / `constant ($a,$b)=...` (missing
+      initializer) and block-less `for 1, 2` (missing block).
+    - X::Obsolete: trailing Perl 5 substitution flags `s/a/b/i` (mirrors the
+      `m//` reject). (`<>` readline diamond was deferred — the whitelisted
+      Perl5 helper `roast/t/fudge.t` uses a bare `<>` that mutsu parses
+      leniently, so flagging it regresses that file.)
+    - X::Syntax::Variable::Numeric/Match/Twigil for illegal `$`-sigil names in
+      a `my`/`our`/`state` declaration (`my $0`, `my $<a>`, `my $?FILE`).
+    - X::Does::TypeObject + X::Mixin::NotComposable for `does`/`but` (role into
+      a built-in type object errors; concrete value or role into a user class
+      type object is allowed — distinguished via `has_class`).
+    - X::Constructor::Positional (default constructor handed positionals).
+    - X::Inheritance::Unsupported (`class B is A` where A is a `package`).
+  - Remaining clusters (each its own feature; pick one per PR):
+    X::Syntax::Perl5Var (`$;`, `$,`, `$.`), X::Placeholder::Mainline/Block
+    (`$^x`/`@_` at mainline / in `do {}`/`class {}` — needs block-context
+    tracking + an explicit-signature flag on SubDecl), X::Redeclaration of
+    subs/methods, X::Syntax::Confused (`1∞`, given/when-as-value), X::Comp::Group,
+    X::Bind / X::Bind::ZenSlice, X::Role::Initialization, X::Attribute::Package,
+    X::Declaration::Scope, X::Syntax::Reserved (`my @a()`, `my &a()`),
+    X::Augment::NoSuchType, X::Hash::Store::OddNumber (`my %h = 1` — the
+    odd-check lives in the infallible `coerce_to_hash`; needs care),
+    X::Phaser::PrePost, … and the abort at test 241 (X::Multi::NoMatch /
+    X::Syntax::Adverb throws-like).
 - [ ] roast/S32-exceptions/misc.t
   - 42/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -287,6 +287,29 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
 
     let (rest, _) = ws(rest)?;
 
+    // `()` immediately after the variable name is the reserved shape syntax
+    // (`my @a()`, `my &a()`), not a valid declaration. A real declaration has
+    // `=`/`:=`/`;`/`[`/a trait here instead.
+    if rest.starts_with('(') && (is_array || is_code || is_hash) {
+        let (kind, instead) = if is_code {
+            ("routine", " (maybe use :() to declare a longname?)")
+        } else if is_array {
+            ("array", "")
+        } else {
+            ("hash", "")
+        };
+        let msg = format!(
+            "The () shape syntax in {} declarations is reserved{}",
+            kind, instead
+        );
+        let reserved = format!("() shape syntax in {} declarations", kind);
+        return Err(illegal_my_var_error(
+            "X::Syntax::Reserved",
+            &msg,
+            &[("reserved", reserved.as_str()), ("instead", ":()")],
+        ));
+    }
+
     // Parse hash key-type parameterization: %h{Str}, %h{Int}, ...
     let (rest, hash_key_constraint) = if is_hash
         && rest.starts_with('{')

--- a/t/my-reserved-shape.t
+++ b/t/my-reserved-shape.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 5;
+
+# `()` immediately after the variable name in a declaration is the reserved
+# shape syntax, not a valid declaration.
+throws-like 'my @a()', X::Syntax::Reserved, reserved => /shape/ & /array/,
+    'my @a() is the reserved () shape syntax';
+throws-like 'my &a()', X::Syntax::Reserved, instead => /':()'/,
+    'my &a() is reserved (suggests :() for a longname)';
+throws-like 'my %h()', X::Syntax::Reserved,
+    'my %h() is the reserved () shape syntax';
+
+# Ordinary and shaped declarations are unaffected.
+{
+    my @ok = 1, 2, 3;
+    is @ok.elems, 3, 'an ordinary array declaration still works';
+}
+{
+    my @sh[2; 2];
+    ok @sh.defined, 'a shaped array declaration still works';
+}


### PR DESCRIPTION
`my @a()` / `my &a()` / `my %h()` — a `()` immediately after the variable name in a declaration — is the reserved shape syntax, not a valid declaration. It now throws a typed **X::Syntax::Reserved** carrying `reserved` ("() shape syntax in &lt;kind&gt; declarations") and `instead` (":()") attributes, so the roast matchers `reserved => /shape/ & /array/` and `instead => /':()'/` accept it.

Ordinary and shaped (`my @a[2;2]`) declarations are unaffected.

Also updates `TODO_roast/S32.md` to record the X:: exception clusters landed for `misc2.t` (126 → 105 failing).

## Tests

- New: `t/my-reserved-shape.t` (5 subtests, all pass).
- `make test`: PASS (612 files, 5390 tests, 0 failed).
- clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)