### PR TITLE
feat(objecthash): distinct mixin keys + .new preserves object-hash type

### DIFF
--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -83,17 +83,25 @@ object keys are written into the same `&mut HashData` as the element insert.
 
 `make test` green; no whitelisted regression.
 
-**NOT fixed by Stage 2 (separate object-hash *enforcement/construction*
-features, still failing in the non-whitelisted `S09-hashes/objecthash.t`):**
-- key-type check on assignment (`%h{Any}` must reject a `Mu` key — test 3; its
-  failure also makes the order-sensitive test 4 flaky by leaving an extra key)
-- `Hash.push` key/value type checks (tests 21, 23, 24)
-- `.new`/`.clone` on an object-hash instance must stay an object hash
-  (tests 34–35 see `Hash[Any,Any]` where `Hash` is expected)
-- mixin objects as keys (test 36 — aborts the file at line 104)
-
-These are object-hash *type enforcement*, independent of where the original keys
-are stored; tackle them next now that the key map is COW-stable.
+**Object-hash enforcement/construction follow-ups (non-whitelisted
+`S09-hashes/objecthash.t`):**
+- DONE (separate PR): mixin objects as keys (test 36) — `value_which_key` now has
+  a `Value::Mixin` arm folding the sorted role/mixin names into the key, so
+  `"x" but $r1` and `"x" but $r2` are distinct object-hash keys; the original key
+  objects come back via the COW-stable `original_keys`. Also fixes the
+  order-flaky test 4 in part.
+- DONE (same PR): `.new` on an object-hash instance stays an object hash
+  (tests 34–35) — `dispatch_new`'s Hash arm delegates to `Hash[vt,kt].new` when
+  the receiver carries a `key_type`, mirroring the typed-Array `.new` path.
+- STILL OPEN — key-type check rejecting a `Mu` key for `%h{Any}` (test 3, and the
+  dependent order-flaky test 4). ROOT CAUSE is NOT object-hash: `Mu.new` builds an
+  instance whose `.WHICH`/`value_type_name` is `Any` (`Any|46`), not `Mu`, so
+  `Mu.new ~~ Any` wrongly returns True. Fix `Mu.new` construction/typing first
+  (broad blast radius — smartmatch), THEN test 3 falls out for free.
+- STILL OPEN — `Hash.push` key/value type checks (tests 21, 23, 24).
+- STILL OPEN — object-hash in list→hash context (`my %c = (%objhash,)`) throws
+  "Odd number of elements" and aborts the file at block ~line 110 (rakudo #5165),
+  blocking tests 37–62.
 
 ---
 (original plan below)

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -624,6 +624,21 @@ impl Interpreter {
             };
             return self.dispatch_new(Value::Package(Symbol::intern(&type_name)), args);
         }
+        // Calling .new() on a concrete object hash (`%h{KeyType}`) produces a
+        // new object hash of the same key/value type, not a plain Hash — mirror
+        // the typed-Array `.new` path above.
+        if let Value::Hash(_) = &target
+            && let Some(info) = self.container_type_metadata(&target)
+            && let Some(kt) = info.key_type.clone()
+        {
+            let vt = if info.value_type.is_empty() {
+                "Any".to_string()
+            } else {
+                info.value_type.clone()
+            };
+            let pkg = format!("Hash[{},{}]", vt, kt);
+            return self.dispatch_new(Value::Package(Symbol::intern(&pkg)), args);
+        }
         // Calling .new() on a concrete Hash/Bag/Mix delegates to the type constructor
         {
             let type_pkg = match &target {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3506,6 +3506,21 @@ pub(crate) fn value_which_key(value: &Value) -> String {
         Value::Enum { enum_type, key, .. } => {
             format!("{}|{}", enum_type.resolve(), key.resolve())
         }
+        // A `but`-mixed value (e.g. `"quux" but $role`) keeps the identity of
+        // its base value but is a DISTINCT object per mixed-in role set — raku's
+        // `.WHICH` is `Str+{<role>}|quux`. Fold the (sorted) mixin type/role
+        // names into the key so two different roles over the same base value are
+        // distinct object-hash keys, while the same value+role collides.
+        Value::Mixin(inner, mixins) => {
+            let mut roles: Vec<&str> = mixins.keys().map(|s| s.as_str()).collect();
+            roles.sort_unstable();
+            format!(
+                "{}+{{{}}}|{}",
+                value_type_name(inner),
+                roles.join(","),
+                value_which_key(inner)
+            )
+        }
         _ => {
             format!("{}|{}", value_type_name(value), value.to_string_value())
         }


### PR DESCRIPTION
Two object-hash correctness fixes (follow-up to the HashData migration #2952/#2954),
moving `S09-hashes/objecthash.t` forward (non-whitelisted).

## Mixin objects as keys (test 36; also helps the order-flaky test 4)
`value_which_key` had no `Value::Mixin` arm, so `"quux" but $r1` and
`"quux" but $r2` collapsed to the SAME object-hash key (the default arm ignored
the mixed-in role). Added a Mixin arm that folds the sorted mixin/role names into
the key (`Str+{<role>}|quux`) — distinct per role set, same for same value+role,
matching rakudo's `.WHICH`. The original key objects (with roles) come back via
the COW-stable `HashData.original_keys`, so `%h.keys>>.foo` dispatches into the role.

## `.new` on an object-hash instance (tests 34–35)
`dispatch_new`'s Hash arm delegated to plain `Hash`, dropping the key type:
`(my %h{Any}).new.WHAT` was `Hash`, not `Hash[Any,Any]`. Now it delegates to
`Hash[vt,kt].new` when the receiver carries a `key_type`, mirroring the typed-Array
`.new` path right above it.

## Verification
- `make test` 6588/6588 green
- clippy clean
- 417-file container whitelist sweep (S02/S04/S09/S12/S14/S32) green — no regression

## Out of scope (documented follow-ups)
- test 3: `%h{Any}` must reject a `Mu` key — root cause is `Mu.new` building an
  `Any`-typed instance (`.WHICH` = `Any|46`), so `Mu.new ~~ Any` wrongly returns
  True. Broad (smartmatch) blast radius; fix separately.
- tests 21/23/24: `Hash.push` key/value type checks.
- object-hash in list→hash context (`my %c = (%objhash,)`) throws "Odd number of
  elements" and aborts the file (rakudo #5165), blocking tests 37–62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)