### PR TITLE
feat(exceptions): X::Syntax::NoSelf for $.attr where no self is available

### DIFF
--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -32,14 +32,9 @@ impl Compiler {
         if let Some(attr_name) = name.strip_prefix('.')
             && !attr_name.is_empty()
         {
-            // Load self and call the accessor method to validate it exists
-            if let Some(&slot) = self.local_map.get("self") {
-                self.code.emit(OpCode::GetLocal(slot));
-            } else {
-                let self_name = self.qualify_variable_name("self");
-                let self_idx = self.code.add_constant(Value::str(self_name));
-                self.code.emit(OpCode::GetGlobal(self_idx));
-            }
+            // Load self (or raise X::Syntax::NoSelf when unavailable) and call
+            // the accessor method to validate it exists.
+            self.emit_load_self_for_accessor(&format!("${}", name));
             let method_idx = self.code.add_constant(Value::str(attr_name.to_string()));
             self.emit_source_line_if_known();
             self.code.emit(OpCode::CallMethod {

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -399,6 +399,19 @@ impl Compiler {
         self.code.emit(OpCode::GetLocal(acc_slot));
     }
 
+    /// Load `self` for a `$.attr` accessor: emit `GetLocal` when `self` is a
+    /// direct local (method body), otherwise `GetSelfOrNoSelf` which resolves
+    /// `self` from the captured environment and raises X::Syntax::NoSelf
+    /// (carrying the accessor's display name) when it is unavailable.
+    pub(super) fn emit_load_self_for_accessor(&mut self, var_display: &str) {
+        if let Some(&slot) = self.local_map.get("self") {
+            self.code.emit(OpCode::GetLocal(slot));
+        } else {
+            let name_idx = self.code.add_constant(Value::str(var_display.to_string()));
+            self.code.emit(OpCode::GetSelfOrNoSelf(name_idx));
+        }
+    }
+
     /// Compile Expr::Var -- variable access with all special cases.
     pub(super) fn compile_expr_var(&mut self, name: &str) {
         // $.attr (public twigil) — compile as self.attr() method call.
@@ -406,14 +419,9 @@ impl Compiler {
         if let Some(attr_name) = name.strip_prefix('.')
             && !attr_name.is_empty()
         {
-            // Load self — use GetLocal when available (method bodies)
-            if let Some(&slot) = self.local_map.get("self") {
-                self.code.emit(OpCode::GetLocal(slot));
-            } else {
-                let self_name = self.qualify_variable_name("self");
-                let self_idx = self.code.add_constant(Value::str(self_name));
-                self.code.emit(OpCode::GetGlobal(self_idx));
-            }
+            // Load self (or raise X::Syntax::NoSelf when unavailable, e.g. in
+            // the mainline or a bare statement in a class body).
+            self.emit_load_self_for_accessor(&format!("${}", name));
             // Call method
             let method_idx = self.code.add_constant(Value::str(attr_name.to_string()));
             self.code.emit(OpCode::CallMethod {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -43,6 +43,10 @@ pub(crate) enum OpCode {
     GetLocalRaw(u32),
     SetLocal(u32),
     GetGlobal(u32),
+    /// Load `self` from the captured environment for a `$.attr` accessor.
+    /// Raises X::Syntax::NoSelf (the operand is the constant index of the
+    /// accessor's display name, e.g. `$.a`) when `self` is unavailable.
+    GetSelfOrNoSelf(u32),
     SetGlobal(u32),
     /// Like SetGlobal but skips @/% coercion (used for `constant @x` / `constant %x`).
     SetGlobalRaw(u32),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1073,6 +1073,27 @@ impl VM {
                 self.stack.push(val);
                 *ip += 1;
             }
+            OpCode::GetSelfOrNoSelf(name_idx) => {
+                // Load `self` for a `$.attr` accessor from the captured env.
+                if let Some(self_val) = self.get_env_with_main_alias("self") {
+                    self.stack.push(self_val);
+                    *ip += 1;
+                } else {
+                    // No enclosing method/submethod: X::Syntax::NoSelf.
+                    let variable = Self::const_str(code, *name_idx).to_string();
+                    let message =
+                        format!("Variable {} used where no 'self' is available", variable);
+                    let mut err = RuntimeError::new(message.clone());
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("variable".to_string(), Value::str(variable));
+                    attrs.insert("message".to_string(), Value::str(message));
+                    err.exception = Some(Box::new(Value::make_instance(
+                        Symbol::intern("X::Syntax::NoSelf"),
+                        attrs,
+                    )));
+                    return Err(err);
+                }
+            }
             OpCode::GetArrayVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
                 // Reject @!attr (private attribute twigil) when no self is available

--- a/t/syntax-noself.t
+++ b/t/syntax-noself.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 8;
+
+# A `$.attr` accessor used where no `self` is available is X::Syntax::NoSelf.
+# This is distinct from bare `self` (X::Syntax::Self::WithoutObject).
+
+throws-like '$.a', X::Syntax::NoSelf, variable => '$.a';
+
+throws-like 'my class B0Rk { $.a }', X::Syntax::NoSelf, variable => '$.a';
+
+# Bare `self` still reports X::Syntax::Self::WithoutObject, not NoSelf.
+throws-like 'self', X::Syntax::Self::WithoutObject;
+
+# Inside a method, `$.attr` resolves against the invocant — including in
+# nested blocks, loops, gather, and `.map` callbacks lexically within it.
+lives-ok {
+    EVAL 'class A1 { has $.x = 5; method m { $.x } }; A1.new.m'
+}, '$.attr works directly in a method body';
+
+is-deeply
+    EVAL('class A2 { has $.x = 5; method m { my $f = { $.x }; $f() } }; A2.new.m'),
+    5,
+    '$.attr works in a nested closure within a method';
+
+is-deeply
+    EVAL('class A3 { has $.n = 3; method m { (1..2).map({ $_ * $.n }).list } }; A3.new.m'),
+    (3, 6),
+    '$.attr works in a .map callback within a method';
+
+is-deeply
+    EVAL('class A4 { has @.xs = 1, 2; method m { gather for @.xs { take $_ } }.list }; A4.new.m'),
+    (1, 2),
+    '$.attr works in gather/take within a method';
+
+# A submethod (e.g. TWEAK) also provides `self`.
+lives-ok {
+    EVAL 'class A5 { has $.x = 9; submethod TWEAK { $.x } }; A5.new'
+}, '$.attr works in a submethod body';


### PR DESCRIPTION
## Summary

A `$.attr` accessor used where `self` is unavailable (the mainline, or a bare statement in a class body) now raises `X::Syntax::NoSelf` with `variable` (e.g. `$.a`), distinct from bare `self`'s `X::Syntax::Self::WithoutObject`. Previously both produced an unstructured runtime error.

- `$.a` (mainline) → `X::Syntax::NoSelf`, `variable => '$.a'`
- `my class B0Rk { $.a }` → `X::Syntax::NoSelf`, `variable => '$.a'`
- `self` → unchanged, `X::Syntax::Self::WithoutObject`

## Implementation

The `$.attr` lowering emits a new `GetSelfOrNoSelf` opcode for the captured-env self load (the `GetLocal` path inside a method body is unchanged). The opcode resolves `self` from the environment and raises `NoSelf` only when genuinely absent.

A runtime check (rather than a compile-time flag) was chosen deliberately: `self` availability is a lexical-then-dynamic property and the many runtime method-compilation entry points use inconsistent param conventions, so a compile-time `self_available` flag produced false positives in nested closures / `.map` callbacks / submethods. The opcode is correct by construction — it only fires when `self` is truly absent at runtime.

## Tests

`t/syntax-noself.t` (8 subtests): both no-self cases, bare `self` still `WithoutObject`, and `$.attr` still working in method bodies, nested closures, `.map` callbacks, gather/take, and submethods. Unblocks `roast/S32-exceptions/misc2.t` tests 227/229 (now 59 failing, was 61). All 112 whitelisted S12/S14/misc2 tests pass.

Note: `$.x = 9` (rw-accessor assignment not writing back) is a separate pre-existing bug, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)