### PR TITLE
feat(attributes): `has $.x does Role` attribute trait (role mixin)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -1,8 +1,12 @@
 # S03 - binding, buf, feeds, junctions, metaops, operators, sequence, smartmatch
 
 - [ ] roast/S03-binding/arrays.t
-- [ ] roast/S03-binding/attributes.t
-  10/16 pass (3 skipped). Tests 11-12 fail: `our $x` class attribute binding requires package-level ContainerRef. Test 13 fails: `has $.scalar does Foo` role mixin on attribute declaration not implemented.
+- [x] roast/S03-binding/attributes.t
+  16/16. `has $.x does Role` now parses the `does` as an attribute trait (was
+  mis-parsed as a class-level `does` composition) and mixes the role into the
+  attribute's value at construction (`__mutsu_role__<Name>` mixin), so
+  `$o.x.role-method` dispatches. Attributes with a does-trait fall through the
+  native fast constructor to the full path.
 - [ ] roast/S03-binding/closure.t
 - [ ] roast/S03-binding/hashes.t
 - [x] roast/S03-binding/nested.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -160,6 +160,7 @@ roast/S02-types/unicode.t
 roast/S02-types/version-stress.t
 roast/S02-types/version.t
 roast/S03-binding/arrays.t
+roast/S03-binding/attributes.t
 roast/S03-binding/closure.t
 roast/S03-binding/hashes.t
 roast/S03-binding/nested.t

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -543,6 +543,19 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         }
     }
 
+    // `does Role` trait on an attribute, e.g. `has $.x does Foo` — mixes the role
+    // into the attribute's container. Parsed here as an attribute trait (recorded
+    // in `unknown_traits` as `("does", role, None)`); without this it is left for
+    // the statement parser, which mis-reads it as a class-level `does Foo`
+    // composition. Applied to the attribute's value at construction.
+    while let Some(r) = keyword("does", rest) {
+        let Ok((r, _)) = ws1(r) else { break };
+        let Ok((r, role_name)) = ident(r) else { break };
+        unknown_traits.push(("does".to_string(), role_name.to_string(), None));
+        let (r, _) = ws(r)?;
+        rest = r;
+    }
+
     // `handles` trait, e.g. `has $.x handles <a b>`
     let mut handles = Vec::new();
     while let Some(r) = keyword("handles", rest) {

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -2337,6 +2337,17 @@ impl Interpreter {
         type_constraint: Option<&str>,
     ) -> Result<(), RuntimeError> {
         for (kind, trait_name, trait_arg) in unknown_traits {
+            // `has $.x does Foo` — record the role so construction mixes it into
+            // the attribute's value (its container does the role). Not a
+            // `trait_mod:<does>` dispatch.
+            if kind == "does" {
+                self.registry_mut()
+                    .class_attribute_does_roles
+                    .entry((owner.to_string(), attr_name_str.to_string()))
+                    .or_default()
+                    .push(trait_name.clone());
+                continue;
+            }
             let trait_mod_name = format!("trait_mod:<{}>", kind);
             let has_handler =
                 self.has_proto(&trait_mod_name) || self.has_multi_candidates(&trait_mod_name);

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -76,6 +76,16 @@ impl Interpreter {
                 }
             }
         }
+        // An attribute with a `does Role` trait mixes the role into its value at
+        // construction (full path only) — fall through.
+        if self.mro_readonly(cn_resolved).iter().any(|cls| {
+            self.registry()
+                .class_attribute_does_roles
+                .keys()
+                .any(|(c, _)| c == cls)
+        }) {
+            return false;
+        }
         let mut has_attribute = false;
         for cls in self.mro_readonly(cn_resolved) {
             if cls == "Any" || cls == "Mu" || cls == "Cool" {
@@ -4017,6 +4027,34 @@ impl Interpreter {
                     }
                     if let Some(val) = attrs.get(attr_name).cloned() {
                         self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, &val)?;
+                    }
+                }
+                // Apply `has $.x does Role` attribute traits: mix each declared
+                // role into the attribute's value so `$o.x` does the role and
+                // `$o.x.method` dispatches into it. (raku mixes into the Scalar
+                // *container*; mutsu has no per-attribute container, so the value
+                // carries the mixin — enough for method dispatch.)
+                {
+                    let mro = self.class_mro(class_key);
+                    let does_attrs: Vec<(String, Vec<String>)> = self
+                        .registry()
+                        .class_attribute_does_roles
+                        .iter()
+                        .filter(|((c, _), _)| mro.contains(c))
+                        .map(|((_, a), roles)| (a.clone(), roles.clone()))
+                        .collect();
+                    for (attr_name, roles) in does_attrs {
+                        let Some(base) = attrs.get(&attr_name).cloned() else {
+                            continue;
+                        };
+                        // Role mixins are keyed `__mutsu_role__<Name>` with a marker
+                        // value; method dispatch resolves the role from the registry
+                        // by that name (mirrors the `does`/role-pun construction).
+                        let mut mixins = HashMap::new();
+                        for role in &roles {
+                            mixins.insert(format!("__mutsu_role__{}", role), Value::Bool(true));
+                        }
+                        attrs.insert(attr_name, Value::mixin(base, mixins));
                     }
                 }
                 let instance = Value::make_instance(*class_name, attrs);

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -81,6 +81,10 @@ pub(crate) struct Registry {
     pub(crate) class_attribute_defaults: HashMap<(String, String), Value>,
     /// Per-attribute declared type: (class, attr) -> type name.
     pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
+    /// Per-attribute `does Role` traits: (class, attr) -> role names mixed into
+    /// the attribute's container (`has $.x does Foo`). Applied to the attribute's
+    /// value at construction so `$o.x` does the role.
+    pub(crate) class_attribute_does_roles: HashMap<(String, String), Vec<String>>,
     /// Per-attribute `is DEPRECATED` message: (class, attr) -> message.
     pub(crate) class_attribute_deprecated: HashMap<(String, String), String>,
 

--- a/t/attr-does-role-trait.t
+++ b/t/attr-does-role-trait.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 5;
+
+# `has $.x does Role` mixes the role into the attribute, so reading the
+# attribute returns a value that does the role and `$o.x.method` dispatches into
+# it. Mirrors roast/S03-binding/attributes.t subtests 13-16.
+{
+    my role Foo { method bar { 42 } }
+    my class A {
+        has $.scalar does Foo;
+        has @.array  does Foo;
+        has %.hash   does Foo;
+        has &.code   does Foo;
+    }
+    my $a = A.new;
+    is $a.scalar.bar, 42, 'scalar attribute is mixed in';
+    is $a.array.bar,  42, 'array attribute is mixed in';
+    is $a.hash.bar,   42, 'hash attribute is mixed in';
+    is $a.code.bar,   42, 'code attribute is mixed in';
+}
+
+# Multiple roles on one attribute.
+{
+    my role R1 { method m1 { 1 } }
+    my role R2 { method m2 { 2 } }
+    my class C { has $.x does R1 does R2 }
+    my $c = C.new;
+    ok $c.x.m1 == 1 && $c.x.m2 == 2, 'multiple does-roles on one attribute';
+}


### PR DESCRIPTION
## Summary

`has $.scalar does Foo` mixes role `Foo` into the attribute, so reading it returns a value that does the role and `$o.scalar.bar` dispatches into it:

```raku
role Foo { method bar { 42 } }
class A { has $.scalar does Foo; has @.array does Foo; has %.hash does Foo; has &.code does Foo }
A.new.scalar.bar;   # 42
```

mutsu mis-parsed the trailing `does Foo` as a **class-level** `does` composition (composing Foo into class A), leaving the attribute un-mixed and aborting `roast/S03-binding/attributes.t` at test 13.

### Fix

- **Parser** (`has_decl.rs`): after the `is`/`will` trait loops, parse a trailing `does Role` as an attribute trait, recorded in `unknown_traits` as `("does", role, None)`.
- **Registration** (`apply_attribute_traits`): a `("does", role)` entry is stored in a new `class_attribute_does_roles` registry map keyed by `(class, attr)`, not dispatched as a `trait_mod:<does>`.
- **Construction**: an attribute with a does-trait falls through the native fast constructor (`is_native_default_constructible` returns false) to the full path, which mixes each role into the attribute's value as a `__mutsu_role__<Name>` mixin — the same shape the `does` operator / role-pun construction uses — so method dispatch resolves the role from the registry. (raku mixes into the Scalar *container*; mutsu has no per-attribute container, so the value carries the mixin — enough for method dispatch, which is all the spec test checks.)

## Tests

- `roast/S03-binding/attributes.t`: 12/13-then-abort → **16/16** — **whitelisted**.
- New `t/attr-does-role-trait.t` (5 subtests, incl. multiple `does` roles on one attribute), validated against `raku`.
- `make test`: 717 files / 6494 tests PASS. No regression in S03/S12/S14 attribute, role, and instance tests.

On the BLOCKERS "container identity / first-class containers" track (attribute trait facet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)