### PR TITLE
refactor(io): VM-native dispatch for Tier-1 state-only IO::Handle methods (③ native IO PR-D)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -186,3 +186,25 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
     （cargo 458 + prove 6338）緑、再入 panic ゼロ。double-close が False 返し（raku は True）の差は**抽出前から存在
     する既存挙動**（verbatim 抽出ゆえ PR-C は不変、roast close.t/open.t も緑）。次 = **PR-D**（read/write/lines/slurp
     等の重 IO メソッドを段階的に VM ネイティブ化。emit_output/env/encoding 依存ゆえ ③ 後段/④ の状態移管が前提）。
+- **PR-D Tier-1 完了（2026-06-11）**: 状態専有 setter/getter `chomp`/`nl-out`/`out-buffer`/`encoding` +
+  `native-descriptor` を VM ネイティブ dispatch へ。純粋ロジックを `impl IoHandleState` へ追加（`chomp_setting`/
+  `nl_out_setting`/`out_buffer_setting`/`encoding_setting`/`native_descriptor`）、Interpreter の native_io ハンドラと
+  `set_handle_encoding` をこれらへ委譲（「1 操作 = 1 実装」）。`try_native_io_handle_method` に arm 追加（encoding は
+  Nil↔bin の Value 整形を arm 内で実施＝native_io と完全一致、out-buffer の `parse_out_buffer_size` を `pub(crate)`
+  化）。
+  - **★ PR-C 遮蔽バグを発見・修正（本スライスの crux）**: PR-C の `try_native_io_handle_method` は **catch-all 直前**に
+    置かれていたが、`try_compiled_method_or_interpret`/`try_compiled_method_mut_or_interpret` の**先頭に
+    `is_native_method` 早期フォールバックゲート**があり、IO::Handle の native メソッド（tell/seek/close…全部）は
+    そのゲートで `call_method_with_values` へ落ちて L430 に到達せず＝**PR-C の dispatch は丸ごとデッドコードだった**
+    （`t/io-handle-pure-methods.t` が緑だったのはフォールバック結果が同一だったため）。修正: native-IO dispatch を
+    **早期ゲートの直前**へ移設（mut/非mut 両パス）、デッド配置を削除。`MUTSU_VM_STATS` で確認: native-descriptor.t が
+    method-call fallback 0%、io-handle-pure-methods.t も tell/seek/close/eof/opened/t が全て native 化（PR-C が**初めて
+    実効化**）。**教訓: native dispatch は必ず `MUTSU_VM_STATS` の method-fallback カウンタで実効を確認する**（テスト緑
+    だけでは遮蔽を検出できない）。
+  - **挙動不変**: encoding 名 verbatim（mutsu `latin1` / raku `iso-8859-1`）・out-buffer default 0（raku 8192）は
+    **変更前から存在する既存差**でスコープ外。新規 `t/io-handle-tier1-methods.t`（14 本）を mutsu/raku 双方で 14/14 緑
+    （encoding 名差は setter return と getter の一致で吸収）。whitelisted S32-io（native-descriptor/out-buffering/open/
+    seek/tell/slurp/spurt/io-special/note/null-char/other + socket/pipe/procasync）緑、再入 panic ゼロ。
+  - **次 = PR-D Tier-2**（③ 後段/④ 必須・本丸の §1 fork 撲滅）: 出力 print/say/put/printf/write/flush/spurt + 読み
+    get/getc/readchars/lines/words/read/slurp/split/comb。emit_output/env(@*ARGS)/非UTF8 encode が VM 到達可能になる
+    状態移管が前提。Tier-3 = open(reopen)/path/Supply/DESTROY/Str。

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -160,10 +160,82 @@ impl IoHandleState {
             _ => false,
         }
     }
+
+    /// `.chomp` getter/setter — auto-chomp on line reads. `set` carries the new
+    /// truthy value when called as a setter; returns the resulting setting.
+    pub(crate) fn chomp_setting(&mut self, set: Option<bool>) -> bool {
+        if let Some(v) = set {
+            self.line_chomp = v;
+        }
+        self.line_chomp
+    }
+
+    /// `.nl-out` getter/setter — the output line terminator. Returns the
+    /// resulting terminator string.
+    pub(crate) fn nl_out_setting(&mut self, set: Option<String>) -> String {
+        if let Some(v) = set {
+            self.nl_out = v;
+        }
+        self.nl_out.clone()
+    }
+
+    /// `.out-buffer` getter/setter — output buffer capacity. When `set` is
+    /// `Some(cap)` the pending buffer is flushed first and the capacity is
+    /// replaced (a `None` capacity means unbounded/disabled). Returns the
+    /// resulting capacity (0 when unset).
+    pub(crate) fn out_buffer_setting(
+        &mut self,
+        set: Option<Option<usize>>,
+    ) -> Result<usize, RuntimeError> {
+        if let Some(cap) = set {
+            self.flush_buffer()?;
+            self.out_buffer_capacity = cap;
+        }
+        Ok(self.out_buffer_capacity.unwrap_or(0))
+    }
+
+    /// `.encoding` getter/setter — the handle's character encoding (`"bin"` for
+    /// binary mode). On set, returns the *previous* encoding; on get, the
+    /// current one (mirrors the interpreter's `set_handle_encoding`).
+    pub(crate) fn encoding_setting(&mut self, set: Option<String>) -> String {
+        match set {
+            Some(enc) => std::mem::replace(&mut self.encoding, enc),
+            None => self.encoding.clone(),
+        }
+    }
+
+    /// `.native-descriptor` — the underlying OS file descriptor. Std streams map
+    /// to 0/1/2; file handles report their real `fd` on Unix.
+    pub(crate) fn native_descriptor(&self) -> Result<i64, RuntimeError> {
+        match self.target {
+            IoHandleTarget::Stdin => Ok(0),
+            IoHandleTarget::Stdout => Ok(1),
+            IoHandleTarget::Stderr => Ok(2),
+            _ => {
+                #[cfg(unix)]
+                {
+                    if let Some(ref file) = self.file {
+                        use std::os::unix::io::AsRawFd;
+                        Ok(file.as_raw_fd() as i64)
+                    } else {
+                        Err(RuntimeError::new(
+                            "native-descriptor: handle has no file descriptor",
+                        ))
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    Err(RuntimeError::new(
+                        "native-descriptor: not supported on this platform",
+                    ))
+                }
+            }
+        }
+    }
 }
 
 impl Interpreter {
-    pub(super) fn parse_out_buffer_size(value: &Value) -> Option<usize> {
+    pub(crate) fn parse_out_buffer_size(value: &Value) -> Option<usize> {
         match value {
             Value::Int(i) if *i >= 0 => Some(*i as usize),
             Value::BigInt(i) if i.sign() != num_bigint::Sign::Minus => i.to_usize(),
@@ -1117,15 +1189,7 @@ impl Interpreter {
         handle_value: &Value,
         encoding: Option<String>,
     ) -> Result<String, RuntimeError> {
-        self.with_handle_mut(handle_value, |state| {
-            if let Some(enc) = encoding {
-                let prev = state.encoding.clone();
-                state.encoding = enc;
-                Ok(prev)
-            } else {
-                Ok(state.encoding.clone())
-            }
-        })
+        self.with_handle_mut(handle_value, |state| Ok(state.encoding_setting(encoding)))
     }
 
     pub(super) fn system_time_to_int(time: SystemTime) -> i64 {

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2343,15 +2343,9 @@ impl Interpreter {
                 }
             }
             "nl-out" => {
-                if let Some(arg) = args.first() {
-                    let val = arg.to_string_value();
-                    self.with_handle_mut(&target_val, |state| {
-                        state.nl_out = val.clone();
-                        Ok(())
-                    })?;
-                    return Ok(Value::str(val));
-                }
-                let nl = self.with_handle_mut(&target_val, |state| Ok(state.nl_out.clone()))?;
+                let set = args.first().map(|a| a.to_string_value());
+                let nl =
+                    self.with_handle_mut(&target_val, |state| Ok(state.nl_out_setting(set)))?;
                 Ok(Value::str(nl))
             }
             "nl-in" => {
@@ -2406,15 +2400,9 @@ impl Interpreter {
                 }
             }
             "chomp" => {
-                if let Some(arg) = args.first() {
-                    let val = arg.truthy();
-                    self.with_handle_mut(&target_val, |state| {
-                        state.line_chomp = val;
-                        Ok(())
-                    })?;
-                    return Ok(Value::Bool(val));
-                }
-                let chomp = self.with_handle_mut(&target_val, |state| Ok(state.line_chomp))?;
+                let set = args.first().map(|a| a.truthy());
+                let chomp =
+                    self.with_handle_mut(&target_val, |state| Ok(state.chomp_setting(set)))?;
                 Ok(Value::Bool(chomp))
             }
             "print-nl" => {
@@ -2721,13 +2709,9 @@ impl Interpreter {
                 }
             }
             "out-buffer" => {
-                let size = self.with_handle_mut(&target_val, |state| {
-                    if let Some(arg) = args.first() {
-                        state.flush_buffer()?;
-                        state.out_buffer_capacity = Self::parse_out_buffer_size(arg);
-                    }
-                    Ok(state.out_buffer_capacity.unwrap_or(0))
-                })?;
+                let set = args.first().map(Self::parse_out_buffer_size);
+                let size =
+                    self.with_handle_mut(&target_val, |state| state.out_buffer_setting(set))?;
                 Ok(Value::Int(size as i64))
             }
             "seek" => {
@@ -2876,34 +2860,7 @@ impl Interpreter {
             }
             "Supply" => self.handle_supply(target, &args),
             "native-descriptor" => {
-                let fd = self.with_handle_mut(&target_val, |state| {
-                    let fd = match state.target {
-                        IoHandleTarget::Stdin => 0i64,
-                        IoHandleTarget::Stdout => 1i64,
-                        IoHandleTarget::Stderr => 2i64,
-                        _ => {
-                            #[cfg(unix)]
-                            {
-                                if let Some(ref file) = state.file {
-                                    use std::os::unix::io::AsRawFd;
-                                    file.as_raw_fd() as i64
-                                } else {
-                                    return Err(RuntimeError::new(
-                                        "native-descriptor: handle has no file descriptor",
-                                    ));
-                                }
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                let _ = state;
-                                return Err(RuntimeError::new(
-                                    "native-descriptor: not supported on this platform",
-                                ));
-                            }
-                        }
-                    };
-                    Ok(fd)
-                })?;
+                let fd = self.with_handle_mut(&target_val, |state| state.native_descriptor())?;
                 Ok(Value::Int(fd))
             }
             _ => Err(RuntimeError::new(format!(

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -115,6 +115,17 @@ impl VM {
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
+            // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
+            // resolve `IO::Handle`'s state-only methods (close/tell/eof/seek/
+            // opened/t and the Tier-1 setters/getters chomp/nl-out/out-buffer/
+            // encoding/native-descriptor) in the VM through its own `io_handles`
+            // handle, *before* the generic native-method fallback below would
+            // otherwise pre-empt them. Returns `None` (falling through to that
+            // fallback unchanged) for any receiver/method/args it cannot handle
+            // natively, so this is behavior-invariant.
+            if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
+                return result;
+            }
             if self.interpreter.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
@@ -421,15 +432,6 @@ impl VM {
         {
             return result;
         }
-        // Native pure-handle IO methods on an `IO::Handle` receiver
-        // (close/tell/eof/seek/opened/t): resolve in the VM through its own
-        // `io_handles` handle (PLAN.md ③ native IO PR-C), shrinking the §1
-        // native-IO fork. Only methods that touch *only* handle state are handled
-        // here; read/write/lines/slurp/etc. (which need emit_output / env /
-        // encoding) still fall through to the interpreter below.
-        if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
-            return result;
-        }
         // TODO: compile to bytecode — native/Buf/Failure method fork (ledger §1).
         // User-defined Instance methods now always run as bytecode (compiled at
         // registration, or on demand above via `populate_uncompiled_method`), so
@@ -442,8 +444,10 @@ impl VM {
     }
 
     /// VM-native dispatch for the pure-handle methods of an `IO::Handle`
-    /// (`close`/`tell`/`eof`/`seek`/`opened`/`t`) — the ones that touch only the
-    /// handle's own state, with no `emit_output` / env / encoding dependency.
+    /// (`close`/`tell`/`eof`/`seek`/`opened`/`t` plus the PR-D Tier-1
+    /// setters/getters `chomp`/`nl-out`/`out-buffer`/`encoding` and
+    /// `native-descriptor`) — the ones that touch only the handle's own state,
+    /// with no `emit_output` / env / encoding-helper dependency.
     /// Operates on the VM's own [`io_handles`](VM::io_handles_mut) handle and the
     /// shared `IoHandleState` methods (the single authoritative impl the
     /// interpreter's `*_handle_value` wrappers also use), so behavior is identical
@@ -472,6 +476,25 @@ impl VM {
             _ => return None,
         };
 
+        // Pure-handle setters/getters whose argument touches only handle state
+        // (PLAN.md ③ native IO PR-D Tier-1). Junction arguments fall through to
+        // the interpreter for autothreading.
+        if args.iter().any(|a| matches!(a, Value::Junction { .. })) {
+            return None;
+        }
+
+        // `.encoding` returns Nil for binary mode and a Str otherwise, so its
+        // result shaping is method-specific (mirrors the interpreter's
+        // `native_io` arm exactly).
+        enum EncodingOp {
+            /// Getter: shape the current encoding into Nil("bin") / Str.
+            Get,
+            /// Setter to binary mode (`:bin`, `"bin"`, or `Nil` arg) -> Nil.
+            SetBin,
+            /// Setter to a named encoding -> Str(encoding).
+            Set(String),
+        }
+
         enum Op {
             Tell,
             Eof,
@@ -479,6 +502,11 @@ impl VM {
             Tty,
             Close,
             Seek(i64, i32),
+            Chomp(Option<bool>),
+            NlOut(Option<String>),
+            OutBuffer(Option<Option<usize>>),
+            Encoding(EncodingOp),
+            NativeDescriptor,
         }
         let op = match method {
             "tell" if args.is_empty() => Op::Tell,
@@ -486,6 +514,25 @@ impl VM {
             "opened" if args.is_empty() => Op::Opened,
             "t" if args.is_empty() => Op::Tty,
             "close" if args.is_empty() => Op::Close,
+            "native-descriptor" if args.is_empty() => Op::NativeDescriptor,
+            "chomp" => Op::Chomp(args.first().map(|a| a.truthy())),
+            "nl-out" => Op::NlOut(args.first().map(|a| a.to_string_value())),
+            "out-buffer" => Op::OutBuffer(
+                args.first()
+                    .map(crate::runtime::Interpreter::parse_out_buffer_size),
+            ),
+            "encoding" => Op::Encoding(match args.first() {
+                None => EncodingOp::Get,
+                Some(Value::Nil) => EncodingOp::SetBin,
+                Some(arg) => {
+                    let enc = arg.to_string_value();
+                    if enc == "bin" {
+                        EncodingOp::SetBin
+                    } else {
+                        EncodingOp::Set(enc)
+                    }
+                }
+            }),
             "seek" => {
                 // seek($offset, $whence = SeekFromBeginning). Mirror the
                 // interpreter's `native_io_handle` arg handling exactly: a
@@ -524,6 +571,28 @@ impl VM {
             Op::Tty => Ok(Value::Bool(state.is_tty())),
             Op::Close => state.close().map(Value::Bool),
             Op::Seek(pos, mode) => state.seek(pos, mode).map(Value::Int),
+            Op::Chomp(set) => Ok(Value::Bool(state.chomp_setting(set))),
+            Op::NlOut(set) => Ok(Value::str(state.nl_out_setting(set))),
+            Op::OutBuffer(set) => state.out_buffer_setting(set).map(|n| Value::Int(n as i64)),
+            Op::NativeDescriptor => state.native_descriptor().map(Value::Int),
+            Op::Encoding(enc_op) => Ok(match enc_op {
+                EncodingOp::Get => {
+                    let cur = state.encoding_setting(None);
+                    if cur == "bin" {
+                        Value::Nil
+                    } else {
+                        Value::str(cur)
+                    }
+                }
+                EncodingOp::SetBin => {
+                    state.encoding_setting(Some("bin".to_string()));
+                    Value::Nil
+                }
+                EncodingOp::Set(enc) => {
+                    state.encoding_setting(Some(enc.clone()));
+                    Value::str(enc)
+                }
+            }),
         };
         Some(result)
     }
@@ -946,6 +1015,15 @@ impl VM {
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
+            // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D),
+            // mut path: `$fh.method` on a variable receiver routes here, so the
+            // same state-only `IO::Handle` methods must be intercepted before the
+            // generic native-method fallback below. These methods mutate only the
+            // shared handle-table state (not the receiver binding), so the native
+            // path returns the result directly; `None` falls through unchanged.
+            if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
+                return result;
+            }
             if self.interpreter.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork, mut (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);

--- a/t/io-handle-tier1-methods.t
+++ b/t/io-handle-tier1-methods.t
@@ -1,0 +1,50 @@
+use Test;
+
+# Tier-1 state-only IO::Handle methods (chomp / nl-out / out-buffer / encoding /
+# native-descriptor) — resolved VM-native via the shared IoHandleState methods
+# (③ native IO PR-D Tier-1). These touch only the handle's own state, so they
+# must behave identically to the interpreter's native fork.
+
+plan 14;
+
+my $path = $*TMPDIR.child("mutsu-io-tier1-{$*PID}.txt");
+$path.spurt("hello\nworld\n");
+
+my $fh = $path.open(:w);
+
+# .chomp getter/setter (rw accessor)
+ok $fh.chomp ~~ Bool, '.chomp returns a Bool';
+ok $fh.chomp, '.chomp defaults to True';
+$fh.chomp = False;
+nok $fh.chomp, '.chomp = False updates the setting';
+$fh.chomp = True;
+ok $fh.chomp, '.chomp = True restores it';
+
+# .nl-out getter/setter
+is $fh.nl-out, "\n", '.nl-out defaults to "\n"';
+$fh.nl-out = "\r\n";
+is $fh.nl-out, "\r\n", '.nl-out = updates the output terminator';
+
+# .encoding getter/setter (method-call form)
+ok $fh.encoding.defined, '.encoding returns a defined value';
+# (the setter return and a follow-up getter agree on the resolved name; mutsu
+# keeps it verbatim, raku normalizes it — assert consistency rather than a name)
+my $enc = $fh.encoding('latin1');
+is $fh.encoding, $enc, '.encoding(name) switches and reads back consistently';
+
+# .out-buffer getter/setter
+ok $fh.out-buffer ~~ Int, '.out-buffer returns an Int';
+$fh.out-buffer = 4096;
+is $fh.out-buffer, 4096, '.out-buffer = sets the capacity';
+
+# .native-descriptor returns a real fd on a file handle
+ok $fh.native-descriptor >= 0, 'file handle exposes a native descriptor';
+
+$fh.close;
+
+# standard handles map to the conventional fds
+is $*IN.native-descriptor, 0, '$*IN native-descriptor is 0';
+is $*OUT.native-descriptor, 1, '$*OUT native-descriptor is 1';
+is $*ERR.native-descriptor, 2, '$*ERR native-descriptor is 2';
+
+$path.unlink;


### PR DESCRIPTION
## Summary

Continues the ③ native-IO ownership campaign (`docs/vm-io-ownership.md`), **PR-D Tier-1**: bring the state-only `IO::Handle` setters/getters `chomp` / `nl-out` / `out-buffer` / `encoding` and `native-descriptor` into the VM-native IO dispatch (`try_native_io_handle_method`). These touch only the handle's own state — no `emit_output` / env / encoding-helper access — so they qualify for native dispatch without ③ state migration.

- Pure state logic moves into shared `impl IoHandleState` methods (`chomp_setting` / `nl_out_setting` / `out_buffer_setting` / `encoding_setting` / `native_descriptor`); the interpreter's `native_io` handlers and `set_handle_encoding` now delegate to them — single authoritative impl ("1 operation = 1 impl").
- The VM arm mirrors the interpreter's Value-level arg parsing exactly (encoding `Nil`↔`bin` shaping, `out-buffer`'s `parse_out_buffer_size`; junction args fall through for autothreading).

## Crux: fixes a PR-C shadowing bug

PR-C (#2904) placed `try_native_io_handle_method` just **before the catch-all**, but `try_compiled_method_or_interpret` and its mut twin gate on `is_native_method` at the **top** of the function and fall straight back to the interpreter for *every* `IO::Handle` native method — so PR-C's dispatch never ran. It was **dead code**; the test stayed green only because the fallback produced identical results.

Fix: move the native-IO dispatch to just **before that early gate** on both the mut and non-mut paths, and drop the dead placement. Confirmed with `MUTSU_VM_STATS`: `native-descriptor.t` now shows **0% method-call fallback** and `io-handle-pure-methods.t`'s `tell`/`seek`/`close`/`eof`/`opened`/`t` go native **for the first time**.

> Lesson recorded in the doc: native dispatch must be verified with the `MUTSU_VM_STATS` method-fallback counter — a green test alone can't detect shadowing.

## Behavior invariance

The encoding-name (mutsu `latin1` vs raku `iso-8859-1`) and `out-buffer` default (0 vs 8192) divergences from raku **pre-date** this change and are out of scope.

## Testing

- New `t/io-handle-tier1-methods.t` (14 cases) passes **14/14 under both mutsu and raku** (the encoding-name divergence is absorbed by asserting setter-return/getter consistency).
- Whitelisted S32-io (`native-descriptor` / `out-buffering` / `open` / `seek` / `tell` / `slurp` / `spurt` / `io-special` / `note` / `null-char` / `other` + socket / pipe / procasync) green.
- `make test` (cargo 458 + prove 6352) green; zero reentry panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)