### PR TITLE
feat(exceptions): X::DateTime::TimezoneClash for offset string + :timezone

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2,6 +2,20 @@ use super::*;
 use crate::symbol::Symbol;
 use num_traits::ToPrimitive;
 
+/// Whether an ISO 8601 datetime string carries a numeric timezone offset
+/// (`+HHMM` / `-HH:MM`, including `+0000`). The bare `Z` UTC designator is not
+/// a numeric offset. Only the time portion (after `T`/`t`) is inspected so the
+/// `-` separators in the date part are not mistaken for an offset sign.
+fn string_has_numeric_tz_offset(s: &str) -> bool {
+    match s.find(['T', 't']) {
+        Some(pos) => {
+            let time_part = &s[pos + 1..];
+            time_part.contains('+') || time_part.contains('-')
+        }
+        None => false,
+    }
+}
+
 fn is_datetime_constructor_named_arg(key: &str) -> bool {
     matches!(
         key,
@@ -1322,6 +1336,25 @@ impl Interpreter {
                     } else if let Some(v) = positional.first() {
                         match v {
                             Value::Str(s) => {
+                                // X::DateTime::TimezoneClash: a numeric timestamp
+                                // offset in the string (e.g. `+0200`, even `+0000`)
+                                // cannot be combined with an explicit `:timezone`
+                                // argument. A bare `Z` (UTC designator) is exempt.
+                                if timezone_set && string_has_numeric_tz_offset(s) {
+                                    let message =
+                                        "DateTime.new(Str): :timezone argument not allowed with a timestamp offset"
+                                            .to_string();
+                                    let mut attrs = std::collections::HashMap::new();
+                                    attrs
+                                        .insert("message".to_string(), Value::str(message.clone()));
+                                    let ex = Value::make_instance(
+                                        crate::symbol::Symbol::intern("X::DateTime::TimezoneClash"),
+                                        attrs,
+                                    );
+                                    let mut err = RuntimeError::new(message);
+                                    err.exception = Some(Box::new(ex));
+                                    return Err(err);
+                                }
                                 let (y, mo, d, h, mi, sec, tz) =
                                     temporal::parse_datetime_string(s)?;
                                 year = y;

--- a/t/datetime-timezoneclash.t
+++ b/t/datetime-timezoneclash.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# A numeric timestamp offset in the string combined with an explicit
+# :timezone argument raises X::DateTime::TimezoneClash. A bare `Z` is exempt.
+
+throws-like 'DateTime.new("1998-12-31T23:59:60+0200", :timezone<Z>)',
+    X::DateTime::TimezoneClash;
+
+throws-like 'DateTime.new("2024-01-01T00:00:00+0000", :timezone(3600))',
+    X::DateTime::TimezoneClash;
+
+throws-like 'DateTime.new("2024-01-01T00:00:00+0200", :timezone(0))',
+    X::DateTime::TimezoneClash, message => /:s not allowed with a timestamp offset/;
+
+# `Z` (UTC designator) is not a numeric offset, so :timezone is allowed.
+lives-ok { EVAL 'DateTime.new("2024-01-01T00:00:00Z", :timezone(3600))' },
+    'Z designator allows :timezone';
+
+# No offset in the string + :timezone is fine.
+lives-ok { EVAL 'DateTime.new("2024-01-01T00:00:00", :timezone(3600))' },
+    'no offset allows :timezone';
+
+# An offset in the string without :timezone is fine.
+is DateTime.new("2024-01-01T00:00:00+0200").Str, '2024-01-01T00:00:00+02:00',
+    'offset string without :timezone parses';


### PR DESCRIPTION
## Summary

`DateTime.new(Str)` with a numeric timestamp offset in the string combined with an explicit `:timezone` argument now raises `X::DateTime::TimezoneClash`, before leap-second validation.

- `DateTime.new("1998-12-31T23:59:60+0200", :timezone<Z>)` → `X::DateTime::TimezoneClash`
- `DateTime.new("...+0000", :timezone(3600))` → clash (even `+0000`)

A bare `Z` UTC designator is **not** a numeric offset, so `:timezone` is allowed with it (matching rakudo). An offset string without `:timezone`, or `:timezone` without an offset, are both fine.

## Implementation

A small `string_has_numeric_tz_offset` helper inspects only the time portion (after `T`) for a `+`/`-` sign, so the date separators aren't mistaken for an offset. The check runs before `parse_datetime_string`, so it precedes the existing leap-second range validation (which otherwise masked the clash).

## Tests

`t/datetime-timezoneclash.t` (6 subtests): clash cases, `Z` exemption, no-offset, and offset-without-`:timezone`. All whitelisted `S32-temporal/*` tests pass (1103 subtests). Unblocks `roast/S32-exceptions/misc2.t` test 380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)