### PR TITLE
feat(class): per-class storage for same-named child-redeclared attribute

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -101,7 +101,14 @@
     metamodel HOW supersession, which reference rakudo also lacks.
 - [x] roast/S12-meta/grammarhow.t
 - [ ] roast/S12-meta/primitives.t
-- [ ] roast/S12-methods/accessors.t
+- [x] roast/S12-methods/accessors.t
+  - 11/11 (subtest 11 is `#?rakudo todo`). `$.attr`/`%.attr` now apply item/hash
+    context (#2932), and a same-named attribute redeclared in a child class gets
+    per-class private storage: same-named classes fall through the native fast
+    constructor to the full path (which builds `"Class\0attr"` keys), each
+    declaring class's copy is initialized from the constructor named arg
+    (per-class BUILD), and `$o.Class::attr = v` writes the qualifier's own copy
+    (syncing the bare key only when the qualifier is the most-derived declarer).
 - [ ] roast/S12-methods/attribute-params.t
 - [ ] roast/S12-methods/calling_sets.t
 - [ ] roast/S12-methods/calling_syntax.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -642,6 +642,7 @@ roast/S12-introspection/roles.t
 roast/S12-meta/classhow.t
 roast/S12-meta/grammarhow.t
 roast/S12-meta/primitives.t
+roast/S12-methods/accessors.t
 roast/S12-methods/attribute-params.t
 roast/S12-methods/calling_sets.t
 roast/S12-methods/calling_syntax.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -105,6 +105,51 @@ impl Interpreter {
         }
     }
 
+    /// The class in `class_name`'s MRO (most-derived first) that *locally*
+    /// declares `attr`. For a same-named attribute redeclared in a child, this is
+    /// the child; the instance's bare attribute key mirrors this class's value
+    /// (what a public `$.attr` accessor reads). Returns `None` if undeclared.
+    fn most_derived_attr_declarer(&mut self, class_name: &str, attr: &str) -> Option<String> {
+        for cn in self.class_mro(class_name) {
+            if let Some(cd) = self.registry().classes.get(&cn)
+                && cd.attributes.iter().any(|a| a.0 == attr)
+            {
+                return Some(cn);
+            }
+        }
+        None
+    }
+
+    /// Write `value` for a class-qualified attribute assignment (`$o.C::attr = …`).
+    /// When `attr` is stored per-class (a same-named attribute redeclared across
+    /// the hierarchy, so the instance carries `"C\0attr"` keys), target the
+    /// qualifier's own key so sibling classes' copies are untouched, and keep the
+    /// bare key in sync only when `qualifier` is the most-derived declarer (the
+    /// bare key is what the public `$.attr` accessor reads). Otherwise (the common
+    /// single-class case, no qualified key) fall back to the bare key as before.
+    fn store_qualified_attr(
+        &mut self,
+        updated: &mut std::collections::HashMap<String, Value>,
+        instance_class: &str,
+        qualifier: &str,
+        attr: &str,
+        value: Value,
+    ) {
+        let qualified_key = format!("{}\0{}", qualifier, attr);
+        if updated.contains_key(&qualified_key) {
+            updated.insert(qualified_key, value.clone());
+            if self
+                .most_derived_attr_declarer(instance_class, attr)
+                .as_deref()
+                == Some(qualifier)
+            {
+                updated.insert(attr.to_string(), value);
+            }
+        } else {
+            updated.insert(attr.to_string(), value);
+        }
+    }
+
     fn normalize_rw_accessor_assignment(current: Option<Value>, value: Value) -> Value {
         let current = current.map(Value::into_descalarized);
         match current {
@@ -1111,8 +1156,14 @@ impl Interpreter {
                     {
                         assigned_value = def;
                     }
-                    updated.insert(attr_name, assigned_value.clone());
                     let cn = *class_name;
+                    self.store_qualified_attr(
+                        &mut updated,
+                        &cn.resolve(),
+                        qualifier,
+                        &attr_name,
+                        assigned_value.clone(),
+                    );
                     if let Some(var_name) = target_var {
                         self.overwrite_instance_bindings_by_identity(
                             &cn.resolve(),
@@ -1163,8 +1214,14 @@ impl Interpreter {
                     {
                         assigned_value = def;
                     }
-                    updated.insert(actual_method.to_string(), assigned_value.clone());
                     let cn = *class_name;
+                    self.store_qualified_attr(
+                        &mut updated,
+                        &cn.resolve(),
+                        qualifier,
+                        actual_method,
+                        assigned_value.clone(),
+                    );
                     if let Some(var_name) = target_var {
                         self.overwrite_instance_bindings_by_identity(
                             &cn.resolve(),

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -60,6 +60,22 @@ impl Interpreter {
         if self.registry().cunion_classes.contains(cn_resolved) {
             return false;
         }
+        // A same-named attribute redeclared across the hierarchy (Parent and Child
+        // both `has $.x`) needs per-class private storage (`"Class\0attr"` keys),
+        // which only the full constructor path builds. Such classes are rare, so
+        // fall through to the interpreter rather than duplicate that logic here.
+        {
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for cls in self.mro_readonly(cn_resolved) {
+                if let Some(cd) = self.registry().classes.get(&cls) {
+                    for attr in &cd.attributes {
+                        if !seen.insert(attr.0.clone()) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
         let mut has_attribute = false;
         for cls in self.mro_readonly(cn_resolved) {
             if cls == "Any" || cls == "Mu" || cls == "Cool" {
@@ -3858,6 +3874,19 @@ impl Interpreter {
                 // Methods access $!attr via the qualified key for their owner class.
                 {
                     let per_class_attrs = self.collect_per_class_attrs(class_key);
+                    // Named-arg keys explicitly passed to the constructor. In Raku
+                    // each class's BUILD binds its own same-named attribute from the
+                    // named args (a provided named arg wins over the class's own
+                    // default), so EVERY declaring class's private copy gets that
+                    // value — not just the most-derived one. The most-derived value
+                    // already lives in the bare key, so reuse it.
+                    let provided_keys: std::collections::HashSet<String> = args
+                        .iter()
+                        .filter_map(|a| match a {
+                            Value::Pair(k, _) => Some(k.clone()),
+                            _ => None,
+                        })
+                        .collect();
                     for (
                         declaring_class,
                         (attr_name, _is_public, default, _is_rw, _is_required, sigil, _),
@@ -3865,6 +3894,15 @@ impl Interpreter {
                     {
                         let qualified_key = format!("{}\0{}", declaring_class, attr_name);
                         if attrs.contains_key(&qualified_key) {
+                            continue;
+                        }
+                        // Constructor named arg provided → initialize this class's
+                        // copy from it (per-class BUILD), regardless of which class
+                        // in the hierarchy declared it.
+                        if provided_keys.contains(&attr_name)
+                            && let Some(val) = attrs.get(&attr_name)
+                        {
+                            attrs.insert(qualified_key, val.clone());
                             continue;
                         }
                         // Use the unqualified value if it was provided via constructor args

--- a/t/per-class-same-name-attr.t
+++ b/t/per-class-same-name-attr.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 8;
+
+# A same-named attribute redeclared in a child class gets its OWN private
+# storage: `$o.Parent::x = v` must touch only the parent's copy, leaving the
+# child's intact, and each class's `$!x` resolves to its own. Mirrors
+# roast/S12-methods/accessors.t subtests 8-10.
+class Parent {
+    has $.x is rw;
+    method parent-x() { $!x }
+}
+class Child is Parent {
+    has $.x is rw;
+    method child-x() { $!x }
+}
+
+my $o = Child.new(x => 42);
+# Both classes' BUILD bind their own x from the named arg.
+is $o.parent-x, 42, 'parent copy initialized from named arg';
+is $o.child-x,  42, 'child copy initialized from named arg';
+is $o.x,        42, 'public accessor reads the most-derived copy';
+
+$o.Parent::x = 5;
+is $o.parent-x, 5,  'qualified assign updates the parent copy';
+is $o.child-x,  42, 'child copy is untouched by Parent:: assign';
+is $o.x,        42, 'public accessor still reads the child copy';
+
+# Sanity: a plain single-class qualified rw accessor assign still works.
+class Solo { has $.y is rw }
+my $s = Solo.new(y => 1);
+lives-ok { $s.Solo::y = 9 }, 'single-class qualified rw assign lives';
+is $s.y, 9, 'single-class qualified rw assign updates the attribute';


### PR DESCRIPTION
## Summary

When a child class redeclares an attribute the parent already declares, each class needs its own private copy:

```raku
class Parent { has $.x is rw; method px { $!x } }
class Child is Parent { has $.x is rw; method cx { $!x } }
my $o = Child.new(x => 42);
$o.Parent::x = 5;
$o.px;  # 5   $o.cx;  # 42   $o.x;  # 42
```

mutsu stored attributes in a flat `HashMap<String, Value>` keyed by bare name, so `Parent.x` and `Child.x` collided and `$o.Parent::x = 5` clobbered both (px=cx=ox=5).

The qualified-key infra (`"Class\0attr"`) and qualified-aware `$!x` reads already existed; this wires up the two missing halves:

- **Construction**: a class with a same-named attribute across its MRO now falls through the native fast constructor (`is_native_default_constructible` returns false for it) to the full path, whose per-class init builds the `"Class\0attr"` keys. That init now seeds **every** declaring class's copy from the constructor named arg (matching Raku's per-class BUILD — a provided named arg wins over a class's own default), not just the most-derived class.
- **Qualified assignment**: `$o.Class::attr = v` (`store_qualified_attr`) writes the qualifier's own `"Class\0attr"` key, leaving sibling classes' copies untouched, and syncs the bare key (what the public `$.attr` accessor reads) only when the qualifier is the most-derived declarer.

## Tests

- `roast/S12-methods/accessors.t`: **11/11** (subtest 11 is `#?rakudo todo`) — **whitelisted**, combining this with the item/hash-context accessors from #2932.
- New `t/per-class-same-name-attr.t` (8 subtests), validated against `raku`, incl. a single-class qualified-rw-assign sanity case.
- `make test`: 716 files / 6489 tests PASS. No regression in S12 class/method/attribute or S14 role instantiation tests.

This is on the BLOCKERS "container identity / first-class containers" track (the per-class attribute storage facet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)