### PR TITLE
fix(flat): descend Seq/List element arrays in the .flat method

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -4,7 +4,7 @@ use crate::value::{RuntimeError, Value};
 use num_traits::{Signed, Zero};
 use std::sync::Arc;
 
-use super::{flatten_deep_value, is_infinite_range, raku_round, raku_round_to_value};
+use super::{is_infinite_range, raku_round, raku_round_to_value};
 
 pub(super) fn dispatch(
     target: &Value,
@@ -37,29 +37,22 @@ pub(super) fn dispatch(
             })
         }
         "flat" => Some(match target {
-            Value::Array(items, kind) => {
-                if *kind == crate::value::ArrayKind::Shaped {
-                    let leaves = crate::runtime::utils::shaped_array_leaves(target);
-                    return Some(Some(Ok(Value::Seq(Arc::new(leaves)))));
-                }
-                let mut result = Vec::new();
-                for item in items.iter() {
-                    flatten_deep_value(item, &mut result, false);
-                }
-                Some(Ok(Value::Seq(Arc::new(result))))
-            }
-            Value::Seq(items) | Value::Slip(items) => {
-                let mut result = Vec::new();
-                for item in items.iter() {
-                    flatten_deep_value(item, &mut result, false);
-                }
-                Some(Ok(Value::Seq(Arc::new(result))))
+            Value::Array(_, crate::value::ArrayKind::Shaped) => {
+                let leaves = crate::runtime::utils::shaped_array_leaves(target);
+                Some(Ok(Value::Seq(Arc::new(leaves))))
             }
             other if is_infinite_range(other) => Some(Ok(other.clone())),
             Value::LazyList(_) => Some(Ok(target.clone())), // flat of a lazy list is still lazy
             _ => {
+                // Single source of truth: delegate to `flat_val` (also used by
+                // the `flat()` function) with List context (flatten_arrays =
+                // true). A Seq/List of nested arrays then descends one level --
+                // e.g. `(@a xx 4).flat` flattens its element arrays to match
+                // raku -- while a top-level real Array still itemizes its `[..]`
+                // children. The old per-method `flatten_deep_value` passed
+                // `false` for Seq children and so left them un-flattened.
                 let mut result = Vec::new();
-                flatten_deep_value(target, &mut result, false);
+                crate::builtins::flat_val(target, &mut result, true);
                 Some(Ok(Value::Seq(Arc::new(result))))
             }
         }),

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -670,27 +670,6 @@ pub(crate) fn is_value_lazy(value: &Value) -> bool {
         || matches!(value, Value::Seq(items) if crate::value::seq_is_lazy(items))
 }
 
-fn flatten_deep_value(value: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
-    match value {
-        Value::Array(items, kind) if *kind == ArrayKind::List || flatten_arrays => {
-            for item in items.iter() {
-                flatten_deep_value(item, out, flatten_arrays);
-            }
-        }
-        Value::Seq(items) | Value::Slip(items) => {
-            for item in items.iter() {
-                flatten_deep_value(item, out, flatten_arrays);
-            }
-        }
-        Value::Range(..)
-        | Value::RangeExcl(..)
-        | Value::RangeExclStart(..)
-        | Value::RangeExclBoth(..)
-        | Value::GenericRange { .. } => out.extend(crate::runtime::utils::value_to_list(value)),
-        other => out.push(other.clone()),
-    }
-}
-
 /// Format a range endpoint for display, converting i64::MAX to Inf and i64::MIN to -Inf.
 fn range_endpoint_display(v: i64) -> String {
     if v == i64::MAX {

--- a/t/flat-seq-nested-array.t
+++ b/t/flat-seq-nested-array.t
@@ -1,0 +1,26 @@
+use Test;
+
+# `.flat` on a Seq/List descends one level into its element arrays (they are
+# not itemized), while a top-level real Array `[..]` keeps its `[..]` children
+# itemized. Regression: the `.flat` method used a separate flattener that passed
+# `false` for Seq children, so e.g. `(@a xx 4).flat` left the repeated arrays
+# un-flattened (4 elems instead of 12) -- which broke roast S32-str/Collation.t.
+
+plan 8;
+
+my @c = -1, 0, 1;
+is (@c xx 4).flat.elems, 12, '(@a xx 4).flat fully descends the repeated arrays';
+is-deeply (@c xx 4).flat.List, (-1, 0, 1, -1, 0, 1, -1, 0, 1, -1, 0, 1),
+    '(@a xx 4).flat values';
+
+# Seq/List of arrays: descend one level.
+is ([1, 2], [3, 4]).flat.elems, 4, 'List of two arrays flattens one level';
+is ((1, 2), (3, 4)).flat.elems, 4, 'List of two lists flattens';
+is (1, (2, 3), 4).flat.elems, 4, 'mixed list flattens nested list';
+
+# Top-level real Array itemizes its `[..]` children: do NOT descend them.
+is [[1, 2], [3, 4]].flat.elems, 2, 'real Array does not descend itemized children';
+is [1, [2, 3]].flat.elems, 2, 'real Array keeps nested array itemized';
+
+# Plain flat is identity-ish on a flat array.
+is [1, 2, 3].flat.elems, 3, 'flat of a flat array is unchanged';


### PR DESCRIPTION
## Summary

The `.flat` **method** used a separate flattener (`flatten_deep_value`) that passed `flatten_arrays=false` for the children of a `Seq`/`Slip`, so a `Seq`/`List` of arrays was **not** descended. `(@a xx 4).flat` left the four repeated arrays intact (4 elems) instead of flattening to 12 — and disagreed with the `flat()` **function**, which uses the correct `flat_val`.

### Fix

Delegate the `.flat` method to the same `flat_val` used by `flat()`, with List context (`flatten_arrays=true`):
- a `Seq`/`List` descends one level into its element arrays (they are not itemized),
- a top-level real `Array` `[..]` still keeps its `[..]` children itemized.

Removes the now-dead `flatten_deep_value`. Single source of truth for flattening.

### Verified against rakudo

| expr | raku | mutsu (after) |
|------|------|------|
| `[[1,2],[3,4]].flat.elems` | 2 | 2 |
| `([1,2],[3,4]).flat.elems` | 4 | 4 |
| `((1,2),(3,4)).flat.elems` | 4 | 4 |
| `my @c=-1,0,1; (@c xx 4).flat.elems` | 12 | 12 |
| `[1,[2,3]].flat.elems` | 2 | 2 |

### Context

Surfaced via subtest plan enforcement on `roast/S32-str/Collation.t`: its 81-case loop `for (@c xx 4).flat.combinations(4).unique(...)` ran only **once** because `.flat` collapsed `(@c xx 4)` to 4 elements, so `combinations(4)` yielded a single combination. With this fix the subtest runs all 81 and Collation.t passes 15/15.

## Tests

- New `t/flat-seq-nested-array.t` (8 cases, verified under rakudo).
- `roast/S02-types/flattening.t`, `S32-list/flat.t`, `S17-supply/flat.t`, `Collation.t` PASS; `t/flat-method.t` and array/list local tests unaffected; non-whitelisted `array.t`/`for.t` fail identically to main (no regression).
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)