### PR TITLE
feat(atomics): cell-CAS for instance attributes; drop the shared_vars side channel (Phase 3)

### DIFF
--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -462,7 +462,22 @@ instance の binding に届かない。同一 id でも変異が frame 復帰で
               と等価になったが CAS の atomic-sync 意図マーカとして名前のみ残置（→ `make_instance_with_id` 委譲）。`_class_name` vestigial param 撤去。
               副次効果: グローバル Mutex registry の Weak エントリ蓄積（メモリリーク）解消、id-0 sentinel Supply の cell 誤共有 latent バグ解消。
               検証: cargo test 461、clippy 緑、whitelisted S12/S14/S17/S32-temporal/buf 40 ファイル + cross-frame/closure/temp-let/proxy/buf/iterator/grammar 全緑。
-        - [ ] **残（別 slice）**: CAS の cell-CAS 化（`make_instance_detached` + shared_vars 側道撤去、cell を atomic primitive に）。
+        - [x] **CAS cell-CAS 化（branch `phase3-cas-cell`）**: instance 属性の cas/atomic ops を shared_vars 側道
+              （`!attr::{id}` 値キー / `__mutsu_atomic_attr::{id}::{attr}` / `__mutsu_instance::{id}` 親回収 + env scan-replace /
+              `make_instance_detached` / `sync_atomic_attribute_to_instance`）から **cell 直接の atomic primitive** へ全面移行。
+              `InstanceAttrs::compare_and_swap(key, matches, new)`（単一 write lock 下で比較+格納）/ `fetch_update(key, f)`
+              （単一 write lock 下で RMW、atomic add/inc/dec 用）を新設し、`builtin_cas_var`（3-arg/2-arg）・
+              `builtin_atomic_update_unit`・`builtin_atomic_{add,fetch_add,fetch,store}_var` に attr-cell 分岐
+              （`self_attr_cell_target`: `!x`/`.x` → self の cell + qualified key 解決）。Stage 1 の livelock は
+              cell-direct read（2a）完備で解消（cas.t 5 連続 PASS で確認）。
+              **発見した第2の lost-update race**: method exit の reconcile snapshot を caller が毎回
+              `cell.commit_attrs(new_attrs)` で whole-map 書き戻し → 並行 cell-RMW を TOCTOU clobber
+              （8スレッド `$!count⚛++` ×500 が 2448/4000。main では親に全く伝播せず **0** だった）。
+              **修正**: `reconcile_attrs` が「cell snapshot を超える調整（`:=` ContainerRef 回収）があったか」の
+              bool を返し、`(Value, HashMap, bool)` で呼び出し元へ伝播 — 未調整なら exit commit / `write_back_sharing`
+              を **skip**（snapshot==cell なので no-op、かつ race 源）。調整あり（`:=`）のみ commit。
+              副次効果: 毎 method exit の冗長 whole-map 書き込み消滅（perf）。回帰テスト `t/cas-cell-attr.t`（14、
+              4スレッド increment/2-arg cas/await 後親可視を含む、raku 一致）。
   - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
 
   #### 現状メカニズム（CI 調査で確定したフルマップ）

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -141,6 +141,11 @@ impl Interpreter {
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let name = self.atomic_var_name_arg(args)?;
+        // Phase 3 cell-CAS: attribute targets read the receiver's shared cell.
+        if let Some((attrs, key)) = self.self_attr_cell_target(&name) {
+            let val = attrs.as_map().get(&key).cloned().unwrap_or(Value::Nil);
+            return Ok(val);
+        }
         let value_key = self.atomic_value_key_for_name(&name);
         let shared = self.shared_vars.read().unwrap();
         Ok(self.atomic_current_value(&shared, &name, &value_key))
@@ -158,6 +163,12 @@ impl Interpreter {
         let raw_name = args[0].to_string_value();
         let name = self.canonical_atomic_var_name(&raw_name, args.first());
         let value = self.atomic_assign_coerced_value(&name, args[1].clone())?;
+        // Phase 3 cell-CAS: attribute targets store into the receiver's cell.
+        if let Some((attrs, key)) = self.self_attr_cell_target(&name) {
+            attrs.insert(key, value.clone());
+            self.env.insert(name, value.clone());
+            return Ok(value);
+        }
         let value_key = self.atomic_value_key_for_name(&name);
         self.env.insert(name.clone(), value.clone());
         self.shared_vars
@@ -181,6 +192,18 @@ impl Interpreter {
         let name = self.canonical_atomic_var_name(&raw_name, args.first());
         let delta = args[1].clone();
         self.check_readonly_for_modify(&name)?;
+        // Phase 3 cell-CAS: attribute targets RMW the receiver's shared cell.
+        if let Some((attrs, key)) = self.self_attr_cell_target(&name) {
+            let (_, next) = attrs.fetch_update(&key, |cur| {
+                let base = match cur {
+                    Value::Nil | Value::Package(_) => Value::Int(0),
+                    other => other.clone(),
+                };
+                crate::builtins::arith_add(base, delta.clone())
+            })?;
+            self.env.insert(name, next.clone());
+            return Ok(next);
+        }
         let value_key = self.atomic_value_key_for_name(&name);
         let mut shared = self.shared_vars.write().unwrap();
         let current = self.atomic_current_value(&shared, &name, &value_key);
@@ -209,6 +232,18 @@ impl Interpreter {
         let name = self.canonical_atomic_var_name(&raw_name, args.first());
         let delta = args[1].clone();
         self.check_readonly_for_modify(&name)?;
+        // Phase 3 cell-CAS: attribute targets RMW the receiver's shared cell.
+        if let Some((attrs, key)) = self.self_attr_cell_target(&name) {
+            let (old, next) = attrs.fetch_update(&key, |cur| {
+                let base = match cur {
+                    Value::Nil | Value::Package(_) => Value::Int(0),
+                    other => other.clone(),
+                };
+                crate::builtins::arith_add(base, delta.clone())
+            })?;
+            self.env.insert(name, next);
+            return Ok(old);
+        }
         let value_key = self.atomic_value_key_for_name(&name);
         let mut shared = self.shared_vars.write().unwrap();
         let current = self.atomic_current_value(&shared, &name, &value_key);
@@ -231,29 +266,24 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let name = self.atomic_var_name_arg(args)?;
         self.check_readonly_for_modify(&name)?;
-        // For instance attribute variables (private `!attr` or public `.attr`),
-        // use a per-instance shared_vars key so that multiple method calls on the
-        // same object (via different Value clones, e.g. in Junction gist) see
-        // consistent state. The key includes the instance ID for isolation.
+        // Phase 3 cell-CAS: instance attribute variables (private `!attr` or
+        // public `.attr`) read-modify-write the receiver's shared attribute
+        // cell under its write lock — atomic across every alias and thread.
         if name.starts_with('!') || name.starts_with('.') {
-            let instance_id = match self.env.get("self") {
-                Some(Value::Instance { id, .. }) => Some(*id),
-                _ => None,
-            };
-            if let Some(id) = instance_id {
-                // Use shared_vars keyed by instance ID + attr name for atomicity
-                let instance_key = format!("__mutsu_atomic_attr::{}::{}", id, name);
-                let mut shared = self.shared_vars.write().unwrap();
-                let current = shared
-                    .get(&instance_key)
-                    .cloned()
-                    .or_else(|| self.env.get(&name).cloned())
-                    .unwrap_or(Value::Int(0));
-                let next = crate::builtins::arith_add(current.clone(), Value::Int(delta))?;
+            if let Some((attrs, key)) = self.self_attr_cell_target(&name) {
+                let (old, next) = attrs.fetch_update(&key, |cur| {
+                    let base = match cur {
+                        Value::Nil | Value::Package(_) => Value::Int(0),
+                        other => other.clone(),
+                    };
+                    crate::builtins::arith_add(base, Value::Int(delta))
+                })?;
+                let old = match old {
+                    Value::Nil | Value::Package(_) => Value::Int(0),
+                    other => other,
+                };
                 self.env.insert(name, next.clone());
-                shared.insert(instance_key, next.clone());
-                drop(shared);
-                return if return_old { Ok(current) } else { Ok(next) };
+                return if return_old { Ok(old) } else { Ok(next) };
             }
             // Fallback for non-instance context: use env directly
             let current = self.env.get(&name).cloned().unwrap_or(Value::Int(0));
@@ -315,24 +345,33 @@ impl Interpreter {
         let raw_name = args[0].to_string_value();
         let name = self.canonical_atomic_var_name(&raw_name, args.first());
         self.check_readonly_for_modify(&name)?;
-        // For instance attributes, use an instance-specific key to avoid
-        // stale data when a new instance reuses the same attribute name.
-        let effective_name = if name.starts_with('!') {
-            if let Some(Value::Instance { id, .. }) = self.env.get("self") {
-                format!("{}::{}", name, id)
-            } else {
-                name.clone()
-            }
+        // Phase 3 cell-CAS: an instance attribute target operates directly on
+        // the receiver's shared attribute cell — its write lock is the atomic
+        // primitive and every alias shares the cell, so the swap is visible to
+        // all frames and threads without the legacy shared_vars side channel.
+        let attr_cell = self.self_attr_cell_target(&name);
+        let value_key = if attr_cell.is_none() {
+            self.atomic_value_key_for_name(&name)
         } else {
-            name.clone()
+            String::new()
         };
-        let value_key = self.atomic_value_key_for_name(&effective_name);
 
         if args.len() == 3 {
             // 3-arg form: cas($var, $expected, $new)
             let expected = &args[1];
             let new_val = args[2].clone();
             let coerced = self.atomic_assign_coerced_value(&name, new_val)?;
+            if let Some((attrs, key)) = attr_cell {
+                let (current, swapped) = attrs.compare_and_swap(
+                    &key,
+                    |cur| Self::cas_retry_matches(cur, expected),
+                    coerced.clone(),
+                );
+                // Keep the frame's env copy coherent for legacy env readers.
+                let env_val = if swapped { coerced } else { current.clone() };
+                self.env.insert(name, env_val);
+                return Ok(current);
+            }
             let mut did_swap = false;
             let current = {
                 let mut shared = self.shared_vars.write().unwrap();
@@ -348,12 +387,6 @@ impl Interpreter {
                 if let Ok(mut dirty) = self.shared_vars_dirty.write() {
                     dirty.insert(value_key);
                     dirty.insert(name.clone());
-                }
-                // If the variable is an instance attribute (!attr_name),
-                // also update the Instance in env and shared_vars so the
-                // main thread can pick up the change after await.
-                if let Some(attr_name) = name.strip_prefix('!') {
-                    self.sync_atomic_attribute_to_instance(attr_name, &coerced);
                 }
             } else {
                 self.env.insert(name.clone(), current.clone());
@@ -440,7 +473,13 @@ impl Interpreter {
                 }
             }
             loop {
-                let current = {
+                let current = if let Some((attrs, key)) = &attr_cell {
+                    attrs
+                        .as_map()
+                        .get(key.as_str())
+                        .cloned()
+                        .unwrap_or(Value::Nil)
+                } else {
                     let shared = self.shared_vars.read().unwrap();
                     self.atomic_current_value(&shared, &name, &value_key)
                 };
@@ -503,20 +542,33 @@ impl Interpreter {
                 // pre-block snapshot rather than the value the block may have modified.
                 self.env.insert(name.clone(), current.clone());
 
-                let mut updated = false;
-                {
+                let updated = if let Some((attrs, key)) = &attr_cell {
+                    let (seen, swapped) = attrs.compare_and_swap(
+                        key,
+                        |cur| Self::cas_retry_matches(&current, cur),
+                        coerced.clone(),
+                    );
+                    if !swapped {
+                        self.env.insert(name.clone(), seen);
+                    }
+                    swapped
+                } else {
                     let mut shared = self.shared_vars.write().unwrap();
                     let seen = self.atomic_current_value(&shared, &name, &value_key);
                     if Self::cas_retry_matches(&current, &seen) {
                         shared.insert(value_key.clone(), coerced.clone());
-                        updated = true;
+                        true
                     } else {
+                        drop(shared);
                         self.env.insert(name.clone(), seen);
+                        false
                     }
-                }
+                };
                 if updated {
                     self.env.insert(name.clone(), coerced.clone());
-                    if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+                    if attr_cell.is_none()
+                        && let Ok(mut dirty) = self.shared_vars_dirty.write()
+                    {
                         dirty.insert(value_key.clone());
                         dirty.insert(name.clone());
                     }
@@ -723,38 +775,43 @@ impl Interpreter {
     /// After CAS updates an attribute variable (`!attr_name`), update the
     /// corresponding Instance object in env ("self") and store the updated
     /// Instance in shared_vars so the main thread can pick it up after await.
-    fn sync_atomic_attribute_to_instance(&mut self, attr_name: &str, new_val: &Value) {
-        if let Some(Value::Instance {
-            class_name,
-            attributes,
-            id,
-        }) = self.env.get("self").cloned()
+    /// Phase 3 cell-CAS: resolve an attribute-twigil atomic target (`!x`/`.x`)
+    /// to `self`'s shared attribute cell and the map key, preferring the method
+    /// owner class's qualified private key (Parent/Child same-named `$!priv`
+    /// disambiguation, matching the VM's cell-direct access). Returns `None`
+    /// when not in an instance method context, falling back to the shared_vars
+    /// atomic machinery for plain variables.
+    fn self_attr_cell_target(
+        &self,
+        name: &str,
+    ) -> Option<(std::sync::Arc<crate::value::InstanceAttrs>, String)> {
+        let bare = name.strip_prefix('!').or_else(|| name.strip_prefix('.'))?;
+        if !bare
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic() || c == '_')
         {
-            let new_attrs = (*attributes).clone();
-            new_attrs.insert(attr_name.to_string(), new_val.clone());
-            // Build a *detached* instance (fresh, unregistered cell) for the
-            // cross-thread sync. Using the cell-reusing `make_instance_with_id`
-            // here would let concurrent CAS winners write the shared cell out of
-            // order (the writes happen outside the CAS critical section),
-            // dropping updates. The atomic source of truth is shared_vars; the
-            // parent picks this instance up via the `__mutsu_instance::` key
-            // after `await`.
-            let updated_instance =
-                Value::make_instance_detached(class_name, new_attrs.to_map(), id);
-            self.env
-                .insert("self".to_string(), updated_instance.clone());
-            self.env
-                .insert("__ANON_STATE__".to_string(), updated_instance.clone());
-            // Store the updated instance in shared_vars keyed by instance id
-            let instance_key = format!("__mutsu_instance::{id}");
-            {
-                let mut shared = self.shared_vars.write().unwrap();
-                shared.insert(instance_key.clone(), updated_instance);
-            }
-            if let Ok(mut dirty) = self.shared_vars_dirty.write() {
-                dirty.insert(instance_key);
-            }
+            return None;
         }
+        let Some(Value::Instance { attributes, .. }) = self.env.get("self") else {
+            return None;
+        };
+        let attrs = attributes.clone();
+        let key = {
+            let map = attrs.as_map();
+            match self.method_class_stack.last() {
+                Some(owner) => {
+                    let qualified = format!("{}\0{}", owner, bare);
+                    if map.contains_key(&qualified) {
+                        qualified
+                    } else {
+                        bare.to_string()
+                    }
+                }
+                None => bare.to_string(),
+            }
+        };
+        Some((attrs, key))
     }
 
     /// CAS on a hash element: cas(%hash{key}, &code)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5827,26 +5827,11 @@ impl Interpreter {
             }
             updates
         };
-        let mut instance_updates: Vec<(u64, Value)> = Vec::new();
+        // Instance attribute CAS updates need no propagation here: cell-CAS
+        // mutates the receiver's shared attribute cell in place, so every
+        // alias (including the parent thread's) observes the swap directly.
         for (key, val) in updates {
-            if let Some(id_str) = key.strip_prefix("__mutsu_instance::") {
-                if let Ok(id) = id_str.parse::<u64>() {
-                    instance_updates.push((id, val));
-                }
-            } else {
-                self.env.insert(key, val);
-            }
-        }
-        // Propagate Instance attribute updates from shared_vars into
-        // all matching Instance bindings in the local env.
-        for (target_id, updated_instance) in &instance_updates {
-            for value in self.env.values_mut() {
-                if let Value::Instance { id, .. } = value
-                    && *id == *target_id
-                {
-                    *value = updated_instance.clone();
-                }
-            }
+            self.env.insert(key, val);
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -739,6 +739,42 @@ impl InstanceAttrs {
         write_cell_respecting_reads(&self.attributes, map);
     }
 
+    /// Phase 3 cell-CAS: atomically compare-and-swap one attribute under a
+    /// single write lock. When `matches(current)` returns true the new value is
+    /// stored; returns `(current, swapped)`. The cell's write lock is the
+    /// atomic primitive for cross-thread `cas`/atomic ops on instance
+    /// attributes — every alias of the instance shares this cell, so the swap
+    /// is immediately visible everywhere (no shared_vars side channel).
+    pub(crate) fn compare_and_swap(
+        &self,
+        key: &str,
+        matches: impl FnOnce(&Value) -> bool,
+        new: Value,
+    ) -> (Value, bool) {
+        let mut guard = write_attrs(&self.attributes);
+        let current = guard.get(key).cloned().unwrap_or(Value::Nil);
+        let swapped = matches(&current);
+        if swapped {
+            guard.insert(key.to_string(), new);
+        }
+        (current, swapped)
+    }
+
+    /// Phase 3 cell-CAS: atomically read-modify-write one attribute under a
+    /// single write lock (atomic add / increment / decrement). Returns
+    /// `(old, new)`; an error from `f` leaves the attribute unchanged.
+    pub(crate) fn fetch_update(
+        &self,
+        key: &str,
+        f: impl FnOnce(&Value) -> Result<Value, RuntimeError>,
+    ) -> Result<(Value, Value), RuntimeError> {
+        let mut guard = write_attrs(&self.attributes);
+        let current = guard.get(key).cloned().unwrap_or(Value::Nil);
+        let next = f(&current)?;
+        guard.insert(key.to_string(), next.clone());
+        Ok((current, next))
+    }
+
     /// Build an `InstanceAttrs` that SHARES this cell but carries a different
     /// `class_name` (rebless / role mixin). The mutation visibility comes from the
     /// shared cell; only the class tag differs.
@@ -3085,19 +3121,6 @@ impl Value {
     ) -> Value {
         attrs.commit_attrs(map);
         Value::instance_sharing_cell(attrs, class_name, id)
-    }
-
-    /// Build an instance with the given id and a fresh cell, used by the
-    /// cross-thread atomic write-back where the authoritative store is
-    /// `shared_vars`. Equivalent to [`Self::make_instance_with_id`] now that
-    /// instances no longer share cells through a global registry; kept as a
-    /// distinct name to mark the atomic-sync intent at the call site.
-    pub(crate) fn make_instance_detached(
-        class_name: Symbol,
-        attributes: HashMap<String, Value>,
-        id: u64,
-    ) -> Self {
-        Self::make_instance_with_id(class_name, attributes, id)
     }
 
     /// An independent snapshot for `temp`/`let` saves. An instance is deep-copied

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -763,6 +763,7 @@ impl InstanceAttrs {
     /// Phase 3 cell-CAS: atomically read-modify-write one attribute under a
     /// single write lock (atomic add / increment / decrement). Returns
     /// `(old, new)`; an error from `f` leaves the attribute unchanged.
+    #[allow(clippy::result_large_err)]
     pub(crate) fn fetch_update(
         &self,
         key: &str,

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -222,9 +222,12 @@ impl VM {
                             self.interpreter.pop_method_dispatch();
                         }
                         self.interpreter.pop_method_samewith_context();
-                        let (result, new_attrs) = method_result?;
+                        let (result, new_attrs, attrs_adjusted) = method_result?;
                         if let Some(id) = target_id {
-                            if let Some(cell) = &attrs_cell {
+                            // Commit only a `:=`-adjusted snapshot: an unadjusted
+                            // one equals the cell and the whole-map write would
+                            // race with concurrent cell-CAS (lost updates).
+                            if attrs_adjusted && let Some(cell) = &attrs_cell {
                                 cell.commit_attrs(new_attrs.clone());
                             }
                             if !self.interpreter.in_lvalue_assignment
@@ -1339,9 +1342,12 @@ impl VM {
             self.interpreter.pop_method_samewith_context();
             result
         };
-        let (result, new_attrs) = method_result?;
+        let (result, new_attrs, attrs_adjusted) = method_result?;
         if let Some(id) = target_id {
-            if let Some(cell) = &attrs_cell {
+            // Commit only a `:=`-adjusted snapshot: an unadjusted one equals the
+            // cell and the whole-map write would race with concurrent cell-CAS
+            // from another thread (lost updates).
+            if attrs_adjusted && let Some(cell) = &attrs_cell {
                 cell.commit_attrs(new_attrs.clone());
             }
             if !self.interpreter.in_lvalue_assignment
@@ -1579,9 +1585,12 @@ impl VM {
                             self.interpreter.pop_method_dispatch();
                         }
                         self.interpreter.pop_method_samewith_context();
-                        let (result, new_attrs) = method_result?;
+                        let (result, new_attrs, attrs_adjusted) = method_result?;
                         if let Some(id) = target_id {
-                            if let Some(cell) = &attrs_cell {
+                            // Commit only a `:=`-adjusted snapshot: an unadjusted
+                            // one equals the cell and the whole-map write would
+                            // race with concurrent cell-CAS (lost updates).
+                            if attrs_adjusted && let Some(cell) = &attrs_cell {
                                 cell.commit_attrs(new_attrs.clone());
                             }
                             if !self.interpreter.in_lvalue_assignment
@@ -1679,9 +1688,11 @@ impl VM {
                     self.interpreter.pop_method_dispatch();
                 }
                 self.interpreter.pop_method_samewith_context();
-                let (result, new_attrs) = method_result?;
+                let (result, new_attrs, attrs_adjusted) = method_result?;
                 if let Some(id) = target_id {
-                    if let Some(cell) = &attrs_cell {
+                    // Commit only a `:=`-adjusted snapshot (cell-CAS race
+                    // avoidance — see the primary dispatch site).
+                    if attrs_adjusted && let Some(cell) = &attrs_cell {
                         cell.commit_attrs(new_attrs.clone());
                     }
                     if !self.interpreter.in_lvalue_assignment

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -17,7 +17,7 @@ impl VM {
         args: Vec<Value>,
         invocant: Option<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, HashMap<String, Value>, bool), RuntimeError> {
         // Check for `is DEPRECATED` trait on the method
         if let Some(ref msg) = method_def.deprecated_message {
             let cl = self.interpreter.env().get("?LINE").and_then(|v| match v {
@@ -573,12 +573,13 @@ impl VM {
             self.interpreter.set_state_var(key.clone(), val);
         }
 
+        let attrs_adjusted;
         if can_skip_merge {
             // Phase 3 Stage 2: all attributes (scalar/array/hash) are reconciled
             // against the live cell + local/env writes before the env is torn
             // down. The cell-direct reads + per-op mirrors make the cell the
             // single source; the legacy attribute writeback is gone.
-            self.reconcile_attrs(&base, cc, &mut attributes);
+            attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
 
             let method_var_bindings = self.interpreter.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -601,7 +602,7 @@ impl VM {
 
             // Phase 3 Stage 2: reconcile all attributes against the live cell +
             // local/env writes before the env is merged away.
-            self.reconcile_attrs(&base, cc, &mut attributes);
+            attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
             let mut method_local_keys: HashSet<String> = HashSet::from_iter([
                 "self".to_string(),
                 "__ANON_STATE__".to_string(),
@@ -710,7 +711,11 @@ impl VM {
             }
         };
 
-        // Adjust return value if it's the same instance (update attributes)
+        // Adjust return value if it's the same instance (update attributes).
+        // Only commit the reconcile snapshot when it was adjusted beyond the
+        // cell contents (`:=` recovery): an unadjusted snapshot is already what
+        // the cell holds, and writing it back would race with concurrent
+        // cell-CAS / cell-direct writes from other threads (lost updates).
         final_result.map(|v| {
             let adjusted = match (&base, &v) {
                 (
@@ -721,11 +726,20 @@ impl VM {
                     },
                     Value::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    Value::write_back_sharing(base_attrs, *class_name, attributes.clone(), *base_id)
+                    if attrs_adjusted {
+                        Value::write_back_sharing(
+                            base_attrs,
+                            *class_name,
+                            attributes.clone(),
+                            *base_id,
+                        )
+                    } else {
+                        Value::instance_sharing_cell(base_attrs, *class_name, *base_id)
+                    }
                 }
                 _ => v,
             };
-            (adjusted, attributes)
+            (adjusted, attributes, attrs_adjusted)
         })
     }
 
@@ -744,19 +758,27 @@ impl VM {
     /// an external `ContainerRef` held in env/locals rather than the cell. The
     /// cell-direct write path does not carry that binding, so recover it from
     /// env/locals here and let it win, keeping the alias alive past method exit.
+    ///
+    /// Returns `true` when the map was adjusted beyond the raw cell snapshot
+    /// (a `:=` ContainerRef was recovered). When `false`, the map is exactly the
+    /// cell's current contents, so committing it back would be a no-op at best —
+    /// and a lost-update race at worst: a concurrent cell-CAS / cell-direct write
+    /// from another thread between this snapshot and the commit would be
+    /// clobbered by the stale whole-map write. Callers skip the commit then.
     fn reconcile_attrs(
         &self,
         base: &Value,
         code: &CompiledCode,
         attributes: &mut HashMap<String, Value>,
-    ) {
+    ) -> bool {
         let Value::Instance {
             attributes: cell, ..
         } = base
         else {
-            return;
+            return false;
         };
         *attributes = cell.to_map();
+        let mut adjusted = false;
         // Preserve `:=`-bound attributes: their authoritative value is the shared
         // ContainerRef in env/locals, not the cell snapshot.
         let keys: Vec<String> = attributes.keys().cloned().collect();
@@ -781,10 +803,12 @@ impl VM {
                     && v.is_container_ref()
                 {
                     attributes.insert(k.clone(), v);
+                    adjusted = true;
                     break;
                 }
             }
         }
+        adjusted
     }
 
     /// Read the current value of `name` from the method's local slot if present,
@@ -833,7 +857,7 @@ impl VM {
         base: Value,
         compiled_fns: &HashMap<String, CompiledFunction>,
         can_skip_merge: bool,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, HashMap<String, Value>, bool), RuntimeError> {
         if let Some(ref msg) = method_def.deprecated_message {
             self.interpreter.check_deprecation_for_method_with_line(
                 method_name,
@@ -1173,7 +1197,7 @@ impl VM {
         }
         // Phase 3 Stage 2: reconcile all attributes against the live cell +
         // local/env writes before the env is torn down.
-        self.reconcile_attrs(&base, cc, &mut attributes);
+        let attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
 
         let method_var_bindings = self.interpreter.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;
@@ -1260,6 +1284,8 @@ impl VM {
             }
         };
 
+        // Only commit the reconcile snapshot when `:=` recovery adjusted it
+        // beyond the cell contents (see `call_compiled_method` exit).
         final_result.map(|v| {
             let adjusted = match (&base, &v) {
                 (
@@ -1270,11 +1296,20 @@ impl VM {
                     },
                     Value::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    Value::write_back_sharing(base_attrs, *class_name, attributes.clone(), *base_id)
+                    if attrs_adjusted {
+                        Value::write_back_sharing(
+                            base_attrs,
+                            *class_name,
+                            attributes.clone(),
+                            *base_id,
+                        )
+                    } else {
+                        Value::instance_sharing_cell(base_attrs, *class_name, *base_id)
+                    }
                 }
                 _ => v,
             };
-            (adjusted, attributes)
+            (adjusted, attributes, attrs_adjusted)
         })
     }
 }

--- a/t/cas-cell-attr.t
+++ b/t/cas-cell-attr.t
@@ -1,0 +1,83 @@
+use v6;
+use Test;
+
+plan 14;
+
+# Phase 3 cell-CAS: cas/atomic ops on instance attributes operate directly on
+# the instance's shared attribute cell (its write lock is the atomic
+# primitive), with no shared_vars side channel.
+
+class Box {
+    has $!x = 10;
+    has atomicint $.n = 0;
+
+    method cas-swap() { cas($!x, 10, 20) }
+    method cas-miss() { cas($!x, 999, 30) }
+    method cas-block() { cas($!x, -> $v { $v + 5 }) }
+    method bump() { $!n⚛++ }
+    method drop() { $!n⚛-- }
+    method fetch-n() { atomic-fetch($!n) }
+    method x() { $!x }
+}
+
+my $b = Box.new;
+is $b.cas-swap, 10, '3-arg cas returns the old value on swap';
+is $b.x, 20, '3-arg cas stores the new value when expected matches';
+is $b.cas-miss, 20, '3-arg cas returns the current value on mismatch';
+is $b.x, 20, '3-arg cas leaves the attribute unchanged on mismatch';
+is $b.cas-block, 25, '2-arg cas returns the block result';
+is $b.x, 25, '2-arg cas stores the block result';
+
+$b.bump; $b.bump; $b.bump; $b.drop;
+is $b.n, 2, 'atomic increment/decrement on attribute accumulates';
+is $b.fetch-n, 2, 'atomic-fetch reads the attribute';
+
+# Cross-instance isolation: each instance has its own cell.
+class Counter {
+    has atomicint $!c = 0;
+    method add() { cas($!c, -> $v { $v + 1 }) }
+    method c() { $!c }
+}
+my $c1 = Counter.new;
+my $c2 = Counter.new;
+$c1.add; $c1.add; $c2.add;
+is $c1.c, 2, 'cas on instance 1 stays in its own cell';
+is $c2.c, 1, 'cas on instance 2 stays in its own cell';
+
+# Atomic increments from a closure (cross-frame cell visibility).
+my $bump = -> { $b.bump };
+$bump(); $bump();
+is $b.n, 4, 'atomic attr increments through a closure accumulate';
+
+# Cross-thread atomic increment: no lost updates (the lost-update race was the
+# per-method-exit whole-map cell commit clobbering concurrent cell RMWs).
+class Tally {
+    has atomicint $.count = 0;
+    method incr() { $!count⚛++ }
+}
+my $t = Tally.new;
+my @p = (1..4).map: { start { $t.incr for ^250 } };
+await @p;
+is $t.count, 1000, 'cross-thread atomic attr increments lose no updates';
+
+# Cross-thread 2-arg cas accumulation.
+class Sum {
+    has $!total = 0;
+    method add($v) { cas($!total, -> $cur { $cur + $v }) }
+    method total() { $!total }
+}
+my $s = Sum.new;
+my @q = (1..4).map: -> $i { start { $s.add($i) for ^100 } };
+await @q;
+is $s.total, 100 * (1 + 2 + 3 + 4), 'cross-thread 2-arg cas loses no updates';
+
+# Parent sees the swapped value immediately after await (shared cell, no
+# post-await collection step).
+class Flag {
+    has $!state = 'init';
+    method set() { cas($!state, 'init', 'done') }
+    method state() { $!state }
+}
+my $f = Flag.new;
+await start { $f.set };
+is $f.state, 'done', 'parent observes a child-thread cas through the shared cell';


### PR DESCRIPTION
## Summary

Resume map #2 of the instance-cells Phase 3 campaign: make the instance attribute cell the **atomic primitive** for `cas`/atomic ops, removing the legacy shared_vars side channel.

### What was wrong

- Attr cas/atomic truth lived in shared_vars (`!attr::{id}` keys, `__mutsu_atomic_attr::{id}::{attr}`), with a detached-instance sync under `__mutsu_instance::{id}` collected by the parent after `await` via an env scan-replace.
- Cross-thread visibility only worked for 3-arg cas. An atomic attr increment (`$!count⚛++`) across threads **never reached the parent at all** — 8 threads × 500 increments observed as **0** on main.

### Changes

- New `InstanceAttrs::compare_and_swap` / `fetch_update`: compare+store and RMW under a single cell write lock.
- `builtin_cas_var` (3-arg + 2-arg retry loop), `builtin_atomic_update_unit`, `builtin_atomic_{add,fetch_add,fetch,store}_var` route attribute targets to the cell (`self_attr_cell_target`, qualified-key aware). Every alias shares the cell → swaps visible to all frames/threads immediately.
- Removed: `sync_atomic_attribute_to_instance`, `Value::make_instance_detached`, the parent-side `__mutsu_instance::` collection + env scan-replace. (The Stage 1 cell-CAS livelock no longer applies — attr reads are cell-direct since Stage 2a.)

### Second race found and fixed

Cell-CAS alone still lost ~40% of updates: the per-method-exit reconcile snapshot was committed back **wholesale on every call** (`cell.commit_attrs` at 4 dispatch sites + `write_back_sharing` on self-returning methods), clobbering concurrent cell RMWs between snapshot and commit (TOCTOU). The snapshot only differs from the cell by `:=` ContainerRef recovery, so `reconcile_attrs` now reports whether it adjusted anything and the exit commit is skipped otherwise — removing both the race and the redundant whole-map write on every method return.

## Testing

- New `t/cas-cell-attr.t` (14 tests): 3-arg swap/miss, 2-arg block, ⚛++/⚛--, atomic-fetch, cross-instance isolation, closure visibility, 4-thread increment (1000/1000), 4-thread 2-arg cas, post-await parent visibility — verified against `raku`
- 8-thread × 500 `$!count⚛++` stress: 4000/4000 stable ×3 (main: 0; cell-CAS without the commit fix: ~2400)
- `roast/S17-lowlevel/cas.t` ×5 consecutive PASS (livelock check), full S12/S14/S17 whitelist 175 files / 2929 tests PASS
- `make test` PASS (723 files / 6550 tests), cargo test, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)