### PR TITLE
feat(exceptions): X::Syntax::Confused "Two terms in a row" in array literals

### DIFF
--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -889,10 +889,31 @@ pub(super) fn array_literal(input: &str) -> PResult<'_, Expr> {
             rest = r;
         } else {
             let (r, _) = ws(r)?;
+            if let Ok((r, _)) = parse_char(r, ']') {
+                return Ok((r, Expr::BracketArray(merge_sequence_seeds(items), false)));
+            }
+            // Neither a separator nor the closing bracket: if another term
+            // follows, this is "Two terms in a row" (X::Syntax::Confused),
+            // e.g. `["a" "b"]`.
+            if expression(r).is_ok() {
+                return Err(two_terms_confused());
+            }
             let (r, _) = parse_char(r, ']')?;
             return Ok((r, Expr::BracketArray(merge_sequence_seeds(items), false)));
         }
     }
+}
+
+/// Build a fatal `X::Syntax::Confused` parse error with reason
+/// "Two terms in a row".
+fn two_terms_confused() -> PError {
+    let reason = "Two terms in a row";
+    let message = format!("Confused: {}", reason);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("reason".to_string(), Value::str(reason.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Syntax::Confused"), attrs);
+    PError::fatal_with_exception(message, Box::new(exception))
 }
 
 fn merge_sequence_seeds(items: Vec<Expr>) -> Vec<Expr> {


### PR DESCRIPTION
## Summary

An array literal `[...]` whose elements are separated only by whitespace (no comma or operator), e.g. `["a" "b"]`, is a compile-time error in Raku: `X::Syntax::Confused` with `reason => 'Two terms in a row'`.

## Implementation

In `array_literal` (parser/primary/container.rs), after parsing an element, if the next token is neither a separator (`,`) nor the closing `]` but another term follows (the next `expression(...)` parse succeeds), raise a typed `X::Syntax::Confused` carrying `reason => 'Two terms in a row'` instead of the generic "expected ']'" parse error. When no term follows, the existing `]`-expectation error is preserved.

## Tests

Fixes `roast/S32-exceptions/misc2.t` test 235 (`["a" "b"]`). Legal arrays (`[1,2,3]`, `["x"]`, `[]`, `[1..3]`) are unaffected; `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)