### PR TITLE
feat(vm): native default construction for `is required` attributes (§1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -293,6 +293,18 @@
   fallthrough/typed-element fallthrough/ループ構築)。S12/S14/binding/roles 184 件全緑、cargo test 458/0、make test PASS。
   **残: typed `@`/`%`・`is Type`・shaped・required・where・coercion 型・native 型は依然 interpreter。**
 
+- **2026-06-10 (③ PR-13, §1 = native construction を `is required` 属性へ拡張)**: PR-11/12 の続きで native default
+  構築を **`is required` 属性**へ拡張（従来ゲートが `!is_required` で reject）。提供された required 属性は native 構築
+  （`$` typed は型チェック込み）、**未提供の required 属性は fallthrough**（interpreter が `X::Attribute::Required`）。
+  ゲートから `!is_required` を外し、build 先頭に「required かつ未 provided → None」検査を追加。**behavior-invariant**:
+  required `$` 未提供は interpreter が die（raku 一致）、required `@`/`%` 未提供は interpreter が **enforce しない**
+  （NODIE＝raku と異なる pre-existing ギャップだが native は fallthrough で interpreter 挙動に一致）。pin
+  `t/native-ctor-required-attrs.t`(14, 全 required 提供→build / 未提供 `$`→dies / 型不一致→dies / required `@`/`%`
+  提供→build / 継承 required)。S12/S14/binding/roles 184 件全緑、cargo test 458/0、make test PASS。
+  （pin 作成中に **連続 bare block `} { ` のパース不可**と **クラス名 `Q` のクォート演算子衝突**という 2 つの
+  pre-existing パーサ制約に遭遇＝テストをトップレベル構造＋非衝突名に変更して回避。本 slice とは無関係。）
+  **残: where・coercion 型・native 型・typed `@`/`%`・`is Type`・shaped は依然 interpreter。**
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -84,9 +84,8 @@ impl Interpreter {
                     p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
-                    |(name, _, _, is_required, type_constraint, sigil, where_constraint)| {
-                        // Not required, no `where` clause, and a constructible
-                        // sigil/type shape:
+                    |(name, _, _, _is_required, type_constraint, sigil, where_constraint)| {
+                        // No `where` clause, and a constructible sigil/type shape:
                         // - `$`: a type constraint is allowed only when it is a
                         //   plain `type_matches_value`-checkable class/role/subset
                         //   type (see `is_simple_native_ctor_constraint`); native /
@@ -94,8 +93,10 @@ impl Interpreter {
                         // - `@`/`%`: only untyped with no `is Type` trait — typed
                         //   elements need container type metadata and `is Type`
                         //   builds a typed container, both interpreter-owned.
-                        !is_required
-                            && where_constraint.is_none()
+                        // `is required` is allowed through: an unprovided required
+                        // attribute falls through at build time (the interpreter
+                        // raises X::Attribute::Required).
+                        where_constraint.is_none()
                             && match sigil {
                                 '$' => match type_constraint {
                                     None => true,
@@ -207,6 +208,13 @@ impl Interpreter {
                         attrs.insert(key.clone(), *val.clone());
                     }
                 }
+            }
+        }
+        // A required attribute that was not provided is `X::Attribute::Required`
+        // — let the interpreter raise it.
+        for (attr_name, _, _, is_required, _, _, _) in &class_attrs {
+            if *is_required && !attrs.contains_key(attr_name) {
+                return None;
             }
         }
         // A typed `$` attribute that is neither provided nor defaulted is

--- a/t/native-ctor-required-attrs.t
+++ b/t/native-ctor-required-attrs.t
@@ -1,0 +1,48 @@
+use Test;
+
+# VM-native default construction extended to `is required` attributes (ledger
+# §1 / phase ③). A provided required attribute is built natively (with the same
+# type check as any typed `$`); an unprovided required attribute falls through
+# to the interpreter, which raises X::Attribute::Required. These assertions
+# match `raku`.
+
+plan 14;
+
+class P { has Int $.x is required; has Int $.y is required; has $.z = 9 }
+class Reqd { has $.a is required; has $.b is required }
+class R { has Int $.n is required }
+class S { has @.items is required; has %.opts is required }
+class Base { has $.id is required }
+class Child is Base { has $.name = "?" }
+
+# all required provided -> native build
+my $p = P.new(x => 1, y => 2);
+is $p.x, 1, 'required attr x provided';
+is $p.y, 2, 'required attr y provided';
+is $p.z, 9, 'non-required default alongside required attrs';
+
+# a missing required attribute dies (X::Attribute::Required)
+my $ok = Reqd.new(a => 1, b => 2);
+is $ok.a, 1, 'both required provided builds';
+is $ok.b, 2, '... and keeps b';
+dies-ok { Reqd.new(a => 1) }, 'one missing required attr dies';
+dies-ok { Reqd.new }, 'all required missing dies';
+
+# required + typed: provided wrong type still dies
+is R.new(n => 5).n, 5, 'required typed attr provided & matches';
+dies-ok { R.new(n => "x") }, 'required typed attr wrong type dies';
+dies-ok { R.new }, 'required typed attr missing dies';
+
+# required @ / % attributes (provided -> native build). Note: the interpreter
+# only enforces `is required` for `$`-scalar attributes, so a *missing* required
+# `@`/`%` attribute does not die here (a pre-existing raku divergence); the
+# native path matches the interpreter by falling through for any missing
+# required attribute.
+my $s = S.new(items => (1, 2, 3), opts => { k => 1 });
+is-deeply $s.items, [1, 2, 3], 'required @ attr provided';
+is $s.opts<k>, 1, 'required % attr provided';
+
+# inheritance: required attr in a parent
+my $c = Child.new(id => 42);
+is $c.id, 42, 'inherited required attr provided';
+dies-ok { Child.new }, 'inherited required attr missing dies';


### PR DESCRIPTION
## What

Extends the native default constructor (`methods_object.rs`, shared by the VM's `try_compiled_method_or_interpret` and the interpreter's `dispatch_new`) to admit `is required` attributes, continuing to peel the `Package.new` §1 catch-all category off the interpreter bridge (phase ③). Follows #2833 (typed `$`) and #2834 (untyped `@`/`%`).

A provided required attribute is built natively (same type check as any typed `$`); an unprovided required attribute falls through to the interpreter. The gate drops the `!is_required` rejection; the build adds a first pre-validation that returns `None` whenever a required attribute was not provided.

## Behavior-invariant vs the interpreter

- a missing required `$`-scalar dies (interpreter raises `X::Attribute::Required`, matching raku)
- a missing required `@`/`%` does **not** die — the interpreter only enforces `is required` for `$`-scalars (a pre-existing raku divergence); the native path matches by falling through for any missing required attribute

## Testing

- pin `t/native-ctor-required-attrs.t` (14 subtests)
- S12 / S14 / S03-binding / roles whitelist (184 files) all green
- cargo test 458/0, make test PASS

(Writing the pin test surfaced two unrelated pre-existing parser limitations — consecutive top-level bare blocks `} {`, and a class named `Q` colliding with the `Q` quoting operator — sidestepped with a flat top-level test structure and non-colliding names.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)