### PR TITLE
feat(exceptions): seven more misc2.t throws-like cases

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -107,6 +107,19 @@
     odd-check lives in the infallible `coerce_to_hash`; needs care),
     X::Phaser::PrePost, … and the abort at test 241 (X::Multi::NoMatch /
     X::Syntax::Adverb throws-like).
+  - 2026-06-10: file now runs the full 265 tests; only **1 subtest** remains
+    (264). Landed this round: X::TypeCheck::Binding for typed scalar `:=`
+    (`my Str $x := 3`); X::TypeCheck::Assignment for `%a.AT-KEY(k) = v` on a
+    typed hash; compile-time X::Undeclared for variables used inside `sub`/
+    `method`/`class` bodies and string interpolation (with `$!attr`/param
+    suggestions); X::Syntax::Confused for `1∞` (bogus postfix) and
+    `when {} when {}` on one line ("strange text after block"); X::Syntax::Adverb
+    for `infix:(...)`.
+  - **Remaining (test 264):** `open("/bad/path", :w).print: 42` must throw
+    X::Multi::NoMatch. Needs two semantic changes: (1) `open` returns a
+    `Failure` on error instead of dying, and (2) calling `.print` (an IO multi)
+    on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
+    re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
   - 42/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -139,6 +139,26 @@ impl Compiler {
                             self.code.emit(OpCode::Dup);
                             self.emit_set_named_var(name);
                         } else {
+                            // Enforce a scalar type constraint in expression
+                            // position too (e.g. a bare `my Str $x := 3` whose
+                            // value is the program result). Skip uninitialized
+                            // typed decls (`my Str $x` -> Nil).
+                            if let Some(tc) = type_constraint
+                                && !matches!(expr, Expr::Literal(Value::Nil))
+                            {
+                                let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                                let display_name = format!("${}", name);
+                                let var_name_idx = self.code.add_constant(Value::str(display_name));
+                                let is_bind =
+                                    custom_traits.iter().any(|(t, _)| t == "__scalar_bind");
+                                if is_bind {
+                                    self.code
+                                        .emit(OpCode::TypeCheckBind(tc_idx, Some(var_name_idx)));
+                                } else {
+                                    self.code
+                                        .emit(OpCode::TypeCheck(tc_idx, Some(var_name_idx)));
+                                }
+                            }
                             self.code.emit(OpCode::Dup);
                             self.emit_set_named_var(name);
                         }

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -110,6 +110,7 @@ impl Compiler {
                         expr,
                         is_dynamic: ast_is_dynamic,
                         type_constraint,
+                        custom_traits,
                         ..
                     } => {
                         // my $x = expr in block-final position: declare and return value
@@ -140,6 +141,29 @@ impl Compiler {
                             self.code.emit(OpCode::SetLocal(slot));
                         } else {
                             self.compile_expr(expr);
+                            // Enforce a scalar type constraint here too, so a
+                            // block-final `my Str $x := 3` raises
+                            // X::TypeCheck::Binding instead of silently storing
+                            // (or hitting the readonly check). Skip @/% and
+                            // uninitialized typed decls (`my Str $x` -> Nil).
+                            if let Some(tc) = type_constraint
+                                && !name.starts_with('@')
+                                && !name.starts_with('%')
+                                && !matches!(expr, Expr::Literal(Value::Nil))
+                            {
+                                let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                                let display_name = format!("${}", name);
+                                let var_name_idx = self.code.add_constant(Value::str(display_name));
+                                let is_bind =
+                                    custom_traits.iter().any(|(t, _)| t == "__scalar_bind");
+                                if is_bind {
+                                    self.code
+                                        .emit(OpCode::TypeCheckBind(tc_idx, Some(var_name_idx)));
+                                } else {
+                                    self.code
+                                        .emit(OpCode::TypeCheck(tc_idx, Some(var_name_idx)));
+                                }
+                            }
                             self.code.emit(OpCode::Dup);
                             self.emit_set_named_var(name);
                         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -810,8 +810,15 @@ impl Compiler {
                         format!("${}", name)
                     };
                     let var_name_idx = self.code.add_constant(Value::str(display_name));
-                    self.code
-                        .emit(OpCode::TypeCheck(tc_idx, Some(var_name_idx)));
+                    // A `:=` bind to a typed scalar reports X::TypeCheck::Binding
+                    // on mismatch (e.g. `my Str $x := 3`), not Assignment.
+                    if scalar_bind_decont && !name.starts_with('@') && !name.starts_with('%') {
+                        self.code
+                            .emit(OpCode::TypeCheckBind(tc_idx, Some(var_name_idx)));
+                    } else {
+                        self.code
+                            .emit(OpCode::TypeCheck(tc_idx, Some(var_name_idx)));
+                    }
                 }
                 let slot = self.alloc_local(name);
                 if *is_state {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -927,6 +927,12 @@ pub(crate) enum OpCode {
     /// Optional second u32 is a constant index for the variable name (for error messages).
     TypeCheck(u32, Option<u32>),
 
+    /// Like TypeCheck, but for `:=` binds to a typed scalar. On a type
+    /// mismatch this raises X::TypeCheck::Binding (e.g. `my Str $x := 3`)
+    /// instead of X::TypeCheck::Assignment. First u32 is the type name
+    /// constant index; optional second u32 is the variable name index.
+    TypeCheckBind(u32, Option<u32>),
+
     /// Set a pragma value. Pops the value from the stack.
     /// The u32 is a constant index for the pragma name.
     SetPragma(u32),

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1386,6 +1386,30 @@ fn try_extend_colon_name<'a>(input: &'a str, base: &str) -> (&'a str, String) {
     (rest, name)
 }
 
+/// Given input beginning with `(`, return the balanced parenthesised group
+/// including the surrounding parens (e.g. `(&)` from `(&) extra`), or None if
+/// unbalanced. Used to render the offending text in an X::Syntax::Adverb error.
+fn balanced_paren_text(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    if bytes.first() != Some(&b'(') {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (idx, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(input[..=idx].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Given input beginning with `(`, skip the balanced parenthesised group and
 /// return true if the next non-whitespace character is `{` (the start of a
 /// block). Used to distinguish `if() {}` (keyword-as-function) from `if(5)`
@@ -1557,6 +1581,17 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // Handle special expression keywords before qualified name resolution
     match name.as_str() {
         "infix" | "prefix" | "postfix" | "circumfix" | "postcircumfix" => {
+            // `infix:(...)` adverbs the operator declarator with a signature
+            // literal, which is illegal -> X::Syntax::Adverb ("You can't adverb
+            // :(...)"). Operator names use `:<...>`/`:sym<...>`, never `:(...)`.
+            if rest.starts_with(":(") {
+                let adverb_text =
+                    balanced_paren_text(&rest[1..]).unwrap_or_else(|| "(...)".to_string());
+                return Err(PError::fatal(format!(
+                    "X::Syntax::Adverb: You can't adverb :{}",
+                    adverb_text
+                )));
+            }
             // infix:<OP>(args) — operator reference
             if rest.starts_with(":<") || rest.starts_with(":<<") {
                 let r = &rest[1..]; // skip ':'

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -553,6 +553,12 @@ fn is_block_ending_stmt(stmt: &Stmt) -> bool {
         // sub_decl does NOT call parse_statement_modifier, so trailing separators
         // remain in the rest for us to check.
         Stmt::SubDecl { body, .. } => !body.is_empty(),
+        // `when`/`default` block statements take a `{...}` body and, unlike
+        // `if`/`for`/etc., are not followed by any same-line continuation
+        // keyword (no `else`/`elsif`) and do not consume trailing statement
+        // modifiers. So `when 1 { } when 2 { }` on one line (no `;`) is a
+        // "Strange text after block" error in Raku, matching `given $x { ... }`.
+        Stmt::When { .. } | Stmt::Default(_) => true,
         // Note: MethodDecl is excluded because it can arrive via my_decl which calls
         // parse_statement_modifier, consuming the trailing separator before we see it.
         // Stmt::Block, Stmt::If, Stmt::For, ClassDecl, RoleDecl, Package, etc. are

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -81,6 +81,10 @@ fn starts_with_unambiguous_term(input: &str) -> bool {
                 | '\u{201C}'
                 | '\u{201D}'
                 | '\u{201E}'
+                // U+221E INFINITY: the `Inf` literal. A value directly followed
+                // by `∞` with no infix operator (`1∞`) is a bogus postfix in
+                // Raku -> X::Syntax::Confused.
+                | '\u{221E}'
         )
 }
 

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -689,6 +689,24 @@ impl Interpreter {
                 || matches!(inner, Value::Package(n) if matches!(n.resolve().as_str(), "Any" | "Mu"))
             {
                 let old_meta = self.container_type_metadata(inner).clone();
+                // Enforce the declared element type, so
+                // `my Str %a; %a.AT-KEY("K") = 1` raises X::TypeCheck::Assignment
+                // just like `%a<K> = 1` does.
+                let value_type = old_meta
+                    .as_ref()
+                    .map(|m| m.value_type.clone())
+                    .or_else(|| target_var.and_then(|v| self.var_type_constraint(v)));
+                if let Some(vt) = value_type.as_deref()
+                    && !matches!(vt, "Any" | "Mu" | "")
+                    && !matches!(&value, Value::Nil)
+                    && !self.type_matches_value(vt, &value)
+                {
+                    return Err(crate::runtime::utils::type_check_element_typed_error(
+                        target_var.unwrap_or("%"),
+                        vt,
+                        &value,
+                    ));
+                }
                 let key = method_args[0].to_string_value();
                 let mut hash = match inner {
                     Value::Hash(map) => (**map).clone(),

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -426,7 +426,9 @@ impl Interpreter {
         for stmt in stmts {
             Self::check_self_referential_init(stmt)?;
             Self::collect_declared_vars(stmt, &mut declared);
-            if let Some((sigil, var_name)) = self.find_undeclared_var_in_stmt(stmt, &declared) {
+            if let Some((sigil, var_name, suggestions)) =
+                self.find_undeclared_var_in_stmt(stmt, &declared)
+            {
                 let symbol = format!("{}{}", sigil, var_name);
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert("name".to_string(), Value::str(symbol.clone()));
@@ -438,8 +440,6 @@ impl Interpreter {
                 // still expecting at the eject point. For an undeclared variable
                 // there is nothing else expected, so it is an empty list.
                 attrs.insert("highexpect".to_string(), Value::array(vec![]));
-                // Suggest close lexically-declared names (Did-you-mean).
-                let suggestions = Self::suggest_declared_vars(&symbol, &declared);
                 let mut message = format!("Variable '{}' is not declared.", symbol);
                 if suggestions.len() == 1 {
                     message.push_str(&format!(" Did you mean '{}'?", suggestions[0]));
@@ -651,12 +651,12 @@ impl Interpreter {
     }
 
     /// Find an undeclared Var reference in a statement.
-    /// Returns (sigil, name) if undeclared, None otherwise.
+    /// Returns (sigil, name, suggestions) if undeclared, None otherwise.
     fn find_undeclared_var_in_stmt(
         &self,
         stmt: &Stmt,
         declared: &HashSet<String>,
-    ) -> Option<(&'static str, String)> {
+    ) -> Option<(&'static str, String, Vec<String>)> {
         match stmt {
             Stmt::Say(exprs) | Stmt::Print(exprs) | Stmt::Note(exprs) | Stmt::Put(exprs) => {
                 for expr in exprs {
@@ -664,7 +664,9 @@ impl Interpreter {
                         && !self.has_function(name)
                         && !self.has_class(name)
                     {
-                        return Some(("$", name.clone()));
+                        let suggestions =
+                            Self::suggest_declared_vars(&format!("${}", name), declared);
+                        return Some(("$", name.clone(), suggestions));
                     }
                     if let Some(result) = self.find_undeclared_var_in_expr(expr, declared) {
                         return Some(result);
@@ -673,17 +675,90 @@ impl Interpreter {
                 None
             }
             Stmt::Expr(expr) => self.find_undeclared_var_in_expr(expr, declared),
+            // Descend into `sub`/`method` bodies so undeclared variables used
+            // inside them (e.g. `sub greet($name) { say "$nam" }`) are caught at
+            // EVAL/compile time. The body's lexical scope adds the routine's
+            // parameters (and, for methods inside a class, the attributes).
+            Stmt::SubDecl { params, body, .. } => {
+                let mut inner = declared.clone();
+                Self::add_routine_locals(params, body, &mut inner);
+                self.find_undeclared_var_in_body(body, &inner)
+            }
+            Stmt::MethodDecl { params, body, .. } => {
+                let mut inner = declared.clone();
+                Self::add_routine_locals(params, body, &mut inner);
+                self.find_undeclared_var_in_body(body, &inner)
+            }
+            Stmt::ClassDecl { body, .. } | Stmt::RoleDecl { body, .. } => {
+                // Attributes become `$!x` / `$.x` (and a bare `$x` only for
+                // `has $x` aliases). Methods in the body see them in scope.
+                let mut inner = declared.clone();
+                Self::add_class_attributes(body, &mut inner);
+                // Class-body lexicals (`my @a`) are also in scope for sibling
+                // statements/methods; collect them all up front.
+                for s in body {
+                    Self::collect_declared_vars(s, &mut inner);
+                }
+                for s in body {
+                    if let Some(result) = self.find_undeclared_var_in_stmt(s, &inner) {
+                        return Some(result);
+                    }
+                }
+                None
+            }
             _ => None,
         }
     }
 
+    /// Seed a lexical scope with a routine's parameters and any variables its
+    /// body declares, so they are not flagged as undeclared.
+    fn add_routine_locals(params: &[String], body: &[Stmt], out: &mut HashSet<String>) {
+        for p in params {
+            out.insert(p.trim_start_matches(['$', '@', '%', '&']).to_string());
+        }
+        for s in body {
+            Self::collect_declared_vars(s, out);
+        }
+    }
+
+    /// Seed a scope with a class/role body's attributes. `has $.name` makes
+    /// `$!name` and `$.name` available (but not a bare `$name`); `has $x`
+    /// (alias form) additionally makes `$x` available.
+    fn add_class_attributes(body: &[Stmt], out: &mut HashSet<String>) {
+        for s in body {
+            if let Stmt::HasDecl { name, is_alias, .. } = s {
+                let attr = name.resolve();
+                // Rakudo's "did you mean" for a bare `$name` that refers to an
+                // attribute suggests `$!name` (the private accessor form).
+                out.insert(format!("!{}", attr));
+                if *is_alias {
+                    out.insert(attr);
+                }
+            }
+        }
+    }
+
+    /// Scan a routine body for the first undeclared variable reference.
+    fn find_undeclared_var_in_body(
+        &self,
+        body: &[Stmt],
+        declared: &HashSet<String>,
+    ) -> Option<(&'static str, String, Vec<String>)> {
+        for s in body {
+            if let Some(result) = self.find_undeclared_var_in_stmt(s, declared) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
     /// Find an undeclared Var reference in an expression.
-    /// Returns (sigil, name) if undeclared, None otherwise.
+    /// Returns (sigil, name, suggestions) if undeclared, None otherwise.
     fn find_undeclared_var_in_expr(
         &self,
         expr: &Expr,
         declared: &HashSet<String>,
-    ) -> Option<(&'static str, String)> {
+    ) -> Option<(&'static str, String, Vec<String>)> {
         match expr {
             Expr::Var(name) => {
                 // Skip special variables, variables with twigils, and capture vars ($0, $1, ...)
@@ -723,7 +798,8 @@ impl Interpreter {
                 {
                     return None;
                 }
-                Some(("$", name.clone()))
+                let suggestions = Self::suggest_declared_vars(&sigiled, declared);
+                Some(("$", name.clone(), suggestions))
             }
             Expr::ArrayVar(name) => {
                 if name.starts_with("__ANON_") {
@@ -736,7 +812,8 @@ impl Interpreter {
                 if self.env.contains_key(&sigiled) || self.env.contains_key(name) {
                     return None;
                 }
-                Some(("@", name.clone()))
+                let suggestions = Self::suggest_declared_vars(&sigiled, declared);
+                Some(("@", name.clone(), suggestions))
             }
             Expr::HashVar(name) => {
                 if name.starts_with("__ANON_") {
@@ -749,7 +826,8 @@ impl Interpreter {
                 if self.env.contains_key(&sigiled) || self.env.contains_key(name) {
                     return None;
                 }
-                Some(("%", name.clone()))
+                let suggestions = Self::suggest_declared_vars(&sigiled, declared);
+                Some(("%", name.clone(), suggestions))
             }
             // Recurse into string interpolation, indexing, and method calls
             Expr::StringInterpolation(parts) => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3405,6 +3405,34 @@ pub(crate) fn type_check_assignment_error(var_name: &str, expected: &str, val: &
     }
 }
 
+/// Build a structured X::TypeCheck::Binding RuntimeError, for `:=` binds to a
+/// typed scalar (e.g. `my Str $x := 3`), matching Raku's format:
+/// `Type check failed in binding; expected Str but got Int (3)`
+pub(crate) fn type_check_binding_typed_error(expected: &str, val: &Value) -> RuntimeError {
+    let got_type = value_type_name(val);
+    let repr = value_short_repr(val);
+    let msg = if repr.is_empty() {
+        format!(
+            "X::TypeCheck::Binding: Type check failed in binding; expected {} but got {}",
+            expected, got_type
+        )
+    } else {
+        format!(
+            "X::TypeCheck::Binding: Type check failed in binding; expected {} but got {} {}",
+            expected, got_type, repr
+        )
+    };
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert(
+        "expected".to_string(),
+        Value::Package(crate::symbol::Symbol::intern(expected)),
+    );
+    attrs.insert("got".to_string(), val.clone());
+    attrs.insert("operation".to_string(), Value::str("bind".to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    RuntimeError::typed("X::TypeCheck::Binding", attrs)
+}
+
 /// Build a structured X::TypeCheck::Assignment RuntimeError.
 /// This creates a proper exception object that `throws-like` can match.
 pub(crate) fn type_check_assignment_typed_error(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3660,6 +3660,10 @@ impl VM {
                 self.exec_type_check_op(code, *tc_idx, *var_name_idx)?;
                 *ip += 1;
             }
+            OpCode::TypeCheckBind(tc_idx, var_name_idx) => {
+                self.exec_type_check_bind_op(code, *tc_idx, *var_name_idx)?;
+                *ip += 1;
+            }
             OpCode::SetPragma(name_idx) => {
                 let value = self.stack.pop().unwrap_or(Value::Nil);
                 let name = Self::const_str(code, *name_idx);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2384,6 +2384,27 @@ impl VM {
         tc_idx: u32,
         var_name_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        self.exec_type_check_op_inner(code, tc_idx, var_name_idx, false)
+    }
+
+    /// Type check for `:=` binds to a typed scalar; raises X::TypeCheck::Binding
+    /// on mismatch instead of X::TypeCheck::Assignment.
+    pub(super) fn exec_type_check_bind_op(
+        &mut self,
+        code: &CompiledCode,
+        tc_idx: u32,
+        var_name_idx: Option<u32>,
+    ) -> Result<(), RuntimeError> {
+        self.exec_type_check_op_inner(code, tc_idx, var_name_idx, true)
+    }
+
+    pub(super) fn exec_type_check_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        tc_idx: u32,
+        var_name_idx: Option<u32>,
+        bind_mode: bool,
+    ) -> Result<(), RuntimeError> {
         let raw_constraint = Self::const_str(code, tc_idx);
         let var_name: Option<&str> = var_name_idx.map(|idx| Self::const_str(code, idx));
         // Apply `use variables :D/:U` pragma to the constraint
@@ -2568,6 +2589,12 @@ impl VM {
                     {
                         return Err(err);
                     }
+                    if bind_mode {
+                        return Err(crate::runtime::utils::type_check_binding_typed_error(
+                            base_constraint,
+                            &value,
+                        ));
+                    }
                     return Err(RuntimeError::typecheck_assignment(
                         base_constraint,
                         &value,
@@ -2629,6 +2656,11 @@ impl VM {
             && !self.interpreter.type_matches_value(constraint, &value)
             && !self.interpreter.is_container_subclass(constraint)
         {
+            if bind_mode {
+                return Err(crate::runtime::utils::type_check_binding_typed_error(
+                    constraint, &value,
+                ));
+            }
             return Err(RuntimeError::typecheck_assignment(
                 constraint, &value, var_name,
             ));


### PR DESCRIPTION
Advances the `S32-exceptions/misc2.t` campaign from 6 failing subtests down to **1** by implementing seven distinct compile-time / typecheck exceptions. Each is a general-purpose fix, not a test-specific hack.

## What landed

- **X::TypeCheck::Binding** for `:=` binds to a typed scalar (`my Str $x := 3`). New `TypeCheckBind` opcode; emitted by the bind path in `compile_stmt`, the block-final VarDecl path (`helpers_block_inline`), and the expression-position VarDecl path (`expr_block`). Previously these gave `X::TypeCheck::Assignment` or a spurious `X::Assignment::RO`.
- **X::TypeCheck::Assignment** for `%a.AT-KEY("K") = v` on a typed hash, matching the existing `%a<K> = v` subscript behavior.
- **Compile-time X::Undeclared** for variables used inside `sub`/`method`/`class` bodies and string interpolation (`sub greet($n) { say "$nam" }`), with param/attribute-aware suggestions (`$name`, `$!name`). The EVAL undeclared-var walker now descends into routine/class bodies, seeding scope with parameters and `has` attributes.
- **X::Syntax::Confused** for `1∞` (value directly followed by U+221E = bogus postfix) and for `when {} when {}` on one line ("strange text after block").
- **X::Syntax::Adverb** for `infix:(...)` (signature literal used as an adverb).

## Remaining (test 264)

`open("/bad", :w).print: 42` must throw `X::Multi::NoMatch`. Needs `open` to return a `Failure` on error plus IO-multi dispatch on a `Failure` invocant resolving into NoMatch instead of re-throwing. Deferred (broad IO blast radius); documented in `TODO_roast/S32.md`.

## Testing

`make test` passes locally. Full roast runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)