### PR TITLE
refactor(instance): drop id->cell registry; mutate receiver Arc cell in place (Phase 3)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -444,9 +444,19 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
                 **captured env コピー経由**で cell 非経由（撤去すると最初の要素変異が落ちる）。これは pre-existing な hash-element-via-closure の
                 cell 非対応（main でも `%!cache{k}=v` の closure 経由で最初の write が `(Any)` になる既知バグ）に依存しており、cell 化は別件。
                 fast-path scalar attr は locals 直挿入（env 非経由）のため対象外。
-        - [ ] **registry 撤去（別 slice・後回し）**: `instance_cells` + `make_instance_detached`/`update_instance_cell` 撤去
-              （callers が `self` の Arc を直接 in-place 変異する形へ。~50 の make_instance_with_id rebuild を全変換する all-or-nothing 大改修）+
-              CAS の cell-CAS 化。
+        - [x] **registry 撤去（done, branch `phase3-drop-instance-cell-registry`）**: `instance_cells`（`id -> Weak<cell>` グローバル
+              Mutex registry）+ `register_instance_cell`/`lookup_instance_cell`/`update_instance_cell`/`overwrite_instance_bindings_by_identity`
+              を**全廃**。~98 の writeback/rebuild サイト（`overwrite_*` 47 + rebuild `make_instance_with_id` 51）を、receiver の
+              `Arc<InstanceAttrs>` cell を直接 in-place 変異する 3 つの新ヘルパへ全変換:
+              `InstanceAttrs::commit_attrs(map)`（live cell へ in-place 書き、deadlock-safe な `write_cell_respecting_reads` 経由）/
+              `Value::instance_sharing_cell(attrs, class, id)`（Arc を共有して rebuild、class 変更時のみ cell 共有の新 InstanceAttrs）/
+              `Value::write_back_sharing(attrs, class, map, id)`（commit + share の複合）。**`make_instance_with_id` から id→cell reuse 分岐を削除**
+              （以後 fresh cell 専用＝genuinely-new / sentinel id 用のみ）。snapshot+id しか持たなかった `proxy_store`・buf write・MRO multi
+              invocant 等は receiver の Arc を呼び出しチェーンへ通して解決。`make_instance_detached` は registry 撤去後 `make_instance_with_id`
+              と等価になったが CAS の atomic-sync 意図マーカとして名前のみ残置（→ `make_instance_with_id` 委譲）。`_class_name` vestigial param 撤去。
+              副次効果: グローバル Mutex registry の Weak エントリ蓄積（メモリリーク）解消、id-0 sentinel Supply の cell 誤共有 latent バグ解消。
+              検証: cargo test 461、clippy 緑、whitelisted S12/S14/S17/S32-temporal/buf 40 ファイル + cross-frame/closure/temp-let/proxy/buf/iterator/grammar 全緑。
+        - [ ] **残（別 slice）**: CAS の cell-CAS 化（`make_instance_detached` + shared_vars 側道撤去、cell を atomic primitive に）。
   - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -2094,18 +2094,28 @@ impl Interpreter {
     }
 
     /// Restore one `let`/`temp` save. For an instance, write the saved
-    /// attributes back into the *live* shared cell (via cell reuse) so every
-    /// alias sees the restoration and object identity (id + cell) is preserved,
-    /// rather than rebinding the name to a detached copy.
+    /// attributes back into the *live* shared cell of the variable's current
+    /// binding so every alias sees the restoration and object identity (id +
+    /// cell) is preserved, rather than rebinding the name to a detached copy.
     fn restore_let_value(&mut self, name: String, restored: Value) {
         if let Value::Instance {
-            class_name,
-            id,
-            attributes,
+            attributes: saved_attrs,
+            ..
         } = &restored
         {
-            let inst = Value::make_instance_with_id(*class_name, attributes.to_map(), *id);
-            self.env.insert(name, inst);
+            // The current binding for `name` holds the live instance (the same
+            // shared cell that was mutated during the dynamic scope). Write the
+            // saved snapshot straight back into that cell; the env binding already
+            // aliases it, so no re-insert is needed.
+            if let Some(Value::Instance {
+                attributes: live_attrs,
+                ..
+            }) = self.env.get(&name)
+            {
+                live_attrs.commit_attrs(saved_attrs.to_map());
+                return;
+            }
+            self.env.insert(name, restored);
         } else {
             self.env.insert(name, restored);
         }

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -180,14 +180,10 @@ impl Interpreter {
                         call_args,
                         Some(invocant.clone()),
                     )?;
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        *target_id,
-                        updated.clone(),
-                    );
                     (
                         result,
-                        Some(Value::make_instance_with_id(
+                        Some(Value::write_back_sharing(
+                            attributes,
                             *class_name,
                             updated,
                             *target_id,

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -620,9 +620,9 @@ impl Interpreter {
         }
 
         let Value::Instance {
-            class_name,
             attributes,
             id: target_id,
+            ..
         } = &target
         else {
             // Fallback: just call the method on the accessor result
@@ -653,14 +653,10 @@ impl Interpreter {
         let new_value = self.env.get(&temp_var).cloned().unwrap_or(result.clone());
         self.env.remove(&temp_var);
 
-        // Update the instance attribute
+        // Update the instance attribute in the live shared cell
         let mut updated = attributes.to_map();
         updated.insert(attr_key, new_value.clone());
-        let cn = *class_name;
-        let tid = *target_id;
-
-        // Propagate to all env bindings referencing this instance
-        self.overwrite_instance_bindings_by_identity(&cn.resolve(), tid, updated);
+        attributes.commit_attrs(updated);
 
         // Also propagate the array/hash change to all instances sharing
         // the same Arc (handles clone semantics).

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1460,12 +1460,12 @@ impl Interpreter {
                 (
                     Value::Instance {
                         class_name,
+                        attributes: base_attrs,
                         id: base_id,
-                        ..
                     },
                     Value::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    Value::make_instance_with_id(*class_name, attributes.clone(), *base_id)
+                    Value::write_back_sharing(base_attrs, *class_name, attributes.clone(), *base_id)
                 }
                 _ => v,
             };

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2929,10 +2929,9 @@ impl Interpreter {
                 id,
             }) = self.env.get(key).cloned()
             {
-                let mut new_attrs: HashMap<String, Value> =
-                    (crate::value::InstanceAttrs::clone(&attributes)).to_map();
+                let mut new_attrs = attributes.to_map();
                 new_attrs.insert("version".to_string(), new_version.clone());
-                let new_val = Value::make_instance_with_id(class_name, new_attrs, id);
+                let new_val = Value::write_back_sharing(&attributes, class_name, new_attrs, id);
                 self.env.insert(key.to_string(), new_val);
             }
         }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -710,7 +710,7 @@ impl Interpreter {
                             v,
                             Some(*class_name),
                             Some(*id),
-                            Some(attributes.as_ref().clone()),
+                            Some(attributes.clone()),
                         )
                     } else {
                         (false, None, Vec::new(), None, None, None)
@@ -749,19 +749,16 @@ impl Interpreter {
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
-                    let updated_attrs = attrs_opt.unwrap();
-                    updated_attrs.insert(
+                    let updated_cell = attrs_opt.unwrap();
+                    let mut updated_map = updated_cell.to_map();
+                    updated_map.insert(
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
                     );
-                    self.overwrite_instance_bindings_by_identity(
-                        &cn,
-                        id,
-                        (updated_attrs.clone()).to_map(),
-                    );
-                    return Ok(Value::make_instance_with_id(
+                    return Ok(Value::write_back_sharing(
+                        &updated_cell,
                         class_sym,
-                        (updated_attrs).to_map(),
+                        updated_map,
                         id,
                     ));
                 }
@@ -810,7 +807,7 @@ impl Interpreter {
                             v,
                             Some(*class_name),
                             Some(*id),
-                            Some(attributes.as_ref().clone()),
+                            Some(attributes.clone()),
                         )
                     } else {
                         (false, None, Vec::new(), None, None, None)
@@ -849,19 +846,16 @@ impl Interpreter {
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
-                    let updated_attrs = attrs_opt.unwrap();
-                    updated_attrs.insert(
+                    let updated_cell = attrs_opt.unwrap();
+                    let mut updated_map = updated_cell.to_map();
+                    updated_map.insert(
                         "bytes".to_string(),
                         Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
                     );
-                    self.overwrite_instance_bindings_by_identity(
-                        &cn,
-                        id,
-                        (updated_attrs.clone()).to_map(),
-                    );
-                    return Ok(Value::make_instance_with_id(
+                    return Ok(Value::write_back_sharing(
+                        &updated_cell,
                         class_sym,
-                        (updated_attrs).to_map(),
+                        updated_map,
                         id,
                     ));
                 }

--- a/src/runtime/methods_collection_ops/collation_temporal.rs
+++ b/src/runtime/methods_collection_ops/collation_temporal.rs
@@ -55,7 +55,7 @@ impl Interpreter {
                     }
                 }
 
-                let result = Value::make_instance_with_id(*class_name, new_attrs, *id);
+                let result = Value::write_back_sharing(attributes, *class_name, new_attrs, *id);
                 // Also update the target in-place (Collation.set mutates and returns self)
                 Ok(result)
             }

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -625,7 +625,7 @@ impl Interpreter {
         {
             let mut attrs = attributes.to_map();
             attrs.insert("formatter".to_string(), formatter_value.clone());
-            let dt_with_formatter = Value::make_instance_with_id(class_name, attrs, id);
+            let dt_with_formatter = Value::write_back_sharing(attributes, class_name, attrs, id);
             let saved_env = self.env().clone();
             let saved_readonly = self.save_readonly_vars();
             let rendered =
@@ -641,11 +641,12 @@ impl Interpreter {
                 id,
             } = dt_with_formatter
             {
-                let updated = (*attributes).clone();
+                let mut updated = attributes.to_map();
                 updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
-                return Some(Ok(Value::make_instance_with_id(
+                return Some(Ok(Value::write_back_sharing(
+                    &attributes,
                     class_name,
-                    (updated).to_map(),
+                    updated,
                     id,
                 )));
             }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -277,9 +277,9 @@ impl Interpreter {
                     ..
                 } = &result
                 {
-                    let attrs = attributes.as_ref().clone();
+                    let mut attrs = attributes.to_map();
                     attrs.insert("actions".to_string(), actions.clone());
-                    Value::make_instance_with_id(*class_name, (attrs).to_map(), *id)
+                    Value::write_back_sharing(attributes, *class_name, attrs, *id)
                 } else {
                     result
                 }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -89,11 +89,7 @@ impl Interpreter {
                         args,
                         Some(target.clone()),
                     )?;
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        *target_id,
-                        updated,
-                    );
+                    attributes.commit_attrs(updated);
                     return Ok(result);
                 }
                 // Private method not found — fall back to private attribute access.
@@ -135,18 +131,13 @@ impl Interpreter {
                         _ => Self::value_to_list(value),
                     }
                 };
-                let mut update_items = |new_items: Vec<Value>| {
+                let update_items = |new_items: Vec<Value>| {
                     let mut updated_attrs = attributes.to_map();
                     updated_attrs.insert(
                         "__mutsu_iterationbuffer_items".to_string(),
                         Value::real_array(new_items),
                     );
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        *target_id,
-                        updated_attrs.clone(),
-                    );
-                    Value::make_instance_with_id(*class_name, updated_attrs, *target_id)
+                    Value::write_back_sharing(attributes, *class_name, updated_attrs, *target_id)
                 };
                 match method {
                     "elems" if args.is_empty() => return Ok(Value::Int(items.len() as i64)),
@@ -316,18 +307,13 @@ impl Interpreter {
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
                         if let Value::Instance {
-                            class_name: obj_class,
                             attributes: obj_attrs,
-                            id: obj_id,
+                            ..
                         } = &args[0]
                         {
-                            let updated = (**obj_attrs).clone();
+                            let mut updated = obj_attrs.to_map();
                             updated.insert(attr_name, new_val);
-                            self.overwrite_instance_bindings_by_identity(
-                                &obj_class.resolve(),
-                                *obj_id,
-                                (updated).to_map(),
-                            );
+                            obj_attrs.commit_attrs(updated);
                         }
                         return Ok(Value::Nil);
                     }
@@ -652,11 +638,7 @@ impl Interpreter {
                         method,
                         args,
                     )?;
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        *target_id,
-                        updated,
-                    );
+                    attributes.commit_attrs(updated);
                     return Ok(result);
                 }
                 if matches!(
@@ -840,11 +822,7 @@ impl Interpreter {
                     args,
                     Some(target.clone()),
                 )?;
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    *target_id,
-                    updated.clone(),
-                );
+                attributes.commit_attrs(updated.clone());
                 // Auto-FETCH if the method returned a Proxy
                 if !self.in_lvalue_assignment
                     && let Value::Proxy { ref fetcher, .. } = result

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -109,13 +109,11 @@ impl Interpreter {
                 // attributes like `@.order`) so that `$.attr` accessors inside
                 // the role method see and can mutate the class's state, then
                 // overlay the role's own `__mutsu_attr__` attributes.
-                let (inner_class, inner_id, mut method_attrs) = match inner.as_ref() {
-                    Value::Instance {
-                        class_name,
-                        attributes,
-                        id,
-                    } => (Some(class_name.resolve()), Some(*id), attributes.to_map()),
-                    _ => (None, None, HashMap::new()),
+                let (inner_cell, mut method_attrs) = match inner.as_ref() {
+                    Value::Instance { attributes, .. } => {
+                        (Some(attributes.clone()), attributes.to_map())
+                    }
+                    _ => (None, HashMap::new()),
                 };
                 for (key, value) in mixins.iter() {
                     if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
@@ -146,8 +144,8 @@ impl Interpreter {
                 // `push @.order, ...`) are visible after the call returns. This
                 // updates every binding in scope that holds the same instance
                 // (including the one wrapped inside this Mixin).
-                if let (Some(class_name), Some(id)) = (inner_class, inner_id) {
-                    self.overwrite_instance_bindings_by_identity(&class_name, id, updated);
+                if let Some(cell) = &inner_cell {
+                    cell.commit_attrs(updated);
                 }
                 return Some(Ok(result));
             }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1,8 +1,10 @@
 use super::methods_signature::make_x_immutable_error;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::InstanceAttrs;
 use num_bigint::BigInt;
 use num_traits::Signed;
+use std::sync::Arc;
 
 fn value_to_bigint(value: &Value) -> BigInt {
     match value {
@@ -297,31 +299,23 @@ impl Interpreter {
         needle: &std::sync::Arc<Vec<Value>>,
         replacement: &Value,
     ) {
-        let mut updates: Vec<(Symbol, Symbol, u64, String)> = Vec::new();
+        let mut updates: Vec<(Symbol, String)> = Vec::new();
         for (var_name, value) in self.env.iter() {
-            if let Value::Instance {
-                class_name,
-                attributes,
-                id,
-            } = value
-            {
+            if let Value::Instance { attributes, .. } = value {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Array(arc, ..) = attr_val
                         && std::sync::Arc::ptr_eq(arc, needle)
                     {
-                        updates.push((*var_name, *class_name, *id, attr_key.clone()));
+                        updates.push((*var_name, attr_key.clone()));
                     }
                 }
             }
         }
-        for (var_name, class_name, id, attr_key) in updates {
+        for (var_name, attr_key) in updates {
             if let Some(Value::Instance { attributes, .. }) = self.env.get_sym(var_name) {
-                let mut updated = attributes.to_map();
-                updated.insert(attr_key, replacement.clone());
-                self.env.insert_sym(
-                    var_name,
-                    Value::make_instance_with_id(class_name, updated, id),
-                );
+                // The env binding shares this instance's live cell, so the in-place
+                // insert is visible without rebuilding/re-inserting the value.
+                attributes.insert(attr_key, replacement.clone());
             }
         }
     }
@@ -332,31 +326,22 @@ impl Interpreter {
         needle: &std::sync::Arc<std::collections::HashMap<String, Value>>,
         replacement: &Value,
     ) {
-        let mut updates: Vec<(Symbol, Symbol, u64, String)> = Vec::new();
+        let mut updates: Vec<(Symbol, String)> = Vec::new();
         for (var_name, value) in self.env.iter() {
-            if let Value::Instance {
-                class_name,
-                attributes,
-                id,
-            } = value
-            {
+            if let Value::Instance { attributes, .. } = value {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Hash(arc) = attr_val
                         && std::sync::Arc::ptr_eq(arc, needle)
                     {
-                        updates.push((*var_name, *class_name, *id, attr_key.clone()));
+                        updates.push((*var_name, attr_key.clone()));
                     }
                 }
             }
         }
-        for (var_name, class_name, id, attr_key) in updates {
+        for (var_name, attr_key) in updates {
             if let Some(Value::Instance { attributes, .. }) = self.env.get_sym(var_name) {
-                let mut updated = attributes.to_map();
-                updated.insert(attr_key, replacement.clone());
-                self.env.insert_sym(
-                    var_name,
-                    Value::make_instance_with_id(class_name, updated, id),
-                );
+                // Shared live cell — in-place insert is visible to the env binding.
+                attributes.insert(attr_key, replacement.clone());
             }
         }
     }
@@ -455,28 +440,6 @@ impl Interpreter {
                 }
             }
         }
-    }
-
-    pub(crate) fn overwrite_instance_bindings_by_identity(
-        &mut self,
-        _class_name: &str,
-        id: u64,
-        updated: std::collections::HashMap<String, Value>,
-    ) {
-        // Phase 3, Stage 2c: write the new attributes straight into the live
-        // shared cell. Because every alias of this instance — in this frame, any
-        // caller frame, a `ContainerRef`-boxed capture, a role `Mixin`, or a
-        // nested attribute of another instance — shares that cell (the
-        // `Arc<InstanceAttrs>` is cloned by reference, never deep-copied except
-        // for an explicit `.clone`), this single write makes the mutation visible
-        // everywhere. The former by-identity scan over `self.env`/`self.locals`
-        // that rebuilt each holder via `make_instance_with_id` is now redundant —
-        // those rebuilds reused the very same cell — and has been removed.
-        //
-        // `_class_name` is vestigial (the cell is keyed by `id` alone); it is kept
-        // on the signature to avoid churning ~40 call sites in this slice and will
-        // be dropped when this choke point is retired in a later Stage 2c slice.
-        crate::value::update_instance_cell(id, &updated);
     }
 
     /// Call a Proxy callback (FETCH or STORE) in the context of an instance's attributes.
@@ -590,13 +553,17 @@ impl Interpreter {
     }
 
     /// Call Proxy STORE with a new value, propagating attribute updates to the instance.
+    ///
+    /// `attributes` is the (post-method-run) snapshot fed to the STORE callback;
+    /// `attrs_cell` is the receiver instance's live shared cell that the updated
+    /// attributes are written back into in place (Phase 3 registry-removal).
     pub(crate) fn proxy_store(
         &mut self,
         storer: &Value,
         target_var: Option<&str>,
-        class_name: &str,
+        class_name: Symbol,
         attributes: &HashMap<String, Value>,
-        target_id: u64,
+        attrs_cell: &Arc<InstanceAttrs>,
         new_value: Value,
     ) -> Result<Value, RuntimeError> {
         let proxy_val = Value::Proxy {
@@ -607,12 +574,12 @@ impl Interpreter {
         };
         let (_result, updated) =
             self.call_proxy_callback(storer, vec![proxy_val, new_value.clone()], attributes)?;
-        // Propagate attribute changes back to the instance
+        // Propagate attribute changes back to the instance's live cell.
         if let Some(var_name) = target_var {
-            self.overwrite_instance_bindings_by_identity(class_name, target_id, updated.clone());
+            attrs_cell.commit_attrs(updated);
             self.env.insert(
                 var_name.to_string(),
-                Value::make_instance_with_id(Symbol::intern(class_name), updated, target_id),
+                Value::instance_sharing_cell(attrs_cell, class_name, attrs_cell.instance_id()),
             );
         }
         // Assignment returns the assigned value, not the STORE callback's return value
@@ -861,15 +828,11 @@ impl Interpreter {
             let mut new_attrs = attributes.to_map();
             new_attrs.insert("chomp".to_string(), Value::Bool(new_chomp));
             let tid = *inst_id;
-            self.overwrite_instance_bindings_by_identity(
-                &class_name.resolve(),
-                tid,
-                new_attrs.clone(),
-            );
+            attributes.commit_attrs(new_attrs);
             if let Some(var_name) = target_var {
                 self.env.insert(
                     var_name.to_string(),
-                    Value::make_instance_with_id(*class_name, new_attrs, tid),
+                    Value::instance_sharing_cell(attributes, *class_name, tid),
                 );
             }
             return Ok(value);
@@ -1101,18 +1064,12 @@ impl Interpreter {
             let mut updated = attributes.to_map();
             updated.insert(attr_name, value.clone());
             let cn = *class_name;
+            attributes.commit_attrs(updated);
             if let Some(var_name) = target_var {
-                self.overwrite_instance_bindings_by_identity(
-                    &cn.resolve(),
-                    target_id,
-                    updated.clone(),
-                );
                 self.env.insert(
                     var_name.to_string(),
-                    Value::make_instance_with_id(cn, updated, target_id),
+                    Value::instance_sharing_cell(attributes, cn, target_id),
                 );
-            } else {
-                self.overwrite_instance_bindings_by_identity(&cn.resolve(), target_id, updated);
             }
             return Ok(value);
         }
@@ -1165,14 +1122,9 @@ impl Interpreter {
                         assigned_value.clone(),
                     );
                     if let Some(var_name) = target_var {
-                        self.overwrite_instance_bindings_by_identity(
-                            &cn.resolve(),
-                            target_id,
-                            updated.clone(),
-                        );
                         self.env.insert(
                             var_name.to_string(),
-                            Value::make_instance_with_id(cn, updated, target_id),
+                            Value::write_back_sharing(attributes, cn, updated, target_id),
                         );
                     }
                     return Ok(assigned_value);
@@ -1223,14 +1175,9 @@ impl Interpreter {
                         assigned_value.clone(),
                     );
                     if let Some(var_name) = target_var {
-                        self.overwrite_instance_bindings_by_identity(
-                            &cn.resolve(),
-                            target_id,
-                            updated.clone(),
-                        );
                         self.env.insert(
                             var_name.to_string(),
-                            Value::make_instance_with_id(cn, updated, target_id),
+                            Value::write_back_sharing(attributes, cn, updated, target_id),
                         );
                     }
                     return Ok(assigned_value);
@@ -1428,11 +1375,9 @@ impl Interpreter {
                 } else {
                     method.to_string()
                 };
-                let updated = (*attributes).clone();
-                let mut assigned_value = Self::normalize_rw_accessor_assignment(
-                    updated.as_map().get(&attr_key).cloned(),
-                    value,
-                );
+                let mut updated = attributes.to_map();
+                let mut assigned_value =
+                    Self::normalize_rw_accessor_assignment(updated.get(&attr_key).cloned(), value);
                 // When Nil is assigned to an attribute with `is default(...)`,
                 // restore the default value instead of setting Nil.
                 if matches!(assigned_value, Value::Nil)
@@ -1449,20 +1394,15 @@ impl Interpreter {
                     assigned_value = Value::Package(crate::symbol::Symbol::intern(&tc));
                 }
                 updated.insert(attr_key.clone(), assigned_value.clone());
-                // Always propagate the change to all env bindings referencing
-                // this instance (by identity). This handles chained accessor
-                // assignment like `$outer.inner.arr = ...` where target_var
-                // may be None but the instance is reachable through other
-                // env bindings.
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    (updated.clone()).to_map(),
-                );
+                // Always propagate the change into this instance's live shared
+                // cell. This handles chained accessor assignment like
+                // `$outer.inner.arr = ...` where target_var may be None but the
+                // instance is reachable through other aliases.
+                attributes.commit_attrs(updated);
                 if let Some(var_name) = target_var {
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                        Value::instance_sharing_cell(&attributes, class_name, target_id),
                     );
                     // Also update attribute env variables so compiled method
                     // writeback picks up the change (e.g. $.cnt += 4 inside a method)
@@ -1479,20 +1419,16 @@ impl Interpreter {
                 all_args.push(value.clone());
                 match self.call_native_instance_method_mut(
                     &class_name.resolve(),
-                    ((*attributes).clone()).to_map(),
+                    attributes.to_map(),
                     method,
                     all_args,
                 ) {
                     Ok((result, updated_attrs)) => {
-                        self.overwrite_instance_bindings_by_identity(
-                            &class_name.resolve(),
-                            target_id,
-                            updated_attrs.clone(),
-                        );
+                        attributes.commit_attrs(updated_attrs);
                         if let Some(var_name) = target_var {
                             self.env.insert(
                                 var_name.to_string(),
-                                Value::make_instance_with_id(class_name, updated_attrs, target_id),
+                                Value::instance_sharing_cell(&attributes, class_name, target_id),
                             );
                         }
                         return Ok(result);
@@ -1537,17 +1473,12 @@ impl Interpreter {
                 )?;
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
-                let updated = (*attributes).clone();
+                let mut updated = attributes.to_map();
                 updated.insert(attr_key.to_string(), updated_delegate);
                 if let Some(var_name) = target_var {
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        target_id,
-                        (updated.clone()).to_map(),
-                    );
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                        Value::write_back_sharing(&attributes, class_name, updated, target_id),
                     );
                 }
                 return Ok(result);
@@ -1560,7 +1491,7 @@ impl Interpreter {
             )));
         }
         if let Some(attr_name) = Self::rw_method_attribute_target(&method_def.body) {
-            let updated = (*attributes).clone();
+            let mut updated = attributes.to_map();
             let current = if method_args.is_empty() {
                 self.call_method_with_values(
                     Value::Instance {
@@ -1589,14 +1520,9 @@ impl Interpreter {
             }
             updated.insert(attr_name, assigned_value.clone());
             if let Some(var_name) = target_var {
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    (updated.clone()).to_map(),
-                );
                 self.env.insert(
                     var_name.to_string(),
-                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                    Value::write_back_sharing(&attributes, class_name, updated, target_id),
                 );
             }
             return Ok(assigned_value);
@@ -1629,18 +1555,13 @@ impl Interpreter {
                 // Read back the potentially-updated delegate
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
-                // Write the updated delegate back into the frontend's attributes
-                let updated = (*attributes).clone();
+                // Write the updated delegate back into the frontend's live cell.
+                let mut updated = attributes.to_map();
                 updated.insert(attr_key.to_string(), updated_delegate);
                 if let Some(var_name) = target_var {
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        target_id,
-                        (updated.clone()).to_map(),
-                    );
                     self.env.insert(
                         var_name.to_string(),
-                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                        Value::write_back_sharing(&attributes, class_name, updated, target_id),
                     );
                 }
                 return Ok(result);
@@ -1652,10 +1573,9 @@ impl Interpreter {
         // results, allowing the raw Proxy to flow back for STORE dispatch.
         let was_lvalue = self.in_lvalue_assignment;
         self.in_lvalue_assignment = true;
-        let attrs_map = (*attributes).clone();
         let method_result = self.run_instance_method(
             &class_name.resolve(),
-            (attrs_map).to_map(),
+            attributes.to_map(),
             method,
             method_args,
             None,
@@ -1666,9 +1586,9 @@ impl Interpreter {
             return self.proxy_store(
                 storer,
                 target_var,
-                &class_name.resolve(),
+                class_name,
                 &updated_attrs,
-                target_id,
+                &attributes,
                 value,
             );
         }
@@ -1902,7 +1822,7 @@ impl Interpreter {
                     ));
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
-                let updated_attrs = attributes.as_ref().clone();
+                let mut updated_attrs = attributes.to_map();
                 updated_attrs.insert(
                     "bytes".to_string(),
                     Value::array(
@@ -1912,14 +1832,10 @@ impl Interpreter {
                             .collect::<Vec<_>>(),
                     ),
                 );
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    *id,
-                    (updated_attrs.clone()).to_map(),
-                );
-                return Ok(Value::make_instance_with_id(
+                return Ok(Value::write_back_sharing(
+                    attributes,
                     *class_name,
-                    (updated_attrs).to_map(),
+                    updated_attrs,
                     *id,
                 ));
             }
@@ -1977,17 +1893,12 @@ impl Interpreter {
             crate::builtins::buf_write_num::apply_write_num(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
-            let updated_attrs = attributes.as_ref().clone();
+            let mut updated_attrs = attributes.to_map();
             updated_attrs.insert(
                 "bytes".to_string(),
                 Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
             );
-            self.overwrite_instance_bindings_by_identity(
-                &class_name.resolve(),
-                *id,
-                (updated_attrs.clone()).to_map(),
-            );
-            let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
+            let updated = Value::write_back_sharing(attributes, *class_name, updated_attrs, *id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
         }
@@ -2079,17 +1990,12 @@ impl Interpreter {
             crate::builtins::buf_write_int::apply_write_int(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
-            let updated_attrs = attributes.as_ref().clone();
+            let mut updated_attrs = attributes.to_map();
             updated_attrs.insert(
                 "bytes".to_string(),
                 Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
             );
-            self.overwrite_instance_bindings_by_identity(
-                &class_name.resolve(),
-                *id,
-                (updated_attrs.clone()).to_map(),
-            );
-            let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
+            let updated = Value::write_back_sharing(attributes, *class_name, updated_attrs, *id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
         }
@@ -3050,9 +2956,8 @@ impl Interpreter {
                 }
                 let from = from as usize;
                 let bits = bits as usize;
-                let updated = (*attributes).clone();
-                let mut bytes = if let Some(Value::Array(items, ..)) = updated.as_map().get("bytes")
-                {
+                let mut updated = attributes.to_map();
+                let mut bytes = if let Some(Value::Array(items, ..)) = updated.get("bytes") {
                     items
                         .iter()
                         .map(|v| match v {
@@ -3076,46 +2981,34 @@ impl Interpreter {
                     "bytes".to_string(),
                     Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
                 );
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    (updated.clone()).to_map(),
-                );
                 let updated_instance =
-                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id);
+                    Value::write_back_sharing(&attributes, class_name, updated, target_id);
                 self.env
                     .insert(target_var.to_string(), updated_instance.clone());
                 return Ok(updated_instance);
             }
 
             if class_name == "Iterator" {
-                let updated = (*attributes).clone();
-                // Bind the source out in its own statement so the `as_map()` read
-                // guard is released before the body mutates `updated` in place
-                // (`updated.insert` below) — an `if let … = updated.as_map()…`
-                // would hold the guard for the whole body and self-deadlock.
-                let squish_source = updated.as_map().get("squish_source").cloned();
+                // A detached working copy of the attribute map; written back into
+                // the instance's live shared cell at the end.
+                let mut updated = attributes.to_map();
+                let squish_source = updated.get("squish_source").cloned();
                 if let Some(Value::Array(source, ..)) = squish_source {
-                    let mut scan_index = match updated.as_map().get("squish_scan_index") {
+                    let mut scan_index = match updated.get("squish_scan_index") {
                         Some(Value::Int(i)) if *i >= 0 => *i as usize,
                         _ => 0,
                     };
                     let mut prev_key = updated
-                        .as_map()
                         .get("squish_prev_key")
                         .cloned()
                         .unwrap_or(Value::Nil);
-                    let mut initialized = matches!(
-                        updated.as_map().get("squish_initialized"),
-                        Some(Value::Bool(true))
-                    );
+                    let mut initialized =
+                        matches!(updated.get("squish_initialized"), Some(Value::Bool(true)));
                     let as_func = updated
-                        .as_map()
                         .get("squish_as")
                         .cloned()
                         .filter(|v| !matches!(v, Value::Nil));
                     let with_func = updated
-                        .as_map()
                         .get("squish_with")
                         .cloned()
                         .filter(|v| !matches!(v, Value::Nil));
@@ -3164,10 +3057,10 @@ impl Interpreter {
 
                     let ret = match method {
                         "count-only" => self
-                            .iterator_count_only_from_attrs(&updated.as_map())?
+                            .iterator_count_only_from_attrs(&updated)?
                             .unwrap_or_else(|| Value::Int(0)),
                         "bool-only" => self
-                            .iterator_bool_only_from_attrs(&updated.as_map())?
+                            .iterator_bool_only_from_attrs(&updated)?
                             .unwrap_or(Value::Bool(false)),
                         "pull-one" => pull_one_squish(self)?,
                         "push-all" | "push-until-lazy" => {
@@ -3225,11 +3118,7 @@ impl Interpreter {
                                         "squish_initialized".to_string(),
                                         Value::Bool(initialized),
                                     );
-                                    self.overwrite_instance_bindings_by_identity(
-                                        &class_name.resolve(),
-                                        target_id,
-                                        (updated.clone()).to_map(),
-                                    );
+                                    attributes.commit_attrs(updated.clone());
                                     return Ok(Value::str_from("IterationEnd"));
                                 }
                             }
@@ -3305,23 +3194,18 @@ impl Interpreter {
                     );
                     updated.insert("squish_prev_key".to_string(), prev_key);
                     updated.insert("squish_initialized".to_string(), Value::Bool(initialized));
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        target_id,
-                        (updated.clone()).to_map(),
-                    );
                     let updated_instance =
-                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id);
+                        Value::write_back_sharing(&attributes, class_name, updated, target_id);
                     self.env
                         .insert(target_var.to_string(), updated_instance.clone());
                     return Ok(ret);
                 }
 
-                let items = match updated.as_map().get("items") {
+                let items = match updated.get("items") {
                     Some(Value::Array(values, ..)) => values.to_vec(),
                     _ => Vec::new(),
                 };
-                let mut index = match updated.as_map().get("index") {
+                let mut index = match updated.get("index") {
                     Some(Value::Int(i)) if *i >= 0 => *i as usize,
                     _ => 0,
                 };
@@ -3329,7 +3213,7 @@ impl Interpreter {
                 // A known logical count (set for `LHS xx N` lazy repeats) overrides
                 // the materialized prefix length, so `.count-only` / `.bool-only`
                 // on a stored iterator report the true (possibly infinite) count.
-                let known_count = updated.as_map().get("known_count").cloned();
+                let known_count = updated.get("known_count").cloned();
 
                 let mut append_to_first_array_arg = |vals: &[Value]| {
                     if vals.is_empty() {
@@ -3450,14 +3334,9 @@ impl Interpreter {
                 };
 
                 updated.insert("index".to_string(), Value::Int(index as i64));
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    (updated.clone()).to_map(),
-                );
                 self.env.insert(
                     target_var.to_string(),
-                    Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                    Value::write_back_sharing(&attributes, class_name, updated, target_id),
                 );
                 return Ok(ret);
             }
@@ -3478,11 +3357,8 @@ impl Interpreter {
                     .trim_start_matches('!');
                 let delegate = if is_method_based {
                     let source_method = attr_var_name.trim_start_matches('&').to_string();
-                    let invocant_val = Value::make_instance_with_id(
-                        class_name,
-                        ((*attributes).clone()).to_map(),
-                        target_id,
-                    );
+                    let invocant_val =
+                        Value::instance_sharing_cell(&attributes, class_name, target_id);
                     self.call_method_with_values(invocant_val, &source_method, Vec::new())?
                 } else {
                     attributes
@@ -3512,17 +3388,12 @@ impl Interpreter {
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::Nil);
                 self.env.remove(&temp_var);
                 if !is_method_based {
-                    // Write the updated delegate back into the frontend's attributes
-                    let updated = (*attributes).clone();
+                    // Write the updated delegate back into the frontend's live cell.
+                    let mut updated = attributes.to_map();
                     updated.insert(attr_key.to_string(), updated_delegate);
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        target_id,
-                        (updated.clone()).to_map(),
-                    );
                     self.env.insert(
                         target_var.to_string(),
-                        Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                        Value::write_back_sharing(&attributes, class_name, updated, target_id),
                     );
                 }
                 // Restore skip_pseudo for the outer caller.
@@ -3547,17 +3418,12 @@ impl Interpreter {
                         .resolve_method(&class_name.resolve(), method, &[])
                         .is_some_and(|m| m.is_rw);
                     if !has_rw_method {
-                        let updated = (*attributes).clone();
+                        let mut updated = attributes.to_map();
                         let assigned = args[0].clone();
                         updated.insert(method.to_string(), assigned.clone());
-                        self.overwrite_instance_bindings_by_identity(
-                            &class_name.resolve(),
-                            target_id,
-                            (updated.clone()).to_map(),
-                        );
                         self.env.insert(
                             target_var.to_string(),
-                            Value::make_instance_with_id(class_name, (updated).to_map(), target_id),
+                            Value::write_back_sharing(&attributes, class_name, updated, target_id),
                         );
                         return Ok(assigned);
                     }
@@ -3598,19 +3464,14 @@ impl Interpreter {
                 // Try mutable dispatch first; if no mutable handler, fall back to immutable
                 match self.call_native_instance_method_mut(
                     &class_name.resolve(),
-                    ((*attributes).clone()).to_map(),
+                    attributes.to_map(),
                     method,
                     args.clone(),
                 ) {
                     Ok((result, updated)) => {
-                        self.overwrite_instance_bindings_by_identity(
-                            &class_name.resolve(),
-                            target_id,
-                            updated.clone(),
-                        );
                         self.env.insert(
                             target_var.to_string(),
-                            Value::make_instance_with_id(class_name, updated, target_id),
+                            Value::write_back_sharing(&attributes, class_name, updated, target_id),
                         );
                         return Ok(result);
                     }
@@ -3643,20 +3504,16 @@ impl Interpreter {
             {
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
-                    ((*attributes).clone()).to_map(),
+                    attributes.to_map(),
                     method,
                     args,
                     Some(target.clone()),
                 )?;
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    target_id,
-                    updated.clone(),
-                );
                 let updated_clone = updated.clone();
+                attributes.commit_attrs(updated);
                 self.env.insert(
                     target_var.to_string(),
-                    Value::make_instance_with_id(class_name, updated, target_id),
+                    Value::instance_sharing_cell(&attributes, class_name, target_id),
                 );
                 // Auto-FETCH if the method returned a Proxy
                 if !self.in_lvalue_assignment
@@ -3911,7 +3768,7 @@ impl Interpreter {
         target: Value,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
-        let (class_name_sym, mut bytes, orig_id) = if let Value::Instance {
+        let (class_name_sym, mut bytes, orig_id, attrs_cell) = if let Value::Instance {
             class_name,
             attributes,
             id,
@@ -3931,7 +3788,7 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-            (*class_name, items, *id)
+            (*class_name, items, *id, attributes.clone())
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -3942,7 +3799,7 @@ impl Interpreter {
         bytes.resize(new_size, Value::Int(0));
         let mut attrs = HashMap::new();
         attrs.insert("bytes".to_string(), Value::array(bytes));
-        let updated = Value::make_instance_with_id(class_name_sym, attrs, orig_id);
+        let updated = Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -3996,7 +3853,7 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        let (class_name_sym, mut bytes, orig_id) = if let Value::Instance {
+        let (class_name_sym, mut bytes, orig_id, attrs_cell) = if let Value::Instance {
             class_name,
             attributes,
             id,
@@ -4008,7 +3865,7 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-            (*class_name, items, *id)
+            (*class_name, items, *id, attributes.clone())
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -4045,7 +3902,7 @@ impl Interpreter {
 
         let mut attrs = HashMap::new();
         attrs.insert("bytes".to_string(), Value::array(bytes));
-        let updated = Value::make_instance_with_id(class_name_sym, attrs, orig_id);
+        let updated = Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -4057,7 +3914,7 @@ impl Interpreter {
         method: &str,
         _args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        let (class_name_sym, mut bytes, orig_id) = if let Value::Instance {
+        let (class_name_sym, mut bytes, orig_id, attrs_cell) = if let Value::Instance {
             class_name,
             attributes,
             id,
@@ -4077,7 +3934,7 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-            (*class_name, items, *id)
+            (*class_name, items, *id, attributes.clone())
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -4103,7 +3960,8 @@ impl Interpreter {
                 let popped = bytes.pop().unwrap();
                 let mut attrs = HashMap::new();
                 attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated = Value::make_instance_with_id(class_name_sym, attrs, orig_id);
+                let updated =
+                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
                 self.env.insert(target_var.to_string(), updated);
                 Ok(popped)
             }
@@ -4127,7 +3985,8 @@ impl Interpreter {
                 let shifted = bytes.remove(0);
                 let mut attrs = HashMap::new();
                 attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated = Value::make_instance_with_id(class_name_sym, attrs, orig_id);
+                let updated =
+                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
                 self.env.insert(target_var.to_string(), updated);
                 Ok(shifted)
             }
@@ -4137,7 +3996,8 @@ impl Interpreter {
                 bytes.clear();
                 let mut attrs = HashMap::new();
                 attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated = Value::make_instance_with_id(class_name_sym, attrs, orig_id);
+                let updated =
+                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
                 self.env.insert(target_var.to_string(), updated);
                 // Return a Buf with the spliced elements
                 let mut result_attrs = HashMap::new();

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1912,7 +1912,7 @@ impl Interpreter {
                             let mut attrs = attributes.to_map();
                             attrs.insert("formatter".to_string(), formatter_value.clone());
                             let dt_with_formatter =
-                                Value::make_instance_with_id(class_name, attrs, id);
+                                Value::write_back_sharing(attributes, class_name, attrs, id);
                             let saved_env = self.env().clone();
                             let saved_readonly = self.save_readonly_vars();
                             let rendered = self
@@ -1929,14 +1929,15 @@ impl Interpreter {
                                 id,
                             } = dt_with_formatter
                             {
-                                let updated = (*attributes).clone();
+                                let mut updated = attributes.to_map();
                                 updated.insert(
                                     "__formatter_rendered".to_string(),
                                     Value::str(rendered),
                                 );
-                                return Ok(Value::make_instance_with_id(
+                                return Ok(Value::write_back_sharing(
+                                    &attributes,
                                     class_name,
-                                    (updated).to_map(),
+                                    updated,
                                     id,
                                 ));
                             }
@@ -4525,7 +4526,9 @@ impl Interpreter {
             self.restore_readonly_vars(saved_readonly);
             let mut updated = attributes.to_map();
             updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
-            Ok(Value::make_instance_with_id(class_name, updated, id))
+            Ok(Value::write_back_sharing(
+                attributes, class_name, updated, id,
+            ))
         } else {
             Ok(date)
         }

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -66,7 +66,7 @@ impl Interpreter {
         let Value::Instance {
             class_name: inst_class,
             attributes,
-            id: target_id,
+            ..
         } = target
         else {
             return None;
@@ -132,8 +132,6 @@ impl Interpreter {
             self.resolve_method_with_owner(qualifier, actual_method, &args)
         {
             let attrs_map = attributes.to_map();
-            let inst_cn = inst_cn_str.to_string();
-            let tid = *target_id;
             let (result, updated) = match self.run_instance_method(
                 qualifier,
                 attrs_map,
@@ -144,7 +142,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
-            self.overwrite_instance_bindings_by_identity(&inst_cn, tid, updated);
+            attributes.commit_attrs(updated);
             if !self.in_lvalue_assignment
                 && let Value::Proxy { ref fetcher, .. } = result
             {
@@ -169,7 +167,6 @@ impl Interpreter {
                 {
                     let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
-                    let tid = *target_id;
                     let (result, updated) = match self.run_instance_method_resolved(
                         &inst_cn,
                         qualifier,
@@ -181,7 +178,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Some(Err(e)),
                     };
-                    self.overwrite_instance_bindings_by_identity(&inst_cn, tid, updated);
+                    attributes.commit_attrs(updated);
                     return Some(Ok(result));
                 }
             }
@@ -203,7 +200,6 @@ impl Interpreter {
                 if !def.is_private && self.method_args_match(&args, &def.param_defs) {
                     let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
-                    let tid = *target_id;
                     let (result, updated) = match self.run_instance_method_resolved(
                         &inst_cn,
                         qualifier,
@@ -215,7 +211,7 @@ impl Interpreter {
                         Ok(v) => v,
                         Err(e) => return Some(Err(e)),
                     };
-                    self.overwrite_instance_bindings_by_identity(&inst_cn, tid, updated);
+                    attributes.commit_attrs(updated);
                     return Some(Ok(result));
                 }
             }

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1129,11 +1129,7 @@ impl Interpreter {
                         args,
                         Some(target.clone()),
                     )?;
-                    self.overwrite_instance_bindings_by_identity(
-                        &class_name.resolve(),
-                        *target_id,
-                        updated,
-                    );
+                    attributes.commit_attrs(updated);
                     return Ok(vec![result]);
                 } else {
                     // Private method not found -- return structured X::Method::NotFound
@@ -1154,8 +1150,12 @@ impl Interpreter {
                     // Build an invocant with the latest attributes so that
                     // `$.attr` accessor reads inside the method body see
                     // values updated by preceding calls in the MRO chain.
-                    let invocant =
-                        Value::make_instance_with_id(*class_name, attrs.clone(), *target_id);
+                    let invocant = Value::write_back_sharing(
+                        attributes,
+                        *class_name,
+                        attrs.clone(),
+                        *target_id,
+                    );
                     let (result, updated) = self.run_instance_method_resolved(
                         &class_name.resolve(),
                         &resolved_owner,
@@ -1167,11 +1167,7 @@ impl Interpreter {
                     attrs = updated;
                     out.push(result);
                 }
-                self.overwrite_instance_bindings_by_identity(
-                    &class_name.resolve(),
-                    *target_id,
-                    attrs,
-                );
+                attributes.commit_attrs(attrs);
                 return Ok(out);
             }
             // If the method is defined but no multi candidate matched,

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -228,11 +228,11 @@ impl Interpreter {
                 id,
             }) = self.env.get("self").cloned()
             {
-                let updated_attrs = (*attributes).clone();
+                let mut updated_attrs = attributes.to_map();
                 updated_attrs.insert(attr_name.to_string(), value.clone());
                 self.env.insert(
                     "self".to_string(),
-                    Value::make_instance_with_id(class_name, (updated_attrs).to_map(), id),
+                    Value::write_back_sharing(&attributes, class_name, updated_attrs, id),
                 );
             }
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -546,36 +546,6 @@ impl Drop for AttrReadGuard<'_> {
     }
 }
 
-/// Registry mapping an instance id to its live attribute cell.
-///
-/// Phase 3, Stage 1 scaffolding: the legacy mutation path computes an updated
-/// `HashMap` and then rebuilds the instance via [`Value::make_instance_with_id`]
-/// / `overwrite_instance_bindings_by_identity`. With shared cells, rebuilding
-/// must reuse the *existing* cell (not allocate a detached one), or aliases in
-/// other call frames would stop seeing mutations. This `id -> Weak<cell>` map
-/// lets `make_instance_with_id` find and write through the live cell, which is
-/// what makes the by-reference sharing visible across frames and fixes the
-/// cross-frame mutation bug (see docs/container-identity.md Phase 3). Stage 2
-/// removes the rebuild hacks and this registry along with them.
-type InstanceCellRegistry = HashMap<u64, Weak<RwLock<HashMap<String, Value>>>>;
-
-fn instance_cells() -> &'static Mutex<InstanceCellRegistry> {
-    static INSTANCE_CELLS: OnceLock<Mutex<InstanceCellRegistry>> = OnceLock::new();
-    INSTANCE_CELLS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Register a freshly created cell for `id`.
-fn register_instance_cell(id: u64, cell: &AttrCell) {
-    if let Ok(mut map) = instance_cells().lock() {
-        map.insert(id, Arc::downgrade(cell));
-    }
-}
-
-/// Return the live cell for `id`, if one still exists.
-fn lookup_instance_cell(id: u64) -> Option<AttrCell> {
-    instance_cells().lock().ok()?.get(&id)?.upgrade()
-}
-
 #[derive(Debug)]
 pub(crate) struct InstanceAttrs {
     class_name: Symbol,
@@ -594,12 +564,10 @@ pub(crate) struct InstanceAttrs {
 }
 
 impl Clone for InstanceAttrs {
-    /// Deep, independent copy: a fresh cell with a snapshot of the map. This is
-    /// the rare explicit struct clone (writeback "updated" copies); it must NOT
-    /// share the cell — sharing flows through `Arc<InstanceAttrs>`. The copy is
-    /// transient, so it does not register in `instance_cells` (which must keep
-    /// pointing at the live shared cell) and does not participate in DESTROY
-    /// refcounting (`queue_destroy = false`).
+    /// Deep, independent copy: a fresh cell with a snapshot of the map. Used for
+    /// `.clone`-style independent copies and `temp`/`let` snapshots; it must NOT
+    /// share the cell — sharing flows through `Arc<InstanceAttrs>`. The copy does
+    /// not participate in DESTROY refcounting (`queue_destroy = false`).
     fn clone(&self) -> Self {
         Self {
             class_name: self.class_name,
@@ -614,7 +582,7 @@ impl Clone for InstanceAttrs {
 /// guard on it.
 ///
 /// If this thread is mid-read of the cell, a blocking write would self-deadlock
-/// (the `RwLock` is not reentrant): this happens when the legacy writeback runs
+/// (the `RwLock` is not reentrant): this happens when an attribute writeback runs
 /// while an outer call frame on the same thread still holds an `as_map()` borrow
 /// on this instance (e.g. the `$obj.attr = v` accessor, whose let-chain
 /// condition keeps the guard alive across the write-back). We can't skip the
@@ -624,8 +592,6 @@ impl Clone for InstanceAttrs {
 /// When this thread is *not* reading the cell we take a blocking write lock,
 /// which is required for correctness under genuine cross-thread contention
 /// (e.g. concurrent `cas` on a shared instance attribute must not drop updates).
-/// Stage 2 replaces this writeback with a mutate-at-the-source model where the
-/// guard is never held across the write.
 fn write_cell_respecting_reads(cell: &AttrCell, map: HashMap<String, Value>) {
     let addr = cell_addr(cell);
     if HELD_READ_CELLS.with(|c| c.borrow().contains(&addr)) {
@@ -633,15 +599,6 @@ fn write_cell_respecting_reads(cell: &AttrCell, map: HashMap<String, Value>) {
         return;
     }
     *write_attrs(cell) = map;
-}
-
-pub(crate) fn update_instance_cell(id: u64, map: &HashMap<String, Value>) -> bool {
-    if let Some(cell) = lookup_instance_cell(id) {
-        write_cell_respecting_reads(&cell, map.clone());
-        true
-    } else {
-        false
-    }
 }
 
 /// Recover the map from a poisoned lock instead of propagating the panic. A
@@ -670,7 +627,6 @@ impl InstanceAttrs {
             *counts.entry(id).or_insert(0) += 1;
         }
         let cell: AttrCell = Arc::new(RwLock::new(attributes));
-        register_instance_cell(id, &cell);
         Self {
             class_name,
             attributes: cell,
@@ -710,6 +666,11 @@ impl InstanceAttrs {
         self.as_map().clone()
     }
 
+    /// This instance's stable identity id.
+    pub(crate) fn instance_id(&self) -> u64 {
+        self.id
+    }
+
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.as_map().contains_key(key)
     }
@@ -731,6 +692,31 @@ impl InstanceAttrs {
     /// idiom), in place under the write lock.
     pub(crate) fn insert_if_absent(&self, key: String, value: Value) {
         write_attrs(&self.attributes).entry(key).or_insert(value);
+    }
+
+    /// Phase 3 registry-removal: replace the whole attribute map in place through
+    /// this instance's shared cell, deadlock-safe with respect to a same-thread
+    /// read guard (see [`write_cell_respecting_reads`]). Because every alias of the
+    /// instance shares this `Arc<InstanceAttrs>` cell, the new map is visible
+    /// everywhere — in this frame, any caller frame, a `ContainerRef`-boxed
+    /// capture, a role `Mixin`, or a nested attribute of another instance. This is
+    /// the in-place replacement for the legacy id→cell registry writeback
+    /// (`overwrite_instance_bindings_by_identity` / `update_instance_cell`), which
+    /// computed an updated `HashMap` and looked the cell up by id.
+    pub(crate) fn commit_attrs(&self, map: HashMap<String, Value>) {
+        write_cell_respecting_reads(&self.attributes, map);
+    }
+
+    /// Build an `InstanceAttrs` that SHARES this cell but carries a different
+    /// `class_name` (rebless / role mixin). The mutation visibility comes from the
+    /// shared cell; only the class tag differs.
+    fn with_class(&self, class_name: Symbol) -> Self {
+        Self::from_cell(
+            class_name,
+            Arc::clone(&self.attributes),
+            self.id,
+            self.queue_destroy,
+        )
     }
 }
 
@@ -3014,27 +3000,16 @@ impl Value {
         Self::make_instance_with_destroy(class_name, attributes, false)
     }
 
+    /// Build an instance with the given id and a fresh attribute cell. Used for
+    /// constructing a value with an explicit id (genuinely new instances, or
+    /// sentinel ids). Cross-frame sharing of mutations comes from cloning an
+    /// existing instance's `Arc<InstanceAttrs>` (see [`Value::instance_sharing_cell`]),
+    /// not from this constructor — so this never reuses another holder's cell.
     pub(crate) fn make_instance_with_id(
         class_name: Symbol,
         attributes: HashMap<String, Value>,
         id: u64,
     ) -> Self {
-        // Phase 3, Stage 1: if a live cell already exists for this id, this is a
-        // rebuild of an existing logical instance (the legacy writeback path).
-        // Write the new attributes through the *existing* shared cell and return
-        // an instance aliasing it, so every other holder of the instance — even
-        // ones in caller frames the scan never visits — sees the mutation.
-        if let Some(cell) = lookup_instance_cell(id) {
-            // Reuse the live cell. The write respects an outstanding same-thread
-            // read guard (see `write_cell_respecting_reads`) to avoid a
-            // self-deadlock, while still blocking for cross-thread contention.
-            write_cell_respecting_reads(&cell, attributes);
-            return Value::Instance {
-                class_name,
-                attributes: Arc::new(InstanceAttrs::from_cell(class_name, cell, id, true)),
-                id,
-            };
-        }
         Value::Instance {
             class_name,
             attributes: Arc::new(InstanceAttrs::new(class_name, attributes, id, true)),
@@ -3042,28 +3017,55 @@ impl Value {
         }
     }
 
-    /// Build an instance with the given id but a *fresh, unregistered* cell.
-    ///
-    /// Unlike [`Self::make_instance_with_id`], this does NOT reuse or register
-    /// the live shared cell for `id`, so it produces a value that is independent
-    /// of the in-flight instance. Used by the cross-thread atomic write-back,
-    /// where the authoritative store is `shared_vars` and reusing the shared
-    /// cell would let concurrent writers clobber it out of order.
+    /// Phase 3 registry-removal: return a `Value::Instance` that SHARES `attrs`'s
+    /// live cell, optionally under a new `class_name` (rebless / role mixin). This
+    /// replaces the `make_instance_with_id` rebuild branch, which reused the cell
+    /// by looking it up in the global `instance_cells` registry. Sharing the
+    /// `Arc<InstanceAttrs>` directly keeps in-place mutations visible to every
+    /// existing alias and to the returned value, without the registry.
+    pub(crate) fn instance_sharing_cell(
+        attrs: &Arc<InstanceAttrs>,
+        class_name: Symbol,
+        id: u64,
+    ) -> Value {
+        debug_assert_eq!(attrs.id, id, "instance_sharing_cell id mismatch");
+        let attributes = if attrs.class_name == class_name {
+            Arc::clone(attrs)
+        } else {
+            Arc::new(attrs.with_class(class_name))
+        };
+        Value::Instance {
+            class_name,
+            attributes,
+            id,
+        }
+    }
+
+    /// Phase 3 registry-removal: write `map` into `attrs`'s shared cell in place
+    /// and return a `Value::Instance` aliasing that same cell. The single helper
+    /// for the common writeback-then-rebuild pattern: it replaces the paired
+    /// `overwrite_instance_bindings_by_identity(..) + make_instance_with_id(..)`.
+    pub(crate) fn write_back_sharing(
+        attrs: &Arc<InstanceAttrs>,
+        class_name: Symbol,
+        map: HashMap<String, Value>,
+        id: u64,
+    ) -> Value {
+        attrs.commit_attrs(map);
+        Value::instance_sharing_cell(attrs, class_name, id)
+    }
+
+    /// Build an instance with the given id and a fresh cell, used by the
+    /// cross-thread atomic write-back where the authoritative store is
+    /// `shared_vars`. Equivalent to [`Self::make_instance_with_id`] now that
+    /// instances no longer share cells through a global registry; kept as a
+    /// distinct name to mark the atomic-sync intent at the call site.
     pub(crate) fn make_instance_detached(
         class_name: Symbol,
         attributes: HashMap<String, Value>,
         id: u64,
     ) -> Self {
-        Value::Instance {
-            class_name,
-            attributes: Arc::new(InstanceAttrs::from_cell(
-                class_name,
-                Arc::new(RwLock::new(attributes)),
-                id,
-                true,
-            )),
-            id,
-        }
+        Self::make_instance_with_id(class_name, attributes, id)
     }
 
     /// An independent snapshot for `temp`/`let` saves. An instance is deep-copied

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -186,6 +186,10 @@ impl VM {
                             Value::Instance { id, .. } => Some(*id),
                             _ => None,
                         };
+                        let attrs_cell = match &target {
+                            Value::Instance { attributes, .. } => Some(attributes.clone()),
+                            _ => None,
+                        };
                         let attributes = match &target {
                             Value::Instance { attributes, .. } => attributes.to_map(),
                             _ => std::collections::HashMap::new(),
@@ -220,11 +224,9 @@ impl VM {
                         self.interpreter.pop_method_samewith_context();
                         let (result, new_attrs) = method_result?;
                         if let Some(id) = target_id {
-                            self.interpreter.overwrite_instance_bindings_by_identity(
-                                &cn,
-                                id,
-                                new_attrs.clone(),
-                            );
+                            if let Some(cell) = &attrs_cell {
+                                cell.commit_attrs(new_attrs.clone());
+                            }
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -1124,7 +1126,7 @@ impl VM {
         let Value::Instance {
             class_name,
             attributes,
-            id,
+            ..
         } = target
         else {
             return None;
@@ -1212,16 +1214,6 @@ impl VM {
             // Write through the shared cell in place: every alias of this
             // iterator instance (caller var, locals) sees the advance directly.
             attributes.insert("index".to_string(), Value::Int(index as i64));
-            let cn = class_name.resolve();
-            let inst_id = *id;
-            let snapshot = attributes.to_map();
-            // Legacy by-identity propagation (redundant now that the cell is
-            // shared; removed in Stage 2).
-            self.interpreter.overwrite_instance_bindings_by_identity(
-                &cn,
-                inst_id,
-                snapshot.clone(),
-            );
             self.env_dirty = true;
         }
         Some(Ok(ret))
@@ -1276,6 +1268,10 @@ impl VM {
     ) -> Result<Value, RuntimeError> {
         let target_id = match &target {
             Value::Instance { id, .. } => Some(*id),
+            _ => None,
+        };
+        let attrs_cell = match &target {
+            Value::Instance { attributes, .. } => Some(attributes.clone()),
             _ => None,
         };
         let attributes = match &target {
@@ -1345,8 +1341,9 @@ impl VM {
         };
         let (result, new_attrs) = method_result?;
         if let Some(id) = target_id {
-            self.interpreter
-                .overwrite_instance_bindings_by_identity(cn, id, new_attrs.clone());
+            if let Some(cell) = &attrs_cell {
+                cell.commit_attrs(new_attrs.clone());
+            }
             if !self.interpreter.in_lvalue_assignment
                 && let Value::Proxy { ref fetcher, .. } = result
             {
@@ -1546,6 +1543,10 @@ impl VM {
                             Value::Instance { id, .. } => Some(*id),
                             _ => None,
                         };
+                        let attrs_cell = match &target {
+                            Value::Instance { attributes, .. } => Some(attributes.clone()),
+                            _ => None,
+                        };
                         let attributes = match &target {
                             Value::Instance { attributes, .. } => attributes.to_map(),
                             _ => std::collections::HashMap::new(),
@@ -1580,11 +1581,9 @@ impl VM {
                         self.interpreter.pop_method_samewith_context();
                         let (result, new_attrs) = method_result?;
                         if let Some(id) = target_id {
-                            self.interpreter.overwrite_instance_bindings_by_identity(
-                                &cn,
-                                id,
-                                new_attrs.clone(),
-                            );
+                            if let Some(cell) = &attrs_cell {
+                                cell.commit_attrs(new_attrs.clone());
+                            }
                             if !self.interpreter.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
@@ -1644,6 +1643,10 @@ impl VM {
                     Value::Instance { id, .. } => Some(*id),
                     _ => None,
                 };
+                let attrs_cell = match &target {
+                    Value::Instance { attributes, .. } => Some(attributes.clone()),
+                    _ => None,
+                };
                 let attributes = match &target {
                     Value::Instance { attributes, .. } => attributes.to_map(),
                     _ => std::collections::HashMap::new(),
@@ -1678,11 +1681,9 @@ impl VM {
                 self.interpreter.pop_method_samewith_context();
                 let (result, new_attrs) = method_result?;
                 if let Some(id) = target_id {
-                    self.interpreter.overwrite_instance_bindings_by_identity(
-                        &cn,
-                        id,
-                        new_attrs.clone(),
-                    );
+                    if let Some(cell) = &attrs_cell {
+                        cell.commit_attrs(new_attrs.clone());
+                    }
                     if !self.interpreter.in_lvalue_assignment
                         && let Value::Proxy { ref fetcher, .. } = result
                     {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1723,10 +1723,10 @@ impl VM {
             }
             bytes
         };
-        // Build updated attributes and write back by instance identity (so aliases
-        // observing the same buf see the mutation), then refresh the receiver
-        // binding to match the interpreter's `env.insert(target_var, ...)`.
-        let updated_attrs = attributes.as_ref().clone();
+        // Write the updated bytes straight into the receiver's live shared cell
+        // (so aliases observing the same buf see the mutation), then refresh the
+        // receiver binding to match the interpreter's `env.insert(target_var, ...)`.
+        let mut updated_attrs = attributes.to_map();
         updated_attrs.insert(
             "bytes".to_string(),
             Value::array(
@@ -1736,12 +1736,7 @@ impl VM {
                     .collect(),
             ),
         );
-        self.interpreter.overwrite_instance_bindings_by_identity(
-            &cn,
-            *id,
-            (updated_attrs.clone()).to_map(),
-        );
-        let updated = Value::make_instance_with_id(*class_name, (updated_attrs).to_map(), *id);
+        let updated = Value::write_back_sharing(attributes, *class_name, updated_attrs, *id);
         self.interpreter
             .env_mut()
             .insert(target_name.to_string(), updated.clone());

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -716,12 +716,12 @@ impl VM {
                 (
                     Value::Instance {
                         class_name,
+                        attributes: base_attrs,
                         id: base_id,
-                        ..
                     },
                     Value::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    Value::make_instance_with_id(*class_name, attributes.clone(), *base_id)
+                    Value::write_back_sharing(base_attrs, *class_name, attributes.clone(), *base_id)
                 }
                 _ => v,
             };
@@ -1284,12 +1284,12 @@ impl VM {
                 (
                     Value::Instance {
                         class_name,
+                        attributes: base_attrs,
                         id: base_id,
-                        ..
                     },
                     Value::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    Value::make_instance_with_id(*class_name, attributes.clone(), *base_id)
+                    Value::write_back_sharing(base_attrs, *class_name, attributes.clone(), *base_id)
                 }
                 _ => v,
             };


### PR DESCRIPTION
## Summary

Phase 3 first-class instance cells — **registry removal** (Track B #1).

Instance attribute mutations previously rebuilt the value and looked the live cell up in a global `id -> Weak<cell>` registry (`instance_cells`). This PR removes that registry entirely: mutations now write straight through the receiver's shared `Arc<InstanceAttrs>` cell, which every alias already shares (since Stage 1/2a/2b/2c).

## What changed

**Removed**
- `instance_cells()` global Mutex registry + `register_instance_cell` / `lookup_instance_cell` / `update_instance_cell`
- the id→cell *reuse* branch of `make_instance_with_id` (now fresh-cell only, for genuinely-new / sentinel ids)
- `overwrite_instance_bindings_by_identity` (and its vestigial `_class_name` param)

**Added three helpers**, and converted all ~98 writeback/rebuild sites (47 `overwrite_*` + 51 rebuild `make_instance_with_id`) to them:
- `InstanceAttrs::commit_attrs(map)` — in-place whole-map write via the deadlock-safe `write_cell_respecting_reads`
- `Value::instance_sharing_cell(attrs, class, id)` — share the `Arc` (allocates a new `InstanceAttrs` over the *same* cell only when the class tag changes, e.g. rebless/mixin)
- `Value::write_back_sharing(attrs, class, map, id)` — commit + share, for the common writeback-then-rebuild pattern

Sites that only had a snapshot map + id (`proxy_store`, buf write paths, the MRO multi-dispatch invocant, mixin role dispatch, `let`/`temp` restore) now thread the receiver's `Arc` through so they can reach the live cell.

`make_instance_detached` became equivalent to `make_instance_with_id` and now delegates to it; kept as a distinct name to mark the cross-thread atomic-sync intent at the CAS call site.

## Approach

Staged for safety: the registry stayed functional while every site was converted (a hybrid state is consistent because converted in-place writes and not-yet-converted registry rebuilds touch the *same* cell), building/testing throughout; the registry infrastructure was deleted only after every site was converted.

## Side effects (latent bugs fixed)
- the registry's `Weak` entries no longer accumulate in a global `Mutex` map (memory leak gone)
- two unrelated id-0 sentinel `Supply`s can no longer collide on a reused cell

## Verification
- `cargo test` 461 passed, `cargo clippy` clean, `cargo fmt`
- `make test` PASS (718 files / 6499 tests, 0 failures)
- targeted whitelisted roast across S12 / S14 / S17 (incl. `cas.t`) / S32-temporal / buf, plus cross-frame mutation, closure rw-param writeback, `temp`/`let` restore, Proxy, buf mutate, iterator squish, and grammar action tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)