### PR TITLE
fix(parser): fake-infix adverb args on parenthesized `.=` method call

### DIFF
--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1635,6 +1635,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
         // Parse regular method name
         let (r, method_name) =
             take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
+        let r_before_ws = r;
         let (r, _) = ws(r)?;
         // Parse optional args in parens or colon-form
         let (rest, args) = if r.starts_with('(') {
@@ -1662,8 +1663,8 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 let (r, _) = parse_char(r, ')')?;
                 (r, args)
             }
-        } else if r.starts_with(':') && !r.starts_with("::") {
-            // Colon-arg syntax: .=method: arg, arg2
+        } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
+            // Colon-arg syntax: .=method: arg, arg2 (no space before colon)
             let r = &r[1..];
             let (r, _) = ws(r)?;
             let (r, first_arg) = parse_colon_method_arg(r)?;
@@ -1693,6 +1694,20 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 let (r2, next) = parse_colon_method_arg(r2)?;
                 args.push(next);
                 r_inner = r2;
+            }
+            (r_inner, args)
+        } else if r.starts_with(':') && !r.starts_with("::") {
+            // Fake-infix adverb form: .=method :key<val> (space before colon)
+            let mut args = Vec::new();
+            let mut r_inner = r;
+            while r_inner.starts_with(':') && !r_inner.starts_with("::") {
+                if let Ok((r2, arg)) = crate::parser::primary::misc::colonpair_expr(r_inner) {
+                    args.push(arg);
+                    let (r3, _) = ws(r2)?;
+                    r_inner = r3;
+                } else {
+                    break;
+                }
             }
             (r_inner, args)
         } else {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2407,11 +2407,21 @@ impl Interpreter {
                     if named_key.is_some() || named_value.is_some() {
                         let key = named_key.unwrap_or(Value::Nil);
                         let value = named_value.unwrap_or(Value::Nil);
-                        return Ok(Value::Pair(key.to_string_value(), Box::new(value)));
+                        // Preserve the original key type: a string key uses Pair,
+                        // any other key type uses ValuePair (mirrors the `=>` and
+                        // positional Pair.new behavior).
+                        return Ok(match &key {
+                            Value::Str(_) => Value::Pair(key.to_string_value(), Box::new(value)),
+                            _ => Value::ValuePair(Box::new(key), Box::new(value)),
+                        });
                     }
                     let key = positional.first().cloned().unwrap_or(Value::Nil);
                     let value = positional.get(1).cloned().unwrap_or(Value::Nil);
-                    return Ok(Value::ValuePair(Box::new(key), Box::new(value)));
+                    // A string positional key also uses Pair for consistent display.
+                    return Ok(match &key {
+                        Value::Str(_) => Value::Pair(key.to_string_value(), Box::new(value)),
+                        _ => Value::ValuePair(Box::new(key), Box::new(value)),
+                    });
                 }
                 "Set" | "SetHash" => {
                     // Check for lazy inputs

--- a/t/dot-assign-adverb-args.t
+++ b/t/dot-assign-adverb-args.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 6;
+
+# Fake-infix adverb args (space-separated colonpairs) on a `.=` method call.
+# Previously these parsed correctly at statement level but were mis-parsed
+# inside parentheses (the parenthesized-assignment path stripped the leading
+# colon and parsed the colonpairs as a function call).
+
+# Statement level (already worked).
+{
+    my Pair $p;
+    $p .= new :key<foo> :value<bar>;
+    is-deeply $p, :foo<bar>.Pair, 'statement-level fake-infix adverbs on .=';
+}
+
+# Inside parentheses (the bug).
+{
+    my Pair $p;
+    is-deeply ($p .= new :key<foo> :value<bar>), :foo<bar>.Pair,
+        'parenthesized fake-infix adverbs on .=';
+}
+
+# Parenthesized with paren-style colonpair values.
+{
+    my Pair $p;
+    is-deeply ($p .= new :key(1) :value(2)), (1 => 2),
+        'parenthesized fake-infix adverbs with () values';
+}
+
+# A single fake-infix adverb inside parens.
+{
+    my Pair $p;
+    is-deeply ($p .= new :key<foo>), Pair.new(:key<foo>),
+        'single parenthesized fake-infix adverb';
+}
+
+# Colon-arg form (no space before colon) still works inside parens.
+{
+    my @a;
+    is-deeply (@a .= grep: { $_ > 1 }), [], 'colon-arg form still parses in parens';
+}
+
+# The whole construct works as an argument to another routine.
+{
+    my Pair $p;
+    my @collected;
+    @collected.push: ($p .= new :key<x> :value<y>);
+    is-deeply @collected[0], :x<y>.Pair, 'parenthesized .= adverbs as routine argument';
+}


### PR DESCRIPTION
## Summary

`\$p .= new :key<foo> :value<bar>` parsed correctly at statement level but was mis-parsed inside parentheses. The parenthesized-assignment path (`try_parse_assign_expr`) lacked the `r_before_ws` distinction (present in the statement-level handler) between:

- the **colon-arg form** `.=method: arg` (no space before `:`), and
- the **fake-infix adverb form** `.=method :key<val>` (space before `:`).

It always stripped the leading colon and parsed the colonpairs as a function call, producing a bogus `__mutsu_subscript_adverb_error` at runtime that aborted the whole file.

The fix mirrors the working statement-level handler: save `r_before_ws`, then split into a colon-arg branch (no space) and a fake-infix branch (space before colon, looped `colonpair_expr`).

Also fixes `Pair.new(:key(1), :value(2))` / `Pair.new(key => 1, value => 2)` forcing the key to `Str`: it now preserves the key type via `ValuePair` for non-string keys (mirroring `=>` and positional `Pair.new`), so an `Int` key renders as `1 => 2` rather than `:1(2)`.

## Impact

Unblocks the last two subtests of `roast/S02-types/pair.t` (181, 182). Previously test 181's parenthesized `.= new` construct threw mid-file, so the file ran only 180 of 182 planned tests; now all 182 run (179 pass; the remaining 3 — 128/139/171 — need `=>` container-capture semantics, tracked separately).

## Tests

- New `t/dot-assign-adverb-args.t` (6 cases: statement-level, parenthesized, `()`-value, single adverb, colon-arg still works, as routine argument).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)