### PR TITLE
Phase 3 Stage 1: shared mutable instance attribute cells

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -192,9 +192,25 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
       Deref 撤去でコンパイラが ~197 サイトを列挙：deref-coercion（`fn(&HashMap)` へ `&Arc<InstanceAttrs>` 渡し）は
       `.as_map()` へ、`(**attributes).clone()` は `.to_map()` へ機械置換。make test 6112 全緑・cargo test 458/0・
       clippy 緑。これで Stage 1（内部を共有可変セルへ）の表現切替が局所化された。
-- [ ] **Stage 1 — 表現切替（共有セル化）**: `InstanceAttrs` 内部を `Arc<RwLock<HashMap>>` に。read は Stage 0 の
-      API（read-lock + clone）、変異は **in-place（write-lock で書く）**。clone は **セルを共有**（Arc clone）。
-      これで closure 跨ぎの変異が caller に可視になり、note/$*ERR バグが解消。
+- [x] **Stage 1 — 表現切替（共有セル化）完了**: `InstanceAttrs.attributes` を `HashMap` → `Arc<RwLock<HashMap>>`
+      （`AttrCell`）に。`Value::Instance` は従来どおり `Arc<InstanceAttrs>` を保持。
+  - **read API**: `as_map()` は `RwLockReadGuard`（`Deref`→`&HashMap`）を返す。チェーン呼び（`.get`/`.iter`/`for`）は
+        無改変、`fn(&HashMap)` へ渡す ~87 サイトは `&` 付与のみ。`get()`（owned 化は `*x`/`.cloned()`/`and_then(fn(&Value))`
+        を全部壊す）は**削除**し、全 `.get()` を `.as_map().get()` へ降ろして借用セマンティクスを温存（504 サイト機械置換）。
+  - **mutation**: `insert`/`insert_if_absent`/`with_attr_mut` は `&self`（write-lock で in-place）。`make_mut(attributes)`
+        サイトは直接 `&self` 変異へ。
+  - **クロスフレーム可視化（バグ修正の本体）**: `id→Weak<cell>` レジストリ（`instance_cells`）を新設。
+        `make_instance_with_id` は既存の生きたセルを**再利用**（map を書き込んで alias 共有のインスタンスを返す）。
+        `overwrite_instance_bindings_by_identity` はスキャン前に `update_instance_cell(id, &updated)` で**生きたセルへ
+        直接書き込む** → スキャンが訪れない caller フレームの alias にも変異が届く。これで `note`/$*ERR・closure 経由
+        instance mutation が解消。レジストリは Stage 2 で scan ごと撤去するための足場。
+  - **`.clone`（Raku 独立コピー）保全**: `InstanceAttrs::clone` を手書きで**deep copy（新セル・queue_destroy=false・
+        非登録）**に。共有は `Arc<InstanceAttrs>`（Value clone）経由のみ。これで ~30 の `(*attributes).clone()`
+        writeback サイトは無改変で独立コピー意味論を維持。`temp`/`let` save も同型の独立スナップショットが必要だった
+        （`into_temp_snapshot` で instance を deep copy、restore は `make_instance_with_id` で**生きたセルへ書き戻し**
+        identity と alias 可視性を保つ）— これを怠ると `t/lvalue-method-rw.t` の temp 復元が壊れる（実際に踏んで修正）。
+  - 検証: cross-frame note/closure mutation・alias 共有・`.clone` 独立・`===`/`.WHICH`/`eqv` identity・DESTROY(1回)・
+        temp/let 復元 すべて raku 一致。clippy 緑。
 - [ ] **Stage 2 — 伝播ハック全廃**: `overwrite_instance_bindings_by_identity` と by-id scan、CoW `make_mut` 16 箇所を
       削除（変異が by-reference で可視になったので不要）。dual-store の instance writeback 経路も縮小。
 - [ ] **Stage 3 — 仕上げ / perf**: escape 解析で「捕捉も `.clone` もされない instance はセル省略」（hot path 救済。

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -176,7 +176,7 @@ fn instance_days(value: &Value) -> Option<i64> {
             class_name,
             attributes,
             ..
-        } if class_name == "Date" => match attributes.get("days") {
+        } if class_name == "Date" => match attributes.as_map().get("days") {
             Some(Value::Int(days)) => Some(*days),
             _ => None,
         },
@@ -190,7 +190,10 @@ fn instance_instant_value(value: &Value) -> Option<f64> {
             class_name,
             attributes,
             ..
-        } if class_name == "Instant" => attributes.get("value").and_then(runtime::to_float_value),
+        } if class_name == "Instant" => attributes
+            .as_map()
+            .get("value")
+            .and_then(runtime::to_float_value),
         _ => None,
     }
 }
@@ -200,7 +203,7 @@ fn instance_instant_raw(value: &Value) -> Option<Value> {
             class_name,
             attributes,
             ..
-        } if class_name == "Instant" => attributes.get("value").cloned(),
+        } if class_name == "Instant" => attributes.as_map().get("value").cloned(),
         _ => None,
     }
 }
@@ -220,7 +223,10 @@ fn instance_duration_value(value: &Value) -> Option<f64> {
             class_name,
             attributes,
             ..
-        } if class_name == "Duration" => attributes.get("value").and_then(runtime::to_float_value),
+        } if class_name == "Duration" => attributes
+            .as_map()
+            .get("value")
+            .and_then(runtime::to_float_value),
         _ => None,
     }
 }
@@ -232,7 +238,7 @@ fn instance_duration_raw_value(value: &Value) -> Option<Value> {
             class_name,
             attributes,
             ..
-        } if class_name == "Duration" => attributes.get("value").cloned(),
+        } if class_name == "Duration" => attributes.as_map().get("value").cloned(),
         _ => None,
     }
 }
@@ -298,7 +304,7 @@ fn instance_datetime_parts(value: &Value) -> Option<(i64, i64, i64, i64, i64, f6
                 && attributes.contains_key("timezone") =>
         {
             Some(crate::builtins::methods_0arg::temporal::datetime_attrs(
-                (attributes).as_map(),
+                &(attributes).as_map(),
             ))
         }
         _ => None,

--- a/src/builtins/collation.rs
+++ b/src/builtins/collation.rs
@@ -38,6 +38,7 @@ impl CollationSettings {
             Value::Instance { attributes, .. } => {
                 let get_i64 = |name: &str| -> i64 {
                     attributes
+                        .as_map()
                         .get(name)
                         .map(|v| match v {
                             Value::Int(n) => *n,

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1037,7 +1037,7 @@ fn native_function_2arg(
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Failure" => attributes.get("exception").cloned(),
+            } if class_name == "Failure" => attributes.as_map().get("exception").cloned(),
             Value::Mixin(inner, mixins) => {
                 if let Some(mixed) = mixins.get("Failure")
                     && let Some(ex) = failure_exception(mixed)

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -147,9 +147,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Pair" => {
-                Some(Ok(attributes.get("key").cloned().unwrap_or(Value::Nil)))
-            }
+            } if class_name == "Pair" => Some(Ok(attributes
+                .as_map()
+                .get("key")
+                .cloned()
+                .unwrap_or(Value::Nil))),
             Value::Bool(true) => Some(Ok(Value::str_from("True"))),
             Value::Bool(false) => Some(Ok(Value::str_from("False"))),
             _ => None,
@@ -161,12 +163,17 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 attributes,
                 ..
             } if class_name == "Pair" => {
-                if let (Some(Value::Hash(hash)), Some(Value::Str(key))) =
-                    (attributes.get("__mutsu_hash_ref"), attributes.get("key"))
-                {
+                if let (Some(Value::Hash(hash)), Some(Value::Str(key))) = (
+                    attributes.as_map().get("__mutsu_hash_ref"),
+                    attributes.as_map().get("key"),
+                ) {
                     Some(Ok(hash.get(key.as_str()).cloned().unwrap_or(Value::Nil)))
                 } else {
-                    Some(Ok(attributes.get("value").cloned().unwrap_or(Value::Nil)))
+                    Some(Ok(attributes
+                        .as_map()
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Nil)))
                 }
             }
             Value::Bool(b) => Some(Ok(Value::Int(if *b { 1 } else { 0 }))),
@@ -230,7 +237,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     || cn.starts_with("blob")
             } =>
             {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     Some(Ok(Value::Array(
                         items.clone(),
                         crate::value::ArrayKind::List,
@@ -360,7 +367,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 attributes,
                 ..
             } if class_name == "Supply" => {
-                let items = match attributes.get("values") {
+                let items = match attributes.as_map().get("values") {
                     Some(Value::Array(items, ..)) => items.to_vec(),
                     _ => Vec::new(),
                 };
@@ -415,7 +422,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     || cn.starts_with("blob")
             } =>
             {
-                let bytes = match attributes.get("bytes") {
+                let bytes = match attributes.as_map().get("bytes") {
                     Some(Value::Array(items, ..)) => items.to_vec(),
                     _ => Vec::new(),
                 };

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -166,7 +166,7 @@ fn invert_value(target: &Value) -> Option<Value> {
         }
         // Instance types that compose Baggy: delegate to internal bag data
         Value::Instance { attributes, .. } => {
-            if let Some(bag_data) = attributes.get("__baggy_data__") {
+            if let Some(bag_data) = attributes.as_map().get("__baggy_data__") {
                 return invert_value(bag_data);
             }
             return None;

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -22,7 +22,7 @@ pub(super) fn dispatch(
             } = target
                 && class_name == "Failure"
                 && !target.is_failure_handled()
-                && let Some(ex) = attributes.get("exception")
+                && let Some(ex) = attributes.as_map().get("exception")
             {
                 let msg = ex.to_string_value();
                 let mut err = crate::value::RuntimeError::new(msg);
@@ -288,7 +288,7 @@ pub(super) fn dispatch(
                 ..
             } if class_name == "Failure" => {
                 // Using a Failure in string context throws the wrapped exception.
-                if let Some(ex) = attributes.get("exception") {
+                if let Some(ex) = attributes.as_map().get("exception") {
                     Some(Err(RuntimeError::from_exception_value(ex.clone())))
                 } else {
                     Some(Err(RuntimeError::new("Failed")))
@@ -343,6 +343,7 @@ pub(super) fn dispatch(
                     ..
                 } if class_name == "Instant" || class_name == "Duration" => {
                     let numeric = attributes
+                        .as_map()
                         .get("value")
                         .and_then(|v| match v {
                             Value::Int(i) => Some(*i as f64),
@@ -422,7 +423,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                         Value::Int(bytes.len() as i64)
                     } else {
                         Value::Int(0)
@@ -508,6 +509,7 @@ pub(super) fn dispatch(
                     ..
                 } if class_name == "Instant" || class_name == "Duration" => {
                     let numeric = attributes
+                        .as_map()
                         .get("value")
                         .and_then(|v| match v {
                             Value::Int(i) => Some(*i as f64),
@@ -653,6 +655,7 @@ pub(super) fn dispatch(
                     ..
                 } if class_name == "Instant" || class_name == "Duration" => {
                     let numeric = attributes
+                        .as_map()
                         .get("value")
                         .and_then(|v| match v {
                             Value::Int(i) => Some(*i as f64),
@@ -688,7 +691,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                         Value::Int(bytes.len() as i64)
                     } else {
                         Value::Int(0)
@@ -699,7 +702,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if class_name == "Stash" => {
-                    let count = match attributes.get("symbols") {
+                    let count = match attributes.as_map().get("symbols") {
                         Some(Value::Hash(map)) => map.len() as i64,
                         _ => 0,
                     };
@@ -724,6 +727,7 @@ pub(super) fn dispatch(
                     ..
                 } if class_name == "Instant" || class_name == "Duration" => {
                     let bridged = attributes
+                        .as_map()
                         .get("value")
                         .and_then(|v| match v {
                             Value::Int(i) => Some(*i as f64),

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -26,7 +26,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                         Some(Ok(Value::Int(bytes.len() as i64 - 1)))
                     } else {
                         Some(Ok(Value::Int(-1)))
@@ -142,11 +142,12 @@ pub(super) fn dispatch(
                 attributes,
                 ..
             } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                let mut bytes = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes =
+                    if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
+                        items.to_vec()
+                    } else {
+                        Vec::new()
+                    };
                 bytes.reverse();
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert("bytes".to_string(), Value::array(bytes));

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -126,14 +126,17 @@ fn cool_instance_numeric(target: &Value) -> Option<f64> {
     match class_name.resolve().as_str() {
         "IO::Path" => target.to_string_value().trim().parse::<f64>().ok(),
         "Match" => attributes
+            .as_map()
             .get("str")
             .and_then(|v| v.to_string_value().trim().parse::<f64>().ok()),
         "StrDistance" => {
             let before = attributes
+                .as_map()
                 .get("before")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
             let after = attributes
+                .as_map()
                 .get("after")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
@@ -415,7 +418,7 @@ pub(super) fn dispatch(
                 attributes,
                 ..
             } if matches!(class_name.resolve().as_str(), "Duration" | "Instant") => {
-                match attributes.get("value") {
+                match attributes.as_map().get("value") {
                     Some(inner) => match dispatch(inner, "Rat") {
                         Some(Some(r)) => Some(r),
                         _ => Some(Ok(make_rat(0, 1))),
@@ -572,7 +575,7 @@ pub(super) fn dispatch(
                 attributes,
                 ..
             } if class_name == "Failure" => {
-                if let Some(ex) = attributes.get("exception") {
+                if let Some(ex) = attributes.as_map().get("exception") {
                     let mut err = RuntimeError::new(ex.to_string_value());
                     err.exception = Some(Box::new(ex.clone()));
                     Some(Err(err))

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -108,7 +108,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                         Value::Int(bytes.len() as i64)
                     } else {
                         Value::Int(0)
@@ -146,7 +146,7 @@ pub(super) fn dispatch(
                     class_name,
                     attributes,
                     ..
-                } if class_name == "Stash" => match attributes.get("symbols") {
+                } if class_name == "Stash" => match attributes.as_map().get("symbols") {
                     Some(Value::Hash(map)) => Value::Int(map.len() as i64),
                     _ => Value::Int(0),
                 },

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -574,7 +574,7 @@ pub(super) fn dispatch(
                 attributes,
                 ..
             } => {
-                if let Some(constraint) = attributes.get("__keyof_constraint") {
+                if let Some(constraint) = attributes.as_map().get("__keyof_constraint") {
                     return Some(Some(Ok(constraint.clone())));
                 }
                 let cn = class_name.resolve();

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -141,6 +141,7 @@ pub(super) fn dispatch(
         } if class_name == "Signature" => {
             let attr_key = if method == "gist" { "gist" } else { "raku" };
             Some(Ok(attributes
+                .as_map()
                 .get(attr_key)
                 .cloned()
                 .unwrap_or_else(|| Value::str(format!("{}()", class_name)))))
@@ -151,7 +152,7 @@ pub(super) fn dispatch(
             ..
         } if class_name == "Parameter" && (method == "raku" || method == "perl") => {
             Some(Ok(Value::str(crate::value::signature::parameter_to_raku(
-                (attributes).as_map(),
+                &(attributes).as_map(),
             ))))
         }
         Value::Instance {
@@ -160,6 +161,7 @@ pub(super) fn dispatch(
             ..
         } if class_name == "Failure" => {
             let msg = attributes
+                .as_map()
                 .get("exception")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| "Failed".to_string());
@@ -177,7 +179,7 @@ pub(super) fn dispatch(
             } else {
                 // Str, Numeric, Int, etc. -- using a Failure in a value
                 // context throws the wrapped exception.
-                if let Some(ex) = attributes.get("exception") {
+                if let Some(ex) = attributes.as_map().get("exception") {
                     Some(Err(RuntimeError::from_exception_value(ex.clone())))
                 } else {
                     Some(Err(RuntimeError::new(&msg)))
@@ -191,10 +193,12 @@ pub(super) fn dispatch(
         } if class_name == "CallFrame" => {
             if method == "gist" {
                 let file = attributes
+                    .as_map()
                     .get("file")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
                 let line = attributes
+                    .as_map()
                     .get("line")
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|| "0".to_string());
@@ -202,10 +206,12 @@ pub(super) fn dispatch(
             } else {
                 // .raku: CallFrame.new(...)
                 let file = attributes
+                    .as_map()
                     .get("file")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
                 let line = attributes
+                    .as_map()
                     .get("line")
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|| "0".to_string());
@@ -220,7 +226,7 @@ pub(super) fn dispatch(
             attributes,
             ..
         } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-            if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+            if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                 if method == "raku" || method == "perl" {
                     let elems: Vec<String> = bytes
                         .iter()
@@ -295,7 +301,11 @@ pub(super) fn dispatch(
             attributes,
             ..
         } if class_name == "Instant" && (method == "raku" || method == "perl") => {
-            let tai = attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0);
+            let tai = attributes
+                .as_map()
+                .get("value")
+                .map(|v| v.to_f64())
+                .unwrap_or(0.0);
             let posix = crate::builtins::methods_0arg::temporal::instant_to_posix(tai);
             Some(Ok(Value::str(format!(
                 "Instant.from-posix({})",
@@ -307,7 +317,11 @@ pub(super) fn dispatch(
             attributes,
             ..
         } if class_name == "Duration" && (method == "raku" || method == "perl") => {
-            let val = attributes.get("value").cloned().unwrap_or(Value::Num(0.0));
+            let val = attributes
+                .as_map()
+                .get("value")
+                .cloned()
+                .unwrap_or(Value::Num(0.0));
             Some(Ok(Value::str(format!(
                 "Duration.new({})",
                 format_temporal_num(val.to_f64())
@@ -428,7 +442,7 @@ pub(super) fn dispatch(
             ..
         } if class_name == "Stash" && (method == "gist" || method == "Str") => {
             // Stash.gist and Stash.Str return the package name
-            if let Some(Value::Str(name)) = attributes.get("name") {
+            if let Some(Value::Str(name)) = attributes.as_map().get("name") {
                 Some(Ok(Value::str(name.to_string())))
             } else {
                 Some(Ok(Value::str(String::new())))
@@ -519,7 +533,7 @@ pub(super) fn dispatch(
                         attributes,
                         ..
                     } if class_name == "Match" => {
-                        crate::runtime::utils::match_gist((attributes).as_map(), 0)
+                        crate::runtime::utils::match_gist(&(attributes).as_map(), 0)
                     }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
@@ -577,7 +591,7 @@ pub(super) fn dispatch(
                         attributes,
                         ..
                     } if class_name == "Match" => {
-                        crate::runtime::utils::match_gist((attributes).as_map(), 0)
+                        crate::runtime::utils::match_gist(&(attributes).as_map(), 0)
                     }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -84,7 +84,7 @@ pub(super) fn dispatch(
             } = target
                 && class_name == "Iterator"
             {
-                let lazy = matches!(attributes.get("is_lazy"), Some(Value::Bool(true)));
+                let lazy = matches!(attributes.as_map().get("is_lazy"), Some(Value::Bool(true)));
                 return Some(Some(Ok(Value::Bool(lazy))));
             }
             // A consumed gather-based LazyList throws X::Seq::Consumed on .is-lazy

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -28,7 +28,8 @@ pub(super) fn dispatch(
                     || cn.starts_with("blob")
             } =>
             {
-                let elems = if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                let elems = if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes")
+                {
                     bytes.len() as i64
                 } else {
                     0

--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -63,7 +63,7 @@ fn value_raku_repr(val: &Value) -> String {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => match_raku_repr((attributes).as_map()),
+        } if class_name == "Match" => match_raku_repr(&(attributes).as_map()),
         Value::Array(items, ..) => {
             let items_raku: Vec<String> = items.iter().map(value_raku_repr).collect();
             format!("[{}]", items_raku.join(", "))
@@ -78,7 +78,7 @@ fn value_raku_repr(val: &Value) -> String {
 /// Extract the `from` position from a Match object value.
 pub(super) fn match_value_from(val: &Value) -> i64 {
     if let Value::Instance { attributes, .. } = val
-        && let Some(Value::Int(n)) = attributes.get("from")
+        && let Some(Value::Int(n)) = attributes.as_map().get("from")
     {
         return *n;
     }
@@ -88,7 +88,7 @@ pub(super) fn match_value_from(val: &Value) -> i64 {
 /// Extract the `to` position from a Match object value.
 pub(super) fn match_value_to(val: &Value) -> i64 {
     if let Value::Instance { attributes, .. } = val
-        && let Some(Value::Int(n)) = attributes.get("to")
+        && let Some(Value::Int(n)) = attributes.as_map().get("to")
     {
         return *n;
     }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -333,7 +333,7 @@ pub(crate) fn native_method_0arg(
     // Instance with __baggy_data__: delegate Bag-like methods to the inner Bag/Set
     // so that subclasses of Bag/Set (e.g. `my class MyBag is Bag {}`) work correctly.
     if let Value::Instance { attributes, .. } = target
-        && let Some(inner) = attributes.get("__baggy_data__")
+        && let Some(inner) = attributes.as_map().get("__baggy_data__")
         && !matches!(
             method,
             "WHAT" | "WHICH" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
@@ -880,13 +880,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     match target {
         Value::Instance { attributes, .. } if has_datetime_attrs(attributes) => {
             if let Some(result) =
-                temporal_dispatch::datetime_method_0arg((attributes).as_map(), method)
+                temporal_dispatch::datetime_method_0arg(&(attributes).as_map(), method)
             {
                 return Some(result);
             }
         }
         Value::Instance { attributes, .. } if has_date_attrs(attributes) => {
-            if let Some(result) = temporal_dispatch::date_method_0arg((attributes).as_map(), method)
+            if let Some(result) =
+                temporal_dispatch::date_method_0arg(&(attributes).as_map(), method)
             {
                 return Some(result);
             }
@@ -918,7 +919,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             use crate::builtins::methods_0arg::temporal;
             match method {
                 "to-posix" => {
-                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let val = attributes
+                        .as_map()
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Int(0));
                     let tai = crate::runtime::to_float_value(&val).unwrap_or(0.0);
                     let tai_int = tai.floor() as i64;
                     let mut is_leap = false;
@@ -937,7 +942,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     return Some(Ok(Value::array(vec![posix_val, Value::Bool(is_leap)])));
                 }
                 "DateTime" => {
-                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let val = attributes
+                        .as_map()
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Int(0));
                     let (tai_int, tai_frac) = match &val {
                         Value::Rat(n, d) if *d != 0 => (*n / *d, (*n % *d) as f64 / *d as f64),
                         _ => {
@@ -950,7 +959,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     return Some(Ok(temporal::make_datetime(y, m, d, h, mi, s, 0)));
                 }
                 "Date" => {
-                    let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                    let val = attributes
+                        .as_map()
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Int(0));
                     let tai = crate::runtime::to_float_value(&val).unwrap_or(0.0);
                     let posix = temporal::instant_to_posix(tai);
                     let (y, m, d) = temporal::epoch_days_to_civil((posix / 86400.0).floor() as i64);
@@ -958,6 +971,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 }
                 "tai" => {
                     return Some(Ok(attributes
+                        .as_map()
                         .get("value")
                         .cloned()
                         .unwrap_or(Value::Int(0))));
@@ -968,7 +982,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         if class_name == "Duration" {
             match method {
                 "narrow" => {
-                    let val = attributes.get("value").cloned().unwrap_or(Value::Num(0.0));
+                    let val = attributes
+                        .as_map()
+                        .get("value")
+                        .cloned()
+                        .unwrap_or(Value::Num(0.0));
                     // Delegate narrow to the inner numeric value
                     match val {
                         Value::Num(f) if f.is_finite() => {
@@ -1013,6 +1031,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 }
                 "tai" => {
                     return Some(Ok(attributes
+                        .as_map()
                         .get("value")
                         .cloned()
                         .unwrap_or(Value::Num(0.0))));
@@ -1046,7 +1065,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         && let Value::Instance { attributes, .. } = target
         && crate::vm::VM::is_buf_value(target)
     {
-        if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+        if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
             return Some(Ok(Value::array(bytes.to_vec())));
         }
         return Some(Ok(Value::array(Vec::new())));
@@ -1063,6 +1082,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         match method {
             "message" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("message")
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
@@ -1070,6 +1090,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             "resume" => return Some(Err(RuntimeError::resume_signal())),
             "gist" | "Str" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("message")
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
@@ -1088,7 +1109,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     {
         match method {
             "meta" => {
-                return Some(Ok(attributes.get("$!meta").cloned().unwrap_or(
+                return Some(Ok(attributes.as_map().get("$!meta").cloned().unwrap_or(
                     Value::Hash(std::sync::Arc::new(std::collections::HashMap::new())),
                 )));
             }
@@ -1112,6 +1133,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             match method {
                 "gist" => {
                     let bt = attributes
+                        .as_map()
                         .get("backtrace")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
@@ -1122,7 +1144,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                             format!("{}\n{}", msg, bt)
                         }
                     };
-                    if let Some(msg) = attributes.get("message") {
+                    if let Some(msg) = attributes.as_map().get("message") {
                         let msg_str = msg.to_string_value();
                         if !msg_str.is_empty() {
                             return Some(Ok(Value::str(append_bt(msg_str))));
@@ -1134,7 +1156,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         ))));
                     }
                     if cn == "X::AdHoc" {
-                        if let Some(payload) = attributes.get("payload") {
+                        if let Some(payload) = attributes.as_map().get("payload") {
                             let payload_str = payload.to_string_value();
                             if !payload_str.is_empty() {
                                 return Some(Ok(Value::str(append_bt(payload_str))));
@@ -1146,7 +1168,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
                             &cn,
-                            (attributes).as_map(),
+                            &(attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(append_bt(formatted))));
@@ -1154,7 +1176,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     return Some(Ok(Value::str(append_bt(format!("{} with no message", cn)))));
                 }
                 "Str" => {
-                    if let Some(msg) = attributes.get("message") {
+                    if let Some(msg) = attributes.as_map().get("message") {
                         let msg_str = msg.to_string_value();
                         if !msg_str.is_empty() {
                             return Some(Ok(Value::str(msg_str)));
@@ -1167,7 +1189,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
                             &cn,
-                            (attributes).as_map(),
+                            &(attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(formatted)));
@@ -1175,11 +1197,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     return Some(Ok(Value::str(format!("{} with no message", cn))));
                 }
                 "message" => {
-                    if let Some(msg) = attributes.get("message") {
+                    if let Some(msg) = attributes.as_map().get("message") {
                         return Some(Ok(msg.clone()));
                     }
                     if cn == "X::AdHoc"
-                        && let Some(payload) = attributes.get("payload")
+                        && let Some(payload) = attributes.as_map().get("payload")
                     {
                         return Some(Ok(payload.clone()));
                     }
@@ -1187,7 +1209,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
                             &cn,
-                            (attributes).as_map(),
+                            &(attributes).as_map(),
                         )
                     {
                         return Some(Ok(Value::str(formatted)));
@@ -1195,19 +1217,19 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     return Some(Ok(Value::str(String::new())));
                 }
                 "line" => {
-                    if let Some(line) = attributes.get("line") {
+                    if let Some(line) = attributes.as_map().get("line") {
                         return Some(Ok(line.clone()));
                     }
                     return Some(Ok(Value::Nil));
                 }
                 "file" => {
-                    if let Some(file) = attributes.get("file") {
+                    if let Some(file) = attributes.as_map().get("file") {
                         return Some(Ok(file.clone()));
                     }
                     return Some(Ok(Value::Nil));
                 }
                 "backtrace" => {
-                    if let Some(bt) = attributes.get("backtrace") {
+                    if let Some(bt) = attributes.as_map().get("backtrace") {
                         return Some(Ok(bt.clone()));
                     }
                     return Some(Ok(Value::str(String::new())));
@@ -1229,6 +1251,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             match method {
                 "Str" | "Stringy" => {
                     let text = attributes
+                        .as_map()
                         .get("text")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
@@ -1236,19 +1259,20 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 }
                 "gist" => {
                     let count = attributes
+                        .as_map()
                         .get("frames")
                         .map(|v| crate::runtime::utils::value_to_list(v).len())
                         .unwrap_or(0);
                     return Some(Ok(Value::str(format!("Backtrace({} frames)", count))));
                 }
                 "list" | "List" => {
-                    if let Some(frames) = attributes.get("frames") {
+                    if let Some(frames) = attributes.as_map().get("frames") {
                         return Some(Ok(frames.clone()));
                     }
                     return Some(Ok(Value::array(vec![])));
                 }
                 "elems" => {
-                    if let Some(frames) = attributes.get("frames") {
+                    if let Some(frames) = attributes.as_map().get("frames") {
                         let count = crate::runtime::utils::value_to_list(frames).len();
                         return Some(Ok(Value::Int(count as i64)));
                     }
@@ -1260,29 +1284,38 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             match method {
                 "subname" => {
                     return Some(Ok(attributes
+                        .as_map()
                         .get("subname")
                         .cloned()
                         .unwrap_or(Value::str(String::new()))));
                 }
                 "file" => {
                     return Some(Ok(attributes
+                        .as_map()
                         .get("file")
                         .cloned()
                         .unwrap_or(Value::str(String::new()))));
                 }
                 "line" => {
-                    return Some(Ok(attributes.get("line").cloned().unwrap_or(Value::Int(0))));
+                    return Some(Ok(attributes
+                        .as_map()
+                        .get("line")
+                        .cloned()
+                        .unwrap_or(Value::Int(0))));
                 }
                 "Str" | "gist" => {
                     let subname = attributes
+                        .as_map()
                         .get("subname")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
                     let file = attributes
+                        .as_map()
                         .get("file")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
                     let line = attributes
+                        .as_map()
                         .get("line")
                         .map(|v| v.to_string_value())
                         .unwrap_or_else(|| "0".to_string());
@@ -1328,6 +1361,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         // should raise a control exception.
         if cn == "Exception" || cn.starts_with("X::") || cn == "Failure" {
             let msg = attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| target.to_string_value());
@@ -1372,6 +1406,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         && (method == "hash" || method == "Hash")
     {
         let map: HashMap<String, Value> = attributes
+            .as_map()
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
@@ -1388,19 +1423,28 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     {
         match method {
             "from" => {
-                return Some(Ok(attributes.get("from").cloned().unwrap_or(Value::Int(0))));
+                return Some(Ok(attributes
+                    .as_map()
+                    .get("from")
+                    .cloned()
+                    .unwrap_or(Value::Int(0))));
             }
             "to" | "pos" => {
-                return Some(Ok(attributes.get("to").cloned().unwrap_or(Value::Int(0))));
+                return Some(Ok(attributes
+                    .as_map()
+                    .get("to")
+                    .cloned()
+                    .unwrap_or(Value::Int(0))));
             }
             "gist" => {
                 // Full Match gist: corner-quoted text plus positional/named
                 // sub-captures, ordered by position and nested recursively.
-                let gist = crate::runtime::utils::match_gist((attributes).as_map(), 0);
+                let gist = crate::runtime::utils::match_gist(&(attributes).as_map(), 0);
                 return Some(Ok(Value::str(gist)));
             }
             "Str" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("str")
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
@@ -1408,35 +1452,38 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             "Bool" => return Some(Ok(Value::Bool(true))),
             "orig" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("orig")
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
             }
             "raku" | "perl" => {
                 return Some(Ok(Value::str(match_helpers::match_raku_repr(
-                    (attributes).as_map(),
+                    &(attributes).as_map(),
                 ))));
             }
             "list" | "Array" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("list")
                     .cloned()
                     .unwrap_or_else(|| Value::array(Vec::new()))));
             }
             "hash" | "Hash" => {
                 return Some(Ok(attributes
+                    .as_map()
                     .get("named")
                     .cloned()
                     .unwrap_or_else(|| Value::hash(HashMap::new()))));
             }
             "keys" => {
                 let mut keys = Vec::new();
-                if let Some(Value::Array(list, _)) = attributes.get("list") {
+                if let Some(Value::Array(list, _)) = attributes.as_map().get("list") {
                     for i in 0..list.len() {
                         keys.push(Value::Int(i as i64));
                     }
                 }
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     let mut sorted: Vec<&String> = named.keys().collect();
                     sorted.sort();
                     for k in sorted {
@@ -1447,10 +1494,10 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "values" => {
                 let mut vals = Vec::new();
-                if let Some(Value::Array(list, _)) = attributes.get("list") {
+                if let Some(Value::Array(list, _)) = attributes.as_map().get("list") {
                     vals.extend(list.iter().cloned());
                 }
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (_, v) in sorted {
@@ -1461,12 +1508,12 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "pairs" => {
                 let mut pairs = Vec::new();
-                if let Some(Value::Array(list, _)) = attributes.get("list") {
+                if let Some(Value::Array(list, _)) = attributes.as_map().get("list") {
                     for (i, v) in list.iter().enumerate() {
                         pairs.push(Value::Pair(i.to_string(), Box::new(v.clone())));
                     }
                 }
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (k, v) in sorted {
@@ -1477,13 +1524,13 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "kv" => {
                 let mut kv = Vec::new();
-                if let Some(Value::Array(list, _)) = attributes.get("list") {
+                if let Some(Value::Array(list, _)) = attributes.as_map().get("list") {
                     for (i, v) in list.iter().enumerate() {
                         kv.push(Value::Int(i as i64));
                         kv.push(v.clone());
                     }
                 }
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (k, v) in sorted {
@@ -1494,19 +1541,23 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::array(kv)));
             }
             "elems" => {
-                let count = match attributes.get("list") {
+                let count = match attributes.as_map().get("list") {
                     Some(Value::Array(list, _)) => list.len(),
                     _ => 0,
                 };
                 return Some(Ok(Value::Int(count as i64)));
             }
             "ast" | "made" => {
-                return Some(Ok(attributes.get("ast").cloned().unwrap_or(Value::Nil)));
+                return Some(Ok(attributes
+                    .as_map()
+                    .get("ast")
+                    .cloned()
+                    .unwrap_or(Value::Nil)));
             }
             "prematch" => {
-                if let Some(orig_val) = attributes.get("orig") {
+                if let Some(orig_val) = attributes.as_map().get("orig") {
                     let orig = orig_val.to_string_value();
-                    let from = match attributes.get("from") {
+                    let from = match attributes.as_map().get("from") {
                         Some(Value::Int(n)) => *n as usize,
                         _ => 0,
                     };
@@ -1517,9 +1568,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::str(String::new())));
             }
             "postmatch" => {
-                if let Some(orig_val) = attributes.get("orig") {
+                if let Some(orig_val) = attributes.as_map().get("orig") {
                     let orig = orig_val.to_string_value();
-                    let to = match attributes.get("to") {
+                    let to = match attributes.as_map().get("to") {
                         Some(Value::Int(n)) => *n as usize,
                         _ => 0,
                     };
@@ -1530,13 +1581,17 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::str(String::new())));
             }
             "actions" => {
-                return Some(Ok(attributes.get("actions").cloned().unwrap_or(Value::Nil)));
+                return Some(Ok(attributes
+                    .as_map()
+                    .get("actions")
+                    .cloned()
+                    .unwrap_or(Value::Nil)));
             }
             "caps" => {
-                return Some(Ok(match_helpers::match_caps((attributes).as_map())));
+                return Some(Ok(match_helpers::match_caps(&(attributes).as_map())));
             }
             "chunks" => {
-                return Some(Ok(match_helpers::match_chunks((attributes).as_map())));
+                return Some(Ok(match_helpers::match_chunks(&(attributes).as_map())));
             }
             "Capture" => {
                 // Match.Capture returns self

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -651,7 +651,7 @@ pub(crate) fn native_method_1arg(
     let target = target.descalarize();
     // Instance with __baggy_data__: delegate to the inner Bag/Set for collection methods
     if let Value::Instance { attributes, .. } = target
-        && let Some(inner) = attributes.get("__baggy_data__")
+        && let Some(inner) = attributes.as_map().get("__baggy_data__")
         && !matches!(
             method,
             "WHAT" | "WHICH" | "raku" | "gist" | "Str" | "perl" | "isa" | "^name"
@@ -1055,7 +1055,8 @@ pub(crate) fn native_method_1arg(
                         attributes,
                         ..
                     } if class_name == "Match" => {
-                        if let Some(Value::Array(positional, ..)) = attributes.get("list") {
+                        if let Some(Value::Array(positional, ..)) = attributes.as_map().get("list")
+                        {
                             return Some(Ok(positional.get(idx).cloned().unwrap_or(Value::Nil)));
                         }
                         Some(Ok(Value::Nil))
@@ -1065,7 +1066,7 @@ pub(crate) fn native_method_1arg(
                         attributes,
                         ..
                     } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                        if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                             return Some(Ok(bytes.get(idx).cloned().unwrap_or(Value::Int(0))));
                         }
                         Some(Ok(Value::Int(0)))
@@ -1617,7 +1618,7 @@ pub(crate) fn native_method_1arg(
                     Ok(r) => r,
                     Err(_) => return Some(Ok(out_of_range_failure("base requires radix 2..36"))),
                 };
-                if let Some(val) = attributes.get("value") {
+                if let Some(val) = attributes.as_map().get("value") {
                     match val {
                         Value::Int(i) => {
                             Some(Ok(Value::str(rat_to_base(*i, 1, radix, BaseDigits::Auto))))
@@ -2505,7 +2506,7 @@ fn buf_class_name(val: &Value) -> String {
 
 fn buf_get_int_items(target: &Value) -> Option<Vec<Value>> {
     if let Value::Instance { attributes, .. } = target
-        && let Some(Value::Array(items, ..)) = attributes.get("bytes")
+        && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
     {
         Some(items.to_vec())
     } else {
@@ -2617,7 +2618,7 @@ fn buf_get_bytes(target: &Value) -> Option<Vec<u8>> {
         ..
     } = target
         && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
-        && let Some(Value::Array(items, ..)) = attributes.get("bytes")
+        && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
     {
         return Some(
             items
@@ -2944,7 +2945,7 @@ pub(crate) fn native_method_2arg(
                     Some(Ok(Value::str(rat_to_base(*n, *d, radix, digits_mode))))
                 }
                 Value::Instance { attributes, .. } => {
-                    if let Some(val) = attributes.get("value") {
+                    if let Some(val) = attributes.as_map().get("value") {
                         match val {
                             Value::Int(i) => {
                                 Some(Ok(Value::str(rat_to_base(*i, 1, radix, digits_mode))))

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -270,7 +270,8 @@ fn decode_buf_target_bytes(target: &Value, encoding_name: &str) -> Option<Vec<u8
         return None;
     }
 
-    let Value::Array(items, ..) = attributes.get("bytes")? else {
+    let map = attributes.as_map();
+    let Value::Array(items, ..) = map.get("bytes")? else {
         return Some(Vec::new());
     };
 

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -151,7 +151,7 @@ pub(crate) fn to_set(target: Value) -> Result<Value, RuntimeError> {
         }
         // Instance types composing Baggy: delegate to internal bag data
         Value::Instance { ref attributes, .. } if attributes.contains_key("__baggy_data__") => {
-            let bag_data = attributes.get("__baggy_data__").unwrap().clone();
+            let bag_data = attributes.as_map().get("__baggy_data__").unwrap().clone();
             return to_set(bag_data);
         }
         other if other.is_range() => {

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -144,7 +144,8 @@ fn extract_signature_param_infos(expr: &Expr) -> Option<Vec<SigParamInfo>> {
     if class_name != "Signature" {
         return None;
     }
-    let params = attributes.get("params")?;
+    let map = attributes.as_map();
+    let params = map.get("params")?;
     let Value::Array(param_list, ..) = params else {
         return None;
     };
@@ -158,12 +159,12 @@ fn extract_signature_param_infos(expr: &Expr) -> Option<Vec<SigParamInfo>> {
             });
             continue;
         };
-        let sigiled_name = match attributes.get("name") {
+        let sigiled_name = match attributes.as_map().get("name") {
             Some(Value::Str(name)) => name.to_string(),
             _ => String::new(),
         };
-        let is_named = matches!(attributes.get("named"), Some(Value::Bool(true)));
-        let named_keys = match attributes.get("named_names") {
+        let is_named = matches!(attributes.as_map().get("named"), Some(Value::Bool(true)));
+        let named_keys = match attributes.as_map().get("named_names") {
             Some(Value::Array(arr, ..)) => arr
                 .iter()
                 .filter_map(|v| match v {

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -131,6 +131,7 @@ impl Interpreter {
     fn failure_value_to_error(exception: &Value) -> RuntimeError {
         let message = if let Value::Instance { attributes, .. } = exception {
             attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| "Died".to_string())
@@ -160,7 +161,7 @@ impl Interpreter {
         if value.is_failure_handled() {
             return None;
         }
-        if let Some(exception) = attributes.get("exception") {
+        if let Some(exception) = attributes.as_map().get("exception") {
             return Some(Self::failure_value_to_error(exception));
         }
         Some(RuntimeError::new("Failed"))
@@ -192,7 +193,7 @@ impl Interpreter {
             ..
         } = value
             && class_name == "Failure"
-            && let Some(ex) = attributes.get("exception")
+            && let Some(ex) = attributes.as_map().get("exception")
         {
             return Self::failure_value_to_error(ex);
         }
@@ -986,6 +987,7 @@ impl Interpreter {
                 {
                     let msg = if let Value::Instance { attributes, .. } = &err_val {
                         attributes
+                            .as_map()
                             .get("message")
                             .map(|v| v.to_string_value())
                             .unwrap_or_else(|| "Cannot assign to readonly variable".to_string())
@@ -1552,7 +1554,8 @@ impl Interpreter {
         if class_name != "Stash" {
             return None;
         }
-        let Value::Hash(symbols) = attributes.get("symbols")? else {
+        let map = attributes.as_map();
+        let Value::Hash(symbols) = map.get("symbols")? else {
             return None;
         };
         if let Some(value) = symbols.get(key) {
@@ -2083,7 +2086,29 @@ impl Interpreter {
     /// Push a saved variable value for `let`/`temp` scope management.
     /// `is_temp`: true for `temp` (always restore), false for `let` (restore on failure only).
     pub(crate) fn let_saves_push(&mut self, name: String, value: Value, is_temp: bool) {
-        self.let_saves.push((name, value, is_temp));
+        // Take an independent snapshot: an instance value must be deep-copied so
+        // a later in-place mutation through its shared cell does not corrupt the
+        // saved-for-restore value (Phase 3, Stage 1).
+        self.let_saves
+            .push((name, value.into_temp_snapshot(), is_temp));
+    }
+
+    /// Restore one `let`/`temp` save. For an instance, write the saved
+    /// attributes back into the *live* shared cell (via cell reuse) so every
+    /// alias sees the restoration and object identity (id + cell) is preserved,
+    /// rather than rebinding the name to a detached copy.
+    fn restore_let_value(&mut self, name: String, restored: Value) {
+        if let Value::Instance {
+            class_name,
+            id,
+            attributes,
+        } = &restored
+        {
+            let inst = Value::make_instance_with_id(*class_name, attributes.to_map(), *id);
+            self.env.insert(name, inst);
+        } else {
+            self.env.insert(name, restored);
+        }
     }
 
     /// Current length of let_saves stack (used as a mark).
@@ -2106,7 +2131,7 @@ impl Interpreter {
         for i in (mark..self.let_saves.len()).rev() {
             let (name, old_val, _is_temp) = self.let_saves[i].clone();
             let restored = self.resolve_restore_value(&name, &old_val);
-            self.env.insert(name, restored);
+            self.restore_let_value(name, restored);
         }
         self.let_saves.truncate(mark);
     }
@@ -2128,7 +2153,7 @@ impl Interpreter {
             .collect();
         for (name, old_val) in restores {
             let restored = self.resolve_restore_value(&name, &old_val);
-            self.env.insert(name, restored);
+            self.restore_let_value(name, restored);
         }
         self.let_saves.truncate(mark);
     }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -862,7 +862,7 @@ impl Interpreter {
                         ..
                     } = &value
                         && class_name == "Failure"
-                        && let Some(ex) = attributes.get("exception")
+                        && let Some(ex) = attributes.as_map().get("exception")
                     {
                         let mut err = RuntimeError::new(ex.to_string_value());
                         err.exception = Some(Box::new(ex.clone()));
@@ -874,7 +874,7 @@ impl Interpreter {
                     ..
                 }) = args.first()
                     && class_name == "Failure"
-                    && let Some(ex) = attributes.get("exception")
+                    && let Some(ex) = attributes.as_map().get("exception")
                 {
                     let mut err = RuntimeError::new(ex.to_string_value());
                     err.exception = Some(Box::new(ex.clone()));

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -730,7 +730,7 @@ impl Interpreter {
             id,
         }) = self.env.get("self").cloned()
         {
-            let mut new_attrs = (*attributes).clone();
+            let new_attrs = (*attributes).clone();
             new_attrs.insert(attr_name.to_string(), new_val.clone());
             let updated_instance =
                 Value::make_instance_with_id(class_name, (new_attrs).to_map(), id);

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -732,8 +732,15 @@ impl Interpreter {
         {
             let new_attrs = (*attributes).clone();
             new_attrs.insert(attr_name.to_string(), new_val.clone());
+            // Build a *detached* instance (fresh, unregistered cell) for the
+            // cross-thread sync. Using the cell-reusing `make_instance_with_id`
+            // here would let concurrent CAS winners write the shared cell out of
+            // order (the writes happen outside the CAS critical section),
+            // dropping updates. The atomic source of truth is shared_vars; the
+            // parent picks this instance up via the `__mutsu_instance::` key
+            // after `await`.
             let updated_instance =
-                Value::make_instance_with_id(class_name, (new_attrs).to_map(), id);
+                Value::make_instance_detached(class_name, new_attrs.to_map(), id);
             self.env
                 .insert("self".to_string(), updated_instance.clone());
             self.env

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -380,7 +380,7 @@ impl Interpreter {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Failure" => attributes.get("exception").cloned(),
+            } if class_name == "Failure" => attributes.as_map().get("exception").cloned(),
             Value::Mixin(inner, mixins) => {
                 if let Some(mixed) = mixins.get("Failure")
                     && let Some(ex) = Self::failure_exception_from_value(mixed)

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -37,6 +37,7 @@ impl Interpreter {
 
         let msg = if let Value::Instance { attributes, .. } = value {
             attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| {
@@ -131,7 +132,7 @@ impl Interpreter {
                 ..
             } = &v
                 && class_name.resolve() == "Failure"
-                && let Some(exc) = attributes.get("exception").cloned()
+                && let Some(exc) = attributes.as_map().get("exception").cloned()
             {
                 return Err(self.runtime_error_from_die_value(&exc, "Failed", true));
             }

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -257,7 +257,7 @@ impl Interpreter {
                     ..
                 } if crate::runtime::utils::is_buf_like_class(&class_name.resolve()) => {
                     // Buf argument: decode as UTF-8
-                    if let Some(Value::Array(items, _)) = attributes.get("bytes") {
+                    if let Some(Value::Array(items, _)) = attributes.as_map().get("bytes") {
                         let bytes: Vec<u8> = items
                             .iter()
                             .map(|v| match v {

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -204,7 +204,7 @@ impl Interpreter {
             let method_args = std::iter::once(content_value)
                 .chain(args.iter().skip(2).cloned())
                 .collect();
-            return self.native_io_handle((attributes).as_map(), "spurt", method_args);
+            return self.native_io_handle(&(attributes).as_map(), "spurt", method_args);
         }
         let path = args
             .first()
@@ -396,11 +396,12 @@ impl Interpreter {
                 {
                     requested_opt = Some(
                         attributes
+                            .as_map()
                             .get("path")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default(),
                     );
-                    requested_cwd_opt = attributes.get("cwd").map(|v| v.to_string_value());
+                    requested_cwd_opt = attributes.as_map().get("cwd").map(|v| v.to_string_value());
                 } else {
                     requested_opt = Some(arg.to_string_value());
                 }
@@ -677,10 +678,11 @@ impl Interpreter {
             && class_name == "IO::Path"
         {
             requested = attributes
+                .as_map()
                 .get("path")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            requested_cwd_opt = attributes.get("cwd").map(|v| v.to_string_value());
+            requested_cwd_opt = attributes.as_map().get("cwd").map(|v| v.to_string_value());
         }
         check_null_in_path(&requested)?;
         let path_buf = if Path::new(&requested).is_absolute() {
@@ -754,10 +756,11 @@ impl Interpreter {
             && class_name == "IO::Path"
         {
             requested = attributes
+                .as_map()
                 .get("path")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            requested_cwd_opt = attributes.get("cwd").map(|v| v.to_string_value());
+            requested_cwd_opt = attributes.as_map().get("cwd").map(|v| v.to_string_value());
         }
         check_null_in_path(&requested)?;
         let path_buf = if Path::new(&requested).is_absolute() {

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -631,7 +631,11 @@ impl Interpreter {
         };
 
         let attr_key = attr_name.clone();
-        let current = attributes.get(&attr_key).cloned().unwrap_or(Value::Nil);
+        let current = attributes
+            .as_map()
+            .get(&attr_key)
+            .cloned()
+            .unwrap_or(Value::Nil);
         let old_array_arc = match &current {
             Value::Array(arc, ..) => Some(arc.clone()),
             _ => None,

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -218,7 +218,7 @@ impl Interpreter {
             ..
         } = target
             && class_name == "Stash"
-            && let Some(Value::Hash(symbols)) = attributes.get("symbols")
+            && let Some(Value::Hash(symbols)) = attributes.as_map().get("symbols")
         {
             let stash_exists = |idx: &Value| {
                 let key = idx.to_string_value();

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1588,7 +1588,7 @@ impl Interpreter {
             ..
         } = &value
             && class_name == "Match"
-            && let Some(str_val) = attributes.get("str")
+            && let Some(str_val) = attributes.as_map().get("str")
         {
             let s = str_val.to_string_value();
             let s = s.trim();

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -195,7 +195,8 @@ impl Interpreter {
         if class_name != "Failure" {
             return None;
         }
-        let exception = attributes.get("exception")?;
+        let map = attributes.as_map();
+        let exception = map.get("exception")?;
         let Value::Instance {
             attributes: ex_attrs,
             ..
@@ -203,7 +204,7 @@ impl Interpreter {
         else {
             return None;
         };
-        let message = ex_attrs.get("message")?.to_string_value();
+        let message = ex_attrs.as_map().get("message")?.to_string_value();
         let prefix = "No such symbol '";
         let rest = message.strip_prefix(prefix)?;
         let symbol = rest.strip_suffix('\'')?;
@@ -715,7 +716,7 @@ impl Interpreter {
             if let Value::Instance {
                 attributes: ref a, ..
             } = pipe
-                && let Some(Value::Int(id)) = a.get("pipe-id")
+                && let Some(Value::Int(id)) = a.as_map().get("pipe-id")
             {
                 pipe_ids.push(*id);
             }
@@ -726,7 +727,7 @@ impl Interpreter {
             if let Value::Instance {
                 attributes: ref a, ..
             } = pipe
-                && let Some(Value::Int(id)) = a.get("pipe-id")
+                && let Some(Value::Int(id)) = a.as_map().get("pipe-id")
             {
                 pipe_ids.push(*id);
             }
@@ -854,15 +855,15 @@ impl Interpreter {
             && class_name.resolve() == "IO::Pipe"
         {
             opts.capture_in = true;
-            if let Some(Value::Int(pid)) = attributes.get("live-pid") {
+            if let Some(Value::Int(pid)) = attributes.as_map().get("live-pid") {
                 opts.in_pipe_pid = Some(*pid);
                 return;
             }
-            if let Some(Value::Int(pid)) = attributes.get("proc-pid") {
+            if let Some(Value::Int(pid)) = attributes.as_map().get("proc-pid") {
                 opts.in_pipe_pid = Some(*pid);
                 return;
             }
-            let content = if let Some(Value::Int(id)) = attributes.get("pipe-id")
+            let content = if let Some(Value::Int(id)) = attributes.as_map().get("pipe-id")
                 && let Ok(mut map) = io_pipe_state_map().lock()
                 && let Some(state) = map.get_mut(id)
             {
@@ -871,6 +872,7 @@ impl Interpreter {
                 c
             } else {
                 attributes
+                    .as_map()
                     .get("content")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default()
@@ -889,7 +891,7 @@ impl Interpreter {
             ..
         } = value
             && class_name.resolve() == "IO::Handle"
-            && let Some(Value::Int(id)) = attributes.get("handle")
+            && let Some(Value::Int(id)) = attributes.as_map().get("handle")
         {
             opts.out_handle_id = Some(*id as usize);
             return;
@@ -949,7 +951,8 @@ impl Interpreter {
                     ..
                 } if idx == 0 && class_name.resolve() == "IO::Path" => {
                     first_arg_io_path = true;
-                    if let Some(path) = attributes.get("path").map(Value::to_string_value) {
+                    if let Some(path) = attributes.as_map().get("path").map(Value::to_string_value)
+                    {
                         positional.push(path);
                     } else {
                         positional.push(arg.to_string_value());
@@ -1265,8 +1268,7 @@ impl Interpreter {
     /// produces "exit code: -1, ... OS error = No such file or directory").
     fn attach_proc_os_error(proc: &mut Value, os_error: &str) {
         if let Value::Instance { attributes, .. } = proc {
-            let attrs = std::sync::Arc::make_mut(attributes);
-            attrs.insert("os-error".to_string(), Value::str(os_error.to_string()));
+            attributes.insert("os-error".to_string(), Value::str(os_error.to_string()));
         }
     }
 
@@ -1394,7 +1396,7 @@ impl Interpreter {
         let proc_value = self.builtin_shell(&shell_args)?;
 
         if let Value::Instance { attributes, .. } = proc_value {
-            if let Some(err_pipe) = attributes.get("err") {
+            if let Some(err_pipe) = attributes.as_map().get("err") {
                 let stderr = self.call_method_with_values(err_pipe.clone(), "slurp", vec![])?;
                 let stderr_text = stderr.to_string_value();
                 if !stderr_text.is_empty() {
@@ -1402,7 +1404,7 @@ impl Interpreter {
                     let _ = std::io::Write::flush(&mut std::io::stderr());
                 }
             }
-            if let Some(out_pipe) = attributes.get("out") {
+            if let Some(out_pipe) = attributes.as_map().get("out") {
                 return self.call_method_with_values(out_pipe.clone(), "slurp", vec![]);
             }
         }
@@ -1524,6 +1526,7 @@ impl Interpreter {
             }) if class_name.resolve() == "Instant" => {
                 // Instant stores TAI time; convert back to POSIX
                 attributes
+                    .as_map()
                     .get("value")
                     .and_then(super::to_float_value)
                     .map(crate::builtins::methods_0arg::temporal::instant_to_posix)
@@ -1536,7 +1539,7 @@ impl Interpreter {
                 // Compute posix from DateTime attributes
                 use crate::builtins::methods_0arg::temporal::{datetime_attrs, datetime_to_posix};
                 let (year, month, day, hour, minute, second, timezone) =
-                    datetime_attrs((attributes).as_map());
+                    datetime_attrs(&(attributes).as_map());
                 Some(datetime_to_posix(
                     year, month, day, hour, minute, second, timezone,
                 ))
@@ -1649,7 +1652,11 @@ impl Interpreter {
                     attributes,
                     ..
                 } if class_name == "Promise" => {
-                    let result = attributes.get("result").cloned().unwrap_or(Value::Nil);
+                    let result = attributes
+                        .as_map()
+                        .get("result")
+                        .cloned()
+                        .unwrap_or(Value::Nil);
                     results.push(result);
                 }
                 Value::Array(elems, ..) => {
@@ -1672,8 +1679,11 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Promise" => {
-                                let result =
-                                    attributes.get("result").cloned().unwrap_or(Value::Nil);
+                                let result = attributes
+                                    .as_map()
+                                    .get("result")
+                                    .cloned()
+                                    .unwrap_or(Value::Nil);
                                 results.push(result);
                             }
                             _ => results.push(elem.clone()),
@@ -1721,13 +1731,22 @@ impl Interpreter {
             && class_name == "IO::Socket::Async::StatusResult"
         {
             let status = attributes
+                .as_map()
                 .get("status")
                 .map(Value::to_string_value)
                 .unwrap_or_else(|| "Broken".to_string());
             if status == "Kept" {
-                return Ok(attributes.get("result").cloned().unwrap_or(Value::Nil));
+                return Ok(attributes
+                    .as_map()
+                    .get("result")
+                    .cloned()
+                    .unwrap_or(Value::Nil));
             }
-            let cause = attributes.get("cause").cloned().unwrap_or(Value::Nil);
+            let cause = attributes
+                .as_map()
+                .get("cause")
+                .cloned()
+                .unwrap_or(Value::Nil);
             let message = cause.to_string_value();
             let mut err = RuntimeError::new(message.clone());
             if matches!(cause, Value::Instance { .. }) {

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -385,7 +385,7 @@ impl Interpreter {
             ..
         } = &val
             && class_name == "Failure"
-            && let Some(exception) = attributes.get("exception")
+            && let Some(exception) = attributes.as_map().get("exception")
         {
             let message = if let Value::Instance {
                 attributes: ex_attrs,
@@ -393,6 +393,7 @@ impl Interpreter {
             } = exception
             {
                 ex_attrs
+                    .as_map()
                     .get("message")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default()
@@ -415,25 +416,27 @@ impl Interpreter {
         } = &val
             && class_name.resolve() == "Proc"
         {
-            let exitcode = match attributes.get("exitcode") {
+            let exitcode = match attributes.as_map().get("exitcode") {
                 Some(Value::Int(i)) => *i,
                 _ => 0,
             };
             // A still-"live" Proc (from `run(:in, ...)`) carries a placeholder
             // exitcode of -1 until it is finalized; sinking it must not throw.
-            let is_live = matches!(attributes.get("live"), Some(Value::Bool(true)));
+            let is_live = matches!(attributes.as_map().get("live"), Some(Value::Bool(true)));
             if exitcode != 0 && !is_live {
-                let signal = match attributes.get("signal") {
+                let signal = match attributes.as_map().get("signal") {
                     Some(Value::Int(i)) => *i,
                     _ => 0,
                 };
                 let command = attributes
+                    .as_map()
                     .get("command")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
                 // A command that could not be spawned (exit code -1) reports the
                 // underlying OS error, matching rakudo's X::Proc::Unsuccessful.
                 let os_error = attributes
+                    .as_map()
                     .get("os-error")
                     .map(|v| v.to_string_value())
                     .filter(|s| !s.is_empty());

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -620,6 +620,7 @@ impl Interpreter {
             } = *ex
             {
                 let mut new_attrs: std::collections::HashMap<String, Value> = attributes
+                    .as_map()
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1301,6 +1301,7 @@ impl Interpreter {
         }) = self.env.get("self")
         {
             let self_attrs_snapshot: Vec<(String, Value)> = self_attrs
+                .as_map()
                 .iter()
                 .filter(|(k, _)| !k.contains('\0'))
                 .map(|(k, v)| (k.clone(), v.clone()))

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -103,7 +103,7 @@ impl Interpreter {
             ..
         } = value
             && (class_name == "IO::Handle" || class_name == "IO::Socket::INET")
-            && let Some(Value::Int(id)) = attributes.get("handle")
+            && let Some(Value::Int(id)) = attributes.as_map().get("handle")
             && *id >= 0
         {
             return Some(*id as usize);

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -3179,7 +3179,7 @@ impl Interpreter {
             Value::Str(s) => Some(s.to_string()),
             Value::Instance { attributes, .. } => {
                 // Support IO::Path instances (e.g., $*CWD)
-                attributes.get("path").map(|v| v.to_string_value())
+                attributes.as_map().get("path").map(|v| v.to_string_value())
             }
             _ => None,
         })

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -482,6 +482,7 @@ impl Interpreter {
                 }
                 // throw / rethrow: build a RuntimeError carrying this exception.
                 let msg = attributes
+                    .as_map()
                     .get("message")
                     .map(|v| v.to_string_value())
                     .or_else(|| {
@@ -568,7 +569,7 @@ impl Interpreter {
                     attributes,
                     ..
                 }) if crate::runtime::utils::is_buf_like_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(items, _)) = attributes.get("bytes") {
+                    if let Some(Value::Array(items, _)) = attributes.as_map().get("bytes") {
                         let bytes: Vec<u8> = items
                             .iter()
                             .map(|v| match v {
@@ -693,7 +694,7 @@ impl Interpreter {
                     let cn = class_name.resolve();
                     if crate::runtime::utils::is_buf_or_blob_class(&cn) {
                         let mut v: Vec<u8> = Vec::new();
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             v.reserve(items.len());
                             for it in items.iter() {
                                 v.push(match it {
@@ -748,7 +749,7 @@ impl Interpreter {
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
-                    let mut updated_attrs = attrs_opt.unwrap();
+                    let updated_attrs = attrs_opt.unwrap();
                     updated_attrs.insert(
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
@@ -793,7 +794,7 @@ impl Interpreter {
                     let cn = class_name.resolve();
                     if crate::runtime::utils::is_buf_or_blob_class(&cn) {
                         let mut v: Vec<u8> = Vec::new();
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             v.reserve(items.len());
                             for it in items.iter() {
                                 v.push(match it {
@@ -848,7 +849,7 @@ impl Interpreter {
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
-                    let mut updated_attrs = attrs_opt.unwrap();
+                    let updated_attrs = attrs_opt.unwrap();
                     updated_attrs.insert(
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
@@ -902,14 +903,14 @@ impl Interpreter {
             match method {
                 "count-only" if args.is_empty() => {
                     if let Some(value) =
-                        self.iterator_count_only_from_attrs((attributes.as_ref()).as_map())?
+                        self.iterator_count_only_from_attrs(&(attributes.as_ref()).as_map())?
                     {
                         return Ok(value);
                     }
                 }
                 "bool-only" if args.is_empty() => {
                     if let Some(value) =
-                        self.iterator_bool_only_from_attrs((attributes.as_ref()).as_map())?
+                        self.iterator_bool_only_from_attrs(&(attributes.as_ref()).as_map())?
                     {
                         return Ok(value);
                     }
@@ -917,7 +918,7 @@ impl Interpreter {
                 "can"
                     if args.len() == 1
                         && Self::iterator_supports_predictive_methods(
-                            (attributes.as_ref()).as_map(),
+                            &(attributes.as_ref()).as_map(),
                         ) =>
                 {
                     let method_name = args[0].to_string_value();
@@ -928,11 +929,11 @@ impl Interpreter {
                 // pull-one on a temporary iterator (no variable): read from items at current index.
                 // Since the iterator is a temporary, index is always 0 or whatever is in attrs.
                 "pull-one" if args.is_empty() => {
-                    let items = match attributes.get("items") {
+                    let items = match attributes.as_map().get("items") {
                         Some(Value::Array(values, ..)) => values.to_vec(),
                         _ => Vec::new(),
                     };
-                    let index = match attributes.get("index") {
+                    let index = match attributes.as_map().get("index") {
                         Some(Value::Int(i)) if *i >= 0 => *i as usize,
                         _ => 0,
                     };
@@ -957,7 +958,7 @@ impl Interpreter {
                 .class_mro(&class_name.resolve())
                 .iter()
                 .any(|name| name == "DateTime" || name == "Date")
-            && let Some(formatter) = attributes.get("formatter")
+            && let Some(formatter) = attributes.as_map().get("formatter")
         {
             let saved_env = self.env().clone();
             let saved_readonly = self.save_readonly_vars();
@@ -1744,11 +1745,12 @@ impl Interpreter {
                     Some(v) => super::to_int(v) as usize,
                     None => 0,
                 };
-                let mut bytes = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes =
+                    if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
+                        items.to_vec()
+                    } else {
+                        Vec::new()
+                    };
                 // When growing, fill with zeros; when shrinking, truncate
                 // After reallocate(0).reallocate(N), the new bytes should be zeros
                 bytes.resize(new_size, Value::Int(0));
@@ -1799,7 +1801,8 @@ impl Interpreter {
                         cn, method
                     )));
                 }
-                let bytes = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                let bytes = if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
+                {
                     items.to_vec()
                 } else {
                     Vec::new()
@@ -1895,6 +1898,7 @@ impl Interpreter {
                     .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
             if is_exception {
                 let msg = attributes
+                    .as_map()
                     .get("message")
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|| target.to_string_value());
@@ -1983,7 +1987,7 @@ impl Interpreter {
                 && attributes.contains_key("formatter")
                 && !attributes.contains_key("__formatter_rendered")
             {
-                let formatter = attributes.get("formatter").unwrap().clone();
+                let formatter = attributes.as_map().get("formatter").unwrap().clone();
                 return self.render_date_formatter(val, formatter);
             }
             return Ok(val);
@@ -2010,7 +2014,7 @@ impl Interpreter {
             && method == "make"
         {
             let value = args.first().cloned().unwrap_or(Value::Nil);
-            let mut attrs = crate::value::InstanceAttrs::clone(attributes);
+            let attrs = crate::value::InstanceAttrs::clone(attributes);
             attrs.insert("ast".to_string(), value.clone());
             let updated = Value::Instance {
                 class_name: *class_name,
@@ -2037,14 +2041,14 @@ impl Interpreter {
             && class_name.resolve() == "Routine::WrapHandle"
             && method == "restore"
         {
-            let sub_id = attributes.get("sub-id").and_then(|v| {
+            let sub_id = attributes.as_map().get("sub-id").and_then(|v| {
                 if let Value::Int(i) = v {
                     Some(*i as u64)
                 } else {
                     None
                 }
             });
-            let handle_id = attributes.get("handle-id").and_then(|v| {
+            let handle_id = attributes.as_map().get("handle-id").and_then(|v| {
                 if let Value::Int(i) = v {
                     Some(*i as u64)
                 } else {
@@ -3066,7 +3070,7 @@ impl Interpreter {
                     | Some(Value::Instance { .. })
                     | Some(Value::ParametricRole { .. })
                     | Some(Value::Mixin(_, _))
-            ) && let Some(Value::Str(type_name)) = attributes.get("name")
+            ) && let Some(Value::Str(type_name)) = attributes.as_map().get("name")
             {
                 how_args.insert(0, Value::Package(Symbol::intern(type_name)));
             }
@@ -3084,6 +3088,7 @@ impl Interpreter {
             && args.is_empty()
         {
             return Ok(attributes
+                .as_map()
                 .get("composable")
                 .cloned()
                 .unwrap_or(Value::Bool(false)));
@@ -3208,7 +3213,7 @@ impl Interpreter {
         } = &target
             && class_name.resolve() == "Promise::Vow"
         {
-            return self.dispatch_promise_vow_method((attributes).as_map(), method, args);
+            return self.dispatch_promise_vow_method(&(attributes).as_map(), method, args);
         }
 
         // Mixin fallback: check __mutsu_attr__ and delegate to inner

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -377,7 +377,7 @@ impl Interpreter {
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     // Extract bytes from Buf/Blob instance and cycle them
                     let pattern: Vec<Value> =
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             items.to_vec()
                         } else {
                             Vec::new()

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -744,6 +744,7 @@ impl Interpreter {
                     && attr_class.resolve() == "Attribute"
                 {
                     let attr_name_raw = attr_attrs
+                        .as_map()
                         .get("name")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
@@ -752,11 +753,16 @@ impl Interpreter {
                         .trim_start_matches(|c: char| "$.!@%&".contains(c))
                         .to_string();
                     let has_accessor = attr_attrs
+                        .as_map()
                         .get("has_accessor")
                         .map(|v| v.truthy())
                         .unwrap_or(false);
-                    let is_rw = attr_attrs.get("rw").map(|v| v.truthy()).unwrap_or(false);
-                    let type_constraint = attr_attrs.get("type").and_then(|v| match v {
+                    let is_rw = attr_attrs
+                        .as_map()
+                        .get("rw")
+                        .map(|v| v.truthy())
+                        .unwrap_or(false);
+                    let type_constraint = attr_attrs.as_map().get("type").and_then(|v| match v {
                         Value::Package(name) => Some(name.resolve()),
                         _ => None,
                     });
@@ -997,7 +1003,7 @@ impl Interpreter {
                 // Check for per-candidate language revision embedded as an
                 // attribute (set by ^candidates for role candidate instances).
                 if let Value::Instance { attributes, .. } = &args[0]
-                    && let Some(rev) = attributes.get("__mutsu_language_revision")
+                    && let Some(rev) = attributes.as_map().get("__mutsu_language_revision")
                 {
                     return Ok(rev.clone());
                 }
@@ -1733,6 +1739,7 @@ impl Interpreter {
             if !result.iter().any(|v| {
                 if let Value::Instance { attributes, .. } = v {
                     attributes
+                        .as_map()
                         .get("name")
                         .map(|n| n.to_string_value())
                         .as_deref()

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -226,7 +226,7 @@ impl Interpreter {
                 ..
             } if class_name == "Match" => {
                 // %($/) returns the named captures hash
-                if let Some(named) = attributes.get("named") {
+                if let Some(named) = attributes.as_map().get("named") {
                     Ok(named.clone())
                 } else {
                     Ok(Value::hash(HashMap::new()))

--- a/src/runtime/methods_collection_ops/collation_temporal.rs
+++ b/src/runtime/methods_collection_ops/collation_temporal.rs
@@ -22,7 +22,11 @@ impl Interpreter {
 
         match method {
             "primary" | "secondary" | "tertiary" | "quaternary" if args.is_empty() => {
-                Ok(attributes.get(method).cloned().unwrap_or(Value::Int(1)))
+                Ok(attributes
+                    .as_map()
+                    .get(method)
+                    .cloned()
+                    .unwrap_or(Value::Int(1)))
             }
             "set" => {
                 // .set accepts named arguments: primary, secondary, tertiary, quaternary
@@ -97,7 +101,7 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "Supply" => {
-                let values = match attributes.get("values") {
+                let values = match attributes.as_map().get("values") {
                     Some(Value::Array(items, ..)) => items.to_vec(),
                     _ => Vec::new(),
                 };

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -91,7 +91,7 @@ impl Interpreter {
         } = &target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_first((attributes).as_map(), func, has_end);
+            return self.dispatch_supply_first(&(attributes).as_map(), func, has_end);
         }
 
         let items = crate::runtime::utils::value_to_list(&target);

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -245,29 +245,30 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "Supply" => {
-                let source_values = if let Some(on_demand_cb) = attributes.get("on_demand_callback")
-                {
-                    let emitter = Value::make_instance(Symbol::intern("Supplier"), {
-                        let mut a = HashMap::new();
-                        a.insert("emitted".to_string(), Value::array(Vec::new()));
-                        a.insert("done".to_string(), Value::Bool(false));
-                        a
-                    });
-                    self.supply_emit_buffer.push(Vec::new());
-                    let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
-                    self.supply_emit_buffer.pop().unwrap_or_default()
-                } else {
-                    attributes
-                        .get("values")
-                        .and_then(|v| {
-                            if let Value::Array(items, ..) = v {
-                                Some(items.to_vec())
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or_default()
-                };
+                let source_values =
+                    if let Some(on_demand_cb) = attributes.as_map().get("on_demand_callback") {
+                        let emitter = Value::make_instance(Symbol::intern("Supplier"), {
+                            let mut a = HashMap::new();
+                            a.insert("emitted".to_string(), Value::array(Vec::new()));
+                            a.insert("done".to_string(), Value::Bool(false));
+                            a
+                        });
+                        self.supply_emit_buffer.push(Vec::new());
+                        let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
+                        self.supply_emit_buffer.pop().unwrap_or_default()
+                    } else {
+                        attributes
+                            .as_map()
+                            .get("values")
+                            .and_then(|v| {
+                                if let Value::Array(items, ..) = v {
+                                    Some(items.to_vec())
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or_default()
+                    };
                 let filtered = self.eval_grep_over_items(args.first().cloned(), source_values)?;
                 let filtered_values = Self::value_to_list(&filtered);
                 let mut attrs = HashMap::new();
@@ -276,6 +277,7 @@ impl Interpreter {
                 attrs.insert(
                     "live".to_string(),
                     attributes
+                        .as_map()
                         .get("live")
                         .cloned()
                         .unwrap_or(Value::Bool(false)),

--- a/src/runtime/methods_collection_ops/minmax_extrema.rs
+++ b/src/runtime/methods_collection_ops/minmax_extrema.rs
@@ -188,7 +188,7 @@ impl Interpreter {
         let Value::Instance { attributes, .. } = target else {
             return Err(RuntimeError::new("Expected Supply instance"));
         };
-        let values = if let Some(Value::Array(items, ..)) = attributes.get("values") {
+        let values = if let Some(Value::Array(items, ..)) = attributes.as_map().get("values") {
             items.to_vec()
         } else {
             Vec::new()

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -255,45 +255,45 @@ impl Interpreter {
         &mut self,
         attributes: &Arc<crate::value::InstanceAttrs>,
     ) {
-        let mut stdout_taps = match attributes.get("stdout_taps") {
+        let mut stdout_taps = match attributes.as_map().get("stdout_taps") {
             Some(Value::Array(taps, ..)) => taps.to_vec(),
             _ => Vec::new(),
         };
-        let mut stderr_taps = match attributes.get("stderr_taps") {
+        let mut stderr_taps = match attributes.as_map().get("stderr_taps") {
             Some(Value::Array(taps, ..)) => taps.to_vec(),
             _ => Vec::new(),
         };
-        if let Some(Value::Int(sid)) = attributes.get("stdout_supply_id") {
+        if let Some(Value::Int(sid)) = attributes.as_map().get("stdout_supply_id") {
             let live = super::super::native_methods::get_supply_taps(*sid as u64);
             if !live.is_empty() {
                 stdout_taps = live;
             }
         }
-        if let Some(Value::Int(sid)) = attributes.get("stderr_supply_id") {
+        if let Some(Value::Int(sid)) = attributes.as_map().get("stderr_supply_id") {
             let live = super::super::native_methods::get_supply_taps(*sid as u64);
             if !live.is_empty() {
                 stderr_taps = live;
             }
         }
-        let collected_stdout = match attributes.get("collected_stdout") {
+        let collected_stdout = match attributes.as_map().get("collected_stdout") {
             Some(Value::Str(s)) => s.to_string(),
             _ => String::new(),
         };
-        let collected_stderr = match attributes.get("collected_stderr") {
+        let collected_stderr = match attributes.as_map().get("collected_stderr") {
             Some(Value::Str(s)) => s.to_string(),
             _ => String::new(),
         };
-        let mut supply_taps = match attributes.get("supply_taps") {
+        let mut supply_taps = match attributes.as_map().get("supply_taps") {
             Some(Value::Array(taps, ..)) => taps.to_vec(),
             _ => Vec::new(),
         };
-        if let Some(Value::Int(sid)) = attributes.get("supply_id") {
+        if let Some(Value::Int(sid)) = attributes.as_map().get("supply_id") {
             let live = super::super::native_methods::get_supply_taps(*sid as u64);
             if !live.is_empty() {
                 supply_taps = live;
             }
         }
-        let collected_merged = match attributes.get("collected_merged") {
+        let collected_merged = match attributes.as_map().get("collected_merged") {
             Some(Value::Str(s)) => s.to_string(),
             _ => format!("{}{}", collected_stdout, collected_stderr),
         };

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -113,7 +113,7 @@ impl Interpreter {
                 }
                 if let Some(updated_iter) = self.env.get(iter_slot).cloned() {
                     if let Value::Instance { attributes, .. } = &updated_iter {
-                        for (meta_key, source_name) in attributes.iter() {
+                        for (meta_key, source_name) in attributes.as_map().iter() {
                             let Some(attr_name) = meta_key.strip_prefix("__mutsu_attr_alias::")
                             else {
                                 continue;
@@ -121,7 +121,7 @@ impl Interpreter {
                             let Value::Str(source_name) = source_name else {
                                 continue;
                             };
-                            if let Some(attr_value) = attributes.get(attr_name).cloned() {
+                            if let Some(attr_value) = attributes.as_map().get(attr_name).cloned() {
                                 self.env.insert(source_name.to_string(), attr_value);
                             }
                         }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -22,7 +22,7 @@ impl Interpreter {
                     && class_name == "Supply"
                 {
                     return Some(
-                        self.supply_list_values((attributes).as_map(), true)
+                        self.supply_list_values(&(attributes).as_map(), true)
                             .map(Value::array),
                     );
                 }
@@ -403,7 +403,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return Some(self.dispatch_supply_elems((attributes).as_map(), &args));
+            return Some(self.dispatch_supply_elems(&(attributes).as_map(), &args));
         }
         // .elems on a Seq caches it (makes it available for multiple calls)
         if let Value::Seq(items) = &target {
@@ -425,7 +425,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_map((attributes).as_map(), &args);
+            return self.dispatch_supply_map(&(attributes).as_map(), &args);
         }
         // Validate that the map argument is callable (X::Cannot::Map)
         if let Some(func) = args.first() {

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -298,7 +298,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return Some(self.dispatch_supply_grab((attributes).as_map(), &args));
+            return Some(self.dispatch_supply_grab(&(attributes).as_map(), &args));
         }
         if let Value::Package(ref class_name) = target
             && class_name == "Supply"
@@ -490,7 +490,7 @@ impl Interpreter {
         } = target
             && class_name == "Supply"
         {
-            return self.dispatch_supply_skip((attributes).as_map(), &args);
+            return self.dispatch_supply_skip(&(attributes).as_map(), &args);
         }
         let items = crate::runtime::utils::value_to_list(&target);
         let n = if args.is_empty() {
@@ -602,7 +602,7 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "Stash" => {
-                let keys = match attributes.get("symbols") {
+                let keys = match attributes.as_map().get("symbols") {
                     Some(Value::Hash(map)) => {
                         map.keys().cloned().map(Value::str).collect::<Vec<Value>>()
                     }
@@ -692,7 +692,7 @@ impl Interpreter {
                 },
                 idx,
             ) if class_name == "Stash" => {
-                if let Some(Value::Hash(symbols)) = attributes.get("symbols") {
+                if let Some(Value::Hash(symbols)) = attributes.as_map().get("symbols") {
                     let stash_lookup = |raw_key: &str| {
                         if let Some(value) = symbols.get(raw_key) {
                             return Some(value.clone());

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -640,7 +640,7 @@ impl Interpreter {
                 id,
             } = dt_with_formatter
             {
-                let mut updated = (*attributes).clone();
+                let updated = (*attributes).clone();
                 updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
                 return Some(Ok(Value::make_instance_with_id(
                     class_name,

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -78,14 +78,22 @@ impl Interpreter {
                 ..
             } if class_name.resolve() == "CompUnit::DependencySpecification" => {
                 let sn = attributes
+                    .as_map()
                     .get("short-name")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
-                let auth = attributes.get("auth-matcher").map(|v| v.to_string_value());
+                let auth = attributes
+                    .as_map()
+                    .get("auth-matcher")
+                    .map(|v| v.to_string_value());
                 let ver = attributes
+                    .as_map()
                     .get("version-matcher")
                     .map(|v| v.to_string_value());
-                let api = attributes.get("api-matcher").map(|v| v.to_string_value());
+                let api = attributes
+                    .as_map()
+                    .get("api-matcher")
+                    .map(|v| v.to_string_value());
                 (sn, auth, ver, api)
             }
             Value::Str(s) => (s.to_string(), None, None, None),
@@ -346,8 +354,13 @@ impl Interpreter {
         }
         let (meta, dist_prefix) = match dist {
             Value::Instance { attributes, .. } => {
-                let m = attributes.get("meta").cloned().unwrap_or(Value::Nil);
+                let m = attributes
+                    .as_map()
+                    .get("meta")
+                    .cloned()
+                    .unwrap_or(Value::Nil);
                 let p = attributes
+                    .as_map()
                     .get("prefix")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
@@ -488,6 +501,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let dist_id = match dist {
             Value::Instance { attributes, .. } => attributes
+                .as_map()
                 .get("dist-id")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default(),
@@ -564,7 +578,9 @@ impl Interpreter {
     /// resolvable through `::('Name')`. Used by `GLOBALish.WHO.merge-symbols`.
     pub(crate) fn merge_global_symbols(&mut self, pkg: &Value) -> Value {
         let symbols = match pkg {
-            Value::Instance { attributes, .. } => attributes.get("globalish-symbols").cloned(),
+            Value::Instance { attributes, .. } => {
+                attributes.as_map().get("globalish-symbols").cloned()
+            }
             _ => pkg.hash_get_str("globalish-symbols"),
         };
         if let Some(Value::Array(syms, _)) = symbols {
@@ -601,9 +617,11 @@ impl Interpreter {
         };
         let dist_meta = |dist: &Value| -> Value {
             match dist {
-                Value::Instance { attributes, .. } => {
-                    attributes.get("meta").cloned().unwrap_or(Value::Nil)
-                }
+                Value::Instance { attributes, .. } => attributes
+                    .as_map()
+                    .get("meta")
+                    .cloned()
+                    .unwrap_or(Value::Nil),
                 _ => Value::Nil,
             }
         };

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -53,6 +53,7 @@ impl Interpreter {
                 ..
             } if class_name.resolve() == "Format" => Some(
                 attributes
+                    .as_map()
                     .get("format")
                     .map(Value::to_string_value)
                     .unwrap_or_default(),

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -237,7 +237,7 @@ impl Interpreter {
                 ..
             } = &match_obj
             {
-                let mut attrs = attributes.as_ref().clone();
+                let attrs = attributes.as_ref().clone();
                 if let Some(ast) = self.env.get("made").cloned() {
                     attrs.insert("ast".to_string(), ast);
                 }
@@ -257,7 +257,7 @@ impl Interpreter {
             };
             // Set named capture env vars from match object
             if let Value::Instance { attributes, .. } = &match_obj
-                && let Some(Value::Hash(named_hash)) = attributes.get("named")
+                && let Some(Value::Hash(named_hash)) = attributes.as_map().get("named")
             {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());
@@ -277,7 +277,7 @@ impl Interpreter {
                     ..
                 } = &result
                 {
-                    let mut attrs = attributes.as_ref().clone();
+                    let attrs = attributes.as_ref().clone();
                     attrs.insert("actions".to_string(), actions.clone());
                     Value::make_instance_with_id(*class_name, (attrs).to_map(), *id)
                 } else {
@@ -317,7 +317,7 @@ impl Interpreter {
     /// Extract `action_name` from a Match object (set for aliased captures).
     fn get_action_name(match_obj: &Value) -> Option<String> {
         if let Value::Instance { attributes, .. } = match_obj
-            && let Some(Value::Str(action_name)) = attributes.get("action_name")
+            && let Some(Value::Str(action_name)) = attributes.as_map().get("action_name")
         {
             return Some(action_name.to_string());
         }
@@ -343,8 +343,8 @@ impl Interpreter {
         };
 
         // First, recursively process child named captures (bottom-up order)
-        let mut updated_attrs = attributes.clone();
-        if let Some(Value::Hash(named_hash)) = attributes.get("named") {
+        let updated_attrs = attributes.clone();
+        if let Some(Value::Hash(named_hash)) = attributes.as_map().get("named") {
             let mut updated_named = named_hash.as_ref().clone();
             let mut children: Vec<(String, Value)> = named_hash
                 .iter()
@@ -352,7 +352,7 @@ impl Interpreter {
                 .collect();
             children.sort_by_key(|(_, v)| {
                 if let Value::Instance { attributes, .. } = v
-                    && let Some(Value::Int(from)) = attributes.get("from")
+                    && let Some(Value::Int(from)) = attributes.as_map().get("from")
                 {
                     return *from;
                 }
@@ -398,7 +398,7 @@ impl Interpreter {
             self.env.remove_sym(*k);
         }
         // Set named capture env vars (<a>, <b>, etc.) so $<a> works inside action methods
-        if let Some(Value::Hash(named_hash)) = updated_attrs.get("named") {
+        if let Some(Value::Hash(named_hash)) = updated_attrs.as_map().get("named") {
             for (k, v) in named_hash.iter() {
                 self.env.insert(format!("<{}>", k), v.clone());
             }
@@ -411,7 +411,7 @@ impl Interpreter {
             let key = i.to_string();
             saved_positional.push((i, self.env.remove(&key)));
         }
-        if let Some(Value::Array(pos_arr, _)) = updated_attrs.get("list") {
+        if let Some(Value::Array(pos_arr, _)) = updated_attrs.as_map().get("list") {
             for (i, v) in pos_arr.iter().enumerate() {
                 self.env.insert(i.to_string(), v.clone());
             }
@@ -422,17 +422,18 @@ impl Interpreter {
 
         // For protoregex :sym<> variants, try dispatching to the specific
         // action method (e.g., alt:sym<baz>) first.
-        let sym_method_name = if let Some(Value::Str(sym_val)) = updated_attrs.get("sym_variant") {
-            // Use «» delimiters when the sym value contains '<' or '>'
-            // to match method names stored with French-quote delimiters
-            if sym_val.contains('<') || sym_val.contains('>') {
-                Some(format!("{rule_name}:sym\u{ab}{sym_val}\u{bb}"))
+        let sym_method_name =
+            if let Some(Value::Str(sym_val)) = updated_attrs.as_map().get("sym_variant") {
+                // Use «» delimiters when the sym value contains '<' or '>'
+                // to match method names stored with French-quote delimiters
+                if sym_val.contains('<') || sym_val.contains('>') {
+                    Some(format!("{rule_name}:sym\u{ab}{sym_val}\u{bb}"))
+                } else {
+                    Some(format!("{rule_name}:sym<{sym_val}>"))
+                }
             } else {
-                Some(format!("{rule_name}:sym<{sym_val}>"))
-            }
-        } else {
-            None
-        };
+                None
+            };
         let method_result = if let Some(ref sym_name) = sym_method_name {
             let result =
                 self.call_method_with_values(actions.clone(), sym_name, vec![match_obj.clone()]);
@@ -523,10 +524,10 @@ impl Interpreter {
         // If make() was called (via action_made which persists across env restore),
         // update .ast on match
         let final_obj = if let Some(ast) = self.action_made.take() {
-            let mut attrs = updated_attrs;
+            let attrs = updated_attrs;
             attrs.insert("ast".to_string(), ast);
             // Preserve actions attribute if present
-            if let Some(act_val) = attributes.get("actions") {
+            if let Some(act_val) = attributes.as_map().get("actions") {
                 attrs.insert("actions".to_string(), act_val.clone());
             }
             Value::make_instance(class_name, (attrs).to_map())

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -100,7 +100,7 @@ impl Interpreter {
                 // In Raku, `$obj!Owner::attr` accesses the private attribute `$!attr`
                 // directly when no explicit private method is defined.
                 if args.is_empty()
-                    && let Some(val) = attributes.get(pm_name)
+                    && let Some(val) = attributes.as_map().get(pm_name)
                 {
                     return Ok(val.clone());
                 }
@@ -112,7 +112,7 @@ impl Interpreter {
             }
 
             if class_name == "IterationBuffer" {
-                let mut items = match attributes.get("__mutsu_iterationbuffer_items") {
+                let mut items = match attributes.as_map().get("__mutsu_iterationbuffer_items") {
                     Some(Value::Array(values, ..))
                     | Some(Value::Seq(values))
                     | Some(Value::Slip(values)) => values.to_vec(),
@@ -125,7 +125,7 @@ impl Interpreter {
                             attributes,
                             ..
                         } if class_name == "IterationBuffer" => {
-                            match attributes.get("__mutsu_iterationbuffer_items") {
+                            match attributes.as_map().get("__mutsu_iterationbuffer_items") {
                                 Some(Value::Array(values, ..))
                                 | Some(Value::Seq(values))
                                 | Some(Value::Slip(values)) => values.to_vec(),
@@ -211,13 +211,14 @@ impl Interpreter {
                         let build = args.first().cloned().ok_or_else(|| {
                             RuntimeError::new("Attribute.set_build expects a build callback")
                         })?;
-                        let owner = attributes
+                        let map = attributes.as_map();
+                        let owner = map
                             .get("__mutsu_attr_owner")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
-                        let attr_name = attributes
+                        let attr_name = map
                             .get("__mutsu_attr_name")
-                            .or_else(|| attributes.get("name"))
+                            .or_else(|| map.get("name"))
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
                         if owner.is_empty() || attr_name.is_empty() {
@@ -231,35 +232,47 @@ impl Interpreter {
                         return Ok(target.clone());
                     }
                     "name" => {
-                        return Ok(attributes.get("name").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("name")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     "type" => {
                         return Ok(attributes
+                            .as_map()
                             .get("type")
                             .cloned()
                             .unwrap_or(Value::Package(crate::symbol::Symbol::intern("Mu"))));
                     }
                     "has_accessor" => {
                         return Ok(attributes
+                            .as_map()
                             .get("has_accessor")
                             .cloned()
                             .unwrap_or(Value::Bool(false)));
                     }
                     "rw" => {
                         return Ok(attributes
+                            .as_map()
                             .get("is_rw")
                             .cloned()
                             .unwrap_or(Value::Bool(false)));
                     }
                     "readonly" => {
-                        let is_rw = attributes.get("is_rw").map(|v| v.truthy()).unwrap_or(false);
+                        let is_rw = attributes
+                            .as_map()
+                            .get("is_rw")
+                            .map(|v| v.truthy())
+                            .unwrap_or(false);
                         return Ok(Value::Bool(!is_rw));
                     }
                     "build" => {
-                        if let Some(build_val) = attributes.get("build") {
+                        if let Some(build_val) = attributes.as_map().get("build") {
                             return Ok(build_val.clone());
                         }
                         if attributes
+                            .as_map()
                             .get("__mutsu_has_build")
                             .map(|v| v.truthy())
                             .unwrap_or(false)
@@ -273,6 +286,7 @@ impl Interpreter {
                             RuntimeError::new("Attribute.get_value expects an object argument")
                         })?;
                         let attr_name = attributes
+                            .as_map()
                             .get("__mutsu_attr_name")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
@@ -281,7 +295,11 @@ impl Interpreter {
                             ..
                         } = obj
                         {
-                            return Ok(obj_attrs.get(&attr_name).cloned().unwrap_or(Value::Nil));
+                            return Ok(obj_attrs
+                                .as_map()
+                                .get(&attr_name)
+                                .cloned()
+                                .unwrap_or(Value::Nil));
                         }
                         return Ok(Value::Nil);
                     }
@@ -293,6 +311,7 @@ impl Interpreter {
                         }
                         let new_val = args[1].clone();
                         let attr_name = attributes
+                            .as_map()
                             .get("__mutsu_attr_name")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
@@ -302,7 +321,7 @@ impl Interpreter {
                             id: obj_id,
                         } = &args[0]
                         {
-                            let mut updated = (**obj_attrs).clone();
+                            let updated = (**obj_attrs).clone();
                             updated.insert(attr_name, new_val);
                             self.overwrite_instance_bindings_by_identity(
                                 &obj_class.resolve(),
@@ -314,6 +333,7 @@ impl Interpreter {
                     }
                     "gist" | "Str" => {
                         let type_name = attributes
+                            .as_map()
                             .get("type")
                             .map(|v| match v {
                                 Value::Package(name) => name.resolve(),
@@ -321,6 +341,7 @@ impl Interpreter {
                             })
                             .unwrap_or_else(|| "Mu".to_string());
                         let name = attributes
+                            .as_map()
                             .get("name")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
@@ -331,6 +352,7 @@ impl Interpreter {
                     }
                     "raku" => {
                         let is_bootstrap = attributes
+                            .as_map()
                             .get("__mutsu_is_bootstrapattr")
                             .is_some_and(|v| v.truthy());
                         if is_bootstrap {
@@ -340,6 +362,7 @@ impl Interpreter {
                     }
                     "package" => {
                         let owner = attributes
+                            .as_map()
                             .get("__mutsu_attr_owner")
                             .map(|v| v.to_string_value())
                             .unwrap_or_else(|| "Any".to_string());
@@ -349,6 +372,7 @@ impl Interpreter {
                         // TODO: Return the actual container descriptor
                         // For now, return a basic array/hash container or Nil
                         let sigil = attributes
+                            .as_map()
                             .get("sigil")
                             .map(|v| v.to_string_value())
                             .unwrap_or_else(|| "$".to_string());
@@ -382,7 +406,7 @@ impl Interpreter {
             if class_name.resolve().starts_with("Distribution::")
                 && let Some(result) = self.dispatch_distribution_method(
                     &class_name.resolve(),
-                    (attributes).as_map(),
+                    &(attributes).as_map(),
                     method,
                     args.clone(),
                 )
@@ -391,7 +415,7 @@ impl Interpreter {
             }
             if class_name == "CompUnit::Repository::Installation"
                 && let Some(result) = self.dispatch_cur_installation_method(
-                    (attributes).as_map(),
+                    &(attributes).as_map(),
                     method,
                     args.clone(),
                 )
@@ -401,28 +425,39 @@ impl Interpreter {
             if class_name == "CompUnit::DependencySpecification" {
                 match method {
                     "short-name" => {
-                        return Ok(attributes.get("short-name").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("short-name")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     "auth-matcher" => {
                         return Ok(attributes
+                            .as_map()
                             .get("auth-matcher")
                             .cloned()
                             .unwrap_or(Value::Bool(true)));
                     }
                     "version-matcher" => {
                         return Ok(attributes
+                            .as_map()
                             .get("version-matcher")
                             .cloned()
                             .unwrap_or(Value::Bool(true)));
                     }
                     "api-matcher" => {
                         return Ok(attributes
+                            .as_map()
                             .get("api-matcher")
                             .cloned()
                             .unwrap_or(Value::Bool(true)));
                     }
                     "Str" | "gist" => {
-                        return Ok(attributes.get("short-name").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("short-name")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     _ => {}
                 }
@@ -431,6 +466,7 @@ impl Interpreter {
                 match method {
                     "candidates" => {
                         let prefix = attributes
+                            .as_map()
                             .get("prefix")
                             .map(Value::to_string_value)
                             .unwrap_or_default();
@@ -447,6 +483,7 @@ impl Interpreter {
                         };
                         let short_name_str = short_name.resolve();
                         let prefix = attributes
+                            .as_map()
                             .get("prefix")
                             .map(Value::to_string_value)
                             .unwrap_or_default();
@@ -479,6 +516,7 @@ impl Interpreter {
                             return Ok(Value::Nil);
                         };
                         let repo_precomp_enabled = attributes
+                            .as_map()
                             .get("__mutsu_precomp_enabled")
                             .is_none_or(Value::truthy);
                         // Load the module, using precompilation cache when available.
@@ -531,20 +569,32 @@ impl Interpreter {
             if class_name == "CompUnit" {
                 match method {
                     "short-name" => {
-                        return Ok(attributes.get("short-name").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("short-name")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     "name" => {
-                        return Ok(attributes.get("short-name").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("short-name")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     "version" => {
-                        return Ok(attributes.get("version").cloned().unwrap_or(Value::Nil));
+                        return Ok(attributes
+                            .as_map()
+                            .get("version")
+                            .cloned()
+                            .unwrap_or(Value::Nil));
                     }
                     // Rakudo exposes a handle object that can answer .globalish-package.
                     // For mutsu, the handle carries the symbols this CompUnit loaded so
                     // they can later be merged into GLOBAL via `merge-symbols`.
                     "handle" => {
                         let mut handle_attrs = HashMap::new();
-                        if let Some(syms) = attributes.get("globalish-symbols") {
+                        if let Some(syms) = attributes.as_map().get("globalish-symbols") {
                             handle_attrs.insert("globalish-symbols".to_string(), syms.clone());
                         }
                         return Ok(Value::make_instance(
@@ -553,13 +603,16 @@ impl Interpreter {
                         ));
                     }
                     "globalish-package" => {
-                        return Ok(self.make_globalish_package(attributes.get("globalish-symbols")));
+                        return Ok(self
+                            .make_globalish_package(attributes.as_map().get("globalish-symbols")));
                     }
                     _ => {}
                 }
             }
             if class_name == "CompUnit::Handle" && method == "globalish-package" {
-                return Ok(self.make_globalish_package(attributes.get("globalish-symbols")));
+                return Ok(
+                    self.make_globalish_package(attributes.as_map().get("globalish-symbols"))
+                );
             }
             if class_name == "Stash" && method == "merge-symbols" {
                 let pkg = args.first().cloned().unwrap_or(Value::Nil);
@@ -612,7 +665,7 @@ impl Interpreter {
                 ) {
                     return self.call_native_instance_method(
                         &class_name.resolve(),
-                        (attributes).as_map(),
+                        &(attributes).as_map(),
                         method,
                         args,
                     );
@@ -621,7 +674,7 @@ impl Interpreter {
             if self.is_native_method(&class_name.resolve(), method) {
                 return self.call_native_instance_method(
                     &class_name.resolve(),
-                    (attributes).as_map(),
+                    &(attributes).as_map(),
                     method,
                     args,
                 );
@@ -651,13 +704,13 @@ impl Interpreter {
                     || class_name == "Exception"
                     || class_name.resolve().ends_with("Exception"))
             {
-                if let Some(msg) = attributes.get("message") {
+                if let Some(msg) = attributes.as_map().get("message") {
                     return Ok(Value::str(msg.to_string_value()));
                 }
                 if let Some(formatted) =
                     crate::builtins::exception_message::format_exception_message(
                         &class_name.resolve(),
-                        (attributes).as_map(),
+                        &(attributes).as_map(),
                     )
                 {
                     return Ok(Value::str(formatted));
@@ -671,6 +724,7 @@ impl Interpreter {
                     || *class_name == Symbol::intern("ValueObjAt")
                 {
                     let which = attributes
+                        .as_map()
                         .get("WHICH")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
@@ -683,7 +737,7 @@ impl Interpreter {
                 // Collect public attributes for .raku representation
                 let class_key = class_name.resolve();
                 let public_attrs =
-                    self.collect_public_raku_attrs(&class_key, (attributes).as_map());
+                    self.collect_public_raku_attrs(&class_key, &(attributes).as_map());
                 if public_attrs.is_empty() {
                     return Ok(Value::str(format!("{}.new", class_name)));
                 }
@@ -694,7 +748,11 @@ impl Interpreter {
                 )));
             }
             if method == "name" && args.is_empty() {
-                return Ok(attributes.get("name").cloned().unwrap_or(Value::Nil));
+                return Ok(attributes
+                    .as_map()
+                    .get("name")
+                    .cloned()
+                    .unwrap_or(Value::Nil));
             }
             if method == "clone" {
                 let mut attrs: HashMap<String, Value> = attributes.to_map();
@@ -806,7 +864,7 @@ impl Interpreter {
                 let cn = class_name.resolve();
                 let class_attrs = self.collect_class_attributes(&cn);
                 if class_attrs.is_empty() {
-                    if let Some(val) = attributes.get(method) {
+                    if let Some(val) = attributes.as_map().get(method) {
                         // Check for deprecated attribute accessor
                         if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                             self.check_deprecation_for_method(method, &cn, &msg);
@@ -820,7 +878,11 @@ impl Interpreter {
                             if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                                 self.check_deprecation_for_method(method, &cn, &msg);
                             }
-                            let val = attributes.get(method).cloned().unwrap_or(Value::Nil);
+                            let val = attributes
+                                .as_map()
+                                .get(method)
+                                .cloned()
+                                .unwrap_or(Value::Nil);
                             // For typed @/% attributes, register type metadata on the
                             // returned value so push/insert type enforcement works.
                             if (*sigil == '@' || *sigil == '%')
@@ -854,7 +916,8 @@ impl Interpreter {
                         && variants.iter().any(|(vname, _)| vname == method)
                     {
                         // Get the stored enum value from the instance attribute
-                        let stored = attributes.get(enum_name);
+                        let map = attributes.as_map();
+                        let stored = map.get(enum_name);
                         if let Some(Value::Enum { key, .. }) = stored {
                             return Ok(Value::Bool(key.resolve() == method));
                         }
@@ -1191,16 +1254,23 @@ impl Interpreter {
                             let pattern = &attr_var[regex_idx + ":regex:".len()..];
                             let attr_key =
                                 real_attr.trim_start_matches('!').trim_start_matches('.');
-                            // Check if method name matches the regex pattern
-                            if let Ok(re) = fancy_regex::Regex::new(pattern)
-                                && re.is_match(method).unwrap_or(false)
-                                && let Some(delegate) = attributes.get(attr_key)
-                            {
-                                match self.call_method_with_values(
-                                    delegate.clone(),
-                                    method,
-                                    args.clone(),
-                                ) {
+                            // Check if method name matches the regex pattern. Clone
+                            // the delegate out *in its own statement* so the
+                            // attribute read guard is released before the
+                            // (re-entrant) method call below — a let-chain
+                            // condition keeps its temporaries (the guard) alive for
+                            // the whole `if` body, which would deadlock when the
+                            // callee writes back to this same instance's cell.
+                            let matches = fancy_regex::Regex::new(pattern)
+                                .map(|re| re.is_match(method).unwrap_or(false))
+                                .unwrap_or(false);
+                            let delegate = if matches {
+                                attributes.as_map().get(attr_key).cloned()
+                            } else {
+                                None
+                            };
+                            if let Some(delegate) = delegate {
+                                match self.call_method_with_values(delegate, method, args.clone()) {
                                     Ok(val) => return Ok(val),
                                     Err(_) => continue,
                                 }
@@ -1208,13 +1278,11 @@ impl Interpreter {
                             continue;
                         }
                         let attr_key = attr_var.trim_start_matches('!').trim_start_matches('.');
-                        if let Some(delegate) = attributes.get(attr_key) {
+                        // Clone out before calling (release the read guard first).
+                        let delegate = attributes.as_map().get(attr_key).cloned();
+                        if let Some(delegate) = delegate {
                             // Try calling the method on the delegate; if it succeeds, return
-                            match self.call_method_with_values(
-                                delegate.clone(),
-                                method,
-                                args.clone(),
-                            ) {
+                            match self.call_method_with_values(delegate, method, args.clone()) {
                                 Ok(val) => return Ok(val),
                                 Err(_) => continue, // delegate doesn't handle it either
                             }

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -328,8 +328,10 @@ impl Interpreter {
                 ..
             } => {
                 // Role candidate with index metadata
-                if let Some(Value::Int(idx)) = attributes.get("__mutsu_role_candidate_idx") {
+                if let Some(Value::Int(idx)) = attributes.as_map().get("__mutsu_role_candidate_idx")
+                {
                     let base_name = attributes
+                        .as_map()
                         .get("__mutsu_role_base_name")
                         .and_then(|v| match v {
                             Value::Str(s) => Some(s.to_string()),
@@ -345,16 +347,17 @@ impl Interpreter {
                 } else if class_name == "Attribute" {
                     // Attribute objects: look up by "ClassName::$!attrname"
                     let mut k = Vec::new();
-                    if let Some(Value::Str(attr_name)) = attributes.get("name") {
+                    if let Some(Value::Str(attr_name)) = attributes.as_map().get("name") {
                         // Try __mutsu_attr_owner first, then package
                         let owner = attributes
+                            .as_map()
                             .get("__mutsu_attr_owner")
                             .and_then(|v| match v {
                                 Value::Str(s) => Some(s.to_string()),
                                 _ => None,
                             })
                             .or_else(|| {
-                                attributes.get("package").and_then(|v| match v {
+                                attributes.as_map().get("package").and_then(|v| match v {
                                     Value::Package(p) => Some(p.resolve()),
                                     Value::Str(s) => Some(s.to_string()),
                                     _ => None,
@@ -370,6 +373,7 @@ impl Interpreter {
                     // Parameter objects: look up by "owner_sub::param_name"
                     let mut k = Vec::new();
                     let param_name = attributes
+                        .as_map()
                         .get("name")
                         .and_then(|v| match v {
                             Value::Str(s) => Some(s.to_string()),
@@ -377,13 +381,14 @@ impl Interpreter {
                         })
                         .unwrap_or_default();
                     let sigil = attributes
+                        .as_map()
                         .get("sigil")
                         .and_then(|v| match v {
                             Value::Str(s) => Some(s.to_string()),
                             _ => None,
                         })
                         .unwrap_or_default();
-                    if let Some(Value::Str(owner)) = attributes.get("__mutsu_owner_sub") {
+                    if let Some(Value::Str(owner)) = attributes.as_map().get("__mutsu_owner_sub") {
                         // Try scoped key with param name
                         if !param_name.is_empty() {
                             k.push(format!("{}::{}", owner, param_name));

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -120,7 +120,7 @@ impl Interpreter {
                 .map(|e| e.name.as_str().to_lowercase())
                 .unwrap_or_else(|| encoding.to_lowercase());
             let bytes = if is_wide {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     let use_be = normalized_encoding == "utf-16be";
                     let mut out = Vec::with_capacity(items.len() * 2);
                     for item in items.iter() {
@@ -139,7 +139,7 @@ impl Interpreter {
                 } else {
                     Vec::new()
                 }
-            } else if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+            } else if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                 items
                     .iter()
                     .map(|v| match v {
@@ -176,7 +176,7 @@ impl Interpreter {
         } = target
             && (class_name == "Buf" || class_name == "Blob")
         {
-            let bytes = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+            let bytes = if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                 items.to_vec()
             } else {
                 Vec::new()

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -168,7 +168,7 @@ impl Interpreter {
             );
             // Set positional capture env vars ($0, $1, ...) from match object
             if let Value::Instance { ref attributes, .. } = match_obj
-                && let Some(Value::Array(list, _)) = attributes.get("list")
+                && let Some(Value::Array(list, _)) = attributes.as_map().get("list")
             {
                 for (i, v) in list.iter().enumerate() {
                     self.env.insert(i.to_string(), v.clone());
@@ -176,7 +176,7 @@ impl Interpreter {
             }
             // Set named capture env vars from match object
             if let Value::Instance { ref attributes, .. } = match_obj
-                && let Some(Value::Hash(named_hash)) = attributes.get("named")
+                && let Some(Value::Hash(named_hash)) = attributes.as_map().get("named")
             {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -3059,9 +3059,12 @@ impl Interpreter {
 
             if class_name == "Iterator" {
                 let updated = (*attributes).clone();
-                if let Some(Value::Array(source, ..)) =
-                    updated.as_map().get("squish_source").cloned()
-                {
+                // Bind the source out in its own statement so the `as_map()` read
+                // guard is released before the body mutates `updated` in place
+                // (`updated.insert` below) — an `if let … = updated.as_map()…`
+                // would hold the guard for the whole body and self-deadlock.
+                let squish_source = updated.as_map().get("squish_source").cloned();
+                if let Some(Value::Array(source, ..)) = squish_source {
                     let mut scan_index = match updated.as_map().get("squish_scan_index") {
                         Some(Value::Int(i)) if *i >= 0 => *i as usize,
                         _ => 0,

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -260,7 +260,7 @@ impl Interpreter {
                 id,
             } = value
             {
-                for (attr_key, attr_val) in attributes.iter() {
+                for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Array(arc, ..) = attr_val
                         && std::sync::Arc::ptr_eq(arc, needle)
                     {
@@ -295,7 +295,7 @@ impl Interpreter {
                 id,
             } = value
             {
-                for (attr_key, attr_val) in attributes.iter() {
+                for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Hash(arc) = attr_val
                         && std::sync::Arc::ptr_eq(arc, needle)
                     {
@@ -418,6 +418,14 @@ impl Interpreter {
         id: u64,
         updated: std::collections::HashMap<String, Value>,
     ) {
+        // Phase 3, Stage 1: write the new attributes straight into the live
+        // shared cell. Because every alias of this instance (in this frame and
+        // any caller frame the scan below never visits) shares that cell, this
+        // single write is what makes the mutation visible across call frames —
+        // the fix for the long-standing closure-frame mutation bug. The
+        // by-identity scan that follows is now redundant (it rebuilds bindings
+        // that already share the updated cell) and is removed in Stage 2.
+        crate::value::update_instance_cell(id, &updated);
         for bound in self.env.values_mut() {
             Self::overwrite_instance_recursive(bound, class_name, id, &updated);
         }
@@ -451,7 +459,7 @@ impl Interpreter {
                 let this_id_val = *this_id;
                 if this_id_val != id {
                     // Check if any attribute contains the target instance
-                    let has_target = attributes.values().any(|v| {
+                    let has_target = attributes.as_map().values().any(|v| {
                         matches!(v, Value::Instance { class_name: cn, id: vid, .. }
                             if cn.resolve() == class_name && *vid == id)
                     });
@@ -816,7 +824,7 @@ impl Interpreter {
                 ..
             } = &target
             && (class_name == "IO::Socket::INET" || class_name == "IO::Handle")
-            && let Some(Value::Int(handle_id)) = attributes.get("handle")
+            && let Some(Value::Int(handle_id)) = attributes.as_map().get("handle")
         {
             let id = *handle_id as usize;
             let new_seps = match &value {
@@ -840,7 +848,7 @@ impl Interpreter {
                 ..
             } = &target
             && class_name == "IO::Handle"
-            && let Some(Value::Int(handle_id)) = attributes.get("handle")
+            && let Some(Value::Int(handle_id)) = attributes.as_map().get("handle")
         {
             let id = *handle_id as usize;
             let new_nl_out = value.to_string_value();
@@ -857,7 +865,7 @@ impl Interpreter {
                 id: inst_id,
             } = &target
             && class_name == "IO::Handle"
-            && let Some(Value::Int(handle_id)) = attributes.get("handle")
+            && let Some(Value::Int(handle_id)) = attributes.as_map().get("handle")
         {
             let hid = *handle_id as usize;
             let new_chomp = value.truthy();
@@ -888,8 +896,8 @@ impl Interpreter {
                 ..
             } = &target
             && class_name == "Pair"
-            && let Some(Value::Str(key)) = attributes.get("key")
-            && let Some(Value::Hash(source_hash)) = attributes.get("__mutsu_hash_ref")
+            && let Some(Value::Str(key)) = attributes.as_map().get("key")
+            && let Some(Value::Hash(source_hash)) = attributes.as_map().get("__mutsu_hash_ref")
         {
             let mut updated = (**source_hash).clone();
             updated.insert(key.to_string(), value.clone());
@@ -1423,9 +1431,11 @@ impl Interpreter {
                 } else {
                     method.to_string()
                 };
-                let mut updated = (*attributes).clone();
-                let mut assigned_value =
-                    Self::normalize_rw_accessor_assignment(updated.get(&attr_key).cloned(), value);
+                let updated = (*attributes).clone();
+                let mut assigned_value = Self::normalize_rw_accessor_assignment(
+                    updated.as_map().get(&attr_key).cloned(),
+                    value,
+                );
                 // When Nil is assigned to an attribute with `is default(...)`,
                 // restore the default value instead of setting Nil.
                 if matches!(assigned_value, Value::Nil)
@@ -1508,7 +1518,11 @@ impl Interpreter {
             let attr_key = attr_var_name
                 .trim_start_matches('.')
                 .trim_start_matches('!');
-            let delegate = attributes.get(attr_key).cloned().unwrap_or(Value::Nil);
+            let delegate = attributes
+                .as_map()
+                .get(attr_key)
+                .cloned()
+                .unwrap_or(Value::Nil);
             if delegate != Value::Nil {
                 let sigil = match &delegate {
                     Value::Array(..) => "@",
@@ -1526,7 +1540,7 @@ impl Interpreter {
                 )?;
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
-                let mut updated = (*attributes).clone();
+                let updated = (*attributes).clone();
                 updated.insert(attr_key.to_string(), updated_delegate);
                 if let Some(var_name) = target_var {
                     self.overwrite_instance_bindings_by_identity(
@@ -1549,7 +1563,7 @@ impl Interpreter {
             )));
         }
         if let Some(attr_name) = Self::rw_method_attribute_target(&method_def.body) {
-            let mut updated = (*attributes).clone();
+            let updated = (*attributes).clone();
             let current = if method_args.is_empty() {
                 self.call_method_with_values(
                     Value::Instance {
@@ -1598,7 +1612,11 @@ impl Interpreter {
             let attr_key = attr_var_name
                 .trim_start_matches('.')
                 .trim_start_matches('!');
-            let delegate = attributes.get(attr_key).cloned().unwrap_or(Value::Nil);
+            let delegate = attributes
+                .as_map()
+                .get(attr_key)
+                .cloned()
+                .unwrap_or(Value::Nil);
             if delegate != Value::Nil {
                 // Temporarily bind the delegate to an env variable for update tracking
                 let temp_var = "__mutsu_delegation_tmp__".to_string();
@@ -1615,7 +1633,7 @@ impl Interpreter {
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
                 // Write the updated delegate back into the frontend's attributes
-                let mut updated = (*attributes).clone();
+                let updated = (*attributes).clone();
                 updated.insert(attr_key.to_string(), updated_delegate);
                 if let Some(var_name) = target_var {
                     self.overwrite_instance_bindings_by_identity(
@@ -1728,7 +1746,10 @@ impl Interpreter {
                 return Ok(Value::proxy_var_object(target, target_var.to_string()));
             }
             if let Value::Instance { attributes, .. } = &target
-                && matches!(attributes.get("__mutsu_var_target"), Some(Value::Str(_)))
+                && matches!(
+                    attributes.as_map().get("__mutsu_var_target"),
+                    Some(Value::Str(_))
+                )
             {
                 return Ok(target);
             }
@@ -1829,6 +1850,7 @@ impl Interpreter {
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
             let bytes = attributes
+                .as_map()
                 .get("bytes")
                 .and_then(|v| match v {
                     Value::Array(items, ..) => Some(
@@ -1883,7 +1905,7 @@ impl Interpreter {
                     ));
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
-                let mut updated_attrs = attributes.as_ref().clone();
+                let updated_attrs = attributes.as_ref().clone();
                 updated_attrs.insert(
                     "bytes".to_string(),
                     Value::array(
@@ -1943,7 +1965,7 @@ impl Interpreter {
             };
             let mut bytes = {
                 let mut v: Vec<u8> = Vec::new();
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     v.reserve(items.len());
                     for it in items.iter() {
                         v.push(match it {
@@ -1958,7 +1980,7 @@ impl Interpreter {
             crate::builtins::buf_write_num::apply_write_num(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
-            let mut updated_attrs = attributes.as_ref().clone();
+            let updated_attrs = attributes.as_ref().clone();
             updated_attrs.insert(
                 "bytes".to_string(),
                 Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
@@ -2045,7 +2067,7 @@ impl Interpreter {
             };
             let mut bytes = {
                 let mut v: Vec<u8> = Vec::new();
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     v.reserve(items.len());
                     for it in items.iter() {
                         v.push(match it {
@@ -2060,7 +2082,7 @@ impl Interpreter {
             crate::builtins::buf_write_int::apply_write_int(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
-            let mut updated_attrs = attributes.as_ref().clone();
+            let updated_attrs = attributes.as_ref().clone();
             updated_attrs.insert(
                 "bytes".to_string(),
                 Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
@@ -2997,8 +3019,9 @@ impl Interpreter {
                 }
                 let from = from as usize;
                 let bits = bits as usize;
-                let mut updated = (*attributes).clone();
-                let mut bytes = if let Some(Value::Array(items, ..)) = updated.get("bytes") {
+                let updated = (*attributes).clone();
+                let mut bytes = if let Some(Value::Array(items, ..)) = updated.as_map().get("bytes")
+                {
                     items
                         .iter()
                         .map(|v| match v {
@@ -3035,23 +3058,30 @@ impl Interpreter {
             }
 
             if class_name == "Iterator" {
-                let mut updated = (*attributes).clone();
-                if let Some(Value::Array(source, ..)) = updated.get("squish_source").cloned() {
-                    let mut scan_index = match updated.get("squish_scan_index") {
+                let updated = (*attributes).clone();
+                if let Some(Value::Array(source, ..)) =
+                    updated.as_map().get("squish_source").cloned()
+                {
+                    let mut scan_index = match updated.as_map().get("squish_scan_index") {
                         Some(Value::Int(i)) if *i >= 0 => *i as usize,
                         _ => 0,
                     };
                     let mut prev_key = updated
+                        .as_map()
                         .get("squish_prev_key")
                         .cloned()
                         .unwrap_or(Value::Nil);
-                    let mut initialized =
-                        matches!(updated.get("squish_initialized"), Some(Value::Bool(true)));
+                    let mut initialized = matches!(
+                        updated.as_map().get("squish_initialized"),
+                        Some(Value::Bool(true))
+                    );
                     let as_func = updated
+                        .as_map()
                         .get("squish_as")
                         .cloned()
                         .filter(|v| !matches!(v, Value::Nil));
                     let with_func = updated
+                        .as_map()
                         .get("squish_with")
                         .cloned()
                         .filter(|v| !matches!(v, Value::Nil));
@@ -3100,10 +3130,10 @@ impl Interpreter {
 
                     let ret = match method {
                         "count-only" => self
-                            .iterator_count_only_from_attrs(updated.as_map())?
+                            .iterator_count_only_from_attrs(&updated.as_map())?
                             .unwrap_or_else(|| Value::Int(0)),
                         "bool-only" => self
-                            .iterator_bool_only_from_attrs(updated.as_map())?
+                            .iterator_bool_only_from_attrs(&updated.as_map())?
                             .unwrap_or(Value::Bool(false)),
                         "pull-one" => pull_one_squish(self)?,
                         "push-all" | "push-until-lazy" => {
@@ -3253,11 +3283,11 @@ impl Interpreter {
                     return Ok(ret);
                 }
 
-                let items = match updated.get("items") {
+                let items = match updated.as_map().get("items") {
                     Some(Value::Array(values, ..)) => values.to_vec(),
                     _ => Vec::new(),
                 };
-                let mut index = match updated.get("index") {
+                let mut index = match updated.as_map().get("index") {
                     Some(Value::Int(i)) if *i >= 0 => *i as usize,
                     _ => 0,
                 };
@@ -3412,7 +3442,11 @@ impl Interpreter {
                     );
                     self.call_method_with_values(invocant_val, &source_method, Vec::new())?
                 } else {
-                    attributes.get(attr_key).cloned().unwrap_or(Value::Nil)
+                    attributes
+                        .as_map()
+                        .get(attr_key)
+                        .cloned()
+                        .unwrap_or(Value::Nil)
                 };
                 if delegate == Value::Nil {
                     return Err(RuntimeError::new(format!(
@@ -3436,7 +3470,7 @@ impl Interpreter {
                 self.env.remove(&temp_var);
                 if !is_method_based {
                     // Write the updated delegate back into the frontend's attributes
-                    let mut updated = (*attributes).clone();
+                    let updated = (*attributes).clone();
                     updated.insert(attr_key.to_string(), updated_delegate);
                     self.overwrite_instance_bindings_by_identity(
                         &class_name.resolve(),
@@ -3470,7 +3504,7 @@ impl Interpreter {
                         .resolve_method(&class_name.resolve(), method, &[])
                         .is_some_and(|m| m.is_rw);
                     if !has_rw_method {
-                        let mut updated = (*attributes).clone();
+                        let updated = (*attributes).clone();
                         let assigned = args[0].clone();
                         updated.insert(method.to_string(), assigned.clone());
                         self.overwrite_instance_bindings_by_identity(
@@ -3504,7 +3538,11 @@ impl Interpreter {
                             .any(|(attr_name, is_public, ..)| *is_public && attr_name == method)
                     };
                     if is_public_accessor {
-                        let current = attributes.get(method).cloned().unwrap_or(Value::Nil);
+                        let current = attributes
+                            .as_map()
+                            .get(method)
+                            .cloned()
+                            .unwrap_or(Value::Nil);
                         return Err(RuntimeError::assignment_ro_typename(
                             super::utils::value_type_name(&current),
                             &current.to_string_value(),
@@ -3537,7 +3575,7 @@ impl Interpreter {
                         if err.message.starts_with("No native mutable method") {
                             return self.call_native_instance_method(
                                 &class_name.resolve(),
-                                attributes.as_map(),
+                                &attributes.as_map(),
                                 method,
                                 args,
                             );
@@ -3787,7 +3825,7 @@ impl Interpreter {
         value: Value,
     ) -> Result<Value, RuntimeError> {
         let mut items = if let Value::Instance { attributes, .. } = &target
-            && let Some(Value::Array(items, ..)) = attributes.get("bytes")
+            && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
         {
             items.to_vec()
         } else {
@@ -3798,7 +3836,7 @@ impl Interpreter {
         let len = method_args.get(1).map(crate::runtime::to_int).unwrap_or(0) as usize;
 
         let new_bytes = if let Value::Instance { attributes, .. } = &value
-            && let Some(Value::Array(new_items, ..)) = attributes.get("bytes")
+            && let Some(Value::Array(new_items, ..)) = attributes.as_map().get("bytes")
         {
             new_items.to_vec()
         } else {
@@ -3845,7 +3883,7 @@ impl Interpreter {
                     cn
                 )));
             }
-            let items = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+            let items = if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                 items.to_vec()
             } else {
                 Vec::new()
@@ -3882,7 +3920,7 @@ impl Interpreter {
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                         result.extend(items.to_vec());
                     }
                 }
@@ -3922,7 +3960,7 @@ impl Interpreter {
             ..
         } = &target
         {
-            let items = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+            let items = if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                 items.to_vec()
             } else {
                 Vec::new()
@@ -3991,7 +4029,7 @@ impl Interpreter {
                     cn, method
                 )));
             }
-            let items = if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+            let items = if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                 items.to_vec()
             } else {
                 Vec::new()

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -911,7 +911,7 @@ impl Interpreter {
                 if let Value::Instance { attributes, .. } = &date {
                     // Now build the subclass instance with all Date attrs plus any custom named attrs
                     let mut new_args = Vec::new();
-                    for (k, v) in attributes.iter() {
+                    for (k, v) in attributes.as_map().iter() {
                         new_args.push(Value::Pair(k.clone(), Box::new(v.clone())));
                     }
                     // Add any non-Date named args from the original call
@@ -966,12 +966,14 @@ impl Interpreter {
                         {
                             positional_path = Some(
                                 attributes
+                                    .as_map()
                                     .get("path")
                                     .map(|v| v.to_string_value())
                                     .unwrap_or_default(),
                             );
                             if cwd_attr.is_none() {
-                                cwd_attr = attributes.get("cwd").map(|v| v.to_string_value());
+                                cwd_attr =
+                                    attributes.as_map().get("cwd").map(|v| v.to_string_value());
                             }
                         }
                         Value::Pair(_, _) => {}
@@ -1062,7 +1064,7 @@ impl Interpreter {
                             } if class_name == "IterationBuffer" => {
                                 if let Some(
                                     Value::Array(vals, ..) | Value::Seq(vals) | Value::Slip(vals),
-                                ) = attributes.get("__mutsu_iterationbuffer_items")
+                                ) = attributes.as_map().get("__mutsu_iterationbuffer_items")
                                 {
                                     items.extend(vals.iter().cloned());
                                 }
@@ -1427,11 +1429,13 @@ impl Interpreter {
                             }
                             return Ok(seq);
                         }
-                        if let Value::Instance { attributes, .. } = iterator
-                            && let Some(Value::Array(items, ..)) =
-                                attributes.get("items").or_else(|| attributes.get("stuff"))
-                        {
-                            return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
+                        if let Value::Instance { attributes, .. } = iterator {
+                            let map = attributes.as_map();
+                            if let Some(Value::Array(items, ..)) =
+                                map.get("items").or_else(|| map.get("stuff"))
+                            {
+                                return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
+                            }
                         }
                         // Register deferred iterator: don't pull eagerly.
                         // Raku's Seq.new(iterator) creates a lazy Seq; pulling
@@ -1574,7 +1578,7 @@ impl Interpreter {
                                 ..
                             } if class_name == "DateTime" => {
                                 let (y, m, d, _, _, _, _) =
-                                    temporal::datetime_attrs((attributes).as_map());
+                                    temporal::datetime_attrs(&(attributes).as_map());
                                 year = y;
                                 month = m;
                                 day = d;
@@ -1585,6 +1589,7 @@ impl Interpreter {
                                 ..
                             } if class_name == "Instant" => {
                                 let tai = attributes
+                                    .as_map()
                                     .get("value")
                                     .and_then(crate::runtime::to_float_value)
                                     .unwrap_or(0.0);
@@ -1676,7 +1681,8 @@ impl Interpreter {
                                     } = value.as_ref()
                                         && class_name == "Date"
                                     {
-                                        let (y, m, d) = temporal::date_attrs((attributes).as_map());
+                                        let (y, m, d) =
+                                            temporal::date_attrs(&(attributes).as_map());
                                         year = y;
                                         month = m;
                                         day = d;
@@ -1804,7 +1810,7 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Date" => {
-                                let (y, m, d) = temporal::date_attrs((attributes).as_map());
+                                let (y, m, d) = temporal::date_attrs(&(attributes).as_map());
                                 year = y;
                                 month = m;
                                 day = d;
@@ -1818,7 +1824,11 @@ impl Interpreter {
                                 attributes,
                                 ..
                             } if class_name == "Instant" => {
-                                let val = attributes.get("value").cloned().unwrap_or(Value::Int(0));
+                                let val = attributes
+                                    .as_map()
+                                    .get("value")
+                                    .cloned()
+                                    .unwrap_or(Value::Int(0));
                                 let (tai_int, tai_frac) = match &val {
                                     Value::Rat(n, d) if *d != 0 => {
                                         (*n / *d, (*n % *d) as f64 / *d as f64)
@@ -1893,7 +1903,7 @@ impl Interpreter {
                                 id,
                             } = dt_with_formatter
                             {
-                                let mut updated = (*attributes).clone();
+                                let updated = (*attributes).clone();
                                 updated.insert(
                                     "__formatter_rendered".to_string(),
                                     Value::str(rendered),
@@ -2214,7 +2224,7 @@ impl Interpreter {
                                 attributes: ia,
                                 ..
                             } if crate::runtime::utils::is_buf_or_blob_class(&cn.resolve()) => {
-                                if let Some(Value::Array(items, ..)) = ia.get("bytes") {
+                                if let Some(Value::Array(items, ..)) = ia.as_map().get("bytes") {
                                     items.to_vec()
                                 } else {
                                     vec![]
@@ -2254,7 +2264,9 @@ impl Interpreter {
                                 || class_name.resolve().starts_with("buf")
                                 || class_name.resolve().starts_with("blob") =>
                             {
-                                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                                if let Some(Value::Array(items, ..)) =
+                                    attributes.as_map().get("bytes")
+                                {
                                     items.to_vec()
                                 } else {
                                     Vec::new()
@@ -3329,7 +3341,7 @@ impl Interpreter {
                             attributes: src_attrs,
                             ..
                         } if class_mro.iter().any(|name| name == &src_class.resolve()) => {
-                            for (attr, value) in src_attrs.iter() {
+                            for (attr, value) in src_attrs.as_map().iter() {
                                 attrs.insert(attr.clone(), value.clone());
                             }
                         }

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -62,7 +62,11 @@ impl Interpreter {
                     attributes,
                     ..
                 }) if class_name == "Instant" => {
-                    let tai = attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0);
+                    let tai = attributes
+                        .as_map()
+                        .get("value")
+                        .map(|v| v.to_f64())
+                        .unwrap_or(0.0);
                     crate::builtins::methods_0arg::temporal::instant_to_posix(tai)
                 }
                 Some(v) => v.to_f64(),

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -120,6 +120,7 @@ impl Interpreter {
             for (attr_name, is_public, ..) in &class_attrs {
                 if *is_public && attr_name == actual_method {
                     return Some(Ok(attributes
+                        .as_map()
                         .get(actual_method)
                         .cloned()
                         .unwrap_or(Value::Nil)));

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -683,10 +683,12 @@ impl Interpreter {
     pub(super) fn var_target_from_meta_value(value: &Value) -> Option<String> {
         match value {
             Value::Mixin(inner, _) => Self::var_target_from_meta_value(inner),
-            Value::Instance { attributes, .. } => match attributes.get("__mutsu_var_target") {
-                Some(Value::Str(name)) => Some(name.to_string()),
-                _ => None,
-            },
+            Value::Instance { attributes, .. } => {
+                match attributes.as_map().get("__mutsu_var_target") {
+                    Some(Value::Str(name)) => Some(name.to_string()),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     }

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -925,7 +925,7 @@ impl Interpreter {
                 self.env.insert("0".to_string(), Value::Nil);
             }
             if let Value::Instance { ref attributes, .. } = match_obj
-                && let Some(Value::Hash(named_hash)) = attributes.get("named")
+                && let Some(Value::Hash(named_hash)) = attributes.as_map().get("named")
             {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -176,6 +176,7 @@ impl Interpreter {
                     self.call_method_with_values(candidates[0].clone(), "signature", Vec::new())
                 {
                     attributes
+                        .as_map()
                         .get("gist")
                         .map(|v| v.to_string_value())
                         .unwrap_or_else(|| "()".to_string())
@@ -216,6 +217,7 @@ impl Interpreter {
                 let sig = make_signature_value(info);
                 if let Value::Instance { attributes, .. } = &sig {
                     attributes
+                        .as_map()
                         .get("gist")
                         .map(|v| v.to_string_value())
                         .unwrap_or_else(|| "()".to_string())
@@ -617,6 +619,7 @@ impl Interpreter {
             let sig = self.sub_signature_value(data);
             let sig_gist = if let Value::Instance { attributes, .. } = &sig {
                 attributes
+                    .as_map()
                     .get("gist")
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|| "()".to_string())
@@ -890,7 +893,7 @@ impl Interpreter {
     fn extract_wrap_handle_id(&self, handle: &Value) -> Option<u64> {
         match handle {
             Value::Instance { attributes, .. } => {
-                if let Some(Value::Int(id)) = attributes.get("handle-id") {
+                if let Some(Value::Int(id)) = attributes.as_map().get("handle-id") {
                     Some(*id as u64)
                 } else {
                     None

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -35,7 +35,7 @@ impl Interpreter {
         let mut all_values = Vec::new();
         for arg in args {
             if let Value::Instance { attributes, .. } = arg
-                && let Some(Value::Array(items, ..)) = attributes.get("values")
+                && let Some(Value::Array(items, ..)) = attributes.as_map().get("values")
             {
                 all_values.extend(items.iter().cloned());
             }
@@ -129,7 +129,7 @@ impl Interpreter {
         let mut supply_values: Vec<Vec<Value>> = Vec::new();
         for arg in &supplies {
             if let Value::Instance { attributes, .. } = arg {
-                let items = match attributes.get("values") {
+                let items = match attributes.as_map().get("values") {
                     Some(Value::Array(items, ..)) => items.to_vec(),
                     _ => Vec::new(),
                 };
@@ -176,13 +176,13 @@ impl Interpreter {
 
         for supply in supplies {
             if let Value::Instance { attributes, .. } = supply {
-                if let Some(Value::Int(sid)) = attributes.get("supply_id")
+                if let Some(Value::Int(sid)) = attributes.as_map().get("supply_id")
                     && let Some(rx) = take_supply_channel(*sid as u64)
                 {
                     sources.push(SourceKind::Channel(rx));
                     continue;
                 }
-                let items = match attributes.get("values") {
+                let items = match attributes.as_map().get("values") {
                     Some(Value::Array(items, ..)) => items.to_vec(),
                     _ => Vec::new(),
                 };
@@ -578,7 +578,7 @@ impl Interpreter {
                     Box::new(Value::array(init)),
                 ));
             }
-            self.native_supply((attributes).as_map(), "zip-latest", method_args)
+            self.native_supply(&(attributes).as_map(), "zip-latest", method_args)
         } else {
             Err(RuntimeError::new(
                 "Cannot call zip-latest on non-Supply".to_string(),

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -38,11 +38,11 @@ fn rebless_datetime_result(
     if class_name != "DateTime" {
         return result;
     }
-    let mut merged = (**original_attrs).clone();
+    let merged = (**original_attrs).clone();
     for key in [
         "year", "month", "day", "hour", "minute", "second", "timezone",
     ] {
-        if let Some(value) = attributes.get(key) {
+        if let Some(value) = attributes.as_map().get(key) {
             merged.insert(key.to_string(), value.clone());
         }
     }
@@ -78,9 +78,9 @@ fn rebless_date_result(
     if class_name != "Date" {
         return result;
     }
-    let mut merged = (**original_attrs).clone();
+    let merged = (**original_attrs).clone();
     for key in ["year", "month", "day"] {
-        if let Some(value) = attributes.get(key) {
+        if let Some(value) = attributes.as_map().get(key) {
             merged.insert(key.to_string(), value.clone());
         }
     }
@@ -109,14 +109,14 @@ pub(super) fn dispatch_temporal_method(
             attributes,
             ..
         } if has_date_attrs(attributes) && !has_datetime_attrs(attributes) => {
-            let (year, month, day) = temporal::date_attrs((attributes).as_map());
+            let (year, month, day) = temporal::date_attrs(&(attributes).as_map());
             match method {
                 "later" | "earlier" => Some(
                     date_later_earlier(year, month, day, args, method)
                         .map(|v| rebless_date_result(v, *class_name, attributes)),
                 ),
                 "clone" => {
-                    let existing_formatter = attributes.get("formatter").cloned();
+                    let existing_formatter = attributes.as_map().get("formatter").cloned();
                     Some(
                         date_clone(year, month, day, existing_formatter, args)
                             .map(|v| rebless_date_result(v, *class_name, attributes)),
@@ -136,14 +136,14 @@ pub(super) fn dispatch_temporal_method(
                     }
                 }
                 "first-date-in-month" if args.is_empty() => {
-                    let formatter = attributes.get("formatter").cloned();
+                    let formatter = attributes.as_map().get("formatter").cloned();
                     Some(Ok(temporal::make_date_with_formatter(
                         year, month, 1, formatter,
                     )))
                 }
                 "last-date-in-month" if args.is_empty() => {
                     let last_day = temporal::days_in_month(year, month);
-                    let formatter = attributes.get("formatter").cloned();
+                    let formatter = attributes.as_map().get("formatter").cloned();
                     Some(Ok(temporal::make_date_with_formatter(
                         year, month, last_day, formatter,
                     )))
@@ -157,7 +157,7 @@ pub(super) fn dispatch_temporal_method(
             ..
         } if has_datetime_attrs(attributes) => {
             let (year, month, day, hour, minute, second, timezone) =
-                temporal::datetime_attrs((attributes).as_map());
+                temporal::datetime_attrs(&(attributes).as_map());
             match method {
                 "later" | "earlier" => Some(
                     datetime_later_earlier(

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -13,21 +13,22 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "Supply" => {
-                let values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
-                    let emitter = Value::make_instance(Symbol::intern("Supplier"), {
-                        let mut a = HashMap::new();
-                        a.insert("emitted".to_string(), Value::array(Vec::new()));
-                        a.insert("done".to_string(), Value::Bool(false));
-                        a
-                    });
-                    self.supply_emit_buffer.push(Vec::new());
-                    let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
-                    self.supply_emit_buffer.pop().unwrap_or_default()
-                } else if attributes.get("values").is_some() {
-                    self.supply_list_values(attributes.as_map(), true)?
-                } else {
-                    Vec::new()
-                };
+                let values =
+                    if let Some(on_demand_cb) = attributes.as_map().get("on_demand_callback") {
+                        let emitter = Value::make_instance(Symbol::intern("Supplier"), {
+                            let mut a = HashMap::new();
+                            a.insert("emitted".to_string(), Value::array(Vec::new()));
+                            a.insert("done".to_string(), Value::Bool(false));
+                            a
+                        });
+                        self.supply_emit_buffer.push(Vec::new());
+                        let _ = self.call_sub_value(on_demand_cb.clone(), vec![emitter], false);
+                        self.supply_emit_buffer.pop().unwrap_or_default()
+                    } else if attributes.as_map().get("values").is_some() {
+                        self.supply_list_values(&attributes.as_map(), true)?
+                    } else {
+                        Vec::new()
+                    };
                 Value::Seq(std::sync::Arc::new(values))
             }
             Value::LazyList(ll) => {
@@ -58,7 +59,7 @@ impl Interpreter {
                     || cn.starts_with("blob")
             } =>
             {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     Value::Seq(items.clone())
                 } else {
                     Value::Seq(std::sync::Arc::new(Vec::new()))
@@ -86,7 +87,7 @@ impl Interpreter {
                 || cn.starts_with("buf")
                 || cn.starts_with("blob")
             {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     return Ok(Value::Array(items.clone(), crate::value::ArrayKind::List));
                 }
                 return Ok(Value::Array(

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2231,6 +2231,7 @@ impl Interpreter {
                             attributes,
                             ..
                         } if class_name == "IO::Path" => attributes
+                            .as_map()
                             .get("path")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default(),
@@ -2251,6 +2252,7 @@ impl Interpreter {
                             attributes,
                             ..
                         } if class_name == "IO::Path" => attributes
+                            .as_map()
                             .get("path")
                             .map(|p| p.to_string_value())
                             .unwrap_or_default(),
@@ -3048,8 +3050,8 @@ impl Interpreter {
                                 ) =>
                                 {
                                     // Try "bytes" first (make_buf), then "data"
-                                    let bytes_arr =
-                                        attributes.get("bytes").or_else(|| attributes.get("data"));
+                                    let map = attributes.as_map();
+                                    let bytes_arr = map.get("bytes").or_else(|| map.get("data"));
                                     if let Some(Value::Array(bytes, _)) = bytes_arr {
                                         let data: Vec<u8> =
                                             bytes.iter().map(|v| v.to_f64() as u8).collect();

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -21,7 +21,7 @@ fn extend_buffer_from_value(out: &mut Vec<u8>, v: &Value) {
             }
         }
         Value::Instance { attributes, .. } => {
-            if let Some(bytes_val) = attributes.get("bytes") {
+            if let Some(bytes_val) = attributes.as_map().get("bytes") {
                 extend_buffer_from_value(out, bytes_val);
             }
         }

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -196,7 +196,7 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     return items
                         .iter()
                         .map(|v| match v {
@@ -212,7 +212,7 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "utf16" => {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     let use_be = normalized == "utf-16be";
                     let mut bytes = Vec::with_capacity(items.len() * 2);
                     for item in items.iter() {

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -33,11 +33,11 @@ impl Interpreter {
         else {
             return Ok((Value::Bool(false), attributes));
         };
-        let new_pid = match new_attrs.get("pid") {
+        let new_pid = match new_attrs.as_map().get("pid") {
             Some(Value::Int(p)) => *p,
             _ => 0,
         };
-        let exitcode = match new_attrs.get("exitcode") {
+        let exitcode = match new_attrs.as_map().get("exitcode") {
             Some(Value::Int(c)) => *c,
             _ => -1,
         };
@@ -46,15 +46,15 @@ impl Interpreter {
         // previous pid in that case (matches rakudo's `.spawn` semantics).
         if new_pid != 0 {
             for key in ["pid", "command", "out", "err"] {
-                if let Some(v) = new_attrs.get(key) {
+                if let Some(v) = new_attrs.as_map().get(key) {
                     updated.insert(key.to_string(), v.clone());
                 }
             }
         }
-        if let Some(v) = new_attrs.get("exitcode") {
+        if let Some(v) = new_attrs.as_map().get("exitcode") {
             updated.insert("exitcode".to_string(), v.clone());
         }
-        if let Some(v) = new_attrs.get("signal") {
+        if let Some(v) = new_attrs.as_map().get("signal") {
             updated.insert("signal".to_string(), v.clone());
         }
         Ok((Value::Bool(exitcode == 0), updated))

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -201,7 +201,7 @@ impl Interpreter {
                 let cancellation = Self::cancellation_instance();
                 let cancellation_id = match &cancellation {
                     Value::Instance { attributes, .. } => {
-                        match attributes.get("cancellation-id").cloned() {
+                        match attributes.as_map().get("cancellation-id").cloned() {
                             Some(Value::Int(id)) if id > 0 => id as u64,
                             _ => 0,
                         }

--- a/src/runtime/native_methods/socket_helpers.rs
+++ b/src/runtime/native_methods/socket_helpers.rs
@@ -20,7 +20,7 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     Some(
                         items
                             .iter()

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -73,7 +73,7 @@ impl Interpreter {
                 // Get stdout/stderr supply IDs
                 let stdout_supply_id = attrs.get("stdout").and_then(|v| {
                     if let Value::Instance { attributes, .. } = v
-                        && let Some(Value::Int(id)) = attributes.get("supply_id")
+                        && let Some(Value::Int(id)) = attributes.as_map().get("supply_id")
                     {
                         return Some(*id as u64);
                     }
@@ -81,7 +81,7 @@ impl Interpreter {
                 });
                 let stderr_supply_id = attrs.get("stderr").and_then(|v| {
                     if let Value::Instance { attributes, .. } = v
-                        && let Some(Value::Int(id)) = attributes.get("supply_id")
+                        && let Some(Value::Int(id)) = attributes.as_map().get("supply_id")
                     {
                         return Some(*id as u64);
                     }
@@ -89,7 +89,7 @@ impl Interpreter {
                 });
                 let merged_supply_id = attrs.get("supply").and_then(|v| {
                     if let Value::Instance { attributes, .. } = v
-                        && let Some(Value::Int(id)) = attributes.get("supply_id")
+                        && let Some(Value::Int(id)) = attributes.as_map().get("supply_id")
                     {
                         return Some(*id as u64);
                     }
@@ -181,7 +181,7 @@ impl Interpreter {
                     ..
                 }) = attrs.get("stdout")
                     && let Some(Value::Promise(promise)) =
-                        stdout_attrs.get("native_descriptor_promise")
+                        stdout_attrs.as_map().get("native_descriptor_promise")
                 {
                     promise.try_keep(Value::Int(1)).ok();
                 }
@@ -190,7 +190,7 @@ impl Interpreter {
                     ..
                 }) = attrs.get("stderr")
                     && let Some(Value::Promise(promise)) =
-                        stderr_attrs.get("native_descriptor_promise")
+                        stderr_attrs.as_map().get("native_descriptor_promise")
                 {
                     promise.try_keep(Value::Int(2)).ok();
                 }
@@ -532,7 +532,7 @@ impl Interpreter {
                             || cn.starts_with("Blob[")
                     } =>
                     {
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             items
                                 .iter()
                                 .map(|v| match v {
@@ -827,7 +827,7 @@ impl Interpreter {
             ..
         } = value
             && class_name == "Supply"
-            && let Some(Value::Int(sid)) = attributes.get("supply_id")
+            && let Some(Value::Int(sid)) = attributes.as_map().get("supply_id")
             && *sid >= 0
         {
             return Some(*sid as u64);

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -18,7 +18,7 @@ impl Interpreter {
             ..
         } = &done_cb
             && *class_name == "__WheneverDoneGroup"
-            && let Some(Value::Int(group_id)) = attributes.get("group_id")
+            && let Some(Value::Int(group_id)) = attributes.as_map().get("group_id")
         {
             if let Some(real_done_cb) = whenever_done_group_decrement(*group_id as u64) {
                 let _ = self.call_sub_value(real_done_cb, vec![], true);
@@ -630,7 +630,8 @@ impl Interpreter {
                                 attributes: inner_attrs,
                                 ..
                             } = inner_supply
-                                && let Some(Value::Int(sid)) = inner_attrs.get("supplier_id")
+                                && let Some(Value::Int(sid)) =
+                                    inner_attrs.as_map().get("supplier_id")
                             {
                                 let supplier_id = *sid as u64;
                                 // Register the body callback as a tap on the
@@ -665,14 +666,12 @@ impl Interpreter {
                             } else {
                                 // Non-supplier supply: run body_cb for each
                                 // value synchronously (cold supply path).
-                                let empty_attrs = HashMap::new();
-                                let inner_attrs_ref =
+                                let inner_vals =
                                     if let Value::Instance { attributes: a, .. } = inner_supply {
-                                        a.as_map()
+                                        self.supply_list_values(&a.as_map(), true)?
                                     } else {
-                                        &empty_attrs
+                                        self.supply_list_values(&HashMap::new(), true)?
                                     };
-                                let inner_vals = self.supply_list_values(inner_attrs_ref, true)?;
                                 for v in inner_vals {
                                     match self.call_sub_value(body_cb.clone(), vec![v], true) {
                                         Ok(_) => {}
@@ -927,7 +926,7 @@ impl Interpreter {
                 }
                 for arg in &args {
                     if let Value::Instance { attributes, .. } = arg
-                        && let Some(Value::Array(items, ..)) = attributes.get("values")
+                        && let Some(Value::Array(items, ..)) = attributes.as_map().get("values")
                     {
                         all_values.extend(items.iter().cloned());
                     }
@@ -1359,7 +1358,7 @@ impl Interpreter {
                 let any_live = self_is_live
                     || other_supplies.iter().any(|s| {
                         if let Value::Instance { attributes, .. } = s {
-                            supplier_id_from_attrs((attributes).as_map()).is_some()
+                            supplier_id_from_attrs(&(attributes).as_map()).is_some()
                                 || attributes.contains_key("supply_id")
                         } else {
                             false
@@ -1392,11 +1391,13 @@ impl Interpreter {
                             Static(Vec<Value>),
                         }
 
-                        // Collect all sources (self + others)
-                        let mut all_supplies: Vec<&HashMap<String, Value>> = vec![attributes];
+                        // Collect all sources (self + others). Own each map so we
+                        // don't hold attribute read guards across the loop below.
+                        let mut all_supplies: Vec<HashMap<String, Value>> =
+                            vec![attributes.clone()];
                         for supply in &other_supplies {
                             if let Value::Instance { attributes: a, .. } = supply {
-                                all_supplies.push((a).as_map());
+                                all_supplies.push(a.to_map());
                             }
                         }
 
@@ -1506,7 +1507,7 @@ impl Interpreter {
                             } = supply
                             {
                                 let source_index = i + 1;
-                                if let Some(sid) = supplier_id_from_attrs((other_attrs).as_map()) {
+                                if let Some(sid) = supplier_id_from_attrs(&(other_attrs).as_map()) {
                                     register_supplier_zip_latest_tap(
                                         sid,
                                         zip_latest_state_id,
@@ -1528,7 +1529,7 @@ impl Interpreter {
                             } = supply
                             {
                                 let source_index = i + 1;
-                                if let Some(sid) = supplier_id_from_attrs((other_attrs).as_map()) {
+                                if let Some(sid) = supplier_id_from_attrs(&(other_attrs).as_map()) {
                                     register_supplier_zip_tap(sid, zip_state_id, source_index);
                                 }
                             }
@@ -1556,7 +1557,7 @@ impl Interpreter {
                         } = arg
                             && class_name == "Supply"
                         {
-                            other_values.push(self.supply_get_values((attributes).as_map())?);
+                            other_values.push(self.supply_get_values(&(attributes).as_map())?);
                         }
                     }
                     let min_len = std::iter::once(source_values.len())
@@ -2598,7 +2599,8 @@ impl Interpreter {
                                 attributes: inner_attrs,
                                 ..
                             } = inner_supply
-                                && let Some(Value::Int(sid)) = inner_attrs.get("supplier_id")
+                                && let Some(Value::Int(sid)) =
+                                    inner_attrs.as_map().get("supplier_id")
                             {
                                 let supplier_id = *sid as u64;
                                 register_supplier_tap(supplier_id, body_cb, 0.0);
@@ -2625,14 +2627,12 @@ impl Interpreter {
                                     register_supplier_done_callback(supplier_id, marker.clone());
                                 }
                             } else {
-                                let empty_attrs = HashMap::new();
-                                let inner_attrs_ref =
+                                let inner_vals =
                                     if let Value::Instance { attributes: a, .. } = inner_supply {
-                                        a.as_map()
+                                        self.supply_list_values(&a.as_map(), true)?
                                     } else {
-                                        &empty_attrs
+                                        self.supply_list_values(&HashMap::new(), true)?
                                     };
-                                let inner_vals = self.supply_list_values(inner_attrs_ref, true)?;
                                 for v in inner_vals {
                                     match self.call_sub_value(body_cb.clone(), vec![v], true) {
                                         Ok(_) => {}
@@ -3290,9 +3290,10 @@ impl Interpreter {
                 } = source
                 {
                     // Try to get channel via supply_id (or parent_supply_id for lines)
-                    let supply_id = inner_attrs
+                    let inner_map = inner_attrs.as_map();
+                    let supply_id = inner_map
                         .get("parent_supply_id")
-                        .or_else(|| inner_attrs.get("supply_id"))
+                        .or_else(|| inner_map.get("supply_id"))
                         .and_then(|v| {
                             if let Value::Int(id) = v {
                                 Some(*id as u64)
@@ -3393,14 +3394,14 @@ impl Interpreter {
         }
         let control_supplier_id = Self::named_value(&args, "control").and_then(|v| {
             if let Value::Instance { attributes, .. } = &v {
-                supplier_id_from_attrs((attributes).as_map())
+                supplier_id_from_attrs(&(attributes).as_map())
             } else {
                 None
             }
         });
         let status_supplier_id = Self::named_value(&args, "status").and_then(|v| {
             if let Value::Instance { attributes, .. } = &v {
-                supplier_id_from_attrs((attributes).as_map())
+                supplier_id_from_attrs(&(attributes).as_map())
             } else {
                 None
             }
@@ -3603,7 +3604,7 @@ impl Interpreter {
         } = &target
             && class_name == "Supply"
         {
-            self.native_supply((attributes).as_map(), method, args.to_vec())
+            self.native_supply(&(attributes).as_map(), method, args.to_vec())
         } else {
             Err(RuntimeError::new(format!(
                 "Cannot call .{} on non-Supply",

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -760,7 +760,7 @@ impl Interpreter {
 
     fn extract_buf_bytes(val: &Value) -> Vec<u8> {
         if let Value::Instance { attributes, .. } = val
-            && let Some(Value::Array(items, ..)) = attributes.get("bytes")
+            && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
         {
             items
                 .iter()
@@ -1324,11 +1324,11 @@ impl Interpreter {
                     {
                         let (ly, lm, ld, lh, lmin, ls, ltz) =
                             crate::builtins::methods_0arg::temporal::datetime_attrs(
-                                (left_attrs).as_map(),
+                                &(left_attrs).as_map(),
                             );
                         let (ry, rm, rd, rh, rmin, rs, rtz) =
                             crate::builtins::methods_0arg::temporal::datetime_attrs(
-                                (right_attrs).as_map(),
+                                &(right_attrs).as_map(),
                             );
                         let left_instant =
                             crate::builtins::methods_0arg::temporal::datetime_to_instant_leap_aware(
@@ -1434,10 +1434,10 @@ impl Interpreter {
                 {
                     let (y, m, d, _, _, _, _) =
                         crate::builtins::methods_0arg::temporal::datetime_attrs(
-                            (dt_attrs).as_map(),
+                            &(dt_attrs).as_map(),
                         );
                     let (dy, dm, dd) =
-                        crate::builtins::methods_0arg::temporal::date_attrs((d_attrs).as_map());
+                        crate::builtins::methods_0arg::temporal::date_attrs(&(d_attrs).as_map());
                     return Ok(Value::Bool(y == dy && m == dm && d == dd));
                 }
                 // Basic smartmatch fallback: value equality

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -85,9 +85,9 @@ impl Interpreter {
             if class_name != "Supply" {
                 return None;
             }
-            let supply_id = self.resolve_supply_channel_id_for_react((attributes).as_map());
-            let is_lines = matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
-            let head_limit = Self::extract_supply_head_limit((attributes).as_map());
+            let supply_id = self.resolve_supply_channel_id_for_react(&(attributes).as_map());
+            let is_lines = matches!(attributes.as_map().get("is_lines"), Some(Value::Bool(true)));
+            let head_limit = Self::extract_supply_head_limit(&(attributes).as_map());
             if let Some(sid) = supply_id
                 && let Some(rx) = take_supply_channel(sid)
             {
@@ -104,7 +104,7 @@ impl Interpreter {
                     supplier_id: None,
                     supplier_next_index: 0,
                     callback,
-                    close_callbacks: Self::extract_supply_on_close_cbs((attributes).as_map()),
+                    close_callbacks: Self::extract_supply_on_close_cbs(&(attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
                     done: false,
@@ -116,7 +116,7 @@ impl Interpreter {
                     promise: None,
                 });
             }
-            if let Some(Value::Int(sid)) = attributes.get("supplier_id") {
+            if let Some(Value::Int(sid)) = attributes.as_map().get("supplier_id") {
                 let last_cbs = items
                     .get(2)
                     .and_then(Self::react_value_array_items)
@@ -130,7 +130,7 @@ impl Interpreter {
                     supplier_id: Some(*sid as u64),
                     supplier_next_index: 0,
                     callback,
-                    close_callbacks: Self::extract_supply_on_close_cbs((attributes).as_map()),
+                    close_callbacks: Self::extract_supply_on_close_cbs(&(attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
                     done: false,

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -427,7 +427,7 @@ impl Interpreter {
                         ..
                     } = match_obj
                     {
-                        let mut attrs = attributes.as_ref().clone();
+                        let attrs = attributes.as_ref().clone();
                         attrs.insert("ast".to_string(), ast.clone());
                         Value::make_instance(class_name, (attrs).to_map())
                     } else {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1523,9 +1523,9 @@ impl Interpreter {
             Value::Instance { attributes, .. } => {
                 // Try "meta" first (Distribution::Installation from detect_inst_distribution),
                 // then fall back to "$!meta" (plain Distribution from detect_distribution).
-                attributes
-                    .get("meta")
-                    .or_else(|| attributes.get("$!meta"))
+                let map = attributes.as_map();
+                map.get("meta")
+                    .or_else(|| map.get("$!meta"))
                     .cloned()
                     .unwrap_or(Value::Nil)
             }

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -108,7 +108,7 @@ impl Interpreter {
         }
         // Set named capture env vars from the match object's named hash
         if let Value::Instance { ref attributes, .. } = match_obj
-            && let Some(Value::Hash(named_hash)) = attributes.get("named")
+            && let Some(Value::Hash(named_hash)) = attributes.as_map().get("named")
         {
             for (k, v) in named_hash.iter() {
                 self.env.insert(format!("<{}>", k), v.clone());
@@ -377,7 +377,7 @@ impl Interpreter {
     /// Get the match continuation position from `$/.to`, defaulting to 0.
     pub(in crate::runtime) fn get_match_to_position(&self) -> usize {
         if let Some(Value::Instance { attributes, .. }) = self.env.get("/")
-            && let Some(Value::Int(to)) = attributes.get("to")
+            && let Some(Value::Int(to)) = attributes.as_map().get("to")
         {
             return *to as usize;
         }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -8,10 +8,12 @@ impl Interpreter {
         attrs: &std::sync::Arc<crate::value::InstanceAttrs>,
     ) -> (String, String) {
         let path = attrs
+            .as_map()
             .get("path")
             .map(|v: &Value| v.to_string_value())
             .unwrap_or_default();
         let cwd = attrs
+            .as_map()
             .get("cwd")
             .map(|v: &Value| v.to_string_value())
             .unwrap_or_else(|| {
@@ -50,9 +52,9 @@ impl Interpreter {
                 },
             ) if left_class == "DateTime" && right_class == "Date" => {
                 let (y, m, d, _, _, _, _) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(&(left_attrs).as_map());
                 let (ry, rm, rd) =
-                    crate::builtins::methods_0arg::temporal::date_attrs((right_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::date_attrs(&(right_attrs).as_map());
                 y == ry && m == rm && d == rd
             }
             (Value::Version { .. }, Value::Version { parts, plus, minus }) => {
@@ -709,21 +711,22 @@ impl Interpreter {
                             ref mut attributes, ..
                         } = match_obj
                     {
-                        let attrs = std::sync::Arc::make_mut(attributes);
-                        if let Some(Value::Hash(named_hash)) = attrs.get_mut("named") {
-                            let named_hash = std::sync::Arc::make_mut(named_hash);
-                            for (hash_name, entries) in &captures.hash_captures {
-                                let mut hash_map: HashMap<String, Value> = HashMap::new();
-                                for (key, value) in entries {
-                                    let val = match value {
-                                        Some(v) => Value::str(v.clone()),
-                                        None => Value::Nil,
-                                    };
-                                    hash_map.insert(key.clone(), val);
+                        attributes.with_attr_mut("named", |named| {
+                            if let Value::Hash(named_hash) = named {
+                                let named_hash = std::sync::Arc::make_mut(named_hash);
+                                for (hash_name, entries) in &captures.hash_captures {
+                                    let mut hash_map: HashMap<String, Value> = HashMap::new();
+                                    for (key, value) in entries {
+                                        let val = match value {
+                                            Some(v) => Value::str(v.clone()),
+                                            None => Value::Nil,
+                                        };
+                                        hash_map.insert(key.clone(), val);
+                                    }
+                                    named_hash.insert(hash_name.clone(), Value::hash(hash_map));
                                 }
-                                named_hash.insert(hash_name.clone(), Value::hash(hash_map));
                             }
-                        }
+                        });
                     }
                     // If the original value is not a Str, store the original value
                     // as the `orig` attribute so .orig preserves the type
@@ -732,8 +735,7 @@ impl Interpreter {
                             ref mut attributes, ..
                         } = match_obj
                     {
-                        let attrs = std::sync::Arc::make_mut(attributes);
-                        attrs.insert("orig".to_string(), left.clone());
+                        attributes.insert("orig".to_string(), left.clone());
                     }
                     // If `make` was called in a code block, set the ast attribute
                     if let Some(made_val) = self.env.get("made").cloned()
@@ -741,12 +743,11 @@ impl Interpreter {
                             ref mut attributes, ..
                         } = match_obj
                     {
-                        let attrs = std::sync::Arc::make_mut(attributes);
-                        attrs.insert("ast".to_string(), made_val);
+                        attributes.insert("ast".to_string(), made_val);
                     }
                     // Upgrade positional capture env vars ($0, $1, ...) to Match objects
                     if let Value::Instance { ref attributes, .. } = match_obj
-                        && let Some(Value::Array(list, _)) = attributes.get("list")
+                        && let Some(Value::Array(list, _)) = attributes.as_map().get("list")
                     {
                         for (i, v) in list.iter().enumerate() {
                             self.env.insert(i.to_string(), v.clone());
@@ -755,7 +756,7 @@ impl Interpreter {
                     // Set named capture env vars from the match object's named hash
                     // so subcapture-aware Match objects are used (not plain strings)
                     if let Value::Instance { ref attributes, .. } = match_obj
-                        && let Some(Value::Hash(named_hash)) = attributes.get("named")
+                        && let Some(Value::Hash(named_hash)) = attributes.as_map().get("named")
                     {
                         for (k, v) in named_hash.iter() {
                             self.env.insert(format!("<{}>", k), v.clone());
@@ -819,7 +820,7 @@ impl Interpreter {
                 ) =>
             {
                 let negated = matches!(val.as_ref(), Value::Bool(false));
-                let path_str = attributes.get("path").map(|v| v.to_string_value());
+                let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
                 if let Some(p) = path_str {
                     let path = std::path::Path::new(&p);
                     let result = match key.as_str() {
@@ -1512,7 +1513,7 @@ impl Interpreter {
                 },
                 _,
             ) if class_name == "X::AdHoc" => {
-                if let Some(payload) = attributes.get("payload") {
+                if let Some(payload) = attributes.as_map().get("payload") {
                     self.smart_match(payload, right)
                 } else {
                     false

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -189,10 +189,10 @@ impl Interpreter {
                         ..
                     } if class_name == "Supply" => {
                         // Find the supply channel
-                        let supply_id = self.resolve_supply_channel_id((attributes).as_map());
+                        let supply_id = self.resolve_supply_channel_id(&(attributes).as_map());
                         let is_lines =
-                            matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
-                        let head_limit = Self::extract_head_limit((attributes).as_map());
+                            matches!(attributes.as_map().get("is_lines"), Some(Value::Bool(true)));
+                        let head_limit = Self::extract_head_limit(&(attributes).as_map());
                         if let Some(sid) = supply_id
                             && let Some(rx) = take_supply_channel(sid)
                         {
@@ -210,7 +210,7 @@ impl Interpreter {
                                 supplier_next_index: 0,
                                 callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
-                                    (attributes).as_map(),
+                                    &(attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
@@ -224,7 +224,9 @@ impl Interpreter {
                             });
                             continue;
                         }
-                        if let Some(Value::Int(supplier_id)) = attributes.get("supplier_id") {
+                        if let Some(Value::Int(supplier_id)) =
+                            attributes.as_map().get("supplier_id")
+                        {
                             let last_callbacks = items
                                 .get(2)
                                 .and_then(Self::value_array_items)
@@ -239,7 +241,7 @@ impl Interpreter {
                                 supplier_next_index: 0,
                                 callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
-                                    (attributes).as_map(),
+                                    &(attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
@@ -254,7 +256,7 @@ impl Interpreter {
                             continue;
                         }
                         // Handle on-demand supplies: execute the callback to produce values
-                        if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
+                        if let Some(on_demand_cb) = attributes.as_map().get("on_demand_callback") {
                             let mut emitter_attrs = HashMap::new();
                             emitter_attrs.insert("emitted".to_string(), Value::array(Vec::new()));
                             emitter_attrs.insert("done".to_string(), Value::Bool(false));
@@ -285,7 +287,7 @@ impl Interpreter {
                             }
                         } else {
                             // No channel, no on-demand - replay static values
-                            self.replay_static_supply((attributes).as_map(), &callback)?;
+                            self.replay_static_supply(&(attributes).as_map(), &callback)?;
                         }
                         // Fire LAST callbacks after static/on-demand supply completes
                         let last_cbs = items
@@ -731,14 +733,14 @@ impl Interpreter {
             } = &supply_val
                 && class_name == "Supply"
             {
-                if let Some(Value::Int(sid)) = attributes.get("supply_id") {
+                if let Some(Value::Int(sid)) = attributes.as_map().get("supply_id") {
                     crate::runtime::native_methods::register_supply_tap(
                         *sid as u64,
                         callback.clone(),
                     );
                 }
                 // Also register on parent for lines supplies
-                if let Some(Value::Int(pid)) = attributes.get("parent_supply_id") {
+                if let Some(Value::Int(pid)) = attributes.as_map().get("parent_supply_id") {
                     crate::runtime::native_methods::register_supply_tap(
                         *pid as u64,
                         callback.clone(),

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -251,7 +251,7 @@ impl Interpreter {
             for (attr_name, expected_val) in &named_checks {
                 let actual_val = exception_val.as_ref().and_then(|ex| {
                     if let Value::Instance { attributes, .. } = ex {
-                        attributes.get(attr_name).cloned()
+                        attributes.as_map().get(attr_name).cloned()
                     } else {
                         None
                     }

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -33,7 +33,11 @@ impl Interpreter {
 
         // 2. Check .live matches expected :live value
         let actual_live = if let Value::Instance { ref attributes, .. } = supply {
-            attributes.get("live").map(|v| v.truthy()).unwrap_or(false)
+            attributes
+                .as_map()
+                .get("live")
+                .map(|v| v.truthy())
+                .unwrap_or(false)
         } else {
             true
         };
@@ -59,19 +63,25 @@ impl Interpreter {
             // Scheduler-based Supply: register counter cue and let after-tap
             // drive emissions via progress-by
             if let Value::Instance { ref attributes, .. } = supply {
-                let scheduler = attributes.get("scheduler").cloned().unwrap_or(Value::Nil);
+                let scheduler = attributes
+                    .as_map()
+                    .get("scheduler")
+                    .cloned()
+                    .unwrap_or(Value::Nil);
                 let interval = attributes
+                    .as_map()
                     .get("scheduler_interval")
                     .map(|v| v.to_f64())
                     .unwrap_or(1.0);
                 let delay = attributes
+                    .as_map()
                     .get("scheduler_delay")
                     .map(|v| v.to_f64())
                     .unwrap_or(0.0);
 
                 // Get scheduler_id from the scheduler instance
                 let scheduler_id = if let Value::Instance { ref attributes, .. } = scheduler {
-                    match attributes.get("scheduler_id") {
+                    match attributes.as_map().get("scheduler_id") {
                         Some(Value::Int(id)) => *id as u64,
                         _ => 0,
                     }
@@ -105,7 +115,7 @@ impl Interpreter {
             // Non-scheduler supply: original logic
             if let Value::Instance { ref attributes, .. } = supply {
                 // For on-demand supplies, execute the callback to produce values
-                if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
+                if let Some(on_demand_cb) = attributes.as_map().get("on_demand_callback") {
                     let emitter = Value::make_instance(Symbol::intern("Supplier"), {
                         let mut a = HashMap::new();
                         a.insert("emitted".to_string(), Value::array(Vec::new()));
@@ -118,13 +128,28 @@ impl Interpreter {
                     tap_values = self.supply_emit_buffer.pop().unwrap_or_default();
                     let _ = self.supply_emit_timed_buffer.pop();
                 } else {
-                    let values = if let Some(Value::Int(sid)) = attributes.get("supplier_id") {
-                        let (snap_values, _, _) =
-                            crate::runtime::native_methods::supplier_snapshot(*sid as u64);
-                        if !snap_values.is_empty() {
-                            snap_values
+                    let values =
+                        if let Some(Value::Int(sid)) = attributes.as_map().get("supplier_id") {
+                            let (snap_values, _, _) =
+                                crate::runtime::native_methods::supplier_snapshot(*sid as u64);
+                            if !snap_values.is_empty() {
+                                snap_values
+                            } else {
+                                attributes
+                                    .as_map()
+                                    .get("values")
+                                    .and_then(|v| {
+                                        if let Value::Array(a, ..) = v {
+                                            Some(a.to_vec())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or_default()
+                            }
                         } else {
                             attributes
+                                .as_map()
                                 .get("values")
                                 .and_then(|v| {
                                     if let Value::Array(a, ..) = v {
@@ -134,20 +159,9 @@ impl Interpreter {
                                     }
                                 })
                                 .unwrap_or_default()
-                        }
-                    } else {
-                        attributes
-                            .get("values")
-                            .and_then(|v| {
-                                if let Value::Array(a, ..) = v {
-                                    Some(a.to_vec())
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or_default()
-                    };
+                        };
                     let do_cbs = attributes
+                        .as_map()
                         .get("do_callbacks")
                         .and_then(|v| {
                             if let Value::Array(a, ..) = v {
@@ -183,7 +197,7 @@ impl Interpreter {
                 // etc.) are emitted to the downstream supplier. Use the downstream
                 // supplier snapshot instead of raw emissions.
                 let emitted = if let Value::Instance { ref attributes, .. } = supply
-                    && let Some(Value::Int(sid)) = attributes.get("supplier_id")
+                    && let Some(Value::Int(sid)) = attributes.as_map().get("supplier_id")
                 {
                     let (snap_values, _, _) =
                         crate::runtime::native_methods::supplier_snapshot(*sid as u64);
@@ -197,12 +211,17 @@ impl Interpreter {
                 };
 
                 let emitted = if let Value::Instance { ref attributes, .. } = supply {
-                    if matches!(attributes.get("elems_filter"), Some(Value::Bool(true))) {
+                    if matches!(
+                        attributes.as_map().get("elems_filter"),
+                        Some(Value::Bool(true))
+                    ) {
                         let interval = attributes
+                            .as_map()
                             .get("elems_interval")
                             .map(Value::to_f64)
                             .unwrap_or(0.0);
                         let initial_count = attributes
+                            .as_map()
                             .get("elems_initial_count")
                             .and_then(|v| match v {
                                 Value::Int(i) => Some(*i),
@@ -237,10 +256,14 @@ impl Interpreter {
                             }
                             out
                         }
-                    } else if matches!(attributes.get("unique_filter"), Some(Value::Bool(true))) {
-                        let as_fn = attributes.get("unique_as").cloned();
-                        let with_fn = attributes.get("unique_with").cloned();
-                        let expires_secs = attributes.get("unique_expires").map(Value::to_f64);
+                    } else if matches!(
+                        attributes.as_map().get("unique_filter"),
+                        Some(Value::Bool(true))
+                    ) {
+                        let as_fn = attributes.as_map().get("unique_as").cloned();
+                        let with_fn = attributes.as_map().get("unique_with").cloned();
+                        let expires_secs =
+                            attributes.as_map().get("unique_expires").map(Value::to_f64);
                         let mut seen: Vec<(Value, std::time::Instant)> = Vec::new();
                         let mut unique = Vec::new();
                         let events = if timed_emitted.is_empty() {
@@ -292,11 +315,12 @@ impl Interpreter {
                 } = supply
                 {
                     let is_lines = class_name == "Supply"
-                        && matches!(attributes.get("is_lines"), Some(Value::Bool(true)));
+                        && matches!(attributes.as_map().get("is_lines"), Some(Value::Bool(true)));
                     let is_words = class_name == "Supply"
-                        && matches!(attributes.get("is_words"), Some(Value::Bool(true)));
+                        && matches!(attributes.as_map().get("is_words"), Some(Value::Bool(true)));
                     if is_lines {
                         let chomp = attributes
+                            .as_map()
                             .get("line_chomp")
                             .map(Value::truthy)
                             .unwrap_or(true);
@@ -318,7 +342,7 @@ impl Interpreter {
         // Supply.reduce produces a derived Supply that carries reducer metadata
         // for live sources. Apply the same reduction over collected tap values.
         if let Value::Instance { ref attributes, .. } = supply
-            && let Some(reduce_callable) = attributes.get("reduce_callable").cloned()
+            && let Some(reduce_callable) = attributes.as_map().get("reduce_callable").cloned()
             && tap_values.len() > 1
         {
             let reduced = self.reduce_items(reduce_callable, tap_values)?;
@@ -333,7 +357,7 @@ impl Interpreter {
         // values computed by the produce_callable. For live sources, tap-ok
         // snapshots raw emissions, so we must apply the scan here.
         if let Value::Instance { ref attributes, .. } = supply
-            && let Some(produce_callable) = attributes.get("produce_callable").cloned()
+            && let Some(produce_callable) = attributes.as_map().get("produce_callable").cloned()
             && !tap_values.is_empty()
         {
             let mut scanned = Vec::with_capacity(tap_values.len());

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -83,14 +83,15 @@ impl Interpreter {
                                 && let Value::Instance { attributes, .. } = exc_box.as_mut()
                             {
                                 let line = e.line.unwrap_or(1) as i64;
-                                let attrs = std::sync::Arc::make_mut(attributes);
-                                attrs.entry("line".to_string()).or_insert(Value::Int(line));
-                                attrs
-                                    .entry("filename".to_string())
-                                    .or_insert(Value::str("EVAL_0".to_string()));
-                                attrs
-                                    .entry("file".to_string())
-                                    .or_insert(Value::str("EVAL_0".to_string()));
+                                attributes.insert_if_absent("line".to_string(), Value::Int(line));
+                                attributes.insert_if_absent(
+                                    "filename".to_string(),
+                                    Value::str("EVAL_0".to_string()),
+                                );
+                                attributes.insert_if_absent(
+                                    "file".to_string(),
+                                    Value::str("EVAL_0".to_string()),
+                                );
                             }
                             Err(e)
                         }
@@ -431,14 +432,15 @@ impl Interpreter {
                                 && let Value::Instance { attributes, .. } = exc_box.as_mut()
                             {
                                 let line = e.line.unwrap_or(1) as i64;
-                                let attrs = std::sync::Arc::make_mut(attributes);
-                                attrs.entry("line".to_string()).or_insert(Value::Int(line));
-                                attrs
-                                    .entry("filename".to_string())
-                                    .or_insert(Value::str("EVAL_0".to_string()));
-                                attrs
-                                    .entry("file".to_string())
-                                    .or_insert(Value::str("EVAL_0".to_string()));
+                                attributes.insert_if_absent("line".to_string(), Value::Int(line));
+                                attributes.insert_if_absent(
+                                    "filename".to_string(),
+                                    Value::str("EVAL_0".to_string()),
+                                );
+                                attributes.insert_if_absent(
+                                    "file".to_string(),
+                                    Value::str("EVAL_0".to_string()),
+                                );
                             }
                             Err(e)
                         }

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -253,7 +253,7 @@ impl Interpreter {
         for (attr_name, expected_val) in &named_checks {
             let actual_val = exception_val.as_ref().and_then(|ex| {
                 if let Value::Instance { attributes, .. } = ex {
-                    attributes.get(attr_name).cloned()
+                    attributes.as_map().get(attr_name).cloned()
                 } else {
                     None
                 }

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -187,7 +187,7 @@ impl Interpreter {
                 .class_mro(&class_name.resolve())
                 .iter()
                 .any(|c| c == "Str")
-            && let Some(inner) = attributes.get("value").cloned()
+            && let Some(inner) = attributes.as_map().get("value").cloned()
             && !matches!(inner, Value::Nil)
             && let Ok(coerced) = self.try_coerce_value_with_method(target, inner)
             && self.type_matches_value(base_target, &coerced)

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -210,7 +210,7 @@ impl Interpreter {
                 id,
             }) = self.env.get("self").cloned()
             {
-                let mut updated_attrs = (*attributes).clone();
+                let updated_attrs = (*attributes).clone();
                 updated_attrs.insert(attr_name.to_string(), value.clone());
                 self.env.insert(
                     "self".to_string(),

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -207,10 +207,12 @@ impl Interpreter {
     fn var_target_name_from_value(value: &Value) -> Option<String> {
         match value {
             Value::Mixin(inner, _) => Self::var_target_name_from_value(inner),
-            Value::Instance { attributes, .. } => match attributes.get("__mutsu_var_target") {
-                Some(Value::Str(name)) => Some(name.to_string()),
-                _ => None,
-            },
+            Value::Instance { attributes, .. } => {
+                match attributes.as_map().get("__mutsu_var_target") {
+                    Some(Value::Str(name)) => Some(name.to_string()),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     }
@@ -218,10 +220,12 @@ impl Interpreter {
     /// Check if a value is a HOW meta-object and return the target class name.
     fn how_target_from_value(value: &Value) -> Option<String> {
         match value {
-            Value::Instance { attributes, .. } => match attributes.get("__mutsu_how_target") {
-                Some(Value::Str(name)) => Some(name.to_string()),
-                _ => None,
-            },
+            Value::Instance { attributes, .. } => {
+                match attributes.as_map().get("__mutsu_how_target") {
+                    Some(Value::Str(name)) => Some(name.to_string()),
+                    _ => None,
+                }
+            }
             Value::Mixin(inner, _) => Self::how_target_from_value(inner),
             _ => None,
         }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -463,7 +463,7 @@ impl Interpreter {
                         if !class_ok {
                             return false;
                         }
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             return items.iter().all(|v| self.type_matches_value(inner, v));
                         }
                     }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -397,8 +397,8 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
                 left.eqv(right)
             } else if a_name == b_name && (a_name == "ObjAt" || a_name == "ValueObjAt") {
                 // ObjAt/ValueObjAt instances are === when their WHICH content matches
-                let a_val = a_attrs.get("WHICH").map(|v| v.to_string_value());
-                let b_val = b_attrs.get("WHICH").map(|v| v.to_string_value());
+                let a_val = a_attrs.as_map().get("WHICH").map(|v| v.to_string_value());
+                let b_val = b_attrs.as_map().get("WHICH").map(|v| v.to_string_value());
                 a_val == b_val
             } else {
                 a_id == b_id
@@ -649,7 +649,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             ..
         } if class_name == "Match" => {
             // %($/) returns the named captures hash
-            if let Some(named) = attributes.get("named") {
+            if let Some(named) = attributes.as_map().get("named") {
                 named.clone()
             } else {
                 Value::hash(HashMap::new())
@@ -925,7 +925,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => match_gist((attributes).as_map(), 0),
+        } if class_name == "Match" => match_gist(&(attributes).as_map(), 0),
         _ => value.to_string_value(),
     }
 }
@@ -966,7 +966,7 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                 ..
             } if class_name == "Match" => {
                 entries.push((
-                    match_from((attributes).as_map()),
+                    match_from(&(attributes).as_map()),
                     label.to_string(),
                     value.clone(),
                 ));
@@ -982,7 +982,7 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                         && class_name == "Match"
                     {
                         entries.push((
-                            match_from((attributes).as_map()),
+                            match_from(&(attributes).as_map()),
                             label.to_string(),
                             item.clone(),
                         ));
@@ -1016,7 +1016,7 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
                 "\n{}{} => {}",
                 indent,
                 label,
-                match_gist((attributes).as_map(), depth + 1)
+                match_gist(&(attributes).as_map(), depth + 1)
             ));
         }
     }
@@ -2007,13 +2007,13 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
                             };
                             let (sy, sm, sd) =
                                 if let Value::Instance { attributes, .. } = start.as_ref() {
-                                    date_attrs((attributes).as_map())
+                                    date_attrs(&(attributes).as_map())
                                 } else {
                                     unreachable!()
                                 };
                             let (ey, em, ed) =
                                 if let Value::Instance { attributes, .. } = end.as_ref() {
-                                    date_attrs((attributes).as_map())
+                                    date_attrs(&(attributes).as_map())
                                 } else {
                                     unreachable!()
                                 };
@@ -2021,7 +2021,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
                             let end_days = civil_to_epoch_days(ey, em, ed);
                             let formatter =
                                 if let Value::Instance { attributes, .. } = start.as_ref() {
-                                    attributes.get("formatter").cloned()
+                                    attributes.as_map().get("formatter").cloned()
                                 } else {
                                     None
                                 };
@@ -2091,7 +2091,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             .collect(),
         Value::Slip(items) => items.to_vec(),
         Value::Instance { attributes, .. } => {
-            if let Some(Value::Array(items, ..)) = attributes.get("__array_items") {
+            if let Some(Value::Array(items, ..)) = attributes.as_map().get("__array_items") {
                 return items.to_vec();
             }
             vec![val.clone()]
@@ -2294,21 +2294,27 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
             ref class_name,
             ref attributes,
             ..
-        } if class_name == "Instant" => attributes.get("value").cloned().unwrap_or(Value::Num(0.0)),
+        } if class_name == "Instant" => attributes
+            .as_map()
+            .get("value")
+            .cloned()
+            .unwrap_or(Value::Num(0.0)),
         Value::Instance {
             ref class_name,
             ref attributes,
             ..
-        } if class_name == "Duration" => {
-            attributes.get("value").cloned().unwrap_or(Value::Num(0.0))
-        }
+        } if class_name == "Duration" => attributes
+            .as_map()
+            .get("value")
+            .cloned()
+            .unwrap_or(Value::Num(0.0)),
         Value::Instance {
             ref class_name,
             ref attributes,
             ..
         } if class_name == "Date" => {
             let (y, m, d) =
-                crate::builtins::methods_0arg::temporal::date_attrs((attributes).as_map());
+                crate::builtins::methods_0arg::temporal::date_attrs(&(attributes).as_map());
             let epoch = crate::builtins::methods_0arg::temporal::civil_to_epoch_days(y, m, d);
             Value::Int(epoch * 86400)
         }
@@ -2318,7 +2324,7 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
             ..
         } if class_name == "DateTime" => {
             let (y, mo, d, h, mi, s, tz) =
-                crate::builtins::methods_0arg::temporal::datetime_attrs((attributes).as_map());
+                crate::builtins::methods_0arg::temporal::datetime_attrs(&(attributes).as_map());
             Value::Num(crate::builtins::methods_0arg::temporal::datetime_to_posix(
                 y, mo, d, h, mi, s, tz,
             ))
@@ -3126,15 +3132,16 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
             class_name,
             attributes,
             ..
-        } if class_name == "Instant" => attributes.get("value").and_then(to_float_value),
+        } if class_name == "Instant" => attributes.as_map().get("value").and_then(to_float_value),
         Value::Instance {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => attributes.get("str").and_then(to_float_value),
-        Value::Instance { attributes, .. } => {
-            attributes.get("__mutsu_int_value").and_then(to_float_value)
-        }
+        } if class_name == "Match" => attributes.as_map().get("str").and_then(to_float_value),
+        Value::Instance { attributes, .. } => attributes
+            .as_map()
+            .get("__mutsu_int_value")
+            .and_then(to_float_value),
         // A numeric type object (e.g. `Rat`, `FatRat`, `Int`) numifies to 0 in
         // numeric context (Raku warns "Use of uninitialized value"). This makes
         // `(Rat) == 0` true, matching Rakudo.
@@ -3343,7 +3350,10 @@ pub(crate) fn to_int(v: &Value) -> i64 {
         Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => items.len() as i64,
         Value::Slip(items) => items.len() as i64,
         Value::Capture { positional, .. } => positional.len() as i64,
-        Value::Instance { attributes, .. } => attributes.get("__mutsu_int_value").map_or(0, to_int),
+        Value::Instance { attributes, .. } => attributes
+            .as_map()
+            .get("__mutsu_int_value")
+            .map_or(0, to_int),
         _ => 0,
     }
 }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -607,6 +607,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Backtrace" => attributes
+                .as_map()
                 .get("text")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
@@ -616,6 +617,7 @@ impl Value {
                 ..
             } if class_name == "IO::Path" || class_name.resolve().starts_with("IO::Path::") => {
                 attributes
+                    .as_map()
                     .get("path")
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
@@ -629,6 +631,7 @@ impl Value {
                 || class_name.resolve().starts_with("CX::") =>
             {
                 attributes
+                    .as_map()
                     .get("message")
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
@@ -638,6 +641,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "ObjAt" || class_name == "ValueObjAt" => attributes
+                .as_map()
                 .get("WHICH")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
@@ -646,6 +650,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Match" => attributes
+                .as_map()
                 .get("str")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
@@ -654,6 +659,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Proc" => attributes
+                .as_map()
                 .get("exitcode")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
@@ -662,7 +668,7 @@ impl Value {
                 attributes,
                 ..
             } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                     if bytes.is_empty() {
                         format!("{}()", class_name)
                     } else {
@@ -705,7 +711,11 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Instant" => {
-                let val = attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0);
+                let val = attributes
+                    .as_map()
+                    .get("value")
+                    .map(|v| v.to_f64())
+                    .unwrap_or(0.0);
                 format!("Instant:{}", val)
             }
             Value::Instance {
@@ -713,7 +723,11 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Duration" => {
-                let val = attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0);
+                let val = attributes
+                    .as_map()
+                    .get("value")
+                    .map(|v| v.to_f64())
+                    .unwrap_or(0.0);
                 if val == val.floor() {
                     format!("{}", val as i64)
                 } else {
@@ -725,6 +739,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Signature" => attributes
+                .as_map()
                 .get("gist")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
@@ -733,6 +748,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Stash" => attributes
+                .as_map()
                 .get("name")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
@@ -742,6 +758,7 @@ impl Value {
                 ..
             } if class_name == "Method" || class_name == "Sub" || class_name == "Routine" => {
                 attributes
+                    .as_map()
                     .get("name")
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
@@ -751,6 +768,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Format" => attributes
+                .as_map()
                 .get("format")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
@@ -760,11 +778,11 @@ impl Value {
                     && attributes.contains_key("day")
                     && !attributes.contains_key("hour") =>
             {
-                if let Some(Value::Str(s)) = attributes.get("__formatter_rendered") {
+                if let Some(Value::Str(s)) = attributes.as_map().get("__formatter_rendered") {
                     return s.to_string();
                 }
                 let (y, m, d) =
-                    crate::builtins::methods_0arg::temporal::date_attrs((attributes).as_map());
+                    crate::builtins::methods_0arg::temporal::date_attrs(&(attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_date(y, m, d)
             }
             Value::Instance { attributes, .. }
@@ -776,11 +794,11 @@ impl Value {
                     && attributes.contains_key("second")
                     && attributes.contains_key("timezone") =>
             {
-                if let Some(Value::Str(s)) = attributes.get("__formatter_rendered") {
+                if let Some(Value::Str(s)) = attributes.as_map().get("__formatter_rendered") {
                     return s.to_string();
                 }
                 let (y, mo, d, h, mi, s, tz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((attributes).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(&(attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_datetime(y, mo, d, h, mi, s, tz)
             }
             Value::Instance {
@@ -788,6 +806,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Pod::Block::Declarator" => attributes
+                .as_map()
                 .get("contents")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
@@ -796,6 +815,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "StrDistance" => attributes
+                .as_map()
                 .get("after")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -146,6 +146,7 @@ impl RuntimeError {
     pub(crate) fn from_exception_value(ex: Value) -> Self {
         let msg = if let Value::Instance { attributes, .. } = &ex {
             attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| ex.to_string_value())
@@ -932,6 +933,7 @@ impl RuntimeError {
                 } => (
                     class_name.resolve(),
                     attributes
+                        .as_map()
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -462,50 +462,87 @@ thread_local! {
     /// *cross-thread* contention (which must block and write — e.g. concurrent
     /// `cas` on a shared instance attribute). See [`write_cell_respecting_reads`].
     static HELD_READ_CELLS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+
+    /// Writes to instance cells that were deferred because this thread held a
+    /// read guard on the cell at write time (a self-deadlock hazard). Applied —
+    /// in order — when the last read guard on that cell is dropped. This keeps a
+    /// legacy write-back that runs inside an outstanding `as_map()` borrow (e.g.
+    /// the `$obj.attr = v` accessor, whose let-chain condition holds the guard
+    /// across the write-back) from either deadlocking *or* silently dropping a
+    /// real mutation.
+    static PENDING_CELL_WRITES: RefCell<Vec<PendingCellWrite>> = const { RefCell::new(Vec::new()) };
 }
+
+/// A deferred cell write: `(cell address, cell, new map)`. See
+/// [`PENDING_CELL_WRITES`].
+type PendingCellWrite = (usize, AttrCell, HashMap<String, Value>);
 
 fn cell_addr(cell: &RwLock<HashMap<String, Value>>) -> usize {
     cell as *const RwLock<HashMap<String, Value>> as usize
 }
 
-/// True if the current thread already holds a read guard on `cell`.
-fn this_thread_reads(cell: &RwLock<HashMap<String, Value>>) -> bool {
-    let addr = cell_addr(cell);
-    HELD_READ_CELLS.with(|c| c.borrow().contains(&addr))
-}
-
 /// A read guard over an instance's attribute map. Derefs to `&HashMap`, so the
 /// vast majority of read sites (`.get`, `.iter`, `.len`, `for (k, v) in ...`)
 /// and `&guard` argument coercions to `&HashMap` keep working unchanged. On
-/// construction it records the cell address in [`HELD_READ_CELLS`] and removes
-/// it on drop, so the writeback can avoid a self-deadlocking blocking write.
+/// construction it records the cell address in [`HELD_READ_CELLS`]; on drop it
+/// removes it and, when this was the last read guard on the cell, applies any
+/// write that was deferred while the cell was read-locked.
 pub(crate) struct AttrReadGuard<'a> {
-    guard: std::sync::RwLockReadGuard<'a, HashMap<String, Value>>,
+    // `Option` so `Drop` can release the read lock *before* flushing deferred
+    // writes — otherwise the flush's blocking write lock would deadlock against
+    // this guard's own still-held read lock (struct fields drop after `drop`).
+    guard: Option<std::sync::RwLockReadGuard<'a, HashMap<String, Value>>>,
     addr: usize,
 }
 
 impl<'a> AttrReadGuard<'a> {
     fn new(guard: std::sync::RwLockReadGuard<'a, HashMap<String, Value>>, addr: usize) -> Self {
         HELD_READ_CELLS.with(|c| c.borrow_mut().push(addr));
-        Self { guard, addr }
+        Self {
+            guard: Some(guard),
+            addr,
+        }
     }
 }
 
 impl std::ops::Deref for AttrReadGuard<'_> {
     type Target = HashMap<String, Value>;
     fn deref(&self) -> &Self::Target {
-        &self.guard
+        self.guard.as_ref().expect("attr read guard live")
     }
 }
 
 impl Drop for AttrReadGuard<'_> {
     fn drop(&mut self) {
-        HELD_READ_CELLS.with(|c| {
+        let still_held = HELD_READ_CELLS.with(|c| {
             let mut v = c.borrow_mut();
             if let Some(pos) = v.iter().rposition(|&a| a == self.addr) {
                 v.swap_remove(pos);
             }
+            v.contains(&self.addr)
         });
+        // Release this read lock before flushing, so a deferred blocking write
+        // does not deadlock against it.
+        self.guard = None;
+        if still_held {
+            return;
+        }
+        let flush = PENDING_CELL_WRITES.with(|p| {
+            let mut v = p.borrow_mut();
+            let mut mine: Vec<(AttrCell, HashMap<String, Value>)> = Vec::new();
+            v.retain(|(a, cell, map)| {
+                if *a == self.addr {
+                    mine.push((cell.clone(), map.clone()));
+                    false
+                } else {
+                    true
+                }
+            });
+            mine
+        });
+        for (cell, map) in flush {
+            *write_attrs(&cell) = map;
+        }
     }
 }
 
@@ -573,25 +610,26 @@ impl Clone for InstanceAttrs {
     }
 }
 
-/// Write `map` into `cell`, unless the current thread already holds a read guard
-/// on it.
+/// Write `map` into `cell`, deferring if the current thread already holds a read
+/// guard on it.
 ///
 /// If this thread is mid-read of the cell, a blocking write would self-deadlock
 /// (the `RwLock` is not reentrant): this happens when the legacy writeback runs
-/// while an outer call frame on the same thread still reads this instance (e.g.
-/// a read-only method invoked from inside `if let … = $obj.attr`, whose
-/// mut-dispatch writes the invocant back). In that case we skip the in-place
-/// write — the contended writeback is almost always a *read-only* invocant
-/// write-back where `map` already equals the cell, and the legacy by-identity
-/// env scan still propagates the value either way.
+/// while an outer call frame on the same thread still holds an `as_map()` borrow
+/// on this instance (e.g. the `$obj.attr = v` accessor, whose let-chain
+/// condition keeps the guard alive across the write-back). We can't skip the
+/// write (it may be a real mutation, not a no-op), so we *defer* it: queue it in
+/// `PENDING_CELL_WRITES` and apply it when the last read guard on the cell drops.
 ///
 /// When this thread is *not* reading the cell we take a blocking write lock,
 /// which is required for correctness under genuine cross-thread contention
 /// (e.g. concurrent `cas` on a shared instance attribute must not drop updates).
 /// Stage 2 replaces this writeback with a mutate-at-the-source model where the
 /// guard is never held across the write.
-fn write_cell_respecting_reads(cell: &RwLock<HashMap<String, Value>>, map: HashMap<String, Value>) {
-    if this_thread_reads(cell) {
+fn write_cell_respecting_reads(cell: &AttrCell, map: HashMap<String, Value>) {
+    let addr = cell_addr(cell);
+    if HELD_READ_CELLS.with(|c| c.borrow().contains(&addr)) {
+        PENDING_CELL_WRITES.with(|p| p.borrow_mut().push((addr, cell.clone(), map)));
         return;
     }
     *write_attrs(cell) = map;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock, Weak};
 
 use crate::ast::{ParamDef, Stmt};
 use crate::env::Env;
@@ -451,12 +451,119 @@ fn live_instance_refcounts() -> &'static Mutex<HashMap<u64, usize>> {
     LIVE_INSTANCE_REFCOUNTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-#[derive(Debug, Clone)]
+/// The shared mutable attribute cell of an instance (Phase 3, Stage 1).
+pub(crate) type AttrCell = Arc<RwLock<HashMap<String, Value>>>;
+
+/// A read guard over an instance's attribute map. Derefs to `&HashMap`, so the
+/// vast majority of read sites (`.get`, `.iter`, `.len`, `for (k, v) in ...`)
+/// and `&guard` argument coercions to `&HashMap` keep working unchanged.
+pub(crate) type AttrReadGuard<'a> = std::sync::RwLockReadGuard<'a, HashMap<String, Value>>;
+
+/// Registry mapping an instance id to its live attribute cell.
+///
+/// Phase 3, Stage 1 scaffolding: the legacy mutation path computes an updated
+/// `HashMap` and then rebuilds the instance via [`Value::make_instance_with_id`]
+/// / `overwrite_instance_bindings_by_identity`. With shared cells, rebuilding
+/// must reuse the *existing* cell (not allocate a detached one), or aliases in
+/// other call frames would stop seeing mutations. This `id -> Weak<cell>` map
+/// lets `make_instance_with_id` find and write through the live cell, which is
+/// what makes the by-reference sharing visible across frames and fixes the
+/// cross-frame mutation bug (see docs/container-identity.md Phase 3). Stage 2
+/// removes the rebuild hacks and this registry along with them.
+type InstanceCellRegistry = HashMap<u64, Weak<RwLock<HashMap<String, Value>>>>;
+
+fn instance_cells() -> &'static Mutex<InstanceCellRegistry> {
+    static INSTANCE_CELLS: OnceLock<Mutex<InstanceCellRegistry>> = OnceLock::new();
+    INSTANCE_CELLS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Register a freshly created cell for `id`.
+fn register_instance_cell(id: u64, cell: &AttrCell) {
+    if let Ok(mut map) = instance_cells().lock() {
+        map.insert(id, Arc::downgrade(cell));
+    }
+}
+
+/// Return the live cell for `id`, if one still exists.
+fn lookup_instance_cell(id: u64) -> Option<AttrCell> {
+    instance_cells().lock().ok()?.get(&id)?.upgrade()
+}
+
+#[derive(Debug)]
 pub(crate) struct InstanceAttrs {
     class_name: Symbol,
-    attributes: HashMap<String, Value>,
+    /// Shared mutable attribute cell.
+    ///
+    /// Cross-frame *sharing* (the Raku object-identity semantics that makes an
+    /// in-place mutation visible to every alias) comes from cloning the
+    /// `Arc<InstanceAttrs>` held by `Value::Instance` — that aliases this same
+    /// struct and cell. An explicit `InstanceAttrs::clone` (see the manual
+    /// `Clone` impl below) instead makes an *independent* deep copy with a fresh
+    /// cell, preserving the long-standing semantics of the legacy writeback
+    /// sites that do `(*attributes).clone()` to build a detached "updated" map.
+    attributes: AttrCell,
     id: u64,
     queue_destroy: bool,
+}
+
+impl Clone for InstanceAttrs {
+    /// Deep, independent copy: a fresh cell with a snapshot of the map. This is
+    /// the rare explicit struct clone (writeback "updated" copies); it must NOT
+    /// share the cell — sharing flows through `Arc<InstanceAttrs>`. The copy is
+    /// transient, so it does not register in `instance_cells` (which must keep
+    /// pointing at the live shared cell) and does not participate in DESTROY
+    /// refcounting (`queue_destroy = false`).
+    fn clone(&self) -> Self {
+        Self {
+            class_name: self.class_name,
+            attributes: Arc::new(RwLock::new(read_attrs(&self.attributes).clone())),
+            id: self.id,
+            queue_destroy: false,
+        }
+    }
+}
+
+/// Try to write `map` into the live shared cell for `id` without blocking.
+///
+/// Returns true if the cell was found and updated. Uses `try_write` so it never
+/// deadlocks: the legacy writeback can run while an outer call frame still holds
+/// a read guard on this very instance (e.g. a method invoked from inside an
+/// `if let … = $obj.attr` whose mut-dispatch then writes the invocant back).
+/// In that same-thread read-then-write situation a blocking write would hang
+/// forever. When the cell is contended we skip the in-place write — the legacy
+/// by-identity env scan still propagates the value, and the common contended
+/// case is a *read-only* invocant write-back where `map` already equals the
+/// cell's contents (a no-op). Stage 2 replaces this writeback with a
+/// mutate-at-the-source model where the guard is never held across the write.
+pub(crate) fn try_write_attrs(cell: &RwLock<HashMap<String, Value>>, map: HashMap<String, Value>) {
+    match cell.try_write() {
+        Ok(mut g) => *g = map,
+        Err(std::sync::TryLockError::Poisoned(e)) => *e.into_inner() = map,
+        Err(std::sync::TryLockError::WouldBlock) => {}
+    }
+}
+
+pub(crate) fn update_instance_cell(id: u64, map: &HashMap<String, Value>) -> bool {
+    if let Some(cell) = lookup_instance_cell(id) {
+        try_write_attrs(&cell, map.clone());
+        true
+    } else {
+        false
+    }
+}
+
+/// Recover the map from a poisoned lock instead of propagating the panic. A
+/// poisoned attribute lock only means some thread panicked mid-mutation; the
+/// map itself is still a valid `HashMap`, and matching the codebase's other
+/// `lock().unwrap()` sites would just turn a poison into a second panic.
+fn read_attrs(cell: &RwLock<HashMap<String, Value>>) -> AttrReadGuard<'_> {
+    cell.read().unwrap_or_else(|e| e.into_inner())
+}
+
+fn write_attrs(
+    cell: &RwLock<HashMap<String, Value>>,
+) -> std::sync::RwLockWriteGuard<'_, HashMap<String, Value>> {
+    cell.write().unwrap_or_else(|e| e.into_inner())
 }
 
 impl InstanceAttrs {
@@ -469,77 +576,77 @@ impl InstanceAttrs {
         if queue_destroy && let Ok(mut counts) = live_instance_refcounts().lock() {
             *counts.entry(id).or_insert(0) += 1;
         }
+        let cell: AttrCell = Arc::new(RwLock::new(attributes));
+        register_instance_cell(id, &cell);
         Self {
             class_name,
-            attributes,
+            attributes: cell,
             id,
             queue_destroy,
         }
     }
 
-    // --- Attribute access API (Phase 3, Stage 0 — encapsulation boundary) ---
+    /// Build an `InstanceAttrs` that shares an existing cell (used by the cell
+    /// reuse path in `make_instance_with_id`).
+    fn from_cell(class_name: Symbol, cell: AttrCell, id: u64, queue_destroy: bool) -> Self {
+        if queue_destroy && let Ok(mut counts) = live_instance_refcounts().lock() {
+            *counts.entry(id).or_insert(0) += 1;
+        }
+        Self {
+            class_name,
+            attributes: cell,
+            id,
+            queue_destroy,
+        }
+    }
+
+    // --- Attribute access API (Phase 3 — encapsulation boundary) ---
     //
-    // The attribute map used to be exposed via `Deref<Target = HashMap>`, which
-    // leaked the storage representation to ~150 call sites. Phase 3 (option C)
-    // will make the storage a *shared mutable cell* so an instance mutation is
-    // visible by-reference across call frames (see docs/container-identity.md).
-    // A locked cell cannot `Deref` to `&HashMap` (guard lifetime), so all access
-    // now goes through these inherent methods. Stage 0 keeps the plain `HashMap`
-    // backing and mirrors `HashMap`'s signatures, so this change is
-    // behaviour-identical; Stage 1 swaps the backing and adjusts the few methods
-    // that must return owned values.
+    // The storage is a shared mutable cell (`Arc<RwLock<HashMap>>`). A locked
+    // cell cannot `Deref` to `&HashMap` (guard lifetime), so all access goes
+    // through these inherent methods. Reads take a read lock; mutations take a
+    // write lock and happen in place (visible to every alias).
 
-    /// Borrow the backing map. Stage 1 will remove this (a locked cell cannot
-    /// hand out a `&HashMap`); the remaining users are owned-snapshot consumers
-    /// that become [`Self::to_map`].
-    pub(crate) fn as_map(&self) -> &HashMap<String, Value> {
-        &self.attributes
+    /// Take a read lock over the attribute map. The guard derefs to `&HashMap`.
+    pub(crate) fn as_map(&self) -> AttrReadGuard<'_> {
+        read_attrs(&self.attributes)
     }
 
-    /// An owned clone of the backing map (the old `attributes.to_map()`).
+    /// An owned clone of the backing map.
     pub(crate) fn to_map(&self) -> HashMap<String, Value> {
-        self.attributes.clone()
-    }
-
-    pub(crate) fn get(&self, key: &str) -> Option<&Value> {
-        self.attributes.get(key)
+        self.as_map().clone()
     }
 
     pub(crate) fn contains_key(&self, key: &str) -> bool {
-        self.attributes.contains_key(key)
+        self.as_map().contains_key(key)
     }
 
-    pub(crate) fn insert(&mut self, key: String, value: Value) -> Option<Value> {
-        self.attributes.insert(key, value)
+    /// In-place insert through the shared cell (visible to all aliases).
+    pub(crate) fn insert(&self, key: String, value: Value) -> Option<Value> {
+        write_attrs(&self.attributes).insert(key, value)
     }
 
-    pub(crate) fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
-        self.attributes.get_mut(key)
+    /// Mutate one attribute in place under the write lock, returning the
+    /// closure's result. Returns `None` if the key is absent. Replaces the old
+    /// `get_mut` (which cannot hand out a `&mut` past the guard).
+    pub(crate) fn with_attr_mut<R>(&self, key: &str, f: impl FnOnce(&mut Value) -> R) -> Option<R> {
+        let mut guard = write_attrs(&self.attributes);
+        guard.get_mut(key).map(f)
     }
 
-    pub(crate) fn entry(
-        &mut self,
-        key: String,
-    ) -> std::collections::hash_map::Entry<'_, String, Value> {
-        self.attributes.entry(key)
-    }
-
-    pub(crate) fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Value> {
-        self.attributes.iter()
-    }
-
-    pub(crate) fn keys(&self) -> std::collections::hash_map::Keys<'_, String, Value> {
-        self.attributes.keys()
-    }
-
-    pub(crate) fn values(&self) -> std::collections::hash_map::Values<'_, String, Value> {
-        self.attributes.values()
+    /// Insert `value` only if `key` is absent (the `entry(..).or_insert(..)`
+    /// idiom), in place under the write lock.
+    pub(crate) fn insert_if_absent(&self, key: String, value: Value) {
+        write_attrs(&self.attributes).entry(key).or_insert(value);
     }
 }
 
 impl PartialEq for InstanceAttrs {
     fn eq(&self, other: &Self) -> bool {
-        self.attributes == other.attributes
+        if Arc::ptr_eq(&self.attributes, &other.attributes) {
+            return true;
+        }
+        *read_attrs(&self.attributes) == *read_attrs(&other.attributes)
     }
 }
 
@@ -573,7 +680,7 @@ impl Drop for InstanceAttrs {
         let _ = PENDING_INSTANCE_DESTROYS.try_with(|pending| {
             pending.borrow_mut().push(PendingInstanceDestroy {
                 class_name: self.class_name,
-                attributes: self.attributes.clone(),
+                attributes: read_attrs(&self.attributes).clone(),
             });
         });
     }
@@ -1844,10 +1951,8 @@ impl PartialEq for Value {
             if arr.len() != 2 {
                 return false;
             }
-            let Some(from) = attrs.get("from") else {
-                return false;
-            };
-            let Some(matched) = attrs.get("str") else {
+            let map = attrs.as_map();
+            let (Some(from), Some(matched)) = (map.get("from"), map.get("str")) else {
                 return false;
             };
             arr[0] == *from && arr[1] == *matched
@@ -2719,10 +2824,48 @@ impl Value {
         attributes: HashMap<String, Value>,
         id: u64,
     ) -> Self {
+        // Phase 3, Stage 1: if a live cell already exists for this id, this is a
+        // rebuild of an existing logical instance (the legacy writeback path).
+        // Write the new attributes through the *existing* shared cell and return
+        // an instance aliasing it, so every other holder of the instance — even
+        // ones in caller frames the scan never visits — sees the mutation.
+        if let Some(cell) = lookup_instance_cell(id) {
+            // Non-blocking: see `try_write_attrs`. If the cell is read-locked by
+            // an outer frame on this thread we keep its current contents and just
+            // share it (preserving identity + cross-frame visibility) rather than
+            // deadlocking on a blocking write.
+            try_write_attrs(&cell, attributes);
+            return Value::Instance {
+                class_name,
+                attributes: Arc::new(InstanceAttrs::from_cell(class_name, cell, id, true)),
+                id,
+            };
+        }
         Value::Instance {
             class_name,
             attributes: Arc::new(InstanceAttrs::new(class_name, attributes, id, true)),
             id,
+        }
+    }
+
+    /// An independent snapshot for `temp`/`let` saves. An instance is deep-copied
+    /// into a fresh, *unregistered* cell, so a later in-place mutation through
+    /// the live shared cell does not alter the saved value (pre-Stage-1 this
+    /// independence came for free from copy-on-write). Arrays/hashes keep their
+    /// CoW `Arc` (forked on first mutation), so a plain clone is already
+    /// independent for them.
+    pub(crate) fn into_temp_snapshot(self) -> Value {
+        match self {
+            Value::Instance {
+                class_name,
+                attributes,
+                id,
+            } => Value::Instance {
+                class_name,
+                attributes: Arc::new((*attributes).clone()),
+                id,
+            },
+            other => other,
         }
     }
 
@@ -3114,13 +3257,16 @@ impl Value {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Instant" || class_name == "Duration" => {
-                attributes.get("value").map(|v| v.to_f64()).unwrap_or(0.0)
-            }
+            } if class_name == "Instant" || class_name == "Duration" => attributes
+                .as_map()
+                .get("value")
+                .map(|v| v.to_f64())
+                .unwrap_or(0.0),
             // A subclass of native Int (e.g. `class Foo is Int`) carries its
             // integer payload in the reserved `__mutsu_int_value` attribute.
             Value::Instance { attributes, .. } if attributes.contains_key("__mutsu_int_value") => {
                 attributes
+                    .as_map()
                     .get("__mutsu_int_value")
                     .map(|v| v.to_f64())
                     .unwrap_or(0.0)
@@ -3131,6 +3277,7 @@ impl Value {
                 attributes,
                 ..
             } if class_name == "Match" => attributes
+                .as_map()
                 .get("str")
                 .map(|v| v.to_string_value().trim().parse::<f64>().unwrap_or(0.0))
                 .unwrap_or(0.0),
@@ -3164,6 +3311,7 @@ impl Value {
             // A subclass of native Int (e.g. `class Foo is Int`) carries its
             // integer payload in the reserved `__mutsu_int_value` attribute.
             Value::Instance { attributes, .. } => attributes
+                .as_map()
                 .get("__mutsu_int_value")
                 .map(|v| v.to_bigint())
                 .unwrap_or_else(|| NumBigInt::from(0)),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -454,10 +454,60 @@ fn live_instance_refcounts() -> &'static Mutex<HashMap<u64, usize>> {
 /// The shared mutable attribute cell of an instance (Phase 3, Stage 1).
 pub(crate) type AttrCell = Arc<RwLock<HashMap<String, Value>>>;
 
+thread_local! {
+    /// Addresses of attribute cells this thread is currently holding a read
+    /// guard on (with nesting; the same cell can be read-locked recursively).
+    /// The writeback consults this to tell apart a *same-thread* read-then-write
+    /// (which would self-deadlock on the non-reentrant `RwLock`) from legitimate
+    /// *cross-thread* contention (which must block and write — e.g. concurrent
+    /// `cas` on a shared instance attribute). See [`write_cell_respecting_reads`].
+    static HELD_READ_CELLS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+fn cell_addr(cell: &RwLock<HashMap<String, Value>>) -> usize {
+    cell as *const RwLock<HashMap<String, Value>> as usize
+}
+
+/// True if the current thread already holds a read guard on `cell`.
+fn this_thread_reads(cell: &RwLock<HashMap<String, Value>>) -> bool {
+    let addr = cell_addr(cell);
+    HELD_READ_CELLS.with(|c| c.borrow().contains(&addr))
+}
+
 /// A read guard over an instance's attribute map. Derefs to `&HashMap`, so the
 /// vast majority of read sites (`.get`, `.iter`, `.len`, `for (k, v) in ...`)
-/// and `&guard` argument coercions to `&HashMap` keep working unchanged.
-pub(crate) type AttrReadGuard<'a> = std::sync::RwLockReadGuard<'a, HashMap<String, Value>>;
+/// and `&guard` argument coercions to `&HashMap` keep working unchanged. On
+/// construction it records the cell address in [`HELD_READ_CELLS`] and removes
+/// it on drop, so the writeback can avoid a self-deadlocking blocking write.
+pub(crate) struct AttrReadGuard<'a> {
+    guard: std::sync::RwLockReadGuard<'a, HashMap<String, Value>>,
+    addr: usize,
+}
+
+impl<'a> AttrReadGuard<'a> {
+    fn new(guard: std::sync::RwLockReadGuard<'a, HashMap<String, Value>>, addr: usize) -> Self {
+        HELD_READ_CELLS.with(|c| c.borrow_mut().push(addr));
+        Self { guard, addr }
+    }
+}
+
+impl std::ops::Deref for AttrReadGuard<'_> {
+    type Target = HashMap<String, Value>;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl Drop for AttrReadGuard<'_> {
+    fn drop(&mut self) {
+        HELD_READ_CELLS.with(|c| {
+            let mut v = c.borrow_mut();
+            if let Some(pos) = v.iter().rposition(|&a| a == self.addr) {
+                v.swap_remove(pos);
+            }
+        });
+    }
+}
 
 /// Registry mapping an instance id to its live attribute cell.
 ///
@@ -523,29 +573,33 @@ impl Clone for InstanceAttrs {
     }
 }
 
-/// Try to write `map` into the live shared cell for `id` without blocking.
+/// Write `map` into `cell`, unless the current thread already holds a read guard
+/// on it.
 ///
-/// Returns true if the cell was found and updated. Uses `try_write` so it never
-/// deadlocks: the legacy writeback can run while an outer call frame still holds
-/// a read guard on this very instance (e.g. a method invoked from inside an
-/// `if let … = $obj.attr` whose mut-dispatch then writes the invocant back).
-/// In that same-thread read-then-write situation a blocking write would hang
-/// forever. When the cell is contended we skip the in-place write — the legacy
-/// by-identity env scan still propagates the value, and the common contended
-/// case is a *read-only* invocant write-back where `map` already equals the
-/// cell's contents (a no-op). Stage 2 replaces this writeback with a
-/// mutate-at-the-source model where the guard is never held across the write.
-pub(crate) fn try_write_attrs(cell: &RwLock<HashMap<String, Value>>, map: HashMap<String, Value>) {
-    match cell.try_write() {
-        Ok(mut g) => *g = map,
-        Err(std::sync::TryLockError::Poisoned(e)) => *e.into_inner() = map,
-        Err(std::sync::TryLockError::WouldBlock) => {}
+/// If this thread is mid-read of the cell, a blocking write would self-deadlock
+/// (the `RwLock` is not reentrant): this happens when the legacy writeback runs
+/// while an outer call frame on the same thread still reads this instance (e.g.
+/// a read-only method invoked from inside `if let … = $obj.attr`, whose
+/// mut-dispatch writes the invocant back). In that case we skip the in-place
+/// write — the contended writeback is almost always a *read-only* invocant
+/// write-back where `map` already equals the cell, and the legacy by-identity
+/// env scan still propagates the value either way.
+///
+/// When this thread is *not* reading the cell we take a blocking write lock,
+/// which is required for correctness under genuine cross-thread contention
+/// (e.g. concurrent `cas` on a shared instance attribute must not drop updates).
+/// Stage 2 replaces this writeback with a mutate-at-the-source model where the
+/// guard is never held across the write.
+fn write_cell_respecting_reads(cell: &RwLock<HashMap<String, Value>>, map: HashMap<String, Value>) {
+    if this_thread_reads(cell) {
+        return;
     }
+    *write_attrs(cell) = map;
 }
 
 pub(crate) fn update_instance_cell(id: u64, map: &HashMap<String, Value>) -> bool {
     if let Some(cell) = lookup_instance_cell(id) {
-        try_write_attrs(&cell, map.clone());
+        write_cell_respecting_reads(&cell, map.clone());
         true
     } else {
         false
@@ -557,7 +611,8 @@ pub(crate) fn update_instance_cell(id: u64, map: &HashMap<String, Value>) -> boo
 /// map itself is still a valid `HashMap`, and matching the codebase's other
 /// `lock().unwrap()` sites would just turn a poison into a second panic.
 fn read_attrs(cell: &RwLock<HashMap<String, Value>>) -> AttrReadGuard<'_> {
-    cell.read().unwrap_or_else(|e| e.into_inner())
+    let guard = cell.read().unwrap_or_else(|e| e.into_inner());
+    AttrReadGuard::new(guard, cell_addr(cell))
 }
 
 fn write_attrs(
@@ -2830,11 +2885,10 @@ impl Value {
         // an instance aliasing it, so every other holder of the instance — even
         // ones in caller frames the scan never visits — sees the mutation.
         if let Some(cell) = lookup_instance_cell(id) {
-            // Non-blocking: see `try_write_attrs`. If the cell is read-locked by
-            // an outer frame on this thread we keep its current contents and just
-            // share it (preserving identity + cross-frame visibility) rather than
-            // deadlocking on a blocking write.
-            try_write_attrs(&cell, attributes);
+            // Reuse the live cell. The write respects an outstanding same-thread
+            // read guard (see `write_cell_respecting_reads`) to avoid a
+            // self-deadlock, while still blocking for cross-thread contention.
+            write_cell_respecting_reads(&cell, attributes);
             return Value::Instance {
                 class_name,
                 attributes: Arc::new(InstanceAttrs::from_cell(class_name, cell, id, true)),
@@ -2844,6 +2898,30 @@ impl Value {
         Value::Instance {
             class_name,
             attributes: Arc::new(InstanceAttrs::new(class_name, attributes, id, true)),
+            id,
+        }
+    }
+
+    /// Build an instance with the given id but a *fresh, unregistered* cell.
+    ///
+    /// Unlike [`Self::make_instance_with_id`], this does NOT reuse or register
+    /// the live shared cell for `id`, so it produces a value that is independent
+    /// of the in-flight instance. Used by the cross-thread atomic write-back,
+    /// where the authoritative store is `shared_vars` and reusing the shared
+    /// cell would let concurrent writers clobber it out of order.
+    pub(crate) fn make_instance_detached(
+        class_name: Symbol,
+        attributes: HashMap<String, Value>,
+        id: u64,
+    ) -> Self {
+        Value::Instance {
+            class_name,
+            attributes: Arc::new(InstanceAttrs::from_cell(
+                class_name,
+                Arc::new(RwLock::new(attributes)),
+                id,
+                true,
+            )),
             id,
         }
     }

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -246,6 +246,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             id,
         } => {
             let ser_attrs: Result<HashMap<_, _>, _> = attributes
+                .as_map()
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
                 .collect();

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -177,12 +177,12 @@ impl Value {
                 },
             ) if cn_a == "Signature" && cn_b == "Signature" => {
                 let raku_a = if let Value::Instance { attributes, .. } = self {
-                    attributes.get("raku").map(|v| v.to_string_value())
+                    attributes.as_map().get("raku").map(|v| v.to_string_value())
                 } else {
                     None
                 };
                 let raku_b = if let Value::Instance { attributes, .. } = other {
-                    attributes.get("raku").map(|v| v.to_string_value())
+                    attributes.as_map().get("raku").map(|v| v.to_string_value())
                 } else {
                     None
                 };
@@ -216,9 +216,9 @@ impl Value {
                 && b_attrs.contains_key("timezone") =>
             {
                 let (ay, am, ad, ah, amin, asec, atz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((a_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(&(a_attrs).as_map());
                 let (by, bm, bd, bh, bmin, bsec, btz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((b_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(&(b_attrs).as_map());
                 ay == by
                     && am == bm
                     && ad == bd
@@ -250,9 +250,9 @@ impl Value {
                 && !b_attrs.contains_key("hour") =>
             {
                 let (ay, am, ad) =
-                    crate::builtins::methods_0arg::temporal::date_attrs((a_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::date_attrs(&(a_attrs).as_map());
                 let (by, bm, bd) =
-                    crate::builtins::methods_0arg::temporal::date_attrs((b_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::date_attrs(&(b_attrs).as_map());
                 ay == by && am == bm && ad == bd
             }
             // StrDistance instances: structural equality on before/after
@@ -268,12 +268,16 @@ impl Value {
                     ..
                 },
             ) if cn_a == "StrDistance" && cn_b == "StrDistance" => {
-                let before_eq = match (a_attrs.get("before"), b_attrs.get("before")) {
+                let before_eq = match (
+                    a_attrs.as_map().get("before"),
+                    b_attrs.as_map().get("before"),
+                ) {
                     (Some(a), Some(b)) => a.eqv(b),
                     (None, None) => true,
                     _ => false,
                 };
-                let after_eq = match (a_attrs.get("after"), b_attrs.get("after")) {
+                let after_eq = match (a_attrs.as_map().get("after"), b_attrs.as_map().get("after"))
+                {
                     (Some(a), Some(b)) => a.eqv(b),
                     (None, None) => true,
                     _ => false,
@@ -350,7 +354,10 @@ impl Value {
                 return handled;
             }
             // Fall back to the attribute
-            attributes.get("handled").is_some_and(|v| v.truthy())
+            attributes
+                .as_map()
+                .get("handled")
+                .is_some_and(|v| v.truthy())
         } else {
             false
         }
@@ -401,7 +408,7 @@ impl Value {
             } => {
                 if class_name == "Proc" {
                     // Proc is truthy when exitcode == 0
-                    return match attributes.get("exitcode") {
+                    return match attributes.as_map().get("exitcode") {
                         Some(Value::Int(code)) => *code == 0,
                         _ => false,
                     };
@@ -418,7 +425,7 @@ impl Value {
                     || cn.starts_with("buf")
                     || cn.starts_with("blob")
                 {
-                    return match attributes.get("bytes") {
+                    return match attributes.as_map().get("bytes") {
                         Some(Value::Array(items, ..)) => !items.is_empty(),
                         _ => false,
                     };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -289,7 +289,7 @@ impl VM {
         }) = stack.last_mut()
             && *class_name == "Failure"
         {
-            Arc::make_mut(attributes).insert("handled".to_string(), Value::Bool(true));
+            attributes.insert("handled".to_string(), Value::Bool(true));
             crate::value::mark_failure_handled(*id);
         }
     }
@@ -335,6 +335,7 @@ impl VM {
 
         let message = if let Value::Instance { attributes, .. } = &value {
             attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| {
@@ -1127,7 +1128,7 @@ impl VM {
                         }
                         let self_val = self.get_env_with_main_alias("self")?;
                         if let Value::Instance { attributes, .. } = &self_val {
-                            attributes.get(attr_name).cloned()
+                            attributes.as_map().get(attr_name).cloned()
                         } else {
                             None
                         }
@@ -1193,7 +1194,7 @@ impl VM {
                         }
                         let self_val = self.get_env_with_main_alias("self")?;
                         if let Value::Instance { attributes, .. } = &self_val {
-                            attributes.get(attr_name).cloned()
+                            attributes.as_map().get(attr_name).cloned()
                         } else {
                             None
                         }
@@ -2598,21 +2599,24 @@ impl VM {
                             } = &val
                                 && class_name.resolve() == "Proc"
                             {
-                                let exitcode = match attributes.get("exitcode") {
+                                let exitcode = match attributes.as_map().get("exitcode") {
                                     Some(Value::Int(i)) => *i,
                                     _ => 0,
                                 };
                                 // A still-"live" Proc (from `run(:in, ...)`)
                                 // carries a placeholder exitcode of -1 until it
                                 // is finalized; sinking it must not throw.
-                                let is_live =
-                                    matches!(attributes.get("live"), Some(Value::Bool(true)));
+                                let is_live = matches!(
+                                    attributes.as_map().get("live"),
+                                    Some(Value::Bool(true))
+                                );
                                 if exitcode != 0 && !is_live {
-                                    let signal = match attributes.get("signal") {
+                                    let signal = match attributes.as_map().get("signal") {
                                         Some(Value::Int(i)) => *i,
                                         _ => 0,
                                     };
                                     let command = attributes
+                                        .as_map()
                                         .get("command")
                                         .map(|v| v.to_string_value())
                                         .unwrap_or_default();
@@ -2620,6 +2624,7 @@ impl VM {
                                     // (exit code -1), rakudo reports the underlying
                                     // OS error in the message.
                                     let os_error = attributes
+                                        .as_map()
                                         .get("os-error")
                                         .map(|v| v.to_string_value())
                                         .filter(|s| !s.is_empty());
@@ -3295,17 +3300,12 @@ impl VM {
                 if let Some(ref mut exc_box) = err.exception
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
-                    let attrs = std::sync::Arc::make_mut(attributes);
-                    attrs.insert("backtrace".to_string(), backtrace_val);
+                    attributes.insert("backtrace".to_string(), backtrace_val);
                     if let Some(line) = current_line {
-                        attrs
-                            .entry("line".to_string())
-                            .or_insert(Value::Int(line as i64));
+                        attributes.insert_if_absent("line".to_string(), Value::Int(line as i64));
                     }
                     if let Some(ref file) = current_file {
-                        attrs
-                            .entry("file".to_string())
-                            .or_insert(Value::str_from(file));
+                        attributes.insert_if_absent("file".to_string(), Value::str_from(file));
                     }
                 }
                 return Err(err);
@@ -3321,7 +3321,7 @@ impl VM {
                 } = &val
                     && class_name.resolve() == "Failure"
                 {
-                    if let Some(exc) = attributes.get("exception") {
+                    if let Some(exc) = attributes.as_map().get("exception") {
                         exc.clone()
                     } else {
                         val
@@ -3339,17 +3339,12 @@ impl VM {
                 if let Some(ref mut exc_box) = err.exception
                     && let Value::Instance { attributes, .. } = exc_box.as_mut()
                 {
-                    let attrs = std::sync::Arc::make_mut(attributes);
-                    attrs.insert("backtrace".to_string(), backtrace_val);
+                    attributes.insert("backtrace".to_string(), backtrace_val);
                     if let Some(line) = current_line {
-                        attrs
-                            .entry("line".to_string())
-                            .or_insert(Value::Int(line as i64));
+                        attributes.insert_if_absent("line".to_string(), Value::Int(line as i64));
                     }
                     if let Some(ref file) = current_file {
-                        attrs
-                            .entry("file".to_string())
-                            .or_insert(Value::str_from(file));
+                        attributes.insert_if_absent("file".to_string(), Value::str_from(file));
                     }
                 }
                 return Err(err);

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -681,7 +681,7 @@ impl VM {
 
     pub fn extract_buf_bytes(val: &Value) -> Vec<u8> {
         if let Value::Instance { attributes, .. } = val
-            && let Some(Value::Array(items, ..)) = attributes.get("bytes")
+            && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
         {
             return items
                 .iter()

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -554,7 +554,7 @@ impl VM {
             && let Some(attr_name) = name.strip_prefix('!').filter(|n| !n.is_empty())
             && let Some(Value::Instance { attributes, .. }) =
                 self.get_env_with_main_alias("self").as_ref()
-            && let Some(attr_val) = attributes.get(attr_name)
+            && let Some(attr_val) = attributes.as_map().get(attr_name)
         {
             target = attr_val.clone();
         }

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -307,6 +307,7 @@ impl VM {
                     };
                 let has_attr_aliases = match &target {
                     Value::Instance { attributes, .. } => attributes
+                        .as_map()
                         .keys()
                         .any(|k| k.starts_with(super::vm_method_dispatch::ATTR_ALIAS_META_PREFIX)),
                     _ => false,
@@ -576,15 +577,21 @@ impl VM {
             return None;
         }
         // Only a concrete array-backed iterator (excludes predictive/coroutine
-        // iterators whose state lives off the instance).
-        let Some(Value::Array(items, ..)) = attributes.get("items") else {
-            return None;
+        // iterators whose state lives off the instance). Snapshot the (cheap Arc
+        // clone of the) backing array and the start index, then drop the read
+        // guard before the writeback below write-locks the same cell.
+        let (items, start_index) = {
+            let map = attributes.as_map();
+            let Some(Value::Array(items, ..)) = map.get("items") else {
+                return None;
+            };
+            let start_index = match map.get("index") {
+                Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                _ => 0,
+            };
+            (items.clone(), start_index)
         };
         let len = items.len();
-        let start_index = match attributes.get("index") {
-            Some(Value::Int(i)) if *i >= 0 => *i as usize,
-            _ => 0,
-        };
         let mut index = start_index;
         let ret = match method {
             "pull-one" => {
@@ -640,16 +647,20 @@ impl VM {
         // the interpreter's mutating iterator dispatch does, so the receiver
         // variable and aliases see the advance.
         if index != start_index {
-            let mut updated = attributes.as_ref().clone();
-            updated.insert("index".to_string(), Value::Int(index as i64));
+            // Write through the shared cell in place: every alias of this
+            // iterator instance (caller var, locals) sees the advance directly.
+            attributes.insert("index".to_string(), Value::Int(index as i64));
             let cn = class_name.resolve();
             let inst_id = *id;
+            let snapshot = attributes.to_map();
+            // Legacy by-identity propagation (redundant now that the cell is
+            // shared; removed in Stage 2).
             self.interpreter.overwrite_instance_bindings_by_identity(
                 &cn,
                 inst_id,
-                (updated.clone()).to_map(),
+                snapshot.clone(),
             );
-            self.overwrite_instance_in_locals(&cn, inst_id, updated.as_map());
+            self.overwrite_instance_in_locals(&cn, inst_id, &snapshot);
             self.env_dirty = true;
         }
         Some(Ok(ret))

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -540,7 +540,7 @@ impl VM {
             } = &target
             && (class_name.resolve() == "Lock::Async" || class_name.resolve() == "Lock")
         {
-            let lock_id = match attributes.get("lock-id") {
+            let lock_id = match attributes.as_map().get("lock-id") {
                 Some(Value::Int(id)) if *id > 0 => *id as u64,
                 _ => {
                     return Err(RuntimeError::new(
@@ -693,7 +693,7 @@ impl VM {
                 id,
             } = target
             {
-                let mut attrs = crate::value::InstanceAttrs::clone(&attributes);
+                let attrs = crate::value::InstanceAttrs::clone(&attributes);
                 attrs.insert("ast".to_string(), value.clone());
                 let updated = Value::Instance {
                     class_name,
@@ -1291,6 +1291,7 @@ impl VM {
                             .any(|n| n == "Array")
                     {
                         let mut storage = attributes
+                            .as_map()
                             .get("__mutsu_array_storage")
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));
@@ -1322,7 +1323,7 @@ impl VM {
                         }
                         self.interpreter.env_mut().remove("__mutsu_array_tmp");
                         // Update the instance with the new storage
-                        let mut new_attrs = crate::value::InstanceAttrs::clone(attributes);
+                        let new_attrs = crate::value::InstanceAttrs::clone(attributes);
                         new_attrs.insert("__mutsu_array_storage".to_string(), storage);
                         let updated_instance = Value::Instance {
                             class_name: *inst_class,
@@ -1665,7 +1666,7 @@ impl VM {
         }
         // Extract the current bytes (same clamping the interpreter uses).
         let mut bytes: Vec<u8> = Vec::new();
-        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
             bytes.reserve(items.len());
             for it in items.iter() {
                 bytes.push(match it {
@@ -1725,7 +1726,7 @@ impl VM {
         // Build updated attributes and write back by instance identity (so aliases
         // observing the same buf see the mutation), then refresh the receiver
         // binding to match the interpreter's `env.insert(target_var, ...)`.
-        let mut updated_attrs = attributes.as_ref().clone();
+        let updated_attrs = attributes.as_ref().clone();
         updated_attrs.insert(
             "bytes".to_string(),
             Value::array(

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -146,9 +146,9 @@ impl VM {
         // type); extending it to the mut path means an accessor read on a
         // *variable* (`$obj.x`, compiled as CallMethodMut) no longer falls back
         // to the interpreter.
-        let val = attributes
-            .get(method)
-            .or_else(|| attributes.get(&format!("{}!", method)));
+        let map = attributes.as_map();
+        let priv_key = format!("{}!", method);
+        let val = map.get(method).or_else(|| map.get(&priv_key));
         match val {
             Some(v) => {
                 let out = v.clone();
@@ -362,7 +362,7 @@ impl VM {
             } = &target
             && (class_name.resolve() == "Lock::Async" || class_name.resolve() == "Lock")
         {
-            let lock_id = match attributes.get("lock-id") {
+            let lock_id = match attributes.as_map().get("lock-id") {
                 Some(Value::Int(id)) if *id > 0 => *id as u64,
                 _ => {
                     return Err(RuntimeError::new(
@@ -865,6 +865,7 @@ impl VM {
                             .any(|n| n == "Array")
                     {
                         let storage = attributes
+                            .as_map()
                             .get("__mutsu_array_storage")
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -867,9 +867,11 @@ impl VM {
                 && right_attrs.contains_key("timezone") =>
             {
                 let (ly, lm, ld, lh, lmin, ls, ltz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(&(left_attrs).as_map());
                 let (ry, rm, rd, rh, rmin, rs, rtz) =
-                    crate::builtins::methods_0arg::temporal::datetime_attrs((right_attrs).as_map());
+                    crate::builtins::methods_0arg::temporal::datetime_attrs(
+                        &(right_attrs).as_map(),
+                    );
                 let left_instant =
                     crate::builtins::methods_0arg::temporal::datetime_to_instant_leap_aware(
                         ly, lm, ld, lh, lmin, ls, ltz,
@@ -1324,7 +1326,7 @@ impl VM {
                 attributes,
                 ..
             } if class_name == "Match" => {
-                if let Some(Value::Array(items, _)) = attributes.get("list") {
+                if let Some(Value::Array(items, _)) = attributes.as_map().get("list") {
                     Value::Int(items.len() as i64)
                 } else {
                     Value::Int(1)

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -54,7 +54,7 @@ impl VM {
         } = &target
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+            if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                 bytes.to_vec()
             } else {
                 Vec::new()

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1055,7 +1055,7 @@ impl VM {
             && let Some(attr_name) = name.strip_prefix('!').filter(|n| !n.is_empty())
             && let Some(Value::Instance { attributes, .. }) =
                 self.get_env_with_main_alias("self").as_ref()
-            && let Some(attr_val) = attributes.get(attr_name)
+            && let Some(attr_val) = attributes.as_map().get(attr_name)
         {
             val = attr_val.clone();
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -917,7 +917,7 @@ impl VM {
                         .collect(),
                     Value::Instance { attributes, .. } => {
                         // Extract items from an existing Buf/Blob instance
-                        if let Some(Value::Array(items, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                             items
                                 .iter()
                                 .map(|v| Value::Int(crate::runtime::to_int(v)))

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -19,10 +19,12 @@ fn io_path_cleanup_absolute(path: &str, cwd: &str) -> String {
 /// Extract path and CWD from IO::Path attributes.
 fn io_path_attrs(attrs: &std::sync::Arc<crate::value::InstanceAttrs>) -> (String, String) {
     let path = attrs
+        .as_map()
         .get("path")
         .map(|v: &Value| v.to_string_value())
         .unwrap_or_default();
     let cwd = attrs
+        .as_map()
         .get("cwd")
         .map(|v: &Value| v.to_string_value())
         .unwrap_or_else(|| {
@@ -80,9 +82,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             },
         ) if left_class == "DateTime" && right_class == "Date" => {
             let (y, m, d, _, _, _, _) =
-                crate::builtins::methods_0arg::temporal::datetime_attrs((left_attrs).as_map());
+                crate::builtins::methods_0arg::temporal::datetime_attrs(&(left_attrs).as_map());
             let (ry, rm, rd) =
-                crate::builtins::methods_0arg::temporal::date_attrs((right_attrs).as_map());
+                crate::builtins::methods_0arg::temporal::date_attrs(&(right_attrs).as_map());
             Some(y == ry && m == rm && d == rd)
         }
 
@@ -432,7 +434,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             ) =>
         {
             let negated = matches!(val.as_ref(), Value::Bool(false));
-            let path_str = attributes.get("path").map(|v| v.to_string_value());
+            let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
             if let Some(p) = path_str {
                 let path = std::path::Path::new(&p);
                 let result = match key.as_str() {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3026,7 +3026,7 @@ impl VM {
                         let display = format!("{}()", cn);
                         return Err(RuntimeError::assignment_ro_typename(&cn, &display));
                     }
-                    let hash_map: HashMap<String, Value> = HashMap::clone(attributes.as_map());
+                    let hash_map: HashMap<String, Value> = HashMap::clone(&attributes.as_map());
                     let hash_val = Value::hash(hash_map);
                     self.interpreter
                         .env_mut()
@@ -4088,6 +4088,7 @@ impl VM {
                 ..
             } if class_name == "Stash" => {
                 let package = attributes
+                    .as_map()
                     .get("name")
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -63,7 +63,7 @@ impl VM {
                     class_name,
                     attributes,
                     ..
-                } if class_name == "Stash" => match attributes.get("symbols") {
+                } if class_name == "Stash" => match attributes.as_map().get("symbols") {
                     Some(Value::Hash(map)) => Some(map.clone()),
                     _ => None,
                 },
@@ -477,7 +477,7 @@ impl VM {
                             },
                             Value::Str(key),
                         ) if class_name == "Stash" => {
-                            if let Some(Value::Hash(symbols)) = attributes.get("symbols") {
+                            if let Some(Value::Hash(symbols)) = attributes.as_map().get("symbols") {
                                 symbols.contains_key(key.as_str())
                             } else {
                                 false
@@ -491,7 +491,7 @@ impl VM {
                             },
                             other,
                         ) if class_name == "Stash" => {
-                            if let Some(Value::Hash(symbols)) = attributes.get("symbols") {
+                            if let Some(Value::Hash(symbols)) = attributes.as_map().get("symbols") {
                                 symbols.contains_key(&other.to_string_value())
                             } else {
                                 false

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -839,7 +839,7 @@ impl VM {
                 },
                 Value::Array(keys, ..),
             ) if class_name == "Match" => {
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     Value::array(
                         keys.iter()
                             .map(|k| {
@@ -860,7 +860,7 @@ impl VM {
                 },
                 Value::Str(key),
             ) if class_name == "Match" => {
-                if let Some(Value::Hash(named)) = attributes.get("named") {
+                if let Some(Value::Hash(named)) = attributes.as_map().get("named") {
                     named.get(key.as_str()).cloned().unwrap_or(Value::Nil)
                 } else {
                     Value::Nil
@@ -876,7 +876,7 @@ impl VM {
             ) if class_name == "Match" => {
                 if i < 0 {
                     Value::Nil
-                } else if let Some(Value::Array(items, ..)) = attributes.get("list") {
+                } else if let Some(Value::Array(items, ..)) = attributes.as_map().get("list") {
                     items.get(i as usize).cloned().unwrap_or(Value::Nil)
                 } else {
                     Value::Nil
@@ -886,7 +886,7 @@ impl VM {
             (Value::Instance { ref attributes, .. }, ref idx)
                 if attributes.contains_key("__baggy_data__") =>
             {
-                let inner = attributes.get("__baggy_data__").unwrap().clone();
+                let inner = attributes.as_map().get("__baggy_data__").unwrap().clone();
                 let idx_clone = idx.clone();
                 // Re-enter the index logic with the inner bag/set value
                 self.stack.push(inner);
@@ -1358,7 +1358,7 @@ impl VM {
             ) => {
                 // Get element count from the instance
                 let len = if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
-                    if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                    if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                         bytes.len() as i64
                     } else {
                         0
@@ -1391,7 +1391,7 @@ impl VM {
                 };
                 match i {
                     Some(i) if i >= 0 => {
-                        if let Some(Value::Array(bytes, ..)) = attributes.get("bytes") {
+                        if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                             bytes.get(i as usize).cloned().unwrap_or(Value::Nil)
                         } else {
                             Value::Nil

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -378,6 +378,7 @@ impl VM {
     fn failure_to_error(exception: &Value) -> RuntimeError {
         let message = if let Value::Instance { attributes, .. } = exception {
             attributes
+                .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| "Died".to_string())
@@ -397,7 +398,7 @@ impl VM {
                 attributes,
                 ..
             } if class_name == "Failure" => {
-                if let Some(ex) = attributes.get("exception") {
+                if let Some(ex) = attributes.as_map().get("exception") {
                     return Err(Self::failure_to_error(ex));
                 }
             }


### PR DESCRIPTION
## Summary

Phase 3 (option C) **Stage 1** of the first-class instance-cell work (`docs/container-identity.md`). Switches `InstanceAttrs.attributes` from a plain `HashMap` to a shared `Arc<RwLock<HashMap>>` cell so an in-place instance mutation is **visible by-reference across call frames**.

This fixes the long-standing closure-frame mutation bug: a mutation inside a closure-provided block (e.g. `note`/`$*ERR` rebound in a `sub cap(&code){ my $*ERR=…; &code() }` test harness, or any mutating method on a caller-held instance) previously did not reach the caller's binding, because `overwrite_*_by_identity` only scanned the current frame's env overlay. With shared cells the mutation reaches every alias directly.

## What changed

- **Representation**: `Value::Instance` still holds `Arc<InstanceAttrs>`; cloning a `Value::Instance` aliases the same cell (Raku object identity). `InstanceAttrs::clone` is a manual **deep copy** (fresh, unregistered cell), so the ~30 legacy `(*attributes).clone()` writeback sites keep their independent-copy semantics with no change.
- **Read API**: `as_map()` returns a `RwLockReadGuard` (derefs to `&HashMap`, so chained `.get`/`.iter`/`for` are unchanged; ~87 `fn(&HashMap)` arg sites take `&`). The owned-returning `get()` was removed and routed through `as_map().get()` to preserve borrow semantics (504 sites). Mutation (`insert`/`insert_if_absent`/`with_attr_mut`) is in place via write-lock.
- **Cross-frame visibility**: an `id -> Weak<cell>` registry lets `make_instance_with_id` **reuse the live cell**, and `overwrite_instance_bindings_by_identity` writes the live cell directly via `update_instance_cell`. These cell writes use **`try_write`** so a writeback that runs while an outer frame holds a read guard on the same instance (e.g. mut-dispatch invocant write-back called from inside `if let … = $obj.attr`) **never deadlocks**. Stage 2 removes the scan + registry entirely.
- **`temp`/`let`**: saves take a deep snapshot (`into_temp_snapshot`) and restore by writing back into the live cell, preserving identity and restore semantics.

## Testing

- `make test` PASS (6170 tests)
- Whitelisted roast subset S12/S14/S06/S04/S32-temporal: **282 PASS / 0 FAIL**
- Verified against `raku`: cross-frame `note`/`$*ERR`, closure-provided mutation, alias sharing, `.clone` independence, `===`/`.WHICH`/`eqv` identity, DESTROY (fires once), `temp`/`let` restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)