### PR TITLE
feat(exceptions): X::Str::Trans::InvalidArg / IllegalKey for .trans

### DIFF
--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -234,6 +234,16 @@ impl Interpreter {
                         | Value::RangeExclBoth(..)
                         | Value::GenericRange { .. }
                 ) {
+                    // A from-side element that is neither a Str nor a Regex
+                    // (e.g. an `Any` object via `[Any.new]`) is an illegal
+                    // substitution key.
+                    if let Value::Array(items, ..) = key.as_ref()
+                        && let Some(bad) = items
+                            .iter()
+                            .find(|v| matches!(v, Value::Instance { .. } | Value::Package(_)))
+                    {
+                        return Err(self.str_trans_illegal_key_error(bad));
+                    }
                     // Check if the to-side array contains any closures.
                     let has_closures = if let Value::Array(items, ..) = value.as_ref() {
                         items.iter().any(is_closure)
@@ -338,6 +348,10 @@ impl Interpreter {
                     let key_str = key.to_string_value();
                     rules.push(self.parse_trans_pair(&key_str, value));
                 }
+            } else {
+                // Only Pair objects are valid positional arguments to .trans
+                // (e.g. `"a".trans(rx/a/)` passes a bare Regex).
+                return Err(self.str_trans_invalid_arg_error(arg));
             }
         }
 
@@ -347,6 +361,47 @@ impl Interpreter {
 
         let result = self.apply_trans_rules(&text, &rules, squash, delete, complement)?;
         Ok(Value::str(result))
+    }
+
+    /// Build an X::Str::Trans::InvalidArg error for a non-Pair argument passed
+    /// to `.trans`. `got` is the offending value's type object.
+    fn str_trans_invalid_arg_error(&self, arg: &Value) -> RuntimeError {
+        let type_name = crate::value::types::what_type_name(arg);
+        let msg = format!(
+            "Only Pair objects are allowed as arguments to Str.trans, got {}",
+            type_name
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert(
+            "got".to_string(),
+            Value::Package(crate::symbol::Symbol::intern(&type_name)),
+        );
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        let mut err = RuntimeError::new(&msg);
+        err.exception = Some(Box::new(Value::make_instance(
+            crate::symbol::Symbol::intern("X::Str::Trans::InvalidArg"),
+            attrs,
+        )));
+        err
+    }
+
+    /// Build an X::Str::Trans::IllegalKey error for a substitution key element
+    /// that is not a Str or Regex. `key` is the offending value.
+    fn str_trans_illegal_key_error(&self, key: &Value) -> RuntimeError {
+        let type_name = crate::value::types::what_type_name(key);
+        let msg = format!(
+            "in Str.trans, got illegal substitution key of type {} (should be a Regex or Str)",
+            type_name
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("key".to_string(), key.clone());
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        let mut err = RuntimeError::new(&msg);
+        err.exception = Some(Box::new(Value::make_instance(
+            crate::symbol::Symbol::intern("X::Str::Trans::IllegalKey"),
+            attrs,
+        )));
+        err
     }
 
     fn parse_trans_pair(&self, key: &str, value: &Value) -> TransRule {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2799,6 +2799,8 @@ impl Interpreter {
         register_x("X::Method::Private::Permission", "Exception");
         register_x("X::Method::Private::Unqualified", "Exception");
         register_x("X::Routine::Unwrap", "Exception");
+        register_x("X::Str::Trans::InvalidArg", "Exception");
+        register_x("X::Str::Trans::IllegalKey", "Exception");
 
         // X::ParametricConstant
         register_x("X::ParametricConstant", "Exception");

--- a/t/str-trans-errors.t
+++ b/t/str-trans-errors.t
@@ -1,0 +1,18 @@
+use Test;
+
+# .trans validates its arguments:
+#  - a non-Pair positional argument throws X::Str::Trans::InvalidArg (got);
+#  - a substitution key element that is not a Str/Regex throws
+#    X::Str::Trans::IllegalKey (key).
+
+plan 4;
+
+throws-like '"a".trans(rx/a/)', X::Str::Trans::InvalidArg,
+    'bare Regex argument', got => Regex;
+
+throws-like '"a".trans([Any.new] => [Any.new])', X::Str::Trans::IllegalKey,
+    'illegal substitution key', key => Any;
+
+# Valid transliterations still work.
+is "abc".trans("a" => "x"), "xbc", 'simple pair trans';
+is "hello".trans(["el"] => ["ip"]), "hiplo", 'array-keyed (token) trans';


### PR DESCRIPTION
## Summary

`.trans` now validates its arguments instead of silently ignoring bad ones:

- A non-Pair positional argument (`"a".trans(rx/a/)`) throws
  **X::Str::Trans::InvalidArg** carrying `got` (the argument's type object). The
  argument loop previously had no final `else`, so a bare Regex was dropped and
  `.trans` returned the string unchanged.
- A substitution-key element that is neither a Str nor a Regex
  (`"a".trans([Any.new] => [Any.new])`) throws **X::Str::Trans::IllegalKey**
  carrying `key` (the offending value).

Two helpers build the structured exceptions; both classes registered. Valid
char/token/regex/closure transliterations are unaffected (all of
`roast/S05-transliteration/` stays green).

Covers `roast/S32-exceptions/misc2.t:288-289` (misc2.t 36 → 34 failing).

## Test plan

- New `t/str-trans-errors.t` (4 subtests).
- `roast/S05-transliteration/*` all pass; `make test` only the known-flaky
  `t/proc-async.t` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)