### PR TITLE
feat(exceptions): X::Syntax::Pod::BeginWithoutIdentifier for bare =begin

### DIFF
--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -81,10 +81,18 @@ fn ws_inner_with_bol(input: &str, bol: bool) -> PResult<'_, ()> {
             }
         }
         // Pod blocks only appear at the start of a line
-        if at_line_start && let Ok((r, _)) = pod_block(r) {
-            rest = r;
-            at_line_start = true;
-            continue;
+        if at_line_start {
+            match pod_block(r) {
+                Ok((r, _)) => {
+                    rest = r;
+                    at_line_start = true;
+                    continue;
+                }
+                // A fatal Pod error (e.g. `=begin` without an identifier) must
+                // propagate, not be silently treated as "not a Pod block".
+                Err(e) if e.is_fatal() => return Err(e),
+                Err(_) => {}
+            }
         }
         break;
     }
@@ -185,6 +193,18 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         let begin_line_end = rest.find('\n').unwrap_or(rest.len());
         let begin_line = &rest[..begin_line_end];
         let target = begin_line.split_whitespace().next().unwrap_or("");
+        // `=begin` must be followed by an identifier (the block name).
+        if target.is_empty() {
+            let msg = "=begin must be followed by an identifier; (did you mean \"=begin pod\"?)"
+                .to_string();
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Pod::BeginWithoutIdentifier"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+        }
         let is_table = target == "table";
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();
         let mut depth = 1usize;

--- a/t/pod-begin-without-identifier.t
+++ b/t/pod-begin-without-identifier.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 5;
+
+# `=begin` must be followed by an identifier naming the block.
+throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier;
+throws-like "=begin   \n", X::Syntax::Pod::BeginWithoutIdentifier;
+
+# The error propagates even when the bare `=begin` is not the first statement.
+throws-like "say 1; =begin\nsay 2;", X::Syntax::Pod::BeginWithoutIdentifier;
+
+# `=begin pod ... =end pod` is valid and produces no runtime output.
+is EVAL("=begin pod\nHello\n=end pod\n42"), 42,
+    'named =begin pod block parses';
+
+# `=begin code` is also valid.
+is EVAL("=begin code\nsome code\n=end code\n7"), 7,
+    'named =begin code block parses';


### PR DESCRIPTION
## Summary

A Pod `=begin` directive must be followed by an identifier naming the block. A bare `=begin` (no target) is rejected by Raku at compile time:

```
=begin
# ===SORRY!=== =begin must be followed by an identifier; (did you mean "=begin pod"?)
```

Previously mutsu's `pod_block` silently consumed the rest of the input looking for a matching `=end ` with an empty target.

Two changes:
- `pod_block` returns a fatal `X::Syntax::Pod::BeginWithoutIdentifier` for an empty `=begin` target.
- `ws()` now **propagates** a fatal Pod error instead of treating it as "not a Pod block" (the `let Ok(..) = pod_block(..)` arm previously swallowed it), so the error surfaces even when the bare `=begin` is not the first statement.

Named blocks (`=begin pod`, `=begin code`, ...) are unaffected.

## Test

- New `t/pod-begin-without-identifier.t` (5 cases)
- Fixes `roast/S32-exceptions/misc2.t` test 94

🤖 Generated with [Claude Code](https://claude.com/claude-code)