### PR TITLE
docs(comments): scrub references to removed overwrite_instance_bindings_by_identity

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1309,8 +1309,9 @@ impl Interpreter {
         } else {
             result
         };
-        // If `self` in the env was updated (e.g. by overwrite_instance_bindings_by_identity
-        // after a nested method call like `self.some-method(...)`), sync the attribute env
+        // If `self` in the env was updated (e.g. by an in-place write into its shared
+        // attribute cell after a nested method call like `self.some-method(...)`),
+        // sync the attribute env
         // variables (!attr, .attr) from `self`'s updated attributes. Without this,
         // attribute mutations made by nested method calls on `self` would be lost during
         // the writeback below, because the env variables still hold the pre-call values.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1627,9 +1627,10 @@ impl VM {
     /// to `target_name` (ledger §1: native receiver dispatch -> VM-native). Mirrors
     /// the interpreter's instance-mutate branches in `methods_mut.rs` exactly: the
     /// byte transforms are the single shared pure implementations in `builtins/`
-    /// (`buf_bits`/`buf_write_num`/`buf_write_int`), and the writeback uses the
-    /// same identity-based `overwrite_instance_bindings_by_identity` so aliases of
-    /// the same buf observe the mutation — so the result is behavior-invariant.
+    /// (`buf_bits`/`buf_write_num`/`buf_write_int`), and the writeback goes
+    /// straight into the receiver's shared cell (`Value::write_back_sharing`) so
+    /// aliases of the same buf observe the mutation — so the result is
+    /// behavior-invariant.
     ///
     /// Returns `None` (fall through to the interpreter) for type-object receivers
     /// (`buf8.write-...` on the type returns a fresh buf), immutable `Blob`, and

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1634,7 +1634,7 @@ impl VM {
 
         // React callbacks run through the interpreter path and capture from env.
         // First, pull any pending env updates into locals (e.g., instance attribute
-        // mutations from overwrite_instance_bindings_by_identity after bind-stdin).
+        // mutations written into the shared cell after bind-stdin).
         // Then flush all locals to env so captured vars are visible/mutable from
         // whenever callbacks.
         self.ensure_locals_synced(code);


### PR DESCRIPTION
Follow-up to #2940 (Phase 3 `id->cell` registry removal).

Three comments still named the deleted `overwrite_instance_bindings_by_identity` choke point. Reword them to describe the in-place shared-cell write (`Value::write_back_sharing` / `commit_attrs`) that replaced it, so the comments don't point at a function that no longer exists.

Comment-only; no behavior change. `cargo build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)