### PR TITLE
fix(temporal): make Date.today use the local timezone

### DIFF
--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -205,7 +205,21 @@ impl Interpreter {
                         cn == "Date" || self.class_mro(&cn).iter().any(|name| name == "Date");
                     if is_date_like {
                         use crate::builtins::methods_0arg::temporal;
-                        let secs = crate::value::current_time_secs_f64() as i64;
+                        // Date.today uses the local timezone ($*TZ), matching
+                        // rakudo. Without the offset the date would be UTC, which
+                        // differs from DateTime.now.Date in non-UTC zones.
+                        let tz = self
+                            .env
+                            .get("*TZ")
+                            .and_then(|v| {
+                                if let Value::Int(n) = v {
+                                    Some(*n)
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(0i64);
+                        let secs = crate::value::current_time_secs_f64() as i64 + tz;
                         let epoch_days = secs.div_euclid(86400);
                         let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
                         if cn == "Date" {


### PR DESCRIPTION
## Summary
`Date.today` derived the civil date straight from UTC seconds (`current_time_secs_f64().div_euclid(86400)`), so in a non-UTC local timezone (e.g. JST) it could be a day off from `DateTime.now.Date`. rakudo's `Date.today` uses the local timezone, so this applies the `$*TZ` offset before computing the epoch day — the same source `dispatch_datetime_now` already uses.

## Why it mattered
This was the open bug noted while landing the subtest-plan enforcement work: `roast/S32-temporal/DateTime.t` tests 185 (coercion to Date) and 231 (positive smartmatch against a Date) failed **locally** in JST. They passed on CI only because CI runs in UTC, where UTC and local dates coincide.

## Verification
- `Date.today` now shifts with `$*TZ` (confirmed by forcing `$*TZ = ±172800`).
- `roast/S32-temporal/DateTime.t`: 314/314 PASS (release build).
- `roast/S32-temporal/Date.t`: 139/139 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)