### PR TITLE
refactor(io): closure-form handle-state API (③ native IO PR-A)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -116,4 +116,15 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
 - **crux 発見（着手時, 2026-06-11）**: `handle_state_mut` の `&mut IoHandleState` 返し API（~32 呼び出し側）が
   guard 寿命と両立せず、registry の軽い抽出にならないと判明。スライスを「PR-A=closure 形 API 再設計（plain
   field のまま地ならし）→ PR-B=lock 化 → PR-C=VM ハンドル → PR-D=VM ネイティブ dispatch」に分割。
-  次の着手 = PR-A（`with_handle_mut` 化）。Arc<RwLock> 試行コードは revert 済み（本 doc に知見を残す）。
+- **PR-A 完了（2026-06-11）**: `handle_state_mut`（`&mut IoHandleState` 返し）を撤去し、closure 形
+  `with_handle_mut(id, |state| …)` / `with_handle_mut_opt`（handle 無効時 `Ok(None)` フォールバック）へ全面置換。
+  32 呼び出し側を変換。self 再入を含む 4 メソッドは extract→drop→re-enter に再構成して borrow を closure に
+  封じ込め: `write_to_handle_value_trying`（phase1 payload/bytes_written → phase2 `encode_with_encoding` →
+  phase3 dispatch、Stdout/Stderr の `emit_output` は borrow 外）、`write_bytes_to_handle_value`（同型）、
+  `read_line_from_handle_value`（`LineOutcome::{Done,NeedsDecode}` で raw record を closure 内 read → 外で
+  `decode_with_encoding`）、`read_bytes_from_handle_value`（target/own_paths を peek → ArgFiles の `@*ARGS`
+  読みを borrow 間に挟む）。**plain field のまま**（borrow checker が再入を引き続き強制）で挙動完全不変
+  （say+nl-out / print-nl / latin-1 enc / words / getc / read / seek・tell・eof を raku と byte 一致で確認、
+  whitelisted S32-io 8 本 PASS）。次の着手 = **PR-B**（`IoHandleTable` 新設 + `reentry_check` を
+  `lock_reentry.rs` へ汎用化 + `handles`/`next_handle_id` → `io_handles: Arc<RwLock<IoHandleTable>>`、
+  `with_handle_mut` を guard 経由へ）。

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -1229,7 +1229,10 @@ impl Interpreter {
                 // (e.g. `words($fh, :close)[1,2]`) leaves the handle open, while a
                 // full consumer triggers close-on-exhaust when `:close` was given.
                 if close_after {
-                    self.handle_state_mut(&handle)?.close_on_word_exhaust = true;
+                    self.with_handle_mut(&handle, |state| {
+                        state.close_on_word_exhaust = true;
+                        Ok(())
+                    })?;
                 }
                 return Ok(Value::LazyIoLines {
                     handle: Box::new(handle),

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -111,15 +111,46 @@ impl Interpreter {
         None
     }
 
-    pub(super) fn handle_state_mut(
+    /// Run `f` with a mutable borrow of the handle's `IoHandleState`, returning
+    /// whatever the closure produces. The `&mut IoHandleState` borrow is
+    /// confined to the closure body, so a caller can never hold it across
+    /// another `self.*` handle operation. That re-entry-free discipline is what
+    /// makes a later `Arc<RwLock>` lift (PR-B) safe: the lock is taken, the
+    /// closure runs, the lock is released — no same-thread re-acquisition.
+    ///
+    /// Returns `Err("Expected IO::Handle" / "Invalid IO::Handle")` when the
+    /// value is not a usable handle. Use [`with_handle_mut_opt`] instead when a
+    /// missing handle should fall back to a default rather than error.
+    pub(super) fn with_handle_mut<R>(
         &mut self,
         handle_value: &Value,
-    ) -> Result<&mut IoHandleState, RuntimeError> {
+        f: impl FnOnce(&mut IoHandleState) -> Result<R, RuntimeError>,
+    ) -> Result<R, RuntimeError> {
         let id = Self::handle_id_from_value(handle_value)
             .ok_or_else(|| RuntimeError::new("Expected IO::Handle"))?;
-        self.handles
+        let state = self
+            .handles
             .get_mut(&id)
-            .ok_or_else(|| RuntimeError::new("Invalid IO::Handle"))
+            .ok_or_else(|| RuntimeError::new("Invalid IO::Handle"))?;
+        f(state)
+    }
+
+    /// Like [`with_handle_mut`], but yields `Ok(None)` when the value is not a
+    /// live handle (instead of an error). Errors raised *inside* the closure
+    /// still propagate as `Err`, so callers can distinguish "no such handle"
+    /// (`Ok(None)`) from "the operation failed" (`Err`).
+    pub(super) fn with_handle_mut_opt<R>(
+        &mut self,
+        handle_value: &Value,
+        f: impl FnOnce(&mut IoHandleState) -> Result<R, RuntimeError>,
+    ) -> Result<Option<R>, RuntimeError> {
+        let Some(id) = Self::handle_id_from_value(handle_value) else {
+            return Ok(None);
+        };
+        let Some(state) = self.handles.get_mut(&id) else {
+            return Ok(None);
+        };
+        f(state).map(Some)
     }
 
     pub(super) fn write_to_handle_value(
@@ -138,33 +169,35 @@ impl Interpreter {
         newline: bool,
         trying: &str,
     ) -> Result<(), RuntimeError> {
-        let id = Self::handle_id_from_value(handle_value)
-            .ok_or_else(|| RuntimeError::new("Expected IO::Handle"))?;
-        let state = self
-            .handles
-            .get_mut(&id)
-            .ok_or_else(|| RuntimeError::new("Invalid IO::Handle"))?;
-        if state.closed {
-            return Err(RuntimeError::io_closed(trying));
-        }
-        let mut payload = String::from(content);
-        if newline {
-            payload.push_str(&state.nl_out.clone());
-        }
-        // Encode payload using the handle's encoding
-        let encoding = state.encoding.clone();
+        // Phase 1: validate the handle, build the payload (appending the
+        // handle's `nl_out` when requested) and account the bytes. Done inside
+        // a confined borrow so no `&mut IoHandleState` is held across the
+        // self-re-entrant `encode_with_encoding` / `emit_output` calls below.
+        let (target, encoding, payload) = self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed(trying));
+            }
+            let mut payload = String::from(content);
+            if newline {
+                payload.push_str(&state.nl_out);
+            }
+            state.bytes_written += payload.len() as i64;
+            Ok((state.target, state.encoding.clone(), payload))
+        })?;
+
+        // Phase 2: encode (only File targets honour a non-UTF-8 encoding). This
+        // re-enters `self`, hence it must run outside the handle borrow.
         let needs_encoding =
             !encoding.is_empty() && encoding != "utf-8" && encoding != "utf8" && encoding != "bin";
-        let encoded_bytes = if needs_encoding && matches!(state.target, IoHandleTarget::File) {
-            // Drop mutable borrow on state before calling encode_with_encoding
+        let encoded_bytes = if needs_encoding && matches!(target, IoHandleTarget::File) {
             Some(self.encode_with_encoding(&payload, &encoding)?)
         } else {
             None
         };
-        // Re-borrow state after encoding
-        let state = self.handles.get_mut(&id).unwrap();
-        state.bytes_written += payload.len() as i64;
-        match state.target {
+
+        // Phase 3: dispatch. Stdout/Stderr touch `self`; File/Socket touch only
+        // the handle state (a fresh confined borrow).
+        match target {
             IoHandleTarget::Stdout => {
                 self.emit_output(&payload);
                 Ok(())
@@ -179,13 +212,13 @@ impl Interpreter {
                 }
                 Ok(())
             }
-            IoHandleTarget::File => {
+            IoHandleTarget::File => self.with_handle_mut(handle_value, |state| {
                 if matches!(state.mode, IoHandleMode::Read) {
                     return Err(RuntimeError::new("Handle not open for writing"));
                 }
-                let Some(_) = state.file.as_mut() else {
+                if state.file.is_none() {
                     return Err(RuntimeError::new("IO::Handle is not attached to a file"));
-                };
+                }
                 let payload_bytes = if let Some(ref enc_bytes) = encoded_bytes {
                     enc_bytes.as_slice()
                 } else {
@@ -224,8 +257,8 @@ impl Interpreter {
                 } else {
                     Err(RuntimeError::new("IO::Handle is not attached to a file"))
                 }
-            }
-            IoHandleTarget::Socket => {
+            }),
+            IoHandleTarget::Socket => self.with_handle_mut(handle_value, |state| {
                 if let Some(sock) = state.socket.as_mut() {
                     sock.write_all(payload.as_bytes()).map_err(|err| {
                         RuntimeError::new(format!("Failed to write to socket: {}", err))
@@ -234,7 +267,7 @@ impl Interpreter {
                 } else {
                     Err(RuntimeError::new("Socket not connected"))
                 }
-            }
+            }),
             IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => {
                 Err(RuntimeError::new("Cannot write to read-only handle"))
             }
@@ -246,20 +279,19 @@ impl Interpreter {
         handle_value: &Value,
         bytes: &[u8],
     ) -> Result<(), RuntimeError> {
-        let id = Self::handle_id_from_value(handle_value)
-            .ok_or_else(|| RuntimeError::new("Expected IO::Handle"))?;
-        let state = self
-            .handles
-            .get_mut(&id)
-            .ok_or_else(|| RuntimeError::new("Invalid IO::Handle"))?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("write"));
-        }
-        if matches!(state.mode, IoHandleMode::Read) {
-            return Err(RuntimeError::new("Handle not open for writing"));
-        }
-        state.bytes_written += bytes.len() as i64;
-        match state.target {
+        // Validate + account the bytes inside a confined borrow, then dispatch.
+        // Stdout/Stderr re-enter `self`, so the handle borrow is dropped first.
+        let target = self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("write"));
+            }
+            if matches!(state.mode, IoHandleMode::Read) {
+                return Err(RuntimeError::new("Handle not open for writing"));
+            }
+            state.bytes_written += bytes.len() as i64;
+            Ok(state.target)
+        })?;
+        match target {
             IoHandleTarget::Stdout => {
                 // For stdout, convert bytes to lossy string and emit
                 let content = String::from_utf8_lossy(bytes).to_string();
@@ -277,7 +309,7 @@ impl Interpreter {
                 }
                 Ok(())
             }
-            IoHandleTarget::File => {
+            IoHandleTarget::File => self.with_handle_mut(handle_value, |state| {
                 if let Some(file) = state.file.as_mut() {
                     file.write_all(bytes).map_err(|err| {
                         RuntimeError::new(format!("Failed to write to file: {}", err))
@@ -286,8 +318,8 @@ impl Interpreter {
                 } else {
                     Err(RuntimeError::new("IO::Handle is not attached to a file"))
                 }
-            }
-            IoHandleTarget::Socket => {
+            }),
+            IoHandleTarget::Socket => self.with_handle_mut(handle_value, |state| {
                 if let Some(sock) = state.socket.as_mut() {
                     sock.write_all(bytes).map_err(|err| {
                         RuntimeError::new(format!("Failed to write to socket: {}", err))
@@ -296,7 +328,7 @@ impl Interpreter {
                 } else {
                     Err(RuntimeError::new("Socket not connected"))
                 }
-            }
+            }),
             IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => {
                 Err(RuntimeError::new("Cannot write to read-only handle"))
             }
@@ -307,20 +339,22 @@ impl Interpreter {
         &mut self,
         handle_value: &Value,
     ) -> Result<bool, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Ok(false);
-        }
-        if matches!(state.target, IoHandleTarget::File) {
-            Self::flush_file_handle_buffer(state)?;
-            if let Some(file) = state.file.as_mut() {
-                file.flush()
-                    .map_err(|err| RuntimeError::new(format!("Failed to flush handle: {}", err)))?;
+        self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Ok(false);
             }
-        }
-        state.closed = true;
-        state.file = None;
-        Ok(true)
+            if matches!(state.target, IoHandleTarget::File) {
+                Self::flush_file_handle_buffer(state)?;
+                if let Some(file) = state.file.as_mut() {
+                    file.flush().map_err(|err| {
+                        RuntimeError::new(format!("Failed to flush handle: {}", err))
+                    })?;
+                }
+            }
+            state.closed = true;
+            state.file = None;
+            Ok(true)
+        })
     }
 
     fn read_record_bytes<R: Read>(
@@ -392,44 +426,59 @@ impl Interpreter {
                 Some((in_state.line_separators.clone(), in_state.line_chomp))
             });
 
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
+        // The File branch may need to decode the raw record via
+        // `self.decode_with_encoding`, which re-enters `self`. Read the record
+        // inside the confined handle borrow, then decode outside it.
+        enum LineOutcome {
+            Done(Option<String>),
+            NeedsDecode(Vec<u8>, String),
         }
-        state.read_attempted = true;
-        let encoding = state.encoding.clone();
-        let needs_decode =
-            !encoding.is_empty() && encoding != "utf-8" && encoding != "utf8" && encoding != "bin";
-        match state.target {
-            IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
-                Err(RuntimeError::new("Handle not readable"))
+        let outcome = self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
             }
-            IoHandleTarget::Stdin => {
-                let seps = state.line_separators.clone();
-                let chomp = state.line_chomp;
-                let mut stdin = std::io::stdin().lock();
-                Self::read_record_with_separators(&mut stdin, &seps, chomp)
-            }
-            IoHandleTarget::ArgFiles => {
-                let seps = state.line_separators.clone();
-                let chomp = state.line_chomp;
-                // An `IO::ArgFiles.new(@files)` handle carries its own file list;
-                // a plain `$*ARGFILES` handle falls back to the global `@*ARGS`.
-                let effective_list = match &state.argfiles_paths {
-                    Some(paths) => paths.clone(),
-                    None => argfiles_list,
-                };
-                if effective_list.is_empty() {
-                    // No file args — read from stdin, using $*IN's nl-in if available
-                    let (effective_seps, effective_chomp) =
-                        stdin_seps.clone().unwrap_or((seps.clone(), chomp));
+            state.read_attempted = true;
+            let encoding = state.encoding.clone();
+            let needs_decode = !encoding.is_empty()
+                && encoding != "utf-8"
+                && encoding != "utf8"
+                && encoding != "bin";
+            match state.target {
+                IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
+                    Err(RuntimeError::new("Handle not readable"))
+                }
+                IoHandleTarget::Stdin => {
+                    let seps = state.line_separators.clone();
+                    let chomp = state.line_chomp;
                     let mut stdin = std::io::stdin().lock();
-                    Self::read_record_with_separators(&mut stdin, &effective_seps, effective_chomp)
-                } else {
+                    Self::read_record_with_separators(&mut stdin, &seps, chomp)
+                        .map(LineOutcome::Done)
+                }
+                IoHandleTarget::ArgFiles => {
+                    let seps = state.line_separators.clone();
+                    let chomp = state.line_chomp;
+                    // An `IO::ArgFiles.new(@files)` handle carries its own file
+                    // list; a plain `$*ARGFILES` handle falls back to `@*ARGS`.
+                    let effective_list = match &state.argfiles_paths {
+                        Some(paths) => paths.clone(),
+                        None => argfiles_list,
+                    };
+                    if effective_list.is_empty() {
+                        // No file args — read from stdin, using $*IN's nl-in.
+                        let (effective_seps, effective_chomp) =
+                            stdin_seps.unwrap_or((seps.clone(), chomp));
+                        let mut stdin = std::io::stdin().lock();
+                        return Self::read_record_with_separators(
+                            &mut stdin,
+                            &effective_seps,
+                            effective_chomp,
+                        )
+                        .map(LineOutcome::Done);
+                    }
                     // Read from files listed in the effective list sequentially
                     loop {
                         if state.argfiles_index >= effective_list.len() {
-                            return Ok(None);
+                            return Ok(LineOutcome::Done(None));
                         }
                         // Open the next file if we don't have a reader
                         if state.argfiles_reader.is_none() {
@@ -438,7 +487,7 @@ impl Interpreter {
                                 // `-` means read from stdin
                                 let mut stdin = std::io::stdin().lock();
                                 match Self::read_record_with_separators(&mut stdin, &seps, chomp)? {
-                                    Some(line) => return Ok(Some(line)),
+                                    Some(line) => return Ok(LineOutcome::Done(Some(line))),
                                     None => {
                                         state.argfiles_index += 1;
                                         continue;
@@ -452,7 +501,7 @@ impl Interpreter {
                         }
                         let reader = state.argfiles_reader.as_mut().unwrap();
                         match Self::read_record_with_separators(reader, &seps, chomp)? {
-                            Some(line) => return Ok(Some(line)),
+                            Some(line) => return Ok(LineOutcome::Done(Some(line))),
                             None => {
                                 // Current file exhausted, move to next
                                 state.argfiles_reader = None;
@@ -461,32 +510,41 @@ impl Interpreter {
                         }
                     }
                 }
-            }
-            IoHandleTarget::File => {
-                let seps = state.line_separators.clone();
-                let chomp = state.line_chomp;
-                let file = state
-                    .file
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                if needs_decode {
-                    match Self::read_record_bytes(file, &seps, chomp)? {
-                        Some(bytes) => {
-                            let decoded = self.decode_with_encoding(&bytes, &encoding)?;
-                            Ok(Some(decoded))
+                IoHandleTarget::File => {
+                    let seps = state.line_separators.clone();
+                    let chomp = state.line_chomp;
+                    let file = state
+                        .file
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                    if needs_decode {
+                        match Self::read_record_bytes(file, &seps, chomp)? {
+                            Some(bytes) => Ok(LineOutcome::NeedsDecode(bytes, encoding)),
+                            None => Ok(LineOutcome::Done(None)),
                         }
-                        None => Ok(None),
+                    } else {
+                        Self::read_record_with_separators(file, &seps, chomp).map(LineOutcome::Done)
                     }
-                } else {
-                    Self::read_record_with_separators(file, &seps, chomp)
+                }
+                IoHandleTarget::Socket => {
+                    let sock = state
+                        .socket
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("Socket not connected"))?;
+                    Self::read_record_with_separators(
+                        sock,
+                        &state.line_separators,
+                        state.line_chomp,
+                    )
+                    .map(LineOutcome::Done)
                 }
             }
-            IoHandleTarget::Socket => {
-                let sock = state
-                    .socket
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("Socket not connected"))?;
-                Self::read_record_with_separators(sock, &state.line_separators, state.line_chomp)
+        })?;
+        match outcome {
+            LineOutcome::Done(line) => Ok(line),
+            LineOutcome::NeedsDecode(bytes, encoding) => {
+                let decoded = self.decode_with_encoding(&bytes, &encoding)?;
+                Ok(Some(decoded))
             }
         }
     }
@@ -502,10 +560,8 @@ impl Interpreter {
         handle_value: &Value,
     ) -> Result<Option<String>, RuntimeError> {
         loop {
-            if let Some(word) = self
-                .handle_state_mut(handle_value)?
-                .pending_words
-                .pop_front()
+            if let Some(word) =
+                self.with_handle_mut(handle_value, |state| Ok(state.pending_words.pop_front()))?
             {
                 return Ok(Some(word));
             }
@@ -516,12 +572,15 @@ impl Interpreter {
                     if words.is_empty() {
                         continue;
                     }
-                    let state = self.handle_state_mut(handle_value)?;
-                    state.pending_words.extend(words);
+                    self.with_handle_mut(handle_value, |state| {
+                        state.pending_words.extend(words);
+                        Ok(())
+                    })?;
                 }
                 None => {
-                    let state = self.handle_state_mut(handle_value)?;
-                    let should_close = state.close_on_word_exhaust && !state.closed;
+                    let should_close = self.with_handle_mut(handle_value, |state| {
+                        Ok(state.close_on_word_exhaust && !state.closed)
+                    })?;
                     if should_close {
                         let _ = self.close_handle_value(handle_value);
                     }
@@ -536,16 +595,35 @@ impl Interpreter {
         handle_value: &Value,
         count: usize,
     ) -> Result<Vec<u8>, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
-        }
-        state.read_attempted = true;
-        match state.target {
-            IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
-                Err(RuntimeError::new("Handle not readable"))
+        // Validate, mark the handle read, and capture the target plus any
+        // handle-owned ArgFiles list inside a confined borrow. The ArgFiles
+        // fallback needs `@*ARGS` from `self.env`, so it runs between borrows.
+        let (target, own_paths) = self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
             }
-            IoHandleTarget::Stdin => {
+            state.read_attempted = true;
+            Ok((state.target, state.argfiles_paths.clone()))
+        })?;
+        if matches!(target, IoHandleTarget::ArgFiles) {
+            // Read bytes from files listed in @*ARGS sequentially, unless the
+            // handle carries its own explicit list (`IO::ArgFiles.new(@files)`).
+            let argfiles_list: Vec<String> = match own_paths {
+                Some(paths) => paths,
+                None => self
+                    .env
+                    .get("@*ARGS")
+                    .and_then(|v| {
+                        if let Value::Array(items, ..) = v {
+                            Some(items.iter().map(|v| v.to_string_value()).collect())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default(),
+            };
+            if argfiles_list.is_empty() {
+                // No file args — read from stdin
                 use std::io::Read;
                 let mut stdin = std::io::stdin().lock();
                 let mut buffer = vec![0u8; count];
@@ -553,39 +631,9 @@ impl Interpreter {
                     RuntimeError::new(format!("Failed to read from stdin: {}", err))
                 })?;
                 buffer.truncate(bytes_read);
-                Ok(buffer)
+                return Ok(buffer);
             }
-            IoHandleTarget::ArgFiles => {
-                // Read bytes from files listed in @*ARGS sequentially, unless the
-                // handle carries its own explicit list (`IO::ArgFiles.new(@files)`).
-                let argfiles_list: Vec<String> =
-                    match self.handle_state_mut(handle_value)?.argfiles_paths.clone() {
-                        Some(paths) => paths,
-                        None => self
-                            .env
-                            .get("@*ARGS")
-                            .and_then(|v| {
-                                if let Value::Array(items, ..) = v {
-                                    Some(items.iter().map(|v| v.to_string_value()).collect())
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or_default(),
-                    };
-                if argfiles_list.is_empty() {
-                    // No file args — read from stdin
-                    use std::io::Read;
-                    let mut stdin = std::io::stdin().lock();
-                    let mut buffer = vec![0u8; count];
-                    let bytes_read = stdin.read(&mut buffer).map_err(|err| {
-                        RuntimeError::new(format!("Failed to read from stdin: {}", err))
-                    })?;
-                    buffer.truncate(bytes_read);
-                    return Ok(buffer);
-                }
-                // Re-borrow state after extracting args list
-                let state = self.handle_state_mut(handle_value)?;
+            return self.with_handle_mut(handle_value, |state| {
                 let mut result = Vec::new();
                 loop {
                     if state.argfiles_index >= argfiles_list.len() {
@@ -616,6 +664,22 @@ impl Interpreter {
                 }
                 result.truncate(count);
                 Ok(result)
+            });
+        }
+        // Non-ArgFiles targets touch only the handle state.
+        self.with_handle_mut(handle_value, |state| match state.target {
+            IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
+                Err(RuntimeError::new("Handle not readable"))
+            }
+            IoHandleTarget::Stdin => {
+                use std::io::Read;
+                let mut stdin = std::io::stdin().lock();
+                let mut buffer = vec![0u8; count];
+                let bytes_read = stdin.read(&mut buffer).map_err(|err| {
+                    RuntimeError::new(format!("Failed to read from stdin: {}", err))
+                })?;
+                buffer.truncate(bytes_read);
+                Ok(buffer)
             }
             IoHandleTarget::File => {
                 let file = state
@@ -641,7 +705,8 @@ impl Interpreter {
                 buffer.truncate(bytes);
                 Ok(buffer)
             }
-        }
+            IoHandleTarget::ArgFiles => unreachable!("ArgFiles handled above"),
+        })
     }
 
     fn read_utf8_char<R: Read>(reader: &mut R) -> Result<Option<String>, RuntimeError> {
@@ -735,90 +800,120 @@ impl Interpreter {
         handle_value: &Value,
         count: Option<usize>,
     ) -> Result<String, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
-        }
-        state.read_attempted = true;
-        let encoding = state.encoding.to_lowercase();
-        // Determine if this is a utf16 stream and its byte order
-        let utf16_auto = matches!(encoding.as_str(), "utf-16" | "utf16");
-        let utf16_mode = match encoding.as_str() {
-            "utf-16be" | "utf16be" => Some(true),  // big endian
-            "utf-16le" | "utf16le" => Some(false), // little endian
-            "utf-16" | "utf16" => {
-                // Use previously detected endianness, or default to native
-                Some(
-                    state
-                        .utf16_detected_be
-                        .unwrap_or(cfg!(target_endian = "big")),
-                )
+        self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
             }
-            _ => None,
-        };
-        match state.target {
-            IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
-                Err(RuntimeError::new("Handle not readable"))
-            }
-            IoHandleTarget::Stdin => {
-                let mut stdin = std::io::stdin().lock();
-                if let Some(limit) = count {
-                    if limit == 0 {
-                        return Ok(String::new());
-                    }
-                    let mut out = String::new();
-                    for _ in 0..limit {
-                        let Some(ch) = Self::read_utf8_char(&mut stdin)? else {
-                            break;
-                        };
-                        out.push_str(&ch);
-                    }
-                    Ok(out)
-                } else {
-                    let mut bytes = Vec::new();
-                    stdin
-                        .read_to_end(&mut bytes)
-                        .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
-                    Ok(String::from_utf8_lossy(&bytes).to_string())
+            state.read_attempted = true;
+            let encoding = state.encoding.to_lowercase();
+            // Determine if this is a utf16 stream and its byte order
+            let utf16_auto = matches!(encoding.as_str(), "utf-16" | "utf16");
+            let utf16_mode = match encoding.as_str() {
+                "utf-16be" | "utf16be" => Some(true),  // big endian
+                "utf-16le" | "utf16le" => Some(false), // little endian
+                "utf-16" | "utf16" => {
+                    // Use previously detected endianness, or default to native
+                    Some(
+                        state
+                            .utf16_detected_be
+                            .unwrap_or(cfg!(target_endian = "big")),
+                    )
                 }
-            }
-            IoHandleTarget::ArgFiles => Ok(String::new()),
-            IoHandleTarget::File => {
-                let file = state
-                    .file
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                if let Some(mut big_endian) = utf16_mode {
-                    // For utf16 auto-detect: detect BOM on first read
-                    if utf16_auto && state.utf16_detected_be.is_none() {
-                        let mut bom_buf = [0u8; 2];
-                        let n = file
-                            .read(&mut bom_buf)
-                            .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
-                        if n >= 2 {
-                            if bom_buf[0] == 0xFE && bom_buf[1] == 0xFF {
-                                big_endian = true;
-                                state.utf16_detected_be = Some(true);
-                                // BOM consumed, don't include in output
-                            } else if bom_buf[0] == 0xFF && bom_buf[1] == 0xFE {
-                                big_endian = false;
-                                state.utf16_detected_be = Some(false);
-                                // BOM consumed, don't include in output
-                            } else {
-                                // No BOM, seek back
-                                state.utf16_detected_be = Some(cfg!(target_endian = "big"));
-                                use std::io::Seek;
-                                let _ = file.seek(std::io::SeekFrom::Current(-2));
-                            }
-                        }
-                    }
+                _ => None,
+            };
+            match state.target {
+                IoHandleTarget::Stdout | IoHandleTarget::Stderr => {
+                    Err(RuntimeError::new("Handle not readable"))
+                }
+                IoHandleTarget::Stdin => {
+                    let mut stdin = std::io::stdin().lock();
                     if let Some(limit) = count {
                         if limit == 0 {
                             return Ok(String::new());
                         }
                         let mut out = String::new();
                         for _ in 0..limit {
-                            let Some(ch) = Self::read_utf16_char(file, big_endian)? else {
+                            let Some(ch) = Self::read_utf8_char(&mut stdin)? else {
+                                break;
+                            };
+                            out.push_str(&ch);
+                        }
+                        Ok(out)
+                    } else {
+                        let mut bytes = Vec::new();
+                        stdin
+                            .read_to_end(&mut bytes)
+                            .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
+                        Ok(String::from_utf8_lossy(&bytes).to_string())
+                    }
+                }
+                IoHandleTarget::ArgFiles => Ok(String::new()),
+                IoHandleTarget::File => {
+                    let file = state
+                        .file
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                    if let Some(mut big_endian) = utf16_mode {
+                        // For utf16 auto-detect: detect BOM on first read
+                        if utf16_auto && state.utf16_detected_be.is_none() {
+                            let mut bom_buf = [0u8; 2];
+                            let n = file.read(&mut bom_buf).map_err(|err| {
+                                RuntimeError::new(format!("Failed to read: {}", err))
+                            })?;
+                            if n >= 2 {
+                                if bom_buf[0] == 0xFE && bom_buf[1] == 0xFF {
+                                    big_endian = true;
+                                    state.utf16_detected_be = Some(true);
+                                    // BOM consumed, don't include in output
+                                } else if bom_buf[0] == 0xFF && bom_buf[1] == 0xFE {
+                                    big_endian = false;
+                                    state.utf16_detected_be = Some(false);
+                                    // BOM consumed, don't include in output
+                                } else {
+                                    // No BOM, seek back
+                                    state.utf16_detected_be = Some(cfg!(target_endian = "big"));
+                                    use std::io::Seek;
+                                    let _ = file.seek(std::io::SeekFrom::Current(-2));
+                                }
+                            }
+                        }
+                        if let Some(limit) = count {
+                            if limit == 0 {
+                                return Ok(String::new());
+                            }
+                            let mut out = String::new();
+                            for _ in 0..limit {
+                                let Some(ch) = Self::read_utf16_char(file, big_endian)? else {
+                                    break;
+                                };
+                                out.push_str(&ch);
+                            }
+                            Ok(out)
+                        } else {
+                            let mut bytes = Vec::new();
+                            file.read_to_end(&mut bytes).map_err(|err| {
+                                RuntimeError::new(format!("Failed to read: {}", err))
+                            })?;
+                            // Decode all bytes using the utf16 decoder
+                            let units: Vec<u16> = bytes
+                                .chunks_exact(2)
+                                .map(|c| {
+                                    if big_endian {
+                                        u16::from_be_bytes([c[0], c[1]])
+                                    } else {
+                                        u16::from_le_bytes([c[0], c[1]])
+                                    }
+                                })
+                                .collect();
+                            Ok(String::from_utf16_lossy(&units))
+                        }
+                    } else if let Some(limit) = count {
+                        if limit == 0 {
+                            return Ok(String::new());
+                        }
+                        let mut out = String::new();
+                        for _ in 0..limit {
+                            let Some(ch) = Self::read_utf8_char(file)? else {
                                 break;
                             };
                             out.push_str(&ch);
@@ -828,63 +923,35 @@ impl Interpreter {
                         let mut bytes = Vec::new();
                         file.read_to_end(&mut bytes)
                             .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
-                        // Decode all bytes using the utf16 decoder
-                        let units: Vec<u16> = bytes
-                            .chunks_exact(2)
-                            .map(|c| {
-                                if big_endian {
-                                    u16::from_be_bytes([c[0], c[1]])
-                                } else {
-                                    u16::from_le_bytes([c[0], c[1]])
-                                }
-                            })
-                            .collect();
-                        Ok(String::from_utf16_lossy(&units))
+                        Ok(String::from_utf8_lossy(&bytes).to_string())
                     }
-                } else if let Some(limit) = count {
-                    if limit == 0 {
-                        return Ok(String::new());
+                }
+                IoHandleTarget::Socket => {
+                    let sock = state
+                        .socket
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("Socket not connected"))?;
+                    if let Some(limit) = count {
+                        if limit == 0 {
+                            return Ok(String::new());
+                        }
+                        let mut out = String::new();
+                        for _ in 0..limit {
+                            let Some(ch) = Self::read_utf8_char(sock)? else {
+                                break;
+                            };
+                            out.push_str(&ch);
+                        }
+                        Ok(out)
+                    } else {
+                        let mut bytes = Vec::new();
+                        sock.read_to_end(&mut bytes)
+                            .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
+                        Ok(String::from_utf8_lossy(&bytes).to_string())
                     }
-                    let mut out = String::new();
-                    for _ in 0..limit {
-                        let Some(ch) = Self::read_utf8_char(file)? else {
-                            break;
-                        };
-                        out.push_str(&ch);
-                    }
-                    Ok(out)
-                } else {
-                    let mut bytes = Vec::new();
-                    file.read_to_end(&mut bytes)
-                        .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
-                    Ok(String::from_utf8_lossy(&bytes).to_string())
                 }
             }
-            IoHandleTarget::Socket => {
-                let sock = state
-                    .socket
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("Socket not connected"))?;
-                if let Some(limit) = count {
-                    if limit == 0 {
-                        return Ok(String::new());
-                    }
-                    let mut out = String::new();
-                    for _ in 0..limit {
-                        let Some(ch) = Self::read_utf8_char(sock)? else {
-                            break;
-                        };
-                        out.push_str(&ch);
-                    }
-                    Ok(out)
-                } else {
-                    let mut bytes = Vec::new();
-                    sock.read_to_end(&mut bytes)
-                        .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
-                    Ok(String::from_utf8_lossy(&bytes).to_string())
-                }
-            }
-        }
+        })
     }
 
     pub(super) fn seek_handle_value(
@@ -893,105 +960,108 @@ impl Interpreter {
         pos: i64,
         mode: i32,
     ) -> Result<i64, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
-        }
-        state.read_attempted = true;
-        let file = state
-            .file
-            .as_mut()
-            .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-        let seek_from = match mode {
-            1 => SeekFrom::Current(pos),
-            2 => SeekFrom::End(pos),
-            _ => {
-                if pos < 0 {
+        self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
+            }
+            state.read_attempted = true;
+            let file = state
+                .file
+                .as_mut()
+                .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+            let seek_from = match mode {
+                1 => SeekFrom::Current(pos),
+                2 => SeekFrom::End(pos),
+                _ => {
+                    if pos < 0 {
+                        return Err(RuntimeError::new(
+                            "X::IO::Seek: Cannot seek to a negative position",
+                        ));
+                    }
+                    SeekFrom::Start(pos as u64)
+                }
+            };
+            if mode == 1 || mode == 2 {
+                let current = file
+                    .stream_position()
+                    .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                let target_pos = match mode {
+                    1 => current as i64 + pos,
+                    2 => {
+                        let end = file
+                            .seek(SeekFrom::End(0))
+                            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                        file.seek(SeekFrom::Start(current))
+                            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                        end as i64 + pos
+                    }
+                    _ => unreachable!(),
+                };
+                if target_pos < 0 {
                     return Err(RuntimeError::new(
                         "X::IO::Seek: Cannot seek to a negative position",
                     ));
                 }
-                SeekFrom::Start(pos as u64)
             }
-        };
-        if mode == 1 || mode == 2 {
-            let current = file
-                .stream_position()
+            let new_pos = file
+                .seek(seek_from)
                 .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-            let target_pos = match mode {
-                1 => current as i64 + pos,
-                2 => {
-                    let end = file
-                        .seek(SeekFrom::End(0))
-                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                    file.seek(SeekFrom::Start(current))
-                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                    end as i64 + pos
-                }
-                _ => unreachable!(),
-            };
-            if target_pos < 0 {
-                return Err(RuntimeError::new(
-                    "X::IO::Seek: Cannot seek to a negative position",
-                ));
-            }
-        }
-        let new_pos = file
-            .seek(seek_from)
-            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-        Ok(new_pos as i64)
+            Ok(new_pos as i64)
+        })
     }
 
     pub(super) fn tell_handle_value(&mut self, handle_value: &Value) -> Result<i64, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
-        }
-        match state.target {
-            IoHandleTarget::File => {
-                let file = state
-                    .file
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                let pos = file.stream_position().map_err(|err| {
-                    RuntimeError::new(format!("Failed to query position: {}", err))
-                })?;
-                Ok(pos as i64)
+        self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
             }
-            _ => Ok(state.bytes_written),
-        }
+            match state.target {
+                IoHandleTarget::File => {
+                    let file = state
+                        .file
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                    let pos = file.stream_position().map_err(|err| {
+                        RuntimeError::new(format!("Failed to query position: {}", err))
+                    })?;
+                    Ok(pos as i64)
+                }
+                _ => Ok(state.bytes_written),
+            }
+        })
     }
 
     pub(super) fn handle_eof_value(&mut self, handle_value: &Value) -> Result<bool, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if state.closed {
-            return Err(RuntimeError::io_closed("handle operation"));
-        }
-        match state.target {
-            IoHandleTarget::File => {
-                let file = state
-                    .file
-                    .as_mut()
-                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                let pos = file.stream_position().map_err(|err| {
-                    RuntimeError::new(format!("Failed to query position: {}", err))
-                })?;
-                let end = file
-                    .metadata()
-                    .map_err(|err| RuntimeError::new(format!("Failed to stat file: {}", err)))?
-                    .len();
-                // Raku semantics: a freshly opened file where pos == 0 and
-                // the reported size is 0 returns False for .eof until a read
-                // or seek has been performed. This handles both truly empty
-                // files and /proc virtual files that report size 0.
-                if pos == 0 && end == 0 && !state.read_attempted {
-                    return Ok(false);
-                }
-                Ok(pos >= end)
+        self.with_handle_mut(handle_value, |state| {
+            if state.closed {
+                return Err(RuntimeError::io_closed("handle operation"));
             }
-            IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => Ok(false),
-            _ => Err(RuntimeError::new("Handle not readable")),
-        }
+            match state.target {
+                IoHandleTarget::File => {
+                    let file = state
+                        .file
+                        .as_mut()
+                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                    let pos = file.stream_position().map_err(|err| {
+                        RuntimeError::new(format!("Failed to query position: {}", err))
+                    })?;
+                    let end = file
+                        .metadata()
+                        .map_err(|err| RuntimeError::new(format!("Failed to stat file: {}", err)))?
+                        .len();
+                    // Raku semantics: a freshly opened file where pos == 0 and
+                    // the reported size is 0 returns False for .eof until a read
+                    // or seek has been performed. This handles both truly empty
+                    // files and /proc virtual files that report size 0.
+                    if pos == 0 && end == 0 && !state.read_attempted {
+                        return Ok(false);
+                    }
+                    Ok(pos >= end)
+                }
+                IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => Ok(false),
+                _ => Err(RuntimeError::new("Handle not readable")),
+            }
+        })
     }
 
     pub(super) fn set_handle_encoding(
@@ -999,14 +1069,15 @@ impl Interpreter {
         handle_value: &Value,
         encoding: Option<String>,
     ) -> Result<String, RuntimeError> {
-        let state = self.handle_state_mut(handle_value)?;
-        if let Some(enc) = encoding {
-            let prev = state.encoding.clone();
-            state.encoding = enc;
-            Ok(prev)
-        } else {
-            Ok(state.encoding.clone())
-        }
+        self.with_handle_mut(handle_value, |state| {
+            if let Some(enc) = encoding {
+                let prev = state.encoding.clone();
+                state.encoding = enc;
+                Ok(prev)
+            } else {
+                Ok(state.encoding.clone())
+            }
+        })
     }
 
     pub(super) fn system_time_to_int(time: SystemTime) -> i64 {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -30,9 +30,10 @@ impl Interpreter {
                     crate::runtime::IoHandleMode::Read,
                     None,
                 );
-                if let Ok(state) = self.handle_state_mut(&handle) {
+                let _ = self.with_handle_mut_opt(&handle, |state| {
                     state.argfiles_paths = Some(paths);
-                }
+                    Ok(())
+                });
                 Some(Ok(handle))
             }
             "new" if matches!(target, Value::Package(name) if matches!(name.resolve().as_str(), "ObjAt" | "ValueObjAt")) =>

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2345,16 +2345,18 @@ impl Interpreter {
             "nl-out" => {
                 if let Some(arg) = args.first() {
                     let val = arg.to_string_value();
-                    let state = self.handle_state_mut(&target_val)?;
-                    state.nl_out = val.clone();
+                    self.with_handle_mut(&target_val, |state| {
+                        state.nl_out = val.clone();
+                        Ok(())
+                    })?;
                     return Ok(Value::str(val));
                 }
-                let state = self.handle_state_mut(&target_val)?;
-                Ok(Value::str(state.nl_out.clone()))
+                let nl = self.with_handle_mut(&target_val, |state| Ok(state.nl_out.clone()))?;
+                Ok(Value::str(nl))
             }
             "nl-in" => {
                 if let Some(arg) = args.first() {
-                    if let Ok(state) = self.handle_state_mut(&target_val) {
+                    let _ = self.with_handle_mut_opt(&target_val, |state| {
                         match arg {
                             Value::Array(items, ..) => {
                                 let seps: Vec<Vec<u8>> = items
@@ -2368,10 +2370,11 @@ impl Interpreter {
                                 state.line_separators = vec![s.clone().into_bytes()];
                             }
                         }
-                    }
+                        Ok(())
+                    })?;
                     return Ok(arg.clone());
                 }
-                if let Ok(state) = self.handle_state_mut(&target_val) {
+                let got = self.with_handle_mut_opt(&target_val, |state| {
                     if state.line_separators.len() == 1 {
                         Ok(Value::str(
                             String::from_utf8_lossy(&state.line_separators[0]).to_string(),
@@ -2384,35 +2387,38 @@ impl Interpreter {
                             .collect();
                         Ok(Value::real_array(items))
                     }
-                } else {
-                    // Default nl-in for unopened handles
-                    let items: Vec<Value> = self
-                        .default_line_separators()
-                        .iter()
-                        .map(|s| Value::str(String::from_utf8_lossy(s).to_string()))
-                        .collect();
-                    if items.len() == 1 {
-                        Ok(items.into_iter().next().unwrap())
-                    } else {
-                        Ok(Value::real_array(items))
+                })?;
+                match got {
+                    Some(v) => Ok(v),
+                    None => {
+                        // Default nl-in for unopened handles
+                        let items: Vec<Value> = self
+                            .default_line_separators()
+                            .iter()
+                            .map(|s| Value::str(String::from_utf8_lossy(s).to_string()))
+                            .collect();
+                        if items.len() == 1 {
+                            Ok(items.into_iter().next().unwrap())
+                        } else {
+                            Ok(Value::real_array(items))
+                        }
                     }
                 }
             }
             "chomp" => {
                 if let Some(arg) = args.first() {
                     let val = arg.truthy();
-                    let state = self.handle_state_mut(&target_val)?;
-                    state.line_chomp = val;
+                    self.with_handle_mut(&target_val, |state| {
+                        state.line_chomp = val;
+                        Ok(())
+                    })?;
                     return Ok(Value::Bool(val));
                 }
-                let state = self.handle_state_mut(&target_val)?;
-                Ok(Value::Bool(state.line_chomp))
+                let chomp = self.with_handle_mut(&target_val, |state| Ok(state.line_chomp))?;
+                Ok(Value::Bool(chomp))
             }
             "print-nl" => {
-                let nl = {
-                    let state = self.handle_state_mut(&target_val)?;
-                    state.nl_out.clone()
-                };
+                let nl = self.with_handle_mut(&target_val, |state| Ok(state.nl_out.clone()))?;
                 self.write_to_handle_value(&target_val, &nl, false)?;
                 Ok(Value::Bool(true))
             }
@@ -2422,10 +2428,8 @@ impl Interpreter {
                 .map(Value::str)
                 .unwrap_or(Value::Nil)),
             "getc" => {
-                let encoding = {
-                    let state = self.handle_state_mut(&target_val)?;
-                    state.encoding.clone()
-                };
+                let encoding =
+                    self.with_handle_mut(&target_val, |state| Ok(state.encoding.clone()))?;
                 let needs_decode = !encoding.is_empty()
                     && encoding != "utf-8"
                     && encoding != "utf8"
@@ -2544,7 +2548,10 @@ impl Interpreter {
                     // (e.g. `$fh.words[1,2]`) leaves the handle open, while a full
                     // consumer triggers close-on-exhaust when `:close` was given.
                     if close_after {
-                        self.handle_state_mut(&target_val)?.close_on_word_exhaust = true;
+                        self.with_handle_mut(&target_val, |state| {
+                            state.close_on_word_exhaust = true;
+                            Ok(())
+                        })?;
                     }
                     return Ok(Value::LazyIoLines {
                         handle: Box::new(target_val.clone()),
@@ -2674,11 +2681,9 @@ impl Interpreter {
                 } else {
                     let content = content_value.to_string_value();
                     // Determine encoding from the handle's state
-                    let enc = if let Ok(state) = self.handle_state_mut(&target_val) {
-                        state.encoding.clone()
-                    } else {
-                        "utf-8".to_string()
-                    };
+                    let enc = self
+                        .with_handle_mut_opt(&target_val, |state| Ok(state.encoding.clone()))?
+                        .unwrap_or_else(|| "utf-8".to_string());
                     let bytes = if enc == "utf-8" || enc == "utf8" {
                         content.into_bytes()
                     } else {
@@ -2689,13 +2694,16 @@ impl Interpreter {
                 Ok(Value::Bool(true))
             }
             "flush" => {
-                if let Ok(state) = self.handle_state_mut(&target_val) {
+                let flushed = self.with_handle_mut_opt(&target_val, |state| {
                     Self::flush_file_handle_buffer(state)?;
                     if let Some(file) = state.file.as_mut() {
                         file.flush().map_err(|err| {
                             RuntimeError::new(format!("Failed to flush handle: {}", err))
                         })?;
                     }
+                    Ok(())
+                })?;
+                if flushed.is_some() {
                     Ok(Value::Bool(true))
                 } else {
                     let mut ex_attrs = HashMap::new();
@@ -2713,12 +2721,13 @@ impl Interpreter {
                 }
             }
             "out-buffer" => {
-                let state = self.handle_state_mut(&target_val)?;
-                if let Some(arg) = args.first() {
-                    Self::flush_file_handle_buffer(state)?;
-                    state.out_buffer_capacity = Self::parse_out_buffer_size(arg);
-                }
-                let size = state.out_buffer_capacity.unwrap_or(0);
+                let size = self.with_handle_mut(&target_val, |state| {
+                    if let Some(arg) = args.first() {
+                        Self::flush_file_handle_buffer(state)?;
+                        state.out_buffer_capacity = Self::parse_out_buffer_size(arg);
+                    }
+                    Ok(state.out_buffer_capacity.unwrap_or(0))
+                })?;
                 Ok(Value::Int(size as i64))
             }
             "seek" => {
@@ -2754,20 +2763,21 @@ impl Interpreter {
             "t" => {
                 // Check if the handle is a TTY
                 use std::io::IsTerminal;
-                let state = self.handle_state_mut(&target_val)?;
-                let is_tty = match state.target {
-                    IoHandleTarget::Stdin => std::io::stdin().is_terminal(),
-                    IoHandleTarget::Stdout => std::io::stdout().is_terminal(),
-                    IoHandleTarget::Stderr => std::io::stderr().is_terminal(),
-                    IoHandleTarget::File => {
-                        if let Some(file) = state.file.as_ref() {
-                            file.is_terminal()
-                        } else {
-                            false
+                let is_tty = self.with_handle_mut(&target_val, |state| {
+                    Ok(match state.target {
+                        IoHandleTarget::Stdin => std::io::stdin().is_terminal(),
+                        IoHandleTarget::Stdout => std::io::stdout().is_terminal(),
+                        IoHandleTarget::Stderr => std::io::stderr().is_terminal(),
+                        IoHandleTarget::File => {
+                            if let Some(file) = state.file.as_ref() {
+                                file.is_terminal()
+                            } else {
+                                false
+                            }
                         }
-                    }
-                    _ => false,
-                };
+                        _ => false,
+                    })
+                })?;
                 Ok(Value::Bool(is_tty))
             }
             "encoding" => {
@@ -2792,17 +2802,16 @@ impl Interpreter {
                 Ok(Value::str(current))
             }
             "opened" => {
-                let state = self.handle_state_mut(&target_val)?;
-                Ok(Value::Bool(!state.closed))
+                let opened = self.with_handle_mut(&target_val, |state| Ok(!state.closed))?;
+                Ok(Value::Bool(opened))
             }
             "slurp" => {
                 let has_bin_arg = Self::named_bool(&args, "bin");
-                let (is_bin, handle_encoding) = {
-                    let state = self.handle_state_mut(&target_val)?;
+                let (is_bin, handle_encoding) = self.with_handle_mut(&target_val, |state| {
                     let bin = has_bin_arg || state.bin || state.encoding == "bin";
                     let enc = state.encoding.clone();
-                    (bin, enc)
-                };
+                    Ok((bin, enc))
+                })?;
                 let mut all_bytes = Vec::new();
                 loop {
                     let chunk = self.read_bytes_from_handle_value(&target_val, 8192)?;
@@ -2883,32 +2892,34 @@ impl Interpreter {
             }
             "Supply" => self.handle_supply(target, &args),
             "native-descriptor" => {
-                let state = self.handle_state_mut(&target_val)?;
-                let fd = match state.target {
-                    IoHandleTarget::Stdin => 0i64,
-                    IoHandleTarget::Stdout => 1i64,
-                    IoHandleTarget::Stderr => 2i64,
-                    _ => {
-                        #[cfg(unix)]
-                        {
-                            if let Some(ref file) = state.file {
-                                use std::os::unix::io::AsRawFd;
-                                file.as_raw_fd() as i64
-                            } else {
+                let fd = self.with_handle_mut(&target_val, |state| {
+                    let fd = match state.target {
+                        IoHandleTarget::Stdin => 0i64,
+                        IoHandleTarget::Stdout => 1i64,
+                        IoHandleTarget::Stderr => 2i64,
+                        _ => {
+                            #[cfg(unix)]
+                            {
+                                if let Some(ref file) = state.file {
+                                    use std::os::unix::io::AsRawFd;
+                                    file.as_raw_fd() as i64
+                                } else {
+                                    return Err(RuntimeError::new(
+                                        "native-descriptor: handle has no file descriptor",
+                                    ));
+                                }
+                            }
+                            #[cfg(not(unix))]
+                            {
+                                let _ = state;
                                 return Err(RuntimeError::new(
-                                    "native-descriptor: handle has no file descriptor",
+                                    "native-descriptor: not supported on this platform",
                                 ));
                             }
                         }
-                        #[cfg(not(unix))]
-                        {
-                            let _ = state;
-                            return Err(RuntimeError::new(
-                                "native-descriptor: not supported on this platform",
-                            ));
-                        }
-                    }
-                };
+                    };
+                    Ok(fd)
+                })?;
                 Ok(Value::Int(fd))
             }
             _ => Err(RuntimeError::new(format!(


### PR DESCRIPTION
## Summary

PR-A of the **③ native IO ownership** campaign (`docs/vm-io-ownership.md`). Pure "地ならし" before the `Arc<RwLock>` lift — **no behavior change**.

Replaces the `&mut IoHandleState`-returning `handle_state_mut` accessor with closure-form helpers:

- `with_handle_mut(handle, |state| …)` — errors on an invalid handle.
- `with_handle_mut_opt(handle, |state| …)` — `Ok(None)` for a missing handle (fallback sites), while errors *inside* the closure still propagate.

All 32 `handle_state_mut` call sites are converted. Confining every `&mut IoHandleState` borrow to a closure body makes it syntactically impossible to hold the borrow across another `self.*` handle operation, so PR-B's guard-based table cannot deadlock on same-thread re-acquisition.

### Methods restructured (extract → drop borrow → re-enter)

Four methods re-entered `self` mid-borrow (the crux that made registry's mechanical lift inapplicable):

- **`write_to_handle_value_trying`** — phase 1 builds the payload + accounts bytes in-borrow; phase 2 `encode_with_encoding` outside; phase 3 dispatches (Stdout/Stderr `emit_output` outside; File/Socket in a fresh confined borrow).
- **`write_bytes_to_handle_value`** — same shape, no encoding.
- **`read_line_from_handle_value`** — reads the raw record in-borrow, returns `LineOutcome::{Done, NeedsDecode}`; `decode_with_encoding` runs outside.
- **`read_bytes_from_handle_value`** — peeks target + handle-owned argfiles list, then interleaves the `@*ARGS` lookup between borrows.

Still plain `self.handles` fields; the borrow checker keeps enforcing re-entry freedom.

## Verification

- say+nl-out, print-nl, latin-1 encoded read/write, words, getc, read, seek/tell/eof all match `raku` byte-for-byte.
- 8 whitelisted `S32-io` tests pass (`native-descriptor`, `note`, `null-char`, `open`, `out-buffering`, `seek`, `slurp`, `spurt`).
- `cargo clippy -D warnings` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)