### PR TITLE
Phase 3 Stage 2c (ii): route sigilless attributes through the shared cell

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -267,7 +267,19 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
                 後に変異が消えるバグ（`method set-and-read($!x){ say $!x }` が in-body 7 でなく stale cell 99 を読み属性も 99 のまま）を修正。
                 検証: make test 6247、S12/S14/S17/S06 whitelist 140 ファイル 2890 テスト PASS、named `:$!x`/BUILD/array/hash param・
                 in-body read・cross-frame すべて raku 一致。reconcile は (ii)(iii) まで維持（attributive param 経路は今や mirror で冗長だが無害）。
-          - [ ] **(ii) sigilless `has $x` を cell-direct 化**（2a 相当・bare `Var("x")` を実行時 alias テーブル参照で cell に回す）。
+          - [x] **(ii) sigilless `has $x` を cell-direct 化（landed: branch `phase3-stage2c-sigilless-cell`）**: bare `Var("x")`
+                （sigilless attr）を実行時 `__mutsu_sigilless_alias::` テーブル参照で cell に回す。**read**: `read_self_attr_cell` を
+                `canonical_attr_twigil`（直接 twigil → そのまま / bare sigilless → alias chain 辿って `!x` twigil 解決）経由に拡張。
+                sigilless `$x` は method local 宣言でないため **GetGlobal** で読まれる（GetLocal でない）と判明 → vm.rs の GetGlobal handler
+                にも cell-direct read を追加（env read の前）。**write**: 6つの alias-chain 伝播ループ（inc/dec 4 + name-based assign 1 +
+                SetGlobal 1）の各 alias target に `write_self_attr_cell` を追加し attr-twigil alias (`!x`) を cell へミラー。inc/dec の
+                4ループは重複していたので共通ヘルパ `propagate_sigilless_alias_chain` に factor（cell mirror 込み）。**perf**: read 経路は
+                hot なので新フラグ `Interpreter::sigilless_attrs_active`（materialize で sigilless alias 設定時に立てる process-sticky bool）で
+                ゲート → 非 sigilless プログラム（大多数）は string check のみ。**修正バグ**: 同フレーム/nested-frame の sigilless read が
+                entry env コピー（stale）を読んでいた（`method outer { self.inner; $y }` が inner の変異後 10 でなく 99 を返すべき所で 10）。
+                検証: make test 6247、S12/S14/S17/S06/S32-num whitelist 171 ファイル 6432・S02/S03/S04 318 ファイル 32004 PASS、
+                int.t perf 0.085s（回帰なし）、nested-read/same-method write-read/inc-dec/closure/multi-attr すべて raku 一致。
+                reconcile は (iii) まで維持（sigilless 経路は今や cell 直結で reconcile case-2 は冗長だが無害）。
           - [ ] **(iii) reconcile を `cell.to_map()` 置換 + materialize の attr-value env コピー撤去**。
         - [ ] **registry 撤去（別 slice・後回し）**: `instance_cells` + `make_instance_detached`/`update_instance_cell` 撤去
               （callers が `self` の Arc を直接 in-place 変異する形へ。~50 の make_instance_with_id rebuild を全変換する all-or-nothing 大改修）+

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1161,6 +1161,9 @@ impl Interpreter {
             const ATTR_ALIAS_META_PREFIX: &str = "__mutsu_attr_alias::";
             if let Some(actual_attr) = attr_name.strip_prefix(ATTR_ALIAS_META_PREFIX) {
                 if let Value::Str(source_name) = attr_val {
+                    // A sigilless attribute is in play — enable cell-direct
+                    // alias-table routing (Phase 3 Stage 2c (ii)).
+                    self.sigilless_attrs_active = true;
                     // Set up: !attr → source_name alias (for write propagation)
                     self.env.insert(
                         format!("__mutsu_sigilless_alias::!{}", actual_attr),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1032,6 +1032,14 @@ pub struct Interpreter {
     /// True when this interpreter participates in cross-thread variable sharing.
     /// Set by `clone_for_thread` on both parent and child.
     pub(crate) shared_vars_active: bool,
+    /// True once any sigilless attribute alias (`has $x`) has been materialized.
+    /// Sigilless attributes are read/written through a bare `Var("x")` that is
+    /// disambiguated only by the runtime `__mutsu_sigilless_alias::` table, so
+    /// the cell-direct read/write routing must consult that table. This flag
+    /// gates that extra lookup so programs without sigilless attributes (the vast
+    /// majority) pay nothing on the hot variable-read path. Process-sticky: set
+    /// true on first use, never reset (Phase 3 Stage 2c (ii)).
+    pub(crate) sigilless_attrs_active: bool,
     /// Keys in shared_vars that were explicitly updated (not just initialized by
     /// `clone_for_thread`). `sync_shared_vars_to_env` only syncs these keys so
     /// that function parameters aren't overwritten with stale values.
@@ -3127,6 +3135,7 @@ impl Interpreter {
             supply_emit_timed_buffer: Vec::new(),
             shared_vars: Arc::new(RwLock::new(HashMap::new())),
             shared_vars_active: false,
+            sigilless_attrs_active: false,
             shared_vars_dirty: Arc::new(RwLock::new(HashSet::new())),
             encoding_registry: Self::builtin_encodings(),
             skip_pseudo_method_native: None,
@@ -5397,6 +5406,7 @@ impl Interpreter {
             supply_emit_timed_buffer: Vec::new(),
             shared_vars: Arc::clone(&self.shared_vars),
             shared_vars_active: true,
+            sigilless_attrs_active: self.sigilless_attrs_active,
             shared_vars_dirty: Arc::clone(&self.shared_vars_dirty),
             encoding_registry: self.encoding_registry.clone(),
             skip_pseudo_method_native: None,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -885,6 +885,17 @@ impl VM {
                         return Ok(());
                     }
                 }
+                // Phase 3 Stage 2c (ii): a sigilless attribute (`has $x`) compiles
+                // to a bare `Var("x")` that reads via GetGlobal (it is not a method
+                // local), so route it to `self`'s shared cell here too — otherwise
+                // a read after a nested-frame mutation sees the stale entry copy.
+                // `read_self_attr_cell` is gated on `sigilless_attrs_active`, so
+                // non-sigilless programs pay only a string check.
+                if let Some(cell_val) = self.read_self_attr_cell(name) {
+                    self.stack.push(cell_val);
+                    *ip += 1;
+                    return Ok(());
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| {
@@ -1697,6 +1708,10 @@ impl VM {
                     }
                     self.set_env_with_main_alias(&current_alias, val.clone());
                     self.update_local_if_exists(code, &current_alias, &val);
+                    // Sigilless attribute write: mirror an attr-twigil alias (`!x`)
+                    // into self's shared cell so a same-method cell-direct read of
+                    // the sigilless attr sees the new value (Phase 3 Stage 2c (ii)).
+                    self.write_self_attr_cell(&current_alias, val.clone());
                     let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
                     alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
                         if let Value::Str(name) = v {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -357,6 +357,9 @@ impl VM {
             }
             if let Some(actual_attr) = attr_name.strip_prefix(ATTR_ALIAS_META_PREFIX) {
                 if let Value::Str(source_name) = attr_val {
+                    // A sigilless attribute is in play — enable the cell-direct
+                    // routing's alias-table lookup (Phase 3 Stage 2c (ii)).
+                    self.interpreter.sigilless_attrs_active = true;
                     // Set up bidirectional alias: !x ↔ alias_name
                     self.interpreter.env_mut().insert(
                         format!("__mutsu_sigilless_alias::!{}", actual_attr),

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1462,6 +1462,40 @@ impl VM {
         Ok(Self::decrement_value(val))
     }
 
+    /// Propagate a scalar write along the `__mutsu_sigilless_alias::` chain from
+    /// `name`: each alias target receives `val` in env and its local slot, and an
+    /// attribute-twigil alias (`!x`) is additionally mirrored into self's shared
+    /// cell so a sigilless attribute write (`has $x; $x = v`) reaches the cell
+    /// (Phase 3 Stage 2c (ii)). Shared by the inc/dec ops; the cycle guard copes
+    /// with the bidirectional `x ↔ !x` alias table.
+    fn propagate_sigilless_alias_chain(&mut self, code: &CompiledCode, name: &str, val: &Value) {
+        let alias_key = format!("__mutsu_sigilless_alias::{}", name);
+        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+            if let Value::Str(n) = v {
+                Some(n.to_string())
+            } else {
+                None
+            }
+        });
+        let mut seen_aliases = std::collections::HashSet::new();
+        while let Some(current_alias) = alias_name {
+            if !seen_aliases.insert(current_alias.clone()) {
+                break;
+            }
+            self.set_env_with_main_alias(&current_alias, val.clone());
+            self.update_local_if_exists(code, &current_alias, val);
+            self.write_self_attr_cell(&current_alias, val.clone());
+            let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
+            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                if let Value::Str(n) = v {
+                    Some(n.to_string())
+                } else {
+                    None
+                }
+            });
+        }
+    }
+
     pub(super) fn exec_post_increment_op(
         &mut self,
         code: &CompiledCode,
@@ -1514,31 +1548,9 @@ impl VM {
             let new_val = self.increment_value_smart(&val)?;
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
-            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
-            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
-                if let Value::Str(n) = v {
-                    Some(n.to_string())
-                } else {
-                    None
-                }
-            });
-            let mut seen_aliases = std::collections::HashSet::new();
-            while let Some(current_alias) = alias_name {
-                if !seen_aliases.insert(current_alias.clone()) {
-                    break;
-                }
-                self.set_env_with_main_alias(&current_alias, new_val.clone());
-                self.update_local_if_exists(code, &current_alias, &new_val);
-                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
-                    if let Value::Str(n) = v {
-                        Some(n.to_string())
-                    } else {
-                        None
-                    }
-                });
-            }
+            // Propagate the new value along the sigilless alias chain and into
+            // self's shared cell for an attribute-twigil alias.
+            self.propagate_sigilless_alias_chain(code, name, &new_val);
             self.stack.push(val);
             return Ok(());
         }
@@ -1589,30 +1601,9 @@ impl VM {
                 self.set_env_with_main_alias(&target_name, val);
             }
         }
-        let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
-            if let Value::Str(name) = v {
-                Some(name.to_string())
-            } else {
-                None
-            }
-        });
-        let mut seen_aliases = std::collections::HashSet::new();
-        while let Some(current_alias) = alias_name {
-            if !seen_aliases.insert(current_alias.clone()) {
-                break;
-            }
-            self.set_env_with_main_alias(&current_alias, new_val.clone());
-            self.update_local_if_exists(code, &current_alias, &new_val);
-            let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
-                if let Value::Str(name) = v {
-                    Some(name.to_string())
-                } else {
-                    None
-                }
-            });
-        }
+        // Propagate the new value along the sigilless alias chain and into self's
+        // shared cell for an attribute-twigil alias.
+        self.propagate_sigilless_alias_chain(code, name, &new_val);
         // Write back to source variable when incrementing $_ bound to a container
         if name == "_"
             && let Some(ref source_var) = self.topic_source_var
@@ -1667,31 +1658,9 @@ impl VM {
             let new_val = self.decrement_value_smart(&val)?;
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
-            // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
-            let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
-                if let Value::Str(n) = v {
-                    Some(n.to_string())
-                } else {
-                    None
-                }
-            });
-            let mut seen_aliases = std::collections::HashSet::new();
-            while let Some(current_alias) = alias_name {
-                if !seen_aliases.insert(current_alias.clone()) {
-                    break;
-                }
-                self.set_env_with_main_alias(&current_alias, new_val.clone());
-                self.update_local_if_exists(code, &current_alias, &new_val);
-                let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
-                    if let Value::Str(n) = v {
-                        Some(n.to_string())
-                    } else {
-                        None
-                    }
-                });
-            }
+            // Propagate the new value along the sigilless alias chain and into
+            // self's shared cell for an attribute-twigil alias.
+            self.propagate_sigilless_alias_chain(code, name, &new_val);
             self.stack.push(val);
             return Ok(());
         }
@@ -1715,30 +1684,9 @@ impl VM {
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
-        let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
-            if let Value::Str(name) = v {
-                Some(name.to_string())
-            } else {
-                None
-            }
-        });
-        let mut seen_aliases = std::collections::HashSet::new();
-        while let Some(current_alias) = alias_name {
-            if !seen_aliases.insert(current_alias.clone()) {
-                break;
-            }
-            self.set_env_with_main_alias(&current_alias, new_val.clone());
-            self.update_local_if_exists(code, &current_alias, &new_val);
-            let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
-                if let Value::Str(name) = v {
-                    Some(name.to_string())
-                } else {
-                    None
-                }
-            });
-        }
+        // Propagate the new value along the sigilless alias chain and into self's
+        // shared cell for an attribute-twigil alias.
+        self.propagate_sigilless_alias_chain(code, name, &new_val);
         self.stack.push(val);
         Ok(())
     }
@@ -4215,13 +4163,52 @@ impl VM {
     /// when `name` is a scalar attr-twigil, `self` is a concrete instance, and
     /// the attribute exists in the cell.
     pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
-        Self::attr_twigil_base(name)?;
+        let twigil = self.canonical_attr_twigil(name)?;
         let self_val = self.get_env_with_main_alias("self")?;
         let Value::Instance { attributes, .. } = &self_val else {
             return None;
         };
-        let key = self.resolve_attr_cell_key(name, attributes)?;
+        let key = self.resolve_attr_cell_key(&twigil, attributes)?;
         attributes.as_map().get(&key).cloned()
+    }
+
+    /// Map a variable name to its canonical attribute-twigil form for cell access:
+    /// a direct twigil (`!x`/`@.y`/…) maps to itself; a bare sigilless name
+    /// (`has $x` → `Var("x")`) resolves through the runtime alias table to its
+    /// `!x` twigil. Returns `None` for ordinary (non-attribute) names. The
+    /// sigilless lookup is gated on `sigilless_attrs_active` so the common case
+    /// (no sigilless attributes) costs only a string check on the hot read path.
+    fn canonical_attr_twigil(&self, name: &str) -> Option<String> {
+        if Self::attr_twigil_base(name).is_some() {
+            return Some(name.to_string());
+        }
+        if !self.interpreter.sigilless_attrs_active {
+            return None;
+        }
+        self.sigilless_attr_twigil(name)
+    }
+
+    /// Follow the `__mutsu_sigilless_alias::` chain from a bare sigilless name
+    /// until it reaches an attribute twigil (`!x`), returning that twigil. The
+    /// alias table is bidirectional (`x ↔ !x`), so the `seen` guard prevents a
+    /// cycle; returns `None` if the chain has no attribute-twigil link.
+    fn sigilless_attr_twigil(&self, name: &str) -> Option<String> {
+        let mut current = name.to_string();
+        let mut seen = std::collections::HashSet::new();
+        while seen.insert(current.clone()) {
+            let key = format!("__mutsu_sigilless_alias::{}", current);
+            match self.interpreter.env().get(&key) {
+                Some(Value::Str(next)) => {
+                    let next = next.to_string();
+                    if Self::attr_twigil_base(&next).is_some() {
+                        return Some(next);
+                    }
+                    current = next;
+                }
+                _ => return None,
+            }
+        }
+        None
     }
 
     /// Skip mirroring slot values that keep their legacy handling (`:=` bindings,
@@ -4241,7 +4228,7 @@ impl VM {
     /// `name` (`!x`/`.x`), resolving the qualified private key when present.
     /// No-op when `name` is not a scalar attr-twigil, `self` is not a concrete
     /// instance, or the attribute does not exist on `self`.
-    fn write_self_attr_cell(&self, name: &str, val: Value) {
+    pub(super) fn write_self_attr_cell(&self, name: &str, val: Value) {
         if Self::attr_twigil_base(name).is_none() {
             return;
         }
@@ -5607,6 +5594,9 @@ impl VM {
             self.interpreter
                 .env_mut()
                 .insert(current_alias.clone(), val.clone());
+            // Sigilless attribute write: mirror an attr-twigil alias (`!x`) into
+            // self's shared cell (no-op for non-attribute aliases). Stage 2c (ii).
+            self.write_self_attr_cell(&current_alias, val.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
             alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
                 if let Value::Str(name) = v {


### PR DESCRIPTION
## Summary

Second step of **Phase 3 Stage 2c materialize/reconcile removal** (staged). Routes sigilless attributes (`has $x`) through the shared attribute cell, fixing a stale-read bug and taking that case out of the exit-time `reconcile_attrs`.

A sigilless attribute compiles to a bare `Var("x")` disambiguated only by the runtime `__mutsu_sigilless_alias::` table, so it never went through the Stage 2a twigil-keyed cell routing. A read of `$x` after a nested-frame (or same-frame) mutation saw the stale entry-time env copy:

```raku
class A { has $v = 1; method outer { self.inner; $v }; method inner { $v = 10 } }
A.new.outer   # returned 1 (the default), should be 10
```

## Changes

- **read**: `read_self_attr_cell` resolves a name to its canonical attribute twigil via `canonical_attr_twigil` (direct twigil → itself; bare sigilless → follow the alias chain to its `!x` twigil). Sigilless `$x` is not a method local so it reads via **GetGlobal** — added the cell-direct read there too.
- **write**: each of the six `__mutsu_sigilless_alias::` propagation loops (inc/dec ×4, name-based assign, SetGlobal) mirrors an attribute-twigil alias into the cell via `write_self_attr_cell`. The four identical inc/dec loops are factored into a single `propagate_sigilless_alias_chain` helper.
- **perf**: hot read path gated on a new process-sticky `sigilless_attrs_active` flag — programs without sigilless attributes pay only a string check. `int.t` unchanged (0.085s).

Both cell-bypass paths (attributive params from (i), sigilless here) now land in the cell at write time, clearing the way for reconcile/materialize removal in Stage 2c (iii).

## Verification

- `make test`: 6247 pass.
- S12/S14/S17/S06/S32-num whitelist (171 files, 6432 tests) and S02/S03/S04 (318 files, 32004 tests) all pass in release.
- Matches Rakudo: nested-frame read, same-method write-then-read, inc/dec, closure capture, multi-attribute mutation.
- `cargo clippy --all-targets`: clean. No `int.t` perf regression.

Design: `docs/container-identity.md` Phase 3 Stage 2c (ii).

🤖 Generated with [Claude Code](https://claude.com/claude-code)