### PR TITLE
refactor(io): VM-native write/spurt raw byte output for File IO::Handle (③ native IO PR-D Tier-2c)

### DIFF
--- a/docs/vm-io-ownership.md
+++ b/docs/vm-io-ownership.md
@@ -236,6 +236,23 @@ make roast のタイムアウト（静的には捕捉できない＝必ずスモ
     再現不能ゆえ）。closed-but-in-table は Bool(true)＝interpreter の既存挙動と一致（raku は Failure＝既存差・スコープ外）。
   - **検証**: 新 `t/io-handle-tier2b-printf-flush.t`(9) mutsu/raku 双方 9/9。out-buffering.t の **flush が fallback から
     消滅**（flush=15→0）、printf も native。S32-io（out-buffering/open/io-special/slurp/spurt）緑。`make test` 緑。
-  - **次 = PR-D Tier-2c**: `write`/`spurt`（Buf/bytes、`write_bytes_to_handle_value` の out-buffer 非対応 File 分岐を
-    共有ヘルパ化して native 化）。**Stdout/Stderr 出力 + 読み系（get/lines/read/slurp + ArgFiles `@*ARGS`/非UTF8 decode）の
-    真の撲滅は emit_output/env/encode を VM 到達可能にする ③後段/④ が前提**。Tier-3 = open(reopen)/path/Supply/DESTROY/Str。
+- **PR-D Tier-2c 完了（2026-06-11）**: `write`/`spurt`（File ターゲットの raw byte 書き込み）を VM ネイティブ化。
+  - **raw write の共有**: `write_bytes_to_handle_value` の File 分岐（out-buffer 非対応の `file.write_all`）を
+    `IoHandleState::write_all_to_file` へ抽出（interpreter が委譲）。VM 用に `is_file_target`（File ゲート、encoding 非依存）
+    と `native_write_bytes_file`（closed/mode-Read 検査+bytes 計上+`write_all_to_file`＝write_bytes の phase1+File 分岐の
+    File 専用結合）を `impl IoHandleState` に追加。
+  - **byte 構築**は現行ハンドラと同一: `write`=各引数を buffer 型(Buf/Blob/utf8/utf16)なら `supply_chunk_to_bytes`(utf16 対応・
+    `pub(crate)` 化)、非 buffer は `render_str_value`(UTF-8 bytes)で連結。`spurt`=Buf は `VM::extract_buf_bytes`、Str は
+    UTF-8 bytes。VM 新 `try_native_io_handle_byte_output`（output dispatch の次、mut/非mut 両パス）。
+  - **ゲート**: write は File のみ（encoding 無関係＝raw bytes）。spurt は File かつ、**Str 引数のときは encoding が UTF-8**
+    （非UTF8 Str は `encode_with_encoding` 再入ゆえ fall through）。Buf spurt は File のみで OK。junction fall-through。
+  - **検証**: 新 `t/io-handle-tier2c-write-spurt.t`(8) mutsu/raku 双方 8/8。MUTSU_VM_STATS で `$fh.write`/`$fh.spurt`
+    が native（latin1-Str spurt は spurt=1 で fall through、closed write は die）。S32-io（spurt/out-buffering/open/io-special/
+    slurp/null-char/**utf16**）緑＝utf16 buffer write path 検証。`make test` 緑。**注: `IO::Path.spurt`（受け手が Path）は
+    別メソッドで対象外**（spurt.t の spurt fallback はこれ）。
+  - **次 = PR-D Tier-3 / 真の本丸**: 残る `IO::Handle` メソッドは全て interpreter 状態依存:
+    - **Stdout/Stderr 出力**（print/say/put/printf/write/spurt の非 File 分岐）= `emit_output`/`stderr_output`（output バッファ/
+      output_emitted/TAP/thread-clone）。
+    - **読み系** get/getc/readchars/lines/words/read/slurp/split/comb = `@*ARGS`(env) の ArgFiles + 非UTF8 `decode_with_encoding`。
+    - これらの真の撲滅は **emit_output/env/encode を VM 到達可能にする ③後段/④ の状態移管が前提**＝native IO 撤去の最終段。
+    - Tier-3 = open(reopen)/path/Supply/DESTROY/Str/gist。**Tier-1 nl-in getter** の小残り（未open時 newline_mode fallback）も。

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -99,6 +99,43 @@ impl IoHandleState {
         self.write_file_payload(payload.as_bytes())
     }
 
+    /// Whether this handle targets a regular file (the gate for the VM-native
+    /// byte-write methods `write`/`spurt`, which write raw bytes straight to the
+    /// file independent of `:out-buffer` and encoding — ③ native IO PR-D
+    /// Tier-2c). Stdout/Stderr/Socket return `false` and fall through.
+    pub(crate) fn is_file_target(&self) -> bool {
+        matches!(self.target, IoHandleTarget::File)
+    }
+
+    /// Raw `file.write_all` to a File handle — the shared leaf used by the
+    /// interpreter's `write_bytes_to_handle_value` File branch and the VM-native
+    /// `write`/`spurt` byte-write. Deliberately bypasses the `:out-buffer`
+    /// (matching the existing `write_bytes_to_handle_value` semantics).
+    pub(crate) fn write_all_to_file(&mut self, bytes: &[u8]) -> Result<(), RuntimeError> {
+        if let Some(file) = self.file.as_mut() {
+            file.write_all(bytes)
+                .map_err(|err| RuntimeError::new(format!("Failed to write to file: {}", err)))?;
+            Ok(())
+        } else {
+            Err(RuntimeError::new("IO::Handle is not attached to a file"))
+        }
+    }
+
+    /// VM-native raw byte write to a File handle (`write`/`spurt`): closed-check,
+    /// not-open-for-writing check, byte accounting, then the raw file write.
+    /// Mirrors `write_bytes_to_handle_value`'s phase-1 validation + File branch
+    /// for a File target. Caller guarantees [`is_file_target`].
+    pub(crate) fn native_write_bytes_file(&mut self, bytes: &[u8]) -> Result<(), RuntimeError> {
+        if self.closed {
+            return Err(RuntimeError::io_closed("write"));
+        }
+        if matches!(self.mode, IoHandleMode::Read) {
+            return Err(RuntimeError::new("Handle not open for writing"));
+        }
+        self.bytes_written += bytes.len() as i64;
+        self.write_all_to_file(bytes)
+    }
+
     /// `.flush` — flush the `:out-buffer` pending bytes and the OS file buffer.
     /// Pure handle state (no `Interpreter`), so the VM-native dispatch and the
     /// interpreter's `flush` handler share it (③ native IO PR-D Tier-2b). Works
@@ -601,16 +638,9 @@ impl Interpreter {
                 }
                 Ok(())
             }
-            IoHandleTarget::File => self.with_handle_mut(handle_value, |state| {
-                if let Some(file) = state.file.as_mut() {
-                    file.write_all(bytes).map_err(|err| {
-                        RuntimeError::new(format!("Failed to write to file: {}", err))
-                    })?;
-                    Ok(())
-                } else {
-                    Err(RuntimeError::new("IO::Handle is not attached to a file"))
-                }
-            }),
+            IoHandleTarget::File => {
+                self.with_handle_mut(handle_value, |state| state.write_all_to_file(bytes))
+            }
             IoHandleTarget::Socket => self.with_handle_mut(handle_value, |state| {
                 if let Some(sock) = state.socket.as_mut() {
                     sock.write_all(bytes).map_err(|err| {

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -174,7 +174,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn supply_chunk_to_bytes(&self, chunk: &Value, encoding_name: &str) -> Vec<u8> {
+    pub(crate) fn supply_chunk_to_bytes(&self, chunk: &Value, encoding_name: &str) -> Vec<u8> {
         let normalized = self
             .find_encoding(encoding_name)
             .map(|e| e.name.as_str())

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -132,6 +132,12 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
                 return result;
             }
+            // VM-native raw byte output to a File `IO::Handle` (write/spurt):
+            // raw file write, no buffering/encoding (PR-D Tier-2c). Stdout/Stderr
+            // and a non-UTF8 spurt of a Str fall through.
+            if let Some(result) = self.try_native_io_handle_byte_output(&target, method, &args) {
+                return result;
+            }
             if self.interpreter.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
@@ -734,6 +740,99 @@ impl VM {
         )
     }
 
+    /// VM-native raw byte output for a `File` `IO::Handle` receiver
+    /// (`write` / `spurt`): build the bytes exactly as the interpreter's
+    /// `native_io` handlers do and write them straight to the file via the
+    /// shared `IoHandleState::native_write_bytes_file` (raw, `:out-buffer`- and
+    /// encoding-bypassing — same semantics as `write_bytes_to_handle_value`).
+    /// PLAN.md ③ native IO PR-D Tier-2c.
+    ///
+    /// `write` concatenates each arg's bytes — buffer types (Buf/Blob/utf8/
+    /// utf16) via `supply_chunk_to_bytes` (utf16-aware), non-buffers via
+    /// `render_str_value` (their UTF-8 bytes). `spurt` writes its single
+    /// argument: a Buf's raw bytes, or a Str's UTF-8 bytes.
+    ///
+    /// Returns `None` (fall through) for any non-`IO::Handle` receiver, any other
+    /// method, a junction argument, a non-File target (Stdout/Stderr need
+    /// `emit_output`), or a `spurt` of a Str on a non-UTF-8 handle (needs
+    /// `encode_with_encoding`). The File gate is read before the bytes are built.
+    fn try_native_io_handle_byte_output(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let id = match target {
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "IO::Handle" => match attributes.as_map().get("handle") {
+                Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                _ => return None,
+            },
+            _ => return None,
+        };
+        if !matches!(method, "write" | "spurt") {
+            return None;
+        }
+        // Junction args autothread in the interpreter; fall through for those.
+        if args.iter().any(|a| matches!(a, Value::Junction { .. })) {
+            return None;
+        }
+
+        // File-target gate, read before building the bytes. For `spurt` of a Str
+        // the handle encoding must also be UTF-8 (a non-UTF-8 encoding re-enters
+        // `encode_with_encoding`); `write` and a Buf `spurt` ignore encoding.
+        let spurt_str_needs_utf8 =
+            method == "spurt" && !args.first().map(Self::is_buf_value).unwrap_or(false);
+        {
+            let table = self.io_handles_mut();
+            let state = table.map.get(&id)?;
+            if !state.is_file_target() {
+                return None;
+            }
+            if spurt_str_needs_utf8 && !state.can_native_text_write() {
+                return None;
+            }
+        }
+
+        let bytes: Vec<u8> = if method == "spurt" {
+            let content_value = args
+                .first()
+                .cloned()
+                .unwrap_or_else(|| Value::Str(String::new().into()));
+            if Self::is_buf_value(&content_value) {
+                Self::extract_buf_bytes(&content_value)
+            } else {
+                // Gate guaranteed UTF-8, so the Str's bytes are its UTF-8 bytes.
+                content_value.to_string_value().into_bytes()
+            }
+        } else {
+            // write: concatenate each arg — buffer types via supply_chunk_to_bytes
+            // (utf16-aware), non-buffers via render_str_value (UTF-8 bytes).
+            let mut out = Vec::new();
+            for arg in args {
+                if Self::is_buf_value(arg) {
+                    out.extend(self.interpreter.supply_chunk_to_bytes(arg, "utf-8"));
+                } else {
+                    out.extend(self.interpreter.render_str_value(arg).into_bytes());
+                }
+            }
+            out
+        };
+
+        let mut table = self.io_handles_mut();
+        let Some(state) = table.map.get_mut(&id) else {
+            return Some(Err(RuntimeError::new("Invalid IO::Handle")));
+        };
+        Some(
+            state
+                .native_write_bytes_file(&bytes)
+                .map(|_| Value::Bool(true)),
+        )
+    }
+
     /// VM-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
     /// over a list-like receiver (List/Array/Seq/Slip/Hash/Set/Bag/Mix/Pair/Range).
     /// Delegates the element folding to the single authoritative pure
@@ -1164,6 +1263,12 @@ impl VM {
             // VM-native text output to a File+UTF8 `IO::Handle` (print/put/say/
             // print-nl), mut path (PR-D Tier-2a). See the non-mut twin above.
             if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
+                return result;
+            }
+            // VM-native raw byte output to a File `IO::Handle` (write/spurt):
+            // raw file write, no buffering/encoding (PR-D Tier-2c). Stdout/Stderr
+            // and a non-UTF8 spurt of a Str fall through.
+            if let Some(result) = self.try_native_io_handle_byte_output(&target, method, &args) {
                 return result;
             }
             if self.interpreter.is_native_method(&class, method) {

--- a/t/io-handle-tier2c-write-spurt.t
+++ b/t/io-handle-tier2c-write-spurt.t
@@ -1,0 +1,64 @@
+use Test;
+
+# VM-native raw byte output on a File IO::Handle: write / spurt (③ native IO
+# PR-D Tier-2c). Both write straight to the file (raw, bypassing :out-buffer and
+# encoding), so they resolve in the VM via the shared
+# IoHandleState::native_write_bytes_file. Must behave identically to the
+# interpreter's native fork.
+
+plan 8;
+
+my $path = $*TMPDIR.child("mutsu-io-t2c-{$*PID}.bin");
+
+# write a Blob
+{
+    my $fh = $path.open(:w);
+    ok $fh.write(Buf.new(72, 73, 33)) === True, 'write(Blob) returns True';
+    $fh.close;
+    is-deeply $path.slurp(:bin).list, (72, 73, 33), 'write(Blob) writes the raw bytes';
+}
+
+# write multiple Blob args concatenates
+{
+    my $fh = $path.open(:w);
+    $fh.write(Buf.new(1, 2));
+    $fh.write(Buf.new(3, 4));
+    $fh.close;
+    is-deeply $path.slurp(:bin).list, (1, 2, 3, 4), 'multiple write() calls concatenate';
+}
+
+# spurt a Buf
+{
+    my $fh = $path.open(:w);
+    ok $fh.spurt(Buf.new(10, 20, 30)) === True, 'spurt(Buf) returns True';
+    $fh.close;
+    is-deeply $path.slurp(:bin).list, (10, 20, 30), 'spurt(Buf) writes the raw bytes';
+}
+
+# spurt a Str (UTF-8) — including multibyte
+{
+    my $fh = $path.open(:w);
+    $fh.spurt("café");
+    $fh.close;
+    is $path.slurp, "café", 'spurt(Str) writes UTF-8 bytes';
+}
+
+# spurt on a non-UTF8 handle still encodes (falls through)
+{
+    my $lp = $*TMPDIR.child("mutsu-io-t2c-latin1-{$*PID}.txt");
+    my $fh = $lp.open(:w);
+    $fh.encoding('latin1');
+    $fh.spurt("é");
+    $fh.close;
+    is $lp.slurp(:bin).elems, 1, 'spurt(Str) on latin1 encodes (fall through)';
+    $lp.unlink;
+}
+
+# writing to a closed handle dies
+{
+    my $fh = $path.open(:w);
+    $fh.close;
+    dies-ok { $fh.write(Buf.new(1)) }, 'write on a closed handle dies';
+}
+
+$path.unlink;


### PR DESCRIPTION
## Summary

Continues the ③ native-IO ownership campaign (`docs/vm-io-ownership.md`), **PR-D Tier-2c**: bring `write` and `spurt` on a File-target `IO::Handle` into the VM-native IO dispatch. Both write raw bytes straight to the file (bypassing `:out-buffer` and encoding), so they resolve in the VM via the shared `IoHandleState::native_write_bytes_file`.

- The raw `file.write_all` is extracted into `IoHandleState::write_all_to_file` (the interpreter's `write_bytes_to_handle_value` File branch now delegates to it). `native_write_bytes_file` adds the closed / not-open-for-writing / byte-accounting around it (mirroring `write_bytes_to_handle_value`'s phase-1 + File branch). `is_file_target` is the File gate.
- Byte building matches the handlers exactly: `write` concatenates each arg — buffer types (Buf/Blob/utf8/utf16) via `supply_chunk_to_bytes` (now `pub(crate)`), non-buffers via `render_str_value` — and `spurt` writes a Buf's raw bytes or a Str's UTF-8 bytes.
- `try_native_io_handle_byte_output` runs after the text-output dispatch on both paths. `write` gates on a File target only (ignores encoding); a `spurt` of a Str additionally requires UTF-8 (a non-UTF-8 Str re-enters `encode_with_encoding`, so it falls through), while a Buf `spurt` needs only a File target. Junction args fall through. `IO::Path.spurt` (a Path receiver) is unaffected.

## Testing

- New `t/io-handle-tier2c-write-spurt.t` (8 cases) passes **8/8 under both mutsu and raku**.
- `MUTSU_VM_STATS` confirms `$fh.write`/`$fh.spurt` go native while a latin1 Str spurt and `IO::Path.spurt` correctly fall through.
- Whitelisted S32-io (spurt / out-buffering / open / io-special / slurp / null-char / **utf16**) green — utf16 exercises the buffer-write path.
- `make test` (cargo 461 + prove 6393) green; zero reentry panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)