### PR TITLE
feat(exceptions): X::Signature::NameClash for a rename key colliding with an inner alias

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1727,6 +1727,25 @@ fn check_duplicate_params(params: &[ParamDef]) -> Result<(), PError> {
         if p.named
             && let Some(sub_params) = &p.sub_signature
         {
+            // The outer param's rename name (e.g. `:in` in `:in(:$in)`) is an
+            // external named-argument key. If a sub-param is ALSO named with the
+            // same key (`:$in` -> external name "in"), the key is used for more
+            // than one named parameter -> X::Signature::NameClash (not a plain
+            // variable Redeclaration).
+            let outer_base = strip_param_sigil(&p.name);
+            for sp in sub_params {
+                if sp.named && !outer_base.is_empty() && strip_param_sigil(&sp.name) == outer_base {
+                    let msg = format!(
+                        "X::Signature::NameClash: Name {} used for more than one named parameter",
+                        outer_base
+                    );
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("name".to_string(), Value::str(outer_base.to_string()));
+                    attrs.insert("message".to_string(), Value::str(msg.clone()));
+                    let ex = Value::make_instance(Symbol::intern("X::Signature::NameClash"), attrs);
+                    return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+                }
+            }
             for sp in sub_params {
                 let sp_name = &sp.name;
                 let sp_without_sigil = strip_param_sigil(sp_name);

--- a/t/signature-nameclash.t
+++ b/t/signature-nameclash.t
@@ -1,0 +1,17 @@
+use Test;
+
+# A named parameter whose rename key collides with an inner named alias
+# (`:in(:$in)` -> external name "in" twice) is X::Signature::NameClash.
+
+plan 4;
+
+throws-like 'sub f(:in(:$in)) { }', X::Signature::NameClash, name => 'in';
+throws-like 'sub g(:foo(:$foo)) { }', X::Signature::NameClash, name => 'foo';
+
+# A rename with a differently-named inner alias is fine (two distinct keys).
+sub h(:foo(:$bar)) { $bar }
+is h(foo => 5), 5, ':foo(:$bar) binds via either key';
+
+# A plain rename `:k($var)` with no inner colon is fine.
+sub k(:label($text)) { $text }
+is k(label => 'hi'), 'hi', ':label($text) rename works';


### PR DESCRIPTION
A named parameter whose rename key collides with an inner named alias
(`:in(:$in)` declares the external name "in" twice) now raises
X::Signature::NameClash carrying `.name`, instead of a plain variable
X::Redeclaration. The check fires only when the inner sub-param is itself named
(`:$in`) and its base name equals the outer rename key; `:in($in)` (plain rename)
and `:foo(:$bar)` (distinct keys) are unaffected.

Unblocks roast/S32-exceptions/misc2.t test 69.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
