### PR TITLE
feat(exceptions): X::HyperOp::NonDWIM exposes operator routine handle

### DIFF
--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1279,12 +1279,22 @@ impl VM {
         err
     }
 
-    /// Build an `X::HyperOp::NonDWIM` exception carrying `left-elems` and
-    /// `right-elems` attributes for a non-dwimmy hyper op length mismatch.
-    fn hyperop_nondwim_error(left_elems: usize, right_elems: usize) -> RuntimeError {
+    /// Build an `X::HyperOp::NonDWIM` exception carrying `left-elems`,
+    /// `right-elems`, and `operator` attributes for a non-dwimmy hyper op length
+    /// mismatch. `op` is the infix source (e.g. `+`); `.operator` is exposed as
+    /// a routine handle named `infix:<+>` so `.operator.name` works.
+    fn hyperop_nondwim_error(left_elems: usize, right_elems: usize, op: &str) -> RuntimeError {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("left-elems".to_string(), Value::Int(left_elems as i64));
         attrs.insert("right-elems".to_string(), Value::Int(right_elems as i64));
+        attrs.insert(
+            "operator".to_string(),
+            Value::Routine {
+                package: crate::symbol::Symbol::intern("GLOBAL"),
+                name: crate::symbol::Symbol::intern(&format!("infix:<{}>", op)),
+                is_regex: false,
+            },
+        );
         let msg = format!(
             "Lists on both sides of non-dwimmy hyperop are not of the same length: \
              left: {} elements, right: {} elements",
@@ -1429,7 +1439,7 @@ impl VM {
             let right_fixed = !dwim_right && !right_ext;
             // A non-dwimmy, non-extensible hyper requires equal lengths.
             if left_fixed && right_fixed && left_len != right_len {
-                return Err(Self::hyperop_nondwim_error(left_len, right_len));
+                return Err(Self::hyperop_nondwim_error(left_len, right_len, op));
             }
             // An empty operand cannot be cycled or padded to fill a dwim side, so
             // any empty side yields an empty result (`True »+» ()` is `()`, not a

--- a/t/hyperop-nondwim.t
+++ b/t/hyperop-nondwim.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 5;
+
+# A non-dwimmy hyper op (»op«) over lists of differing lengths raises
+# X::HyperOp::NonDWIM carrying left-elems, right-elems, and an `operator`
+# routine handle whose .name is the infix name.
+
+throws-like '<a b> »+« <c>', X::HyperOp::NonDWIM,
+    left-elems => 2, right-elems => 1,
+    operator => { .name eq 'infix:<+>' };
+
+throws-like '(1, 2, 3) »*« (1, 2)', X::HyperOp::NonDWIM,
+    left-elems => 3, right-elems => 2,
+    operator => { .name eq 'infix:<*>' };
+
+throws-like '<a b> »+« <c>', X::HyperOp::NonDWIM,
+    message => /:s not of the same length/;
+
+# Equal-length non-dwimmy hyper ops still work.
+is-deeply (1, 2, 3) »+« (10, 20, 30), (11, 22, 33),
+    'equal-length non-dwimmy hyperop works';
+
+# A dwimmy side cycles/pads, so unequal lengths are allowed.
+is-deeply (1, 2, 3, 4) »+» (10, 20), (11, 22, 13, 24),
+    'dwimmy hyperop cycles the shorter side';


### PR DESCRIPTION
## Summary

A non-dwimmy hyper op (`»op«`) over unequal-length lists now carries an `operator` attribute (alongside the existing `left-elems`/`right-elems`): a routine handle named `infix:<op>`, so `.operator.name` returns the infix name as rakudo does.

- `<a b> »+« <c>` → `left-elems => 2`, `right-elems => 1`, `.operator.name eq 'infix:<+>'`

## Tests

`t/hyperop-nondwim.t` (5 subtests): two operators, message, and equal-length / dwimmy hyperops still working. Whitelisted hyper/race tests pass. Unblocks `roast/S32-exceptions/misc2.t` test 361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)