### PR TITLE
feat(exceptions): X::Placeholder::Mainline/Block for stray placeholders

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -863,6 +863,145 @@ pub(crate) fn collect_placeholders_shallow(stmts: &[Stmt]) -> Vec<String> {
     names
 }
 
+/// Collect placeholder variables that belong directly to the *current*
+/// (non-signature) scope: the mainline, a `do {}` block, or a class/role/module
+/// body. Descends through expressions and statement header positions but stops
+/// at any nested `{}` block (control-flow bodies, bare/pointy blocks, closures,
+/// do-blocks, gather/try/phasers) since those introduce their own placeholder
+/// scope and capture the placeholders inside them.
+///
+/// Also recognizes the implicit slurpy placeholders `@_` / `%_`. Returns
+/// display names like `$^x`, `@^a`, `@_`. False negatives are safe (we just
+/// miss raising an error); a positive means a placeholder is genuinely used
+/// where no signature can capture it.
+pub(crate) fn collect_unattached_placeholders(stmts: &[Stmt]) -> Vec<String> {
+    let mut names = Vec::new();
+    for stmt in stmts {
+        collect_unattached_ph_stmt(stmt, &mut names);
+    }
+    names
+}
+
+fn collect_unattached_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
+    match stmt {
+        Stmt::Expr(e)
+        | Stmt::Return(e)
+        | Stmt::Die(e)
+        | Stmt::Fail(e)
+        | Stmt::Take(e)
+        | Stmt::Goto(e) => collect_unattached_ph_expr(e, out),
+        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+            collect_unattached_ph_expr(expr, out)
+        }
+        Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
+            for e in es {
+                collect_unattached_ph_expr(e, out);
+            }
+        }
+        Stmt::Call { args, .. } => {
+            for arg in args {
+                match arg {
+                    CallArg::Positional(e) | CallArg::Invocant(e) | CallArg::Slip(e) => {
+                        collect_unattached_ph_expr(e, out)
+                    }
+                    CallArg::Named { value: Some(e), .. } => collect_unattached_ph_expr(e, out),
+                    CallArg::Named { value: None, .. } => {}
+                }
+            }
+        }
+        // Control-flow headers are evaluated in the current scope, but their
+        // bodies are signature-capable blocks -> do NOT descend into bodies.
+        Stmt::If { cond, .. } | Stmt::While { cond, .. } | Stmt::When { cond, .. } => {
+            collect_unattached_ph_expr(cond, out)
+        }
+        Stmt::For { iterable, .. } => collect_unattached_ph_expr(iterable, out),
+        Stmt::Given { topic, .. } => collect_unattached_ph_expr(topic, out),
+        Stmt::Label { stmt, .. } => collect_unattached_ph_stmt(stmt, out),
+        // Everything else (blocks, sub/class decls, ...) is a boundary.
+        _ => {}
+    }
+}
+
+fn collect_unattached_ph_expr(expr: &Expr, out: &mut Vec<String>) {
+    let push = |name: String, out: &mut Vec<String>| {
+        if !out.contains(&name) {
+            out.push(name);
+        }
+    };
+    match expr {
+        Expr::Var(name) if name.starts_with('^') || name.starts_with(':') => {
+            push(format!("${}", name), out)
+        }
+        Expr::CodeVar(name) if name.starts_with('^') => push(format!("&{}", name), out),
+        Expr::ArrayVar(name) if name.starts_with('^') || name.starts_with(':') => {
+            push(format!("@{}", name), out)
+        }
+        Expr::HashVar(name) if name.starts_with('^') || name.starts_with(':') => {
+            push(format!("%{}", name), out)
+        }
+        // Implicit slurpy placeholders.
+        Expr::ArrayVar(name) if name == "_" => push("@_".to_string(), out),
+        Expr::HashVar(name) if name == "_" => push("%_".to_string(), out),
+        Expr::Binary { left, right, .. } => {
+            collect_unattached_ph_expr(left, out);
+            collect_unattached_ph_expr(right, out);
+        }
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => {
+            collect_unattached_ph_expr(expr, out)
+        }
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            collect_unattached_ph_expr(target, out);
+            for a in args {
+                collect_unattached_ph_expr(a, out);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                collect_unattached_ph_expr(a, out);
+            }
+        }
+        Expr::CallOn { target, args } => {
+            collect_unattached_ph_expr(target, out);
+            for a in args {
+                collect_unattached_ph_expr(a, out);
+            }
+        }
+        Expr::Index { target, index, .. } => {
+            collect_unattached_ph_expr(target, out);
+            collect_unattached_ph_expr(index, out);
+        }
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            collect_unattached_ph_expr(cond, out);
+            collect_unattached_ph_expr(then_expr, out);
+            collect_unattached_ph_expr(else_expr, out);
+        }
+        Expr::AssignExpr { expr, .. } | Expr::PositionalPair(expr) | Expr::ZenSlice(expr) => {
+            collect_unattached_ph_expr(expr, out)
+        }
+        Expr::ArrayLiteral(es)
+        | Expr::BracketArray(es, _)
+        | Expr::StringInterpolation(es)
+        | Expr::CaptureLiteral(es) => {
+            for e in es {
+                collect_unattached_ph_expr(e, out);
+            }
+        }
+        Expr::Hash(pairs) => {
+            for (_, v) in pairs {
+                if let Some(e) = v {
+                    collect_unattached_ph_expr(e, out);
+                }
+            }
+        }
+        // Closures and nested blocks define their own placeholder scope: stop.
+        _ => {}
+    }
+}
+
 fn placeholder_sort_key(name: &str) -> &str {
     let without_sigil = if let Some(first) = name.chars().next() {
         if matches!(first, '$' | '@' | '%' | '&') {

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -3,6 +3,55 @@ use crate::symbol::Symbol;
 use std::sync::Arc;
 
 impl Compiler {
+    /// Build an `X::Placeholder::Mainline` (`kind == "mainline"`) or
+    /// `X::Placeholder::Block` exception value for a placeholder variable used
+    /// where no signature-capable block can capture it.
+    pub(super) fn placeholder_scope_error(kind: &str, placeholder: &str) -> Value {
+        let (type_name, message) = if kind == "mainline" {
+            (
+                "X::Placeholder::Mainline",
+                format!(
+                    "Cannot use placeholder parameter {} outside of a sub or block",
+                    placeholder
+                ),
+            )
+        } else {
+            (
+                "X::Placeholder::Block",
+                format!(
+                    "Placeholder variable '{}' may not be used here because the \
+                     surrounding block does not take a signature.",
+                    placeholder
+                ),
+            )
+        };
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message));
+        attrs.insert(
+            "placeholder".to_string(),
+            Value::str(placeholder.to_string()),
+        );
+        Value::make_instance(Symbol::intern(type_name), attrs)
+    }
+
+    /// If `body` uses a placeholder variable directly (not captured by any inner
+    /// signature-capable block), emit an `X::Placeholder::Block` die and return
+    /// true. Used for class/role bodies, which do not take a signature.
+    pub(super) fn emit_block_placeholder_die(&mut self, body: &[Stmt]) -> bool {
+        if let Some(ph) = crate::ast::collect_unattached_placeholders(body)
+            .into_iter()
+            .next()
+        {
+            let err = Self::placeholder_scope_error("block", &ph);
+            let idx = self.code.add_constant(err);
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::Die);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Compile AnonSub expression.
     /// `is_block` = true for bare blocks `{ }`, false for `sub { }`.
     /// Bare blocks are NOT routine boundaries for `return`.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -2,6 +2,18 @@ use super::*;
 
 impl Compiler {
     pub(super) fn compile_do_block_expr(&mut self, body: &[Stmt], label: &Option<String>) {
+        // A `do {}` block does not take a signature, so a placeholder variable
+        // used directly inside it cannot be captured -> X::Placeholder::Block.
+        if let Some(ph) = crate::ast::collect_unattached_placeholders(body)
+            .into_iter()
+            .next()
+        {
+            let err = Self::placeholder_scope_error("block", &ph);
+            let idx = self.code.add_constant(err);
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::Die);
+            return;
+        }
         // DoBlocks from lifted CHECK phasers carry a sentinel label so we can
         // wrap them in CheckPhaserStart/CheckPhaserEnd, ensuring errors inside
         // are wrapped in X::Comp::BeginTime.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -99,6 +99,10 @@ pub(crate) struct Compiler {
     /// non-escaping (immediately-invoked) classification, so call arguments and
     /// control-construct blocks never over-box (the #2746 perf guard).
     escaping_position: bool,
+    /// True only for the outermost compilation unit (the mainline / a top-level
+    /// EVAL). Used to detect placeholder variables (`$^x`, `@_`, ...) that appear
+    /// outside any sub or block -> X::Placeholder::Mainline.
+    pub(crate) is_mainline: bool,
 }
 
 impl Compiler {
@@ -127,6 +131,7 @@ impl Compiler {
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
             escaping_position: false,
+            is_mainline: false,
         }
     }
 
@@ -566,6 +571,21 @@ impl Compiler {
         } else {
             stmts
         };
+        // A placeholder variable ($^x, @_, ...) directly in the mainline is
+        // outside any sub or block -> X::Placeholder::Mainline. Emit the Die
+        // first so it fires before any other statement runs.
+        if self.is_mainline
+            && let Some(ph) = crate::ast::collect_unattached_placeholders(stmts)
+                .into_iter()
+                .next()
+        {
+            let err = Self::placeholder_scope_error("mainline", &ph);
+            let idx = self.code.add_constant(err);
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::Die);
+            self.code.compute_needs_env_sync();
+            return (self.code, self.compiled_functions);
+        }
         self.hoist_sub_decls(stmts, false);
         // If the top-level body contains a CATCH or CONTROL block, wrap in
         // an implicit try so the phaser can observe exceptions / control

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2235,6 +2235,7 @@ impl Compiler {
                 let idx = self.code.add_stmt(stmt.clone());
                 self.code.emit(OpCode::RegisterEnum(idx));
             }
+            Stmt::ClassDecl { body, .. } if self.emit_block_placeholder_die(body) => {}
             Stmt::ClassDecl { .. } => {
                 // Pre-qualify the class name when compiling inside a
                 // `unit module`/`unit class` body so that the runtime
@@ -2248,6 +2249,7 @@ impl Compiler {
                 let idx = self.code.add_stmt(stmt.clone());
                 self.code.emit(OpCode::AugmentClass(idx));
             }
+            Stmt::RoleDecl { body, .. } if self.emit_block_placeholder_die(body) => {}
             Stmt::RoleDecl { .. } => {
                 let stmt = self.qualify_decl_name(stmt);
                 let idx = self.code.add_stmt(stmt);

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -829,6 +829,7 @@ impl Interpreter {
         self.preregister_top_level_subs(&body_main)?;
         let mut compiler = crate::compiler::Compiler::new();
         compiler.set_current_package(self.current_package.clone());
+        compiler.is_mainline = true;
         let (code, compiled_fns) = compiler.compile(&body_main);
         let interp = std::mem::take(self);
         let vm = crate::vm::VM::new(interp);
@@ -942,6 +943,9 @@ impl Interpreter {
         let mut compiler = crate::compiler::Compiler::new();
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
+        // The outermost compilation unit is the mainline: placeholder variables
+        // ($^x, @_, ...) appearing here are outside any sub or block.
+        compiler.is_mainline = self.routine_stack.is_empty();
         compiler.set_current_package(self.current_package.clone());
         // Resolve distribution context: prefer the current one, then look up
         // by the current package name in case we're running a function body

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -327,6 +327,31 @@ impl Interpreter {
     /// Check for undeclared variable references in EVAL'd code.
     /// Collects declared variable names from VarDecl/Assign nodes and checks
     /// Var references against them and the outer environment.
+    /// Placeholder variables ($^x, @_, ...) used directly in the mainline are
+    /// X::Placeholder::Mainline. This must take precedence over the undeclared
+    /// check (otherwise `@_` would be reported as X::Undeclared).
+    pub(crate) fn check_eval_mainline_placeholders(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        if let Some(ph) = crate::ast::collect_unattached_placeholders(stmts)
+            .into_iter()
+            .next()
+        {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("placeholder".to_string(), Value::str(ph.clone()));
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!(
+                    "Cannot use placeholder parameter {} outside of a sub or block",
+                    ph
+                )),
+            );
+            return Err(RuntimeError::typed("X::Placeholder::Mainline", attrs));
+        }
+        Ok(())
+    }
+
     pub(crate) fn check_eval_undeclared_vars(&self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
         let mut declared: HashSet<String> = HashSet::new();
         for stmt in stmts {

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -70,7 +70,8 @@ impl Interpreter {
                         &imported_names,
                     ) {
                         Ok((stmts, _)) => nested
-                            .check_eval_class_redeclarations(&stmts)
+                            .check_eval_mainline_placeholders(&stmts)
+                            .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(e) => Err(e),
@@ -389,7 +390,8 @@ impl Interpreter {
                         &imported_names,
                     ) {
                         Ok((stmts, _)) => nested
-                            .check_eval_class_redeclarations(&stmts)
+                            .check_eval_mainline_placeholders(&stmts)
+                            .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(e) => Err(e),


### PR DESCRIPTION
## Summary

A placeholder variable (`$^x`, `@_`, `%_`, `&^x`, ...) must be captured by a signature-capable block. When one appears where no such block exists, Raku raises a compile-time error. This PR implements the two missing cases:

- directly in the **mainline** (or a top-level EVAL) → `X::Placeholder::Mainline`
  ("Cannot use placeholder parameter $^x outside of a sub or block")
- inside a `do {}` block or a **class/role body**, which do not take a signature → `X::Placeholder::Block`
  ("Placeholder variable '$^x' may not be used here because the surrounding block does not take a signature.")

## Implementation

- New `collect_unattached_placeholders()` (ast.rs): finds placeholders belonging directly to the current non-signature scope. It descends through expressions and statement headers but stops at every nested `{}` block (control-flow bodies, bare/pointy blocks, closures, do-blocks) since those introduce their own placeholder scope. Recognizes the implicit slurpy placeholders `@_` / `%_`.
- New `Compiler::is_mainline` flag gates the mainline check (set only for the outermost compilation unit).
- `do`-blocks and class/role bodies emit the Block error at their compile sites.
- `throws-like`'s eval pre-check runs the mainline placeholder check **before** the undeclared-variable check so bare `@_` is reported as `X::Placeholder::Mainline` rather than `X::Undeclared`.

## Tests

Fixes the placeholder cases in `roast/S32-exceptions/misc2.t` (tests 10–15): `do { $^x }`, `do { @_ }`, `class { $^x }` → Block; `$^x`, `@_`, `"foo".{ say $^a }` → Mainline.

`make test` passes locally; legal placeholder usage (if/for bodies, bare-block closures, subs without explicit signature, `S06-signature/*placeholders*`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)