### PR TITLE
feat(exceptions): X::Comp with payload for definite-return + return arg

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2811,6 +2811,21 @@ impl Interpreter {
         register_x("X::Channel::SendOnClosed", "Exception");
         register_x("X::Channel::ReceiveOnClosed", "Exception");
 
+        // X::Comp::AdHoc does both X::Comp and X::AdHoc in rakudo (it is the
+        // compile-time wrapper around an ad-hoc die), so `$e ~~ X::AdHoc` must
+        // also be True. register_x only threads a single parent, so splice
+        // X::AdHoc into the MRO here (after the closure's borrow of `classes`
+        // has ended).
+        if let Some(def) = classes.get_mut("X::Comp::AdHoc") {
+            if !def.parents.iter().any(|p| p == "X::AdHoc") {
+                def.parents.push("X::AdHoc".to_string());
+            }
+            if !def.mro.iter().any(|m| m == "X::AdHoc") {
+                let insert_at = def.mro.len().saturating_sub(1);
+                def.mro.insert(insert_at, "X::AdHoc".to_string());
+            }
+        }
+
         let mut interpreter = Self {
             env: Env::from(env),
             output: String::new(),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -712,15 +712,26 @@ impl Interpreter {
         self.args_match_param_types(args, &def.param_defs)
     }
 
-    pub(super) fn malformed_return_value_compile_error() -> RuntimeError {
-        let mut err = RuntimeError::new("Malformed return value");
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert(
-            "message".to_string(),
-            Value::str_from("Malformed return value"),
+    /// A routine whose signature already pins the return value (`--> Nil`,
+    /// `--> 42`, `--> "foo"`) may not also `return` an argument. Raku rejects
+    /// this at compile time with an X::Comp::AdHoc carrying the offending value
+    /// in its `payload`. `spec` is the verbatim return-type source (e.g. `Nil`,
+    /// `42`, `"foo"`).
+    pub(super) fn malformed_return_value_compile_error(spec: &str) -> RuntimeError {
+        let message = format!(
+            "No return arguments allowed when return value {} is already specified in the signature",
+            spec.trim()
         );
+        let mut err = RuntimeError::new(&message);
+        err.code = Some(crate::value::RuntimeErrorCode::ParseGeneric);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        attrs.insert("payload".to_string(), Value::str(message));
+        // X::Comp::AdHoc does both X::Comp and X::AdHoc in rakudo, so this
+        // satisfies both `~~ X::Comp` (misc2.t:326-329) and `~~ X::AdHoc`
+        // (S06-signature/definite-return.t "even a Failure").
         err.exception = Some(Box::new(Value::make_instance(
-            Symbol::intern("X::AdHoc"),
+            Symbol::intern("X::Comp::AdHoc"),
             attrs,
         )));
         err

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -237,7 +237,7 @@ impl Interpreter {
             && self.is_definite_return_spec(spec)
             && Self::body_contains_non_nil_return(body)
         {
-            return Err(Self::malformed_return_value_compile_error());
+            return Err(Self::malformed_return_value_compile_error(spec));
         }
         // Auto-detect @_ / %_ usage for subs without explicit signatures
         let (effective_param_defs, empty_sig) = if param_defs.is_empty() && params.is_empty() {
@@ -721,7 +721,7 @@ impl Interpreter {
             && self.is_definite_return_spec(spec)
             && Self::body_contains_non_nil_return(body)
         {
-            return Err(Self::malformed_return_value_compile_error());
+            return Err(Self::malformed_return_value_compile_error(spec));
         }
         // Auto-detect @_ / %_ usage for subs without explicit signatures
         let (effective_param_defs, empty_sig) = if param_defs.is_empty() && params.is_empty() {

--- a/t/definite-return.t
+++ b/t/definite-return.t
@@ -7,8 +7,9 @@ is return-two(), 2, 'definite return value overrides implicit final expression';
 
 throws-like
     'my sub bad(--> Nil) { return 1 }',
-    X::AdHoc,
-    'return with a value is rejected for definite return specs';
+    X::Comp,
+    'return with a value is rejected for definite return specs',
+    payload => /Nil/;
 
 my $sunk = False;
 my sub return-empty(--> Empty) { 1, { ++$sunk; last } ... * }

--- a/t/return-value-spec-comp.t
+++ b/t/return-value-spec-comp.t
@@ -1,0 +1,17 @@
+use Test;
+
+# A routine whose signature pins the return value (`--> Nil`, `--> 42`,
+# `--> "foo"`) may not also `return` an argument. Raku rejects this at compile
+# time with an X::Comp carrying the offending value in its `payload`.
+
+plan 5;
+
+throws-like 'sub f(--> Nil) { return 5 }; f', X::Comp, 'Nil return spec', payload => /Nil/;
+throws-like 'sub f(--> 42) { return 43 }; f', X::Comp, 'int return spec', payload => /42/;
+throws-like 'sub f(--> 42) { return 42 }; f', X::Comp,
+    "same value still not allowed", payload => /42/;
+throws-like 'sub f(--> "foo") { return () }; f', X::Comp, 'str return spec',
+    payload => /'"foo"'/;
+
+# A bare `return` (no arguments) is fine with a definite return spec.
+lives-ok { my sub g(--> 7) { return }; }, 'bare return is allowed';


### PR DESCRIPTION
## Summary

A routine whose signature pins the return value (`--> Nil`, `--> 42`,
`--> \"foo\"`) may not also `return` an argument. Raku rejects this at compile
time with an **X::Comp** whose `payload` carries the offending value.

mutsu already detected this case (definite return spec + a non-Nil `return` in
the body) but raised a bare `X::AdHoc` "Malformed return value". Now
`malformed_return_value_compile_error(spec)` builds an `X::Comp` instance with
the rakudo message `No return arguments allowed when return value <spec> is
already specified in the signature`, exposes it as `payload`, and tags the error
with a parse code so `throws-like` recognises it as a compile-time error.

Covers `roast/S32-exceptions/misc2.t:326-329` (misc2.t 46 → 42 failing).

## Test plan

- Updated `t/definite-return.t` (`X::AdHoc` → `X::Comp`; roast is authoritative —
  raku reports this at compile time).
- New `t/return-value-spec-comp.t` (5 subtests): `--> Nil/42/\"foo\"` + `return`
  throws `X::Comp` with matching `payload`; bare `return` is still allowed.
- `make test` — Result: PASS (Files=653, Tests=5860).

🤖 Generated with [Claude Code](https://claude.com/claude-code)