### PR TITLE
feat(exceptions): X::Bind for call / pseudo-package bind left-hand sides

### DIFF
--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -93,6 +93,27 @@ fn is_literal_expr(expr: &Expr) -> bool {
     matches!(expr, Expr::Literal(_))
 }
 
+/// True for the Raku pseudo-package names (lexical/dynamic scope pseudo-stashes).
+/// Binding to one of these (`OUTER := 5`) is illegal → X::Bind.
+fn is_pseudo_package(name: &str) -> bool {
+    matches!(
+        name,
+        "MY" | "OUR"
+            | "CORE"
+            | "GLOBAL"
+            | "PROCESS"
+            | "UNIT"
+            | "SETTING"
+            | "OUTER"
+            | "CALLER"
+            | "CALLERS"
+            | "DYNAMIC"
+            | "COMPILING"
+            | "CLIENT"
+            | "LEXICAL"
+    )
+}
+
 /// Extract variable names from a Signature literal expression for signature binding.
 /// Returns None if the expression is not a Signature literal.
 /// Returns Some(Vec<String>) where each string is either a variable name (e.g., "f")
@@ -1287,8 +1308,29 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             );
             return Err(PError::fatal_with_exception(message, Box::new(ex)));
         }
-        // Reject binding to a literal: `0 := 1` → X::Bind
-        if is_literal_expr(&expr) {
+        // Reject binding to a pseudo-package (`OUTER := 5`) → X::Bind with target.
+        if let Expr::BareWord(name) = &expr
+            && is_pseudo_package(name)
+        {
+            let message = format!("Cannot bind to pseudo-package {}", name);
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Bind"),
+                std::collections::HashMap::from([
+                    (
+                        "message".to_string(),
+                        crate::value::Value::str(message.clone()),
+                    ),
+                    (
+                        "target".to_string(),
+                        crate::value::Value::str(name.to_string()),
+                    ),
+                ]),
+            );
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
+        // Reject binding to a literal (`0 := 1`) or a function call (`f() := 2`)
+        // — neither is a bindable container. → X::Bind
+        if is_literal_expr(&expr) || matches!(expr, Expr::Call { .. }) {
             let ex = crate::value::Value::make_instance(
                 crate::symbol::Symbol::intern("X::Bind"),
                 std::collections::HashMap::from([(

--- a/t/bind-invalid-lhs.t
+++ b/t/bind-invalid-lhs.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 6;
+
+# Binding to a function call is illegal.
+throws-like 'sub f() { }; f() := 2', X::Bind;
+throws-like 'sub g($x) { }; g(1) := 2', X::Bind;
+
+# Binding to a pseudo-package is illegal.
+throws-like 'OUTER := 5', X::Bind, target => /OUTER/;
+throws-like 'MY := 5', X::Bind, target => /MY/;
+
+# Ordinary binds remain valid.
+my $x;
+$x := 2;
+is $x, 2, 'scalar bind works';
+
+my @a;
+@a[0] := 9;
+is @a[0], 9, 'array element bind works';


### PR DESCRIPTION
## Summary

Binding to a function call (`f() := 2`) or a pseudo-package (`OUTER := 5`) is illegal in Raku — neither is a bindable container. Previously mutsu silently accepted both.

The `:=` bind handler now rejects:
- a **pseudo-package** bareword LHS (`MY`/`OUR`/`CORE`/`OUTER`/`CALLER`/...) with `X::Bind` carrying `target`, message *"Cannot bind to pseudo-package X"*;
- a **function-call** LHS (`Expr::Call`) with `X::Bind`, message *"Cannot use bind operator with this left-hand side"* (alongside the existing literal-LHS rejection).

Scalar / array-element / signature binds are unaffected.

## Test

- New `t/bind-invalid-lhs.t` (6 cases)
- Fixes `roast/S32-exceptions/misc2.t` tests 38 and 39

🤖 Generated with [Claude Code](https://claude.com/claude-code)