### PR TITLE
feat(container): complete nested.t — write through bound cell on stack-target index-assign

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -5,12 +5,12 @@
   10/16 pass (3 skipped). Tests 11-12 fail: `our $x` class attribute binding requires package-level ContainerRef. Test 13 fails: `has $.scalar does Foo` role mixin on attribute declaration not implemented.
 - [ ] roast/S03-binding/closure.t
 - [ ] roast/S03-binding/hashes.t
-- [ ] roast/S03-binding/nested.t
-  41/43 pass (PR #2922). Element-element / container-leaf `:=` binds (32-37,
-  incl. cyclic self-reference) now share a `ContainerRef` cell so writes
-  propagate both ways. Remaining failures 11-12: `$struct[1]<key>()` mid-path
-  (a `<key>()` call / method-lvalue form routed through IndexAssignGeneric) —
-  a separate path not covered by the shared-cell bind work.
+- [x] roast/S03-binding/nested.t
+  43/43, whitelisted. Element-element / container-leaf `:=` binds (32-37, incl.
+  cyclic self-reference) share a `ContainerRef` cell (PR #2922). Tests 11-12
+  (`$struct[1]<key>()<subkey>[1]` bind through an `is raw` sub mid-path) fixed by
+  routing the IndexAssignGeneric Array arm through `assign_element_slot` so a
+  stack-target write goes through the bound cell instead of clobbering it.
 - [ ] roast/S03-binding/ro.t
 - [ ] roast/S03-binding/scalars.t
 - [ ] roast/S03-buf/read-int.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -162,6 +162,7 @@ roast/S02-types/version.t
 roast/S03-binding/arrays.t
 roast/S03-binding/closure.t
 roast/S03-binding/hashes.t
+roast/S03-binding/nested.t
 roast/S03-binding/ro.t
 roast/S03-buf/read-int.t
 roast/S03-buf/read-num.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4181,10 +4181,21 @@ impl VM {
                 if let Ok(i) = key.parse::<usize>() {
                     let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
                     unsafe {
-                        while (&(*ptr)).len() <= i {
-                            (&mut (*ptr)).push(Value::Nil);
+                        let v = &mut *ptr;
+                        while v.len() <= i {
+                            v.push(Value::Nil);
                         }
-                        (&mut (*ptr))[i] = val.clone();
+                        if bind_source.is_some() {
+                            // Bind mode installs the payload directly (the
+                            // ArraySlotRef back-reference below aliases it).
+                            v[i] = val.clone();
+                        } else {
+                            // Write THROUGH an existing `:=`-bound cell so an
+                            // assignment reached via a stack target (e.g.
+                            // `get()<subkey>[1] = …`) updates the shared cell
+                            // instead of clobbering it (nested.t 11-12).
+                            Value::assign_element_slot(&mut v[i], val.clone());
+                        }
                     }
                     // For bind mode, set up an ArraySlotRef on the source variable
                     if let Some(source_name) = &bind_source {

--- a/t/element-bind-cell.t
+++ b/t/element-bind-cell.t
@@ -6,7 +6,7 @@ use Test;
 # `$struct[..]<..>[..]` paths (which the old index-back-reference lost when an
 # enclosing container was COW-cloned on a later write).
 
-plan 50;
+plan 54;
 
 # Single-level array element
 {
@@ -217,6 +217,24 @@ plan 50;
     my %h = a => {n => 1}, b => {n => 2};
     my $c := %h<a>;
     is %h<a>.WHAT.^name, 'Hash', 'no cell leak in hash element read type';
+}
+
+# Binding to an element reached *through an `is raw` sub call* in the middle of
+# the path (`$struct[1]<key>()<subkey>[1]`, nested.t 11-12). The sub returns the
+# inner structure raw, so the element shares a cell with the source; a write
+# reached via the stack-target generic handler must go THROUGH that cell.
+{
+    my $inner = { subkey => [ "ig", 42 ] };
+    my sub get_inner () is raw { $inner }
+    my $struct = [ "ig", { key => &get_inner } ];
+
+    is $struct[1]<key>()<subkey>[1], 42, 'sub-mid-path: sanity read';
+    my $abbrev := $struct[1]<key>()<subkey>[1];
+    is $abbrev, 42, 'sub-mid-path: bind read';
+    $struct[1]<key>()<subkey>[1] = 43;
+    is $abbrev, 43, 'sub-mid-path: source write -> bind';
+    $abbrev = 44;
+    is $struct[1]<key>()<subkey>[1], 44, 'sub-mid-path: bind write -> source';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Completes `roast/S03-binding/nested.t` (**43/43**, now whitelisted) by fixing tests 11-12 — the last two failures, previously deferred as out of scope by the element-element bind plan.

## The case
Tests 11-12 bind an element reached **through an `is raw` sub call in the middle of the path**:

```raku
my sub get_innerstruct () is raw { $innerstruct }
my $struct = [ "ig", { key => &get_innerstruct, ... } ];
my $abbrev := $struct[1]<key>()<subkey>[1];   # bind
$struct[1]<key>()<subkey>[1] = 43;            # source -> bind must propagate
$abbrev = 44;                                 # bind -> source must propagate
```

## Root cause
The bind correctly promotes the element to a shared `ContainerRef` cell (the bind→source direction already worked). But a write to the *source* (`$struct[1]<key>()<subkey>[1] = 43`) has a `Call` at the root of its target chain, so it is compiled as a **stack-target** `IndexAssign` and routed through `exec_index_assign_generic_op`. Its **Array arm replaced `arr[i]` directly**, clobbering the cell — so the write never reached the binding (`$abbrev` stayed stale).

## Fix
Route the generic handler's Array arm through `Value::assign_element_slot` (exactly as the Hash arm already does via `hash_insert_through`), so a stack-target write goes **through** an existing bound cell. Behavior-invariant when the element is not a cell (plain replace) — list-construction / slice / nested-autoviv generic assigns are unaffected. Bind mode still installs the payload directly.

## Verification
- `roast/S03-binding/nested.t`: **43/43**, added to whitelist.
- `t/element-bind-cell.t`: 50 → 54 (sub-mid-path bind, both directions).
- `make test` exit 0 (only the documented `native-array-mut.t` #26 Arc-ptr flaky).
- Spot-checked IndexAssignGeneric paths (list-construction `($a,$b)[0]=`, slice `@a[1,2]=`, nested hash autoviv) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)