### PR TITLE
fix(lazy): route sub-form map/first over Range through pull iterator (§8.1 PR-2)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1370,12 +1370,15 @@ impl Interpreter {
                             list_items.push(Value::Pair(k.clone(), Box::new(v.clone())));
                         }
                     }
-                    Value::Range(a, b) => list_items.extend((*a..=*b).map(Value::Int)),
-                    Value::RangeExcl(a, b) => list_items.extend((*a..*b).map(Value::Int)),
-                    Value::RangeExclStart(a, b) => list_items.extend((*a + 1..=*b).map(Value::Int)),
-                    Value::RangeExclBoth(a, b) => list_items.extend((*a + 1..*b).map(Value::Int)),
                     v if v.is_range() => {
-                        list_items.extend(crate::runtime::utils::value_to_list(v));
+                        // Route ranges through the unified pull iterator so an
+                        // open-ended range (`1..Inf` == `Range(1, i64::MAX)`) is
+                        // truncated at the cap instead of panicking with
+                        // `capacity overflow` (ANALYSIS §8.2).
+                        list_items.extend(crate::runtime::value_iterator::materialize_capped(
+                            v,
+                            crate::runtime::utils::MAX_RANGE_EXPAND as usize,
+                        ));
                     }
                     other => list_items.push(other.clone()),
                 }
@@ -1670,10 +1673,15 @@ impl Interpreter {
         for arg in positional.iter().skip(1) {
             match arg {
                 Value::Array(items, ..) => list_items.extend(items.iter().cloned()),
-                Value::Range(a, b) => list_items.extend((*a..=*b).map(Value::Int)),
-                Value::RangeExcl(a, b) => list_items.extend((*a..*b).map(Value::Int)),
                 v if v.is_range() => {
-                    list_items.extend(crate::runtime::utils::value_to_list(v));
+                    // Route ranges through the unified pull iterator so an
+                    // open-ended range (`1..Inf` == `Range(1, i64::MAX)`) is
+                    // truncated at the cap instead of panicking with
+                    // `capacity overflow` (ANALYSIS §8.2).
+                    list_items.extend(crate::runtime::value_iterator::materialize_capped(
+                        v,
+                        crate::runtime::utils::MAX_RANGE_EXPAND as usize,
+                    ));
                 }
                 other => list_items.push(other.clone()),
             }

--- a/t/map-first-lazy-range.t
+++ b/t/map-first-lazy-range.t
@@ -1,0 +1,26 @@
+use Test;
+
+# Sub-form map()/first() over an infinite Range (1..Inf == Range(1, i64::MAX))
+# must not panic with `capacity overflow` — they share grep's unified pull
+# iterator now (PLAN.md §8.1 PR-2).
+
+plan 9;
+
+# Sub-form map on infinite range
+is map(* * 2, 1..Inf)[^3].join(','), '2,4,6', 'sub map on 1..Inf, subscript ^3';
+is map(* * 2, 1..Inf).head(4).join(','), '2,4,6,8', 'sub map on 1..Inf, .head(4)';
+
+# Sub-form first on infinite range (short-circuits to the first match)
+is first(* > 5, 1..Inf), 6, 'sub first(* > 5) on 1..Inf';
+is first(*.is-prime, 1..Inf), 2, 'sub first(is-prime) on 1..Inf';
+
+# Finite ranges unchanged (no regression)
+is map(* * 2, 1..5).join(','), '2,4,6,8,10', 'finite sub map';
+is map(* + 1, 1..^5).join(','), '2,3,4,5', 'finite sub map half-open range';
+is first(* > 2, 1..10), 3, 'finite sub first';
+is first(* %% 3, (2, 4, 6, 9)), 6, 'sub first over plain list';
+
+# Method-form first on infinite range still works
+is (1..Inf).first(* > 100), 101, 'method first on 1..Inf';
+
+done-testing;


### PR DESCRIPTION
## Context

Follow-up to #2791 (PR-1). After PR-1 fixed `grep`, the **sub (function) forms** of `map` and `first` still panicked the whole process with `capacity overflow` (exit 101) on an infinite range:

```
$ ./target/debug/mutsu -e 'say map(* * 2, 1..Inf)[^3]'   # was: panic exit 101
$ ./target/debug/mutsu -e 'say first(* > 5, 1..Inf)'      # was: panic exit 101
```

`builtin_map` and `builtin_first` still expanded `Value::Range(a, b)` eagerly via `(a..=b).map(Value::Int)` to `i64::MAX` (`1..Inf` == `Range(1, i64::MAX)`).

This is **PR-2** of the lazy-list / Iterator pull-model unification (PLAN.md §8.1).

## What this does

- Routes `builtin_map` and `builtin_first` Range arms through `value_iterator::materialize_capped` (introduced in PR-1) — the same unified pull helper `grep` now uses. The per-range-kind arms (`Range` / `RangeExcl` / `RangeExclStart` / `RangeExclBoth` / `value_to_list` fallback) collapse into one `is_range()` arm.
- `first` over an infinite range materializes up to the cap and returns the first match (correct result). A truly-lazy short-circuit for the **sub** form is a follow-up; the **method** form `(1..Inf).first(...)` already short-circuits.
- The method forms (`(1..Inf).map`/`.first`) already route through the capped `value_to_list` and are **intentionally left untouched** (avoids regressing the `ArrayKind::Lazy` marking / shaped-array handling).

## Verification

```
$ ./target/debug/mutsu -e 'say map(* * 2, 1..Inf)[^3]'      # (2 4 6)
$ ./target/debug/mutsu -e 'say first(* > 5, 1..Inf)'         # 6
$ ./target/debug/mutsu -e 'say first(*.is-prime, 1..Inf)'    # 2
```

All match `raku`. New pin test `t/map-first-lazy-range.t` (9 subtests). `make test` green (cargo 458 / prove PASS), clippy/fmt clean.

## Follow-ups (not in this PR)
- PR-3: for-loop dispatch onto the iterator (preserve fast paths).
- PR-4: sweep the remaining ~43 unguarded `(a..=b).collect()` sites (§8.2); truly-lazy short-circuit for sub-form `first`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)