### PR TITLE
refactor(dispatch): VM-native has_function / has_multi_function via shared Registry impl

### DIFF
--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -678,12 +678,8 @@ impl Interpreter {
     }
 
     pub(crate) fn has_declared_function(&self, name: &str) -> bool {
-        let fq = format!("{}::{}", self.current_package(), name);
-        self.registry().functions.contains_key(&Symbol::intern(&fq))
-            || self
-                .registry()
-                .functions
-                .contains_key(&Symbol::intern(name))
+        let pkg = self.current_package();
+        self.registry().has_declared_function(&pkg, name)
     }
 
     pub(crate) fn is_implicit_zero_arg_builtin(name: &str) -> bool {
@@ -692,11 +688,8 @@ impl Interpreter {
 
     /// Check if a multi-dispatched function with the given name exists (any arity).
     pub(crate) fn has_multi_function(&self, name: &str) -> bool {
-        let fq_slash = format!("{}::{}/", self.current_package(), name);
-        self.registry()
-            .functions
-            .keys()
-            .any(|k| k.resolve().starts_with(&fq_slash))
+        let pkg = self.current_package();
+        self.registry().has_multi_function(&pkg, name)
     }
 
     /// Check if a user-defined function with the given name can accept the

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -370,6 +370,26 @@ impl Registry {
         })
     }
 
+    /// Whether a (non-multi) function `name` is declared, visible from the
+    /// `current_package` scope: either fully qualified under the current package
+    /// or as a bare global name. Pure registry+scope read, shared by
+    /// `Interpreter::has_declared_function` and the VM's native dispatch path.
+    pub(crate) fn has_declared_function(&self, current_package: &str, name: &str) -> bool {
+        let fq = format!("{}::{}", current_package, name);
+        self.functions.contains_key(&Symbol::intern(&fq))
+            || self.functions.contains_key(&Symbol::intern(name))
+    }
+
+    /// Whether a `multi`-dispatched function `name` exists at any arity, visible
+    /// from the `current_package` scope. Pure registry+scope read, shared by
+    /// `Interpreter::has_multi_function` and the VM's native dispatch path.
+    pub(crate) fn has_multi_function(&self, current_package: &str, name: &str) -> bool {
+        let fq_slash = format!("{}::{}/", current_package, name);
+        self.functions
+            .keys()
+            .any(|k| k.resolve().starts_with(&fq_slash))
+    }
+
     /// Whether `name` is marked `is hidden` (excluded from `.^mro` etc.).
     pub(crate) fn is_hidden_class(&self, name: &str) -> bool {
         self.hidden_classes.contains(name)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -527,6 +527,31 @@ impl VM {
         self.registry().has_multi_candidates(&pkg, name)
     }
 
+    /// VM-native declared-(non-multi-)function check, mirroring
+    /// `Interpreter::has_declared_function` via the single
+    /// [`Registry::has_declared_function`] implementation.
+    #[inline]
+    pub(crate) fn has_declared_function(&self, name: &str) -> bool {
+        let pkg = self.current_package();
+        self.registry().has_declared_function(&pkg, name)
+    }
+
+    /// Alias of [`Self::has_declared_function`], mirroring
+    /// `Interpreter::has_function` (which delegates to `has_declared_function`).
+    #[inline]
+    pub(crate) fn has_function(&self, name: &str) -> bool {
+        self.has_declared_function(name)
+    }
+
+    /// VM-native multi-function check, mirroring
+    /// `Interpreter::has_multi_function` via the single
+    /// [`Registry::has_multi_function`] implementation.
+    #[inline]
+    pub(crate) fn has_multi_function(&self, name: &str) -> bool {
+        let pkg = self.current_package();
+        self.registry().has_multi_function(&pkg, name)
+    }
+
     /// The in-scope package name, read out of the VM's own `current_package`
     /// handle as an owned `String` (no `self.interpreter` bounce). The guard is
     /// dropped before returning, so no lock is held across the caller's work.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -193,7 +193,7 @@ impl VM {
             // handling for `note` inside a caller-provided block).
             if self.has_proto(name_str)
                 || self.has_multi_candidates(name_str)
-                || !self.interpreter.has_function(name_str)
+                || !self.has_function(name_str)
             {
                 None
             } else {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -157,9 +157,7 @@ impl VM {
             .cloned()
             .map(Self::unwrap_var_ref_value)
             .collect();
-        if self.interpreter.has_declared_function(name)
-            || self.interpreter.has_multi_function(name)
-            || self.has_proto(name)
+        if self.has_declared_function(name) || self.has_multi_function(name) || self.has_proto(name)
         {
             raw_args
         } else {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -376,11 +376,11 @@ impl VM {
             let fns = compiled_fns.unwrap_or(&empty_fns);
             if !pkg.is_empty() && pkg != "GLOBAL" {
                 let fq = format!("{pkg}::{name_str}");
-                if self.interpreter.has_function(&fq) {
+                if self.has_function(&fq) {
                     return self.call_function_compiled_first(&fq, args, fns);
                 }
             }
-            if self.interpreter.has_function(&name_str)
+            if self.has_function(&name_str)
                 || self.has_proto(&name_str)
                 || self.has_multi_candidates(&name_str)
             {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1280,8 +1280,8 @@ impl VM {
         if name.starts_with('&') && !name.contains("::") {
             let bare = name.trim_start_matches('&');
             let has_variable_slot = self.interpreter.env().contains_key(&name);
-            let is_routine_symbol = self.interpreter.has_function(bare)
-                || self.interpreter.has_multi_function(bare)
+            let is_routine_symbol = self.has_function(bare)
+                || self.has_multi_function(bare)
                 || self.has_proto(bare)
                 || self.interpreter.resolve_token_defs(bare).is_some()
                 || self.interpreter.has_proto_token(bare);

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -58,9 +58,7 @@ impl VM {
             && let Some(stripped_sym) = sym.strip_prefix('&')
         {
             let qualified_name = format!("{pkg}::{stripped_sym}");
-            if self.interpreter.has_function(&qualified_name)
-                || self.interpreter.has_multi_function(&qualified_name)
-            {
+            if self.has_function(&qualified_name) || self.has_multi_function(&qualified_name) {
                 Value::Routine {
                     package: Symbol::intern(pkg),
                     name: Symbol::intern(&qualified_name),
@@ -191,9 +189,9 @@ impl VM {
             let result = self.interpreter.call_function(name, Vec::new())?;
             self.env_dirty = true;
             result
-        } else if self.interpreter.has_function(name)
+        } else if self.has_function(name)
             || Interpreter::is_implicit_zero_arg_builtin(name)
-            || self.interpreter.has_multi_function(name)
+            || self.has_multi_function(name)
         {
             if let Some(cf) = self.find_compiled_function(compiled_fns, name, &[]) {
                 let pkg = self.current_package().to_string();
@@ -240,7 +238,7 @@ impl VM {
             // Try resolving as a package-qualified function call (e.g.
             // `Module::func` used as a term without parens).
             if let Some((_pkg, short)) = name.rsplit_once("::")
-                && self.interpreter.has_function(&format!("GLOBAL::{}", short))
+                && self.has_function(&format!("GLOBAL::{}", short))
             {
                 // Route the package-qualified term fork through the VM's unified
                 // compiled-first function dispatch (ledger §2): interpreter remains
@@ -253,10 +251,10 @@ impl VM {
                 && last_seg.starts_with(|c: char| c.is_ascii_lowercase())
                 && !self.interpreter.has_type(name)
                 && !Self::is_builtin_type(name)
-                && !self.interpreter.has_function(name)
-                && !self.interpreter.has_multi_function(name)
-                && !self.interpreter.has_function(last_seg)
-                && !self.interpreter.has_multi_function(last_seg)
+                && !self.has_function(name)
+                && !self.has_multi_function(name)
+                && !self.has_function(last_seg)
+                && !self.has_multi_function(last_seg)
             {
                 // The last segment starts with lowercase, indicating a qualified
                 // function/sub call (e.g. `Our::Package::pkg`). If the prefix


### PR DESCRIPTION
## What

Follow-up to #2929. Make the remaining pure dispatch predicates `has_function` /
`has_declared_function` / `has_multi_function` resolve from the VM's own handles instead
of bouncing through `self.interpreter`, with a single implementation on the Registry.

## Why

Like `has_proto` / `has_multi_candidates`, these need only the registry plus
`current_package` — no env, no user-code re-entry — so they are pure registry+scope reads
that can be served from the VM's own `registry` + `current_package` handles (available
since #2927/#2929), removing the interpreter bounce and collapsing the duplicate.

## How (behavior-invariant)

- `Registry::has_declared_function(current_package, name)` /
  `has_multi_function(current_package, name)`: the single pure implementations.
- `Interpreter::has_declared_function` / `has_multi_function` become thin delegates
  (`has_function` already delegates to `has_declared_function`).
- VM-native `has_declared_function` / `has_function` (alias) / `has_multi_function`
  reading the VM's own handles. ~15 VM call sites `self.interpreter.has_*` → `self.has_*`.

The VM and interpreter share the same registry + current_package locks, so the result is
identical.

## Verification

- `cargo test` 461/0, `clippy -D warnings` / `fmt` clean, `make test` **PASS**.
- roast: S06-multi (syntax/proto), S10-packages, S11-modules (import/nested),
  S02-names/our all PASS. S10-packages/basic.t pre-existing partial (59/18, identical
  with/without this change, non-whitelisted).
- plain/multi/proto/recursive dispatch smoke matches raku.
- Full `make test` + `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)