### PR TITLE
feat(vm): correct construction of coercion-typed attributes + native path (§1)

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -179,6 +179,21 @@ pub(in crate::parser::stmt) fn scope_declaration_error(scope: &str, rest: &str) 
     None
 }
 
+/// If `tc` is a coercion type constraint (`Int()`, `Int(Str)`), return its
+/// target type name (`Int`). A parametric type such as `Positional[Int]` (which
+/// contains `[`) is not a coercion type.
+fn coercion_target_type(tc: &str) -> Option<&str> {
+    if tc.ends_with(')')
+        && !tc.contains('[')
+        && let Some(open) = tc.find('(')
+        && open > 0
+    {
+        Some(&tc[..open])
+    } else {
+        None
+    }
+}
+
 /// Parse `has` attribute declaration.
 pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("has", input).ok_or_else(|| PError::expected("has declaration"))?;
@@ -734,6 +749,12 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             default = Some(Expr::Var("?CLASS".to_string()));
         } else if tc == "::?ROLE" {
             default = Some(Expr::Var("?ROLE".to_string()));
+        } else if let Some(target) = coercion_target_type(tc) {
+            // A coercion type (`Int()`, `Int(Str)`): an uninitialized attribute
+            // defaults to the *target* type object (`Int`), not a bareword of the
+            // whole coercion spec. (The provided-value coercion happens at
+            // construction time.)
+            default = Some(Expr::BareWord(target.to_string()));
         } else {
             default = Some(match tc.as_str() {
                 "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -109,6 +109,7 @@ impl Interpreter {
                                     Some(inner) => inner.as_deref().is_some_and(|tc| {
                                         Self::is_simple_native_ctor_constraint(tc)
                                             || Self::native_scalar_default(tc).is_some()
+                                            || Self::is_native_coercion_ctor_constraint(tc)
                                     }),
                                 },
                                 '@' | '%' => {
@@ -122,13 +123,15 @@ impl Interpreter {
                     },
                 )
                 && class_def.attribute_types.values().all(|tc| {
-                    // A typed scalar `$` constraint: either a plain class type
-                    // (`type_matches_value`-checkable) or a native scalar type
-                    // (`int`/`num`/`str`, which defaults to a native zero rather
-                    // than a type object). Typed `@`/`%` containers are already
-                    // rejected by the per-attribute sigil branch above.
+                    // A typed scalar `$` constraint: a plain class type
+                    // (`type_matches_value`-checkable), a native scalar type
+                    // (`int`/`num`/`str`, defaulting to a native zero rather than a
+                    // type object), or a built-in-target coercion type (`Int()`).
+                    // Typed `@`/`%` containers are already rejected by the
+                    // per-attribute sigil branch above.
                     Self::is_simple_native_ctor_constraint(tc)
                         || Self::native_scalar_default(tc).is_some()
+                        || Self::is_native_coercion_ctor_constraint(tc)
                 })
                 && class_def.attribute_smileys.is_empty();
             if !simple {
@@ -147,6 +150,22 @@ impl Interpreter {
     /// keeps the interpreter's richer construction semantics.
     fn is_simple_native_ctor_constraint(tc: &str) -> bool {
         tc.starts_with(char::is_uppercase) && !tc.contains('(') && !tc.contains('[')
+    }
+
+    /// A coercion-type constraint (`Int()`, `Int(Str)`) whose target is a
+    /// built-in scalar type the native constructor can coerce to without running
+    /// user-defined code. A user-class coercion target (with a `COERCE` method)
+    /// keeps the interpreter, which runs that method. Coercion itself is routed
+    /// through the shared `coerce_value_for_constraint`, so a native-coerced value
+    /// is identical to the interpreter's.
+    fn is_native_coercion_ctor_constraint(tc: &str) -> bool {
+        match crate::runtime::types::parse_coercion_type(tc) {
+            Some((target, _src)) => matches!(
+                target,
+                "Int" | "Num" | "Rat" | "FatRat" | "Complex" | "Str" | "Bool" | "Numeric" | "Real"
+            ),
+            None => false,
+        }
     }
 
     /// The default value for an uninitialized native-typed scalar attribute
@@ -229,9 +248,12 @@ impl Interpreter {
                         // through. Native-typed attributes (`int`/`num`/`str`)
                         // are exempt: the interpreter stores the provided value
                         // as-is without coercing or type-checking it, so we do
-                        // the same and never fall through on them.
+                        // the same and never fall through on them. Coercion-typed
+                        // attributes (`Int()`) are also exempt — their provided
+                        // value is coerced in the final pass below, not checked.
                         if let Some(c) = type_constraints.get(key)
                             && Self::native_scalar_default(c).is_none()
+                            && !Self::is_native_coercion_ctor_constraint(c)
                             && !self.type_matches_value(c, val)
                         {
                             return None;
@@ -359,9 +381,11 @@ impl Interpreter {
                     // A non-native default whose value does not match the
                     // attribute's type constraint needs the interpreter — fall
                     // through. Native-typed attributes are exempt (their default
-                    // is stored without a type check).
+                    // is stored without a type check); coercion-typed attributes
+                    // are exempt too (their default is coerced in the final pass).
                     if let Some(c) = type_constraints.get(attr_name)
                         && Self::native_scalar_default(c).is_none()
+                        && !Self::is_native_coercion_ctor_constraint(c)
                         && !self.type_matches_value(c, &val)
                     {
                         typed_default_mismatch = true;
@@ -394,6 +418,25 @@ impl Interpreter {
         }
         if typed_default_mismatch {
             return None;
+        }
+        // Final pass: coerce every coercion-typed `$` attribute (`has Int() $.x`)
+        // through its target type. This uniformly covers a provided value, a
+        // literal/computed default, and the bare type-object default of an
+        // uninitialized attribute (which coerces to itself). The shared
+        // `coerce_value_for_constraint` is the exact path the interpreter uses, so
+        // the result is identical; the gate already excluded user-class targets,
+        // so only built-in coercion logic runs here.
+        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+            if *sigil != '$' {
+                continue;
+            }
+            if let Some(tc) = type_constraints.get(attr_name)
+                && Self::is_native_coercion_ctor_constraint(tc)
+                && let Some(val) = attrs.remove(attr_name)
+            {
+                let coerced = self.coerce_value_for_constraint(tc, val);
+                attrs.insert(attr_name.clone(), coerced);
+            }
         }
         // Add alias metadata for `has $x` (no twigil) attributes
         self.add_alias_attribute_metadata(cn_resolved, &mut attrs);
@@ -3119,6 +3162,9 @@ impl Interpreter {
                     .iter()
                     .map(|(name, _, _, _, _, sigil, _)| (name.clone(), *sigil))
                     .collect();
+                // Attribute type constraints (MRO-wide), used to coerce a provided
+                // value for a coercion-typed attribute (`has Int() $.x`).
+                let attr_type_constraints = self.collect_attribute_type_constraints(class_key);
                 // First, collect constructor args into attrs
                 self.env = saved_default_env.clone();
                 let class_mro = self.class_mro(class_key);
@@ -3138,10 +3184,18 @@ impl Interpreter {
                     match val {
                         Value::Pair(k, v) => {
                             if !any_build && self.is_attribute_buildable(class_key, k) {
-                                let coerced = Self::coerce_attr_value_by_sigil(
-                                    *v.clone(),
-                                    sigil_map.get(k).copied().unwrap_or('$'),
-                                );
+                                let sigil = sigil_map.get(k).copied().unwrap_or('$');
+                                let mut value = *v.clone();
+                                // A coercion-typed attribute (`has Int() $.x`)
+                                // coerces its provided value through the target
+                                // type (built-in coercion or a user COERCE method).
+                                if sigil == '$'
+                                    && let Some(tc) = attr_type_constraints.get(k)
+                                    && crate::runtime::types::is_coercion_constraint(tc)
+                                {
+                                    value = self.coerce_value_for_constraint(tc, value);
+                                }
+                                let coerced = Self::coerce_attr_value_by_sigil(value, sigil);
                                 attrs.insert(k.clone(), coerced);
                             }
                             // When BUILD exists, named args are passed to BUILD
@@ -3406,6 +3460,18 @@ impl Interpreter {
                             }
                             _ => Value::Nil,
                         }
+                    };
+                    // A coercion-typed attribute (`has Int() $.x = "42"`) coerces
+                    // its evaluated default through the target type, just like a
+                    // provided value. (The bare type-object default for an
+                    // uninitialized coercion attribute coerces to itself.)
+                    let val = if sigil == '$'
+                        && let Some(tc) = attr_type_constraints.get(&attr_name)
+                        && crate::runtime::types::is_coercion_constraint(tc)
+                    {
+                        self.coerce_value_for_constraint(tc, val)
+                    } else {
+                        val
                     };
                     attrs.insert(attr_name, val);
                 }

--- a/t/coercion-typed-attr-ctor.t
+++ b/t/coercion-typed-attr-ctor.t
@@ -1,0 +1,91 @@
+use Test;
+
+# Construction of coercion-typed scalar attributes (`has Int() $.x`).
+# - An uninitialized attribute defaults to the *target* type object (undefined).
+# - A provided value is coerced through the target type.
+# - An explicit default is coerced too.
+# Built-in coercion targets (Int/Num/Rat/Str/Bool/...) are constructed natively;
+# a user-class target with a COERCE method falls through to the interpreter but
+# must produce the same result.
+
+plan 23;
+
+# --- uninitialized: target type object, undefined ---
+{
+    class C0 { has Int() $.x }
+    my $c = C0.new;
+    is $c.x.^name, 'Int', 'uninit coercion attr is the target type object';
+    nok $c.x.defined, 'uninit coercion attr is undefined';
+}
+
+# --- provided value coerced ---
+{
+    class C1 { has Int() $.x }
+    my $c = C1.new(x => "42");
+    is $c.x, 42, 'provided Str coerced to Int';
+    is $c.x.^name, 'Int', 'provided value has target type';
+}
+
+# --- Num() / Rat() / Bool() targets ---
+{
+    class C2 { has Num() $.y }
+    my $c = C2.new(y => 3);
+    is $c.y, 3, 'Int coerced to Num';
+    is $c.y.^name, 'Num', 'Num() target type';
+}
+{
+    class C3 { has Rat() $.r }
+    my $c = C3.new(r => "1.5");
+    is $c.r, 1.5, 'Str coerced to Rat';
+    is $c.r.^name, 'Rat', 'Rat() target type';
+}
+{
+    class C4 { has Bool() $.b }
+    my $c = C4.new(b => 1);
+    is $c.b, True, 'Int coerced to Bool';
+    is $c.b.^name, 'Bool', 'Bool() target type';
+}
+
+# --- explicit default is coerced ---
+{
+    class C5 { has Int() $.x = "42" }
+    my $c = C5.new;
+    is $c.x, 42, 'explicit Str default coerced to Int';
+    is $c.x.^name, 'Int', 'explicit default has target type';
+}
+
+# --- provided value overrides (and coerces) the default ---
+{
+    class C6 { has Int() $.x = "42" }
+    my $c = C6.new(x => "99");
+    is $c.x, 99, 'provided value overrides default';
+    is $c.x.^name, 'Int', 'override is coerced';
+}
+
+# --- coercion attr coexisting with native / class / untyped attributes ---
+{
+    class C7 { has int $.n; has Int() $.c; has Str $.s; has @.a }
+    my $o = C7.new(c => "7", a => [1, 2]);
+    is $o.n, 0,            'native int default still 0';
+    is $o.c, 7,            'coercion attr coerced';
+    is $o.c.^name, 'Int',  'coercion attr target type';
+    is $o.s.^name, 'Str',  'class-typed scalar default is its type object';
+    is $o.a, [1, 2],       'untyped array attr provided';
+}
+
+# --- user-class coercion target uses its COERCE method ---
+{
+    class Temp { has $.c; method COERCE($v) { self.new(c => $v) } }
+    class W { has Temp() $.t }
+    my $w = W.new(t => 5);
+    is $w.t.^name, 'Temp', 'user COERCE target produces the class';
+    is $w.t.c, 5,          'user COERCE received the value';
+}
+
+# --- Numeric() coerces a string through the numeric grammar ---
+{
+    class C8 { has Numeric() $.n }
+    my $c = C8.new(n => "3.5");
+    is $c.n, 3.5,         'Numeric() coerces "3.5"';
+    is $c.n.^name, 'Rat', 'Numeric() of "3.5" is Rat';
+}


### PR DESCRIPTION
## Summary

Coercion-typed scalar attributes (`has Int() $.x`) were **broken**: the parser stored the coercion spec as a bareword default (`BareWord("Int()")`), so an uninitialized attribute became a bogus `Str`, and a provided value was stored without any coercion. Signatures (`sub f(Int() $x)`) and `my Int() $x = ...` already coerced correctly — only **attributes** were missing the coercion path.

This fixes it end-to-end (matching Rakudo) and then makes built-in-target coercion attributes natively constructible — the next §1 native-ctor slice after native-typed scalars (#2837).

## Changes

**Parser (`has_decl.rs`)** — the auto-default for a coercion type is now the *target* type object (`Int`), not a bareword of the whole spec. `has Int() $.x` uninitialized → `Int` (undefined), as in Rakudo.

**Interpreter (`dispatch_new`)** — a provided value and an evaluated default for a coercion-typed `$` attribute are coerced through the target via the shared `coerce_value_for_constraint` (built-in coercion or a user `COERCE` method), the same helper signatures use.

**Native ctor** — built-in-target coercion types (`Int()`/`Num()`/`Rat()`/`Str()`/`Bool()`/`Numeric()`/`Real()`/...) are now natively constructible. A final pass coerces every coercion-typed attribute through the *same* `coerce_value_for_constraint`, so the native result is byte-identical to the interpreter's; user-class `COERCE` targets are gated out and fall through to the interpreter (which runs their method).

## Behavior (now matches `raku`)

| case | before | after |
|---|---|---|
| `has Int() $.x` uninit | `Str` (defined) | `Int` (undefined) |
| `.new(x => "42")` | `"42"` (Str) | `42` (Int) |
| `has Int() $.x = "42"` | `"42"` (Str) | `42` (Int) |
| `has Numeric() $.n` ← `"3.5"` | not coerced | `3.5` (Rat) |
| user `COERCE` target | not coerced | runs `COERCE` |

## Tests

- New `t/coercion-typed-attr-ctor.t` (23 assertions): uninit type object, provided/default coercion, Num/Rat/Bool/Numeric targets, native + class-typed + untyped coexistence, user `COERCE` fallthrough.
- Whitelisted regression set green: `S12-coercion/*.t`, `S02-types/{int-uint,signed-unsigned-native,native}.t`, `S12-attributes/*`, `S12-class/*` (852 subtests).
- 20k-iteration coercion-attr construction loop runs in ~2.5s (native path, no per-call interpreter dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)