### PR TITLE
feat(exceptions): X::TypeCheck::Assignment .got is value, .expected is type object

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1345,7 +1345,7 @@ impl Interpreter {
                 {
                     return Err(RuntimeError::typecheck_assignment(
                         &type_constraint,
-                        super::utils::value_type_name(&value),
+                        &value,
                         Some(&format!("$!{}", method)),
                     ));
                 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3363,11 +3363,16 @@ pub(crate) fn type_check_assignment_typed_error(
     val: &Value,
 ) -> RuntimeError {
     let msg = type_check_assignment_error(var_name, expected, val);
-    let got_type = value_type_name(val);
     let display_name = format_var_name_for_error(var_name);
     let mut attrs = std::collections::HashMap::new();
-    attrs.insert("expected".to_string(), Value::str(expected.to_string()));
-    attrs.insert("got".to_string(), Value::str(got_type.to_string()));
+    // raku exposes `.expected` as the expected type OBJECT and `.got` as the
+    // offending VALUE (not its type name), so `throws-like` matchers like
+    // `expected => Int` / `got => 'foo'` succeed.
+    attrs.insert(
+        "expected".to_string(),
+        Value::Package(crate::symbol::Symbol::intern(expected)),
+    );
+    attrs.insert("got".to_string(), val.clone());
     attrs.insert("symbol".to_string(), Value::str(display_name));
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     RuntimeError::typed("X::TypeCheck::Assignment", attrs)

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -753,22 +753,32 @@ impl RuntimeError {
         Self::typed("X::ControlFlow::Return", attrs)
     }
 
-    /// X::TypeCheck::Assignment - Type check failed in assignment (with optional symbol)
-    pub(crate) fn typecheck_assignment(expected: &str, got: &str, symbol: Option<&str>) -> Self {
+    /// X::TypeCheck::Assignment - Type check failed in assignment (with optional symbol).
+    /// raku exposes `.expected` as the expected type OBJECT and `.got` as the
+    /// offending VALUE; the message still names the value's type.
+    pub(crate) fn typecheck_assignment(
+        expected: &str,
+        got_value: &Value,
+        symbol: Option<&str>,
+    ) -> Self {
+        let got_type = crate::value::types::what_type_name(got_value);
         let msg = if let Some(sym) = symbol {
             format!(
                 "Type check failed in assignment to {}; expected {}, got {}",
-                sym, expected, got
+                sym, expected, got_type
             )
         } else {
             format!(
                 "Type check failed in assignment; expected {}, got {}",
-                expected, got
+                expected, got_type
             )
         };
         let mut attrs = HashMap::new();
-        attrs.insert("expected".to_string(), Value::str(expected.to_string()));
-        attrs.insert("got".to_string(), Value::str(got.to_string()));
+        attrs.insert(
+            "expected".to_string(),
+            Value::Package(crate::symbol::Symbol::intern(expected)),
+        );
+        attrs.insert("got".to_string(), got_value.clone());
         if let Some(sym) = symbol {
             attrs.insert("symbol".to_string(), Value::str(sym.to_string()));
         }

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -424,7 +424,7 @@ impl VM {
                 if !self.interpreter.type_matches_value(&type_name, item) {
                     return Err(RuntimeError::typecheck_assignment(
                         &type_name,
-                        crate::runtime::value_type_name(item),
+                        item,
                         Some(target_name),
                     ));
                 }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2570,7 +2570,7 @@ impl VM {
                     }
                     return Err(RuntimeError::typecheck_assignment(
                         base_constraint,
-                        crate::runtime::utils::value_type_name(&value),
+                        &value,
                         var_name,
                     ));
                 }
@@ -2630,9 +2630,7 @@ impl VM {
             && !self.interpreter.is_container_subclass(constraint)
         {
             return Err(RuntimeError::typecheck_assignment(
-                constraint,
-                crate::runtime::utils::value_type_name(&value),
-                var_name,
+                constraint, &value, var_name,
             ));
         }
         if !matches!(value, Value::Nil) {

--- a/t/typecheck-assignment-got.t
+++ b/t/typecheck-assignment-got.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 5;
+
+# X::TypeCheck::Assignment exposes `.expected` as the expected type object and
+# `.got` as the offending value (not its type name).
+
+throws-like 'my Int $x = "foo"', X::TypeCheck::Assignment,
+    got => 'foo', expected => Int, symbol => '$x';
+
+throws-like 'my Int $x = "foo"', X::TypeCheck::Assignment,
+    message => /:s expected Int, got Str/;
+
+# A different expected type / value.
+throws-like 'my Str $s = 42', X::TypeCheck::Assignment,
+    got => 42, expected => Str, symbol => '$s';
+
+# `.expected` is the type object (matched here via the type-object matcher).
+throws-like 'my Str $s = 42', X::TypeCheck::Assignment, expected => Str;
+
+# A valid typed assignment still works.
+lives-ok { my Int $ok = 5; $ok }, 'valid typed assignment lives';


### PR DESCRIPTION
## Summary

`X::TypeCheck::Assignment` now exposes `.got` as the offending **value** (not its type name) and `.expected` as the expected **type object**, matching rakudo. This lets `throws-like` matchers like `got => 'foo'` and `expected => Int` succeed.

- `my Int $x = "foo"` → `.got` = `"foo"`, `.expected` = `Int`, `.symbol` = `$x`

The message is unchanged (it still names the value's type: `expected Int, got Str`).

## Implementation

`RuntimeError::typecheck_assignment` now takes the offending `&Value` instead of a pre-computed type-name string; it derives the type name internally for the message and stores the value/type-object in the attributes. All four call sites pass the value through. The parallel `type_check_assignment_typed_error` helper (array/hash element + atomic paths) gets the same treatment for consistency.

## Tests

`t/typecheck-assignment-got.t` (5 subtests): `.got`/`.expected`/`.symbol`, message, type-object matcher, and a valid typed assignment. All whitelisted `S09-typed-arrays/*` and `S32-exceptions/*` tests pass (2765 + suite). Unblocks `roast/S32-exceptions/misc2.t` test 331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)