### PR TITLE
fix(test): report EVAL line/filename on throws-like compile-time exceptions

### DIFF
--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -74,7 +74,26 @@ impl Interpreter {
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
-                        Err(e) => Err(e),
+                        Err(mut e) => {
+                            // A compile-time exception raised while parsing the
+                            // EVAL'd code reports the EVAL pseudo-file and the
+                            // line within that source (Raku exposes `.filename`
+                            // matching /EVAL/ and `.line`).
+                            if let Some(ref mut exc_box) = e.exception
+                                && let Value::Instance { attributes, .. } = exc_box.as_mut()
+                            {
+                                let line = e.line.unwrap_or(1) as i64;
+                                let attrs = std::sync::Arc::make_mut(attributes);
+                                attrs.entry("line".to_string()).or_insert(Value::Int(line));
+                                attrs
+                                    .entry("filename".to_string())
+                                    .or_insert(Value::str("EVAL_0".to_string()));
+                                attrs
+                                    .entry("file".to_string())
+                                    .or_insert(Value::str("EVAL_0".to_string()));
+                            }
+                            Err(e)
+                        }
                     }
                 };
                 if let Err(e) = pre_check_result {
@@ -403,7 +422,26 @@ impl Interpreter {
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
-                        Err(e) => Err(e),
+                        Err(mut e) => {
+                            // A compile-time exception raised while parsing the
+                            // EVAL'd code reports the EVAL pseudo-file and the
+                            // line within that source (Raku exposes `.filename`
+                            // matching /EVAL/ and `.line`).
+                            if let Some(ref mut exc_box) = e.exception
+                                && let Value::Instance { attributes, .. } = exc_box.as_mut()
+                            {
+                                let line = e.line.unwrap_or(1) as i64;
+                                let attrs = std::sync::Arc::make_mut(attributes);
+                                attrs.entry("line".to_string()).or_insert(Value::Int(line));
+                                attrs
+                                    .entry("filename".to_string())
+                                    .or_insert(Value::str("EVAL_0".to_string()));
+                                attrs
+                                    .entry("file".to_string())
+                                    .or_insert(Value::str("EVAL_0".to_string()));
+                            }
+                            Err(e)
+                        }
                     }
                 };
                 if let Err(e) = pre_check_result {


### PR DESCRIPTION
## Summary

`throws-like` parses its string argument via `parse_program_with_operators` as a pre-check; a compile-time exception (e.g. `X::Syntax::Pod::BeginWithoutIdentifier` from `=begin`) surfaced with the correct type but no `.line`/`.filename`, so assertions like `line => 1, filename => rx/EVAL/` failed.

The pre-check `Err` arm now injects `line` (from the parse error's line, defaulting to 1) and `filename`/`file` (the `EVAL_0` pseudo-file) into the exception's attributes when absent, in both `test_fn_throws_like` and `test_fn_throws_like_any`. Exceptions that already carry these attributes are left untouched.

## Context

`#2868` made `roast/S32-exceptions/misc2.t` test 94 emit the right exception **type** for bare `=begin`, but the full subtest also checks `line => 1` and `filename => rx/EVAL/`. `misc2.t` is not whitelisted, so CI did not surface the partial pass. This completes test 94.

## Test

Verified `throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier, line => 1, filename => rx/EVAL/` now passes all four sub-assertions; unit tests and throws-like-heavy whitelisted roast tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)