### PR TITLE
feat(exceptions): X::Syntax::NegatedPair for an argument on a negated colonpair

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -776,6 +776,16 @@ pub(in crate::parser) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     // :!name (negated boolean pair)
     if let Some(after_bang) = r.strip_prefix('!') {
         let (rest, name) = parse_ident_with_hyphens(after_bang)?;
+        // A negated pair may not carry an argument: `:!foo(3)` is
+        // X::Syntax::NegatedPair ("Argument not allowed on negated pair").
+        if rest.starts_with('(') {
+            let message = format!("Argument not allowed on negated pair with key '{}'", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("key".to_string(), Value::str(name.to_string()));
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(Symbol::intern("X::Syntax::NegatedPair"), attrs);
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
         return Ok((
             rest,
             Expr::Binary {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2711,6 +2711,7 @@ impl Interpreter {
         register_x("X::Syntax::Extension::Null", "X::Syntax");
         register_x("X::Syntax::Missing", "X::Syntax");
         register_x("X::Syntax::VirtualCall", "X::Syntax");
+        register_x("X::Syntax::NegatedPair", "X::Syntax");
         register_x("X::Syntax::Malformed", "X::Syntax");
         register_x("X::Syntax::Variable::Numeric", "X::Syntax");
         register_x("X::Syntax::Variable::Initializer", "X::Syntax");

--- a/t/negated-pair.t
+++ b/t/negated-pair.t
@@ -1,0 +1,14 @@
+use Test;
+
+# A negated colonpair may not carry an argument: `:!foo(3)` is a compile-time
+# X::Syntax::NegatedPair carrying the offending key.
+
+plan 4;
+
+throws-like ':!foo(3)', X::Syntax::NegatedPair, key => 'foo';
+throws-like ':!bar(1, 2)', X::Syntax::NegatedPair, key => 'bar';
+
+# A plain negated pair (no argument) is fine: `:!foo` means foo => False.
+my %h = (:!foo, :baz);
+is %h<foo>, False, ':!foo is foo => False';
+is %h<baz>, True, ':baz is baz => True';


### PR DESCRIPTION
A negated colonpair may not carry an argument: `:!foo(3)` now raises a
compile-time X::Syntax::NegatedPair carrying `.key`, with rakudo's message
"Argument not allowed on negated pair with key 'foo'", instead of parsing the
pair and failing at runtime with a CALL-ME error. A plain `:!foo` (no argument,
meaning foo => False) is unaffected.

Unblocks roast/S32-exceptions/misc2.t test 52.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
