### PR TITLE
feat(exceptions): X::Bind::ZenSlice for binding to a zen slice

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2226,6 +2226,14 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     rest = after;
                     continue;
                 }
+                // Binding to an array zen slice (`@a[] := ...`) is illegal; keep
+                // the ZenSlice wrapper so the bind site can raise
+                // X::Bind::ZenSlice instead of silently dropping the subscript.
+                if r_adv.starts_with(":=") || r_adv.starts_with("::=") {
+                    expr = Expr::ZenSlice(Box::new(expr));
+                    rest = after;
+                    continue;
+                }
                 rest = after;
                 continue;
             }

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1265,6 +1265,28 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             let stmt = Stmt::SyntheticBlock(stmts);
             return parse_statement_modifier(r, stmt);
         }
+        // Reject binding to a zen slice: `@a[] := ...` / `%a{} := ...` → X::Bind::ZenSlice
+        if let Expr::ZenSlice(inner) = &expr {
+            let type_name = match inner.as_ref() {
+                Expr::HashVar(_) => "Hash",
+                _ => "Array",
+            };
+            let message = format!("Cannot bind to {} zen slice", type_name);
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Bind::ZenSlice"),
+                std::collections::HashMap::from([
+                    (
+                        "type".to_string(),
+                        crate::value::Value::Package(crate::symbol::Symbol::intern(type_name)),
+                    ),
+                    (
+                        "message".to_string(),
+                        crate::value::Value::str(message.clone()),
+                    ),
+                ]),
+            );
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
         // Reject binding to a literal: `0 := 1` → X::Bind
         if is_literal_expr(&expr) {
             let ex = crate::value::Value::make_instance(

--- a/t/bind-zen-slice.t
+++ b/t/bind-zen-slice.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 6;
+
+# Binding to a zen slice (`@a[]` / `%a{}`) is illegal: X::Bind::ZenSlice.
+throws-like 'my @a; @a[] := <foo bar baz>', X::Bind::ZenSlice, type => Array;
+throws-like 'my %a; %a{} := foo=>1, bar=>2, baz=>3', X::Bind::ZenSlice, type => Hash;
+throws-like 'my @a; @a[] := 1', X::Bind::ZenSlice;
+throws-like 'my %h; %h{} := 1', X::Bind::ZenSlice;
+
+# Ordinary container binding must still work (not a zen slice).
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    is @b.elems, 3, 'plain array binding still works';
+}
+{
+    my %h = a => 1;
+    my %g := %h;
+    is %g<a>, 1, 'plain hash binding still works';
+}


### PR DESCRIPTION
Binding to a zen slice (`@a[] := ...`, `%a{} := ...`) is illegal in Raku,
which throws X::Bind::ZenSlice ("Cannot bind to Array/Hash zen slice").
mutsu previously parsed these into a silent two-expression block that
evaluated both sides and dropped the subscript, raising no error.

- parser/expr/postfix.rs: an array zen slice `@a[]` normally collapses to
  the bare `@a` (identity on lists); keep the `ZenSlice` wrapper when it is
  immediately followed by `:=`/`::=` so the bind site can detect it. (Hash
  `%a{}` already stays a `ZenSlice`.)
- parser/stmt/simple_expr_stmt.rs: the `:=` bind path now rejects a
  `ZenSlice` LHS with a structured X::Bind::ZenSlice exception carrying
  `type` (the `Array`/`Hash` type object) and the rakudo message.

Plain container binding (`my @b := @a`, `my %g := %h`) is unaffected.

Fixes 2 subtests in roast/S32-exceptions/misc2.t (75 -> 73 failing).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
