### PR TITLE
fix: make `use MONKEY-TYPING` lexically scoped

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1178,7 +1178,14 @@ pub(crate) type RoutineRegistrySnapshot = (
     HashSet<Symbol>,
 );
 
-pub(crate) type ImportScopeSnapshot = (HashSet<Symbol>, HashSet<String>, NewlineMode, bool, bool);
+pub(crate) type ImportScopeSnapshot = (
+    HashSet<Symbol>,
+    HashSet<String>,
+    NewlineMode,
+    bool,
+    bool,
+    bool,
+);
 
 impl Default for Interpreter {
     fn default() -> Self {
@@ -3444,14 +3451,21 @@ impl Interpreter {
             self.newline_mode,
             self.strict_mode,
             self.fatal_mode,
+            self.monkey_typing,
         ));
     }
 
     /// Restore function/class registries to the last saved snapshot,
     /// removing any entries added since the push.
     pub(crate) fn pop_import_scope(&mut self) {
-        if let Some((func_snapshot, class_snapshot, newline_mode, strict_mode, fatal_mode)) =
-            self.import_scope_stack.pop()
+        if let Some((
+            func_snapshot,
+            class_snapshot,
+            newline_mode,
+            strict_mode,
+            fatal_mode,
+            monkey_typing,
+        )) = self.import_scope_stack.pop()
         {
             self.registry_mut()
                 .functions
@@ -3462,6 +3476,7 @@ impl Interpreter {
             self.newline_mode = newline_mode;
             self.strict_mode = strict_mode;
             self.fatal_mode = fatal_mode;
+            self.monkey_typing = monkey_typing;
         }
     }
 

--- a/t/monkey-typing-lexical.t
+++ b/t/monkey-typing-lexical.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 4;
+
+# `use MONKEY-TYPING` is lexical: a `use` inside a block does not enable
+# augmentation outside that block.
+throws-like '{ use MONKEY-TYPING; }; augment class Any { }',
+    X::Syntax::Augment::WithoutMonkeyTyping,
+    'MONKEY-TYPING applies lexically';
+
+# Without any MONKEY-TYPING, augment is rejected.
+throws-like 'augment class Any { }',
+    X::Syntax::Augment::WithoutMonkeyTyping,
+    'augment without MONKEY-TYPING is rejected';
+
+# MONKEY-TYPING in scope (same block) allows augmentation.
+is EVAL('{ use MONKEY-TYPING; augment class Int { method ttt { 7 } }; 3.ttt }'),
+    7, 'augment works inside the MONKEY-TYPING block';
+
+# Top-level MONKEY-TYPING enables augmentation for the rest of the unit.
+is EVAL('use MONKEY-TYPING; augment class Int { method uuu { 9 } }; 5.uuu'),
+    9, 'top-level MONKEY-TYPING enables augmentation';


### PR DESCRIPTION
## Summary

`use MONKEY-TYPING` set a single interpreter-global flag that never reverted, so a `use MONKEY-TYPING` inside a block leaked out and allowed augmentation in the enclosing scope. Raku applies the pragma lexically:

```
{ use MONKEY-TYPING; }; augment class Any { }
# ===SORRY!=== augment not allowed without 'use MONKEY-TYPING'
```

The block import-scope snapshot (`push_import_scope`/`pop_import_scope`) already saves and restores the other lexical pragmas (`newline`/`strict`/`fatal`); this adds `monkey_typing` to that snapshot so it reverts at block exit. Blocks containing a `use` already emit `PushImportScope`/`PopImportScope`, so no new compiler wiring is needed.

## Test

- New `t/monkey-typing-lexical.t` (4 cases)
- Fixes `roast/S32-exceptions/misc2.t` test 64 ("MONKEY-TYPING applies lexically")

🤖 Generated with [Claude Code](https://claude.com/claude-code)