### PR TITLE
feat(pair): element write-through via a Pair value/key shared container

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -266,19 +266,19 @@
 - [ ] roast/S02-types/num.t
   - 108/112 pass. Tests 109-112 fail (same failures as raku itself: num%0e0, 0e0%0e0, num/0e0, num**-1e20 Failure handling)
 - [ ] roast/S02-types/pair.t
-  - 180/182 pass. Remaining: 128, 171.
-  - Test 128: `$pair.value<f> = 3` should write through to the source `$hashitem`.
-    `key => $var` now captures `$var`'s container, but capture_var_cell does NOT
-    box Array/Hash-valued vars into a ContainerRef (only plain scalars), so a
-    nested element assignment on the Pair value does not propagate back to the
-    source hash. Needs hash/array-element write-through to a shared cell.
+  - 181/182 pass. Remaining: 171 only.
   - Test 171: `Pair.new("foo", my Int $)` — assigning a Str to the typed Int
     container should throw X::TypeCheck::Assignment. The Pair value would need
-    to be a *typed* value container carrying the Int constraint; type
-    constraints are currently tracked per-variable (compiler locals /
-    type_metadata), not attached to a free value passed to Pair.new.
+    to be a *typed* value container carrying the Int constraint. mutsu currently
+    represents both `my Int $` (a mutable typed Scalar container) and a bare type
+    object `Int` as `Package(Int)`, losing the container, so the constraint is
+    not enforced on `.value =`. Needs a typed-scalar-container value
+    representation that survives into the Pair (Raku: `(k => Int).value = x`
+    throws X::Assignment::RO, while `Pair.new("foo", my Int $).value = "bar"`
+    throws X::TypeCheck::Assignment). Substantial type-system work.
   - DONE: parser fake-infix adverbs on parenthesized `.=` (#2939, unblocked
-    181/182); `key => $var` container capture / `.value =` write-through (139).
+    181/182); `key => $var` container capture / `.value =` write-through (#2942,
+    139); Array/Hash element write-through through a Pair value/key (128).
 - [x] roast/S02-types/parsing-bool.t
 - [ ] roast/S02-types/range-iterator.t
   - 0/? pass. Parse error at line 21

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -393,9 +393,15 @@ impl Interpreter {
         // same array/hash container).
         if let Some(old_arc) = &old_array_arc {
             self.propagate_shared_array_in_instances(old_arc, &updated);
+            // Also propagate to plain variables sharing the same Arc, so a
+            // mutation through a Pair value (`$pair.value[0] = x`) writes back
+            // to the source variable the Pair aliases (`my $a = [...]; $p = ($a
+            // => $a); $p.value[0] = x` updates `$a`). See roast S02-types/pair.t.
+            self.overwrite_array_bindings_by_identity(old_arc, updated.clone());
         }
         if let Some(old_arc) = &old_hash_arc {
             self.propagate_shared_hash_in_instances(old_arc, &updated);
+            self.overwrite_hash_bindings_by_identity(old_arc, updated.clone());
         }
 
         // Write back via the setter

--- a/t/pair-value-element-writethrough.t
+++ b/t/pair-value-element-writethrough.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 6;
+
+# Mutating an Array/Hash element *through* a Pair value (or key) writes back to
+# the source variable the Pair aliases, because they share the same container.
+# (roast S02-types/pair.t "=> should not stringify the key")
+
+# Hash value: $pair.value<f> = 3 reaches the source hash.
+{
+    my $h = { :d(1), :e(2) };
+    my $p = ($h => $h);
+    $p.value<f> = 3;
+    is $p.value<f>, 3, 'hash element assigned through pair value';
+    is $h<f>, 3, 'hash element write-through reaches the source variable';
+    is ~$p.value, ~$h, 'pair value and source hash stay equal';
+}
+
+# Array value: $pair.value[3] = "x" reaches the source array.
+{
+    my @src = <a b c>;
+    my $a = @src;
+    my $p = (k => $a);
+    $p.value[3] = "x";
+    is $p.value[3], "x", 'array element assigned through pair value';
+    is $a[3], "x", 'array element write-through reaches the source variable';
+}
+
+# Array key: push $pair.key reaches the source array (already worked, regression
+# guard).
+{
+    my $a = [< a b c >];
+    my $p = ($a => 1);
+    push $p.key, "d";
+    is ~$p.key, ~$a, 'pushing the pair key reaches the source array';
+}


### PR DESCRIPTION
## Summary

Mutating an Array/Hash element *through* a Pair value (`\$pair.value<f> = 3`, `\$pair.value[3] = \"x\"`) now writes back to the source variable the Pair aliases, matching Raku's reference-aliasing semantics (`S02-types/pair.t` "=> should not stringify the key").

`builtin_index_assign_method_lvalue` already propagated the rebuilt Array/Hash to **instances** sharing the same `Arc`, but not to plain variables. After computing the updated container it now also overwrites plain env bindings that share the old `Arc` (`overwrite_array_bindings_by_identity` / `overwrite_hash_bindings_by_identity`), so:

```raku
my $h = { :d(1), :e(2) };
my $p = ($h => $h);
$p.value<f> = 3;     # now updates $h too
```

## Impact

Fixes `roast/S02-types/pair.t` test 128. pair.t is now **181/182** — only test 171 remains, which needs a typed-value-container representation (`Pair.new("foo", my Int \$).value = "bar"` should throw `X::TypeCheck::Assignment`); documented in `TODO_roast/S02.md`.

## Tests

- New `t/pair-value-element-writethrough.t` (6 cases: hash value element, array value element, array key push regression guard).
- `make test` passes; relied on CI for the full roast blast-radius check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)