### PR TITLE
feat(exceptions): X::Routine::Unwrap for invalid unwrap handles

### DIFF
--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -2,6 +2,18 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::signature::{extract_sig_info, make_signature_value, param_defs_to_sig_info};
 
+/// Build a structured `X::Routine::Unwrap` error (`&f.unwrap($bad-handle)`).
+fn routine_unwrap_error(message: &str) -> RuntimeError {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.to_string()));
+    let mut err = RuntimeError::new(message);
+    err.exception = Some(Box::new(Value::make_instance(
+        Symbol::intern("X::Routine::Unwrap"),
+        attrs,
+    )));
+    err
+}
+
 impl Interpreter {
     /// Dispatch methods on callable values (Routine, Sub, WeakSub).
     /// Returns Some(result) if handled, None to fall through to common dispatch.
@@ -802,8 +814,8 @@ impl Interpreter {
             if args.is_empty() {
                 // unwrap with no args on a never-wrapped sub should error
                 if !self.wrap_chains.contains_key(&sub_id) || self.wrap_chains[&sub_id].is_empty() {
-                    return Some(Err(RuntimeError::new(
-                        "Cannot unwrap a sub that has not been wrapped",
+                    return Some(Err(routine_unwrap_error(
+                        "Cannot unwrap routine: not wrapped",
                     )));
                 }
                 // Pop the outermost wrapper
@@ -819,8 +831,8 @@ impl Interpreter {
             let handle = &args[0];
             let handle_id = self.extract_wrap_handle_id(handle);
             let Some(handle_id) = handle_id else {
-                return Some(Err(RuntimeError::new(
-                    "unwrap requires a valid WrapHandle argument",
+                return Some(Err(routine_unwrap_error(
+                    "Cannot unwrap routine: invalid wrap handle",
                 )));
             };
             let chain = self.wrap_chains.get_mut(&sub_id);
@@ -828,8 +840,8 @@ impl Interpreter {
                 let before_len = chain.len();
                 chain.retain(|(hid, _)| *hid != handle_id);
                 if chain.len() == before_len {
-                    return Some(Err(RuntimeError::new(
-                        "Cannot unwrap: handle not found (already unwrapped?)",
+                    return Some(Err(routine_unwrap_error(
+                        "Cannot unwrap routine: invalid wrap handle",
                     )));
                 }
                 if chain.is_empty() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2798,6 +2798,7 @@ impl Interpreter {
         // X::Method::Private::Permission
         register_x("X::Method::Private::Permission", "Exception");
         register_x("X::Method::Private::Unqualified", "Exception");
+        register_x("X::Routine::Unwrap", "Exception");
 
         // X::ParametricConstant
         register_x("X::ParametricConstant", "Exception");

--- a/t/routine-unwrap-error.t
+++ b/t/routine-unwrap-error.t
@@ -1,0 +1,22 @@
+use Test;
+
+# &routine.unwrap with something that is not a valid wrap handle throws
+# X::Routine::Unwrap.
+
+plan 3;
+
+throws-like 'sub f() { }; &f.unwrap("foo")', X::Routine::Unwrap,
+    'unwrap with a non-handle argument';
+
+throws-like 'sub g() { }; &g.unwrap', X::Routine::Unwrap,
+    'unwrap of a never-wrapped routine';
+
+# A valid wrap/unwrap round-trip still works.
+lives-ok {
+    my $h = &?ROUTINE.WHO ?? Nil !! Nil;  # no-op to keep block non-empty
+    sub h() { 1 }
+    my $handle = &h.wrap(sub { callsame() + 10 });
+    die "wrap broken" unless h() == 11;
+    &h.unwrap($handle);
+    die "unwrap broken" unless h() == 1;
+}, 'wrap then unwrap with a real handle works';


### PR DESCRIPTION
## Summary

`&routine.unwrap($x)` where `$x` is not a valid wrap handle (`&f.unwrap("foo")`),
and `&routine.unwrap` on a never-wrapped routine, now throw a structured
**X::Routine::Unwrap** instead of a bare ad-hoc error. A new
`routine_unwrap_error` helper builds the instance with rakudo's "Cannot unwrap
routine: ..." message; the three unwrap failure sites in `methods_sub.rs` use
it. Registered `X::Routine::Unwrap`. Valid wrap/unwrap round-trips are
unaffected.

Covers `roast/S32-exceptions/misc2.t:261`.

## Test plan

- New `t/routine-unwrap-error.t` (3 subtests).
- Existing `t/wrap.t`, `t/wrap-closure-capture.t` still pass.
- `make test` — only the known-flaky `t/proc-async.t` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)