### PR TITLE
feat(exceptions): complete misc2.t — open() returns Failure, print/say/put on Failure -> X::Multi::NoMatch

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -49,7 +49,11 @@
 - [ ] roast/S32-encoding/decoder.t
 - [ ] roast/S32-encoding/encoder.t
 - [ ] roast/S32-encoding/registry.t
-- [ ] roast/S32-exceptions/misc2.t
+- [x] roast/S32-exceptions/misc2.t — **DONE 2026-06-10, 265/265, whitelisted.**
+  Last case (264 X::Multi::NoMatch) fixed in PR #2875: `open()` now returns a
+  Failure on error (NUL byte stays a hard X::IO::Null throw), and
+  print/say/put/note with a positional arg on an unhandled Failure throws
+  X::Multi::NoMatch instead of exploding the Failure.
   - **Hard, multi-PR campaign** (reference rakudo fails only 1 of 265). mutsu
     runs 241/265 (aborts at 241), 131 failing — each failing `throws-like` needs
     a distinct compile-time exception type thrown at the right place. Landed so

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -994,6 +994,7 @@ roast/S32-container/zip.t
 roast/S32-encoding/decoder.t
 roast/S32-encoding/encoder.t
 roast/S32-encoding/registry.t
+roast/S32-exceptions/misc2.t
 roast/S32-hash/antipairs.t
 roast/S32-hash/delete-adverb.t
 roast/S32-hash/delete.t

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -336,7 +336,7 @@ impl Interpreter {
             create,
         ) = self.parse_io_flags_values(&args[1..]);
         let path_buf = self.resolve_path(&path);
-        self.open_file_handle(
+        match self.open_file_handle(
             &path_buf,
             read,
             write,
@@ -348,7 +348,24 @@ impl Interpreter {
             nl_out,
             enc,
             create,
-        )
+        ) {
+            Ok(handle) => Ok(handle),
+            // Raku returns a Failure (wrapping the exception) when open() fails,
+            // rather than dying immediately. Sinking/using the Failure later
+            // throws the exception. Preserve any specific exception type the
+            // error already carries; otherwise default to X::AdHoc.
+            Err(err) => {
+                let class_name = err
+                    .exception
+                    .as_deref()
+                    .and_then(|ex| match ex {
+                        Value::Instance { class_name, .. } => Some(class_name.to_string()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "X::AdHoc".to_string());
+                Ok(io_exception_failure(&class_name, err.message))
+            }
+        }
     }
 
     pub(super) fn builtin_close(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -3,6 +3,56 @@ use crate::symbol::Symbol;
 use std::sync::Arc;
 
 impl VM {
+    /// Build an X::Multi::NoMatch error for a `print`/`say`/`put`/`note` call
+    /// made with a positional argument on an invocant whose only candidate is
+    /// the default `(Mu: *%_)` one. The `capture` attribute carries the full
+    /// call capture (invocant + arguments) so a `capture => { ... }` matcher
+    /// can inspect it (e.g. `$_[0] ~~ Failure`).
+    pub(super) fn print_routine_no_match_error(
+        method: &str,
+        target: &Value,
+        args: &[Value],
+    ) -> RuntimeError {
+        let invocant_type = crate::value::types::what_type_name(target);
+        let arg_profile: Vec<String> = args
+            .iter()
+            .filter(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+            .map(|a| {
+                let tn = crate::value::types::what_type_name(a);
+                if matches!(a, Value::Nil) {
+                    tn
+                } else {
+                    format!("{}:D", tn)
+                }
+            })
+            .collect();
+        let message = format!(
+            "Cannot resolve caller {}({}:D: {}); none of these signatures matches:\n    (Mu: *%_)",
+            method,
+            invocant_type,
+            arg_profile.join(", ")
+        );
+        let mut positional = vec![target.clone()];
+        for a in args {
+            if !matches!(a, Value::Pair(..) | Value::ValuePair(..)) {
+                positional.push(a.clone());
+            }
+        }
+        let capture = Value::Capture {
+            positional,
+            named: std::collections::HashMap::new(),
+        };
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        attrs.insert("capture".to_string(), capture);
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(Value::make_instance(
+            Symbol::intern("X::Multi::NoMatch"),
+            attrs,
+        )));
+        err
+    }
+
     /// Fast path for a 0-arg public attribute-accessor read on an Instance
     /// (`$obj.x`). Returns `Some(value)` to push when it handled the call, or
     /// `None` to fall through to full method dispatch.
@@ -712,6 +762,22 @@ impl VM {
             }
             self.env_dirty = true;
             return Ok(());
+        }
+        // `.print(arg)` / `.say(arg)` / `.put(arg)` / `.note(arg)` on a Failure
+        // invocant: the default Mu candidates for these routines take only a
+        // slurpy named hash (`(Mu: *%_)`), so a positional argument fails to
+        // resolve and Raku throws X::Multi::NoMatch (rather than exploding the
+        // Failure). IO::Handle / user classes override these with a positional
+        // signature and are dispatched normally before reaching this point.
+        if matches!(method, "print" | "say" | "put" | "note")
+            && args
+                .iter()
+                .any(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+            && let Value::Instance { class_name, .. } = &target
+            && class_name.resolve() == "Failure"
+            && !target.is_failure_handled()
+        {
+            return Err(Self::print_routine_no_match_error(method, &target, &args));
         }
         // Unhandled Failure explosion: calling a non-Failure method on an unhandled
         // Failure should throw the stored exception (Raku behavior).

--- a/t/open-failure-print-nomatch.t
+++ b/t/open-failure-print-nomatch.t
@@ -1,0 +1,42 @@
+use Test;
+
+# open() on an unopenable path returns a Failure (rather than dying
+# immediately); the Failure throws when sunk/used.
+{
+    my $r = open("/a/b/c/d/bogus", :w);
+    isa-ok $r, Failure, "open() of a bad path returns a Failure";
+    nok $r.defined, "the returned Failure is undefined";
+}
+
+# Calling print/say/put/note with a *positional* argument on the Failure
+# resolves to the default (Mu: *%_) candidate, which takes no positional, so
+# it throws X::Multi::NoMatch (it must NOT explode the Failure).
+# https://github.com/rakudo/rakudo/issues/2492
+{
+    throws-like { open("/a/b/c/d/bogus", :w).print: 42 },
+        X::Multi::NoMatch,
+        capture => { so $_[0]; $_[0] ~~ Failure },
+        "print(positional) on a Failure throws X::Multi::NoMatch";
+
+    throws-like { open("/a/b/c/d/bogus", :w).say: 42 },
+        X::Multi::NoMatch,
+        "say(positional) on a Failure throws X::Multi::NoMatch";
+
+    throws-like { open("/a/b/c/d/bogus", :w).put: 42 },
+        X::Multi::NoMatch,
+        "put(positional) on a Failure throws X::Multi::NoMatch";
+}
+
+# Opening a directory also yields a Failure (not a hard die).
+{
+    my $r = open("t");
+    isa-ok $r, Failure, "open() of a directory returns a Failure";
+}
+
+# A NUL byte in the path is still a hard throw (X::IO::Null), not a Failure.
+{
+    my $nul = "foo\0bar";
+    dies-ok { open($nul) }, "open() with a NUL byte in the path dies";
+}
+
+done-testing;


### PR DESCRIPTION
Completes `roast/S32-exceptions/misc2.t` — the last failing case was test 264
(`open("/bad", :w).print: 42` should throw `X::Multi::NoMatch`). misc2.t now
passes **265/265** and is added to `roast-whitelist.txt`.

## Changes (rakudo/rakudo#2492)

**A. `open()` returns a Failure on error** instead of dying immediately.
The Failure wraps the error (preserving any specific exception type, defaulting
to `X::AdHoc`). Sinking/using the Failure later still throws. A NUL byte in the
path stays a hard `X::IO::Null` throw (matches rakudo). Opening a directory also
yields a Failure now.

**B. `.print`/`.say`/`.put`/`.note` with a positional arg on an unhandled
Failure -> `X::Multi::NoMatch`** (carrying a `capture` attr = the call capture),
rather than exploding the Failure. The default `Mu` candidates for these
routines take only a slurpy named hash `(Mu: *%_)`, so a positional argument
fails to resolve. `IO::Handle` / user overrides with positional signatures
dispatch normally and are unaffected.

## Testing

- `roast/S32-exceptions/misc2.t`: 265/265 PASS (now whitelisted)
- `make test`: PASS (6231 tests)
- No regressions in `S32-io` — `io-handle` (4/4), `io-cathandle` (29/29),
  `io-path` (10/10) failure counts identical to `main`; whitelisted IO tests
  (`open.t`, `slurp.t`, `null-char.t`, ...) all green.
- New: `t/open-failure-print-nomatch.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)