### PR TITLE
refactor(vm): route Routine value dispatch through compiled-first (③ PR-1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -124,9 +124,16 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             実行時 guard で保証**: `registry()`/`registry_mut()` を再入検出ラッパ（debug 限定・ロックアドレスでキー付け）へ
             差し替え、同一ロック再取得を `.read()`/`.write()` 手前で位置付き panic（サイレントデッドロックを即・明示化）。
             台帳に②抽出/read/write-through 完了＋登録の CARRIER 性を記録。**②完了 → 次は ③（env/型/state 移管）**。
-- [ ] **③ VM が借用している Interpreter 状態を VM 所有へ移管**: env HashMap（変数ストア本体）・classes/roles/enums
-      レジストリ・型検査（`type_matches_value`/`var_type_constraint`）・readonly 追跡・`let`/`temp` 復元・multi 解決・
-      state 変数・`current_package`。これが移れば **interpreter ブリッジ自体が不要**になる。最大の山。
+- [~] **③ VM が借用している Interpreter 状態を VM 所有へ移管**（設計: [docs/vm-state-ownership.md](docs/vm-state-ownership.md)）:
+      env HashMap（変数ストア本体）・型検査（`type_matches_value`/`var_type_constraint`）・readonly 追跡・
+      `let`/`temp` 復元・multi 解決・state 変数・`current_package`。これが移れば **interpreter ブリッジ自体が
+      不要**になる。最大の山。**核心の確定**: ③は②と異なり**フォールバック撲滅駆動**（env は単一所有者で真の
+      同時共有が無く、終状態は plain VM field＝共有ハンドル `Arc<RwLock>` 方式は採れない／最ホットで perf 破綻。
+      かつ高価値 state は runtime/ tree-walk に浸透し §1/§2 フォールバック経由で読まれるため、フィールド再配置は
+      tree-walk 実行パス撲滅後にしかできない）。よって**③のスライス＝台帳 §1/§2 の撲滅**。
+      - [x] **PR-1（Routine dispatch）**: `vm_dispatch_helpers` の Routine 値解決を統一 compiled-first へ
+            （builtin 名 Routine は builtin 優先維持）。台帳 §2 Routine 行消化。pin `t/routine-value-dispatch.t`。
+      - [ ] 次: §1 catch-all メソッド dispatch（本丸）/ §2 `vm_call_func_ops` multi/sub 解決。
 - [ ] **④ 本質的キャリアの扱いを確定**（消すのではなく分離 or 明示）: `EVAL`/`EVALFILE`（既に compile→サブ VM 実行で
       tree-walk ではない＝env/レジストリ所有のため Interpreter を借りる**キャリア**）、正規表現の埋め込み `{}` ブロック
       （interpreter regex エンジン経由で caller local を名前書き込み）、pseudo-package（`CALLER::`/`OUTER::` の reflective

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -41,7 +41,7 @@
 | ~~`vm_var_get_ops.rs` pkg-qualified~~ | ~~`Module::func` を term 位置で~~ | — | **✅消化 (PR3)**: 同上 |
 | `vm_call_func_ops.rs` builtin-shadow / multi-dispatch / final else | `call_function_fallback` 直呼び等 | HARD | ② レジストリ / VM 側 multi 解決 / ③ |
 | `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端 | HARD | ③ |
-| `vm_dispatch_helpers.rs` Routine call_function | Routine 値の関数解決（method 部は消化済） | MEDIUM | ② レジストリ / multi 解決 |
+| ~~`vm_dispatch_helpers.rs` Routine call_function~~ | ~~Routine 値の関数解決~~ | — | **✅消化 (③ PR-1)**: 3 サイトを統一 compiled-first へ（builtin 名 Routine は builtin 優先維持） |
 
 ## §C — CARRIER（撲滅対象外・文書化して残す。④で確定）
 
@@ -82,6 +82,17 @@
   ブロッキング呼び出し手前で位置付き panic、ロックアドレスでキー付けして別 registry 同時保持の正当ケースは許容）。
   これで §2 の関数 dispatch fallback（`vm_call_func_ops.rs` multi/sub 解決, `vm_dispatch_helpers.rs` Routine）撲滅の
   構造前提（②）が整った。残る §1/§2 は ③（state 所有移管）が前提。
+
+- **2026-06-08 (③ PR-1, Routine dispatch)**: ③設計を `docs/vm-state-ownership.md` に確定（③は②と異なり
+  **フォールバック撲滅駆動**＝共有ハンドル方式不可・env は plain field 終状態。状態×結合度マップ作成）。最初の
+  スライスとして `vm_dispatch_helpers.rs` の Routine 値 dispatch（vm_call_on_value）の 3 つの生
+  `interpreter.call_function`（qualified / bare / 末端）を統一エントリ `call_function_compiled_first` へ寄せ、
+  ユーザ定義 sub/multi/proto を compiled bytecode 実行に。**builtin 優先の保全**: `&SETTING::...::not` は
+  `Routine{GLOBAL, "not"}` に解決される（accessors.rs）＝ユーザ `sub not` が名前を shadow していても builtin を
+  指す意図。`Interpreter::is_builtin_function` ガードで、builtin 名を持つ Routine のみ `call_function` の
+  builtin 優先を維持（平の user `&not` は `Value::Sub` で Routine 枝に来ない）。最初の naive 変換で
+  `S02-names/SETTING-6e.t` が回帰（user `sub not` + `&SETTING::not`）し実証。pin = `t/routine-value-dispatch.t`(10)。
+  S06/S02-magicals/S02-names/S03-smartmatch whitelist 137 件緑。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/docs/vm-state-ownership.md
+++ b/docs/vm-state-ownership.md
@@ -1,0 +1,130 @@
+# ③ 実行状態の VM 所有移管（interpreter ブリッジ撤去・構造設計）
+
+[PLAN.md](../PLAN.md) 最終ゴール「tree-walking Interpreter 実行パス撤去 → dual-store 削除」の
+**ステップ③**。①（個別フォールバック撲滅）→ ②（宣言レジストリの VM 所有化, #2760-2775, 完了）に続く
+**最大の山**。本書は③の確定設計。前提: [vm-registry-ownership.md](vm-registry-ownership.md)（②）、
+一次台帳 [vm-interpreter-fallback-ledger.md](vm-interpreter-fallback-ledger.md)、
+[vm-dual-store.md](vm-dual-store.md)（locals↔env、レバー B）。
+
+## ③が解くべき状態
+
+`VM` は `interpreter: Interpreter` を**値で所有**（`src/vm.rs:88`）。VM ネイティブコードが借用している
+Interpreter 状態のうち、②で移した宣言レジストリ（`Arc<RwLock<Registry>>`）以外の**実行状態**:
+
+- **env**（変数ストア本体, `Interpreter.env: Env`）— 圧倒的最ホット。`self.interpreter.env`/`env_mut` =
+  VM ツリーだけで **483 サイト**。
+- **型検査**: `type_matches_value`（VM 8 + runtime 26 ファイル）, `var_type_constraint`/`var_type_constraints`,
+  `var_hash_key_constraints`。
+- **readonly 追跡**: `readonly_vars`/`mark_readonly`/`unmark_readonly`（VM 4 + runtime 2）。
+- **let/temp 復元**: `let_saves`/`restore_let_saves`/`discard_let_saves`（VM 5 + runtime 2）。
+- **state 変数**: `state_vars`/`our_vars`/`once_values`（VM 0 + runtime 3 — ほぼ tree-walk 側）。
+- **`current_package`**（VM 8 + runtime 33）。
+- **multi 解決**: `resolve_function_with_types`/`has_multi_*`/`has_proto`。
+
+これらが VM へ移れば **interpreter ブリッジ自体が不要**になり、④（carrier 確定）→ ⑤（dual-store 機構削除）
+へ進める。
+
+## 核心: ③は②と方式が決定的に異なる（共有ハンドル方式は採れない）
+
+②は registry を `Arc<RwLock<Registry>>` 足場へ持ち上げた。③で同じことを env にしてはならない:
+
+1. **env には「真の同時共有」が無い。** env は**ただ1つの `Interpreter` オブジェクトにだけ存在**し、
+   ping-pong（`Interpreter::run_block_raw` → `VM::new(self)` → `vm.run()` → `*self = interp`,
+   `src/runtime/run.rs:956`）で **VM ネスト間を値で往復**する。VM ネイティブ → `interpreter.call_function`
+   → 内部で新たな `VM::new` … という再帰も、その都度 Interpreter を**move**するだけで、生きた env は
+   常に1個。スレッド跨ぎは `clone_for_thread` の**スナップショット**（書き戻し無し）。
+   → ②で Arc<RwLock> が要ったのは「`Interpreter` が `spawn_user_thread` でスレッド境界を越え、registry を
+   複数スレッドが触る」から。**env は単一所有者なので、エンドステートは plain な VM フィールド一択**で、
+   足場の Arc/lock は不要。
+2. **env を Arc<RwLock> 化すると perf が破綻する。** env は全変数 read/write の最ホットパス
+   （483 サイト + runtime 深部）。②の registry でさえ遷移期 RwLock 取得で release microbench +2-4%。
+   env に lock を1アクセスごとに乗せれば桁違いの退行になる（`Env` は既に内部 `Arc<HashMap>` COW なので、
+   さらに外側 lock を被せる意味も無い）。
+
+→ **③は「フィールドを共有ハンドルへ持ち上げる」方式（②の playbook）では進められない。**
+
+## なぜ「フィールド再配置を先に」も採れない — 強制される戦略
+
+では「env を Interpreter から VM の plain field へ今すぐ移す」が直接できるか。**できない**:
+
+- 高価値 state は `src/runtime/` の **tree-walk コードに浸透**している（`type_matches_value` 26 ファイル、
+  `current_package` 33 ファイル、env は事実上全 runtime）。これらの tree-walk メソッドは、VM 実行中に
+  **§1/§2 フォールバック経由でユーザコードを実行**し、その最中に `self.env`/`self.type_matches_value`/
+  `self.current_package` を読む。
+- フィールドを Interpreter から物理的に抜くと、これら数千の `self.env` アクセスが全部壊れる。env を引数で
+  全 runtime tree-walk 呼び出しグラフに通すのは非現実的。
+
+→ 結論: **③はフィールド再配置駆動ではなく、フォールバック撲滅駆動である。**
+台帳 §1/§2 の tree-walk 実行パス（catch-all メソッド dispatch / 関数 dispatch / native-method）を
+**VM ネイティブ実装に置換**し、各撲滅が「その state の tree-walk 読者」を1クラスずつ消す。最後の
+tree-walk 実行パスが消えた時点で env/型/state/current_package は runtime/ に読者を持たなくなり、
+**plain な VM フィールドへ畳める**（この最終 fold が ④/⑤）。**③のスライス ＝ 台帳 §1/§2 の行**。
+
+## 状態 × 結合度マップ（調査確定 2026-06-08）
+
+| state | VM サイト | runtime/ 結合 | 単独移管可否 | ③での扱い |
+|---|---|---|---|---|
+| `env`/`env_mut` | 483 | 全域 | 不可（最ホット・全域） | フォールバック撲滅後に最後に畳む |
+| `type_matches_value` | 8 | 26 ファイル | 不可（tree-walk 深部） | §1 撲滅で読者が減る |
+| `current_package` | 27 | 33 ファイル | 不可（tree-walk 深部） | §1/§2 撲滅で読者が減る |
+| `var_type_constraint(s)` | 33 | 8 | 困難 | 型検査と同時 |
+| `readonly_vars`/`mark_readonly` | 8 | 3 | **比較的局所** | 早期に VM へ寄せられる候補 |
+| `let_saves`/`restore_let_saves` | 10 | 3 | **比較的局所** | 同上（が env 残存中は decoupling 価値小） |
+| `state_vars`/`our_vars`/`once_values` | 0 | 3 | runtime 専属 | tree-walk 撲滅に追従 |
+
+要点: **局所的な state（readonly/let）を先に VM へ移しても、env が Interpreter に残る限り
+decoupling 価値は小さい**（Interpreter オブジェクトは消えない）。価値が出るのは tree-walk 実行パスが
+消えて env が畳めた瞬間。よって投資は §1/§2 撲滅に集中する。
+
+## 台帳 §1/§2 = ③のスライス（撲滅順）
+
+一次状態は [vm-interpreter-fallback-ledger.md](vm-interpreter-fallback-ledger.md)。残る tree-walk:
+
+- **§1 catch-all メソッド dispatch**（最大）: `vm_call_method_compiled.rs:427/857`,
+  `vm_call_method_mut_ops.rs:303` の `interpreter.call_method_with_values` =
+  生きた Instance/Buf/Failure メソッド fork。**残る主 tree-walk**。
+- **§1 native-method**（IO 系）: `native_io_*` がファイルハンドル等の interpreter 所有状態を要求 →
+  state（handles）移管前提。
+- **§2 関数 dispatch**: `vm_call_func_ops.rs`（builtin-shadow / multi-dispatch / final else）,
+  `vm_call_dispatch.rs` catch-all, `vm_dispatch_helpers.rs:356-384` Routine 値の関数解決。
+  **②（registry の VM 所有）で構造前提が整った**＝ここが ③ の最初の現実的着手点。
+
+撲滅の必須手順（②/dedup と同じ）: native 実装が authoritative であることを **EVAL 経路で同値確認**
+（`mutsu -e 'say EVAL(q{...})'` が raku と一致）してから tree-walk を外し、`make roast` で確認。
+
+## スライス計画（strangler-fig・各 PR 挙動不変・CI が安全網）
+
+> 順序は「②で構造前提が整った §2 関数 dispatch」→「§1 catch-all メソッド dispatch（本丸）」→
+> 「native-method（IO state 移管と同時）」→「env/型/state を plain VM フィールドへ畳む（④/⑤）」。
+
+- **PR-1（§2 関数/Routine dispatch の VM ネイティブ化）**: `vm_dispatch_helpers.rs` Routine 値解決と
+  `vm_call_func_ops.rs` の multi/sub 解決を、②で VM アクセス可能になった `Registry` メソッド
+  （`resolve_*` / `has_multi_*`）を使って VM ネイティブ dispatch へ。builtin 優先順位
+  （Routine が builtin を指す場合）を VM 側で再現。interpreter は終端（EVAL/carrier）のみ。
+- **PR-2 以降（§1 catch-all メソッド dispatch）**: 生きた Instance メソッド呼びを
+  `call_compiled_method_*` 統一 dispatch へ寄せ、ユーザ定義クラスメソッドを全て bytecode 実行に。
+  native/reflective/MOP のみが共有末端（carrier）へ。Buf/Failure の native メソッドは builtins/ へ降ろす。
+- **PR-n（native-method IO）**: `handles` を VM 所有へ移し `native_io_*` を VM ネイティブに。
+- **最終 fold（④/⑤）**: tree-walk 実行パスが消えたら env/型検査/readonly/let/state/current_package を
+  `Interpreter` から `VM` の plain フィールドへ移し、`Interpreter` オブジェクトと ping-pong を撤去、
+  `env_dirty`/`saved_env_dirty`/`ensure_locals_synced`/`sync_locals_from_env` を削除。
+
+## スコープ / 非ゴール
+
+- スコープ = **tree-walk 実行パスの VM ネイティブ化**（台帳 §1/§2 の行を消す）。各 PR は挙動不変。
+- 非ゴール（後段）: env/state の plain フィールド畳み込み（④/⑤、Interpreter 撤去後）、§C carrier の
+  最終確定（EVAL サブ VM / 正規表現埋め込み `{}` / pseudo-package）、`type_metadata` の Arc-ptr keying 解消
+  （🟣第一級コンテナ）、スレッド間 registry の真共有（PLAN §8.3 concurrency）。
+
+## 進捗
+
+- **設計確定（本書, 2026-06-08）**: ③は②と異なり**フォールバック撲滅駆動**（共有ハンドル方式不可・
+  env は plain field 終状態）と確定。状態×結合度マップを作成。スライス計画 = 台帳 §1/§2 の撲滅。
+  次の着手 = PR-1（②解禁の §2 関数/Routine dispatch の VM ネイティブ化）。
+- **PR-1 完了（Routine dispatch, 2026-06-08）**: `vm_dispatch_helpers.rs::vm_call_on_value` の Routine 値解決の
+  3 つの生 `interpreter.call_function`（qualified / bare / 末端）を統一エントリ `call_function_compiled_first`
+  へ寄せ、ユーザ定義 sub/multi/proto を compiled bytecode 実行に。**builtin 優先保全**: builtin 名を持つ
+  Routine（`&SETTING::...::not` → `Routine{GLOBAL, "not"}`）のみ `is_builtin_function` ガードで `call_function`
+  の builtin 優先を維持（平 user `&not` は `Value::Sub` で Routine 枝に来ない）。naive 変換で
+  `S02-names/SETTING-6e.t` 回帰 → 実証して修正。pin = `t/routine-value-dispatch.t`(10)。台帳 §2 の Routine 行を消化。
+  **次は §1 catch-all メソッド dispatch（本丸）または §2 vm_call_func_ops の multi/sub 解決。**

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -345,28 +345,40 @@ impl VM {
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 
-        // TODO: compile to bytecode — Routine value dispatch (the call_function
-        // sites in this block; the method-dispatch site now routes through the
-        // unified compiled-first path). Blocked-by: VM-side function/multi
-        // resolution (ledger §2).
-        // Routine: resolve to function name and dispatch
-        // Keep using interpreter.call_function here because Routine values may
-        // reference builtin functions (e.g. &SETTING::not resolves to Routine{name:"not"})
-        // and call_function correctly prioritizes builtins over user-defined functions.
+        // Routine value dispatch (ledger §2, ③ PR-1). Resolve to a function name
+        // and route through the VM's unified compiled-first entry
+        // (`call_function_compiled_first`): user-defined subs/multi/proto run as
+        // compiled bytecode, native builtins fall through to `native_function`, and
+        // only genuine carriers (EVAL/pseudo-package) reach the interpreter terminal.
+        // This replaces the raw `interpreter.call_function` fallbacks; builtin
+        // priority is preserved because a bare builtin Routine (e.g. `&SETTING::not`
+        // -> Routine{GLOBAL, "not"}) is not a declared user function, so it skips the
+        // `has_function` branches and resolves natively in compiled-first.
         if let Value::Routine { package, name, .. } = &target {
             let pkg = package.resolve();
             let name_str = name.resolve();
+            let empty_fns = HashMap::new();
+            let fns = compiled_fns.unwrap_or(&empty_fns);
             if !pkg.is_empty() && pkg != "GLOBAL" {
                 let fq = format!("{pkg}::{name_str}");
                 if self.interpreter.has_function(&fq) {
-                    return self.interpreter.call_function(&fq, args);
+                    return self.call_function_compiled_first(&fq, args, fns);
                 }
             }
             if self.interpreter.has_function(&name_str)
                 || self.interpreter.has_proto(&name_str)
                 || self.interpreter.has_multi_candidates(&name_str)
             {
-                return self.interpreter.call_function(&name_str, args);
+                // A Routine whose name is also a builtin (e.g. `&SETTING::...::not`
+                // resolves to Routine{GLOBAL, "not"}, accessors.rs) intentionally
+                // refers to the builtin, not a user sub that shadows the name. Keep
+                // builtin priority via `call_function` for those (a plain user `&not`
+                // is a `Value::Sub` and never reaches this Routine branch). Otherwise
+                // route user subs/multi/proto through compiled-first.
+                if crate::runtime::Interpreter::is_builtin_function(&name_str) {
+                    return self.interpreter.call_function(&name_str, args);
+                }
+                return self.call_function_compiled_first(&name_str, args, fns);
             }
             // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
             // Only use this when the package is a known class.
@@ -381,7 +393,7 @@ impl VM {
                 // user-defined methods run as compiled bytecode, native fall back.
                 return self.try_compiled_method_or_interpret(invocant, &name_str, method_args);
             }
-            return self.interpreter.call_function(&name_str, args);
+            return self.call_function_compiled_first(&name_str, args, fns);
         }
 
         // Junction: thread over values

--- a/t/routine-value-dispatch.t
+++ b/t/routine-value-dispatch.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Regression pin for ③ PR-1: Routine value dispatch (vm_dispatch_helpers
+# vm_call_on_value) now routes user subs/multi/proto through the VM's unified
+# compiled-first entry instead of the raw interpreter.call_function fallback,
+# while preserving builtin priority for builtin-named Routines (e.g. &SETTING::not).
+
+plan 10;
+
+# &?ROUTINE recursion produces a Routine value that resolves to the user sub.
+sub fact($n) { $n <= 1 ?? 1 !! $n * &?ROUTINE($n - 1) }
+is fact(5), 120, '&?ROUTINE recursion via Routine value (compiled)';
+is fact(1), 1, '&?ROUTINE base case';
+
+# A Routine value stored in a scalar and invoked.
+sub greet($x) { "hi $x" }
+my $r = &greet;
+is $r("bob"), "hi bob", 'Routine value stored and called';
+
+# Routine value over a multi sub.
+multi describe(Int $x) { "int:$x" }
+multi describe(Str $x) { "str:$x" }
+my $d = &describe;
+is $d(7), "int:7", 'Routine value resolves multi (Int)';
+is $d("z"), "str:z", 'Routine value resolves multi (Str)';
+
+# Builtin priority preserved: &SETTING::...::not refers to the builtin even
+# when a user sub shadows the name.
+sub not($x) { "USER" } #OK shadow
+is &SETTING::not(False), True, '&SETTING::not uses builtin (priority preserved)';
+is &SETTING::not(True), False, '&SETTING::not builtin negates True';
+
+# Routine value invoked via map (block dispatch path).
+sub dbl($n) { $n * 2 }
+my @out = (1, 2, 3).map(&dbl);
+is @out, [2, 4, 6], 'Routine value as &dbl through map';
+
+# Junction of callables threads the dispatch.
+sub inc($n) { $n + 1 }
+sub dec($n) { $n - 1 }
+my $j = &inc | &dec;
+ok $j(10) == 11 | $j(10) == 9, 'Junction of Routine values threads dispatch';
+
+# Package-qualified user sub via Routine.
+package Calc { our sub sq($n) is export { $n * $n } }
+my $sq = &Calc::sq;
+is $sq(4), 16, 'package-qualified Routine value (compiled)';


### PR DESCRIPTION
## ③ (interpreter execution-state ownership) — PR-1

Phase ③ (VM ownership of interpreter execution state — the largest decoupling step) is **fallback-elimination-driven**, not field-relocation-driven. Design captured in `docs/vm-state-ownership.md`:

- **env has no true concurrent sharing** — a single `Interpreter` is moved up/down the VM nesting stack (the `run_block_raw → VM::new → vm.run → *self = interp` ping-pong); threads snapshot via `clone_for_thread`. So the end state is a **plain VM field**, and the ② `Arc<RwLock>` shared-handle scaffold **can't** be used (env is the hottest path — a per-access lock would be catastrophic, far worse than ②'s +2-4%).
- The high-value state (`env`, `type_matches_value` 26 runtime files, `current_package` 33) is **pervasively read by `src/runtime/` tree-walk code** that still runs user code via the §1/§2 fallbacks, so a field can't leave the `Interpreter` while those readers exist.
- Therefore ③'s slices **are the ledger §1/§2 rows**; eliminating each removes a class of tree-walk readers, until the state can collapse into plain VM fields (④/⑤).

## This PR

Routes the §2 **Routine-value dispatch** (`vm_dispatch_helpers::vm_call_on_value`) through the unified `call_function_compiled_first` entry. The three raw `interpreter.call_function` fallbacks (qualified / bare / terminal) are replaced, so user-defined subs / multi / proto run as **compiled bytecode** and only genuine carriers reach the interpreter terminal.

**Builtin priority preserved**: a Routine whose name is also a builtin (e.g. `&SETTING::...::not` resolves to `Routine{GLOBAL, "not"}` in `accessors.rs`) intentionally refers to the builtin even when a user sub shadows the name. An `is_builtin_function` guard keeps builtin priority for those (a plain user `&not` is a `Value::Sub` and never reaches the Routine branch). The naive conversion without the guard regressed `S02-names/SETTING-6e.t` (`sub not` + `&SETTING::not`), which confirmed the load-bearing semantics.

## Validation

- Pin: `t/routine-value-dispatch.t` (10 cases; verified identical on raku).
- `cargo test` 458 green.
- S06 / S02-magicals / S02-names / S03-smartmatch whitelist (137 files) green.
- Ledger §2 Routine row consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)