### PR TITLE
feat(exceptions): X::Parameter::Default for default on required/slurpy params

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -144,6 +144,17 @@ fn default_type_matches_constraint(
     }
 }
 
+/// Reconstruct a parameter's display name with its sigil. Array/hash/code
+/// parameters already store the sigil in `name` (e.g. `@x`, `%x`); scalar
+/// parameters store the bare name (e.g. `x`) and get a `$` prefix.
+fn param_display_name(name: &str) -> String {
+    if name.starts_with(['@', '%', '&']) {
+        name.to_string()
+    } else {
+        format!("${}", name)
+    }
+}
+
 pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PError> {
     let mut saw_optional_positional = false;
     let mut saw_named = false;
@@ -168,6 +179,43 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
             return Err(PError::fatal(
                 "X::Trait::Invalid: Cannot make an 'is rw' parameter optional".to_string(),
             ));
+        }
+        // X::Parameter::Default: a default value is illegal on a slurpy parameter
+        // (`*@a = 2`, `*@ = 2`) or a required parameter (`$x! = 3`, `:$x! = 3`).
+        if pd.default.is_some() {
+            let is_slurpy = pd.slurpy || pd.double_slurpy || pd.onearg;
+            if is_slurpy || pd.required {
+                let (how, parameter, message) = if is_slurpy {
+                    let anonymous = pd.name.contains("__ANON_");
+                    let param = if anonymous {
+                        String::new()
+                    } else {
+                        param_display_name(&pd.name)
+                    };
+                    let message = if anonymous {
+                        "Cannot put default on anonymous slurpy parameter".to_string()
+                    } else {
+                        format!("Cannot put default on slurpy parameter {}", param)
+                    };
+                    ("slurpy", param, message)
+                } else {
+                    let param = param_display_name(&pd.name);
+                    let message = format!("Cannot put default on required parameter {}", param);
+                    ("required", param, message)
+                };
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("how".to_string(), crate::value::Value::str(how.to_string()));
+                attrs.insert("parameter".to_string(), crate::value::Value::str(parameter));
+                attrs.insert(
+                    "message".to_string(),
+                    crate::value::Value::str(message.clone()),
+                );
+                let ex = crate::value::Value::make_instance(
+                    crate::symbol::Symbol::intern("X::Parameter::Default"),
+                    attrs,
+                );
+                return Err(PError::fatal_with_exception(message, Box::new(ex)));
+            }
         }
         if let (Some(constraint), Some(default_expr)) = (&pd.type_constraint, &pd.default)
             && let Some(default_type) = static_default_type(default_expr)

--- a/t/parameter-default.t
+++ b/t/parameter-default.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 9;
+
+# X::Parameter::Default: default value on a required parameter
+throws-like 'sub f($x! = 3) { }', X::Parameter::Default,
+    how => 'required', parameter => '$x';
+throws-like 'sub f(:$x! = 3) { }', X::Parameter::Default,
+    how => 'required';
+throws-like 'sub f(@x! = [1]) { }', X::Parameter::Default,
+    how => 'required', parameter => '@x';
+throws-like 'sub f(%x! = {}) { }', X::Parameter::Default,
+    how => 'required', parameter => '%x';
+
+# X::Parameter::Default: default value on an anonymous slurpy parameter
+throws-like 'sub f(*@ = 2) { }', X::Parameter::Default,
+    how => 'slurpy', parameter => *.not;
+throws-like 'sub f(*% = 2) { }', X::Parameter::Default,
+    how => 'slurpy', parameter => *.not;
+
+# X::Parameter::Default: default value on a named slurpy parameter
+throws-like 'sub f(*@a = 2) { }', X::Parameter::Default,
+    how => 'slurpy', parameter => '@a';
+
+# Valid signatures must NOT throw
+lives-ok { my &f = sub ($x = 3) { $x } }, 'optional positional default is fine';
+lives-ok { my &g = sub (*@a) { @a.elems } }, 'slurpy without default is fine';


### PR DESCRIPTION
A signature parameter may not carry a default value when it is required
(`$x! = 3`, `:$x! = 3`) or slurpy (`*@a = 2`, `*@ = 2`, `*% = 2`). mutsu
previously accepted these silently; Raku rejects them at compile time with
X::Parameter::Default.

`validate_signature_params` now throws a structured X::Parameter::Default
exception carrying:
- `how`: 'required' or 'slurpy'
- `parameter`: the parameter's display name with sigil ('$x', '@a'), or ''
  for an anonymous slurpy
- `message`: rakudo-matching text ("Cannot put default on required parameter
  $x" / "... on slurpy parameter @a" / "... on anonymous slurpy parameter")

Fixes 3 subtests in roast/S32-exceptions/misc2.t (88 -> 85 failing).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
