### PR TITLE
feat(exceptions): X::Attribute::Package for has in module/package body

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -470,6 +470,25 @@ pub(crate) enum ForMode {
     Lazy,
 }
 
+/// The declarator keyword used for a `Stmt::Package`. Determines the
+/// `package-kind` reported by X::Attribute::Package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum PackageKind {
+    Module,
+    Package,
+    Grammar,
+}
+
+impl PackageKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            PackageKind::Module => "module",
+            PackageKind::Package => "package",
+            PackageKind::Grammar => "grammar",
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) enum Stmt {
     VarDecl {
@@ -538,6 +557,10 @@ pub(crate) enum Stmt {
     Package {
         name: Symbol,
         body: Vec<Stmt>,
+        /// The declarator keyword used (`module`, `package`, `grammar`), which
+        /// determines `package-kind` in the X::Attribute::Package error raised
+        /// when a `has` attribute is declared in this package's body.
+        kind: PackageKind,
         /// True for `unit module Foo;` / `unit package Foo;` where the scope
         /// extends to the rest of the enclosing scope, false for brace-scoped
         /// `package Foo { ... }`.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -44,6 +44,11 @@ pub(crate) struct Compiler {
     /// prefix at compile time, since the runtime does not get a
     /// PackageScope opcode for unit declarations.
     pub(crate) in_unit_package: bool,
+    /// The kind of package (`module`/`package`/`grammar`) whose body is
+    /// currently being compiled, or `None` in the mainline. Used to raise
+    /// X::Attribute::Package when a `has` attribute is declared in a
+    /// module/package body (which cannot hold attributes).
+    pub(crate) current_package_kind: Option<crate::ast::PackageKind>,
     /// The enclosing package name before closure mangling. Used for `$?PACKAGE`
     /// so that methods inside a class report the class name, not the internal
     /// closure package name.
@@ -114,6 +119,7 @@ impl Compiler {
             compiled_functions: HashMap::new(),
             current_package: "GLOBAL".to_string(),
             in_unit_package: false,
+            current_package_kind: None,
             enclosing_package: None,
             tmp_counter: 0,
             dynamic_scope_all: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1786,14 +1786,29 @@ impl Compiler {
                     *sigil
                 };
                 let full_name = format!("{}{}{}", sigil_ch, twigil, bare);
-                let message = format!(
-                    "You cannot declare attribute '{}' here; maybe you'd like a class or a role?",
-                    full_name
-                );
                 let mut attrs = std::collections::HashMap::new();
-                attrs.insert("name".to_string(), Value::str(full_name));
-                attrs.insert("message".to_string(), Value::str(message));
-                let err = Value::make_instance(Symbol::intern("X::Attribute::NoPackage"), attrs);
+                let err = if let Some(pkg_kind) = self.current_package_kind {
+                    // Inside a `module`/`package` body: a package cannot hold
+                    // attributes — X::Attribute::Package.
+                    let kind_str = pkg_kind.as_str();
+                    let message = format!(
+                        "A {} cannot have attributes, but you tried to declare '{}'",
+                        kind_str, full_name
+                    );
+                    attrs.insert("name".to_string(), Value::str(full_name));
+                    attrs.insert("package-kind".to_string(), Value::str(kind_str.to_string()));
+                    attrs.insert("message".to_string(), Value::str(message));
+                    Value::make_instance(Symbol::intern("X::Attribute::Package"), attrs)
+                } else {
+                    // Mainline: no enclosing package at all — X::Attribute::NoPackage.
+                    let message = format!(
+                        "You cannot declare attribute '{}' here; maybe you'd like a class or a role?",
+                        full_name
+                    );
+                    attrs.insert("name".to_string(), Value::str(full_name));
+                    attrs.insert("message".to_string(), Value::str(message));
+                    Value::make_instance(Symbol::intern("X::Attribute::NoPackage"), attrs)
+                };
                 let idx = self.code.add_constant(err);
                 self.code.emit(OpCode::LoadConst(idx));
                 self.code.emit(OpCode::Die);
@@ -1820,6 +1835,7 @@ impl Compiler {
             Stmt::Package {
                 name,
                 body,
+                kind,
                 is_unit,
                 is_my,
             } => {
@@ -1839,6 +1855,11 @@ impl Compiler {
                     // unit module/package — set package for the rest of the scope
                     self.current_package = qualified_name.clone();
                     self.in_unit_package = true;
+                    // A `grammar` body legitimately holds attributes; only
+                    // `module`/`package` bodies reject `has`.
+                    if !matches!(kind, crate::ast::PackageKind::Grammar) {
+                        self.current_package_kind = Some(*kind);
+                    }
                     // Register the package name so it's accessible as a value
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
                     self.code.emit(OpCode::RegisterPackage { name_idx });
@@ -1863,16 +1884,26 @@ impl Compiler {
                     });
                     let saved_package = self.current_package.clone();
                     let saved_in_unit = self.in_unit_package;
+                    let saved_package_kind = self.current_package_kind;
                     self.current_package = qualified_name;
                     // Inside a non-unit `module Foo { ... }` block, runtime
                     // PackageScope handles the package context, so we must
                     // not pre-qualify nested class/role decls here.
                     self.in_unit_package = false;
+                    // A `grammar` body legitimately holds attributes; only
+                    // `module`/`package` bodies reject `has`.
+                    self.current_package_kind = if matches!(kind, crate::ast::PackageKind::Grammar)
+                    {
+                        None
+                    } else {
+                        Some(*kind)
+                    };
                     for s in body {
                         self.compile_stmt(s);
                     }
                     self.current_package = saved_package;
                     self.in_unit_package = saved_in_unit;
+                    self.current_package_kind = saved_package_kind;
                     self.code.patch_body_end(pkg_idx);
                 }
             }

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -1706,6 +1706,7 @@ pub(super) fn anon_grammar_expr(input: &str) -> PResult<'_, Expr> {
         Expr::DoStmt(Box::new(Stmt::Package {
             name: Symbol::intern(&name),
             body,
+            kind: crate::ast::PackageKind::Grammar,
             is_unit: false,
             is_my: false,
         })),

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1729,6 +1729,7 @@ pub(super) fn module_decl(input: &str) -> PResult<'_, Stmt> {
     let package_stmt = Stmt::Package {
         name: Symbol::intern(&name),
         body,
+        kind: crate::ast::PackageKind::Module,
         is_unit: false,
         is_my: false,
     };
@@ -1945,9 +1946,13 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         ));
     }
     // Accept both `unit module Foo;` and `unit package Foo;`
-    let rest = keyword("module", rest)
-        .or_else(|| keyword("package", rest))
-        .ok_or_else(|| PError::expected("'module' or 'package' after 'unit'"))?;
+    let (rest, kind) = if let Some(r) = keyword("module", rest) {
+        (r, crate::ast::PackageKind::Module)
+    } else if let Some(r) = keyword("package", rest) {
+        (r, crate::ast::PackageKind::Package)
+    } else {
+        return Err(PError::expected("'module' or 'package' after 'unit'"));
+    };
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;
     check_pseudo_package_in_decl(&name)?;
@@ -1958,6 +1963,7 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         Stmt::Package {
             name: Symbol::intern(&name),
             body: Vec::new(),
+            kind,
             is_unit: true,
             is_my: false,
         },
@@ -1987,6 +1993,7 @@ fn package_decl_with_scope(input: &str, is_my: bool) -> PResult<'_, Stmt> {
         Stmt::Package {
             name: Symbol::intern(&name),
             body,
+            kind: crate::ast::PackageKind::Package,
             is_unit: false,
             is_my,
         },

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -100,9 +100,18 @@ fn after_default_error(kind: &str, modifier: &str, default: &str) -> PError {
     );
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
-    attrs.insert("type".to_string(), crate::value::Value::str(kind.to_string()));
-    attrs.insert("modifier".to_string(), crate::value::Value::str(modifier.to_string()));
-    attrs.insert("default".to_string(), crate::value::Value::str(default.to_string()));
+    attrs.insert(
+        "type".to_string(),
+        crate::value::Value::str(kind.to_string()),
+    );
+    attrs.insert(
+        "modifier".to_string(),
+        crate::value::Value::str(modifier.to_string()),
+    );
+    attrs.insert(
+        "default".to_string(),
+        crate::value::Value::str(default.to_string()),
+    );
     let ex = crate::value::Value::make_instance(
         crate::symbol::Symbol::intern("X::Parameter::AfterDefault"),
         attrs,
@@ -1591,7 +1600,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         let after_eq = &rest[1..];
         let (expr_start, _) = ws(after_eq)?;
         let (rest, expr) = expression(expr_start)?;
-        default_src = expr_start[..expr_start.len() - rest.len()].trim().to_string();
+        default_src = expr_start[..expr_start.len() - rest.len()]
+            .trim()
+            .to_string();
         (rest, Some(expr))
     } else {
         (rest, None)

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -89,6 +89,27 @@ fn make_param(name: String) -> ParamDef {
     }
 }
 
+/// Build an `X::Parameter::AfterDefault` error for a trait or post-constraint
+/// that appears after the parameter's default value (e.g. `$x = 60 is rw` or
+/// `$x = 60 where Int`). `kind` is `"trait"` or `"post constraint"`; `modifier`
+/// is the offending source fragment (`is rw`, `where Int`); `default` is the
+/// default value source (`60`).
+fn after_default_error(kind: &str, modifier: &str, default: &str) -> PError {
+    let msg = format!(
+        "The {kind} '{modifier}' came after the default value.  Did you mean: ...{modifier} = {default} ?"
+    );
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    attrs.insert("type".to_string(), crate::value::Value::str(kind.to_string()));
+    attrs.insert("modifier".to_string(), crate::value::Value::str(modifier.to_string()));
+    attrs.insert("default".to_string(), crate::value::Value::str(default.to_string()));
+    let ex = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Parameter::AfterDefault"),
+        attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn parse_param_default_expr(input: &str) -> PResult<'_, Expr> {
     if let Ok((rest, expr)) = expression(input) {
         return Ok((rest, expr));
@@ -1565,14 +1586,43 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     }
 
     // Default value
+    let mut default_src = String::new();
     let (rest, mut default) = if rest.starts_with('=') && !rest.starts_with("==") {
-        let rest = &rest[1..];
-        let (rest, _) = ws(rest)?;
-        let (rest, expr) = expression(rest)?;
+        let after_eq = &rest[1..];
+        let (expr_start, _) = ws(after_eq)?;
+        let (rest, expr) = expression(expr_start)?;
+        default_src = expr_start[..expr_start.len() - rest.len()].trim().to_string();
         (rest, Some(expr))
     } else {
         (rest, None)
     };
+
+    // X::Parameter::AfterDefault: a trait (`is rw`) or post-constraint
+    // (`where Int`) that appears AFTER the default value is illegal.
+    if default.is_some() {
+        let (after_default, _) = ws(rest)?;
+        if let Some(after_is) = keyword("is", after_default) {
+            let (trait_start, _) = ws1(after_is)?;
+            let (_, trait_name) = ident(trait_start)?;
+            return Err(after_default_error(
+                "trait",
+                &format!("is {trait_name}"),
+                &default_src,
+            ));
+        }
+        if let Some(after_where) = keyword("where", after_default) {
+            let (constraint_start, _) = ws1(after_where)?;
+            let (rest_after, _) = parse_where_constraint_expr(constraint_start)?;
+            let constraint_src = constraint_start[..constraint_start.len() - rest_after.len()]
+                .trim()
+                .to_string();
+            return Err(after_default_error(
+                "post constraint",
+                &format!("where {constraint_src}"),
+                &default_src,
+            ));
+        }
+    }
 
     // `is copy`, `is rw`, `is readonly`, `is raw` traits (may have multiple)
     let (mut rest, _) = ws(rest)?;

--- a/t/attribute-package.t
+++ b/t/attribute-package.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 9;
+
+# A `has` attribute declared in a module/package body is illegal: a package
+# cannot hold attributes. This is X::Attribute::Package, distinct from the
+# mainline X::Attribute::NoPackage.
+
+throws-like 'my module A { has $.x }', X::Attribute::Package,
+    package-kind => 'module';
+
+throws-like 'package Y { has $.foo }', X::Attribute::Package,
+    package-kind => 'package';
+
+# Public ($.x) and private ($!x) twigils both error.
+throws-like 'module M { has $!secret }', X::Attribute::Package,
+    package-kind => 'module';
+
+# The reported attribute name keeps its sigil + twigil.
+throws-like 'package P { has $.foo }', X::Attribute::Package,
+    name => '$.foo';
+
+# unit form extends the package to the rest of the scope.
+throws-like 'unit module U; has $.x;', X::Attribute::Package,
+    package-kind => 'module';
+
+# The mainline `has` (no enclosing package) stays NoPackage.
+throws-like 'has $.x', X::Attribute::NoPackage;
+
+# A class/role/grammar legitimately holds attributes.
+lives-ok { EVAL 'class C { has $.x = 5 }' }, 'class can have attributes';
+lives-ok { EVAL 'role R { has $.y = 6 }' }, 'role can have attributes';
+lives-ok { EVAL 'grammar G { has $.z = 7; token TOP { . } }' },
+    'grammar can have attributes';


### PR DESCRIPTION
## Summary

A `has` attribute declared in a `module`/`package` body now raises `X::Attribute::Package` (with `package-kind => 'module'/'package'` and `name`), distinct from the mainline `X::Attribute::NoPackage`. Previously both cases raised `NoPackage`.

- `my module A { has $.x }` → `X::Attribute::Package`, `package-kind => 'module'`
- `package Y { has $.foo }` → `X::Attribute::Package`, `package-kind => 'package'`
- `has $.x` (mainline) → unchanged, `X::Attribute::NoPackage`

## Implementation

- Add `kind: PackageKind` (`Module`/`Package`/`Grammar`) to `Stmt::Package`, set at the four parser construction sites.
- Track `current_package_kind` in the compiler, set when entering a `module`/`package` body (a `grammar` body legitimately holds attributes, so it stays `None`).
- The HasDecl error arm picks `X::Attribute::Package` vs `X::Attribute::NoPackage` based on that context.

## Tests

`t/attribute-package.t` (9 subtests): both kinds, public/private twigil, `name` attribute, unit form, mainline NoPackage, and class/role/grammar still accepting attributes. Unblocks `roast/S32-exceptions/misc2.t` tests 232/235 (now 61 failing, was 63). S10-packages/basic.t failures are pre-existing (identical before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)