### PR TITLE
fix(constant): call .Map once for our/implied %-sigil constant

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -839,7 +839,15 @@ impl Compiler {
                         self.code.emit(OpCode::StateVarInit(slot, key_idx));
                     }
                 } else {
-                    if *is_our {
+                    let is_constant = custom_traits.iter().any(|(t, _)| t == "__constant");
+                    // For `our` we need a second copy of the value to store into the
+                    // global. Normally we `Dup` the raw initializer up front, but for
+                    // a constant the global store (`SetGlobalRaw`) coerces the value
+                    // (e.g. calling `.Map` on a `%`-sigil RHS) — coercing the raw
+                    // value a second time would invoke that side-effecting coercion
+                    // twice. Instead, for constants we re-read the already-coerced
+                    // value from the local slot via `GetLocal` after `SetLocal`.
+                    if *is_our && !is_constant {
                         self.code.emit(OpCode::Dup);
                     }
                     if self.bind_vardecl && (name.starts_with('@') || name.starts_with('%')) {
@@ -848,7 +856,6 @@ impl Compiler {
                     }
                     // Mark constant context so SetLocal uses List coercion for @ and
                     // skips Hash coercion for %, matching Raku's constant semantics.
-                    let is_constant = custom_traits.iter().any(|(t, _)| t == "__constant");
                     if is_constant && (name.starts_with('@') || name.starts_with('%')) {
                         self.code.emit(OpCode::MarkConstantContext);
                     }
@@ -887,8 +894,11 @@ impl Compiler {
                         // Constants should not have their values coerced by the
                         // @/% container rules: `constant @x` stores a List,
                         // `constant %x` stores a Map (not Array/Hash).
-                        let is_constant = custom_traits.iter().any(|(t, _)| t == "__constant");
                         if is_constant {
+                            // Re-read the value `SetLocal` already coerced (and
+                            // cached in the slot) so `SetGlobalRaw` does not run
+                            // the coercion — and its side effects — a second time.
+                            self.code.emit(OpCode::GetLocal(slot));
                             self.code.emit(OpCode::SetGlobalRaw(idx));
                         } else {
                             self.code.emit(OpCode::SetGlobal(idx));

--- a/t/constant-hash-coerce-once.t
+++ b/t/constant-hash-coerce-once.t
@@ -1,0 +1,25 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# An `our`/implied-scope `constant %h = Obj` must coerce its value to a Map by
+# calling `.Map` exactly once -- not twice (regression: the global store used to
+# re-coerce the raw initializer after the local store had already coerced it,
+# invoking the side-effecting `.Map` twice).
+
+plan 3;
+
+is_run 'class Foo { method Map { print "M"; Map.new: (:1a) } };'
+     ~ 'constant %h = Foo.new;',
+    { :out("M"), :err(''), :0status },
+    'implied-scope constant calls .Map exactly once';
+
+is_run 'class Foo { method Map { print "M"; Map.new: (:1a) } };'
+     ~ 'our constant %h = Foo.new;',
+    { :out("M"), :err(''), :0status },
+    'our-scope constant calls .Map exactly once';
+
+is_run 'class Foo { method Map { print "M"; Map.new: (:1a) } };'
+     ~ 'my constant %h = Foo.new;',
+    { :out("M"), :err(''), :0status },
+    'my-scope constant calls .Map exactly once';


### PR DESCRIPTION
## Summary

An `our`-scoped or implied-scope `constant %h = Obj` (where `Obj` is a non-Associative object) coerces its value to a `Map` by calling `Obj.Map`. mutsu called `.Map` **twice**; `my constant %h` correctly called it once.

### Root cause

The codegen for an `our` variable `Dup`'d the raw initializer before `SetLocal`:

```
Dup
SetLocal(slot)      # coerces one copy -> .Map call #1
SetGlobalRaw(idx)   # re-coerces the raw duplicate -> .Map call #2
```

`my constant` emits no global store, so it coerced once.

### Fix

For `our` **constants**, skip the up-front `Dup` and re-read the value `SetLocal` already coerced (cached in the slot) via `GetLocal` before `SetGlobalRaw`. The already-Associative value passes the second coercion as a no-op, so `.Map` runs exactly once. Non-constant `our` keeps the `Dup` + `SetGlobal` path unchanged.

### Context

Surfaced while preparing subtest-plan enforcement: `roast/S04-declarations/constant-6.d.t`'s `%-sigilled` subtests ran one extra `.Map`-`pass` test (17 instead of the planned 16). With this fix `constant-6.d.t` runs the correct count and passes 25/25.

## Tests

- New `t/constant-hash-coerce-once.t` — asserts `.Map` is printed exactly once for implied/`our`/`my` constants (verified to also pass under rakudo).
- `roast/S04-declarations/constant-6.d.t` 25/25, `constant.t`/`our.t` unaffected.
- `make test` PASS (458 cargo tests + prove suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)