### PR TITLE
feat(exceptions): X::Syntax::VirtualCall for $.attr in an attribute initializer

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1025,6 +1025,122 @@ fn collect_unattached_ph_expr(expr: &Expr, out: &mut Vec<String>) {
     }
 }
 
+/// Find the first virtual accessor call (`$.attr` / `@.attr` / `%.attr`) used in
+/// an attribute initializer expression. Such a call dereferences the
+/// partially-constructed invocant and is X::Syntax::VirtualCall. Descends into
+/// bare blocks (block initializers) but stops at sub/method/class boundaries,
+/// which rebind the invocant.
+pub(crate) fn first_virtual_call_in_expr(expr: &Expr) -> Option<String> {
+    let mut found = None;
+    collect_virtual_call_expr(expr, &mut found);
+    found
+}
+
+fn collect_virtual_call_expr(expr: &Expr, out: &mut Option<String>) {
+    if out.is_some() {
+        return;
+    }
+    let hit = |sigil: char, name: &str, out: &mut Option<String>| {
+        if out.is_none() && name.starts_with('.') {
+            *out = Some(format!("{}{}", sigil, name));
+        }
+    };
+    match expr {
+        Expr::Var(name) => hit('$', name, out),
+        Expr::ArrayVar(name) => hit('@', name, out),
+        Expr::HashVar(name) => hit('%', name, out),
+        Expr::Binary { left, right, .. } => {
+            collect_virtual_call_expr(left, out);
+            collect_virtual_call_expr(right, out);
+        }
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => {
+            collect_virtual_call_expr(expr, out)
+        }
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            collect_virtual_call_expr(target, out);
+            for a in args {
+                collect_virtual_call_expr(a, out);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                collect_virtual_call_expr(a, out);
+            }
+        }
+        Expr::CallOn { target, args } => {
+            collect_virtual_call_expr(target, out);
+            for a in args {
+                collect_virtual_call_expr(a, out);
+            }
+        }
+        Expr::Index { target, index, .. } => {
+            collect_virtual_call_expr(target, out);
+            collect_virtual_call_expr(index, out);
+        }
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            collect_virtual_call_expr(cond, out);
+            collect_virtual_call_expr(then_expr, out);
+            collect_virtual_call_expr(else_expr, out);
+        }
+        Expr::AssignExpr { expr, .. } | Expr::PositionalPair(expr) | Expr::ZenSlice(expr) => {
+            collect_virtual_call_expr(expr, out)
+        }
+        Expr::ArrayLiteral(es)
+        | Expr::BracketArray(es, _)
+        | Expr::StringInterpolation(es)
+        | Expr::CaptureLiteral(es) => {
+            for e in es {
+                collect_virtual_call_expr(e, out);
+            }
+        }
+        Expr::Hash(pairs) => {
+            for (_, v) in pairs {
+                if let Some(e) = v {
+                    collect_virtual_call_expr(e, out);
+                }
+            }
+        }
+        // A bare block initializer (`has $.x = { $.y }`) is still evaluated on the
+        // partially-constructed object, so descend into it.
+        Expr::AnonSub {
+            body,
+            is_block: true,
+            ..
+        } => {
+            for stmt in body {
+                collect_virtual_call_stmt(stmt, out);
+            }
+        }
+        // Real subs/methods/classes rebind the invocant: stop.
+        _ => {}
+    }
+}
+
+fn collect_virtual_call_stmt(stmt: &Stmt, out: &mut Option<String>) {
+    if out.is_some() {
+        return;
+    }
+    match stmt {
+        Stmt::Expr(e)
+        | Stmt::Return(e)
+        | Stmt::Die(e)
+        | Stmt::Fail(e)
+        | Stmt::Take(e)
+        | Stmt::Goto(e) => collect_virtual_call_expr(e, out),
+        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => collect_virtual_call_expr(expr, out),
+        Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
+            for e in es {
+                collect_virtual_call_expr(e, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn placeholder_sort_key(name: &str) -> &str {
     let without_sigil = if let Some(first) = name.chars().next() {
         if matches!(first, '$' | '@' | '%' | '&') {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1131,7 +1131,9 @@ fn collect_virtual_call_stmt(stmt: &Stmt, out: &mut Option<String>) {
         | Stmt::Fail(e)
         | Stmt::Take(e)
         | Stmt::Goto(e) => collect_virtual_call_expr(e, out),
-        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => collect_virtual_call_expr(expr, out),
+        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+            collect_virtual_call_expr(expr, out)
+        }
         Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
             for e in es {
                 collect_virtual_call_expr(e, out);

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -687,6 +687,24 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         return Err(PError::fatal_with_exception(message, Box::new(ex)));
     }
 
+    // A virtual accessor call (`$.y`) in an attribute initializer dereferences the
+    // partially-constructed invocant -> X::Syntax::VirtualCall.
+    if let Some(def) = default.as_ref()
+        && let Some(call) = crate::ast::first_virtual_call_in_expr(def)
+    {
+        // suggest the $!attr direct-access form (e.g. `$.y` -> `$!y`)
+        let direct = format!("{}!{}", &call[..1], &call[2..]);
+        let message = format!(
+            "Virtual method call {} may not be used on partially constructed object (maybe you mean {} for direct attribute access here?)",
+            call, direct
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("call".to_string(), Value::str(call));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(Symbol::intern("X::Syntax::VirtualCall"), attrs);
+        return Err(PError::fatal_with_exception(message, Box::new(ex)));
+    }
+
     // Apply `use attributes :D/:U/:_` pragma if no explicit smiley on the type
     let smiley_from_pragma = type_smiley.is_none() && type_constraint.is_some() && {
         let pragma = super::super::simple::current_attributes_pragma();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2707,6 +2707,7 @@ impl Interpreter {
         register_x("X::Syntax", "X::Comp");
         register_x("X::Syntax::Confused", "X::Syntax");
         register_x("X::Syntax::Missing", "X::Syntax");
+        register_x("X::Syntax::VirtualCall", "X::Syntax");
         register_x("X::Syntax::Malformed", "X::Syntax");
         register_x("X::Syntax::Variable::Numeric", "X::Syntax");
         register_x("X::Syntax::Variable::Initializer", "X::Syntax");

--- a/t/virtual-call-attr.t
+++ b/t/virtual-call-attr.t
@@ -1,0 +1,20 @@
+use Test;
+
+# A virtual accessor call (`$.y`) in an attribute initializer dereferences the
+# partially-constructed invocant and is a compile-time X::Syntax::VirtualCall.
+
+plan 6;
+
+throws-like 'class { has $.x = $.y }', X::Syntax::VirtualCall, call => '$.y';
+throws-like 'class { has $.x = $.y + 1 }', X::Syntax::VirtualCall, call => '$.y';
+throws-like 'class { has $.x = { $.y } }', X::Syntax::VirtualCall, call => '$.y';
+
+# Valid initializers still compile and run.
+my $c = class C { has $.a = 1; has $.b = 2 }.new;
+is $c.b, 2, 'literal attribute defaults work';
+
+my $outer = 9;
+is (class D { has $.x = $outer }).new.x, 9, 'closure-captured outer var default works';
+
+# Direct attribute access ($!y) in an initializer is allowed.
+lives-ok { (class E { has $.y; has $.x = $!y }).new(y => 3) }, '$!y direct access is allowed';


### PR DESCRIPTION
A virtual accessor call (`$.y` / `@.y` / `%.y`) in an attribute initializer
dereferences the partially-constructed invocant, which is a compile-time
X::Syntax::VirtualCall carrying `.call`. The check descends into bare block
initializers (`has $.x = { $.y }`) but stops at sub/method/class boundaries that
rebind the invocant; direct attribute access (`$!y`) stays legal.

Adds `first_virtual_call_in_expr` AST walker in ast.rs, wired into the has-decl
default-initializer path, and registers X::Syntax::VirtualCall.

Unblocks roast/S32-exceptions/misc2.t test 152.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
