### PR TITLE
Phase 3 Stage 2c (i): route attributive params through the shared cell

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -254,9 +254,24 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
               ~40 call site churn 回避のため signature 維持（後続 slice で撤去）。検証: make test 6247・S12/S14/S17 whitelist
               106 ファイル 2111 テスト PASS（cross-thread cas・全 role/mixin・cross-frame note/closure・nested・escaping-closure
               scalar-holding-instance すべて緑）、clippy 緑。net -108 行。
-        - [ ] **slice 2（残）**: `instance_cells` registry + `make_instance_detached`/`update_instance_cell` の撤去
-              （callers が `self` の Arc を直接 in-place 変異する形へ。compiled-method の `(Value, attributes)` 戻り規約を変える）+
-              materialize の env コピー挿入撤去 + CAS の cell-CAS 化再検討。
+        - **materialize/reconcile 撤去（ユーザー選択 2026-06-11、段階 PR）**: reconcile は `attributes`(entry snapshot) を最終値へ
+              書き換え、cell 非経由の2経路を merge する: (a) attributive param (`method m($!x)`)、(b) sigilless `has $x`（bare `Var("x")`
+              にコンパイルされ実行時 alias テーブルのみが属性と判別）。`is rw` accessor 等は既に cell に届く。reconcile を単純撤去すると
+              caller の cell writeback が snapshot で cell を巻き戻すため、最終的に `reconcile → attributes = base.cell.to_map()`（cell 単一源）
+              へ置換する。exit-mirror は 2b 実証の stale-clobber を起こすため write-time の cell routing が必須。→ (i) attributive param、
+              (ii) sigilless cell-direct（2a 相当）、(iii) reconcile/materialize 撤去、の3段に分割。
+          - [x] **(i) attributive param → cell（landed: branch `phase3-stage2c-registry-removal`）**: binding 直後に
+                `mirror_attributive_params_to_cell`（`mirror_attr_value_to_cell_by_name` 再利用、scalar/array/hash 全 twigil）で param を
+                self の cell へ。**併せて read-only fast path から attributive param を除外**（`attr_twigil_base(pd.name).is_some()` を
+                `has_complex_params` に追加）—— attributive param は属性を変異させるのに fast path は writeback を落とすため `$obj.m($!x)`
+                後に変異が消えるバグ（`method set-and-read($!x){ say $!x }` が in-body 7 でなく stale cell 99 を読み属性も 99 のまま）を修正。
+                検証: make test 6247、S12/S14/S17/S06 whitelist 140 ファイル 2890 テスト PASS、named `:$!x`/BUILD/array/hash param・
+                in-body read・cross-frame すべて raku 一致。reconcile は (ii)(iii) まで維持（attributive param 経路は今や mirror で冗長だが無害）。
+          - [ ] **(ii) sigilless `has $x` を cell-direct 化**（2a 相当・bare `Var("x")` を実行時 alias テーブル参照で cell に回す）。
+          - [ ] **(iii) reconcile を `cell.to_map()` 置換 + materialize の attr-value env コピー撤去**。
+        - [ ] **registry 撤去（別 slice・後回し）**: `instance_cells` + `make_instance_detached`/`update_instance_cell` 撤去
+              （callers が `self` の Arc を直接 in-place 変異する形へ。~50 の make_instance_with_id rebuild を全変換する all-or-nothing 大改修）+
+              CAS の cell-CAS 化。
   - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -77,6 +77,13 @@ impl VM {
                 if pd.slurpy && pd.name == "%_" {
                     return false;
                 }
+                // An attributive parameter (`$!x`/`@!a`) binds straight to an
+                // attribute, i.e. it mutates `self` — so it is not read-only and
+                // must take the full path (which mirrors it into the shared cell
+                // and writes it back). The read-only fast path drops the write.
+                if Self::attr_twigil_base(&pd.name).is_some() {
+                    return true;
+                }
                 pd.slurpy
                     || pd.double_slurpy
                     || pd.named
@@ -467,6 +474,13 @@ impl VM {
                 self.locals[i] = val.clone();
             }
         }
+        // Phase 3 Stage 2c (i): an attributive parameter (`method m($!x)` /
+        // `method m(@!a)`) binds straight to the attribute. The binding above
+        // writes only env/locals; mirror it into `self`'s shared cell now so the
+        // method body's cell-direct reads of `$!x` see the parameter value (not
+        // the stale entry value) and the mutation is visible to every alias. This
+        // removes the attributive-param case from the exit-time reconcile.
+        self.mirror_attributive_params_to_cell(cc, method_def);
         // Load persisted state variable values
         for (slot, key) in &cc.state_locals {
             if let Some(val) = self.interpreter.get_state_var(key) {
@@ -803,6 +817,27 @@ impl VM {
                 attributes.insert(k, v);
             } else if let Some(cv) = cell_val {
                 attributes.insert(k, cv);
+            }
+        }
+    }
+
+    /// Phase 3 Stage 2c (i): mirror attributive parameters (`$!x`/`@!a`/`%!h`)
+    /// into `self`'s shared attribute cell right after argument binding. The
+    /// parameter binding writes the value to env/locals keyed by the attribute
+    /// twigil name (`!x`, `@!a`, …); this pushes it through to the cell so that
+    /// cell-direct body reads and cross-frame aliases observe it, taking the
+    /// attributive-param case out of the exit-time `reconcile_attrs`.
+    fn mirror_attributive_params_to_cell(
+        &self,
+        code: &CompiledCode,
+        method_def: &crate::runtime::MethodDef,
+    ) {
+        for pd in &method_def.param_defs {
+            if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") {
+                continue;
+            }
+            if Self::attr_twigil_base(&pd.name).is_some() {
+                self.mirror_attr_value_to_cell_by_name(code, &pd.name);
             }
         }
     }


### PR DESCRIPTION
## Summary

First step of **Phase 3 Stage 2c materialize/reconcile removal** (staged). Routes attributive parameters (`method m($!x)` / `method m(@!a)`) through the shared attribute cell, taking that case out of the exit-time `reconcile_attrs`.

An attributive parameter binds straight to an attribute, i.e. it mutates `self`. Two bugs on main:

1. A method with an attributive param but an otherwise read-only body (e.g. `method set-x($!x) {}`) was misclassified as read-only → took the fast path → the attribute writeback was dropped, so the mutation was lost.
2. Even on the slow path, the param value reached only env/locals, so a Stage 2a cell-direct body read of `$!x` saw the stale entry value (`method set-and-read($!x) { say $!x }` printed the default `99` instead of `7`).

## Changes

- **Exclude attributive params from the read-only fast path** (`attr_twigil_base(pd.name).is_some()` added to `has_complex_params`) — they mutate state, so the full path (which writes back) must run.
- **Mirror each attributive parameter into `self`'s shared cell after binding** (`mirror_attributive_params_to_cell`, reusing the Stage 2a/2b `mirror_attr_value_to_cell_by_name` for all six twigils), so body cell-direct reads and cross-frame aliases see the parameter value.

`reconcile_attrs` stays in place for the remaining sigilless `has $x` bypass, removed in Stage 2c (ii)/(iii).

## Verification

- `make test`: 6247 pass.
- S12/S14/S17/S06 whitelist (140 files, 2890 tests) all pass in release.
- Matches Rakudo: named `:$!x`, `submethod BUILD(:$!a, :$!b)`, array/hash attributive params, in-body read of an attributive param, and cross-frame mutation via a closure-provided block.
- `cargo clippy --all-targets`: clean.

Design: `docs/container-identity.md` Phase 3 Stage 2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)