### PR TITLE
feat(container): element-element / container-leaf := bind via shared cells

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -496,6 +496,7 @@ pub(super) fn dispatch(
             fn gist_item(v: &Value) -> String {
                 match v {
                     Value::Nil => "Nil".to_string(),
+                    Value::ContainerRef(cell) => gist_item(&cell.lock().unwrap()),
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");
                         gist_array_wrap(&elems, *kind)
@@ -554,6 +555,7 @@ pub(super) fn dispatch(
             fn gist_item(v: &Value) -> String {
                 match v {
                     Value::Nil => "Nil".to_string(),
+                    Value::ContainerRef(cell) => gist_item(&cell.lock().unwrap()),
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");
                         gist_array_wrap(&elems, *kind)

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -263,6 +263,13 @@ pub fn raku_value(v: &Value) -> String {
         static ARRAY_CYCLE_FOUND: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     }
     match v {
+        // A `:=`-bound element holds a `ContainerRef` cell; render the held
+        // value so a bound element inside a hash/array renders like a plain one
+        // (Phase 5 leak hardening).
+        Value::ContainerRef(cell) => {
+            let inner = cell.lock().unwrap().clone();
+            raku_value(&inner)
+        }
         Value::Array(items, kind) => {
             // Lazy arrays should not be materialized
             if *kind == crate::value::ArrayKind::Lazy {

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -258,6 +258,31 @@ impl Compiler {
     /// `outer_positional` is the `is_positional` flag of the outermost
     /// subscript (i.e. `[...]` vs `{...}`/`<...>`), preserved from the
     /// `IndexAssign` AST node.
+    /// Compile the RHS value of an `IndexAssign`. When the value is a `:=` bind
+    /// marker (`__mutsu_bind_index_value(...)`) whose RHS is itself an indexed
+    /// element (`$bar[..]<..> := $foo[1]<key>`), compile it with terminal
+    /// promotion (`scalar_bind_autovivify` + `bind_terminal`) so the bound
+    /// element shares a `ContainerRef` cell with the source. That makes
+    /// element-to-element binds propagate writes bidirectionally (nested.t
+    /// 32-37). For a plain (non-bind) value, this is just `compile_expr`.
+    fn compile_bind_index_value(&mut self, value: &Expr) {
+        let is_bind = matches!(
+            value,
+            Expr::Call { name, .. } if *name == "__mutsu_bind_index_value"
+        );
+        if is_bind {
+            let saved_av = self.scalar_bind_autovivify;
+            let saved_term = self.bind_terminal;
+            self.scalar_bind_autovivify = true;
+            self.bind_terminal = true;
+            self.compile_expr(value);
+            self.scalar_bind_autovivify = saved_av;
+            self.bind_terminal = saved_term;
+        } else {
+            self.compile_expr(value);
+        }
+    }
+
     pub(super) fn compile_expr_index_assign(
         &mut self,
         target: &Expr,
@@ -310,7 +335,7 @@ impl Compiler {
                 self.compile_expr(target);
                 self.code.emit(OpCode::Pop);
             }
-            self.compile_expr(value);
+            self.compile_bind_index_value(value);
             self.compile_expr(index);
             let name_idx = self.code.add_constant(Value::str(name));
             self.code.emit(OpCode::IndexAssignExprNamed {
@@ -330,7 +355,7 @@ impl Compiler {
                 crate::value::ArrayKind::Array,
             ));
             // Stack order: [value, idx_outermost, ..., idx_innermost]
-            self.compile_expr(value);
+            self.compile_bind_index_value(value);
             self.compile_expr(index); // outermost
             for (idx_expr, _) in chain.iter().rev() {
                 self.compile_expr(idx_expr);
@@ -347,7 +372,7 @@ impl Compiler {
             // `outer_positional` (the outermost subscript flag) is passed in
             // from the IndexAssign AST node. `inner_positional` is the inner
             // Index node's flag (the subscript closer to the variable).
-            self.compile_expr(value);
+            self.compile_bind_index_value(value);
             self.compile_expr(index);
             self.compile_expr(inner_index);
             let name_idx = self.code.add_constant(Value::str(name));

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -327,6 +327,14 @@ impl Compiler {
         // When in scalar bind context (`:=`), emit IndexAutovivifyLazy so that
         // binding alone doesn't autovivify (deferred until assignment).
         let use_autovivify = self.scalar_bind_autovivify;
+        let is_terminal = use_autovivify && self.bind_terminal;
+        let lazy_op = if is_terminal {
+            OpCode::IndexAutovivifyLazyTerminal
+        } else {
+            OpCode::IndexAutovivifyLazy
+        };
+        let saved_terminal = self.bind_terminal;
+        self.bind_terminal = false; // inner `target` indices are intermediate
 
         // Special case: %*ENV<key> compiles to GetEnvIndex
         if let Expr::HashVar(name) = target {
@@ -338,7 +346,7 @@ impl Compiler {
                     self.compile_expr(target);
                     self.compile_expr(index);
                     if use_autovivify {
-                        self.code.emit(OpCode::IndexAutovivifyLazy);
+                        self.code.emit(lazy_op);
                     } else {
                         self.code.emit(OpCode::Index { is_positional });
                     }
@@ -347,7 +355,7 @@ impl Compiler {
                 self.compile_expr(target);
                 self.compile_expr(index);
                 if use_autovivify {
-                    self.code.emit(OpCode::IndexAutovivifyLazy);
+                    self.code.emit(lazy_op);
                 } else {
                     self.code.emit(OpCode::Index { is_positional });
                 }
@@ -356,11 +364,12 @@ impl Compiler {
             self.compile_expr(target);
             self.compile_expr(index);
             if use_autovivify {
-                self.code.emit(OpCode::IndexAutovivifyLazy);
+                self.code.emit(lazy_op);
             } else {
                 self.code.emit(OpCode::Index { is_positional });
             }
         }
+        self.bind_terminal = saved_terminal;
     }
 
     /// Compile StringInterpolation expression.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -71,6 +71,12 @@ pub(crate) struct Compiler {
     /// Index.  Set only during scalar `:=` bind VarDecl compilation so that
     /// `my $b := %h<foo><baz>` creates a HashSlotRef.
     scalar_bind_autovivify: bool,
+    /// When true (alongside `scalar_bind_autovivify`), the next Index compiled is
+    /// the TERMINAL element of the bind RHS (outermost subscript whose value is
+    /// bound). A terminal index promotes even a container-valued (Array/Hash) leaf
+    /// to a cell. Cleared while compiling the inner `target` so only the outermost
+    /// index is terminal.
+    bind_terminal: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
     /// Subset of `constant_vars` whose declaring lexical block is still open.
@@ -129,6 +135,7 @@ impl Compiler {
             lexically_in_routine: false,
             bind_vardecl: false,
             scalar_bind_autovivify: false,
+            bind_terminal: false,
             constant_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -765,8 +765,10 @@ impl Compiler {
                     // only emit WrapVarRef when the RHS is a simple variable.
                     self.bind_vardecl = false;
                     self.scalar_bind_autovivify = true;
+                    self.bind_terminal = true;
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
+                    self.bind_terminal = false;
                 } else {
                     let rhs_expr = if has_default_trait
                         && !name.starts_with('@')

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -504,6 +504,10 @@ pub(crate) enum OpCode {
     /// Used for the outermost level of `:=` bind so that binding alone
     /// does not autovivify (e.g. `my $b := %h<a><b>` keeps %h empty).
     IndexAutovivifyLazy,
+    /// Like IndexAutovivifyLazy, but the index is the TERMINAL element of a `:=`
+    /// bind RHS. A container-valued (Array/Hash) leaf is promoted to a
+    /// `ContainerRef` cell — not kept as a traversal SlotRef.
+    IndexAutovivifyLazyTerminal,
     DeleteIndexNamed(u32),
     DeleteIndexExpr,
     /// Multi-dimensional indexing: @a[$x;$y;$z]

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -858,6 +858,9 @@ pub(crate) fn gist_value(value: &Value) -> String {
         }
     }
     match value {
+        // A `:=`-bound element holds a `ContainerRef` cell; render the held
+        // value so a bound element gists like a plain one (Phase 5 leak).
+        Value::ContainerRef(cell) => gist_value(&cell.lock().unwrap()),
         Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigRat(_, _) => {
             // Rat.gist is identical to Rat.Str in Raku
             value.to_string_value()

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2578,7 +2578,7 @@ impl Value {
     ///
     /// Reads decontainerize at the single chokepoint (`resolve_hash_entry`);
     /// writes go through `hash_insert_through` (Stage 0).
-    pub fn hash_slot_ref(&self, key: &str) -> Option<Value> {
+    pub fn hash_slot_ref(&self, key: &str, terminal: bool) -> Option<Value> {
         if let Value::Hash(arc) = self {
             // SAFETY: mutsu is single-threaded; no immutable borrow into the
             // map is alive across this mutation.
@@ -2586,7 +2586,7 @@ impl Value {
             unsafe {
                 match (*ptr).get_mut(key) {
                     Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
-                    Some(elem @ (Value::Array(..) | Value::Hash(..))) => {
+                    Some(elem @ (Value::Array(..) | Value::Hash(..))) if !terminal => {
                         // Intermediate container: preserve traversal via SlotRef.
                         let _ = elem;
                         Some(Value::HashSlotRef {
@@ -2724,7 +2724,7 @@ impl Value {
     /// `Arc<Mutex>` cell is shared on every clone, so the alias survives
     /// arbitrarily deep `$struct[..]<..>[..]` paths. Reads decontainerize the
     /// element at the single read chokepoint (`resolve_array_entry`).
-    pub fn array_slot_ref(&self, idx: usize) -> Option<Value> {
+    pub fn array_slot_ref(&self, idx: usize, terminal: bool) -> Option<Value> {
         if let Value::Array(arc, _kind) = self {
             // SAFETY: mutsu is single-threaded.
             let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
@@ -2741,7 +2741,7 @@ impl Value {
                 // (`$s[1][1]`, `$s[1]<k>`); keep the old `ArraySlotRef`, whose
                 // resolution shares the inner Arc, so the eventual leaf promotion
                 // lands in the same physical Vec the stored element points to.
-                if matches!(elem, Value::Array(..) | Value::Hash(..)) {
+                if !terminal && matches!(elem, Value::Array(..) | Value::Hash(..)) {
                     return Some(Value::ArraySlotRef {
                         array: arc.clone(),
                         index: idx,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3032,7 +3032,11 @@ impl VM {
                 *ip += 1;
             }
             OpCode::IndexAutovivifyLazy => {
-                self.exec_index_autovivify_lazy_op()?;
+                self.exec_index_autovivify_lazy_op(false)?;
+                *ip += 1;
+            }
+            OpCode::IndexAutovivifyLazyTerminal => {
+                self.exec_index_autovivify_lazy_op(true)?;
                 *ip += 1;
             }
             OpCode::DeleteIndexNamed(name_idx) => {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3091,7 +3091,7 @@ impl VM {
                         return Ok(());
                     }
                 }
-                if let Some(container) = self.interpreter.env_mut().get_mut(&var_name) {
+                if let Some(container) = self.env_root_descended_mut(&var_name) {
                     match *container {
                         Value::Hash(ref mut hash) => {
                             let is_self_hash_ref = matches!(
@@ -3705,7 +3705,7 @@ impl VM {
         {
             self.locals[slot] = Value::Nil;
         }
-        if let Some(Value::Array(outer_arr, _kind)) = self.interpreter.env_mut().get_mut(&var_name)
+        if let Some(Value::Array(outer_arr, _kind)) = self.env_root_descended_mut(&var_name)
             && let Ok(inner_i) = inner_key.parse::<usize>()
         {
             let arr = Arc::make_mut(outer_arr);
@@ -3774,7 +3774,7 @@ impl VM {
         if let Some(slot) = self.find_local_slot(code, &var_name) {
             self.locals[slot] = Value::Nil;
         }
-        if let Some(Value::Hash(outer_hash)) = self.interpreter.env_mut().get_mut(&var_name) {
+        if let Some(Value::Hash(outer_hash)) = self.env_root_descended_mut(&var_name) {
             let oh = Arc::make_mut(outer_hash);
             // Vivify the missing entry as Array if the OUTER (second) subscript
             // is positional (e.g. `%h<key>[42] = ...`), otherwise as Hash.
@@ -3785,42 +3785,92 @@ impl VM {
                     Value::hash(std::collections::HashMap::new())
                 }
             });
-            match inner_val {
-                Value::Array(arr, _) => {
-                    // Hash-containing-Array: $hash<key>[idx] = val
-                    // Use interior mutation when the array is shared (supports
-                    // ArraySlotRef and cross-variable identity).
-                    if let Ok(i) = outer_key.parse::<usize>() {
-                        if Arc::strong_count(arr) > 1 {
-                            // SAFETY: mutsu is single-threaded.
-                            let ptr = Arc::as_ptr(arr) as *mut Vec<Value>;
-                            unsafe {
-                                while (&(*ptr)).len() <= i {
-                                    (&mut (*ptr)).push(Value::Nil);
-                                }
-                                (&mut (*ptr))[i] = val.clone();
-                            }
-                        } else {
-                            let a = Arc::make_mut(arr);
-                            if i >= a.len() {
-                                a.resize(i + 1, Value::Nil);
-                            }
-                            a[i] = val.clone();
-                        }
-                    }
-                }
-                Value::Hash(h) => {
-                    // Hash-in-Hash: $hash<key1><key2> = val
-                    Value::hash_insert_through(Arc::make_mut(h), outer_key, val.clone());
-                }
-                _ => {}
-            }
+            Self::assign_into_nested_container(inner_val, &outer_key, val.clone());
         }
         if let Some(updated) = self.get_env_with_main_alias(&var_name) {
             self.update_local_if_exists(code, &var_name, &updated);
         }
         self.stack.push(val);
         Ok(())
+    }
+
+    /// Assign `val` into `target[outer_key]`, descending through any chain of
+    /// `:=`-bound container cells (`ContainerRef`). Used by the 2-level nested
+    /// assign so that a write to a container-valued bound element
+    /// (`%h<key><inner> = ...` where `%h<key>` is a cell) mutates the shared,
+    /// held container in place instead of being silently dropped.
+    fn assign_into_nested_container(target: &mut Value, outer_key: &str, val: Value) {
+        match target {
+            Value::ContainerRef(cell) => {
+                let mut guard = cell.lock().unwrap();
+                Self::assign_into_nested_container(&mut guard, outer_key, val);
+            }
+            Value::Array(arr, _) => {
+                if let Ok(i) = outer_key.parse::<usize>() {
+                    if Arc::strong_count(arr) > 1 {
+                        // SAFETY: mutsu is single-threaded.
+                        let ptr = Arc::as_ptr(arr) as *mut Vec<Value>;
+                        unsafe {
+                            let v = &mut *ptr;
+                            while v.len() <= i {
+                                v.push(Value::Nil);
+                            }
+                            Value::assign_element_slot(&mut v[i], val);
+                        }
+                    } else {
+                        let a = Arc::make_mut(arr);
+                        if i >= a.len() {
+                            a.resize(i + 1, Value::Nil);
+                        }
+                        Value::assign_element_slot(&mut a[i], val);
+                    }
+                }
+            }
+            Value::Hash(h) => {
+                Value::hash_insert_through(Arc::make_mut(h), outer_key.to_string(), val);
+            }
+            _ => {}
+        }
+    }
+
+    /// Follow `current` through any chain of `:=`-bound container cells
+    /// (`ContainerRef`), returning a raw pointer to the innermost held value.
+    ///
+    /// SAFETY: mutsu is single-threaded; the pointer derived from the cell's
+    /// mutex data stays valid after the transient guard drops (the held `Value`
+    /// is owned by the `Arc`, which the caller keeps alive).
+    ///
+    /// Cycle-safety (Phase 4): a self-referential bind can make a cell
+    /// transitively hold a `ContainerRef` back to itself. A normal cell holds a
+    /// Hash/Array (the loop stops immediately); only a cell-holding-cell chain
+    /// can loop. Bound the descent depth and stop on overflow so a cyclic bind
+    /// terminates instead of hanging.
+    unsafe fn descend_container_ref(mut current: *mut Value) -> *mut Value {
+        const MAX_DESCENT: usize = 256;
+        for _ in 0..MAX_DESCENT {
+            let cell = match unsafe { &mut *current } {
+                Value::ContainerRef(cell) => cell.clone(),
+                _ => return current,
+            };
+            let mut guard = cell.lock().unwrap();
+            current = &mut *guard as *mut Value;
+        }
+        current
+    }
+
+    /// Read a root variable for index-assignment, descending through any
+    /// `:=`-bound container cell so a `ContainerRef` root resolves to its held
+    /// Hash/Array. Without this, a write to `$x[i]`/`$x<k>` where `$x` is itself
+    /// a bound cell would fall through every handler's `Value::Hash`/`Value::Array`
+    /// match and be silently dropped (Phase 3).
+    ///
+    /// SAFETY: single-threaded; the returned reference points into the cell's
+    /// mutex data, kept alive by the `Arc` stored in env (see
+    /// `descend_container_ref`).
+    fn env_root_descended_mut(&mut self, var_name: &str) -> Option<&mut Value> {
+        let root = self.interpreter.env_mut().get_mut(var_name)? as *mut Value;
+        let descended = unsafe { Self::descend_container_ref(root) };
+        Some(unsafe { &mut *descended })
     }
 
     /// Deep nested index assignment (3+ levels): @a[i][j][k]... = val
@@ -3906,6 +3956,10 @@ impl VM {
             let key = &indices[level];
             let is_positional = positional_flags[level];
 
+            // Descend through any `:=`-bound container cell at this level so the
+            // traversal/assignment reaches the shared, held container.
+            current = unsafe { Self::descend_container_ref(current) };
+
             if level < depth - 1 {
                 // Intermediate level: autovivify and descend
                 let next_positional = positional_flags[level + 1];
@@ -3918,9 +3972,14 @@ impl VM {
                                     let fill = native_fill.clone();
                                     arr.resize(i + 1, fill);
                                 }
-                                // Autovivify if needed
-                                let needs_viv =
-                                    !matches!(&arr[i], Value::Array(..) | Value::Hash(..));
+                                // Autovivify if needed. A `ContainerRef` is a
+                                // `:=`-bound cell that holds (and is descended to)
+                                // a container on the next iteration; treating it
+                                // as "needs vivify" would clobber the binding.
+                                let needs_viv = !matches!(
+                                    &arr[i],
+                                    Value::Array(..) | Value::Hash(..) | Value::ContainerRef(..)
+                                );
                                 if needs_viv {
                                     arr[i] = if next_positional {
                                         Value::real_array(Vec::new())

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -119,7 +119,7 @@ impl VM {
             Value::Array(..) => {
                 // Positional autovivify: return an ArraySlotRef
                 if let Some(idx) = Self::index_to_usize(&index) {
-                    if let Some(slot_ref) = resolved.array_slot_ref(idx) {
+                    if let Some(slot_ref) = resolved.array_slot_ref(idx, false) {
                         self.stack.push(slot_ref);
                     } else {
                         self.stack.push(Value::Nil);
@@ -156,7 +156,10 @@ impl VM {
     /// Lazy variant of IndexAutovivify: returns a HashSlotRef without creating
     /// the hash entry if it doesn't exist. Used for `:=` bind expressions
     /// so that `my $b := %h<a><b>` doesn't autovivify until assignment.
-    pub(super) fn exec_index_autovivify_lazy_op(&mut self) -> Result<(), RuntimeError> {
+    pub(super) fn exec_index_autovivify_lazy_op(
+        &mut self,
+        terminal: bool,
+    ) -> Result<(), RuntimeError> {
         let index = self.stack.pop().unwrap();
         let target = self.stack.pop().unwrap();
 
@@ -173,11 +176,27 @@ impl VM {
                 // Phase 2 Stage 1: promote an existing scalar leaf to a shared
                 // `ContainerRef` cell so deep `%h<a><b>` binds survive COW; an
                 // intermediate container keeps a lazy HashSlotRef, and a missing
-                // key stays lazy (no entry created).
-                if let Some(slot_ref) = resolved.hash_slot_ref(&key) {
+                // key stays lazy (no entry created). When `terminal` (outermost
+                // bind subscript), promote a container-valued leaf to a cell too.
+                if let Some(slot_ref) = resolved.hash_slot_ref(&key, terminal) {
                     self.stack.push(slot_ref);
                 } else {
                     self.stack.push(Value::Nil);
+                }
+            }
+            // Terminal bind index into an Array leaf: promote the element to a
+            // shared `ContainerRef` cell (container-valued leaves included).
+            Value::Array(..) if terminal => {
+                if let Some(idx) = Self::index_to_usize(&index) {
+                    if let Some(slot_ref) = resolved.array_slot_ref(idx, true) {
+                        self.stack.push(slot_ref);
+                    } else {
+                        self.stack.push(Value::Nil);
+                    }
+                } else {
+                    self.stack.push(resolved);
+                    self.stack.push(index);
+                    return self.exec_index_autovivify_op();
                 }
             }
             // When resolved is an Array (from a HashSlotRef or ArraySlotRef), create
@@ -288,6 +307,15 @@ impl VM {
         // values (e.g. `$hash.item<key>` or `from-json(…)<key>`).
         if let Value::Scalar(inner) = &target {
             self.stack.push(inner.as_ref().clone());
+            self.stack.push(index);
+            return self.exec_index_op_with_positional(is_positional);
+        }
+        // Decontainerize a `:=`-bound container cell so a read through a bound
+        // element (`$x<k>` where `$x<k>` resolves to a `ContainerRef`) sees the
+        // shared, held container rather than the cell wrapper.
+        if let Value::ContainerRef(cell) = &target {
+            let inner = cell.lock().unwrap().clone();
+            self.stack.push(inner);
             self.stack.push(index);
             return self.exec_index_op_with_positional(is_positional);
         }

--- a/t/element-bind-cell.t
+++ b/t/element-bind-cell.t
@@ -6,7 +6,7 @@ use Test;
 # `$struct[..]<..>[..]` paths (which the old index-back-reference lost when an
 # enclosing container was COW-cloned on a later write).
 
-plan 35;
+plan 50;
 
 # Single-level array element
 {
@@ -153,6 +153,70 @@ plan 35;
     $x = 30;
     is ~@copy2, "1 20 3", 'RHS-bound element: array copy snapshots the value';
     is ~@a2, "1 30 3", 'RHS-bound element: original still aliases the source';
+}
+
+# Binding to a *container-valued* element (the leaf holds a Hash/Array) must
+# promote the leaf to a shared cell too, so deep writes through either side are
+# mutually visible.
+{
+    my %h = key => { inner => 5 };
+    my $x := %h<key>;
+    is $x<inner>, 5, 'container-leaf bind: initial read';
+    %h<key><inner> = 50;
+    is $x<inner>, 50, 'container-leaf bind: source write -> element';
+    $x<inner> = 500;
+    is %h<key><inner>, 500, 'container-leaf bind: element write -> source';
+}
+
+# RHS deep container-leaf bind: the bound root is itself a cell, so writes in
+# both directions must traverse it.
+{
+    my $foo = [ "ig", { key => { subkey => [ "ig", 2 ] } } ];
+    my $x := $foo[1]<key>;
+    is $x<subkey>[1], 2, 'deep container-leaf: initial read';
+    $foo[1]<key><subkey>[1] = 7;
+    is $x<subkey>[1], 7, 'deep container-leaf: source write -> element';
+    $x<subkey>[1] = 8;
+    is $foo[1]<key><subkey>[1], 8, 'deep container-leaf: element write -> source';
+}
+
+# Element-to-element bind: bind a deep element of one structure to a deep
+# element of another (roast S03-binding/nested.t 32-33 shape). Writes in both
+# directions propagate through the shared cell.
+{
+    my $foo = [ "ig", { key => { subkey => [ "ig", 2 ] } } ];
+    my $bar = [ "ig", { key => { subkey => [ "ig", 5 ] } } ];
+    $bar[1]<key><subkey> := $foo[1]<key>;
+    is $bar[1]<key><subkey><subkey>[1], 2, 'element-element: initial read';
+    $foo[1]<key><subkey>[1] = 7;
+    is $bar[1]<key><subkey><subkey>[1], 7, 'element-element: source write -> element';
+    $bar[1]<key><subkey><subkey>[1] = 8;
+    is $foo[1]<key><subkey>[1], 8, 'element-element: element write -> source';
+}
+
+# Self-referential (cyclic) bind: bind an element of a structure to an element
+# of the SAME structure (nested.t 35-37). Writes must terminate and propagate
+# both ways through the cycle.
+{
+    my $struct = [ "ig", { key => { foo => "bar", subkey => [ "ig", 100 ] } } ];
+    $struct[1]<key><subkey>[1] := $struct[1]<key>;
+    is $struct[1]<key><subkey>[1]<foo>, "bar", 'cyclic bind: initial read';
+    $struct[1]<key><subkey>[1]<foo> = "new_value";
+    is $struct[1]<key><foo>, "new_value", 'cyclic bind: long write -> short read';
+    $struct[1]<key><foo> = "very_new_value";
+    is $struct[1]<key><subkey>[1]<foo>, "very_new_value", 'cyclic bind: short write -> long read';
+}
+
+# A bound container-valued element must NOT leak the `ContainerRef` cell into
+# rendering / iteration of the enclosing structure (Phase 5).
+{
+    my @a = [{x => 1}, {y => 2}, {z => 3}];
+    my $b := @a[1];
+    is @a.raku, '[{:x(1)}, {:y(2)}, {:z(3)}]', 'no cell leak in array .raku';
+    is @a.list[1].WHAT.^name, 'Hash', 'no cell leak in array .list element type';
+    my %h = a => {n => 1}, b => {n => 2};
+    my $c := %h<a>;
+    is %h<a>.WHAT.^name, 'Hash', 'no cell leak in hash element read type';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Implements the element-element / container-leaf `:=` bind plan from `docs/element-element-bind-plan.md` (Phase 2 Stage 2 — the hardest remaining bind slice).

## Result
- `roast/S03-binding/nested.t`: **7 fails → 2** (32-37 now pass; remaining 11-12 are a separate `<key>()` mid-path, explicitly out of scope).
- `t/element-bind-cell.t`: **35 → 50** cases (container-leaf, element-element, cyclic self-reference, no-cell-leak).

## How
Binding a *container-valued* or deeply-nested element to another element now shares a `ContainerRef` cell so writes through either side are mutually visible.

- **Phase 1 — terminal promotion.** New `bind_terminal` compiler flag + `IndexAutovivifyLazyTerminal` opcode promote the outermost bind subscript's leaf (even Array/Hash) to a shared cell; intermediate subscripts keep a traversal SlotRef. `=:=` operands are deliberately not promoted.
- **Phase 2 — deep write-through.** `assign_into_nested_container` + `descend_container_ref` follow a chain of bound cells so `%h<key><inner> = …` mutates the held container in place.
- **Phase 3 — root-cell descent.** `env_root_descended_mut` descends a `ContainerRef` root in the nested + named index-assign handlers (`$x<k> = v` where `$x` is itself a cell). The bind RHS is compiled with terminal promotion so an indexed source (`$bar[..] := $foo[1]<key>`) shares a cell with its source. Reads decontainerize at the index-read chokepoint. Fixes a clobber bug where an intermediate array level vivified over an existing `ContainerRef`.
- **Phase 4 — cycle-safety.** Self-referential binds (nested.t 35-37) terminate via a bounded descent (`MAX_DESCENT`) instead of looping.
- **Phase 5 — leak hardening.** `.raku`/`.gist` rendering decontainerizes `ContainerRef` so a bound element renders like a plain one.

## Verification
- Repros A–D from the plan all match `raku` (D terminates).
- `make test` completes (exit 0); only the documented `native-array-mut.t` #26 Arc-ptr flaky may intermittently fail.
- Spot-checked roast `S02-types/hash.t`, `S03-binding/arrays.t`, `S32-array/push.t`, `S32-hash/keys_values.t` — all pass.
- `.kv`/`.pairs`/`.values`/`.list`/sort/iteration/slices all decontainerize bound elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)