### PR TITLE
feat(exceptions): X::Augment::NoSuchType for augmenting a missing type

### DIFF
--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2440,10 +2440,18 @@ impl Interpreter {
                 "Capture",
             ];
             if !BUILTIN_TYPES.contains(&name) {
-                return Err(RuntimeError::new(format!(
-                    "You tried to augment class {}, but it does not exist",
-                    name
-                )));
+                let message = format!("You tried to augment class {}, but it does not exist", name);
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("message".to_string(), Value::str(message.clone()));
+                attrs.insert("package-kind".to_string(), Value::str("class".to_string()));
+                attrs.insert("package".to_string(), Value::str(name.to_string()));
+                let ex = Value::make_instance(
+                    crate::symbol::Symbol::intern("X::Augment::NoSuchType"),
+                    attrs,
+                );
+                let mut err = RuntimeError::new(message);
+                err.exception = Some(Box::new(ex));
+                return Err(err);
             }
             // Create a minimal entry for the builtin type
             self.registry_mut()

--- a/t/augment-nosuchtype.t
+++ b/t/augment-nosuchtype.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 5;
+
+# Augmenting a non-existent type is X::Augment::NoSuchType, carrying the
+# package-kind and the (possibly qualified) package name.
+
+throws-like 'use MONKEY-TYPING; augment class NoSuchClass { }',
+    X::Augment::NoSuchType, package-kind => 'class', package => 'NoSuchClass';
+
+throws-like 'use MONKEY-TYPING; augment class No::Such::Class { }',
+    X::Augment::NoSuchType, package => 'No::Such::Class';
+
+throws-like 'use MONKEY-TYPING; augment class NoSuchClass { }',
+    X::Augment::NoSuchType, message => /:s does not exist/;
+
+# Augmenting an existing user class still works.
+lives-ok {
+    EVAL 'class HasC { method a { 1 } }; use MONKEY-TYPING; augment class HasC { method b { 2 } }'
+}, 'augmenting an existing class lives';
+
+# Augmenting a builtin type still works.
+lives-ok {
+    EVAL 'use MONKEY-TYPING; augment class Int { method my-triple { self * 3 } }; 5.my-triple'
+}, 'augmenting a builtin type lives';


### PR DESCRIPTION
## Summary

Augmenting a non-existent type now raises a structured `X::Augment::NoSuchType` carrying `package-kind` and `package`, instead of a plain runtime error (the message is unchanged).

- `augment class NoSuchClass { }` → `package-kind => 'class'`, `package => 'NoSuchClass'`
- `augment class No::Such::Class { }` → `package => 'No::Such::Class'`

## Tests

`t/augment-nosuchtype.t` (5 subtests): both cases, message, and augmenting an existing user class / builtin type still works. Whitelisted `S12-attributes/augment-and-initialization.t` and `S12-class/augment-supersede.t` pass. Unblocks `roast/S32-exceptions/misc2.t` tests 244/247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)