### PR TITLE
refactor(hash): Stage 2 — embed object-hash original_keys in HashData, delete both side tables

### DIFF
--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -63,14 +63,37 @@ branch only because `map` happened to land at offset 0; adding the
 `declared_type` field reordered the struct and turned it into a SEGV. Fixed to
 cast to `*mut HashData` and go through `.map`.
 
-### Remaining (Stage 2 — object-hash original_keys)
+### Stage 2 — object-hash original_keys (DONE: embed; side tables deleted)
 
-`original_keys` (the `.WHICH`-string → original-key-object map) is STILL on the
-two Arc-pointer side tables (`hash_object_keys` + the `hash_original_keys_registry`
-in `runtime/utils.rs`). Object-hash tests `S09-hashes/objecthash.t` (7 fail) and
-`S32-list/classify.t` (1 fail) — both NOT whitelisted — remain blocked on this;
-they are unchanged by Stage 1b. Embed `original_keys` in `HashData` next, using
-the same `tag`/write-back pattern, then delete those two side tables.
+**Status (2026-06-12):** `original_keys` (the `.WHICH`-string → original-key-object
+map) now lives in `HashData.original_keys`. Both Arc-pointer side tables are
+DELETED: the interpreter's `hash_object_keys` field (+ `set_hash_object_key` /
+`hash_object_keys_get` / `migrate_hash_object_keys`) and the global
+`hash_original_keys_registry` in `runtime/utils.rs` (+ the `*_by_id` /
+`take_*_by_id` pointer helpers). Because the map travels with the hash through
+copy-on-write, the entire COW pointer-migration dance in the element-assignment
+path (`migrate` + `take_by_id` + `register_by_id` after each make_mut) is GONE —
+object keys are written into the same `&mut HashData` as the element insert.
+
+- Writers: element-assignment paths set `hd.original_keys` in the same
+  in-place/`make_mut` mutation; result-builders (Set/Bag/Mix→Hash coercions,
+  typed-hash coercion) use `runtime::utils::set_hash_original_keys(value, keys)`.
+- Readers: `hash_original_keys_snapshot` / `hash_typed_key` read
+  `HashData.original_keys`; the `.keys` object-hash path reads the single source.
+
+`make test` green; no whitelisted regression.
+
+**NOT fixed by Stage 2 (separate object-hash *enforcement/construction*
+features, still failing in the non-whitelisted `S09-hashes/objecthash.t`):**
+- key-type check on assignment (`%h{Any}` must reject a `Mu` key — test 3; its
+  failure also makes the order-sensitive test 4 flaky by leaving an extra key)
+- `Hash.push` key/value type checks (tests 21, 23, 24)
+- `.new`/`.clone` on an object-hash instance must stay an object hash
+  (tests 34–35 see `Hash[Any,Any]` where `Hash` is expected)
+- mixin objects as keys (test 36 — aborts the file at line 104)
+
+These are object-hash *type enforcement*, independent of where the original keys
+are stored; tackle them next now that the key map is COW-stable.
 
 ---
 (original plan below)

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -300,11 +300,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     // Tag so .keys can distinguish setty-origin hashes
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                    result = crate::runtime::utils::set_hash_original_keys(result, original_keys);
                 }
                 Some(Ok(result))
             }
@@ -320,10 +320,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                    result = crate::runtime::utils::set_hash_original_keys(result, original_keys);
                 }
                 Some(Ok(result))
             }
@@ -339,10 +339,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    crate::runtime::utils::register_hash_original_keys(&result, original_keys);
+                    result = crate::runtime::utils::set_hash_original_keys(result, original_keys);
                 }
                 Some(Ok(result))
             }

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -175,10 +175,10 @@ impl Interpreter {
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    super::utils::register_hash_original_keys(&result, original_keys);
+                    result = super::utils::set_hash_original_keys(result, original_keys);
                 }
                 Ok(result)
             }
@@ -194,10 +194,10 @@ impl Interpreter {
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    super::utils::register_hash_original_keys(&result, original_keys);
+                    result = super::utils::set_hash_original_keys(result, original_keys);
                 }
                 Ok(result)
             }
@@ -213,10 +213,10 @@ impl Interpreter {
                         original_keys.insert(k.clone(), typed);
                     }
                 }
-                let result = Value::hash(map);
+                let mut result = Value::hash(map);
                 if has_typed {
                     original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                    super::utils::register_hash_original_keys(&result, original_keys);
+                    result = super::utils::set_hash_original_keys(result, original_keys);
                 }
                 Ok(result)
             }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -628,22 +628,8 @@ impl Interpreter {
                 if let Some(info) = self.container_type_metadata(&target)
                     && info.key_type.is_some()
                 {
-                    // Object hash: use original key objects from interpreter storage
-                    let hash_ptr = std::sync::Arc::as_ptr(map) as usize;
-                    if let Some(orig_map) = self.hash_object_keys_get(hash_ptr) {
-                        let orig_map_clone = orig_map.clone();
-                        let keys: Vec<Value> = map
-                            .keys()
-                            .map(|k| {
-                                orig_map_clone
-                                    .get(k)
-                                    .cloned()
-                                    .unwrap_or_else(|| Value::str(k.clone()))
-                            })
-                            .collect();
-                        return Some(Ok(Value::array(keys)));
-                    }
-                    // Also try global registry (for hashes from Set/Bag/Mix coercion)
+                    // Object hash: use the original key objects embedded in the
+                    // hash's `HashData` (single source, COW-stable).
                     if let Some(ref orig) = utils::hash_original_keys_snapshot(&target)
                         && !orig.is_empty()
                     {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1037,12 +1037,8 @@ pub struct Interpreter {
     set_type_metadata: PtrKeyedMap<crate::value::SetData, ContainerTypeInfo>,
     /// Type metadata for Bag values (pointer-keyed, Weak-guarded).
     bag_type_metadata: PtrKeyedMap<crate::value::BagData, ContainerTypeInfo>,
-    /// Original key objects for object hashes, keyed by Hash Arc pointer
-    /// identity. Deliberately NOT Weak-guarded: object-hash construction
-    /// mutates the hash repeatedly and relies on in-place pointer stability;
-    /// the structural fix is embedding `original_keys` in `HashData`
-    /// (docs/hashdata-migration-plan.md Stage 2), not a guard.
-    hash_object_keys: HashMap<usize, HashMap<String, Value>>,
+    // Object-hash original keys are embedded in `HashData.original_keys`
+    // (Stage 2) — no side table.
     /// Type metadata for instance values keyed by stable instance id.
     instance_type_metadata: HashMap<u64, ContainerTypeInfo>,
     let_saves: Vec<(String, Value, bool)>,
@@ -3137,7 +3133,6 @@ impl Interpreter {
             mix_type_metadata: PtrKeyedMap::new(),
             set_type_metadata: PtrKeyedMap::new(),
             bag_type_metadata: PtrKeyedMap::new(),
-            hash_object_keys: HashMap::new(),
             instance_type_metadata: HashMap::new(),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
@@ -4779,32 +4774,10 @@ impl Interpreter {
         }
     }
 
-    /// Store an original key object for an object hash entry.
-    pub(crate) fn set_hash_object_key(
-        &mut self,
-        hash_ptr: usize,
-        which_key: &str,
-        original_key: Value,
-    ) {
-        self.hash_object_keys
-            .entry(hash_ptr)
-            .or_default()
-            .insert(which_key.to_string(), original_key);
-    }
-
-    /// Get the original key objects for a hash by Arc pointer id.
-    pub(crate) fn hash_object_keys_get(&self, hash_ptr: usize) -> Option<&HashMap<String, Value>> {
-        self.hash_object_keys.get(&hash_ptr)
-    }
-
-    /// Copy object keys from old Arc pointer to new Arc pointer (after COW).
-    pub(crate) fn migrate_hash_object_keys(&mut self, old_ptr: usize, new_ptr: usize) {
-        if old_ptr != new_ptr
-            && let Some(keys) = self.hash_object_keys.remove(&old_ptr)
-        {
-            self.hash_object_keys.insert(new_ptr, keys);
-        }
-    }
+    // Object-hash original keys are embedded in `HashData.original_keys`
+    // (see `runtime::utils::set_hash_original_keys` / `hash_original_keys_snapshot`),
+    // so the `hash_object_keys` side table and its pointer-migration helpers are
+    // gone — the map now travels with the hash across copy-on-write.
 
     /// Check if a hash is an object hash (has a key_type constraint).
     pub(crate) fn is_object_hash(&self, hash: &Value) -> bool {
@@ -5559,7 +5532,6 @@ impl Interpreter {
             mix_type_metadata: self.mix_type_metadata.clone(),
             set_type_metadata: self.set_type_metadata.clone(),
             bag_type_metadata: self.bag_type_metadata.clone(),
-            hash_object_keys: self.hash_object_keys.clone(),
             instance_type_metadata: self.instance_type_metadata.clone(),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -89,77 +89,40 @@ fn shaped_array_ids() -> &'static Mutex<ShapedArrayIds> {
     SHAPED_ARRAY_IDS.get_or_init(|| Mutex::new(PtrKeyedMap::new()))
 }
 
-/// Global registry of original (non-string) keys for object hashes.
-/// Keyed by the hash's Arc pointer identity. Deliberately NOT Weak-guarded
-/// (unlike `shaped_array_ids`/`grep_view_bindings`): object-hash construction
-/// mutates the hash repeatedly and relies on in-place pointer stability; the
-/// structural fix is embedding `original_keys` in `HashData`
-/// (docs/hashdata-migration-plan.md Stage 2), not a guard.
-fn hash_original_keys_registry() -> &'static Mutex<HashMap<usize, HashMap<String, Value>>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<usize, HashMap<String, Value>>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Register original keys for a hash value.
-pub(crate) fn register_hash_original_keys(hash: &Value, original_keys: HashMap<String, Value>) {
+/// Embed original (non-string) keys for an object hash into its `HashData`,
+/// returning the (possibly rebuilt) value. The map travels WITH the hash
+/// through copy-on-write — replacing the old Arc-pointer-keyed side tables, so
+/// no `migrate`/`by_id` pointer bookkeeping is needed across COW. Callers must
+/// use the returned value (store it back into its slot).
+pub(crate) fn set_hash_original_keys(value: Value, original_keys: HashMap<String, Value>) -> Value {
     if original_keys.is_empty() {
-        return;
+        return value;
     }
-    if let Value::Hash(arc) = hash {
-        let id = Arc::as_ptr(arc) as usize;
-        if let Ok(mut reg) = hash_original_keys_registry().lock() {
-            reg.insert(id, original_keys);
-        }
+    if let Value::Hash(mut arc) = value {
+        Arc::make_mut(&mut arc).original_keys = Some(original_keys);
+        return Value::Hash(arc);
     }
+    value
 }
 
-/// Snapshot the original keys for a hash, if any are registered.
+/// Snapshot the original keys embedded in an object hash, if any.
 pub(crate) fn hash_original_keys_snapshot(hash: &Value) -> Option<HashMap<String, Value>> {
     if let Value::Hash(arc) = hash {
-        let id = Arc::as_ptr(arc) as usize;
-        if let Ok(reg) = hash_original_keys_registry().lock() {
-            return reg.get(&id).cloned();
-        }
+        return arc.original_keys.clone();
     }
     None
 }
 
 /// Retrieve the original (typed) key value for a hash entry, if available.
-/// Falls back to the string key if no original key is registered.
+/// Falls back to the string key if no original key is embedded.
 pub(crate) fn hash_typed_key(hash: &Value, str_key: &str) -> Value {
-    if let Value::Hash(arc) = hash {
-        let id = Arc::as_ptr(arc) as usize;
-        if let Ok(reg) = hash_original_keys_registry().lock()
-            && let Some(orig_keys) = reg.get(&id)
-            && let Some(orig) = orig_keys.get(str_key)
-        {
-            return orig.clone();
-        }
+    if let Value::Hash(arc) = hash
+        && let Some(orig_keys) = arc.original_keys.as_ref()
+        && let Some(orig) = orig_keys.get(str_key)
+    {
+        return orig.clone();
     }
     Value::str(str_key.to_string())
-}
-
-/// Register original keys for a hash value by Arc pointer ID directly.
-pub(crate) fn register_hash_original_keys_by_id(id: usize, original_keys: HashMap<String, Value>) {
-    if let Ok(mut reg) = hash_original_keys_registry().lock() {
-        reg.insert(id, original_keys);
-    }
-}
-
-/// Snapshot original keys by Arc pointer ID.
-pub(crate) fn hash_original_keys_snapshot_by_id(id: usize) -> Option<HashMap<String, Value>> {
-    if let Ok(reg) = hash_original_keys_registry().lock() {
-        return reg.get(&id).cloned();
-    }
-    None
-}
-
-/// Take (remove and return) original keys by Arc pointer ID.
-pub(crate) fn take_hash_original_keys_by_id(id: usize) -> Option<HashMap<String, Value>> {
-    if let Ok(mut reg) = hash_original_keys_registry().lock() {
-        return reg.remove(&id);
-    }
-    None
 }
 
 fn grep_view_bindings() -> &'static Mutex<GrepViewMap> {
@@ -532,9 +495,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     i += 2;
                 }
             }
-            let result = Value::hash(map);
-            register_hash_original_keys(&result, original_keys);
-            result
+            set_hash_original_keys(Value::hash(map), original_keys)
         }
         Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) | Value::Slip(items) => {
             let mut map = HashMap::new();
@@ -581,10 +542,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     original_keys.insert(key.clone(), typed);
                 }
             }
-            let result = Value::hash(map);
+            let mut result = Value::hash(map);
             if has_typed {
                 original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                register_hash_original_keys(&result, original_keys);
+                result = set_hash_original_keys(result, original_keys);
             }
             result
         }
@@ -600,10 +561,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     original_keys.insert(key.clone(), typed);
                 }
             }
-            let result = Value::hash(map);
+            let mut result = Value::hash(map);
             if has_typed {
                 original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                register_hash_original_keys(&result, original_keys);
+                result = set_hash_original_keys(result, original_keys);
             }
             result
         }
@@ -619,10 +580,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     original_keys.insert(key.clone(), typed);
                 }
             }
-            let result = Value::hash(map);
+            let mut result = Value::hash(map);
             if has_typed {
                 original_keys.insert("__mutsu_setty_origin".to_string(), Value::Bool(true));
-                register_hash_original_keys(&result, original_keys);
+                result = set_hash_original_keys(result, original_keys);
             }
             result
         }
@@ -710,9 +671,7 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
             }
         }
     }
-    let result = Value::hash(map);
-    register_hash_original_keys(&result, original_keys);
-    Ok(result)
+    Ok(set_hash_original_keys(Value::hash(map), original_keys))
 }
 
 /// Maximum number of elements when expanding an infinite range into an Array.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1147,10 +1147,10 @@ impl VM {
                 };
                 coerced_map.insert(coerced_key, coerced_val);
             }
-            let result = Value::hash(coerced_map);
-            // Re-register original keys on the new hash Arc.
+            let mut result = Value::hash(coerced_map);
+            // Re-embed original keys on the new (coerced) hash.
             if let Some(orig) = saved_original_keys {
-                runtime::utils::register_hash_original_keys(&result, orig);
+                result = runtime::utils::set_hash_original_keys(result, orig);
             }
             return Ok(result);
         }
@@ -2315,13 +2315,6 @@ impl VM {
             .env()
             .get(&save_var_name)
             .and_then(|v| self.interpreter.container_type_metadata(v));
-        // Save old hash pointer for object key migration after COW.
-        let saved_hash_obj_keys_ptr =
-            if let Some(Value::Hash(arc)) = self.interpreter.env().get(&save_var_name) {
-                Some(Arc::as_ptr(arc) as usize)
-            } else {
-                None
-            };
         // Guard against stale pointer-keyed defaults (Arc reuse across
         // allocations): only trust the saved default when a name-based
         // var_default is also registered.
@@ -2368,18 +2361,8 @@ impl VM {
         {
             self.interpreter.set_container_default(&container, def);
         }
-        // Migrate object hash keys if the hash Arc pointer changed (COW).
-        if let Some(old_ptr) = saved_hash_obj_keys_ptr
-            && let Some(Value::Hash(arc)) = self.interpreter.env().get(&save_var_name)
-        {
-            let new_ptr = Arc::as_ptr(arc) as usize;
-            self.interpreter.migrate_hash_object_keys(old_ptr, new_ptr);
-            if old_ptr != new_ptr
-                && let Some(keys) = runtime::utils::take_hash_original_keys_by_id(old_ptr)
-            {
-                runtime::utils::register_hash_original_keys_by_id(new_ptr, keys);
-            }
-        }
+        // Object-hash original keys are embedded in `HashData` and travel with
+        // the hash across copy-on-write, so no pointer migration is needed.
         result
     }
 
@@ -2837,11 +2820,6 @@ impl VM {
                     .is_some();
                 let mut pending_source_updates: Vec<(String, Value)> = Vec::new();
                 if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(&var_name) {
-                    let old_slice_ptr = if slice_is_object_hash {
-                        Some(Arc::as_ptr(hash) as usize)
-                    } else {
-                        None
-                    };
                     let h = Arc::make_mut(hash);
                     for (i, key) in keys.iter().enumerate() {
                         let k = if slice_is_object_hash {
@@ -2867,23 +2845,16 @@ impl VM {
                             h.insert(k, v);
                         }
                     }
-                    // Store original keys for object hashes after slice insert
+                    // Store original keys for object hashes (embedded in
+                    // HashData, COW-stable) after slice insert.
                     if slice_is_object_hash {
-                        let new_ptr = Arc::as_ptr(hash) as usize;
-                        if let Some(old_ptr) = old_slice_ptr
-                            && old_ptr != new_ptr
-                            && let Some(old_keys) =
-                                runtime::utils::take_hash_original_keys_by_id(old_ptr)
-                        {
-                            runtime::utils::register_hash_original_keys_by_id(new_ptr, old_keys);
-                        }
-                        let mut orig = runtime::utils::hash_original_keys_snapshot_by_id(new_ptr)
-                            .unwrap_or_default();
+                        let orig = h
+                            .original_keys
+                            .get_or_insert_with(std::collections::HashMap::new);
                         for key in keys.iter() {
                             let wk = runtime::utils::value_which_key(key);
                             orig.insert(wk, key.clone());
                         }
-                        runtime::utils::register_hash_original_keys_by_id(new_ptr, orig);
                     }
                 }
                 for (source_name, source_value) in pending_source_updates {
@@ -3183,60 +3154,41 @@ impl VM {
                             // modifications propagate to the bound source.
                             // %-sigiled vars have names like "%h", scalar vars
                             // have names without a sigil prefix (e.g. "bar").
-                            let old_hash_ptr = if is_object_hash {
-                                Some(Arc::as_ptr(hash) as usize)
-                            } else {
-                                None
-                            };
                             let use_inplace = Arc::strong_count(hash) > 1
                                 && (!var_name.starts_with('%') || is_bound_hash_var);
-                            let h: &mut std::collections::HashMap<String, Value> = if use_inplace {
-                                unsafe {
-                                    &mut (*(Arc::as_ptr(hash) as *mut crate::value::HashData)).map
-                                }
+                            // Mutate the whole `HashData` (map + embedded
+                            // object-hash original keys) so the original-key map
+                            // travels with the hash through copy-on-write.
+                            let hd: &mut crate::value::HashData = if use_inplace {
+                                unsafe { &mut *(Arc::as_ptr(hash) as *mut crate::value::HashData) }
                             } else {
-                                &mut Arc::make_mut(hash).map
+                                Arc::make_mut(hash)
                             };
                             if bind_mode && let Some(Some(source_name)) = bind_sources.first() {
                                 pending_source_update = Some((source_name.clone(), val.clone()));
-                                h.insert(
+                                hd.map.insert(
                                     key.clone(),
                                     Value::Pair(
                                         super::vm_var_ops::BOUND_HASH_REF_SENTINEL.to_string(),
                                         Box::new(Value::str(source_name.clone())),
                                     ),
                                 );
-                            } else if let Some(Value::Pair(marker, source_name)) = h.get(&key)
+                            } else if let Some(Value::Pair(marker, source_name)) = hd.map.get(&key)
                                 && marker == super::vm_var_ops::BOUND_HASH_REF_SENTINEL
                             {
                                 let source_name = source_name.to_string_value();
                                 pending_source_update = Some((source_name, val.clone()));
                             } else if is_self_hash_ref {
-                                h.insert(key.clone(), Self::self_hash_ref_marker());
+                                hd.map.insert(key.clone(), Self::self_hash_ref_marker());
                             } else {
-                                Value::hash_insert_through(h, key.clone(), val.clone());
+                                Value::hash_insert_through(&mut hd.map, key.clone(), val.clone());
                             }
-                            // For object hashes, store the original key object
+                            // For object hashes, store the original key object in
+                            // the embedded `original_keys` map (COW-stable).
                             if is_object_hash {
-                                let new_ptr = Arc::as_ptr(hash) as usize;
-                                if let Some(old_ptr) = old_hash_ptr {
-                                    self.interpreter.migrate_hash_object_keys(old_ptr, new_ptr);
-                                    if old_ptr != new_ptr
-                                        && let Some(old_keys) =
-                                            runtime::utils::take_hash_original_keys_by_id(old_ptr)
-                                    {
-                                        runtime::utils::register_hash_original_keys_by_id(
-                                            new_ptr, old_keys,
-                                        );
-                                    }
-                                }
-                                self.interpreter
-                                    .set_hash_object_key(new_ptr, &key, idx.clone());
-                                let mut orig =
-                                    runtime::utils::hash_original_keys_snapshot_by_id(new_ptr)
-                                        .unwrap_or_default();
-                                orig.insert(key.clone(), idx.clone());
-                                runtime::utils::register_hash_original_keys_by_id(new_ptr, orig);
+                                hd.original_keys
+                                    .get_or_insert_with(std::collections::HashMap::new)
+                                    .insert(key.clone(), idx.clone());
                             }
                         }
                         Value::Array(..) => {
@@ -3455,13 +3407,14 @@ impl VM {
                             } else {
                                 let mut hash = std::collections::HashMap::new();
                                 hash.insert(key.clone(), val.clone());
-                                *container = Value::hash(hash);
-                                if is_object_hash && let Value::Hash(arc) = &*container {
-                                    let ptr = Arc::as_ptr(arc) as usize;
+                                let mut hash_val = Value::hash(hash);
+                                if is_object_hash {
                                     let mut orig = HashMap::new();
                                     orig.insert(key.clone(), idx.clone());
-                                    runtime::utils::register_hash_original_keys_by_id(ptr, orig);
+                                    hash_val =
+                                        runtime::utils::set_hash_original_keys(hash_val, orig);
                                 }
+                                *container = hash_val;
                             }
                         }
                     }
@@ -3478,15 +3431,11 @@ impl VM {
                     } else {
                         let mut hash = std::collections::HashMap::new();
                         hash.insert(key.clone(), val.clone());
-                        let hash_val = Value::hash(hash);
+                        let mut hash_val = Value::hash(hash);
                         if is_object_hash {
-                            if let Value::Hash(arc) = &hash_val {
-                                let ptr = Arc::as_ptr(arc) as usize;
-                                self.interpreter.set_hash_object_key(ptr, &key, idx.clone());
-                            }
                             let mut orig = HashMap::new();
                             orig.insert(key.clone(), idx.clone());
-                            runtime::utils::register_hash_original_keys(&hash_val, orig);
+                            hash_val = runtime::utils::set_hash_original_keys(hash_val, orig);
                         }
                         self.interpreter
                             .env_mut()


### PR DESCRIPTION
Stage 2 of the `HashData` migration (follow-on to #2952). Object-hash original
keys (the `.WHICH`-string → original-key-object map) move from **two** parallel
Arc-pointer-keyed side tables into `HashData.original_keys`, where they travel
with the hash through copy-on-write — so the entire COW pointer-migration dance
in the element-assignment path is deleted.

## Deleted
- interpreter `hash_object_keys` field + `set_hash_object_key` /
  `hash_object_keys_get` / `migrate_hash_object_keys`
- the global `hash_original_keys_registry` (runtime/utils.rs) + the `*_by_id` /
  `take_*_by_id` pointer helpers
- the per-assignment `migrate` + `take_by_id` + `register_by_id` bookkeeping

## New
- `runtime::utils::set_hash_original_keys(value, keys) -> Value` (owned embed +
  write-back); used by Set/Bag/Mix→Hash and typed-hash coercion builders
- element-assignment writes object keys into the same `&mut HashData` as the
  element insert; readers read `HashData.original_keys`

Net ~-100 lines.

## Verification
- `make test` 6588/6588 green
- clippy clean
- 417-file container-focused whitelist sweep (S02/S04/S09/S12/S14/S32) green — no regression

## Out of scope (follow-up)
Object-hash *type enforcement/construction* gaps remain in the non-whitelisted
`S09-hashes/objecthash.t` (key-type check, `Hash.push` checks, `.new`/`.clone`
object-hash-ness, mixin keys). These are independent of where the original keys
are stored and are easier now that the key map is COW-stable. Documented in
`docs/hashdata-migration-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)