### PR TITLE
feat(capture): write-through container binding for `\($a)` Capture elements

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -186,7 +186,14 @@
   - 38/69 pass (67 reached). Only 2 failures: test 37 (`Bool::True.but`), test 39 (`Bool::False.but`) — `.but` mixin not implemented on Bool
 - [x] roast/S02-types/built-in.t
 - [ ] roast/S02-types/capture.t
-  - 30/46 pass. Failures: (28-29) Capture container binding — `$c[0]++` must modify original variable, requires storing container references in Capture; (31) `(1..*).list.Capture` should throw X::Cannot::Lazy — `.list` on infinite ranges returns Range instead of lazy List; (34-46) never executed — runtime aborts after test 33 for unknown reason (parsing succeeds, individual tests pass in isolation); within 34-46: (35) `!===` identity for captures with different containers, (36) anonymous class `.Str` for Pair key in `.Capture`, (39) multiple `.Capture` throws subtests for Callable/WhateverCode/Signature/Version/Failure types, (40) Blob/Channel/Supply `.Capture`, (41) Mu.Capture for Complex/Rat/DateTime/etc types needing `make-temp-file`, (45) `is Capture` class inheritance
+  - Failed 0 (still aborts at test 33, so not whitelistable). FIXED: (28-29)
+    Capture element container binding — `\($a)`/`\(:$a)` now capture the
+    variable's `ContainerRef` cell, so `$c[0]++`/`$c<a>++` write through to the
+    original (CaptureLiteral tags scalar-var elements with WrapVarRef; MakeCapture
+    boxes the named local; the inc/dec-index op increments through a Capture
+    element cell). Still blocked from whitelist by (31) `(1..*).list.Capture`
+    needing X::Cannot::Lazy (real lazy infinite sequences — mutsu materializes
+    `1..*`) and the post-33 abort that follows it.
 - [ ] roast/S02-types/catch_type_cast_mismatch.t
   - 9/11 pass. Test 3: `[0]` on non-Positional should return self. Test 5: accessing array as hash should fail (throws-like)
 - [ ] roast/S02-types/compact.t

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -154,7 +154,34 @@ impl Compiler {
             Expr::CaptureLiteral(items) => {
                 self.with_escape(true, |c| {
                     for item in items {
+                        // A named scalar-var element (`\(:$a)` -> `a => $a`)
+                        // captures the variable's container too, so `$c<a>` aliases
+                        // `$a`. Compile key + value, tag the value with WrapVarRef,
+                        // then MakePair; MakeCapture boxes the named local.
+                        if let Expr::Binary { op, left, right } = item
+                            && *op == crate::token_kind::TokenKind::FatArrow
+                            && let Expr::Var(name) = right.as_ref()
+                            && !name.contains("::")
+                        {
+                            c.compile_expr(left);
+                            c.compile_expr(right);
+                            let name_idx = c.code.add_constant(Value::str(name.clone()));
+                            c.code.emit(OpCode::WrapVarRef(name_idx));
+                            c.code.emit(OpCode::MakePair);
+                            continue;
+                        }
                         c.compile_expr(item);
+                        // A plain scalar variable positional (`\($a)`) captures the
+                        // variable's *container*, so `$c[0]` aliases `$a` and
+                        // `$c[0]++` writes through. Tag it with its source name via
+                        // WrapVarRef; MakeCapture boxes the named local into a shared
+                        // cell. Non-variable items capture by value.
+                        if let Expr::Var(name) = item
+                            && !name.contains("::")
+                        {
+                            let name_idx = c.code.add_constant(Value::str(name.clone()));
+                            c.code.emit(OpCode::WrapVarRef(name_idx));
+                        }
                     }
                 });
                 self.code.emit(OpCode::MakeCapture(items.len() as u32));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2890,7 +2890,7 @@ impl VM {
                 *ip += 1;
             }
             OpCode::MakeCapture(n) => {
-                self.exec_make_capture_op(*n);
+                self.exec_make_capture_op(code, *n);
                 *ip += 1;
             }
 

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -168,16 +168,85 @@ impl VM {
         self.stack.push(Value::hash(map));
     }
 
-    pub(super) fn exec_make_capture_op(&mut self, n: u32) {
+    /// Box the local scalar variable `name` into a shared `ContainerRef` cell and
+    /// return that cell, so a Capture positional built from `\($name)` aliases the
+    /// variable's container (`$c[0]++` writes through to `$name`). If the variable
+    /// is not a local slot in this frame (or is already a cell), fall back to the
+    /// captured `inner` value / existing cell. Mirrors `box_captured_lexicals`.
+    fn capture_var_cell(&mut self, code: &CompiledCode, name: &str, inner: Value) -> Value {
+        if inner.is_container_ref() {
+            return inner;
+        }
+        let Some(idx) = code.locals.iter().rposition(|n| n == name) else {
+            return inner;
+        };
+        if self.locals[idx].is_container_ref() {
+            return self.locals[idx].clone();
+        }
+        // Only box a plain scalar container; reference/type values are not
+        // re-containerized (mirrors the box-on-capture guard).
+        if matches!(
+            self.locals[idx],
+            Value::Package(_)
+                | Value::Array(..)
+                | Value::Hash(..)
+                | Value::Sub(..)
+                | Value::Instance { .. }
+                | Value::Proxy { .. }
+        ) {
+            return self.locals[idx].clone();
+        }
+        let cell = self.locals[idx].clone().into_container_ref();
+        self.locals[idx] = cell.clone();
+        self.flush_local_to_env(code, idx);
+        cell
+    }
+
+    pub(super) fn exec_make_capture_op(&mut self, code: &CompiledCode, n: u32) {
         let n = n as usize;
         let start = self.stack.len() - n;
         let raw: Vec<Value> = self.stack.drain(start..).collect();
         let mut positional = Vec::new();
         let mut named = HashMap::new();
         for val in raw {
+            // A `WrapVarRef`-tagged scalar variable positional (`\($a)`): capture
+            // the variable's *container* so `$c[0]` aliases `$a` and `$c[0]++`
+            // writes through. Box the named local into a shared `ContainerRef`
+            // cell (same scope as `$c`, so sharing the slot's cell suffices) and
+            // store that cell as the positional element.
+            if let Value::Capture {
+                positional: p,
+                named: nm,
+            } = &val
+                && p.is_empty()
+                && let Some(Value::Str(source_name)) = nm.get("__mutsu_varref_name")
+                && let Some(inner) = nm.get("__mutsu_varref_value")
+            {
+                let source_name = source_name.to_string();
+                let inner = inner.clone();
+                positional.push(self.capture_var_cell(code, &source_name, inner));
+                continue;
+            }
             match val {
                 Value::Pair(k, v) => {
-                    named.insert(k, *v);
+                    // A named scalar-var element (`\(:$a)`): the value is a
+                    // WrapVarRef-tagged capture — box the named local so `$c<a>`
+                    // aliases `$a` and `$c<a>++` writes through.
+                    if let Value::Capture {
+                        positional: p,
+                        named: nm,
+                    } = v.as_ref()
+                        && p.is_empty()
+                        && let Some(Value::Str(source_name)) = nm.get("__mutsu_varref_name")
+                        && let Some(inner) = nm.get("__mutsu_varref_value")
+                    {
+                        let source_name = source_name.to_string();
+                        let inner = inner.clone();
+                        let cell = self.capture_var_cell(code, &source_name, inner);
+                        named.insert(k, cell);
+                    } else {
+                        named.insert(k, *v);
+                    }
                 }
                 Value::Capture {
                     positional: p,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1777,6 +1777,30 @@ impl VM {
         let idx_val = self.stack.pop().unwrap_or(Value::Nil);
         let key = idx_val.to_string_value();
         let container = self.get_env_with_main_alias(&name);
+        // `$c[0]++` / `$c<a>++` on a Capture: when the element is a shared
+        // `ContainerRef` cell (built from `\($a)` / `\(:$a)`), increment *through*
+        // the cell so the original variable observes the change. The generic
+        // Hash/Array path below does not understand Captures.
+        if let Some(Value::Capture { positional, named }) = container.as_ref() {
+            let elem = if let Ok(i) = key.parse::<usize>() {
+                positional.get(i).cloned()
+            } else {
+                named.get(&key).cloned()
+            };
+            if let Some(Value::ContainerRef(arc)) = elem {
+                let inner = arc.lock().unwrap().clone();
+                let effective = Self::normalize_incdec_source(inner);
+                let new_val = if increment {
+                    self.increment_value_smart(&effective)?
+                } else {
+                    self.decrement_value_smart(&effective)?
+                };
+                arc.lock().unwrap().clone_from(&new_val);
+                self.stack
+                    .push(if return_new { new_val } else { effective });
+                return Ok(());
+            }
+        }
         let current = if let Some(container_value) = container.as_ref() {
             match container_value {
                 Value::Hash(h) => h.get(&key).cloned().unwrap_or(Value::Nil),

--- a/t/capture-element-writethrough.t
+++ b/t/capture-element-writethrough.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 5;
+
+# A Capture built from `\($a)` / `\(:$a)` captures the variable's *container*, so
+# mutating the Capture element (via `++`/`--`) writes through to the original
+# variable. Mirrors roast/S02-types/capture.t subtests 28-29.
+
+# Positional element.
+{
+    my $a = 41;
+    my $c = \($a);
+    $c[0]++;
+    is $a, 42, 'incrementing a Capture positional writes through to the variable';
+}
+
+# Named element.
+{
+    my $a = 41;
+    my $c = \(:$a);
+    $c<a>++;
+    is $a, 42, 'incrementing a Capture named element writes through';
+}
+
+# Two variables in one capture stay independent.
+{
+    my $x = 10;
+    my $y = 20;
+    my $c = \($x, $y);
+    $c[0]++;
+    $c[1]--;
+    is $x, 11, 'first capture element writes through independently';
+    is $y, 19, 'second capture element writes through independently';
+}
+
+# A non-variable element captures by value (no container to alias).
+{
+    my $c = \(5);
+    is $c[0], 5, 'a literal capture element is just a value';
+}


### PR DESCRIPTION
## Summary

A Capture built from `\($a)` / `\(:$a)` captures the variable's **container**, so mutating the Capture element writes through to the original variable:

```raku
my $a = 41;
my $c = \($a);
$c[0]++;
say $a;            # 42
```

mutsu captured a decontainerized value copy, so `$c[0]++` was lost (roast `S02-types/capture.t` tests 28-29 failed).

### Fix (reuses the Phase-2 `ContainerRef` cell infra)

- **`CaptureLiteral` compilation** tags a scalar-variable element — positional (`$a`) or named (`:$a` → `a => $a`) — with `WrapVarRef`, carrying its source name.
- **`MakeCapture`** boxes the named local into a shared `ContainerRef` cell (same scope as the capture, so sharing the slot's cell suffices) and stores that cell as the positional/named element.
- The **inc/dec-index op** increments *through* a Capture element that is a cell, so the original variable observes the change. Non-variable elements (`\(5)`) capture by value as before.

## Tests

- `roast/S02-types/capture.t`: **Failed 2 → 0** (28-29 fixed).
- New `t/capture-element-writethrough.t` (5 subtests), validated against `raku`.
- `make test`: 718 files / 6499 tests PASS — no regression (Capture is widely used for function-arg passing; all binding/signature tests green).

### Not whitelisted

The file still **aborts at test 33** on `(1..*).list.Capture` needing `X::Cannot::Lazy` — that requires real lazy infinite sequences (mutsu materializes `1..*`), a separate Hard blocker. This PR is a genuine container-identity improvement (like #2932 was before #2935), not a whitelist. On the BLOCKERS "container identity" top-lever track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)