### PR TITLE
fix(lazy): guard grep over infinite Range via unified pull iterator (§8.1 PR-1)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1456,10 +1456,15 @@ impl Interpreter {
                 {
                     list_items.extend(items.iter().cloned());
                 }
-                Value::Range(a, b) => list_items.extend((*a..=*b).map(Value::Int)),
-                Value::RangeExcl(a, b) => list_items.extend((*a..*b).map(Value::Int)),
                 v if v.is_range() => {
-                    list_items.extend(crate::runtime::utils::value_to_list(v));
+                    // Route ranges through the unified pull iterator so an
+                    // open-ended range (`1..Inf` == `Range(1, i64::MAX)`) is
+                    // truncated at the cap instead of panicking with
+                    // `capacity overflow` (ANALYSIS §8.2).
+                    list_items.extend(crate::runtime::value_iterator::materialize_capped(
+                        v,
+                        crate::runtime::utils::MAX_RANGE_EXPAND as usize,
+                    ));
                 }
                 other => list_items.push(other.clone()),
             }

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -302,20 +302,19 @@ impl Interpreter {
                 }
                 grep_adverb.transform_result(filtered, &indices)
             }
-            Value::Range(a, b) => {
-                let items: Vec<Value> = (a..=b).map(Value::Int).collect();
-                self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
-            }
-            Value::RangeExcl(a, b) => {
-                let items: Vec<Value> = (a..b).map(Value::Int).collect();
-                self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
-            }
-            Value::RangeExclStart(a, b) => {
-                let items: Vec<Value> = (a + 1..=b).map(Value::Int).collect();
-                self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
-            }
-            Value::RangeExclBoth(a, b) => {
-                let items: Vec<Value> = (a + 1..b).map(Value::Int).collect();
+            Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..) => {
+                // Route integer ranges through the unified pull iterator so an
+                // open-ended range (`1..Inf` == `Range(1, i64::MAX)`) is
+                // truncated at the cap instead of panicking with
+                // `capacity overflow` (ANALYSIS §8.2). This matches the cap the
+                // `GenericRange` arm already uses via `value_to_list`.
+                let items = crate::runtime::value_iterator::materialize_capped(
+                    &target,
+                    crate::runtime::utils::MAX_RANGE_EXPAND as usize,
+                );
                 self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
             }
             Value::GenericRange { .. } => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -220,6 +220,7 @@ pub(crate) mod types;
 mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;
+pub(crate) mod value_iterator;
 pub(crate) use self::registration_class::ClassDeclModifiers;
 pub(crate) use self::registry::Registry;
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -8,7 +8,7 @@ use num_integer::Integer;
 use num_traits::{Signed, ToPrimitive, Zero};
 
 /// Maximum number of elements when expanding an infinite range to a list.
-const MAX_RANGE_EXPAND: i64 = 1_000_000;
+pub(crate) const MAX_RANGE_EXPAND: i64 = 1_000_000;
 
 /// Strip a leading UTF-8 BOM (U+FEFF) from a string, as Raku does when reading files.
 pub(crate) fn strip_utf8_bom(s: String) -> String {

--- a/src/runtime/value_iterator.rs
+++ b/src/runtime/value_iterator.rs
@@ -1,0 +1,132 @@
+//! Unified pull-model iterator over `Value` sources.
+//!
+//! This is the skeleton of the lazy-list / Iterator unification (PLAN.md §8.1).
+//! Raku's iteration is pull-based (`Iterator.pull-one` returns the next value or
+//! the `IterationEnd` sentinel). mutsu historically grew ~7 ad-hoc iteration
+//! mechanisms with inconsistent guards, so an infinite `Range` (`1..Inf`, stored
+//! as `Value::Range(1, i64::MAX)`) reaching an unguarded `(a..=b).collect()`
+//! panics the whole process with `capacity overflow` (ANALYSIS §8.2).
+//!
+//! `ValueIterator` is the single place where a `Value` is turned into a stream of
+//! elements pulled one at a time. PR-1 implements the *pure* sources (those that
+//! need no VM/Interpreter callback): integer ranges and already-materialized
+//! slices. Sources that require running bytecode to produce the next element
+//! (gather coroutines, lazy map, sequence specs, string succession, hashes) are
+//! reported by [`ValueIterator::from_value`] returning `None`; the caller then
+//! falls back to the existing `value_to_list`. Later PRs add VM-driven variants
+//! that pull those lazily via the VM's `force_lazy_list_vm_n`.
+
+use crate::value::Value;
+use std::sync::Arc;
+
+/// A pull source over `Value` elements.
+pub(crate) enum ValueIterator {
+    /// Already-materialized elements (Array / Seq / Slip). Shares the source `Arc`.
+    Slice { items: Arc<Vec<Value>>, idx: usize },
+    /// Lazy integer counter. `end == i64::MAX` with `inclusive` represents an
+    /// open-ended (infinite) range and must never be eagerly collected.
+    IntRange { cur: i64, end: i64, inclusive: bool },
+}
+
+impl ValueIterator {
+    /// Build a pull iterator for `val`, or `None` if `val` needs VM/Interpreter
+    /// context (or per-type logic) to enumerate — in which case the caller falls
+    /// back to [`crate::runtime::utils::value_to_list`].
+    ///
+    /// Range-family and already-materialized sequences become pure iterators;
+    /// `LazyList`, `GenericRange`, `Hash` and scalars return `None`.
+    pub(crate) fn from_value(val: &Value) -> Option<ValueIterator> {
+        match val {
+            // Already-materialized sequences: share the backing Arc, no copy.
+            Value::Array(items, kind) if !kind.is_itemized() => Some(ValueIterator::Slice {
+                items: items.clone(),
+                idx: 0,
+            }),
+            Value::Seq(items) | Value::Slip(items) => Some(ValueIterator::Slice {
+                items: items.clone(),
+                idx: 0,
+            }),
+            // Integer ranges: lazy counters. The only sources that can be
+            // infinite via `i64::MAX` and thus the crash vector we must guard.
+            Value::Range(a, b) => Some(ValueIterator::IntRange {
+                cur: *a,
+                end: *b,
+                inclusive: true,
+            }),
+            Value::RangeExcl(a, b) => Some(ValueIterator::IntRange {
+                cur: *a,
+                end: *b,
+                inclusive: false,
+            }),
+            Value::RangeExclStart(a, b) => Some(ValueIterator::IntRange {
+                cur: *a + 1,
+                end: *b,
+                inclusive: true,
+            }),
+            Value::RangeExclBoth(a, b) => Some(ValueIterator::IntRange {
+                cur: *a + 1,
+                end: *b,
+                inclusive: false,
+            }),
+            // LazyList, GenericRange, Hash, scalars, ...: need the interpreter/VM
+            // or per-type logic to enumerate. Defer to value_to_list.
+            _ => None,
+        }
+    }
+
+    /// Pull the next value, or `None` when the source is exhausted.
+    pub(crate) fn pull_one(&mut self) -> Option<Value> {
+        match self {
+            ValueIterator::Slice { items, idx } => {
+                let v = items.get(*idx).cloned()?;
+                *idx += 1;
+                Some(v)
+            }
+            ValueIterator::IntRange {
+                cur,
+                end,
+                inclusive,
+            } => {
+                let in_bounds = if *inclusive {
+                    *cur <= *end
+                } else {
+                    *cur < *end
+                };
+                if !in_bounds {
+                    return None;
+                }
+                let v = Value::Int(*cur);
+                match cur.checked_add(1) {
+                    Some(next) => *cur = next,
+                    // Reached i64::MAX: make the next pull terminate.
+                    None => *inclusive = false,
+                }
+                Some(v)
+            }
+        }
+    }
+}
+
+/// Materialize `val` to a `Vec`, truncating at `cap` elements.
+///
+/// This is the single guarded expansion point for the pure pull sources: an
+/// infinite integer `Range` (`b == i64::MAX`) is truncated at `cap` instead of
+/// panicking with `capacity overflow`. Sources that need VM/Interpreter context
+/// (where [`ValueIterator::from_value`] returns `None`) fall back to the existing
+/// [`crate::runtime::utils::value_to_list`], which has its own per-type guards.
+///
+/// Later PRs will replace the fallback with real VM-driven pulls and route the
+/// remaining unguarded `(a..=b).collect()` sites here (PLAN.md §8.2).
+pub(crate) fn materialize_capped(val: &Value, cap: usize) -> Vec<Value> {
+    let Some(mut it) = ValueIterator::from_value(val) else {
+        return crate::runtime::utils::value_to_list(val);
+    };
+    let mut out = Vec::new();
+    while let Some(v) = it.pull_one() {
+        if out.len() >= cap {
+            break;
+        }
+        out.push(v);
+    }
+    out
+}

--- a/t/grep-lazy-range.t
+++ b/t/grep-lazy-range.t
@@ -1,0 +1,29 @@
+use Test;
+
+# grep over an infinite Range (1..Inf == Range(1, i64::MAX)) must stay lazy
+# enough to be subscripted/headed without panicking with `capacity overflow`
+# (ANALYSIS §8.2 / PLAN.md §8.1 pull-model unification).
+
+plan 10;
+
+# Method form
+is (1..Inf).grep(* %% 2)[^3].join(','), '2,4,6', 'method grep on 1..Inf, subscript ^3';
+is (1..Inf).grep(* %% 2).head(3).join(','), '2,4,6', 'method grep on 1..Inf, .head(3)';
+is (1..Inf).grep(*.is-prime)[^5].join(','), '2,3,5,7,11', 'method grep is-prime on 1..Inf';
+
+# Sub form
+is grep(* %% 2, 1..Inf)[^3].join(','), '2,4,6', 'sub grep on 1..Inf, subscript ^3';
+is grep(*.is-prime, 1..Inf)[^5].join(','), '2,3,5,7,11', 'sub grep is-prime on 1..Inf';
+
+# Finite ranges must be unchanged (no regression)
+is (1..10).grep(* %% 2).join(','), '2,4,6,8,10', 'finite method grep';
+is grep(* %% 2, 1..10).join(','), '2,4,6,8,10', 'finite sub grep';
+
+# Exclusive range endpoints
+is (1..^10).grep(* %% 2).join(','), '2,4,6,8', 'half-open range grep';
+is (1^..^10).grep(* %% 2).join(','), '2,4,6,8', 'open range grep';
+
+# :k adverb on finite range
+is (1..10).grep(* %% 2, :k).join(','), '1,3,5,7,9', 'grep :k indices on finite range';
+
+done-testing;


### PR DESCRIPTION
## Context

`(1..Inf).grep(* %% 2)[^3]` and the sub form `grep(* %% 2, 1..Inf)[^3]` **panicked the whole process** with `capacity overflow` (exit 101). grep's `Value::Range(a, b)` arms eagerly ran `(a..=b).map(Value::Int).collect()`, expanding to `i64::MAX` (`1..Inf` is stored as `Range(1, i64::MAX)`). `map`/`head`/`first` survive only because they route through `value_to_list`, which caps the expansion; grep's direct collect bypassed every guard (ANALYSIS §8.1/§8.2).

This is **PR-1 (the wedge)** of the lazy-list / Iterator pull-model unification (PLAN.md §8.1).

## What this does

- **New module `runtime::value_iterator`** — the skeleton of the pull model. `ValueIterator` turns a `Value` into a stream pulled one element at a time. PR-1 implements the *pure* sources (integer ranges + already-materialized slices). VM-needing sources (LazyList, GenericRange, gather coroutines) return `None` from `from_value` and fall back to `value_to_list`; later PRs add VM-driven pulls.
- **`materialize_capped()`** — the single guarded expansion point. An open-ended range is truncated at the cap instead of panicking, matching the cap the `GenericRange` grep arm already uses.
- **grep routed through it** — both the method form (`methods_collection_ops/grep.rs`) and sub form (`builtins_collection.rs`). The 4 separate Range arms in the method form collapse to one.

map / first / for-loop paths are **intentionally untouched** (deferred to PR-2/3/4) to keep blast radius minimal.

## Verification

```
$ ./target/debug/mutsu -e 'say (1..Inf).grep(* %% 2)[^3]'      # (2 4 6)  was: panic exit 101
$ ./target/debug/mutsu -e 'say grep(* %% 2, 1..Inf)[^3]'       # (2 4 6)
$ ./target/debug/mutsu -e 'say (1..Inf).grep(*.is-prime)[^5]'  # (2 3 5 7 11)
```

- New pin test `t/grep-lazy-range.t` (10 subtests, all pass).
- `make test` green (cargo 458 passed / prove PASS).
- `roast/S03-sequence/basic.t`, `roast/S07-iterators/range-iterator.t` pass. `gather.t` fails only on its pre-existing test 38 (take-rw container identity, BLOCKERS.md), unrelated and not whitelisted.

## Follow-ups (not in this PR)
- PR-2: map/grep/first onto the iterator.
- PR-3: for-loop dispatch onto the iterator (preserve fast paths).
- PR-4: sweep the remaining ~43 unguarded `(a..=b).collect()` sites (§8.2), including the map/first sub-form arms in this same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)