### PR TITLE
feat(exceptions): X::Signature::Placeholder for placeholders with explicit signature

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -299,6 +299,36 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
     Ok(())
 }
 
+/// If a routine body uses a placeholder variable (`$^x`, `@_`, `$:named`, ...)
+/// that is not captured by a nested signature-capable block, build the fatal
+/// `X::Signature::Placeholder` error. The placeholder is reported with its
+/// display name and the source line on which it appears.
+fn placeholder_overrides_signature_error(body: &[Stmt]) -> Option<PError> {
+    let mut line: i64 = 0;
+    for stmt in body {
+        if let Stmt::SetLine(l) = stmt {
+            line = *l;
+            continue;
+        }
+        if let Some(ph) = crate::ast::collect_unattached_placeholders(std::slice::from_ref(stmt))
+            .into_iter()
+            .next()
+        {
+            let message = format!(
+                "Placeholder variable '{}' cannot override existing signature",
+                ph
+            );
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("placeholder".to_string(), Value::str(ph));
+            attrs.insert("line".to_string(), Value::Int(line));
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(Symbol::intern("X::Signature::Placeholder"), attrs);
+            return Some(PError::fatal_with_exception(message, Box::new(ex)));
+        }
+    }
+    None
+}
+
 /// Parse a sub name, which can be a regular identifier or an operator-style name
 /// like `infix:<+>`, `prefix:<->`, `postfix:<++>`, `circumfix:<[ ]>`.
 pub(super) fn parse_sub_name(input: &str) -> PResult<'_, String> {
@@ -1079,6 +1109,12 @@ pub(super) fn sub_decl_body(
             Err(err) => return Err(err),
         }
     };
+    // A routine declared with an explicit signature (`sub f() { ... }`, even an
+    // empty one) cannot also use placeholder variables in its body — that would
+    // override the existing signature. This is X::Signature::Placeholder.
+    if has_explicit_signature && let Some(err) = placeholder_overrides_signature_error(&body) {
+        return Err(err);
+    }
     // When no explicit signature is given, collect placeholder variables
     // ($^a, $^b, &^c, etc.) from the body as implicit parameters.
     let (params, param_defs) = if params.is_empty() && param_defs.is_empty() {

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -308,6 +308,16 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
 /// placeholders `@_` / `%_` are legal when they are explicitly declared as
 /// parameters (`sub f(%_) { %_<k> }`), so such declared names are skipped.
 fn placeholder_overrides_signature_error(body: &[Stmt], param_defs: &[ParamDef]) -> Option<PError> {
+    // `$^X`, `$^O`, ... (a sigil, a caret, then a single uppercase ASCII letter)
+    // are Perl 5 special variables, not Raku placeholders, so they never
+    // override a signature (Rakudo reports them as "Unsupported use" instead).
+    let is_perl5_caret_special = |ph: &str| {
+        let b = ph.as_bytes();
+        b.len() == 3
+            && matches!(b[0], b'$' | b'@' | b'%' | b'&')
+            && b[1] == b'^'
+            && b[2].is_ascii_uppercase()
+    };
     let declared: std::collections::HashSet<&str> =
         param_defs.iter().map(|p| p.name.as_str()).collect();
     let mut line: i64 = 0;
@@ -318,7 +328,7 @@ fn placeholder_overrides_signature_error(body: &[Stmt], param_defs: &[ParamDef])
         }
         if let Some(ph) = crate::ast::collect_unattached_placeholders(std::slice::from_ref(stmt))
             .into_iter()
-            .find(|ph| !declared.contains(ph.as_str()))
+            .find(|ph| !declared.contains(ph.as_str()) && !is_perl5_caret_special(ph))
         {
             let message = format!(
                 "Placeholder variable '{}' cannot override existing signature",

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -303,7 +303,13 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
 /// that is not captured by a nested signature-capable block, build the fatal
 /// `X::Signature::Placeholder` error. The placeholder is reported with its
 /// display name and the source line on which it appears.
-fn placeholder_overrides_signature_error(body: &[Stmt]) -> Option<PError> {
+///
+/// `param_defs` is the routine's explicit signature; the implicit slurpy
+/// placeholders `@_` / `%_` are legal when they are explicitly declared as
+/// parameters (`sub f(%_) { %_<k> }`), so such declared names are skipped.
+fn placeholder_overrides_signature_error(body: &[Stmt], param_defs: &[ParamDef]) -> Option<PError> {
+    let declared: std::collections::HashSet<&str> =
+        param_defs.iter().map(|p| p.name.as_str()).collect();
     let mut line: i64 = 0;
     for stmt in body {
         if let Stmt::SetLine(l) = stmt {
@@ -312,7 +318,7 @@ fn placeholder_overrides_signature_error(body: &[Stmt]) -> Option<PError> {
         }
         if let Some(ph) = crate::ast::collect_unattached_placeholders(std::slice::from_ref(stmt))
             .into_iter()
-            .next()
+            .find(|ph| !declared.contains(ph.as_str()))
         {
             let message = format!(
                 "Placeholder variable '{}' cannot override existing signature",
@@ -1112,7 +1118,9 @@ pub(super) fn sub_decl_body(
     // A routine declared with an explicit signature (`sub f() { ... }`, even an
     // empty one) cannot also use placeholder variables in its body — that would
     // override the existing signature. This is X::Signature::Placeholder.
-    if has_explicit_signature && let Some(err) = placeholder_overrides_signature_error(&body) {
+    if has_explicit_signature
+        && let Some(err) = placeholder_overrides_signature_error(&body, &param_defs)
+    {
         return Err(err);
     }
     // When no explicit signature is given, collect placeholder variables

--- a/t/signature-placeholder.t
+++ b/t/signature-placeholder.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 7;
+plan 9;
 
 # A routine with an explicit signature (even empty) may not use placeholder
 # variables in its body -> X::Signature::Placeholder.
@@ -26,3 +26,11 @@ lives-ok { EVAL 'sub g() { -> { $^y } }' },
 # The message is the canonical Rakudo one.
 throws-like 'sub h() { $^z }', X::Signature::Placeholder,
     message => /"Placeholder variable '\$^z' cannot override existing signature"/;
+
+# `@_` / `%_` are legal when explicitly declared as parameters — they do not
+# override the signature, they ARE the signature, so the declaration must not
+# raise X::Signature::Placeholder.
+lives-ok { EVAL 'sub f(%_) { %_<a> }' },
+    'explicitly declared %_ parameter is allowed';
+lives-ok { EVAL 'sub f(@_) { @_[0] }' },
+    'explicitly declared @_ parameter is allowed';

--- a/t/signature-placeholder.t
+++ b/t/signature-placeholder.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 7;
+
+# A routine with an explicit signature (even empty) may not use placeholder
+# variables in its body -> X::Signature::Placeholder.
+throws-like 'sub f() { $^x }', X::Signature::Placeholder,
+    line => 1, placeholder => '$^x';
+
+throws-like 'sub f($a) { $^x }', X::Signature::Placeholder,
+    placeholder => '$^x';
+
+throws-like 'sub f() { @_ }', X::Signature::Placeholder,
+    placeholder => '@_';
+
+throws-like 'sub f() { $:named }', X::Signature::Placeholder,
+    placeholder => '$:named';
+
+# Without an explicit signature, placeholders define the signature implicitly.
+lives-ok { EVAL 'sub f { $^x }; f(1)' }, 'placeholder defines implicit signature';
+
+# A placeholder captured by an inner block is fine.
+lives-ok { EVAL 'sub g() { -> { $^y } }' },
+    'placeholder captured by nested block is allowed';
+
+# The message is the canonical Rakudo one.
+throws-like 'sub h() { $^z }', X::Signature::Placeholder,
+    message => /"Placeholder variable '\$^z' cannot override existing signature"/;

--- a/t/signature-placeholder.t
+++ b/t/signature-placeholder.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 9;
+plan 10;
 
 # A routine with an explicit signature (even empty) may not use placeholder
 # variables in its body -> X::Signature::Placeholder.
@@ -34,3 +34,8 @@ lives-ok { EVAL 'sub f(%_) { %_<a> }' },
     'explicitly declared %_ parameter is allowed';
 lives-ok { EVAL 'sub f(@_) { @_[0] }' },
     'explicitly declared @_ parameter is allowed';
+
+# `$^X` (a single uppercase letter after the caret) is a Perl 5 special
+# variable, not a placeholder, so it must not raise X::Signature::Placeholder.
+lives-ok { EVAL 'sub f($a) { my $s = qq/x$^X/ }' },
+    'single-uppercase caret var ($^X) is not a placeholder';


### PR DESCRIPTION
## Summary

A routine declared with an explicit signature — including an empty `()` — may not use placeholder variables (`$^x`, `@_`, `$:named`, …) in its body. Previously mutsu silently folded the placeholders of `sub f() { $^x }` into implicit parameters (the explicit empty signature also has no params), so no error was raised.

The sub-declaration parser now rejects this with a fatal `X::Signature::Placeholder` carrying:

- `.placeholder` → display name (`$^x`, `@_`, …)
- `.line` → source line of the placeholder
- `.message` → `Placeholder variable '$^x' cannot override existing signature`

Placeholders captured by a nested signature-capable block (e.g. `sub g() { -> { $^y } }`) are still allowed — detection uses the existing `collect_unattached_placeholders`, which stops at nested block boundaries.

## Tests

- New `t/signature-placeholder.t` (7 cases: explicit-empty/explicit-param/`@_`/`$:named` errors, implicit-signature OK, nested-capture OK, message check).
- Unblocks the `X::Signature::Placeholder` subtest in `roast/S32-exceptions/misc2.t` (test 4; all 4 inner assertions pass).
- Existing `S06-signature/*-placeholders.t` (positional/named/slurpy/mixed) still pass.
- `make test` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)