### PR TITLE
Phase 3 Stage 2c (iii-b): drop slow-path materialize attribute env copies

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -289,8 +289,15 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
                 2994 PASS、has-attr-binding 6/6、全 bypass/sigilless/attrparam テスト raku 一致。（S32-temporal/DateTime.t の 2 失敗は
                 `Date.today`=UTC vs `DateTime.now.Date`=local の pre-existing timezone バグで、変更退避した baseline でも同一＝非関連・
                 ローカル JST のみの artifact、CI=UTC では両者一致でパス。）
-          - [ ] **(iii-b) materialize の attr-value env コピー撤去**（reads は全 cell-direct なので冗長だが、env コピーの他消費者
-                — locals init / closure 捕捉 / `:=` ContainerRef 経路 — の監査が必要でより高リスク。別 PR）。
+          - [x] **(iii-b) slow-path materialize の attr-value env コピー撤去（landed: branch `phase3-stage2c-materialize-removal`）**:
+                complex-param メソッド経路（`call_compiled_method`）の attr value env コピー挿入（`!attr`/`.attr`/`@!attr`/`@.attr`/
+                `%!attr`/`%.attr`、~30行）を撤去。reads は全 cell-direct（2a/2b/2c-ii）、exit reconcile は cell.to_map()（iii-a）なので冗長。
+                sigilless alias テーブル設定 + `is default` 登録は保持。検証: make test 6265、S12/S14/S04/S03-binding/S06 144 ファイル 3076 PASS、
+                closure が private/array/hash/sigilless attr を捕捉・読み書きするケース（reader/writer 返却・nested+closure・map/gather）すべて raku 一致。
+                **fast-path（`call_compiled_method_fast`）の array/hash env コピーは保持**: closure が `%!h<k>=v` 要素変異する経路は
+                **captured env コピー経由**で cell 非経由（撤去すると最初の要素変異が落ちる）。これは pre-existing な hash-element-via-closure の
+                cell 非対応（main でも `%!cache{k}=v` の closure 経由で最初の write が `(Any)` になる既知バグ）に依存しており、cell 化は別件。
+                fast-path scalar attr は locals 直挿入（env 非経由）のため対象外。
         - [ ] **registry 撤去（別 slice・後回し）**: `instance_cells` + `make_instance_detached`/`update_instance_cell` 撤去
               （callers が `self` の Arc を直接 in-place 変異する形へ。~50 の make_instance_with_id rebuild を全変換する all-or-nothing 大改修）+
               CAS の cell-CAS 化。

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -387,36 +387,12 @@ impl VM {
                 }
                 continue;
             }
-            // For private attributes ($!attr), prefer the class-qualified value
-            // from the method's owner class. This ensures that when Parent and Child
-            // both declare `$!priv`, Parent's method gets Parent's value.
-            let qualified_key = format!("{}\0{}", owner_class, attr_name);
-            let private_val = attributes.get(&qualified_key).unwrap_or(attr_val);
-            self.interpreter
-                .env_mut()
-                .insert(format!("!{}", attr_name), private_val.clone());
-            self.interpreter
-                .env_mut()
-                .insert(format!(".{}", attr_name), attr_val.clone());
-            match private_val {
-                Value::Array(..) => {
-                    self.interpreter
-                        .env_mut()
-                        .insert(format!("@!{}", attr_name), private_val.clone());
-                    self.interpreter
-                        .env_mut()
-                        .insert(format!("@.{}", attr_name), attr_val.clone());
-                }
-                Value::Hash(..) => {
-                    self.interpreter
-                        .env_mut()
-                        .insert(format!("%!{}", attr_name), private_val.clone());
-                    self.interpreter
-                        .env_mut()
-                        .insert(format!("%.{}", attr_name), attr_val.clone());
-                }
-                _ => {}
-            }
+            // Phase 3 Stage 2c (iii-b): the attribute value env copies (`!attr`,
+            // `.attr`, `@!attr`, …) that materialize used to insert here are no
+            // longer needed — every read of `$!x`/`$.x`/`@!a`/`%!h`/sigilless `$x`
+            // goes cell-direct (Stage 2a/2b/2c (ii)), and the exit reconcile reads
+            // the cell (Stage 2c (iii-a)). Only the sigilless alias table above is
+            // still required.
         }
 
         // Register `is default(...)` values for attribute variables so that
@@ -990,6 +966,12 @@ impl VM {
             } else {
                 env.remove("?ROLE");
             }
+            // Array/hash attribute env copies are still materialized here: an
+            // inner closure that mutates `@!a`/`%!h` by element (`%!h<k> = v`)
+            // observes them through the captured env copy, not the cell, so
+            // removing them drops the first such mutation (Stage 2c (iii-b) keeps
+            // the cell-direct *read* path but this write-capture path still needs
+            // the copy; see tmp closure hash-element test).
             for (attr_name, attr_val) in &attributes {
                 if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
                     continue;


### PR DESCRIPTION
## Summary

Final step of **Phase 3 Stage 2c materialize/reconcile removal** (staged). The complex-param method path (`call_compiled_method`) materialized an env copy of every attribute under all six twigil keys (`!attr`, `.attr`, `@!attr`, …). These are now redundant: every `$!x`/`$.x`/`@!a`/`%!h`/sigilless `$x` read goes cell-direct (Stage 2a/2b/2c (ii)) and the exit reconcile reads the cell (Stage 2c (iii-a)).

## Changes

- Remove the ~30-line attribute value env-copy insertion from the slow path. Keep the sigilless alias table setup and the `is default` registration.

## Kept (with reason)

- The **fast-path** (`call_compiled_method_fast`) array/hash env copies are kept: a closure that mutates `%!h<k> = v` by element observes the container through the captured env copy, not the cell, so removing it drops the first such mutation. That write-via-closure path is a **pre-existing** cell-bypass (on main, a closure doing `%!cache{$k} = $v` already loses its first write — returns `(Any)`); routing it to the cell is separate work.
- Fast-path **scalar** attributes are loaded straight into locals (never env), so they are unaffected.

## Verification

- `make test`: 6265 pass.
- S12/S14/S04/S03-binding/S06 whitelist (144 files, 3076 tests) all pass in release.
- Closures capturing and reading/writing private, array, hash, and sigilless attributes (reader/writer return, nested + closure, map/gather) all match Rakudo. clippy clean.

Design: `docs/container-identity.md` Phase 3 Stage 2c (iii-b). This completes the reconcile/materialize-removal arc; the remaining propagation-hack work (registry / `make_instance_with_id` rebuild / CAS cell-CAS) is tracked as a separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)