### PR TITLE
feat(lazy): method-form .map/.grep over infinite source stay truly lazy

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -306,6 +306,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                             scan_spec: None,
                             sequence_spec: None,
                             coroutine: None,
+                            lazy_pipe: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
@@ -329,6 +330,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                     scan_spec: None,
                     sequence_spec: None,
                     coroutine: None,
+                    lazy_pipe: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1090,6 +1090,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     scan_spec: None,
                     sequence_spec: None,
                     coroutine: None,
+                    lazy_pipe: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -122,6 +122,10 @@ pub(super) fn dispatch(
                                 .coroutine
                                 .as_ref()
                                 .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
+                            lazy_pipe: list
+                                .lazy_pipe
+                                .as_ref()
+                                .map(|p| std::sync::Mutex::new(p.lock().unwrap().clone())),
                         },
                     )))));
                 }
@@ -165,6 +169,7 @@ pub(super) fn dispatch(
                     scan_spec: None,
                     sequence_spec: None,
                     coroutine: None,
+                    lazy_pipe: None,
                 },
             )))))
         }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2954,6 +2954,13 @@ impl Interpreter {
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)
+            // A chained `.map`/`.grep` on a lazy map/grep pipeline appends
+            // another lazy stage (`dispatch_map_method`/`dispatch_grep`); a
+            // laziness-preserving coercion returns the pipeline unchanged.
+            // Neither forces the (possibly infinite) pipeline.
+            && !(ll.lazy_pipe.is_some()
+                && (matches!(method, "map" | "grep")
+                    || crate::vm::VM::lazy_pipe_preserving_coercion(method)))
         {
             let saved_env = self.env.clone();
             let items = self.force_lazy_list_bridge(ll)?;

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -197,6 +197,49 @@ impl Interpreter {
         }
     }
 
+    /// Whether `.map`/`.grep` on `target` should produce a truly lazy pipeline
+    /// stage (a `LazyList` carrying a [`crate::value::MapGrepSpec`]) instead of
+    /// materializing the source. Intentionally narrow to keep the blast radius
+    /// small: only an infinite integer `Range` (the headline crash/slow case)
+    /// and continuation of an existing lazy pipeline (chained `.map`/`.grep`).
+    /// Gathers / sequence / scan lists keep their current dispatch unchanged.
+    pub(crate) fn is_lazy_pipe_source(target: &Value) -> bool {
+        match target {
+            Value::Range(_, end)
+            | Value::RangeExcl(_, end)
+            | Value::RangeExclStart(_, end)
+            | Value::RangeExclBoth(_, end) => *end == i64::MAX,
+            Value::LazyList(ll) => ll.lazy_pipe.is_some(),
+            _ => false,
+        }
+    }
+
+    /// Build a lazy `map`/`grep` pipeline stage over `target` if `func` is
+    /// eligible for single-element pull (arity-1, no full-binding signature and
+    /// no grep adverbs handled by the caller). Returns `None` to fall back to
+    /// the eager path.
+    pub(crate) fn make_lazy_pipe(target: Value, func: Value, is_grep: bool) -> Option<Value> {
+        // Only callbacks that consume one element per call can be pulled lazily.
+        // A multi-arity block (`-> $a, $b { }`) or a slurpy param (`*@a`)
+        // consumes a chunk of the source per call, which single-element pull
+        // cannot reproduce; defer those to the eager path (unchanged behaviour).
+        // Other signature features (types, defaults, where, …) still bind one
+        // element per call in `eval_map_over_items`, so they stay eligible.
+        if let Value::Sub(data) = &func {
+            let arity = data
+                .params
+                .len()
+                .saturating_sub(data.assumed_positional.len());
+            let has_slurpy = data.param_defs.iter().any(|pd| pd.slurpy);
+            if arity > 1 || has_slurpy {
+                return None;
+            }
+        }
+        Some(Value::LazyList(std::sync::Arc::new(
+            crate::value::LazyList::new_pipe(target, func, is_grep),
+        )))
+    }
+
     fn is_infinite_endpoint(v: &Value) -> bool {
         match v {
             Value::Num(n) => n.is_infinite(),

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -224,6 +224,18 @@ impl Interpreter {
         };
         let args = &positional_args;
 
+        // Infinite/lazy source with the default (`:v`) adverb: return a truly
+        // lazy `grep` pipeline stage instead of materializing the (possibly
+        // infinite) source. Adverbed greps (`:k`/`:kv`/`:p`) need positional
+        // indices over the whole result, so they keep the eager path.
+        if matches!(grep_adverb, GrepAdverb::V)
+            && Self::is_lazy_pipe_source(&target)
+            && let Some(func) = args.first().cloned()
+            && let Some(pipe) = Self::make_lazy_pipe(target.clone(), func, true)
+        {
+            return Ok(pipe);
+        }
+
         match target {
             Value::Package(class_name) if class_name == "Supply" => Err(RuntimeError::new(
                 "Cannot call .grep on a Supply type object",

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -456,6 +456,16 @@ impl Interpreter {
                 return Err(err);
             }
         }
+        // Infinite/lazy source: return a truly lazy `map` pipeline stage instead
+        // of materializing the (possibly infinite) source. Falls back to the
+        // eager path for callbacks that need chunked binding (multi-arity /
+        // slurpy). See `is_lazy_pipe_source` / `make_lazy_pipe`.
+        if Self::is_lazy_pipe_source(&target)
+            && let Some(func) = args.first().cloned()
+            && let Some(pipe) = Self::make_lazy_pipe(target.clone(), func, false)
+        {
+            return Ok(pipe);
+        }
         let items = if crate::runtime::utils::is_shaped_array(&target) {
             crate::runtime::utils::shaped_array_leaves(&target)
         } else {
@@ -522,6 +532,7 @@ impl Interpreter {
             scan_spec: None,
             sequence_spec: None,
             coroutine: None,
+            lazy_pipe: None,
         };
         Value::LazyList(std::sync::Arc::new(list))
     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -877,6 +877,17 @@ impl Interpreter {
     }
 
     pub(super) fn force_lazy_list(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {
+        // A lazy map/grep pipeline is rooted at an infinite source; a strict
+        // force cannot terminate. Match raku (and the VM path) and throw
+        // X::Cannot::Lazy. Bounded pulls go through the VM's `force_lazy_pipe`.
+        // (Its cache is seeded empty, so the early cache return below would
+        // otherwise yield a wrong partial/empty result.)
+        if list.lazy_pipe.is_some() {
+            return Err(RuntimeError::typed_msg(
+                "X::Cannot::Lazy",
+                "Cannot coerce an infinite lazy list to a strict list",
+            ));
+        }
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);
         }
@@ -1611,6 +1622,10 @@ impl Interpreter {
                             .coroutine
                             .as_ref()
                             .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
+                        lazy_pipe: list
+                            .lazy_pipe
+                            .as_ref()
+                            .map(|p| std::sync::Mutex::new(p.lock().unwrap().clone())),
                     }))
                 } else {
                     v

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1155,6 +1155,26 @@ pub(crate) struct ScanSpec {
     pub(crate) computed_count: usize,
 }
 
+/// A single lazy `map`/`grep` stage applied to a source, pulled element by
+/// element. Chains nest: the `source` of one [`MapGrepSpec`] can itself be a
+/// `LazyList` carrying another [`MapGrepSpec`], so `(1..Inf).map(...).grep(...)`
+/// becomes a grep stage whose source is the map stage. See
+/// [`crate::value::LazyList::lazy_pipe`].
+#[derive(Debug, Clone)]
+pub(crate) struct MapGrepSpec {
+    /// The source to pull elements from (infinite `Range`, or another lazy
+    /// `LazyList`). Pulled one element at a time via the VM.
+    pub(crate) source: Value,
+    /// The `map`/`grep` callback (a `Sub`, `WhateverCode`, regex, …).
+    pub(crate) func: Value,
+    /// `true` for `grep` (filter), `false` for `map` (transform).
+    pub(crate) is_grep: bool,
+    /// Index of the next element to pull from `source`.
+    pub(crate) source_idx: usize,
+    /// `true` once `source` reported exhaustion (finite source ran out).
+    pub(crate) done: bool,
+}
+
 /// Saved for-loop state for resuming a gather coroutine mid-iteration.
 #[derive(Debug, Clone)]
 pub(crate) enum ForLoopResumeState {
@@ -1214,6 +1234,11 @@ pub(crate) struct LazyList {
     /// Suspended coroutine state for lazy gather/take.
     /// When present, the gather body can be resumed from where `take` paused it.
     pub(crate) coroutine: Option<Mutex<GatherCoroutineState>>,
+    /// Lazy `map`/`grep` pipeline stage. When present, elements are produced by
+    /// pulling from `lazy_pipe.source` and applying the stage's callback on
+    /// demand, so `(1..Inf).map(...)`/`.grep(...)` stay truly lazy instead of
+    /// materializing the (possibly infinite) source.
+    pub(crate) lazy_pipe: Option<Mutex<MapGrepSpec>>,
 }
 
 impl std::fmt::Debug for LazyList {
@@ -1222,6 +1247,7 @@ impl std::fmt::Debug for LazyList {
             .field("body_len", &self.body.len())
             .field("has_compiled_code", &self.compiled_code.is_some())
             .field("has_coroutine", &self.coroutine.is_some())
+            .field("has_lazy_pipe", &self.lazy_pipe.is_some())
             .finish()
     }
 }
@@ -1244,6 +1270,10 @@ impl Clone for LazyList {
                 .coroutine
                 .as_ref()
                 .map(|c| Mutex::new(c.lock().unwrap().clone())),
+            lazy_pipe: self
+                .lazy_pipe
+                .as_ref()
+                .map(|p| Mutex::new(p.lock().unwrap().clone())),
         }
     }
 }
@@ -1261,6 +1291,7 @@ impl LazyList {
             scan_spec: None,
             sequence_spec: None,
             coroutine: None,
+            lazy_pipe: None,
         }
     }
 
@@ -1276,6 +1307,7 @@ impl LazyList {
             scan_spec: None,
             sequence_spec: Some(spec),
             coroutine: None,
+            lazy_pipe: None,
         }
     }
 
@@ -1291,6 +1323,39 @@ impl LazyList {
             scan_spec: Some(Mutex::new(spec)),
             sequence_spec: None,
             coroutine: None,
+            lazy_pipe: None,
+        }
+    }
+
+    /// Create a lazy `map`/`grep` pipeline stage over `source`.
+    ///
+    /// The result stays lazy: its elements are produced on demand by pulling
+    /// from `source` and applying `func`. The `__mutsu_lazylist_from_gather`
+    /// marker is set so the VM's `.head`/`.first`/index dispatch routes through
+    /// the bounded incremental-pull path.
+    pub(crate) fn new_pipe(source: Value, func: Value, is_grep: bool) -> Self {
+        let mut env = crate::env::Env::new();
+        env.insert(
+            "__mutsu_lazylist_from_gather".to_string(),
+            Value::Bool(true),
+        );
+        Self {
+            body: Vec::new(),
+            env,
+            cache: Mutex::new(Some(Vec::new())),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: None,
+            sequence_spec: None,
+            coroutine: None,
+            lazy_pipe: Some(Mutex::new(MapGrepSpec {
+                source,
+                func,
+                is_grep,
+                source_idx: 0,
+                done: false,
+            })),
         }
     }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -375,15 +375,30 @@ impl VM {
                 Some(crate::value::Value::Bool(true))
             )
             && Self::lazy_list_needs_forcing(&method)
+            // A chained `.map`/`.grep` on a lazy pipeline appends another stage
+            // (interpreter dispatch); laziness-preserving coercions return the
+            // pipeline unchanged (native dispatch) — neither forces.
+            && !(ll.lazy_pipe.is_some()
+                && (matches!(method.as_str(), "map" | "grep")
+                    || Self::lazy_pipe_preserving_coercion(&method)))
         {
             let saved_env = self.interpreter.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(&method, &args) {
                 Some(n) => self.force_lazy_list_vm_n(ll, n)?,
+                // A strict force of an infinite lazy pipeline cannot terminate:
+                // raise X::Cannot::Lazy with this method's name.
+                None if ll.lazy_pipe.is_some() => {
+                    return Err(RuntimeError::cannot_lazy(&method));
+                }
                 None => self.force_lazy_list_vm(ll)?,
             };
-            if !matches!(method.as_str(), "elems" | "hyper" | "race") {
+            // A lazy map/grep pipeline runs its callback via `vm_call_on_value`
+            // in this VM, so its side effects on enclosing variables are
+            // legitimate and must persist (unlike gather coroutine corruption,
+            // which the env restore undoes).
+            if !matches!(method.as_str(), "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
                 *self.interpreter.env_mut() = saved_env;
             }
             Value::Seq(std::sync::Arc::new(items))

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -480,15 +480,29 @@ impl VM {
             )
             && Self::lazy_list_needs_forcing(method)
             && !(ll.coroutine.is_some() && matches!(method, "List" | "values"))
+            // A chained `.map`/`.grep` on a lazy pipeline appends another stage
+            // (interpreter dispatch); laziness-preserving coercions return the
+            // pipeline unchanged (native dispatch) — neither forces.
+            && !(ll.lazy_pipe.is_some()
+                && (matches!(method, "map" | "grep") || Self::lazy_pipe_preserving_coercion(method)))
         {
             let saved_env = self.interpreter.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(method, &args) {
                 Some(n) => self.force_lazy_list_vm_n(ll, n)?,
+                // A strict force of an infinite lazy pipeline cannot terminate:
+                // raise X::Cannot::Lazy with this method's name.
+                None if ll.lazy_pipe.is_some() => {
+                    return Err(RuntimeError::cannot_lazy(method));
+                }
                 None => self.force_lazy_list_vm(ll)?,
             };
-            if !matches!(method, "elems" | "hyper" | "race") {
+            // Restoring the pre-force env undoes captured-variable corruption
+            // from gather coroutine forcing. A lazy map/grep pipeline runs its
+            // callback via `vm_call_on_value` in this VM, so its side effects on
+            // enclosing variables are legitimate and must persist.
+            if !matches!(method, "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
                 *self.interpreter.env_mut() = saved_env;
             }
             Value::Seq(std::sync::Arc::new(items))

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -464,10 +464,11 @@ impl VM {
             }
         }
 
-        // For gather-based or sequence-spec LazyList iterables, iterate lazily
-        // by pulling items one at a time. This avoids materializing infinite sequences.
+        // For gather-based, sequence-spec, or lazy map/grep pipeline LazyList
+        // iterables, iterate lazily by pulling items one at a time. This avoids
+        // materializing infinite sequences.
         if let Value::LazyList(ref ll) = iterable
-            && (ll.coroutine.is_some() || ll.sequence_spec.is_some())
+            && (ll.coroutine.is_some() || ll.sequence_spec.is_some() || ll.lazy_pipe.is_some())
         {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -283,6 +283,17 @@ impl VM {
     }
 
     /// Check if a method on LazyList requires forcing the list first.
+    /// Methods that coerce a lazy `Seq` to another lazy view and so must
+    /// preserve the laziness of a map/grep pipeline (return it unchanged)
+    /// instead of forcing it. `.eager`/`.elems`/`.sort`/… are NOT here — those
+    /// genuinely need the whole list and correctly raise X::Cannot::Lazy.
+    pub(crate) fn lazy_pipe_preserving_coercion(method: &str) -> bool {
+        matches!(
+            method,
+            "Seq" | "List" | "list" | "cache" | "values" | "lazy"
+        )
+    }
+
     pub(super) fn lazy_list_needs_forcing(method: &str) -> bool {
         matches!(
             method,
@@ -362,6 +373,18 @@ impl VM {
         // Handle scan-based lazy lists: compute elements on demand
         if list.scan_spec.is_some() {
             return self.force_scan_lazy_list(list, 200_000);
+        }
+
+        // A lazy map/grep pipeline is rooted at an infinite source, so a full
+        // (strict) force can never terminate. Match raku and throw
+        // X::Cannot::Lazy rather than spinning forever. Methods that know their
+        // own name (e.g. `.elems`/`.sort`) raise a more specific message at the
+        // dispatch site before reaching here.
+        if list.lazy_pipe.is_some() {
+            return Err(RuntimeError::typed_msg(
+                "X::Cannot::Lazy",
+                "Cannot coerce an infinite lazy list to a strict list",
+            ));
         }
 
         // For sequence-spec lazy lists, return current cache (infinite lists
@@ -541,6 +564,13 @@ impl VM {
         // For sequence-spec lazy lists, generate more elements on demand
         if let Some(ref spec) = list.sequence_spec {
             return Self::extend_sequence_cache(list, spec, needed);
+        }
+
+        // Lazy map/grep pipeline: pull from the source and apply the stage on
+        // demand (one source element at a time), so an infinite source stays
+        // lazy instead of materializing.
+        if list.lazy_pipe.is_some() {
+            return self.force_lazy_pipe(list, needed);
         }
 
         // Check if coroutine is finished (body completed, all elements produced)
@@ -762,6 +792,133 @@ impl VM {
             items
         };
         Ok(result)
+    }
+
+    /// Produce at least `needed` output elements of a lazy `map`/`grep` pipeline
+    /// (a `LazyList` carrying a [`crate::value::MapGrepSpec`]).
+    ///
+    /// Elements are produced by pulling from the stage's source one at a time
+    /// and applying the `map`/`grep` callback, accumulating outputs in the
+    /// list's cache. A `grep` stage filters (0 or 1 output per source element);
+    /// a `map` stage transforms (a `Slip` result contributes multiple). The
+    /// source itself may be another lazy pipeline, so chains nest.
+    pub(super) fn force_lazy_pipe(
+        &mut self,
+        list: &LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        loop {
+            // Fast path: enough already cached, or the source is exhausted.
+            {
+                let cache = list.cache.lock().unwrap();
+                let done = list
+                    .lazy_pipe
+                    .as_ref()
+                    .map(|p| p.lock().unwrap().done)
+                    .unwrap_or(true);
+                if let Some(c) = cache.as_ref()
+                    && (c.len() >= needed || done)
+                {
+                    let n = needed.min(c.len());
+                    return Ok(c[..n].to_vec());
+                }
+            }
+
+            // Snapshot the stage so no pipe lock is held across the pull/apply
+            // (which may recursively pull from a nested pipe source).
+            let (source, func, is_grep, source_idx) = {
+                let spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
+                (
+                    spec.source.clone(),
+                    spec.func.clone(),
+                    spec.is_grep,
+                    spec.source_idx,
+                )
+            };
+
+            match self.pull_source_element(&source, source_idx)? {
+                None => {
+                    // Source exhausted: mark done and return what we have.
+                    let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
+                    spec.done = true;
+                    drop(spec);
+                    let cache = list.cache.lock().unwrap();
+                    let c = cache.as_ref().cloned().unwrap_or_default();
+                    let n = needed.min(c.len());
+                    return Ok(c[..n].to_vec());
+                }
+                Some(elem) => {
+                    // Apply the stage with VM-native dispatch so the callback
+                    // runs in *this* VM (keeping locals/env coherent and letting
+                    // side effects reach the enclosing scope). A `grep` keeps the
+                    // element when the matcher is truthy; a `map` transforms it (a
+                    // `Slip` result contributes multiple elements).
+                    let produced: Vec<Value> = if is_grep {
+                        if self.vm_grep_item_matches(&func, &elem)? {
+                            vec![elem]
+                        } else {
+                            Vec::new()
+                        }
+                    } else {
+                        match self.vm_call_on_value(func, vec![elem], None)? {
+                            Value::Slip(items) => items.as_ref().clone(),
+                            v => vec![v],
+                        }
+                    };
+                    {
+                        let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
+                        spec.source_idx = source_idx + 1;
+                    }
+                    let mut cache = list.cache.lock().unwrap();
+                    cache.get_or_insert_with(Vec::new).extend(produced);
+                }
+            }
+        }
+    }
+
+    /// Pull the `idx`-th element of a pipeline source, or `None` when the source
+    /// has fewer than `idx + 1` elements (finite source exhausted). Infinite
+    /// integer ranges always produce. Nested lazy pipelines / gathers are pulled
+    /// incrementally via [`Self::force_lazy_list_vm_n`].
+    fn pull_source_element(
+        &mut self,
+        source: &Value,
+        idx: usize,
+    ) -> Result<Option<Value>, RuntimeError> {
+        match source {
+            Value::Range(a, b)
+            | Value::RangeExcl(a, b)
+            | Value::RangeExclStart(a, b)
+            | Value::RangeExclBoth(a, b) => {
+                let start = match source {
+                    Value::RangeExclStart(..) | Value::RangeExclBoth(..) => a.saturating_add(1),
+                    _ => *a,
+                };
+                let inclusive = matches!(source, Value::Range(..) | Value::RangeExclStart(..));
+                let cur = match start.checked_add(idx as i64) {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                let in_bounds = if inclusive { cur <= *b } else { cur < *b };
+                if in_bounds {
+                    Ok(Some(Value::Int(cur)))
+                } else {
+                    Ok(None)
+                }
+            }
+            Value::Seq(items) | Value::Slip(items) => Ok(items.get(idx).cloned()),
+            Value::Array(items, _) => Ok(items.get(idx).cloned()),
+            Value::LazyList(ll) => {
+                let items = self.force_lazy_list_vm_n(ll, idx + 1)?;
+                Ok(items.get(idx).cloned())
+            }
+            // Other sources (GenericRange, etc.) are not gated into the lazy
+            // pipeline; materialize once and index.
+            other => {
+                let items = crate::runtime::value_to_list(other);
+                Ok(items.get(idx).cloned())
+            }
+        }
     }
 
     /// Force a LazyList into a Seq by evaluating the gather body.

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -20,6 +20,24 @@ impl VM {
             }
         }
         let method_name = method_sym.resolve();
+        // A chained `.map`/`.grep` on a lazy map/grep pipeline must append
+        // another lazy stage (interpreter `dispatch_map_method`/`dispatch_grep`),
+        // not run the native impl over the pipeline's (empty) cache. Defer.
+        if let Value::LazyList(ll) = target
+            && ll.lazy_pipe.is_some()
+            && matches!(method_name.as_str(), "map" | "grep")
+        {
+            return None;
+        }
+        // A laziness-preserving coercion on a lazy map/grep pipeline returns the
+        // pipeline unchanged (it stays pullable). Intercept before the native
+        // impl, which would otherwise wrap/empty the pipeline's (empty) cache.
+        if let Value::LazyList(ll) = target
+            && ll.lazy_pipe.is_some()
+            && Self::lazy_pipe_preserving_coercion(method_name.as_str())
+        {
+            return Some(Ok(target.clone()));
+        }
         // Eager list operations cannot run on a lazy/infinite source: throw
         // X::Cannot::Lazy instead of hanging while the native impl materializes
         // it (matches raku). Shared with the interpreter dispatch path.

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -35,6 +35,20 @@ impl FirstMatcher for VmFirstMatcher<'_> {
 }
 
 impl VM {
+    /// Test a `grep`/`first`-style matcher against a single `item` using
+    /// VM-native dispatch (a `Sub` block via `vm_call_on_value`, any other
+    /// pattern via the shared `smart_match`). Used by the lazy map/grep
+    /// pipeline (`force_lazy_pipe`) so the matcher runs in this VM and keeps
+    /// locals/env coherent (the interpreter's `eval_grep_over_items` spins up a
+    /// nested VM via `mem::take`, which would discard the surrounding frame).
+    pub(super) fn vm_grep_item_matches(
+        &mut self,
+        pattern: &Value,
+        item: &Value,
+    ) -> Result<bool, RuntimeError> {
+        VmFirstMatcher(self).item_matches(pattern, item)
+    }
+
     /// Try to run `target.first(...)` natively. Returns `Some(result)` when
     /// handled in the VM, `None` to fall back unchanged.
     pub(super) fn try_native_first(

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -51,6 +51,7 @@ impl VM {
                     finished: false,
                     for_loop_resume: None,
                 })),
+                lazy_pipe: None,
             };
             let val = Value::LazyList(std::sync::Arc::new(list));
             self.stack.push(val);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -337,9 +337,9 @@ impl VM {
                     Some(n) => self.force_scan_lazy_list(ll, n)?,
                     None => self.force_lazy_list_vm(ll)?,
                 }
-            } else if ll.coroutine.is_some() {
-                // Gather-based lazy list with coroutine support:
-                // force only as many elements as needed via VM coroutine.
+            } else if ll.coroutine.is_some() || ll.lazy_pipe.is_some() {
+                // Gather-based lazy list / lazy map-grep pipeline: force only as
+                // many elements as needed via bounded incremental pull.
                 match &index {
                     Value::Int(i) if *i >= 0 => {
                         self.force_lazy_list_vm_n(ll, (*i as usize).saturating_add(1))?

--- a/t/lazy-method-map-grep.t
+++ b/t/lazy-method-map-grep.t
@@ -1,0 +1,48 @@
+use Test;
+
+# Method-form `.map` / `.grep` over an infinite source must stay truly lazy:
+# they return a lazy Seq and never materialize the (infinite) source. Before
+# this was implemented, `(1..Inf).map(...)` eagerly expanded the range to a 1M
+# cap (slow, wrong `.elems`/`.is-lazy`) and chained `.map(...).grep(...)` could
+# take tens of seconds. See PLAN.md §8.1 (pull-model unification).
+
+plan 22;
+
+# --- map over an infinite range stays lazy --------------------------------
+is (1..Inf).map(* * 2).head(3).join(","), "2,4,6", "map.head(3)";
+is (1..Inf).map(* * 2)[3], 8, "map[3]";
+is (1..Inf).map(* * 2)[^4].join(","), "2,4,6,8", "map[^4]";
+is (1..Inf).map(* * 2).first(* > 10), 12, "map.first";
+ok (1..Inf).map(* * 2).is-lazy, "map result is-lazy";
+is (1..Inf).map(* * 2).WHAT.^name, "Seq", "map returns a Seq";
+
+# --- grep over an infinite range stays lazy -------------------------------
+is (1..Inf).grep(* %% 2).head(3).join(","), "2,4,6", "grep.head(3)";
+is (1..Inf).grep(* %% 2)[^3].join(","), "2,4,6", "grep[^3]";
+is (1..Inf).grep(* %% 3).first(* > 10), 12, "grep.first";
+is (1..Inf).grep(*.is-prime).head(5).join(","), "2,3,5,7,11", "grep prime";
+ok (1..Inf).grep(* %% 2).is-lazy, "grep result is-lazy";
+
+# --- chained lazy stages --------------------------------------------------
+is (1..Inf).map(* * 2).grep(* %% 4).head(3).join(","), "4,8,12", "map.grep.head";
+is (1..Inf).grep(*.is-prime).map(* + 1).head(3).join(","), "3,4,6", "grep.map.head";
+is (1..Inf).map(* * 2).grep(* %% 4).map(* + 1).head(3).join(","), "5,9,13", "map.grep.map.head";
+is (1..Inf).map(* * 2).grep(* %% 4)[^3].join(","), "4,8,12", "chain[^3]";
+is (1..Inf).map(* * 2).grep(* %% 4).first(* > 20), 24, "chain.first";
+ok (1..Inf).map(* * 2).grep(* %% 4).is-lazy, "chained result is-lazy";
+
+# --- lazy iteration via for-loop ------------------------------------------
+my @seen;
+for (1..Inf).map(* * 2) { @seen.push($_); last if $_ >= 6 }
+is @seen.join(","), "2,4,6", "for over lazy map";
+
+my @seen2;
+for (1..Inf).map(* * 2).grep(* %% 4) { @seen2.push($_); last if $_ >= 12 }
+is @seen2.join(","), "4,8,12", "for over lazy chain";
+
+# --- strict (whole-list) ops on an infinite lazy pipe throw X::Cannot::Lazy
+throws-like { (1..Inf).map(* * 2).elems }, X::Cannot::Lazy, "elems throws";
+throws-like { (1..Inf).map(* * 2).sort }, X::Cannot::Lazy, "sort throws";
+
+# --- finite sources keep their eager behaviour (no regression) ------------
+is (1..5).map(* * 2).join(","), "2,4,6,8,10", "finite map unchanged";


### PR DESCRIPTION
## What

`(1..Inf).map(...)` / `(1..Inf).grep(...)` previously eagerly expanded the
infinite source to a 1M cap (`MAX_RANGE_EXPAND`). Symptoms:

- `(1..Inf).map(* * 2).head(3)` took **~7s** (materialized 1M then took 3).
- `(1..Inf).map(* * 2).grep(* %% 4).head(3)` took **~27s**.
- `.is-lazy` returned `False` (raku: `True`), `.elems` returned `1000001`
  (raku: throws `Cannot .elems a lazy list`).

Now method-form `.map`/`.grep` over an infinite source return a truly lazy
`Seq` (a `LazyList` carrying a `MapGrepSpec` pipeline stage), pulled one source
element at a time on demand. This is the headline item of PLAN.md §8.1
(pull-model unification).

## How

- New `MapGrepSpec` + `LazyList::lazy_pipe` field; `LazyList::new_pipe`.
- `dispatch_map_method` / `dispatch_grep`: when the source is an infinite
  integer `Range` or an existing lazy pipeline (`is_lazy_pipe_source`), build or
  append a lazy stage (`make_lazy_pipe`) instead of materializing. Multi-arity /
  slurpy callbacks and grep adverbs (`:k`/`:kv`/`:p`) keep the eager path.
- VM `force_lazy_pipe`: bounded incremental pull, applying each stage via
  VM-native `vm_call_on_value` / `vm_grep_item_matches` so callback side effects
  reach the enclosing scope and locals/env stay coherent (the interpreter's
  `eval_grep_over_items` spins up a nested VM via `mem::take`, which would
  discard the surrounding frame). Wired into `force_lazy_list_vm_n`, the
  for-loop, and index dispatch.
- Strict whole-list ops (`.elems`/`.sort`/…) on an infinite pipe throw
  `X::Cannot::Lazy` (matching raku) instead of hanging; laziness-preserving
  coercions (`.Seq`/`.List`/`.list`/`.cache`/`.values`/`.lazy`) return the
  pipeline unchanged.

Finite sources keep their existing eager behaviour (no regression).

## Tests

- New pin: `t/lazy-method-map-grep.t` (22 subtests: head/first/index/chaining,
  for-loop, is-lazy, X::Cannot::Lazy, finite-unchanged).
- `make test` passes (5611 tests). Existing lazy pins
  (`grep-lazy-range`, `map-first-lazy-range`, `gather-infinite-coroutine`,
  `eager-ops-cannot-lazy`) and whitelisted S03/S04/S32 map/grep/seq roast tests
  pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)