### PR TITLE
fix(test): enforce subtest plan count

### DIFF
--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -75,7 +75,11 @@ impl Interpreter {
             .as_ref()
             .map(|s| s.effective_ran())
             .unwrap_or(0);
-        let has_plan = subtest_state.as_ref().and_then(|s| s.planned).is_some();
+        let subtest_planned = subtest_state.as_ref().and_then(|s| s.planned);
+        let has_plan = subtest_planned.is_some();
+        // A subtest that declares a plan must run exactly that many tests. When it
+        // under/over-runs, rakudo reports it as a failure with a diagnostic line.
+        let plan_mismatch = matches!(subtest_planned, Some(p) if p != subtest_ran);
 
         self.tap.set_state(ctx.parent_test_state);
         self.output = ctx.parent_output;
@@ -93,6 +97,14 @@ impl Interpreter {
         self.emit_output(&format!("# Subtest: {}\n", label));
         if !has_plan {
             subtest_output.push_str(&format!("1..{}\n", subtest_ran));
+        } else if let Some(planned) = subtest_planned
+            && plan_mismatch
+        {
+            let plural = if planned == 1 { "" } else { "s" };
+            subtest_output.push_str(&format!(
+                "# You planned {} test{}, but ran {}\n",
+                planned, plural, subtest_ran
+            ));
         }
 
         let mut rendered_lines = Vec::new();
@@ -140,11 +152,11 @@ impl Interpreter {
             && subtest_had_not_ok
             && uses_parent_historical_reason;
         let ok = if parent_forced_todo_reason.is_some() {
-            run_result.is_ok() && !subtest_had_not_ok
+            run_result.is_ok() && !subtest_had_not_ok && !plan_mismatch
         } else if inherited_parent_todo {
             false
         } else {
-            run_result.is_ok() && subtest_failed == 0
+            run_result.is_ok() && subtest_failed == 0 && !plan_mismatch
         };
         self.test_ok(ok, label, inherited_parent_todo)?;
         Ok(())

--- a/t/subtest-plan.t
+++ b/t/subtest-plan.t
@@ -1,0 +1,31 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 4;
+
+# A subtest that declares a plan must run exactly that many tests. Under-running
+# the plan makes the subtest report `not ok` even when no inner test failed.
+is_run 'use Test; plan 1; subtest "under", { plan 3; ok 1, "a"; };', {
+    :out(/'# Subtest: under' .+ 'ok 1 - a' .+ 'planned 3 test' .+ 'but ran 1' .+ 'not ok 1 - under'/),
+    :err(/:i 'failed 1 test of 1'/),
+    :1status,
+}, 'under-running a subtest plan fails the subtest';
+
+# Over-running the plan also fails the subtest.
+is_run 'use Test; plan 1; subtest "over", { plan 1; ok 1, "a"; ok 1, "b"; };', {
+    :out(/'not ok 1 - over'/),
+    :1status,
+}, 'over-running a subtest plan fails the subtest';
+
+# A subtest that runs exactly its planned count passes.
+is_run 'use Test; plan 1; subtest "exact", { plan 2; ok 1, "a"; ok 1, "b"; };', {
+    :out(/'ok 1 - exact'/),
+    :0status,
+}, 'matching the subtest plan passes';
+
+# A planless subtest still passes when all inner tests pass.
+is_run 'use Test; plan 1; subtest "planless", { ok 1, "a"; ok 1, "b"; };', {
+    :out(/'ok 1 - planless'/),
+    :0status,
+}, 'planless subtest passes with all inner tests ok';


### PR DESCRIPTION
## Summary

mutsu's `subtest { plan N; ... }` did **not** enforce its plan: a subtest that planned N but ran a different number of tests still reported `ok`. Only the top-level (file) plan was checked. This let several whitelisted tests pass **vacuously** — a subtest whose body ran 0 of its planned tests (e.g. a `for @empty { ... }` that produced no iterations) was reported green.

`finish_subtest` now, when a subtest declares a plan, emits rakudo's `# You planned N tests, but ran M` diagnostic on mismatch and factors the mismatch into the ok/not-ok decision (forced-todo and normal branches). Uses the shared-atomic-aware count (`effective_ran`) so threaded passes are counted.

```raku
plan 1;
subtest "under-run" => sub { plan 3; ok 1, "a"; };
# before: ok 1 - under-run     (wrong)
# after:  # You planned 3 tests, but ran 1
#         not ok 1 - under-run
```

## Prerequisite fixes

Enforcement surfaced exactly four whitelisted tests that were passing vacuously — each a real latent bug now fixed in its own merged PR. This PR lands last, on top of all four:

- #2884 — `our`/implied `constant %h = Obj` called `.Map` twice (`constant-6.d.t`)
- #2885 — threaded `pass`/Promise `.then` not counted in subtest TAP (`S17-promise/in.t`)
- #2887 — `.flat` method didn't descend `Seq`/`List` element arrays (`S32-str/Collation.t`)
- #2888 — method/hyper resumable `warn` not resumable by `CONTROL { .resume }` (`S32-str/indent.t`)

## Verification

- Local: `t/subtest-plan.t` (new), `roast/S24-testing/11-plan-skip-all-subtests.t`, `12-subtest-todo.t` PASS.
- All four surfaced roast tests PASS **with** enforcement on this branch.
- Full `make roast` on this branch: the only failure is `S32-temporal/DateTime.t` (tests 185/231), a **pre-existing** `Date.today` UTC-vs-local timezone bug that fails identically on `main` in non-UTC local time and passes on CI (UTC). Unrelated to this change (top-level `is`, not a subtest).
- `make test` PASS (the lone transient `t/io-socket-async-listen.t` failure is flaky async-networking timing, passes on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)