### PR TITLE
test(roast): whitelist S06-signature/slurpy-blocks.t

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -504,6 +504,7 @@ roast/S06-signature/scalar-type.t
 roast/S06-signature/shape.t
 roast/S06-signature/sigilless.t
 roast/S06-signature/slurpy-and-interpolation.t
+roast/S06-signature/slurpy-blocks.t
 roast/S06-signature/slurpy-placeholders.t
 roast/S06-signature/sub-ref.t
 roast/S06-signature/tree-node-parameters.t


### PR DESCRIPTION
`roast/S06-signature/slurpy-blocks.t` already passes fully (6/6) — slurpy
parameters in block signatures work. The `BLOCKERS.md` entry claiming it aborts
before test 1 was stale. Add it to the whitelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)