### PR TITLE
feat(exceptions): X::Comp::NYI for a constant with a twigil

### DIFF
--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -43,6 +43,11 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
         register_term_symbol_from_decl_name(&n);
         (r, n)
     };
+    // A constant with a `?` twigil (e.g. `constant $?FILE = ...`) is not
+    // implemented; Raku rejects it at compile time with X::Comp::NYI.
+    if name.starts_with('?') || name.starts_with("@?") || name.starts_with("%?") {
+        return Err(constant_twigil_nyi_error('?'));
+    }
     // Record the source sigil so the compiler can distinguish a scalar
     // `constant $x` from a sigilless `constant x` for X::Redeclaration purposes
     // (the VarDecl `name` strips the `$`, so both would otherwise collide).
@@ -180,6 +185,20 @@ fn missing_initializer_error() -> PError {
     attrs.insert("what".to_string(), Value::str("initializer".to_string()));
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(Symbol::intern("X::Syntax::Missing"), attrs);
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
+/// `constant $?FILE = ...` — a constant declared with a twigil is not yet
+/// implemented; Raku rejects it at compile time with X::Comp::NYI.
+fn constant_twigil_nyi_error(twigil: char) -> PError {
+    let msg = format!(
+        "Constants with a '{}' twigil not yet implemented. Sorry.",
+        twigil
+    );
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("feature".to_string(), Value::str(msg.clone()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Comp::NYI"), attrs);
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2700,6 +2700,7 @@ impl Interpreter {
         register_x("X::Comp", "Exception");
         register_x("X::Comp::Group", "X::Comp");
         register_x("X::Comp::AdHoc", "X::Comp");
+        register_x("X::Comp::NYI", "X::Comp");
 
         // X::Syntax hierarchy (syntax errors, subtypes of X::Comp)
         register_x("X::Syntax", "X::Comp");

--- a/t/constant-twigil-nyi.t
+++ b/t/constant-twigil-nyi.t
@@ -1,0 +1,21 @@
+use Test;
+
+# A constant declared with a `?` twigil (compiler variable) is not implemented;
+# Raku rejects it at compile time with X::Comp::NYI.
+
+plan 5;
+
+throws-like 'constant $?FILE = "foo"', X::Comp::NYI, 'scalar ? twigil constant';
+throws-like 'constant $?LINE = 1', X::Comp::NYI, 'another ? twigil constant';
+throws-like 'constant @?FOO = 1, 2', X::Comp::NYI, 'array ? twigil constant';
+
+# Ordinary constants are unaffected.
+lives-ok {
+    constant $pi = 3;
+    constant NAME = "ok";
+    constant @list = 1, 2, 3;
+    die unless $pi == 3 && NAME eq "ok" && @list.elems == 3;
+}, 'plain constants still work';
+
+# The compiler variable itself is still usable as a term.
+ok $?FILE.defined, '$?FILE is still a usable term';


### PR DESCRIPTION
## Summary

`constant $?FILE = "foo"` — a constant declared with a `?` twigil — is not
implemented; Raku rejects it at compile time with **X::Comp::NYI** ("Constants
with a '?' twigil not yet implemented. Sorry."). mutsu previously parsed it as an
ordinary constant named `?FILE` and failed at runtime with "Cannot modify an
immutable value". `constant_decl` now detects a leading `?` twigil on the
declared name and raises a structured X::Comp::NYI. Registered X::Comp::NYI.
Plain constants and the `$?FILE` term itself are unaffected.

Covers `roast/S32-exceptions/misc2.t:124`.

## Test plan

- New `t/constant-twigil-nyi.t` (5 subtests).
- `make test` — only the known-flaky `t/proc-async.t` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)