### PR TITLE
Phase 3 Stage 2c (iii-a): simplify reconcile to the shared cell as sole source

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -280,7 +280,17 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
                 検証: make test 6247、S12/S14/S17/S06/S32-num whitelist 171 ファイル 6432・S02/S03/S04 318 ファイル 32004 PASS、
                 int.t perf 0.085s（回帰なし）、nested-read/same-method write-read/inc-dec/closure/multi-attr すべて raku 一致。
                 reconcile は (iii) まで維持（sigilless 経路は今や cell 直結で reconcile case-2 は冗長だが無害）。
-          - [ ] **(iii) reconcile を `cell.to_map()` 置換 + materialize の attr-value env コピー撤去**。
+          - [x] **(iii-a) reconcile を cell 単一源に簡素化（landed: branch `phase3-stage2c-reconcile-removal`）**: `reconcile_attrs` の
+                entry-snapshot-vs-env の値比較（case-1 cell-changed / case-2 env-changed の優先判定 + sigil-by-type twigil 推定）を撤去し、
+                `*attributes = base.cell.to_map()`（cell が単一源）に。全 plain write（2a/2b/2c-i/ii）は write-time で cell に着地済みなので
+                cell snapshot が最終値。**例外 = `:=` 束縛属性**（`$!x := $outer`）: 外部 ContainerRef を env/locals に持ち cell を経由しない
+                **第3の bypass**（has-attr-binding.t で発覚）。cell.to_map() 後に env/locals の各 attr key（bare sigilless + 6 twigil）を走査し
+                ContainerRef なら優先採用して `:=` alias を method exit 越しに保全。検証: make test 6260、S12/S14/S17/S03-binding/S06 144 ファイル
+                2994 PASS、has-attr-binding 6/6、全 bypass/sigilless/attrparam テスト raku 一致。（S32-temporal/DateTime.t の 2 失敗は
+                `Date.today`=UTC vs `DateTime.now.Date`=local の pre-existing timezone バグで、変更退避した baseline でも同一＝非関連・
+                ローカル JST のみの artifact、CI=UTC では両者一致でパス。）
+          - [ ] **(iii-b) materialize の attr-value env コピー撤去**（reads は全 cell-direct なので冗長だが、env コピーの他消費者
+                — locals init / closure 捕捉 / `:=` ContainerRef 経路 — の監査が必要でより高リスク。別 PR）。
         - [ ] **registry 撤去（別 slice・後回し）**: `instance_cells` + `make_instance_detached`/`update_instance_cell` 撤去
               （callers が `self` の Arc を直接 in-place 変異する形へ。~50 の make_instance_with_id rebuild を全変換する all-or-nothing 大改修）+
               CAS の cell-CAS 化。

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -754,24 +754,21 @@ impl VM {
         })
     }
 
-    /// Phase 3 Stage 2: reconcile the entry-time attribute snapshot against the
-    /// two possible sources of an in-method change, while the method's
-    /// locals/env are still live. Covers scalar, array, and hash attributes.
+    /// Phase 3 Stage 2c (iii): the shared attribute cell is the source of truth
+    /// for ordinary attribute writes, so the post-method attribute map is its
+    /// current contents.
     ///
-    /// An attribute may have been changed two ways during the method:
-    /// 1. through the shared cell — cell-direct scalar writes (`$!x = v`),
-    ///    per-op mirrored array/hash mutations (`@!a.push`, `%!h<k>=`), and any
-    ///    mutation made in a nested method frame all land in the live cell, or
-    /// 2. through an env/local copy that never reached the cell — attributive
-    ///    params (`method m($!s)`/`method m(@!a)`), no-twigil sigilless aliases
-    ///    (`has $x; ... $x = v`), or `is rw` accessor stores.
+    /// Every plain in-method attribute change now lands in the cell at write time:
+    /// cell-direct scalar writes (`$!x = v`, Stage 2a), per-op mirrored array/hash
+    /// mutations (`@!a.push`, `%!h<k>=`, Stage 2b), attributive params
+    /// (`method m($!s)`, Stage 2c (i)), and sigilless aliases (`has $x`, Stage 2c
+    /// (ii)); cross-frame and nested-frame mutations are visible through the same
+    /// shared cell. The former entry-snapshot-vs-env value reconcile is gone.
     ///
-    /// Precedence: the cell wins when it changed from the entry snapshot (it is
-    /// the authoritative store and includes cross-frame mutations); otherwise an
-    /// env/local write that changed wins (case 2); otherwise the value is
-    /// unchanged. `attributes[k]` is the entry snapshot here because writeback no
-    /// longer mutates it. The result is written back through the cell by the
-    /// caller.
+    /// The one exception is a `:=`-bound attribute (`$!x := $outer`), which aliases
+    /// an external `ContainerRef` held in env/locals rather than the cell. The
+    /// cell-direct write path does not carry that binding, so recover it from
+    /// env/locals here and let it win, keeping the alias alive past method exit.
     fn reconcile_attrs(
         &self,
         base: &Value,
@@ -784,44 +781,44 @@ impl VM {
         else {
             return;
         };
-        // Snapshot the cell once (single read lock) rather than per attribute.
-        let cell_snapshot = cell.to_map();
+        *attributes = cell.to_map();
+        // Preserve `:=`-bound attributes: their authoritative value is the shared
+        // ContainerRef in env/locals, not the cell snapshot.
         let keys: Vec<String> = attributes.keys().cloned().collect();
         for k in keys {
             if k.starts_with(ATTR_ALIAS_META_PREFIX) {
                 continue;
             }
-            let original = attributes.get(&k).cloned().unwrap_or(Value::Nil);
-            let cell_val = cell_snapshot.get(&k).cloned();
-            // (1) The cell is authoritative when it changed from the entry value.
-            if let Some(cv) = &cell_val
-                && *cv != original
-            {
-                attributes.insert(k, cv.clone());
-                continue;
-            }
-            // (2) Otherwise an env/local write that bypassed the cell wins. Pick
-            // the twigil keys by the attribute's sigil (inferred from its value
-            // type). Qualified private key (`Owner\0attr`) maps to bare `!attr`.
             let bare = k.rsplit('\0').next().unwrap_or(&k);
-            let (priv_key, pub_key) = match cell_val.as_ref().unwrap_or(&original) {
-                Value::Array(..) => (format!("@!{}", bare), format!("@.{}", bare)),
-                Value::Hash(..) => (format!("%!{}", bare), format!("%.{}", bare)),
-                _ => (format!("!{}", bare), format!(".{}", bare)),
-            };
-            let env_changed = self
-                .attr_env_or_local(code, &priv_key)
-                .filter(|v| *v != original)
-                .or_else(|| {
-                    self.attr_env_or_local(code, &pub_key)
-                        .filter(|v| *v != original)
-                });
-            if let Some(v) = env_changed {
-                attributes.insert(k, v);
-            } else if let Some(cv) = cell_val {
-                attributes.insert(k, cv);
+            // Sigilless (`has $x` → bare `x`) and twigil (`$!x`/`@.x`/…) keys may
+            // hold the `:=` ContainerRef alias.
+            let candidates = [
+                bare.to_string(),
+                format!("!{}", bare),
+                format!(".{}", bare),
+                format!("@!{}", bare),
+                format!("@.{}", bare),
+                format!("%!{}", bare),
+                format!("%.{}", bare),
+            ];
+            for key in candidates {
+                if let Some(v) = self.attr_env_or_local(code, &key)
+                    && v.is_container_ref()
+                {
+                    attributes.insert(k.clone(), v);
+                    break;
+                }
             }
         }
+    }
+
+    /// Read the current value of `name` from the method's local slot if present,
+    /// else from env.
+    fn attr_env_or_local(&self, code: &CompiledCode, name: &str) -> Option<Value> {
+        if let Some(slot) = code.locals.iter().position(|n| n == name) {
+            return Some(self.locals[slot].clone());
+        }
+        self.interpreter.env().get(name).cloned()
     }
 
     /// Phase 3 Stage 2c (i): mirror attributive parameters (`$!x`/`@!a`/`%!h`)
@@ -843,15 +840,6 @@ impl VM {
                 self.mirror_attr_value_to_cell_by_name(code, &pd.name);
             }
         }
-    }
-
-    /// Read the current value of `name` from the method's local slot if present,
-    /// else from env.
-    fn attr_env_or_local(&self, code: &CompiledCode, name: &str) -> Option<Value> {
-        if let Some(slot) = code.locals.iter().position(|n| n == name) {
-            return Some(self.locals[slot].clone());
-        }
-        self.interpreter.env().get(name).cloned()
     }
 
     /// Fast path for read-only compiled methods. Bypasses all env_mut() calls


### PR DESCRIPTION
## Summary

Third step of **Phase 3 Stage 2c materialize/reconcile removal** (staged). With attributive params (i) and sigilless attributes (ii) now writing the cell at write time — joining the Stage 2a/2b cell-direct scalar and array/hash writes — every plain in-method attribute change lands in the shared cell. So the post-method attribute map is simply the cell's current contents.

## Changes

- Replace the entry-snapshot-vs-env value reconcile in `reconcile_attrs` (case-1 cell-changed / case-2 env-changed precedence + sigil-by-value-type twigil inference) with `*attributes = base.cell.to_map()`.
- **`:=`-bound attribute exception**: `$!x := $outer` aliases an external `ContainerRef` held in env/locals, not the cell (the cell-direct write path does not carry the binding). After the cell snapshot, scan env/locals for each attribute's bare sigilless name + six twigil forms and let a `ContainerRef` win, keeping the alias alive past method exit. (Regression caught by `t/has-attr-binding.t`, now passing.)

## Verification

- `make test`: 6260 pass.
- S12/S14/S17/S03-binding/S06 whitelist (144 files, 2994 tests) all pass in release.
- `t/has-attr-binding.t` 6/6; all bypass/sigilless/attributive-param cases match Rakudo. clippy clean.

> Note: `S32-temporal/DateTime.t` fails 2 subtests **locally** due to a pre-existing `Date.today`=UTC vs `DateTime.now.Date`=local timezone bug (reproduced identically with this change stashed) — visible only when the local TZ is a day ahead of UTC near midnight. CI runs in UTC where both agree.

Design: `docs/container-identity.md` Phase 3 Stage 2c (iii-a). The materialize attr-value env-copy removal (iii-b) is deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)