### PR TITLE
feat(exceptions): structured X::Method::Private::Permission/Unqualified

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -38,7 +38,11 @@ impl Interpreter {
                                 },
                             );
                         if !caller_allowed {
-                            return Err(make_private_permission_error(pm_name, owner_class));
+                            return Err(make_private_permission_error(
+                                pm_name,
+                                owner_class,
+                                caller_class.as_deref().unwrap_or("GLOBAL"),
+                            ));
                         }
                         (
                             pm_name,
@@ -74,6 +78,7 @@ impl Interpreter {
                         return Err(make_private_permission_error(
                             pm_name,
                             &class_name.resolve(),
+                            caller_class.as_deref().unwrap_or("GLOBAL"),
                         ));
                     }
                     let (result, updated) = self.run_instance_method_resolved(
@@ -1034,7 +1039,11 @@ impl Interpreter {
                                 },
                             );
                     if !caller_allowed {
-                        return Err(make_private_permission_error(pm_name, owner_class));
+                        return Err(make_private_permission_error(
+                            pm_name,
+                            owner_class,
+                            caller_class.as_deref().unwrap_or("GLOBAL"),
+                        ));
                     }
                     (
                         pm_name,
@@ -1063,7 +1072,11 @@ impl Interpreter {
                                     .is_some_and(|caller| trusted.contains(caller))
                             });
                     if !caller_allowed {
-                        return Err(make_private_permission_error(pm_name, &name.resolve()));
+                        return Err(make_private_permission_error(
+                            pm_name,
+                            &name.resolve(),
+                            caller_class.as_deref().unwrap_or("GLOBAL"),
+                        ));
                     }
                     let attrs = HashMap::new();
                     let (result, _updated) = self.run_instance_method_resolved(

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -1,4 +1,6 @@
-use super::methods_signature::{make_method_not_found_error, make_private_permission_error};
+use super::methods_signature::{
+    make_method_not_found_error, make_private_permission_error, make_private_unqualified_error,
+};
 use super::*;
 
 impl Interpreter {
@@ -37,17 +39,16 @@ impl Interpreter {
                 return Some(Err(make_private_permission_error(
                     private_name,
                     owner_class,
+                    caller_class.as_deref().unwrap_or("GLOBAL"),
                 )));
             }
+            // Owner trusts the caller but the value is not an instance of it:
+            // the private method genuinely does not exist on this invocant.
+            return Some(Err(make_method_not_found_error(private_name, "Any", true)));
         }
-        // Unqualified private method on non-Instance — not found
-        Some(Err(make_method_not_found_error(
-            private_rest
-                .split_once("::")
-                .map_or(private_rest, |(_o, m)| m),
-            "Any",
-            true,
-        )))
+        // An unqualified private call (`$o!meth`) on something other than `self`
+        // must name the defining package; Raku reports X::Method::Private::Unqualified.
+        Some(Err(make_private_unqualified_error(private_rest)))
     }
 
     /// Handle qualified method names: Class::method (e.g., $o.Parent::x).

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -3,11 +3,17 @@ use crate::ast::CallArg;
 use crate::symbol::Symbol;
 use crate::value::signature::{make_signature_value_with_owner, param_defs_to_sig_info};
 
-/// Create a structured X::Method::Private::Permission error.
-pub(super) fn make_private_permission_error(method_name: &str, class_name: &str) -> RuntimeError {
+/// Create a structured X::Method::Private::Permission error: a fully-qualified
+/// private call `$o!Owner::meth` where `Owner` does not trust the calling
+/// package. Carries `method`, `source-package` (the owner) and `calling-package`.
+pub(super) fn make_private_permission_error(
+    method_name: &str,
+    class_name: &str,
+    calling_package: &str,
+) -> RuntimeError {
     let msg = format!(
-        "Cannot call private method '{}' on package {}",
-        method_name, class_name
+        "Cannot call private method '{}' on package {} because it does not trust {}",
+        method_name, class_name, calling_package
     );
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("method".to_string(), Value::str(method_name.to_string()));
@@ -15,8 +21,29 @@ pub(super) fn make_private_permission_error(method_name: &str, class_name: &str)
         "source-package".to_string(),
         Value::str(class_name.to_string()),
     );
+    attrs.insert(
+        "calling-package".to_string(),
+        Value::str(calling_package.to_string()),
+    );
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(Symbol::intern("X::Method::Private::Permission"), attrs);
+    let mut err = RuntimeError::new(&msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
+/// Create a structured X::Method::Private::Unqualified error: an unqualified
+/// private call `$o!meth` on something other than `self`. Raku requires such
+/// calls to name the package that defines the private method.
+pub(super) fn make_private_unqualified_error(method_name: &str) -> RuntimeError {
+    let msg = format!(
+        "Calling private method '{}' must be fully qualified with the package containing that private method.",
+        method_name
+    );
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("method".to_string(), Value::str(method_name.to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Method::Private::Unqualified"), attrs);
     let mut err = RuntimeError::new(&msg);
     err.exception = Some(Box::new(ex));
     err
@@ -1085,6 +1112,7 @@ impl Interpreter {
                         return Err(make_private_permission_error(
                             pm_name,
                             &class_name.resolve(),
+                            caller_class.as_deref().unwrap_or("GLOBAL"),
                         ));
                     }
                     let (result, updated) = self.run_instance_method_resolved(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2797,6 +2797,7 @@ impl Interpreter {
 
         // X::Method::Private::Permission
         register_x("X::Method::Private::Permission", "Exception");
+        register_x("X::Method::Private::Unqualified", "Exception");
 
         // X::ParametricConstant
         register_x("X::ParametricConstant", "Exception");

--- a/t/method-private-errors.t
+++ b/t/method-private-errors.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Private method call failures are structured exceptions:
+#  - a fully-qualified call `$o!Owner::meth` where Owner does not trust the
+#    caller throws X::Method::Private::Permission (method / source-package /
+#    calling-package);
+#  - an unqualified call `$o!meth` on something other than self throws
+#    X::Method::Private::Unqualified (method).
+
+plan 3;
+
+throws-like 'my class A { my @a; @a!List::foo() }',
+    X::Method::Private::Permission,
+    'qualified call without trust',
+    method          => 'foo',
+    calling-package => 'A',
+    source-package  => 'List';
+
+throws-like '1!foo()',
+    X::Method::Private::Unqualified,
+    'unqualified call on a non-self invocant',
+    method => 'foo';
+
+# A legitimate trusted call still works.
+lives-ok {
+    EVAL q:to/CODE/;
+        class Safe {
+            trusts Caller;
+            has $!secret = 42;
+            method !reveal() { $!secret }
+        }
+        class Caller {
+            method peek(Safe $s) { $s!Safe::reveal() }
+        }
+        die "wrong" unless Caller.new.peek(Safe.new) == 42;
+        CODE
+}, 'a trusted qualified private call works';


### PR DESCRIPTION
## Summary

Private-method call failures are now structured, attribute-carrying exceptions:

- A fully-qualified call `\$o!Owner::meth` where `Owner` does not trust the
  calling package throws **X::Method::Private::Permission** carrying `method`,
  `source-package` (the owner) and the newly-added `calling-package`. The
  message gains the rakudo "...because it does not trust <caller>" suffix.
- An unqualified call `\$o!meth` on something other than `self` (e.g. `1!foo()`)
  now throws the new **X::Method::Private::Unqualified** (`method`) instead of a
  generic X::Method::NotFound — Raku requires such calls to name the defining
  package.

`make_private_permission_error` gained a `calling_package` parameter (all six
call sites pass the resolved caller class); `make_private_unqualified_error` is
new. The qualified-but-trusted case where the method genuinely does not exist on
the invocant still yields X::Method::NotFound.

Covers `roast/S32-exceptions/misc2.t:78-86` (misc2.t 42 → 40 failing).

## Test plan

- New `t/method-private-errors.t` (3 subtests): permission error carries
  method/source-package/calling-package; unqualified error carries method; a
  trusted qualified private call still works.
- Existing `roast/S12-methods/private.t` / `trusts.t`, `t/private-trusts.t`,
  `t/private-owner-qualified-permission.t` still pass.
- `make test` — only the known-flaky `t/proc-async.t` differs (passes on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)