### PR TITLE
feat(exceptions): X::Str::Match::x for invalid :x adverb to .match

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -29,6 +29,9 @@ impl Interpreter {
                 } else if (key == "g" || key == "global") && value.truthy() {
                     global = true;
                 } else if key == "x" {
+                    if !Self::is_valid_match_x_arg(value) {
+                        return Err(Self::str_match_x_error("match", value));
+                    }
                     repeat_bounds = Self::parse_match_repeat_bounds(value);
                 } else if key == "nth" {
                     nth_arg = Some(*value.clone());

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -152,6 +152,37 @@ impl Interpreter {
 
     /// Parse :x(...) style repeat bounds.
     /// Returns (min_required, max_to_return). `max_to_return = None` means unbounded.
+    /// The `:x` adverb to `.match` / `s///` must be an Int or a Range. Anything
+    /// else (e.g. an Array) is an X::Str::Match::x error.
+    pub(in crate::runtime) fn is_valid_match_x_arg(value: &Value) -> bool {
+        matches!(
+            value,
+            Value::Int(_)
+                | Value::Num(_)
+                | Value::Str(_)
+                | Value::Whatever
+                | Value::Range(_, _)
+                | Value::RangeExcl(_, _)
+                | Value::RangeExclStart(_, _)
+                | Value::RangeExclBoth(_, _)
+                | Value::GenericRange { .. }
+        )
+    }
+
+    /// Build the X::Str::Match::x error for an invalid `:x` adverb value.
+    pub(in crate::runtime) fn str_match_x_error(routine: &str, got: &Value) -> RuntimeError {
+        let type_name = crate::value::types::what_type_name(got);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("got".to_string(), got.clone());
+        let message = format!(
+            "in Str.{}, got invalid value of type {} for :x, must be Int or Range",
+            routine, type_name
+        );
+        attrs.insert("message".to_string(), Value::str(message));
+        let ex = Value::make_instance(Symbol::intern("X::Str::Match::x"), attrs);
+        RuntimeError::from_exception_value(ex)
+    }
+
     pub(in crate::runtime) fn parse_match_repeat_bounds(
         value: &Value,
     ) -> Option<(usize, Option<usize>)> {

--- a/t/str-match-x.t
+++ b/t/str-match-x.t
@@ -1,0 +1,17 @@
+use Test;
+
+# The :x adverb to .match must be an Int or a Range. Passing anything else
+# (e.g. an Array) throws X::Str::Match::x carrying the offending value in .got.
+
+plan 6;
+
+throws-like '"a".match(:x([1, 2, 3]), /a/).Str', X::Str::Match::x, got => Array;
+throws-like '"a".match(:x({:a}), /a/).Str', X::Str::Match::x, got => Hash;
+
+# Valid :x arguments still work.
+is "aaa".match(:x(2), /a/).elems, 2, ':x with an Int selects N matches';
+is "aaaa".match(:x(2..3), /a/).elems, 3, ':x with a Range selects within bounds';
+is "aaa".match(:x(*), /a/).elems, 3, ':x(*) selects all matches';
+
+# Too few matches for :x(N) yields no match (not an error).
+ok "a".match(:x(2), /a/) === Nil || !"a".match(:x(2), /a/), ':x with too few matches is Nil';


### PR DESCRIPTION
The `:x` adverb to `.match` must be an Int or a Range. Passing any other type
(e.g. an Array or Hash) now raises X::Str::Match::x carrying the offending value
in `.got`, with rakudo's message
"in Str.match, got invalid value of type <T> for :x, must be Int or Range",
instead of silently ignoring the adverb.

Adds `is_valid_match_x_arg` / `str_match_x_error` helpers in regex_captures.rs.

Unblocks roast/S32-exceptions/misc2.t test 187.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
