### PR TITLE
feat(exceptions): X::Syntax::NonAssociative carries .left / .right

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -74,6 +74,21 @@ fn non_associative_error(op_name: &str) -> PError {
     )
 }
 
+/// Non-associative chain of two named operators (e.g. `1 <=> 2 <=> 3`).
+/// Carries `.left` / `.right` like rakudo's `X::Syntax::NonAssociative`.
+fn non_associative_pair_error(left: &str, right: &str) -> PError {
+    let message = format!(
+        "Operators '{}' and '{}' are non-associative and require parentheses",
+        left, right
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("left".to_string(), Value::str(left.to_string()));
+    attrs.insert("right".to_string(), Value::str(right.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Syntax::NonAssociative"), attrs);
+    PError::fatal_with_exception(message, Box::new(exception))
+}
+
 fn conditional_precedence_too_loose_error() -> PError {
     syntax_exception(
         "X::Syntax::ConditionalOperator::PrecedenceTooLoose",
@@ -146,11 +161,10 @@ fn structural_comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
     if let Some((next_op, _)) = parse_comparison_op(r2)
         && is_structural_comparison_op(next_op)
     {
-        return Err(non_associative_error(&format!(
-            "{} and {}",
+        return Err(non_associative_pair_error(
             comparison_nonassoc_key(&op.token_kind()).unwrap_or("<=>"),
-            comparison_nonassoc_key(&next_op.token_kind()).unwrap_or("<=>")
-        )));
+            comparison_nonassoc_key(&next_op.token_kind()).unwrap_or("<=>"),
+        ));
     }
     Ok((r, expr))
 }

--- a/t/nonassoc-comparison.t
+++ b/t/nonassoc-comparison.t
@@ -1,0 +1,14 @@
+use Test;
+
+# Chaining a structural (non-associative) comparison operator such as `<=>`
+# is a compile-time X::Syntax::NonAssociative carrying .left / .right.
+
+plan 5;
+
+throws-like '1 <=> 2 <=> 3', X::Syntax::NonAssociative, left => '<=>', right => '<=>';
+throws-like '1 cmp 2 cmp 3', X::Syntax::NonAssociative, left => 'cmp', right => 'cmp';
+throws-like '1 leg 2 leg 3', X::Syntax::NonAssociative, left => 'leg', right => 'leg';
+
+# A single comparison is fine, and parenthesized chains are fine.
+is (1 <=> 2), Order::Less, 'single <=> works';
+lives-ok { my $x = (1 <=> 2); my $y = ($x <=> Order::Same) }, 'parenthesized <=> chain works';


### PR DESCRIPTION
Chaining a structural (non-associative) comparison operator such as
`1 <=> 2 <=> 3` now raises X::Syntax::NonAssociative carrying `.left` and
`.right` operator names, with rakudo's message
"Operators '<=>' and '<=>' are non-associative and require parentheses".
Previously it threw a NonAssociative exception with only a `.message`.

Unblocks roast/S32-exceptions/misc2.t test 278.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
