### PR TITLE
feat(exceptions): X::OutOfRange for scalar index + adverbed regex matchers

### DIFF
--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -294,6 +294,15 @@ impl Interpreter {
             Value::Regex(pattern) => self
                 .regex_match_with_captures(pattern, actual_str)
                 .is_some(),
+            // `rx:i/.../` and friends carry adverbs, so route through the full
+            // smart-match engine (which honours `:i`, `:m`, ...) rather than the
+            // bare-pattern matcher above.
+            Value::RegexWithAdverbs { .. } => {
+                let topic = actual_val
+                    .cloned()
+                    .unwrap_or_else(|| Value::str(actual_str.to_string()));
+                self.smart_match_values(&topic, matcher)
+            }
             Value::Sub(_) | Value::Routine { .. } => {
                 let call_arg = actual_val.cloned().unwrap_or(Value::Nil);
                 match self.call_sub_value(matcher.clone(), vec![call_arg], false) {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -48,6 +48,27 @@ impl VM {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Create a Failure wrapping X::OutOfRange for indexing a scalar value (a
+    /// single-element list) past index 0, e.g. `"foo"[2]`. Raku reports
+    /// `what => "Index"`, `range => "0..0"` and the offending index as `got`.
+    fn make_scalar_index_out_of_range_failure(index: i64) -> Value {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            Value::str_from(&format!(
+                "Index out of range. Is: {}, should be in 0..0",
+                index
+            )),
+        );
+        attrs.insert("what".to_string(), Value::str_from("Index"));
+        attrs.insert("got".to_string(), Value::Int(index));
+        attrs.insert("range".to_string(), Value::str_from("0..0"));
+        let ex = Value::make_instance(Symbol::intern("X::OutOfRange"), attrs);
+        let mut failure_attrs = std::collections::HashMap::new();
+        failure_attrs.insert("exception".to_string(), ex);
+        Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+    }
+
     /// Auto-vivifying index: creates intermediate Hash/Array entries and returns
     /// a `HashSlotRef` or `ArraySlotRef` so that `:=` bind to nested elements works.
     /// Stack: [target, key] -> [HashSlotRef | ArraySlotRef]
@@ -1638,7 +1659,7 @@ impl VM {
             (ref val, Value::Int(i))
                 if !matches!(val, Value::Array(..) | Value::Hash(_)) && i > 0 =>
             {
-                Self::make_out_of_range_failure(i)
+                Self::make_scalar_index_out_of_range_failure(i)
             }
             // Scalar value with WhateverCode index: treat as single-element list
             (ref val, Value::Sub(ref data))

--- a/t/out-of-range-scalar-index.t
+++ b/t/out-of-range-scalar-index.t
@@ -1,0 +1,25 @@
+use Test;
+
+# Indexing a scalar value (a single-element list) past index 0 throws
+# X::OutOfRange with what => "Index", range => "0..0" and the offending index.
+# Also exercises throws-like with an adverbed regex matcher (rx:i/.../).
+
+plan 6;
+
+throws-like 'use fatal; "foo"[2]', X::OutOfRange,
+    'scalar string index out of range',
+    what => rx:i/index/, range => '0..0', got => 2;
+
+throws-like 'use fatal; 42[1]', X::OutOfRange,
+    'scalar int index out of range',
+    range => '0..0', got => 1;
+
+# Index 0 on a scalar is the value itself.
+is "foo"[0], "foo", 'index 0 of a string is the string';
+is 42[0], 42, 'index 0 of an int is the int';
+
+# Date / DateTime range errors keep their structured attributes.
+throws-like 'Date.new("2012-02-30")', X::OutOfRange,
+    'invalid day', :message{ .match: /«1»/ & /«29»/ };
+throws-like 'DateTime.new(year => 2012, month => 5, day => 22, hour => 18, minute => 3, second => 60)',
+    X::OutOfRange, 'leap second', comment => /'leap second'/;


### PR DESCRIPTION
## Summary

Two related fixes for misc2.t's X::OutOfRange block:

1. **Scalar index out of range.** Indexing a scalar value (a single-element
   list) past index 0 — `"foo"[2]`, `42[1]` — now reports **X::OutOfRange** with
   `what => "Index"`, `range => "0..0"` and the offending index as `got`,
   matching rakudo. Previously it reused the negative-effective-index failure
   (`Effective index out of range ... 0..^Inf`), which carried the wrong range
   and no `what`. Index 0 still returns the value itself.

2. **Adverbed regex matchers in `throws-like`.** `what => rx:i/index/` now
   matches: `matcher_accepts` gained a `Value::RegexWithAdverbs` arm routing
   through `smart_match_values` (honouring `:i`/`:m`/...). Previously only bare
   `Value::Regex` was handled, so an adverbed matcher fell through to string
   equality and never matched.

Covers `roast/S32-exceptions/misc2.t:259` (misc2.t 38 → 37 failing).

## Test plan

- New `t/out-of-range-scalar-index.t` (6 subtests).
- `make test` — only the known-flaky `t/proc-async.t` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)