### PR TITLE
feat(vm): native dispatch for the array-backed Iterator protocol (§1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -27,6 +27,7 @@
 | `vm_call_method_mut_ops.rs` catch-all | generic mut メソッド（plain untyped `@`-array mutators ＋ mutable Buf write methods は除く） | HARD | ③ |
 | ~~`vm_call_method_mut_ops.rs` plain `@`-array mutators~~ | ~~append/prepend/unshift/pop/shift~~ | — | **✅消化 (③ PR-5)**: `try_native_array_mut` で VM ネイティブ。typed/shaped/lazy/shared/constrained は interpreter 維持 |
 | ~~`vm_call_method_mut_ops.rs` mutable Buf write methods~~ | ~~write-bits/write-ubits/write-num*/write-int*/write-uint*~~ | — | **✅消化 (③ PR-7)**: `try_native_buf_mut` で VM ネイティブ。pure 変換は `builtins/{buf_bits,buf_write_num,buf_write_int}` に一本化。type-object/Blob/malformed-arity は interpreter 維持 |
+| ~~`vm_call_method_mut_ops.rs` 単純 array-backed Iterator~~ | ~~pull-one/skip-one/skip-at-least/skip-at-least-pull-one/sink-all~~ | — | **✅消化 (③ PR-9)**: `try_native_iterator` で VM ネイティブ（`$it.pull-one` は CallMethodMut＝mut パス）。`items`+`index` 自己完結のみ。squish（コールバック）/ lazy（gather/coroutine, `is_lazy`）/ push-*（外部バッファ）/ count-only/bool-only は interpreter 維持 |
 | `vm_call_method_mut_ops.rs` array-backed instance | `is Array` storage の push/pop/shift | MEDIUM | 第一級コンテナ Phase 2 |
 | `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B（共有セル所有） |
 | `vm_data_ops.rs` shaped push | shaped 配列 push | MEDIUM | shaped 次元メタ検査の VM 化 |
@@ -228,6 +229,22 @@
   pin `t/native-quanthash-coerce.t`(26)。whitelisted set/bag/mix 29 件全緑、cargo test 458/0。（set.t/bag.t の既知 fail は
   BLOCKERS.md 記載の pre-existing〔bag.t 215=BigInt weight・252=Foo instance union, set.t 226=typed-hash bind〕で本変更と無関係。）
   **次候補: iterator protocol（pull-one/skip-one/push-exactly）の VM ネイティブ化、または `AT-POS` native。本丸は `new`（③ ctor）。**
+
+- **2026-06-09 (③ PR-9, §1 = 単純 array-backed Iterator protocol の VM ネイティブ化)**: PR-8 の広がり実測で次点だった
+  iterator protocol（pull-one=2466/skip-one=2130 等、4-5 files・高カウント）を着手。`vm_call_method_mut_ops.rs` の
+  `try_native_buf_mut` の隣に `try_native_iterator` を追加し、**`items`(Array)+`index`(Int) 自己完結な `Iterator` インスタンス**への
+  `pull-one`/`skip-one`/`skip-at-least`/`skip-at-least-pull-one`/`sink-all` を VM ネイティブに（index 前進 →
+  `overwrite_instance_bindings_by_identity`(env) + `overwrite_instance_in_locals`(locals) で identity writeback＝interpreter の
+  mutating iterator dispatch と同一。エイリアス・sub ローカルスロットも正しく前進）。**重要な発見**: `$it.pull-one` は
+  **CallMethodMut にコンパイルされる**（`expr_method.rs:110` 変数受け手は全て CallMethodMut）＝当初 non-mut パスに置いて発火せず、
+  mut パスへ移して解決。**保守的フォールスルー**: squish iterator（`squish_source`＝ユーザー `as`/`with` コールバック）/ lazy
+  iterator（gather/coroutine＝`is_lazy` 属性、materialized items snapshot でなく interpreter コルーチン pull）/ push-*（外部
+  バッファ arg へ array-identity writeback が必要）/ count-only/bool-only（predictive 扱い）は interpreter 維持＝behavior-invariant。
+  **gather 回帰を1件発見・修正**: 初版が `is_lazy` 付き iterator も掴み `gather{...}.iterator.pull-one` が IterationEnd 即返し →
+  `is_lazy` 除外で解消（除外後は interpreter フォールスルー＝pre-existing 動作）。実測: List/Array/finite-Range iterator の pull-one
+  fallback → 0。pin `t/native-iterator.t`(18, エイリアス/sub ローカル/Range 含む)。S07-iterationbuffer/*-iterator 全緑、cargo test 458/0。
+  （gather.t の Failed:1 は BLOCKERS.md 記載の pre-existing take-rw〔test 38〕で本変更と無関係。）
+  **次候補: `AT-POS` native、coercion 以外の broad な §1、または本丸 `new`（③ ctor）の設計。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -532,6 +532,126 @@ impl VM {
         Some(result)
     }
 
+    /// VM-native Iterator protocol over a self-contained, array-backed `Iterator`
+    /// instance (`items` Array + `index` Int, no `squish_source` callbacks).
+    /// Handles the index-advancing protocol methods `pull-one`/`skip-one`/
+    /// `skip-at-least`/`skip-at-least-pull-one`/`sink-all`, mirroring the
+    /// interpreter's mutating iterator dispatch in `methods_mut.rs` exactly,
+    /// including the identity-based writeback (env + locals) so the receiver
+    /// variable and any aliases observe the advance. Behavior-invariant.
+    ///
+    /// Returns `None` (fall through to the interpreter) for: non-`Iterator`
+    /// receivers; squish iterators (which invoke user `as`/`with` callbacks);
+    /// predictive / coroutine iterators (no concrete `items` array); the
+    /// `push-*` family (it writes pulled elements into an external buffer arg,
+    /// needing array-identity writeback handled by the interpreter); and
+    /// `count-only`/`bool-only` (left to the interpreter's predictive handling).
+    pub(super) fn try_native_iterator(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(
+            method,
+            "pull-one" | "skip-one" | "skip-at-least" | "skip-at-least-pull-one" | "sink-all"
+        ) {
+            return None;
+        }
+        let Value::Instance {
+            class_name,
+            attributes,
+            id,
+        } = target
+        else {
+            return None;
+        };
+        if class_name.resolve() != "Iterator"
+            || attributes.contains_key("squish_source")
+            || attributes.contains_key("is_lazy")
+        {
+            // squish iterators invoke user callbacks; lazy iterators (gather /
+            // lazy Seq) pull through interpreter-owned coroutine state rather than
+            // a materialized `items` snapshot — leave both to the interpreter.
+            return None;
+        }
+        // Only a concrete array-backed iterator (excludes predictive/coroutine
+        // iterators whose state lives off the instance).
+        let Some(Value::Array(items, ..)) = attributes.get("items") else {
+            return None;
+        };
+        let len = items.len();
+        let start_index = match attributes.get("index") {
+            Some(Value::Int(i)) if *i >= 0 => *i as usize,
+            _ => 0,
+        };
+        let mut index = start_index;
+        let ret = match method {
+            "pull-one" => {
+                if index < len {
+                    let out = items[index].clone();
+                    index += 1;
+                    out
+                } else {
+                    Value::str_from("IterationEnd")
+                }
+            }
+            "sink-all" => {
+                index = len;
+                Value::str_from("IterationEnd")
+            }
+            "skip-one" => {
+                if index < len {
+                    index += 1;
+                    Value::Bool(true)
+                } else {
+                    Value::Bool(false)
+                }
+            }
+            "skip-at-least" => {
+                let want = args.first().map(crate::runtime::to_int).unwrap_or(0).max(0) as usize;
+                if len.saturating_sub(index) >= want {
+                    index += want;
+                    Value::Bool(true)
+                } else {
+                    index = len;
+                    Value::Bool(false)
+                }
+            }
+            "skip-at-least-pull-one" => {
+                let want = args.first().map(crate::runtime::to_int).unwrap_or(0).max(0) as usize;
+                if len.saturating_sub(index) >= want {
+                    index += want;
+                    if index < len {
+                        let out = items[index].clone();
+                        index += 1;
+                        out
+                    } else {
+                        Value::str_from("IterationEnd")
+                    }
+                } else {
+                    index = len;
+                    Value::str_from("IterationEnd")
+                }
+            }
+            _ => unreachable!(),
+        };
+        // Write the advanced index back by instance identity (env + locals), as
+        // the interpreter's mutating iterator dispatch does, so the receiver
+        // variable and aliases see the advance.
+        if index != start_index {
+            let mut updated = attributes.as_ref().clone();
+            updated.insert("index".to_string(), Value::Int(index as i64));
+            let cn = class_name.resolve();
+            let inst_id = *id;
+            self.interpreter
+                .overwrite_instance_bindings_by_identity(&cn, inst_id, updated.clone());
+            self.overwrite_instance_in_locals(&cn, inst_id, &updated);
+            self.env_dirty = true;
+        }
+        Some(Ok(ret))
+    }
+
     /// Compile a resolved user method's body on demand when it lacks bytecode,
     /// then dispatch as bytecode instead of through the interpreter bridge.
     /// Almost all user methods are already compiled at class registration

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1213,6 +1213,17 @@ impl VM {
                     self.env_dirty = true;
                     return Ok(());
                 }
+                // Native fast path for the Iterator protocol on a self-contained
+                // array-backed iterator (ledger §1: native receiver dispatch ->
+                // VM-native). `$it.pull-one` etc. compile to CallMethodMut, so the
+                // index-advancing dispatch lands here.
+                if modifier.is_none()
+                    && let Some(result) = self.try_native_iterator(&target, &method, &args)
+                {
+                    self.stack.push(result?);
+                    self.env_dirty = true;
+                    return Ok(());
+                }
                 // Array-subclass instance delegation (mut path): when the Instance's
                 // class inherits from Array, delegate mutating Array methods to the
                 // backing __mutsu_array_storage attribute and write back.

--- a/t/native-iterator.t
+++ b/t/native-iterator.t
@@ -1,0 +1,76 @@
+use Test;
+
+# Pin for VM-native Iterator protocol dispatch (ledger §1: native receiver
+# dispatch -> VM-native). `$it.pull-one` etc. compile to CallMethodMut; the
+# index-advancing dispatch over a self-contained array-backed iterator runs in
+# the VM (try_native_iterator), writing the advanced index back by instance
+# identity exactly as the interpreter's mutating iterator dispatch does. Lazy /
+# squish / predictive iterators stay on the interpreter, so behaviour matches.
+
+plan 18;
+
+# --- pull-one over a List iterator ---
+{
+    my $i = (1, 2, 3).iterator;
+    is $i.pull-one, 1, 'pull-one #1';
+    is $i.pull-one, 2, 'pull-one #2';
+    is $i.pull-one, 3, 'pull-one #3';
+    ok $i.pull-one =:= IterationEnd, 'pull-one at end is IterationEnd';
+    ok $i.pull-one =:= IterationEnd, 'pull-one stays IterationEnd';
+}
+
+# --- pull-one over an Array iterator ---
+{
+    my @a = <a b c>;
+    my $i = @a.iterator;
+    is $i.pull-one, 'a', 'Array iterator pull-one';
+    is $i.pull-one, 'b', 'Array iterator pull-one #2';
+}
+
+# --- pull-one over a (finite) Range iterator ---
+{
+    my $i = (10 .. 13).iterator;
+    my @got;
+    loop {
+        my $x = $i.pull-one;
+        last if $x =:= IterationEnd;
+        @got.push($x);
+    }
+    is @got, [10, 11, 12, 13], 'Range iterator fully drained via pull-one';
+}
+
+# --- skip-one ---
+{
+    my $i = (1, 2, 3).iterator;
+    ok $i.skip-one, 'skip-one returns True with elements left';
+    is $i.pull-one, 2, 'skip-one advanced past the first';
+    ok $i.skip-one, 'skip-one #2 (skips the last element)';
+    nok $i.skip-one, 'skip-one returns False when exhausted';
+}
+
+# --- skip-at-least ---
+{
+    my $i = (1 .. 10).iterator;
+    ok $i.skip-at-least(3), 'skip-at-least(3) succeeds';
+    is $i.pull-one, 4, 'skip-at-least advanced by 3';
+    nok $i.skip-at-least(100), 'skip-at-least past the end returns False';
+    ok $i.pull-one =:= IterationEnd, 'iterator exhausted after over-skip';
+}
+
+# --- iterator advance persists through a local variable inside a sub ---
+{
+    sub drain() {
+        my $i = (1, 2, 3, 4).iterator;
+        $i.skip-at-least(2);
+        $i.pull-one;
+    }
+    is drain(), 3, 'iterator state advances correctly in a sub-local slot';
+}
+
+# --- alias observes the advance (same iterator object) ---
+{
+    my $i = (1, 2, 3).iterator;
+    my $j := $i;
+    $i.pull-one;
+    is $j.pull-one, 2, 'aliased iterator shares advanced state';
+}


### PR DESCRIPTION
## What

VM-native dispatch for `pull-one`/`skip-one`/`skip-at-least`/`skip-at-least-pull-one`/`sink-all` over a self-contained, array-backed `Iterator` instance (`items` + `index`), eliminating a §1 tree-walk fallback (advances interpreter-execution-path removal toward the ④/⑤ env fold).

Breadth-driven slice plan: after the QuantHash coercions (PR #2819), the iterator protocol was the next-highest fallback category (pull-one ~2466, skip-one ~2130).

## Changes

`$it.pull-one` etc. compile to **CallMethodMut** (every variable-receiver method does), so the new `try_native_iterator` lives in the mut path (`vm_call_method_mut_ops.rs`) alongside `try_native_array_mut`/`try_native_buf_mut`. It advances the index and writes the iterator back **by instance identity** — `overwrite_instance_bindings_by_identity` (env) + `overwrite_instance_in_locals` (VM locals) — exactly as the interpreter's mutating iterator dispatch does, so aliases and sub-local iterators observe the advance.

**Conservative fallthrough** (`None` → interpreter), behavior-invariant:
- squish iterators (`squish_source` → user `as`/`with` callbacks)
- lazy iterators (`is_lazy`: gather / lazy Seq → interpreter coroutine pull, not a materialized `items` snapshot)
- the `push-*` family (writes pulled elements into an external buffer arg)
- `count-only`/`bool-only` (interpreter's predictive handling)

A regression was caught and fixed during development: the first cut also grabbed `is_lazy` iterators, making `gather {...}.iterator.pull-one` return `IterationEnd`; the `is_lazy` exclusion restores the interpreter coroutine path.

## Verification

- Measured: List/Array/finite-Range iterator pull-one fallback → **0**.
- pin `t/native-iterator.t` (18: pull-one/skip drain, alias sharing, sub-local slot, Range).
- `cargo test` 458/0, `make test` PASS, S07-iterationbuffer / `*-iterator` green.
- `gather.t` Failed:1 is the pre-existing BLOCKERS-documented take-rw failure (test 38), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)