### PR TITLE
feat(exceptions): X::Placeholder::Attribute for placeholders in attribute initializers

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -652,6 +652,26 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
     // Track whether user provided an explicit default (before auto-default)
     let has_explicit_default = default.is_some();
 
+    // A placeholder variable (`$^b`, `@_`, ...) used directly in an attribute
+    // initializer cannot be captured by any signature -> X::Placeholder::Attribute.
+    if let Some(def) = default.as_ref()
+        && let Some(ph) = crate::ast::collect_unattached_placeholders(std::slice::from_ref(
+            &Stmt::Expr(def.clone()),
+        ))
+        .into_iter()
+        .next()
+    {
+        let message = format!(
+            "Cannot use placeholder parameter {} in an attribute initializer",
+            ph
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("placeholder".to_string(), Value::str(ph));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(Symbol::intern("X::Placeholder::Attribute"), attrs);
+        return Err(PError::fatal_with_exception(message, Box::new(ex)));
+    }
+
     // Apply `use attributes :D/:U/:_` pragma if no explicit smiley on the type
     let smiley_from_pragma = type_smiley.is_none() && type_constraint.is_some() && {
         let pragma = super::super::simple::current_attributes_pragma();

--- a/t/placeholder-attribute.t
+++ b/t/placeholder-attribute.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 5;
+
+# A placeholder variable used directly in an attribute initializer cannot be
+# captured by any signature -> X::Placeholder::Attribute.
+throws-like 'class RT78112 { has $.a = $^b + 1; }', X::Placeholder::Attribute,
+    placeholder => '$^b';
+
+throws-like 'class C { has $.a = $^x; }', X::Placeholder::Attribute,
+    placeholder => '$^x',
+    message => /'Cannot use placeholder parameter $^x in an attribute initializer'/;
+
+# Plain initializers and non-placeholder expressions are fine.
+lives-ok { EVAL 'class D { has $.a = 5; }' }, 'plain default is allowed';
+
+lives-ok { EVAL 'class E { has $.a = 1 + 2; }' }, 'expression default is allowed';
+
+# A placeholder captured by a nested block initializer is allowed.
+lives-ok { EVAL 'class F { has $.a = { $^b }; }' },
+    'placeholder inside a block initializer is allowed';


### PR DESCRIPTION
## Summary

A placeholder variable (`$^b`, `@_`, …) used directly in an attribute default initializer (`has $.a = $^b + 1`) cannot be captured by any signature, so Rakudo raises `X::Placeholder::Attribute`. mutsu previously accepted it silently (returning `Any`).

The `has` declaration parser now checks the initializer for unattached placeholders (those not captured by a nested signature-capable block) and raises a fatal `X::Placeholder::Attribute` with:

- `.placeholder` → `$^b`
- `.message` → `Cannot use placeholder parameter $^b in an attribute initializer`

A placeholder inside a nested block initializer (`has $.a = { $^b }`) remains allowed (the block captures it).

## Tests

- New `t/placeholder-attribute.t` (5 cases: class & message-checked errors, plain/expression defaults OK, nested-block initializer OK).
- Unblocks the `X::Placeholder::Attribute` subtest in `roast/S32-exceptions/misc2.t` (test 16; all 3 inner assertions pass).
- `make test` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)