### PR TITLE
fix(ctor): correct construction of `is Type` and shaped container attributes

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -480,6 +480,76 @@ impl Interpreter {
         Some(Ok(Value::make_instance(class_name, attrs)))
     }
 
+    /// The `is Type` trait declared on an `@`/`%` attribute (`has @.a is Buf`),
+    /// searched across the class's MRO so an inherited typed-container attribute
+    /// is found. Returns the declared type name (e.g. `Buf`, `Array[Int]`).
+    pub(crate) fn attribute_is_type_in_mro(&self, class_name: &str, attr: &str) -> Option<String> {
+        for cls in self.mro_readonly(class_name) {
+            if let Some(t) = self
+                .registry()
+                .class_attribute_is_types
+                .get(&(cls.clone(), attr.to_string()))
+            {
+                return Some(t.clone());
+            }
+        }
+        None
+    }
+
+    /// Coerce a provided constructor value to an `is Type` container attribute
+    /// (`has @.a is Buf` / `has %.h is BagHash` / `has @.x is Array[Int]`). A
+    /// parameterized array type (`Array[T]`) is built as pure data (typed array +
+    /// element-type metadata + element type-check); any other container type is
+    /// produced by dispatching to that type's `.new`, mirroring the uninitialized
+    /// `is Type` path. A value that already matches the declared type is kept.
+    pub(crate) fn coerce_value_to_is_type(
+        &mut self,
+        type_name: &str,
+        sigil: char,
+        value: Value,
+    ) -> Result<Value, RuntimeError> {
+        if self.type_matches_value(type_name, &value) {
+            return Ok(value);
+        }
+        if let Some(inner) = type_name
+            .strip_prefix("Array[")
+            .or_else(|| type_name.strip_prefix("array["))
+            .and_then(|s| s.strip_suffix(']'))
+        {
+            let inner = inner.trim().to_string();
+            let items = match Self::coerce_attr_value_by_sigil(value, '@') {
+                Value::Array(items, _) => (*items).clone(),
+                other => vec![other],
+            };
+            if inner.starts_with(char::is_uppercase) {
+                for it in &items {
+                    if !matches!(it, Value::Nil) && !self.type_matches_value(&inner, it) {
+                        return Err(crate::runtime::utils::type_check_element_typed_error(
+                            "", &inner, it,
+                        ));
+                    }
+                }
+            }
+            let arr = Value::real_array(items);
+            self.register_container_type_metadata(
+                &arr,
+                super::ContainerTypeInfo {
+                    value_type: inner,
+                    key_type: None,
+                    declared_type: Some(type_name.to_string()),
+                },
+            );
+            Ok(arr)
+        } else {
+            // A non-Array container type (Buf, BagHash, ...): dispatch to its
+            // `.new` with the provided (sigil-coerced) value, just like the
+            // uninitialized `is Type` path builds an empty one with `.new`.
+            let arg = Self::coerce_attr_value_by_sigil(value, sigil);
+            let type_obj = Value::Package(crate::symbol::Symbol::intern(type_name));
+            self.call_method_with_values(type_obj, "new", vec![arg])
+        }
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,
@@ -3233,6 +3303,17 @@ impl Interpreter {
                                     value = self.coerce_value_for_constraint(tc, value);
                                 }
                                 let coerced = Self::coerce_attr_value_by_sigil(value, sigil);
+                                // An `is Type` container attribute (`has @.a is
+                                // Buf`) coerces its provided value to the declared
+                                // container type (Buf, BagHash, Array[T], ...).
+                                let coerced = if matches!(sigil, '@' | '%')
+                                    && let Some(type_name) =
+                                        self.attribute_is_type_in_mro(class_key, k)
+                                {
+                                    self.coerce_value_to_is_type(&type_name, sigil, coerced)?
+                                } else {
+                                    coerced
+                                };
                                 attrs.insert(k.clone(), coerced);
                             }
                             // When BUILD exists, named args are passed to BUILD

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4847,11 +4847,31 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         if elem_type != "Mu" && elem_type != "Any" {
             let display = format!("{}!{}", sigil, attr_name);
-            let elems: Vec<&Value> = match value {
-                Value::Array(items, _) => items.iter().collect(),
-                Value::Hash(map) => map.values().collect(),
-                _ => Vec::new(),
-            };
+            // Collect the values to type-check. A shaped array (`has Int @.g[2;2]`)
+            // nests its leaves inside per-dimension sub-arrays, so descend to the
+            // leaves; a plain array checks its direct elements (a `has Array @.x`
+            // legitimately holds array elements, so do not descend into those).
+            fn collect_leaves<'a>(v: &'a Value, descend: bool, out: &mut Vec<&'a Value>) {
+                match v {
+                    Value::Array(items, kind) if descend || matches!(kind, ArrayKind::Shaped) => {
+                        for it in items.iter() {
+                            collect_leaves(it, true, out);
+                        }
+                    }
+                    _ => out.push(v),
+                }
+            }
+            let mut elems: Vec<&Value> = Vec::new();
+            match value {
+                Value::Array(items, ArrayKind::Shaped) => {
+                    for it in items.iter() {
+                        collect_leaves(it, true, &mut elems);
+                    }
+                }
+                Value::Array(items, _) => elems.extend(items.iter()),
+                Value::Hash(map) => elems.extend(map.values()),
+                _ => {}
+            }
             for it in elems {
                 if !matches!(it, Value::Nil) && !self.type_matches_value(elem_type, it) {
                     return Err(crate::runtime::utils::type_check_element_typed_error(

--- a/t/ctor-istype-shaped-attrs.t
+++ b/t/ctor-istype-shaped-attrs.t
@@ -1,0 +1,66 @@
+use Test;
+
+# Constructor correctness for `is Type` and shaped container attributes.
+#
+# 1. Shaped typed arrays (`has Int @.g[2;2]`) must not crash during
+#    construction (regression from typed-`@`/`%` element type-checking, which
+#    naively treated the per-dimension sub-arrays as elements) and must carry
+#    the element type (`.of` == Int).
+# 2. `is Type` container attributes (`has @.a is Buf`) must coerce a *provided*
+#    value to the declared container type, not just leave it a plain Array/Hash.
+
+plan 19;
+
+# --- shaped typed array: no crash, correct shape + element type ---
+class Grid { has Int @.g[2;2]; }
+my $grid = Grid.new();
+is $grid.g.^name, 'Array[Int]', 'shaped typed array .WHAT is Array[Int]';
+is $grid.g.shape, (2, 2), 'shaped typed array keeps shape';
+is $grid.g.of.^name, 'Int', 'shaped typed array .of is Int';
+
+class Row { has Int @.r[3]; }
+my $row = Row.new(r => [1, 2, 3]);
+is $row.r, [1, 2, 3], 'shaped typed array provided values';
+is $row.r.shape, (3,), 'shaped typed array provided keeps shape';
+is $row.r.of.^name, 'Int', 'shaped typed array provided .of is Int';
+
+# shaped untyped still works
+class Plain { has @.p[2;2]; }
+my $plain = Plain.new();
+is $plain.p.shape, (2, 2), 'shaped untyped array keeps shape';
+
+# bad element in shaped typed array dies (leaf-level check)
+dies-ok { Grid.new(g => [[1, 'x'], [3, 4]]) }, 'bad leaf element in shaped array dies';
+
+# --- is Type container attributes: provided value coercion ---
+class C {
+    has @.a is Buf;
+    has %.h is BagHash;
+}
+# uninitialized
+my $c = C.new();
+ok $c.a ~~ Buf, 'is Buf uninit is a Buf';
+ok $c.h ~~ BagHash, 'is BagHash uninit is a BagHash';
+
+# provided values coerce to the declared container type
+my $c2 = C.new(a => [1, 2, 3], h => <x y x>);
+ok $c2.a ~~ Buf, 'is Buf provided value coerces to Buf';
+is $c2.a.elems, 3, 'is Buf provided has the right elems';
+is $c2.a[0], 1, 'is Buf provided keeps values';
+ok $c2.h ~~ BagHash, 'is BagHash provided value coerces to BagHash';
+is $c2.h<x>, 2, 'is BagHash provided counts duplicates';
+
+# an already-correct value is kept as-is
+my $buf = Buf.new(9, 8);
+my $c3 = C.new(a => $buf);
+ok $c3.a ~~ Buf, 'already-Buf provided value stays a Buf';
+is $c3.a[0], 9, 'already-Buf value preserved';
+
+# inheritance: is Type attribute on a parent
+class Base { has @.b is Buf; }
+class Derived is Base { }
+my $d = Derived.new(b => [7, 7]);
+ok $d.b ~~ Buf, 'inherited is Buf attribute coerces provided value';
+is $d.b[1], 7, 'inherited is Buf keeps values';
+
+# done


### PR DESCRIPTION
Two constructor correctness fixes for typed / `is Type` / shaped container attributes (the `is Type`/shaped slice of `docs/vm-interpreter-fallback-ledger.md` §1 ③).

## 1. Regression fix (from #2841): shaped typed array crash

#2841 added element type-checking for typed `@`/`%` attributes, but a shaped typed array (`has Int @.g[2;2]`) nests its leaves inside per-dimension sub-arrays — the naive element check treated a *row* (an Array) as an element and raised a bogus `X::TypeCheck::Assignment` (expected Int but got Array), aborting construction. `finalize_typed_container_attr` now descends shaped arrays to their leaves before type-checking. As a bonus, shaped typed arrays now also carry their element type (`.of` == Int, previously Mu).

> This regression is latent on `main` (no whitelisted test uses `has Int @.g[2;2]`), so #2841's CI was green; this PR fixes it.

## 2. `is Type` provided-value coercion

A *provided* value for an `is Type` container attribute (`has @.a is Buf` constructed with `a => [1,2,3]`) was stored as a plain Array instead of being coerced to the declared container type (only the uninitialized path built the right type). `dispatch_new` now coerces a provided `@`/`%` value to its `is Type`:

- a parameterized `Array[T]` is built as pure data (typed array + element metadata + element check),
- any other container type (`Buf`, `BagHash`, …) is produced via that type's `.new`,
- a value that already matches the declared type is kept.

## Note on native-ization

`is Type` / shaped construction dispatches to the container / `Array` `.new` (e.g. `Array.new(:shape(...))`, `Buf.new`), so it is **not pure-data** and stays interpreter-owned for now — native-izing it would relocate the same interpreter dispatch, not remove it. Deferred to phase ④ (native method dispatch).

## Tests

- pin `t/ctor-istype-shaped-attrs.t` (19)
- S02-types/is-type, S09-typed-arrays/{arrays,hashes}, S09-multidim/decl, S12-attributes/{instance,recursive,clone}, S12-introspection/attributes, S12-class/attributes green
- cargo test 458/0, make test PASS
- (S02-types/generics.t and S14-traits/attributes.t fail identically on `main` — pre-existing, not whitelisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)