### PR TITLE
feat(exceptions): X::Backslash::NonVariableDollar for a bare $ in a string

### DIFF
--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -18,6 +18,16 @@ pub(super) fn unrecognized_backslash_perror(seq: char) -> PError {
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 
+/// Build the structured `X::Backslash::NonVariableDollar` parse error for a bare
+/// `$` inside an interpolating string that does not introduce a variable.
+pub(super) fn non_variable_dollar_perror() -> PError {
+    let msg = "Non-variable $ must be backslashed".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    let ex = Value::make_instance(Symbol::intern("X::Backslash::NonVariableDollar"), attrs);
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn make_list_expr(items: Vec<Expr>) -> Expr {
     Expr::Call {
         name: Symbol::intern("list"),
@@ -2676,6 +2686,16 @@ pub(super) fn double_quoted_string(input: &str) -> PResult<'_, Expr> {
                 rest = &rest[end + 1..];
                 continue;
             }
+        }
+        // A `$` that reached here did not introduce a variable or `${...}`/
+        // `{...}` interpolation, so it is a non-variable dollar and must be
+        // backslashed (Raku: "Non-variable $ must be backslashed"). A `$`
+        // immediately followed by another sigil (`$@arr`, `$$aref`, `$%hash`,
+        // `$&code`) is a contextualizer prefix on the following sigil-variable,
+        // not a bare dollar — leave it so the sigil-variable interpolates on
+        // the next iteration.
+        if rest.starts_with('$') && !rest[1..].starts_with(['$', '@', '%', '&']) {
+            return Err(non_variable_dollar_perror());
         }
         let ch = rest.chars().next().unwrap();
         current.push(ch);

--- a/t/non-variable-dollar.t
+++ b/t/non-variable-dollar.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 9;
+
+# A bare `$` in an interpolating string must be backslashed.
+throws-like '"$"',       X::Backslash::NonVariableDollar;
+throws-like '"a$"',      X::Backslash::NonVariableDollar;
+throws-like '"$ x"',     X::Backslash::NonVariableDollar;
+throws-like '"price $"', X::Backslash::NonVariableDollar;
+
+# A backslashed dollar is a literal `$`.
+is "money \$5", 'money $5', 'backslashed dollar is literal';
+
+# Normal variable interpolation is unaffected.
+my $x = 42;
+is "v=$x", 'v=42', 'scalar interpolation works';
+
+# A `$` before another sigil is a contextualizer prefix, not a bare dollar:
+# the following sigil-variable interpolates (here undeclared -> X::Undeclared).
+throws-like '"$@whoopsies[]"', X::Undeclared, symbol => '@whoopsies';
+throws-like '"$%whoopsies{}"', X::Undeclared, symbol => '%whoopsies';
+
+# A `$` before a sigil must not be rejected as a bare dollar (full deref
+# interpolation of `$@arr` is a separate, pre-existing limitation).
+lives-ok { my @arr = 1, 2, 3; EVAL '"$@arr"' },
+    'sigil-prefixed dollar is not rejected as a non-variable dollar';


### PR DESCRIPTION
## Summary

A `$` inside an interpolating double-quoted string that does not introduce a variable or `${...}`/`{...}` interpolation must be backslashed. Raku rejects it at compile time:

```
"$"
# ===SORRY!=== Non-variable $ must be backslashed
```

Previously mutsu silently treated the dollar as a literal character.

`double_quoted_string` now raises a fatal `X::Backslash::NonVariableDollar` when a `$` falls through all interpolation handling — **except** when it is immediately followed by another sigil (`$@arr`, `$$aref`, `$%hash`, `$&code`), where the `$` is a contextualizer prefix on the following sigil-variable (which interpolates on the next iteration). That carve-out keeps `roast/S02-literals/string-interpolation.t` passing.

## Test

- New `t/non-variable-dollar.t` (9 cases)
- Fixes `roast/S32-exceptions/misc2.t` test 143

🤖 Generated with [Claude Code](https://claude.com/claude-code)