### PR TITLE
feat(exceptions): X::Obsolete for the bare `<>` diamond

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1254,5 +1254,4 @@ roast/integration/sequence.t
 roast/integration/substr-after-match-in-gather-in-for.t
 roast/integration/topic_in_double_loop.t
 roast/integration/variables-in-do.t
-roast/t/fudge.t
 roast/t/test-util/01-is-eqv.t

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -1042,8 +1042,9 @@ fn parse_quote_word_list<'a>(
     };
     let content = &input[..end];
     let rest = &input[end + close.len()..];
-    // A bare empty `<>` is the obsolete Perl diamond, not an empty word list.
-    if reject_lt_operators && content.trim().is_empty() {
+    // A bare *empty* `<>` is the obsolete Perl diamond. `< >` (with whitespace)
+    // is a legal empty `List`, so only the truly-empty form errors.
+    if reject_lt_operators && content.is_empty() {
         return Err(crate::parser::stmt::control::make_obsolete_error(
             "<>",
             None,

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -1042,6 +1042,15 @@ fn parse_quote_word_list<'a>(
     };
     let content = &input[..end];
     let rest = &input[end + close.len()..];
+    // A bare empty `<>` is the obsolete Perl diamond, not an empty word list.
+    if reject_lt_operators && content.trim().is_empty() {
+        return Err(crate::parser::stmt::control::make_obsolete_error(
+            "<>",
+            None,
+            "Unsupported use of <>. In Raku please use: lines() to read input, \
+             ('') to represent a null string or () to represent an empty list.",
+        ));
+    }
     if quoted_words {
         let exprs = split_quotish_words(content)?;
         return Ok((rest, super::string::make_word_result_expr(exprs)));

--- a/t/obsolete-diamond.t
+++ b/t/obsolete-diamond.t
@@ -3,10 +3,14 @@ use Test;
 # A bare empty `<>` is the obsolete Perl diamond, not an empty word list.
 # Raku rejects it at compile time with X::Obsolete (old => "<>").
 
-plan 5;
+plan 7;
 
 throws-like '<>', X::Obsolete, 'empty diamond', old => "<>";
 throws-like 'my $x = <>', X::Obsolete, 'empty diamond in assignment';
+
+# `< >` (with whitespace) is a legal empty List, NOT the diamond.
+isa-ok < >, List, '< > (whitespace) is an empty List';
+is < >.elems, 0, '.. and it is really empty';
 
 # Non-empty angle word lists are unaffected.
 is-deeply <a b c>, ("a", "b", "c"), 'word list still works';

--- a/t/obsolete-diamond.t
+++ b/t/obsolete-diamond.t
@@ -1,0 +1,17 @@
+use Test;
+
+# A bare empty `<>` is the obsolete Perl diamond, not an empty word list.
+# Raku rejects it at compile time with X::Obsolete (old => "<>").
+
+plan 5;
+
+throws-like '<>', X::Obsolete, 'empty diamond', old => "<>";
+throws-like 'my $x = <>', X::Obsolete, 'empty diamond in assignment';
+
+# Non-empty angle word lists are unaffected.
+is-deeply <a b c>, ("a", "b", "c"), 'word list still works';
+is <42>, 42, 'single-word allomorph still works';
+
+# Hash zen-slice `%h<>` is a different construct and keeps working.
+is-deeply (my %h = a => 1, b => 2)<>.sort, (:a(1), :b(2)),
+    'hash zen-slice is not the diamond';


### PR DESCRIPTION
## Summary

(Supersedes #2842.) A bare empty `<>` is the obsolete Perl input diamond, not an
empty word list. Raku rejects it at compile time with **X::Obsolete**
(`old => "<>"`). mutsu previously parsed `<>` as an empty `ArrayLiteral([])` and
silently produced an empty list. `parse_quote_word_list` now raises X::Obsolete
when the bare-angle `<...>` form has **empty** content. `< >` (with whitespace)
is a legal empty `List` and stays working; the `«»`/`<<>>` quote forms and the
hash zen-slice `%h<>` (a different postcircumfix parser) are unaffected.

### De-whitelisting `roast/t/fudge.t`

fudge.t lines 33-34 use the Perl-5 diamond in real code
(`do { local(@ARGV, $/) = $got; <> }`). rakudo rejects this with "Unsupported
use of <>", so fudge.t cannot compile in a correct Raku — it only compiled on
mutsu because of the lenient `<>`-as-empty-list bug this PR fixes. It was passing
for the wrong reason, so it is removed from the whitelist (per maintainer
guidance: ship the correct implementation).

Covers `roast/S32-exceptions/misc2.t:105`.

## Test plan

- New `t/obsolete-diamond.t` (7 subtests): `<>` throws; `< >`/`<a b c>`/`<42>`/
  `%h<>` still work.
- `roast/S02-literals/listquote-whitespace.t` green; whitelist stays sorted.
- `make test` — only the known-flaky `t/proc-async.t` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)