### PR TITLE
feat(exceptions): X::Syntax::Variable::IndirectDeclaration for my $::(EXPR)

### DIFF
--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -257,6 +257,16 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
                 ));
             }
         }
+        // `my $::("foo")` — declaring a variable by an indirect (symbolic) name
+        // is illegal. The indirect form is a valid *lookup* as an rvalue/lvalue
+        // (`$::("foo")`, parsed elsewhere), but never a declarable name.
+        if (sigil == b'$' || is_array || is_hash || is_code) && rest[1..].starts_with("::(") {
+            return Err(illegal_my_var_error(
+                "X::Syntax::Variable::IndirectDeclaration",
+                "Cannot declare a variable by indirect name (use a hash instead?)",
+                &[],
+            ));
+        }
         let (r, n) = var_name(rest)?;
         // Reject `!`/`?` twigils in `my` scope: `my $!foo` / `my $?FILE` are
         // invalid. Bare special variables (`my $!`, `my $?`) are still allowed.

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -241,6 +241,20 @@ fn var_name(input: &str) -> PResult<'_, String> {
                 return Ok((&after_bracket[end + 1..], format!("::<{symbol}>")));
             }
         }
+        // `$::(EXPR)` is an indirect (symbolic) variable name. It is a legal
+        // *lookup* as an rvalue, but declaring a variable by an indirect name
+        // (`my $::("foo")`) is rejected at compile time. var_name is only
+        // reached from declaration contexts, so flag it here.
+        if twigil.is_empty() && r.starts_with("::(") {
+            let message =
+                "Cannot declare a variable by indirect name (use a hash instead?)".to_string();
+            let attrs = std::collections::HashMap::new();
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Variable::IndirectDeclaration"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
         // A fatal qualified-name error (e.g. a null component `$a::::b`) must
         // propagate, not fall through to the `$foo::` / anonymous-variable arms.
         if let Err(e) = qualified_ident(r)

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -241,20 +241,6 @@ fn var_name(input: &str) -> PResult<'_, String> {
                 return Ok((&after_bracket[end + 1..], format!("::<{symbol}>")));
             }
         }
-        // `$::(EXPR)` is an indirect (symbolic) variable name. It is a legal
-        // *lookup* as an rvalue, but declaring a variable by an indirect name
-        // (`my $::("foo")`) is rejected at compile time. var_name is only
-        // reached from declaration contexts, so flag it here.
-        if twigil.is_empty() && r.starts_with("::(") {
-            let message =
-                "Cannot declare a variable by indirect name (use a hash instead?)".to_string();
-            let attrs = std::collections::HashMap::new();
-            let ex = crate::value::Value::make_instance(
-                crate::symbol::Symbol::intern("X::Syntax::Variable::IndirectDeclaration"),
-                attrs,
-            );
-            return Err(PError::fatal_with_exception(message, Box::new(ex)));
-        }
         // A fatal qualified-name error (e.g. a null component `$a::::b`) must
         // propagate, not fall through to the `$foo::` / anonymous-variable arms.
         if let Err(e) = qualified_ident(r)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2714,6 +2714,7 @@ impl Interpreter {
         register_x("X::Syntax::Malformed", "X::Syntax");
         register_x("X::Syntax::Variable::Numeric", "X::Syntax");
         register_x("X::Syntax::Variable::Initializer", "X::Syntax");
+        register_x("X::Syntax::Variable::IndirectDeclaration", "X::Syntax");
         register_x("X::Syntax::Variable::ConflictingTypes", "X::Syntax");
         register_x("X::Syntax::Number::LiteralType", "X::Syntax");
         register_x("X::Syntax::Regex::Adverb", "X::Syntax");

--- a/t/indirect-declaration.t
+++ b/t/indirect-declaration.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 5;
+
+# Declaring a variable by an indirect (symbolic) name is rejected at compile time.
+throws-like 'my $::("foo")', X::Syntax::Variable::IndirectDeclaration;
+throws-like 'my @::("foo")', X::Syntax::Variable::IndirectDeclaration;
+throws-like 'my %::("foo")', X::Syntax::Variable::IndirectDeclaration;
+
+# An indirect name as an rvalue (symbolic reference lookup) is still legal.
+my $foo = 42;
+is $::("foo"), 42, 'indirect rvalue lookup still works';
+
+# A normal declaration is unaffected.
+{
+    my $bar = 7;
+    is $bar, 7, 'ordinary declaration unaffected';
+}


### PR DESCRIPTION
## Summary

Declaring a variable by an indirect (symbolic) name is rejected by Raku at compile time:

```
my $::("foo")
# ===SORRY!=== Cannot declare a variable by indirect name (use a hash instead?)
```

Previously mutsu silently parsed it as an anonymous declaration followed by a stray `::("foo")` statement.

`var_name` (the declaration-name parser, never reached for rvalues) now raises a fatal parse error carrying the structured `X::Syntax::Variable::IndirectDeclaration` exception when the sigil is immediately followed by `::(`. Indirect names used as **rvalues** (`$::("foo")` symbolic lookup) are parsed by a different path and remain legal. Applies to all sigils (`$`/`@`/`%`).

## Test

- New `t/indirect-declaration.t`
- Fixes `roast/S32-exceptions/misc2.t` test 60

🤖 Generated with [Claude Code](https://claude.com/claude-code)