### PR TITLE
feat(exceptions): X::Backslash::UnrecognizedSequence for unknown string escapes

### DIFF
--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -8,6 +8,19 @@ use crate::value::Value;
 use super::super::expr::expression;
 use super::var::parse_var_name_from_str;
 
+/// Build the structured `X::Backslash::UnrecognizedSequence` parse error for an
+/// unknown backslash escape (e.g. `\u`) inside an interpolating string.
+pub(super) fn unrecognized_backslash_perror(seq: char) -> PError {
+    let msg = format!("Unrecognized backslash sequence: '\\{seq}'");
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("sequence".to_string(), Value::str(seq.to_string()));
+    let ex = Value::make_instance(
+        Symbol::intern("X::Backslash::UnrecognizedSequence"),
+        attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn make_list_expr(items: Vec<Expr>) -> Expr {
     Expr::Call {
         name: Symbol::intern("list"),
@@ -2610,10 +2623,8 @@ pub(super) fn double_quoted_string(input: &str) -> PResult<'_, Expr> {
                     }
                 }
                 Ok(None) => {
-                    let c = rest.as_bytes()[1] as char;
-                    current.push('\\');
-                    current.push(c);
-                    rest = &rest[2..];
+                    let c = rest[1..].chars().next().unwrap();
+                    return Err(unrecognized_backslash_perror(c));
                 }
                 Err(msg) => {
                     return Err(PError::fatal(msg));
@@ -2714,10 +2725,8 @@ pub(super) fn smart_double_quoted_string(input: &str) -> PResult<'_, Expr> {
                     }
                 }
                 Ok(None) => {
-                    let c = rest.as_bytes()[1] as char;
-                    current.push('\\');
-                    current.push(c);
-                    rest = &rest[2..];
+                    let c = rest[1..].chars().next().unwrap();
+                    return Err(unrecognized_backslash_perror(c));
                 }
                 Err(msg) => {
                     return Err(PError::fatal(msg));

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -14,10 +14,7 @@ pub(super) fn unrecognized_backslash_perror(seq: char) -> PError {
     let msg = format!("Unrecognized backslash sequence: '\\{seq}'");
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("sequence".to_string(), Value::str(seq.to_string()));
-    let ex = Value::make_instance(
-        Symbol::intern("X::Backslash::UnrecognizedSequence"),
-        attrs,
-    );
+    let ex = Value::make_instance(Symbol::intern("X::Backslash::UnrecognizedSequence"), attrs);
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 

--- a/t/backslash-unrecognized.t
+++ b/t/backslash-unrecognized.t
@@ -1,0 +1,23 @@
+use Test;
+
+# An unrecognized alphabetic backslash sequence inside an interpolating
+# (double-quoted / qq) string is a compile-time
+# X::Backslash::UnrecognizedSequence error.
+
+plan 9;
+
+throws-like '"\u"', X::Backslash::UnrecognizedSequence, sequence => 'u';
+throws-like '"\d"', X::Backslash::UnrecognizedSequence, sequence => 'd';
+throws-like '"\w"', X::Backslash::UnrecognizedSequence, sequence => 'w';
+throws-like '"a\hb"', X::Backslash::UnrecognizedSequence, sequence => 'h';
+
+# Recognized escapes still work.
+is "a\nb", "a\x[0A]b", 'recognized \n still works';
+is "a\tb".chars, 3, 'recognized \t still works';
+
+# Non-alphanumeric backslash escapes produce themselves (no error).
+is "a\.b", 'a.b', 'backslash before . is literal .';
+is "a\/b", 'a/b', 'backslash before / is literal /';
+
+# Single-quoted strings keep an unknown backslash sequence literal.
+is '\u', "\\u", 'single-quoted \u stays literal';


### PR DESCRIPTION
An unrecognized alphanumeric backslash escape (e.g. `\u`, `\d`, `\h`) inside an
interpolating double-quoted / smart-double-quoted string now raises a structured
compile-time `X::Backslash::UnrecognizedSequence` carrying `.sequence`, matching
rakudo. Previously such sequences were silently kept literal.

Non-alphanumeric escapes (`\.`, `\/`) still produce themselves, single-quoted
strings keep unknown sequences literal, and regex / tr/// escape handling is
unchanged.

Unblocks roast/S32-exceptions/misc2.t test 149.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
