### PR TITLE
feat(exceptions): carry adverb/construct on X::Syntax::Regex::Adverb

### DIFF
--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -45,12 +45,16 @@ fn validate_regex_pattern_or_perror(pattern: &str) -> Result<(), PError> {
     })
 }
 
-fn regex_adverb_error(adverb: &str, message: impl Into<String>) -> PError {
-    let err = RuntimeError::typed_msg("X::Syntax::Regex::Adverb", message);
-    let message = err.message;
-    let exception = err.exception.expect("typed regex adverb error");
-    let _ = adverb;
-    PError::fatal_with_exception(message, exception)
+fn regex_adverb_error(adverb: &str, construct: Option<&str>, message: impl Into<String>) -> PError {
+    let message = message.into();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("adverb".to_string(), Value::str(adverb.to_string()));
+    if let Some(c) = construct {
+        attrs.insert("construct".to_string(), Value::str(c.to_string()));
+    }
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Regex::Adverb"), attrs);
+    PError::fatal_with_exception(message, Box::new(ex))
 }
 
 /// Reject adverbs that make no sense on a substitution. `:overlap`/`:ov` and
@@ -60,13 +64,18 @@ fn regex_adverb_error(adverb: &str, message: impl Into<String>) -> PError {
 fn reject_subst_only_adverbs(adverbs: &MatchAdverbs) -> Result<(), PError> {
     if adverbs.overlap {
         return Err(regex_adverb_error(
-            "overlap",
+            adverbs.first_match_adverb.as_deref().unwrap_or("overlap"),
+            Some("substitution"),
             "Adverb overlap not allowed on substitution",
         ));
     }
     if adverbs.exhaustive {
         return Err(regex_adverb_error(
-            "exhaustive",
+            adverbs
+                .first_match_adverb
+                .as_deref()
+                .unwrap_or("exhaustive"),
+            Some("substitution"),
             "Adverb exhaustive not allowed on substitution",
         ));
     }
@@ -145,6 +154,10 @@ struct MatchAdverbs {
     pos: bool,
     continue_: bool,
     nth: Option<String>,
+    /// The first match-time adverb name as written by the user (`g`, `global`,
+    /// `ov`, `ex`, ...). Used to report X::Syntax::Regex::Adverb.adverb when a
+    /// match-time adverb appears where it is not allowed (rx// / substitution).
+    first_match_adverb: Option<String>,
 }
 
 fn is_regex_quote_open(ch: char) -> bool {
@@ -257,6 +270,26 @@ fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
             return Err(PError::fatal_with_exception(message, Box::new(ex)));
         }
 
+        // Record the first match-time adverb (those not allowed on rx// or
+        // substitution) under its written name, for error reporting.
+        if adverbs.first_match_adverb.is_none()
+            && matches!(
+                name.as_str(),
+                "g" | "global"
+                    | "ex"
+                    | "exhaustive"
+                    | "ov"
+                    | "overlap"
+                    | "p"
+                    | "pos"
+                    | "c"
+                    | "continue"
+                    | "nth"
+                    | "x"
+            )
+        {
+            adverbs.first_match_adverb = Some(name.clone());
+        }
         if name == "g" || name == "global" {
             adverbs.global = true;
         } else if name == "ex" || name == "exhaustive" {
@@ -319,6 +352,7 @@ fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
         } else {
             return Err(regex_adverb_error(
                 &name,
+                None,
                 format!("Unsupported regex adverb :{}", name),
             ));
         }
@@ -1156,7 +1190,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             || adverbs.continue_
         {
             return Err(regex_adverb_error(
-                "rx",
+                adverbs.first_match_adverb.as_deref().unwrap_or("g"),
+                Some("rx"),
                 "Match-time adverbs are not allowed on rx// regex literals",
             ));
         }

--- a/t/regex-adverb-error.t
+++ b/t/regex-adverb-error.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 8;
+
+# Match-time adverbs are not allowed on rx// regex literals.
+throws-like 'rx:g/a/',  X::Syntax::Regex::Adverb, adverb => 'g',  construct => 'rx';
+throws-like 'rx:ov/a/', X::Syntax::Regex::Adverb, adverb => 'ov', construct => 'rx';
+throws-like 'rx:ex/a/', X::Syntax::Regex::Adverb, adverb => 'ex', construct => 'rx';
+throws-like 'rx:global/a/', X::Syntax::Regex::Adverb,
+    adverb => 'global', construct => 'rx';
+
+# :overlap / :exhaustive make no sense on a substitution.
+throws-like 'my $x = "a"; $x ~~ s:overlap/a/b/', X::Syntax::Regex::Adverb,
+    adverb => 'overlap', construct => 'substitution';
+throws-like 'my $x = "a"; $x ~~ s:exhaustive/a/b/', X::Syntax::Regex::Adverb,
+    adverb => 'exhaustive', construct => 'substitution';
+
+# Compile-time switch adverbs are still fine on rx//.
+ok 'abc' ~~ rx:i/ABC/, ':i is allowed on rx//';
+
+# :g is allowed on m//.
+ok ('a1b2' ~~ m:g/\d/).elems == 2, ':g is allowed on m//';


### PR DESCRIPTION
## Summary

mutsu already rejected match-time adverbs on `rx//` literals (`rx:g/a/`) and `:overlap`/`:exhaustive` on substitutions with `X::Syntax::Regex::Adverb`, but the exception carried only a message — not the `adverb` and `construct` attributes Raku exposes.

`regex_adverb_error` now builds the instance directly with:
- **`adverb`** — the offending adverb as the user wrote it (`g`, `ov`, `global`, ...)
- **`construct`** — `rx` or `substitution`

`MatchAdverbs` gained a `first_match_adverb` field that records the first match-time adverb's written name during parsing, so the reported adverb matches the source exactly (raku reports `g` vs `global` as written).

## Test

- New `t/regex-adverb-error.t` (8 cases)
- Fixes `roast/S32-exceptions/misc2.t` test 169

🤖 Generated with [Claude Code](https://claude.com/claude-code)