### PR TITLE
feat(exceptions): X::Comp::Group for a statement keyword used as a function

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1384,9 +1384,97 @@ fn try_extend_colon_name<'a>(input: &'a str, base: &str) -> (&'a str, String) {
     (rest, name)
 }
 
+/// Given input beginning with `(`, skip the balanced parenthesised group and
+/// return true if the next non-whitespace character is `{` (the start of a
+/// block). Used to distinguish `if() {}` (keyword-as-function) from `if(5)`
+/// (undeclared routine). A simple paren-depth counter is sufficient here.
+fn parens_then_block(input: &str) -> bool {
+    let bytes = input.as_bytes();
+    debug_assert_eq!(bytes.first(), Some(&b'('));
+    let mut depth = 0usize;
+    let mut idx = 0usize;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    idx += 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+        idx += 1;
+    }
+    if depth != 0 {
+        return false;
+    }
+    input[idx..].trim_start().starts_with('{')
+}
+
+/// Build the X::Comp::Group error for a statement-control keyword used as a
+/// function call (`if() {}`). The group's first sorrow is an
+/// X::Syntax::KeywordAsFunction instance carrying the offending word.
+fn keyword_as_function_error(word: &str) -> PError {
+    let msg = format!(
+        "The word '{}' is interpreted as a '{}()' function call. \
+         Please use whitespace instead of parentheses.",
+        word, word
+    );
+    let mut sorrow_attrs = std::collections::HashMap::new();
+    sorrow_attrs.insert(
+        "word".to_string(),
+        crate::value::Value::str(word.to_string()),
+    );
+    sorrow_attrs.insert("needparens".to_string(), crate::value::Value::Bool(false));
+    sorrow_attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    let sorrow = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Syntax::KeywordAsFunction"),
+        sorrow_attrs,
+    );
+    let mut group_attrs = std::collections::HashMap::new();
+    group_attrs.insert(
+        "sorrows".to_string(),
+        crate::value::Value::array(vec![sorrow]),
+    );
+    group_attrs.insert("worries".to_string(), crate::value::Value::array(vec![]));
+    group_attrs.insert("panic".to_string(), crate::value::Value::Nil);
+    group_attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    let exception = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Comp::Group"),
+        group_attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(exception))
+}
+
 pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     let (rest, name) = super::super::stmt::parse_raku_ident(input)?;
     let name = normalize_raku_identifier(name);
+
+    // A statement-control keyword immediately followed by `(...) { ... }` (no
+    // whitespace before the parens) is a `keyword()`-as-function mistake
+    // (`if() {}`, `with() {}`). Raku rejects this with an X::Comp::Group whose
+    // first sorrow is X::Syntax::KeywordAsFunction. Without a trailing block
+    // (`loop(5)`) Raku instead reports an undeclared routine, so we only flag
+    // the block form here.
+    if rest.starts_with('(')
+        && matches!(
+            name.as_str(),
+            "if" | "unless"
+                | "while"
+                | "until"
+                | "for"
+                | "given"
+                | "when"
+                | "with"
+                | "without"
+                | "loop"
+        )
+        && parens_then_block(rest)
+    {
+        return Err(keyword_as_function_error(&name));
+    }
 
     // If the identifier is followed by `=>` (fat arrow), treat it as a pair
     // key regardless of whether it would otherwise be a declarator keyword.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2720,6 +2720,7 @@ impl Interpreter {
         register_x("X::Syntax::WithoutElse", "X::Syntax");
         register_x("X::Syntax::UnlessElse", "X::Syntax");
         register_x("X::Syntax::Reserved", "X::Syntax");
+        register_x("X::Syntax::KeywordAsFunction", "X::Syntax");
 
         // X::Obsolete (compile-time, subtype of X::Comp)
         register_x("X::Obsolete", "X::Comp");

--- a/t/keyword-as-function.t
+++ b/t/keyword-as-function.t
@@ -1,0 +1,30 @@
+use Test;
+
+# A statement-control keyword immediately followed by `(` (no whitespace) is a
+# `keyword()`-as-function mistake. Raku rejects it with an X::Comp::Group whose
+# first sorrow is X::Syntax::KeywordAsFunction.
+
+plan 13;
+
+for <if unless while until for given when with without loop> -> $kw {
+    throws-like
+        $kw ~ '() {}',
+        X::Comp::Group,
+        "$kw\() is rejected",
+        sorrows => sub (@s) { @s[0] ~~ X::Syntax::KeywordAsFunction };
+}
+
+# The offending word is exposed on the sorrow.
+throws-like
+    q[if() {}],
+    X::Comp::Group,
+    'sorrow exposes .word',
+    sorrows => sub (@s) { @s[0].word eq 'if' };
+
+# Legitimate uses with whitespace still parse and run.
+lives-ok { my $r = (if-marker => 1); }, 'identifier containing keyword still ok';
+
+is-deeply
+    (do { my @out; for 1, 2 -> $x { @out.push: $x }; @out }),
+    [1, 2],
+    'for with whitespace still works';


### PR DESCRIPTION
## Summary

`if() {}`, `with() {}`, `without() {}` — a statement-control keyword immediately
followed by `(...)` and then a block — are a `keyword()`-as-function mistake.
Raku rejects these at compile time with an **X::Comp::Group** whose first sorrow
is an **X::Syntax::KeywordAsFunction**.

mutsu previously parsed `if(...)` (no whitespace) as a `Call` to an undeclared
routine and failed at runtime with `Unknown function: if`. Now
`identifier_or_call` detects a statement-control keyword
(`if`/`unless`/`while`/`until`/`for`/`given`/`when`/`with`/`without`/`loop`)
directly followed by a parenthesised group **and a `{` block**, and raises a
structured `X::Comp::Group` via `PError::fatal_with_exception`.

The trailing-block check (`parens_then_block`) keeps `loop(5)` — keyword + parens
with **no** following block — on the existing undeclared-routine path, matching
rakudo (which reports `Undeclared routine` there, not `KeywordAsFunction`). This
also preserves the `primary_parses_keyword_named_sub_calls` unit test.

Covers `roast/S32-exceptions/misc2.t:148-151` (misc2.t 49 → 46 failing).

## Test plan

- New `t/keyword-as-function.t` (13 subtests): each keyword `kw() {}` throws
  `X::Comp::Group` with `sorrows[0] ~~ X::Syntax::KeywordAsFunction`; the sorrow
  exposes `.word`; whitespace forms still parse and run.
- `make test` — Result: PASS (cargo 458 passed; prove all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)