### PR TITLE
fix(control): make method/hyper warns resumable by CONTROL { .resume }

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2830,7 +2830,18 @@ impl VM {
                 arity,
                 modifier_idx,
             } => {
-                self.exec_call_method_dynamic_op(code, *arity, *modifier_idx)?;
+                match self.exec_call_method_dynamic_op(code, *arity, *modifier_idx) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // Record a resume point so a method that raises a
+                        // control signal (e.g. a resumable `warn`) can be
+                        // resumed after the call site by `.resume`.
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::CallMethodDynamicMut {
@@ -2839,12 +2850,20 @@ impl VM {
                 modifier_idx,
             } => {
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
-                self.exec_call_method_dynamic_mut_op(
+                match self.exec_call_method_dynamic_mut_op(
                     code,
                     *arity,
                     *target_name_idx,
                     *modifier_idx,
-                )?;
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
@@ -2863,7 +2882,7 @@ impl VM {
                 arg_sources_idx,
             } => {
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
-                self.exec_call_method_mut_op(
+                match self.exec_call_method_mut_op(
                     code,
                     *name_idx,
                     *arity,
@@ -2871,7 +2890,15 @@ impl VM {
                     *modifier_idx,
                     *quoted,
                     *arg_sources_idx,
-                )?;
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
@@ -3608,14 +3635,39 @@ impl VM {
                 modifier_idx,
                 quoted,
             } => {
-                self.exec_hyper_method_call_op(code, *name_idx, *arity, *modifier_idx, *quoted)?;
+                match self.exec_hyper_method_call_op(
+                    code,
+                    *name_idx,
+                    *arity,
+                    *modifier_idx,
+                    *quoted,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // A per-element method may raise a resumable warn (the
+                        // hyper op re-raises it carrying the full result); record
+                        // the resume point so `.resume` continues after the call.
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::HyperMethodCallDynamic {
                 arity,
                 modifier_idx,
             } => {
-                self.exec_hyper_method_call_dynamic_op(code, *arity, *modifier_idx)?;
+                match self.exec_hyper_method_call_dynamic_op(code, *arity, *modifier_idx) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
 

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -67,6 +67,19 @@ impl VM {
         // .reverse/.sort/.elems) operates on each node rather than recursing to
         // leaves, and its hyper result is a List rather than an Array.
         let mut method_is_nodal = false;
+        // A per-element native method may raise a *resumable* warn (e.g.
+        // `.indent(-N)` when asked to outdent more than exists). We cannot
+        // suspend the Rust loop to let an enclosing `CONTROL { .resume }` resume
+        // mid-iteration, so for the plain Array/List result path we collect the
+        // first such warn, use each element's carried resume value, and re-raise
+        // once after the loop with the *whole* result as the resume value. That
+        // lets the outer CONTROL (or the default warn handler) resume the entire
+        // hyper expression instead of aborting it. Container targets
+        // (Hash/Set/Bag/Mix) take their own early-return paths, so we leave their
+        // warns propagating as before.
+        let collect_warns = hash_keys.is_none()
+            && !matches!(&target, Value::Mix(..) | Value::Bag(..) | Value::Set(..));
+        let mut pending_warn: Option<RuntimeError> = None;
         for (idx, item) in items.iter_mut().enumerate() {
             let method = Self::rewrite_method_name(method_raw, modifier);
             // Special case: CALL-ME on callable items (from >>.(args) syntax).
@@ -312,7 +325,20 @@ impl VM {
                             if let Some(native_result) =
                                 self.try_native_method(item, Symbol::intern(&method), &item_args)
                             {
-                                native_result?
+                                match native_result {
+                                    Ok(v) => v,
+                                    // Resumable warn from a per-element native
+                                    // method: use its carried resume value and
+                                    // remember the warn to re-raise after the loop.
+                                    Err(e) if collect_warns && e.is_warn => {
+                                        let rv = e.return_value.clone().unwrap_or(Value::Nil);
+                                        if pending_warn.is_none() {
+                                            pending_warn = Some(e);
+                                        }
+                                        rv
+                                    }
+                                    Err(e) => return Err(e),
+                                }
                             } else {
                                 let (v, updated) = self.call_method_mut_with_temp_target(
                                     item, &method, item_args, idx,
@@ -460,8 +486,16 @@ impl VM {
             Value::Array(_, kind) if kind.is_real_array() && !method_is_nodal => ArrayKind::Array,
             _ => ArrayKind::List,
         };
-        self.stack
-            .push(Value::Array(std::sync::Arc::new(results), result_kind));
+        let result = Value::Array(std::sync::Arc::new(results), result_kind);
+        // A per-element native method raised a resumable warn: re-raise it once,
+        // carrying the whole hyper result as the resume value, so an enclosing
+        // `CONTROL { .resume }` (or the default warn handler) resumes the entire
+        // expression. The HyperMethodCall opcode records the resume point.
+        if let Some(mut warn) = pending_warn {
+            warn.return_value = Some(result);
+            return Err(warn);
+        }
+        self.stack.push(result);
         Ok(())
     }
 

--- a/t/control-resume-method-warn.t
+++ b/t/control-resume-method-warn.t
@@ -1,0 +1,65 @@
+use Test;
+
+# A resumable `warn` raised by a method call must be resumable by an enclosing
+# `CONTROL { .resume }`, regardless of whether the receiver is a literal (the
+# `CallMethod` opcode), a mutable variable (`CallMethodMut`), or each element of
+# a hyper call (`@a>>.meth`). Regression: only the literal-receiver path
+# recorded a resume point, so `$s.indent(-N)` and `@a>>.indent(-N)` under a
+# CONTROL block abandoned the rest of the enclosing block (roast S32-str/indent.t).
+
+plan 5;
+
+# Variable receiver: CallMethodMut path.
+{
+    my @log;
+    my $s = "A";
+    {
+        CONTROL { default { .resume } }
+        my $r = $s.indent(-4);
+        @log.push: "resumed:$r";
+    }
+    is @log, ["resumed:A"], 'CONTROL resumes a warn from a var-receiver method';
+}
+
+# Literal receiver: CallMethod path (was already working -- guard against regress).
+{
+    my @log;
+    {
+        CONTROL { default { .resume } }
+        my $r = "A".indent(-4);
+        @log.push: "resumed:$r";
+    }
+    is @log, ["resumed:A"], 'CONTROL resumes a warn from a literal-receiver method';
+}
+
+# Hyper receiver: each element warns; CONTROL resumes the whole expression.
+{
+    my @log;
+    my @c = "A", "B", "C";
+    {
+        CONTROL { default { .resume } }
+        my @r = @c>>.indent(-4);
+        @log.push: "elems:" ~ @r.elems;
+        @log.push: "join:" ~ @r.join(",");
+    }
+    is @log, ["elems:3", "join:A,B,C"],
+        'CONTROL resumes the whole hyper result through per-element warns';
+}
+
+# The block after a resumed hyper warn keeps executing (no early abort).
+{
+    my $reached = False;
+    my @c = "X";
+    {
+        CONTROL { default { .resume } }
+        my @r = @c>>.indent(-9);
+        $reached = True;
+    }
+    ok $reached, 'execution continues past a resumed hyper warn';
+}
+
+# A non-warning hyper method is unaffected.
+{
+    my @c = "a", "b";
+    is-deeply @c>>.uc, ["A", "B"], 'normal hyper method still works';
+}


### PR DESCRIPTION
## Summary

A resumable `warn` raised by a method (e.g. `.indent(-N)` asked to outdent more than exists) was only resumable when the **receiver was a literal**: only the `CallMethod` opcode recorded a resume point (`resume_ip`). With a mutable-variable receiver (`CallMethodMut`/`CallMethodDynamic`/`CallMethodDynamicMut`) or a hyper call (`@a>>.meth`), the warn propagated **without** a resume point, so an enclosing `CONTROL { .resume }` resumed to the end of the block and abandoned the rest of the body.

```raku
my $s = "A";
{
    CONTROL { default { .resume } }
    my $r = $s.indent(-4);   # before: block abandoned here
    say "after: $r";          # before: never printed; after: "after: A"
}
```

## Fix

1. Record `resume_ip` on a control-signal error in the `Mut`/`Dynamic` method-call opcodes and the two hyper-method opcodes, matching `CallMethod`.
2. The hyper op can't suspend its Rust loop to resume mid-iteration, so it now **collects the first per-element resumable warn** (using each element's carried resume value) and re-raises it once after the loop, carrying the **whole hyper result** as the resume value. An enclosing `CONTROL { .resume }` (or the default warn handler) then resumes the entire expression with correct results. Container targets (Hash/Set/Bag/Mix) keep propagating as before.

### Known minor fidelity gap

Without a CONTROL block, a hyper that warns on N elements now prints **one** warning rather than N; under `CONTROL { .resume }` (the case that matters) both suppress to zero and the result is correct. Per-element re-warning would require re-entering the Rust loop, which the resume model can't express.

## Context

Surfaced via subtest plan enforcement on `roast/S32-str/indent.t`, whose `@cases».indent(-N)` under `CONTROL { default { .resume } }` ran 1 of 6 tests. Now indent.t passes 63/63.

## Tests

- New `t/control-resume-method-warn.t` (5 cases: var/literal/hyper receivers + continuation + non-warning hyper; verified under rakudo).
- `roast/S32-str/indent.t` 63/63; `S04-exception-handlers/control.t`, `S04-statements/label.t` PASS; all `t/hyper*.t`/`t/warn*.t`/`t/control.t` unaffected.
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)