### PR TITLE
feat(hash): HashData wrapper + embed type metadata (kill hash_type_metadata side-table flaky)

### DIFF
--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -1,0 +1,79 @@
+# `Value::Hash` → `Arc<HashData>` migration (stable-container-ID, PLAN Q2 本筋)
+
+> Goal: kill the `Arc::as_ptr`-keyed side tables (`hash_type_metadata`,
+> `register_hash_original_keys`, …) — the root of the intermittent typed-hash /
+> object-hash flaky — by carrying the metadata IN the hash value, so it survives
+> copy-on-write and pointer reuse. Unblocks object-hash (`%{Mu}`, classify.t,
+> objecthash.t) and removes a class of flaky.
+
+## Status (2026-06-12)
+
+**Stage 1a — HashData wrapper (DONE, on branch `refactor/hashdata-wrapper`,
+pushed, NOT merged).** `Value::Hash(Arc<HashMap>)` → `Value::Hash(Arc<HashData>)`.
+
+```rust
+pub struct HashData {
+    pub map: HashMap<String, Value>,
+    pub value_type: Option<String>,    // element type (my Int %h)
+    pub key_type: Option<String>,      // object-hash key type (my %h{Mu})
+    pub original_keys: Option<HashMap<String, Value>>, // WHICH -> key object
+}
+// Deref/DerefMut -> map (reads unchanged); PartialEq compares map only.
+```
+
+- 120 compile errors fixed across 31 files. `Value::hash`/`hash_arc` take
+  `impl Into<HashData>` (accept HashMap OR HashData, preserving meta on rebuild).
+  Deref absorbed ~398 read sites; only structural mutation/rebuild sites changed.
+- Builds, clippy-clean. The `value_type`/`key_type`/`original_keys` fields are
+  **declared but not yet populated/read** — the Arc-ptr side tables still do all
+  the work (keyed by the HashData ptr now). So it is *intended* behavior-invariant.
+
+**BLOCKER (why 1a is not shippable alone):** the allocation-pattern shift makes
+the latent Arc-ptr-reuse flaky DETERMINISTIC: `t/typed-hash-bind-typecheck.t`
+test 11 fails — after `my Int %a; my Cool %b := %a;` a fresh `{a=>1}` literal
+reuses the dropped Int hash's pointer and inherits its stale
+`hash_type_metadata` entry, so `my Int %h := {a=>1}` wrongly type-matches and
+does not throw `X::TypeCheck::Binding`. (Repro:
+`my Int %a; %a<x>=1; my Cool %b := %a; my Int %h := { a => 1 }` — should throw.)
+This is exactly the flaky 1b removes; 1a alone perturbs it into determinism.
+
+## Stage 1b — embed hash metadata in HashData (the remaining work)
+
+The fix is to make HashData the **authoritative** source of hash metadata and
+delete the side-table fallback, so a fresh hash (HashData fields = None) cannot
+inherit a stale entry.
+
+The hard part: `register_container_type_metadata(&self, value: &Value, info)`
+currently *tags an existing* (often shared, borrowed) hash by pointer. To embed
+metadata in HashData it must instead be set **at/near construction** (when the
+Arc is uniquely owned, so `Arc::make_mut` is a no-op clone) or the call site must
+own the slot and re-store the mutated hash. ~67 register call sites + the var-decl
+typed-hash path.
+
+Concrete steps:
+1. `container_type_metadata` / `hash_key_type` Hash arm: read `items.value_type`
+   / `items.key_type` (return early if `items.has_meta()`); REMOVE the
+   `hash_type_metadata` side-table read for hashes.
+2. Migrate every hash metadata writer to set `HashData` fields instead of
+   `hash_type_metadata.insert`. For writers that hold the owning slot
+   (`my Int %h` decl, `%h := ...`, coercions building a fresh hash), build the
+   HashData with the fields set, or `Arc::make_mut(slot).value_type = ...`.
+3. `register_hash_original_keys` → set `HashData.original_keys`; readers
+   (`.keys`/`.raku`/subscript/object-hash WHICH lookup) read it from HashData.
+   This is what makes object-hash survive COW (the classify.t fix that regressed
+   on the side table — see memory `phase2-status-and-objecthash-blocker`).
+4. Delete `hash_type_metadata` (+ the name-based reconcile workarounds it needed).
+5. Verify: `t/typed-hash-bind-typecheck.t` (the canary), `make test`, and the
+   **release roast** (Arc-ptr flaky only shows in release — S02-names-vars/perl.t,
+   S02-types/hash.t). Then object-hash (classify.t/objecthash.t) as Stage 2,
+   reusing the now-COW-stable original_keys.
+
+Array/Set/Bag/Mix have the SAME Arc-ptr side tables (array_type_metadata, …) and
+the same flaky; apply the same wrapper (ArrayData, …) after the hash one lands.
+
+## Why staged this way
+
+Stage 1a (wrapper, intended-invariant) is the mechanical foundation; 1b (embed +
+delete side table) is the value (kills the flaky, enables object-hash) but needs
+the register-at-construction rework. Do 1b in one focused PR with the canary test
+above gating it.

--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -37,7 +37,43 @@ does not throw `X::TypeCheck::Binding`. (Repro:
 `my Int %a; %a<x>=1; my Cool %b := %a; my Int %h := { a => 1 }` — should throw.)
 This is exactly the flaky 1b removes; 1a alone perturbs it into determinism.
 
-## Stage 1b — embed hash metadata in HashData (the remaining work)
+## Stage 1b — embed hash *type* metadata in HashData (DONE)
+
+**Status (2026-06-12): type metadata embedded; `hash_type_metadata` side table
+deleted.** The canary `t/typed-hash-bind-typecheck.t` (11/11) and the original
+repro now throw correctly; `S02-types/hash.t` is 112/112 again (it had been
+SEGV-ing — see below). value_type/key_type/declared_type live in `HashData` and
+travel through copy-on-write; `container_type_metadata`/`is_object_hash`/
+`hash_key_type` read them directly (no side table for hashes).
+
+Key mechanism: `Interpreter::tag_container_metadata(value, info) -> Value` embeds
+the type info into the `HashData` (via `Arc::make_mut`) for hashes and falls back
+to the Arc-pointer side tables for Array/Set/Bag/Mix/Instance (returning the same
+Arc). Every hash-reachable `register_container_type_metadata` writer was migrated
+to `tag_container_metadata` + write-back of the returned value into its owning
+slot (env/local). `register_container_type_metadata`'s Hash arm is now a
+`debug_assert!(false)` tripwire to catch any missed site. The name-based
+`reconcile_hash_type_metadata_from_name` healing workaround is deleted (no longer
+needed — embedded metadata is COW-stable).
+
+**Latent UB found & fixed:** `hash_autovivify` / `hash_slot_ref`
+(`src/value/mod.rs`) still cast `Arc::as_ptr(arc) as *mut HashMap` — reading the
+`HashData` as a bare `HashMap`. This was accidentally working on the Stage-1a
+branch only because `map` happened to land at offset 0; adding the
+`declared_type` field reordered the struct and turned it into a SEGV. Fixed to
+cast to `*mut HashData` and go through `.map`.
+
+### Remaining (Stage 2 — object-hash original_keys)
+
+`original_keys` (the `.WHICH`-string → original-key-object map) is STILL on the
+two Arc-pointer side tables (`hash_object_keys` + the `hash_original_keys_registry`
+in `runtime/utils.rs`). Object-hash tests `S09-hashes/objecthash.t` (7 fail) and
+`S32-list/classify.t` (1 fail) — both NOT whitelisted — remain blocked on this;
+they are unchanged by Stage 1b. Embed `original_keys` in `HashData` next, using
+the same `tag`/write-back pattern, then delete those two side tables.
+
+---
+(original plan below)
 
 The fix is to make HashData the **authoritative** source of hash metadata and
 delete the side-table fallback, so a fresh hash (HashData fields = None) cannot

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -37,7 +37,7 @@ pub(super) fn dispatch(
                 Value::Array(items, kind) => {
                     Some(Some(Ok(Value::Array(Arc::new(items.to_vec()), *kind))))
                 }
-                Value::Hash(map) => Some(Some(Ok(Value::Hash(Arc::new((**map).clone()))))),
+                Value::Hash(map) => Some(Some(Ok(Value::Hash(Value::hash_arc((**map).clone()))))),
                 Value::Set(data, mutable) => {
                     Some(Some(Ok(Value::Set(Arc::new((**data).clone()), *mutable))))
                 }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1089,7 +1089,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         match method {
             "meta" => {
                 return Some(Ok(attributes.as_map().get("$!meta").cloned().unwrap_or(
-                    Value::Hash(std::sync::Arc::new(std::collections::HashMap::new())),
+                    Value::Hash(Value::hash_arc(std::collections::HashMap::new())),
                 )));
             }
             "Str" | "gist" => {

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -840,7 +840,7 @@ impl Interpreter {
                     .env
                     .get(&hash_name)
                     .cloned()
-                    .unwrap_or_else(|| Value::Hash(std::sync::Arc::new(HashMap::new())));
+                    .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
                 let mut shared = self.shared_vars.write().unwrap();
                 if !shared.contains_key(&atomic_key) {
                     shared.insert(atomic_key.clone(), hash);
@@ -879,13 +879,13 @@ impl Interpreter {
                     let hash = shared
                         .get(&atomic_key)
                         .cloned()
-                        .unwrap_or_else(|| Value::Hash(std::sync::Arc::new(HashMap::new())));
+                        .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
                     if let Value::Hash(ref map) = hash {
                         let current = map.get(&key).cloned().unwrap_or(Value::Int(0));
                         let new_val = crate::builtins::arith_add(current, Value::Int(d))?;
                         let mut new_map = (**map).clone();
                         new_map.insert(key, new_val);
-                        let updated = Value::Hash(std::sync::Arc::new(new_map));
+                        let updated = Value::Hash(Value::hash_arc(new_map));
                         shared.insert(atomic_key.clone(), updated.clone());
                         shared.insert(hash_name.clone(), updated.clone());
                         drop(shared);
@@ -907,7 +907,7 @@ impl Interpreter {
                 let hash = shared
                     .get(&atomic_key)
                     .cloned()
-                    .unwrap_or_else(|| Value::Hash(std::sync::Arc::new(HashMap::new())));
+                    .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
                 if let Value::Hash(ref map) = hash {
                     map.get(&key).cloned().unwrap_or(Value::Int(0))
                 } else {
@@ -933,13 +933,13 @@ impl Interpreter {
             let hash = shared
                 .get(&atomic_key)
                 .cloned()
-                .unwrap_or_else(|| Value::Hash(std::sync::Arc::new(HashMap::new())));
+                .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
             if let Value::Hash(ref map) = hash {
                 let seen = map.get(&key).cloned().unwrap_or(Value::Int(0));
                 if Self::cas_retry_matches(&current, &seen) {
                     let mut new_map = (**map).clone();
                     new_map.insert(key, new_val);
-                    let updated = Value::Hash(std::sync::Arc::new(new_map));
+                    let updated = Value::Hash(Value::hash_arc(new_map));
                     shared.insert(atomic_key.clone(), updated.clone());
                     shared.insert(hash_name.clone(), updated.clone());
                     drop(shared);

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -540,14 +540,14 @@ impl Interpreter {
 
     fn extrema_from_hash(
         &mut self,
-        map: &std::sync::Arc<HashMap<String, Value>>,
+        map: &std::sync::Arc<crate::value::HashData>,
         by: Option<Value>,
         want_max: bool,
     ) -> Result<Value, RuntimeError> {
         let mut best_pair: Option<Value> = None;
         let mut best_key: Option<Value> = None;
 
-        for (k, v) in map.as_ref() {
+        for (k, v) in map.as_ref().iter() {
             let pair = Value::Pair(k.clone(), Box::new(v.clone()));
             let key = if let Some(by_callable) = &by {
                 match self.call_sub_value(by_callable.clone(), vec![pair.clone()], true) {
@@ -1906,7 +1906,7 @@ impl Interpreter {
         }
 
         let mut buckets: HashMap<String, Value> = match into_target.as_ref() {
-            Some(Value::Hash(map)) => map.as_ref().clone(),
+            Some(Value::Hash(map)) => map.as_ref().map.clone(),
             _ => HashMap::new(),
         };
         let mut bag_counts: Option<HashMap<String, i64>> = match into_target.as_ref() {
@@ -2248,7 +2248,7 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(Value::Hash(std::sync::Arc::new(result)))
+                Ok(Value::Hash(Value::hash_arc(result)))
             }
             // Single non-iterable value: try the block on it directly
             _ => self.duckmap_element(block, target),
@@ -2346,7 +2346,7 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(Value::Hash(std::sync::Arc::new(result)))
+                Ok(Value::Hash(Value::hash_arc(result)))
             }
             // Leaf value: apply the block
             _ => self.call_sub_value(block.clone(), vec![target.clone()], false),
@@ -2425,7 +2425,7 @@ impl Interpreter {
                         for (k, v) in map.iter() {
                             result.insert(k.clone(), self.duckmap_element(block, v)?);
                         }
-                        Ok(Value::Hash(std::sync::Arc::new(result)))
+                        Ok(Value::Hash(Value::hash_arc(result)))
                     }
                     // Not iterable — return unchanged
                     _ => Ok(value.clone()),

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -398,7 +398,7 @@ impl Interpreter {
                 let new_val = apply_hyper_prefix(self, &routine, v.clone())?;
                 result_map.insert(k.clone(), new_val);
             }
-            let result = Value::Hash(std::sync::Arc::new(result_map));
+            let result = Value::Hash(Value::hash_arc(result_map));
             if mutating {
                 self.overwrite_hash_bindings_by_identity(map, result.clone());
             }

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1419,7 +1419,7 @@ impl Interpreter {
             Value::Seq(items) => Ok(Value::array(items.as_ref().clone())),
             // xx thunks the LHS: each repetition must be an independent copy
             Value::Array(items, kind) => Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind)),
-            Value::Hash(map) => Ok(Value::Hash(Arc::new(map.as_ref().clone()))),
+            Value::Hash(map) => Ok(Value::Hash(Value::hash_arc(map.as_ref().clone()))),
             _ => Ok(left.clone()),
         }
     }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -1824,7 +1824,7 @@ mod tests {
     fn extract_proc_options_reads_win_verbatim_hash() {
         let mut map = HashMap::new();
         map.insert("win-verbatim-args".to_string(), Value::Bool(true));
-        let args = vec![Value::Hash(map.into())];
+        let args = vec![Value::hash(map)];
         let opts = Interpreter::extract_proc_options(&args, 0);
         assert!(opts.win_verbatim_args);
     }

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -2968,7 +2968,7 @@ impl Interpreter {
         // properties: a non-empty hash so the value is truthy.
         let mut props = HashMap::new();
         props.insert("name".to_string(), Value::str_from("mutsu"));
-        attrs.insert("properties".to_string(), Value::Hash(props.into()));
+        attrs.insert("properties".to_string(), Value::hash(props));
         // config: a non-empty hash so the value is truthy.
         let mut config = HashMap::new();
         config.insert("name".to_string(), Value::str_from("mutsu"));
@@ -2979,7 +2979,7 @@ impl Interpreter {
             "0"
         };
         config.insert("be".to_string(), Value::str_from(be_val));
-        attrs.insert("config".to_string(), Value::Hash(config.into()));
+        attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("VM"), attrs)
     }
 

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1060,13 +1060,13 @@ impl Interpreter {
             };
             // Check if we can mutate in-place (shared reference)
             if Arc::strong_count(arc) > 1 {
-                let ptr = Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
+                let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
                 unsafe {
                     for arg in args {
                         match arg {
                             Value::Pair(k, v) => {
                                 let key = k.as_str().to_string();
-                                let map = &mut *ptr;
+                                let map = &mut (*ptr).map;
                                 if let Some(existing) = map.get(&key) {
                                     // Key exists: create itemized array
                                     let arr = Value::Array(
@@ -1080,7 +1080,7 @@ impl Interpreter {
                             }
                             Value::ValuePair(k, v) => {
                                 let key = k.to_string_value();
-                                let map = &mut *ptr;
+                                let map = &mut (*ptr).map;
                                 if let Some(existing) = map.get(&key) {
                                     let arr = Value::Array(
                                         Arc::new(vec![existing.clone(), *v]),

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -592,7 +592,7 @@ impl Interpreter {
                 Value::Package(crate::symbol::Symbol::intern("GLOBAL")),
             );
             let mut handle_attrs = std::collections::HashMap::new();
-            handle_attrs.insert("unit".to_string(), Value::Hash(unit_hash.into()));
+            handle_attrs.insert("unit".to_string(), Value::hash(unit_hash));
             return Ok(Value::make_instance(
                 crate::symbol::Symbol::intern("CompUnit::Handle"),
                 handle_attrs,
@@ -1128,7 +1128,7 @@ impl Interpreter {
                     _ => {}
                 }
             }
-            return Ok(Value::Hash(Arc::new(new_map)));
+            return Ok(Value::Hash(Value::hash_arc(new_map)));
         }
         // IO::Special.new("<STDOUT>")
         if let Value::Package(name) = &target

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -135,7 +135,7 @@ impl Interpreter {
                             key_type: None,
                             declared_type: Some("Map".to_string()),
                         };
-                        self.register_container_type_metadata(&result, info);
+                        return Some(Ok(self.tag_container_metadata(result, info)));
                     }
                     return Some(Ok(result));
                 }

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -62,7 +62,7 @@ impl Interpreter {
                 files.insert(format!("bin/{name}"), Value::str(path));
             }
         }
-        Value::Hash(Arc::new(files))
+        Value::Hash(Value::hash_arc(files))
     }
 
     /// Extract short-name and matcher fields from a depspec value.
@@ -205,7 +205,7 @@ impl Interpreter {
             let meta = if let Value::Hash(map) = &meta {
                 let mut m = (**map).clone();
                 m.insert("files".to_string(), files_hash.clone());
-                Value::Hash(Arc::new(m))
+                Value::Hash(Value::hash_arc(m))
             } else {
                 meta
             };
@@ -231,13 +231,16 @@ impl Interpreter {
                     meta_map.insert("name".to_string(), Value::str(short_name.clone()));
                     let mut provides_map = HashMap::new();
                     provides_map.insert(short_name.clone(), Value::str(format!("{relative}{ext}")));
-                    meta_map.insert("provides".to_string(), Value::Hash(Arc::new(provides_map)));
-                    let meta = Value::Hash(Arc::new(meta_map));
+                    meta_map.insert(
+                        "provides".to_string(),
+                        Value::Hash(Value::hash_arc(provides_map)),
+                    );
+                    let meta = Value::Hash(Value::hash_arc(meta_map));
                     let files_hash = self.build_dist_files_hash(prefix, &meta);
                     let meta = if let Value::Hash(map) = &meta {
                         let mut m = (**map).clone();
                         m.insert("files".to_string(), files_hash.clone());
-                        Value::Hash(Arc::new(m))
+                        Value::Hash(Value::hash_arc(m))
                     } else {
                         meta
                     };
@@ -268,7 +271,7 @@ impl Interpreter {
         let meta = if let Value::Hash(map) = &meta {
             let mut m = (**map).clone();
             m.insert("files".to_string(), files_hash.clone());
-            Value::Hash(Arc::new(m))
+            Value::Hash(Value::hash_arc(m))
         } else {
             meta
         };
@@ -419,7 +422,7 @@ impl Interpreter {
                 }
                 let mut inner = HashMap::new();
                 inner.insert("file".to_string(), Value::str(source_id));
-                installed_provides.insert(k.clone(), Value::Hash(Arc::new(inner)));
+                installed_provides.insert(k.clone(), Value::Hash(Value::hash_arc(inner)));
             }
         }
         let mut installed_resources = HashMap::new();
@@ -474,18 +477,18 @@ impl Interpreter {
             other => other,
         };
         let mut meta_map = match meta_inner {
-            Value::Hash(map) => (**map).clone(),
+            Value::Hash(map) => map.map.clone(),
             _ => HashMap::new(),
         };
         meta_map.insert(
             "provides".to_string(),
-            Value::Hash(Arc::new(installed_provides)),
+            Value::Hash(Value::hash_arc(installed_provides)),
         );
         let mut all_files = installed_resources;
         all_files.extend(installed_bin);
-        meta_map.insert("files".to_string(), Value::Hash(Arc::new(all_files)));
+        meta_map.insert("files".to_string(), Value::Hash(Value::hash_arc(all_files)));
         meta_map.insert("dist-id".to_string(), Value::str(dist_id.clone()));
-        let meta_value = Value::Hash(Arc::new(meta_map));
+        let meta_value = Value::Hash(Value::hash_arc(meta_map));
         let json_str = value_to_json_string(&meta_value);
         let dist_file = dist_dir.join(format!("{dist_id}.json"));
         std::fs::write(&dist_file, json_str)
@@ -905,7 +908,7 @@ fn parse_json_object(s: &str) -> Result<(Value, &str), String> {
     let mut map = HashMap::new();
     let mut s = s.trim_start();
     if let Some(rest) = s.strip_prefix('}') {
-        return Ok((Value::Hash(Arc::new(map)), rest));
+        return Ok((Value::Hash(Value::hash_arc(map)), rest));
     }
     loop {
         let s2 = s.trim_start();
@@ -922,7 +925,7 @@ fn parse_json_object(s: &str) -> Result<(Value, &str), String> {
         map.insert(key, val);
         let rest = rest.trim_start();
         if let Some(after) = rest.strip_prefix('}') {
-            return Ok((Value::Hash(Arc::new(map)), after));
+            return Ok((Value::Hash(Value::hash_arc(map)), after));
         }
         if let Some(after) = rest.strip_prefix(',') {
             s = after;

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -874,7 +874,7 @@ impl Interpreter {
                                     key_type: None,
                                     declared_type: Some(tc.clone()),
                                 };
-                                self.register_container_type_metadata(&val, info);
+                                return Ok(self.tag_container_metadata(val, info));
                             }
                             return Ok(val);
                         }

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -314,7 +314,7 @@ impl Interpreter {
         if let Value::CustomType { name, .. } = target {
             return Ok(self.package_stash_value(&name.resolve()));
         }
-        Ok(Value::Hash(Arc::new(HashMap::new())))
+        Ok(Value::Hash(Value::hash_arc(HashMap::new())))
     }
 
     /// Dispatch .WHY method — returns a Pod::Block::Declarator instance

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -657,8 +657,8 @@ impl Interpreter {
             }
             let result = Value::hash(map);
             // Mark as Map (immutable hash)
-            self.register_container_type_metadata(
-                &result,
+            let result = self.tag_container_metadata(
+                result,
                 ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -70,7 +70,7 @@ impl Interpreter {
                 true
             }
             Value::Hash(map) => {
-                updated.extend((*map).clone());
+                updated.extend(map.map.clone());
                 true
             }
             _ => false,
@@ -156,7 +156,7 @@ impl Interpreter {
         let current = current.map(Value::into_descalarized);
         match current {
             Some(Value::Hash(existing_hash)) => {
-                Self::normalize_hash_like_assignment((*existing_hash).clone(), value)
+                Self::normalize_hash_like_assignment(existing_hash.map.clone(), value)
             }
             Some(Value::Array(..)) => super::coerce_to_array(value),
             _ => value,
@@ -274,7 +274,7 @@ impl Interpreter {
 
     pub(crate) fn overwrite_hash_bindings_by_identity(
         &mut self,
-        needle: &std::sync::Arc<std::collections::HashMap<String, Value>>,
+        needle: &std::sync::Arc<crate::value::HashData>,
         replacement: Value,
     ) {
         let keys: Vec<Symbol> = self
@@ -323,7 +323,7 @@ impl Interpreter {
     /// Same as `propagate_shared_array_in_instances` but for Hash attributes.
     pub(crate) fn propagate_shared_hash_in_instances(
         &mut self,
-        needle: &std::sync::Arc<std::collections::HashMap<String, Value>>,
+        needle: &std::sync::Arc<crate::value::HashData>,
         replacement: &Value,
     ) {
         let mut updates: Vec<(Symbol, String)> = Vec::new();
@@ -669,11 +669,11 @@ impl Interpreter {
                 }
                 let key = method_args[0].to_string_value();
                 let mut hash = match inner {
-                    Value::Hash(map) => (**map).clone(),
+                    Value::Hash(map) => map.map.clone(),
                     _ => std::collections::HashMap::new(),
                 };
                 hash.insert(key, value.clone());
-                let new_hash = Value::Hash(std::sync::Arc::new(hash));
+                let new_hash = Value::Hash(Value::hash_arc(hash));
                 // Propagate container type metadata to avoid stale pointer reuse
                 let meta = old_meta.unwrap_or(ContainerTypeInfo {
                     value_type: "Any".to_string(),
@@ -885,9 +885,7 @@ impl Interpreter {
                     *cell.lock().unwrap() = value.clone();
                     return Ok(value);
                 }
-                let mut selected_hash: Option<
-                    std::sync::Arc<std::collections::HashMap<String, Value>>,
-                > = None;
+                let mut selected_hash: Option<std::sync::Arc<crate::value::HashData>> = None;
                 let mut selected_array: Option<std::sync::Arc<Vec<Value>>> = None;
 
                 if let Some(var_name) = target_var
@@ -2486,14 +2484,14 @@ impl Interpreter {
 
                     // Fallback: create from target value
                     let mut hash: std::collections::HashMap<String, Value> = match &target {
-                        Value::Hash(h, ..) => (**h).clone(),
+                        Value::Hash(h, ..) => h.map.clone(),
                         _ => std::collections::HashMap::new(),
                     };
                     let pairs = Self::hash_push_collect_pairs(args);
                     for (k, v) in pairs {
                         Self::hash_push_insert(&mut hash, k, v, is_push);
                     }
-                    let result = Value::Hash(Arc::new(hash));
+                    let result = Value::Hash(Value::hash_arc(hash));
                     self.env.insert(key, result.clone());
                     return Ok(result);
                 }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1414,6 +1414,23 @@ impl Interpreter {
                 {
                     assigned_value = Value::Package(crate::symbol::Symbol::intern(&tc));
                 }
+                // Embed the attribute's declared element type into the stored
+                // container so it survives later reads (`$o.h.of`, `.push` type
+                // enforcement). Hash metadata lives in `HashData`; without this
+                // an assignment to a typed `%`/`@` attribute would drop the type
+                // (the old side table re-derived it on every read).
+                if matches!(attr_sigil, '@' | '%')
+                    && matches!(assigned_value, Value::Hash(_) | Value::Array(..))
+                    && let Some(tc) = self.get_attr_type_constraint(&class_name.resolve(), method)
+                    && !matches!(tc.as_str(), "Mu" | "Any")
+                {
+                    let info = ContainerTypeInfo {
+                        value_type: tc,
+                        key_type: None,
+                        declared_type: None,
+                    };
+                    assigned_value = self.tag_container_metadata(assigned_value, info);
+                }
                 updated.insert(attr_key.clone(), assigned_value.clone());
                 // Always propagate the change into this instance's live shared
                 // cell. This handles chained accessor assignment like

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -680,7 +680,7 @@ impl Interpreter {
                     key_type: None,
                     declared_type: None,
                 });
-                self.register_container_type_metadata(&new_hash, meta);
+                let new_hash = self.tag_container_metadata(new_hash, meta);
                 if let Some(var_name) = target_var {
                     self.env.insert(var_name.to_string(), new_hash);
                 }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -494,11 +494,15 @@ impl Interpreter {
             let Some(elem_type) = type_constraints.get(attr_name).cloned() else {
                 continue;
             };
-            if let Some(val) = attrs.get(attr_name).cloned()
-                && let Err(e) =
-                    self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, &val)
-            {
-                return Some(Err(e));
+            if let Some(val) = attrs.get(attr_name).cloned() {
+                match self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, val) {
+                    // Hashes embed the element type in `HashData`, so store the
+                    // tagged value back into the attrs that move into the instance.
+                    Ok(tagged) => {
+                        attrs.insert(attr_name.clone(), tagged);
+                    }
+                    Err(e) => return Some(Err(e)),
+                }
             }
         }
         // Add alias metadata for `has $x` (no twigil) attributes
@@ -1403,7 +1407,7 @@ impl Interpreter {
                             key_type,
                             declared_type: Some(class_name.resolve()),
                         };
-                        self.register_container_type_metadata(&result, info);
+                        return Ok(self.tag_container_metadata(result, info));
                     }
                     return Ok(result);
                 }
@@ -3065,15 +3069,12 @@ impl Interpreter {
                         .cloned()
                         .unwrap_or_else(|| "Any".to_string());
                     let key_type = type_args.get(1).cloned();
-                    self.register_container_type_metadata(
-                        &result,
-                        crate::runtime::ContainerTypeInfo {
-                            value_type,
-                            key_type,
-                            declared_type: Some(class_name.resolve()),
-                        },
-                    );
-                    return Ok(result);
+                    let info = crate::runtime::ContainerTypeInfo {
+                        value_type,
+                        key_type,
+                        declared_type: Some(class_name.resolve()),
+                    };
+                    return Ok(self.tag_container_metadata(result, info));
                 }
             }
             // Hoist clone to a `let` so the guard drops before the body re-enters
@@ -3618,16 +3619,17 @@ impl Interpreter {
                                         .and_then(|cd| cd.attribute_types.get(&attr_name))
                                         .cloned();
                                     if let Some(tc) = tc {
-                                        self.register_container_type_metadata(
-                                            &h,
+                                        self.tag_container_metadata(
+                                            h,
                                             super::ContainerTypeInfo {
                                                 value_type: tc,
                                                 key_type: None,
                                                 declared_type: None,
                                             },
-                                        );
+                                        )
+                                    } else {
+                                        h
                                     }
-                                    h
                                 }
                             }
                             _ => Value::Nil,
@@ -4037,7 +4039,9 @@ impl Interpreter {
                         continue;
                     }
                     if let Some(val) = attrs.get(attr_name).cloned() {
-                        self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, &val)?;
+                        let tagged =
+                            self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, val)?;
+                        attrs.insert(attr_name.clone(), tagged);
                     }
                 }
                 // Apply `has $.x does Role` attribute traits: mix each declared

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -275,7 +275,7 @@ impl Interpreter {
                     // A single Pair coerces to a one-element hash
                     let mut map = HashMap::new();
                     map.insert(k.clone(), *v.clone());
-                    Value::Hash(std::sync::Arc::new(map))
+                    Value::Hash(Value::hash_arc(map))
                 }
                 Value::Array(arr, _) => {
                     // Convert array of pairs to hash
@@ -288,7 +288,7 @@ impl Interpreter {
                         }
                     }
                     if has_pairs {
-                        Value::Hash(std::sync::Arc::new(map))
+                        Value::Hash(Value::hash_arc(map))
                     } else {
                         val
                     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4626,7 +4626,11 @@ impl Interpreter {
     /// value — store it back into the env/local slot it came from. For other
     /// container types this defers to the Arc-pointer side tables (unchanged)
     /// and returns the value untouched.
-    pub(crate) fn tag_container_metadata(&mut self, value: Value, info: ContainerTypeInfo) -> Value {
+    pub(crate) fn tag_container_metadata(
+        &mut self,
+        value: Value,
+        info: ContainerTypeInfo,
+    ) -> Value {
         match value {
             Value::Hash(mut arc) => {
                 // Skip the copy-on-write clone when the metadata is already

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1033,8 +1033,6 @@ pub struct Interpreter {
     set_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Type metadata for Bag values keyed by Arc pointer identity.
     bag_type_metadata: HashMap<usize, ContainerTypeInfo>,
-    /// Type metadata for Hash values keyed by Arc pointer identity.
-    hash_type_metadata: HashMap<usize, ContainerTypeInfo>,
     /// Original key objects for object hashes, keyed by Hash Arc pointer identity.
     hash_object_keys: HashMap<usize, HashMap<String, Value>>,
     /// Type metadata for instance values keyed by stable instance id.
@@ -3130,7 +3128,6 @@ impl Interpreter {
             mix_type_metadata: HashMap::new(),
             set_type_metadata: HashMap::new(),
             bag_type_metadata: HashMap::new(),
-            hash_type_metadata: HashMap::new(),
             hash_object_keys: HashMap::new(),
             instance_type_metadata: HashMap::new(),
             let_saves: Vec::new(),
@@ -4599,6 +4596,64 @@ impl Interpreter {
         Ok(Some(result))
     }
 
+    /// Build a `ContainerTypeInfo` from a hash's embedded type metadata, or
+    /// `None` when the hash carries no type metadata. This is the authoritative
+    /// source of hash type metadata, replacing the old `hash_type_metadata`
+    /// Arc-pointer-keyed side table: the metadata travels WITH the `HashData`
+    /// through copy-on-write and rebuilds, so a freshly-built hash literal can
+    /// never inherit a stale typed-hash entry via pointer reuse.
+    pub(crate) fn hashdata_type_info(hd: &crate::value::HashData) -> Option<ContainerTypeInfo> {
+        if !hd.has_type_meta() {
+            return None;
+        }
+        Some(ContainerTypeInfo {
+            value_type: hd.value_type.clone().unwrap_or_default(),
+            key_type: hd.key_type.clone(),
+            declared_type: hd.declared_type.clone(),
+        })
+    }
+
+    /// Write a `ContainerTypeInfo`'s type fields into a hash's embedded metadata.
+    fn apply_type_info_to_hashdata(hd: &mut crate::value::HashData, info: &ContainerTypeInfo) {
+        hd.value_type = (!info.value_type.is_empty()).then(|| info.value_type.clone());
+        hd.key_type = info.key_type.clone();
+        hd.declared_type = info.declared_type.clone();
+    }
+
+    /// Attach container type metadata to `value`, returning the (possibly
+    /// rebuilt) value. For hashes the metadata is embedded in the `HashData`
+    /// (via copy-on-write `Arc::make_mut`), so callers MUST use the returned
+    /// value — store it back into the env/local slot it came from. For other
+    /// container types this defers to the Arc-pointer side tables (unchanged)
+    /// and returns the value untouched.
+    pub(crate) fn tag_container_metadata(&mut self, value: Value, info: ContainerTypeInfo) -> Value {
+        match value {
+            Value::Hash(mut arc) => {
+                // Skip the copy-on-write clone when the metadata is already
+                // present. `Arc::make_mut` on a shared hash clones the backing
+                // `HashData`, which changes the hash's identity (`.WHICH` is
+                // pointer-based) — so a no-op re-tag of e.g. `$map.Map` would
+                // otherwise break `$map.Map === $map`.
+                let new_vt = (!info.value_type.is_empty()).then(|| info.value_type.clone());
+                if arc.value_type != new_vt
+                    || arc.key_type != info.key_type
+                    || arc.declared_type != info.declared_type
+                {
+                    Self::apply_type_info_to_hashdata(Arc::make_mut(&mut arc), &info);
+                }
+                Value::Hash(arc)
+            }
+            Value::Mixin(inner, m) if matches!(inner.as_ref(), Value::Hash(_)) => {
+                let tagged = self.tag_container_metadata((*inner).clone(), info);
+                Value::Mixin(Arc::new(tagged), m)
+            }
+            other => {
+                self.register_container_type_metadata(&other, info);
+                other
+            }
+        }
+    }
+
     pub(crate) fn register_container_type_metadata(
         &mut self,
         value: &Value,
@@ -4621,9 +4676,16 @@ impl Interpreter {
                 let id = Arc::as_ptr(items) as usize;
                 self.bag_type_metadata.insert(id, info);
             }
-            Value::Hash(items) => {
-                let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata.insert(id, info);
+            Value::Hash(_) => {
+                // Hash type metadata is embedded in `HashData` — see
+                // `tag_container_metadata`. Reaching here means a hash flowed
+                // through the by-reference register path, which cannot embed
+                // (it has no owning slot to write back). Such sites are migrated
+                // to `tag_container_metadata`; this arm is intentionally a no-op.
+                debug_assert!(
+                    false,
+                    "register_container_type_metadata called on a Hash; use tag_container_metadata"
+                );
             }
             Value::Instance { id, .. } => {
                 self.instance_type_metadata.insert(*id, info);
@@ -4665,13 +4727,25 @@ impl Interpreter {
                 let id = Arc::as_ptr(items) as usize;
                 self.array_type_metadata.remove(&id);
             }
-            Value::Hash(items) => {
-                let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata.remove(&id);
+            Value::Hash(_) => {
+                // Hash type metadata lives in `HashData`; clearing it requires
+                // an owning slot. See `clear_hash_type_metadata`.
             }
             Value::Mixin(inner, _) => self.unregister_container_type_metadata(inner),
             _ => {}
         }
+    }
+
+    /// Clear a hash's embedded type metadata, returning the rebuilt value.
+    /// Callers must store the returned value back into its slot.
+    pub(crate) fn clear_hash_type_metadata(value: Value) -> Value {
+        if let Value::Hash(mut arc) = value {
+            if arc.has_type_meta() {
+                Arc::make_mut(&mut arc).clear_type_meta();
+            }
+            return Value::Hash(arc);
+        }
+        value
     }
 
     pub(crate) fn container_type_metadata(&self, value: &Value) -> Option<ContainerTypeInfo> {
@@ -4692,21 +4766,11 @@ impl Interpreter {
                 let id = Arc::as_ptr(items) as usize;
                 self.bag_type_metadata.get(&id).cloned()
             }
-            Value::Hash(items) => {
-                let id = Arc::as_ptr(items) as usize;
-                self.hash_type_metadata.get(&id).cloned()
-            }
+            Value::Hash(items) => Self::hashdata_type_info(items),
             Value::Instance { id, .. } => self.instance_type_metadata.get(id).cloned(),
             Value::Mixin(inner, _) => self.container_type_metadata(inner),
             _ => None,
         }
-    }
-
-    /// Fast check whether a hash (by pointer id) has type metadata registered.
-    /// Used by the hash-assignment fast path to avoid the full
-    /// `container_type_metadata` lookup.
-    pub(crate) fn hash_type_metadata_exists(&self, id: usize) -> bool {
-        self.hash_type_metadata.contains_key(&id)
     }
 
     /// Store an original key object for an object hash entry.
@@ -4738,70 +4802,26 @@ impl Interpreter {
 
     /// Check if a hash is an object hash (has a key_type constraint).
     pub(crate) fn is_object_hash(&self, hash: &Value) -> bool {
-        if let Value::Hash(arc) = hash {
-            let id = Arc::as_ptr(arc) as usize;
-            if let Some(info) = self.hash_type_metadata.get(&id) {
-                return info.key_type.is_some();
-            }
-        }
-        false
+        self.hash_key_type(hash).is_some()
     }
 
     /// Get the key type constraint for an object hash, if any.
     pub(crate) fn hash_key_type(&self, hash: &Value) -> Option<String> {
         if let Value::Hash(arc) = hash {
-            let id = Arc::as_ptr(arc) as usize;
-            if let Some(info) = self.hash_type_metadata.get(&id) {
-                return info.key_type.clone();
-            }
+            return arc.key_type.clone();
         }
         None
     }
 
     fn register_var_container_type_metadata(&mut self, name: &str, info: &ContainerTypeInfo) {
         if let Some(value) = self.env.get(name).cloned() {
-            self.register_container_type_metadata(&value, info.clone());
+            // Hashes embed metadata in `HashData`, so the tagged value must be
+            // stored back; non-hash containers use the Arc-pointer side tables
+            // and `tag_container_metadata` returns the same Arc (re-insert is a
+            // no-op for them).
+            let tagged = self.tag_container_metadata(value, info.clone());
+            self.env.insert(name.to_string(), tagged);
         }
-    }
-
-    /// Re-establish a named typed hash's Arc-pointer-keyed metadata from its
-    /// authoritative, scope-correct name-based key constraint.
-    ///
-    /// `hash_type_metadata` is keyed by the hash's `Arc` pointer, which is
-    /// reused after the hash is dropped and changes across copy-on-write. Across
-    /// block scopes (e.g. a `my %h{Int}` declared after an earlier exited
-    /// `my Int %h`) the pointer-keyed entry can intermittently go missing while
-    /// the name-based `var_hash_key_constraints` entry stays correct — making
-    /// `%h{$int} = ...` lose object-hash (`.WHICH`-keyed) semantics so the value
-    /// is stored under a stringified key and later reads return Nil. Healing the
-    /// pointer-keyed entry from the name-based constraint before each typed-hash
-    /// element assignment removes that nondeterminism. No-op for hashes without
-    /// a key constraint (the common case).
-    pub(crate) fn reconcile_hash_type_metadata_from_name(&mut self, name: &str) {
-        let Some(name_key) = self.var_hash_key_constraint(name) else {
-            return;
-        };
-        let Some(value @ Value::Hash(_)) = self.env.get(name).cloned() else {
-            return;
-        };
-        let current = self.container_type_metadata(&value);
-        if current.as_ref().and_then(|i| i.key_type.clone()) == Some(name_key.clone()) {
-            return; // already correct
-        }
-        let info = match current {
-            Some(mut i) => {
-                i.key_type = Some(name_key);
-                i
-            }
-            None => ContainerTypeInfo {
-                value_type: self
-                    .var_type_constraint(name)
-                    .unwrap_or_else(|| "Mu".to_string()),
-                key_type: Some(name_key),
-                declared_type: None,
-            },
-        };
-        self.register_container_type_metadata(&value, info);
     }
 
     fn parse_container_constraint(name: &str, raw: &str) -> ContainerTypeInfo {
@@ -4902,8 +4922,8 @@ impl Interpreter {
         attr_name: &str,
         sigil: char,
         elem_type: &str,
-        value: &Value,
-    ) -> Result<(), RuntimeError> {
+        value: Value,
+    ) -> Result<Value, RuntimeError> {
         if elem_type != "Mu" && elem_type != "Any" {
             let display = format!("{}!{}", sigil, attr_name);
             // Collect the values to type-check. A shaped array (`has Int @.g[2;2]`)
@@ -4921,7 +4941,7 @@ impl Interpreter {
                 }
             }
             let mut elems: Vec<&Value> = Vec::new();
-            match value {
+            match &value {
                 Value::Array(items, ArrayKind::Shaped) => {
                     for it in items.iter() {
                         collect_leaves(it, true, &mut elems);
@@ -4939,15 +4959,12 @@ impl Interpreter {
                 }
             }
         }
-        self.register_container_type_metadata(
-            value,
-            ContainerTypeInfo {
-                value_type: elem_type.to_string(),
-                key_type: None,
-                declared_type: None,
-            },
-        );
-        Ok(())
+        let info = ContainerTypeInfo {
+            value_type: elem_type.to_string(),
+            key_type: None,
+            declared_type: None,
+        };
+        Ok(self.tag_container_metadata(value, info))
     }
 
     pub(crate) fn is_var_dynamic(&self, name: &str) -> bool {
@@ -5535,7 +5552,6 @@ impl Interpreter {
             mix_type_metadata: self.mix_type_metadata.clone(),
             set_type_metadata: self.set_type_metadata.clone(),
             bag_type_metadata: self.bag_type_metadata.clone(),
-            hash_type_metadata: self.hash_type_metadata.clone(),
             hash_object_keys: self.hash_object_keys.clone(),
             instance_type_metadata: self.instance_type_metadata.clone(),
             let_saves: Vec::new(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1256,10 +1256,7 @@ impl Interpreter {
             for (key, value) in std::env::vars() {
                 env_hash.insert(key, builtins_collection::builtin_val(&[Value::str(value)]));
             }
-            env.insert(
-                "%*ENV".to_string(),
-                Value::Hash(std::sync::Arc::new(env_hash)),
-            );
+            env.insert("%*ENV".to_string(), Value::Hash(Value::hash_arc(env_hash)));
         }
         env.insert(
             "*SCHEDULER".to_string(),

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1385,7 +1385,7 @@ impl Interpreter {
                     // Build a distribution instance with files resolved to absolute paths
                     // Remap the "files" entries to full paths
                     use std::collections::HashMap;
-                    use std::sync::Arc;
+
                     let mut resolved_files: HashMap<String, Value> = HashMap::new();
                     if let Some(files_val) = meta_val.hash_get_str("files")
                         && let Value::Hash(fmap) = files_val
@@ -1402,13 +1402,16 @@ impl Interpreter {
                         }
                     }
                     let mut meta_map = match &meta_val {
-                        Value::Hash(m) => (**m).clone(),
+                        Value::Hash(m) => m.map.clone(),
                         _ => HashMap::new(),
                     };
-                    meta_map.insert("files".to_string(), Value::Hash(Arc::new(resolved_files)));
+                    meta_map.insert(
+                        "files".to_string(),
+                        Value::Hash(Value::hash_arc(resolved_files)),
+                    );
                     meta_map.insert("prefix".to_string(), Value::str(prefix.to_string()));
                     let mut attrs = HashMap::new();
-                    attrs.insert("meta".to_string(), Value::Hash(Arc::new(meta_map)));
+                    attrs.insert("meta".to_string(), Value::Hash(Value::hash_arc(meta_map)));
                     attrs.insert("prefix".to_string(), Value::str(prefix.to_string()));
                     return Some(Value::make_instance_without_destroy(
                         crate::symbol::Symbol::intern("Distribution::Installation"),
@@ -1500,7 +1503,6 @@ impl Interpreter {
     /// and returns a Hash mapping resource names to their absolute paths on disk.
     pub(crate) fn build_resources_for_package(&self) -> Value {
         use std::collections::HashMap;
-        use std::sync::Arc;
 
         // Priority 1: current_distribution (set during module loading)
         if let Some(dist) = &self.current_distribution {
@@ -1516,12 +1518,11 @@ impl Interpreter {
         if let Some(dist) = self.package_distributions.get(&self.current_package()) {
             return Self::build_resources_from_dist(dist);
         }
-        Value::Hash(Arc::new(HashMap::new()))
+        Value::Hash(Value::hash_arc(HashMap::new()))
     }
 
     fn build_resources_from_dist(dist: &Value) -> Value {
         use std::collections::HashMap;
-        use std::sync::Arc;
 
         let meta = match dist {
             Value::Instance { attributes, .. } => {
@@ -1594,7 +1595,7 @@ impl Interpreter {
             }
             _ => {}
         }
-        Value::Hash(Arc::new(result))
+        Value::Hash(Value::hash_arc(result))
     }
 
     /// Detect a distribution (META6.json) for the given module source path.
@@ -1624,7 +1625,7 @@ impl Interpreter {
         let mut attrs = HashMap::new();
         attrs.insert(
             "$!meta".to_string(),
-            Value::Hash(std::sync::Arc::new(meta_hash)),
+            Value::Hash(Value::hash_arc(meta_hash)),
         );
         Some(Value::make_instance_without_destroy(
             crate::symbol::Symbol::intern("Distribution"),
@@ -1647,11 +1648,11 @@ impl Interpreter {
         {
             Self::scan_resources(rd)
         } else {
-            Value::Hash(std::sync::Arc::new(HashMap::new()))
+            Value::Hash(Value::hash_arc(HashMap::new()))
         };
         meta.insert("resources".to_string(), resources);
         let mut attrs = HashMap::new();
-        attrs.insert("$!meta".to_string(), Value::Hash(std::sync::Arc::new(meta)));
+        attrs.insert("$!meta".to_string(), Value::Hash(Value::hash_arc(meta)));
         Value::make_instance_without_destroy(crate::symbol::Symbol::intern("Distribution"), attrs)
     }
 
@@ -1674,7 +1675,7 @@ impl Interpreter {
                 }
             }
         }
-        Value::Hash(std::sync::Arc::new(provides))
+        Value::Hash(Value::hash_arc(provides))
     }
 
     fn scan_resources(resources_dir: &Path) -> Value {
@@ -1690,7 +1691,7 @@ impl Interpreter {
                 }
             }
         }
-        Value::Hash(std::sync::Arc::new(files))
+        Value::Hash(Value::hash_arc(files))
     }
 
     fn parse_meta6_json(content: &str) -> Option<HashMap<String, Value>> {
@@ -1725,7 +1726,7 @@ impl Interpreter {
                 for (k, v) in obj {
                     map.insert(k.clone(), Self::json_to_value(v));
                 }
-                Value::Hash(std::sync::Arc::new(map))
+                Value::Hash(Value::hash_arc(map))
             }
         }
     }

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -77,7 +77,7 @@ impl Interpreter {
     ) -> Option<(Vec<Value>, HashMap<String, Value>)> {
         match value {
             Value::Capture { positional, named } => Some((positional.clone(), named.clone())),
-            Value::Hash(map) => Some((Vec::new(), (**map).clone())),
+            Value::Hash(map) => Some((Vec::new(), map.map.clone())),
             Value::Set(items, _) => Some((
                 Vec::new(),
                 items

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -909,7 +909,7 @@ impl Interpreter {
                                         }
                                         self.env.insert(
                                             param.clone(),
-                                            Value::Hash(std::sync::Arc::new(map)),
+                                            Value::Hash(Value::hash_arc(map)),
                                         );
                                         break;
                                     }

--- a/src/runtime/test_functions/subprocess.rs
+++ b/src/runtime/test_functions/subprocess.rs
@@ -164,7 +164,7 @@ impl Interpreter {
         hash.insert("out".to_string(), Value::str(out));
         hash.insert("err".to_string(), Value::str(err));
         hash.insert("status".to_string(), Value::Int(status));
-        Ok(Value::Hash(std::sync::Arc::new(hash)))
+        Ok(Value::Hash(Value::hash_arc(hash)))
     }
 
     pub(crate) fn test_fn_run(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -191,12 +191,12 @@ impl Interpreter {
                     && !is_capture_param
                     && !is_subsig_capture
                 {
-                    let missing = Self::missing_optional_param_value(pd);
+                    let mut missing = Self::missing_optional_param_value(pd);
                     if let Some(constraint) = &pd.type_constraint
                         && (pd.name.starts_with('@') || pd.name.starts_with('%'))
                     {
                         let info = Self::parse_container_constraint(&pd.name, constraint);
-                        self.register_container_type_metadata(&missing, info);
+                        missing = self.tag_container_metadata(missing, info);
                     }
                     arg_for_checks = Some(missing);
                 }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -365,7 +365,7 @@ impl Interpreter {
                     // Default value based on sigil: @ -> [], % -> {}, $ -> Nil
                     match sigil {
                         '@' => Value::real_array(Vec::new()),
-                        '%' => Value::Hash(std::sync::Arc::new(HashMap::new())),
+                        '%' => Value::Hash(Value::hash_arc(HashMap::new())),
                         _ => Value::Nil,
                     }
                 };

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -178,7 +178,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
 ) -> std::collections::HashMap<String, Value> {
     match value {
         Value::Capture { named, .. } => named.clone(),
-        Value::Hash(map) => (**map).clone(),
+        Value::Hash(map) => map.map.clone(),
         Value::Pair(key, val) => {
             let mut out = std::collections::HashMap::new();
             out.insert(key.clone(), *val.clone());

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1187,6 +1187,70 @@ impl ArrayKind {
     }
 }
 
+/// Backing storage for `Value::Hash`. Bundles the key/value map with its
+/// container type metadata (element/key types) and object-hash original keys,
+/// so the metadata travels WITH the hash through copy-on-write and rebuilds —
+/// replacing the fragile `Arc::as_ptr`-keyed side tables (the root of the
+/// intermittent typed-hash / object-hash flaky). `Deref`s to the inner map so
+/// the overwhelming majority of read sites (`.get`/`.iter`/`.len`/`.values`/…)
+/// are unchanged; only structural mutation/rebuild sites touch the wrapper.
+#[derive(Debug, Clone, Default)]
+pub struct HashData {
+    pub map: HashMap<String, Value>,
+    /// Element value-type constraint (e.g. `Int` for `my Int %h`), if any.
+    pub value_type: Option<String>,
+    /// Object-hash key-type constraint (e.g. `Mu` for `my %h{Mu}`), if any.
+    /// `Some(..)` marks this as an object hash (`.WHICH`-keyed).
+    pub key_type: Option<String>,
+    /// For object hashes / typed-key hashes: maps each stored `.WHICH` key
+    /// string back to the original key object (so `.keys`/subscript see the
+    /// real key, not the WHICH string).
+    pub original_keys: Option<HashMap<String, Value>>,
+}
+
+impl HashData {
+    pub fn new(map: HashMap<String, Value>) -> Self {
+        HashData {
+            map,
+            value_type: None,
+            key_type: None,
+            original_keys: None,
+        }
+    }
+
+    /// Whether any container metadata is attached (type or object-hash keys).
+    pub fn has_meta(&self) -> bool {
+        self.value_type.is_some() || self.key_type.is_some() || self.original_keys.is_some()
+    }
+}
+
+impl std::ops::Deref for HashData {
+    type Target = HashMap<String, Value>;
+    fn deref(&self) -> &HashMap<String, Value> {
+        &self.map
+    }
+}
+
+impl std::ops::DerefMut for HashData {
+    fn deref_mut(&mut self) -> &mut HashMap<String, Value> {
+        &mut self.map
+    }
+}
+
+impl From<HashMap<String, Value>> for HashData {
+    fn from(map: HashMap<String, Value>) -> Self {
+        HashData::new(map)
+    }
+}
+
+/// Hash equality ignores container metadata — only the key/value map matters
+/// (preserves the prior `Arc<HashMap>` PartialEq semantics).
+impl PartialEq for HashData {
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
 /// Value stored in an enum variant: an integer, a string, or an arbitrary Value.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum EnumValue {
@@ -1244,7 +1308,7 @@ pub enum Value {
     },
     /// Distinguishes Array, List, and their itemized (Scalar-wrapped) variants.
     Array(Arc<Vec<Value>>, ArrayKind),
-    Hash(Arc<HashMap<String, Value>>),
+    Hash(Arc<HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),
     BigRat(NumBigInt, NumBigInt),
@@ -1390,7 +1454,7 @@ pub enum Value {
     /// Assigning to it writes back to the parent hash via interior mutation.
     /// Indexing it autovivifies (creates an empty Hash at the key if missing).
     HashSlotRef {
-        hash: Arc<HashMap<String, Value>>,
+        hash: Arc<HashData>,
         key: String,
     },
     /// A reference to an array slot, used for binding to array elements.
@@ -2461,8 +2525,18 @@ impl Value {
     pub fn shaped_array(items: Vec<Value>) -> Self {
         Value::Array(Arc::new(items), ArrayKind::Shaped)
     }
-    pub fn hash(map: HashMap<String, Value>) -> Self {
-        Value::Hash(Arc::new(map))
+    /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)
+    /// or a `HashData` (a cloned/rebuilt hash whose container metadata is then
+    /// preserved) via `Into<HashData>`.
+    pub fn hash(map: impl Into<HashData>) -> Self {
+        Value::Hash(Arc::new(map.into()))
+    }
+
+    /// Build an `Arc<HashData>` from a map or `HashData`. Lets call sites that
+    /// constructed `Value::Hash(Arc::new(x))` keep their shape as
+    /// `Value::Hash(Value::hash_arc(x))` while the variant moved to `HashData`.
+    pub fn hash_arc(map: impl Into<HashData>) -> Arc<HashData> {
+        Arc::new(map.into())
     }
 
     /// Coerce a value into item context (`.item` method).
@@ -2671,9 +2745,9 @@ impl Value {
     /// Uses the same interior-mutation approach as `hash_autovivify`.
     pub fn hash_assign_at(&self, key: &str, val: Value) -> Option<Value> {
         if let Value::Hash(arc) = self {
-            let ptr = Arc::as_ptr(arc) as *mut HashMap<String, Value>;
+            let ptr = Arc::as_ptr(arc) as *mut HashData;
             unsafe {
-                Value::hash_insert_through(&mut *ptr, key.to_string(), val.clone());
+                Value::hash_insert_through(&mut (*ptr).map, key.to_string(), val.clone());
             }
             Some(val)
         } else {
@@ -2701,9 +2775,9 @@ impl Value {
     /// Uses interior mutation (same as hash_autovivify).
     pub fn hash_slot_write(&self, val: Value) {
         if let Value::HashSlotRef { hash, key } = self {
-            let ptr = Arc::as_ptr(hash) as *mut HashMap<String, Value>;
+            let ptr = Arc::as_ptr(hash) as *mut HashData;
             unsafe {
-                Value::hash_insert_through(&mut *ptr, key.clone(), val);
+                Value::hash_insert_through(&mut (*ptr).map, key.clone(), val);
             }
         }
     }
@@ -2724,9 +2798,9 @@ impl Value {
             };
             // Now write the value to the inner hash at the given key
             if let Value::Hash(arc) = &inner_hash {
-                let ptr = Arc::as_ptr(arc) as *mut HashMap<String, Value>;
+                let ptr = Arc::as_ptr(arc) as *mut HashData;
                 unsafe {
-                    (*ptr).insert(key.clone(), val);
+                    (*ptr).map.insert(key.clone(), val);
                 }
             }
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1202,6 +1202,10 @@ pub struct HashData {
     /// Object-hash key-type constraint (e.g. `Mu` for `my %h{Mu}`), if any.
     /// `Some(..)` marks this as an object hash (`.WHICH`-keyed).
     pub key_type: Option<String>,
+    /// Declared container type name (e.g. `Map`, `Hash[Int]`, `array[int]`) —
+    /// mirrors `ContainerTypeInfo::declared_type`. Distinguishes an immutable
+    /// `Map` from a plain `Hash`, etc.
+    pub declared_type: Option<String>,
     /// For object hashes / typed-key hashes: maps each stored `.WHICH` key
     /// string back to the original key object (so `.keys`/subscript see the
     /// real key, not the WHICH string).
@@ -1214,13 +1218,29 @@ impl HashData {
             map,
             value_type: None,
             key_type: None,
+            declared_type: None,
             original_keys: None,
         }
     }
 
     /// Whether any container metadata is attached (type or object-hash keys).
     pub fn has_meta(&self) -> bool {
-        self.value_type.is_some() || self.key_type.is_some() || self.original_keys.is_some()
+        self.has_type_meta() || self.original_keys.is_some()
+    }
+
+    /// Whether container *type* metadata (element/key/declared type) is attached.
+    /// This is the authoritative replacement for the `hash_type_metadata` side
+    /// table: a freshly-built hash literal has `false` here, so it can never
+    /// inherit a stale typed-hash entry via Arc-pointer reuse.
+    pub fn has_type_meta(&self) -> bool {
+        self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
+    }
+
+    /// Clear all container *type* metadata (used when re-tagging in place).
+    pub fn clear_type_meta(&mut self) {
+        self.value_type = None;
+        self.key_type = None;
+        self.declared_type = None;
     }
 }
 
@@ -2659,11 +2679,11 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: mutsu is single-threaded.  We ensure no immutable
             // references into the HashMap are alive when we mutate.
-            let ptr = Arc::as_ptr(arc) as *mut HashMap<String, Value>;
+            let ptr = Arc::as_ptr(arc) as *mut HashData;
             unsafe {
-                if !(*ptr).contains_key(key) {
+                if !(*ptr).map.contains_key(key) {
                     let new_hash = Value::hash(HashMap::new());
-                    (*ptr).insert(key.to_string(), new_hash);
+                    (*ptr).map.insert(key.to_string(), new_hash);
                 }
             }
             Some(Value::HashSlotRef {
@@ -2711,9 +2731,9 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: mutsu is single-threaded; no immutable borrow into the
             // map is alive across this mutation.
-            let ptr = Arc::as_ptr(arc) as *mut HashMap<String, Value>;
+            let ptr = Arc::as_ptr(arc) as *mut HashData;
             unsafe {
-                match (*ptr).get_mut(key) {
+                match (*ptr).map.get_mut(key) {
                     Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
                     Some(elem @ (Value::Array(..) | Value::Hash(..))) if !terminal => {
                         // Intermediate container: preserve traversal via SlotRef.

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -342,9 +342,11 @@ fn ser_to_value(sv: SerValue) -> Value {
             Arc::new(items.into_iter().map(ser_to_value).collect()),
             kind,
         ),
-        SerValue::Hash(map) => Value::Hash(Arc::new(
-            map.into_iter().map(|(k, v)| (k, ser_to_value(v))).collect(),
-        )),
+        SerValue::Hash(map) => Value::hash(
+            map.into_iter()
+                .map(|(k, v)| (k, ser_to_value(v)))
+                .collect::<HashMap<String, Value>>(),
+        ),
         SerValue::Rat(n, d) => Value::Rat(n, d),
         SerValue::FatRat(n, d) => Value::FatRat(n, d),
         SerValue::BigRat(n, d) => Value::BigRat(n, d),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3256,9 +3256,8 @@ impl VM {
                             unsafe { (*ptr).clear() };
                         }
                         Value::Hash(arc) => {
-                            let ptr =
-                                Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
-                            unsafe { (*ptr).clear() };
+                            let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
+                            unsafe { (*ptr).map.clear() };
                         }
                         _ => {}
                     }
@@ -3271,9 +3270,8 @@ impl VM {
                             unsafe { (*ptr).clear() };
                         }
                         Value::Hash(arc) => {
-                            let ptr =
-                                Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
-                            unsafe { (*ptr).clear() };
+                            let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
+                            unsafe { (*ptr).map.clear() };
                         }
                         _ => {
                             self.locals[slot] = Value::Nil;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1965,8 +1965,11 @@ impl VM {
                         },
                         declared_type: None,
                     };
-                    self.interpreter
-                        .register_container_type_metadata(&value, info);
+                    // Hashes embed metadata in `HashData`; write the tagged value
+                    // back (no-op Arc for array/instance side-table containers).
+                    let tagged = self.interpreter.tag_container_metadata(value, info);
+                    self.set_env_with_main_alias(&name, tagged.clone());
+                    self.update_local_if_exists(code, &name, &tagged);
                 }
                 *ip += 1;
             }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -884,11 +884,11 @@ impl VM {
                             .container_type_metadata(inner_target)
                             .clone();
                         let mut hash = match inner_target {
-                            Value::Hash(map) => (**map).clone(),
+                            Value::Hash(map) => map.map.clone(),
                             _ => std::collections::HashMap::new(),
                         };
                         hash.insert(key, value.clone());
-                        let new_hash = Value::Hash(Arc::new(hash));
+                        let new_hash = Value::Hash(Value::hash_arc(hash));
                         let meta = old_meta.unwrap_or(crate::runtime::ContainerTypeInfo {
                             value_type: "Any".to_string(),
                             key_type: None,
@@ -965,7 +965,7 @@ impl VM {
                         hash.insert(key, value.clone());
                         self.interpreter
                             .env_mut()
-                            .insert(target_name.to_string(), Value::Hash(Arc::new(hash)));
+                            .insert(target_name.to_string(), Value::Hash(Value::hash_arc(hash)));
                         self.stack.push(value);
                         self.env_dirty = true;
                         return Ok(());
@@ -996,7 +996,7 @@ impl VM {
                         };
                         let mut new_map = (**map).clone();
                         new_map.remove(&key);
-                        let new_hash = Value::Hash(Arc::new(new_map));
+                        let new_hash = Value::Hash(Value::hash_arc(new_map));
                         let meta = old_meta.unwrap_or(crate::runtime::ContainerTypeInfo {
                             value_type: "Any".to_string(),
                             key_type: None,
@@ -1094,7 +1094,7 @@ impl VM {
                         } else {
                             new_map.insert(key, value.clone());
                         }
-                        let new_hash = Value::Hash(Arc::new(new_map));
+                        let new_hash = Value::Hash(Value::hash_arc(new_map));
                         let meta = old_meta.unwrap_or(crate::runtime::ContainerTypeInfo {
                             value_type: "Any".to_string(),
                             key_type: None,
@@ -1128,9 +1128,10 @@ impl VM {
                         } else {
                             new_map.insert(key, value.clone());
                         }
-                        self.interpreter
-                            .env_mut()
-                            .insert(target_name.to_string(), Value::Hash(Arc::new(new_map)));
+                        self.interpreter.env_mut().insert(
+                            target_name.to_string(),
+                            Value::Hash(Value::hash_arc(new_map)),
+                        );
                         self.stack.push(value);
                         self.env_dirty = true;
                         return Ok(());

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -894,8 +894,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        self.interpreter
-                            .register_container_type_metadata(&new_hash, meta);
+                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
                         self.interpreter
                             .env_mut()
                             .insert(target_name.to_string(), new_hash);
@@ -1002,8 +1001,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        self.interpreter
-                            .register_container_type_metadata(&new_hash, meta);
+                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
                         self.interpreter
                             .env_mut()
                             .insert(target_name.to_string(), new_hash);
@@ -1100,8 +1098,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        self.interpreter
-                            .register_container_type_metadata(&new_hash, meta);
+                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
                         self.interpreter
                             .env_mut()
                             .insert(target_name.to_string(), new_hash);

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -676,7 +676,7 @@ impl VM {
 
     /// Extract the (hash Arc, key) from a HashSlotRef or DeferredHashAccess.
     /// For DeferredHashAccess, resolves the parent_slot to find the inner hash.
-    fn extract_hash_ref(val: &Value) -> Option<(&Arc<HashMap<String, Value>>, &str)> {
+    fn extract_hash_ref(val: &Value) -> Option<(&Arc<crate::value::HashData>, &str)> {
         match val {
             Value::HashSlotRef { hash, key } => Some((hash, key.as_str())),
             Value::DeferredHashAccess { parent_slot, key } => {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1916,7 +1916,7 @@ impl VM {
                         let mut updated = hash_items.as_ref().clone();
                         let key_str = key.to_string_value();
                         updated.insert(key_str, val);
-                        let updated_value = Value::Hash(std::sync::Arc::new(updated));
+                        let updated_value = Value::Hash(Value::hash_arc(updated));
                         self.set_env_with_main_alias(source, updated_value.clone());
                         self.update_local_if_exists(code, source, &updated_value);
                     }
@@ -1930,7 +1930,7 @@ impl VM {
                     {
                         let mut updated = hash_items.as_ref().clone();
                         updated.insert(keys[idx].clone(), val);
-                        let updated_value = Value::Hash(std::sync::Arc::new(updated));
+                        let updated_value = Value::Hash(Value::hash_arc(updated));
                         self.set_env_with_main_alias(source, updated_value.clone());
                         self.update_local_if_exists(code, source, &updated_value);
                     }

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -391,10 +391,8 @@ impl VM {
             for (key, item) in keys.iter().zip(items.iter()) {
                 map.insert(key.clone(), item.clone());
             }
-            self.interpreter.overwrite_hash_bindings_by_identity(
-                existing,
-                Value::Hash(std::sync::Arc::new(map)),
-            );
+            self.interpreter
+                .overwrite_hash_bindings_by_identity(existing, Value::Hash(Value::hash_arc(map)));
             self.env_dirty = true;
         }
         // Preserve the container type of the target for QuantHash types.
@@ -476,7 +474,7 @@ impl VM {
             for (key, value) in keys.into_iter().zip(results) {
                 map.insert(key, value);
             }
-            self.stack.push(Value::Hash(std::sync::Arc::new(map)));
+            self.stack.push(Value::Hash(Value::hash_arc(map)));
             return Ok(());
         }
         // Preserve the container type of the target: Array->Array, List->List.
@@ -553,8 +551,8 @@ impl VM {
                     mut_map.insert(k, m);
                 }
                 Ok((
-                    Value::Hash(std::sync::Arc::new(res_map)),
-                    Value::Hash(std::sync::Arc::new(mut_map)),
+                    Value::Hash(Value::hash_arc(res_map)),
+                    Value::Hash(Value::hash_arc(mut_map)),
                 ))
             }
             _ => {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3343,7 +3343,7 @@ impl VM {
                     .iter()
                     .map(|(k, v)| (k.clone(), Self::deep_copy_value(v)))
                     .collect();
-                Value::Hash(std::sync::Arc::new(copied))
+                Value::Hash(Value::hash_arc(copied))
             }
             other => other.clone(),
         }

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -172,7 +172,7 @@ impl VM {
         {
             return None;
         }
-        let result = if args.len() == 2 {
+        let mut result = if args.len() == 2 {
             crate::builtins::native_method_2arg(target, method_sym, &args[0], &args[1])
         } else if args.len() == 1 {
             crate::builtins::native_method_1arg(target, method_sym, &args[0])
@@ -285,11 +285,13 @@ impl VM {
         // metadata, copy the metadata to the cloned value so the clone
         // preserves the type constraint (e.g. %h.clone ~~ Hash[Int,Int]).
         if method_name == "clone"
-            && let Some(Ok(ref cloned)) = result
+            && matches!(&result, Some(Ok(_)))
             && let Some(info) = self.interpreter.container_type_metadata(target)
+            && let Some(Ok(v)) = result.take()
         {
-            self.interpreter
-                .register_container_type_metadata(cloned, info);
+            // Hashes embed metadata in `HashData`; re-tag the cloned value
+            // (no-op Arc for array/instance side-table containers).
+            result = Some(Ok(self.interpreter.tag_container_metadata(v, info)));
         }
 
         result

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -948,8 +948,11 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                self.interpreter
-                    .register_container_type_metadata(&container, info);
+                // Hashes embed metadata in `HashData`; store the tagged value
+                // back into both the local slot and env.
+                let tagged = self.interpreter.tag_container_metadata(container, info);
+                self.locals_set_by_name(code, &name_str, tagged.clone());
+                self.set_env_with_main_alias(&name_str, tagged);
             }
             // Mark the variable read-only to prevent mutation
             self.interpreter.mark_readonly(&name_str);

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1388,7 +1388,7 @@ impl VM {
                 let v = self.hyper_op_pair(op, &l, &r, dwim_left, dwim_right)?;
                 result.insert(key, v);
             }
-            return Ok(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(Value::Hash(Value::hash_arc(result)));
         }
         // Hyper op between a hash and a scalar: apply the op to each value with
         // the scalar broadcast over every key (`%h >>*>> 4`, `2 <<**<< %h`).
@@ -1401,7 +1401,7 @@ impl VM {
                 let v = self.hyper_op_pair(op, value, right, dwim_left, dwim_right)?;
                 result.insert(key.clone(), v);
             }
-            return Ok(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(Value::Hash(Value::hash_arc(result)));
         }
         if let Value::Hash(map) = &right
             && !Self::is_listy(left)
@@ -1412,7 +1412,7 @@ impl VM {
                 let v = self.hyper_op_pair(op, left, value, dwim_left, dwim_right)?;
                 result.insert(key.clone(), v);
             }
-            return Ok(Value::Hash(std::sync::Arc::new(result)));
+            return Ok(Value::Hash(Value::hash_arc(result)));
         }
         // At least one side is a (non-hash) Iterable: distribute element-wise,
         // recursing so nested Iterables/Hashes are handled at every depth.
@@ -1536,7 +1536,7 @@ impl VM {
                 .collect(),
             other => return other.clone(),
         };
-        Value::Hash(std::sync::Arc::new(map))
+        Value::Hash(Value::hash_arc(map))
     }
 
     /// Rebuild a QuantHash of the given kind/mutability from a result Hash,
@@ -1910,10 +1910,10 @@ impl VM {
                 result.insert(key, v);
             }
         }
-        let result_hash = Value::Hash(std::sync::Arc::new(result));
+        let result_hash = Value::Hash(Value::hash_arc(result));
         if writeback {
             let writeback_val = if do_writeback {
-                Value::Hash(std::sync::Arc::new(mutated))
+                Value::Hash(Value::hash_arc(mutated))
             } else {
                 left.clone()
             };

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -78,7 +78,7 @@ impl VM {
             Value::Hash(hash) if matches!(idx, Value::Str(_)) => {
                 let mut updated = (**hash).clone();
                 updated.insert(idx.to_string_value(), val.clone());
-                *attr_value = Value::Hash(Arc::new(updated));
+                *attr_value = Value::Hash(Value::hash_arc(updated));
                 true
             }
             Value::Nil if !matches!(idx, Value::Str(_)) => {
@@ -102,7 +102,7 @@ impl VM {
             Value::Nil if matches!(idx, Value::Str(_)) => {
                 let mut updated = std::collections::HashMap::new();
                 updated.insert(idx.to_string_value(), val.clone());
-                *attr_value = Value::Hash(Arc::new(updated));
+                *attr_value = Value::Hash(Value::hash_arc(updated));
                 true
             }
             _ => false,
@@ -319,15 +319,17 @@ impl VM {
                 new_map.insert(k.clone(), v.clone());
             }
             // Create the new Arc with the map
-            let result_arc = Arc::new(new_map);
+            let result_arc = Value::hash_arc(new_map);
             // Now fix up the circular references: set the placeholder values
             // to point to the result_arc itself.
-            let map = Arc::as_ptr(&result_arc) as *mut HashMap<String, Value>;
+            let map = Arc::as_ptr(&result_arc) as *mut crate::value::HashData;
             for key in &circular_keys {
                 // SAFETY: We just created result_arc and hold the only reference,
                 // so no other thread can access it.
                 unsafe {
-                    (*map).insert(key.clone(), Value::Hash(result_arc.clone()));
+                    (*map)
+                        .map
+                        .insert(key.clone(), Value::Hash(result_arc.clone()));
                 }
             }
             *new_arc = result_arc;
@@ -398,18 +400,20 @@ impl VM {
                             new_map.insert(k.clone(), hv.clone());
                         }
                     }
-                    let new_hash_arc = Arc::new(new_map);
+                    let new_hash_arc = Value::hash_arc(new_map);
                     let new_hash_ptr = Arc::as_ptr(&new_hash_arc) as usize;
                     // Mark the new hash as seen so recursive calls don't
                     // re-enter it via self-referencing values.
                     seen_hashes.push(new_hash_ptr);
                     // SAFETY: We just created new_hash_arc and hold the only ref.
-                    let map_ptr = Arc::as_ptr(&new_hash_arc) as *mut HashMap<String, Value>;
+                    let map_ptr = Arc::as_ptr(&new_hash_arc) as *mut crate::value::HashData;
                     unsafe {
                         for key in &self_ref_keys {
-                            (*map_ptr).insert(key.clone(), Value::Hash(new_hash_arc.clone()));
+                            (*map_ptr)
+                                .map
+                                .insert(key.clone(), Value::Hash(new_hash_arc.clone()));
                         }
-                        for hv in (*map_ptr).values_mut() {
+                        for hv in (*map_ptr).map.values_mut() {
                             Self::replace_array_refs_in_value(
                                 hv,
                                 old_ptr,
@@ -646,7 +650,7 @@ impl VM {
                     let mut flattened = Vec::new();
                     for item in items.iter() {
                         if let Value::Hash(h) = item {
-                            for (k, v) in h.as_ref() {
+                            for (k, v) in h.as_ref().iter() {
                                 flattened.push(Value::Pair(k.clone(), Box::new(v.clone())));
                             }
                         } else {
@@ -1920,7 +1924,11 @@ impl VM {
         {
             match container_value {
                 Value::Hash(h) => {
-                    Value::hash_insert_through(Arc::make_mut(h), key.clone(), new_val.clone());
+                    Value::hash_insert_through(
+                        &mut Arc::make_mut(h).map,
+                        key.clone(),
+                        new_val.clone(),
+                    );
                     true
                 }
                 Value::Array(arr, ..) => {
@@ -2221,7 +2229,11 @@ impl VM {
                     self.locals[slot] = Value::Nil;
                 }
                 if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(var_name) {
-                    Value::hash_insert_through(Arc::make_mut(hash), key.clone(), val.clone());
+                    Value::hash_insert_through(
+                        &mut Arc::make_mut(hash).map,
+                        key.clone(),
+                        val.clone(),
+                    );
                 }
                 // Restore the local slot to point to the (now mutated) env Arc
                 if let Some(slot) = local_slot
@@ -3188,9 +3200,11 @@ impl VM {
                             let use_inplace = Arc::strong_count(hash) > 1
                                 && (!var_name.starts_with('%') || is_bound_hash_var);
                             let h: &mut std::collections::HashMap<String, Value> = if use_inplace {
-                                unsafe { &mut *(Arc::as_ptr(hash) as *mut _) }
+                                unsafe {
+                                    &mut (*(Arc::as_ptr(hash) as *mut crate::value::HashData)).map
+                                }
                             } else {
-                                Arc::make_mut(hash)
+                                &mut Arc::make_mut(hash).map
                             };
                             if bind_mode && let Some(Some(source_name)) = bind_sources.first() {
                                 pending_source_update = Some((source_name.clone(), val.clone()));
@@ -3881,7 +3895,7 @@ impl VM {
                 }
             }
             Value::Hash(h) => {
-                Value::hash_insert_through(Arc::make_mut(h), outer_key.to_string(), val);
+                Value::hash_insert_through(&mut Arc::make_mut(h).map, outer_key.to_string(), val);
             }
             _ => {}
         }
@@ -6309,7 +6323,7 @@ impl VM {
                 let display_key = Self::add_sigil_prefix(&key_str);
                 entries.insert(display_key, val.clone());
             }
-            self.stack.push(Value::Hash(Arc::new(entries)));
+            self.stack.push(Value::Hash(Value::hash_arc(entries)));
             return;
         }
         if name.strip_suffix("::") == Some("OUR") {
@@ -6318,7 +6332,7 @@ impl VM {
                 let display_key = Self::add_sigil_prefix(key);
                 entries.insert(display_key, val.clone());
             }
-            self.stack.push(Value::Hash(Arc::new(entries)));
+            self.stack.push(Value::Hash(Value::hash_arc(entries)));
             return;
         }
         if let Some(package) = name.strip_suffix("::")
@@ -6346,7 +6360,7 @@ impl VM {
             let display_key = Self::add_sigil_prefix(&key_str);
             entries.entry(display_key).or_insert_with(|| val.clone());
         }
-        self.stack.push(Value::Hash(Arc::new(entries)));
+        self.stack.push(Value::Hash(Value::hash_arc(entries)));
     }
 
     /// Build a pseudo-stash hash for a given pseudo-package name.
@@ -6362,7 +6376,7 @@ impl VM {
                 let display_key = Self::add_sigil_prefix(&key_str);
                 entries.insert(display_key, val.clone());
             }
-            return Value::Hash(Arc::new(entries));
+            return Value::Hash(Value::hash_arc(entries));
         }
         if name == "OUR" {
             let mut entries: HashMap<String, Value> = HashMap::new();
@@ -6370,7 +6384,7 @@ impl VM {
                 let display_key = Self::add_sigil_prefix(key);
                 entries.insert(display_key, val.clone());
             }
-            return Value::Hash(Arc::new(entries));
+            return Value::Hash(Value::hash_arc(entries));
         }
         if name != "MY" && name != "LEXICAL" {
             return self.interpreter.package_stash_value(name);
@@ -6391,7 +6405,7 @@ impl VM {
             let display_key = Self::add_sigil_prefix(&key_str);
             entries.entry(display_key).or_insert_with(|| val.clone());
         }
-        Value::Hash(Arc::new(entries))
+        Value::Hash(Value::hash_arc(entries))
     }
 
     /// Add a sigil prefix to a variable name for display in pseudo-stash.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5793,9 +5793,10 @@ impl VM {
             self.interpreter.unregister_container_type_metadata(&val);
             // Hashes: clear the embedded `HashData` type metadata in place so an
             // untyped variable never reports a typed element/key constraint.
-            let cleared = crate::runtime::Interpreter::clear_hash_type_metadata(
-                std::mem::replace(&mut self.locals[idx], Value::Nil),
-            );
+            let cleared = crate::runtime::Interpreter::clear_hash_type_metadata(std::mem::replace(
+                &mut self.locals[idx],
+                Value::Nil,
+            ));
             self.locals[idx] = cleared;
         }
         // When binding a typed hash/array to a variable, propagate the container's

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3807,10 +3807,13 @@ impl VM {
                 }
                 Value::Hash(inner_hash) => {
                     if Arc::strong_count(inner_hash) > 1 {
-                        let ptr = Arc::as_ptr(inner_hash)
-                            as *mut std::collections::HashMap<String, Value>;
+                        let ptr = Arc::as_ptr(inner_hash) as *mut crate::value::HashData;
                         unsafe {
-                            Value::hash_insert_through(&mut *ptr, outer_key.clone(), val.clone());
+                            Value::hash_insert_through(
+                                &mut (*ptr).map,
+                                outer_key.clone(),
+                                val.clone(),
+                            );
                         }
                     } else {
                         let h = Arc::make_mut(inner_hash);
@@ -4217,9 +4220,9 @@ impl VM {
                 }
                 // Interior mutation: write into the hash via raw pointer
                 // so the change is visible to all holders of the same Arc.
-                let ptr = Arc::as_ptr(arc) as *mut std::collections::HashMap<String, Value>;
+                let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
                 unsafe {
-                    Value::hash_insert_through(&mut *ptr, key.clone(), val.clone());
+                    Value::hash_insert_through(&mut (*ptr).map, key.clone(), val.clone());
                 }
                 // For bind mode, set up a HashSlotRef on the source variable
                 if let Some(source_name) = &bind_source {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -775,9 +775,7 @@ impl VM {
                         key_type: None,
                         declared_type: Some("Map".to_string()),
                     };
-                    self.interpreter
-                        .register_container_type_metadata(&mapped_val, info);
-                    Ok(mapped_val)
+                    Ok(self.interpreter.tag_container_metadata(mapped_val, info))
                 }
             }
             // Non-Associative values: coerce to Map
@@ -788,9 +786,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                self.interpreter
-                    .register_container_type_metadata(&hash, info);
-                Ok(hash)
+                Ok(self.interpreter.tag_container_metadata(hash, info))
             }
             Value::Seq(items) | Value::Slip(items) => {
                 let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
@@ -799,9 +795,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                self.interpreter
-                    .register_container_type_metadata(&hash, info);
-                Ok(hash)
+                Ok(self.interpreter.tag_container_metadata(hash, info))
             }
             _ => {
                 // For other types (Int, Str, etc.), coerce to Map via
@@ -813,9 +807,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                self.interpreter
-                    .register_container_type_metadata(&hash, info);
-                Ok(hash)
+                Ok(self.interpreter.tag_container_metadata(hash, info))
             }
         }
     }
@@ -2200,8 +2192,7 @@ impl VM {
                     None
                 };
                 // Reject if there's container type metadata
-                let id = Arc::as_ptr(hash_arc) as usize;
-                if self.interpreter.hash_type_metadata_exists(id) {
+                if hash_arc.has_type_meta() {
                     return None;
                 }
                 // Peek at the key to check if the existing element is a bound ref
@@ -2316,13 +2307,9 @@ impl VM {
         // metadata key. Reapply them on the final container so typed-array
         // hole semantics and `is default(...)` are preserved.
         let save_var_name = Self::const_str(code, name_idx).to_string();
-        // Heal the hash's Arc-pointer-keyed type metadata from its authoritative
-        // name-based key constraint before assigning, so object-hash semantics
-        // survive across copy-on-write and Arc-pointer reuse (otherwise typed
-        // `%h{$int} = ...` intermittently loses its key constraint and stores the
-        // value under a stringified key, returning Nil on later reads).
-        self.interpreter
-            .reconcile_hash_type_metadata_from_name(&save_var_name);
+        // Hash type metadata (including the object-hash key constraint) is now
+        // embedded in `HashData` and travels with the hash across copy-on-write,
+        // so the old name-based reconcile healing is no longer needed.
         let saved_type_meta_outer = self
             .interpreter
             .env()
@@ -2365,11 +2352,15 @@ impl VM {
                 .as_ref()
                 != Some(&info)
         {
+            // Hashes embed metadata in `HashData`, so the re-tagged value must
+            // be written back into both env and the fast-path local slot
+            // (`tag_container_metadata` returns the same Arc for non-hash
+            // containers, whose Arc-pointer side table is updated in place).
+            let tagged = self.interpreter.tag_container_metadata(container, info);
             self.interpreter
-                .register_container_type_metadata(&container, info);
-            // Sync the refreshed container pointer into locals so fast-path
-            // reads see the preserved metadata.
-            self.locals_set_by_name(code, &save_var_name, container);
+                .env_mut()
+                .insert(save_var_name.clone(), tagged.clone());
+            self.locals_set_by_name(code, &save_var_name, tagged);
         }
         if let Some(def) = saved_default_outer
             && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
@@ -5798,7 +5789,14 @@ impl VM {
             && self.interpreter.var_type_constraint(name).is_none()
             && self.interpreter.container_type_metadata(&val).is_some()
         {
+            // Arrays: drop the stale Arc-pointer side-table entry.
             self.interpreter.unregister_container_type_metadata(&val);
+            // Hashes: clear the embedded `HashData` type metadata in place so an
+            // untyped variable never reports a typed element/key constraint.
+            let cleared = crate::runtime::Interpreter::clear_hash_type_metadata(
+                std::mem::replace(&mut self.locals[idx], Value::Nil),
+            );
+            self.locals[idx] = cleared;
         }
         // When binding a typed hash/array to a variable, propagate the container's
         // type constraints to the variable so that subsequent element assignments
@@ -5836,6 +5834,32 @@ impl VM {
         // a true circular reference (matching Raku container semantics).
         if name.starts_with('@') && !is_bind && !is_constant {
             Self::fixup_circular_array_refs(&mut self.locals[idx], &old_array_arc);
+        }
+        // Apply the variable's declared element/key type to the stored
+        // container. For hashes this embeds the metadata in `HashData` so it
+        // travels with the value through later copy-on-write; for arrays it
+        // updates the Arc-pointer side table. Done before the value is cloned
+        // and propagated to env/aliases below, so every copy carries it.
+        if (name.starts_with('@') || name.starts_with('%'))
+            && let Some(value_type) = self.interpreter.var_type_constraint(name)
+        {
+            let info = crate::runtime::ContainerTypeInfo {
+                declared_type: if name.starts_with('@')
+                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
+                {
+                    Some(format!("array[{value_type}]"))
+                } else {
+                    None
+                },
+                value_type,
+                key_type: if name.starts_with('%') {
+                    self.interpreter.var_hash_key_constraint(name)
+                } else {
+                    None
+                },
+            };
+            let stored = std::mem::replace(&mut self.locals[idx], Value::Nil);
+            self.locals[idx] = self.interpreter.tag_container_metadata(stored, info);
         }
         // Use the potentially fixed-up value for env/shared_vars.
         let val = self.locals[idx].clone();
@@ -5919,27 +5943,6 @@ impl VM {
             let sv = source_var.clone();
             self.set_env_with_main_alias(&sv, val.clone());
             self.update_local_if_exists(code, &sv, &val);
-        }
-        if (name.starts_with('@') || name.starts_with('%'))
-            && let Some(value_type) = self.interpreter.var_type_constraint(name)
-        {
-            let info = crate::runtime::ContainerTypeInfo {
-                declared_type: if name.starts_with('@')
-                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
-                {
-                    Some(format!("array[{value_type}]"))
-                } else {
-                    None
-                },
-                value_type,
-                key_type: if name.starts_with('%') {
-                    self.interpreter.var_hash_key_constraint(name)
-                } else {
-                    None
-                },
-            };
-            self.interpreter
-                .register_container_type_metadata(&val, info);
         }
         Ok(())
     }
@@ -6263,6 +6266,29 @@ impl VM {
         {
             return Err(err);
         }
+        // Apply the variable's declared element/key type to the container value
+        // before it is stored, so the embedded `HashData` metadata (or array
+        // side-table entry) is carried by every copy below.
+        if (name.starts_with('@') || name.starts_with('%'))
+            && let Some(value_type) = self.interpreter.var_type_constraint(name)
+        {
+            let info = crate::runtime::ContainerTypeInfo {
+                declared_type: if name.starts_with('@')
+                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
+                {
+                    Some(format!("array[{value_type}]"))
+                } else {
+                    None
+                },
+                value_type,
+                key_type: if name.starts_with('%') {
+                    self.interpreter.var_hash_key_constraint(name)
+                } else {
+                    None
+                },
+            };
+            val = self.interpreter.tag_container_metadata(val, info);
+        }
         self.locals[idx] = val.clone();
         self.set_env_with_main_alias(name, val.clone());
         if let Some(alias_name) = self.interpreter.env().get(&alias_key).and_then(|v| {
@@ -6283,27 +6309,6 @@ impl VM {
             self.interpreter
                 .env_mut()
                 .insert(format!(".{}", attr), val.clone());
-        }
-        if (name.starts_with('@') || name.starts_with('%'))
-            && let Some(value_type) = self.interpreter.var_type_constraint(name)
-        {
-            let info = crate::runtime::ContainerTypeInfo {
-                declared_type: if name.starts_with('@')
-                    && crate::runtime::native_types::is_native_array_element_type(&value_type)
-                {
-                    Some(format!("array[{value_type}]"))
-                } else {
-                    None
-                },
-                value_type,
-                key_type: if name.starts_with('%') {
-                    self.interpreter.var_hash_key_constraint(name)
-                } else {
-                    None
-                },
-            };
-            self.interpreter
-                .register_container_type_metadata(&val, info);
         }
         self.stack.push(val);
         Ok(())

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -135,8 +135,7 @@ impl VM {
                 } else {
                     None
                 };
-                let id = Arc::as_ptr(hash_arc) as usize;
-                if self.interpreter.hash_type_metadata_exists(id) {
+                if hash_arc.has_type_meta() {
                     return None;
                 }
                 let key = idx.to_string_value();
@@ -354,7 +353,9 @@ impl VM {
         } else {
             result
         };
-        // Re-register type metadata if it was lost due to Arc::make_mut
+        // Re-register type metadata if it was lost due to Arc::make_mut. Hashes
+        // embed metadata in `HashData`, so the re-tagged value is written back
+        // (no-op Arc for array/instance side-table containers).
         if let Some(info) = saved_meta
             && let Some(container) = self.interpreter.env().get(&var_name)
             && self
@@ -363,8 +364,11 @@ impl VM {
                 .is_none()
         {
             let container = container.clone();
+            let tagged = self.interpreter.tag_container_metadata(container, info);
             self.interpreter
-                .register_container_type_metadata(&container, info);
+                .env_mut()
+                .insert(var_name.to_string(), tagged.clone());
+            self.update_local_if_exists(code, &var_name, &tagged);
         }
         // Re-register container default if it was lost due to Arc::make_mut.
         // Use the pointer-keyed container_default saved before delete so we

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -452,7 +452,7 @@ impl VM {
         match target {
             Value::Hash(..) => {}
             Value::Nil | Value::Package(..) => {
-                *target = Value::Hash(std::sync::Arc::new(std::collections::HashMap::new()));
+                *target = Value::Hash(Value::hash_arc(std::collections::HashMap::new()));
             }
             _ => {}
         }

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -315,12 +315,17 @@ impl VM {
             self.update_local_if_exists(code, &var_name, &updated);
         }
 
-        // Re-register container type metadata if Arc pointer changed
+        // Re-register container type metadata if Arc pointer changed. Hashes
+        // embed metadata in `HashData`, so the re-tagged value must be written
+        // back (no-op Arc for array/instance side-table containers).
         if let Some(info) = old_type_info
             && let Some(updated) = self.interpreter.env().get(&var_name).cloned()
         {
+            let tagged = self.interpreter.tag_container_metadata(updated, info);
             self.interpreter
-                .register_container_type_metadata(&updated, info);
+                .env_mut()
+                .insert(var_name.clone(), tagged.clone());
+            self.update_local_if_exists(code, &var_name, &tagged);
         }
 
         self.stack.push(value);

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -84,7 +84,7 @@ impl VM {
 
     pub(super) fn resolve_hash_entry(
         &self,
-        items: &Arc<HashMap<String, Value>>,
+        items: &Arc<crate::value::HashData>,
         key: &str,
     ) -> Value {
         match items.get(key) {
@@ -117,7 +117,7 @@ impl VM {
 
     /// Resolve all sentinel entries in a hash, returning a new hash with
     /// bound variable references replaced by their current values.
-    pub(super) fn resolve_hash_for_iteration(&self, items: &Arc<HashMap<String, Value>>) -> Value {
+    pub(super) fn resolve_hash_for_iteration(&self, items: &Arc<crate::value::HashData>) -> Value {
         let mut resolved = HashMap::new();
         for (key, value) in items.iter() {
             let resolved_value = match value {
@@ -136,7 +136,7 @@ impl VM {
             };
             resolved.insert(key.clone(), resolved_value);
         }
-        Value::Hash(Arc::new(resolved))
+        Value::Hash(Value::hash_arc(resolved))
     }
 
     pub(super) fn self_array_ref_marker() -> Value {


### PR DESCRIPTION
Migrates `Value::Hash(Arc<HashMap>)` → `Value::Hash(Arc<HashData>)` (Stage 1a) and
makes `HashData` the **authoritative** source of hash element/key/declared type
metadata (Stage 1b), deleting the Arc-pointer-keyed `hash_type_metadata` side
table.

## Why
The `hash_type_metadata` side table is keyed by the hash's `Arc` pointer, which is
reused after a hash is dropped. A freshly-built hash literal whose backing `Arc`
reuses a freed typed hash's address inherits its stale `Hash[Int]` metadata —
the root of the intermittent typed-hash / object-hash flaky. Stage 1a alone made
this **deterministic** (`t/typed-hash-bind-typecheck.t` test 11). Stage 1b fixes
it by carrying the metadata IN the hash value, where it survives COW and pointer
reuse.

## What
- **Stage 1a**: `HashData { map, value_type, key_type, declared_type, original_keys }`
  with `Deref`/`DerefMut` to the map (read sites unchanged) and map-only `PartialEq`.
- **Stage 1b**: embed `value_type`/`key_type`/`declared_type`; readers
  (`container_type_metadata`, `is_object_hash`, `hash_key_type`, fast-path guards)
  read the embedded fields. New `tag_container_metadata(value, info) -> Value`
  embeds into the `HashData` (skipping the COW clone when unchanged, preserving
  `.WHICH` identity) and falls back to the side tables for non-hash containers;
  all hash writers migrated + write-back. Delete `hash_type_metadata` and the
  name-based reconcile workaround.
- **Latent UB fix**: `hash_autovivify`/`hash_slot_ref` cast `Arc::as_ptr as *mut
  HashMap` — reinterpreting `HashData` as a bare `HashMap`. Worked by accident on
  the 1a branch (`map` at offset 0); the new field reordered it into a SEGV.
  Cast through `*mut HashData`.

## Verification
- `t/typed-hash-bind-typecheck.t` 11/11 (canary)
- `S02-types/hash.t` 112/112 (was SEGV-ing)
- `make test` 6570/6570, clippy clean
- `S02-names-vars/perl.t` (was the release-only flaky) passes repeatedly

Object-hash `original_keys` (`S09-hashes/objecthash.t`, `S32-list/classify.t`,
both non-whitelisted) stay on the side tables — Stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)