### PR TITLE
refactor(io): VM-native dispatch for pure IO::Handle methods (③ native IO PR-C)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -151,3 +151,25 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
     slurp/spurt/out-buffering/utf16/null-char + IO-Socket-INET/UNIX/accept-threads/fail-invalid/pipe/note/other +
     Async/Async-UDP/signals）+ t/（io-*/socket/thread/concurrency/proc-async/subtest-threaded）緑、再入 panic ゼロ。
     `make test`（cargo 458 + prove 6292）緑。次の着手 = **PR-C**（VM へ io_handles ハンドル移管、② #2895 相当）。
+- **PR-C 完了（2026-06-11）**: VM へ `io_handles` ハンドル移管（② #2895 相当）＋**最初の VM ネイティブ IO dispatch
+  スライス**。② registry は VM 直アクセスサイト（package_stubs）が既存だったため #2895 が純粋なハンドル追加で済んだが、
+  IO は VM 直アクセスが**ゼロ**（catch-all が `self.interpreter.call_method_with_values` へ全部落とす）。よってハンドル
+  だけ足すと dead_code になる → #2895 同様「実ユーザを伴うハンドル移管」とし、**純粋ハンドルメソッド**を最初の
+  ネイティブ dispatch として実装。
+  - **純粋ロジックを `impl IoHandleState` へ抽出**（`handle.rs`）: `flush_buffer`/`tell`/`eof`/`seek`/`close`/
+    `is_opened`/`is_tty` — emit_output/env/encoding 非依存の状態専有操作。Interpreter の `*_handle_value` ラッパは
+    これらへ委譲（`with_handle_mut(hv, |s| s.tell())` 等）、native_io の `t`/`opened` も委譲。`flush_file_handle_buffer`
+    （Interpreter 関連関数）→ `IoHandleState::flush_buffer`（6 呼び出し側変換）。＝「1 操作 = 1 実装」。
+  - **VM ハンドル**: `Interpreter::io_handles_handle()`（Arc clone、`registry_handle()` 同型）、VM に `io_handles`
+    フィールド（`VM::new` で clone）+ `io_handles_mut()` アクセサ。両ハンドルは同一 RwLock を指し、debug 再入 guard
+    が deadlock を検出。`clone_for_thread` が fresh Interpreter を作るため VM 寿命中 Arc は安定（#2895 と同じ論拠）。
+  - **`try_native_io_handle_method`**（`vm_call_method_compiled.rs`、catch-all 直前）: 受け手が **`IO::Handle`
+    厳密一致**（`IO::Socket::INET` の socket-close / `IO::Pipe` の process-reap close は除外）かつ method ∈
+    {close/tell/eof/seek/opened/t} かつ引数が純粋（junction はインタプリタ autothread へ fall through）のとき VM の
+    `io_handles_mut()` で state を引き共有メソッドを呼ぶ。seek の arg 解釈は native_io と完全一致（非Int offset→0、
+    whence 文字列→0/1/2）。それ以外は全て `None`（fall through）。`handle_id_from_value` を `pub(crate)` 化。
+  - **検証**: PR-B smoke + 新規 `t/io-handle-pure-methods.t`（16 本、tell/eof/seek/opened/close/t）を raku と byte
+    一致、whitelisted S32-io（seek/tell/open 等が VM ネイティブ経路を通過）+ socket/pipe/thread 緑、`make test`
+    （cargo 458 + prove 6338）緑、再入 panic ゼロ。double-close が False 返し（raku は True）の差は**抽出前から存在
+    する既存挙動**（verbatim 抽出ゆえ PR-C は不変、roast close.t/open.t も緑）。次 = **PR-D**（read/write/lines/slurp
+    等の重 IO メソッドを段階的に VM ネイティブ化。emit_output/env/encoding 依存ゆえ ③ 後段/④ の状態移管が前提）。

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -1,6 +1,167 @@
 use super::*;
 use num_traits::ToPrimitive;
 
+/// Pure per-handle operations that touch only the handle's own state — no
+/// `Interpreter` state (no `emit_output`, env, or encoding helpers). These are
+/// the single authoritative implementation shared by the interpreter's
+/// `*_handle_value` wrappers and the VM-native IO dispatch
+/// (`try_native_io_handle_method`), so the §1 native-IO fork for these methods
+/// can resolve in the VM via its own `io_handles` handle without bouncing
+/// through `self.interpreter` (PLAN.md ③ native IO PR-C).
+impl IoHandleState {
+    /// Flush any buffered (`:out-buffer`) bytes to the underlying file.
+    pub(crate) fn flush_buffer(&mut self) -> Result<(), RuntimeError> {
+        if self.out_buffer_pending.is_empty() {
+            return Ok(());
+        }
+        let Some(file) = self.file.as_mut() else {
+            return Err(RuntimeError::new("IO::Handle is not attached to a file"));
+        };
+        file.write_all(&self.out_buffer_pending)
+            .map_err(|err| RuntimeError::new(format!("Failed to write to file: {}", err)))?;
+        self.out_buffer_pending.clear();
+        Ok(())
+    }
+
+    /// `.tell` — current byte offset (file position, or bytes written for
+    /// non-file targets).
+    pub(crate) fn tell(&mut self) -> Result<i64, RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed("handle operation"));
+        }
+        match self.target {
+            IoHandleTarget::File => {
+                let file = self
+                    .file
+                    .as_mut()
+                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                let pos = file.stream_position().map_err(|err| {
+                    RuntimeError::new(format!("Failed to query position: {}", err))
+                })?;
+                Ok(pos as i64)
+            }
+            _ => Ok(self.bytes_written),
+        }
+    }
+
+    /// `.eof` — whether the read position is at end of file.
+    pub(crate) fn eof(&mut self) -> Result<bool, RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed("handle operation"));
+        }
+        match self.target {
+            IoHandleTarget::File => {
+                let file = self
+                    .file
+                    .as_mut()
+                    .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+                let pos = file.stream_position().map_err(|err| {
+                    RuntimeError::new(format!("Failed to query position: {}", err))
+                })?;
+                let end = file
+                    .metadata()
+                    .map_err(|err| RuntimeError::new(format!("Failed to stat file: {}", err)))?
+                    .len();
+                // Raku semantics: a freshly opened file where pos == 0 and the
+                // reported size is 0 returns False for .eof until a read or seek
+                // has been performed (handles truly empty files and /proc
+                // virtual files that report size 0).
+                if pos == 0 && end == 0 && !self.read_attempted {
+                    return Ok(false);
+                }
+                Ok(pos >= end)
+            }
+            IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => Ok(false),
+            _ => Err(RuntimeError::new("Handle not readable")),
+        }
+    }
+
+    /// `.seek($offset, $whence)` — reposition the file cursor. `mode`: 0 = from
+    /// beginning, 1 = from current, 2 = from end. Returns the new position.
+    pub(crate) fn seek(&mut self, pos: i64, mode: i32) -> Result<i64, RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed("handle operation"));
+        }
+        self.read_attempted = true;
+        let file = self
+            .file
+            .as_mut()
+            .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
+        let seek_from = match mode {
+            1 => SeekFrom::Current(pos),
+            2 => SeekFrom::End(pos),
+            _ => {
+                if pos < 0 {
+                    return Err(RuntimeError::new(
+                        "X::IO::Seek: Cannot seek to a negative position",
+                    ));
+                }
+                SeekFrom::Start(pos as u64)
+            }
+        };
+        if mode == 1 || mode == 2 {
+            let current = file
+                .stream_position()
+                .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+            let target_pos = match mode {
+                1 => current as i64 + pos,
+                2 => {
+                    let end = file
+                        .seek(SeekFrom::End(0))
+                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                    file.seek(SeekFrom::Start(current))
+                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                    end as i64 + pos
+                }
+                _ => unreachable!(),
+            };
+            if target_pos < 0 {
+                return Err(RuntimeError::new(
+                    "X::IO::Seek: Cannot seek to a negative position",
+                ));
+            }
+        }
+        let new_pos = file
+            .seek(seek_from)
+            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+        Ok(new_pos as i64)
+    }
+
+    /// `.close` — flush + close a file handle. Returns false if already closed.
+    pub(crate) fn close(&mut self) -> Result<bool, RuntimeError> {
+        if self.closed {
+            return Ok(false);
+        }
+        if matches!(self.target, IoHandleTarget::File) {
+            self.flush_buffer()?;
+            if let Some(file) = self.file.as_mut() {
+                file.flush()
+                    .map_err(|err| RuntimeError::new(format!("Failed to flush handle: {}", err)))?;
+            }
+        }
+        self.closed = true;
+        self.file = None;
+        Ok(true)
+    }
+
+    /// `.opened` — whether the handle is still open.
+    pub(crate) fn is_opened(&self) -> bool {
+        !self.closed
+    }
+
+    /// `.t` — whether the handle is attached to a TTY.
+    pub(crate) fn is_tty(&self) -> bool {
+        use std::io::IsTerminal;
+        match self.target {
+            IoHandleTarget::Stdin => std::io::stdin().is_terminal(),
+            IoHandleTarget::Stdout => std::io::stdout().is_terminal(),
+            IoHandleTarget::Stderr => std::io::stderr().is_terminal(),
+            IoHandleTarget::File => self.file.as_ref().is_some_and(|f| f.is_terminal()),
+            _ => false,
+        }
+    }
+}
+
 impl Interpreter {
     pub(super) fn parse_out_buffer_size(value: &Value) -> Option<usize> {
         match value {
@@ -8,19 +169,6 @@ impl Interpreter {
             Value::BigInt(i) if i.sign() != num_bigint::Sign::Minus => i.to_usize(),
             _ => None,
         }
-    }
-
-    pub(super) fn flush_file_handle_buffer(state: &mut IoHandleState) -> Result<(), RuntimeError> {
-        if state.out_buffer_pending.is_empty() {
-            return Ok(());
-        }
-        let Some(file) = state.file.as_mut() else {
-            return Err(RuntimeError::new("IO::Handle is not attached to a file"));
-        };
-        file.write_all(&state.out_buffer_pending)
-            .map_err(|err| RuntimeError::new(format!("Failed to write to file: {}", err)))?;
-        state.out_buffer_pending.clear();
-        Ok(())
     }
 
     pub(super) fn default_line_separators(&self) -> Vec<Vec<u8>> {
@@ -96,7 +244,7 @@ impl Interpreter {
         result
     }
 
-    pub(super) fn handle_id_from_value(value: &Value) -> Option<usize> {
+    pub(crate) fn handle_id_from_value(value: &Value) -> Option<usize> {
         if let Value::Instance {
             class_name,
             attributes,
@@ -233,7 +381,7 @@ impl Interpreter {
                 };
                 if let Some(capacity) = state.out_buffer_capacity {
                     if capacity == 0 {
-                        Self::flush_file_handle_buffer(state)?;
+                        state.flush_buffer()?;
                         if let Some(file) = state.file.as_mut() {
                             file.write_all(payload_bytes).map_err(|err| {
                                 RuntimeError::new(format!("Failed to write to file: {}", err))
@@ -243,7 +391,7 @@ impl Interpreter {
                     }
                     if payload_bytes.len() > capacity {
                         // Large payloads bypass buffering after flushing queued data.
-                        Self::flush_file_handle_buffer(state)?;
+                        state.flush_buffer()?;
                         if let Some(file) = state.file.as_mut() {
                             file.write_all(payload_bytes).map_err(|err| {
                                 RuntimeError::new(format!("Failed to write to file: {}", err))
@@ -252,7 +400,7 @@ impl Interpreter {
                         return Ok(());
                     }
                     if state.out_buffer_pending.len() + payload_bytes.len() > capacity {
-                        Self::flush_file_handle_buffer(state)?;
+                        state.flush_buffer()?;
                     }
                     state.out_buffer_pending.extend_from_slice(payload_bytes);
                     Ok(())
@@ -346,22 +494,7 @@ impl Interpreter {
         &mut self,
         handle_value: &Value,
     ) -> Result<bool, RuntimeError> {
-        self.with_handle_mut(handle_value, |state| {
-            if state.closed {
-                return Ok(false);
-            }
-            if matches!(state.target, IoHandleTarget::File) {
-                Self::flush_file_handle_buffer(state)?;
-                if let Some(file) = state.file.as_mut() {
-                    file.flush().map_err(|err| {
-                        RuntimeError::new(format!("Failed to flush handle: {}", err))
-                    })?;
-                }
-            }
-            state.closed = true;
-            state.file = None;
-            Ok(true)
-        })
+        self.with_handle_mut(handle_value, |state| state.close())
     }
 
     fn read_record_bytes<R: Read>(
@@ -968,108 +1101,15 @@ impl Interpreter {
         pos: i64,
         mode: i32,
     ) -> Result<i64, RuntimeError> {
-        self.with_handle_mut(handle_value, |state| {
-            if state.closed {
-                return Err(RuntimeError::io_closed("handle operation"));
-            }
-            state.read_attempted = true;
-            let file = state
-                .file
-                .as_mut()
-                .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-            let seek_from = match mode {
-                1 => SeekFrom::Current(pos),
-                2 => SeekFrom::End(pos),
-                _ => {
-                    if pos < 0 {
-                        return Err(RuntimeError::new(
-                            "X::IO::Seek: Cannot seek to a negative position",
-                        ));
-                    }
-                    SeekFrom::Start(pos as u64)
-                }
-            };
-            if mode == 1 || mode == 2 {
-                let current = file
-                    .stream_position()
-                    .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                let target_pos = match mode {
-                    1 => current as i64 + pos,
-                    2 => {
-                        let end = file
-                            .seek(SeekFrom::End(0))
-                            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                        file.seek(SeekFrom::Start(current))
-                            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                        end as i64 + pos
-                    }
-                    _ => unreachable!(),
-                };
-                if target_pos < 0 {
-                    return Err(RuntimeError::new(
-                        "X::IO::Seek: Cannot seek to a negative position",
-                    ));
-                }
-            }
-            let new_pos = file
-                .seek(seek_from)
-                .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-            Ok(new_pos as i64)
-        })
+        self.with_handle_mut(handle_value, |state| state.seek(pos, mode))
     }
 
     pub(super) fn tell_handle_value(&mut self, handle_value: &Value) -> Result<i64, RuntimeError> {
-        self.with_handle_mut(handle_value, |state| {
-            if state.closed {
-                return Err(RuntimeError::io_closed("handle operation"));
-            }
-            match state.target {
-                IoHandleTarget::File => {
-                    let file = state
-                        .file
-                        .as_mut()
-                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                    let pos = file.stream_position().map_err(|err| {
-                        RuntimeError::new(format!("Failed to query position: {}", err))
-                    })?;
-                    Ok(pos as i64)
-                }
-                _ => Ok(state.bytes_written),
-            }
-        })
+        self.with_handle_mut(handle_value, |state| state.tell())
     }
 
     pub(super) fn handle_eof_value(&mut self, handle_value: &Value) -> Result<bool, RuntimeError> {
-        self.with_handle_mut(handle_value, |state| {
-            if state.closed {
-                return Err(RuntimeError::io_closed("handle operation"));
-            }
-            match state.target {
-                IoHandleTarget::File => {
-                    let file = state
-                        .file
-                        .as_mut()
-                        .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-                    let pos = file.stream_position().map_err(|err| {
-                        RuntimeError::new(format!("Failed to query position: {}", err))
-                    })?;
-                    let end = file
-                        .metadata()
-                        .map_err(|err| RuntimeError::new(format!("Failed to stat file: {}", err)))?
-                        .len();
-                    // Raku semantics: a freshly opened file where pos == 0 and
-                    // the reported size is 0 returns False for .eof until a read
-                    // or seek has been performed. This handles both truly empty
-                    // files and /proc virtual files that report size 0.
-                    if pos == 0 && end == 0 && !state.read_attempted {
-                        return Ok(false);
-                    }
-                    Ok(pos >= end)
-                }
-                IoHandleTarget::Stdin | IoHandleTarget::ArgFiles => Ok(false),
-                _ => Err(RuntimeError::new("Handle not readable")),
-            }
-        })
+        self.with_handle_mut(handle_value, |state| state.eof())
     }
 
     pub(super) fn set_handle_encoding(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -221,6 +221,7 @@ mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) mod value_iterator;
+pub(crate) use self::io_handles::{IoHandleTable, IoHandlesWriteGuard};
 pub(crate) use self::registration_class::ClassDeclModifiers;
 pub(crate) use self::registry::{Registry, RegistryWriteGuard};
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};
@@ -5274,6 +5275,18 @@ impl Interpreter {
     #[inline]
     pub(crate) fn io_handles_mut(&self) -> io_handles::IoHandlesWriteGuard<'_> {
         io_handles::IoHandlesWriteGuard::new(&self.io_handles, "io_handles")
+    }
+
+    /// Clone the shared [`IoHandleTable`](io_handles::IoHandleTable) handle so the
+    /// VM can hold it as a peer (PLAN.md ③ native IO PR-C: VM owns its own handle
+    /// to the same `RwLock`, mirroring [`Self::registry_handle`]). Both point at
+    /// the same lock, so mutations through either are visible and the debug
+    /// re-entrancy guard (keyed by lock address) still flags deadlocking
+    /// re-acquires. Collapses to a plain VM field once the Interpreter execution
+    /// path is removed (④/⑤).
+    #[inline]
+    pub(crate) fn io_handles_handle(&self) -> Arc<RwLock<io_handles::IoHandleTable>> {
+        self.io_handles.clone()
     }
 
     /// Allocate a fresh handle id, store `state` under it, and return the id.

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2695,7 +2695,7 @@ impl Interpreter {
             }
             "flush" => {
                 let flushed = self.with_handle_mut_opt(&target_val, |state| {
-                    Self::flush_file_handle_buffer(state)?;
+                    state.flush_buffer()?;
                     if let Some(file) = state.file.as_mut() {
                         file.flush().map_err(|err| {
                             RuntimeError::new(format!("Failed to flush handle: {}", err))
@@ -2723,7 +2723,7 @@ impl Interpreter {
             "out-buffer" => {
                 let size = self.with_handle_mut(&target_val, |state| {
                     if let Some(arg) = args.first() {
-                        Self::flush_file_handle_buffer(state)?;
+                        state.flush_buffer()?;
                         state.out_buffer_capacity = Self::parse_out_buffer_size(arg);
                     }
                     Ok(state.out_buffer_capacity.unwrap_or(0))
@@ -2761,23 +2761,7 @@ impl Interpreter {
                 Ok(Value::Bool(at_end))
             }
             "t" => {
-                // Check if the handle is a TTY
-                use std::io::IsTerminal;
-                let is_tty = self.with_handle_mut(&target_val, |state| {
-                    Ok(match state.target {
-                        IoHandleTarget::Stdin => std::io::stdin().is_terminal(),
-                        IoHandleTarget::Stdout => std::io::stdout().is_terminal(),
-                        IoHandleTarget::Stderr => std::io::stderr().is_terminal(),
-                        IoHandleTarget::File => {
-                            if let Some(file) = state.file.as_ref() {
-                                file.is_terminal()
-                            } else {
-                                false
-                            }
-                        }
-                        _ => false,
-                    })
-                })?;
+                let is_tty = self.with_handle_mut(&target_val, |state| Ok(state.is_tty()))?;
                 Ok(Value::Bool(is_tty))
             }
             "encoding" => {
@@ -2802,7 +2786,7 @@ impl Interpreter {
                 Ok(Value::str(current))
             }
             "opened" => {
-                let opened = self.with_handle_mut(&target_val, |state| Ok(!state.closed))?;
+                let opened = self.with_handle_mut(&target_val, |state| Ok(state.is_opened()))?;
                 Ok(Value::Bool(opened))
             }
             "slurp" => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -94,6 +94,14 @@ pub(crate) struct VM {
     /// Arc is only ever replaced by `clone_for_thread` (which builds a fresh
     /// Interpreter for a child thread), never reassigned in place during a run.
     registry: Arc<RwLock<crate::runtime::Registry>>,
+    /// Handle to the shared [`IoHandleTable`](crate::runtime::IoHandleTable),
+    /// cloned from the interpreter at construction (PLAN.md ③ native IO PR-C: the
+    /// VM holds the IO handle table as a *peer*, mirroring `registry`). Points at
+    /// the same `RwLock` as `self.interpreter`'s handle, so mutations through
+    /// either are visible. Stable for the VM's lifetime (same `clone_for_thread`
+    /// reasoning as `registry`). Used by `try_native_io_handle_method` to resolve
+    /// pure-handle IO methods natively instead of bouncing through the interpreter.
+    io_handles: Arc<RwLock<crate::runtime::IoHandleTable>>,
     stack: Vec<Value>,
     locals: Vec<Value>,
     in_smartmatch_rhs: bool,
@@ -408,9 +416,11 @@ impl VM {
 
     pub(crate) fn new(interpreter: Interpreter) -> Self {
         let registry = interpreter.registry_handle();
+        let io_handles = interpreter.io_handles_handle();
         Self {
             interpreter,
             registry,
+            io_handles,
             stack: Vec::new(),
             locals: Vec::new(),
             in_smartmatch_rhs: false,
@@ -474,6 +484,15 @@ impl VM {
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::RegistryWriteGuard<'_> {
         crate::runtime::RegistryWriteGuard::new(&self.registry, "registry")
+    }
+
+    /// Write access to the shared [`IoHandleTable`](crate::runtime::IoHandleTable)
+    /// via the VM's own handle (no `self.interpreter` bounce). Same lock and guard
+    /// discipline as the interpreter's `io_handles_mut`: never hold the guard
+    /// across a re-entrant handle op.
+    #[inline]
+    pub(crate) fn io_handles_mut(&self) -> crate::runtime::IoHandlesWriteGuard<'_> {
+        crate::runtime::IoHandlesWriteGuard::new(&self.io_handles, "io_handles")
     }
 
     /// Run the compiled bytecode. Always returns the interpreter back

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -421,6 +421,15 @@ impl VM {
         {
             return result;
         }
+        // Native pure-handle IO methods on an `IO::Handle` receiver
+        // (close/tell/eof/seek/opened/t): resolve in the VM through its own
+        // `io_handles` handle (PLAN.md ③ native IO PR-C), shrinking the §1
+        // native-IO fork. Only methods that touch *only* handle state are handled
+        // here; read/write/lines/slurp/etc. (which need emit_output / env /
+        // encoding) still fall through to the interpreter below.
+        if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
+            return result;
+        }
         // TODO: compile to bytecode — native/Buf/Failure method fork (ledger §1).
         // User-defined Instance methods now always run as bytecode (compiled at
         // registration, or on demand above via `populate_uncompiled_method`), so
@@ -430,6 +439,93 @@ impl VM {
         crate::vm::vm_stats::record_method_fallback(method);
         self.interpreter
             .call_method_with_values(target, method, args)
+    }
+
+    /// VM-native dispatch for the pure-handle methods of an `IO::Handle`
+    /// (`close`/`tell`/`eof`/`seek`/`opened`/`t`) — the ones that touch only the
+    /// handle's own state, with no `emit_output` / env / encoding dependency.
+    /// Operates on the VM's own [`io_handles`](VM::io_handles_mut) handle and the
+    /// shared `IoHandleState` methods (the single authoritative impl the
+    /// interpreter's `*_handle_value` wrappers also use), so behavior is identical
+    /// to the interpreter's native fork.
+    ///
+    /// Returns `None` (fall through to the interpreter) for any other receiver,
+    /// any other method, unexpected arity, or junction arguments (which need
+    /// interpreter autothreading). Restricted to the exact `"IO::Handle"` class:
+    /// `IO::Socket::INET` (socket-semantic close) and `IO::Pipe` (process-reaping
+    /// close) are intentionally excluded.
+    fn try_native_io_handle_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let id = match target {
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "IO::Handle" => match attributes.as_map().get("handle") {
+                Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                _ => return None,
+            },
+            _ => return None,
+        };
+
+        enum Op {
+            Tell,
+            Eof,
+            Opened,
+            Tty,
+            Close,
+            Seek(i64, i32),
+        }
+        let op = match method {
+            "tell" if args.is_empty() => Op::Tell,
+            "eof" if args.is_empty() => Op::Eof,
+            "opened" if args.is_empty() => Op::Opened,
+            "t" if args.is_empty() => Op::Tty,
+            "close" if args.is_empty() => Op::Close,
+            "seek" => {
+                // seek($offset, $whence = SeekFromBeginning). Mirror the
+                // interpreter's `native_io_handle` arg handling exactly: a
+                // non-Int offset coerces to 0 (`unwrap_or(0)`), and the whence
+                // string maps to 0/1/2 (anything else -> 0). Defer to the
+                // interpreter when an arg is a junction (needs autothreading) or
+                // the arity is unexpected.
+                if args.len() > 2 || args.iter().any(|a| matches!(a, Value::Junction { .. })) {
+                    return None;
+                }
+                let pos = match args.first() {
+                    Some(Value::Int(i)) => *i,
+                    _ => 0,
+                };
+                let mode = match args.get(1) {
+                    Some(v) => match v.to_string_value().as_str() {
+                        "SeekFromCurrent" => 1,
+                        "SeekFromEnd" => 2,
+                        _ => 0,
+                    },
+                    None => 0,
+                };
+                Op::Seek(pos, mode)
+            }
+            _ => return None,
+        };
+
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&id) else {
+            return Some(Err(RuntimeError::new("Invalid IO::Handle")));
+        };
+        let result = match op {
+            Op::Tell => state.tell().map(Value::Int),
+            Op::Eof => state.eof().map(Value::Bool),
+            Op::Opened => Ok(Value::Bool(state.is_opened())),
+            Op::Tty => Ok(Value::Bool(state.is_tty())),
+            Op::Close => state.close().map(Value::Bool),
+            Op::Seek(pos, mode) => state.seek(pos, mode).map(Value::Int),
+        };
+        Some(result)
     }
 
     /// VM-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`

--- a/t/io-handle-pure-methods.t
+++ b/t/io-handle-pure-methods.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Pure-handle IO::Handle methods (tell/eof/seek/opened/close/t) — resolved
+# VM-native via the shared IoHandleState methods (③ native IO PR-C). These must
+# behave identically to the interpreter's native fork.
+
+plan 16;
+
+my $path = $*TMPDIR.child("mutsu-io-pure-{$*PID}.txt");
+$path.spurt("abcdefghij\nklmno\n");   # 17 bytes
+
+my $fh = $path.open;
+ok $fh.opened, 'opened on a fresh handle is True';
+is $fh.tell, 0, 'tell starts at 0';
+nok $fh.eof, 'eof is False at start';
+is $fh.get, 'abcdefghij', 'get reads the first line';
+is $fh.tell, 11, 'tell advances past the first line';
+
+$fh.seek(0, SeekFromBeginning);
+is $fh.tell, 0, 'seek from beginning resets to 0';
+
+$fh.seek(3, SeekFromCurrent);
+is $fh.tell, 3, 'seek from current advances';
+
+$fh.seek(-1, SeekFromEnd);
+is $fh.tell, 16, 'seek from end with negative offset';
+nok $fh.eof, 'eof is False just before the last byte';
+
+$fh.seek(0, SeekFromEnd);
+ok $fh.eof, 'eof is True at end of file';
+
+ok $fh.close, 'close returns True the first time';
+nok $fh.opened, 'opened is False after close';
+
+# tell on a non-file handle ($*OUT) tracks bytes written
+my $before = $*OUT.tell;
+print "";
+ok $*OUT.tell >= $before, 'tell on $*OUT is monotonic';
+
+# negative seek from the beginning is an error
+my $fh2 = $path.open;
+dies-ok { $fh2.seek(-5, SeekFromBeginning) }, 'negative seek from beginning dies';
+$fh2.close;
+
+# .t (is-tty) is a Bool and does not throw on a file handle
+my $fh3 = $path.open;
+ok $fh3.t ~~ Bool, '.t returns a Bool on a file handle';
+nok $fh3.t, 'a regular file is not a TTY';
+$fh3.close;
+
+$path.unlink;


### PR DESCRIPTION
## Summary

Phase ③ native IO ownership, **PR-C**: give the VM its own `io_handles` handle (mirroring ② #2895's registry handle) **and** wire its first real user — VM-native dispatch for the pure-handle `IO::Handle` methods. Design: `docs/vm-io-ownership.md`.

Unlike ②, the VM had **zero** direct IO-handle access (the catch-all routes every IO method to `self.interpreter.call_method_with_values`), so a handle-only migration would be dead code. Following #2895's "handle + a real user" shape, this slice also lands the first native dispatch.

## Changes

- **Extract the pure per-handle operations into `impl IoHandleState`** (`handle.rs`): `flush_buffer`/`tell`/`eof`/`seek`/`close`/`is_opened`/`is_tty` — they touch only handle state (no `emit_output` / env / encoding). The interpreter's `*_handle_value` wrappers and native_io's `t`/`opened` now delegate to these (**1 operation = 1 implementation**). `flush_file_handle_buffer` (Interpreter assoc fn) becomes `IoHandleState::flush_buffer` (6 call sites updated).
- **VM handle**: `Interpreter::io_handles_handle()` clones the shared `Arc` (mirrors `registry_handle()`); VM gains an `io_handles` field (cloned at `VM::new`) + `io_handles_mut()` accessor. Same lock as the interpreter's handle; stable for the VM's lifetime (`clone_for_thread` builds a fresh Interpreter, never reassigns in place).
- **`try_native_io_handle_method`** (`vm_call_method_compiled.rs`, just before the catch-all): for a strict `IO::Handle` receiver (excludes `IO::Socket::INET`'s socket-close and `IO::Pipe`'s process-reaping close) and method in `{close,tell,eof,seek,opened,t}` with non-junction args, resolve natively via the VM's `io_handles_mut()` and the shared `IoHandleState` methods. `seek` arg parsing mirrors `native_io` exactly (non-Int offset → 0, whence string → 0/1/2); anything else falls through to the interpreter. `handle_id_from_value` made `pub(crate)`.

## Verification

Behavior-invariant (the native methods are the same impl the interpreter fork used).

- PR-B smoke + new `t/io-handle-pure-methods.t` (16 cases) **byte-identical to `raku`**.
- Whitelisted S32-io (seek/tell/open now traverse the VM-native path) + socket/pipe/thread green.
- `make test` (cargo 458/0 + prove 6338) green; **zero reentry panics** in the debug guard.

Next: **PR-D** — stage the heavy IO methods (read/write/lines/slurp/getc) to VM-native, which requires the `emit_output`/env/encoding state to be VM-reachable (③ later stages / ④).

🤖 Generated with [Claude Code](https://claude.com/claude-code)