### PR TITLE
feat(exceptions): X::Hash::Store::OddNumber for a single-scalar hash assignment

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -636,6 +636,24 @@ impl VM {
             Value::Seq(ref items) | Value::Slip(ref items) => {
                 runtime::utils::build_hash_from_items(items.iter().cloned().collect())?
             }
+            // A single bare scalar assigned to a hash is a one-element (odd)
+            // initializer: `my %h = 1` is X::Hash::Store::OddNumber. Hashes,
+            // pairs, sets, instances, Nil, etc. keep their existing coercion.
+            ref scalar
+                if matches!(
+                    scalar.clone().into_descalarized(),
+                    Value::Int(_)
+                        | Value::BigInt(_)
+                        | Value::Num(_)
+                        | Value::Str(_)
+                        | Value::Bool(_)
+                        | Value::Rat(..)
+                        | Value::FatRat(..)
+                        | Value::BigRat(..)
+                ) =>
+            {
+                runtime::utils::build_hash_from_items(vec![value])?
+            }
             _ => runtime::coerce_to_hash(value),
         };
         // Resolve hash sentinel entries (bound variable refs) when assigning

--- a/t/hash-odd-number.t
+++ b/t/hash-odd-number.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 8;
+
+# A single bare scalar (a one-element, odd initializer) assigned to a hash is
+# X::Hash::Store::OddNumber.
+throws-like 'my %h = 1', X::Hash::Store::OddNumber,
+    'my %h = 1 is an odd hash initializer';
+throws-like 'my %h = "key"', X::Hash::Store::OddNumber,
+    'my %h = "key" is an odd hash initializer';
+throws-like 'my %h = 1, 2, 3', X::Hash::Store::OddNumber,
+    'an odd-length list is an odd hash initializer';
+
+# Even/valid initializers are unaffected.
+{
+    my %h = 1, 2;
+    is %h{1}, 2, 'an even key/value list assigns';
+}
+{
+    my %h = a => 1, b => 2;
+    is %h<a> + %h<b>, 3, 'pair-list assignment works';
+}
+{
+    my %o = x => 9; my %h = %o;
+    is %h<x>, 9, 'hash-to-hash assignment copies';
+}
+{
+    my $s = { y => 7 }; my %h = $s;
+    is %h<y>, 7, 'a hash held in a scalar assigns';
+}
+{
+    my %h = Nil;
+    is %h.elems, 0, 'assigning Nil yields an empty hash';
+}


### PR DESCRIPTION
`my %h = 1` (and `my %h = "key"`) assigns a one-element — odd — initializer to a hash and now throws **X::Hash::Store::OddNumber**, like an odd-length list (`my %h = 1, 2, 3`) already did.

The check fires only for a bare scalar (`Int`/`Str`/`Num`/`Bool`/`Rat`) RHS in the hash-assignment path; hashes, pairs, a hash held in a scalar, `Nil`, and even key/value lists keep their existing coercion.

Verified unaffected: `my %h = %other`, `my %h = $hash`, `my %h = Nil`, `my %h = 1, 2`, `my %h = a => 1`.

## Tests

- New: `t/hash-odd-number.t` (8 subtests, all pass).
- `make test`: PASS (613 files, 5397 tests, 0 failed).
- clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)