### PR TITLE
feat(exceptions): X::Syntax::Missing for a bare `sub` without a block

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1956,11 +1956,23 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     }
                 }
             }
-            // sub not followed by { or ( in expression context — not valid
+            // sub not followed by { or ( in expression context — not valid.
+            // A bare `sub` with neither a signature nor a block is a missing block
+            // (`for () { sub }` → X::Syntax::Missing, what => 'block').
             if rest.starts_with('(') {
                 // Let generic identifier/call parsing handle `sub(...)` call syntax.
             } else {
-                return Err(PError::expected_at("anonymous sub body '{' or '('", r));
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("what".to_string(), Value::str("block".to_string()));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str("Missing block".to_string()),
+                );
+                let ex = Value::make_instance(Symbol::intern("X::Syntax::Missing"), attrs);
+                return Err(PError::fatal_with_exception(
+                    "X::Syntax::Missing: Missing block".to_string(),
+                    Box::new(ex),
+                ));
             }
         }
         "multi" => {

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1957,11 +1957,14 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 }
             }
             // sub not followed by { or ( in expression context — not valid.
-            // A bare `sub` with neither a signature nor a block is a missing block
-            // (`for () { sub }` → X::Syntax::Missing, what => 'block').
             if rest.starts_with('(') {
                 // Let generic identifier/call parsing handle `sub(...)` call syntax.
-            } else {
+            } else if super::super::stmt::parse_sub_name_pub(r).is_err() {
+                // A bare anonymous `sub` with neither a signature nor a block is a
+                // missing block (`for () { sub }` -> X::Syntax::Missing, what =>
+                // 'block'). A *named* forward sub without a body (`sub foo;`) is a
+                // separate X::UnitScope::Invalid handled by the statement path, so
+                // only fire here for the anonymous case.
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert("what".to_string(), Value::str("block".to_string()));
                 attrs.insert(
@@ -1973,6 +1976,8 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     "X::Syntax::Missing: Missing block".to_string(),
                     Box::new(ex),
                 ));
+            } else {
+                return Err(PError::expected_at("anonymous sub body '{' or '('", r));
             }
         }
         "multi" => {

--- a/t/missing-block-sub.t
+++ b/t/missing-block-sub.t
@@ -1,0 +1,15 @@
+use Test;
+
+# A bare `sub` term with neither a signature nor a block is a missing block:
+# X::Syntax::Missing, what => 'block'.
+
+plan 4;
+
+throws-like 'for () { sub }', X::Syntax::Missing, what => 'block';
+throws-like 'my $x = sub', X::Syntax::Missing, what => 'block';
+
+# Valid anonymous subs still parse and run.
+my $f = sub { 42 };
+is $f(), 42, 'anonymous sub with block works';
+my &g = sub ($x) { $x * 2 };
+is g(3), 6, 'anonymous sub with signature works';


### PR DESCRIPTION
A `sub` term in expression context that is followed by neither a signature
`(...)` nor a block `{...}` (e.g. `for () { sub }`) now raises
X::Syntax::Missing carrying `what => 'block'` and rakudo's "Missing block"
message, instead of a generic "expected anonymous sub body" parse error.

Unblocks roast/S32-exceptions/misc2.t test 179.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
