### PR TITLE
feat(exceptions): X::Assignment::RO for assigning to an immutable literal

### DIFF
--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1117,9 +1117,20 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             return parse_statement_modifier(r, stmt);
         }
         let stmt = match expr {
-            Expr::Literal(_) | Expr::BareWord(_) => {
-                Stmt::Block(vec![Stmt::Expr(expr), Stmt::Expr(rhs)])
-            }
+            // Assigning to an immutable literal (`120 = 3`, `"a" = 3`, `1.0 = 3`)
+            // is illegal: Raku throws X::Assignment::RO. Pass the literal to
+            // `__mutsu_assignment_ro` so it can report the value's type and repr.
+            Expr::Literal(_) => Stmt::Expr(Expr::DoBlock {
+                body: vec![
+                    Stmt::Expr(rhs),
+                    Stmt::Expr(Expr::Call {
+                        name: Symbol::intern("__mutsu_assignment_ro"),
+                        args: vec![expr],
+                    }),
+                ],
+                label: None,
+            }),
+            Expr::BareWord(_) => Stmt::Block(vec![Stmt::Expr(expr), Stmt::Expr(rhs)]),
             Expr::SymbolicDeref { sigil, expr: inner } => Stmt::Expr(Expr::SymbolicDerefAssign {
                 sigil,
                 expr: inner,

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -408,7 +408,15 @@ impl Interpreter {
         self.assign_callable_lvalue_with_values(callable, call_args, value)
     }
 
-    pub(super) fn builtin_assignment_ro(&mut self, _args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_assignment_ro(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // When the read-only left-hand side value is supplied (e.g. assigning to
+        // a literal `120 = 3`), report its type and representation to match
+        // rakudo: "Cannot modify an immutable Int (120)".
+        if let Some(lhs) = args.first() {
+            let typename = crate::runtime::utils::value_type_name(lhs);
+            let repr = lhs.to_string_value();
+            return Err(RuntimeError::assignment_ro_typename(typename, &repr));
+        }
         Err(RuntimeError::assignment_ro(None))
     }
 

--- a/t/assignment-ro-literal.t
+++ b/t/assignment-ro-literal.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 8;
+
+# Assigning to an immutable literal must throw X::Assignment::RO
+# with a rakudo-matching "Cannot modify an immutable <Type> (<repr>)" message.
+throws-like '120 = 3', X::Assignment::RO,
+    message => /'Cannot modify an immutable Int (120)'/;
+throws-like '1.0 = 3', X::Assignment::RO,
+    message => /'Cannot modify an immutable Rat (1)'/;
+throws-like '1e0 = 3', X::Assignment::RO,
+    message => /'Cannot modify an immutable Num (1)'/;
+throws-like '"a" = 3', X::Assignment::RO,
+    message => /'Cannot modify an immutable Str (a)'/;
+
+# Assigning to the return value of a non-rw sub is also read-only.
+throws-like 'sub f() { 42 }; f() = 3', X::Assignment::RO;
+
+# Negative cases: real assignments must still work.
+lives-ok { my $x = 1; $x = 2 }, 'scalar assignment is fine';
+lives-ok { my @a = 1, 2; @a[0] = 9 }, 'array element assignment is fine';
+lives-ok { my %h; %h<k> = 5 }, 'hash element assignment is fine';


### PR DESCRIPTION
Assigning to an immutable literal (`120 = 3`, `1.0 = 3`, `1e0 = 3`,
`"a" = 3`) is illegal in Raku, which throws X::Assignment::RO with
"Cannot modify an immutable <Type> (<repr>)". mutsu previously parsed
such statements into a silent two-expression block that evaluated both
sides and discarded the result, raising no error.

The generic non-variable assignment handler now routes a literal LHS to
`__mutsu_assignment_ro`, passing the literal value so the builtin can
report the value's type and representation via assignment_ro_typename
(e.g. "Cannot modify an immutable Int (120)"), matching rakudo. BareWord
LHS keeps its previous behaviour.

Fixes 4 subtests in roast/S32-exceptions/misc2.t (88 -> 84 failing).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
