### PR TITLE
feat(exceptions): X::Syntax::Extension::Null for an empty operator symbol

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -364,6 +364,52 @@ fn placeholder_overrides_signature_error(body: &[Stmt], param_defs: &[ParamDef])
 /// Parse a sub name, which can be a regular identifier or an operator-style name
 /// like `infix:<+>`, `prefix:<->`, `postfix:<++>`, `circumfix:<[ ]>`.
 pub(super) fn parse_sub_name(input: &str) -> PResult<'_, String> {
+    let (rest, name) = parse_sub_name_inner(input)?;
+    if let Some(err) = null_operator_error(&name) {
+        return Err(err);
+    }
+    Ok((rest, name))
+}
+
+/// Detect an operator declaration with an empty (whitespace-only) operator
+/// symbol, e.g. `infix:sym< >` or `infix:< >` -> X::Syntax::Extension::Null.
+fn null_operator_error(name: &str) -> Option<PError> {
+    const CATEGORIES: &[&str] = &[
+        "infix",
+        "prefix",
+        "postfix",
+        "term",
+        "circumfix",
+        "postcircumfix",
+        "trait_mod",
+        "trait_auxiliary",
+    ];
+    let colon = name.find(':')?;
+    let cat = &name[..colon];
+    if !CATEGORIES.contains(&cat) {
+        return None;
+    }
+    // After the category, the symbol is `<SYM>`, `«SYM»`, or `sym<SYM>`.
+    let after = &name[colon + 1..];
+    let after = after.strip_prefix("sym").unwrap_or(after);
+    let inner = if let Some(s) = after.strip_prefix('<') {
+        s.strip_suffix('>')?
+    } else if let Some(s) = after.strip_prefix('\u{ab}') {
+        s.strip_suffix('\u{bb}')?
+    } else {
+        return None;
+    };
+    if !inner.trim().is_empty() {
+        return None;
+    }
+    let message = "Null operator is not allowed".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Extension::Null"), attrs);
+    Some(PError::fatal_with_exception(message, Box::new(ex)))
+}
+
+fn parse_sub_name_inner(input: &str) -> PResult<'_, String> {
     let (rest, base) = if let Ok((rest, base)) = ident(input) {
         (rest, base)
     } else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2706,6 +2706,7 @@ impl Interpreter {
         // X::Syntax hierarchy (syntax errors, subtypes of X::Comp)
         register_x("X::Syntax", "X::Comp");
         register_x("X::Syntax::Confused", "X::Syntax");
+        register_x("X::Syntax::Extension::Null", "X::Syntax");
         register_x("X::Syntax::Missing", "X::Syntax");
         register_x("X::Syntax::Malformed", "X::Syntax");
         register_x("X::Syntax::Variable::Numeric", "X::Syntax");

--- a/t/extension-null.t
+++ b/t/extension-null.t
@@ -1,0 +1,16 @@
+use Test;
+
+# Declaring an operator with an empty (whitespace-only) symbol is a compile-time
+# X::Syntax::Extension::Null ("Null operator is not allowed").
+
+plan 4;
+
+throws-like 'sub infix:sym< >() { }', X::Syntax::Extension::Null;
+throws-like 'sub infix:< >() { }', X::Syntax::Extension::Null;
+
+# Operators with a real symbol still declare and work.
+sub infix:<foo>($a, $b) { $a ~ $b }
+is ('x' foo 'y'), 'xy', 'infix:<foo> works';
+
+sub circumfix:<[ ]>($x) { $x * 2 }
+is [5], 10, 'circumfix:<[ ]> works';


### PR DESCRIPTION
Declaring an operator with an empty (whitespace-only) symbol, e.g.
`sub infix:sym< >() {}` or `sub infix:< >() {}`, now raises a compile-time
X::Syntax::Extension::Null ("Null operator is not allowed") instead of silently
registering a null-named operator. `parse_sub_name` now wraps its inner parse and
validates that an operator-category sub name carries a non-empty symbol.

Unblocks roast/S32-exceptions/misc2.t test 67.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
