### PR TITLE
refactor(dispatch): VM-native has_proto / has_multi_candidates via shared Registry impl

### DIFF
--- a/docs/vm-registry-ownership.md
+++ b/docs/vm-registry-ownership.md
@@ -215,6 +215,26 @@ lookup は accessor 経由（多くは既に owned 返し）。**PR-A**（抽出
 メソッド化）→ **PR-C**（register_* の write-through 整理＋再入跨ぎ guard 無しを実行時 guard で保証）まで全完了。
 **次は ③**（env/型/state 移管＝interpreter ブリッジ撤去の最大の山）。
 
+## PR-D（③ 後続: registry dispatch read の VM ネイティブ化）進捗
+
+②で registry は VM ハンドル化済みだが、VM の dispatch 判定（`has_proto`/`has_multi_candidates`）は
+`self.interpreter.has_proto(...)` バウンス経由だった（これら wrapper が `current_package` に結合し、
+`current_package` が Interpreter 所有の plain field だったため）。`current_package` を共有ハンドル化した
+直後スライス（`docs/vm-state-ownership.md` の current_package 移管エントリ）の上に構築:
+
+- **`has_proto`/`has_multi_candidates` を pure `impl Registry` メソッド化**（`registry.rs`、`current_package`
+  を引数で受ける純 registry+scope read・env/再入なし）。`Interpreter::has_proto`/`has_multi_candidates` は
+  `self.registry().has_proto(&self.current_package(), name)` の薄い委譲へ（**1 操作 = 1 実装**）。
+- **VM に `registry()` read accessor 追加**（`RegistryReadGuard`、`registry_mut()` と同規律＝再入を跨いで
+  保持しない）+ VM ネイティブ `has_proto`/`has_multi_candidates`（VM 自前の `registry`+`current_package`
+  ハンドルで読む）。VM の ~21 サイトを `self.interpreter.has_*` → `self.has_*` へ。`has_multi_candidates_cached`
+  も VM ネイティブ呼びへ。`RegistryReadGuard` を `runtime` から re-export。
+- **`resolve_function_with_types` は据え置き**（`self.env.get(...)` の prefix-package 可視判定 +
+  `choose_best_matching_candidate` の `where` 節＝ユーザコード再入に結合＝pure 化不可。env 移管まで interpreter
+  bounce が正解）。**`has_proto_token` も据え置き**（`mro_readonly` MRO walk に結合）。
+- 挙動不変、build/clippy/make test 緑、S06-multi（proto/syntax/type-based/subsignature/lexical-multis/callsame）
+  /S10-packages/S11-modules roast 緑。
+
 ## 非ゴール
 
 env/型/state 移管（③）、登録の完全 VM ネイティブ化（③/④後）、台帳 §1/§2 の実消化（②完了後の別 PR）、

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1212,28 +1212,14 @@ impl Interpreter {
     }
 
     pub(crate) fn has_proto(&self, name: &str) -> bool {
-        if name.contains("::") {
-            return self.registry().proto_subs.contains(name);
-        }
-        let local = format!("{}::{}", self.current_package(), name);
-        if self.registry().proto_subs.contains(&local) {
-            return true;
-        }
-        self.registry()
-            .proto_subs
-            .contains(&format!("GLOBAL::{}", name))
+        let pkg = self.current_package();
+        self.registry().has_proto(&pkg, name)
     }
 
     /// Check if any multi candidates exist for this function name (any arity).
     pub(crate) fn has_multi_candidates(&self, name: &str) -> bool {
-        let prefixes = [
-            format!("{}::{}/", self.current_package(), name),
-            format!("GLOBAL::{}/", name),
-        ];
-        self.registry().functions.keys().any(|k| {
-            let ks = k.resolve();
-            prefixes.iter().any(|p| ks.starts_with(p))
-        })
+        let pkg = self.current_package();
+        self.registry().has_multi_candidates(&pkg, name)
     }
 
     pub(super) fn resolve_proto_function_with_alias(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -227,7 +227,7 @@ pub(crate) use self::output_sink::OutputSink;
 #[allow(unused_imports)]
 pub(crate) use self::output_sink::{OutputSinkReadGuard, OutputSinkWriteGuard};
 pub(crate) use self::registration_class::ClassDeclModifiers;
-pub(crate) use self::registry::{Registry, RegistryWriteGuard};
+pub(crate) use self::registry::{Registry, RegistryReadGuard, RegistryWriteGuard};
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};
 
 pub(crate) use utils::*;

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -341,6 +341,35 @@ impl Registry {
         self.class_role_param_bindings.get(class_name).cloned()
     }
 
+    /// Whether a `proto sub`/`proto` named `name` is declared, visible from the
+    /// `current_package` scope. Pure registry+scope read (no env, no re-entry):
+    /// the single implementation shared by `Interpreter::has_proto` and the VM's
+    /// native dispatch path.
+    pub(crate) fn has_proto(&self, current_package: &str, name: &str) -> bool {
+        if name.contains("::") {
+            return self.proto_subs.contains(name);
+        }
+        let local = format!("{}::{}", current_package, name);
+        if self.proto_subs.contains(&local) {
+            return true;
+        }
+        self.proto_subs.contains(&format!("GLOBAL::{}", name))
+    }
+
+    /// Whether any `multi` candidate (any arity) exists for `name`, visible from
+    /// the `current_package` scope. Pure registry+scope read, shared by
+    /// `Interpreter::has_multi_candidates` and the VM's native dispatch path.
+    pub(crate) fn has_multi_candidates(&self, current_package: &str, name: &str) -> bool {
+        let prefixes = [
+            format!("{}::{}/", current_package, name),
+            format!("GLOBAL::{}/", name),
+        ];
+        self.functions.keys().any(|k| {
+            let ks = k.resolve();
+            prefixes.iter().any(|p| ks.starts_with(p))
+        })
+    }
+
     /// Whether `name` is marked `is hidden` (excluded from `.^mro` etc.).
     pub(crate) fn is_hidden_class(&self, name: &str) -> bool {
         self.hidden_classes.contains(name)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -493,14 +493,38 @@ impl VM {
     /// Write access to the shared declaration [`Registry`](crate::runtime::Registry)
     /// via the VM's own handle (no `self.interpreter` bounce). Same lock and same
     /// guard discipline as the interpreter's `registry_mut`: never hold the guard
-    /// across user-code re-entry. (A read counterpart will be added when the
-    /// registry dispatch reads — `has_proto` / `has_multi_candidates` /
-    /// `resolve_function_with_types` — are turned into pure `impl Registry` methods
-    /// taking `current_package` as a parameter; `current_package` itself is now
-    /// VM-accessible via [`Self::current_package`], so that follow-up is unblocked.)
+    /// across user-code re-entry.
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::RegistryWriteGuard<'_> {
         crate::runtime::RegistryWriteGuard::new(&self.registry, "registry")
+    }
+
+    /// Read access to the shared declaration [`Registry`] via the VM's own handle.
+    /// Used by the VM-native dispatch predicates ([`Self::has_proto`] /
+    /// [`Self::has_multi_candidates`]) so they read the registry without bouncing
+    /// through `self.interpreter`. The guard must not be held across user-code
+    /// re-entry (same discipline as `registry_mut`).
+    #[inline]
+    pub(crate) fn registry(&self) -> crate::runtime::RegistryReadGuard<'_> {
+        crate::runtime::RegistryReadGuard::new(&self.registry, "registry")
+    }
+
+    /// VM-native `proto`-declaration check, mirroring
+    /// `Interpreter::has_proto`: reads the VM's own registry + `current_package`
+    /// handles and delegates to the single [`Registry::has_proto`] implementation.
+    #[inline]
+    pub(crate) fn has_proto(&self, name: &str) -> bool {
+        let pkg = self.current_package();
+        self.registry().has_proto(&pkg, name)
+    }
+
+    /// VM-native multi-candidate check, mirroring
+    /// `Interpreter::has_multi_candidates` via the single
+    /// [`Registry::has_multi_candidates`] implementation.
+    #[inline]
+    pub(crate) fn has_multi_candidates(&self, name: &str) -> bool {
+        let pkg = self.current_package();
+        self.registry().has_multi_candidates(&pkg, name)
     }
 
     /// The in-scope package name, read out of the VM's own `current_package`

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -25,7 +25,7 @@ impl VM {
         }
     }
 
-    /// Cached version of `interpreter.has_multi_candidates()`.
+    /// Cached version of the VM-native [`Self::has_multi_candidates`].
     /// Uses `fn_resolve_gen` for invalidation so it's O(1) on cache hit.
     pub(super) fn has_multi_candidates_cached(&mut self, name: &str) -> bool {
         if self.multi_candidates_cache_gen != self.fn_resolve_gen {
@@ -36,7 +36,7 @@ impl VM {
         if let Some(&cached) = self.multi_candidates_cache.get(&sym) {
             return cached;
         }
-        let result = self.interpreter.has_multi_candidates(name);
+        let result = self.has_multi_candidates(name);
         self.multi_candidates_cache.insert(sym, result);
         result
     }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -191,8 +191,8 @@ impl VM {
             // this branch prevents regressions where dispatching through
             // `call_sub_value` behaves differently (e.g. dynamic `$*ERR`
             // handling for `note` inside a caller-provided block).
-            if self.interpreter.has_proto(name_str)
-                || self.interpreter.has_multi_candidates(name_str)
+            if self.has_proto(name_str)
+                || self.has_multi_candidates(name_str)
                 || !self.interpreter.has_function(name_str)
             {
                 None
@@ -405,7 +405,7 @@ impl VM {
         let args = self.normalize_call_args_for_target(&name, args);
         let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
         self.interpreter.set_pending_callsite_line(callsite_line);
-        if !self.interpreter.has_proto(&name)
+        if !self.has_proto(&name)
             && let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args)
         {
             let cf_auto_fetch = !cf.is_raw;
@@ -427,7 +427,7 @@ impl VM {
             // candidate dispatch stays correct. Must not fall through to the native
             // arm below (the shadowed builtin).
             if crate::runtime::Interpreter::is_builtin_function(&name)
-                && !self.interpreter.has_proto(&name)
+                && !self.has_proto(&name)
                 && !self.has_multi_candidates_cached(&name)
                 && let Some(def) = self.interpreter.resolve_function_with_types(&name, &args)
                 && Self::def_is_otf_compilable(&def)
@@ -571,7 +571,7 @@ impl VM {
             self.interpreter.maybe_fetch_rw_proxy(result?, sub_is_rw)?
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             native_result?
-        } else if !self.interpreter.has_proto(&name)
+        } else if !self.has_proto(&name)
             && let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args)
         {
             let cf_auto_fetch = !cf.is_raw;
@@ -616,7 +616,7 @@ impl VM {
         } else {
             self.interpreter
                 .set_pending_call_arg_sources(arg_sources.clone());
-            let compiled = if !self.interpreter.has_proto(name) {
+            let compiled = if !self.has_proto(name) {
                 self.find_compiled_function(compiled_fns, name, &args)
             } else {
                 None
@@ -713,7 +713,7 @@ impl VM {
                 // signal env_dirty only when a captured-outer write happened, so
                 // a pure compiled call no longer forces a per-call locals pull.
                 self.env_dirty = true;
-                if self.has_multi_candidates_cached(name) && !self.interpreter.has_proto(name) {
+                if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
                     // User-defined multi candidates take priority over builtins.
                     // Resolve the winning candidate VM-side via the same resolver
                     // call_function_fallback uses (③ PR-3, ledger §2). When the
@@ -770,7 +770,7 @@ impl VM {
                     // must not escape the enclosing routine — Test::Util's
                     // is-deeply-junction). Those keep tree-walking unchanged.
                     if crate::runtime::Interpreter::is_builtin_function(name)
-                        && !self.interpreter.has_proto(name)
+                        && !self.has_proto(name)
                         && !self.has_multi_candidates_cached(name)
                         && let Some(def) = self.interpreter.resolve_function_with_types(name, &args)
                         && Self::def_is_otf_compilable(&def)

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -159,7 +159,7 @@ impl VM {
             .collect();
         if self.interpreter.has_declared_function(name)
             || self.interpreter.has_multi_function(name)
-            || self.interpreter.has_proto(name)
+            || self.has_proto(name)
         {
             raw_args
         } else {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -381,8 +381,8 @@ impl VM {
                 }
             }
             if self.interpreter.has_function(&name_str)
-                || self.interpreter.has_proto(&name_str)
-                || self.interpreter.has_multi_candidates(&name_str)
+                || self.has_proto(&name_str)
+                || self.has_multi_candidates(&name_str)
             {
                 // A Routine whose name is also a builtin (e.g. `&SETTING::...::not`
                 // resolves to Routine{GLOBAL, "not"}, accessors.rs) intentionally

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1282,7 +1282,7 @@ impl VM {
             let has_variable_slot = self.interpreter.env().contains_key(&name);
             let is_routine_symbol = self.interpreter.has_function(bare)
                 || self.interpreter.has_multi_function(bare)
-                || self.interpreter.has_proto(bare)
+                || self.has_proto(bare)
                 || self.interpreter.resolve_token_defs(bare).is_some()
                 || self.interpreter.has_proto_token(bare);
             if is_routine_symbol && !has_variable_slot {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -583,8 +583,8 @@ impl VM {
             }
             // Apply custom trait_mod:<is> for each non-builtin trait (only if defined)
             if !custom_traits.is_empty() {
-                let has_trait_mod = self.interpreter.has_proto("trait_mod:<is>")
-                    || self.interpreter.has_multi_candidates("trait_mod:<is>");
+                let has_trait_mod =
+                    self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
                 for trait_name in custom_traits.iter().filter(|t| {
                     !t.starts_with("__")
                         && *t != "default"
@@ -1121,9 +1121,7 @@ impl VM {
             }
         }
 
-        if !(self.interpreter.has_proto("trait_mod:<is>")
-            || self.interpreter.has_multi_candidates("trait_mod:<is>"))
-        {
+        if !(self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>")) {
             // For uppercase type-like traits (e.g. `is Map`, `is Set`), silently
             // accept them even if trait_mod:<is> is not defined. These are type
             // container traits that may not have runtime trait_mod:<is> handlers.
@@ -1348,8 +1346,8 @@ impl VM {
             // Dispatch custom `is` traits via trait_mod:<is> if defined.
             // Merge explicitly parsed custom_traits with deferred_traits
             // (unknown lowercase parents deferred from register_class_decl).
-            let has_trait_mod = self.interpreter.has_proto("trait_mod:<is>")
-                || self.interpreter.has_multi_candidates("trait_mod:<is>");
+            let has_trait_mod =
+                self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
             if has_trait_mod && (!custom_traits.is_empty() || !deferred_traits.is_empty()) {
                 let type_obj = Value::Package(Symbol::intern(&qualified_name));
                 // Dispatch explicitly parsed custom traits (with args)
@@ -1528,8 +1526,8 @@ impl VM {
                 .unwrap_or_default();
 
             // Dispatch custom `is` traits via trait_mod:<is> if defined
-            let has_trait_mod = self.interpreter.has_proto("trait_mod:<is>")
-                || self.interpreter.has_multi_candidates("trait_mod:<is>");
+            let has_trait_mod =
+                self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
             if has_trait_mod && (!custom_traits.is_empty() || !role_deferred.is_empty()) {
                 let type_obj = Value::Package(Symbol::intern(&qualified_name));
                 for (trait_name, trait_arg) in custom_traits {


### PR DESCRIPTION
## What

Make the registry dispatch predicates `has_proto` / `has_multi_candidates` resolve from
the VM's own handles instead of bouncing through `self.interpreter`, by turning them into
single-implementation `impl Registry` methods that both the Interpreter and the VM call.

## Why

Follow-up to #2927 (current_package shared handle). Those two predicates are the *pure*
registry dispatch reads — they need only the registry plus `current_package`, no env and
no user-code re-entry. With `current_package` now VM-accessible, they can be served from
the VM's own `registry` + `current_package` handles, removing the interpreter bounce and
collapsing the duplicate (1 operation = 1 implementation).

## How (behavior-invariant)

- `Registry::has_proto(current_package, name)` / `has_multi_candidates(current_package,
  name)`: the single pure implementation (registry + scope only).
- `Interpreter::has_proto` / `has_multi_candidates` become thin delegates to the Registry
  impl.
- VM gains a `registry()` read accessor (`RegistryReadGuard`, same "never hold across
  user-code re-entry" discipline as `registry_mut`) plus VM-native `has_proto` /
  `has_multi_candidates`. ~21 VM sites `self.interpreter.has_*` → `self.has_*`;
  `has_multi_candidates_cached` now calls the VM-native predicate. `RegistryReadGuard`
  re-exported from `runtime`.

### Deliberately left as interpreter bounces

- `resolve_function_with_types` — reads `self.env` (prefix-package visibility) and runs
  `choose_best_matching_candidate` (`where`-clauses = user-code re-entry). Not a pure
  Registry read until env migrates (③).
- `has_proto_token` — coupled to the `mro_readonly` MRO walk.

## Verification

- `cargo test` green, `cargo clippy -- -D warnings` / `cargo fmt` clean.
- roast: S06-multi (proto / syntax / type-based / subsignature / lexical-multis /
  callsame), S10-packages, S11-modules all PASS.
- proto/multi/package-scoped-multi/plain-sub dispatch smoke matches raku.
- Full `make test` + `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)