### PR TITLE
Phase 3 Stage 2c slice 1: drop redundant by-id instance propagation scan

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -243,8 +243,20 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
         既知の非対応（pre-existing・非回帰）: `%!h<x>:delete`（DELETE-KEY が Index target 経由でミラー外）、`@b[0]=v` のスペース無し
         パース、継承同名 private。**materialize の array/hash 挿入 / by-id scan (`overwrite_instance_bindings_by_identity`) /
         registry (`instance_cells`) / detached は未撤去**＝Stage 2c（次）で cell 単一源を根拠に全廃。
-  - [ ] **Stage 2c — 伝播ハック全廃**: cell が全 attr の単一源になったので by-id scan + `instance_cells` registry +
-        `make_instance_detached`/`update_instance_cell` + materialize の env コピー挿入を撤去。CAS の cell-CAS 化を再検討。
+  - [~] **Stage 2c — 伝播ハック全廃（着手・slice 1 done）**: cell が全 attr の単一源になったので伝播スキャンを撤去。
+        - [x] **slice 1 — by-id env/locals scan 撤去（branch `phase3-stage2c-drop-byid-scan`）**: `overwrite_instance_bindings_by_identity`
+              の `for bound in self.env.values_mut()` 走査 + 再帰ヘルパ `overwrite_instance_recursive`（Instance/nested-attr/Mixin/
+              ContainerRef の各 arm）と、locals 走査 `overwrite_instance_in_locals`（+ 6 call sites）を**全削除**。伝播は単一の
+              `update_instance_cell(id, &updated)`（live shared cell への直書き）に集約。**根拠**: Stage 1/2a/2b 後、instance の
+              全 alias（同一フレーム・caller フレーム・`ContainerRef` boxed capture・role `Mixin`・他 instance のネスト属性）は
+              `Arc<InstanceAttrs>` 参照共有で**同一 cell を見る**（deep-copy は明示 `.clone` のみ）→ scan が rebuild していた
+              holder は元から同じ cell を共有しており scan は観測上 no-op。`_class_name` は vestigial（cell は id keying）だが
+              ~40 call site churn 回避のため signature 維持（後続 slice で撤去）。検証: make test 6247・S12/S14/S17 whitelist
+              106 ファイル 2111 テスト PASS（cross-thread cas・全 role/mixin・cross-frame note/closure・nested・escaping-closure
+              scalar-holding-instance すべて緑）、clippy 緑。net -108 行。
+        - [ ] **slice 2（残）**: `instance_cells` registry + `make_instance_detached`/`update_instance_cell` の撤去
+              （callers が `self` の Arc を直接 in-place 変異する形へ。compiled-method の `(Value, attributes)` 戻り規約を変える）+
+              materialize の env コピー挿入撤去 + CAS の cell-CAS 化再検討。
   - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -414,84 +414,24 @@ impl Interpreter {
 
     pub(crate) fn overwrite_instance_bindings_by_identity(
         &mut self,
-        class_name: &str,
+        _class_name: &str,
         id: u64,
         updated: std::collections::HashMap<String, Value>,
     ) {
-        // Phase 3, Stage 1: write the new attributes straight into the live
-        // shared cell. Because every alias of this instance (in this frame and
-        // any caller frame the scan below never visits) shares that cell, this
-        // single write is what makes the mutation visible across call frames —
-        // the fix for the long-standing closure-frame mutation bug. The
-        // by-identity scan that follows is now redundant (it rebuilds bindings
-        // that already share the updated cell) and is removed in Stage 2.
+        // Phase 3, Stage 2c: write the new attributes straight into the live
+        // shared cell. Because every alias of this instance — in this frame, any
+        // caller frame, a `ContainerRef`-boxed capture, a role `Mixin`, or a
+        // nested attribute of another instance — shares that cell (the
+        // `Arc<InstanceAttrs>` is cloned by reference, never deep-copied except
+        // for an explicit `.clone`), this single write makes the mutation visible
+        // everywhere. The former by-identity scan over `self.env`/`self.locals`
+        // that rebuilt each holder via `make_instance_with_id` is now redundant —
+        // those rebuilds reused the very same cell — and has been removed.
+        //
+        // `_class_name` is vestigial (the cell is keyed by `id` alone); it is kept
+        // on the signature to avoid churning ~40 call sites in this slice and will
+        // be dropped when this choke point is retired in a later Stage 2c slice.
         crate::value::update_instance_cell(id, &updated);
-        for bound in self.env.values_mut() {
-            Self::overwrite_instance_recursive(bound, class_name, id, &updated);
-        }
-    }
-
-    /// Recursively update all occurrences of an instance (identified by class_name + id)
-    /// in a value tree. This handles instances stored as attributes of other instances.
-    fn overwrite_instance_recursive(
-        value: &mut Value,
-        class_name: &str,
-        id: u64,
-        updated: &std::collections::HashMap<String, Value>,
-    ) {
-        match value {
-            Value::Instance {
-                class_name: existing_class,
-                id: existing_id,
-                ..
-            } if existing_class.resolve() == class_name && *existing_id == id => {
-                *value =
-                    Value::make_instance_with_id(Symbol::intern(class_name), updated.clone(), id);
-            }
-            Value::Instance {
-                attributes,
-                id: this_id,
-                class_name: this_class,
-                ..
-            } => {
-                // Recurse into this instance's attributes, but only if it's a different
-                // instance (avoid infinite recursion on self-referential structures).
-                let this_id_val = *this_id;
-                if this_id_val != id {
-                    // Check if any attribute contains the target instance
-                    let has_target = attributes.as_map().values().any(|v| {
-                        matches!(v, Value::Instance { class_name: cn, id: vid, .. }
-                            if cn.resolve() == class_name && *vid == id)
-                    });
-                    if has_target {
-                        let mut new_attrs: std::collections::HashMap<String, Value> =
-                            attributes.to_map();
-                        for attr_val in new_attrs.values_mut() {
-                            Self::overwrite_instance_recursive(attr_val, class_name, id, updated);
-                        }
-                        *value = Value::make_instance_with_id(*this_class, new_attrs, this_id_val);
-                    }
-                }
-            }
-            // A value mixed in with a role (`$obj does Role`) wraps the original
-            // instance inside a Mixin. Recurse into the inner value so that
-            // mutations to the instance's attributes propagate through the Mixin.
-            Value::Mixin(inner, mixins) => {
-                let mut new_inner = (**inner).clone();
-                Self::overwrite_instance_recursive(&mut new_inner, class_name, id, updated);
-                *value = Value::Mixin(std::sync::Arc::new(new_inner), mixins.clone());
-            }
-            // A captured-and-mutated `$` scalar may be boxed into a shared
-            // `ContainerRef` cell (see box_captured_lexicals). When a mutating
-            // method runs on the instance it holds, write the update THROUGH the
-            // cell in place so all holders of the shared Arc (the outer variable
-            // and any sibling/escaping closure snapshot) observe the mutation.
-            Value::ContainerRef(arc) => {
-                let mut inner = arc.lock().unwrap();
-                Self::overwrite_instance_recursive(&mut inner, class_name, id, updated);
-            }
-            _ => {}
-        }
     }
 
     /// Call a Proxy callback (FETCH or STORE) in the context of an instance's attributes.

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -36,49 +36,6 @@ impl VM {
         }
     }
 
-    /// Update any instances in `self.locals` that match the given class_name and id.
-    /// This is needed because the fast-path SetLocal for simple scalars writes only
-    /// to `self.locals` (not env), so `overwrite_instance_bindings_by_identity` which
-    /// only searches env will miss them.
-    pub(super) fn overwrite_instance_in_locals(
-        &mut self,
-        class_name: &str,
-        id: u64,
-        updated: &std::collections::HashMap<String, Value>,
-    ) {
-        let cn = crate::symbol::Symbol::intern(class_name);
-        for local in self.locals.iter_mut() {
-            // A boxed (`ContainerRef`) scalar holding the instance must be updated
-            // through the shared cell in place (mirrors the env-path ContainerRef
-            // arm in overwrite_instance_recursive); otherwise a sibling/escaping
-            // closure's mutating method call is lost.
-            if let Value::ContainerRef(arc) = local {
-                let mut inner = arc.lock().unwrap();
-                if let Value::Instance {
-                    class_name: existing_class,
-                    id: existing_id,
-                    ..
-                } = &*inner
-                    && *existing_class == cn
-                    && *existing_id == id
-                {
-                    *inner = Value::make_instance_with_id(cn, updated.clone(), id);
-                }
-                continue;
-            }
-            if let Value::Instance {
-                class_name: existing_class,
-                id: existing_id,
-                ..
-            } = local
-                && *existing_class == cn
-                && *existing_id == id
-            {
-                *local = Value::make_instance_with_id(cn, updated.clone(), id);
-            }
-        }
-    }
-
     pub(super) fn try_exec_simple_shared_protect_block(
         &mut self,
         outer_code: &CompiledCode,
@@ -239,7 +196,6 @@ impl VM {
                                 id,
                                 new_attrs.clone(),
                             );
-                            self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -660,7 +616,6 @@ impl VM {
                 inst_id,
                 snapshot.clone(),
             );
-            self.overwrite_instance_in_locals(&cn, inst_id, &snapshot);
             self.env_dirty = true;
         }
         Some(Ok(ret))
@@ -786,7 +741,6 @@ impl VM {
         if let Some(id) = target_id {
             self.interpreter
                 .overwrite_instance_bindings_by_identity(cn, id, new_attrs.clone());
-            self.overwrite_instance_in_locals(cn, id, &new_attrs);
             if !self.interpreter.in_lvalue_assignment
                 && let Value::Proxy { ref fetcher, .. } = result
             {
@@ -999,7 +953,6 @@ impl VM {
                                 id,
                                 new_attrs.clone(),
                             );
-                            self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -1098,7 +1051,6 @@ impl VM {
                         id,
                         new_attrs.clone(),
                     );
-                    self.overwrite_instance_in_locals(&cn, id, &new_attrs);
                     if !self.interpreter.in_lvalue_assignment
                         && let Value::Proxy { ref fetcher, .. } = result
                     {


### PR DESCRIPTION
## Summary

First slice of **Phase 3 Stage 2c** (propagation-hack removal). After Stage 1/2a/2b, instance attributes live in a single shared cell (`Arc<RwLock<HashMap>>`), and every alias of an instance shares that cell by `Arc<InstanceAttrs>` reference — deep copies happen only on an explicit `.clone`. The legacy by-identity **scan** that rebuilt each env/local holder via `make_instance_with_id` reused the very same cell, so it was observably a no-op. This collapses propagation to the single live-cell write.

## Changes

- `overwrite_instance_bindings_by_identity`: remove the `for bound in self.env.values_mut()` scan and the recursive `overwrite_instance_recursive` helper (Instance / nested-attr / Mixin / ContainerRef arms). Body is now just `update_instance_cell(id, &updated)`.
- Remove `overwrite_instance_in_locals` (locals scan) and its 6 call sites in `vm_call_method_compiled.rs`.
- `_class_name` is now vestigial (cell keyed by id); kept on the signature to avoid churning ~40 call sites this slice — dropped in slice 2 along with the registry / `make_instance_detached` / `update_instance_cell`.

net **-108 lines**.

## Why it's safe

Every alias of an instance — same frame, caller frame, `ContainerRef`-boxed capture, role `Mixin`, nested attribute of another instance — shares the same cell. A single write through `update_instance_cell` is visible to all of them. The scan only rebuilt `Value::Instance` holders that already shared the updated cell.

## Verification

- `make test`: 6247 pass.
- S12/S14/S17 whitelist (106 files, 2111 tests) all pass in release: cross-thread `cas`, all role/mixin (`does`), cross-frame `note`/closure mutation, nested instances, and escaping-closure scalar-holding-instance — all green.
- `cargo clippy --all-targets`: clean.

Design: `docs/container-identity.md` Phase 3 Stage 2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)