### PR TITLE
feat(exceptions): X::Eval::NoSuchLang for EVAL with unsupported :lang

### DIFF
--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -281,10 +281,17 @@ impl Interpreter {
         if let Some(lang) = Self::named_value(args, "lang") {
             let lang = lang.to_string_value();
             if !lang.eq_ignore_ascii_case("raku") && !lang.eq_ignore_ascii_case("perl6") {
-                return Err(RuntimeError::new(format!(
-                    "EVAL with :lang<{}> is not supported",
-                    lang
-                )));
+                let message = format!("No compiler available for language '{}'", lang);
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("lang".to_string(), Value::str(lang));
+                attrs.insert("message".to_string(), Value::str(message.clone()));
+                let ex = Value::make_instance(
+                    crate::symbol::Symbol::intern("X::Eval::NoSuchLang"),
+                    attrs,
+                );
+                let mut err = RuntimeError::new(message);
+                err.exception = Some(Box::new(ex));
+                return Err(err);
             }
         }
         if code.contains("&?ROUTINE") && self.routine_stack.is_empty() {

--- a/t/eval-nosuchlang.t
+++ b/t/eval-nosuchlang.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 5;
+
+# EVAL with an unsupported :lang raises X::Eval::NoSuchLang carrying `lang`.
+
+throws-like 'EVAL("foo", :lang<no-such-language>)', X::Eval::NoSuchLang,
+    lang => 'no-such-language';
+
+throws-like 'EVAL("foo", :lang<no-such-language>)', X::Eval::NoSuchLang,
+    message => /:s No compiler available for language/;
+
+throws-like 'EVAL("1", :lang<python>)', X::Eval::NoSuchLang, lang => 'python';
+
+# EVAL of Raku still works, with or without an explicit :lang<raku>.
+is EVAL('1 + 2'), 3, 'plain EVAL works';
+is EVAL('3 * 4', :lang<raku>), 12, 'EVAL :lang<raku> works';


### PR DESCRIPTION
## Summary

`EVAL` with an unsupported `:lang` now raises a structured `X::Eval::NoSuchLang` carrying `lang`, with rakudo's message `No compiler available for language '...'`, instead of a plain runtime error.

- `EVAL("foo", :lang<no-such-language>)` → `X::Eval::NoSuchLang`, `lang => 'no-such-language'`
- `EVAL` of Raku (with or without `:lang<raku>`) still works.

## Tests

`t/eval-nosuchlang.t` (5 subtests). Unblocks `roast/S32-exceptions/misc2.t` test 376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)