### PR TITLE
refactor(io): lift IO handle table into shared Arc<RwLock> (③ native IO PR-B)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -128,3 +128,26 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
   whitelisted S32-io 8 本 PASS）。次の着手 = **PR-B**（`IoHandleTable` 新設 + `reentry_check` を
   `lock_reentry.rs` へ汎用化 + `handles`/`next_handle_id` → `io_handles: Arc<RwLock<IoHandleTable>>`、
   `with_handle_mut` を guard 経由へ）。
+- **PR-B 完了（2026-06-11）**: `handles`/`next_handle_id` を `io_handles: Arc<RwLock<IoHandleTable>>`
+  （`src/runtime/io_handles.rs`、`map`+`next_id`）へ持ち上げ＝② registry 方式の共有ハンドル足場。
+  - **`reentry_check` を `src/runtime/lock_reentry.rs` へ汎用化**: ② の bespoke `RegistryRead/WriteGuard` +
+    `reentry_check` mod を、ジェネリックな `ReentrantReadGuard<'a,T>`/`ReentrantWriteGuard<'a,T>`（lock 名を
+    panic メッセージへ引数化）に統合。`RegistryReadGuard`/`RegistryWriteGuard` は型エイリアス化（呼び出し側
+    無改変、`new` のみ `, "registry"` 追加 = 3 サイト）。IO 側は `IoHandlesReadGuard`/`IoHandlesWriteGuard`
+    エイリアス + `io_handles()`/`io_handles_mut()` アクセサ（`registry()`/`registry_mut()` と同型）。
+  - **アクセサ経由へ全 ~59 サイト変換（10 ファイル）**: `self.handles.get/get_mut/insert/keys/values_mut` →
+    `self.io_handles()/.io_handles_mut().map.*`、`self.next_handle_id` → table の `next_id`。**新設ヘルパ
+    `insert_handle_state(state) -> id`** で `next_id` 採番 + insert を一元化（io.rs/handle.rs/socket 各所の
+    `let id = next_handle_id; next_handle_id += 1; … handles.insert` 重複を畳む。state は `&self` 依存の
+    `default_line_separators()` 等を含むため** guard 取得前に完全構築**してから渡す規律）。
+  - **`with_handle_mut`/`with_handle_mut_opt` は write guard 経由**（PR-A の closure 封じ込めにより guard を
+    closure 跨ぎで保持しても self 再入不能＝per-thread snapshot ゆえ blocking IO 跨ぎでも deadlock せず）。
+  - **`clone_for_thread`**: `Arc::new(RwLock::new(IoHandleTable { map: <try_clone deep copy>, next_id }))` で
+    per-thread snapshot（意味論不変）。**merge-back**（`builtins_system.rs` の spawn/await 両側）は子の
+    `io_handles()` snapshot から open handle を抜いて親 `io_handles_mut()` へ、`next_id` 突き合わせ。
+  - **再入安全性**: debug 実行時 guard（lock アドレス keyed）で read-while-write / write-while-any を即 panic 化。
+    debug ビルド（guard 有効）で smoke（say+nl-out / file get/lines/words/seek/tell/eof/getc / :w print+say /
+    thread が開いた handle の merge-back / `$*OUT`）を raku と byte 一致確認、whitelisted S32-io（seek/tell/open/
+    slurp/spurt/out-buffering/utf16/null-char + IO-Socket-INET/UNIX/accept-threads/fail-invalid/pipe/note/other +
+    Async/Async-UDP/signals）+ t/（io-*/socket/thread/concurrency/proc-async/subtest-threaded）緑、再入 panic ゼロ。
+    `make test`（cargo 458 + prove 6292）緑。次の着手 = **PR-C**（VM へ io_handles ハンドル移管、② #2895 相当）。

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -110,7 +110,7 @@ impl Interpreter {
         let ret = Value::Promise(promise.clone());
         let thread_interp = self.clone_for_thread();
         let parent_handles_snapshot: std::collections::HashSet<usize> =
-            self.handles.keys().copied().collect();
+            self.io_handles().map.keys().copied().collect();
 
         // Raku gives each start block fresh $/ and $!.
         // Strip these from the closure's captured env so they don't override
@@ -132,17 +132,18 @@ impl Interpreter {
             // Transfer any handles opened by this thread back to the awaiter.
             let mut new_handles: Vec<(usize, IoHandleState)> = Vec::new();
             let new_ids: Vec<usize> = thread_interp
-                .handles
+                .io_handles()
+                .map
                 .keys()
                 .copied()
                 .filter(|id| !parent_handles_snapshot.contains(id))
                 .collect();
             for id in new_ids {
-                if let Some(state) = thread_interp.handles.remove(&id) {
+                if let Some(state) = thread_interp.io_handles_mut().map.remove(&id) {
                     new_handles.push((id, state));
                 }
             }
-            let next_id = thread_interp.next_handle_id;
+            let next_id = thread_interp.io_handles().next_id;
             if !new_handles.is_empty() {
                 promise.set_thread_payload(Box::new(ThreadPromisePayload {
                     new_handles,
@@ -1001,8 +1002,9 @@ impl Interpreter {
         // Handle :out with IO::Handle — redirect stdout to that file
         let mut stdout_file_for_merge: Option<std::fs::File> = None;
         if let Some(handle_id) = opts.out_handle_id {
-            let state = self
-                .handles
+            let table = self.io_handles();
+            let state = table
+                .map
                 .get(&handle_id)
                 .ok_or_else(|| RuntimeError::new("Invalid IO::Handle for :out"))?;
             let file = state
@@ -1594,11 +1596,12 @@ impl Interpreter {
                             new_handles,
                             next_handle_id,
                         } = *payload;
+                        let mut table = self.io_handles_mut();
                         for (id, state) in new_handles {
-                            self.handles.entry(id).or_insert(state);
+                            table.map.entry(id).or_insert(state);
                         }
-                        if next_handle_id > self.next_handle_id {
-                            self.next_handle_id = next_handle_id;
+                        if next_handle_id > table.next_id {
+                            table.next_id = next_handle_id;
                         }
                     }
                     if shared.status() == "Broken" {

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -128,8 +128,14 @@ impl Interpreter {
     ) -> Result<R, RuntimeError> {
         let id = Self::handle_id_from_value(handle_value)
             .ok_or_else(|| RuntimeError::new("Expected IO::Handle"))?;
-        let state = self
-            .handles
+        // The write guard is held across `f`, which may perform blocking IO but
+        // (by construction — `f` only receives `&mut IoHandleState`, never
+        // `self`) cannot re-enter another handle op. Per-thread snapshot
+        // semantics make holding the lock across blocking IO deadlock-free; the
+        // debug reentry guard catches any same-thread re-acquire.
+        let mut table = self.io_handles_mut();
+        let state = table
+            .map
             .get_mut(&id)
             .ok_or_else(|| RuntimeError::new("Invalid IO::Handle"))?;
         f(state)
@@ -147,7 +153,8 @@ impl Interpreter {
         let Some(id) = Self::handle_id_from_value(handle_value) else {
             return Ok(None);
         };
-        let Some(state) = self.handles.get_mut(&id) else {
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&id) else {
             return Ok(None);
         };
         f(state).map(Some)
@@ -422,7 +429,8 @@ impl Interpreter {
         let stdin_seps: Option<(Vec<Vec<u8>>, bool)> =
             self.get_dynamic_handle("$*IN").and_then(|in_handle| {
                 let id = Self::handle_id_from_value(&in_handle)?;
-                let in_state = self.handles.get(&id)?;
+                let table = self.io_handles();
+                let in_state = table.map.get(&id)?;
                 Some((in_state.line_separators.clone(), in_state.line_chomp))
             });
 
@@ -1261,8 +1269,6 @@ impl Interpreter {
         let file = options.open(path).map_err(|err| {
             RuntimeError::new(format!("Failed to open '{}': {}", path.display(), err))
         })?;
-        let id = self.next_handle_id;
-        self.next_handle_id += 1;
         let mode = if read && (write || append) {
             IoHandleMode::ReadWrite
         } else if append {
@@ -1327,7 +1333,7 @@ impl Interpreter {
                 state.utf16_bom_written = true;
             }
         }
-        self.handles.insert(id, state);
+        let id = self.insert_handle_state(state);
         Ok(self.make_handle_instance_with_bin(id, bin))
     }
 }

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2595,8 +2595,6 @@ impl Interpreter {
         mode: IoHandleMode,
         path: Option<String>,
     ) -> Value {
-        let id = self.next_handle_id;
-        self.next_handle_id += 1;
         let state = IoHandleState {
             target,
             mode,
@@ -2622,7 +2620,7 @@ impl Interpreter {
             pending_words: std::collections::VecDeque::new(),
             close_on_word_exhaust: false,
         };
-        self.handles.insert(id, state);
+        let id = self.insert_handle_state(state);
         self.make_handle_instance(id)
     }
 
@@ -2633,7 +2631,7 @@ impl Interpreter {
     pub(super) fn make_handle_instance_with_bin(&self, handle_id: usize, bin: bool) -> Value {
         let mut attrs = HashMap::new();
         attrs.insert("handle".to_string(), Value::Int(handle_id as i64));
-        if let Some(state) = self.handles.get(&handle_id) {
+        if let Some(state) = self.io_handles().map.get(&handle_id) {
             if let Some(path) = &state.path {
                 attrs.insert("path".to_string(), Value::str(path.clone()));
             }

--- a/src/runtime/io_handles.rs
+++ b/src/runtime/io_handles.rs
@@ -1,0 +1,58 @@
+//! Shared IO handle table for the VM/Interpreter decoupling (PLAN.md ③).
+//!
+//! Holds the program's *open IO handles* — files, sockets, listeners and their
+//! buffering/encoding state ([`IoHandleState`](super::IoHandleState)) — keyed by
+//! a small integer id that `IO::Handle` / `IO::Socket::INET` values carry. These
+//! used to live as `Interpreter.handles: HashMap<usize, IoHandleState>` plus a
+//! `next_handle_id: usize` counter, trapping native IO state inside the
+//! tree-walking interpreter: VM-native code could only reach it through
+//! `self.interpreter.<field>`. Phase ③ lifts it behind `Arc<RwLock<…>>` so the
+//! VM and the Interpreter can reach it as *peers* (the same shared-handle
+//! playbook ② used for the declaration [`Registry`](super::Registry)).
+//!
+//! Why a shared `Arc<RwLock>` is correct here, unlike `env` (which stays a plain
+//! COW field): IO handles are **per-thread snapshots**, not live-shared.
+//! `clone_for_thread` deep-clones the referenced handles into a fresh `Arc`
+//! (`File::try_clone` etc.), and a child thread's newly opened handles are
+//! merged back into the parent explicitly (`ThreadPromisePayload`). So the lock
+//! never contends across threads; it exists only for the within-thread
+//! VM<->Interpreter ping-pong, which is non-concurrent. `IoHandleState` is not
+//! `Clone` and IO blocks, but because each thread owns its own snapshot, holding
+//! a guard across a blocking read/write cannot deadlock another holder — the
+//! only hazard is the *same* thread re-acquiring the lock, which the debug
+//! re-entrancy guard (see [`crate::runtime::lock_reentry`]) catches.
+//!
+//! Lock discipline (CRITICAL): never hold a guard across a call that re-enters a
+//! handle operation on the same table. The handle accessors confine the
+//! `&mut IoHandleState` borrow inside a closure (`with_handle_mut`) precisely so
+//! a caller cannot hold it across another `self.*` handle op. Once the
+//! Interpreter execution path is removed (PLAN.md ④/⑤), this collapses to a
+//! plain VM-owned field and the `Arc`/lock disappear.
+
+use std::collections::HashMap;
+
+use super::IoHandleState;
+
+/// The program's open IO handles plus the id allocator. See module docs.
+#[derive(Debug, Default)]
+pub(crate) struct IoHandleTable {
+    /// Open handles keyed by id (the integer an `IO::Handle` value carries).
+    pub(crate) map: HashMap<usize, IoHandleState>,
+    /// Next handle id to allocate. Starts at 1 (`Interpreter::new` seeds the
+    /// standard handles at lower ids).
+    pub(crate) next_id: usize,
+}
+
+/// Read guard for the shared [`IoHandleTable`]; a [`ReentrantReadGuard`] keyed by
+/// the `"io_handles"` lock name. See [`crate::runtime::lock_reentry`].
+///
+/// [`ReentrantReadGuard`]: crate::runtime::lock_reentry::ReentrantReadGuard
+pub(crate) type IoHandlesReadGuard<'a> =
+    crate::runtime::lock_reentry::ReentrantReadGuard<'a, IoHandleTable>;
+
+/// Write guard for the shared [`IoHandleTable`]; a [`ReentrantWriteGuard`] keyed
+/// by the `"io_handles"` lock name. See [`crate::runtime::lock_reentry`].
+///
+/// [`ReentrantWriteGuard`]: crate::runtime::lock_reentry::ReentrantWriteGuard
+pub(crate) type IoHandlesWriteGuard<'a> =
+    crate::runtime::lock_reentry::ReentrantWriteGuard<'a, IoHandleTable>;

--- a/src/runtime/lock_reentry.rs
+++ b/src/runtime/lock_reentry.rs
@@ -1,0 +1,206 @@
+//! Shared reentrancy-detecting `RwLock` guard infrastructure (debug-only).
+//!
+//! Several pieces of execution state that the VM and the tree-walking
+//! `Interpreter` share during the decoupling transition live behind
+//! `Arc<RwLock<…>>` scaffolding — the declaration [`Registry`](super::Registry)
+//! (PLAN.md ②) and the IO handle table
+//! ([`IoHandleTable`](super::io_handles::IoHandleTable), PLAN.md ③). Both are
+//! per-thread snapshots (a fresh `Arc` is cloned in `clone_for_thread`), so the
+//! lock never contends *across* threads; it exists only so the VM and the
+//! Interpreter can reach the data as peers *within* one thread, ping-ponging.
+//!
+//! `RwLock` is not reentrant, so the discipline (see each owner's module docs)
+//! is: never hold a read/write guard across a call that re-enters execution and
+//! might re-acquire the same lock. A stray held guard deadlocks, and a silent
+//! deadlock is only caught by `make roast`'s ~13-min timeout — a static text
+//! scanner misses code shapes the borrow checker also misses (e.g. a
+//! `write -> write` inside a `match self.lock_mut()…{}` arm).
+//!
+//! So instead we detect re-entry at runtime, in debug builds: each acquisition
+//! checks a thread-local record of the guards this thread currently holds *on
+//! that same lock* and panics with a located message before the would-be
+//! deadlocking `.read()`/`.write()` call.
+//!
+//! The record is keyed by the lock's address, NOT just by thread: a single
+//! thread legitimately holds guards on *different* locks at once (e.g.
+//! `self.registry_mut().classes = nested.registry().classes.clone();` holds a
+//! write guard on `self`'s registry and a read guard on a sub-interpreter's
+//! simultaneously). Those are independent locks, so there is no deadlock; a
+//! thread-global flag would false-positive. Only re-acquiring the *same* lock
+//! deadlocks.
+//!
+//! The allowed/forbidden matrix (per lock) matches `std::sync::RwLock`'s actual
+//! deadlock conditions:
+//!   - acquiring a WRITE while ANY guard on the same lock is held -> deadlock
+//!   - acquiring a READ while a WRITE on the same lock is held    -> deadlock
+//!   - acquiring a READ while only READ guards are held           -> tolerated
+//!     (nested reads are relied upon, e.g. `a().x && b().y` keeps both temporary
+//!     read guards alive to end-of-statement).
+//!
+//! This is `#[cfg(debug_assertions)]` only: the per-access bookkeeping would
+//! otherwise tax the hot read paths. CI's release `make roast` still backstops
+//! via timeout.
+
+#[cfg(debug_assertions)]
+mod reentry_check {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        // lock address -> (outstanding read guards, write guard held?) on this thread.
+        static HELD: RefCell<HashMap<usize, (u32, bool)>> = RefCell::new(HashMap::new());
+    }
+
+    /// Called before `RwLock::read()`. Panics if this thread already holds a write
+    /// guard on the same lock (read-while-write deadlocks).
+    pub(super) fn enter_read(lock: usize, name: &str) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            let entry = h.entry(lock).or_insert((0, false));
+            assert!(
+                !entry.1,
+                "{name}(): a read guard was acquired while this thread already \
+                 holds a write guard on the same lock (read-while-write). \
+                 RwLock is not reentrant; drop the write guard before re-entering. \
+                 See the lock discipline in src/runtime/lock_reentry.rs.",
+            );
+            entry.0 += 1;
+        });
+    }
+
+    pub(super) fn exit_read(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            if let Some(entry) = h.get_mut(&lock) {
+                entry.0 = entry.0.saturating_sub(1);
+                if entry.0 == 0 && !entry.1 {
+                    h.remove(&lock);
+                }
+            }
+        });
+    }
+
+    /// Called before `RwLock::write()`. Panics if this thread already holds any
+    /// guard on the same lock (write-while-anything deadlocks).
+    pub(super) fn enter_write(lock: usize, name: &str) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            let entry = h.entry(lock).or_insert((0, false));
+            assert!(
+                !entry.1,
+                "{name}_mut(): a write guard was acquired while this thread \
+                 already holds a write guard on the same lock (write -> write). \
+                 RwLock is not reentrant; consolidate into a single write guard. \
+                 See src/runtime/lock_reentry.rs.",
+            );
+            assert!(
+                entry.0 == 0,
+                "{name}_mut(): a write guard was acquired while this thread holds \
+                 a read guard on the same lock (read -> write upgrade). \
+                 RwLock is not reentrant; drop the read guard first. See \
+                 src/runtime/lock_reentry.rs.",
+            );
+            entry.1 = true;
+        });
+    }
+
+    pub(super) fn exit_write(lock: usize) {
+        HELD.with(|h| {
+            let mut h = h.borrow_mut();
+            if let Some(entry) = h.get_mut(&lock) {
+                entry.1 = false;
+                if entry.0 == 0 {
+                    h.remove(&lock);
+                }
+            }
+        });
+    }
+}
+
+/// Reentrancy-checked read guard over an `Arc<RwLock<T>>`. Derefs to `T`; in
+/// debug builds it records the acquisition in a thread-local so a re-entrant
+/// lock attempt panics with a located message instead of silently deadlocking
+/// (see the `reentry_check` module above). `name` identifies the lock in panic
+/// messages (e.g. `"registry"`, `"io_handles"`).
+pub(crate) struct ReentrantReadGuard<'a, T> {
+    inner: std::sync::RwLockReadGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    lock_id: usize,
+}
+
+impl<'a, T> ReentrantReadGuard<'a, T> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, name: &'static str) -> Self {
+        #[cfg(debug_assertions)]
+        let lock_id = lock as *const _ as usize;
+        #[cfg(debug_assertions)]
+        reentry_check::enter_read(lock_id, name);
+        // Acquire only after the reentry check, so a would-be deadlock panics
+        // instead of hanging on the blocking `.read()`.
+        let inner = lock.read().unwrap();
+        Self {
+            inner,
+            #[cfg(debug_assertions)]
+            lock_id,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for ReentrantReadGuard<'_, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T> Drop for ReentrantReadGuard<'_, T> {
+    fn drop(&mut self) {
+        reentry_check::exit_read(self.lock_id);
+    }
+}
+
+/// Reentrancy-checked write guard over an `Arc<RwLock<T>>`. Same instrumentation
+/// as [`ReentrantReadGuard`].
+pub(crate) struct ReentrantWriteGuard<'a, T> {
+    inner: std::sync::RwLockWriteGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    lock_id: usize,
+}
+
+impl<'a, T> ReentrantWriteGuard<'a, T> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, name: &'static str) -> Self {
+        #[cfg(debug_assertions)]
+        let lock_id = lock as *const _ as usize;
+        #[cfg(debug_assertions)]
+        reentry_check::enter_write(lock_id, name);
+        let inner = lock.write().unwrap();
+        Self {
+            inner,
+            #[cfg(debug_assertions)]
+            lock_id,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for ReentrantWriteGuard<'_, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> std::ops::DerefMut for ReentrantWriteGuard<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T> Drop for ReentrantWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        reentry_check::exit_write(self.lock_id);
+    }
+}

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -100,8 +100,6 @@ impl Interpreter {
                 let listener = std::os::unix::net::UnixListener::bind(&path).map_err(|e| {
                     RuntimeError::new(format!("Failed to bind UNIX socket '{}': {}", path, e))
                 })?;
-                let id = self.next_handle_id;
-                self.next_handle_id += 1;
                 let state = IoHandleState {
                     target: IoHandleTarget::Socket,
                     mode: IoHandleMode::ReadWrite,
@@ -127,7 +125,7 @@ impl Interpreter {
                     pending_words: std::collections::VecDeque::new(),
                     close_on_word_exhaust: false,
                 };
-                self.handles.insert(id, state);
+                let id = self.insert_handle_state(state);
                 let mut attrs = HashMap::new();
                 attrs.insert("handle".to_string(), Value::Int(id as i64));
                 attrs.insert("localport".to_string(), Value::Int(0i64));
@@ -146,8 +144,6 @@ impl Interpreter {
                 RuntimeError::new(format!("Failed to bind to '{}': {}", bind_addr, e))
             })?;
             let actual_port = listener.local_addr().map(|a| a.port()).unwrap_or(localport);
-            let id = self.next_handle_id;
-            self.next_handle_id += 1;
             let state = IoHandleState {
                 target: IoHandleTarget::Socket,
                 mode: IoHandleMode::ReadWrite,
@@ -173,7 +169,7 @@ impl Interpreter {
                 pending_words: std::collections::VecDeque::new(),
                 close_on_word_exhaust: false,
             };
-            self.handles.insert(id, state);
+            let id = self.insert_handle_state(state);
             let mut attrs = HashMap::new();
             attrs.insert("handle".to_string(), Value::Int(id as i64));
             attrs.insert("localport".to_string(), Value::Int(actual_port as i64));
@@ -205,8 +201,6 @@ impl Interpreter {
                         path, e
                     ))
                 })?;
-                let id = self.next_handle_id;
-                self.next_handle_id += 1;
                 let state = IoHandleState {
                     target: IoHandleTarget::Socket,
                     mode: IoHandleMode::ReadWrite,
@@ -232,7 +226,7 @@ impl Interpreter {
                     pending_words: std::collections::VecDeque::new(),
                     close_on_word_exhaust: false,
                 };
-                self.handles.insert(id, state);
+                let id = self.insert_handle_state(state);
                 let mut attrs = HashMap::new();
                 attrs.insert("handle".to_string(), Value::Int(id as i64));
                 attrs.insert("host".to_string(), Value::str(path));

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -27,8 +27,6 @@ impl Interpreter {
             Duration::from_secs(10),
         )
         .map_err(|e| RuntimeError::new(format!("Failed to connect to '{}': {}", addr, e)))?;
-        let id = self.next_handle_id;
-        self.next_handle_id += 1;
         let state = IoHandleState {
             target: IoHandleTarget::Socket,
             mode: IoHandleMode::ReadWrite,
@@ -54,7 +52,7 @@ impl Interpreter {
             pending_words: std::collections::VecDeque::new(),
             close_on_word_exhaust: false,
         };
-        self.handles.insert(id, state);
+        let id = self.insert_handle_state(state);
         let mut attrs = HashMap::new();
         attrs.insert("handle".to_string(), Value::Int(id as i64));
         attrs.insert("host".to_string(), Value::str(host));

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -775,7 +775,7 @@ impl Interpreter {
                     .collect(),
                 other => vec![other.to_string_value().into_bytes()],
             };
-            if let Some(state) = self.handles.get_mut(&id) {
+            if let Some(state) = self.io_handles_mut().map.get_mut(&id) {
                 state.line_separators = new_seps;
             }
             return Ok(value);
@@ -792,7 +792,7 @@ impl Interpreter {
         {
             let id = *handle_id as usize;
             let new_nl_out = value.to_string_value();
-            if let Some(state) = self.handles.get_mut(&id) {
+            if let Some(state) = self.io_handles_mut().map.get_mut(&id) {
                 state.nl_out = new_nl_out;
             }
             return Ok(value);
@@ -809,7 +809,7 @@ impl Interpreter {
         {
             let hid = *handle_id as usize;
             let new_chomp = value.truthy();
-            if let Some(state) = self.handles.get_mut(&hid) {
+            if let Some(state) = self.io_handles_mut().map.get_mut(&hid) {
                 state.line_chomp = new_chomp;
             }
             // Also update instance attribute so .open can inherit it

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -150,6 +150,8 @@ mod dispatch;
 mod eval_check;
 mod handle;
 mod io;
+mod io_handles;
+mod lock_reentry;
 mod main_args;
 mod metamodel;
 mod methods;
@@ -848,8 +850,10 @@ pub struct Interpreter {
     /// remain visible, but non-exported operators from loaded modules do not.
     pub(crate) imported_operator_names: HashSet<String>,
     lib_paths: Vec<String>,
-    handles: HashMap<usize, IoHandleState>,
-    next_handle_id: usize,
+    /// Open IO handles (files/sockets/listeners) shared between the VM and the
+    /// Interpreter behind transitional `Arc<RwLock>` scaffolding. Snapshot-cloned
+    /// per thread (see [`io_handles`] module docs and `clone_for_thread`).
+    io_handles: Arc<RwLock<io_handles::IoHandleTable>>,
     program_path: Option<String>,
     current_package: String,
     routine_stack: Vec<RoutineFrame>,
@@ -2875,8 +2879,10 @@ impl Interpreter {
             operator_assoc: HashMap::new(),
             imported_operator_names: HashSet::new(),
             lib_paths: Vec::new(),
-            handles: HashMap::new(),
-            next_handle_id: 1,
+            io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {
+                map: HashMap::new(),
+                next_id: 1,
+            })),
             program_path: None,
             current_package: "GLOBAL".to_string(),
             routine_stack: Vec::new(),
@@ -4223,7 +4229,8 @@ impl Interpreter {
         self.output_emitted = true;
         let byte_count = text.len() as i64;
         if let Some(stdout_handle) = self
-            .handles
+            .io_handles_mut()
+            .map
             .values_mut()
             .find(|h| matches!(h.target, IoHandleTarget::Stdout))
         {
@@ -5231,7 +5238,7 @@ impl Interpreter {
     /// [`RegistryReadGuard`](crate::runtime::registry::RegistryReadGuard)).
     #[inline]
     pub(crate) fn registry(&self) -> crate::runtime::registry::RegistryReadGuard<'_> {
-        crate::runtime::registry::RegistryReadGuard::new(&self.registry)
+        crate::runtime::registry::RegistryReadGuard::new(&self.registry, "registry")
     }
 
     /// Clone the shared declaration [`Registry`] handle so the VM can hold it as a
@@ -5250,7 +5257,35 @@ impl Interpreter {
     /// as [`Self::registry`].
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::registry::RegistryWriteGuard<'_> {
-        crate::runtime::registry::RegistryWriteGuard::new(&self.registry)
+        crate::runtime::registry::RegistryWriteGuard::new(&self.registry, "registry")
+    }
+
+    /// Read access to the shared [`IoHandleTable`](io_handles::IoHandleTable).
+    /// Same guard discipline as [`Self::registry`]: never hold the returned guard
+    /// across a call that re-enters another handle operation (`RwLock` is not
+    /// reentrant). Use as `self.io_handles().map.get(&id)`.
+    #[inline]
+    pub(crate) fn io_handles(&self) -> io_handles::IoHandlesReadGuard<'_> {
+        io_handles::IoHandlesReadGuard::new(&self.io_handles, "io_handles")
+    }
+
+    /// Write access to the shared [`IoHandleTable`](io_handles::IoHandleTable).
+    /// Same guard discipline as [`Self::io_handles`].
+    #[inline]
+    pub(crate) fn io_handles_mut(&self) -> io_handles::IoHandlesWriteGuard<'_> {
+        io_handles::IoHandlesWriteGuard::new(&self.io_handles, "io_handles")
+    }
+
+    /// Allocate a fresh handle id, store `state` under it, and return the id.
+    /// Build `state` fully (including anything that needs `&self`, e.g.
+    /// `default_line_separators()`) *before* calling this, since the short write
+    /// guard taken here must not be held across other `self` operations.
+    pub(super) fn insert_handle_state(&mut self, state: IoHandleState) -> usize {
+        let mut table = self.io_handles_mut();
+        let id = table.next_id;
+        table.next_id += 1;
+        table.map.insert(id, state);
+        id
     }
 
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
@@ -5302,7 +5337,8 @@ impl Interpreter {
             }
         }
         let mut cloned_handles = HashMap::new();
-        for (id, handle) in &self.handles {
+        let handles_guard = self.io_handles();
+        for (id, handle) in &handles_guard.map {
             if handle.closed || !referenced_handle_ids.contains(id) {
                 continue;
             }
@@ -5333,6 +5369,8 @@ impl Interpreter {
             };
             cloned_handles.insert(*id, cloned);
         }
+        let cloned_next_handle_id = handles_guard.next_id;
+        drop(handles_guard);
         let mut cloned = Self {
             env: self.env.clone(),
             output: String::new(),
@@ -5348,8 +5386,10 @@ impl Interpreter {
             operator_assoc: self.operator_assoc.clone(),
             imported_operator_names: self.imported_operator_names.clone(),
             lib_paths: self.lib_paths.clone(),
-            handles: cloned_handles,
-            next_handle_id: self.next_handle_id,
+            io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {
+                map: cloned_handles,
+                next_id: cloned_next_handle_id,
+            })),
             program_path: self.program_path.clone(),
             current_package: self.current_package.clone(),
             routine_stack: Vec::new(),
@@ -5848,7 +5888,7 @@ impl Interpreter {
 impl Interpreter {
     /// Flush all open file handle buffers. Call before process exit.
     pub fn flush_all_handles(&mut self) {
-        for state in self.handles.values_mut() {
+        for state in self.io_handles_mut().map.values_mut() {
             if state.closed {
                 continue;
             }

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2200,7 +2200,7 @@ impl Interpreter {
             "DESTROY" => {
                 // Standard handles ($*IN, $*OUT, $*ERR) must not be closed by DESTROY
                 let is_std = if let Some(id) = Self::handle_id_from_value(&target_val) {
-                    self.handles.get(&id).is_some_and(|s| {
+                    self.io_handles().map.get(&id).is_some_and(|s| {
                         matches!(
                             s.target,
                             IoHandleTarget::Stdin | IoHandleTarget::Stdout | IoHandleTarget::Stderr
@@ -2217,7 +2217,7 @@ impl Interpreter {
             "path" | "IO" => {
                 // For standard handles ($*IN, $*OUT, $*ERR), return IO::Special
                 if let Some(id) = Self::handle_id_from_value(&target_val)
-                    && let Some(state) = self.handles.get(&id)
+                    && let Some(state) = self.io_handles().map.get(&id)
                 {
                     let special_name = match state.target {
                         IoHandleTarget::Stdout => Some("STDOUT"),

--- a/src/runtime/native_methods/socket_helpers.rs
+++ b/src/runtime/native_methods/socket_helpers.rs
@@ -55,8 +55,9 @@ impl Interpreter {
         bin_mode: bool,
     ) -> Result<Value, RuntimeError> {
         use std::io::Read;
-        let state = self
-            .handles
+        let mut table = self.io_handles_mut();
+        let state = table
+            .map
             .get_mut(&handle_id)
             .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
         let stream = state
@@ -134,8 +135,9 @@ impl Interpreter {
         nbytes: usize,
     ) -> Result<Value, RuntimeError> {
         use std::io::Read;
-        let state = self
-            .handles
+        let mut table = self.io_handles_mut();
+        let state = table
+            .map
             .get_mut(&handle_id)
             .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
         let stream = state
@@ -165,15 +167,17 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         use std::io::Read;
         let separators = {
-            let state = self
-                .handles
+            let table = self.io_handles();
+            let state = table
+                .map
                 .get(&handle_id)
                 .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
             state.line_separators.clone()
         };
 
-        let state = self
-            .handles
+        let mut table = self.io_handles_mut();
+        let state = table
+            .map
             .get_mut(&handle_id)
             .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
         let stream = state

--- a/src/runtime/native_methods/socket_inet.rs
+++ b/src/runtime/native_methods/socket_inet.rs
@@ -20,8 +20,9 @@ impl Interpreter {
             "getpeername" => {
                 let id =
                     handle_id.ok_or_else(|| RuntimeError::new("IO::Socket::INET has no handle"))?;
-                let state = self
-                    .handles
+                let table = self.io_handles();
+                let state = table
+                    .map
                     .get(&id)
                     .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                 if state.closed {
@@ -39,8 +40,9 @@ impl Interpreter {
             "close" => {
                 let id =
                     handle_id.ok_or_else(|| RuntimeError::new("IO::Socket::INET has no handle"))?;
-                let state = self
-                    .handles
+                let mut table = self.io_handles_mut();
+                let state = table
+                    .map
                     .get_mut(&id)
                     .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                 state.closed = true;
@@ -60,8 +62,9 @@ impl Interpreter {
                     handle_id.ok_or_else(|| RuntimeError::new("IO::Socket::INET has no handle"))?;
                 // Take listener out temporarily to avoid borrow issues
                 let listener = {
-                    let state = self
-                        .handles
+                    let mut table = self.io_handles_mut();
+                    let state = table
+                        .map
                         .get_mut(&id)
                         .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                     state.listener.as_ref().and_then(|l| l.try_clone().ok())
@@ -72,8 +75,6 @@ impl Interpreter {
                     .accept()
                     .map_err(|e| RuntimeError::new(format!("accept failed: {}", e)))?;
                 // Create a new handle for the accepted connection
-                let new_id = self.next_handle_id;
-                self.next_handle_id += 1;
                 let state = super::super::IoHandleState {
                     target: super::super::IoHandleTarget::Socket,
                     mode: super::super::IoHandleMode::ReadWrite,
@@ -99,7 +100,7 @@ impl Interpreter {
                     pending_words: std::collections::VecDeque::new(),
                     close_on_word_exhaust: false,
                 };
-                self.handles.insert(new_id, state);
+                let new_id = self.insert_handle_state(state);
                 let mut attrs = HashMap::new();
                 attrs.insert("handle".to_string(), Value::Int(new_id as i64));
                 Ok(Value::make_instance(
@@ -117,8 +118,9 @@ impl Interpreter {
                 if method == "say" || method == "put" {
                     data.push('\n');
                 }
-                let state = self
-                    .handles
+                let mut table = self.io_handles_mut();
+                let state = table
+                    .map
                     .get_mut(&id)
                     .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                 if let Some(ref mut stream) = state.socket {
@@ -143,8 +145,9 @@ impl Interpreter {
                 } else {
                     return Err(RuntimeError::new("write expects a Buf argument"));
                 };
-                let state = self
-                    .handles
+                let mut table = self.io_handles_mut();
+                let state = table
+                    .map
                     .get_mut(&id)
                     .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                 if let Some(ref mut stream) = state.socket {
@@ -203,8 +206,9 @@ impl Interpreter {
                 // Getter for nl-in
                 let id =
                     handle_id.ok_or_else(|| RuntimeError::new("IO::Socket::INET has no handle"))?;
-                let state = self
-                    .handles
+                let table = self.io_handles();
+                let state = table
+                    .map
                     .get(&id)
                     .ok_or_else(|| RuntimeError::new("Invalid socket handle"))?;
                 let seps: Vec<Value> = state

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -787,7 +787,8 @@ impl Interpreter {
         let Some(handle_id) = Self::handle_id_from_value(value) else {
             return Ok(None);
         };
-        let Some(state) = self.handles.get_mut(&handle_id) else {
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&handle_id) else {
             return Err(RuntimeError::new("Invalid IO::Handle"));
         };
         let Some(file) = state.file.as_mut() else {
@@ -809,7 +810,8 @@ impl Interpreter {
         let Some(handle_id) = Self::handle_id_from_value(value) else {
             return Ok(None);
         };
-        let Some(state) = self.handles.get_mut(&handle_id) else {
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&handle_id) else {
             return Err(RuntimeError::new("Invalid IO::Handle"));
         };
         let Some(file) = state.file.as_mut() else {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -387,193 +387,22 @@ impl Registry {
 // enum variant values, parametric role bodies), so a stray held guard silently
 // deadlocks.
 //
-// A silent deadlock is only caught by `make roast`'s ~13-min timeout, and a
-// static text scanner misses code shapes the borrow checker also misses (PR-A
-// slice 5: a `write -> write` inside a `match self.registry_mut()...{}` arm hung
-// at runtime despite passing both checks). So instead we detect re-entry at
-// runtime, in debug builds: each acquisition checks a thread-local record of the
-// guards this thread currently holds *on that same lock* and panics with a
-// located message before the would-be-deadlocking `.read()`/`.write()` call.
-//
-// The record is keyed by the lock's address, NOT just by thread: a single thread
-// legitimately holds guards on *different* registries at once — e.g.
-// `self.registry_mut().classes = nested.registry().classes.clone();` holds a
-// write guard on `self`'s registry and a read guard on a sub-interpreter's
-// (`nested`) registry simultaneously. Those are independent locks, so there is no
-// deadlock; a thread-global flag would false-positive. Only re-acquiring the
-// *same* lock deadlocks.
-//
-// The allowed/forbidden matrix (per lock) matches `std::sync::RwLock`'s actual
-// deadlock conditions:
-//   - acquiring a WRITE while ANY guard (read or write) on the same lock is held -> deadlock
-//   - acquiring a READ while a WRITE on the same lock is held                    -> deadlock
-//   - acquiring a READ while only READ guards on the same lock are held          -> tolerated
-//     (nested reads are relied upon, e.g. `a().x && b().y` keeps both temporary
-//     read guards alive to end-of-statement).
-//
-// This is `#[cfg(debug_assertions)]` only: the per-access bookkeeping would
-// otherwise tax the hot `registry()` read path (method dispatch reads MRO through
-// it). CI's release `make roast` still backstops via timeout.
+// The reentrancy-detecting guard machinery is shared with the IO handle table
+// (PLAN.md ③) in [`crate::runtime::lock_reentry`]; see that module for the full
+// rationale (lock-address keying, the allowed/forbidden matrix, debug-only
+// instrumentation). The registry's guards are concrete type aliases over the
+// generic guards, identified by the `"registry"` lock name in panic messages.
 
-#[cfg(debug_assertions)]
-mod reentry_check {
-    use std::cell::RefCell;
-    use std::collections::HashMap;
+/// Read guard for the shared [`Registry`]; a [`ReentrantReadGuard`] keyed by the
+/// `"registry"` lock name. See [`crate::runtime::lock_reentry`].
+///
+/// [`ReentrantReadGuard`]: crate::runtime::lock_reentry::ReentrantReadGuard
+pub(crate) type RegistryReadGuard<'a> =
+    crate::runtime::lock_reentry::ReentrantReadGuard<'a, Registry>;
 
-    thread_local! {
-        // lock address -> (outstanding read guards, write guard held?) on this thread.
-        static HELD: RefCell<HashMap<usize, (u32, bool)>> = RefCell::new(HashMap::new());
-    }
-
-    /// Called before `RwLock::read()`. Panics if this thread already holds a write
-    /// guard on the same lock (read-while-write deadlocks).
-    pub(super) fn enter_read(lock: usize) {
-        HELD.with(|h| {
-            let mut h = h.borrow_mut();
-            let entry = h.entry(lock).or_insert((0, false));
-            assert!(
-                !entry.1,
-                "registry(): a read guard was acquired while this thread already \
-                 holds a write guard on the same registry. RwLock<Registry> is not \
-                 reentrant; drop the write guard before re-entering. See the lock \
-                 discipline in src/runtime/registry.rs / docs/vm-registry-ownership.md.",
-            );
-            entry.0 += 1;
-        });
-    }
-
-    pub(super) fn exit_read(lock: usize) {
-        HELD.with(|h| {
-            let mut h = h.borrow_mut();
-            if let Some(entry) = h.get_mut(&lock) {
-                entry.0 = entry.0.saturating_sub(1);
-                if entry.0 == 0 && !entry.1 {
-                    h.remove(&lock);
-                }
-            }
-        });
-    }
-
-    /// Called before `RwLock::write()`. Panics if this thread already holds any
-    /// guard on the same lock (write-while-anything deadlocks).
-    pub(super) fn enter_write(lock: usize) {
-        HELD.with(|h| {
-            let mut h = h.borrow_mut();
-            let entry = h.entry(lock).or_insert((0, false));
-            assert!(
-                !entry.1,
-                "registry_mut(): a write guard was acquired while this thread \
-                 already holds a write guard on the same registry (write -> write). \
-                 RwLock<Registry> is not reentrant; consolidate into a single write \
-                 guard. See src/runtime/registry.rs / docs/vm-registry-ownership.md.",
-            );
-            assert!(
-                entry.0 == 0,
-                "registry_mut(): a write guard was acquired while this thread holds \
-                 a read guard on the same registry (read -> write upgrade). \
-                 RwLock<Registry> is not reentrant; drop the read guard first. See \
-                 src/runtime/registry.rs / docs/vm-registry-ownership.md.",
-            );
-            entry.1 = true;
-        });
-    }
-
-    pub(super) fn exit_write(lock: usize) {
-        HELD.with(|h| {
-            let mut h = h.borrow_mut();
-            if let Some(entry) = h.get_mut(&lock) {
-                entry.1 = false;
-                if entry.0 == 0 {
-                    h.remove(&lock);
-                }
-            }
-        });
-    }
-}
-
-/// Read guard for the shared [`Registry`]. Derefs to `Registry`; in debug builds
-/// it records the acquisition in a thread-local so a re-entrant lock attempt
-/// panics with a located message instead of silently deadlocking (see the
-/// `reentry_check` module above).
-pub(crate) struct RegistryReadGuard<'a> {
-    inner: std::sync::RwLockReadGuard<'a, Registry>,
-    #[cfg(debug_assertions)]
-    lock_id: usize,
-}
-
-impl<'a> RegistryReadGuard<'a> {
-    pub(crate) fn new(lock: &'a std::sync::RwLock<Registry>) -> Self {
-        #[cfg(debug_assertions)]
-        let lock_id = lock as *const _ as usize;
-        #[cfg(debug_assertions)]
-        reentry_check::enter_read(lock_id);
-        // Acquire only after the reentry check, so a would-be deadlock panics
-        // instead of hanging on the blocking `.read()`.
-        let inner = lock.read().unwrap();
-        Self {
-            inner,
-            #[cfg(debug_assertions)]
-            lock_id,
-        }
-    }
-}
-
-impl std::ops::Deref for RegistryReadGuard<'_> {
-    type Target = Registry;
-    #[inline]
-    fn deref(&self) -> &Registry {
-        &self.inner
-    }
-}
-
-#[cfg(debug_assertions)]
-impl Drop for RegistryReadGuard<'_> {
-    fn drop(&mut self) {
-        reentry_check::exit_read(self.lock_id);
-    }
-}
-
-/// Write guard for the shared [`Registry`]. Same reentry instrumentation as
-/// [`RegistryReadGuard`].
-pub(crate) struct RegistryWriteGuard<'a> {
-    inner: std::sync::RwLockWriteGuard<'a, Registry>,
-    #[cfg(debug_assertions)]
-    lock_id: usize,
-}
-
-impl<'a> RegistryWriteGuard<'a> {
-    pub(crate) fn new(lock: &'a std::sync::RwLock<Registry>) -> Self {
-        #[cfg(debug_assertions)]
-        let lock_id = lock as *const _ as usize;
-        #[cfg(debug_assertions)]
-        reentry_check::enter_write(lock_id);
-        let inner = lock.write().unwrap();
-        Self {
-            inner,
-            #[cfg(debug_assertions)]
-            lock_id,
-        }
-    }
-}
-
-impl std::ops::Deref for RegistryWriteGuard<'_> {
-    type Target = Registry;
-    #[inline]
-    fn deref(&self) -> &Registry {
-        &self.inner
-    }
-}
-
-impl std::ops::DerefMut for RegistryWriteGuard<'_> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Registry {
-        &mut self.inner
-    }
-}
-
-#[cfg(debug_assertions)]
-impl Drop for RegistryWriteGuard<'_> {
-    fn drop(&mut self) {
-        reentry_check::exit_write(self.lock_id);
-    }
-}
+/// Write guard for the shared [`Registry`]; a [`ReentrantWriteGuard`] keyed by
+/// the `"registry"` lock name. See [`crate::runtime::lock_reentry`].
+///
+/// [`ReentrantWriteGuard`]: crate::runtime::lock_reentry::ReentrantWriteGuard
+pub(crate) type RegistryWriteGuard<'a> =
+    crate::runtime::lock_reentry::ReentrantWriteGuard<'a, Registry>;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -473,7 +473,7 @@ impl VM {
     /// logic — forbidden by the "1 operation = 1 implementation" rule.)
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::RegistryWriteGuard<'_> {
-        crate::runtime::RegistryWriteGuard::new(&self.registry)
+        crate::runtime::RegistryWriteGuard::new(&self.registry, "registry")
     }
 
     /// Run the compiled bytecode. Always returns the interpreter back


### PR DESCRIPTION
## Summary

Phase ③ native IO ownership, **PR-B**: lift `Interpreter.handles` / `next_handle_id` behind `io_handles: Arc<RwLock<IoHandleTable>>` (`src/runtime/io_handles.rs`) — the same shared-handle scaffolding ② used for the declaration `Registry`. Behavior-unchanged restructure. Design: `docs/vm-io-ownership.md`.

Why a shared `Arc<RwLock>` is correct here (unlike `env`): IO handles are **per-thread snapshots**, not live-shared. `clone_for_thread` deep-clones referenced handles into a fresh `Arc`; a child thread's newly opened handles are merged back into the parent explicitly. So the lock never contends across threads — it exists only for the within-thread VM↔Interpreter ping-pong (non-concurrent). Holding a guard across blocking IO cannot deadlock another holder; the only hazard is the *same* thread re-acquiring the lock, which the debug reentry guard catches.

## Changes

- **Generalize the reentrancy-detecting guards** into `src/runtime/lock_reentry.rs`: generic `ReentrantReadGuard<T>` / `ReentrantWriteGuard<T>` (lock name passed into panic messages). ②'s `RegistryReadGuard`/`RegistryWriteGuard` become type aliases (call sites unchanged besides the `, "registry"` arg). IO gets `IoHandlesReadGuard`/`IoHandlesWriteGuard` aliases + `io_handles()`/`io_handles_mut()` accessors mirroring `registry()`/`registry_mut()`.
- **Convert all ~59 access sites (10 files)** to the accessors. New `insert_handle_state(state) -> id` helper centralizes id allocation + insert, folding duplicated `next_handle_id`/`handles.insert` clusters. State is built fully (incl. `&self`-dependent `default_line_separators()`) before the short write guard is taken.
- **`with_handle_mut` / `with_handle_mut_opt`** go through the write guard; PR-A's closure confinement means the guard cannot be held across a self re-entry.
- **`clone_for_thread`** builds a fresh `Arc<RwLock<IoHandleTable>>` (per-thread snapshot, semantics unchanged); spawn/await merge-back reads the child snapshot and merges open handles + `next_id` into the parent via the accessors.

## Verification (debug build, reentry guard active)

- Smoke test **byte-identical to `raku`**: say/nl-out, file get/lines/words/seek/tell/eof/getc, `:w` print+say, thread-opened-handle merge-back, `$*OUT`.
- Whitelisted S32-io (seek/tell/open/slurp/spurt/out-buffering/utf16/null-char + IO-Socket-INET/UNIX/accept-threads/fail-invalid/pipe/note/other + Async/Async-UDP/signals) and `t/` (io-*/socket/thread/concurrency/proc-async/subtest-threaded) green, **zero reentry panics**.
- `make test` (cargo 458 + prove 6292) green.

Next: **PR-C** (migrate the `io_handles` handle into the VM, ② #2895 equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)