### PR TITLE
feat(exceptions): X::Syntax::Name::Null for empty name components

### DIFF
--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -123,11 +123,29 @@ pub(super) fn parse_raku_ident<'a>(input: &'a str) -> PResult<'a, &'a str> {
 }
 
 /// Parse a qualified identifier (Foo::Bar::Baz).
+/// `X::Syntax::Name::Null` — a qualified name with an empty component, e.g.
+/// `Foo::::Bar` or `$a::::b`.
+fn name_null_error() -> PError {
+    let msg = "Name component may not be null".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    let ex = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Syntax::Name::Null"),
+        attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn qualified_ident(input: &str) -> PResult<'_, String> {
     let (mut rest, name) = ident(input)?;
     let mut full = name;
     while rest.starts_with("::") {
         let r = &rest[2..];
+        // `Foo::::Bar` / `$a::::b` — an empty component between `::` separators
+        // is a null name component, which Raku rejects at compile time.
+        if r.starts_with("::") {
+            return Err(name_null_error());
+        }
         // Handle ::<SYMBOL> subscript syntax (e.g., CORE::<&run>)
         if let Some(after_bracket) = r.strip_prefix('<')
             && let Some(end) = after_bracket.find('>')
@@ -222,6 +240,13 @@ fn var_name(input: &str) -> PResult<'_, String> {
             if !symbol.is_empty() {
                 return Ok((&after_bracket[end + 1..], format!("::<{symbol}>")));
             }
+        }
+        // A fatal qualified-name error (e.g. a null component `$a::::b`) must
+        // propagate, not fall through to the `$foo::` / anonymous-variable arms.
+        if let Err(e) = qualified_ident(r)
+            && e.is_fatal()
+        {
+            return Err(e);
         }
         // Handle bare $ (anonymous variable) — no name after sigil
         if let Ok((mut rest, mut name)) = qualified_ident(r) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2723,6 +2723,7 @@ impl Interpreter {
         register_x("X::Syntax::UnlessElse", "X::Syntax");
         register_x("X::Syntax::Reserved", "X::Syntax");
         register_x("X::Syntax::KeywordAsFunction", "X::Syntax");
+        register_x("X::Syntax::Name::Null", "X::Syntax");
 
         // X::Obsolete (compile-time, subtype of X::Comp)
         register_x("X::Obsolete", "X::Comp");

--- a/t/name-null.t
+++ b/t/name-null.t
@@ -1,0 +1,24 @@
+use Test;
+
+# A qualified name with an empty component between `::` separators
+# (`$a::::b`, `Foo::::Bar`) is a null name component — Raku rejects it at
+# compile time with X::Syntax::Name::Null.
+
+plan 6;
+
+throws-like 'my $a::::b', X::Syntax::Name::Null, 'scalar with null component';
+throws-like 'Foo::::Bar.new', X::Syntax::Name::Null, 'type name with null component';
+throws-like '@a::::b', X::Syntax::Name::Null, 'array with null component';
+
+# Ordinary qualified names are unaffected.
+lives-ok {
+    my $Foo::bar = 5;
+    die unless $Foo::bar == 5;
+    my $trailing::;     # package-stash variable, legal
+}, 'normal `Foo::bar` and trailing `::` still work';
+
+lives-ok { class A::B::C { method m { 42 } }; die unless A::B::C.m == 42; },
+    'deeply qualified class name still works';
+
+# Single `::` separators are fine.
+is ('a' ~ '::' ~ 'b'), 'a::b', 'sanity';


### PR DESCRIPTION
## Summary

A qualified name with an empty component between `::` separators — `$a::::b`,
`Foo::::Bar`, `@a::::b` — is a null name component, which Raku rejects at compile
time with **X::Syntax::Name::Null** ("Name component may not be null"). mutsu
previously mis-parsed `$a::::b` as the package-stash variable `$a::` with a
leftover `::b`, producing no error.

`qualified_ident` now raises a fatal X::Syntax::Name::Null when a `::` separator
is immediately followed by another `::`; `var_name` propagates that fatal error
instead of swallowing it (via `if let Ok(...)`) and falling through to the
`$foo::` / anonymous-variable arms. Ordinary `Foo::bar`, deeply-nested `A::B::C`
and the trailing-`::` package-stash form are unaffected.

Covers `roast/S32-exceptions/misc2.t:110`.

## Test plan

- New `t/name-null.t` (6 subtests).
- `roast/S02-names/*` unaffected (varnames.t / S10-packages.t failures are
  pre-existing on main); `make test` only the known-flaky `t/proc-async.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)