### PR TITLE
feat(exceptions): X::Syntax::Augment::Illegal and X::Anon::Augment

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -800,6 +800,9 @@ pub(crate) enum Stmt {
     AugmentClass {
         name: Symbol,
         body: Vec<Stmt>,
+        /// True when declared with `augment role ...` (roles are always closed,
+        /// so augmenting one is illegal); false for `augment class ...`.
+        is_role: bool,
     },
     SubsetDecl {
         name: Symbol,

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -806,12 +806,34 @@ pub(crate) fn class_decl(input: &str) -> PResult<'_, Stmt> {
 }
 
 /// Parse `augment class ClassName { ... }` declaration (monkey-patching).
+/// Also handles `augment role RoleName { ... }` (always illegal — roles are
+/// closed) and the anonymous form `augment class { ... }` (X::Anon::Augment).
 pub(crate) fn augment_class_decl(input: &str) -> PResult<'_, Stmt> {
     let rest =
         keyword("augment", input).ok_or_else(|| PError::expected("augment class declaration"))?;
     let (rest, _) = ws1(rest)?;
-    let rest = keyword("class", rest).ok_or_else(|| PError::expected("'class' after 'augment'"))?;
+    let (rest, is_role) = if let Some(r) = keyword("class", rest) {
+        (r, false)
+    } else if let Some(r) = keyword("role", rest) {
+        (r, true)
+    } else {
+        return Err(PError::expected("'class' or 'role' after 'augment'"));
+    };
     let (rest, _) = ws1(rest)?;
+    // Anonymous augment (`augment class { }` / `augment role { }`) — no name
+    // follows the package kind. Raku rejects this with X::Anon::Augment.
+    let package_kind = if is_role { "role" } else { "class" };
+    if rest.starts_with('{') {
+        let msg = format!("Cannot augment anonymous {}", package_kind);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        attrs.insert(
+            "package-kind".to_string(),
+            Value::str(package_kind.to_string()),
+        );
+        let ex = Value::make_instance(Symbol::intern("X::Anon::Augment"), attrs);
+        return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+    }
     let (rest, name) = qualified_ident(rest)?;
     // Check for type adverbs (:D, :U, :auth, :ver, :api) which are not allowed on augment
     if rest.starts_with(':') && !rest.starts_with("::") {
@@ -837,6 +859,7 @@ pub(crate) fn augment_class_decl(input: &str) -> PResult<'_, Stmt> {
         Stmt::AugmentClass {
             name: Symbol::intern(&name),
             body,
+            is_role,
         },
     ))
 }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2422,6 +2422,57 @@ impl Interpreter {
         Ok(deferred_custom_traits)
     }
 
+    /// Build the error for `augment role RoleName { ... }`. Roles are always
+    /// closed, so augmenting one is illegal — but if the role does not exist at
+    /// all, Raku reports that first (X::Augment::NoSuchType), matching the
+    /// ordering used for `augment class`.
+    pub(crate) fn augment_role_error(&self, name: &str) -> RuntimeError {
+        // Built-in roles that are closed but not present in the user registry.
+        const BUILTIN_ROLES: &[&str] = &[
+            "Positional",
+            "Associative",
+            "Callable",
+            "Iterable",
+            "Numeric",
+            "Real",
+            "Stringy",
+            "Mixy",
+            "Setty",
+            "Baggy",
+            "Blob",
+            "Buf",
+        ];
+        let exists = self.registry().roles.contains_key(name)
+            || self.registry().classes.contains_key(name)
+            || crate::runtime::utils::is_known_type_constraint(name)
+            || BUILTIN_ROLES.contains(&name);
+        if exists {
+            let message = format!("Cannot augment {} because it is closed", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let ex = Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Augment::Illegal"),
+                attrs,
+            );
+            let mut err = RuntimeError::new(message);
+            err.exception = Some(Box::new(ex));
+            err
+        } else {
+            let message = format!("You tried to augment role {}, but it does not exist", name);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            attrs.insert("package-kind".to_string(), Value::str("role".to_string()));
+            attrs.insert("package".to_string(), Value::str(name.to_string()));
+            let ex = Value::make_instance(
+                crate::symbol::Symbol::intern("X::Augment::NoSuchType"),
+                attrs,
+            );
+            let mut err = RuntimeError::new(message);
+            err.exception = Some(Box::new(ex));
+            err
+        }
+    }
+
     /// Augment an existing class by adding methods (and attributes) from the body.
     /// This implements `augment class ClassName { ... }` (monkey-patching).
     pub(crate) fn augment_class(&mut self, name: &str, body: &[Stmt]) -> Result<(), RuntimeError> {

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -325,7 +325,7 @@ impl Interpreter {
 
             // `augment class C { class Nested {} }` redeclares a nested type that
             // the original declaration of C already declared.
-            if let Stmt::AugmentClass { name, body } = stmt {
+            if let Stmt::AugmentClass { name, body, .. } = stmt {
                 let cname = name.resolve().to_string();
                 if let Some(existing) = class_nested.get(&cname) {
                     for nested in collect_nested(body) {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1388,7 +1388,12 @@ impl VM {
         idx: u32,
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::AugmentClass { name, body } = stmt {
+        if let Stmt::AugmentClass {
+            name,
+            body,
+            is_role,
+        } = stmt
+        {
             let name_str = name.resolve();
             // Check MONKEY-TYPING pragma: we check if `use MONKEY-TYPING` or `use MONKEY`
             // was issued. Since the compiler simply ignores these `use` statements,
@@ -1398,6 +1403,9 @@ impl VM {
                     "X::Syntax::Augment::WithoutMonkeyTyping",
                     "augment not allowed without 'use MONKEY-TYPING'",
                 ));
+            }
+            if *is_role {
+                return Err(self.interpreter.augment_role_error(&name_str));
             }
             self.interpreter.augment_class(&name_str, body)?;
             // Recompile augmented class methods for the fast path

--- a/t/augment-role-anon.t
+++ b/t/augment-role-anon.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 7;
+
+# Roles are always closed: augmenting one is illegal.
+throws-like 'use MONKEY-TYPING; augment role Positional { }',
+    X::Syntax::Augment::Illegal;
+throws-like 'use MONKEY-TYPING; augment role Associative { }',
+    X::Syntax::Augment::Illegal;
+
+# A user-defined role is also closed.
+throws-like 'role R { }; use MONKEY-TYPING; augment role R { }',
+    X::Syntax::Augment::Illegal;
+
+# A non-existent role reports that first.
+throws-like 'use MONKEY-TYPING; augment role NoSuchRole { }',
+    X::Augment::NoSuchType, package-kind => 'role';
+
+# An anonymous augment has no package name.
+throws-like 'use MONKEY-TYPING; augment class { }',
+    X::Anon::Augment, package-kind => 'class';
+throws-like 'use MONKEY-TYPING; augment role { }',
+    X::Anon::Augment, package-kind => 'role';
+
+# Augmenting an existing class is still legal.
+is-deeply EVAL('class C { method a { 1 } }; use MONKEY-TYPING; augment class C { method b { 2 } }; C.new.b'),
+    2, 'augmenting an existing class still works';


### PR DESCRIPTION
## Summary

Two `augment` forms were silently no-ops because the parser required the keyword `class` immediately after `augment` and a name after it:

- **`augment role X { }`** — roles are always closed, so augmenting one is illegal. Raku throws `X::Syntax::Augment::Illegal` (*"Cannot augment X because it is closed"*) when the role exists (user-defined or a built-in role such as `Positional`), and `X::Augment::NoSuchType` when it does not.
- **`augment class { }` / `augment role { }`** (anonymous) — Raku throws `X::Anon::Augment` (*"Cannot augment anonymous class/role"*).

The parser now accepts both `class` and `role` after `augment`, raises a fatal `X::Anon::Augment` when no name follows the package kind, and records the kind on `Stmt::AugmentClass` via a new `is_role` flag. At registration time a role augment routes to the new `augment_role_error`, which picks `Illegal` vs `NoSuchType` based on whether the role resolves. Legal class augmentation is unchanged.

## Test

- New `t/augment-role-anon.t` (7 cases)
- Fixes `roast/S32-exceptions/misc2.t` tests 65 and 164

🤖 Generated with [Claude Code](https://claude.com/claude-code)