### PR TITLE
feat(accessors): item/hash context for `$.attr` / `%.attr`

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -48,6 +48,32 @@ impl Compiler {
                 self.code.emit(OpCode::GetArrayVar(name_idx));
             }
             Expr::HashVar(name) => {
+                // `%.attr` is `self.attr` in *hash* context — call the accessor and
+                // coerce the result to a Hash (e.g. an `@.a = (1,2,3,4)` attribute
+                // read as `%.a` yields `{1 => 2, 3 => 4}`). Mirrors the `$.attr`
+                // item-context accessor in `compile_expr_var`.
+                if let Some(attr_name) = name.strip_prefix('.')
+                    && !attr_name.is_empty()
+                {
+                    self.emit_load_self_for_accessor(&format!("%.{}", attr_name));
+                    let method_idx = self.code.add_constant(Value::str(attr_name.to_string()));
+                    self.code.emit(OpCode::CallMethod {
+                        name_idx: method_idx,
+                        arity: 0,
+                        modifier_idx: None,
+                        quoted: false,
+                        arg_sources_idx: None,
+                    });
+                    let hash_idx = self.code.add_constant(Value::str_from("hash"));
+                    self.code.emit(OpCode::CallMethod {
+                        name_idx: hash_idx,
+                        arity: 0,
+                        modifier_idx: None,
+                        quoted: false,
+                        arg_sources_idx: None,
+                    });
+                    return;
+                }
                 let sigiled = format!("%{}", name);
                 let var_name = if self.local_map.contains_key(sigiled.as_str()) {
                     sigiled

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -431,6 +431,12 @@ impl Compiler {
                 quoted: false,
                 arg_sources_idx: None,
             });
+            // `$.attr` is `self.attr` in *item* context — the `$` sigil itemizes a
+            // list/array accessor result so it counts as a single element in list
+            // context (e.g. `flat 0, $.a` sees `$.a` as one item). `@.attr` /
+            // `%.attr` use their own list/hash-context reads; only the `$` form
+            // itemizes here. A scalar accessor result is left unchanged.
+            self.code.emit(OpCode::Itemize);
             return;
         }
         // $!attr (private twigil) — direct attribute access via local slot.

--- a/t/sigil-context-accessor.t
+++ b/t/sigil-context-accessor.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 7;
+
+# A `$.attr` / `%.attr` access is `self.attr` in *item* / *hash* context — the
+# sigil contextualizes the accessor result. `@.attr` keeps list context.
+# Mirrors roast/S12-methods/accessors.t subtests 2, 4, 5.
+class A {
+    has @.a;
+    has $.b;
+    method item-a  { my $x = 0; $x++ for flat 0, $.a; $x - 1 }   # $.a as one item
+    method list-a  { my $x = 0; $x++ for @.a;          $x     }   # @.a flattens
+    method item-b  { my $x = 0; $x++ for flat 0, $.b;  $x - 1 }   # $.b as one item
+    method hash-a  { my $x = 0; $x++ for %.a;          $x     }   # %.a as a hash
+    method raku-a  { ($.a).raku }
+}
+
+my $o = A.new(a => (1, 2, 3, 4), b => [3, 4, 5, 6]);
+
+is $o.list-a, 4, '@.a contextualizes as a flat list';
+is $o.item-a, 1, '$.a contextualizes as a single item';
+is $o.item-b, 1, '$.b (Array in a scalar attr) stays a single item';
+is $o.hash-a, 2, '%.a contextualizes as a hash (2 key/value pairs)';
+ok $o.raku-a.starts-with('$'), '$.a is itemized ($[...]) in .raku';
+
+# Method calls and indexing still see through the itemization.
+is $o.a.elems, 4, '@.a accessor still has 4 elements';
+is ($o.a)[2], 3, 'indexing the accessor result works';


### PR DESCRIPTION
## Summary

`$.attr` and `%.attr` are `self.attr` in **item** and **hash** context — the sigil contextualizes the accessor result. mutsu read both like the raw `@.attr` list accessor, so:

- `$.a` (over a `has @.a`) flattened in list context instead of counting as a single item (`flat 0, $.a` saw 5 items, not 2).
- `%.a` iterated the array elements (count 4) instead of coercing to a Hash (`{1 => 2, 3 => 4}`, count 2).

### Fix

- **`$.attr`**: emit `Itemize` after the accessor `CallMethod`, so a list/array result is itemized (one element in list context); a scalar result is unchanged.
- **`%.attr`**: compile as `self.attr.hash` (accessor call + hash coercion), mirroring the `$.attr` item-context path.

## Tests

- `roast/S12-methods/accessors.t`: **Failed 5 → 2** (subtests 2, 4, 5 now pass).
- New `t/sigil-context-accessor.t` (7 subtests), validated against `raku`.
- `make test`: 715 files / 6481 tests PASS — no regression from the (broad) `$.attr` itemization.

### Not whitelisted yet

accessors.t subtests 9/10 need **per-class storage for a same-named attribute** redeclared in a child class: `Instance.attributes` is a flat `HashMap<String, Value>` keyed by bare name, so `Parent.x` and `Child.x` collide and `$o.Parent::x = 5` clobbers the child's `$!x`. That is a separate first-class-container / instance-storage change (BLOCKERS "container identity" track), left for a follow-up. Subtest 11 is `#?rakudo todo`. This PR is a genuine, regression-free context-correctness improvement that stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)