### PR TITLE
feat(vm): native default construction for typed scalar attributes (§1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -262,6 +262,23 @@
   （splice.t 全体は非whitelist の pre-existing fail＝`array[int]`/`array[int8]` typed-array メタデータ問題で、native
   経路は typed array で必ず bail＝interpreter 維持のためカウント不変。）
 
+- **2026-06-10 (③ PR-11, §1 = native default construction を typed `$` 属性へ拡張)**: §1 catch-all 最大カテゴリ
+  `Package.new`（コンストラクタ）の native 化範囲を拡張。`is_native_default_constructible`/`build_native_default_instance`
+  （`methods_object.rs`、VM の `try_compiled_method_or_interpret` と interpreter の `dispatch_new` が共有）が従来
+  **untyped `$` 属性のみ**だったのを、**simple class 制約付き `$` 属性**（`has Int $.x` 等）へ拡張。**保守的フォールスルー**で
+  divergence を全て interpreter に委ね behavior-invariant に保つ: ① 提供値が型不一致（`!type_matches_value`）→ None
+  （interpreter が `X::TypeCheck::Assignment`／coercion）、② arg も default も無い typed 属性 → None（未初期化 typed 属性は
+  **型オブジェクト**＝`Int` であり Nil でない。合成は interpreter）、③ typed default の値が型不一致 → None。ゲートは
+  **native/coercion/parametric 型を除外**（`is_simple_native_ctor_constraint`＝大文字始まり・`(` `[` なし）し、native
+  lowercase（`int`/`num`/`str`、default 0/""）は interpreter 維持。**重要な落とし穴を roast が捕捉**: 型制約の source of truth は
+  `ClassAttributeDef` tuple の制約スロットではなく `attribute_types` map（tuple 側は None）＝当初 tuple を読んで型チェックが
+  効かず `Int $.x = "str"` を受理する回帰 → `collect_attribute_type_constraints` 由来に修正。さらに **`is built` トレイト／MOP
+  `Attribute.set_build`**（カスタム build closure。`attribute_built` map ＋ registry `attribute_build_overrides`）を持つクラスは
+  pure-data 構築不可なのでゲートで除外（`S12-attributes/defaults.t` の set_build 実行時型チェック回帰を捕捉・修正）。
+  pin `t/native-ctor-typed-attrs.t`(30, 提供値/型オブジェクト未初期化/Str/Real/mixed/継承/相互参照 default/subset 型/
+  型不一致 dies/native int は interpreter/ループ構築)。S12/S14/S03-binding/roles whitelist 184 件全緑、cargo test 458/0。
+  **残: typed `@`/`%` 属性・required・where・coercion 型・native 型は依然 interpreter（本丸 ③ env 実行の手前で止める保守設計）。**
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -69,18 +69,40 @@ impl Interpreter {
                 && !class_def.methods.contains_key("BUILDALL")
                 && !class_def.methods.contains_key("new")
                 && class_def.native_methods.is_empty()
+                // No custom per-attribute build closure (`is built` trait or a
+                // MOP `Attribute.set_build`): those replace plain data assignment
+                // and must run through the full constructor.
+                && class_def.attribute_built.is_empty()
+                && !registry
+                    .attribute_build_overrides
+                    .keys()
+                    .any(|(owner, _)| owner == &cls)
                 && class_def.parents.iter().all(|p| {
                     p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
                     |(_, _, _, is_required, type_constraint, sigil, where_constraint)| {
+                        // `$`-scalar, not required, no `where` clause. A type
+                        // constraint is allowed only when it is a plain
+                        // `type_matches_value`-checkable class/role/subset type
+                        // (see `is_simple_native_ctor_constraint`); native /
+                        // coercion / parametric types keep the interpreter's
+                        // richer construction (coercion, native defaults).
                         *sigil == '$'
                             && !is_required
-                            && type_constraint.is_none()
                             && where_constraint.is_none()
+                            && match type_constraint {
+                                None => true,
+                                Some(inner) => inner
+                                    .as_deref()
+                                    .is_some_and(Self::is_simple_native_ctor_constraint),
+                            }
                     },
                 )
-                && class_def.attribute_types.is_empty()
+                && class_def
+                    .attribute_types
+                    .values()
+                    .all(|tc| Self::is_simple_native_ctor_constraint(tc))
                 && class_def.attribute_smileys.is_empty();
             if !simple {
                 return false;
@@ -88,6 +110,16 @@ impl Interpreter {
             has_attribute |= !class_def.attributes.is_empty();
         }
         has_attribute
+    }
+
+    /// A type constraint the native default constructor can enforce with a plain
+    /// `type_matches_value` check: a normal class/role/subset type (starts
+    /// uppercase). Excludes native lowercase types (`int`/`num`/`str` — they
+    /// coerce and default to `0`/`""`, not a type object), coercion types
+    /// (`Int()`), and parametric types (`Positional[Int]`). Everything excluded
+    /// keeps the interpreter's richer construction semantics.
+    fn is_simple_native_ctor_constraint(tc: &str) -> bool {
+        tc.starts_with(char::is_uppercase) && !tc.contains('(') && !tc.contains('[')
     }
 
     /// Default-construct `class_name` natively when it is eligible (see
@@ -103,29 +135,62 @@ impl Interpreter {
         if !self.is_native_default_constructible(&cn_resolved) {
             return None;
         }
-        Some(self.build_native_default_instance(class_name, &cn_resolved, args))
+        self.build_native_default_instance(class_name, &cn_resolved, args)
     }
 
+    /// Returns `None` to fall through to the full constructor dispatch when a
+    /// case needs the interpreter's richer semantics: a provided value that does
+    /// not match its attribute's type constraint (interpreter raises
+    /// `X::TypeCheck::Assignment`), a typed attribute left uninitialized (its
+    /// default is the *type object*, which the interpreter synthesizes), or a
+    /// typed default whose value does not match. Otherwise builds the instance as
+    /// pure data and returns `Some(Ok(..))`.
     fn build_native_default_instance(
         &mut self,
         class_name: Symbol,
         cn_resolved: &str,
         args: &[Value],
-    ) -> Result<Value, RuntimeError> {
+    ) -> Option<Result<Value, RuntimeError>> {
+        let class_attrs = self.collect_class_attributes(cn_resolved);
+        // Attribute type constraints (MRO-wide) live in `attribute_types`, not in
+        // the `ClassAttributeDef` tuple's constraint slot — and the gate already
+        // guaranteed every one is a simple `type_matches_value`-checkable class
+        // type. Owned map, so it can be read while `self` is borrowed mutably.
+        let type_constraints = self.collect_attribute_type_constraints(cn_resolved);
+
         let mut attrs = HashMap::new();
         for arg in args {
             if let Value::Pair(key, val) = arg
                 && self.is_attribute_buildable(cn_resolved, key)
             {
+                // A provided value that does not already match its attribute's
+                // type constraint needs the interpreter (coercion or a proper
+                // X::TypeCheck::Assignment) — fall through.
+                if let Some(c) = type_constraints.get(key)
+                    && !self.type_matches_value(c, val)
+                {
+                    return None;
+                }
                 attrs.insert(key.clone(), *val.clone());
             }
         }
-        // Fill defaults for missing attributes (including Nil for uninitialized ones).
-        // Set up `self` as the partially-constructed instance so that
-        // default expressions referencing `self` (e.g. `has $.x = self.y`)
-        // work correctly. Update `self` after each default so that later
-        // defaults can see earlier defaults' values.
-        let class_attrs = self.collect_class_attributes(cn_resolved);
+        // A typed attribute that is neither provided nor defaulted is
+        // initialized to its *type object* (e.g. `Int`), not `Nil`. Let the
+        // interpreter synthesize it.
+        for (attr_name, _, default_expr, _, _, _, _) in &class_attrs {
+            if default_expr.is_none()
+                && !attrs.contains_key(attr_name)
+                && type_constraints.contains_key(attr_name)
+            {
+                return None;
+            }
+        }
+
+        // Fill defaults for missing attributes (including Nil for uninitialized
+        // ones). Set up `self` as the partially-constructed instance so that
+        // default expressions referencing `self` (e.g. `has $.x = self.y`) work
+        // correctly. Update `self` after each default so that later defaults can
+        // see earlier defaults' values.
         let has_defaults = class_attrs.iter().any(|(_, _, d, ..)| d.is_some());
         if has_defaults {
             let partial = Value::make_instance(class_name, attrs.clone());
@@ -145,23 +210,40 @@ impl Interpreter {
         if self.has_class_scoped_subs(cn_resolved) {
             self.current_package = cn_resolved.to_string();
         }
+        let mut eval_error: Option<RuntimeError> = None;
+        let mut typed_default_mismatch = false;
         for (attr_name, _is_public, default_expr, _, _, _, _) in &class_attrs {
-            if !attrs.contains_key(attr_name) {
-                if let Some(expr) = default_expr {
-                    let val = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())])?;
-                    attrs.insert(attr_name.clone(), val.clone());
-                    // Update self and !attr/.attr so later defaults see this value
-                    let updated = Value::make_instance(class_name, attrs.clone());
-                    self.env.insert("self".to_string(), updated.clone());
-                    self.env.insert("__ANON_STATE__".to_string(), updated);
-                    self.env.insert(format!("!{}", attr_name), val.clone());
-                    self.env.insert(format!(".{}", attr_name), val);
-                } else {
-                    attrs.insert(attr_name.clone(), Value::Nil);
+            if attrs.contains_key(attr_name) {
+                continue;
+            }
+            if let Some(expr) = default_expr {
+                let val = match self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]) {
+                    Ok(val) => val,
+                    Err(e) => {
+                        eval_error = Some(e);
+                        break;
+                    }
+                };
+                // A default whose value does not match the attribute's type
+                // constraint needs the interpreter's handling — fall through.
+                if let Some(c) = type_constraints.get(attr_name)
+                    && !self.type_matches_value(c, &val)
+                {
+                    typed_default_mismatch = true;
+                    break;
                 }
+                attrs.insert(attr_name.clone(), val.clone());
+                // Update self and !attr/.attr so later defaults see this value
+                let updated = Value::make_instance(class_name, attrs.clone());
+                self.env.insert("self".to_string(), updated.clone());
+                self.env.insert("__ANON_STATE__".to_string(), updated);
+                self.env.insert(format!("!{}", attr_name), val.clone());
+                self.env.insert(format!(".{}", attr_name), val);
+            } else {
+                attrs.insert(attr_name.clone(), Value::Nil);
             }
         }
-        // Restore package after default evaluation
+        // Restore package and env after default evaluation (on every exit path).
         self.current_package = saved_package;
         if has_defaults {
             self.env.remove("self");
@@ -172,9 +254,15 @@ impl Interpreter {
                 self.env.remove(&format!(".{}", k));
             }
         }
+        if let Some(e) = eval_error {
+            return Some(Err(e));
+        }
+        if typed_default_mismatch {
+            return None;
+        }
         // Add alias metadata for `has $x` (no twigil) attributes
         self.add_alias_attribute_metadata(cn_resolved, &mut attrs);
-        Ok(Value::make_instance(class_name, attrs))
+        Some(Ok(Value::make_instance(class_name, attrs)))
     }
 
     pub(super) fn dispatch_new(

--- a/t/native-ctor-typed-attrs.t
+++ b/t/native-ctor-typed-attrs.t
@@ -1,0 +1,110 @@
+use Test;
+
+# VM-native default construction extended to typed `$`-scalar attributes
+# (ledger §1 / phase ③: native `.new` without the interpreter bridge). The
+# native path handles the pure-data cases (provided values that type-match,
+# typed defaults, untyped attrs); anything needing the interpreter's richer
+# semantics (type mismatch, uninitialized typed attr -> type object, coercion,
+# native int/num types, required/where/`@`/`%` attrs) falls through. These
+# assertions all match `raku`.
+
+plan 30;
+
+# --- provided typed value + typed default --------------------------------
+{
+    class P { has Int $.x; has Int $.y = 10 }
+    my $p = P.new(x => 5);
+    is $p.x, 5, 'provided typed Int attribute';
+    is $p.y, 10, 'typed attribute default';
+    is $p.x.^name, 'Int', 'provided value keeps its type';
+}
+
+# --- uninitialized typed attribute is the type object (Int), not Nil -----
+{
+    class P2 { has Int $.x; has Int $.y = 10 }
+    my $q = P2.new;
+    is $q.x.^name, 'Int', 'uninitialized typed attr is the type object';
+    nok $q.x.defined, '... and is undefined';
+    is $q.y, 10, '... while a defaulted typed attr is filled';
+}
+
+# --- Str / Real / Cool typed attributes ----------------------------------
+{
+    class S { has Str $.s = "hi" }
+    is S.new.s, 'hi', 'Str typed default';
+    is S.new(s => "yo").s, 'yo', 'provided Str value';
+}
+{
+    class R { has Real $.v = 1.5 }
+    is R.new.v, 1.5, 'Real typed default';
+    is R.new(v => 3).v, 3, 'Int provided for a Real attribute (Int ~~ Real)';
+}
+
+# --- mixed typed + untyped attributes ------------------------------------
+{
+    class Mixed { has Int $.n; has Str $.t = "z"; has $.u }
+    my $m = Mixed.new(n => 3, u => [1, 2]);
+    is $m.n, 3, 'mixed: provided typed Int';
+    is $m.t, 'z', 'mixed: typed default';
+    is-deeply $m.u, [1, 2], 'mixed: untyped attribute';
+    my $m2 = Mixed.new(n => 7);
+    is $m2.n, 7, 'mixed: only typed provided';
+    is $m2.t, 'z', 'mixed: default still applied';
+    nok $m2.u.defined, 'mixed: unprovided untyped attr is undefined';
+}
+
+# --- inheritance with typed attributes -----------------------------------
+{
+    class Animal { has Str $.name = "?" }
+    class Dog is Animal { has Int $.age = 3 }
+    my $d = Dog.new(name => "Rex", age => 5);
+    is $d.name, 'Rex', 'inherited typed attr provided';
+    is $d.age, 5, 'child typed attr provided';
+    my $d2 = Dog.new;
+    is $d2.name, '?', 'inherited typed default';
+    is $d2.age, 3, 'child typed default';
+}
+
+# --- typed default referencing an earlier attribute ----------------------
+{
+    class Calc { has Int $.a = 2; has Int $.b = 3; has Int $.c = $!a + $!b }
+    my $c = Calc.new;
+    is $c.c, 5, 'typed default referencing earlier typed attrs';
+    my $c2 = Calc.new(a => 10);
+    is $c2.c, 13, 'typed default sees a provided earlier attr';
+}
+
+# --- subset-typed attribute (type_matches_value handles the where) -------
+{
+    subset Even of Int where * %% 2;
+    class Box { has Even $.e = 4 }
+    is Box.new.e, 4, 'subset-typed default';
+    is Box.new(e => 8).e, 8, 'subset-typed provided value that matches';
+}
+
+# --- type mismatch falls through to the interpreter and dies -------------
+# (exact exception type is the interpreter's concern; assert it dies.)
+{
+    class T { has Int $.x }
+    dies-ok { T.new(x => "not an int") }, 'wrong-typed provided value dies';
+}
+{
+    class Num1 { has Int $.x = 1 }
+    dies-ok { Num1.new(x => "str") }, 'wrong-typed value with siblings dies';
+}
+
+# --- native lowercase types still go through the interpreter -------------
+# `has int $.x` defaults to 0 (not a type object); native path bails -> works.
+{
+    class Nat { has int $.x }
+    is Nat.new.x, 0, 'native int attr defaults to 0 (interpreter path)';
+    is Nat.new(x => 42).x, 42, 'native int attr provided';
+}
+
+# --- repeated construction in a loop -------------------------------------
+{
+    class Pt { has Int $.x = 0; has Int $.y = 0 }
+    my @pts = (^4).map({ Pt.new(x => $_, y => $_ * 2) });
+    is-deeply @pts.map(*.x).Array, [0, 1, 2, 3], 'loop construction: x values';
+    is-deeply @pts.map(*.y).Array, [0, 2, 4, 6], 'loop construction: y values';
+}


### PR DESCRIPTION
## What

Extends the native default constructor (`is_native_default_constructible` / `build_native_default_instance` in `methods_object.rs`, shared by the VM's `try_compiled_method_or_interpret` and the interpreter's `dispatch_new`) from **untyped `$`-attributes only** to also cover **`$`-scalar attributes with a simple class type constraint** (`has Int $.x`). This eliminates a slice of the largest §1 catch-all category — the `Package.new` constructor — without routing through the interpreter bridge (phase ③).

## Conservative fallthrough (behavior-invariant)

Construction stays pure data; anything needing the interpreter's richer semantics returns `None` and falls through:

- provided value not matching its constraint (`!type_matches_value`) → interpreter coerces / raises `X::TypeCheck::Assignment`
- typed attribute neither provided nor defaulted → its uninitialized value is the **type object** (`Int`, undefined), not `Nil` — interpreter synthesizes it
- typed default whose value doesn't match → interpreter

The gate (`is_simple_native_ctor_constraint`) admits only plain `type_matches_value`-checkable class/role/subset types (uppercase-initial, no `(` coercion, no `[` parametric). Native lowercase types (`int`/`num`/`str`) keep the interpreter path.

## Two pitfalls caught by roast and fixed

- **Constraint source of truth** is the `attribute_types` map (via `collect_attribute_type_constraints`), NOT the `ClassAttributeDef` tuple slot (which is `None` here). Reading the tuple first made the check a no-op and accepted `has Int $.x = "str"`; fixed.
- A class with a **custom per-attribute build closure** — `is built` trait (`attribute_built`) or MOP `Attribute.set_build` (`attribute_build_overrides`) — is not pure-data constructible; added both to the gate (caught the `set_build` run-time type-check subtest in `S12-attributes/defaults.t`).

## Testing

- pin `t/native-ctor-typed-attrs.t` (30 subtests)
- S12 / S14 / S03-binding / roles whitelist (184 files) all green
- cargo test 458/0, make test PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)