### PR TITLE
fix(lazy): throw X::Cannot::Lazy for eager ops on infinite/lazy sources (§8.1 PR-4)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -258,6 +258,12 @@ fn native_function_0arg(name: &str) -> Option<Result<Value, RuntimeError>> {
 }
 
 fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, RuntimeError>> {
+    // Eager list operations (combinations/permutations/...) cannot run on a
+    // lazy/infinite source: throw X::Cannot::Lazy instead of hanging while
+    // generating an unbounded result. Shared with the method-dispatch paths.
+    if let Some(err) = crate::runtime::Interpreter::lazy_guard_error(name, arg) {
+        return Some(Err(err));
+    }
     match name {
         "combinations" => {
             // combinations($n) where $n is Int => (^$n).combinations (powerset)

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1190,6 +1190,13 @@ impl Interpreter {
             }
         }
 
+        // A lazy/infinite source cannot be sorted: throw X::Cannot::Lazy instead
+        // of materializing it (matches raku). The comparator (a Sub) is never
+        // lazy, so scanning all positionals is safe.
+        if positional.iter().any(Self::is_lazy_for_coerce) {
+            return Err(RuntimeError::cannot_lazy("sort"));
+        }
+
         // sort(comparator, list, ...) or sort(list, ...) or sort(items...)
         if positional.len() >= 2 {
             let first = &positional[0];

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -338,6 +338,12 @@ impl Interpreter {
             }
             return self.call_method_with_values(*inner, method, args);
         }
+        // Operations that need the full (finite) list cannot run on a lazy or
+        // infinite source: throw X::Cannot::Lazy instead of hanging while
+        // materializing it, matching raku.
+        if let Some(err) = Self::lazy_guard_error(method, &target) {
+            return Err(err);
+        }
         // Seq deferred iterator handling: Seq.new(iterator) stores the iterator
         // without pulling. When a method is called on such a Seq, materialize the
         // items first by pulling from the iterator.

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -178,6 +178,25 @@ impl Interpreter {
         }
     }
 
+    /// Operations that need the full (finite) list cannot run on a lazy or
+    /// infinite source. Returns `Some(X::Cannot::Lazy)` when `method` is such an
+    /// operation and `target` is lazy/infinite, else `None`. Matches raku, which
+    /// throws rather than hanging while materializing the whole sequence.
+    /// `.head`/`.first`/`.map`/`[]` handle laziness and are NOT listed here.
+    pub(crate) fn lazy_guard_error(method: &str, target: &Value) -> Option<RuntimeError> {
+        if !Self::is_lazy_for_coerce(target) {
+            return None;
+        }
+        match method {
+            "classify" | "categorize" => Some(RuntimeError::cannot_lazy_with_action(
+                method,
+                "Hash[Any,Mu]",
+            )),
+            "sort" | "combinations" | "permutations" => Some(RuntimeError::cannot_lazy(method)),
+            _ => None,
+        }
+    }
+
     fn is_infinite_endpoint(v: &Value) -> bool {
         match v {
             Value::Num(n) => n.is_infinite(),

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -20,6 +20,14 @@ impl VM {
             }
         }
         let method_name = method_sym.resolve();
+        // Eager list operations cannot run on a lazy/infinite source: throw
+        // X::Cannot::Lazy instead of hanging while the native impl materializes
+        // it (matches raku). Shared with the interpreter dispatch path.
+        if let Some(err) =
+            crate::runtime::Interpreter::lazy_guard_error(method_name.as_str(), target)
+        {
+            return Some(Err(err));
+        }
         // Early exit for Proxy containers
         if matches!(target, Value::Proxy { .. })
             && !matches!(

--- a/t/eager-ops-cannot-lazy.t
+++ b/t/eager-ops-cannot-lazy.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Eager list operations that need the full (finite) list must throw
+# X::Cannot::Lazy on a lazy/infinite source instead of hanging while
+# materializing it (PLAN.md §8.1 / §8.2, matches raku). `.head`/`.first`/`.map`
+# stay lazy and are NOT affected.
+
+plan 18;
+
+# --- method form on infinite Range: throws X::Cannot::Lazy ---
+throws-like { (1..Inf).sort },         X::Cannot::Lazy, 'method sort on 1..Inf';
+throws-like { (1..Inf).combinations }, X::Cannot::Lazy, 'method combinations on 1..Inf';
+throws-like { (1..Inf).permutations }, X::Cannot::Lazy, 'method permutations on 1..Inf';
+throws-like { (1..Inf).classify(* %% 2) },   X::Cannot::Lazy, 'method classify on 1..Inf';
+throws-like { (1..Inf).categorize(* %% 2) }, X::Cannot::Lazy, 'method categorize on 1..Inf';
+
+# --- infinite sequence (LazyList) ---
+throws-like { (1, 2, 4 ... Inf).sort }, X::Cannot::Lazy, 'method sort on infinite sequence';
+
+# --- sub form ---
+throws-like { sort(1..Inf) },         X::Cannot::Lazy, 'sub sort on 1..Inf';
+throws-like { combinations(1..Inf) }, X::Cannot::Lazy, 'sub combinations on 1..Inf';
+throws-like { permutations(1..Inf) }, X::Cannot::Lazy, 'sub permutations on 1..Inf';
+
+# --- finite inputs are completely unaffected (no regression) ---
+is (3, 1, 2).sort.join(','), '1,2,3', 'finite method sort';
+is sort(3, 1, 2).join(','), '1,2,3', 'finite sub sort';
+is (1..3).combinations.elems, 8, 'finite combinations';
+is (1..3).permutations.elems, 6, 'finite permutations';
+is (1..6).classify(* %% 2){True}.join(','), '2,4,6', 'finite classify';
+is <c a b>.sort.join(','), 'a,b,c', 'finite string sort';
+
+# --- finite-but-lazy-origin sources still work (gather/map/Seq force fine) ---
+is (gather { take 3; take 1; take 2 }).sort.join(','), '1,2,3', 'finite gather sort';
+is (1..5).map(* * 2).sort.join(','), '2,4,6,8,10', 'finite lazy-map sort';
+is (1, 2, 3 ... 6).sort.join(','), '1,2,3,4,5,6', 'finite sequence sort';
+
+done-testing;


### PR DESCRIPTION
## Context

Continuation of the lazy-list / pull-model work (#2791 PR-1, #2793 PR-2). While probing the remaining §8.2 sites, the reachable bugs turned out to be **hangs / wrong results on eager operations**, not raw `capacity overflow` crashes (those are handled by PR-1/PR-2 + the existing `value_to_list` caps):

```
$ ./target/debug/mutsu -e 'say (1..Inf).combinations'   # was: HANG (2^∞ results)
$ ./target/debug/mutsu -e 'say (1..Inf).permutations'   # was: HANG
$ ./target/debug/mutsu -e 'say (1..Inf).classify(* %% 2)' # was: HANG
$ ./target/debug/mutsu -e 'say (1..Inf).sort'           # was: wrongly sorted capped 1M
```

`sort` / `combinations` / `permutations` / `classify` / `categorize` need the full finite list; raku throws **X::Cannot::Lazy** for all of them on a lazy/infinite source. mutsu hung or returned a wrong answer.

### Why not PR-3 (for-loop pull-ization)?

I assessed PR-3 (the planned next step) and **deprioritized it after measurement**: the crash is already gone, and the for-loop is already truly lazy on its hot arity-1 path (`for 1..Inf { last }` = 0.01s). A full rewrite of the VM's hottest path to make rare fallback patterns (`for 1..Inf -> \$a,\$b`) lazy is high-risk for perf-only gains. This PR instead fixes the **reachable correctness bugs** surfaced while probing §8.2.

## What this does

Adds `Interpreter::lazy_guard_error(method, target)` next to the existing `is_lazy_for_coerce` detector — returns `Some(X::Cannot::Lazy)` when an eager-only method meets a lazy/infinite source. Wired into every dispatch choke point so **both method and sub forms** are covered:

| path | covers |
|---|---|
| `call_method_with_values` (interp slow path) | `.classify` / `.categorize` |
| VM `try_native_method` (native fast path) | `.sort` / `.combinations` / `.permutations` |
| `native_function_1arg` | sub-form `combinations` / `permutations` |
| `builtin_sort` | sub-form `sort` |

`.head` / `.first` / `.map` / `[]` stay lazy and are **not** guarded. Finite inputs — including finite-but-lazy-origin gather/map/Seq/sequence, which force fine — are unaffected.

## Verification

```
$ ./target/debug/mutsu -e '(1..Inf).sort'            # X::Cannot::Lazy (catchable)
$ ./target/debug/mutsu -e 'sort(1..Inf)'             # X::Cannot::Lazy
$ ./target/debug/mutsu -e 'say (3,1,2).sort'         # (1 2 3)  unaffected
$ ./target/debug/mutsu -e 'say (gather {take 3; take 1}).sort'  # (1 3)  finite lazy-origin OK
```

- New pin test `t/eager-ops-cannot-lazy.t` (18 cases, throws-like X::Cannot::Lazy + no-regression).
- `make test` green (cargo 458 / prove PASS), clippy/fmt clean.
- `roast/S32-list/sort.t` PASS, `roast/S02-types/lazy-lists.t` PASS. `classify.t`'s pre-existing Junction failure is unrelated (confirmed identical on main; not whitelisted).

## Known limitation (out of scope)
`gather { loop { take ... } }.sort/.elems` still hangs — an infinite **coroutine** gather is force-materialized by the VM before the method guard runs (`.elems` hangs too, despite its own guard). That belongs to the deferred VM-driven-pull work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)