### PR TITLE
feat(exceptions): X::Declaration::Scope for illegal `has` declarators

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -136,10 +136,60 @@ fn has_decl_list(input: &str) -> PResult<'_, Stmt> {
     Ok((rest, Stmt::SyntheticBlock(stmts)))
 }
 
+/// Detect `<scope> <declaration>` combinations that are illegal in Raku, e.g.
+/// `has sub`, `has package`. Returns a fatal `X::Declaration::Scope` (or
+/// `X::Declaration::Scope::Multi` for `multi`) parse error when `rest` begins
+/// with such a declarator keyword.
+pub(in crate::parser::stmt) fn scope_declaration_error(scope: &str, rest: &str) -> Option<PError> {
+    // `proto` is reported by Rakudo as a `sub` declaration.
+    const DECLARATORS: &[(&str, &str)] = &[
+        ("sub", "sub"),
+        ("proto", "sub"),
+        ("package", "package"),
+        ("class", "class"),
+        ("module", "module"),
+        ("role", "role"),
+        ("grammar", "grammar"),
+        ("constant", "constant"),
+        ("subset", "subset"),
+        ("enum", "enum"),
+    ];
+
+    if keyword("multi", rest).is_some() {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("scope".to_string(), Value::str(scope.to_string()));
+        let message = format!("Cannot use '{}' with a multi declaration", scope);
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(Symbol::intern("X::Declaration::Scope::Multi"), attrs);
+        return Some(PError::fatal_with_exception(message, Box::new(ex)));
+    }
+
+    for (kw, decl) in DECLARATORS {
+        if keyword(kw, rest).is_some() {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("scope".to_string(), Value::str(scope.to_string()));
+            attrs.insert("declaration".to_string(), Value::str((*decl).to_string()));
+            let message = format!("Cannot use '{}' with {} declaration", scope, decl);
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(Symbol::intern("X::Declaration::Scope"), attrs);
+            return Some(PError::fatal_with_exception(message, Box::new(ex)));
+        }
+    }
+
+    None
+}
+
 /// Parse `has` attribute declaration.
 pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("has", input).ok_or_else(|| PError::expected("has declaration"))?;
     let (rest, _) = ws1(rest)?;
+
+    // `has` cannot be used as the scope for a routine/package-style declaration.
+    // `has sub`, `has package`, `has class`, etc. are X::Declaration::Scope.
+    // (`has method`/`has submethod` are valid and not rejected here.)
+    if let Some(err) = scope_declaration_error("has", rest) {
+        return Err(err);
+    }
 
     // Handle parenthesized list form: has ($a, $.b, $!c)
     // This desugars into a Block containing multiple HasDecl statements.

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -237,6 +237,7 @@ impl Interpreter {
             let single_key = format!("{}::{}", self.current_package, name);
             if is_our_scoped && !self.registry().proto_subs.contains(&single_key) {
                 let mut attrs = std::collections::HashMap::new();
+                attrs.insert("scope".to_string(), Value::str("our".to_string()));
                 attrs.insert(
                     "message".to_string(),
                     Value::str(

--- a/t/declaration-scope.t
+++ b/t/declaration-scope.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 9;
+
+# `has` cannot be used as the scope for routine/package-style declarations.
+throws-like 'has sub a() { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'sub';
+throws-like 'has package a { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'package';
+throws-like 'has class a { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'class';
+throws-like 'has module a { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'module';
+throws-like 'has role a { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'role';
+throws-like 'has grammar a { }', X::Declaration::Scope,
+    scope => 'has', declaration => 'grammar';
+
+# `has multi` is X::Declaration::Scope::Multi, not the plain variant.
+throws-like 'has multi a() { }', X::Declaration::Scope::Multi,
+    scope => 'has';
+
+# `our multi` candidates are also illegal.
+throws-like 'our multi a() { }', X::Declaration::Scope::Multi,
+    scope => 'our';
+
+# `has method` is perfectly valid and must not be rejected.
+lives-ok { EVAL 'class C { has method m() { 42 } }' },
+    'has method is allowed';


### PR DESCRIPTION
## Summary

Implements `X::Declaration::Scope`, thrown at parse time when `has` is used as the scope for a routine/package-style declaration.

- `has sub`, `has package`, `has class`, `has module`, `has role`, `has grammar` → `X::Declaration::Scope` with `.scope` (`has`) and `.declaration` accessors, message `Cannot use 'has' with <decl> declaration` — matching Rakudo.
- `has multi` → `X::Declaration::Scope::Multi`.
- `has method` / `has submethod` remain valid.
- Also fills in the missing `scope` attribute on the existing `X::Declaration::Scope::Multi` raised for `our multi` candidates (`.scope` now reports `our`).

## Tests

- New `t/declaration-scope.t` (9 subtests).
- Unblocks the scope cases in `roast/S32-exceptions/misc2.t` (lines 237-239) and `roast/S06-multi/type-based.t` (line 188); both roast files still pass fully.
- `make test` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)