### PR TITLE
refactor(io): VM-native printf (File+UTF8) and flush (any target) on IO::Handle (③ native IO PR-D Tier-2b)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -224,7 +224,18 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
     fall through（say/print が fallback に残る）。io-handle.t の not-ok 数は main と同一(24＝既存・本変更は不変)。
     `make test`(cargo 458+prove)緑。**`write_bytes_to_handle_value` の File 分岐は out-buffer 非対応の別 semantics ゆえ
     委譲せず据え置き**（`write`/`spurt` は Tier-2b 範囲）。
-  - **次 = PR-D Tier-2b**: 残り出力 `printf`(sprintf)/`write`/`spurt`(Buf/bytes)/`flush`(Failure 整形) を File 対象で
-    native 化。`flush` は closed 時 `Failure` を返す整形が要る。**Stdout/Stderr 出力 + 読み系（get/lines/read/slurp + ArgFiles
-    `@*ARGS`/非UTF8 decode）の真の撲滅は emit_output/env/encode を VM 到達可能にする ③後段/④ が前提**。Tier-3 =
-    open(reopen)/path/Supply/DESTROY/Str。
+- **PR-D Tier-2b 完了（2026-06-11）**: `printf`（File+UTF8）と `flush`（全ターゲット）を VM ネイティブ化。
+  - **printf**: `try_native_io_handle_output` に `Kind::Printf` 追加。payload は pure な
+    `crate::runtime::sprintf::{validate_sprintf_directives, format_sprintf_args}`（`mod sprintf` は `pub(super)`＝crate 可視、
+    現行ハンドラと同一）で構築し File ブランチへ書き込み（newline=false、print と同型）。junction 第一引数は
+    全 junction fall-through で interpreter の threading へ。validate エラーは `Some(Err)` で伝播（ハンドラと一致）。
+  - **flush**: target 非依存・純粋（`flush_buffer` + `file.flush`、Stdout/Stderr は file 無しで no-op）。
+    `IoHandleState::flush_for_method` 抽出、interpreter の `flush` ハンドラが委譲。`try_native_io_handle_method` に
+    **専用 arm**（junction チェック直後、Op enum 前）: id が table に在れば native で `Bool(true)`、**不在なら `None`
+    で fall through**（interpreter が `X::IO::Flush` Failure を value として整形する経路は Err-on-absent な汎用 path で
+    再現不能ゆえ）。closed-but-in-table は Bool(true)＝interpreter の既存挙動と一致（raku は Failure＝既存差・スコープ外）。
+  - **検証**: 新 `t/io-handle-tier2b-printf-flush.t`(9) mutsu/raku 双方 9/9。out-buffering.t の **flush が fallback から
+    消滅**（flush=15→0）、printf も native。S32-io（out-buffering/open/io-special/slurp/spurt）緑。`make test` 緑。
+  - **次 = PR-D Tier-2c**: `write`/`spurt`（Buf/bytes、`write_bytes_to_handle_value` の out-buffer 非対応 File 分岐を
+    共有ヘルパ化して native 化）。**Stdout/Stderr 出力 + 読み系（get/lines/read/slurp + ArgFiles `@*ARGS`/非UTF8 decode）の
+    真の撲滅は emit_output/env/encode を VM 到達可能にする ③後段/④ が前提**。Tier-3 = open(reopen)/path/Supply/DESTROY/Str。

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -99,6 +99,20 @@ impl IoHandleState {
         self.write_file_payload(payload.as_bytes())
     }
 
+    /// `.flush` — flush the `:out-buffer` pending bytes and the OS file buffer.
+    /// Pure handle state (no `Interpreter`), so the VM-native dispatch and the
+    /// interpreter's `flush` handler share it (③ native IO PR-D Tier-2b). Works
+    /// for any target: Stdout/Stderr have no file, so only `flush_buffer` (a
+    /// no-op when nothing is pending) runs.
+    pub(crate) fn flush_for_method(&mut self) -> Result<(), RuntimeError> {
+        self.flush_buffer()?;
+        if let Some(file) = self.file.as_mut() {
+            file.flush()
+                .map_err(|err| RuntimeError::new(format!("Failed to flush handle: {}", err)))?;
+        }
+        Ok(())
+    }
+
     /// VM-native `.print-nl` on a `File` handle: write the handle's `nl_out`
     /// terminator. Mirrors the interpreter's `print-nl` (read `nl_out`, then
     /// `write_to_handle_value(.., newline = false)`). Caller guarantees

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2682,15 +2682,8 @@ impl Interpreter {
                 Ok(Value::Bool(true))
             }
             "flush" => {
-                let flushed = self.with_handle_mut_opt(&target_val, |state| {
-                    state.flush_buffer()?;
-                    if let Some(file) = state.file.as_mut() {
-                        file.flush().map_err(|err| {
-                            RuntimeError::new(format!("Failed to flush handle: {}", err))
-                        })?;
-                    }
-                    Ok(())
-                })?;
+                let flushed =
+                    self.with_handle_mut_opt(&target_val, |state| state.flush_for_method())?;
                 if flushed.is_some() {
                     Ok(Value::Bool(true))
                 } else {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -489,6 +489,19 @@ impl VM {
             return None;
         }
 
+        // `.flush` is target-agnostic and pure (flush pending out-buffer + the OS
+        // file buffer); shared `flush_for_method` (PR-D Tier-2b). A handle id not
+        // in the table falls through — the interpreter shapes that into an
+        // `X::IO::Flush` Failure (a value, not an error), which this Err-on-absent
+        // path below cannot reproduce.
+        if method == "flush" && args.is_empty() {
+            let mut table = self.io_handles_mut();
+            return table
+                .map
+                .get_mut(&id)
+                .map(|state| state.flush_for_method().map(|_| Value::Bool(true)));
+        }
+
         // `.encoding` returns Nil for binary mode and a Str otherwise, so its
         // result shaping is method-specific (mirrors the interpreter's
         // `native_io` arm exactly).
@@ -604,12 +617,12 @@ impl VM {
     }
 
     /// VM-native text output for a `File`+UTF8 `IO::Handle` receiver
-    /// (`print`/`put`/`say`/`print-nl`): build the payload exactly as the
-    /// interpreter's `native_io` handlers do — `render_str_value` for
+    /// (`print`/`put`/`say`/`printf`/`print-nl`): build the payload exactly as
+    /// the interpreter's `native_io` handlers do — `render_str_value` for
     /// print/put, `render_gist_value` for say (byte-identical; the same helpers
-    /// the VM's own `say`/`print` ops use) — and write it through the VM's
-    /// `io_handles` handle via the shared `IoHandleState::native_text_write`
-    /// (PLAN.md ③ native IO PR-D Tier-2a).
+    /// the VM's own `say`/`print` ops use), the pure `sprintf` helpers for
+    /// printf — and write it through the VM's `io_handles` handle via the shared
+    /// `IoHandleState::native_text_write` (PLAN.md ③ native IO PR-D Tier-2a/2b).
     ///
     /// Returns `None` (fall through to the interpreter) for any non-`IO::Handle`
     /// receiver, any other method, a junction argument (autothreading), or a
@@ -640,16 +653,19 @@ impl VM {
             Print,
             Put,
             Say,
+            Printf,
             PrintNl,
         }
         let kind = match method {
             "print" => Kind::Print,
             "put" => Kind::Put,
             "say" => Kind::Say,
+            "printf" => Kind::Printf,
             "print-nl" => Kind::PrintNl,
             _ => return None,
         };
-        // Junction args autothread in the interpreter; fall through for those.
+        // Junction args autothread in the interpreter; fall through for those
+        // (printf's first-arg junction also threads there).
         if args.iter().any(|a| matches!(a, Value::Junction { .. })) {
             return None;
         }
@@ -673,13 +689,38 @@ impl VM {
             return Some(state.native_print_nl().map(|_| Value::Bool(true)));
         }
 
-        let mut content = String::new();
-        for arg in args {
-            match kind {
-                Kind::Say => content.push_str(&self.interpreter.render_gist_value(arg)),
-                _ => content.push_str(&self.interpreter.render_str_value(arg)),
+        let content = match kind {
+            // printf: validate the directives then format, exactly as the
+            // interpreter's `printf` arm (pure `sprintf` helpers, no handle state).
+            Kind::Printf => {
+                let fmt = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let rest = if args.is_empty() { &[][..] } else { &args[1..] };
+                if let Err(e) =
+                    crate::runtime::sprintf::validate_sprintf_directives(&fmt, rest.len())
+                {
+                    return Some(Err(e));
+                }
+                crate::runtime::sprintf::format_sprintf_args(&fmt, rest)
             }
-        }
+            Kind::Say => {
+                let mut c = String::new();
+                for arg in args {
+                    c.push_str(&self.interpreter.render_gist_value(arg));
+                }
+                c
+            }
+            // print / put use `render_str_value`.
+            _ => {
+                let mut c = String::new();
+                for arg in args {
+                    c.push_str(&self.interpreter.render_str_value(arg));
+                }
+                c
+            }
+        };
         let newline = matches!(kind, Kind::Put | Kind::Say);
 
         let mut table = self.io_handles_mut();

--- a/t/io-handle-tier2b-printf-flush.t
+++ b/t/io-handle-tier2b-printf-flush.t
@@ -1,0 +1,69 @@
+use Test;
+
+# VM-native printf (File+UTF8) and flush (any target) on an IO::Handle
+# (③ native IO PR-D Tier-2b). printf builds its payload via the pure sprintf
+# helpers and writes through the shared File path; flush is target-agnostic and
+# pure. Must behave identically to the interpreter's native fork.
+
+plan 9;
+
+my $path = $*TMPDIR.child("mutsu-io-t2b-{$*PID}.txt");
+
+# printf basic + multiple directives + width/precision
+{
+    my $fh = $path.open(:w);
+    $fh.printf("%d-%s|", 42, "x");
+    $fh.printf("%05.2f", 3.14159);
+    $fh.close;
+    is $path.slurp, "42-x|03.14", 'printf formats and writes to the file';
+}
+
+# printf return value is True
+{
+    my $fh = $path.open(:w);
+    ok $fh.printf("%s", "ok") === True, 'printf returns True';
+    $fh.close;
+}
+
+# a malformed printf directive throws (too few args)
+{
+    my $fh = $path.open(:w);
+    dies-ok { $fh.printf("%d %d", 1) }, 'printf with too few args dies';
+    $fh.close;
+}
+
+# flush returns True and the buffered data is persisted
+{
+    my $fh = $path.open(:w);
+    $fh.out-buffer = 1024;
+    $fh.print("buffered");
+    ok $fh.flush === True, 'flush returns True';
+    # after an explicit flush the bytes are on disk even before close
+    is slurp($path), "buffered", 'flush persists buffered bytes';
+    $fh.close;
+}
+
+# flush is idempotent
+{
+    my $fh = $path.open(:w);
+    $fh.print("x");
+    $fh.flush;
+    ok $fh.flush === True, 'a second flush also returns True';
+    $fh.close;
+}
+
+# flush works on the standard handles (universal, not File-gated)
+{
+    lives-ok { $*OUT.flush }, '$*OUT.flush lives';
+    lives-ok { $*ERR.flush }, '$*ERR.flush lives';
+}
+
+# printf honoring the handle encoding still works for UTF-8 multibyte
+{
+    my $fh = $path.open(:w);
+    $fh.printf("%s", "café");
+    $fh.close;
+    is $path.slurp, "café", 'printf writes UTF-8 multibyte correctly';
+}
+
+$path.unlink;


### PR DESCRIPTION
## Summary

Continues the ③ native-IO ownership campaign (`docs/vm-io-ownership.md`), **PR-D Tier-2b**: bring `printf` (File+UTF8) and `flush` (any target) on an `IO::Handle` into the VM-native IO dispatch.

- **printf** — a new `Kind::Printf` in `try_native_io_handle_output`. The payload is built with the pure `crate::runtime::sprintf::{validate_sprintf_directives, format_sprintf_args}` helpers (the very ones the interpreter's printf arm uses) and written through the shared File path (newline = false, like print). A junction argument falls through for threading; a malformed directive propagates the same `Err`.
- **flush** — target-agnostic and pure (`flush_buffer` + `file.flush`; Stdout/Stderr have no file so only the no-op buffer flush runs). Logic moves into the shared `IoHandleState::flush_for_method`, to which the interpreter's `flush` handler now delegates. `try_native_io_handle_method` gets a dedicated arm: a handle present in the table flushes natively to `True`, an absent id **falls through** — the interpreter shapes that into an `X::IO::Flush` Failure (a value, not an error) the generic Err-on-absent path can't reproduce. A closed-but-in-table handle returns `True`, matching the interpreter's existing behavior (raku returns a Failure there — a **pre-existing divergence**, out of scope).

## Testing

- New `t/io-handle-tier2b-printf-flush.t` (9 cases) passes **9/9 under both mutsu and raku**.
- `MUTSU_VM_STATS` confirms `flush` leaves the fallback list entirely (`out-buffering.t`: flush 15 → 0) and `printf` goes native on File targets.
- Whitelisted S32-io (out-buffering / open / io-special / slurp / spurt) green.
- `make test` (cargo 461 + prove 6373) green; zero reentry panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)