### PR TITLE
fix(lazy): pull infinite gather coroutines lazily for .head/.first/index

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1174,6 +1174,11 @@ pub(crate) enum ForLoopResumeState {
         lazy_list: Arc<LazyList>,
         next_index: usize,
     },
+    /// Resume a C-style / `loop` / `while` loop. These loops carry no iteration
+    /// index — their state lives entirely in locals/env — so the marker only
+    /// signals "we suspended inside this loop; re-enter it" and keeps the VM ip
+    /// parked on the loop opcode across a gather coroutine suspend.
+    CStyleLoop,
 }
 
 /// Saved VM state for a suspended gather coroutine.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -356,6 +356,19 @@ impl VM {
         } else {
             target
         };
+        // Lazy `.first` over a gather coroutine: pull incrementally instead of
+        // forcing the (possibly infinite) list to completion.
+        if let Value::LazyList(ref ll) = target
+            && matches!(
+                ll.env.get("__mutsu_lazylist_from_gather"),
+                Some(crate::value::Value::Bool(true))
+            )
+            && method == "first"
+            && let Some(result) = self.try_lazy_gather_first(ll, &args)
+        {
+            self.stack.push(result?);
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && matches!(
                 ll.env.get("__mutsu_lazylist_from_gather"),
@@ -364,7 +377,12 @@ impl VM {
             && Self::lazy_list_needs_forcing(&method)
         {
             let saved_env = self.interpreter.env().clone();
-            let items = self.force_lazy_list_vm(ll)?;
+            // `.head(n)` only needs the first `n` elements: pull them lazily so
+            // an infinite gather does not hang.
+            let items = match Self::gather_head_bound(&method, &args) {
+                Some(n) => self.force_lazy_list_vm_n(ll, n)?,
+                None => self.force_lazy_list_vm(ll)?,
+            };
             if !matches!(method.as_str(), "elems" | "hyper" | "race") {
                 *self.interpreter.env_mut() = saved_env;
             }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -460,6 +460,19 @@ impl VM {
         // Non-gather LazyLists (e.g. from infinite ranges) are NOT forced here — they
         // go through builtins which may return Failure for methods like .elems.
         // Exception: .List and .values on coroutine-equipped gathers preserve laziness.
+        // Lazy `.first` over a gather coroutine: pull incrementally instead of
+        // forcing the (possibly infinite) list to completion.
+        if let Value::LazyList(ref ll) = target
+            && matches!(
+                ll.env.get("__mutsu_lazylist_from_gather"),
+                Some(crate::value::Value::Bool(true))
+            )
+            && method == "first"
+            && let Some(result) = self.try_lazy_gather_first(ll, &args)
+        {
+            self.stack.push(result?);
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && matches!(
                 ll.env.get("__mutsu_lazylist_from_gather"),
@@ -469,7 +482,12 @@ impl VM {
             && !(ll.coroutine.is_some() && matches!(method, "List" | "values"))
         {
             let saved_env = self.interpreter.env().clone();
-            let items = self.force_lazy_list_vm(ll)?;
+            // `.head(n)` only needs the first `n` elements: pull them lazily so
+            // an infinite gather does not hang.
+            let items = match Self::gather_head_bound(method, &args) {
+                Some(n) => self.force_lazy_list_vm_n(ll, n)?,
+                None => self.force_lazy_list_vm(ll)?,
+            };
             if !matches!(method, "elems" | "hyper" | "race") {
                 *self.interpreter.env_mut() = saved_env;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -190,6 +190,16 @@ impl VM {
         };
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
 
+        // When resuming a gather coroutine that suspended inside this loop, the
+        // marker is consumed here; the loop's state lives in locals/env so
+        // re-entering from the top (cond re-check) continues correctly.
+        if matches!(
+            self.gather_for_loop_resume,
+            Some(crate::value::ForLoopResumeState::CStyleLoop)
+        ) {
+            self.gather_for_loop_resume = None;
+        }
+
         // Track loop-body declarations for per-iteration closure capture
         // (owned_captures, incl. `while my $x = ...` condition declarations).
         // Balanced by pop on every exit path.
@@ -290,6 +300,19 @@ impl VM {
                         }
                         break 'body_redo;
                     }
+                    Err(e)
+                        if e.message
+                            == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL =>
+                    {
+                        // Gather coroutine suspend inside a `while`/`until` loop.
+                        // Park a marker so the outer forcer keeps `*ip` on this
+                        // loop opcode (it stays unchanged on this Err path),
+                        // letting us re-enter and continue from locals/env state.
+                        self.gather_for_loop_resume =
+                            Some(crate::value::ForLoopResumeState::CStyleLoop);
+                        self.pop_loop_local_scope(code);
+                        return Err(e);
+                    }
                     Err(e) => {
                         self.pop_loop_local_scope(code);
                         return Err(e);
@@ -315,8 +338,13 @@ impl VM {
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
-        // Check for gather coroutine resume state.
-        if let Some(resume) = self.gather_for_loop_resume.take() {
+        // Check for gather coroutine resume state. A `CStyleLoop` marker belongs
+        // to a `loop`/`while` opcode, not this for-loop, so leave it in place.
+        if !matches!(
+            self.gather_for_loop_resume,
+            Some(crate::value::ForLoopResumeState::CStyleLoop)
+        ) && let Some(resume) = self.gather_for_loop_resume.take()
+        {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;
             match resume {
@@ -367,6 +395,8 @@ impl VM {
                     *ip = loop_end;
                     return Ok(());
                 }
+                // Guarded out above: a CStyleLoop marker is never taken here.
+                crate::value::ForLoopResumeState::CStyleLoop => unreachable!(),
             }
         }
 
@@ -2012,6 +2042,16 @@ impl VM {
         };
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
 
+        // When resuming a gather coroutine that suspended inside this loop, the
+        // marker is consumed here; the loop's actual state lives in locals/env
+        // so re-entering from the top (cond re-check) continues correctly.
+        if matches!(
+            self.gather_for_loop_resume,
+            Some(crate::value::ForLoopResumeState::CStyleLoop)
+        ) {
+            self.gather_for_loop_resume = None;
+        }
+
         // Track loop-body declarations for per-iteration closure capture
         // (owned_captures). Balanced by pop on every exit path.
         self.push_loop_local_scope();
@@ -2069,6 +2109,28 @@ impl VM {
                     }
                     Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
                         break 'body_redo;
+                    }
+                    Err(e)
+                        if e.message
+                            == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL =>
+                    {
+                        // Gather coroutine suspend inside a `loop`/`while`/C-style
+                        // loop. Run this iteration's step now (it would otherwise
+                        // run after the body's normal completion below), so that
+                        // re-entering the loop opcode on resume continues at the
+                        // condition check exactly where normal flow would. Then
+                        // park a marker so the outer forcer keeps `*ip` on this
+                        // loop opcode (it stays unchanged on this Err path).
+                        if let Err(step_err) =
+                            self.run_range(code, step_begin, loop_end, compiled_fns)
+                        {
+                            self.pop_loop_local_scope(code);
+                            return Err(step_err);
+                        }
+                        self.gather_for_loop_resume =
+                            Some(crate::value::ForLoopResumeState::CStyleLoop);
+                        self.pop_loop_local_scope(code);
+                        return Err(e);
                     }
                     Err(e) => {
                         self.pop_loop_local_scope(code);

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -337,6 +337,22 @@ impl VM {
         )
     }
 
+    /// For `.head` on a gather-sourced `LazyList`, return how many leading
+    /// elements need to be produced (so an infinite gather is pulled lazily via
+    /// [`Self::force_lazy_list_vm_n`] instead of forced to completion).
+    /// Returns `None` for forms that need the whole list (e.g. `.head(*-3)`).
+    pub(super) fn gather_head_bound(method: &str, args: &[Value]) -> Option<usize> {
+        if method != "head" {
+            return None;
+        }
+        match args {
+            [] => Some(1),
+            [Value::Int(n)] => Some((*n).max(0) as usize),
+            [Value::Num(f)] => Some((*f as i64).max(0) as usize),
+            _ => None,
+        }
+    }
+
     /// Force a LazyList by running its compiled bytecode in the VM.
     /// Falls back to interpreter if no compiled code is available.
     pub(super) fn force_lazy_list_vm(

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -75,4 +75,62 @@ impl VM {
             Err(e) => Some(Err(e)),
         }
     }
+
+    /// Lazy `.first` over a gather-sourced `LazyList`: pull elements
+    /// incrementally via the coroutine and test the matcher, instead of forcing
+    /// the whole (possibly infinite) list. Returns `Some` when handled, `None`
+    /// to fall back to the eager full-force path (adverbs / `Bool` matcher).
+    pub(super) fn try_lazy_gather_first(
+        &mut self,
+        list: &crate::value::LazyList,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        // Mirror `try_native_first` gating: at most one positional matcher and
+        // no adverbs / `Bool` matcher (those keep interpreter semantics).
+        let mut func: Option<Value> = None;
+        for arg in args {
+            match arg {
+                Value::Pair(..) | Value::Bool(_) => return None,
+                _ if func.is_none() => func = Some(arg.clone()),
+                _ => return None,
+            }
+        }
+
+        // No matcher: `.first` is just the first element.
+        let Some(func) = func else {
+            return match self.force_lazy_list_vm_n(list, 1) {
+                Ok(items) => Some(Ok(items.into_iter().next().unwrap_or(Value::Nil))),
+                Err(e) => Some(Err(e)),
+            };
+        };
+
+        // Pull one element at a time and test it. Pulling singly (rather than in
+        // chunks) keeps the gather body's side effects in step with the match
+        // position, matching Rakudo (`.first(* >= 3)` runs the body exactly as
+        // far as the first match, no further).
+        let mut idx = 0usize;
+        loop {
+            let items = match self.force_lazy_list_vm_n(list, idx + 1) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+            // Fewer items than requested => the gather body finished (finite
+            // source) without a match.
+            if items.len() <= idx {
+                return Some(Ok(Value::Nil));
+            }
+            let item = items[idx].clone();
+            let matched = {
+                let mut matcher = VmFirstMatcher(self);
+                match matcher.item_matches(&func, &item) {
+                    Ok(b) => b,
+                    Err(e) => return Some(Err(e)),
+                }
+            };
+            if matched {
+                return Some(Ok(item));
+            }
+            idx += 1;
+        }
+    }
 }

--- a/t/gather-infinite-coroutine.t
+++ b/t/gather-infinite-coroutine.t
@@ -1,0 +1,69 @@
+use Test;
+
+# Lazy access on an infinite gather coroutine must not force the whole
+# (infinite) list. Covers .head(n), .head, .first(pred), indexing, and the
+# bare-loop / while / C-style-loop coroutine resume paths.
+
+plan 21;
+
+# --- bare `loop { take ... }` --------------------------------------------
+{
+    my $g = gather { my $i = 0; loop { take $i++ } };
+    is-deeply $g.head(5).List, (0, 1, 2, 3, 4), 'loop: .head(5)';
+    is $g.head, 0, 'loop: .head (no arg)';
+    is $g[3], 3, 'loop: index [3]';
+    is $g.first(* > 7), 8, 'loop: .first(* > 7)';
+}
+
+# Side effects run only as far as the first match (no over-pull).
+{
+    my $c = 0;
+    my $g = gather { my $i = 0; loop { $c++; take $i++ } };
+    is $g.first(* >= 3), 3, 'loop: .first body returns match';
+    is $c, 4, 'loop: .first runs body exactly to the match';
+}
+
+# Incremental indexing resumes the coroutine repeatedly.
+{
+    my $g = gather { my $i = 0; loop { take $i++ } };
+    is $g[0], 0, 'loop: incremental [0]';
+    is $g[1], 1, 'loop: incremental [1]';
+    is $g[2], 2, 'loop: incremental [2]';
+    is $g[5], 5, 'loop: incremental [5]';
+}
+
+# --- `while True { take ... }` -------------------------------------------
+{
+    my $g = gather { my $i = 0; while True { take $i++ } };
+    is-deeply $g.head(4).List, (0, 1, 2, 3), 'while: .head(4)';
+    is $g.first(* > 5), 6, 'while: .first(* > 5)';
+    is $g[2], 2, 'while: index [2]';
+}
+
+# --- `until False { take ... }` ------------------------------------------
+{
+    my $g = gather { my $i = 0; until False { take $i++ } };
+    is-deeply $g.head(3).List, (0, 1, 2), 'until: .head(3)';
+}
+
+# --- C-style `loop (init; ; step)` ---------------------------------------
+{
+    my $g = gather { loop (my $i = 0; ; $i++) { take $i } };
+    is-deeply $g.head(4).List, (0, 1, 2, 3), 'c-style: .head(4)';
+    is $g[5], 5, 'c-style: index [5]';
+}
+
+# --- `for 0..Inf` (already worked; guard against regression) -------------
+{
+    my $g = gather { for 0..Inf -> $i { take $i * $i } };
+    is-deeply $g.head(4).List, (0, 1, 4, 9), 'for-Inf: .head(4)';
+    is $g.first(* > 10), 16, 'for-Inf: .first(* > 10)';
+}
+
+# --- finite gather: .head / .first still correct -------------------------
+{
+    my $g = gather { take 1; take 2; take 3 };
+    is-deeply $g.head(2).List, (1, 2), 'finite: .head(2)';
+    is-deeply $g.head(5).List, (1, 2, 3), 'finite: .head past end';
+    is $g.first(* > 9), Nil, 'finite: .first no match -> Nil';
+}


### PR DESCRIPTION
## Summary

Lazy access on an **infinite gather coroutine** was hanging because `.head(n)`, `.head`, `.first(pred)`, and incremental indexing forced the entire (possibly infinite) `LazyList` to completion.

```raku
say (gather { my $i = 0; loop { take $i++ } }).head(5);   # hung; now (0 1 2 3 4)
say (gather { my $i = 0; loop { take $i++ } }).first(* > 3); # hung; now 4
```

These all work in Rakudo; mutsu now matches.

## Changes

- **`.head(n)`** computes a bound (`gather_head_bound`) and pulls only the first `n` elements via `force_lazy_list_vm_n` instead of `force_lazy_list_vm`.
- **`.first(pred)`** (`try_lazy_gather_first`) pulls one element at a time through the coroutine and tests the matcher, stopping at the first match. Pulling singly (not in chunks) keeps the gather body's side effects in step with the match position, matching Rakudo (`.first(* >= 3)` runs the body exactly 4 times).
- **Bare `loop`, `while`/`until`, and C-style `loop (init; ; step)`** now support gather coroutine suspend/resume. Previously only `for` loops saved resume state, so incremental access past the second element silently returned `Nil`. A new `ForLoopResumeState::CStyleLoop` marker parks the VM `ip` on the loop opcode across a take-limit suspend; the loop's state lives in locals/env so re-entering from the condition check continues correctly. C-style loops run their step before suspending so resume lands at the condition exactly as normal flow would.

## Tests

- Adds `t/gather-infinite-coroutine.t` (21 cases): `.head(n)`/`.head`/`.first`/indexing over `loop`/`while`/`until`/C-style/`for 0..Inf` gathers, side-effect-count parity with Rakudo, and finite-gather regression guards.
- `make test` passes (626 files, 5568 tests). `roast/S04-statements/{loop,while}.t` pass; `gather.t` fails only on the pre-existing unrelated `take-rw` subtest (not whitelisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)