### PR TITLE
feat(vm): native default construction for untyped @/% attributes (§1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -279,6 +279,20 @@
   型不一致 dies/native int は interpreter/ループ構築)。S12/S14/S03-binding/roles whitelist 184 件全緑、cargo test 458/0。
   **残: typed `@`/`%` 属性・required・where・coercion 型・native 型は依然 interpreter（本丸 ③ env 実行の手前で止める保守設計）。**
 
+- **2026-06-10 (③ PR-12, §1 = native construction を untyped `@`/`%` 属性へ拡張)**: PR-11 の続きで native default
+  構築を **untyped `@`/`%`-sigil 属性**（`has @.items`/`has %.map`）へ拡張。**behavior-invariance の対象は raku ではなく
+  現 interpreter**（実測で `items => 5`→`5`〔scalar を wrap せず〕、typed `@.nums` の不正要素→NODIE〔構築時に要素型
+  チェックしない〕＝raku と異なる pre-existing 挙動）。interpreter 共有の `coerce_attr_value_by_sigil` を再利用するので
+  提供値 coercion（List/Range→Array, array-of-Pairs→Hash）が完全一致。未提供 default = 空 Array/Hash（型オブジェクト
+  合成不要＝`$` typed より単純）。**保守的フォールスルー**: typed 要素（`Int @.nums`＝container type metadata 登録が
+  必要・Arc-keying ハザード）/ `is Type` トレイト（`class_attribute_is_types`）/ **default_expr を持つ `@`/`%`**（shape は
+  default に encode＝`has @.a[2]`、提供有無に関わらず fallthrough）は interpreter 維持。**roast が shaped 落とし穴を捕捉**:
+  当初「default 持ち＋未提供」のみ fallthrough としたが、shaped `@.a[2]` が**提供された**場合 coerce で shape 喪失
+  （`S12-introspection/attributes.t` の `.a.shape`=(2,) 回帰）→「`@`/`%` が default_expr 持ちなら無条件 fallthrough」へ修正。
+  pin `t/native-ctor-array-attrs.t`(27, 空 default/list・array・range 提供/hash・pairs 提供/mixed typed-$/継承/defaulted
+  fallthrough/typed-element fallthrough/ループ構築)。S12/S14/binding/roles 184 件全緑、cargo test 458/0、make test PASS。
+  **残: typed `@`/`%`・`is Type`・shaped・required・where・coercion 型・native 型は依然 interpreter。**
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -38,12 +38,15 @@ fn is_normalized_datetime_subclass_ctor_args(args: &[Value]) -> bool {
 impl Interpreter {
     /// Returns `true` if `class_name` (and every user class in its MRO) can be
     /// default-constructed (`Foo.new(...)`) without running any user code:
-    /// no BUILD/TWEAK/BUILDALL/custom-new, only public `$`-sigiled attributes
-    /// with no required/type/where constraints, and no native methods. Parents
-    /// must themselves be either `Any`/`Mu`/`Cool` or another such simple class
-    /// (so a plain inheritance chain like `Dog is Animal` still qualifies).
-    /// Construction is then pure data: assign named args to attributes and
-    /// evaluate attribute defaults.
+    /// no BUILD/TWEAK/BUILDALL/custom-new and no custom per-attribute build
+    /// closure, no native methods, and only public attributes that are either a
+    /// `$`-scalar (optionally with a simple `type_matches_value`-checkable class
+    /// constraint) or an untyped `@`/`%` without an `is Type` trait, none of
+    /// them required or `where`-constrained. Parents must themselves be
+    /// `Any`/`Mu`/`Cool` or another such simple class (so a plain inheritance
+    /// chain like `Dog is Animal` still qualifies). Construction is then pure
+    /// data: assign (sigil-coerced) named args to attributes and evaluate
+    /// attribute defaults.
     pub(crate) fn is_native_default_constructible(&self, cn_resolved: &str) -> bool {
         if cn_resolved.contains('[') || cn_resolved.contains("::") {
             return false;
@@ -81,21 +84,32 @@ impl Interpreter {
                     p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
-                    |(_, _, _, is_required, type_constraint, sigil, where_constraint)| {
-                        // `$`-scalar, not required, no `where` clause. A type
-                        // constraint is allowed only when it is a plain
-                        // `type_matches_value`-checkable class/role/subset type
-                        // (see `is_simple_native_ctor_constraint`); native /
-                        // coercion / parametric types keep the interpreter's
-                        // richer construction (coercion, native defaults).
-                        *sigil == '$'
-                            && !is_required
+                    |(name, _, _, is_required, type_constraint, sigil, where_constraint)| {
+                        // Not required, no `where` clause, and a constructible
+                        // sigil/type shape:
+                        // - `$`: a type constraint is allowed only when it is a
+                        //   plain `type_matches_value`-checkable class/role/subset
+                        //   type (see `is_simple_native_ctor_constraint`); native /
+                        //   coercion / parametric types keep the interpreter.
+                        // - `@`/`%`: only untyped with no `is Type` trait — typed
+                        //   elements need container type metadata and `is Type`
+                        //   builds a typed container, both interpreter-owned.
+                        !is_required
                             && where_constraint.is_none()
-                            && match type_constraint {
-                                None => true,
-                                Some(inner) => inner
-                                    .as_deref()
-                                    .is_some_and(Self::is_simple_native_ctor_constraint),
+                            && match sigil {
+                                '$' => match type_constraint {
+                                    None => true,
+                                    Some(inner) => inner
+                                        .as_deref()
+                                        .is_some_and(Self::is_simple_native_ctor_constraint),
+                                },
+                                '@' | '%' => {
+                                    !class_def.attribute_types.contains_key(name)
+                                        && !registry
+                                            .class_attribute_is_types
+                                            .contains_key(&(cls.clone(), name.clone()))
+                                }
+                                _ => false,
                             }
                     },
                 )
@@ -158,23 +172,44 @@ impl Interpreter {
         // type. Owned map, so it can be read while `self` is borrowed mutably.
         let type_constraints = self.collect_attribute_type_constraints(cn_resolved);
 
+        let sigil_of = |name: &str| -> char {
+            class_attrs
+                .iter()
+                .find(|(n, ..)| n == name)
+                .map(|(_, _, _, _, _, s, _)| *s)
+                .unwrap_or('$')
+        };
+
         let mut attrs = HashMap::new();
         for arg in args {
             if let Value::Pair(key, val) = arg
                 && self.is_attribute_buildable(cn_resolved, key)
             {
-                // A provided value that does not already match its attribute's
-                // type constraint needs the interpreter (coercion or a proper
-                // X::TypeCheck::Assignment) — fall through.
-                if let Some(c) = type_constraints.get(key)
-                    && !self.type_matches_value(c, val)
-                {
-                    return None;
+                match sigil_of(key) {
+                    '@' | '%' => {
+                        // Coerce exactly as the interpreter's shared helper does
+                        // (List/Range -> Array, array-of-Pairs -> Hash, …).
+                        attrs.insert(
+                            key.clone(),
+                            Self::coerce_attr_value_by_sigil(*val.clone(), sigil_of(key)),
+                        );
+                    }
+                    _ => {
+                        // A provided value that does not already match its
+                        // attribute's type constraint needs the interpreter
+                        // (coercion or a proper X::TypeCheck::Assignment) — fall
+                        // through.
+                        if let Some(c) = type_constraints.get(key)
+                            && !self.type_matches_value(c, val)
+                        {
+                            return None;
+                        }
+                        attrs.insert(key.clone(), *val.clone());
+                    }
                 }
-                attrs.insert(key.clone(), *val.clone());
             }
         }
-        // A typed attribute that is neither provided nor defaulted is
+        // A typed `$` attribute that is neither provided nor defaulted is
         // initialized to its *type object* (e.g. `Int`), not `Nil`. Let the
         // interpreter synthesize it.
         for (attr_name, _, default_expr, _, _, _, _) in &class_attrs {
@@ -182,6 +217,16 @@ impl Interpreter {
                 && !attrs.contains_key(attr_name)
                 && type_constraints.contains_key(attr_name)
             {
+                return None;
+            }
+        }
+        // An `@`/`%` attribute with a default expression may be shaped (the
+        // shape is encoded in the default, e.g. `has @.a[2]`) or otherwise need
+        // the interpreter's construction — fall through whether or not it was
+        // provided (a shaped attribute must stay shaped even when assigned).
+        // Only the empty-default `@`/`%` case (handled below) is native.
+        for (_attr_name, _, default_expr, _, _, sigil, _) in &class_attrs {
+            if matches!(sigil, '@' | '%') && default_expr.is_some() {
                 return None;
             }
         }
@@ -212,11 +257,13 @@ impl Interpreter {
         }
         let mut eval_error: Option<RuntimeError> = None;
         let mut typed_default_mismatch = false;
-        for (attr_name, _is_public, default_expr, _, _, _, _) in &class_attrs {
+        for (attr_name, _is_public, default_expr, _, _, sigil, _) in &class_attrs {
             if attrs.contains_key(attr_name) {
                 continue;
             }
             if let Some(expr) = default_expr {
+                // Only `$` attributes reach here with a default — `@`/`%` defaults
+                // fell through above.
                 let val = match self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]) {
                     Ok(val) => val,
                     Err(e) => {
@@ -240,7 +287,14 @@ impl Interpreter {
                 self.env.insert(format!("!{}", attr_name), val.clone());
                 self.env.insert(format!(".{}", attr_name), val);
             } else {
-                attrs.insert(attr_name.clone(), Value::Nil);
+                // Uninitialized: `@` -> empty Array, `%` -> empty Hash, `$` -> Nil
+                // (an untyped `$`; typed `$` fell through above).
+                let empty = match sigil {
+                    '@' => Value::real_array(Vec::new()),
+                    '%' => Value::hash(HashMap::new()),
+                    _ => Value::Nil,
+                };
+                attrs.insert(attr_name.clone(), empty);
             }
         }
         // Restore package and env after default evaluation (on every exit path).

--- a/t/native-ctor-array-attrs.t
+++ b/t/native-ctor-array-attrs.t
@@ -1,0 +1,85 @@
+use Test;
+
+# VM-native default construction extended to untyped `@`/`%`-sigiled attributes
+# (ledger §1 / phase ③). The native path handles untyped array/hash attributes
+# (empty default, sigil-coerced provided values), reusing the interpreter's
+# shared `coerce_attr_value_by_sigil` so the result is behavior-invariant.
+# Typed-element (`Int @.nums`), `is Type`, and defaulted `@`/`%` attributes fall
+# through to the interpreter. These assertions match `raku`.
+
+plan 27;
+
+# --- empty defaults ------------------------------------------------------
+{
+    class A { has @.items; has %.map; has $.name = "x" }
+    my $e = A.new;
+    is-deeply $e.items, [], 'empty @ attribute defaults to []';
+    is-deeply $e.map, {}, 'empty % attribute defaults to {}';
+    is $e.name, 'x', 'scalar default alongside @/% attrs';
+    is $e.items.^name, 'Array', 'empty @ attr is an Array';
+    is $e.map.^name, 'Hash', 'empty % attr is a Hash';
+}
+
+# --- provided list / array to @ ------------------------------------------
+{
+    class B { has @.items }
+    is-deeply B.new(items => (1, 2, 3)).items, [1, 2, 3], 'list arg flattens into @';
+    is-deeply B.new(items => [10, 20]).items, [10, 20], 'array arg into @';
+    is-deeply B.new(items => 1..4).items, [1, 2, 3, 4], 'range arg expands into @';
+    is-deeply B.new.items, [], 'no arg -> empty @';
+}
+
+# --- provided hash / pairs to % ------------------------------------------
+{
+    class C { has %.map }
+    my $c = C.new(map => { a => 1, b => 2 });
+    is $c.map<a>, 1, 'hash arg into %: key a';
+    is $c.map<b>, 2, 'hash arg into %: key b';
+    my $c2 = C.new(map => (x => 9, y => 8));
+    is $c2.map<x>, 9, 'list-of-pairs arg into %: key x';
+    is $c2.map<y>, 8, 'list-of-pairs arg into %: key y';
+}
+
+# --- mixed @ / % / typed $ -----------------------------------------------
+{
+    class D { has Int $.n; has @.items; has %.opts; has Str $.tag = "t" }
+    my $d = D.new(n => 5, items => (1, 2), opts => { k => 1 });
+    is $d.n, 5, 'mixed: typed scalar';
+    is-deeply $d.items, [1, 2], 'mixed: @ attribute';
+    is $d.opts<k>, 1, 'mixed: % attribute';
+    is $d.tag, 't', 'mixed: scalar default';
+    my $d2 = D.new(n => 7);
+    is-deeply $d2.items, [], 'mixed: unprovided @ -> []';
+    is-deeply $d2.opts, {}, 'mixed: unprovided % -> {}';
+}
+
+# --- inheritance with @ attributes ---------------------------------------
+{
+    class Base { has @.tags }
+    class Derived is Base { has $.id = 0 }
+    my $x = Derived.new(tags => <a b c>, id => 9);
+    is-deeply $x.tags, ['a', 'b', 'c'], 'inherited @ attribute provided';
+    is $x.id, 9, 'child scalar provided';
+    is-deeply Derived.new.tags, [], 'inherited @ default empty';
+}
+
+# --- a `@`/`%` attr WITH a default falls through (still correct) ----------
+{
+    class E { has @.items = (1, 2, 3) }
+    is-deeply E.new.items, [1, 2, 3], 'defaulted @ attr (interpreter path)';
+    is-deeply E.new(items => (9,)).items, [9], 'defaulted @ attr, provided overrides';
+}
+
+# --- typed-element @ attr falls through (interpreter owns it) ------------
+{
+    class F { has Int @.nums }
+    is F.new(nums => (1, 2, 3)).nums.join(","), "1,2,3", 'typed @ attr (interpreter path)';
+}
+
+# --- loop construction with @ attrs --------------------------------------
+{
+    class Row { has @.cells }
+    my @rows = (^3).map({ Row.new(cells => ($_, $_ + 1)) });
+    is-deeply @rows[0].cells, [0, 1], 'loop construction row 0';
+    is-deeply @rows[2].cells, [2, 3], 'loop construction row 2';
+}


### PR DESCRIPTION
## What

Extends the native default constructor (`methods_object.rs`, shared by the VM's `try_compiled_method_or_interpret` and the interpreter's `dispatch_new`) from `$`-scalar attributes (#2833) to also cover **untyped `@`/`%`-sigiled attributes** (`has @.items`, `has %.map`), continuing to peel the largest §1 catch-all category — `Package.new` — off the interpreter bridge (phase ③).

## Behavior-invariance is vs the interpreter, not raku

The current interpreter already does **not** wrap a scalar arg into an array (`items => 5` → `5`) and does **not** type-check `@`/`%` elements at construction — both pre-existing divergences from raku. The native path reuses the interpreter's own `coerce_attr_value_by_sigil`, so provided-value coercion (List/Range → Array, array-of-Pairs → Hash) is identical; an uninitialized `@`/`%` attribute defaults to an empty Array/Hash (no type-object synthesis, unlike typed `$`).

## Conservative fallthrough (→ interpreter)

- typed-element `@`/`%` (`has Int @.nums`) — needs container type metadata (interpreter-owned; the Arc-pointer-keying hazard)
- an `is Type` trait (`class_attribute_is_types`) — builds a typed container
- any `@`/`%` attribute with a default expression — a shaped attribute's shape (`has @.a[2]`) is encoded in its default, so it must fall through whether or not provided (else a provided value is coerced to a plain Array and loses its shape)

The shaped case was caught by roast (`S12-introspection/attributes.t` `.a.shape == (2,)`): the first cut only fell through for a defaulted-and-*unprovided* `@`/`%`, losing the shape of a *provided* shaped attribute; fixed to fall through whenever an `@`/`%` attribute has a default expression.

## Testing

- pin `t/native-ctor-array-attrs.t` (27 subtests)
- S12 / S14 / S03-binding / roles whitelist (184 files) all green
- cargo test 458/0, make test PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)