### PR TITLE
feat(exceptions): X::Value::Dynamic for a dynamic value on a boolean regex adverb

### DIFF
--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -167,6 +167,40 @@ fn is_regex_quote_terminator(open: char, ch: char) -> bool {
     }
 }
 
+/// True for boolean-switch regex adverbs that take no runtime value (unlike the
+/// value adverbs `:x`, `:nth`, `:pos`, `:continue`, `:g`).
+fn is_boolean_flag_adverb(name: &str) -> bool {
+    matches!(
+        name,
+        "i" | "ignorecase"
+            | "ii"
+            | "samecase"
+            | "s"
+            | "sigspace"
+            | "ss"
+            | "samespace"
+            | "m"
+            | "ignoremark"
+            | "mm"
+            | "samemark"
+            | "r"
+            | "ratchet"
+            | "ex"
+            | "exhaustive"
+            | "ov"
+            | "overlap"
+    )
+}
+
+/// True when an adverb argument source references a dynamic variable
+/// (a `*` twigil: `$*foo`, `@*ARGS`, `%*ENV`, `&*bar`).
+fn contains_dynamic_var(src: &str) -> bool {
+    let bytes = src.as_bytes();
+    bytes
+        .windows(2)
+        .any(|w| matches!(w[0], b'$' | b'@' | b'%' | b'&') && w[1] == b'*')
+}
+
 fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
     let mut spec = input;
     let mut adverbs = MatchAdverbs::default();
@@ -206,6 +240,21 @@ fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
             }
             arg = Some(&r[1..r.len() - after.len() - 1]);
             r = after;
+        }
+
+        // A boolean-flag regex adverb (`:i`, `:s`, `:m`, ...) is a compile-time
+        // switch and cannot take a runtime value. When such an adverb is given an
+        // argument that references a dynamic variable (e.g. `m:i(@*ARGS[0])/`),
+        // it is X::Value::Dynamic ("Adverb i value must be known at compile time").
+        if let Some(arg_src) = arg
+            && is_boolean_flag_adverb(&name)
+            && contains_dynamic_var(arg_src)
+        {
+            let message = format!("Adverb {} value must be known at compile time", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(Symbol::intern("X::Value::Dynamic"), attrs);
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
         }
 
         if name == "g" || name == "global" {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2702,6 +2702,8 @@ impl Interpreter {
         register_x("X::Comp::AdHoc", "X::Comp");
         register_x("X::Comp::NYI", "X::Comp");
         register_x("X::Composition::NotComposable", "Exception");
+        register_x("X::Value", "Exception");
+        register_x("X::Value::Dynamic", "X::Value");
 
         // X::Syntax hierarchy (syntax errors, subtypes of X::Comp)
         register_x("X::Syntax", "X::Comp");

--- a/t/value-dynamic-adverb.t
+++ b/t/value-dynamic-adverb.t
@@ -1,0 +1,13 @@
+use Test;
+
+# A boolean-flag regex adverb (`:i`, `:s`, ...) is a compile-time switch and may
+# not take a runtime/dynamic value. Passing a dynamic variable is X::Value::Dynamic.
+
+plan 4;
+
+throws-like 'm:i(@*ARGS[0])/foo/', X::Value::Dynamic;
+throws-like 'm:s(@*ARGS[0])/foo/', X::Value::Dynamic;
+
+# Plain boolean flags (no argument) and value adverbs still work.
+ok (so 'FOO' ~~ m:i/foo/), ':i flag matches case-insensitively';
+ok (so 'foofoofoo' ~~ m:x(3)/foo/), ':x(3) value adverb still works';


### PR DESCRIPTION
A boolean-flag regex adverb (`:i`, `:s`, `:m`, ...) is a compile-time switch and
may not take a runtime value. Passing an argument that references a dynamic
variable, e.g. `m:i(@*ARGS[0])/foo/`, now raises a compile-time X::Value::Dynamic
("Adverb i value must be known at compile time"). Value adverbs (`:x`, `:nth`,
`:pos`, `:continue`) and plain flags without an argument are unaffected.

Registers X::Value and X::Value::Dynamic.

Unblocks roast/S32-exceptions/misc2.t test 150.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
