### PR TITLE
feat(pair): typed value container completes pair.t (182/182, whitelisted)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -265,20 +265,15 @@
   - 0/? pass. Parse error at line 30
 - [ ] roast/S02-types/num.t
   - 108/112 pass. Tests 109-112 fail (same failures as raku itself: num%0e0, 0e0%0e0, num/0e0, num**-1e20 Failure handling)
-- [ ] roast/S02-types/pair.t
-  - 181/182 pass. Remaining: 171 only.
-  - Test 171: `Pair.new("foo", my Int $)` — assigning a Str to the typed Int
-    container should throw X::TypeCheck::Assignment. The Pair value would need
-    to be a *typed* value container carrying the Int constraint. mutsu currently
-    represents both `my Int $` (a mutable typed Scalar container) and a bare type
-    object `Int` as `Package(Int)`, losing the container, so the constraint is
-    not enforced on `.value =`. Needs a typed-scalar-container value
-    representation that survives into the Pair (Raku: `(k => Int).value = x`
-    throws X::Assignment::RO, while `Pair.new("foo", my Int $).value = "bar"`
-    throws X::TypeCheck::Assignment). Substantial type-system work.
-  - DONE: parser fake-infix adverbs on parenthesized `.=` (#2939, unblocked
-    181/182); `key => $var` container capture / `.value =` write-through (#2942,
-    139); Array/Hash element write-through through a Pair value/key (128).
+- [x] roast/S02-types/pair.t
+  - 182/182. Whitelisted. Fixed across this campaign:
+    - #2939: parser fake-infix adverbs on parenthesized `.=` (unblocked 181/182).
+    - #2942: `key => $var` container capture / `.value =` write-through (139).
+    - #2943: Array/Hash element write-through through a Pair value/key (128).
+    - typed value container (171): `my T $` typed-anonymous scalars now wrap in a
+      ContainerRef whose `of`-type is recorded in a side table
+      (TYPED_CONTAINER_CONSTRAINTS, keyed by Arc ptr), so
+      `Pair.new("foo", my Int $).value = "bar"` raises X::TypeCheck::Assignment.
 - [x] roast/S02-types/parsing-bool.t
 - [ ] roast/S02-types/range-iterator.t
   - 0/? pass. Parse error at line 21

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -145,6 +145,7 @@ roast/S02-types/nested_pairs.t
 roast/S02-types/nil.t
 roast/S02-types/nominalizables.t
 roast/S02-types/num.t
+roast/S02-types/pair.t
 roast/S02-types/parsing-bool.t
 roast/S02-types/range-iterator.t
 roast/S02-types/resolved-in-setting.t

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -199,6 +199,18 @@ impl Compiler {
                 // be wrapped -- their value must be used directly for numeric ops.
                 if name == "__ANON_STATE__" && type_constraint.is_none() {
                     self.code.emit(OpCode::WrapScalar);
+                } else if name == "__ANON_STATE__"
+                    && let Some(tc) = type_constraint
+                    && !matches!(tc.as_str(), "Any" | "Mu" | "")
+                    && !crate::runtime::native_types::is_native_array_element_type(tc)
+                {
+                    // A typed anonymous scalar (`my Int $`) used as a value: wrap
+                    // it in a typed ContainerRef so the `of`-type constraint
+                    // travels with the value (e.g. into a Pair value) and is
+                    // enforced on assignment. Native types stay unwrapped (their
+                    // raw value is needed for numeric ops).
+                    let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                    self.code.emit(OpCode::WrapTypedContainer(tc_idx));
                 }
                 // Apply custom traits (e.g. `is default(...)`) that were
                 // captured by `..` in the original pattern. Without this,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -103,6 +103,12 @@ pub(crate) enum OpCode {
     /// Used for `my $ = expr` (anonymous scalar) in argument position,
     /// so the anonymous container is preserved in immutable List contexts.
     WrapScalar,
+    /// Wrap the top-of-stack value in a typed `ContainerRef` cell and register
+    /// its `of`-type constraint (the u32 is the constant-pool index of the type
+    /// name). Emitted for a typed anonymous scalar `my T $` used as a value, so
+    /// the constraint travels with the value (e.g. into a `Pair` value) and
+    /// `.value = ...` can raise X::TypeCheck::Assignment.
+    WrapTypedContainer(u32),
     /// Recursively flatten a list value into a real Array (like *@ slurpy).
     /// Used to populate @_ in bare if blocks.
     FlattenSlurpy,

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -868,6 +868,20 @@ impl Interpreter {
                 // `$var` (S02:1704). The type constraint, if any, is enforced by
                 // the cell itself on assignment.
                 if let Value::ContainerRef(cell) = current_value.as_ref() {
+                    // Enforce a typed container's `of`-type constraint, so
+                    // `Pair.new("foo", my Int $).value = "bar"` raises
+                    // X::TypeCheck::Assignment (S02-types/pair.t).
+                    if let Some(constraint) = crate::value::lookup_container_constraint(cell)
+                        && !matches!(constraint.as_str(), "Any" | "Mu")
+                        && !matches!(&value, Value::Nil)
+                        && !self.type_matches_value(&constraint, &value)
+                    {
+                        return Err(RuntimeError::typecheck_assignment(
+                            &constraint,
+                            &value,
+                            None,
+                        ));
+                    }
                     *cell.lock().unwrap() = value.clone();
                     return Ok(value);
                 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -563,6 +563,34 @@ pub(crate) struct InstanceAttrs {
     queue_destroy: bool,
 }
 
+/// Type constraints for typed scalar `ContainerRef` cells, keyed by the cell's
+/// `Arc` pointer. A free typed container (e.g. `my Int $` used as a value, then
+/// stored as a `Pair` value) carries no name, so its `of`-type cannot live in
+/// the name-keyed `var_type_constraint` map; this side table lets the
+/// `ContainerRef` write chokepoint enforce the constraint and raise
+/// `X::TypeCheck::Assignment` on a bad assignment. Only `my T $` typed-anonymous
+/// scalars register here, so the table stays tiny.
+static TYPED_CONTAINER_CONSTRAINTS: OnceLock<Mutex<HashMap<usize, String>>> = OnceLock::new();
+
+fn typed_container_constraints() -> &'static Mutex<HashMap<usize, String>> {
+    TYPED_CONTAINER_CONSTRAINTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record that the `ContainerRef` cell `cell` has the `of`-type `type_name`.
+pub fn register_container_constraint(cell: &Arc<Mutex<Value>>, type_name: &str) {
+    let ptr = Arc::as_ptr(cell) as usize;
+    typed_container_constraints()
+        .lock()
+        .unwrap()
+        .insert(ptr, type_name.to_string());
+}
+
+/// Look up the `of`-type constraint of a `ContainerRef` cell, if any.
+pub fn lookup_container_constraint(cell: &Arc<Mutex<Value>>) -> Option<String> {
+    let ptr = Arc::as_ptr(cell) as usize;
+    typed_container_constraints().lock().unwrap().get(&ptr).cloned()
+}
+
 impl Clone for InstanceAttrs {
     /// Deep, independent copy: a fresh cell with a snapshot of the map. Used for
     /// `.clone`-style independent copies and `temp`/`let` snapshots; it must NOT

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -588,7 +588,11 @@ pub fn register_container_constraint(cell: &Arc<Mutex<Value>>, type_name: &str) 
 /// Look up the `of`-type constraint of a `ContainerRef` cell, if any.
 pub fn lookup_container_constraint(cell: &Arc<Mutex<Value>>) -> Option<String> {
     let ptr = Arc::as_ptr(cell) as usize;
-    typed_container_constraints().lock().unwrap().get(&ptr).cloned()
+    typed_container_constraints()
+        .lock()
+        .unwrap()
+        .get(&ptr)
+        .cloned()
 }
 
 impl Clone for InstanceAttrs {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2096,6 +2096,17 @@ impl VM {
                 self.stack.push(Value::Scalar(Box::new(val)));
                 *ip += 1;
             }
+            OpCode::WrapTypedContainer(type_idx) => {
+                // Wrap a typed anonymous scalar (`my T $`) in a ContainerRef cell
+                // and record its `of`-type, so the constraint travels with the
+                // value (e.g. into a Pair value) and is enforced on assignment.
+                let type_name = Self::const_str(code, *type_idx).to_string();
+                let val = self.stack.pop().unwrap_or(Value::Nil);
+                let cell = std::sync::Arc::new(std::sync::Mutex::new(val));
+                crate::value::register_container_constraint(&cell, &type_name);
+                self.stack.push(Value::ContainerRef(cell));
+                *ip += 1;
+            }
             OpCode::FlattenSlurpy => {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 let mut items = Vec::new();

--- a/t/pair-typed-value-container.t
+++ b/t/pair-typed-value-container.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 7;
+
+# A typed anonymous scalar (`my T $`) used as a Pair value carries its `of`-type
+# constraint, so assigning a wrong-typed value through `.value` raises
+# X::TypeCheck::Assignment. (roast S02-types/pair.t)
+
+{
+    my $p = Pair.new("foo", my Int $);
+    isa-ok $p.value, Int, 'typed Pair value reports the constrained type';
+    is ($p.value = 42), 42, 'assigning a matching value returns it';
+    is $p.value, 42, 'the matching value was stored';
+    throws-like { $p.value = "bar" }, X::TypeCheck::Assignment,
+        'assigning a Str to an Int Pair value throws X::TypeCheck::Assignment';
+    is $p.value, 42, 'the failed assignment left the value unchanged';
+}
+
+# The constraint is enforced for other types too.
+{
+    my $p = Pair.new("k", my Str $);
+    $p.value = "ok";
+    is $p.value, "ok", 'Str-constrained Pair value accepts a Str';
+    throws-like { $p.value = 5 }, X::TypeCheck::Assignment,
+        'assigning an Int to a Str Pair value throws X::TypeCheck::Assignment';
+}


### PR DESCRIPTION
## Summary

A typed anonymous scalar (`my Int \$`) used as a value now carries its type constraint, so assigning a wrong-typed value through a Pair raises `X::TypeCheck::Assignment`:

```raku
my \$p = Pair.new("foo", my Int \$);
\$p.value = 42;      # ok
\$p.value = "bar";   # X::TypeCheck::Assignment
```

mutsu tracks scalar type constraints by **variable name** (`var_type_constraint`), so an anonymous `my T \$` passed to `Pair.new` previously lost its constraint (both `my Int \$` and a bare `Int` collapsed to `Package(Int)`). This adds a constraint that travels with the **value**:

- A new `TYPED_CONTAINER_CONSTRAINTS` side table maps a `ContainerRef` cell's `Arc` pointer to its `of`-type name. Only typed-anonymous scalars register, so it stays tiny.
- New opcode `WrapTypedContainer(type_idx)`: wraps a value in a `ContainerRef` cell and registers the constraint. The compiler emits it for a typed anonymous scalar `my T \$` with an **object** (non-native) type; native types (`my int \$`, `my num \$`, …) stay unwrapped so their raw value is used for numeric ops.
- The `.value =` `ContainerRef` write chokepoint looks up the constraint and raises `X::TypeCheck::Assignment` on a mismatch before writing.

## Impact

Completes **`roast/S02-types/pair.t` (182/182)** — added to the whitelist. This is the capstone of the pair.t campaign:

| PR | fix | tests |
|---|---|---|
| #2939 | parser fake-infix adverbs on parenthesized `.=` | 181, 182 |
| #2942 | `key => \$var` container capture / `.value =` write-through | 139 |
| #2943 | Array/Hash element write-through via a Pair value/key | 128 |
| **this** | typed value container | 171 |

## Known edge

`Pair.new(_, my Int \$).value.defined` returns `True` when the typed container is undefined (a direct method call on the `ContainerRef` result skips the deref that a variable read performs). pair.t does not exercise this; noted for follow-up.

## Tests

- New `t/pair-typed-value-container.t` (7 cases: Int/Str constraints, matching accepted, mismatch throws, value preserved on failed assign).
- `make test` passes; relied on CI for the full roast blast-radius check (the `my T \$` representation change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)