### PR TITLE
docs: record method-form .map/.grep lazy fix (#2804)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -385,12 +385,11 @@ NaN-boxing で payload 8byte 化。**各ステップで int.t 等の重量級 ro
 コードベース精読で判明した根本的な正しさ・健全性の問題。Threading/Async (BLOCKERS 31件) の
 最大ボトルネックに直結するため最優先。詳細・再現コマンドは ANALYSIS.md 各節を参照。
 
-- [ ] **無限 Range の即時展開クラッシュを撲滅** (ANALYSIS §8.2) — `(a..=b).map(Value::Int).collect()`
-      が src 全体 43 箇所で無ガード、`MAX_ARRAY_EXPAND` ガードは 9 箇所のみ。無限 Range で
-      `capacity overflow` パニックしプロセスごと落ちる。展開サイトを単一ヘルパに集約しガードを一元化。
-      `(1..Inf).grep(* %% 2)[^3]` がクラッシュ (raku は `(2 4 6)`)。
-- [ ] **遅延リストを pull/Iterator モデルに統一** (ANALYSIS §8.1) — `grep` 等の eager 経路を
-      `map`/`first`/`head`/`[]` と同じ遅延扱いに揃える。Seq/Range を真の遅延イテレータに。
+- [x] **無限 Range の即時展開クラッシュ撲滅 (ANALYSIS §8.2) + 遅延リスト pull モデル統一 (§8.1)**
+      — 実質完了（#2791/#2793/#2796/#2799/#2804、詳細は [news/2026-06.md](news/2026-06.md)）。
+      `materialize_capped` で無限 Range crash 撲滅、eager ops は `X::Cannot::Lazy` throw、
+      無限 gather コルーチンの bounded pull、**method 形 `.map`/`.grep` を真に遅延化**（`LazyList::lazy_pipe`）。
+      残（低優先・実害確認なし）: §8.2 の残り生 `(a..=b).collect()` サイト掃討（多くは end cap 済/`.take`/`0..n`）。
 - [ ] **並行 state 共有の修正** (ANALYSIS §8.3, §2.2) — `clone_for_thread` のスナップショットコピーを
       やめ、共有すべきレキシカル/state/global を `Arc<Mutex>` のライブセルとして真に共有する。
       `start` ブロック間で `$counter`/`state $n` が共有されない (mutsu 1/0、raku 4/3)。

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -401,3 +401,16 @@ Phase 1（#2751 で着手）に収斂する。
   2 要素目より先のアクセスが暗黙に `Nil` を返していた）。新マーカー `ForLoopResumeState::CStyleLoop` で
   take-limit suspend 時に VM の `ip` をループ opcode に留め、locals/env 状態から条件チェックに再入。
   `.first` は 1 要素ずつ pull して副作用回数を Rakudo と一致させた。pin=`t/gather-infinite-coroutine.t`（21 cases）。
+- **本丸: method 形 `.map`/`.grep` の eager materialize 撲滅 (#2804)**: 従来 `(1..Inf).map(* * 2)` は
+  無限ソースを 1M cap で eager 展開していた（`.head(3)`=7s、`.elems`=1000001、`.is-lazy`=False、連鎖
+  `.map(...).grep(...).head(3)`=27s）。これを **真に遅延な `LazyList`（新 `MapGrepSpec` を `lazy_pipe` に
+  持つ pipeline stage）** を返し、ソースを 1 要素ずつ pull する方式に変更。
+  - ゲートは **無限整数 Range / 既存 lazy_pipe への連鎖のみ** に限定し回帰最小化（gather/scan/sequence/
+    有限ソースの map/grep は不変）。multi-arity/slurpy コールバック・grep adverb は eager パス維持。
+  - stage 適用は **VM ネイティブ `vm_call_on_value` / `vm_grep_item_matches`**（interpreter の
+    `eval_grep_over_items` は `mem::take` でネスト VM を作り外側フレームを破棄するため不可）。
+    これにより map コールバックの副作用が外側スコープへ正しく伝播し、locals/env も整合。
+  - strict 全要素 op（`.elems`/`.sort`/…）on 無限 pipe = `X::Cannot::Lazy` throw（raku 一致、従来 HANG）。
+    遅延保持 coercion（`.Seq`/`.List`/`.list`/`.cache`/`.values`/`.lazy`）は pipe をそのまま返す。
+  - `force_lazy_pipe`（`vm_helpers.rs`）を `force_lazy_list_vm_n` / for-loop / index dispatch に配線。
+  - pin=`t/lazy-method-map-grep.t`（22 cases: head/first/index/連鎖/for-loop/is-lazy/X::Cannot::Lazy/有限不変）。


### PR DESCRIPTION
Housekeeping after #2804 (method-form `.map`/`.grep` lazy materialize fix).

- **PLAN.md**: mark §8.1 (pull-model unification) / §8.2 (infinite Range crash)
  as substantially done (#2791/#2793/#2796/#2799/#2804), keeping only the
  low-priority residual raw-`collect` sweep as a future item.
- **news/2026-06.md**: full entry for the #2804 lazy-pipeline work
  (`LazyList::lazy_pipe` / `MapGrepSpec`, VM-native stage application, gate, etc).

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)