### PR TITLE
feat(exceptions): X::Syntax::Regex::NullRegex for empty regexes

### DIFF
--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -260,6 +260,16 @@ fn no_self_error() -> PError {
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 
+/// `X::Syntax::Regex::NullRegex` — an empty `token`/`regex`/`rule` body (e.g.
+/// `regex foo { }`) is a null regex, rejected by Raku at parse time.
+fn null_regex_error() -> PError {
+    let msg = "Null regex not allowed".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Regex::NullRegex"), attrs);
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn expr_is_bare_ident(expr: &Expr, ident: &str) -> bool {
     matches!(expr, Expr::Var(name) | Expr::BareWord(name) if name == ident)
 }
@@ -1600,6 +1610,10 @@ pub(super) fn token_decl(input: &str) -> PResult<'_, Stmt> {
 
     let (rest, _) = ws(rest)?;
     let (rest, mut pattern) = parse_raw_braced_regex_body(rest)?;
+    // An empty `token`/`regex`/`rule` body is a null regex.
+    if pattern.trim().is_empty() {
+        return Err(null_regex_error());
+    }
     pattern = normalize_token_pattern(&pattern);
     if is_rule {
         pattern = inject_implicit_rule_ws(&pattern);

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -255,6 +255,40 @@ fn make_non_quantifiable_error() -> RuntimeError {
     err
 }
 
+/// `X::Syntax::Regex::NullRegex` — a regex (or one of its alternation /
+/// conjunction branches, or a group body) that matches nothing syntactically,
+/// e.g. `/ /`, `/ a | /`, `/ () /`, `s//b/`. Raku rejects these at parse time.
+/// A *single leading* empty alternation branch is allowed for alignment
+/// (`/ | a /`), so callers pass `allow_leading_empty` accordingly.
+fn make_null_regex_error() -> RuntimeError {
+    let msg = "Null regex not allowed";
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.to_string()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Regex::NullRegex"), attrs);
+    let mut err = RuntimeError::new(msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+/// Detect a null branch among a split alternation/conjunction. Returns the
+/// NullRegex error if any branch is empty/whitespace-only, except that a single
+/// leading empty branch is permitted when `allow_leading_empty` is set (Raku
+/// allows `/ | a /` and `/ || a /` for visual alignment).
+fn null_regex_if_empty_branch(
+    branches: &[String],
+    allow_leading_empty: bool,
+) -> Option<RuntimeError> {
+    for (i, b) in branches.iter().enumerate() {
+        if b.trim().is_empty() {
+            if allow_leading_empty && i == 0 {
+                continue;
+            }
+            return Some(make_null_regex_error());
+        }
+    }
+    None
+}
+
 fn make_unrecognized_metachar_error(metachar: char) -> RuntimeError {
     let msg =
         format!("Unrecognized regex metacharacter {metachar} (must be quoted to match literally)");
@@ -1966,9 +2000,24 @@ impl Interpreter {
         if sigspace && source.contains('\n') {
             source = source.trim_end();
         }
+        // A regex whose entire body (or a recursed branch/group body) is empty
+        // or whitespace-only is a null regex; Raku rejects these at parse time
+        // with X::Syntax::Regex::NullRegex (e.g. `/ /`, `s//b/`, an empty
+        // `regex foo { }` body, or an empty `()`/`[]` group).
+        if source.trim().is_empty() {
+            PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(make_null_regex_error()));
+            return None;
+        }
         // Handle top-level alternation (| or ||)
         let (top_alts, is_sequential) = Self::split_top_level_alternation(source);
         if top_alts.len() > 1 {
+            // A trailing or interior empty branch (`/ a | /`, `/ | /`) is a null
+            // regex. A single leading empty branch is allowed for alignment
+            // (`/ | a /`, `/ || a /`).
+            if let Some(err) = null_regex_if_empty_branch(&top_alts, true) {
+                PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(err));
+                return None;
+            }
             let mut alt_patterns = Vec::new();
             for alt in &top_alts {
                 let alt_src = alt.trim();
@@ -2023,6 +2072,12 @@ impl Interpreter {
         // after alternation splitting found no `|`.
         let conj_parts = Self::split_top_level_conjunction(source);
         if conj_parts.len() > 1 {
+            // As with alternation, a trailing/interior empty conjunct (`/ a & /`)
+            // is null; a single leading empty conjunct is allowed (`/ & a /`).
+            if let Some(err) = null_regex_if_empty_branch(&conj_parts, true) {
+                PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(err));
+                return None;
+            }
             let mut conj_patterns = Vec::new();
             for part in &conj_parts {
                 let part_src = part.trim();
@@ -3961,8 +4016,22 @@ impl Interpreter {
                         });
                         return None;
                     }
+                    // An empty capture group `()` is a null regex.
+                    if group_pattern.trim().is_empty() {
+                        PENDING_REGEX_ERROR
+                            .with(|e| *e.borrow_mut() = Some(make_null_regex_error()));
+                        return None;
+                    }
                     let (alternatives, cap_is_sequential) =
                         Self::split_top_level_alternation(&group_pattern);
+                    // A trailing/interior empty branch inside the group (`(a|)`)
+                    // is null; a leading empty branch is allowed (`(|a)`).
+                    if alternatives.len() > 1
+                        && let Some(err) = null_regex_if_empty_branch(&alternatives, true)
+                    {
+                        PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(err));
+                        return None;
+                    }
                     let needs_capture_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();
@@ -4080,9 +4149,23 @@ impl Interpreter {
                             group_pattern.push(ch);
                         }
                     }
+                    // An empty non-capturing group `[]` is a null regex.
+                    if group_pattern.trim().is_empty() {
+                        PENDING_REGEX_ERROR
+                            .with(|e| *e.borrow_mut() = Some(make_null_regex_error()));
+                        return None;
+                    }
                     // Parse the group as top-level alternation, including `||`.
                     let (alternatives, bracket_is_sequential) =
                         Self::split_top_level_alternation(&group_pattern);
+                    // A trailing/interior empty branch inside the group (`[a|]`)
+                    // is null; a leading empty branch is allowed (`[|a]`).
+                    if alternatives.len() > 1
+                        && let Some(err) = null_regex_if_empty_branch(&alternatives, true)
+                    {
+                        PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = Some(err));
+                        return None;
+                    }
                     let needs_scope = ignore_case || sigspace || ratchet || ignore_mark;
                     if alternatives.len() > 1 {
                         let mut alt_patterns = Vec::new();

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1744,14 +1744,31 @@ impl Interpreter {
 
         if sep_mode.is_none() {
             return match max {
-                Some(max) if max == min => repeat_atom(min),
+                // `**0` matches exactly zero repetitions — an empty match, not a
+                // null regex. Emit an empty string literal (a zero-width atom)
+                // rather than a bare empty pattern, which would be rejected as
+                // X::Syntax::Regex::NullRegex.
+                Some(max) if max == min => {
+                    if min == 0 {
+                        "''".to_string()
+                    } else {
+                        repeat_atom(min)
+                    }
+                }
                 Some(max) => {
-                    let alts: Vec<String> = (min..=max).rev().map(repeat_atom).collect();
-                    if alts.len() == 1 {
+                    // For `**0..max`, build the 1..=max alternatives and make the
+                    // whole group optional (`[...]?`) for the zero-rep case,
+                    // instead of appending an empty trailing alternation branch
+                    // like `(aa|a|)` — that empty branch would be misdetected as
+                    // a null regex.
+                    let lo = if min == 0 { 1 } else { min };
+                    let alts: Vec<String> = (lo..=max).rev().map(repeat_atom).collect();
+                    let core = if alts.len() == 1 {
                         alts.into_iter().next().unwrap_or_default()
                     } else {
                         format!("({})", alts.join("|"))
-                    }
+                    };
+                    if min == 0 { format!("[{core}]?") } else { core }
                 }
                 None => format!("{}[{sp}{atom}]*", repeat_atom(min)),
             };

--- a/t/null-regex.t
+++ b/t/null-regex.t
@@ -1,0 +1,41 @@
+use Test;
+
+# X::Syntax::Regex::NullRegex — Raku rejects a regex (or one of its
+# alternation/conjunction branches, or a group body) that matches nothing
+# syntactically. mutsu detects these at parse/compile time.
+
+plan 22;
+
+# Whole-pattern empties.
+throws-like q[/ /],     X::Syntax::Regex::NullRegex, 'bare empty regex';
+throws-like q[s//b/],   X::Syntax::Regex::NullRegex, 'empty substitution pattern';
+
+# Alternation branches.
+throws-like q[/ a | /],  X::Syntax::Regex::NullRegex, 'trailing | branch';
+throws-like q[/ a || /], X::Syntax::Regex::NullRegex, 'trailing || branch';
+throws-like q[/ | /],    X::Syntax::Regex::NullRegex, 'two empty | branches';
+throws-like q[/ || /],   X::Syntax::Regex::NullRegex, 'two empty || branches';
+throws-like q[/ a | | b /], X::Syntax::Regex::NullRegex, 'interior empty | branch';
+
+# Conjunction branches.
+throws-like q[/ a & /],  X::Syntax::Regex::NullRegex, 'trailing & branch';
+throws-like q[/ a && /], X::Syntax::Regex::NullRegex, 'trailing && branch';
+
+# Groups.
+throws-like q{/ () /},   X::Syntax::Regex::NullRegex, 'empty capture group';
+throws-like q{/ [] /},   X::Syntax::Regex::NullRegex, 'empty non-capturing group';
+throws-like q{/ ( ) /},  X::Syntax::Regex::NullRegex, 'whitespace-only capture group';
+throws-like q{/ (a|) /}, X::Syntax::Regex::NullRegex, 'trailing empty branch in group';
+
+# Grammar / named regex bodies.
+throws-like q[my grammar G { regex foo { } }], X::Syntax::Regex::NullRegex, 'empty grammar regex';
+throws-like q[my grammar G { token foo { } }], X::Syntax::Regex::NullRegex, 'empty grammar token';
+throws-like q[my grammar G { rule foo { } }],  X::Syntax::Regex::NullRegex, 'empty grammar rule';
+throws-like q[my regex r { }], X::Syntax::Regex::NullRegex, 'empty my regex';
+
+# These are NOT null and must keep working.
+lives-ok { EVAL q[/ ^ /] },     'anchor-only regex is fine';
+lives-ok { EVAL q[/ "" /] },    'empty string literal atom is fine';
+lives-ok { EVAL q[/ <?> /] },   'zero-width assertion is fine';
+lives-ok { EVAL q[/ | a /] },   'leading empty | branch (alignment) is fine';
+lives-ok { EVAL q[/ (|a) /] },  'leading empty branch in group is fine';


### PR DESCRIPTION
## Summary

Raku rejects a regex (or one of its alternation/conjunction branches, or a group body) that matches nothing syntactically. mutsu silently accepted all of these and returned `Any`; now it throws `X::Syntax::Regex::NullRegex`.

Cases now rejected (all `X::Syntax::Regex::NullRegex`):
- `/ /`, `s//b/` — whole-pattern empty
- `/ a | /`, `/ a || /`, `/ | /` — trailing/interior empty alternation branch
- `/ a & /`, `/ a && /` — trailing/interior empty conjunction branch
- `/ () /`, `/ [] /`, `/ (a|) /` — empty (or trailing-empty-branch) group
- `regex foo { }`, `token foo { }`, `rule foo { }`, `my regex r { }` — empty named-regex bodies

Cases that remain valid (NOT null):
- `/ ^ /`, `/ $ /` — anchors
- `/ <?> /` — zero-width assertion
- `/ "" /` — empty string-literal atom
- `/ | a /`, `/ || a /`, `/ & a /`, `/ (|a) /` — a single leading empty branch (alignment)

## Implementation

Detection is **structural** (a branch/group/whole-pattern source string that is empty or whitespace-only), matching Raku's grammar rather than checking whether the compiled pattern produces tokens.

- `runtime/regex_parse.rs`: `make_null_regex_error()` + `null_regex_if_empty_branch()`; checks at the whole-pattern, top-level alternation, conjunction, and capture/non-capturing group levels. Runs in both `Match` and `Validate` modes, so it fires at parse time (`m//`, `s///`, `/.../`) and at runtime (bare match).
- `parser/stmt/class.rs`: empty `token`/`regex`/`rule` bodies throw at parse time.

## Tests

- New `t/null-regex.t` (22 subtests).
- Unblocks the 9 `X::Syntax::Regex::NullRegex` subtests in `roast/S32-exceptions/misc2.t` and the NullRegex subtests in `roast/S05-substitution/subst.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)