### PR TITLE
feat(exceptions): X::Undeclared::Symbols routine_suggestion / type_suggestion

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -569,10 +569,12 @@ impl Interpreter {
                 return self.eval_call_on_value(callable, args);
             }
         }
-        Err(RuntimeError::undeclared_symbols(format!(
-            "Unknown function: {}",
-            full_name
-        )))
+        let suggestions = self.suggest_routine_names(full_name);
+        Err(RuntimeError::undeclared_routine_symbols(
+            full_name,
+            format!("Unknown function: {}", full_name),
+            suggestions,
+        ))
     }
 
     pub(crate) fn compose_callables(&self, left: Value, right: Value) -> Value {

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -1,6 +1,140 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// All built-in (core) function names. Single source of truth for
+/// `is_builtin_function` and for "Did you mean ...?" routine suggestions.
+pub(crate) const BUILTIN_FUNCTION_NAMES: &[&str] = &[
+    "defined",
+    "undefine",
+    "say",
+    "print",
+    "put",
+    "note",
+    "die",
+    "succeed",
+    "warn",
+    "sink",
+    "quietly",
+    "exit",
+    "abs",
+    "sign",
+    "val",
+    "sqrt",
+    "floor",
+    "ceiling",
+    "ceil",
+    "round",
+    "exp",
+    "log",
+    "cis",
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "sec",
+    "cosec",
+    "cotan",
+    "asec",
+    "acosec",
+    "acotan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "sech",
+    "cosech",
+    "cotanh",
+    "asinh",
+    "acosh",
+    "atanh",
+    "asech",
+    "acosech",
+    "acotanh",
+    "chr",
+    "ord",
+    "unival",
+    "univals",
+    "chars",
+    "chomp",
+    "chop",
+    "flip",
+    "lc",
+    "uc",
+    "tc",
+    "trim",
+    "elems",
+    "end",
+    "keys",
+    "values",
+    "pairs",
+    "sort",
+    "reverse",
+    "rotate",
+    "join",
+    "map",
+    "grep",
+    "roundrobin",
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "dir",
+    "chdir",
+    "QX",
+    "qx",
+    "indir",
+    "run",
+    "splice",
+    "flat",
+    "unique",
+    "repeated",
+    "squish",
+    "min",
+    "max",
+    "minmax",
+    "sum",
+    "any",
+    "all",
+    "none",
+    "one",
+    "so",
+    "not",
+    "truncate",
+    "atan2",
+    "roots",
+    "substr",
+    "substr-rw",
+    "words",
+    "rand",
+    "sprintf",
+    "zprintf",
+    "printf",
+    "uniname",
+    "uninames",
+    "uniprop",
+    "unimatch",
+    "uniparse",
+    "parse-names",
+    "parse-base",
+    "symlink",
+    "link",
+    "spurt",
+    "slurp",
+    "open",
+    "close",
+    "unlink",
+    "mkdir",
+    "rmdir",
+    "rename",
+    "copy",
+    "move",
+    "chmod",
+    "lines",
+    "get",
+    "prompt",
+];
+
 impl Interpreter {
     fn builtin_index_var_meta(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let source_name = args.first().map(Value::to_string_value).unwrap_or_default();
@@ -818,138 +952,7 @@ impl Interpreter {
     }
 
     pub(crate) fn is_builtin_function(name: &str) -> bool {
-        matches!(
-            name,
-            "defined"
-                | "undefine"
-                | "say"
-                | "print"
-                | "put"
-                | "note"
-                | "die"
-                | "succeed"
-                | "warn"
-                | "sink"
-                | "quietly"
-                | "exit"
-                | "abs"
-                | "sign"
-                | "val"
-                | "sqrt"
-                | "floor"
-                | "ceiling"
-                | "ceil"
-                | "round"
-                | "exp"
-                | "log"
-                | "cis"
-                | "sin"
-                | "cos"
-                | "tan"
-                | "asin"
-                | "acos"
-                | "atan"
-                | "sec"
-                | "cosec"
-                | "cotan"
-                | "asec"
-                | "acosec"
-                | "acotan"
-                | "sinh"
-                | "cosh"
-                | "tanh"
-                | "sech"
-                | "cosech"
-                | "cotanh"
-                | "asinh"
-                | "acosh"
-                | "atanh"
-                | "asech"
-                | "acosech"
-                | "acotanh"
-                | "chr"
-                | "ord"
-                | "unival"
-                | "univals"
-                | "chars"
-                | "chomp"
-                | "chop"
-                | "flip"
-                | "lc"
-                | "uc"
-                | "tc"
-                | "trim"
-                | "elems"
-                | "end"
-                | "keys"
-                | "values"
-                | "pairs"
-                | "sort"
-                | "reverse"
-                | "rotate"
-                | "join"
-                | "map"
-                | "grep"
-                | "roundrobin"
-                | "push"
-                | "pop"
-                | "shift"
-                | "unshift"
-                | "dir"
-                | "chdir"
-                | "QX"
-                | "qx"
-                | "indir"
-                | "run"
-                | "splice"
-                | "flat"
-                | "unique"
-                | "repeated"
-                | "squish"
-                | "min"
-                | "max"
-                | "minmax"
-                | "sum"
-                | "any"
-                | "all"
-                | "none"
-                | "one"
-                | "so"
-                | "not"
-                | "truncate"
-                | "atan2"
-                | "roots"
-                | "substr"
-                | "substr-rw"
-                | "words"
-                | "rand"
-                | "sprintf"
-                | "zprintf"
-                | "printf"
-                | "uniname"
-                | "uninames"
-                | "uniprop"
-                | "unimatch"
-                | "uniparse"
-                | "parse-names"
-                | "parse-base"
-                | "symlink"
-                | "link"
-                | "spurt"
-                | "slurp"
-                | "open"
-                | "close"
-                | "unlink"
-                | "mkdir"
-                | "rmdir"
-                | "rename"
-                | "copy"
-                | "move"
-                | "chmod"
-                | "lines"
-                | "get"
-                | "prompt"
-        )
+        BUILTIN_FUNCTION_NAMES.contains(&name)
     }
 
     /// Builtin `skip(N, list)` function — skips N elements from the list.

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -794,10 +794,12 @@ impl Interpreter {
             return self.call_function(short_name, args.to_vec());
         }
 
-        Err(RuntimeError::undeclared_symbols(format!(
-            "Unknown function: {}",
-            name
-        )))
+        let suggestions = self.suggest_routine_names(name);
+        Err(RuntimeError::undeclared_routine_symbols(
+            name,
+            format!("Unknown function: {}", name),
+            suggestions,
+        ))
     }
 
     pub(super) fn call_infix_routine(

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -507,6 +507,49 @@ impl Interpreter {
         scored.into_iter().map(|(_, s)| s).collect()
     }
 
+    /// Suggest close routine names (built-in functions + user-defined subs) for
+    /// an undeclared routine `name`. Used for X::Undeclared::Symbols
+    /// `.routine_suggestion`.
+    pub(crate) fn suggest_routine_names(&self, name: &str) -> Vec<String> {
+        let mut candidates: Vec<String> = crate::runtime::builtins::BUILTIN_FUNCTION_NAMES
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        candidates.extend(self.registry().functions.keys().map(|s| s.resolve()));
+        Self::suggest_from_candidates(name, &candidates)
+    }
+
+    /// Suggest close type names (registered classes/roles) for an undeclared
+    /// type `name`. Used for X::Undeclared::Symbols `.type_suggestion`.
+    pub(crate) fn suggest_type_names(&self, name: &str) -> Vec<String> {
+        let candidates: Vec<String> = self.registry().classes.keys().cloned().collect();
+        Self::suggest_from_candidates(name, &candidates)
+    }
+
+    fn suggest_from_candidates(name: &str, candidates: &[String]) -> Vec<String> {
+        use crate::runtime::did_you_mean::levenshtein_distance;
+        let max_distance = if name.len() <= 3 {
+            1
+        } else if name.len() <= 6 {
+            2
+        } else {
+            3
+        };
+        let mut scored: Vec<(usize, String)> = Vec::new();
+        let mut seen = HashSet::new();
+        for cand in candidates {
+            if cand == name || !seen.insert(cand.clone()) {
+                continue;
+            }
+            let dist = levenshtein_distance(name, cand);
+            if dist > 0 && dist <= max_distance {
+                scored.push((dist, cand.clone()));
+            }
+        }
+        scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        scored.into_iter().map(|(_, s)| s).collect()
+    }
+
     fn collect_declared_vars(stmt: &Stmt, out: &mut HashSet<String>) {
         match stmt {
             Stmt::VarDecl { name, expr, .. } => {
@@ -697,10 +740,12 @@ impl Interpreter {
         }
         for stmt in stmts {
             if let Some(name) = self.find_undeclared_name_in_stmt(stmt, &local_classes, &declared) {
-                return Err(RuntimeError::undeclared_symbols(format!(
-                    "Undeclared name:\n    {} used at line 1",
-                    name
-                )));
+                let suggestions = self.suggest_type_names(&name);
+                return Err(RuntimeError::undeclared_type_symbols(
+                    &name,
+                    format!("Undeclared name:\n    {} used at line 1", name),
+                    suggestions,
+                ));
             }
         }
         Ok(())

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -545,6 +545,44 @@ impl RuntimeError {
         Self::typed_msg("X::Undeclared::Symbols", message)
     }
 
+    /// X::Undeclared::Symbols for a routine, carrying a `routine_suggestion`
+    /// hash `{ name => [close names] }` (empty list when there is no match).
+    pub(crate) fn undeclared_routine_symbols(
+        name: &str,
+        message: impl Into<String>,
+        suggestions: Vec<String>,
+    ) -> Self {
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.into()));
+        attrs.insert("symbol".to_string(), Value::str(name.to_string()));
+        let arr: Vec<Value> = suggestions.iter().cloned().map(Value::str).collect();
+        let mut map = HashMap::new();
+        map.insert(name.to_string(), Value::array(arr.clone()));
+        attrs.insert("routine_suggestion".to_string(), Value::hash(map));
+        // Also expose a flat `suggestions` list so `.suggestions` is uniformly
+        // available on X::Undeclared::Symbols (some call sites check it directly).
+        attrs.insert("suggestions".to_string(), Value::array(arr));
+        Self::typed("X::Undeclared::Symbols", attrs)
+    }
+
+    /// X::Undeclared::Symbols for a type/bareword, carrying a `type_suggestion`
+    /// hash `{ name => [close names] }` plus a flat `suggestions` list.
+    pub(crate) fn undeclared_type_symbols(
+        name: &str,
+        message: impl Into<String>,
+        suggestions: Vec<String>,
+    ) -> Self {
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.into()));
+        attrs.insert("symbol".to_string(), Value::str(name.to_string()));
+        let arr: Vec<Value> = suggestions.iter().cloned().map(Value::str).collect();
+        let mut map = HashMap::new();
+        map.insert(name.to_string(), Value::array(arr.clone()));
+        attrs.insert("type_suggestion".to_string(), Value::hash(map));
+        attrs.insert("suggestions".to_string(), Value::array(arr));
+        Self::typed("X::Undeclared::Symbols", attrs)
+    }
+
     /// X::CompUnit::UnsatisfiedDependency - a required module could not be found.
     pub(crate) fn unsatisfied_dependency(module: &str) -> Self {
         let msg = format!("Could not find {} in:\n    (module repositories)", module);

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -427,10 +427,12 @@ impl VM {
             && !Self::is_builtin_type(&target_name)
             && !self.interpreter.has_class(&target_name)
         {
-            return Err(RuntimeError::undeclared_symbols(format!(
-                "Undeclared name:\n    {} used at line 1",
-                target_name,
-            )));
+            let suggestions = self.interpreter.suggest_type_names(&target_name);
+            return Err(RuntimeError::undeclared_type_symbols(
+                &target_name,
+                format!("Undeclared name:\n    {} used at line 1", target_name),
+                suggestions,
+            ));
         }
         // Junction auto-threading: thread method calls over junction values
         if let Value::Junction { kind, values } = &target

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1075,10 +1075,12 @@ impl VM {
             let env_key = format!("&{}", name);
             let is_declared = self.interpreter.env().contains_key(&env_key);
             if !is_declared {
-                return Err(RuntimeError::undeclared_symbols(format!(
-                    "Undeclared routine:\n    {} used at line 1",
-                    name
-                )));
+                let suggestions = self.interpreter.suggest_routine_names(name);
+                return Err(RuntimeError::undeclared_routine_symbols(
+                    name,
+                    format!("Undeclared routine:\n    {} used at line 1", name),
+                    suggestions,
+                ));
             }
         }
         self.stack.push(val);


### PR DESCRIPTION
## Summary

Add "Did you mean …?" suggestions for undeclared routines and types — the next chunk of the `S32-exceptions/misc2.t` suggestions block (continues #2785).

- Extract the `is_builtin_function` name table into a single `BUILTIN_FUNCTION_NAMES` const, reused both for membership tests and for routine suggestions (no behavior change to `is_builtin_function`).
- `Interpreter::suggest_routine_names` / `suggest_type_names`: Levenshtein matches against builtin functions + user subs, and registered classes, respectively.
- New `RuntimeError::undeclared_routine_symbols` / `undeclared_type_symbols` build `X::Undeclared::Symbols` carrying a `routine_suggestion` / `type_suggestion` hash `{ name => [close names] }` plus a flat `suggestions` list (so `.suggestions` is uniformly available on `X::Undeclared::Symbols`).
- Wire these into the undeclared-routine throw sites (accessors, builtins_operators, vm_misc_ops `&name`) and the undeclared-type sites (`check_eval_undeclared_names`, `vm_call_method_mut_ops` bareword `.method`).

## Tests

Passes `misc2.t` tests 244–249: `&huc`/`huc` suggest `uc`, the strange-name routine yields no suggestions; `Ecxeption.new` suggests `Exception` via `.type_suggestion<Ecxeption>`.

The remaining gated tests still abort later in the block on **separate** bugs (an `is BadParent` misparse → "Unknown function: is", and undeclared-scalar assignment not throwing) — follow-up PRs. `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)