### PR TITLE
fix(types): clear stale Arc-ptr type metadata on untyped @-array assignment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -426,6 +426,13 @@ NaN-boxing で payload 8byte 化。**各ステップで int.t 等の重量級 ro
       されていたが、実体は alloc/hash 順依存の**正しさバグ**（テストは ~0.07s 実行・起動 ~0ms、perf 無関係）。
     - **済**: ハッシュ要素 READ 経路を #2635 で部分対処（name-based reconcile + stale 上書き復元、
       S09-typed-arrays/hashes.t を 0/500 に）。
+    - **済（untyped 代入時の stale クリア、`%`→`@` 対称化）**: `vm_var_assign_ops.rs` は untyped `%h = ...`
+      代入時に「`var_type_constraint` が `None`＝確実に untyped なのに値に型メタが付いている＝ポインタ再利用の
+      stale alias」を `unregister_container_type_metadata` で除去していた。これを `@a = ...` にも拡張
+      （native/typed 配列は `var_type_constraint` Some でスキップ＝不変）。`t/native-array-mut.t` subtest 26
+      flaky の根（drop 済み typed 配列の slot を untyped `@a` の構築が再利用し `Array[Int]` を継承）を断つ。
+      **部分対処**（untyped *変数代入*サイト限定。EVAL 生成リスト等の他サイトや根の Arc-ptr keying 自体は残＝
+      下記「本筋」）。
     - **試して revert（2回・いずれも不成立）**: (1) メタに `Weak` を併存させ lookup 時 `Arc::ptr_eq` 検証
       する案は family 全体を 0/300 にしたが、native typed 配列（`my int @a`/`my str @a`）で
       `native-int.t` 240 件回帰 → revert。(2) ハッシュで効いた name-based reconcile（`var_type_constraints`

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5669,12 +5669,19 @@ impl VM {
             self.interpreter.clear_container_default(&val);
         }
         self.locals[idx] = val.clone();
-        // When assigning (not binding) to an untyped hash variable, clear
-        // stale container type metadata from Arc pointer reuse.
+        // When assigning (not binding) to an untyped hash/array variable, clear
+        // stale container type metadata from Arc pointer reuse. The pointer-keyed
+        // `*_type_metadata` maps are never pruned when a typed container is
+        // dropped, so a freshly-built untyped `@a`/`%h` whose backing `Arc`
+        // reuses a freed typed container's heap address inherits its stale
+        // `Array[Int]`/`Hash[...]` metadata (alloc-order-dependent, intermittent).
+        // The variable is provably untyped here (`var_type_constraint` is `None`),
+        // so any metadata found on its value is necessarily that stale alias and
+        // is safe to remove (a live typed container cannot share the address).
         // Skip for attribute variables (.h, !h) which get typed metadata from
         // the class definition, not from var_type_constraints.
         if !is_bind
-            && name.starts_with('%')
+            && (name.starts_with('%') || name.starts_with('@'))
             && !name.contains('.')
             && !name.contains('!')
             && self.interpreter.var_type_constraint(name).is_none()


### PR DESCRIPTION
## Root cause (investigation)

The pointer-keyed `*_type_metadata` maps (`array_type_metadata` et al., keyed by
`Arc::as_ptr(items) as usize`) are **never pruned when a typed container is dropped**.
So a freshly-built *untyped* `my @a = ...` whose backing `Arc<Vec<Value>>` reuses a freed
typed array's heap address inherits that array's stale `Array[Int]` metadata.

Confirmed via repro:
- The aliasing happens at **`@a` construction** (no mutation needed): a block
  `{ my Int @t = 1,2,3; my Int @u; ... }` followed by `my @a = 'a','b','c'` makes `@a`
  report `Array[Int]` ~14/15 runs.
- **Element values stay correct** (`@a[1]` is `'b'`/`Str`) — only the *container type* is
  mis-attributed. Pure metadata aliasing, no data corruption.
- Rate is **allocator-state dependent** (Int element ~14/15 vs Rat ~1/15, because Rat
  construction does extra BigInt allocations that perturb slot reuse) — hence
  intermittent. This is the root of the long-standing `t/native-array-mut.t` subtest 26
  ("middle element retained") flaky, and shares the Q2 Arc-ptr-keying root.

## Fix

`vm_var_assign_ops.rs` **already** defends the hash form (`my %h = ...`) by clearing
stale metadata on assignment to a provably-untyped variable. This extends that exact,
proven mitigation from `%` to `@`:

> when assigning (not binding) to a variable whose `var_type_constraint` is `None`
> (genuinely untyped) and whose value carries container type metadata, that metadata is
> necessarily a stale pointer alias (a live typed container cannot share the address) and
> is safe to remove.

Native/typed arrays are unaffected — `my int @a` / `my Int @a` have a
`var_type_constraint`, so the clear is skipped and their metadata is preserved.

This is a **targeted mitigation** at the untyped-assignment site (same strategy already
used for hashes), **not** the full fix — the root Arc-ptr keying remains and is resolved
by the first-class-container migration (PLAN.md Q2 / 🟣). Not one of the two cheap
patches previously tried-and-reverted (`Weak` validation / name-reconcile).

## Verification

- `t/native-array-mut.t`: **10/10 PASS** (was intermittent FAIL on subtest 26); full
  `make test` now **Result: PASS**.
- No regression: roast S09-typed-arrays native-int (1840) / native-str (191) / native-num
  / arrays (84) / hashes all green.
- `native-shape1-int/str.t` failures are **pre-existing** (identical with/without this
  change, confirmed by stash-rebuild; non-whitelisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)