### PR TITLE
Phase 3 Stage 2b: array/hash instance attributes as cell-direct

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -227,9 +227,25 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
         CAS・registry/scan/detached/`instance_cells` は Stage 2b まで維持（まだ削除不可）。
         検証: make test 全緑、S12-attributes/instance・native、S12-methods/{attribute-params,lastcall,defer-call,defer-next}・
         S17-lowlevel/cas（whitelist）PASS。継承同名 private（Parent/Child `$!p`）は main と同挙動の pre-existing バグで非回帰。
-  - [ ] **Stage 2b — 配列/ハッシュ属性 (`@!a`/`%!h`) を cell 直結**: in-place 変異 op（push/pop/要素代入/`.=`）の cell 書き戻し配線。
-        これが入れば materialize の array/hash 挿入 + array/hash writeback + by-id scan + registry + detached を全廃できる。
-  - 旧「一括」設計（下記）は Stage 2a+2b に分割。以下は引き続き 2b の参照マップ。
+  - [x] **Stage 2b — 配列/ハッシュ属性 (`@!a`/`%!h`) を cell 直結（landed: branch `phase3-stage2b-array-hash-cell`）**:
+        read を `GetArrayVar`/`GetHashVar` で `self` の cell 直読（`read_self_attr_cell` を全6 twigil 対応に一般化＝
+        `scalar_attr_twigil_base`→`attr_twigil_base`、`(bare, is_private)` 返却）。各変異 op の **後**に env→cell ミラー
+        （`mirror_array_hash_attr_to_cell`）を配線: `CallMethodMut`/`CallMethodDynamicMut`/`ArrayPush`/`IndexAssignExprNamed`/
+        `MultiDimIndexAssign`/名前ベース `AssignExpr`。**重要＝op 前に env スナップショット**（`array_hash_attr_env_snapshot`）を取り、
+        env が実際に変化したときだけミラー：非変異メソッド（`@!a.join`）も `CallMethodMut` で来るため、stale env コピーを
+        無条件ミラーすると cross-frame の cell 変異を clobber する（cf3 で実証・修正）。**スカラー reconcile を全 sigil 統一**
+        （`reconcile_scalar_attrs`→`reconcile_attrs`、ルール「cell が entry から変化→cell 優先、でなければ env 変化を採用」＝
+        cross-frame/per-op ミラーは cell が勝ち、attributive array param `method m(@!a)`・sigilless は env が勝つ）。
+        これで **array/hash writeback (`writeback_attributes*`) を完全撤去**（`AttrSlots` 構造体 + `compute_attr_slots` も削除、net -115 行）。
+        **cross-frame 配列/ハッシュ変異バグ修正**（nested method の `@!a.push`/`%!h<k>=` が caller に可視）。
+        検証: make test 全緑、S12-attributes/methods・S14-traits・S17/cas（whitelist）PASS、Stage 2b edge 21/21
+        （push/pop/shift/unshift/要素代入/`:delete`以外/whole-assign/cross-frame array+hash/attributive param/`.=`/chain/read-no-clobber）。
+        既知の非対応（pre-existing・非回帰）: `%!h<x>:delete`（DELETE-KEY が Index target 経由でミラー外）、`@b[0]=v` のスペース無し
+        パース、継承同名 private。**materialize の array/hash 挿入 / by-id scan (`overwrite_instance_bindings_by_identity`) /
+        registry (`instance_cells`) / detached は未撤去**＝Stage 2c（次）で cell 単一源を根拠に全廃。
+  - [ ] **Stage 2c — 伝播ハック全廃**: cell が全 attr の単一源になったので by-id scan + `instance_cells` registry +
+        `make_instance_detached`/`update_instance_cell` + materialize の env コピー挿入を撤去。CAS の cell-CAS 化を再検討。
+  - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）
   method frame は instance attr を **env/locals コピー**で持ち、cell は writeback でしか同期されない:

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1081,10 +1081,6 @@ pub(crate) struct CompiledCode {
     /// that are NOT method-local (attributes, params, special vars).
     /// When true, the fast method path cannot use a fresh env.
     pub(crate) may_capture_outer_vars: bool,
-    /// Pre-computed attribute slot mapping for fast writeback on method exit.
-    /// Each entry: (attr_name, private_slot, public_slot, arr_private, arr_public, hash_private, hash_public).
-    /// Slots are `None` if not found in `locals`. Avoids 6 × N_attrs linear searches.
-    pub(crate) attr_slots: Vec<AttrSlots>,
     /// Bitmap: true if local[i] needs to be synced to env (because it's
     /// referenced by GetGlobal/SetGlobal in this code or closures exist).
     /// Locals that are only accessed via GetLocal don't need env sync,
@@ -1135,19 +1131,6 @@ pub(crate) struct CompiledCode {
     pub(crate) has_calls: bool,
 }
 
-/// Pre-computed local slot indices for a single attribute.
-#[derive(Debug, Clone)]
-pub(crate) struct AttrSlots {
-    pub(crate) attr_name: String,
-    // Phase 3 Stage 2 (scalar slice): scalar `!x`/`.x` slots are no longer used
-    // for writeback (scalar attributes are written through the cell directly), so
-    // only the array/hash slot indices remain.
-    pub(crate) arr_private: Option<usize>,
-    pub(crate) arr_public: Option<usize>,
-    pub(crate) hash_private: Option<usize>,
-    pub(crate) hash_public: Option<usize>,
-}
-
 impl CompiledCode {
     pub(crate) fn new() -> Self {
         Self {
@@ -1166,30 +1149,12 @@ impl CompiledCode {
             is_pointy_block: false,
             has_env_writes: false,
             may_capture_outer_vars: false,
-            attr_slots: Vec::new(),
             needs_env_sync: Vec::new(),
             free_var_syms: Vec::new(),
             free_var_writes: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
             has_calls: false,
-        }
-    }
-
-    pub(crate) fn compute_attr_slots(&mut self, attr_names: &[String]) {
-        self.attr_slots.clear();
-        for attr_name in attr_names {
-            let find = |prefix: &str| -> Option<usize> {
-                let key = format!("{}{}", prefix, attr_name);
-                self.locals.iter().rposition(|n| *n == key)
-            };
-            self.attr_slots.push(AttrSlots {
-                attr_name: attr_name.clone(),
-                arr_private: find("@!"),
-                arr_public: find("@."),
-                hash_private: find("%!"),
-                hash_public: find("%."),
-            });
         }
     }
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -926,7 +926,6 @@ impl Interpreter {
     fn compile_methods_for_map(
         methods: &mut HashMap<String, Vec<super::MethodDef>>,
         package_name: &str,
-        attr_names: &[String],
     ) {
         let mut to_compile = Vec::new();
         for (method_name, overloads) in methods.iter() {
@@ -952,7 +951,6 @@ impl Interpreter {
                         &def.body,
                     );
                     cc.compute_may_capture_outer_vars();
-                    cc.compute_attr_slots(attr_names);
                     cc.compute_needs_env_sync();
                     to_compile.push((method_name.clone(), idx, std::sync::Arc::new(cc)));
                 }
@@ -1006,17 +1004,14 @@ impl Interpreter {
     /// Compile method bodies for a given class using the bytecode compiler.
     pub(crate) fn compile_class_methods(&mut self, class_name: &str) {
         if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
-            let attr_names: Vec<String> =
-                class_def.attributes.iter().map(|a| a.0.clone()).collect();
-            Self::compile_methods_for_map(&mut class_def.methods, class_name, &attr_names);
+            Self::compile_methods_for_map(&mut class_def.methods, class_name);
         }
     }
 
     /// Compile method bodies for a given role.
     pub(crate) fn compile_role_methods(&mut self, role_name: &str) {
         if let Some(role_def) = self.registry_mut().roles.get_mut(role_name) {
-            let attr_names: Vec<String> = role_def.attributes.iter().map(|a| a.0.clone()).collect();
-            Self::compile_methods_for_map(&mut role_def.methods, role_name, &attr_names);
+            Self::compile_methods_for_map(&mut role_def.methods, role_name);
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1108,6 +1108,22 @@ impl VM {
                         name
                     )));
                 }
+                // Phase 3 Stage 2b: array attributes (`@!a`/`@.a`) read straight
+                // from `self`'s shared cell so a mutation in a nested method frame
+                // is visible here.
+                if let Some(cell_val) = self.read_self_attr_cell(name) {
+                    let val = match cell_val {
+                        Value::Hash(ref map) => Value::real_array(
+                            map.iter()
+                                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                                .collect(),
+                        ),
+                        other => other,
+                    };
+                    self.stack.push(val);
+                    *ip += 1;
+                    return Ok(());
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| self.get_local_by_bare_name(code, name))
@@ -1172,6 +1188,13 @@ impl VM {
                 if name == "%?RESOURCES" {
                     let resources = self.interpreter.build_resources_for_package();
                     self.stack.push(resources);
+                    *ip += 1;
+                    return Ok(());
+                }
+                // Phase 3 Stage 2b: hash attributes (`%!h`/`%.h`) read straight
+                // from `self`'s shared cell (cross-frame visibility).
+                if let Some(cell_val) = self.read_self_attr_cell(name) {
+                    self.stack.push(cell_val);
                     *ip += 1;
                     return Ok(());
                 }
@@ -2815,16 +2838,20 @@ impl VM {
                 target_name_idx,
                 modifier_idx,
             } => {
+                let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 self.exec_call_method_dynamic_mut_op(
                     code,
                     *arity,
                     *target_name_idx,
                     *modifier_idx,
                 )?;
+                self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
             OpCode::ArrayPush { target_name_idx } => {
+                let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 self.exec_array_push_op(code, *target_name_idx)?;
+                self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
             OpCode::CallMethodMut {
@@ -2835,6 +2862,7 @@ impl VM {
                 quoted,
                 arg_sources_idx,
             } => {
+                let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 self.exec_call_method_mut_op(
                     code,
                     *name_idx,
@@ -2844,6 +2872,7 @@ impl VM {
                     *quoted,
                     *arg_sources_idx,
                 )?;
+                self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
             OpCode::CallOnValue {
@@ -2936,7 +2965,9 @@ impl VM {
                 *ip += 1;
             }
             OpCode::MultiDimIndexAssign { name_idx, ndims } => {
+                let pre = self.array_hash_attr_env_snapshot(code, *name_idx);
                 self.exec_multi_dim_index_assign_op(code, *name_idx, *ndims)?;
+                self.mirror_array_hash_attr_to_cell(code, *name_idx, pre);
                 *ip += 1;
             }
             OpCode::MultiDimIndexAssignGeneric(ndims) => {
@@ -3057,7 +3088,9 @@ impl VM {
                 name_idx,
                 is_positional,
             } => {
+                let pre = self.array_hash_attr_env_snapshot(code, *name_idx);
                 self.exec_index_assign_expr_named_op(code, *name_idx, *is_positional)?;
+                self.mirror_array_hash_attr_to_cell(code, *name_idx, pre);
                 *ip += 1;
             }
             OpCode::IndexAssignPseudoStashNamed {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -582,11 +582,11 @@ impl VM {
         }
 
         if can_skip_merge {
-            // Write back attributes directly from locals (skip env round-trip).
-            writeback_attributes_from_locals(cc, &self.locals, &mut attributes, owner_class);
-            // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
-            // live cell + local/env writes before the env is torn down.
-            self.reconcile_scalar_attrs(&base, cc, &mut attributes);
+            // Phase 3 Stage 2: all attributes (scalar/array/hash) are reconciled
+            // against the live cell + local/env writes before the env is torn
+            // down. The cell-direct reads + per-op mirrors make the cell the
+            // single source; the legacy attribute writeback is gone.
+            self.reconcile_attrs(&base, cc, &mut attributes);
 
             let method_var_bindings = self.interpreter.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -607,10 +607,9 @@ impl VM {
                 }
             }
 
-            writeback_attributes(self.interpreter.env(), &mut attributes);
-            // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
-            // live cell + local/env writes before the env is merged away.
-            self.reconcile_scalar_attrs(&base, cc, &mut attributes);
+            // Phase 3 Stage 2: reconcile all attributes against the live cell +
+            // local/env writes before the env is merged away.
+            self.reconcile_attrs(&base, cc, &mut attributes);
             let mut method_local_keys: HashSet<String> = HashSet::from_iter([
                 "self".to_string(),
                 "__ANON_STATE__".to_string(),
@@ -738,24 +737,25 @@ impl VM {
         })
     }
 
-    /// Phase 3 Stage 2 (scalar slice): reconcile the entry-time writeback
-    /// snapshot's scalar attributes against the two possible sources of an
-    /// in-method change, while the method's locals/env are still live.
+    /// Phase 3 Stage 2: reconcile the entry-time attribute snapshot against the
+    /// two possible sources of an in-method change, while the method's
+    /// locals/env are still live. Covers scalar, array, and hash attributes.
     ///
-    /// A scalar attribute may have been changed two ways during the method:
-    /// 1. via the cell-direct var ops (`$!x = v`, `$!x++`) -> the live cell
-    ///    already holds the new value (and a nested-frame mutation lands here
-    ///    too), or
-    /// 2. via a path that writes the env/local copy but not the cell yet:
-    ///    attributive params (`method m($!s)`), no-twigil sigilless attribute
-    ///    aliases (`has $x; ... $x = v`), or `is rw` accessor stores.
+    /// An attribute may have been changed two ways during the method:
+    /// 1. through the shared cell — cell-direct scalar writes (`$!x = v`),
+    ///    per-op mirrored array/hash mutations (`@!a.push`, `%!h<k>=`), and any
+    ///    mutation made in a nested method frame all land in the live cell, or
+    /// 2. through an env/local copy that never reached the cell — attributive
+    ///    params (`method m($!s)`/`method m(@!a)`), no-twigil sigilless aliases
+    ///    (`has $x; ... $x = v`), or `is rw` accessor stores.
     ///
-    /// We detect (2) by comparing the current local/env value of `!bare`/`.bare`
-    /// against the entry snapshot (which is exactly `attributes[k]` here, since
-    /// scalar writeback was skipped). If it changed, that value wins; otherwise
-    /// the live cell value wins (covering case 1 and unchanged attrs). The
-    /// resulting map is then written back through the cell by the caller.
-    fn reconcile_scalar_attrs(
+    /// Precedence: the cell wins when it changed from the entry snapshot (it is
+    /// the authoritative store and includes cross-frame mutations); otherwise an
+    /// env/local write that changed wins (case 2); otherwise the value is
+    /// unchanged. `attributes[k]` is the entry snapshot here because writeback no
+    /// longer mutates it. The result is written back through the cell by the
+    /// caller.
+    fn reconcile_attrs(
         &self,
         base: &Value,
         code: &CompiledCode,
@@ -774,20 +774,29 @@ impl VM {
             if k.starts_with(ATTR_ALIAS_META_PREFIX) {
                 continue;
             }
+            let original = attributes.get(&k).cloned().unwrap_or(Value::Nil);
             let cell_val = cell_snapshot.get(&k).cloned();
-            // Only scalar attributes: array/hash attrs flow through writeback.
-            if matches!(cell_val, Some(Value::Array(..)) | Some(Value::Hash(..))) {
+            // (1) The cell is authoritative when it changed from the entry value.
+            if let Some(cv) = &cell_val
+                && *cv != original
+            {
+                attributes.insert(k, cv.clone());
                 continue;
             }
-            let original = attributes.get(&k).cloned().unwrap_or(Value::Nil);
-            // Qualified private key (`Owner\0attr`) maps to the bare env/local
-            // name `!attr` / `.attr`.
+            // (2) Otherwise an env/local write that bypassed the cell wins. Pick
+            // the twigil keys by the attribute's sigil (inferred from its value
+            // type). Qualified private key (`Owner\0attr`) maps to bare `!attr`.
             let bare = k.rsplit('\0').next().unwrap_or(&k);
+            let (priv_key, pub_key) = match cell_val.as_ref().unwrap_or(&original) {
+                Value::Array(..) => (format!("@!{}", bare), format!("@.{}", bare)),
+                Value::Hash(..) => (format!("%!{}", bare), format!("%.{}", bare)),
+                _ => (format!("!{}", bare), format!(".{}", bare)),
+            };
             let env_changed = self
-                .attr_env_or_local(code, &format!("!{}", bare))
+                .attr_env_or_local(code, &priv_key)
                 .filter(|v| *v != original)
                 .or_else(|| {
-                    self.attr_env_or_local(code, &format!(".{}", bare))
+                    self.attr_env_or_local(code, &pub_key)
                         .filter(|v| *v != original)
                 });
             if let Some(v) = env_changed {
@@ -1158,12 +1167,9 @@ impl VM {
             self.interpreter.set_state_var(key.clone(), val);
         }
 
-        if can_skip_merge {
-            // Writeback attributes directly from locals (no env involved)
-            writeback_attributes_from_locals(cc, &self.locals, &mut attributes, owner_class);
-        } else {
-            // Non-can_skip_merge: AssignExpr may have written attribute
-            // values to env. Sync locals→env first, then use env-based writeback.
+        if !can_skip_merge {
+            // Non-can_skip_merge: AssignExpr may have written attribute values to
+            // env. Sync locals→env first so the merge/reconcile sees them.
             for (i, local_name) in cc.locals.iter().enumerate() {
                 if local_name.starts_with('.')
                     || local_name.starts_with('!')
@@ -1177,11 +1183,10 @@ impl VM {
                         .insert(local_name.clone(), self.locals[i].clone());
                 }
             }
-            writeback_attributes(self.interpreter.env(), &mut attributes);
         }
-        // Phase 3 Stage 2 (scalar slice): reconcile scalar attrs against the
-        // live cell + local/env writes before the env is torn down.
-        self.reconcile_scalar_attrs(&base, cc, &mut attributes);
+        // Phase 3 Stage 2: reconcile all attributes against the live cell +
+        // local/env writes before the env is torn down.
+        self.reconcile_attrs(&base, cc, &mut attributes);
 
         let method_var_bindings = self.interpreter.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;
@@ -1284,198 +1289,6 @@ impl VM {
             };
             (adjusted, attributes)
         })
-    }
-}
-
-/// Write back attribute values from locals after fast-path method execution.
-/// Reads directly from the locals array instead of going through env.
-fn writeback_attributes_from_locals(
-    cc: &CompiledCode,
-    locals: &[Value],
-    attributes: &mut HashMap<String, Value>,
-    owner_class: &str,
-) {
-    // Fast path: use pre-computed slot indices when available
-    if !cc.attr_slots.is_empty() {
-        for slots in &cc.attr_slots {
-            let original = attributes
-                .get(&slots.attr_name)
-                .cloned()
-                .unwrap_or(Value::Nil);
-            // Phase 3 Stage 2 (scalar slice): scalar attributes are written
-            // through the cell directly by the var ops; only array/hash attrs
-            // still write back from locals here.
-            let arr_private_val = slots.arr_private.map(|i| &locals[i]);
-            let arr_public_val = slots.arr_public.map(|i| &locals[i]);
-            let hash_private_val = slots.hash_private.map(|i| &locals[i]);
-            let hash_public_val = slots.hash_public.map(|i| &locals[i]);
-
-            if let (Some(priv_val), Some(pub_val)) = (arr_private_val, arr_public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let (Some(priv_val), Some(pub_val)) = (hash_private_val, hash_public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(slots.attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(slots.attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let Some(val) = arr_private_val.or(hash_private_val) {
-                attributes.insert(slots.attr_name.clone(), val.clone());
-                continue;
-            }
-            if let Some(val) = arr_public_val.or(hash_public_val) {
-                attributes.insert(slots.attr_name.clone(), val.clone());
-            }
-        }
-    } else {
-        // Fallback: linear search (for methods compiled without attr info)
-        for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
-            if attr_name.starts_with(ATTR_ALIAS_META_PREFIX) || attr_name.contains('\0') {
-                continue;
-            }
-            let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
-
-            // Phase 3 Stage 2 (scalar slice): scalar attributes are written
-            // through the cell directly; only array/hash attrs write back here.
-            let arr_private_key = format!("@!{}", attr_name);
-            let arr_public_key = format!("@.{}", attr_name);
-            let hash_private_key = format!("%!{}", attr_name);
-            let hash_public_key = format!("%.{}", attr_name);
-            let arr_private_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &arr_private_key)
-                .map(|i| locals[i].clone());
-            let arr_public_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &arr_public_key)
-                .map(|i| locals[i].clone());
-            let hash_private_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &hash_private_key)
-                .map(|i| locals[i].clone());
-            let hash_public_val = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &hash_public_key)
-                .map(|i| locals[i].clone());
-
-            if let (Some(priv_val), Some(pub_val)) = (&arr_private_val, &arr_public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let (Some(priv_val), Some(pub_val)) = (&hash_private_val, &hash_public_val) {
-                if *priv_val == original && *pub_val != original {
-                    attributes.insert(attr_name.clone(), pub_val.clone());
-                } else {
-                    attributes.insert(attr_name.clone(), priv_val.clone());
-                }
-                continue;
-            }
-            if let Some(val) = arr_private_val.or(hash_private_val) {
-                attributes.insert(attr_name.clone(), val);
-                continue;
-            }
-            if let Some(val) = arr_public_val.or(hash_public_val) {
-                attributes.insert(attr_name, val);
-            }
-        }
-    }
-
-    // Write back class-qualified private array/hash attribute entries. Scalar
-    // qualified keys (`owner\0attr`) are written through the cell directly by the
-    // var ops (Phase 3 Stage 2), so only array/hash values are reconciled here.
-    for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
-        if !attr_name.contains('\0') {
-            continue;
-        }
-        if let Some(bare_attr) = attr_name.strip_prefix(&format!("{}\0", owner_class)) {
-            let arr_private_key = format!("@!{}", bare_attr);
-            let hash_private_key = format!("%!{}", bare_attr);
-            let idx = cc
-                .locals
-                .iter()
-                .rposition(|n| n == &arr_private_key)
-                .or_else(|| cc.locals.iter().rposition(|n| n == &hash_private_key));
-            if let Some(idx) = idx {
-                attributes.insert(attr_name, locals[idx].clone());
-            }
-        }
-    }
-}
-
-/// Write back attribute values from env after method execution.
-///
-/// Compares original attribute values with private (`!name`) and public (`.name`)
-/// env entries, preferring public when private is unchanged and public differs.
-fn writeback_attributes(env: &Env, attributes: &mut HashMap<String, Value>) {
-    for attr_name in attributes.keys().cloned().collect::<Vec<_>>() {
-        if attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
-            continue;
-        }
-        // Skip class-qualified private attribute keys (ClassName\0attrName).
-        // These are written back separately below.
-        if attr_name.contains('\0') {
-            continue;
-        }
-        let original = attributes.get(&attr_name).cloned().unwrap_or(Value::Nil);
-        // Phase 3 Stage 2 (scalar slice): scalar attributes (`!x`/`.x`) are
-        // written through the shared cell directly by the var ops, so they are no
-        // longer reconciled from the env here — doing so would clobber a mutation
-        // made in a nested method frame with this frame's stale snapshot (the
-        // cross-frame bug). Only array (`@!`/`@.`) and hash (`%!`/`%.`) attributes
-        // still use the materialize+writeback path.
-        let env_array_private_key = format!("@!{}", attr_name);
-        let env_array_public_key = format!("@.{}", attr_name);
-        let env_hash_private_key = format!("%!{}", attr_name);
-        let env_hash_public_key = format!("%.{}", attr_name);
-        let env_array_private = env.get(&env_array_private_key).cloned();
-        let env_array_public = env.get(&env_array_public_key).cloned();
-        let env_hash_private = env.get(&env_hash_private_key).cloned();
-        let env_hash_public = env.get(&env_hash_public_key).cloned();
-        if let (Some(private_val), Some(public_val)) = (&env_array_private, &env_array_public) {
-            if *private_val == original && *public_val != original {
-                attributes.insert(attr_name.clone(), public_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), private_val.clone());
-            }
-            continue;
-        }
-        if let (Some(private_val), Some(public_val)) = (&env_hash_private, &env_hash_public) {
-            if *private_val == original && *public_val != original {
-                attributes.insert(attr_name.clone(), public_val.clone());
-            } else {
-                attributes.insert(attr_name.clone(), private_val.clone());
-            }
-            continue;
-        }
-        if let Some(val) = env_array_private.or(env_hash_private) {
-            attributes.insert(attr_name.clone(), val);
-            continue;
-        }
-        if let Some(val) = env_array_public.or(env_hash_public) {
-            attributes.insert(attr_name.clone(), val);
-        }
-        let alias_env_key = format!("__mutsu_sigilless_alias::!{}", attr_name);
-        if let Some(Value::Str(alias_name)) = env.get(&alias_env_key) {
-            attributes.insert(
-                format!("{}{}", ATTR_ALIAS_META_PREFIX, attr_name),
-                Value::str(alias_name.to_string()),
-            );
-        }
     }
 }
 

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1237,14 +1237,20 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // A whole array/hash assign (`@!a = (...)`) always replaces the value, so
+        // there is no stale-copy hazard; pass `None` as the pre-snapshot to force
+        // the mirror.
         let r = self.exec_assign_expr_op_inner(code, name_idx);
-        // Phase 3 Stage 2: mirror name-based scalar attribute writes (`$.x = v`,
-        // `$!x = v` via AssignExpr) into the shared cell.
+        // Phase 3 Stage 2: mirror name-based attribute writes into the shared cell.
         if r.is_ok()
             && let Value::Str(name) = &code.constants[name_idx as usize]
         {
-            let name = name.to_string();
-            self.mirror_attr_value_to_cell_by_name(code, &name);
+            if name.starts_with('@') || name.starts_with('%') {
+                self.mirror_array_hash_attr_to_cell(code, name_idx, None);
+            } else {
+                let name = name.to_string();
+                self.mirror_attr_value_to_cell_by_name(code, &name);
+            }
         }
         r
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4159,36 +4159,46 @@ impl VM {
     // (`writeback_attributes*` skip scalar attrs). Array/hash attributes still
     // use the materialize+writeback path for now (later slices).
 
-    /// If `name` is a scalar attribute-twigil local (`!x` or `.x`), return the
-    /// bare attribute name. Excludes special vars (`!`, `.`) and internal names.
-    pub(super) fn scalar_attr_twigil_base(name: &str) -> Option<&str> {
-        let bare = name.strip_prefix('!').or_else(|| name.strip_prefix('.'))?;
+    /// If `name` is an attribute-twigil local — scalar (`!x`/`.x`), array
+    /// (`@!x`/`@.x`) or hash (`%!x`/`%.x`) — return `(bare attribute name,
+    /// is_private)`. Excludes special vars (`!`, `.`) and internal names. The
+    /// cell stores attributes under the bare name, so all six twigil forms of an
+    /// attribute resolve to the same cell slot.
+    pub(super) fn attr_twigil_base(name: &str) -> Option<(&str, bool)> {
+        // Optional `@`/`%` sigil, then the `!` (private) / `.` (public) twigil.
+        let rest = name
+            .strip_prefix('@')
+            .or_else(|| name.strip_prefix('%'))
+            .unwrap_or(name);
+        let (bare, is_private) = if let Some(b) = rest.strip_prefix('!') {
+            (b, true)
+        } else if let Some(b) = rest.strip_prefix('.') {
+            (b, false)
+        } else {
+            return None;
+        };
         // Attribute names are ordinary identifiers (start alpha/underscore). This
-        // filters out `!=`, the bare `!`/`.` special vars, and `__mutsu_` keys
-        // (which never begin with `!`/`.` anyway).
-        let mut chars = bare.chars();
-        match chars.next() {
-            Some(c) if c.is_alphabetic() || c == '_' => Some(bare),
+        // filters out `!=`, the bare `!`/`.` special vars, and `__mutsu_` keys.
+        match bare.chars().next() {
+            Some(c) if c.is_alphabetic() || c == '_' => Some((bare, is_private)),
             _ => None,
         }
     }
 
-    /// Resolve the cell key for a scalar attribute on the given instance,
-    /// preferring the method owner class's qualified private key when present
-    /// (Parent/Child same-named `$!priv` disambiguation), matching the order used
-    /// when method frames materialize attributes. Returns `None` when the
-    /// attribute does not exist in the cell (so non-attribute `.foo`/`!foo`
-    /// lvalues fall through to the normal local/env handling).
+    /// Resolve the cell key for an attribute on the given instance, preferring
+    /// the method owner class's qualified private key when present (Parent/Child
+    /// same-named `$!priv` disambiguation), matching the order used when method
+    /// frames materialize attributes. Returns `None` when the attribute does not
+    /// exist in the cell (so non-attribute `.foo`/`!foo` lvalues fall through to
+    /// the normal local/env handling).
     fn resolve_attr_cell_key(
         &self,
         name: &str,
         attrs: &crate::value::InstanceAttrs,
     ) -> Option<String> {
-        let bare = Self::scalar_attr_twigil_base(name)?;
+        let (bare, is_private) = Self::attr_twigil_base(name)?;
         let map = attrs.as_map();
-        if name.starts_with('!')
-            && let Some(owner) = self.interpreter.method_class_stack_top()
-        {
+        if is_private && let Some(owner) = self.interpreter.method_class_stack_top() {
             let qkey = format!("{}\0{}", owner, bare);
             if map.contains_key(&qkey) {
                 return Some(qkey);
@@ -4205,7 +4215,7 @@ impl VM {
     /// when `name` is a scalar attr-twigil, `self` is a concrete instance, and
     /// the attribute exists in the cell.
     pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
-        Self::scalar_attr_twigil_base(name)?;
+        Self::attr_twigil_base(name)?;
         let self_val = self.get_env_with_main_alias("self")?;
         let Value::Instance { attributes, .. } = &self_val else {
             return None;
@@ -4232,7 +4242,7 @@ impl VM {
     /// No-op when `name` is not a scalar attr-twigil, `self` is not a concrete
     /// instance, or the attribute does not exist on `self`.
     fn write_self_attr_cell(&self, name: &str, val: Value) {
-        if Self::scalar_attr_twigil_base(name).is_none() {
+        if Self::attr_twigil_base(name).is_none() {
             return;
         }
         let Some(self_val) = self.get_env_with_main_alias("self") else {
@@ -4252,7 +4262,7 @@ impl VM {
         let Some(name) = code.locals.get(idx) else {
             return;
         };
-        if Self::scalar_attr_twigil_base(name).is_none()
+        if Self::attr_twigil_base(name).is_none()
             || Self::is_non_mirrorable_attr_value(&self.locals[idx])
         {
             return;
@@ -4265,7 +4275,7 @@ impl VM {
     /// `AssignExpr`). Reads the value back from the local slot or env after the
     /// op completed.
     pub(super) fn mirror_attr_value_to_cell_by_name(&self, code: &CompiledCode, name: &str) {
-        if Self::scalar_attr_twigil_base(name).is_none() {
+        if Self::attr_twigil_base(name).is_none() {
             return;
         }
         let val = self
@@ -4279,6 +4289,69 @@ impl VM {
             return;
         }
         self.write_self_attr_cell(name, val);
+    }
+
+    /// True if `name` is an array/hash attribute twigil (`@!`/`@.`/`%!`/`%.`).
+    fn is_array_hash_attr_twigil(name: &str) -> bool {
+        (name.starts_with("@!")
+            || name.starts_with("@.")
+            || name.starts_with("%!")
+            || name.starts_with("%."))
+            && Self::attr_twigil_base(name).is_some()
+    }
+
+    /// Snapshot the env/shared value of an array/hash attribute variable before a
+    /// mutating op, so [`mirror_array_hash_attr_to_cell`] can tell a genuine
+    /// mutation (env value changed) from a non-mutating method call (`@!a.join`)
+    /// on a stale env copy — mirroring the stale copy would clobber a cross-frame
+    /// cell mutation. Returns `None` for non-attribute targets (cheap fast path).
+    pub(super) fn array_hash_attr_env_snapshot(
+        &self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Option<Value> {
+        let name = Self::const_str(code, name_idx);
+        if !Self::is_array_hash_attr_twigil(name) {
+            return None;
+        }
+        let name = name.to_string();
+        self.get_env_with_main_alias(&name)
+            .or_else(|| self.interpreter.get_shared_var(&name))
+    }
+
+    /// Mirror an array/hash attribute variable's post-mutation value into `self`'s
+    /// shared cell (Phase 3 Stage 2b). Used after the mutating array/hash ops
+    /// (`@!a.push`, `@!a[i]=`, `%!h<k>=`, …), which write the new container into
+    /// env/shared keyed by `name`. Only fires for `@!`/`@.`/`%!`/`%.` twigils and
+    /// only when the env value actually changed from `pre` (so a non-mutating
+    /// method like `@!a.join` on a stale env copy does not clobber the cell).
+    pub(super) fn mirror_array_hash_attr_to_cell(
+        &self,
+        code: &CompiledCode,
+        name_idx: u32,
+        pre: Option<Value>,
+    ) {
+        let name = Self::const_str(code, name_idx);
+        if !Self::is_array_hash_attr_twigil(name) {
+            return;
+        }
+        let name = name.to_string();
+        // The mutating ops write the new container into env (or shared_vars).
+        let val = self
+            .get_env_with_main_alias(&name)
+            .or_else(|| self.interpreter.get_shared_var(&name));
+        let Some(val) = val else {
+            return;
+        };
+        // No env change -> either a non-mutating method or a no-op; do not write
+        // a possibly-stale env copy over a cross-frame cell mutation.
+        if pre.as_ref() == Some(&val) {
+            return;
+        }
+        if Self::is_non_mirrorable_attr_value(&val) {
+            return;
+        }
+        self.write_self_attr_cell(&name, val);
     }
 
     /// Refresh the local slot from `self`'s cell before a read-modify-write on a
@@ -4300,7 +4373,7 @@ impl VM {
     /// a read-modify-write (used by the increment/decrement ops, which dispatch
     /// by name rather than slot index).
     pub(super) fn sync_attr_local_from_cell_by_name(&mut self, code: &CompiledCode, name: &str) {
-        if Self::scalar_attr_twigil_base(name).is_none() {
+        if Self::attr_twigil_base(name).is_none() {
             return;
         }
         if let Some(slot) = self.find_local_slot(code, name) {
@@ -4311,7 +4384,7 @@ impl VM {
     /// Name-based wrapper: mirror the slot named `name` into `self`'s cell after a
     /// read-modify-write.
     pub(super) fn mirror_attr_local_to_cell_by_name(&self, code: &CompiledCode, name: &str) {
-        if Self::scalar_attr_twigil_base(name).is_none() {
+        if Self::attr_twigil_base(name).is_none() {
             return;
         }
         if let Some(slot) = self.find_local_slot(code, name) {


### PR DESCRIPTION
## Summary

Extends the Stage 2a cell-direct attribute model to **array** (`@!a`/`@.a`) and **hash** (`%!h`/`%.h`) attributes, fixing **cross-frame array/hash mutation**: a nested method's `@!a.push` / `%!h<k>=` was invisible to the caller (it mutated a forked `Arc` / its own env copy, never the caller's view). Now every attribute kind reads and writes the instance's shared cell, so the cell is the single source of truth.

## What changed

- **Reads**: `GetArrayVar`/`GetHashVar` read `@!a`/`%!h` straight from `self`'s cell. `attr_twigil_base` (was `scalar_attr_twigil_base`) now recognizes all six twigil forms and returns `(bare, is_private)`.
- **Writes**: after each mutating op (`CallMethodMut`, `CallMethodDynamicMut`, `ArrayPush`, `IndexAssignExprNamed`, `MultiDimIndexAssign`, name-based `AssignExpr`) the new container is mirrored env → cell. Crucially the op's env value is **snapshotted first** and the mirror only fires when it actually changed — a non-mutating method like `@!a.join` also dispatches through `CallMethodMut`, and mirroring its stale env copy would clobber a cross-frame cell mutation.
- **Reconcile unified** across all sigils (`reconcile_scalar_attrs` → `reconcile_attrs`): the cell wins when it changed from the entry snapshot (cross-frame / per-op mirror), otherwise an env/local write that changed wins (attributive `method m(@!a)` params, no-twigil sigilless aliases, `is rw`).
- The array/hash attribute **writeback is removed entirely**; with it the now-unused `AttrSlots` struct and `compute_attr_slots` are deleted (net −115 lines).

Materialize's env copies, the by-id scan, the `instance_cells` registry and the detached path remain — **Stage 2c** removes them now that the cell is the single source for every attribute kind.

## Verification

- `make test` green.
- Whitelisted: `S12-attributes/*`, `S12-methods/*`, `S14-traits/*`, `S17-lowlevel/cas` pass.
- A 21-case array/hash edge suite passes: push/pop/shift/unshift, element assign, whole-assign, cross-frame array **and** hash, attributive param, `.=`, method chaining, read-inside-outer no-clobber.
- Pre-existing gaps unchanged (fail on `main` too): `%!h<x>:delete` persistence (DELETE-KEY via Index target), inherited same-named private attrs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)