### PR TITLE
feat(exceptions): X::Parameter::InvalidType for unknown sub parameter types

### DIFF
--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -1,7 +1,64 @@
 use super::*;
 use crate::ast::{PhaserKind, Stmt};
 
+/// Collect the names of all types (class/role/enum/subset) declared anywhere in
+/// `stmts`, descending into block-like bodies. Used so a sub parameter type that
+/// names a type declared in the same compilation unit is not falsely rejected.
+fn collect_declared_type_names(stmts: &[Stmt], out: &mut std::collections::HashSet<String>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::ClassDecl { name, body, .. } | Stmt::RoleDecl { name, body, .. } => {
+                out.insert(name.resolve().to_string());
+                collect_declared_type_names(body, out);
+            }
+            Stmt::EnumDecl { name, .. } | Stmt::SubsetDecl { name, .. } => {
+                out.insert(name.resolve().to_string());
+            }
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
+                collect_declared_type_names(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Validate parameter type constraints for plain subs in `stmts` (descending
+/// into bare blocks/packages, but not class/role bodies whose methods may
+/// legitimately forward-reference the enclosing type).
+fn walk_validate_sub_param_types(
+    interp: &Interpreter,
+    stmts: &[Stmt],
+    declared: &std::collections::HashSet<String>,
+) -> Result<(), RuntimeError> {
+    for stmt in stmts {
+        match stmt {
+            Stmt::SubDecl {
+                param_defs, body, ..
+            } => {
+                interp.validate_param_type_constraints(param_defs, declared)?;
+                walk_validate_sub_param_types(interp, body, declared)?;
+            }
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
+                walk_validate_sub_param_types(interp, body, declared)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 impl Interpreter {
+    /// Reject sub parameter types that name a type unknown to this compilation
+    /// unit (e.g. `sub yoink(Junctoin $barf)`) -> X::Parameter::InvalidType.
+    pub(crate) fn check_eval_param_type_constraints(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        let mut declared = std::collections::HashSet::new();
+        collect_declared_type_names(stmts, &mut declared);
+        walk_validate_sub_param_types(self, stmts, &declared)
+    }
+
     /// Parse and run only BEGIN/CHECK phasers from EVAL'd code (`:check` mode).
     fn parse_and_check_only_with_operators(
         &mut self,

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -110,6 +110,76 @@ impl Interpreter {
         }
     }
 
+    /// Reject parameter type constraints that name an unknown type. To avoid
+    /// false positives we only flag a *simple, undecorated* uppercase type name
+    /// (no `[]`/`()`/smiley/`::`/`<`), which is the typo case rakudo reports as
+    /// X::Parameter::InvalidType. Decorated forms (parametric, coercion,
+    /// smileys, qualified, captures) are left alone. `declared_types` holds the
+    /// type names declared anywhere in the current compilation unit (collected
+    /// before execution, since subs are pre-registered before their declaring
+    /// type executes), so backward/forward references within the unit are valid.
+    pub(crate) fn validate_param_type_constraints(
+        &self,
+        param_defs: &[ParamDef],
+        declared_types: &std::collections::HashSet<String>,
+    ) -> Result<(), RuntimeError> {
+        // Type-capture names declared in this signature (e.g. `::T`) are valid
+        // type names for the rest of the signature.
+        let captures: std::collections::HashSet<&str> = param_defs
+            .iter()
+            .filter_map(|pd| pd.type_constraint.as_deref())
+            .filter_map(|tc| tc.strip_prefix("::"))
+            .collect();
+        for pd in param_defs {
+            // Skip synthetic params (`__type_only__`, `__literal__`): a bare
+            // `(Inf)` / `(True)` term param smartmatches a value, so its
+            // "constraint" is not necessarily a type name.
+            if pd.name.starts_with("__") {
+                continue;
+            }
+            let Some(tc) = pd.type_constraint.as_deref() else {
+                continue;
+            };
+            // Only a bare identifier (letters/digits/_/-) starting uppercase is
+            // considered; anything decorated is skipped as potentially valid.
+            if tc.is_empty()
+                || !tc.starts_with(|c: char| c.is_ascii_uppercase())
+                || !tc
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                continue;
+            }
+            if captures.contains(tc)
+                || declared_types.contains(tc)
+                || self.is_resolvable_type(tc)
+                || self.has_type(tc)
+            {
+                continue;
+            }
+            let suggestions = self.suggest_type_names(tc);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("type".to_string(), Value::str(tc.to_string()));
+            attrs.insert(
+                "suggestions".to_string(),
+                Value::array(suggestions.iter().cloned().map(Value::str).collect()),
+            );
+            let mut message = format!("Invalid typename '{}' in parameter declaration.", tc);
+            if suggestions.len() == 1 {
+                message.push_str(&format!(" Did you mean '{}'?", suggestions[0]));
+            } else if suggestions.len() > 1 {
+                let quoted: Vec<String> = suggestions.iter().map(|s| format!("'{}'", s)).collect();
+                message.push_str(&format!(
+                    " Did you mean any of these: {}?",
+                    quoted.join(", ")
+                ));
+            }
+            attrs.insert("message".to_string(), Value::str(message));
+            return Err(RuntimeError::typed("X::Parameter::InvalidType", attrs));
+        }
+        Ok(())
+    }
+
     fn validate_static_default_typechecks(
         &mut self,
         param_defs: &[ParamDef],

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -826,6 +826,7 @@ impl Interpreter {
         }
         crate::runtime::phasers::reorder_phasers(&mut body_main);
         self.update_raku_version_from_parser();
+        self.check_eval_param_type_constraints(&body_main)?;
         self.preregister_top_level_subs(&body_main)?;
         let mut compiler = crate::compiler::Compiler::new();
         compiler.set_current_package(self.current_package.clone());

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -96,6 +96,7 @@ impl Interpreter {
                 self.check_eval_class_redeclarations(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
+                self.check_eval_param_type_constraints(&stmts)?;
                 // When EVAL is called inside a class body, MethodDecl statements
                 // should be added to the enclosing class rather than lowered to subs.
                 let mut stmts = self.inject_eval_methods_into_class(stmts);

--- a/t/parameter-invalidtype.t
+++ b/t/parameter-invalidtype.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 9;
+
+# A sub parameter whose type names an unknown type raises
+# X::Parameter::InvalidType, with a "Did you mean" suggestion when close.
+
+throws-like 'sub yoink(Junctoin $barf) { }', X::Parameter::InvalidType,
+    suggestions => 'Junction';
+
+throws-like 'sub f(Nonexistent $x) { }', X::Parameter::InvalidType;
+
+throws-like 'multi sub f(Junctoin $x) { }', X::Parameter::InvalidType,
+    suggestions => 'Junction';
+
+# Valid types (builtin, user class/role/subset/enum) are accepted, including
+# when the type is declared after the sub in the same compilation unit.
+lives-ok { EVAL 'sub f(Int $x) { $x }' }, 'builtin type accepted';
+lives-ok { EVAL 'class C { }; sub f(C $x) { }' }, 'user class accepted';
+lives-ok { EVAL 'role R { }; sub f(R $x) { }' }, 'role accepted';
+lives-ok { EVAL 'subset Sm of Int where * > 0; sub f(Sm $x) { }' },
+    'subset accepted';
+lives-ok { EVAL 'sub f(Forward $x) { }; class Forward { }' },
+    'type declared later in the same unit is accepted';
+
+# A bare term param (e.g. `(Inf)`) smartmatches a value, not a type.
+lives-ok { EVAL 'multi foo(Inf) { "inf" }; foo(Inf)' },
+    'bare value term parameter is not treated as a type';


### PR DESCRIPTION
## Summary

A sub parameter whose type names a type unknown to the compilation unit now raises `X::Parameter::InvalidType`, carrying `type`, `suggestions`, and a "Did you mean" message.

- `sub yoink(Junctoin $barf) { }` → `X::Parameter::InvalidType`, `suggestions => 'Junction'`

## Implementation

Subs are pre-registered before their declaring types execute, so a registration-time check would false-positive on every user class/role/enum/subset (even backward references). Instead the check runs as a **pre-execution pass** (alongside the other `check_eval_*` passes, and in `run()`): it first collects every type declared anywhere in the unit, so backward/forward references within the unit are accepted (rakudo rejects forward refs; being lenient there is safe — no false positives).

To stay conservative, only a **simple, undecorated uppercase identifier** on a **named** parameter is flagged. Left alone: decorated forms (parametric `Array[Int]`, coercion `Int(Str)`, smileys `Int:D`, qualified `Foo::Bar`, captures `::T`), synthetic `__type_only__` value-term params (e.g. `(Inf)`, `(True)`), roles/enums/subsets, and method signatures.

## Tests

`t/parameter-invalidtype.t` (9 subtests): typo detection (sub + multi), and acceptance of builtin/class/role/subset/forward-declared types and bare value-term params. `make test` passes (5809), and all 145 whitelisted `S06-signature` / `S12` / `S14-roles` / `S32-exceptions` files pass (2993 subtests). Unblocks `roast/S32-exceptions/misc2.t` test 453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)