### PR TITLE
feat(vm): native construction for typed `@`/`%` attributes (§1)

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -113,10 +113,26 @@ impl Interpreter {
                                     }),
                                 },
                                 '@' | '%' => {
-                                    !class_def.attribute_types.contains_key(name)
-                                        && !registry
-                                            .class_attribute_is_types
-                                            .contains_key(&(cls.clone(), name.clone()))
+                                    // An `is Type` container (`has @.a is Buf`)
+                                    // builds a special typed container — keep the
+                                    // interpreter. Otherwise: untyped is fine, and
+                                    // a typed element is allowed only when it is a
+                                    // plain `type_matches_value`-checkable class
+                                    // type (`has Int @.nums`); a native element
+                                    // (`has int @.x` -> packed `array[int]`) or a
+                                    // parametric/coercion element keeps the
+                                    // interpreter's richer construction.
+                                    if registry
+                                        .class_attribute_is_types
+                                        .contains_key(&(cls.clone(), name.clone()))
+                                    {
+                                        false
+                                    } else {
+                                        match class_def.attribute_types.get(name) {
+                                            None => true,
+                                            Some(et) => Self::is_simple_native_ctor_constraint(et),
+                                        }
+                                    }
                                 }
                                 _ => false,
                             }
@@ -436,6 +452,27 @@ impl Interpreter {
             {
                 let coerced = self.coerce_value_for_constraint(tc, val);
                 attrs.insert(attr_name.clone(), coerced);
+            }
+        }
+        // Tag typed `@`/`%` attributes (`has Int @.nums`) with element-type
+        // metadata and type-check their elements, exactly as `dispatch_new` does
+        // (shared `finalize_typed_container_attr`). A failing element raises the
+        // same `X::TypeCheck::Assignment` the interpreter would, so the native
+        // path is byte-identical. The gate already excluded `is Type` containers
+        // and native/parametric element types, so only plain class elements reach
+        // here. Done against the final `attrs` Arcs that move into the instance.
+        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+            if !matches!(sigil, '@' | '%') {
+                continue;
+            }
+            let Some(elem_type) = type_constraints.get(attr_name).cloned() else {
+                continue;
+            };
+            if let Some(val) = attrs.get(attr_name).cloned()
+                && let Err(e) =
+                    self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, &val)
+            {
+                return Some(Err(e));
             }
         }
         // Add alias metadata for `has $x` (no twigil) attributes
@@ -3813,6 +3850,38 @@ impl Interpreter {
                         "__mutsu_array_storage".to_string(),
                         Value::real_array(Vec::new()),
                     );
+                }
+                // Tag typed `@`/`%` attributes (`has Int @.nums`) with
+                // element-type metadata and type-check their elements (the
+                // variable path `my Int @a` does the same). The element type
+                // lives in `attribute_types`; `is Type` containers carry their
+                // own metadata and are skipped. Done here against the final
+                // `attrs` so the Arc-pointer-keyed metadata survives into the
+                // instance (a clone shares the same backing Arc).
+                for (attr_name, _, _, _, _, sigil, _) in &class_attrs_info {
+                    if !matches!(sigil, '@' | '%') {
+                        continue;
+                    }
+                    let Some(elem_type) = attr_type_constraints.get(attr_name).cloned() else {
+                        continue;
+                    };
+                    // Only plain class element types (`has Int @.nums`). Native
+                    // (`has int @.x` -> packed `array[int]`), coercion, and
+                    // parametric elements keep their pre-existing construction
+                    // (the uninit branch already tags native packed arrays).
+                    if !Self::is_simple_native_ctor_constraint(&elem_type) {
+                        continue;
+                    }
+                    if self
+                        .registry()
+                        .class_attribute_is_types
+                        .contains_key(&(class_key.to_string(), attr_name.clone()))
+                    {
+                        continue;
+                    }
+                    if let Some(val) = attrs.get(attr_name).cloned() {
+                        self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, &val)?;
+                    }
                 }
                 let instance = Value::make_instance(*class_name, attrs);
                 if let Some(type_args) = type_args.as_ref() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4826,6 +4826,48 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Finalize a typed `@`/`%` constructor attribute (`has Int @.nums` /
+    /// `has Int %.map`): type-check each element against the declared element
+    /// type (matching the variable path `my Int @a`, and raku's "Type check
+    /// failed for an element of @!nums") and tag the container with element-type
+    /// metadata so `.of` / `.WHAT` / `~~ Array[Int]` reflect the declared type.
+    ///
+    /// `value` must be the exact `Value` (Array/Hash) that will be stored in the
+    /// instance: the metadata is keyed by the backing `Arc`'s pointer, so it has
+    /// to be registered against the Arc that survives into `make_instance`.
+    pub(crate) fn finalize_typed_container_attr(
+        &mut self,
+        attr_name: &str,
+        sigil: char,
+        elem_type: &str,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        if elem_type != "Mu" && elem_type != "Any" {
+            let display = format!("{}!{}", sigil, attr_name);
+            let elems: Vec<&Value> = match value {
+                Value::Array(items, _) => items.iter().collect(),
+                Value::Hash(map) => map.values().collect(),
+                _ => Vec::new(),
+            };
+            for it in elems {
+                if !matches!(it, Value::Nil) && !self.type_matches_value(elem_type, it) {
+                    return Err(crate::runtime::utils::type_check_element_typed_error(
+                        &display, elem_type, it,
+                    ));
+                }
+            }
+        }
+        self.register_container_type_metadata(
+            value,
+            ContainerTypeInfo {
+                value_type: elem_type.to_string(),
+                key_type: None,
+                declared_type: None,
+            },
+        );
+        Ok(())
+    }
+
     pub(crate) fn is_var_dynamic(&self, name: &str) -> bool {
         self.var_dynamic_flags
             .get(Self::normalize_var_meta_name(name))

--- a/t/native-ctor-typed-container-attrs.t
+++ b/t/native-ctor-typed-container-attrs.t
@@ -1,0 +1,96 @@
+use Test;
+
+# Native default construction for typed `@`/`%` attributes (`has Int @.nums`).
+# Provided and defaulted typed containers must carry element-type metadata
+# (`.of` / `.WHAT` / `~~ Array[Int]`) and type-check their elements, matching
+# the variable path `my Int @a` and raku.
+
+plan 32;
+
+# --- typed array, provided ---
+class IntArr { has Int @.nums; }
+my $a = IntArr.new(nums => [1, 2, 3]);
+is $a.nums, [1, 2, 3], 'typed array attr keeps values';
+is $a.nums.^name, 'Array[Int]', 'typed array attr .WHAT is Array[Int]';
+is $a.nums.of.^name, 'Int', 'typed array attr .of is Int';
+ok $a.nums ~~ Array[Int], 'typed array attr smartmatches Array[Int]';
+
+# --- typed hash, provided ---
+class IntHash { has Int %.map; }
+my $h = IntHash.new(map => { a => 1, b => 2 });
+is $h.map<a>, 1, 'typed hash attr keeps values';
+is $h.map.^name, 'Hash[Int]', 'typed hash attr .WHAT is Hash[Int]';
+is $h.map.of.^name, 'Int', 'typed hash attr .of is Int';
+
+# --- uninitialized typed containers ---
+my $u = IntArr.new();
+is $u.nums.^name, 'Array[Int]', 'uninit typed array is Array[Int]';
+is $u.nums.of.^name, 'Int', 'uninit typed array .of is Int';
+is $u.nums.elems, 0, 'uninit typed array is empty';
+my $uh = IntHash.new();
+is $uh.map.^name, 'Hash[Int]', 'uninit typed hash is Hash[Int]';
+is $uh.map.of.^name, 'Int', 'uninit typed hash .of is Int';
+
+# --- list / range provided values coerce ---
+my $lr = IntArr.new(nums => 1..3);
+is $lr.nums, [1, 2, 3], 'range provided coerces to array';
+is $lr.nums.^name, 'Array[Int]', 'range provided is Array[Int]';
+
+# --- mixed: typed $, typed @, typed % in one class ---
+class Mixed { has Int $.n; has Str @.words; has Int %.counts; }
+my $m = Mixed.new(n => 5, words => <a b c>, counts => { x => 1 });
+is $m.n, 5, 'mixed: scalar attr';
+is $m.words, [<a b c>], 'mixed: typed array attr';
+is $m.words.of.^name, 'Str', 'mixed: typed array .of is Str';
+is $m.counts.of.^name, 'Int', 'mixed: typed hash .of is Int';
+
+# --- inheritance: typed container in parent and child ---
+class Base { has Int @.a; }
+class Derived is Base { has Str %.h; }
+my $d = Derived.new(a => [10, 20], h => { k => 'v' });
+is $d.a.of.^name, 'Int', 'inherited typed array .of is Int';
+is $d.h.of.^name, 'Str', 'child typed hash .of is Str';
+
+# --- subset element type ---
+subset Pos of Int where * > 0;
+class PosArr { has Pos @.p; }
+my $pa = PosArr.new(p => [1, 2, 3]);
+is $pa.p.^name, 'Array[Pos]', 'subset element type .WHAT';
+is $pa.p.of.^name, 'Pos', 'subset element type .of';
+
+# --- push after construction preserves element type ---
+class Pushy { has Int @.q; }
+my $p = Pushy.new(q => [1]);
+$p.q.push(2);
+is $p.q, [1, 2], 'push after construction works';
+is $p.q.^name, 'Array[Int]', 'pushed array keeps Array[Int]';
+
+# --- bad element type dies (matches raku + variable path) ---
+dies-ok { IntArr.new(nums => ['x']) }, 'bad array element type dies';
+dies-ok { IntHash.new(map => { a => 'x' }) }, 'bad hash element type dies';
+my $err;
+{
+    IntArr.new(nums => [1, 'x', 3]);
+    CATCH { default { $err = .message } }
+}
+ok $err && $err.contains('element of @!nums'), 'error names the attribute';
+ok $err && $err.contains('expected Int'), 'error names the expected type';
+
+# --- native int element falls through (no element type-check) ---
+class NativeArr { has int @.x; }
+my $na = NativeArr.new(x => [1, 2, 3]);
+is $na.x, [1, 2, 3], 'native int element array keeps values';
+
+# --- loop construction (perf path stays correct) ---
+my @built;
+for ^5 -> $i {
+    @built.push(IntArr.new(nums => [$i]).nums.of.^name);
+}
+is @built, ['Int', 'Int', 'Int', 'Int', 'Int'], 'loop construction preserves element type';
+
+# --- empty typed containers provided explicitly ---
+my $empty = IntArr.new(nums => []);
+is $empty.nums.elems, 0, 'explicit empty array';
+is $empty.nums.^name, 'Array[Int]', 'explicit empty array is Array[Int]';
+
+# done


### PR DESCRIPTION
Extend native default construction (`Foo.new`) to cover **typed `@`/`%` attributes with a plain class element type** (`has Int @.nums`, `has Str %.map`), the next slice of §1 constructor native-ization (`docs/vm-interpreter-fallback-ledger.md` ③).

## What

1. **Interpreter correctness fix.** A *provided* typed container (`C.new(nums => [1,2,3])`) previously lost its element type — `.of` returned `Mu` and `.^name` was `Array`/`Hash` instead of `Array[Int]`/`Hash[Int]` (only the uninitialized path registered metadata). `dispatch_new` now tags every plain-class typed `@`/`%` attribute with element-type metadata and type-checks its elements via the shared `finalize_typed_container_attr`, matching the variable path (`my Int @a`) and raku's `Type check failed for an element of @!nums`.

2. **Native path.** The gate now admits typed `@`/`%` attributes whose element type is a simple `type_matches_value`-checkable class type; the native build registers metadata and element-checks through the same helper, so a failing element raises the byte-identical `X::TypeCheck::Assignment` the interpreter would.

## Conservative fall-through (behavior-invariant)

`is Type` containers (`has @.a is Buf`), native element types (`has int @.x` → packed `array[int]`), coercion/parametric elements, and shaped containers keep the interpreter's richer construction. Native int element behavior is unchanged (no metadata/check), matching the variable path's pre-existing discrepancy with raku.

## Tests

- pin `t/native-ctor-typed-container-attrs.t` (32)
- S12-attributes/{recursive,instance,clone}, S09-typed-arrays/{arrays,hashes}, S02-types/int-uint + signed-unsigned-native (20k loop) green
- cargo test 458/0, make test PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)