### PR TITLE
feat(vm): native dispatch for plain @-array splice (§1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -246,6 +246,22 @@
   （gather.t の Failed:1 は BLOCKERS.md 記載の pre-existing take-rw〔test 38〕で本変更と無関係。）
   **次候補: `AT-POS` native、coercion 以外の broad な §1、または本丸 `new`（③ ctor）の設計。**
 
+- **2026-06-09 (③ PR-10, §1 catch-all = plain `@`-array `splice` の VM ネイティブ化)**: PR-5 の
+  `try_native_array_mut`（append/prepend/unshift/pop/shift）の姉妹として `vm_call_method_mut_ops.rs` に
+  `try_native_array_splice` を追加し、**plain untyped `@`-array（`ArrayKind::Array`）への `splice` の単純形**を VM
+  ネイティブに。interpreter の `methods_mut.rs` の `splice` 枝と同一の `drain`+`insert`（削除要素を `Value::real_array`
+  で返す）＋ `Arc::make_mut` writeback＋make_mut 再確保後の stale type-metadata 防御除去で behavior-invariant。
+  **保守的フォールスルー**（`None`→interpreter）: offset/count が plain 非負 `Int` 以外（WhateverCode/`Whatever`/
+  `Str`/`Num`）・offset 範囲外（`X::OutOfRange`）・count 負（`X::OutOfRange`）・lazy 置換（`X::Cannot::Lazy`）・
+  typed（`var_type_constraint` Some）/ shaped / shared（`shared_vars_active`）/ metadata 持ち配列。**実証**:
+  splice_check で 16 形全て raku 一致、`@j := @i` エイリアスは **interpreter splice 経路（WhateverCode offset で
+  fallthrough）も同じく `[1 2 3 4]`** ＝ pre-existing な container-identity ギャップ（🟣第一級コンテナ Phase 2）で
+  splice 固有でなく挙動不変。pin `t/native-array-splice.t`(28, 置換平坦化・末尾 splice・count クランプ・独立 removed
+  list・fallthrough X::OutOfRange/X::Cannot::Lazy 含む)。`S32-array/splice.t` の untyped 領域（最初60サブテスト）
+  not-ok ゼロ・push/pop/shift/unshift/S03-binding/arrays/S09-multidim/methods 全緑、cargo test 458/0、make test PASS。
+  （splice.t 全体は非whitelist の pre-existing fail＝`array[int]`/`array[int8]` typed-array メタデータ問題で、native
+  経路は typed array で必ず bail＝interpreter 維持のためカウント不変。）
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1203,6 +1203,17 @@ impl VM {
                     self.env_dirty = true;
                     return Ok(());
                 }
+                // Native fast path for the simple (non-erroring) forms of `splice`
+                // on a plain, untyped `@`-array (ledger §1: native receiver
+                // dispatch -> VM-native).
+                if modifier.is_none()
+                    && let Some(result) =
+                        self.try_native_array_splice(&target_name, &target, &method, &args)
+                {
+                    self.stack.push(result?);
+                    self.env_dirty = true;
+                    return Ok(());
+                }
                 // Native fast path for mutating Buf write methods on a mutable Buf
                 // instance (ledger §1: native receiver dispatch -> VM-native).
                 if modifier.is_none()
@@ -1503,6 +1514,108 @@ impl VM {
             self.interpreter.unregister_container_type_metadata(&stored);
         }
         Some(Ok(result))
+    }
+
+    /// VM-native `splice` on a plain, untyped `@`-array bound to `target_name`
+    /// (ledger §1: native receiver dispatch -> VM-native). Mirrors the
+    /// interpreter's `splice` branch in `methods_mut.rs` exactly (`drain` +
+    /// `insert`, returning the removed elements as a real array), so the result
+    /// is behavior-invariant.
+    ///
+    /// Conservatively handles only the simple, non-erroring forms: the offset
+    /// and count arguments must be plain non-negative `Int`s (or absent) and any
+    /// replacement values must be non-lazy. Returns `None` (fall through to the
+    /// interpreter) for every richer case the interpreter owns: a
+    /// WhateverCode/`Whatever`/`Str`/`Num` offset or count, an out-of-range
+    /// offset (`X::OutOfRange`), a lazy replacement (`X::Cannot::Lazy`), and
+    /// typed/shaped/shared/metadata-bearing arrays.
+    fn try_native_array_splice(
+        &mut self,
+        target_name: &str,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "splice" {
+            return None;
+        }
+        // Only a plain `@`-sigiled variable whose value is a real `[...]` array
+        // (ArrayKind::Array). This excludes List/Item/Shaped/Lazy kinds.
+        if !target_name.starts_with('@')
+            || !matches!(target, Value::Array(_, crate::value::ArrayKind::Array))
+        {
+            return None;
+        }
+        // Shared / type-constrained / metadata-bearing containers need the
+        // interpreter's element checks, native-array semantics, and identity
+        // sharing; let it own those.
+        if self.interpreter.shared_vars_active
+            || self.interpreter.var_type_constraint(target_name).is_some()
+            || self.interpreter.container_type_metadata(target).is_some()
+        {
+            return None;
+        }
+        // Offset (arg 0) and count (arg 1): plain non-negative `Int`, or absent.
+        // Anything else (Whatever/Str/Num/Callable) goes to the interpreter,
+        // which also owns the `X::OutOfRange` error for a negative offset/count.
+        let raw_start = match args.first() {
+            None => None,
+            Some(Value::Int(i)) if *i >= 0 => Some(*i as usize),
+            _ => return None,
+        };
+        let raw_count = match args.get(1) {
+            None => None,
+            Some(Value::Int(i)) if *i >= 0 => Some(*i as usize),
+            _ => return None,
+        };
+        // Replacement values (args[2..]): reject lazy values (the interpreter
+        // raises `X::Cannot::Lazy`); flatten `Array` args exactly as the
+        // interpreter's `do_splice` does.
+        let mut replacement: Vec<Value> = Vec::new();
+        for arg in args.iter().skip(2) {
+            match arg {
+                Value::Array(arr, ..) => {
+                    if arr.iter().any(crate::builtins::methods_0arg::is_value_lazy) {
+                        return None;
+                    }
+                    replacement.extend(arr.iter().cloned());
+                }
+                other => {
+                    if crate::builtins::methods_0arg::is_value_lazy(other) {
+                        return None;
+                    }
+                    replacement.push(other.clone());
+                }
+            }
+        }
+        // The receiver must be exactly the array currently bound to this name, so
+        // an in-place `Arc::make_mut` writeback is correct. Compute the splice
+        // bounds from the live binding's length (not `target`).
+        let Some(Value::Array(arc_items, crate::value::ArrayKind::Array)) =
+            self.interpreter.env_mut().get_mut(target_name)
+        else {
+            return None;
+        };
+        let len = arc_items.len();
+        let start = raw_start.unwrap_or(0);
+        // An offset past the end is `X::OutOfRange` in the interpreter.
+        if start > len {
+            return None;
+        }
+        let count = raw_count.unwrap_or(len - start);
+        let end = (start + count).min(len);
+        let items = Arc::make_mut(arc_items);
+        let removed: Vec<Value> = items.drain(start..end).collect();
+        for (i, item) in replacement.into_iter().enumerate() {
+            items.insert(start + i, item);
+        }
+        // `Arc::make_mut` may reallocate the backing buffer; drop any stale
+        // pointer-keyed type metadata that could alias the fresh pointer (same
+        // hazard handled in `try_native_array_mut`).
+        if let Some(stored @ Value::Array(..)) = self.interpreter.env().get(target_name).cloned() {
+            self.interpreter.unregister_container_type_metadata(&stored);
+        }
+        Some(Ok(Value::real_array(removed)))
     }
 
     /// VM-native mutating Buf write methods (`write-bits`/`write-ubits`/

--- a/t/native-array-splice.t
+++ b/t/native-array-splice.t
@@ -1,0 +1,118 @@
+use Test;
+
+# VM-native `splice` on a plain, untyped `@`-array (ledger §1: native receiver
+# dispatch -> VM-native). The native path handles the simple, non-erroring
+# forms (plain non-negative Int offset/count, non-lazy replacements); richer
+# forms fall through to the interpreter. These assertions match `raku`.
+
+plan 28;
+
+# --- removed-list return value + in-place mutation -----------------------
+{
+    my @a = 1, 2, 3, 4, 5;
+    is-deeply @a.splice(1, 2), [2, 3], 'splice(start, count) returns removed';
+    is-deeply @a, [1, 4, 5], '... and mutates the array in place';
+}
+
+# splice(start) removes through the end
+{
+    my @b = 1, 2, 3, 4, 5;
+    is-deeply @b.splice(2), [3, 4, 5], 'splice(start) removes to end';
+    is-deeply @b, [1, 2], '... leaving the prefix';
+}
+
+# splice() with no args removes everything
+{
+    my @c = 1, 2, 3, 4, 5;
+    is-deeply @c.splice, [1, 2, 3, 4, 5], 'splice() removes all';
+    is-deeply @c, [], '... leaving an empty array';
+}
+
+# --- replacement values --------------------------------------------------
+{
+    my @d = 1, 2, 3, 4, 5;
+    is-deeply @d.splice(1, 2, 'x', 'y', 'z'), [2, 3], 'splice with scalar replacements: removed';
+    is-deeply @d, [1, 'x', 'y', 'z', 4, 5], '... inserts the replacements';
+}
+
+# Array replacement is flattened
+{
+    my @f = 1, 2, 3, 4, 5;
+    is-deeply @f.splice(1, 2, [10, 20]), [2, 3], 'array replacement: removed';
+    is-deeply @f, [1, 10, 20, 4, 5], '... array replacement is flattened in';
+}
+
+# Insert without removal (count == 0)
+{
+    my @g = 1, 2, 3;
+    is-deeply @g.splice(1, 0, 'mid'), [], 'splice(start, 0, x): removes nothing';
+    is-deeply @g, [1, 'mid', 2, 3], '... inserts at the offset';
+}
+
+# Splice at the very end (start == elems)
+{
+    my @e = 1, 2, 3;
+    is-deeply @e.splice(3, 0, 99), [], 'splice at end: removes nothing';
+    is-deeply @e, [1, 2, 3, 99], '... appends the replacement';
+}
+
+# Count larger than the remaining elements is clamped
+{
+    my @h = 1, 2, 3;
+    is-deeply @h.splice(1, 100), [2, 3], 'oversized count is clamped: removed';
+    is-deeply @h, [1], '... leaving the unspliced prefix';
+}
+
+# --- emptiness / single element edge cases -------------------------------
+{
+    my @i = 42;
+    is-deeply @i.splice(0, 1), [42], 'splice the only element';
+    is-deeply @i, [], '... empties the array';
+}
+{
+    my @j;
+    is-deeply @j.splice, [], 'splice() on an empty array returns []';
+    is-deeply @j, [], '... and stays empty';
+}
+
+# --- the spliced result is a fresh, independent array --------------------
+{
+    my @k = 1, 2, 3, 4;
+    my @removed = @k.splice(1, 2);
+    @removed.push(99);
+    is-deeply @k, [1, 4], 'mutating the removed list does not touch the source';
+    is-deeply @removed, [2, 3, 99], 'removed list is an independent array';
+}
+
+# --- interpreter-owned forms still work (fall-through) --------------------
+# WhateverCode offset -> interpreter; native path returns None.
+{
+    my @l = 1, 2, 3, 4, 5;
+    is-deeply @l.splice(*-2), [4, 5], 'WhateverCode offset falls through to interpreter';
+    is-deeply @l, [1, 2, 3], '... and mutates correctly';
+}
+
+# Out-of-range offset throws X::OutOfRange (interpreter-owned).
+{
+    my @m = 1, 2, 3;
+    dies-ok { @m.splice(10) }, 'offset past the end dies (X::OutOfRange)';
+}
+
+# Negative count throws (interpreter-owned).
+{
+    my @n = 1, 2, 3;
+    dies-ok { @n.splice(0, -1) }, 'negative count dies (X::OutOfRange)';
+}
+
+# Splicing a lazy list in is X::Cannot::Lazy (interpreter-owned).
+{
+    my @o = 1, 2, 3;
+    dies-ok { @o.splice(1, 1, (1..Inf).grep(* %% 2)) }, 'lazy replacement dies (X::Cannot::Lazy)';
+}
+
+# done in a loop: native writeback survives repeated splices
+{
+    my @p = 0 .. 9;
+    @p.splice(0, 1) for ^5;
+    is-deeply @p, [5, 6, 7, 8, 9], 'repeated splice in a loop mutates each time';
+}


### PR DESCRIPTION
## What

VM-native dispatch for the simple, non-erroring forms of `splice` on a plain, untyped `@`-array (`ArrayKind::Array`), eliminating a §1 catch-all tree-walk fallback. Sibling of #2823's predecessor PR-5 `try_native_array_mut` (append/prepend/unshift/pop/shift): same gating, same in-place `Arc::make_mut` writeback, same defensive stale-metadata cleanup, so behavior is invariant.

`try_native_array_splice` mirrors the interpreter's `splice` branch in `methods_mut.rs` exactly (`drain` + `insert`, returning removed elements as `Value::real_array`), but only for cases the interpreter handles without extra machinery:

- offset (arg 0) and count (arg 1) are plain non-negative `Int`s, or absent
- replacement values (args[2..]) are non-lazy; `Array` args flatten in exactly as `do_splice`
- splice bounds computed from the **live** env binding's length; the receiver must be the array currently bound to this name

## Conservative fallthrough (returns None → interpreter, behavior-invariant)

- WhateverCode/`Whatever`/`Str`/`Num` offset or count (interpreter resolves callables)
- out-of-range offset / negative count (interpreter raises `X::OutOfRange`)
- lazy replacement (interpreter raises `X::Cannot::Lazy`)
- typed / shaped / shared / metadata-bearing arrays

## Notes

The `@j := @i` alias case (splice on `@i` not observed by `@j`) is a **pre-existing** first-class-container gap: the interpreter splice path (reached via a WhateverCode offset) returns the same non-aliased result, and the already-native push/pop/shift have the identical limitation — so this slice is behavior-invariant.

## Testing

- pin `t/native-array-splice.t` (28: replacement flatten, splice-at-end, count clamp, independent removed list, fall-through `X::OutOfRange` / `X::Cannot::Lazy`)
- `S32-array/splice.t` untyped region (first 60 subtests) not-ok-free; push/pop/shift/unshift/S03-binding/arrays/S09-multidim/methods all green
- cargo test 458/0, make test PASS
- splice.t as a whole is a non-whitelisted pre-existing fail in its `array[int]`/`array[int8]` typed-array metadata subtests, which the native path always bails on → interpreter, so its count is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)