### PR TITLE
docs(TODO_roast): nested.t now 41/43 after element-element bind (#2922)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -6,7 +6,11 @@
 - [ ] roast/S03-binding/closure.t
 - [ ] roast/S03-binding/hashes.t
 - [ ] roast/S03-binding/nested.t
-  27/43 pass. 16 failures: multidimensional structure element binding (`$abbrev := $struct[1]<key>[1]`) requires element-level Scalar containers. Changes to the original structure must propagate through the binding and vice versa.
+  41/43 pass (PR #2922). Element-element / container-leaf `:=` binds (32-37,
+  incl. cyclic self-reference) now share a `ContainerRef` cell so writes
+  propagate both ways. Remaining failures 11-12: `$struct[1]<key>()` mid-path
+  (a `<key>()` call / method-lvalue form routed through IndexAssignGeneric) —
+  a separate path not covered by the shared-cell bind work.
 - [ ] roast/S03-binding/ro.t
 - [ ] roast/S03-binding/scalars.t
 - [ ] roast/S03-buf/read-int.t


### PR DESCRIPTION
Updates the `nested.t` status note to reflect the element-element / container-leaf `:=` bind work landed in #2922 (32-37, including cyclic self-reference, now pass). Only 11-12 remain — a separate `<key>()` mid-path / IndexAssignGeneric form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)