### PR TITLE
Phase 2 (A): give the VM its own registry handle

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -220,7 +220,7 @@ pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) mod value_iterator;
 pub(crate) use self::registration_class::ClassDeclModifiers;
-pub(crate) use self::registry::Registry;
+pub(crate) use self::registry::{Registry, RegistryWriteGuard};
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};
 
 pub(crate) use utils::*;
@@ -5211,6 +5211,18 @@ impl Interpreter {
     #[inline]
     pub(crate) fn registry(&self) -> crate::runtime::registry::RegistryReadGuard<'_> {
         crate::runtime::registry::RegistryReadGuard::new(&self.registry)
+    }
+
+    /// Clone the shared declaration [`Registry`] handle so the VM can hold it as a
+    /// peer (PLAN.md ② → A: VM owns its own handle to the same `RwLock`). Both the
+    /// Interpreter and the VM end up pointing at the *same* lock, so mutations
+    /// through either are visible and the debug re-entrancy guard (keyed by lock
+    /// address) still correctly flags a deadlocking re-acquire. Once the
+    /// Interpreter execution path is removed (④/⑤), this collapses to a plain VM
+    /// field and the handle clone disappears.
+    #[inline]
+    pub(crate) fn registry_handle(&self) -> Arc<RwLock<Registry>> {
+        self.registry.clone()
     }
 
     /// Write access to the shared declaration [`Registry`]. Same guard discipline

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::result_large_err)]
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::ast::Stmt;
 use crate::env::Env;
@@ -86,6 +86,14 @@ pub(super) struct VmCallFrame {
 
 pub(crate) struct VM {
     interpreter: Interpreter,
+    /// Handle to the shared declaration [`Registry`](crate::runtime::Registry),
+    /// cloned from the interpreter at construction (PLAN.md ② → A: the VM holds the
+    /// registry as a *peer* rather than reaching through `self.interpreter`). Points
+    /// at the same `RwLock` as `self.interpreter`'s handle, so mutations through
+    /// either are visible. Stable for the VM's lifetime: the interpreter's registry
+    /// Arc is only ever replaced by `clone_for_thread` (which builds a fresh
+    /// Interpreter for a child thread), never reassigned in place during a run.
+    registry: Arc<RwLock<crate::runtime::Registry>>,
     stack: Vec<Value>,
     locals: Vec<Value>,
     in_smartmatch_rhs: bool,
@@ -399,8 +407,10 @@ impl VM {
     }
 
     pub(crate) fn new(interpreter: Interpreter) -> Self {
+        let registry = interpreter.registry_handle();
         Self {
             interpreter,
+            registry,
             stack: Vec::new(),
             locals: Vec::new(),
             in_smartmatch_rhs: false,
@@ -452,6 +462,18 @@ impl VM {
             gather_for_loop_resume: None,
             rw_map_topic_capture: None,
         }
+    }
+
+    /// Write access to the shared declaration [`Registry`](crate::runtime::Registry)
+    /// via the VM's own handle (no `self.interpreter` bounce). Same lock and same
+    /// guard discipline as the interpreter's `registry_mut`: never hold the guard
+    /// across user-code re-entry. (A read counterpart will be added when a
+    /// pure-registry VM read site lands; today every VM-side registry read still
+    /// needs `current_package`/env, so routing it here would duplicate interpreter
+    /// logic — forbidden by the "1 operation = 1 implementation" rule.)
+    #[inline]
+    pub(crate) fn registry_mut(&self) -> crate::runtime::RegistryWriteGuard<'_> {
+        crate::runtime::RegistryWriteGuard::new(&self.registry)
     }
 
     /// Run the compiled bytecode. Always returns the interpreter back
@@ -3618,12 +3640,12 @@ impl VM {
             }
             OpCode::RegisterPackageStub { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.interpreter.registry_mut().package_stubs.insert(name);
+                self.registry_mut().package_stubs.insert(name);
                 *ip += 1;
             }
             OpCode::ClearPackageStub { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.interpreter.registry_mut().package_stubs.remove(&name);
+                self.registry_mut().package_stubs.remove(&name);
                 *ip += 1;
             }
 


### PR DESCRIPTION
## What

First strangler-fig step of **phase ② → A** (VM へ registry ハンドル移管): the VM now holds its own clone of the shared `Arc<RwLock<Registry>>` handle instead of reaching the registry only through `self.interpreter.registry_mut()`.

- `Interpreter::registry_handle()` clones the shared `Arc` handle.
- `VM` gains a `registry` field (cloned at `VM::new`) + a `registry_mut()` accessor. Both handles point at the **same** `RwLock`, so mutations are visible through either and the debug re-entrancy guard (keyed by lock address) still correctly flags deadlocking re-acquires.
- The two VM-direct registry sites (`RegisterPackageStub`/`ClearPackageStub` — the only direct registry access in the VM) now use `self.registry_mut()`.

## Why this is safe

The interpreter's registry `Arc` is **stable for a VM's lifetime** — it is only ever replaced by `clone_for_thread` (which builds a fresh `Interpreter` for a child thread), never reassigned in place during a run — so the clone-at-`new` handle never goes stale.

No read accessor is added yet: every remaining VM-side registry read still needs `current_package`/env, so routing it through `self.registry()` would duplicate interpreter logic (forbidden by the "1 operation = 1 implementation" rule). The read counterpart lands when a pure-registry VM read site appears (③).

## Scope

Behavior-invariant structural refactor. The `Arc`/lock remains transitional scaffolding; the final fold to a plain VM field happens after the Interpreter execution path is removed (④/⑤).

## Verification

- `cargo build` + `cargo clippy -- -D warnings` clean
- `cargo test` 458/0
- `make test` PASS (699 files, 6269 tests)
- whitelisted S12-class/basic, S12-class/inheritance, S14-roles/basic, S12-enums/basic green

🤖 Generated with [Claude Code](https://claude.com/claude-code)