### PR TITLE
Phase 3 Stage 2a: scalar instance attributes as cell-direct (sigil slice)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -211,7 +211,25 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
         identity と alias 可視性を保つ）— これを怠ると `t/lvalue-method-rw.t` の temp 復元が壊れる（実際に踏んで修正）。
   - 検証: cross-frame note/closure mutation・alias 共有・`.clone` 独立・`===`/`.WHICH`/`eqv` identity・DESTROY(1回)・
         temp/let 復元 すべて raku 一致。clippy 緑。
-- [ ] **Stage 2 — cell を唯一の真実源に（keystone）＋ 伝播ハック全廃**: ユーザー判断 (2026-06-10) で**一括 PR**。
+- [ ] **Stage 2 — cell を唯一の真実源に（keystone）＋ 伝播ハック全廃**: ユーザー判断 (2026-06-10) で当初**一括 PR** 想定 →
+      **配列/ハッシュ属性の in-place 変異（`@!a.push`/`%!h<k>=`）の cell 書き戻し配線が別プロジェクト規模**と判明したため、
+      ユーザー再判断 (2026-06-10) で **sigil でスライス**（スカラー先行）に変更。
+  - [x] **Stage 2a — スカラー属性 (`$!x`/`$.x`) を cell 直結（landed: branch `phase3-stage2-scalar-cell`）**:
+        `Var("!x")`/`Var(".x")` の read を `self` の共有 cell 直読に（`read_self_attr_cell`、atomic/CAS チェックの後段＝CAS は
+        従来 `shared_vars` 維持で livelock 回避）。write 経路 — `exec_set_local_op`/`exec_assign_expr_local_op`（ラッパーで
+        `mirror_attr_local_to_cell`）、名前ベース `exec_assign_expr_op`（`$.x = v`/`$!x = v`、`mirror_attr_value_to_cell_by_name`）、
+        post/pre inc・dec（`sync_attr_local_from_cell_by_name` → 実行 → mirror）— を全て cell 書き込みに。**スカラー writeback
+        撤去**（`writeback_attributes*` を array/hash 専用化、`AttrSlots::private/public` 削除）。代わりに method exit の
+        live env/locals 段階で `reconcile_scalar_attrs`：「env/local が entry スナップショットから変化 → その値、不変 → live cell
+        値（cross-frame/cell-direct 変異を採用）」で attr マップを確定し make_instance_with_id へ。これが **attributive param
+        (`method m($!s)`)・no-twigil sigilless attr (`has $x`)・`is rw` accessor 書き込み**（cell 非経由で env を書く 3 経路）を
+        cell に届ける。**cross-frame スカラー変異バグ修正**（`self.bump` が caller の `$!x` に可視、11 vs 旧 10）。配列/ハッシュ属性・
+        CAS・registry/scan/detached/`instance_cells` は Stage 2b まで維持（まだ削除不可）。
+        検証: make test 全緑、S12-attributes/instance・native、S12-methods/{attribute-params,lastcall,defer-call,defer-next}・
+        S17-lowlevel/cas（whitelist）PASS。継承同名 private（Parent/Child `$!p`）は main と同挙動の pre-existing バグで非回帰。
+  - [ ] **Stage 2b — 配列/ハッシュ属性 (`@!a`/`%!h`) を cell 直結**: in-place 変異 op（push/pop/要素代入/`.=`）の cell 書き戻し配線。
+        これが入れば materialize の array/hash 挿入 + array/hash writeback + by-id scan + registry + detached を全廃できる。
+  - 旧「一括」設計（下記）は Stage 2a+2b に分割。以下は引き続き 2b の参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）
   method frame は instance attr を **env/locals コピー**で持ち、cell は writeback でしか同期されない:

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1139,8 +1139,9 @@ pub(crate) struct CompiledCode {
 #[derive(Debug, Clone)]
 pub(crate) struct AttrSlots {
     pub(crate) attr_name: String,
-    pub(crate) private: Option<usize>,
-    pub(crate) public: Option<usize>,
+    // Phase 3 Stage 2 (scalar slice): scalar `!x`/`.x` slots are no longer used
+    // for writeback (scalar attributes are written through the cell directly), so
+    // only the array/hash slot indices remain.
     pub(crate) arr_private: Option<usize>,
     pub(crate) arr_public: Option<usize>,
     pub(crate) hash_private: Option<usize>,
@@ -1184,8 +1185,6 @@ impl CompiledCode {
             };
             self.attr_slots.push(AttrSlots {
                 attr_name: attr_name.clone(),
-                private: find("!"),
-                public: find("."),
                 arr_private: find("@!"),
                 arr_public: find("@."),
                 hash_private: find("%!"),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -584,6 +584,9 @@ impl VM {
         if can_skip_merge {
             // Write back attributes directly from locals (skip env round-trip).
             writeback_attributes_from_locals(cc, &self.locals, &mut attributes, owner_class);
+            // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
+            // live cell + local/env writes before the env is torn down.
+            self.reconcile_scalar_attrs(&base, cc, &mut attributes);
 
             let method_var_bindings = self.interpreter.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -605,6 +608,9 @@ impl VM {
             }
 
             writeback_attributes(self.interpreter.env(), &mut attributes);
+            // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
+            // live cell + local/env writes before the env is merged away.
+            self.reconcile_scalar_attrs(&base, cc, &mut attributes);
             let mut method_local_keys: HashSet<String> = HashSet::from_iter([
                 "self".to_string(),
                 "__ANON_STATE__".to_string(),
@@ -730,6 +736,75 @@ impl VM {
             };
             (adjusted, attributes)
         })
+    }
+
+    /// Phase 3 Stage 2 (scalar slice): reconcile the entry-time writeback
+    /// snapshot's scalar attributes against the two possible sources of an
+    /// in-method change, while the method's locals/env are still live.
+    ///
+    /// A scalar attribute may have been changed two ways during the method:
+    /// 1. via the cell-direct var ops (`$!x = v`, `$!x++`) -> the live cell
+    ///    already holds the new value (and a nested-frame mutation lands here
+    ///    too), or
+    /// 2. via a path that writes the env/local copy but not the cell yet:
+    ///    attributive params (`method m($!s)`), no-twigil sigilless attribute
+    ///    aliases (`has $x; ... $x = v`), or `is rw` accessor stores.
+    ///
+    /// We detect (2) by comparing the current local/env value of `!bare`/`.bare`
+    /// against the entry snapshot (which is exactly `attributes[k]` here, since
+    /// scalar writeback was skipped). If it changed, that value wins; otherwise
+    /// the live cell value wins (covering case 1 and unchanged attrs). The
+    /// resulting map is then written back through the cell by the caller.
+    fn reconcile_scalar_attrs(
+        &self,
+        base: &Value,
+        code: &CompiledCode,
+        attributes: &mut HashMap<String, Value>,
+    ) {
+        let Value::Instance {
+            attributes: cell, ..
+        } = base
+        else {
+            return;
+        };
+        // Snapshot the cell once (single read lock) rather than per attribute.
+        let cell_snapshot = cell.to_map();
+        let keys: Vec<String> = attributes.keys().cloned().collect();
+        for k in keys {
+            if k.starts_with(ATTR_ALIAS_META_PREFIX) {
+                continue;
+            }
+            let cell_val = cell_snapshot.get(&k).cloned();
+            // Only scalar attributes: array/hash attrs flow through writeback.
+            if matches!(cell_val, Some(Value::Array(..)) | Some(Value::Hash(..))) {
+                continue;
+            }
+            let original = attributes.get(&k).cloned().unwrap_or(Value::Nil);
+            // Qualified private key (`Owner\0attr`) maps to the bare env/local
+            // name `!attr` / `.attr`.
+            let bare = k.rsplit('\0').next().unwrap_or(&k);
+            let env_changed = self
+                .attr_env_or_local(code, &format!("!{}", bare))
+                .filter(|v| *v != original)
+                .or_else(|| {
+                    self.attr_env_or_local(code, &format!(".{}", bare))
+                        .filter(|v| *v != original)
+                });
+            if let Some(v) = env_changed {
+                attributes.insert(k, v);
+            } else if let Some(cv) = cell_val {
+                attributes.insert(k, cv);
+            }
+        }
+    }
+
+    /// Read the current value of `name` from the method's local slot if present,
+    /// else from env.
+    fn attr_env_or_local(&self, code: &CompiledCode, name: &str) -> Option<Value> {
+        if let Some(slot) = code.locals.iter().position(|n| n == name) {
+            return Some(self.locals[slot].clone());
+        }
+        self.interpreter.env().get(name).cloned()
     }
 
     /// Fast path for read-only compiled methods. Bypasses all env_mut() calls
@@ -1104,6 +1179,9 @@ impl VM {
             }
             writeback_attributes(self.interpreter.env(), &mut attributes);
         }
+        // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
+        // live cell + local/env writes before the env is torn down.
+        self.reconcile_scalar_attrs(&base, cc, &mut attributes);
 
         let method_var_bindings = self.interpreter.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;
@@ -1224,8 +1302,9 @@ fn writeback_attributes_from_locals(
                 .get(&slots.attr_name)
                 .cloned()
                 .unwrap_or(Value::Nil);
-            let private_val = slots.private.map(|i| &locals[i]);
-            let public_val = slots.public.map(|i| &locals[i]);
+            // Phase 3 Stage 2 (scalar slice): scalar attributes are written
+            // through the cell directly by the var ops; only array/hash attrs
+            // still write back from locals here.
             let arr_private_val = slots.arr_private.map(|i| &locals[i]);
             let arr_public_val = slots.arr_public.map(|i| &locals[i]);
             let hash_private_val = slots.hash_private.map(|i| &locals[i]);
@@ -1247,19 +1326,11 @@ fn writeback_attributes_from_locals(
                 }
                 continue;
             }
-            if let (Some(priv_val), Some(pub_val)) = (private_val, public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let Some(val) = arr_private_val.or(hash_private_val).or(private_val) {
+            if let Some(val) = arr_private_val.or(hash_private_val) {
                 attributes.insert(slots.attr_name.clone(), val.clone());
                 continue;
             }
-            if let Some(val) = arr_public_val.or(hash_public_val).or(public_val) {
+            if let Some(val) = arr_public_val.or(hash_public_val) {
                 attributes.insert(slots.attr_name.clone(), val.clone());
             }
         }
@@ -1271,19 +1342,8 @@ fn writeback_attributes_from_locals(
             }
             let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
 
-            let private_key = format!("!{}", attr_name);
-            let public_key = format!(".{}", attr_name);
-            let private_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &private_key)
-                .map(|i| locals[i].clone());
-            let public_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &public_key)
-                .map(|i| locals[i].clone());
-
+            // Phase 3 Stage 2 (scalar slice): scalar attributes are written
+            // through the cell directly; only array/hash attrs write back here.
             let arr_private_key = format!("@!{}", attr_name);
             let arr_public_key = format!("@.{}", attr_name);
             let hash_private_key = format!("%!{}", attr_name);
@@ -1325,32 +1385,32 @@ fn writeback_attributes_from_locals(
                 }
                 continue;
             }
-            if let (Some(priv_val), Some(pub_val)) = (&private_val, &public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let Some(val) = arr_private_val.or(hash_private_val).or(private_val) {
+            if let Some(val) = arr_private_val.or(hash_private_val) {
                 attributes.insert(attr_name.clone(), val);
                 continue;
             }
-            if let Some(val) = arr_public_val.or(hash_public_val).or(public_val) {
+            if let Some(val) = arr_public_val.or(hash_public_val) {
                 attributes.insert(attr_name, val);
             }
         }
     }
 
-    // Write back class-qualified private attribute entries
+    // Write back class-qualified private array/hash attribute entries. Scalar
+    // qualified keys (`owner\0attr`) are written through the cell directly by the
+    // var ops (Phase 3 Stage 2), so only array/hash values are reconciled here.
     for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
         if !attr_name.contains('\0') {
             continue;
         }
         if let Some(bare_attr) = attr_name.strip_prefix(&format!("{}\0", owner_class)) {
-            let private_key = format!("!{}", bare_attr);
-            if let Some(idx) = cc.locals.iter().rposition(|n| n == &private_key) {
+            let arr_private_key = format!("@!{}", bare_attr);
+            let hash_private_key = format!("%!{}", bare_attr);
+            let idx = cc
+                .locals
+                .iter()
+                .rposition(|n| n == &arr_private_key)
+                .or_else(|| cc.locals.iter().rposition(|n| n == &hash_private_key));
+            if let Some(idx) = idx {
                 attributes.insert(attr_name, locals[idx].clone());
             }
         }
@@ -1372,14 +1432,16 @@ fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
             continue;
         }
         let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
-        let env_key = format!("!{}", attr_name);
-        let public_env_key = format!(".{}", attr_name);
+        // Phase 3 Stage 2 (scalar slice): scalar attributes (`!x`/`.x`) are
+        // written through the shared cell directly by the var ops, so they are no
+        // longer reconciled from the env here — doing so would clobber a mutation
+        // made in a nested method frame with this frame's stale snapshot (the
+        // cross-frame bug). Only array (`@!`/`@.`) and hash (`%!`/`%.`) attributes
+        // still use the materialize+writeback path.
         let env_array_private_key = format!("@!{}", attr_name);
         let env_array_public_key = format!("@.{}", attr_name);
         let env_hash_private_key = format!("%!{}", attr_name);
         let env_hash_public_key = format!("%.{}", attr_name);
-        let env_private = env.get(&env_key).cloned();
-        let env_public = env.get(&public_env_key).cloned();
         let env_array_private = env.get(&env_array_private_key).cloned();
         let env_array_public = env.get(&env_array_public_key).cloned();
         let env_hash_private = env.get(&env_hash_private_key).cloned();
@@ -1400,19 +1462,11 @@ fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
             }
             continue;
         }
-        if let (Some(private_val), Some(public_val)) = (&env_private, &env_public) {
-            if *private_val == original && *public_val != original {
-                attributes.insert(attr_name.clone(), public_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), private_val.clone());
-            }
-            continue;
-        }
-        if let Some(val) = env_array_private.or(env_hash_private).or(env_private) {
+        if let Some(val) = env_array_private.or(env_hash_private) {
             attributes.insert(attr_name.clone(), val);
             continue;
         }
-        if let Some(val) = env_array_public.or(env_hash_public).or(env_public) {
+        if let Some(val) = env_array_public.or(env_hash_public) {
             attributes.insert(attr_name.clone(), val);
         }
         let alias_env_key = format!("__mutsu_sigilless_alias::!{}", attr_name);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -869,6 +869,21 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // Phase 3 Stage 2: scalar attribute increments read-modify-write the cell.
+        let attr_name = Self::const_str(code, name_idx).to_string();
+        self.sync_attr_local_from_cell_by_name(code, &attr_name);
+        let r = self.exec_pre_increment_op_inner(code, name_idx);
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell_by_name(code, &attr_name);
+        }
+        r
+    }
+
+    fn exec_pre_increment_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
@@ -942,6 +957,21 @@ impl VM {
     }
 
     pub(super) fn exec_pre_decrement_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        // Phase 3 Stage 2: scalar attribute decrements read-modify-write the cell.
+        let attr_name = Self::const_str(code, name_idx).to_string();
+        self.sync_attr_local_from_cell_by_name(code, &attr_name);
+        let r = self.exec_pre_decrement_op_inner(code, name_idx);
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell_by_name(code, &attr_name);
+        }
+        r
+    }
+
+    fn exec_pre_decrement_op_inner(
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
@@ -1203,6 +1233,23 @@ impl VM {
     }
 
     pub(super) fn exec_assign_expr_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let r = self.exec_assign_expr_op_inner(code, name_idx);
+        // Phase 3 Stage 2: mirror name-based scalar attribute writes (`$.x = v`,
+        // `$!x = v` via AssignExpr) into the shared cell.
+        if r.is_ok()
+            && let Value::Str(name) = &code.constants[name_idx as usize]
+        {
+            let name = name.to_string();
+            self.mirror_attr_value_to_cell_by_name(code, &name);
+        }
+        r
+    }
+
+    fn exec_assign_expr_op_inner(
         &mut self,
         code: &CompiledCode,
         name_idx: u32,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1467,6 +1467,21 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // Phase 3 Stage 2: scalar attribute increments read-modify-write the cell.
+        let attr_name = Self::const_str(code, name_idx).to_string();
+        self.sync_attr_local_from_cell_by_name(code, &attr_name);
+        let r = self.exec_post_increment_op_inner(code, name_idx);
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell_by_name(code, &attr_name);
+        }
+        r
+    }
+
+    fn exec_post_increment_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
         // Lazily convert pending alias bind names into local_bind_pairs.
         self.resolve_pending_alias_binds(code);
         let name = Self::const_str(code, name_idx);
@@ -1613,6 +1628,21 @@ impl VM {
     }
 
     pub(super) fn exec_post_decrement_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        // Phase 3 Stage 2: scalar attribute decrements read-modify-write the cell.
+        let attr_name = Self::const_str(code, name_idx).to_string();
+        self.sync_attr_local_from_cell_by_name(code, &attr_name);
+        let r = self.exec_post_decrement_op_inner(code, name_idx);
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell_by_name(code, &attr_name);
+        }
+        r
+    }
+
+    fn exec_post_decrement_op_inner(
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
@@ -4119,6 +4149,176 @@ impl VM {
         Ok(())
     }
 
+    // --- Phase 3 Stage 2: scalar instance attributes as cell-direct (slice 1) ---
+    //
+    // For scalar attribute-twigil locals (`$!x` -> `!x`, `$.x` -> `.x`) the
+    // instance's shared attribute cell is the single source of truth. Reads come
+    // straight from the cell (so a mutation made in a nested method frame is
+    // visible to the caller — the cross-frame bug), and every write mirrors the
+    // local back into the cell. This lets the scalar writeback be dropped
+    // (`writeback_attributes*` skip scalar attrs). Array/hash attributes still
+    // use the materialize+writeback path for now (later slices).
+
+    /// If `name` is a scalar attribute-twigil local (`!x` or `.x`), return the
+    /// bare attribute name. Excludes special vars (`!`, `.`) and internal names.
+    pub(super) fn scalar_attr_twigil_base(name: &str) -> Option<&str> {
+        let bare = name.strip_prefix('!').or_else(|| name.strip_prefix('.'))?;
+        // Attribute names are ordinary identifiers (start alpha/underscore). This
+        // filters out `!=`, the bare `!`/`.` special vars, and `__mutsu_` keys
+        // (which never begin with `!`/`.` anyway).
+        let mut chars = bare.chars();
+        match chars.next() {
+            Some(c) if c.is_alphabetic() || c == '_' => Some(bare),
+            _ => None,
+        }
+    }
+
+    /// Resolve the cell key for a scalar attribute on the given instance,
+    /// preferring the method owner class's qualified private key when present
+    /// (Parent/Child same-named `$!priv` disambiguation), matching the order used
+    /// when method frames materialize attributes. Returns `None` when the
+    /// attribute does not exist in the cell (so non-attribute `.foo`/`!foo`
+    /// lvalues fall through to the normal local/env handling).
+    fn resolve_attr_cell_key(
+        &self,
+        name: &str,
+        attrs: &crate::value::InstanceAttrs,
+    ) -> Option<String> {
+        let bare = Self::scalar_attr_twigil_base(name)?;
+        let map = attrs.as_map();
+        if name.starts_with('!')
+            && let Some(owner) = self.interpreter.method_class_stack_top()
+        {
+            let qkey = format!("{}\0{}", owner, bare);
+            if map.contains_key(&qkey) {
+                return Some(qkey);
+            }
+        }
+        if map.contains_key(bare) {
+            Some(bare.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Read a scalar attribute straight from `self`'s shared cell. `Some` only
+    /// when `name` is a scalar attr-twigil, `self` is a concrete instance, and
+    /// the attribute exists in the cell.
+    pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
+        Self::scalar_attr_twigil_base(name)?;
+        let self_val = self.get_env_with_main_alias("self")?;
+        let Value::Instance { attributes, .. } = &self_val else {
+            return None;
+        };
+        let key = self.resolve_attr_cell_key(name, attributes)?;
+        attributes.as_map().get(&key).cloned()
+    }
+
+    /// Skip mirroring slot values that keep their legacy handling (`:=` bindings,
+    /// Proxy accessors, hash/array slot refs, deferred hash access).
+    fn is_non_mirrorable_attr_value(val: &Value) -> bool {
+        matches!(
+            val,
+            Value::ContainerRef(_)
+                | Value::Proxy { .. }
+                | Value::HashSlotRef { .. }
+                | Value::ArraySlotRef { .. }
+                | Value::DeferredHashAccess { .. }
+        )
+    }
+
+    /// Write `val` into `self`'s shared cell for the scalar attribute named
+    /// `name` (`!x`/`.x`), resolving the qualified private key when present.
+    /// No-op when `name` is not a scalar attr-twigil, `self` is not a concrete
+    /// instance, or the attribute does not exist on `self`.
+    fn write_self_attr_cell(&self, name: &str, val: Value) {
+        if Self::scalar_attr_twigil_base(name).is_none() {
+            return;
+        }
+        let Some(self_val) = self.get_env_with_main_alias("self") else {
+            return;
+        };
+        let Value::Instance { attributes, .. } = &self_val else {
+            return;
+        };
+        if let Some(key) = self.resolve_attr_cell_key(name, attributes) {
+            attributes.insert(key, val);
+        }
+    }
+
+    /// Mirror the current local slot value into `self`'s shared cell for a scalar
+    /// attribute, after the normal write logic has finalized the slot.
+    pub(super) fn mirror_attr_local_to_cell(&self, code: &CompiledCode, idx: usize) {
+        let Some(name) = code.locals.get(idx) else {
+            return;
+        };
+        if Self::scalar_attr_twigil_base(name).is_none()
+            || Self::is_non_mirrorable_attr_value(&self.locals[idx])
+        {
+            return;
+        }
+        self.write_self_attr_cell(&name.clone(), self.locals[idx].clone());
+    }
+
+    /// Mirror the finalized value of the variable named `name` into `self`'s
+    /// shared cell, for write ops that dispatch by name (e.g. the name-based
+    /// `AssignExpr`). Reads the value back from the local slot or env after the
+    /// op completed.
+    pub(super) fn mirror_attr_value_to_cell_by_name(&self, code: &CompiledCode, name: &str) {
+        if Self::scalar_attr_twigil_base(name).is_none() {
+            return;
+        }
+        let val = self
+            .find_local_slot(code, name)
+            .map(|slot| self.locals[slot].clone())
+            .or_else(|| self.get_env_with_main_alias(name));
+        let Some(val) = val else {
+            return;
+        };
+        if Self::is_non_mirrorable_attr_value(&val) {
+            return;
+        }
+        self.write_self_attr_cell(name, val);
+    }
+
+    /// Refresh the local slot from `self`'s cell before a read-modify-write on a
+    /// scalar attribute (increment/decrement), so the operation sees a mutation
+    /// made in a nested frame rather than the materialized snapshot.
+    fn sync_attr_local_from_cell(&mut self, code: &CompiledCode, idx: usize) {
+        if self.locals[idx].is_container_ref() {
+            return;
+        }
+        let Some(name) = code.locals.get(idx).cloned() else {
+            return;
+        };
+        if let Some(cell_val) = self.read_self_attr_cell(&name) {
+            self.locals[idx] = cell_val;
+        }
+    }
+
+    /// Name-based wrapper: refresh the slot named `name` from `self`'s cell before
+    /// a read-modify-write (used by the increment/decrement ops, which dispatch
+    /// by name rather than slot index).
+    pub(super) fn sync_attr_local_from_cell_by_name(&mut self, code: &CompiledCode, name: &str) {
+        if Self::scalar_attr_twigil_base(name).is_none() {
+            return;
+        }
+        if let Some(slot) = self.find_local_slot(code, name) {
+            self.sync_attr_local_from_cell(code, slot);
+        }
+    }
+
+    /// Name-based wrapper: mirror the slot named `name` into `self`'s cell after a
+    /// read-modify-write.
+    pub(super) fn mirror_attr_local_to_cell_by_name(&self, code: &CompiledCode, name: &str) {
+        if Self::scalar_attr_twigil_base(name).is_none() {
+            return;
+        }
+        if let Some(slot) = self.find_local_slot(code, name) {
+            self.mirror_attr_local_to_cell(code, slot);
+        }
+    }
+
     /// Like `exec_get_local_op` but does NOT resolve DeferredHashAccess/HashSlotRef.
     /// Pushes the raw local value, preserving container references for `=:=` checks.
     pub(super) fn exec_get_local_raw_op(&mut self, code: &CompiledCode, idx: u32) {
@@ -4213,6 +4413,18 @@ impl VM {
         {
             self.locals[idx] = Value::ContainerRef(arc);
         }
+        // Phase 3 Stage 2 (scalar slice): scalar instance attributes read straight
+        // from `self`'s shared cell, so a mutation made in a nested method frame
+        // is visible here. Gated on a non-container slot so `$!x := outer`
+        // bindings keep their ContainerRef handling. The cell lookup returns None
+        // for non-attribute names and when `self` is not an instance.
+        if !self.locals[idx].is_container_ref()
+            && let Some(cell_val) = self.read_self_attr_cell(&name)
+        {
+            self.locals[idx] = cell_val.clone();
+            self.stack.push(cell_val);
+            return Ok(());
+        }
         let val = self.locals[idx].clone();
         // Resolve DeferredHashAccess to its current value (Any if path doesn't exist)
         if let Value::DeferredHashAccess { .. } = &val {
@@ -4279,6 +4491,19 @@ impl VM {
     }
 
     pub(super) fn exec_set_local_op(
+        &mut self,
+        code: &CompiledCode,
+        idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let r = self.exec_set_local_op_inner(code, idx);
+        // Phase 3 Stage 2: write-through scalar attribute writes to the cell.
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell(code, idx as usize);
+        }
+        r
+    }
+
+    fn exec_set_local_op_inner(
         &mut self,
         code: &CompiledCode,
         idx: u32,
@@ -5478,6 +5703,19 @@ impl VM {
     }
 
     pub(super) fn exec_assign_expr_local_op(
+        &mut self,
+        code: &CompiledCode,
+        idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let r = self.exec_assign_expr_local_op_inner(code, idx);
+        // Phase 3 Stage 2: write-through scalar attribute writes to the cell.
+        if r.is_ok() {
+            self.mirror_attr_local_to_cell(code, idx as usize);
+        }
+        r
+    }
+
+    fn exec_assign_expr_local_op_inner(
         &mut self,
         code: &CompiledCode,
         idx: u32,


### PR DESCRIPTION
## Summary

Phase 3 Stage 2, sliced by sigil. Make **scalar** instance attributes (`$!x`/`$.x`) read and write the instance's shared attribute cell directly, so a mutation made in a nested method frame is visible to the caller — fixing the cross-frame scalar mutation bug.

Before: `self.bump` (a nested method incrementing `$!x`) was invisible to the caller's `$!x` read (returned the stale pre-call value). After: the caller sees the mutation (raku-correct).

Stage 2 was originally planned as a single all-attributes keystone, but in-place mutation of **array/hash** attributes (`@!a.push`, `%!h<k>=`) needs a separate write-back wiring that is its own project. So Stage 2 is sliced by sigil — scalars now, arrays/hashes next (Stage 2b). Each attribute kind keeps a single source of truth, so there is no divergence.

## What changed

- **Read**: `Var("!x")`/`Var(".x")` come from `self`'s cell (`read_self_attr_cell`), placed *after* the atomic/CAS checks so atomic attributes keep using `shared_vars` (avoids the cell-CAS livelock documented in Stage 1).
- **Write**: all scalar-attr write paths now hit the cell — `exec_set_local_op` / `exec_assign_expr_local_op` (wrapper mirrors the finalized local), the name-based `exec_assign_expr_op` (`$.x = v`), and post/pre increment/decrement (sync-from-cell → op → mirror-back).
- **Writeback dropped for scalars**: `writeback_attributes*` are now array/hash only; the unused `AttrSlots::private`/`public` fields are removed. At method exit (while env/locals are live), `reconcile_scalar_attrs` chooses the env/local value when it changed from the entry snapshot — covering attributive params (`method m($!s)`), no-twigil sigilless attributes (`has $x`), and `is rw` accessor stores — and the live cell value otherwise (cross-frame / cell-direct).

Array/hash attributes, CAS, and the Stage 1 cell registry / by-id scan / detached path are unchanged; Stage 2b removes them once array/hash attrs are cell-direct.

## Verification

- `make test` green.
- Whitelisted: `S12-attributes/{instance,native}`, `S12-methods/{attribute-params,lastcall,defer-call,defer-next}`, `S17-lowlevel/cas` pass.
- Remaining `S12/S14` failures (trusts, accessors, qualified, traits/attributes, …) are pre-existing (fail on `main` too). Same-named inherited private attr (`Parent`/`Child` `$!p`) is a pre-existing bug, behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)