### PR TITLE
feat(exceptions): X::Syntax::NegatedPair for an argument on a negated pair

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -776,6 +776,16 @@ pub(in crate::parser) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     // :!name (negated boolean pair)
     if let Some(after_bang) = r.strip_prefix('!') {
         let (rest, name) = parse_ident_with_hyphens(after_bang)?;
+        // A negated pair may not carry an argument: `:!foo(3)` is
+        // X::Syntax::NegatedPair ("Argument not allowed on negated pair").
+        if rest.starts_with('(') {
+            let message = format!("Argument not allowed on negated pair with key '{}'", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("key".to_string(), Value::str(name.to_string()));
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(Symbol::intern("X::Syntax::NegatedPair"), attrs);
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
         return Ok((
             rest,
             Expr::Binary {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2711,6 +2711,7 @@ impl Interpreter {
         register_x("X::Syntax::Extension::Null", "X::Syntax");
         register_x("X::Syntax::Missing", "X::Syntax");
         register_x("X::Syntax::VirtualCall", "X::Syntax");
+        register_x("X::Syntax::NegatedPair", "X::Syntax");
         register_x("X::Syntax::Malformed", "X::Syntax");
         register_x("X::Syntax::Variable::Numeric", "X::Syntax");
         register_x("X::Syntax::Variable::Initializer", "X::Syntax");

--- a/t/negated-pair.t
+++ b/t/negated-pair.t
@@ -1,0 +1,11 @@
+use Test;
+
+plan 4;
+
+# A negated colonpair may not carry an argument.
+throws-like ':!foo(3)', X::Syntax::NegatedPair, key => 'foo';
+throws-like ':!bar(1, 2)', X::Syntax::NegatedPair, key => 'bar';
+throws-like ':!some-name(42)', X::Syntax::NegatedPair, key => 'some-name';
+
+# A bare negated pair (no argument) is legal and is False.
+is (:!foo).value, False, 'bare :!foo is a False-valued pair';


### PR DESCRIPTION
## Summary

`:!foo(3)` supplies an argument to a negated colonpair, which Raku rejects at compile time:

```
===SORRY!=== Error while compiling
Argument not allowed on negated pair with key 'foo'
```

Previously mutsu parsed `:!foo` as a `False`-valued `Pair` and then tried to invoke it with `(3)`, yielding a runtime `No such method 'CALL-ME' for invocant of type 'Pair'`.

`colonpair_expr` now raises a fatal parse error carrying the structured `X::Syntax::NegatedPair` exception (with `key`) when a negated pair is immediately followed by `(`. A bare negated pair `:!foo` (no argument) stays a legal `False`-valued pair.

## Test

- New `t/negated-pair.t`
- Fixes `roast/S32-exceptions/misc2.t` test 52

🤖 Generated with [Claude Code](https://claude.com/claude-code)