### PR TITLE
fix(exceptions): X::Numeric::Real.target should be a type object

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -595,7 +595,7 @@ pub(crate) fn value_is_prime(target: &Value) -> Result<Value, RuntimeError> {
                     }
                 )),
             );
-            attrs.insert("target".to_string(), Value::str_from("Real"));
+            attrs.insert("target".to_string(), Value::Package(Symbol::intern("Real")));
             attrs.insert("source".to_string(), target.clone());
             let ex = Value::make_instance(Symbol::intern("X::Numeric::Real"), attrs);
             let mut err =

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -594,7 +594,8 @@ pub(super) fn dispatch(
                                 "Cannot convert Complex to Real: imaginary part not zero",
                             ),
                         );
-                        ex_attrs.insert("target".to_string(), Value::str_from("Real"));
+                        ex_attrs
+                            .insert("target".to_string(), Value::Package(Symbol::intern("Real")));
                         ex_attrs.insert("source".to_string(), target.clone());
                         let ex = Value::make_instance(Symbol::intern("X::Numeric::Real"), ex_attrs);
                         let mut failure_attrs = std::collections::HashMap::new();

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -73,7 +73,10 @@ impl Interpreter {
                         );
                         let mut attrs = std::collections::HashMap::new();
                         attrs.insert("message".to_string(), Value::str(msg.clone()));
-                        attrs.insert("target".to_string(), Value::str_from("Num"));
+                        attrs.insert(
+                            "target".to_string(),
+                            Value::Package(crate::symbol::Symbol::intern("Num")),
+                        );
                         attrs.insert("source".to_string(), value.clone());
                         let ex = Value::make_instance(
                             crate::symbol::Symbol::intern("X::Numeric::Real"),

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -283,7 +283,7 @@ impl Interpreter {
             );
             let mut attrs = std::collections::HashMap::new();
             attrs.insert("message".to_string(), Value::str(msg.clone()));
-            attrs.insert("target".to_string(), Value::str_from("Num"));
+            attrs.insert("target".to_string(), Value::Package(Symbol::intern("Num")));
             attrs.insert("source".to_string(), target.clone());
             let ex = Value::make_instance(Symbol::intern("X::Numeric::Real"), attrs);
             let mut err = RuntimeError::new(msg);

--- a/t/numeric-real-target.t
+++ b/t/numeric-real-target.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 6;
+
+# X::Numeric::Real carries the target type as a *type object* so that
+# `target => Num` / `target => Real` matchers in throws-like succeed.
+throws-like 'use fatal; (1+2i).Num',  X::Numeric::Real, target => Num;
+throws-like 'use fatal; (1+2i).Real', X::Numeric::Real, target => Real;
+
+# The exception is still thrown (without explicit matcher) and stringifies.
+throws-like '(3+4i).Num', X::Numeric::Real;
+throws-like '(3+4i).Real', X::Numeric::Real;
+
+# A Complex with a zero imaginary part coerces cleanly.
+is (5+0i).Num, 5e0, 'real Complex coerces to Num';
+is (7+0i).Real, 7, 'real Complex coerces to Real';


### PR DESCRIPTION
The `target` attribute of X::Numeric::Real was stored as a plain string
("Num" / "Real"). Raku exposes it as the target *type object*, so
`throws-like ..., X::Numeric::Real, target => Num` (which matches the
attribute against the `Num` type object via `~~`) failed even though the
right exception was thrown.

Store `target` as `Value::Package(Num/Real)` at the four X::Numeric::Real
construction sites (Complex.Num / Complex.Real coercion across the native
bypass, builtins_coerce, dispatch_core_coerce, and the is-prime path), so
the throws-like type-object matcher (`what_type_name(actual) == expected`)
succeeds.

Fixes 2 subtests in roast/S32-exceptions/misc2.t (77 -> 75 failing).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
