### PR TITLE
fix(test): count threaded passes in subtest/plan accounting

### DIFF
--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1025,16 +1025,20 @@ impl Interpreter {
             return Ok(());
         }
         if let Some(state) = self.tap.state() {
-            let plan_mismatch = matches!(state.planned, Some(planned) if planned != state.ran);
+            // Use the shared-atomic-aware count: tests run on a spawned thread
+            // (start blocks, Promise callbacks) bump the shared counter but not
+            // this state's local `ran` field.
+            let ran = state.effective_ran();
+            let plan_mismatch = matches!(state.planned, Some(planned) if planned != ran);
             if state.failed > 0 {
-                self.emit_test_summary_diag(state.planned, state.ran, state.failed);
+                self.emit_test_summary_diag(state.planned, ran, state.failed);
                 return Err(RuntimeError::new("Test failures"));
             }
             if plan_mismatch {
                 if let Some(planned) = state.planned {
                     self.stderr_output.push_str(&format!(
                         "# You planned {} test, but ran {}\n",
-                        planned, state.ran
+                        planned, ran
                     ));
                 }
                 // Dubious: exit code 255

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -71,7 +71,10 @@ impl Interpreter {
         let mut subtest_output = std::mem::take(&mut self.output);
         let subtest_state = self.tap.take_state();
         let subtest_failed = subtest_state.as_ref().map(|s| s.failed).unwrap_or(0);
-        let subtest_ran = subtest_state.as_ref().map(|s| s.ran).unwrap_or(0);
+        let subtest_ran = subtest_state
+            .as_ref()
+            .map(|s| s.effective_ran())
+            .unwrap_or(0);
         let has_plan = subtest_state.as_ref().and_then(|s| s.planned).is_some();
 
         self.tap.set_state(ctx.parent_test_state);

--- a/src/runtime/tap_state.rs
+++ b/src/runtime/tap_state.rs
@@ -57,6 +57,18 @@ impl TestState {
         }
     }
 
+    /// The authoritative number of tests run. When a shared atomic counter is
+    /// active (a `start` block / Promise callback ran tests on another thread),
+    /// the local `ran` field can be stale — a `pass`/`ok` executed on a spawned
+    /// thread bumps the atomic but only that thread's cloned `ran`, not ours.
+    /// Read the atomic in that case so plan accounting stays correct.
+    pub(crate) fn effective_ran(&self) -> usize {
+        match &self.shared_ran {
+            Some(counter) => counter.load(Ordering::SeqCst),
+            None => self.ran,
+        }
+    }
+
     /// Get an Arc to the shared counter, creating one if needed.
     pub(crate) fn ensure_shared_ran(&mut self) -> Arc<AtomicUsize> {
         if let Some(ref counter) = self.shared_ran {

--- a/t/subtest-threaded-pass-count.t
+++ b/t/subtest-threaded-pass-count.t
@@ -1,0 +1,39 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# Tests that run on a spawned thread (e.g. a Promise `.then` callback kept by
+# another thread) bump the shared atomic TAP counter, not the subtest's local
+# `ran` field. The subtest's emitted plan / count must reflect those threaded
+# tests -- regression: a planless threaded subtest reported `1..0` instead of
+# the true number of tests run, and a planned one would mis-count under
+# enforcement (roast S17-promise/in.t).
+
+plan 2;
+
+# Planless subtest: finish emits `1..N` from the counted tests.
+is_run q:to/CODE/,
+    use Test;
+    plan 1;
+    subtest 'planless threaded' => {
+        my $p = Promise.new;
+        start { $p.keep(True); }
+        await $p.then: { pass "a"; pass "b"; pass "c" };
+    }
+    CODE
+    { :out(/'1..3'/ & /'ok 3 - c'/ & /'ok 1 - planless threaded'/), :0status },
+    'planless subtest counts threaded passes (1..3)';
+
+# Planned subtest matching the threaded count passes.
+is_run q:to/CODE/,
+    use Test;
+    plan 1;
+    subtest 'planned threaded' => {
+        plan 2;
+        my $p = Promise.new;
+        start { $p.keep(True); }
+        await $p.then: { pass "x"; pass "y" };
+    }
+    CODE
+    { :out(/'ok 1 - planned threaded'/), :0status },
+    'planned subtest with threaded passes matches its plan';


### PR DESCRIPTION
## Summary

Tests run on a **spawned thread** — a `start` block or a Promise `.then` callback kept by another thread — call `next_ran()`, which bumps the shared atomic TAP counter but only updates *that thread's* cloned `TestState.ran` field. `finish_subtest` and the top-level plan check read the subtest-main's stale local `ran`, so a subtest whose tests all ran on a thread reported the wrong count.

### Deterministic repro

```raku
use Test;
plan 1;
subtest 'planless threaded' => {
    my $p = Promise.new;
    start { $p.keep(True); }
    await $p.then: { pass "a"; pass "b"; pass "c" };
}
```

- Before: subtest emits `1..0`
- After:  subtest emits `1..3` (matches rakudo)

### Fix

Add `TestState::effective_ran()` — returns the shared atomic's value when one is active, else the local `ran` field — and use it in `finish_subtest` and the top-level end-of-run plan check. The local field stays authoritative when no threads are involved.

### Context

Surfaced while preparing subtest-plan enforcement: `roast/S17-promise/in.t`'s `Promise.in with negative value works` subtest counted 0 of its 1 planned tests under parallel load because the `.then` `pass` ran on a thread.

## Tests

- New `t/subtest-threaded-pass-count.t` (planless + planned threaded subtests; verified under rakudo).
- `roast/S17-promise/in.t` PASS; promise/start/thread local tests unaffected.
- `make test` PASS (458 cargo tests + prove suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)