### PR TITLE
feat(vm): native default construction for native-typed scalar attributes (§1)

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -274,89 +274,119 @@ impl Interpreter {
             }
         }
 
-        // Fill defaults for missing attributes (including Nil for uninitialized
-        // ones). Set up `self` as the partially-constructed instance so that
-        // default expressions referencing `self` (e.g. `has $.x = self.y`) work
-        // correctly. Update `self` after each default so that later defaults can
-        // see earlier defaults' values.
-        let has_defaults = class_attrs.iter().any(|(_, _, d, ..)| d.is_some());
-        if has_defaults {
-            let partial = Value::make_instance(class_name, attrs.clone());
-            self.env.insert("self".to_string(), partial.clone());
-            self.env.insert("__ANON_STATE__".to_string(), partial);
-            // Also set !attr and .attr in env so that default expressions
-            // like `has $.c = $!a + $!b` can reference earlier attributes.
-            for (k, v) in &attrs {
-                self.env.insert(format!("!{}", k), v.clone());
-                self.env.insert(format!(".{}", k), v.clone());
-            }
-        }
-        // Switch package to class scope so class-scoped subs are accessible
-        // in default expressions (e.g. `has $.inner = inner()` where `inner`
-        // is a sub defined inside the class body).
-        let saved_package = self.current_package.clone();
-        if self.has_class_scoped_subs(cn_resolved) {
-            self.current_package = cn_resolved.to_string();
-        }
+        // Fill defaults for missing attributes. Mirror the interpreter's
+        // constructor structure: a *literal* default — the common case, since the
+        // parser hands every native-typed attribute a `Literal` zero — takes a
+        // fast path with no `self`/env binding, while a non-literal default binds
+        // `self` and the already-initialized `$!attr`/`$.attr` (so expressions
+        // like `has $.c = $!a + $!b` resolve) only for the duration of that one
+        // evaluation. Rebuilding `self` from the current `attrs` inside the
+        // non-literal branch keeps earlier (literal or computed) defaults visible
+        // to later ones without paying per-construction env churn — the absence of
+        // that fast path made a 20k-iteration native-attr loop time out.
         let mut eval_error: Option<RuntimeError> = None;
         let mut typed_default_mismatch = false;
         for (attr_name, _is_public, default_expr, _, _, sigil, _) in &class_attrs {
             if attrs.contains_key(attr_name) {
                 continue;
             }
-            if let Some(expr) = default_expr {
-                // Only `$` attributes reach here with a default — `@`/`%` defaults
-                // fell through above.
-                let val = match self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        eval_error = Some(e);
+            match default_expr {
+                // Fast path: a literal default needs no evaluation or binding.
+                // The interpreter stores it without a type check, so we do too.
+                Some(Expr::Literal(lit_val)) => {
+                    attrs.insert(
+                        attr_name.clone(),
+                        Self::coerce_attr_value_by_sigil(lit_val.clone(), *sigil),
+                    );
+                }
+                Some(expr) => {
+                    // Bind `self` and the already-set attributes, switch to the
+                    // class package for class-scoped sub lookups, evaluate, then
+                    // restore everything — per the interpreter's per-default setup.
+                    let temp_self = Value::make_instance(class_name, attrs.clone());
+                    let old_self = self.env.get("self").cloned();
+                    let old_anon = self.env.get("__ANON_STATE__").cloned();
+                    self.env.insert("self".to_string(), temp_self.clone());
+                    self.env.insert("__ANON_STATE__".to_string(), temp_self);
+                    let mut saved_attr_env: Vec<(String, Option<Value>)> = Vec::new();
+                    for (a_name, a_val) in &attrs {
+                        let bang = format!("!{}", a_name);
+                        let dot = format!(".{}", a_name);
+                        saved_attr_env.push((bang.clone(), self.env.get(&bang).cloned()));
+                        saved_attr_env.push((dot.clone(), self.env.get(&dot).cloned()));
+                        self.env.insert(bang, a_val.clone());
+                        self.env.insert(dot, a_val.clone());
+                    }
+                    let saved_package = self.current_package.clone();
+                    if self.has_class_scoped_subs(cn_resolved) {
+                        self.current_package = cn_resolved.to_string();
+                    }
+                    let result = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]);
+                    self.current_package = saved_package;
+                    for (key, old_val) in saved_attr_env {
+                        match old_val {
+                            Some(v) => {
+                                self.env.insert(key, v);
+                            }
+                            None => {
+                                self.env.remove(&key);
+                            }
+                        }
+                    }
+                    match old_self {
+                        Some(v) => {
+                            self.env.insert("self".to_string(), v);
+                        }
+                        None => {
+                            self.env.remove("self");
+                        }
+                    }
+                    match old_anon {
+                        Some(v) => {
+                            self.env.insert("__ANON_STATE__".to_string(), v);
+                        }
+                        None => {
+                            self.env.remove("__ANON_STATE__");
+                        }
+                    }
+                    let val = match result {
+                        Ok(val) => val,
+                        Err(e) => {
+                            eval_error = Some(e);
+                            break;
+                        }
+                    };
+                    // A non-native default whose value does not match the
+                    // attribute's type constraint needs the interpreter — fall
+                    // through. Native-typed attributes are exempt (their default
+                    // is stored without a type check).
+                    if let Some(c) = type_constraints.get(attr_name)
+                        && Self::native_scalar_default(c).is_none()
+                        && !self.type_matches_value(c, &val)
+                    {
+                        typed_default_mismatch = true;
                         break;
                     }
-                };
-                // A default whose value does not match the attribute's type
-                // constraint needs the interpreter's handling — fall through.
-                // Native-typed attributes are exempt (the interpreter evaluates
-                // and stores their default without a type check).
-                if let Some(c) = type_constraints.get(attr_name)
-                    && Self::native_scalar_default(c).is_none()
-                    && !self.type_matches_value(c, &val)
-                {
-                    typed_default_mismatch = true;
-                    break;
+                    attrs.insert(
+                        attr_name.clone(),
+                        Self::coerce_attr_value_by_sigil(val, *sigil),
+                    );
                 }
-                attrs.insert(attr_name.clone(), val.clone());
-                // Update self and !attr/.attr so later defaults see this value
-                let updated = Value::make_instance(class_name, attrs.clone());
-                self.env.insert("self".to_string(), updated.clone());
-                self.env.insert("__ANON_STATE__".to_string(), updated);
-                self.env.insert(format!("!{}", attr_name), val.clone());
-                self.env.insert(format!(".{}", attr_name), val);
-            } else {
-                // Uninitialized: `@` -> empty Array, `%` -> empty Hash. For `$`:
-                // a native-typed scalar gets its native zero (`int` -> 0,
-                // `num` -> 0e0, `str` -> ""); an untyped `$` gets Nil. A
-                // class-typed `$` cannot reach here — it fell through above.
-                let empty = match sigil {
-                    '@' => Value::real_array(Vec::new()),
-                    '%' => Value::hash(HashMap::new()),
-                    _ => type_constraints
-                        .get(attr_name)
-                        .and_then(|c| Self::native_scalar_default(c))
-                        .unwrap_or(Value::Nil),
-                };
-                attrs.insert(attr_name.clone(), empty);
-            }
-        }
-        // Restore package and env after default evaluation (on every exit path).
-        self.current_package = saved_package;
-        if has_defaults {
-            self.env.remove("self");
-            self.env.remove("__ANON_STATE__");
-            // Clean up the !attr/.attr env entries we added
-            for k in attrs.keys() {
-                self.env.remove(&format!("!{}", k));
-                self.env.remove(&format!(".{}", k));
+                None => {
+                    // Uninitialized: `@` -> empty Array, `%` -> empty Hash. For
+                    // `$`: a native-typed scalar gets its native zero (`int` -> 0,
+                    // `num` -> 0e0, `str` -> ""); an untyped `$` gets Nil. A
+                    // class-typed `$` cannot reach here — it fell through above.
+                    let empty = match sigil {
+                        '@' => Value::real_array(Vec::new()),
+                        '%' => Value::hash(HashMap::new()),
+                        _ => type_constraints
+                            .get(attr_name)
+                            .and_then(|c| Self::native_scalar_default(c))
+                            .unwrap_or(Value::Nil),
+                    };
+                    attrs.insert(attr_name.clone(), empty);
+                }
             }
         }
         if let Some(e) = eval_error {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -54,6 +54,12 @@ impl Interpreter {
         if !self.registry().classes.contains_key(cn_resolved) {
             return false;
         }
+        // A `repr('CUnion')` class lays its native fields over shared memory, so
+        // construction is a byte overlay (`construct_cunion_instance`), not plain
+        // per-attribute data assignment. Keep it on the interpreter.
+        if self.registry().cunion_classes.contains(cn_resolved) {
+            return false;
+        }
         let mut has_attribute = false;
         for cls in self.mro_readonly(cn_resolved) {
             if cls == "Any" || cls == "Mu" || cls == "Cool" {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -100,9 +100,10 @@ impl Interpreter {
                             && match sigil {
                                 '$' => match type_constraint {
                                     None => true,
-                                    Some(inner) => inner
-                                        .as_deref()
-                                        .is_some_and(Self::is_simple_native_ctor_constraint),
+                                    Some(inner) => inner.as_deref().is_some_and(|tc| {
+                                        Self::is_simple_native_ctor_constraint(tc)
+                                            || Self::native_scalar_default(tc).is_some()
+                                    }),
                                 },
                                 '@' | '%' => {
                                     !class_def.attribute_types.contains_key(name)
@@ -114,10 +115,15 @@ impl Interpreter {
                             }
                     },
                 )
-                && class_def
-                    .attribute_types
-                    .values()
-                    .all(|tc| Self::is_simple_native_ctor_constraint(tc))
+                && class_def.attribute_types.values().all(|tc| {
+                    // A typed scalar `$` constraint: either a plain class type
+                    // (`type_matches_value`-checkable) or a native scalar type
+                    // (`int`/`num`/`str`, which defaults to a native zero rather
+                    // than a type object). Typed `@`/`%` containers are already
+                    // rejected by the per-attribute sigil branch above.
+                    Self::is_simple_native_ctor_constraint(tc)
+                        || Self::native_scalar_default(tc).is_some()
+                })
                 && class_def.attribute_smileys.is_empty();
             if !simple {
                 return false;
@@ -135,6 +141,21 @@ impl Interpreter {
     /// keeps the interpreter's richer construction semantics.
     fn is_simple_native_ctor_constraint(tc: &str) -> bool {
         tc.starts_with(char::is_uppercase) && !tc.contains('(') && !tc.contains('[')
+    }
+
+    /// The default value for an uninitialized native-typed scalar attribute
+    /// (`has int $.x`, `has num $.y`, `has str $.z`): the native zero/empty,
+    /// not a type object. Mirrors the interpreter's `bless` default logic in
+    /// `methods_dispatch_new.rs`. Returns `None` for non-native types so the
+    /// caller can distinguish a native scalar constraint from a class one.
+    fn native_scalar_default(tc: &str) -> Option<Value> {
+        match tc {
+            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
+            | "uint32" | "uint64" | "byte" | "atomicint" => Some(Value::Int(0)),
+            "num" | "num32" | "num64" => Some(Value::Num(0.0)),
+            "str" => Some(Value::str(String::new())),
+            _ => None,
+        }
     }
 
     /// Default-construct `class_name` natively when it is eligible (see
@@ -199,8 +220,12 @@ impl Interpreter {
                         // A provided value that does not already match its
                         // attribute's type constraint needs the interpreter
                         // (coercion or a proper X::TypeCheck::Assignment) — fall
-                        // through.
+                        // through. Native-typed attributes (`int`/`num`/`str`)
+                        // are exempt: the interpreter stores the provided value
+                        // as-is without coercing or type-checking it, so we do
+                        // the same and never fall through on them.
                         if let Some(c) = type_constraints.get(key)
+                            && Self::native_scalar_default(c).is_none()
                             && !self.type_matches_value(c, val)
                         {
                             return None;
@@ -217,13 +242,17 @@ impl Interpreter {
                 return None;
             }
         }
-        // A typed `$` attribute that is neither provided nor defaulted is
+        // A class-typed `$` attribute that is neither provided nor defaulted is
         // initialized to its *type object* (e.g. `Int`), not `Nil`. Let the
-        // interpreter synthesize it.
+        // interpreter synthesize it. Native-typed attributes (`int`/`num`/`str`)
+        // are the exception: they default to a native zero (handled in the fill
+        // loop below), not a type object, so they stay native.
         for (attr_name, _, default_expr, _, _, _, _) in &class_attrs {
             if default_expr.is_none()
                 && !attrs.contains_key(attr_name)
-                && type_constraints.contains_key(attr_name)
+                && type_constraints
+                    .get(attr_name)
+                    .is_some_and(|c| Self::native_scalar_default(c).is_none())
             {
                 return None;
             }
@@ -281,7 +310,10 @@ impl Interpreter {
                 };
                 // A default whose value does not match the attribute's type
                 // constraint needs the interpreter's handling — fall through.
+                // Native-typed attributes are exempt (the interpreter evaluates
+                // and stores their default without a type check).
                 if let Some(c) = type_constraints.get(attr_name)
+                    && Self::native_scalar_default(c).is_none()
                     && !self.type_matches_value(c, &val)
                 {
                     typed_default_mismatch = true;
@@ -295,12 +327,17 @@ impl Interpreter {
                 self.env.insert(format!("!{}", attr_name), val.clone());
                 self.env.insert(format!(".{}", attr_name), val);
             } else {
-                // Uninitialized: `@` -> empty Array, `%` -> empty Hash, `$` -> Nil
-                // (an untyped `$`; typed `$` fell through above).
+                // Uninitialized: `@` -> empty Array, `%` -> empty Hash. For `$`:
+                // a native-typed scalar gets its native zero (`int` -> 0,
+                // `num` -> 0e0, `str` -> ""); an untyped `$` gets Nil. A
+                // class-typed `$` cannot reach here — it fell through above.
                 let empty = match sigil {
                     '@' => Value::real_array(Vec::new()),
                     '%' => Value::hash(HashMap::new()),
-                    _ => Value::Nil,
+                    _ => type_constraints
+                        .get(attr_name)
+                        .and_then(|c| Self::native_scalar_default(c))
+                        .unwrap_or(Value::Nil),
                 };
                 attrs.insert(attr_name.clone(), empty);
             }

--- a/t/native-typed-attr-ctor.t
+++ b/t/native-typed-attr-ctor.t
@@ -5,7 +5,7 @@ use Test;
 # zero (0 / 0e0 / "") rather than a type object, and a provided value is
 # stored as-is (the constructor neither coerces nor type-checks it).
 
-plan 18;
+plan 21;
 
 # --- defaults ---
 {
@@ -60,4 +60,18 @@ plan 18;
     my $b = B5.new(x => 3);
     is $b.x, 3,  'inherited native int provided value kept';
     is $b.y, '', 'native str default in subclass';
+}
+
+# --- repr('CUnion') native fields stay on the byte-overlay constructor, not
+#     the native default fast path (the fields share memory) ---
+{
+    class Overlap is repr('CUnion') {
+        has uint32 $.u32;
+        has uint16 $.u16;
+        has uint8  $.u8;
+    }
+    my $o = Overlap.new(u32 => 1234567);
+    is $o.u32, 1234567, 'CUnion uint32 field';
+    is $o.u16,   54919, 'CUnion uint16 overlays low bytes';
+    is $o.u8,      135, 'CUnion uint8 overlays lowest byte';
 }

--- a/t/native-typed-attr-ctor.t
+++ b/t/native-typed-attr-ctor.t
@@ -1,0 +1,63 @@
+use Test;
+
+# Native default construction for native-typed scalar attributes
+# (`has int $.x` / `has num $.y` / `has str $.z`). These default to a native
+# zero (0 / 0e0 / "") rather than a type object, and a provided value is
+# stored as-is (the constructor neither coerces nor type-checks it).
+
+plan 18;
+
+# --- defaults ---
+{
+    class C0 { has int $.x; has num $.y; has str $.z }
+    my $c = C0.new;
+    is $c.x, 0,       'int default is 0';
+    is $c.x.^name, 'Int', 'int default name is Int';
+    is $c.y, 0,       'num default is 0';
+    is $c.y.^name, 'Num', 'num default name is Num';
+    is $c.z, '',      'str default is empty string';
+    is $c.z.^name, 'Str', 'str default name is Str';
+}
+
+# --- provided values stored as-is ---
+{
+    class C1 { has int $.x; has str $.z }
+    my $c = C1.new(x => 5, z => 'hi');
+    is $c.x, 5,    'provided int kept';
+    is $c.z, 'hi', 'provided str kept';
+}
+
+# --- sized native ints default to 0 ---
+{
+    class C2 { has int8 $.a; has uint16 $.b; has int64 $.c }
+    my $c = C2.new;
+    is $c.a, 0, 'int8 default 0';
+    is $c.b, 0, 'uint16 default 0';
+    is $c.c, 0, 'int64 default 0';
+}
+
+# --- native scalar coexisting with a class-typed scalar ---
+{
+    class C3 { has int $.n; has Int $.i }
+    my $c = C3.new;
+    is $c.n, 0, 'native int defaults to 0';
+    is $c.i.^name, 'Int', 'class-typed scalar defaults to its type object';
+    nok $c.i.defined, 'class-typed scalar default is undefined';
+}
+
+# --- native scalar with an explicit default expression ---
+{
+    class C4 { has int $.a = 9; has num $.c }
+    my $c = C4.new;
+    is $c.a, 9, 'native int explicit default honoured';
+    is $c.c, 0, 'native num default still 0';
+}
+
+# --- inheritance with native-typed attributes ---
+{
+    class A5 { has int $.x }
+    class B5 is A5 { has str $.y }
+    my $b = B5.new(x => 3);
+    is $b.x, 3,  'inherited native int provided value kept';
+    is $b.y, '', 'native str default in subclass';
+}


### PR DESCRIPTION
## Summary

Extends the VM-native `Package.new` constructor fast path (§1 phase ③) to **native-typed scalar attributes** — the next slice after typed `$` (#2833), untyped `@`/`%` (#2834), and `is required` (#2835).

Covers `has int $.x`, `has num $.y`, `has str $.z` and the sized variants (`int8`/`uint16`/`int64`/`num32`/`atomicint`/...).

## Behavior (invariant with the current interpreter)

- An **uninitialized** native scalar defaults to its native zero — `int` → `0`, `num` → `0e0`, `str` → `""` — rather than a type object.
- A **provided** value is stored **as-is**: the interpreter neither coerces nor type-checks native-typed attributes at construction time (e.g. `C.new(x => "7")` on `has int $.x` keeps the `Str` `"7"`), so the native path does the same and never falls through on them.
- `native_scalar_default()` mirrors the interpreter's `bless` default logic in `methods_dispatch_new.rs`.

Class-typed scalars (`has Int $.i`) still fall through to the interpreter so their uninitialized default stays the *type object*; typed `@`/`%` containers remain interpreter-owned (next slice — needs container type metadata).

## Tests

- New pin test `t/native-typed-attr-ctor.t` (18 assertions): defaults, sized ints, provided values, native + class-typed coexistence, explicit defaults, inheritance.
- Whitelisted construction roast tests pass (`S12-attributes/native.t`, `defaults.t`, `instance.t`, `inheritance.t`, `clone.t`, `smiley.t`, `S12-class/attributes*.t`, `instantiate.t`, `basic.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)