### PR TITLE
feat(exceptions): X::Bind::NativeType for binding a native-typed variable

### DIFF
--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -559,6 +559,23 @@ fn handle_binding(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     // would change the value when the bind is used as an expression).
     let is_scalar_bind =
         !s.is_array && !bound_name.starts_with('%') && !bound_name.starts_with('&');
+    // A natively-typed variable (`my int $x`, `my num $n`, `my str $s`) is not a
+    // container, so it cannot be bound with `:=` — Raku raises X::Bind::NativeType.
+    if is_scalar_bind
+        && let Some(tc) = s.type_constraint.as_deref()
+        && crate::runtime::native_types::is_native_array_element_type(tc)
+    {
+        let display = format!("${}", bound_name);
+        let msg = format!(
+            "Cannot bind to natively typed variable '{}'; use assignment instead",
+            display
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("name".to_string(), Value::str(display));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        let ex = Value::make_instance(Symbol::intern("X::Bind::NativeType"), attrs);
+        return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+    }
     let mut custom_traits = s.custom_traits.clone();
     if is_scalar_bind {
         custom_traits.push(("__scalar_bind".to_string(), None));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2772,6 +2772,7 @@ impl Interpreter {
 
         // X::Bind
         register_x("X::Bind", "Exception");
+        register_x("X::Bind::NativeType", "X::Bind");
 
         // X::StubCode
         register_x("X::StubCode", "Exception");

--- a/t/bind-native-type.t
+++ b/t/bind-native-type.t
@@ -1,0 +1,21 @@
+use Test;
+
+# A natively-typed variable (`my int $x`, `my num $n`, `my str $s`) is not a
+# container, so it cannot be bound with `:=` — Raku raises X::Bind::NativeType.
+# Boxed types (Int/Str) and ordinary assignment are unaffected.
+
+plan 7;
+
+throws-like 'my int $x := 2', X::Bind::NativeType, 'int bind', name => '$x';
+throws-like 'my num $n := 2e0', X::Bind::NativeType, 'num bind', name => '$n';
+throws-like 'my str $s := "x"', X::Bind::NativeType, 'str bind', name => '$s';
+throws-like 'my int8 $b := 1', X::Bind::NativeType, 'int8 bind';
+
+# Native assignment still works.
+is (my int $x = 5), 5, 'native int assignment';
+
+# Boxed types can still be bound.
+lives-ok { my Int $y := 3; die unless $y == 3; }, 'boxed Int bind works';
+
+# Untyped bind still works.
+lives-ok { my $z := 7; die unless $z == 7; }, 'untyped bind works';


### PR DESCRIPTION
## Summary

A natively-typed variable — `my int $x`, `my num $n`, `my str $s`, `my int8 $b`
— is not a container, so it cannot be bound with `:=`; Raku raises
**X::Bind::NativeType** ("Cannot bind to natively typed variable '$x'; use
assignment instead"). mutsu previously failed at runtime with the generic
"Cannot assign to a readonly variable".

`handle_binding` now rejects a scalar `:=` whose declared type is a native type
(via `native_types::is_native_array_element_type`, covering
int/int8.../uint.../num/num32/num64/str) with a structured X::Bind::NativeType
carrying `name`. Native *assignment* (`my int $x = 5`), boxed binds
(`my Int $y := 3`) and untyped binds (`my $z := 7`) are unaffected.

Covers `roast/S32-exceptions/misc2.t:90`.

## Test plan

- New `t/bind-native-type.t` (7 subtests).
- `roast/S02-types/native.t` etc. green (int-uint.t's 15 failures are
  pre-existing on main); `make test` only the known-flaky `t/proc-async.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)