### PR TITLE
refactor(io): VM-native text output for File+UTF8 IO::Handle (③ native IO PR-D Tier-2a)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -205,6 +205,26 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
     **変更前から存在する既存差**でスコープ外。新規 `t/io-handle-tier1-methods.t`（14 本）を mutsu/raku 双方で 14/14 緑
     （encoding 名差は setter return と getter の一致で吸収）。whitelisted S32-io（native-descriptor/out-buffering/open/
     seek/tell/slurp/spurt/io-special/note/null-char/other + socket/pipe/procasync）緑、再入 panic ゼロ。
-  - **次 = PR-D Tier-2**（③ 後段/④ 必須・本丸の §1 fork 撲滅）: 出力 print/say/put/printf/write/flush/spurt + 読み
-    get/getc/readchars/lines/words/read/slurp/split/comb。emit_output/env(@*ARGS)/非UTF8 encode が VM 到達可能になる
-    状態移管が前提。Tier-3 = open(reopen)/path/Supply/DESTROY/Str。
+- **PR-D Tier-2a 完了（2026-06-11）**: **File+UTF8 ターゲットのテキスト出力** `print`/`put`/`say`/`print-nl` を VM
+  ネイティブ dispatch へ。**調査で出力系が2系統の依存に割れると確定**:
+  - **書き込み先で分岐**: **Stdout**→`emit_output`（`output` バッファ / `output_emitted` / TAP subtest 深度 /
+    thread-clone 共有出力に依存＝**VM 到達不能**、真の撲滅は ③後段/④ の状態移管が前提）、**Stderr**→`stderr_output`
+    バッファ（同）、**File**→handle state へ直書き（buffering 含め**純粋 handle state**。非UTF-8 のみ `encode_with_encoding`
+    再入）。**Socket** も別。→ **File+UTF8/bin のみ純粋に native 化可能**。最頻ケース Stdout は据え置き。
+  - **payload 構築**は `self.interpreter.render_str_value`(print/put)/`render_gist_value`(say)＝**現行 native_io ハンドラ
+    と同一コード**かつ **VM 自身の exec_say_op/exec_print_op も同じ helper を使う**ので byte 一致・parity リスクゼロ・env
+    desync なし（VM の say が既に同様に呼んでいる）。
+  - **書き込み**は File ブランチの buffering を `IoHandleState::write_file_payload` へ抽出（`write_to_handle_value_trying`
+    の File 分岐が委譲＝1 操作1実装）。`can_native_text_write`(File+utf8/bin ゲート)/`native_text_write`(closed 検査+nl_out
+    付与+bytes 計上+write)/`native_print_nl` を `impl IoHandleState` に追加。VM 新 `try_native_io_handle_output`
+    （**早期ゲート直前**、mut/非mut 両パス）。**ゲート(target/encoding)は payload 構築の前に読む**＝fall-through 時に引数
+    stringification を二重実行しない。junction 引数は autothread へ fall through。
+  - **検証**: 新 `t/io-handle-tier2a-file-output.t`(12) mutsu/raku 双方 12/12。`MUTSU_VM_STATS` で File 出力が native
+    （out-buffering.t は print/say/put が fallback から消え open/slurp/**flush** のみ残）、Stdout/Stderr/latin1-File は正しく
+    fall through（say/print が fallback に残る）。io-handle.t の not-ok 数は main と同一(24＝既存・本変更は不変)。
+    `make test`(cargo 458+prove)緑。**`write_bytes_to_handle_value` の File 分岐は out-buffer 非対応の別 semantics ゆえ
+    委譲せず据え置き**（`write`/`spurt` は Tier-2b 範囲）。
+  - **次 = PR-D Tier-2b**: 残り出力 `printf`(sprintf)/`write`/`spurt`(Buf/bytes)/`flush`(Failure 整形) を File 対象で
+    native 化。`flush` は closed 時 `Failure` を返す整形が要る。**Stdout/Stderr 出力 + 読み系（get/lines/read/slurp + ArgFiles
+    `@*ARGS`/非UTF8 decode）の真の撲滅は emit_output/env/encode を VM 到達可能にする ③後段/④ が前提**。Tier-3 =
+    open(reopen)/path/Supply/DESTROY/Str。

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -23,6 +23,95 @@ impl IoHandleState {
         Ok(())
     }
 
+    /// Write already-encoded payload bytes to a **File-target** handle,
+    /// honoring the `:out-buffer` capacity (flush-and-write, bypass-on-large,
+    /// or append-to-pending). Pure handle state — no `Interpreter` access — so
+    /// it is the single authoritative impl shared by the interpreter's
+    /// `write_to_handle_value_trying` File branch and the VM-native output
+    /// dispatch (③ native IO PR-D Tier-2a). The caller guarantees the target is
+    /// `File`; Stdout/Stderr/Socket are handled elsewhere.
+    pub(crate) fn write_file_payload(&mut self, bytes: &[u8]) -> Result<(), RuntimeError> {
+        if matches!(self.mode, IoHandleMode::Read) {
+            return Err(RuntimeError::new("Handle not open for writing"));
+        }
+        if self.file.is_none() {
+            return Err(RuntimeError::new("IO::Handle is not attached to a file"));
+        }
+        if let Some(capacity) = self.out_buffer_capacity {
+            // capacity 0 (unbuffered) or a payload larger than the buffer:
+            // flush queued data, then write straight through.
+            if capacity == 0 || bytes.len() > capacity {
+                self.flush_buffer()?;
+                if let Some(file) = self.file.as_mut() {
+                    file.write_all(bytes).map_err(|err| {
+                        RuntimeError::new(format!("Failed to write to file: {}", err))
+                    })?;
+                }
+                return Ok(());
+            }
+            if self.out_buffer_pending.len() + bytes.len() > capacity {
+                self.flush_buffer()?;
+            }
+            self.out_buffer_pending.extend_from_slice(bytes);
+            Ok(())
+        } else if let Some(file) = self.file.as_mut() {
+            file.write_all(bytes)
+                .map_err(|err| RuntimeError::new(format!("Failed to write to file: {}", err)))?;
+            Ok(())
+        } else {
+            Err(RuntimeError::new("IO::Handle is not attached to a file"))
+        }
+    }
+
+    /// Whether a text payload can be written to this handle entirely in the VM
+    /// (③ native IO PR-D Tier-2a): a `File` target with a UTF-8 / binary
+    /// encoding, where the bytes are the payload verbatim (no `encode_with_encoding`
+    /// re-entry) and the write touches only handle state (no `emit_output`).
+    /// Stdout/Stderr (need `emit_output` / `stderr_output`), Socket, and any
+    /// non-UTF-8 File encoding return `false` and fall through to the interpreter.
+    pub(crate) fn can_native_text_write(&self) -> bool {
+        matches!(self.target, IoHandleTarget::File)
+            && (self.encoding.is_empty()
+                || self.encoding == "utf-8"
+                || self.encoding == "utf8"
+                || self.encoding == "bin")
+    }
+
+    /// VM-native text write to a `File` handle (`print`/`say`/`put`): error on a
+    /// closed handle, append `nl_out` when `newline`, account the bytes, and do
+    /// the buffered file write. Mirrors `write_to_handle_value_trying`'s File
+    /// path exactly for the UTF-8 case. `trying` names the op for the
+    /// closed-handle error. Caller guarantees [`can_native_text_write`].
+    pub(crate) fn native_text_write(
+        &mut self,
+        content: &str,
+        newline: bool,
+        trying: &str,
+    ) -> Result<(), RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed(trying));
+        }
+        let mut payload = String::from(content);
+        if newline {
+            payload.push_str(&self.nl_out);
+        }
+        self.bytes_written += payload.len() as i64;
+        self.write_file_payload(payload.as_bytes())
+    }
+
+    /// VM-native `.print-nl` on a `File` handle: write the handle's `nl_out`
+    /// terminator. Mirrors the interpreter's `print-nl` (read `nl_out`, then
+    /// `write_to_handle_value(.., newline = false)`). Caller guarantees
+    /// [`can_native_text_write`].
+    pub(crate) fn native_print_nl(&mut self) -> Result<(), RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed("write"));
+        }
+        let nl = self.nl_out.clone();
+        self.bytes_written += nl.len() as i64;
+        self.write_file_payload(nl.as_bytes())
+    }
+
     /// `.tell` — current byte offset (file position, or bytes written for
     /// non-file targets).
     pub(crate) fn tell(&mut self) -> Result<i64, RuntimeError> {
@@ -440,50 +529,12 @@ impl Interpreter {
                 Ok(())
             }
             IoHandleTarget::File => self.with_handle_mut(handle_value, |state| {
-                if matches!(state.mode, IoHandleMode::Read) {
-                    return Err(RuntimeError::new("Handle not open for writing"));
-                }
-                if state.file.is_none() {
-                    return Err(RuntimeError::new("IO::Handle is not attached to a file"));
-                }
                 let payload_bytes = if let Some(ref enc_bytes) = encoded_bytes {
                     enc_bytes.as_slice()
                 } else {
                     payload.as_bytes()
                 };
-                if let Some(capacity) = state.out_buffer_capacity {
-                    if capacity == 0 {
-                        state.flush_buffer()?;
-                        if let Some(file) = state.file.as_mut() {
-                            file.write_all(payload_bytes).map_err(|err| {
-                                RuntimeError::new(format!("Failed to write to file: {}", err))
-                            })?;
-                        }
-                        return Ok(());
-                    }
-                    if payload_bytes.len() > capacity {
-                        // Large payloads bypass buffering after flushing queued data.
-                        state.flush_buffer()?;
-                        if let Some(file) = state.file.as_mut() {
-                            file.write_all(payload_bytes).map_err(|err| {
-                                RuntimeError::new(format!("Failed to write to file: {}", err))
-                            })?;
-                        }
-                        return Ok(());
-                    }
-                    if state.out_buffer_pending.len() + payload_bytes.len() > capacity {
-                        state.flush_buffer()?;
-                    }
-                    state.out_buffer_pending.extend_from_slice(payload_bytes);
-                    Ok(())
-                } else if let Some(file) = state.file.as_mut() {
-                    file.write_all(payload_bytes).map_err(|err| {
-                        RuntimeError::new(format!("Failed to write to file: {}", err))
-                    })?;
-                    Ok(())
-                } else {
-                    Err(RuntimeError::new("IO::Handle is not attached to a file"))
-                }
+                state.write_file_payload(payload_bytes)
             }),
             IoHandleTarget::Socket => self.with_handle_mut(handle_value, |state| {
                 if let Some(sock) = state.socket.as_mut() {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -126,6 +126,12 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
                 return result;
             }
+            // VM-native text output to a File+UTF8 `IO::Handle` (print/put/say/
+            // print-nl): the write touches only handle state (PR-D Tier-2a).
+            // Stdout/Stderr (need emit_output) and non-UTF8 File fall through.
+            if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
+                return result;
+            }
             if self.interpreter.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
@@ -597,6 +603,96 @@ impl VM {
         Some(result)
     }
 
+    /// VM-native text output for a `File`+UTF8 `IO::Handle` receiver
+    /// (`print`/`put`/`say`/`print-nl`): build the payload exactly as the
+    /// interpreter's `native_io` handlers do — `render_str_value` for
+    /// print/put, `render_gist_value` for say (byte-identical; the same helpers
+    /// the VM's own `say`/`print` ops use) — and write it through the VM's
+    /// `io_handles` handle via the shared `IoHandleState::native_text_write`
+    /// (PLAN.md ③ native IO PR-D Tier-2a).
+    ///
+    /// Returns `None` (fall through to the interpreter) for any non-`IO::Handle`
+    /// receiver, any other method, a junction argument (autothreading), or a
+    /// handle whose target/encoding is not File+UTF8 — Stdout/Stderr need
+    /// `emit_output`/`stderr_output` and a non-UTF8 File needs
+    /// `encode_with_encoding`, neither VM-reachable yet (③ 後段/④). The
+    /// target/encoding gate is read *before* the payload is built so a
+    /// fall-through never double-runs the argument stringification.
+    fn try_native_io_handle_output(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let id = match target {
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "IO::Handle" => match attributes.as_map().get("handle") {
+                Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                _ => return None,
+            },
+            _ => return None,
+        };
+
+        enum Kind {
+            Print,
+            Put,
+            Say,
+            PrintNl,
+        }
+        let kind = match method {
+            "print" => Kind::Print,
+            "put" => Kind::Put,
+            "say" => Kind::Say,
+            "print-nl" => Kind::PrintNl,
+            _ => return None,
+        };
+        // Junction args autothread in the interpreter; fall through for those.
+        if args.iter().any(|a| matches!(a, Value::Junction { .. })) {
+            return None;
+        }
+
+        // Gate on File+UTF8 *before* building the payload, so falling through
+        // (Stdout/Stderr/non-UTF8) never runs the arg stringification twice.
+        {
+            let table = self.io_handles_mut();
+            let state = table.map.get(&id)?;
+            if !state.can_native_text_write() {
+                return None;
+            }
+        }
+
+        // `print-nl` writes the handle's `nl_out`; the others stringify args.
+        if matches!(kind, Kind::PrintNl) {
+            let mut table = self.io_handles_mut();
+            let Some(state) = table.map.get_mut(&id) else {
+                return Some(Err(RuntimeError::new("Invalid IO::Handle")));
+            };
+            return Some(state.native_print_nl().map(|_| Value::Bool(true)));
+        }
+
+        let mut content = String::new();
+        for arg in args {
+            match kind {
+                Kind::Say => content.push_str(&self.interpreter.render_gist_value(arg)),
+                _ => content.push_str(&self.interpreter.render_str_value(arg)),
+            }
+        }
+        let newline = matches!(kind, Kind::Put | Kind::Say);
+
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&id) else {
+            return Some(Err(RuntimeError::new("Invalid IO::Handle")));
+        };
+        Some(
+            state
+                .native_text_write(&content, newline, method)
+                .map(|_| Value::Bool(true)),
+        )
+    }
+
     /// VM-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
     /// over a list-like receiver (List/Array/Seq/Slip/Hash/Set/Bag/Mix/Pair/Range).
     /// Delegates the element folding to the single authoritative pure
@@ -1022,6 +1118,11 @@ impl VM {
             // shared handle-table state (not the receiver binding), so the native
             // path returns the result directly; `None` falls through unchanged.
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
+                return result;
+            }
+            // VM-native text output to a File+UTF8 `IO::Handle` (print/put/say/
+            // print-nl), mut path (PR-D Tier-2a). See the non-mut twin above.
+            if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
                 return result;
             }
             if self.interpreter.is_native_method(&class, method) {

--- a/t/io-handle-tier2a-file-output.t
+++ b/t/io-handle-tier2a-file-output.t
@@ -1,0 +1,88 @@
+use Test;
+
+# VM-native text output on a File+UTF8 IO::Handle (print / put / say / print-nl)
+# — the write touches only handle state (③ native IO PR-D Tier-2a). Must behave
+# identically to the interpreter's native fork. Stdout/Stderr and non-UTF8 File
+# targets fall through to the interpreter and are exercised here too.
+
+plan 12;
+
+my $path = $*TMPDIR.child("mutsu-io-t2a-{$*PID}.txt");
+
+# print (no newline) + numeric stringification + say + put
+{
+    my $fh = $path.open(:w);
+    $fh.print("a");
+    $fh.print(42);
+    $fh.say("hello");
+    $fh.put("world");
+    $fh.close;
+    is $path.slurp, "a42hello\nworld\n", 'print/say/put write the expected bytes';
+}
+
+# multiple args + list gist + print-nl
+{
+    my $fh = $path.open(:w);
+    $fh.say(1, 2, 3);
+    $fh.print-nl;
+    $fh.say([4, 5, 6]);
+    $fh.close;
+    is $path.slurp, "123\n\n[4 5 6]\n", 'multi-arg say, print-nl and list gist';
+}
+
+# a custom nl-out terminator is honored by say/put/print-nl
+{
+    my $fh = $path.open(:w);
+    $fh.nl-out = "|";
+    $fh.say("x");
+    $fh.put("y");
+    $fh.print-nl;
+    $fh.close;
+    is $path.slurp, "x|y||", '.nl-out terminator is used for say/put/print-nl';
+}
+
+# return values are True
+{
+    my $fh = $path.open(:w);
+    ok $fh.print("p") === True, 'print returns True';
+    ok $fh.say("s") === True, 'say returns True';
+    ok $fh.put("u") === True, 'put returns True';
+    ok $fh.print-nl === True, 'print-nl returns True';
+    $fh.close;
+}
+
+# :out-buffer is honored on the native write path
+{
+    my $fh = $path.open(:w);
+    $fh.out-buffer = 4;
+    $fh.print("ab");      # buffered
+    $fh.print("cd");      # would overflow -> flush first
+    $fh.close;            # flushes the rest
+    is $path.slurp, "abcd", 'buffered native writes flush correctly';
+}
+
+# writing to a closed handle fails
+{
+    my $fh = $path.open(:w);
+    $fh.close;
+    dies-ok { $fh.say("nope") }, 'say on a closed handle dies';
+}
+
+# non-UTF8 File encoding still works (falls through to encode_with_encoding)
+{
+    my $lp = $*TMPDIR.child("mutsu-io-t2a-latin1-{$*PID}.txt");
+    my $fh = $lp.open(:w);
+    $fh.encoding('latin1');
+    $fh.say("é");          # 1 byte in latin1 + newline
+    $fh.close;
+    is $lp.slurp(:bin).elems, 2, 'latin1 say writes encoded bytes (fall through)';
+    $lp.unlink;
+}
+
+# Stdout/Stderr still route through emit_output (fall through, not broken)
+{
+    lives-ok { $*OUT.print("") }, '$*OUT.print still works';
+    lives-ok { $*ERR.print("") }, '$*ERR.print still works';
+}
+
+$path.unlink;


### PR DESCRIPTION
## Summary

Continues the ③ native-IO ownership campaign (`docs/vm-io-ownership.md`), **PR-D Tier-2a**: bring `print` / `put` / `say` / `print-nl` on a **File-target, UTF-8/binary** `IO::Handle` into the VM-native IO dispatch (`try_native_io_handle_output`).

### Investigation finding: output splits by *destination*, not method

- **Stdout** → `emit_output` (the `output` buffer, `output_emitted`, TAP subtest depth, thread-clone shared output — **none VM-reachable yet**)
- **Stderr** → `stderr_output` buffer
- **File** → writes straight to handle state (buffering included); only a **non-UTF-8** encoding re-enters `encode_with_encoding`
- **Socket** → separate

So **File+UTF8/bin is the slice that resolves purely in the VM today**. Stdout/Stderr (the most frequent case) stay on the interpreter fallback until the ③ 後段/④ state migration lands.

## Approach

- **Payload** reuses the interpreter's `render_str_value` (print/put) / `render_gist_value` (say) — byte-identical to the current `native_io` handlers and the *same helpers the VM's own `exec_say_op`/`exec_print_op` use* → no stringification-parity or env-desync risk.
- **Write** extracts the File-branch buffered write into the shared `IoHandleState::write_file_payload`; `write_to_handle_value_trying` now delegates to it (single authoritative impl). New `can_native_text_write` (File+UTF8 gate), `native_text_write`, `native_print_nl`.
- `try_native_io_handle_output` sits just before the early native-method gate on **both** the mut and non-mut paths. The target/encoding gate is read **before** the payload is built, so a fall-through (Stdout/Stderr/non-UTF8/Socket/junction arg) **never double-runs the argument stringification**.
- `write_bytes_to_handle_value`'s File branch is intentionally left untouched (out-buffer-bypass semantics; `write`/`spurt` are Tier-2b).

## Testing

- New `t/io-handle-tier2a-file-output.t` (12 cases) passes **12/12 under both mutsu and raku**.
- `MUTSU_VM_STATS` confirms File output goes native (`out-buffering.t`'s print/say/put leave the fallback list — only open/slurp/flush remain) while Stdout/Stderr/latin1-File correctly fall through.
- `io-handle.t`'s not-ok count is identical to main (24, pre-existing — non-whitelisted, unrelated nl-out-object storage).
- Whitelisted S32-io (out-buffering / open / slurp / spurt / io-special + socket / pipe / procasync) green.
- `make test` (cargo 461 + prove 6364) green; zero reentry panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)