### PR TITLE
feat(exceptions): X::Parameter::Placeholder/Twigil for placeholder params

### DIFF
--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -278,6 +278,75 @@ fn malformed_double_closure_error() -> PError {
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 
+/// Reject placeholder (`$:x`, `$^x`) and twigil (`$?x`, `$=x`, `$~x`) variables
+/// when they appear as a signature parameter. `input` is the remaining param
+/// text, positioned at the sigil. Returns `Ok(())` when the param is not one of
+/// these forms (the caller proceeds with normal parsing).
+fn reject_placeholder_or_twigil_param(input: &str) -> Result<(), PError> {
+    let bytes = input.as_bytes();
+    if bytes.len() < 3 || !matches!(bytes[0], b'$' | b'@' | b'%' | b'&') {
+        return Ok(());
+    }
+    let sigil = bytes[0] as char;
+    let twigil = bytes[1] as char;
+    if !matches!(twigil, ':' | '^' | '?' | '=' | '~') {
+        return Ok(());
+    }
+    // `$::x` is a package-qualified variable, not a `:` placeholder.
+    if twigil == ':' && bytes[2] == b':' {
+        return Ok(());
+    }
+    // Must be followed by an identifier character to be a placeholder/twigil var.
+    let after = &input[2..];
+    let next = after.chars().next();
+    if !next.is_some_and(|c| c.is_alphanumeric() || c == '_') {
+        return Ok(());
+    }
+    let end = after
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(after.len());
+    let name = &after[..end];
+    let parameter = format!("{sigil}{twigil}{name}");
+
+    let mut attrs = HashMap::new();
+    attrs.insert("parameter".to_string(), Value::str(parameter.clone()));
+
+    let (class, msg) = match twigil {
+        ':' => {
+            let right = format!(":{sigil}{name}");
+            attrs.insert("right".to_string(), Value::str(right.clone()));
+            (
+                "X::Parameter::Placeholder",
+                format!(
+                    "Named placeholder variables like '{parameter}' are not allowed in signatures. \nDid you mean: '{right}' ?"
+                ),
+            )
+        }
+        '^' => {
+            let right = format!("{sigil}{name}");
+            attrs.insert("right".to_string(), Value::str(right.clone()));
+            (
+                "X::Parameter::Placeholder",
+                format!(
+                    "Positional placeholder variables like '{parameter}' are not allowed in signatures.  Did you mean: '{right}' ?"
+                ),
+            )
+        }
+        _ => {
+            attrs.insert("twigil".to_string(), Value::str(twigil.to_string()));
+            (
+                "X::Parameter::Twigil",
+                format!(
+                    "Parameters with a '{twigil}' twigil, like '{parameter}', are not allowed in signatures."
+                ),
+            )
+        }
+    };
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern(class), attrs);
+    Err(PError::fatal_with_exception(msg, Box::new(ex)))
+}
+
 fn stmts_contain_whatever(stmts: &[Stmt]) -> bool {
     stmts.iter().any(stmt_contains_whatever)
 }
@@ -1329,6 +1398,14 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         p.optional_marker = opt_marker;
         return Ok((rest, p));
     }
+
+    // Reject placeholder/twigil variables in signatures:
+    //   $:x @:x %:x  -> X::Parameter::Placeholder (named, right => ':$x')
+    //   $^x          -> X::Parameter::Placeholder (positional, right => '$x')
+    //   $?x $=x $~x  -> X::Parameter::Twigil
+    // ($!x / $.x are attribute twigils, handled separately as X::Syntax::NoSelf
+    // or accessor params; $*x is a dynamic variable and is legal.)
+    reject_placeholder_or_twigil_param(rest)?;
 
     // Capture the original sigil before var_name strips it
     let original_sigil = rest.as_bytes().first().copied().unwrap_or(b'$');

--- a/t/parameter-placeholder.t
+++ b/t/parameter-placeholder.t
@@ -1,0 +1,34 @@
+use Test;
+
+# Placeholder/twigil variables are not allowed as signature parameters.
+#   $:x @:x %:x  -> X::Parameter::Placeholder (named)
+#   $^x          -> X::Parameter::Placeholder (positional)
+#   $?x $=x $~x  -> X::Parameter::Twigil
+
+plan 11;
+
+# Named placeholder: X::Parameter::Placeholder, right => ':$x'
+throws-like 'sub f($:x) { }', X::Parameter::Placeholder,
+        parameter => '$:x', right => ':$x';
+throws-like 'sub f(@:x) { }', X::Parameter::Placeholder,
+        parameter => '@:x', right => ':@x';
+throws-like 'sub f(%:x) { }', X::Parameter::Placeholder,
+        parameter => '%:x', right => ':%x';
+
+# Positional placeholder: X::Parameter::Placeholder, right => '$x'
+throws-like 'sub f($^x) { }', X::Parameter::Placeholder,
+        parameter => '$^x', right => '$x';
+
+# Twigil parameters: X::Parameter::Twigil
+throws-like 'sub f($?x) { }', X::Parameter::Twigil,
+        parameter => '$?x', twigil => '?';
+throws-like 'sub f($=x) { }', X::Parameter::Twigil,
+        parameter => '$=x', twigil => '=';
+throws-like 'sub f($~x) { }', X::Parameter::Twigil,
+        parameter => '$~x', twigil => '~';
+
+# Legal forms must still parse and run.
+ok (sub ($*x) { $*x })(7) == 7, '$*x dynamic var param is legal';
+ok (sub (:$x) { $x })(x => 3) == 3, ':$x named param is legal';
+ok (sub (:$x!) { $x })(x => 4) == 4, ':$x! required named param is legal';
+ok { $^a + $^b }(2, 3) == 5, 'placeholders in a block body are legal';


### PR DESCRIPTION
Reject placeholder and twigil variables used as signature parameters, matching rakudo's compile-time errors:

- `$:x` / `@:x` / `%:x` → `X::Parameter::Placeholder` (named), carrying `parameter` and `right => ':$x'`.
- `$^x` → `X::Parameter::Placeholder` (positional), `right => '$x'`.
- `$?x` / `$=x` / `$~x` → `X::Parameter::Twigil`, carrying `twigil`.

## Root cause

Previously `$:x` was misparsed: `var_name` consumed only the `$` sigil, leaving `:x`, which the param-list loop treated as an invocant marker and wrongly raised `X::Syntax::Signature::InvocantNotAllowed`.

A new `reject_placeholder_or_twigil_param` check in `parse_single_param_inner` (`src/parser/stmt/sub_param.rs`) fires before `var_name`, detecting a sigil immediately followed by a `:`/`^`/`?`/`=`/`~` twigil and an identifier.

## Unaffected

`$*x` (dynamic var), `$::x` (package-qualified), `$!x`/`$.x` (attribute twigils, handled as `X::Syntax::NoSelf`) and body placeholders (`{ $^a + $^b }`) remain legal.

## Impact

Unblocks `roast/S32-exceptions/misc2.t` tests 20-21 (67 → 65 failing). New test `t/parameter-placeholder.t` (11 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)