### PR TITLE
feat(gather): true `take-rw` shared-cell container identity

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -109,28 +109,17 @@
 - [ ] roast/S04-statements/for.t
   - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
 - [ ] roast/S04-statements/for_with_only_one_item.t
-- [ ] roast/S04-statements/gather.t
-  - 38/39 pass. Only remaining failure: test 38 "Got the reference equality
-    expected from take-rw" (line 291). It checks
-    `@neighbors[1][1][0] =:= @spot[0][0]` after populating `@neighbors` via
-    `eager gather for ... { take-rw @spot[i][j] }`. mutsu's `take-rw` currently
-    decontainerizes the expression (it is parsed identically to `take`, the rw
-    flag is dropped in `parser/stmt/simple.rs::take_stmt`), so the gathered value
-    is a copy, not the original container, and `=:=` returns False.
-  - BLOCKER (first-class array-element containers): a genuine fix requires
-    `take-rw EXPR` to capture the real mutable Scalar container of an indexed
-    lvalue (e.g. a shared `ContainerRef` cell vivified into `@spot[i][j]`),
-    preserve that container when it is stored into another nested array element,
-    and make `=:=` compare container identity (Arc pointer) through arbitrary
-    nesting. mutsu arrays store plain `Value`s with no per-element container, and
-    the existing `=:=` machinery for indexed elements only handles single-level
-    `var\x00idx\x00N` encoded sources via `BOUND_ARRAY_REF_SENTINEL`; nested
-    indexes fall through to `ContainerEq`, which compares decontainerized values.
-    Even plain nested binding
-    (`@n[0] := @spot[0]; @n[0][0] =:= @spot[0][0]`) returns False today,
-    confirming this is a broader missing feature (first-class element containers)
-    rather than a gather/take-specific gap. Deferred to avoid a large,
-    regression-prone VM change for a single subtest.
+- [x] roast/S04-statements/gather.t
+  - 39/39. `take-rw EXPR` now carries an `is_rw` flag (`Stmt::Take(Expr, bool)`)
+    and compiles its operand like a `:=` bind RHS (scalar_bind_autovivify +
+    bind_terminal), so an indexed lvalue (`@spot[i][j]`) is promoted to a shared
+    `ContainerRef` cell and the gathered value keeps container identity. Two
+    supporting fixes landed alongside: nested-element `=:=`
+    (`@neighbors[1][1][0] =:= @spot[0][0]`) now promotes both leaves to cells and
+    compares Arc identity via `ContainerEqRaw` (the old path only encoded
+    single-level `var\x00idx\x00N` sources), and `value_is_defined` now looks
+    through a `ContainerRef` so the `// next` guard still fires on an
+    out-of-range element that was promoted to a cell.
 - [ ] roast/S04-statements/given.t
   - ~22/54 pass. Failures: regex match object in when-clause (test 8), for+given iteration ordering (test 21), given return value (tests 26-29)
 - [ ] roast/S04-statements/goto.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -326,6 +326,7 @@ roast/S04-statement-parsing/hash.t
 roast/S04-statements/do.t
 roast/S04-statements/for-scope.t
 roast/S04-statements/for_with_only_one_item.t
+roast/S04-statements/gather.t
 roast/S04-statements/given.t
 roast/S04-statements/goto.t
 roast/S04-statements/if.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -666,7 +666,10 @@ pub(crate) enum Stmt {
     Fail(Expr),
     Catch(Vec<Stmt>),
     Control(Vec<Stmt>),
-    Take(Expr),
+    /// `take` / `take-rw`. The bool is `is_rw`: a `take-rw` of an lvalue captures
+    /// the source container (a shared `ContainerRef` cell) so the gathered value
+    /// keeps container identity with the original (`=:=`), instead of a snapshot.
+    Take(Expr, bool),
     Goto(Expr),
     Label {
         name: String,
@@ -914,7 +917,7 @@ fn collect_unattached_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
         | Stmt::Return(e)
         | Stmt::Die(e)
         | Stmt::Fail(e)
-        | Stmt::Take(e)
+        | Stmt::Take(e, _)
         | Stmt::Goto(e) => collect_unattached_ph_expr(e, out),
         Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
             collect_unattached_ph_expr(expr, out)
@@ -1132,7 +1135,7 @@ fn collect_virtual_call_stmt(stmt: &Stmt, out: &mut Option<String>) {
         | Stmt::Return(e)
         | Stmt::Die(e)
         | Stmt::Fail(e)
-        | Stmt::Take(e)
+        | Stmt::Take(e, _)
         | Stmt::Goto(e) => collect_virtual_call_expr(e, out),
         Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
             collect_virtual_call_expr(expr, out)
@@ -1171,7 +1174,7 @@ fn collect_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
         | Stmt::Return(e)
         | Stmt::Die(e)
         | Stmt::Fail(e)
-        | Stmt::Take(e)
+        | Stmt::Take(e, _)
         | Stmt::Goto(e) => {
             collect_ph_expr(e, out);
         }
@@ -1466,7 +1469,7 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
         | Stmt::Return(e)
         | Stmt::Die(e)
         | Stmt::Fail(e)
-        | Stmt::Take(e)
+        | Stmt::Take(e, _)
         | Stmt::Goto(e) => {
             collect_ph_expr_shallow(e, out);
         }
@@ -1790,7 +1793,7 @@ pub(crate) fn has_var_decl(stmts: &[Stmt], name: &str) -> bool {
 
 fn check_bare_var_stmt(stmt: &Stmt, bare_name: &str, found: &mut bool) {
     match stmt {
-        Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+        Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
             check_bare_var_expr(e, bare_name, found);
         }
         Stmt::Assign { expr, .. } => check_bare_var_expr(expr, bare_name, found),

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -394,6 +394,25 @@ impl Compiler {
                 self.code.emit(OpCode::ContainerEqRaw);
                 return;
             }
+            // Both sides are Index expressions that `encode_index_source` could
+            // not encode (nested `@a[i][j]`, or a non-literal subscript). Promote
+            // each leaf to its shared `ContainerRef` cell via scalar_bind_autovivify
+            // (+ bind_terminal so a scalar leaf is boxed) and compare cell identity
+            // directly. Without this, nested-element `=:=` falls through to the
+            // generic value compare below and reports False even for the same cell
+            // (e.g. take-rw: `@neighbors[1][1][0] =:= @spot[0][0]`).
+            if matches!(left, Expr::Index { .. }) && matches!(right, Expr::Index { .. }) {
+                let saved_av = self.scalar_bind_autovivify;
+                let saved_term = self.bind_terminal;
+                self.scalar_bind_autovivify = true;
+                self.bind_terminal = true;
+                self.compile_expr(left);
+                self.compile_expr(right);
+                self.scalar_bind_autovivify = saved_av;
+                self.bind_terminal = saved_term;
+                self.code.emit(OpCode::ContainerEqRaw);
+                return;
+            }
             let left_fresh = Self::expr_is_fresh_container(left);
             let right_fresh = Self::expr_is_fresh_container(right);
             let flags =

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -257,7 +257,7 @@ impl Compiler {
 
     pub(super) fn stmt_has_placeholder(stmt: &Stmt) -> bool {
         match stmt {
-            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
                 Self::expr_has_placeholder(e)
             }
             Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -314,13 +314,13 @@ impl Compiler {
             let last_idx = stmts.iter().rposition(|s| !matches!(s, AStmt::SetLine(_)));
             if let Some(idx) = last_idx {
                 if let AStmt::Expr(expr) = stmts[idx].clone() {
-                    stmts[idx] = AStmt::Take(expr);
+                    stmts[idx] = AStmt::Take(expr, false);
                 } else {
                     // Wrap non-expr last stmt in Take(Nil) since we need a take
-                    stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil)));
+                    stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil), false));
                 }
             } else {
-                stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil)));
+                stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::Nil), false));
             }
             stmts
         };

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1836,8 +1836,26 @@ impl Compiler {
             Stmt::DoesDecl { .. } | Stmt::TrustsDecl { .. } => {}
 
             // --- Take (gather/take) ---
-            Stmt::Take(expr) => {
-                self.compile_expr(expr);
+            Stmt::Take(expr, is_rw) => {
+                if *is_rw {
+                    // `take-rw <lvalue>`: capture the source container (a shared
+                    // `ContainerRef` cell), not a snapshot, so the gathered value
+                    // keeps container identity with the original (`=:=`). Compile
+                    // the operand exactly like a `:=` bind RHS: `scalar_bind_autovivify`
+                    // makes an element subscript (`@a[i][j]`) yield the promoted
+                    // cell; `bind_terminal` marks the leaf so a scalar element is
+                    // boxed. A leading `// next` guard preserves the cell because
+                    // `//` returns its (peeked) left operand unchanged when defined.
+                    let saved_av = self.scalar_bind_autovivify;
+                    let saved_term = self.bind_terminal;
+                    self.scalar_bind_autovivify = true;
+                    self.bind_terminal = true;
+                    self.compile_expr(expr);
+                    self.scalar_bind_autovivify = saved_av;
+                    self.bind_terminal = saved_term;
+                } else {
+                    self.compile_expr(expr);
+                }
                 self.code.emit(OpCode::Take);
             }
 

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -224,7 +224,7 @@ fn stmt_uses_attr_twigil(stmt: &Stmt) -> bool {
     match stmt {
         Stmt::Expr(expr)
         | Stmt::Return(expr)
-        | Stmt::Take(expr)
+        | Stmt::Take(expr, _)
         | Stmt::Die(expr)
         | Stmt::Fail(expr) => expr_uses_attr_twigil(expr),
         Stmt::VarDecl {

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1739,13 +1739,14 @@ pub(super) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
         && let Ok((rest, _)) = ws1(rest)
     {
         let (rest, expr) = parse_comma_or_expr(rest)?;
-        // TODO: implement true rw semantics (container references)
-        return parse_statement_modifier(rest, Stmt::Take(expr));
+        // `take-rw`: is_rw=true. The compiler captures the source container so the
+        // gathered value keeps container identity (`=:=`) with the original lvalue.
+        return parse_statement_modifier(rest, Stmt::Take(expr, true));
     }
     let rest = keyword("take", input).ok_or_else(|| PError::expected("take statement"))?;
     let (rest, _) = ws1(rest)?;
     let (rest, expr) = parse_comma_or_expr(rest)?;
-    parse_statement_modifier(rest, Stmt::Take(expr))
+    parse_statement_modifier(rest, Stmt::Take(expr, false))
 }
 
 /// Parse CATCH/CONTROL blocks.

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -385,7 +385,7 @@ fn stmt_contains_whatever(stmt: &Stmt) -> bool {
     match stmt {
         Stmt::Expr(expr)
         | Stmt::Return(expr)
-        | Stmt::Take(expr)
+        | Stmt::Take(expr, _)
         | Stmt::Die(expr)
         | Stmt::Fail(expr) => expr_contains_whatever(expr),
         Stmt::VarDecl {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1643,7 +1643,7 @@ impl Interpreter {
             }),
             Stmt::Expr(expr) => Stmt::Expr(Self::rewrite_proto_dispatch_expr(expr)),
             Stmt::Return(expr) => Stmt::Return(Self::rewrite_proto_dispatch_expr(expr)),
-            Stmt::Take(expr) => Stmt::Take(Self::rewrite_proto_dispatch_expr(expr)),
+            Stmt::Take(expr, rw) => Stmt::Take(Self::rewrite_proto_dispatch_expr(expr), *rw),
             Stmt::Die(expr) => Stmt::Die(Self::rewrite_proto_dispatch_expr(expr)),
             Stmt::Fail(expr) => Stmt::Fail(Self::rewrite_proto_dispatch_expr(expr)),
             Stmt::VarDecl {

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -14,7 +14,7 @@ impl Interpreter {
                 | Stmt::Return(expr)
                 | Stmt::Die(expr)
                 | Stmt::Fail(expr)
-                | Stmt::Take(expr) => expr_contains_last(expr),
+                | Stmt::Take(expr, _) => expr_contains_last(expr),
                 Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => expr_contains_last(expr),
                 Stmt::If {
                     cond,

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -302,7 +302,11 @@ impl Interpreter {
     pub(crate) fn auto_signature_uses(stmts: &[Stmt]) -> (bool, bool) {
         fn scan_stmt(stmt: &Stmt, positional: &mut bool, named: &mut bool) {
             match stmt {
-                Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+                Stmt::Expr(e)
+                | Stmt::Return(e)
+                | Stmt::Die(e)
+                | Stmt::Fail(e)
+                | Stmt::Take(e, _) => {
                     scan_expr(e, positional, named);
                 }
                 Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -199,7 +199,7 @@ fn lift_phasers_from_stmt(
         | Stmt::Return(expr)
         | Stmt::Die(expr)
         | Stmt::Fail(expr)
-        | Stmt::Take(expr) => {
+        | Stmt::Take(expr, _) => {
             lift_phasers_from_expr(expr, begin, check, init);
         }
         Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
@@ -594,7 +594,7 @@ fn lift_phasers_from_closure_stmt(
         | Stmt::Return(expr)
         | Stmt::Die(expr)
         | Stmt::Fail(expr)
-        | Stmt::Take(expr) => {
+        | Stmt::Take(expr, _) => {
             lift_phasers_from_expr(expr, begin, check, init);
         }
         Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
@@ -872,7 +872,7 @@ fn recurse_into_stmt(stmt: &mut Stmt) {
             recurse_into_expr(supply);
             reorder_recursive(body);
         }
-        Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+        Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
             recurse_into_expr(e);
         }
         Stmt::VarDecl { expr: e, .. } | Stmt::Assign { expr: e, .. } => {

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -261,7 +261,7 @@ impl Interpreter {
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
         match stmt {
-            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
                 self.validate_private_access_in_expr(caller_class, e)?
             }
             Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
@@ -528,7 +528,7 @@ impl Interpreter {
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
         match stmt {
-            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
                 self.check_private_calls_exist_expr(class_name, class_def, e)?;
             }
             Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -3670,7 +3670,7 @@ impl Interpreter {
 
     fn validate_attr_in_stmt(ctx: &AttrValidationCtx<'_>, stmt: &Stmt) -> Result<(), RuntimeError> {
         match stmt {
-            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e) => {
+            Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
                 Self::validate_attr_in_expr(ctx, e)?;
             }
             Stmt::VarDecl { expr, .. } => {

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -85,6 +85,11 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
         Value::Slip(items) if items.is_empty() => false,
         Value::Instance { class_name, .. } if class_name == "Failure" => false,
         Value::DeferredHashAccess { .. } => false,
+        // A `ContainerRef` cell (`:=`-alias, take-rw, promoted element) is
+        // transparent to definedness: `$x // …` / `take-rw …[i] // next` must
+        // test the *inner* value, not the wrapper, so an undefined element still
+        // triggers the `//` fallback even when it has been promoted to a cell.
+        Value::ContainerRef(arc) => value_is_defined(&arc.lock().unwrap()),
         _ => true,
     }
 }

--- a/t/take-rw-shared-cell.t
+++ b/t/take-rw-shared-cell.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 7;
+
+# `take-rw <lvalue>` must capture the *source container* (a shared cell), so the
+# gathered value keeps container identity (`=:=`) with the original element and a
+# write through one is observed by the other. Mirrors roast/S04-statements/gather.t
+# test 38 (take-rw reference equality through nested indexing).
+
+# Single-level element, stored into an array element (item context preserves the
+# gathered Seq's container elements).
+{
+    my @spot = 10, 20, 30;
+    my @n;
+    @n[0] = eager gather { take-rw @spot[1] };
+    is @n[0][0], 20, 'take-rw gathered the element value';
+    ok @n[0][0] =:= @spot[1], 'take-rw keeps container identity (=:=)';
+    @n[0][0] = 999;
+    is @spot[1], 999, 'writing through the taken cell updates the source element';
+}
+
+# Nested element through a for-gather (the gather.t shape).
+{
+    my @spot = [10, 20, 30], [40, 50, 60];
+    my @neighbors;
+    @neighbors[0] = eager gather for 0, 1, 2 { take-rw @spot[0][$_] };
+    is @neighbors[0][1], 20, 'nested take-rw gathered the right value';
+    ok @neighbors[0][1] =:= @spot[0][1], 'nested take-rw keeps container identity';
+}
+
+# A plain `take` must NOT alias — it snapshots the value (no container identity).
+{
+    my @spot = 10, 20, 30;
+    my @n;
+    @n[0] = eager gather { take @spot[1] };
+    nok @n[0][0] =:= @spot[1], 'plain take is a snapshot, not a live alias';
+}
+
+# Out-of-range element under `// next`: the cell wraps an undefined value, so the
+# `//` fallback must still fire (value_is_defined looks through the cell).
+{
+    my @spot = 10, 20, 30;
+    my @got = eager gather for 0, 5 { take-rw @spot[$_] // next };
+    is @got.elems, 1, '// next skips the undefined (out-of-range) element';
+}


### PR DESCRIPTION
## Summary

`take-rw EXPR` was parsed identically to `take` — the rw flag was dropped (`// TODO: implement true rw semantics (container references)` in `take_stmt`), so the gathered value was a decontainerized **snapshot** and reference equality (`=:=`) against the source element returned False.

This implements true `take-rw` container identity by reusing the Phase-2 array-element `ContainerRef` cell infrastructure (same mechanism `:=` element binds and the recent `is rw` shared-cell PR use):

- **`Stmt::Take(Expr, is_rw)`** carries the distinction through AST → parser → compiler.
- For `take-rw`, the operand is compiled like a `:=` bind RHS (`scalar_bind_autovivify` + `bind_terminal`), so an indexed lvalue `@spot[i][j]` is promoted **in place** to a shared `ContainerRef` cell. `take` then stores that cell, so the gathered value keeps container identity with the source element (a write through one is observed by the other).

### Supporting fixes

- **Nested-element `=:=`** (`@neighbors[1][1][0] =:= @spot[0][0]`): the both-`Index` path only encoded single-level `var\0idx\0N` sources via `encode_index_source` and fell through to a decont value compare for nested subscripts (returned False even for the same cell). Now both leaves are promoted to cells and compared by `Arc` identity via `ContainerEqRaw`.
- **`value_is_defined` looks through `ContainerRef`**: so a `take-rw @a[i] // next` guard still fires when an out-of-range element was promoted to a cell wrapping an undefined value (the `//` checks the inner value, not the wrapper).

## Tests

- `roast/S04-statements/gather.t`: **38/39 → 39/39** (test 38, take-rw reference equality through nested indexing); **whitelisted**.
- New `t/take-rw-shared-cell.t` (7 subtests), validated against `raku`: single/nested take-rw identity, write-through, plain-`take` snapshot guard, `// next` out-of-range skip.
- `make test`: 714 files / 6474 tests PASS. No regression in `S03-binding/*` (nested/scalars/arrays/hashes); `eqv.t`/`whatever.t`/`adverbs.t` fail identically on baseline (pre-existing, BLOCKERS-documented).

This advances the container-identity north-star (first-class array-element containers) the BLOCKERS doc lists as the top lever, and removes a standing `// TODO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)