### PR TITLE
fix(attributes): refresh array/hash attr env copies from the live cell pre-op (Phase 3 Stage 2c iii-c)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -440,10 +440,16 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
                 `%!attr`/`%.attr`、~30行）を撤去。reads は全 cell-direct（2a/2b/2c-ii）、exit reconcile は cell.to_map()（iii-a）なので冗長。
                 sigilless alias テーブル設定 + `is default` 登録は保持。検証: make test 6265、S12/S14/S04/S03-binding/S06 144 ファイル 3076 PASS、
                 closure が private/array/hash/sigilless attr を捕捉・読み書きするケース（reader/writer 返却・nested+closure・map/gather）すべて raku 一致。
-                **fast-path（`call_compiled_method_fast`）の array/hash env コピーは保持**: closure が `%!h<k>=v` 要素変異する経路は
-                **captured env コピー経由**で cell 非経由（撤去すると最初の要素変異が落ちる）。これは pre-existing な hash-element-via-closure の
-                cell 非対応（main でも `%!cache{k}=v` の closure 経由で最初の write が `(Any)` になる既知バグ）に依存しており、cell 化は別件。
-                fast-path scalar attr は locals 直挿入（env 非経由）のため対象外。
+                ~~**fast-path（`call_compiled_method_fast`）の array/hash env コピーは保持**~~ → **(iii-c) で撤去済み（下記）**。
+          - [x] **(iii-c) 変異 op の pre-op cell sync + fast-path env コピー撤去（branch `phase3-attr-cell-presync`）**:
+                `array_hash_attr_env_snapshot`（全変異 op サイトの pre-snapshot）を「**self の live cell から env/locals を refresh**
+                してから cell 値を pre として返す」へ拡張（Arc ptr 比較で同一なら no-op、`:=` ContainerRef は legacy 維持）。
+                これで closure-captured env コピー（closure 生成時の stale snapshot）を変異してミラーする事故が消え、
+                **pre-existing バグ「closure 経由 `%!h{$k}=$v` は最後の write しか残らない（最初の write が `(Any)`）」を修正**。
+                各 closure 呼び出しが live cell 値から開始する。修正後、`call_compiled_method_fast` の array/hash attr env コピー
+                （iii-b で保持した分）を撤去 — 読みは cell-direct（2b）、変異は pre-op sync が env を埋めるので不要。
+                **おまけ: `DeleteIndexNamed`（`%!h{$k}:delete`）にも同じ pre-sync + mirror を配線**し、Stage 2b の
+                pre-existing gap「DELETE-KEY がミラー外で cell に届かない」も修正。回帰テスト `t/closure-attr-element-write.t`（16）。
         - [x] **registry 撤去（done, branch `phase3-drop-instance-cell-registry`）**: `instance_cells`（`id -> Weak<cell>` グローバル
               Mutex registry）+ `register_instance_cell`/`lookup_instance_cell`/`update_instance_cell`/`overwrite_instance_bindings_by_identity`
               を**全廃**。~98 の writeback/rebuild サイト（`overwrite_*` 47 + rebuild `make_instance_with_id` 51）を、receiver の

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3155,7 +3155,9 @@ impl VM {
                 *ip += 1;
             }
             OpCode::DeleteIndexNamed(name_idx) => {
+                let pre = self.array_hash_attr_env_snapshot(code, *name_idx);
                 self.exec_delete_index_named_op(code, *name_idx)?;
+                self.mirror_array_hash_attr_to_cell(code, *name_idx, pre);
                 *ip += 1;
             }
             OpCode::DeleteIndexExpr => {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -964,30 +964,11 @@ impl VM {
             } else {
                 env.remove("?ROLE");
             }
-            // Array/hash attribute env copies are still materialized here: an
-            // inner closure that mutates `@!a`/`%!h` by element (`%!h<k> = v`)
-            // observes them through the captured env copy, not the cell, so
-            // removing them drops the first such mutation (Stage 2c (iii-b) keeps
-            // the cell-direct *read* path but this write-capture path still needs
-            // the copy; see tmp closure hash-element test).
-            for (attr_name, attr_val) in &attributes {
-                if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
-                    continue;
-                }
-                let qualified_key = format!("{}\0{}", owner_class, attr_name);
-                let private_val = attributes.get(&qualified_key).unwrap_or(attr_val);
-                match private_val {
-                    Value::Array(..) => {
-                        env.insert(format!("@!{}", attr_name), private_val.clone());
-                        env.insert(format!("@.{}", attr_name), attr_val.clone());
-                    }
-                    Value::Hash(..) => {
-                        env.insert(format!("%!{}", attr_name), private_val.clone());
-                        env.insert(format!("%.{}", attr_name), attr_val.clone());
-                    }
-                    _ => {}
-                }
-            }
+            // Array/hash attribute env copies are no longer materialized here:
+            // reads are cell-direct (Stage 2b) and the mutating ops refresh
+            // env/locals from the live cell pre-op (`array_hash_attr_env_snapshot`),
+            // so a closure capturing this env resolves `@!a`/`%!h` through the
+            // captured `self` instead of a stale env snapshot.
             for (param_name, param_val) in &param_values {
                 env.insert(param_name.to_string(), param_val.clone());
             }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4483,8 +4483,15 @@ impl VM {
     /// mutation (env value changed) from a non-mutating method call (`@!a.join`)
     /// on a stale env copy — mirroring the stale copy would clobber a cross-frame
     /// cell mutation. Returns `None` for non-attribute targets (cheap fast path).
+    ///
+    /// Also refreshes the env/local copy from `self`'s live cell before the op
+    /// runs: a closure-captured env copy is a stale snapshot from closure
+    /// creation, so letting the op mutate it (and mirroring the result) would
+    /// clobber keys written by earlier calls — `%!h{$k} = $v` inside a returned
+    /// closure kept only the last write. After the refresh the op starts from
+    /// the live cell value and the mirror's pre-snapshot is that same value.
     pub(super) fn array_hash_attr_env_snapshot(
-        &self,
+        &mut self,
         code: &CompiledCode,
         name_idx: u32,
     ) -> Option<Value> {
@@ -4493,8 +4500,44 @@ impl VM {
             return None;
         }
         let name = name.to_string();
-        self.get_env_with_main_alias(&name)
-            .or_else(|| self.interpreter.get_shared_var(&name))
+        let env_val = self
+            .get_env_with_main_alias(&name)
+            .or_else(|| self.interpreter.get_shared_var(&name));
+        // `:=` bindings / slot refs keep their legacy env handling.
+        if env_val
+            .as_ref()
+            .is_some_and(Self::is_non_mirrorable_attr_value)
+        {
+            return env_val;
+        }
+        if let Some(cell_val) = self.read_self_attr_cell(&name) {
+            // Env copies share the cell value's Arc until a copy-on-write fork;
+            // pointer inequality means the copy is stale (or absent) — adopt the
+            // live cell value so the op mutates current state.
+            if !env_val
+                .as_ref()
+                .is_some_and(|v| Self::same_container_arc(v, &cell_val))
+            {
+                self.interpreter
+                    .env_mut()
+                    .insert(name.clone(), cell_val.clone());
+                if let Some(slot) = self.find_local_slot(code, &name) {
+                    self.locals[slot] = cell_val.clone();
+                }
+            }
+            return Some(cell_val);
+        }
+        env_val
+    }
+
+    /// Cheap container identity check: true when both values are the same
+    /// Array/Hash Arc (a clone that has not been copy-on-write forked).
+    fn same_container_arc(a: &Value, b: &Value) -> bool {
+        match (a, b) {
+            (Value::Array(x, _), Value::Array(y, _)) => Arc::ptr_eq(x, y),
+            (Value::Hash(x), Value::Hash(y)) => Arc::ptr_eq(x, y),
+            _ => false,
+        }
     }
 
     /// Mirror an array/hash attribute variable's post-mutation value into `self`'s

--- a/t/closure-attr-element-write.t
+++ b/t/closure-attr-element-write.t
@@ -1,0 +1,86 @@
+use v6;
+use Test;
+
+plan 16;
+
+# Element-level mutation of array/hash attributes through a returned closure
+# must accumulate in the instance (cell-direct), not clobber earlier writes
+# via a stale captured env copy.
+
+class Cache {
+    has %!h;
+    has @!a;
+
+    method h-writer() { -> $k, $v { %!h{$k} = $v } }
+    method a-writer() { -> $i, $v { @!a[$i] = $v } }
+    method a-pusher() { -> $v { @!a.push($v) } }
+    method set($k, $v) { %!h{$k} = $v }
+    method del($k) { %!h{$k}:delete }
+    method get($k) { %!h{$k} }
+    method h() { %!h }
+    method a() { @!a.List }
+}
+
+# closure hash element writes accumulate (first write must survive)
+my $c = Cache.new;
+my $w = $c.h-writer;
+$w('a', 1);
+$w('b', 2);
+$w('c', 3);
+is $c.get('a'), 1, 'first closure hash element write survives';
+is $c.get('b'), 2, 'second closure hash element write survives';
+is $c.get('c'), 3, 'third closure hash element write survives';
+is $c.h.elems, 3, 'all closure hash writes accumulated';
+
+# interleaved method and closure writes see each other
+my $c2 = Cache.new;
+my $w2 = $c2.h-writer;
+$w2('x', 10);
+$c2.set('y', 20);
+$w2('z', 30);
+is $c2.h.elems, 3, 'closure and method hash writes interleave';
+is $c2.get('y'), 20, 'method write between closure writes survives';
+
+# closure array element writes accumulate
+my $c3 = Cache.new;
+my $aw = $c3.a-writer;
+$aw(0, 'first');
+$aw(2, 'third');
+is $c3.a[0], 'first', 'first closure array element write survives';
+is $c3.a[2], 'third', 'second closure array element write survives';
+
+# closure push accumulates
+my $c4 = Cache.new;
+my $p = $c4.a-pusher;
+$p(1);
+$p(2);
+$p(3);
+is $c4.a.elems, 3, 'closure pushes accumulate';
+is $c4.a.join(','), '1,2,3', 'closure pushes in order';
+
+# :delete on a hash attribute reaches the instance
+my $c5 = Cache.new;
+$c5.set('keep', 1);
+$c5.set('drop', 2);
+$c5.del('drop');
+is $c5.h.elems, 1, ':delete on hash attribute removes the key';
+is $c5.get('keep'), 1, ':delete leaves other keys';
+
+# :delete after closure writes
+my $c6 = Cache.new;
+my $w6 = $c6.h-writer;
+$w6('a', 1);
+$w6('b', 2);
+$c6.del('a');
+is $c6.h.elems, 1, ':delete works after closure writes';
+is $c6.get('b'), 2, 'closure write survives :delete of another key';
+
+# two instances have independent attribute storage
+my $i1 = Cache.new;
+my $i2 = Cache.new;
+my $w-i1 = $i1.h-writer;
+my $w-i2 = $i2.h-writer;
+$w-i1('k', 'one');
+$w-i2('k', 'two');
+is $i1.get('k'), 'one', 'instance 1 closure writes its own cell';
+is $i2.get('k'), 'two', 'instance 2 closure writes its own cell';


### PR DESCRIPTION
## Summary

- **Fixes the pre-existing closure attr-element bug**: `%!h{$k} = $v` inside a returned closure kept only the *last* write (the first read back as `(Any)`). Each closure call mutated the closure's captured env copy — a stale snapshot from closure creation — and mirrored it into the instance cell, clobbering keys written by earlier calls.
- **Fix**: `array_hash_attr_env_snapshot` (the pre-snapshot that runs before every mutating array/hash attribute op) now refreshes env/locals from `self`'s live cell first (Arc-pointer compare skips the already-shared common case), so every mutation starts from current instance state regardless of frame. `:=`-bound ContainerRef attrs keep their legacy handling.
- **Removes the fast-path array/hash attr env copies** in `call_compiled_method_fast` that Stage 2c (iii-b) had to keep for exactly this closure-capture path — reads are cell-direct (Stage 2b), mutation is covered by the pre-op sync.
- **Bonus**: wires the same pre-sync + mirror into `DeleteIndexNamed`, fixing the Stage 2b known gap where `%!h{$k}:delete` never reached the cell.

Resume map #1 of the instance-cells Phase 3 campaign (docs/container-identity.md Stage 2c).

## Testing

- New regression test `t/closure-attr-element-write.t` (16 tests) — verified byte-identical against `raku`
- `make test` PASS (721 files / 6530 tests), cargo test 461, clippy clean
- Whitelisted S12-attributes / S12-methods / S12-class / S12-construction / S14-roles / S17-lowlevel (cas) — 97 files / 1834 tests PASS
- Edge cases vs raku: interleaved method+closure writes, array element/push writers, public attr writers, two-instance independence, threads (`start` × 4), gather, nested map closures
- Perf canary roast/S32-num/int.t: no regression (0.18-0.21s vs main 0.23-0.33s debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)