### PR TITLE
feat(whatever): compose a parenthesized WhateverCode operand into a new WhateverCode

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -77,19 +77,14 @@ do NOT spend time here, the file cannot reach a clean pass as written.
 **Genuinely-achievable remainder** (self-contained features; concrete approach
 given so the next worker can start cold):
 
-1. **S03-buf/write-int.t** — *Hard (large but mechanical).* 2530 tests.
-   **Reclassified — the blockers are Whatever-currying, not 128-bit.**
-   128-bit `read-int128`/`write-int128`/`-uint128` and dynamic interpolated method
-   names (`."read-int{8*$_}"(...)`) already work across all endiannesses
-   (verified: `blob8.new(1..16).read-int128(0,BigEndian)` returns the right value).
-   The test aborts in *setup* (before `plan`) on two Whatever-composition bugs:
-   - `1 +< (*-1) - 1` throws "Callable expected" — a WhateverCode `(*-1)` does not
-     curry through an enclosing `1 +< … - 1` into a new WhateverCode.
-   - `(^*).roll` evaluates to the un-rolled Range `0..^N` instead of a
-     WhateverCode `{ (^$_).roll }` — `.roll` (and method calls generally) on a
-     `^*` Whatever-range is not deferred into the curried closure.
-   Fix the Whatever-currying of chained infix ops and trailing method calls
-   first (broad impact, well beyond this file); the Buf widths are already done.
+1. **S03-buf/write-int.t** — *DONE, whitelisted (2530/2530).* The two
+   Whatever-composition setup bugs (`1 +< (*-1) - 1` threw "Callable expected";
+   `(^*).roll` returned the un-rolled Range) are fixed: an already-wrapped
+   WhateverCode operand now composes into a new WhateverCode through general
+   infix/unary/method-call/index/InfixFunc/R-metaop positions (NOT through `xx`,
+   list comma, or a direct `(wc)(args)` call). `count_whatever`/`replace_whatever_*`
+   already knew how to inline a nested closure; only `contains_whatever`/
+   `count_whatever` needed to detect a wrapped-WhateverCode operand.
 
 **Defer — needs deep/crate-level work (file fully passes only after a big lift):**
 - S32-io/io-path.t — 6 *independent* failures; one (test 31 `.gist`) depends on a
@@ -585,10 +580,9 @@ no per-slot `Scalar` container (first-class container identity).
 - roast/S02-types/pair.t — **Hard (container identity)**. 3/180 fail. Tests
   128/139 need `$pair.value` to alias the original variable's container; only
   test 171 (typed-assign throw) is independent. See "Do NOT pick" above.
-- roast/S03-buf/write-int.t — **Hard (large but mechanical)**. 2530 tests. The
-  128-bit read/write and dynamic interpolated method names already work; the file
-  aborts in *setup* on two Whatever-currying bugs (see the Tier 1 entry for the
-  exact reproductions). Fix Whatever-currying first.
+- roast/S03-buf/write-int.t — **DONE, whitelisted (2530/2530).** The two
+  Whatever-currying setup bugs are fixed (see the Tier 1 entry); a parenthesized
+  WhateverCode now composes into a new WhateverCode through surrounding operators.
 - roast/S04-blocks-and-statements/temp.t — **Medium**. 30/37 (7 remaining): `temp`
   restoration interacting with hash/array element containers (container identity).
 - roast/S04-declarations/constant.t — **Medium**. 65/72 (24/26 fixed in #2893).

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -15,7 +15,13 @@
 - [ ] roast/S03-buf/read-num.t
   - Reaches 72/200 subtests, then exits due missing `Blob/Buf` numeric read family (`read-num32`, `read-num64`) behavior/completeness.
 - [ ] roast/S03-buf/read-write-bits.t
-- [ ] roast/S03-buf/write-int.t
+- [x] roast/S03-buf/write-int.t
+  - 2530/2530, whitelisted. 128-bit read/write and dynamic interpolated method
+    names already worked; the file aborted in *setup* on two Whatever-currying
+    bugs (`1 +< (*-1) - 1`, `(^*).roll`). Fixed by composing an already-wrapped
+    WhateverCode operand into a new WhateverCode (general infix/unary/method-call/
+    index/InfixFunc/R-metaop positions), so a parenthesized curry like `(* - 1)`
+    composes through `- 1`, `1 +< ...`, `.roll`, etc.
 - [ ] roast/S03-buf/write-num.t
 - [ ] roast/S03-feeds/basic.t
 - [ ] roast/S03-junctions/associative.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -166,6 +166,7 @@ roast/S03-binding/ro.t
 roast/S03-buf/read-int.t
 roast/S03-buf/read-num.t
 roast/S03-buf/read-write-bits.t
+roast/S03-buf/write-int.t
 roast/S03-buf/write-num.t
 roast/S03-feeds/basic.t
 roast/S03-junctions/associative.t

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -531,6 +531,27 @@ pub(super) fn is_whatever(expr: &Expr) -> bool {
     matches!(expr, Expr::Whatever)
 }
 
+/// True when `expr` is an already-wrapped WhateverCode closure (produced by a
+/// parenthesized curry such as `(* - 1)`). Such a closure is opaque as a *value*
+/// (e.g. when passed as an argument or stored in a variable), but when it appears
+/// as an *operand* of a further operator/method in the same expression, Raku
+/// composes it into a new, larger WhateverCode (`(* - 1) - 1`, `(^*).roll`,
+/// `1 +< (* - 1)`). The currying machinery (`count_whatever` /
+/// `replace_whatever_*`) already knows how to inline such a closure; this helper
+/// lets the composing operand positions detect it.
+fn is_wrapped_whatevercode(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Lambda {
+            is_whatever_code: true,
+            ..
+        } | Expr::AnonSubParams {
+            is_whatever_code: true,
+            ..
+        }
+    )
+}
+
 pub(super) fn contains_whatever(expr: &Expr) -> bool {
     match expr {
         e if is_whatever(e) => true,
@@ -578,8 +599,24 @@ pub(super) fn contains_whatever(expr: &Expr) -> bool {
             op: TokenKind::Ident(name),
             ..
         } if name == "o" || name == "\u{2218}" => false,
-        Expr::Binary { left, right, .. } => contains_whatever(left) || contains_whatever(right),
-        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => contains_whatever(expr),
+        // `xx` replicates its LHS as a value N times (producing a Seq), so a
+        // WhateverCode LHS is NOT composed — `(* - 1) xx 3` is a Seq of three
+        // WhateverCodes, not a curried WhateverCode. Keep the historical
+        // bare-`*` behavior (only the literal placeholder triggers wrapping).
+        Expr::Binary {
+            op: TokenKind::Ident(name),
+            left,
+            right,
+        } if name == "xx" => contains_whatever(left) || contains_whatever(right),
+        Expr::Binary { left, right, .. } => {
+            contains_whatever(left)
+                || contains_whatever(right)
+                || is_wrapped_whatevercode(left)
+                || is_wrapped_whatevercode(right)
+        }
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => {
+            contains_whatever(expr) || is_wrapped_whatevercode(expr)
+        }
         // Pseudo-methods (.WHAT, .WHO, .HOW, etc.) are always evaluated immediately
         // on Whatever, they don't create WhateverCode. e.g. *.WHAT returns (Whatever).
         Expr::MethodCall { target, name, .. }
@@ -591,7 +628,7 @@ pub(super) fn contains_whatever(expr: &Expr) -> bool {
             false
         }
         Expr::MethodCall { target, .. } | Expr::DynamicMethodCall { target, .. } => {
-            contains_whatever(target)
+            contains_whatever(target) || is_wrapped_whatevercode(target)
         }
         Expr::CallOn { target, args } => {
             // Already-wrapped WhateverCode args (Lambda/AnonSubParams with
@@ -614,7 +651,7 @@ pub(super) fn contains_whatever(expr: &Expr) -> bool {
         }
         // Only check target, not index: @a[*-1] should NOT make the whole expr a WhateverCode.
         // The [*-1] subscript handles its own WhateverCode wrapping.
-        Expr::Index { target, .. } => contains_whatever(target),
+        Expr::Index { target, .. } => contains_whatever(target) || is_wrapped_whatevercode(target),
         // User-defined infix operators: `* quack 5`, `3 quack *`, etc.
         // Exclude flip-flop operators (ff, fff and variants) since `ff *` means
         // "stay true forever" and `*` should not trigger WhateverCode wrapping.
@@ -628,14 +665,23 @@ pub(super) fn contains_whatever(expr: &Expr) -> bool {
             if is_flipflop {
                 return false;
             }
-            contains_whatever(left) || right.iter().any(contains_whatever)
+            contains_whatever(left)
+                || is_wrapped_whatevercode(left)
+                || right
+                    .iter()
+                    .any(|e| contains_whatever(e) || is_wrapped_whatevercode(e))
         }
         // R meta-operators with Whatever: `5 R- *` should curry.
         // X/Z meta-operators with bare * in list contexts mean "extend" rather
         // than WhateverCode, so only enable for R (reverse) meta-ops.
         Expr::MetaOp {
             meta, left, right, ..
-        } if meta == "R" => contains_whatever(left) || contains_whatever(right),
+        } if meta == "R" => {
+            contains_whatever(left)
+                || contains_whatever(right)
+                || is_wrapped_whatevercode(left)
+                || is_wrapped_whatevercode(right)
+        }
         _ => false,
     }
 }
@@ -644,6 +690,18 @@ pub(super) fn contains_whatever(expr: &Expr) -> bool {
 fn count_whatever(expr: &Expr) -> usize {
     match expr {
         e if is_whatever(e) => 1,
+        // A nested, already-wrapped WhateverCode operand (e.g. `(* - 1)` inside
+        // `(* - 1) - 1`) contributes its own placeholder count: a single-param
+        // `_`/`__wc_0` lambda counts as 1, a multi-param one as its arity.
+        Expr::Lambda {
+            is_whatever_code: true,
+            ..
+        } => 1,
+        Expr::AnonSubParams {
+            is_whatever_code: true,
+            params,
+            ..
+        } => params.len(),
         Expr::Binary {
             left,
             op: TokenKind::AndAnd,
@@ -1081,6 +1139,21 @@ fn replace_whatever_single(expr: &Expr) -> Expr {
         Expr::Lambda { param, body, .. } if param == "_" => {
             if let Some(Stmt::Expr(e)) = body.first() {
                 e.clone()
+            } else {
+                Expr::Var("_".to_string())
+            }
+        }
+        // A nested single-param WhateverCode built as AnonSubParams (its body
+        // referenced $_, so it uses a numbered param): rename that param to $_
+        // so it shares the composed closure's single topic.
+        Expr::AnonSubParams {
+            params,
+            body,
+            is_whatever_code: true,
+            ..
+        } if params.len() == 1 => {
+            if let Some(Stmt::Expr(e)) = body.first() {
+                rename_var(e, &params[0], "_")
             } else {
                 Expr::Var("_".to_string())
             }

--- a/t/whatevercode-compose.t
+++ b/t/whatevercode-compose.t
@@ -1,0 +1,79 @@
+use Test;
+
+# A parenthesized WhateverCode used as an operand of a further operator/method
+# composes into a new, larger WhateverCode (Raku currying semantics).
+
+plan 17;
+
+# Infix with a WhateverCode operand
+{
+    my $f = (* - 1) - 1;
+    isa-ok $f, Callable, '(* - 1) - 1 is a WhateverCode';
+    is $f(6), 4, '(* - 1) - 1 composes';
+}
+{
+    my $f = 1 +< (* - 1);
+    is $f(6), 32, '1 +< (* - 1) composes';
+}
+{
+    my $f = 1 +< (*-1) - 1;
+    is $f(64), 9223372036854775807, 'chained infix over WhateverCode composes';
+}
+{
+    my $f = (* + 1) * 2;
+    is $f(6), 14, '(* + 1) * 2 composes';
+}
+{
+    my $f = 2 * (* + 1);
+    is $f(6), 14, '2 * (* + 1) composes';
+}
+{
+    my $f = (* - 1) ** 2;
+    is $f(4), 9, '(* - 1) ** 2 composes';
+}
+
+# Each bare * stays a separate positional argument when inlined
+{
+    my $f = * + (* - 1);
+    is $f(10, 20), 29, 'outer * plus a parenthesized WhateverCode -> 2-arg';
+}
+{
+    my $f = (* - 1) + (* - 1);
+    is $f(10, 20), 28, 'two parenthesized WhateverCodes -> 2-arg';
+}
+{
+    my $f = (* + *) - 1;
+    is $f(10, 20), 29, 'parenthesized 2-arg WhateverCode composes';
+}
+
+# Method call on a WhateverCode target composes
+{
+    my $f = (* - 1).abs;
+    is $f(-3), 4, '(* - 1).abs composes';
+}
+{
+    my $f = (^*).roll;
+    ok 0 <= $f(6) < 6, '(^*).roll composes into a rolling WhateverCode';
+}
+{
+    my $f = -(* - 1);
+    is $f(5), -4, 'prefix negate over a WhateverCode composes';
+}
+
+# `x` (string repeat) composes; `xx` does NOT (it replicates as a Seq value)
+{
+    my $f = (* - 1) x 3;
+    is $f(6), '555', '(* - 1) x 3 composes (string repeat)';
+}
+{
+    my @s = (* - 1) xx 3;
+    is @s.elems, 3, '(* - 1) xx 3 is a 3-element Seq, not a WhateverCode';
+    ok @s[0] ~~ Callable, 'each xx element is itself a WhateverCode';
+}
+
+# A direct call of a parenthesized WhateverCode is NOT composed
+{
+    is (* - 1)(5), 4, '(* - 1)(5) is a direct call, not a composition';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

A parenthesized curry like `(* - 1)` is sealed into a WhateverCode closure at parse time. When that closure then appears as an **operand** of a further operator/method in the same expression, Raku composes it into a new, larger WhateverCode — with each bare `*` becoming a separate positional argument:

```raku
(* - 1) - 1      # WhateverCode { ($_ - 1) - 1 }
1 +< (* - 1)     # WhateverCode { 1 +< ($_ - 1) }
(^*).roll        # WhateverCode { (^$_).roll }
(* - 1).abs      # WhateverCode { ($_ - 1).abs }
(* + *) - 1      # 2-arg WhateverCode
```

mutsu sealed the inner closure too eagerly, and `contains_whatever`/`count_whatever` treated it as opaque, so the surrounding operator evaluated it as a value rather than currying (`1 +< (* - 1)` produced an `Int`; `(^*).roll` returned the un-rolled `Range`). The inlining machinery (`replace_whatever_*`) already knew how to splice a nested closure's body — only the detection/count was missing.

## Change

Detect an already-wrapped WhateverCode (`Lambda`/`AnonSubParams` with `is_whatever_code: true`) as a composable operand in the infix, unary, postfix, method-call-target, index-target, user-infix and R-metaop positions; count its placeholders; and inline a single-param `AnonSubParams` in the single-arg path.

Composition is deliberately **not** triggered for `xx` (replicates its LHS as a `Seq`), list comma, or a direct `(wc)(args)` call — matching Raku.

## Impact

Unblocks **roast/S03-buf/write-int.t**, which aborted in *setup* on the two currying bugs above. It now passes **2530/2530** and is whitelisted. `roast/S02-types/whatever.t` also advances 50→73 passing subtests (the remaining failures are unrelated, pre-existing WhateverCode features now reached further into the file).

New focused coverage: `t/whatevercode-compose.t` (17 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)