### PR TITLE
feat(exceptions): X::Phaser::PrePost condition source and message

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1964,7 +1964,11 @@ impl Compiler {
                         self.compile_stmt(inner);
                     }
                 }
-                self.code.emit(OpCode::CheckPhaser { is_pre: true });
+                let condition_idx = self.phaser_condition_idx(body);
+                self.code.emit(OpCode::CheckPhaser {
+                    is_pre: true,
+                    condition_idx,
+                });
             }
             Stmt::Phaser {
                 kind: PhaserKind::Post,
@@ -1984,7 +1988,11 @@ impl Compiler {
                         self.compile_stmt(inner);
                     }
                 }
-                self.code.emit(OpCode::CheckPhaser { is_pre: false });
+                let condition_idx = self.phaser_condition_idx(body);
+                self.code.emit(OpCode::CheckPhaser {
+                    is_pre: false,
+                    condition_idx,
+                });
             }
             Stmt::Phaser { .. } => {}
 
@@ -2421,6 +2429,31 @@ impl Compiler {
     }
 
     /// Compile PRE phasers in forward source order.
+    /// Add the source text of a PRE/POST phaser's condition as a constant and
+    /// return its index, for the X::Phaser::PrePost `condition`/message. The
+    /// condition is the phaser body's final expression (e.g. `0`); block-form
+    /// bodies and non-trivial expressions yield `None`.
+    fn phaser_condition_idx(&mut self, body: &[Stmt]) -> Option<u32> {
+        let last = body.last()?;
+        let Stmt::Expr(expr) = last else { return None };
+        let src = Self::deparse_phaser_condition(expr)?;
+        Some(self.code.add_constant(Value::str(src)))
+    }
+
+    /// Best-effort source reconstruction of a phaser condition expression,
+    /// covering the common literal/variable forms (e.g. statement-form
+    /// `PRE 0`). Non-trivial expressions yield `None`.
+    fn deparse_phaser_condition(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Literal(v) => Some(v.to_string_value()),
+            Expr::Var(name) => Some(format!("${}", name)),
+            Expr::ArrayVar(name) => Some(format!("@{}", name)),
+            Expr::HashVar(name) => Some(format!("%{}", name)),
+            Expr::BareWord(name) => Some(name.to_string()),
+            _ => None,
+        }
+    }
+
     /// Each PRE body is compiled, followed by a CheckPhaser { is_pre: true }.
     pub(super) fn compile_pre_phasers(compiler: &mut Compiler, stmts: &[Stmt]) {
         for s in stmts {
@@ -2444,7 +2477,11 @@ impl Compiler {
                         compiler.compile_stmt(inner);
                     }
                 }
-                compiler.code.emit(OpCode::CheckPhaser { is_pre: true });
+                let condition_idx = compiler.phaser_condition_idx(body);
+                compiler.code.emit(OpCode::CheckPhaser {
+                    is_pre: true,
+                    condition_idx,
+                });
             }
         }
     }
@@ -2471,7 +2508,11 @@ impl Compiler {
                         compiler.compile_stmt(inner);
                     }
                 }
-                compiler.code.emit(OpCode::CheckPhaser { is_pre: false });
+                let condition_idx = compiler.phaser_condition_idx(body);
+                compiler.code.emit(OpCode::CheckPhaser {
+                    is_pre: false,
+                    condition_idx,
+                });
             }
         }
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -439,9 +439,12 @@ pub(crate) enum OpCode {
         body_end: u32,
     },
     /// Check the top-of-stack value; if falsy, throw X::Phaser::PrePost.
-    /// `is_pre` distinguishes PRE (true) from POST (false).
+    /// `is_pre` distinguishes PRE (true) from POST (false). `condition_idx` is
+    /// the constant index of the condition's source text (e.g. `0`), used for
+    /// the exception's `condition` attribute and message; `None` when unknown.
     CheckPhaser {
         is_pre: bool,
+        condition_idx: Option<u32>,
     },
     /// Marks the start of an individual LEAVE phaser body within the
     /// KEEP/UNDO queue. `next` points to the start of the next LEAVE

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3718,8 +3718,12 @@ impl VM {
             OpCode::BlockLocalScope { body_end } => {
                 self.exec_block_local_scope_op(code, *body_end, ip, compiled_fns)?;
             }
-            OpCode::CheckPhaser { is_pre } => {
-                self.exec_check_phaser_op(*is_pre)?;
+            OpCode::CheckPhaser {
+                is_pre,
+                condition_idx,
+            } => {
+                let condition = condition_idx.map(|idx| Self::const_str(code, idx).to_string());
+                self.exec_check_phaser_op(*is_pre, condition)?;
                 *ip += 1;
             }
             OpCode::LeaveGuard { .. } => {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3031,19 +3031,34 @@ impl VM {
     }
 
     /// Execute the CheckPhaser opcode: pop TOS, throw X::Phaser::PrePost if falsy.
-    pub(super) fn exec_check_phaser_op(&mut self, is_pre: bool) -> Result<(), RuntimeError> {
+    /// `condition` is the phaser condition's source text (e.g. `0`) when known.
+    pub(super) fn exec_check_phaser_op(
+        &mut self,
+        is_pre: bool,
+        condition: Option<String>,
+    ) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap_or(Value::Nil);
         if !val.truthy() {
             let phaser_name = if is_pre { "PRE" } else { "POST" };
+            let condition = condition.unwrap_or_default();
             let mut attrs = std::collections::HashMap::new();
             attrs.insert(
                 "phaser".to_string(),
                 Value::Str(Arc::new(phaser_name.to_string())),
             );
-            attrs.insert("condition".to_string(), Value::Str(Arc::new(String::new())));
+            attrs.insert(
+                "condition".to_string(),
+                Value::Str(Arc::new(condition.clone())),
+            );
             let exception =
                 Value::make_instance(crate::symbol::Symbol::intern("X::Phaser::PrePost"), attrs);
-            let mut err = RuntimeError::new(format!("Precondition '{}' failed", phaser_name,));
+            // raku: "Precondition '<cond>' failed" / "Postcondition '<cond>' failed".
+            let kind = if is_pre {
+                "Precondition"
+            } else {
+                "Postcondition"
+            };
+            let mut err = RuntimeError::new(format!("{} '{}' failed", kind, condition));
             err.exception = Some(Box::new(exception));
             return Err(err);
         }

--- a/t/phaser-prepost.t
+++ b/t/phaser-prepost.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 7;
+
+# A failing PRE/POST phaser throws X::Phaser::PrePost carrying the phaser name
+# and the condition's source text, with a "Pre/Postcondition '<cond>' failed"
+# message.
+
+throws-like 'my sub a { PRE 0 }; a()', X::Phaser::PrePost,
+    phaser => 'PRE', condition => /0/;
+
+throws-like 'my sub a { POST 0 }; a()', X::Phaser::PrePost,
+    phaser => 'POST', condition => /0/;
+
+throws-like 'my sub a { PRE 0 }; a()', X::Phaser::PrePost,
+    message => /:s Precondition .0. failed/;
+
+throws-like 'my sub a { POST 0 }; a()', X::Phaser::PrePost,
+    message => /:s Postcondition .0. failed/;
+
+# A satisfied PRE/POST does not throw.
+lives-ok { EVAL 'my sub a { PRE 1; 42 }; a()' }, 'satisfied PRE lives';
+lives-ok { EVAL 'my sub a { POST 1; 42 }; a()' }, 'satisfied POST lives';
+
+# Block-form PRE still enforces the condition (a different code path).
+throws-like 'my sub a(Int $i) { PRE { $i > 0 }; 5 }; a(-1)', X::Phaser::PrePost,
+    phaser => 'PRE';


### PR DESCRIPTION
## Summary

A failing PRE/POST phaser now reports the condition's source text in both the `condition` attribute and the message.

- `my sub a { PRE 0 }; a()` → `condition` = `0`, message `Precondition '0' failed`
- `my sub a { POST 0 }; a()` → `condition` = `0`, message `Postcondition '0' failed`

Previously the `condition` attribute was empty and the message wrongly interpolated the phaser name (`Precondition 'PRE' failed`).

## Implementation

The `CheckPhaser` opcode gains a `condition_idx` operand. The compiler deparses the phaser body's final expression (literal/variable forms — e.g. statement-form `PRE 0`) into a source string and threads it through. Block-form conditions (`PRE { ... }`) yield no source, leaving the condition empty (no behaviour change beyond the already-checked `phaser` attribute).

## Tests

`t/phaser-prepost.t` (7 subtests): both kinds' `condition`/`phaser`/message, satisfied PRE/POST, and block-form still enforcing. All 17 whitelisted `S04-phasers/*` tests pass. Unblocks `roast/S32-exceptions/misc2.t` tests 282/283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)