### PR TITLE
refactor(value): InstanceAttrs encapsulation boundary (Phase 3 Stage 0)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -185,10 +185,13 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
 
 #### 段階導入（big-bang を避ける。各段 CI を安全網に）
 
-- [ ] **Stage 0 — compat read API（挙動不変・最大の機械的下準備）**: `InstanceAttrs` に内部表現非依存の
-      メソッドを足す（`get(&self,k)->Option<Value>`〔cloned〕/`contains_key`/`iter` 代替の `snapshot()->HashMap`/
-      `keys`/`len` 等）。**内部表現は HashMap のまま**で 127 read サイトを Deref から API へ移行＝byte-identical。
-      これで Stage 1 の表現切替が局所化される。最も大きく退屈だが低リスク。
+- [x] **Stage 0 — カプセル化境界の確立（挙動不変）完了 (#2856)**: `InstanceAttrs` から `Deref`/`DerefMut` を撤去し、
+      代わりに `HashMap` と同シグネチャの inherent メソッド（`get`/`contains_key`/`insert`/`get_mut`/`entry`/`iter`/
+      `keys`/`values`）＋owned アクセサ `as_map()->&HashMap` / `to_map()->HashMap` を追加。これで属性ストレージへの
+      全アクセスがメソッド境界を通る（Deref 漏れを排除）。**内部表現は HashMap のまま**＝byte-identical。
+      Deref 撤去でコンパイラが ~197 サイトを列挙：deref-coercion（`fn(&HashMap)` へ `&Arc<InstanceAttrs>` 渡し）は
+      `.as_map()` へ、`(**attributes).clone()` は `.to_map()` へ機械置換。make test 6112 全緑・cargo test 458/0・
+      clippy 緑。これで Stage 1（内部を共有可変セルへ）の表現切替が局所化された。
 - [ ] **Stage 1 — 表現切替（共有セル化）**: `InstanceAttrs` 内部を `Arc<RwLock<HashMap>>` に。read は Stage 0 の
       API（read-lock + clone）、変異は **in-place（write-lock で書く）**。clone は **セルを共有**（Arc clone）。
       これで closure 跨ぎの変異が caller に可視になり、note/$*ERR バグが解消。

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -298,7 +298,7 @@ fn instance_datetime_parts(value: &Value) -> Option<(i64, i64, i64, i64, i64, f6
                 && attributes.contains_key("timezone") =>
         {
             Some(crate::builtins::methods_0arg::temporal::datetime_attrs(
-                attributes,
+                (attributes).as_map(),
             ))
         }
         _ => None,

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -149,9 +149,11 @@ pub(super) fn dispatch(
             class_name,
             attributes,
             ..
-        } if class_name == "Parameter" && (method == "raku" || method == "perl") => Some(Ok(
-            Value::str(crate::value::signature::parameter_to_raku(attributes)),
-        )),
+        } if class_name == "Parameter" && (method == "raku" || method == "perl") => {
+            Some(Ok(Value::str(crate::value::signature::parameter_to_raku(
+                (attributes).as_map(),
+            ))))
+        }
         Value::Instance {
             class_name,
             attributes,
@@ -516,7 +518,9 @@ pub(super) fn dispatch(
                         class_name,
                         attributes,
                         ..
-                    } if class_name == "Match" => crate::runtime::utils::match_gist(attributes, 0),
+                    } if class_name == "Match" => {
+                        crate::runtime::utils::match_gist((attributes).as_map(), 0)
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }
@@ -572,7 +576,9 @@ pub(super) fn dispatch(
                         class_name,
                         attributes,
                         ..
-                    } if class_name == "Match" => crate::runtime::utils::match_gist(attributes, 0),
+                    } if class_name == "Match" => {
+                        crate::runtime::utils::match_gist((attributes).as_map(), 0)
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }

--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -63,7 +63,7 @@ fn value_raku_repr(val: &Value) -> String {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => match_raku_repr(attributes),
+        } if class_name == "Match" => match_raku_repr((attributes).as_map()),
         Value::Array(items, ..) => {
             let items_raku: Vec<String> = items.iter().map(value_raku_repr).collect();
             format!("[{}]", items_raku.join(", "))

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -879,12 +879,15 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     // Date/DateTime 0-arg methods
     match target {
         Value::Instance { attributes, .. } if has_datetime_attrs(attributes) => {
-            if let Some(result) = temporal_dispatch::datetime_method_0arg(attributes, method) {
+            if let Some(result) =
+                temporal_dispatch::datetime_method_0arg((attributes).as_map(), method)
+            {
                 return Some(result);
             }
         }
         Value::Instance { attributes, .. } if has_date_attrs(attributes) => {
-            if let Some(result) = temporal_dispatch::date_method_0arg(attributes, method) {
+            if let Some(result) = temporal_dispatch::date_method_0arg((attributes).as_map(), method)
+            {
                 return Some(result);
             }
         }
@@ -1142,7 +1145,8 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     // Construct message from typed exception attributes
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
-                            &cn, attributes,
+                            &cn,
+                            (attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(append_bt(formatted))));
@@ -1162,7 +1166,8 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     // Construct message from typed exception attributes
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
-                            &cn, attributes,
+                            &cn,
+                            (attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(formatted)));
@@ -1181,7 +1186,8 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     // Construct message from typed exception attributes
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
-                            &cn, attributes,
+                            &cn,
+                            (attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(formatted)));
@@ -1390,7 +1396,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             "gist" => {
                 // Full Match gist: corner-quoted text plus positional/named
                 // sub-captures, ordered by position and nested recursively.
-                let gist = crate::runtime::utils::match_gist(attributes, 0);
+                let gist = crate::runtime::utils::match_gist((attributes).as_map(), 0);
                 return Some(Ok(Value::str(gist)));
             }
             "Str" => {
@@ -1407,7 +1413,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     .unwrap_or(Value::str(String::new()))));
             }
             "raku" | "perl" => {
-                return Some(Ok(Value::str(match_helpers::match_raku_repr(attributes))));
+                return Some(Ok(Value::str(match_helpers::match_raku_repr(
+                    (attributes).as_map(),
+                ))));
             }
             "list" | "Array" => {
                 return Some(Ok(attributes
@@ -1525,10 +1533,10 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(attributes.get("actions").cloned().unwrap_or(Value::Nil)));
             }
             "caps" => {
-                return Some(Ok(match_helpers::match_caps(attributes)));
+                return Some(Ok(match_helpers::match_caps((attributes).as_map())));
             }
             "chunks" => {
-                return Some(Ok(match_helpers::match_chunks(attributes)));
+                return Some(Ok(match_helpers::match_chunks((attributes).as_map())));
             }
             "Capture" => {
                 // Match.Capture returns self

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -732,7 +732,8 @@ impl Interpreter {
         {
             let mut new_attrs = (*attributes).clone();
             new_attrs.insert(attr_name.to_string(), new_val.clone());
-            let updated_instance = Value::make_instance_with_id(class_name, new_attrs, id);
+            let updated_instance =
+                Value::make_instance_with_id(class_name, (new_attrs).to_map(), id);
             self.env
                 .insert("self".to_string(), updated_instance.clone());
             self.env

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -176,7 +176,7 @@ impl Interpreter {
                         &receiver_class,
                         &owner_class,
                         method_def,
-                        (**attributes).clone(),
+                        attributes.to_map(),
                         call_args,
                         Some(invocant.clone()),
                     )?;

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -204,7 +204,7 @@ impl Interpreter {
             let method_args = std::iter::once(content_value)
                 .chain(args.iter().skip(2).cloned())
                 .collect();
-            return self.native_io_handle(attributes, "spurt", method_args);
+            return self.native_io_handle((attributes).as_map(), "spurt", method_args);
         }
         let path = args
             .first()

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -650,7 +650,7 @@ impl Interpreter {
         self.env.remove(&temp_var);
 
         // Update the instance attribute
-        let mut updated = (**attributes).clone();
+        let mut updated = attributes.to_map();
         updated.insert(attr_key, new_value.clone());
         let cn = *class_name;
         let tid = *target_id;

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -1535,7 +1535,8 @@ impl Interpreter {
             }) if class_name.resolve() == "DateTime" => {
                 // Compute posix from DateTime attributes
                 use crate::builtins::methods_0arg::temporal::{datetime_attrs, datetime_to_posix};
-                let (year, month, day, hour, minute, second, timezone) = datetime_attrs(attributes);
+                let (year, month, day, hour, minute, second, timezone) =
+                    datetime_attrs((attributes).as_map());
                 Some(datetime_to_posix(
                     year, month, day, hour, minute, second, timezone,
                 ))

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2932,7 +2932,7 @@ impl Interpreter {
             }) = self.env.get(key).cloned()
             {
                 let mut new_attrs: HashMap<String, Value> =
-                    crate::value::InstanceAttrs::clone(&attributes);
+                    (crate::value::InstanceAttrs::clone(&attributes)).to_map();
                 new_attrs.insert("version".to_string(), new_version.clone());
                 let new_val = Value::make_instance_with_id(class_name, new_attrs, id);
                 self.env.insert(key.to_string(), new_val);

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -753,8 +753,16 @@ impl Interpreter {
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
                     );
-                    self.overwrite_instance_bindings_by_identity(&cn, id, updated_attrs.clone());
-                    return Ok(Value::make_instance_with_id(class_sym, updated_attrs, id));
+                    self.overwrite_instance_bindings_by_identity(
+                        &cn,
+                        id,
+                        (updated_attrs.clone()).to_map(),
+                    );
+                    return Ok(Value::make_instance_with_id(
+                        class_sym,
+                        (updated_attrs).to_map(),
+                        id,
+                    ));
                 }
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
                 return Ok(crate::builtins::buf_write_num::make_buf_value(
@@ -845,8 +853,16 @@ impl Interpreter {
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
                     );
-                    self.overwrite_instance_bindings_by_identity(&cn, id, updated_attrs.clone());
-                    return Ok(Value::make_instance_with_id(class_sym, updated_attrs, id));
+                    self.overwrite_instance_bindings_by_identity(
+                        &cn,
+                        id,
+                        (updated_attrs.clone()).to_map(),
+                    );
+                    return Ok(Value::make_instance_with_id(
+                        class_sym,
+                        (updated_attrs).to_map(),
+                        id,
+                    ));
                 }
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
                 return Ok(crate::builtins::buf_write_num::make_buf_value(
@@ -885,18 +901,24 @@ impl Interpreter {
         {
             match method {
                 "count-only" if args.is_empty() => {
-                    if let Some(value) = self.iterator_count_only_from_attrs(attributes.as_ref())? {
+                    if let Some(value) =
+                        self.iterator_count_only_from_attrs((attributes.as_ref()).as_map())?
+                    {
                         return Ok(value);
                     }
                 }
                 "bool-only" if args.is_empty() => {
-                    if let Some(value) = self.iterator_bool_only_from_attrs(attributes.as_ref())? {
+                    if let Some(value) =
+                        self.iterator_bool_only_from_attrs((attributes.as_ref()).as_map())?
+                    {
                         return Ok(value);
                     }
                 }
                 "can"
                     if args.len() == 1
-                        && Self::iterator_supports_predictive_methods(attributes.as_ref()) =>
+                        && Self::iterator_supports_predictive_methods(
+                            (attributes.as_ref()).as_map(),
+                        ) =>
                 {
                     let method_name = args[0].to_string_value();
                     if matches!(method_name.as_str(), "count-only" | "bool-only") {
@@ -1994,7 +2016,7 @@ impl Interpreter {
                 class_name: *class_name,
                 attributes: std::sync::Arc::new(crate::value::InstanceAttrs::new(
                     *class_name,
-                    attrs,
+                    (attrs).to_map(),
                     *id,
                     false,
                 )),
@@ -3186,7 +3208,7 @@ impl Interpreter {
         } = &target
             && class_name.resolve() == "Promise::Vow"
         {
-            return self.dispatch_promise_vow_method(attributes, method, args);
+            return self.dispatch_promise_vow_method((attributes).as_map(), method, args);
         }
 
         // Mixin fallback: check __mutsu_attr__ and delegate to inner

--- a/src/runtime/methods_collection_ops/collation_temporal.rs
+++ b/src/runtime/methods_collection_ops/collation_temporal.rs
@@ -27,7 +27,7 @@ impl Interpreter {
             "set" => {
                 // .set accepts named arguments: primary, secondary, tertiary, quaternary
                 // Each can be -1, 0, 1, or Bool (False=0, True=1)
-                let mut new_attrs = (**attributes).clone();
+                let mut new_attrs = attributes.to_map();
 
                 for arg in args {
                     if let Value::Pair(key, val) = arg {

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -91,7 +91,7 @@ impl Interpreter {
         } = &target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_first(attributes, func, has_end);
+            return self.dispatch_supply_first((attributes).as_map(), func, has_end);
         }
 
         let items = crate::runtime::utils::value_to_list(&target);

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -21,7 +21,10 @@ impl Interpreter {
                 } = &target
                     && class_name == "Supply"
                 {
-                    return Some(self.supply_list_values(attributes, true).map(Value::array));
+                    return Some(
+                        self.supply_list_values((attributes).as_map(), true)
+                            .map(Value::array),
+                    );
                 }
                 None
             }
@@ -380,7 +383,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            let attrs_clone = (**attributes).clone();
+            let attrs_clone = attributes.to_map();
             return self.dispatch_supply_reduce(target, &attrs_clone, callable);
         }
         let items = Self::value_to_list(&target);
@@ -400,7 +403,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return Some(self.dispatch_supply_elems(attributes, &args));
+            return Some(self.dispatch_supply_elems((attributes).as_map(), &args));
         }
         // .elems on a Seq caches it (makes it available for multiple calls)
         if let Value::Seq(items) = &target {
@@ -422,7 +425,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_map(attributes, &args);
+            return self.dispatch_supply_map((attributes).as_map(), &args);
         }
         // Validate that the map argument is callable (X::Cannot::Map)
         if let Some(func) = args.first() {

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -298,7 +298,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return Some(self.dispatch_supply_grab(attributes, &args));
+            return Some(self.dispatch_supply_grab((attributes).as_map(), &args));
         }
         if let Value::Package(ref class_name) = target
             && class_name == "Supply"
@@ -490,7 +490,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_skip(attributes, &args);
+            return self.dispatch_supply_skip((attributes).as_map(), &args);
         }
         let items = crate::runtime::utils::value_to_list(&target);
         let n = if args.is_empty() {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -622,7 +622,7 @@ impl Interpreter {
                 id,
             } = dt
         {
-            let mut attrs = (**attributes).clone();
+            let mut attrs = attributes.to_map();
             attrs.insert("formatter".to_string(), formatter_value.clone());
             let dt_with_formatter = Value::make_instance_with_id(class_name, attrs, id);
             let saved_env = self.env().clone();
@@ -642,7 +642,11 @@ impl Interpreter {
             {
                 let mut updated = (*attributes).clone();
                 updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
-                return Some(Ok(Value::make_instance_with_id(class_name, updated, id)));
+                return Some(Ok(Value::make_instance_with_id(
+                    class_name,
+                    (updated).to_map(),
+                    id,
+                )));
             }
         }
         if class_name.resolve() != "DateTime" {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -251,7 +251,7 @@ impl Interpreter {
                         .collect();
                     attrs.insert("capture_alias_map".to_string(), Value::hash(alias_hash));
                 }
-                Value::make_instance(*class_name, attrs)
+                Value::make_instance(*class_name, (attrs).to_map())
             } else {
                 match_obj
             };
@@ -279,7 +279,7 @@ impl Interpreter {
                 {
                     let mut attrs = attributes.as_ref().clone();
                     attrs.insert("actions".to_string(), actions.clone());
-                    Value::make_instance_with_id(*class_name, attrs, *id)
+                    Value::make_instance_with_id(*class_name, (attrs).to_map(), *id)
                 } else {
                     result
                 }
@@ -381,7 +381,7 @@ impl Interpreter {
         }
 
         // Rebuild match_obj with updated children
-        let match_obj = Value::make_instance(class_name, updated_attrs.clone());
+        let match_obj = Value::make_instance(class_name, (updated_attrs.clone()).to_map());
 
         // Set $/ to this match and try calling actions.{rule_name}(match)
         self.env.insert("/".to_string(), match_obj.clone());
@@ -529,7 +529,7 @@ impl Interpreter {
             if let Some(act_val) = attributes.get("actions") {
                 attrs.insert("actions".to_string(), act_val.clone());
             }
-            Value::make_instance(class_name, attrs)
+            Value::make_instance(class_name, (attrs).to_map())
         } else {
             match_obj
         };

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -85,7 +85,7 @@ impl Interpreter {
                         &class_name.resolve(),
                         &resolved_owner,
                         method_def,
-                        (**attributes).clone(),
+                        attributes.to_map(),
                         args,
                         Some(target.clone()),
                     )?;
@@ -136,7 +136,7 @@ impl Interpreter {
                     }
                 };
                 let mut update_items = |new_items: Vec<Value>| {
-                    let mut updated_attrs = (**attributes).clone();
+                    let mut updated_attrs = attributes.to_map();
                     updated_attrs.insert(
                         "__mutsu_iterationbuffer_items".to_string(),
                         Value::real_array(new_items),
@@ -307,7 +307,7 @@ impl Interpreter {
                             self.overwrite_instance_bindings_by_identity(
                                 &obj_class.resolve(),
                                 *obj_id,
-                                updated,
+                                (updated).to_map(),
                             );
                         }
                         return Ok(Value::Nil);
@@ -382,7 +382,7 @@ impl Interpreter {
             if class_name.resolve().starts_with("Distribution::")
                 && let Some(result) = self.dispatch_distribution_method(
                     &class_name.resolve(),
-                    attributes,
+                    (attributes).as_map(),
                     method,
                     args.clone(),
                 )
@@ -390,8 +390,11 @@ impl Interpreter {
                 return result;
             }
             if class_name == "CompUnit::Repository::Installation"
-                && let Some(result) =
-                    self.dispatch_cur_installation_method(attributes, method, args.clone())
+                && let Some(result) = self.dispatch_cur_installation_method(
+                    (attributes).as_map(),
+                    method,
+                    args.clone(),
+                )
             {
                 return result;
             }
@@ -592,7 +595,7 @@ impl Interpreter {
                 ) {
                     let (result, updated) = self.call_native_instance_method_mut(
                         &class_name.resolve(),
-                        (**attributes).clone(),
+                        attributes.to_map(),
                         method,
                         args,
                     )?;
@@ -609,7 +612,7 @@ impl Interpreter {
                 ) {
                     return self.call_native_instance_method(
                         &class_name.resolve(),
-                        attributes,
+                        (attributes).as_map(),
                         method,
                         args,
                     );
@@ -618,7 +621,7 @@ impl Interpreter {
             if self.is_native_method(&class_name.resolve(), method) {
                 return self.call_native_instance_method(
                     &class_name.resolve(),
-                    attributes,
+                    (attributes).as_map(),
                     method,
                     args,
                 );
@@ -654,7 +657,7 @@ impl Interpreter {
                 if let Some(formatted) =
                     crate::builtins::exception_message::format_exception_message(
                         &class_name.resolve(),
-                        attributes,
+                        (attributes).as_map(),
                     )
                 {
                     return Ok(Value::str(formatted));
@@ -679,7 +682,8 @@ impl Interpreter {
                 }
                 // Collect public attributes for .raku representation
                 let class_key = class_name.resolve();
-                let public_attrs = self.collect_public_raku_attrs(&class_key, attributes);
+                let public_attrs =
+                    self.collect_public_raku_attrs(&class_key, (attributes).as_map());
                 if public_attrs.is_empty() {
                     return Ok(Value::str(format!("{}.new", class_name)));
                 }
@@ -693,7 +697,7 @@ impl Interpreter {
                 return Ok(attributes.get("name").cloned().unwrap_or(Value::Nil));
             }
             if method == "clone" {
-                let mut attrs: HashMap<String, Value> = (**attributes).clone();
+                let mut attrs: HashMap<String, Value> = attributes.to_map();
                 // Build sigil map from class attributes to coerce values properly
                 let class_attrs_info = self.collect_class_attributes(&class_name.resolve());
                 let sigil_map: HashMap<String, char> = class_attrs_info
@@ -773,7 +777,7 @@ impl Interpreter {
             if self.has_user_method(&class_name.resolve(), method) {
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
-                    (**attributes).clone(),
+                    attributes.to_map(),
                     method,
                     args,
                     Some(target.clone()),
@@ -1313,7 +1317,7 @@ impl Interpreter {
                                 .resolve_method_with_owner(&class_name.resolve(), "raku", &[])
                                 .is_some()
                         {
-                            let attrs_map = (**attributes).clone();
+                            let attrs_map = attributes.to_map();
                             if let Ok((rendered, _)) = self.run_instance_method(
                                 &class_name.resolve(),
                                 attrs_map,

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -114,11 +114,7 @@ impl Interpreter {
                         class_name,
                         attributes,
                         id,
-                    } => (
-                        Some(class_name.resolve()),
-                        Some(*id),
-                        (**attributes).clone(),
-                    ),
+                    } => (Some(class_name.resolve()), Some(*id), attributes.to_map()),
                     _ => (None, None, HashMap::new()),
                 };
                 for (key, value) in mixins.iter() {

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -271,7 +271,7 @@ impl Interpreter {
         }
         for (var_name, class_name, id, attr_key) in updates {
             if let Some(Value::Instance { attributes, .. }) = self.env.get_sym(var_name) {
-                let mut updated = (**attributes).clone();
+                let mut updated = attributes.to_map();
                 updated.insert(attr_key, replacement.clone());
                 self.env.insert_sym(
                     var_name,
@@ -306,7 +306,7 @@ impl Interpreter {
         }
         for (var_name, class_name, id, attr_key) in updates {
             if let Some(Value::Instance { attributes, .. }) = self.env.get_sym(var_name) {
-                let mut updated = (**attributes).clone();
+                let mut updated = attributes.to_map();
                 updated.insert(attr_key, replacement.clone());
                 self.env.insert_sym(
                     var_name,
@@ -457,7 +457,7 @@ impl Interpreter {
                     });
                     if has_target {
                         let mut new_attrs: std::collections::HashMap<String, Value> =
-                            (**attributes).clone();
+                            attributes.to_map();
                         for attr_val in new_attrs.values_mut() {
                             Self::overwrite_instance_recursive(attr_val, class_name, id, updated);
                         }
@@ -847,7 +847,7 @@ impl Interpreter {
                 state.line_chomp = new_chomp;
             }
             // Also update instance attribute so .open can inherit it
-            let mut new_attrs = (**attributes).clone();
+            let mut new_attrs = attributes.to_map();
             new_attrs.insert("chomp".to_string(), Value::Bool(new_chomp));
             let tid = *inst_id;
             self.overwrite_instance_bindings_by_identity(
@@ -1087,7 +1087,7 @@ impl Interpreter {
                     caller_class.as_deref().unwrap_or("GLOBAL")
                 )));
             }
-            let mut updated = (**attributes).clone();
+            let mut updated = attributes.to_map();
             updated.insert(attr_name, value.clone());
             let cn = *class_name;
             if let Some(var_name) = target_var {
@@ -1126,7 +1126,7 @@ impl Interpreter {
                     )));
                 }
                 if let Some(attr_name) = Self::rw_method_attribute_target(&method_def.body) {
-                    let mut updated = (**attributes).clone();
+                    let mut updated = attributes.to_map();
                     let current = if method_args.is_empty() {
                         self.call_method_with_values(target.clone(), actual_method, Vec::new())
                             .ok()
@@ -1178,7 +1178,7 @@ impl Interpreter {
                     }
                 }
                 if found_rw {
-                    let mut updated = (**attributes).clone();
+                    let mut updated = attributes.to_map();
                     let current = if method_args.is_empty() {
                         self.call_method_with_values(target.clone(), actual_method, Vec::new())
                             .ok()
@@ -1432,12 +1432,12 @@ impl Interpreter {
                 self.overwrite_instance_bindings_by_identity(
                     &class_name.resolve(),
                     target_id,
-                    updated.clone(),
+                    (updated.clone()).to_map(),
                 );
                 if let Some(var_name) = target_var {
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, updated, target_id),
+                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                     );
                     // Also update attribute env variables so compiled method
                     // writeback picks up the change (e.g. $.cnt += 4 inside a method)
@@ -1454,7 +1454,7 @@ impl Interpreter {
                 all_args.push(value.clone());
                 match self.call_native_instance_method_mut(
                     &class_name.resolve(),
-                    (*attributes).clone(),
+                    ((*attributes).clone()).to_map(),
                     method,
                     all_args,
                 ) {
@@ -1514,11 +1514,11 @@ impl Interpreter {
                     self.overwrite_instance_bindings_by_identity(
                         &class_name.resolve(),
                         target_id,
-                        updated.clone(),
+                        (updated.clone()).to_map(),
                     );
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, updated, target_id),
+                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                     );
                 }
                 return Ok(result);
@@ -1563,11 +1563,11 @@ impl Interpreter {
                 self.overwrite_instance_bindings_by_identity(
                     &class_name.resolve(),
                     target_id,
-                    updated.clone(),
+                    (updated.clone()).to_map(),
                 );
                 self.env.insert(
                     var_name.to_string(),
-                    Value::make_instance_with_id(class_name, updated, target_id),
+                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                 );
             }
             return Ok(assigned_value);
@@ -1603,11 +1603,11 @@ impl Interpreter {
                     self.overwrite_instance_bindings_by_identity(
                         &class_name.resolve(),
                         target_id,
-                        updated.clone(),
+                        (updated.clone()).to_map(),
                     );
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, updated, target_id),
+                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                     );
                 }
                 return Ok(result);
@@ -1620,8 +1620,13 @@ impl Interpreter {
         let was_lvalue = self.in_lvalue_assignment;
         self.in_lvalue_assignment = true;
         let attrs_map = (*attributes).clone();
-        let method_result =
-            self.run_instance_method(&class_name.resolve(), attrs_map, method, method_args, None);
+        let method_result = self.run_instance_method(
+            &class_name.resolve(),
+            (attrs_map).to_map(),
+            method,
+            method_args,
+            None,
+        );
         self.in_lvalue_assignment = was_lvalue;
         let (method_result, updated_attrs) = method_result?;
         if let Value::Proxy { storer, .. } = &method_result {
@@ -1873,11 +1878,11 @@ impl Interpreter {
                 self.overwrite_instance_bindings_by_identity(
                     &class_name.resolve(),
                     *id,
-                    updated_attrs.clone(),
+                    (updated_attrs.clone()).to_map(),
                 );
                 return Ok(Value::make_instance_with_id(
                     *class_name,
-                    updated_attrs,
+                    (updated_attrs).to_map(),
                     *id,
                 ));
             }
@@ -1943,9 +1948,9 @@ impl Interpreter {
             self.overwrite_instance_bindings_by_identity(
                 &class_name.resolve(),
                 *id,
-                updated_attrs.clone(),
+                (updated_attrs.clone()).to_map(),
             );
-            let updated = Value::make_instance_with_id(*class_name, updated_attrs, *id);
+            let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
         }
@@ -2045,9 +2050,9 @@ impl Interpreter {
             self.overwrite_instance_bindings_by_identity(
                 &class_name.resolve(),
                 *id,
-                updated_attrs.clone(),
+                (updated_attrs.clone()).to_map(),
             );
-            let updated = Value::make_instance_with_id(*class_name, updated_attrs, *id);
+            let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
         }
@@ -3002,9 +3007,10 @@ impl Interpreter {
                 self.overwrite_instance_bindings_by_identity(
                     &class_name.resolve(),
                     target_id,
-                    updated.clone(),
+                    (updated.clone()).to_map(),
                 );
-                let updated_instance = Value::make_instance_with_id(class_name, updated, target_id);
+                let updated_instance =
+                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id);
                 self.env
                     .insert(target_var.to_string(), updated_instance.clone());
                 return Ok(updated_instance);
@@ -3076,10 +3082,10 @@ impl Interpreter {
 
                     let ret = match method {
                         "count-only" => self
-                            .iterator_count_only_from_attrs(&updated)?
+                            .iterator_count_only_from_attrs(updated.as_map())?
                             .unwrap_or_else(|| Value::Int(0)),
                         "bool-only" => self
-                            .iterator_bool_only_from_attrs(&updated)?
+                            .iterator_bool_only_from_attrs(updated.as_map())?
                             .unwrap_or(Value::Bool(false)),
                         "pull-one" => pull_one_squish(self)?,
                         "push-all" | "push-until-lazy" => {
@@ -3140,7 +3146,7 @@ impl Interpreter {
                                     self.overwrite_instance_bindings_by_identity(
                                         &class_name.resolve(),
                                         target_id,
-                                        updated.clone(),
+                                        (updated.clone()).to_map(),
                                     );
                                     return Ok(Value::str_from("IterationEnd"));
                                 }
@@ -3220,10 +3226,10 @@ impl Interpreter {
                     self.overwrite_instance_bindings_by_identity(
                         &class_name.resolve(),
                         target_id,
-                        updated.clone(),
+                        (updated.clone()).to_map(),
                     );
                     let updated_instance =
-                        Value::make_instance_with_id(class_name, updated, target_id);
+                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id);
                     self.env
                         .insert(target_var.to_string(), updated_instance.clone());
                     return Ok(ret);
@@ -3356,11 +3362,11 @@ impl Interpreter {
                 self.overwrite_instance_bindings_by_identity(
                     &class_name.resolve(),
                     target_id,
-                    updated.clone(),
+                    (updated.clone()).to_map(),
                 );
                 self.env.insert(
                     target_var.to_string(),
-                    Value::make_instance_with_id(class_name, updated, target_id),
+                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                 );
                 return Ok(ret);
             }
@@ -3381,8 +3387,11 @@ impl Interpreter {
                     .trim_start_matches('!');
                 let delegate = if is_method_based {
                     let source_method = attr_var_name.trim_start_matches('&').to_string();
-                    let invocant_val =
-                        Value::make_instance_with_id(class_name, (*attributes).clone(), target_id);
+                    let invocant_val = Value::make_instance_with_id(
+                        class_name,
+                        ((*attributes).clone()).to_map(),
+                        target_id,
+                    );
                     self.call_method_with_values(invocant_val, &source_method, Vec::new())?
                 } else {
                     attributes.get(attr_key).cloned().unwrap_or(Value::Nil)
@@ -3414,11 +3423,11 @@ impl Interpreter {
                     self.overwrite_instance_bindings_by_identity(
                         &class_name.resolve(),
                         target_id,
-                        updated.clone(),
+                        (updated.clone()).to_map(),
                     );
                     self.env.insert(
                         target_var.to_string(),
-                        Value::make_instance_with_id(class_name, updated, target_id),
+                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                     );
                 }
                 // Restore skip_pseudo for the outer caller.
@@ -3449,11 +3458,11 @@ impl Interpreter {
                         self.overwrite_instance_bindings_by_identity(
                             &class_name.resolve(),
                             target_id,
-                            updated.clone(),
+                            (updated.clone()).to_map(),
                         );
                         self.env.insert(
                             target_var.to_string(),
-                            Value::make_instance_with_id(class_name, updated, target_id),
+                            Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
                         );
                         return Ok(assigned);
                     }
@@ -3490,7 +3499,7 @@ impl Interpreter {
                 // Try mutable dispatch first; if no mutable handler, fall back to immutable
                 match self.call_native_instance_method_mut(
                     &class_name.resolve(),
-                    (*attributes).clone(),
+                    ((*attributes).clone()).to_map(),
                     method,
                     args.clone(),
                 ) {
@@ -3510,7 +3519,7 @@ impl Interpreter {
                         if err.message.starts_with("No native mutable method") {
                             return self.call_native_instance_method(
                                 &class_name.resolve(),
-                                &attributes,
+                                attributes.as_map(),
                                 method,
                                 args,
                             );
@@ -3535,7 +3544,7 @@ impl Interpreter {
             {
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
-                    (*attributes).clone(),
+                    ((*attributes).clone()).to_map(),
                     method,
                     args,
                     Some(target.clone()),

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1573,7 +1573,8 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "DateTime" => {
-                                let (y, m, d, _, _, _, _) = temporal::datetime_attrs(attributes);
+                                let (y, m, d, _, _, _, _) =
+                                    temporal::datetime_attrs((attributes).as_map());
                                 year = y;
                                 month = m;
                                 day = d;
@@ -1675,7 +1676,7 @@ impl Interpreter {
                                     } = value.as_ref()
                                         && class_name == "Date"
                                     {
-                                        let (y, m, d) = temporal::date_attrs(attributes);
+                                        let (y, m, d) = temporal::date_attrs((attributes).as_map());
                                         year = y;
                                         month = m;
                                         day = d;
@@ -1803,7 +1804,7 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Date" => {
-                                let (y, m, d) = temporal::date_attrs(attributes);
+                                let (y, m, d) = temporal::date_attrs((attributes).as_map());
                                 year = y;
                                 month = m;
                                 day = d;
@@ -1872,7 +1873,7 @@ impl Interpreter {
                                 id,
                             } = dt
                         {
-                            let mut attrs = (**attributes).clone();
+                            let mut attrs = attributes.to_map();
                             attrs.insert("formatter".to_string(), formatter_value.clone());
                             let dt_with_formatter =
                                 Value::make_instance_with_id(class_name, attrs, id);
@@ -1897,7 +1898,11 @@ impl Interpreter {
                                     "__formatter_rendered".to_string(),
                                     Value::str(rendered),
                                 );
-                                return Ok(Value::make_instance_with_id(class_name, updated, id));
+                                return Ok(Value::make_instance_with_id(
+                                    class_name,
+                                    (updated).to_map(),
+                                    id,
+                                ));
                             }
                         }
                         return Ok(dt);
@@ -4430,7 +4435,7 @@ impl Interpreter {
                 .to_string_value();
             *self.env_mut() = saved_env;
             self.restore_readonly_vars(saved_readonly);
-            let mut updated = (**attributes).clone();
+            let mut updated = attributes.to_map();
             updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
             Ok(Value::make_instance_with_id(class_name, updated, id))
         } else {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -130,7 +130,7 @@ impl Interpreter {
         if let Some((_owner, method_def)) =
             self.resolve_method_with_owner(qualifier, actual_method, &args)
         {
-            let attrs_map = (**attributes).clone();
+            let attrs_map = attributes.to_map();
             let inst_cn = inst_cn_str.to_string();
             let tid = *target_id;
             let (result, updated) = match self.run_instance_method(
@@ -148,13 +148,7 @@ impl Interpreter {
                 && let Value::Proxy { ref fetcher, .. } = result
             {
                 let _ = method_def;
-                return Some(self.proxy_fetch(
-                    fetcher,
-                    None,
-                    qualifier,
-                    &(**attributes).clone(),
-                    0,
-                ));
+                return Some(self.proxy_fetch(fetcher, None, qualifier, &attributes.to_map(), 0));
             }
             return Some(Ok(result));
         }
@@ -172,7 +166,7 @@ impl Interpreter {
                     && !def.is_private
                     && self.method_args_match(&args, &def.param_defs)
                 {
-                    let attrs_map = (**attributes).clone();
+                    let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
                     let tid = *target_id;
                     let (result, updated) = match self.run_instance_method_resolved(
@@ -206,7 +200,7 @@ impl Interpreter {
         {
             for def in overloads {
                 if !def.is_private && self.method_args_match(&args, &def.param_defs) {
-                    let attrs_map = (**attributes).clone();
+                    let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
                     let tid = *target_id;
                     let (result, updated) = match self.run_instance_method_resolved(
@@ -348,7 +342,7 @@ impl Interpreter {
                 // role attributes on top (for run-time-applied roles).
                 let mut role_attrs: HashMap<String, Value> =
                     if let Value::Instance { attributes, .. } = inner.as_ref() {
-                        (**attributes).clone()
+                        attributes.to_map()
                     } else {
                         HashMap::new()
                     };
@@ -418,7 +412,7 @@ impl Interpreter {
                 // Use the inner instance's attributes so the method body can read
                 // attributes, but run with the Mixin target as the invocant.
                 let attrs_map = if let Value::Instance { attributes, .. } = inner.as_ref() {
-                    (**attributes).clone()
+                    attributes.to_map()
                 } else {
                     HashMap::new()
                 };

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1119,7 +1119,7 @@ impl Interpreter {
                         &class_name.resolve(),
                         &resolved_owner,
                         method_def,
-                        (**attributes).clone(),
+                        attributes.to_map(),
                         args,
                         Some(target.clone()),
                     )?;
@@ -1142,7 +1142,7 @@ impl Interpreter {
             let candidates =
                 self.resolve_methods_per_mro_level(&class_name.resolve(), method, &args);
             if !candidates.is_empty() {
-                let mut attrs = (**attributes).clone();
+                let mut attrs = attributes.to_map();
                 let mut out = Vec::with_capacity(candidates.len());
                 for (resolved_owner, method_def) in candidates {
                     // Build an invocant with the latest attributes so that

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -578,7 +578,7 @@ impl Interpreter {
                     Box::new(Value::array(init)),
                 ));
             }
-            self.native_supply(attributes, "zip-latest", method_args)
+            self.native_supply((attributes).as_map(), "zip-latest", method_args)
         } else {
             Err(RuntimeError::new(
                 "Cannot call zip-latest on non-Supply".to_string(),

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -50,7 +50,7 @@ fn rebless_datetime_result(
         class_name: target_class_name,
         attributes: Arc::new(crate::value::InstanceAttrs::new(
             target_class_name,
-            merged,
+            (merged).to_map(),
             *id,
             true,
         )),
@@ -88,7 +88,7 @@ fn rebless_date_result(
         class_name: target_class_name,
         attributes: Arc::new(crate::value::InstanceAttrs::new(
             target_class_name,
-            merged,
+            (merged).to_map(),
             *id,
             true,
         )),
@@ -109,7 +109,7 @@ pub(super) fn dispatch_temporal_method(
             attributes,
             ..
         } if has_date_attrs(attributes) && !has_datetime_attrs(attributes) => {
-            let (year, month, day) = temporal::date_attrs(attributes);
+            let (year, month, day) = temporal::date_attrs((attributes).as_map());
             match method {
                 "later" | "earlier" => Some(
                     date_later_earlier(year, month, day, args, method)
@@ -157,7 +157,7 @@ pub(super) fn dispatch_temporal_method(
             ..
         } if has_datetime_attrs(attributes) => {
             let (year, month, day, hour, minute, second, timezone) =
-                temporal::datetime_attrs(attributes);
+                temporal::datetime_attrs((attributes).as_map());
             match method {
                 "later" | "earlier" => Some(
                     datetime_later_earlier(

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -24,7 +24,7 @@ impl Interpreter {
                     let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
                     self.supply_emit_buffer.pop().unwrap_or_default()
                 } else if attributes.get("values").is_some() {
-                    self.supply_list_values(&attributes, true)?
+                    self.supply_list_values(attributes.as_map(), true)?
                 } else {
                     Vec::new()
                 };

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -89,7 +89,7 @@ impl Interpreter {
                 self.lookup_own_walk_method(kind, owner, &receiver_class_name, &method_name)
             {
                 let attributes = match target {
-                    Value::Instance { attributes, .. } => (**attributes).clone(),
+                    Value::Instance { attributes, .. } => attributes.to_map(),
                     _ => std::collections::HashMap::new(),
                 };
                 let result = self.run_instance_method_resolved(

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -668,7 +668,7 @@ impl Interpreter {
                                 let empty_attrs = HashMap::new();
                                 let inner_attrs_ref =
                                     if let Value::Instance { attributes: a, .. } = inner_supply {
-                                        a
+                                        a.as_map()
                                     } else {
                                         &empty_attrs
                                     };
@@ -1359,7 +1359,7 @@ impl Interpreter {
                 let any_live = self_is_live
                     || other_supplies.iter().any(|s| {
                         if let Value::Instance { attributes, .. } = s {
-                            supplier_id_from_attrs(attributes).is_some()
+                            supplier_id_from_attrs((attributes).as_map()).is_some()
                                 || attributes.contains_key("supply_id")
                         } else {
                             false
@@ -1396,7 +1396,7 @@ impl Interpreter {
                         let mut all_supplies: Vec<&HashMap<String, Value>> = vec![attributes];
                         for supply in &other_supplies {
                             if let Value::Instance { attributes: a, .. } = supply {
-                                all_supplies.push(a);
+                                all_supplies.push((a).as_map());
                             }
                         }
 
@@ -1506,7 +1506,7 @@ impl Interpreter {
                             } = supply
                             {
                                 let source_index = i + 1;
-                                if let Some(sid) = supplier_id_from_attrs(other_attrs) {
+                                if let Some(sid) = supplier_id_from_attrs((other_attrs).as_map()) {
                                     register_supplier_zip_latest_tap(
                                         sid,
                                         zip_latest_state_id,
@@ -1528,7 +1528,7 @@ impl Interpreter {
                             } = supply
                             {
                                 let source_index = i + 1;
-                                if let Some(sid) = supplier_id_from_attrs(other_attrs) {
+                                if let Some(sid) = supplier_id_from_attrs((other_attrs).as_map()) {
                                     register_supplier_zip_tap(sid, zip_state_id, source_index);
                                 }
                             }
@@ -1556,7 +1556,7 @@ impl Interpreter {
                         } = arg
                             && class_name == "Supply"
                         {
-                            other_values.push(self.supply_get_values(attributes)?);
+                            other_values.push(self.supply_get_values((attributes).as_map())?);
                         }
                     }
                     let min_len = std::iter::once(source_values.len())
@@ -2628,7 +2628,7 @@ impl Interpreter {
                                 let empty_attrs = HashMap::new();
                                 let inner_attrs_ref =
                                     if let Value::Instance { attributes: a, .. } = inner_supply {
-                                        a
+                                        a.as_map()
                                     } else {
                                         &empty_attrs
                                     };
@@ -3393,14 +3393,14 @@ impl Interpreter {
         }
         let control_supplier_id = Self::named_value(&args, "control").and_then(|v| {
             if let Value::Instance { attributes, .. } = &v {
-                supplier_id_from_attrs(attributes)
+                supplier_id_from_attrs((attributes).as_map())
             } else {
                 None
             }
         });
         let status_supplier_id = Self::named_value(&args, "status").and_then(|v| {
             if let Value::Instance { attributes, .. } = &v {
-                supplier_id_from_attrs(attributes)
+                supplier_id_from_attrs((attributes).as_map())
             } else {
                 None
             }
@@ -3603,7 +3603,7 @@ impl Interpreter {
         } = &target
             && class_name == "Supply"
         {
-            self.native_supply(attributes, method, args.to_vec())
+            self.native_supply((attributes).as_map(), method, args.to_vec())
         } else {
             Err(RuntimeError::new(format!(
                 "Cannot call .{} on non-Supply",

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1323,9 +1323,13 @@ impl Interpreter {
                         && right_attrs.contains_key("timezone") =>
                     {
                         let (ly, lm, ld, lh, lmin, ls, ltz) =
-                            crate::builtins::methods_0arg::temporal::datetime_attrs(left_attrs);
+                            crate::builtins::methods_0arg::temporal::datetime_attrs(
+                                (left_attrs).as_map(),
+                            );
                         let (ry, rm, rd, rh, rmin, rs, rtz) =
-                            crate::builtins::methods_0arg::temporal::datetime_attrs(right_attrs);
+                            crate::builtins::methods_0arg::temporal::datetime_attrs(
+                                (right_attrs).as_map(),
+                            );
                         let left_instant =
                             crate::builtins::methods_0arg::temporal::datetime_to_instant_leap_aware(
                                 ly, lm, ld, lh, lmin, ls, ltz,
@@ -1429,8 +1433,11 @@ impl Interpreter {
                     && d_class == "Date"
                 {
                     let (y, m, d, _, _, _, _) =
-                        crate::builtins::methods_0arg::temporal::datetime_attrs(dt_attrs);
-                    let (dy, dm, dd) = crate::builtins::methods_0arg::temporal::date_attrs(d_attrs);
+                        crate::builtins::methods_0arg::temporal::datetime_attrs(
+                            (dt_attrs).as_map(),
+                        );
+                    let (dy, dm, dd) =
+                        crate::builtins::methods_0arg::temporal::date_attrs((d_attrs).as_map());
                     return Ok(Value::Bool(y == dy && m == dm && d == dd));
                 }
                 // Basic smartmatch fallback: value equality

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -85,9 +85,9 @@ impl Interpreter {
             if class_name != "Supply" {
                 return None;
             }
-            let supply_id = self.resolve_supply_channel_id_for_react(attributes);
+            let supply_id = self.resolve_supply_channel_id_for_react((attributes).as_map());
             let is_lines = matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
-            let head_limit = Self::extract_supply_head_limit(attributes);
+            let head_limit = Self::extract_supply_head_limit((attributes).as_map());
             if let Some(sid) = supply_id
                 && let Some(rx) = take_supply_channel(sid)
             {
@@ -104,7 +104,7 @@ impl Interpreter {
                     supplier_id: None,
                     supplier_next_index: 0,
                     callback,
-                    close_callbacks: Self::extract_supply_on_close_cbs(attributes),
+                    close_callbacks: Self::extract_supply_on_close_cbs((attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
                     done: false,
@@ -130,7 +130,7 @@ impl Interpreter {
                     supplier_id: Some(*sid as u64),
                     supplier_next_index: 0,
                     callback,
-                    close_callbacks: Self::extract_supply_on_close_cbs(attributes),
+                    close_callbacks: Self::extract_supply_on_close_cbs((attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
                     done: false,

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -429,7 +429,7 @@ impl Interpreter {
                     {
                         let mut attrs = attributes.as_ref().clone();
                         attrs.insert("ast".to_string(), ast.clone());
-                        Value::make_instance(class_name, attrs)
+                        Value::make_instance(class_name, (attrs).to_map())
                     } else {
                         match_obj
                     }

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -122,7 +122,7 @@ impl Interpreter {
                 named.insert(k.clone(), *v.clone());
                 Some((Vec::new(), named))
             }
-            Value::Instance { attributes, .. } => Some((Vec::new(), (**attributes).clone())),
+            Value::Instance { attributes, .. } => Some((Vec::new(), (attributes.to_map()))),
             Value::Mixin(inner, _) => Self::signature_capture_like(inner),
             _ => None,
         }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -50,8 +50,9 @@ impl Interpreter {
                 },
             ) if left_class == "DateTime" && right_class == "Date" => {
                 let (y, m, d, _, _, _, _) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(left_attrs);
-                let (ry, rm, rd) = crate::builtins::methods_0arg::temporal::date_attrs(right_attrs);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
+                let (ry, rm, rd) =
+                    crate::builtins::methods_0arg::temporal::date_attrs((right_attrs).as_map());
                 y == ry && m == rm && d == rd
             }
             (Value::Version { .. }, Value::Version { parts, plus, minus }) => {

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -189,10 +189,10 @@ impl Interpreter {
                         ..
                     } if class_name == "Supply" => {
                         // Find the supply channel
-                        let supply_id = self.resolve_supply_channel_id(attributes);
+                        let supply_id = self.resolve_supply_channel_id((attributes).as_map());
                         let is_lines =
                             matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
-                        let head_limit = Self::extract_head_limit(attributes);
+                        let head_limit = Self::extract_head_limit((attributes).as_map());
                         if let Some(sid) = supply_id
                             && let Some(rx) = take_supply_channel(sid)
                         {
@@ -210,7 +210,7 @@ impl Interpreter {
                                 supplier_next_index: 0,
                                 callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
-                                    attributes,
+                                    (attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
@@ -239,7 +239,7 @@ impl Interpreter {
                                 supplier_next_index: 0,
                                 callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
-                                    attributes,
+                                    (attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
@@ -285,7 +285,7 @@ impl Interpreter {
                             }
                         } else {
                             // No channel, no on-demand - replay static values
-                            self.replay_static_supply(attributes, &callback)?;
+                            self.replay_static_supply((attributes).as_map(), &callback)?;
                         }
                         // Fire LAST callbacks after static/on-demand supply completes
                         let last_cbs = items

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -168,7 +168,7 @@ impl Interpreter {
         {
             let (coerced, _) = self.run_instance_method(
                 &class_name.resolve(),
-                (**attributes).clone(),
+                attributes.to_map(),
                 base_target,
                 vec![],
                 Some(value.clone()),

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -214,7 +214,7 @@ impl Interpreter {
                 updated_attrs.insert(attr_name.to_string(), value.clone());
                 self.env.insert(
                     "self".to_string(),
-                    Value::make_instance_with_id(class_name, updated_attrs, id),
+                    Value::make_instance_with_id(class_name, (updated_attrs).to_map(), id),
                 );
             }
         }

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -186,7 +186,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
             out.insert("value".to_string(), *val.clone());
             out
         }
-        Value::Instance { attributes, .. } => (**attributes).clone(),
+        Value::Instance { attributes, .. } => attributes.to_map(),
         _ => std::collections::HashMap::new(),
     }
 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -925,7 +925,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => match_gist(attributes, 0),
+        } if class_name == "Match" => match_gist((attributes).as_map(), 0),
         _ => value.to_string_value(),
     }
 }
@@ -965,7 +965,11 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                 attributes,
                 ..
             } if class_name == "Match" => {
-                entries.push((match_from(attributes), label.to_string(), value.clone()));
+                entries.push((
+                    match_from((attributes).as_map()),
+                    label.to_string(),
+                    value.clone(),
+                ));
             }
             // Quantified capture: a list of Match values under one index.
             Value::Array(items, _) | Value::Seq(items) | Value::Slip(items) => {
@@ -977,7 +981,11 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                     } = item
                         && class_name == "Match"
                     {
-                        entries.push((match_from(attributes), label.to_string(), item.clone()));
+                        entries.push((
+                            match_from((attributes).as_map()),
+                            label.to_string(),
+                            item.clone(),
+                        ));
                     }
                 }
             }
@@ -1008,7 +1016,7 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                 "\n{}{} => {}",
                 indent,
                 label,
-                match_gist(attributes, depth + 1)
+                match_gist((attributes).as_map(), depth + 1)
             ));
         }
     }
@@ -1999,13 +2007,13 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
                             };
                             let (sy, sm, sd) =
                                 if let Value::Instance { attributes, .. } = start.as_ref() {
-                                    date_attrs(attributes)
+                                    date_attrs((attributes).as_map())
                                 } else {
                                     unreachable!()
                                 };
                             let (ey, em, ed) =
                                 if let Value::Instance { attributes, .. } = end.as_ref() {
-                                    date_attrs(attributes)
+                                    date_attrs((attributes).as_map())
                                 } else {
                                     unreachable!()
                                 };
@@ -2299,7 +2307,8 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
             ref attributes,
             ..
         } if class_name == "Date" => {
-            let (y, m, d) = crate::builtins::methods_0arg::temporal::date_attrs(attributes);
+            let (y, m, d) =
+                crate::builtins::methods_0arg::temporal::date_attrs((attributes).as_map());
             let epoch = crate::builtins::methods_0arg::temporal::civil_to_epoch_days(y, m, d);
             Value::Int(epoch * 86400)
         }
@@ -2309,7 +2318,7 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
             ..
         } if class_name == "DateTime" => {
             let (y, mo, d, h, mi, s, tz) =
-                crate::builtins::methods_0arg::temporal::datetime_attrs(attributes);
+                crate::builtins::methods_0arg::temporal::datetime_attrs((attributes).as_map());
             Value::Num(crate::builtins::methods_0arg::temporal::datetime_to_posix(
                 y, mo, d, h, mi, s, tz,
             ))

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -763,7 +763,8 @@ impl Value {
                 if let Some(Value::Str(s)) = attributes.get("__formatter_rendered") {
                     return s.to_string();
                 }
-                let (y, m, d) = crate::builtins::methods_0arg::temporal::date_attrs(attributes);
+                let (y, m, d) =
+                    crate::builtins::methods_0arg::temporal::date_attrs((attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_date(y, m, d)
             }
             Value::Instance { attributes, .. }
@@ -779,7 +780,7 @@ impl Value {
                     return s.to_string();
                 }
                 let (y, mo, d, h, mi, s, tz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(attributes);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_datetime(y, mo, d, h, mi, s, tz)
             }
             Value::Instance {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -477,22 +477,63 @@ impl InstanceAttrs {
         }
     }
 
-    pub(crate) fn clone(&self) -> HashMap<String, Value> {
-        self.attributes.clone()
-    }
-}
+    // --- Attribute access API (Phase 3, Stage 0 — encapsulation boundary) ---
+    //
+    // The attribute map used to be exposed via `Deref<Target = HashMap>`, which
+    // leaked the storage representation to ~150 call sites. Phase 3 (option C)
+    // will make the storage a *shared mutable cell* so an instance mutation is
+    // visible by-reference across call frames (see docs/container-identity.md).
+    // A locked cell cannot `Deref` to `&HashMap` (guard lifetime), so all access
+    // now goes through these inherent methods. Stage 0 keeps the plain `HashMap`
+    // backing and mirrors `HashMap`'s signatures, so this change is
+    // behaviour-identical; Stage 1 swaps the backing and adjusts the few methods
+    // that must return owned values.
 
-impl Deref for InstanceAttrs {
-    type Target = HashMap<String, Value>;
-
-    fn deref(&self) -> &Self::Target {
+    /// Borrow the backing map. Stage 1 will remove this (a locked cell cannot
+    /// hand out a `&HashMap`); the remaining users are owned-snapshot consumers
+    /// that become [`Self::to_map`].
+    pub(crate) fn as_map(&self) -> &HashMap<String, Value> {
         &self.attributes
     }
-}
 
-impl DerefMut for InstanceAttrs {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.attributes
+    /// An owned clone of the backing map (the old `attributes.to_map()`).
+    pub(crate) fn to_map(&self) -> HashMap<String, Value> {
+        self.attributes.clone()
+    }
+
+    pub(crate) fn get(&self, key: &str) -> Option<&Value> {
+        self.attributes.get(key)
+    }
+
+    pub(crate) fn contains_key(&self, key: &str) -> bool {
+        self.attributes.contains_key(key)
+    }
+
+    pub(crate) fn insert(&mut self, key: String, value: Value) -> Option<Value> {
+        self.attributes.insert(key, value)
+    }
+
+    pub(crate) fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
+        self.attributes.get_mut(key)
+    }
+
+    pub(crate) fn entry(
+        &mut self,
+        key: String,
+    ) -> std::collections::hash_map::Entry<'_, String, Value> {
+        self.attributes.entry(key)
+    }
+
+    pub(crate) fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Value> {
+        self.attributes.iter()
+    }
+
+    pub(crate) fn keys(&self) -> std::collections::hash_map::Keys<'_, String, Value> {
+        self.attributes.keys()
+    }
+
+    pub(crate) fn values(&self) -> std::collections::hash_map::Values<'_, String, Value> {
+        self.attributes.values()
     }
 }
 

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -216,9 +216,9 @@ impl Value {
                 && b_attrs.contains_key("timezone") =>
             {
                 let (ay, am, ad, ah, amin, asec, atz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(a_attrs);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((a_attrs).as_map());
                 let (by, bm, bd, bh, bmin, bsec, btz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(b_attrs);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((b_attrs).as_map());
                 ay == by
                     && am == bm
                     && ad == bd
@@ -249,8 +249,10 @@ impl Value {
                 && b_attrs.contains_key("day")
                 && !b_attrs.contains_key("hour") =>
             {
-                let (ay, am, ad) = crate::builtins::methods_0arg::temporal::date_attrs(a_attrs);
-                let (by, bm, bd) = crate::builtins::methods_0arg::temporal::date_attrs(b_attrs);
+                let (ay, am, ad) =
+                    crate::builtins::methods_0arg::temporal::date_attrs((a_attrs).as_map());
+                let (by, bm, bd) =
+                    crate::builtins::methods_0arg::temporal::date_attrs((b_attrs).as_map());
                 ay == by && am == bm && ad == bd
             }
             // StrDistance instances: structural equality on before/after

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2410,7 +2410,7 @@ impl VM {
                     // Call user method directly, bypassing native method dispatch
                     let cn = class_name.unwrap();
                     let attrs = match &val {
-                        Value::Instance { attributes, .. } => (**attributes).clone(),
+                        Value::Instance { attributes, .. } => attributes.to_map(),
                         _ => std::collections::HashMap::new(),
                     };
                     match self.interpreter.run_instance_method(

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -201,7 +201,7 @@ impl VM {
                             _ => None,
                         };
                         let attributes = match &target {
-                            Value::Instance { attributes, .. } => (**attributes).clone(),
+                            Value::Instance { attributes, .. } => attributes.to_map(),
                             _ => std::collections::HashMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
@@ -644,9 +644,12 @@ impl VM {
             updated.insert("index".to_string(), Value::Int(index as i64));
             let cn = class_name.resolve();
             let inst_id = *id;
-            self.interpreter
-                .overwrite_instance_bindings_by_identity(&cn, inst_id, updated.clone());
-            self.overwrite_instance_in_locals(&cn, inst_id, &updated);
+            self.interpreter.overwrite_instance_bindings_by_identity(
+                &cn,
+                inst_id,
+                (updated.clone()).to_map(),
+            );
+            self.overwrite_instance_in_locals(&cn, inst_id, updated.as_map());
             self.env_dirty = true;
         }
         Some(Ok(ret))
@@ -704,7 +707,7 @@ impl VM {
             _ => None,
         };
         let attributes = match &target {
-            Value::Instance { attributes, .. } => (**attributes).clone(),
+            Value::Instance { attributes, .. } => attributes.to_map(),
             _ => std::collections::HashMap::new(),
         };
         let empty_fns = HashMap::new();
@@ -947,7 +950,7 @@ impl VM {
                             _ => None,
                         };
                         let attributes = match &target {
-                            Value::Instance { attributes, .. } => (**attributes).clone(),
+                            Value::Instance { attributes, .. } => attributes.to_map(),
                             _ => std::collections::HashMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
@@ -1046,7 +1049,7 @@ impl VM {
                     _ => None,
                 };
                 let attributes = match &target {
-                    Value::Instance { attributes, .. } => (**attributes).clone(),
+                    Value::Instance { attributes, .. } => attributes.to_map(),
                     _ => std::collections::HashMap::new(),
                 };
                 let invocant_for_dispatch = if attributes.is_empty() {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -698,7 +698,10 @@ impl VM {
                 let updated = Value::Instance {
                     class_name,
                     attributes: Arc::new(crate::value::InstanceAttrs::new(
-                        class_name, attrs, id, false,
+                        class_name,
+                        (attrs).to_map(),
+                        id,
+                        false,
                     )),
                     id,
                 };
@@ -1325,7 +1328,7 @@ impl VM {
                             class_name: *inst_class,
                             attributes: Arc::new(crate::value::InstanceAttrs::new(
                                 *inst_class,
-                                new_attrs,
+                                (new_attrs).to_map(),
                                 inst_id,
                                 true,
                             )),
@@ -1732,9 +1735,12 @@ impl VM {
                     .collect(),
             ),
         );
-        self.interpreter
-            .overwrite_instance_bindings_by_identity(&cn, *id, updated_attrs.clone());
-        let updated = Value::make_instance_with_id(*class_name, updated_attrs, *id);
+        self.interpreter.overwrite_instance_bindings_by_identity(
+            &cn,
+            *id,
+            (updated_attrs.clone()).to_map(),
+        );
+        let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
         self.interpreter
             .env_mut()
             .insert(target_name.to_string(), updated.clone());

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -867,9 +867,9 @@ impl VM {
                 && right_attrs.contains_key("timezone") =>
             {
                 let (ly, lm, ld, lh, lmin, ls, ltz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(left_attrs);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
                 let (ry, rm, rd, rh, rmin, rs, rtz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs(right_attrs);
+                    crate::builtins::methods_0arg::temporal::datetime_attrs((right_attrs).as_map());
                 let left_instant =
                     crate::builtins::methods_0arg::temporal::datetime_to_instant_leap_aware(
                         ly, lm, ld, lh, lmin, ls, ltz,

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -80,8 +80,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             },
         ) if left_class == "DateTime" && right_class == "Date" => {
             let (y, m, d, _, _, _, _) =
-                crate::builtins::methods_0arg::temporal::datetime_attrs(left_attrs);
-            let (ry, rm, rd) = crate::builtins::methods_0arg::temporal::date_attrs(right_attrs);
+                crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
+            let (ry, rm, rd) =
+                crate::builtins::methods_0arg::temporal::date_attrs((right_attrs).as_map());
             Some(y == ry && m == rm && d == rd)
         }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3026,7 +3026,7 @@ impl VM {
                         let display = format!("{}()", cn);
                         return Err(RuntimeError::assignment_ro_typename(&cn, &display));
                     }
-                    let hash_map: HashMap<String, Value> = HashMap::clone(&**attributes);
+                    let hash_map: HashMap<String, Value> = HashMap::clone(attributes.as_map());
                     let hash_val = Value::hash(hash_map);
                     self.interpreter
                         .env_mut()


### PR DESCRIPTION
First slice of **first-class instance cells** (`docs/container-identity.md` Phase 3, option C — the structural fix for the closure-frame instance-mutation bug analyzed in #2849). Behaviour-identical groundwork.

## What

Stop leaking the attribute storage representation through `Deref`/`DerefMut`, so Stage 1 can swap the backing to a shared mutable cell (`Arc<RwLock<HashMap>>`) with the change localized to `InstanceAttrs`.

- Remove `impl Deref/DerefMut for InstanceAttrs`.
- Add inherent methods mirroring `HashMap`'s signatures (`get`/`contains_key`/`insert`/`get_mut`/`entry`/`iter`/`keys`/`values`) plus owned accessors `as_map() -> &HashMap` (the old `&**attributes`) and `to_map() -> HashMap` (the old `(**attributes).clone()`).
- Removing `Deref` let the compiler enumerate every storage-coupled site (~197): `&Arc<InstanceAttrs>` passed where `&HashMap` was expected (deref coercion) now goes through `.as_map()`; owned-HashMap producers go through `.to_map()`.

## Not yet

The internal backing stays a plain `HashMap`, so this is **byte-identical** — it does NOT yet fix the closure-frame instance-mutation bug. That is Stage 1/2 (swap the backing to a shared cell, delete the overlay-only `overwrite_instance_bindings_by_identity` by-id scan).

## Tests

- `make test` 6112/6112
- `cargo test` 458/0
- `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)