### PR TITLE
feat(exceptions): X::Method::NotFound for invoking a non-Callable value

### DIFF
--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -436,7 +436,11 @@ impl VM {
             return self.interpreter.call_sub_value(target, args, true);
         }
 
-        Ok(Value::Nil)
+        // Any remaining value (Int, Str, Num, ...) is not Callable. Invoking it
+        // with `()` resolves the postfix-call to a `CALL-ME` method, which these
+        // types do not provide, so this raises X::Method::NotFound (method
+        // 'CALL-ME', typename = the value's type) — matching Raku.
+        self.try_compiled_method_or_interpret(target, "CALL-ME", args)
     }
 
     /// Force a lazy thunk: evaluate the sub on first access, cache and return the result.

--- a/t/call-me-not-found.t
+++ b/t/call-me-not-found.t
@@ -1,0 +1,19 @@
+use Test;
+
+# Postfix `()` on a non-Callable value resolves to a CALL-ME method, which the
+# basic types do not provide, so invoking them throws X::Method::NotFound with
+# method 'CALL-ME' and the value's typename.
+
+plan 4;
+
+throws-like 'sub (int $i) { $i() }(42)', X::Method::NotFound;
+
+throws-like 'my $i = 42; $i()', X::Method::NotFound,
+    method => 'CALL-ME', typename => 'Int';
+
+throws-like 'my $s = "x"; $s()', X::Method::NotFound,
+    method => 'CALL-ME', typename => 'Str';
+
+# A real Callable still invokes normally.
+my $c = -> $x { $x + 1 };
+is $c(2), 3, 'invoking a Callable value still works';


### PR DESCRIPTION
## Summary

Postfix `()` on a non-Callable value (`my \$i = 42; \$i()`) resolves the call to
a `CALL-ME` method. The basic types do not provide one, so in Raku this raises
**X::Method::NotFound** ("No such method 'CALL-ME' for invocant of type 'Int'").

mutsu's `vm_call_on_value` fell through to a silent `Ok(Value::Nil)` for any
target that was not a Sub/Routine/Junction/Mixin/Instance/Package, so `\$i()`
quietly produced `Nil` instead of erroring. The final fallback now routes the
value through `CALL-ME` method dispatch (the same path Instance/Package already
use), which yields the proper X::Method::NotFound.

Covers `roast/S32-exceptions/misc2.t` `sub (int \$i) { \$i() }(42)`.

## Test plan

- New `t/call-me-not-found.t` (4 subtests): invoking an `Int`/`Str` value throws
  X::Method::NotFound with `method => 'CALL-ME'` and the right `typename`; a real
  Callable still invokes normally.
- `make test` — only the known-flaky `t/proc-async.t` differs (passes on retry);
  unrelated to this VM dispatch change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)