### PR TITLE
fix(quanthash): correct element-assignment semantics for Bag/Mix/Set

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -175,9 +175,11 @@
 - [ ] roast/S02-types/baggy.t
   - 0/? pass. Parse error at line 60
 - [ ] roast/S02-types/baghash.t
-  - 273/290 pass (plan 344). Execution stops at test 290 due to BagHash .kv proxy mutation crash.
-  - Fixed: grab/grabpairs with Callable arg, $(...) scalar decontainerization in arithmetic
-  - Blockers: proxy containers for BagHash .values/.kv/.pairs mutation (14 tests), parameterized BagHash[T] type constraints (2), named arg handling in .new (1), object keys in Hash (1), BagHash type autovivification (1)
+  - 268/270 pass then aborts at 270 (plan 344). Fixed weight=0 removal + Str→X::Str::Numeric
+    on `%h is BagHash`/scalar BagHash element assign (quanthash-element-assign fix).
+  - Remaining before abort: 206 (`does` add wrong-type croak), 268 (named arg eaten by `.new`).
+  - Abort blocker: writable `.values`/`.pairs`/`.kv` aliases into the bag weights need
+    Proxy-style writeback into the QuantHash internal counts (container identity). Hard.
 - [ ] roast/S02-types/bag-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/bag.t
@@ -229,7 +231,10 @@
 - [ ] roast/S02-types/mixed_multi_dimensional.t
   - 0/? pass. Parse error at line 43
 - [ ] roast/S02-types/mixhash.t
-  - 0/? pass. Parse error at line 17
+  - 216/216 pass then aborts at 216 (plan 295). Fixed 161-164 (`%h is MixHash` weight=0
+    removal + Str→X::Str::Numeric on element assign; quanthash-element-assign fix).
+  - Abort blocker: writable `.values`/`.pairs`/`.kv` aliases into the mix weights need
+    Proxy-style writeback into the QuantHash internal weights (container identity). Hard.
 - [ ] roast/S02-types/mix-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -843,6 +843,37 @@ impl VM {
         }
     }
 
+    /// Coerce a value assigned to a Bag/BagHash weight to an `i64` count, with
+    /// the same numeric validation as Mix: a non-numeric `Str` raises
+    /// X::Str::Numeric rather than being silently treated as truthy (1).
+    fn bag_assignment_count(value: &Value) -> Result<i64, RuntimeError> {
+        match value {
+            Value::Int(i) => Ok(*i),
+            Value::Num(n) => Ok(*n as i64),
+            Value::Rat(n, d) if *d != 0 => Ok(*n / *d),
+            Value::Bool(flag) => Ok(i64::from(*flag)),
+            Value::Str(s) => {
+                if let Ok(n) = s.parse::<i64>() {
+                    Ok(n)
+                } else if let Ok(n) = s.parse::<f64>() {
+                    Ok(n as i64)
+                } else {
+                    Err(RuntimeError::str_numeric(
+                        s,
+                        "base-10 number must begin with valid digits or '.'",
+                    ))
+                }
+            }
+            _ => {
+                if value.truthy() {
+                    Ok(1)
+                } else {
+                    Ok(0)
+                }
+            }
+        }
+    }
+
     const LAZY_ASSIGN_PRESERVE_MARKER: &str = "__mutsu_preserve_lazy_on_array_assign";
     const MAX_ASSIGN_SLICE_EXPAND: i64 = 100_000;
 
@@ -2869,7 +2900,18 @@ impl VM {
                     idx.to_string_value()
                 };
                 let array_elem_constraint = self.interpreter.var_type_constraint(&var_name);
+                // A `%h is BagHash`/`MixHash`/`SetHash` (or `Bag`/`Mix`/`Set`)
+                // variable IS that QuantHash: the constraint names the *whole*
+                // container, not the element type, and `%h<k> = weight` sets a
+                // weight (validated/handled by the QuantHash weight-assign path
+                // below), so it must not be element-type-checked against the
+                // container type.
+                let target_is_quanthash = matches!(
+                    &index_target,
+                    Some(Value::Mix(..) | Value::Bag(..) | Value::Set(..))
+                );
                 if let Some(constraint) = array_elem_constraint
+                    && !target_is_quanthash
                     && !matches!(val, Value::Nil)
                     && !self.interpreter.type_matches_value(&constraint, &val)
                     // For `$`-sigil variables holding a container (e.g. a `Hash $h`
@@ -3338,18 +3380,7 @@ impl VM {
                                 return Err(RuntimeError::assignment_ro(Some("Bag")));
                             }
                             let b = Arc::make_mut(bag);
-                            let count = match &val {
-                                Value::Int(i) => *i,
-                                Value::Num(n) => *n as i64,
-                                Value::Bool(flag) => i64::from(*flag),
-                                _ => {
-                                    if val.truthy() {
-                                        1
-                                    } else {
-                                        0
-                                    }
-                                }
-                            };
+                            let count = Self::bag_assignment_count(&val)?;
                             if count == 0 {
                                 b.remove(&key);
                             } else {
@@ -3387,10 +3418,9 @@ impl VM {
                                 }
                                 "BagHash" => {
                                     let mut counts = HashMap::new();
-                                    if let Value::Int(n) = &val
-                                        && *n > 0
-                                    {
-                                        counts.insert(key.clone(), *n);
+                                    let count = Self::bag_assignment_count(&val)?;
+                                    if count > 0 {
+                                        counts.insert(key.clone(), count);
                                     }
                                     *container = Value::bag_hash(counts);
                                 }

--- a/t/quanthash-element-assign.t
+++ b/t/quanthash-element-assign.t
@@ -1,0 +1,55 @@
+use Test;
+
+plan 13;
+
+# A `%h is BagHash/MixHash/SetHash` variable IS that QuantHash: element
+# assignment sets a weight (not a typed-hash element), assigning 0 removes the
+# key, and assigning a non-numeric value throws X::Str::Numeric.
+# (roast S02-types/baghash.t, mixhash.t)
+
+# --- MixHash via `is` trait ---
+{
+    my %h is MixHash = a => 1, b => 0, c => 2;
+    lives-ok { %h<c> = 0 }, 'MixHash: can set a weight to 0';
+    nok %h<c>:exists, 'MixHash: weight-0 key is gone';
+    is %h.elems, 1, 'MixHash: one item left';
+    is %h.keys, ('a'), 'MixHash: the right key remains';
+    throws-like { %h<a> = "foo" }, X::Str::Numeric,
+        'MixHash: assigning a Str weight throws X::Str::Numeric';
+}
+
+# --- BagHash via `is` trait ---
+{
+    my %b is BagHash = a => 1, b => 2;
+    %b<a> = 5;
+    is %b<a>, 5, 'BagHash: can set a weight';
+    %b<a> = 0;
+    nok %b<a>:exists, 'BagHash: weight-0 key is gone';
+    throws-like { %b<b> = "foo" }, X::Str::Numeric,
+        'BagHash: assigning a Str weight throws X::Str::Numeric';
+}
+
+# --- BagHash via scalar ---
+{
+    my $b = <a>.BagHash;
+    $b<a> = 42;
+    is $b<a>, 42, 'scalar BagHash: can set a weight';
+    throws-like { $b<a> = "foo" }, X::Str::Numeric,
+        'scalar BagHash: assigning a Str weight throws X::Str::Numeric';
+}
+
+# --- MixHash via scalar (already worked; regression guard) ---
+{
+    my $m = <a>.MixHash;
+    $m<a> = 1.5;
+    is $m<a>, 1.5, 'scalar MixHash: can set a Real weight';
+    throws-like { $m<a> = "foo" }, X::Str::Numeric,
+        'scalar MixHash: assigning a Str weight throws X::Str::Numeric';
+}
+
+# A real typed hash (value type) is still enforced.
+{
+    my Int %h;
+    throws-like { %h<a> = "x" }, X::TypeCheck::Assignment,
+        'typed hash element type is still enforced';
+}


### PR DESCRIPTION
## Summary

`%h is MixHash` / `is BagHash` / `is SetHash` declares the variable to **be** that QuantHash, so `%h<k> = weight` must set a weight (0 removes the key), not be type-checked as a typed-hash element. The `%`-sigil element-assign path short-circuited the container-type exclusion list and checked the weight value against the container type name (`"MixHash"`), so `%h<c> = 0` died with `Type check failed for an element of %h; expected MixHash but got Int`.

Fix: skip the element type-check when the target container is actually a `Mix`/`Bag`/`Set` value — the QuantHash weight-assign path handles it (weight=0 removal + numeric validation).

Also make Bag/BagHash weight assignment validate numerics like Mix already does: `\$b<a> = "foo"` (and `%b is BagHash; %b<a> = "foo"`) now raise `X::Str::Numeric` instead of silently treating the `Str` as truthy (weight 1). New `bag_assignment_count` helper mirrors `mix_assignment_weight`.

## Roast progress

- `S02-types/mixhash.t`: tests 161-164 now pass (file is **216/216** before its remaining abort).
- `S02-types/baghash.t`: tests 215-216 and 270 now pass.

Neither file whitelists yet — both still abort on writable `.values`/`.pairs`/`.kv` aliases into the weights (needs Proxy-style writeback into the QuantHash internals = container identity; documented in `TODO_roast/S02.md`).

## Tests

- New `t/quanthash-element-assign.t` (13 cases across MixHash/BagHash via `is`-trait and scalar, weight=0 removal, Str→X::Str::Numeric, and a regression guard that real typed-hash element types are still enforced).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)