### PR TITLE
feat(exceptions): X::Syntax::Signature::InvocantMarker for a late `:`

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -156,6 +156,22 @@ fn param_display_name(name: &str) -> String {
 }
 
 pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PError> {
+    // The `:` invocant marker may only appear after the *first* parameter
+    // (`method m($self: ...)`). On any later parameter (`sub f($x, $y:)`,
+    // `method m($x, $y:)`) Raku raises X::Syntax::Signature::InvocantMarker.
+    for pd in params.iter().skip(1) {
+        if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") {
+            let msg = "Can only use : as invocant marker in a signature after the first parameter"
+                .to_string();
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Signature::InvocantMarker"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+        }
+    }
     let mut saw_optional_positional = false;
     let mut saw_named = false;
     let mut saw_variadic = false;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2724,6 +2724,11 @@ impl Interpreter {
         register_x("X::Syntax::Reserved", "X::Syntax");
         register_x("X::Syntax::KeywordAsFunction", "X::Syntax");
         register_x("X::Syntax::Name::Null", "X::Syntax");
+        register_x("X::Syntax::Signature", "X::Syntax");
+        register_x(
+            "X::Syntax::Signature::InvocantMarker",
+            "X::Syntax::Signature",
+        );
 
         // X::Obsolete (compile-time, subtype of X::Comp)
         register_x("X::Obsolete", "X::Comp");

--- a/t/invocant-marker.t
+++ b/t/invocant-marker.t
@@ -1,0 +1,27 @@
+use Test;
+
+# The `:` invocant marker may only follow the FIRST parameter. On any later
+# parameter (`sub f($x, $y:)`, `method m($x, $y:)`) Raku raises
+# X::Syntax::Signature::InvocantMarker, regardless of sub vs method.
+
+plan 5;
+
+throws-like 'my sub f($x, $y:) { }', X::Syntax::Signature::InvocantMarker,
+    'invocant marker on a non-first sub parameter';
+
+throws-like 'class C { method m($x, $y:) { } }', X::Syntax::Signature::InvocantMarker,
+    'invocant marker on a non-first method parameter';
+
+# A method with the invocant marker on the first parameter is legal.
+lives-ok {
+    class C { method m($self: $x) { $x * 2 } }
+    die unless C.new.m(5) == 10;
+}, 'invocant marker on the first method parameter works';
+
+# Ordinary subs/methods without markers are unaffected.
+lives-ok { sub g($x, $y) { $x + $y }; die unless g(2, 3) == 5; },
+    'plain two-positional sub works';
+
+# A sub may not have an invocant at all (distinct error, still rejected).
+throws-like 'my sub h($self:) { }', X::Syntax::Signature::InvocantNotAllowed,
+    'sub with a first-parameter invocant marker is InvocantNotAllowed';


### PR DESCRIPTION
## Summary

The `:` invocant marker may only follow the *first* parameter of a signature
(`method m($self: ...)`). On any later parameter — `sub f($x, $y:)`,
`method m($x, $y:)` — Raku raises **X::Syntax::Signature::InvocantMarker** ("Can
only use : as invocant marker in a signature after the first parameter"),
regardless of sub vs method. mutsu previously reported this (for subs) as the
more generic X::Syntax::Signature::InvocantNotAllowed and accepted it silently
for methods.

`validate_signature_params` (run for both subs and methods) now rejects an
invocant-marked parameter at any index past the first. The first-parameter case
is unchanged: `method m($self: ...)` is legal, and `sub h($self:)` stays
X::Syntax::Signature::InvocantNotAllowed (subs can't have an invocant at all).

Covers `roast/S32-exceptions/misc2.t:253`.

## Test plan

- New `t/invocant-marker.t` (5 subtests).
- `roast/S06-signature/*` / `S12-methods/*` unaffected (the 3 pre-existing
  failures are identical on main); `make test` only the known-flaky
  `t/proc-async.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)