### PR TITLE
feat(exceptions): X::Comp::Group for undeclared my-type + UnknownParent.suggestions

### DIFF
--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -910,15 +910,34 @@ impl Interpreter {
                     return Err(RuntimeError::typed("X::Inheritance::Unsupported", attrs));
                 }
                 {
-                    let msg = format!(
-                        "class '{}' specifies unknown parent class '{}'",
+                    // Suggest close known type names (Did-you-mean).
+                    let suggestions = self.suggest_type_names(resolved_parent_name.as_str());
+                    let mut msg = format!(
+                        "'{}' cannot inherit from '{}' because it is unknown.",
                         name, resolved_parent_name
                     );
+                    if suggestions.len() == 1 {
+                        msg.push_str(&format!("\nDid you mean '{}'?", suggestions[0]));
+                    } else if suggestions.len() > 1 {
+                        msg.push_str("\nDid you mean one of these?\n");
+                        for s in &suggestions {
+                            msg.push_str(&format!("    '{}'\n", s));
+                        }
+                    }
                     let mut attrs = HashMap::new();
                     attrs.insert("child-name".to_string(), Value::str(name.to_string()));
+                    attrs.insert("child".to_string(), Value::str(name.to_string()));
                     attrs.insert(
                         "parent-name".to_string(),
                         Value::str(resolved_parent_name.to_string()),
+                    );
+                    attrs.insert(
+                        "parent".to_string(),
+                        Value::str(resolved_parent_name.to_string()),
+                    );
+                    attrs.insert(
+                        "suggestions".to_string(),
+                        Value::array(suggestions.into_iter().map(Value::str).collect()),
                     );
                     attrs.insert("message".to_string(), Value::str(msg));
                     return Err(RuntimeError::typed("X::Inheritance::UnknownParent", attrs));

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -4,13 +4,69 @@ use crate::symbol::Symbol;
 /// Core built-in type names used as candidates for type-name "Did you mean"
 /// suggestions (in addition to user-registered classes).
 pub(crate) const CORE_TYPE_NAMES: &[&str] = &[
-    "Mu", "Any", "Cool", "Int", "Num", "Rat", "FatRat", "Complex", "Str", "Bool", "Array", "Hash",
-    "List", "Map", "Set", "Bag", "Mix", "SetHash", "BagHash", "MixHash", "Range", "Pair", "Seq",
-    "Slip", "Junction", "Regex", "Match", "Grammar", "Exception", "Failure", "Version", "Nil",
-    "Block", "Code", "Routine", "Sub", "Method", "Whatever", "WhateverCode", "Callable", "Numeric",
-    "Real", "Stringy", "Positional", "Associative", "Iterable", "Iterator", "Capture", "Signature",
-    "Parameter", "Date", "DateTime", "Instant", "Duration", "Buf", "Blob", "Promise", "Supply",
-    "Channel", "Thread", "Proc", "IO", "Scalar",
+    "Mu",
+    "Any",
+    "Cool",
+    "Int",
+    "Num",
+    "Rat",
+    "FatRat",
+    "Complex",
+    "Str",
+    "Bool",
+    "Array",
+    "Hash",
+    "List",
+    "Map",
+    "Set",
+    "Bag",
+    "Mix",
+    "SetHash",
+    "BagHash",
+    "MixHash",
+    "Range",
+    "Pair",
+    "Seq",
+    "Slip",
+    "Junction",
+    "Regex",
+    "Match",
+    "Grammar",
+    "Exception",
+    "Failure",
+    "Version",
+    "Nil",
+    "Block",
+    "Code",
+    "Routine",
+    "Sub",
+    "Method",
+    "Whatever",
+    "WhateverCode",
+    "Callable",
+    "Numeric",
+    "Real",
+    "Stringy",
+    "Positional",
+    "Associative",
+    "Iterable",
+    "Iterator",
+    "Capture",
+    "Signature",
+    "Parameter",
+    "Date",
+    "DateTime",
+    "Instant",
+    "Duration",
+    "Buf",
+    "Blob",
+    "Promise",
+    "Supply",
+    "Channel",
+    "Thread",
+    "Proc",
+    "IO",
+    "Scalar",
 ];
 
 impl Interpreter {
@@ -544,11 +600,8 @@ impl Interpreter {
         // Rakudo accepts a candidate whose Levenshtein distance from the typo
         // is at most `chars div 3` (e.g. a 4-char name tolerates 1 edit, a
         // 9-char name 3 edits), with a floor of 1 for names of length >= 3.
-        let max_distance = (name.chars().count() / 3).max(if name.chars().count() >= 3 {
-            1
-        } else {
-            0
-        });
+        let max_distance =
+            (name.chars().count() / 3).max(if name.chars().count() >= 3 { 1 } else { 0 });
         let mut scored: Vec<(usize, String)> = Vec::new();
         let mut seen = HashSet::new();
         for cand in candidates {

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// Core built-in type names used as candidates for type-name "Did you mean"
+/// suggestions (in addition to user-registered classes).
+pub(crate) const CORE_TYPE_NAMES: &[&str] = &[
+    "Mu", "Any", "Cool", "Int", "Num", "Rat", "FatRat", "Complex", "Str", "Bool", "Array", "Hash",
+    "List", "Map", "Set", "Bag", "Mix", "SetHash", "BagHash", "MixHash", "Range", "Pair", "Seq",
+    "Slip", "Junction", "Regex", "Match", "Grammar", "Exception", "Failure", "Version", "Nil",
+    "Block", "Code", "Routine", "Sub", "Method", "Whatever", "WhateverCode", "Callable", "Numeric",
+    "Real", "Stringy", "Positional", "Associative", "Iterable", "Iterator", "Capture", "Signature",
+    "Parameter", "Date", "DateTime", "Instant", "Duration", "Buf", "Blob", "Promise", "Supply",
+    "Channel", "Thread", "Proc", "IO", "Scalar",
+];
+
 impl Interpreter {
     fn parse_and_eval_with_operators(
         &mut self,
@@ -522,19 +534,21 @@ impl Interpreter {
     /// Suggest close type names (registered classes/roles) for an undeclared
     /// type `name`. Used for X::Undeclared::Symbols `.type_suggestion`.
     pub(crate) fn suggest_type_names(&self, name: &str) -> Vec<String> {
-        let candidates: Vec<String> = self.registry().classes.keys().cloned().collect();
+        let mut candidates: Vec<String> = self.registry().classes.keys().cloned().collect();
+        candidates.extend(CORE_TYPE_NAMES.iter().map(|s| s.to_string()));
         Self::suggest_from_candidates(name, &candidates)
     }
 
     fn suggest_from_candidates(name: &str, candidates: &[String]) -> Vec<String> {
         use crate::runtime::did_you_mean::levenshtein_distance;
-        let max_distance = if name.len() <= 3 {
+        // Rakudo accepts a candidate whose Levenshtein distance from the typo
+        // is at most `chars div 3` (e.g. a 4-char name tolerates 1 edit, a
+        // 9-char name 3 edits), with a floor of 1 for names of length >= 3.
+        let max_distance = (name.chars().count() / 3).max(if name.chars().count() >= 3 {
             1
-        } else if name.len() <= 6 {
-            2
         } else {
-            3
-        };
+            0
+        });
         let mut scored: Vec<(usize, String)> = Vec::new();
         let mut seen = HashSet::new();
         for cand in candidates {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2588,14 +2588,37 @@ impl VM {
                 .is_none()
             {
                 // Unknown user-defined type — reject it.
-                // Include "Malformed my" in the message to match Raku's error output
-                // (raku reports both "Type '...' is not declared" and "Malformed my").
-                let msg = format!("Type '{}' is not declared. Malformed my", constraint);
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("what".to_string(), Value::str("type".to_string()));
-                attrs.insert("symbol".to_string(), Value::str(constraint.to_string()));
-                attrs.insert("message".to_string(), Value::str(msg.clone()));
-                return Err(RuntimeError::typed("X::Undeclared", attrs));
+                // In Raku this is a compile-time failure grouped into an
+                // X::Comp::Group whose `.sorrows` holds the underlying
+                // X::Undeclared (with type "Did you mean" suggestions).
+                let suggestions = self.interpreter.suggest_type_names(constraint);
+                let mut undecl_msg = format!("Type '{}' is not declared.", constraint);
+                if suggestions.len() == 1 {
+                    undecl_msg.push_str(&format!(" Did you mean '{}'?", suggestions[0]));
+                } else if suggestions.len() > 1 {
+                    let quoted: Vec<String> =
+                        suggestions.iter().map(|s| format!("'{}'", s)).collect();
+                    undecl_msg
+                        .push_str(&format!(" Did you mean any of these: {}?", quoted.join(", ")));
+                }
+                let mut undecl_attrs = std::collections::HashMap::new();
+                undecl_attrs.insert("what".to_string(), Value::str("type".to_string()));
+                undecl_attrs.insert("symbol".to_string(), Value::str(constraint.to_string()));
+                undecl_attrs.insert(
+                    "suggestions".to_string(),
+                    Value::array(suggestions.iter().cloned().map(Value::str).collect()),
+                );
+                undecl_attrs.insert("message".to_string(), Value::str(undecl_msg.clone()));
+                let sorrow =
+                    Value::make_instance(crate::symbol::Symbol::intern("X::Undeclared"), undecl_attrs);
+                // Group message mirrors Raku: the sorrow message plus "Malformed my".
+                let group_msg = format!("{}\nMalformed my", undecl_msg);
+                let mut group_attrs = std::collections::HashMap::new();
+                group_attrs.insert("sorrows".to_string(), Value::array(vec![sorrow]));
+                group_attrs.insert("worries".to_string(), Value::array(vec![]));
+                group_attrs.insert("panic".to_string(), Value::Nil);
+                group_attrs.insert("message".to_string(), Value::str(group_msg));
+                return Err(RuntimeError::typed("X::Comp::Group", group_attrs));
             }
         }
         if !matches!(value, Value::Nil)

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2598,8 +2598,10 @@ impl VM {
                 } else if suggestions.len() > 1 {
                     let quoted: Vec<String> =
                         suggestions.iter().map(|s| format!("'{}'", s)).collect();
-                    undecl_msg
-                        .push_str(&format!(" Did you mean any of these: {}?", quoted.join(", ")));
+                    undecl_msg.push_str(&format!(
+                        " Did you mean any of these: {}?",
+                        quoted.join(", ")
+                    ));
                 }
                 let mut undecl_attrs = std::collections::HashMap::new();
                 undecl_attrs.insert("what".to_string(), Value::str("type".to_string()));
@@ -2609,8 +2611,10 @@ impl VM {
                     Value::array(suggestions.iter().cloned().map(Value::str).collect()),
                 );
                 undecl_attrs.insert("message".to_string(), Value::str(undecl_msg.clone()));
-                let sorrow =
-                    Value::make_instance(crate::symbol::Symbol::intern("X::Undeclared"), undecl_attrs);
+                let sorrow = Value::make_instance(
+                    crate::symbol::Symbol::intern("X::Undeclared"),
+                    undecl_attrs,
+                );
                 // Group message mirrors Raku: the sorrow message plus "Malformed my".
                 let group_msg = format!("{}\nMalformed my", undecl_msg);
                 let mut group_attrs = std::collections::HashMap::new();

--- a/t/exceptions-comp-group-unknown-parent.t
+++ b/t/exceptions-comp-group-unknown-parent.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 11;
+
+# X::Inheritance::UnknownParent exposes .suggestions / .child / .parent and a
+# "Did you mean" message when a close type name exists.
+{
+    try EVAL('my class FooBarBazQuuxNoMatch is TotallyUnknownParentName { }');
+    isa-ok $!, X::Inheritance::UnknownParent, 'unknown parent throws X::Inheritance::UnknownParent';
+    is +($!.suggestions), 0, 'no suggestions for a strange parent name';
+    ok $!.message !~~ /:s Did you mean/, 'no "Did you mean" when there are no suggestions';
+}
+
+{
+    class Animal { }
+    try EVAL('my class Dog is Animaal { }');
+    is $!.suggestions.sort, <Animal>, 'close parent name is suggested';
+    ok $!.message ~~ /:s Did you mean/, '"Did you mean" appears when a suggestion exists';
+}
+
+# `my <unknown-type> $x` is a grouped compile failure: X::Comp::Group whose
+# first sorrow is X::Undeclared carrying type-name suggestions.
+{
+    try EVAL('my cool $a');
+    isa-ok $!, X::Comp::Group, 'undeclared type in my-decl throws X::Comp::Group';
+    isa-ok $!.sorrows[0], X::Undeclared, 'first sorrow is X::Undeclared';
+    is $!.sorrows[0].suggestions.sort, <Bool Cool>, 'cool suggests Bool and Cool';
+}
+
+# Levenshtein threshold follows rakudo: a 4-char typo tolerates only 1 edit, so
+# a distance-2 user class must NOT be suggested.
+{
+    class Foo { }
+    try EVAL('my cool $a');
+    is $!.sorrows[0].suggestions.sort, <Bool Cool>, 'distance-2 class Foo is not suggested for cool';
+}
+
+# A longer typo tolerates more edits.
+{
+    try EVAL('Ecxeption.new("x")');
+    isa-ok $!, X::Undeclared::Symbols, 'Ecxeption throws X::Undeclared::Symbols';
+    is $!.type_suggestion<Ecxeption>.grep("Exception"), ["Exception"], 'Exception is suggested for Ecxeption';
+}


### PR DESCRIPTION
## Summary

Three related exception/suggestion fixes that let `roast/S32-exceptions/misc2.t` run to completion. Previously the file aborted mid-run (`Bad plan. You planned 265 tests but ran 249`) because `X::Inheritance::UnknownParent.suggestions` was missing; it now runs all 265 tests and passes the suggestion gates.

1. **`X::Inheritance::UnknownParent`** now carries `.suggestions`, `.child` and `.parent`, and its message uses rakudo's `'<child>' cannot inherit from '<parent>' because it is unknown.` form with a "Did you mean" suffix.

2. **`my <unknown-type> $x`** is a grouped compile failure in rakudo: it now throws `X::Comp::Group` whose first sorrow is an `X::Undeclared` carrying type-name suggestions (e.g. `my cool $a` → `Bool`, `Cool`).

3. **Type-name suggestions** now include core built-in types (`CORE_TYPE_NAMES`), and the shared Levenshtein threshold matches rakudo's `chars div 3` (a 4-char typo tolerates 1 edit, a 9-char typo 3), instead of the looser `len<=6 ⇒ 2` heuristic that wrongly suggested distance-2 names like `Foo` for `cool`.

## Tests

- Adds `t/exceptions-comp-group-unknown-parent.t` (11 subtests).
- `make test` passes (618 files, 5446 tests).
- `roast/S32-exceptions/misc2.t` now runs 265/265 (no abort); remaining failures are unrelated exception types (`X::Parameter::InvalidType`, `X::Multi::NoMatch`, `X::Syntax::Adverb`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)