### PR TITLE
fix(parser): emit a real bind for `bareword := value` at statement level

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -7,7 +7,7 @@
 - [ ] roast/S04-blocks-and-statements/temp.t
 - [ ] roast/S04-declarations/constant-6.d.t
 - [ ] roast/S04-declarations/constant.t
-  - 63/72 pass (60 ok + 3 TODO). Fixed: `foo0()` parens always dispatch to the
+  - 65/72 pass (62 ok + 3 TODO). Fixed: `foo0()` parens always dispatch to the
     sub even when a same-named constant exists; `our`-scoped constants declared
     in an inner block are now visible in the outer scope and inside EVAL
     (resolved via the package `our_vars` store); a `try` that yields a soft
@@ -15,8 +15,11 @@
     last fix unblocked tests 20-72 that previously aborted the whole run).
     Remaining failures, each a distinct prerequisite:
     - Tests 24, 26: `constant baka := 23` (rebinding a term/constant via `:=`)
-      should be a compile-time error ("Cannot bind to '...' because it is a term
-      and terms cannot be rebound"); mutsu currently silently ignores the bind.
+      now raises. FIXED: a sigilless bareword on the LHS of `:=` at statement
+      level was parsed into a no-op block `{ baka; 23 }` that discarded the bind;
+      it now emits a real bind, which hits the readonly path and throws
+      (X::Assignment::RO). rakudo throws X::Bind::Rebind instead, but these
+      subtests only assert that the bind raises. (t/constant-rebind.t)
     - Test 44: enum-variant access through a constant type alias (`G::c` where
       `my constant G = F::B`) does not parse.
     - Test 46: `constant fib := 0, 1, *+* ... *; fib[100]` — indexing a lazy
@@ -30,8 +33,9 @@
       &infix:<snowman>` then a new `multi infix:<comet>` candidate must also be
       visible through `snowman`); plus tests 70-71 need the `ExportConstant`
       module and 72 needs a regex stored in a `constant $`-sigil term.
-    Difficulty: Medium per-fix, but full whitelist blocked by the lazy-sequence
-    (46), constant-aliased qualified name (44), and multi-sharing (69) features.
+    Difficulty: Medium per-fix, but full whitelist still blocked by the
+    lazy-sequence (46), constant-aliased qualified name (44), and multi-sharing
+    (69) features.
 - [ ] roast/S04-declarations/implicit-parameter.t
 - [ ] roast/S04-declarations/multiple.t
   - 3/8 pass (tests 1-3). Failures: `my ($a, $b) = (1, 2)` destructuring works but `my ($a, @b)` with slurpy not supported; `my ($a, *@b)` splat syntax not implemented; `state` declarations not supported. Difficulty: Medium

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1382,7 +1382,19 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
-        let stmt = Stmt::Block(vec![Stmt::Expr(expr), Stmt::Expr(rhs)]);
+        // A sigilless bareword on the LHS of `:=` binds to that named symbol
+        // (e.g. a `constant`). Emit a real bind so it raises for a readonly
+        // constant ("terms cannot be rebound") instead of silently evaluating
+        // both sides as a no-op block.
+        let stmt = if let Expr::BareWord(name) = expr {
+            Stmt::Expr(Expr::AssignExpr {
+                name,
+                expr: Box::new(rhs),
+                is_bind: true,
+            })
+        } else {
+            Stmt::Block(vec![Stmt::Expr(expr), Stmt::Expr(rhs)])
+        };
         return parse_statement_modifier(r, stmt);
     }
 

--- a/t/constant-rebind.t
+++ b/t/constant-rebind.t
@@ -1,0 +1,42 @@
+use Test;
+
+# Binding (`:=`) to a sigilless `constant` at statement level must raise,
+# not silently no-op. Previously `name := value` for a bareword LHS parsed
+# into a meaningless block `{ name; value }` that evaluated both sides and
+# discarded the bind, so the error never fired.
+
+plan 6;
+
+{
+    constant baka = 42;
+    my $ok = 0;
+    $ok++ if baka == 42;
+    try { EVAL 'baka := 23' };
+    $ok++ if $!;            # the bind must throw
+    $ok++ if baka == 42;    # ... and leave the constant unchanged
+    is $ok, 3, 'binding an Int to a constant throws and does not change it';
+}
+
+{
+    constant wibble = 42;
+    my $ok = 0;
+    $ok++ if wibble == 42;
+    try { EVAL 'wibble := { 23 }' };
+    $ok++ if $!;
+    $ok++ if wibble == 42;
+    is $ok, 3, 'binding a block to a constant throws and does not change it';
+}
+
+# Assignment to a constant already raised; keep it covered here too.
+{
+    constant wobble = 7;
+    dies-ok { EVAL 'wobble = 99' }, 'assigning to a constant dies';
+    is wobble, 7, 'constant value is preserved after a failed assignment';
+}
+
+# A sigilless `\term` is readonly as well; reading it still works.
+{
+    my \term = 5;
+    is term, 5, 'sigilless term reads back its value';
+    dies-ok { EVAL 'term := 6' }, 'rebinding a sigilless term dies';
+}


### PR DESCRIPTION
## Summary
A sigilless bareword on the LHS of `:=` at statement level (e.g. binding to a `constant`) was parsed into a meaningless block `{ bareword; value }` that evaluated both sides and **silently discarded the bind**. So `constant c = 1; c := 2` was a no-op instead of raising.

This emits a real bind (`AssignExpr { is_bind: true }`) for a bareword LHS in the statement-level `:=` path (`src/parser/stmt/simple_expr_stmt.rs`), so it goes through the readonly path and raises for a readonly constant — consistent with the rest of the constant-immutability behavior.

rakudo raises `X::Bind::Rebind` ("Cannot bind to '…' because it is a term and terms cannot be rebound"); mutsu raises `X::Assignment::RO` here. Both satisfy the affected roast subtests, which only assert that the bind raises.

## Result
- Fixes `roast/S04-declarations/constant.t` tests **24** and **26** (now 65/72).
  The file is still not whitelistable — it remains blocked on the lazy-sequence `fib[100]` (test 46) and the constant-aliased qualified name `G::c` (test 44), both pre-existing deferred blockers documented in `TODO_roast/S04.md`.
- No regression: `S03-binding/scalars.t` (2) and `S03-binding/nested.t` (18) failure counts are identical before/after (those are sigilled `$var :=`, a different parse path; pre-existing container-identity blockers).
- `make test`: all 699 files pass.
- Adds `t/constant-rebind.t` (6 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)