### PR TITLE
refactor(quanthash): embed Set/Bag/Mix type metadata in their data structs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,15 +133,15 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       - [ ] Phase 0.5 第2段（スタック不変条件 + lvalue opcode）を Phase 2 と同一 PR で。
       - [ ] 配列/ハッシュ要素の COW セル化 → array-backed mut・shaped/non-simple push・hyper temp・
             深い `>>++` を解く（take-rw は #2930、`@a[0]:=`/束縛要素セルは #2902-#2925 で landed）。
-      - [~] **Q2 の型メタ Arc-ptr flaky の構造的除去**（2026-06-12、2 本立てで進行中）:
-            ① **Hash = HashData 埋め込み（完全吸収）DONE (#2952)** — `Value::Hash(Arc<HashData>)` に
-            value_type/key_type/declared_type を埋め込み `hash_type_metadata` 副テーブル削除。
-            残 = original_keys の埋め込み（Stage 2、docs/hashdata-migration-plan.md）→ その後 Array/Set/Bag/Mix へ
-            同じ wrapper を展開。
+      - [~] **Q2 の型メタ Arc-ptr flaky の構造的除去**（2026-06-12〜、2 本立てで進行中）:
+            ① **埋め込み（完全吸収）**: Hash = HashData DONE (#2952、original_keys も Stage 2 #2954 で完了)。
+            **Set/Bag/Mix = 既存 *Data struct への埋め込み DONE (2026-06-13)** — 3 副テーブル削除。
+            **残 = ArrayData wrapper のみ**（`Value::Array(Arc<Vec<Value>>, _)` の表現変更 — 唯一の大物。
+            `Arc::as_ptr as *mut Vec<Value>` unsafe サイトの全監査が必須。is default/shape dims の同時埋め込み候補。
+            docs/hashdata-migration-plan.md Stage 3 節参照）。
             ② **未 wrapper のテーブルは Weak-guard `PtrKeyedMap` で interim 構造防御 (#2953)** —
-            array/set/bag/mix 型メタ・container defaults・shaped dims・grep-view。Weak が ArcInner を pin ＝
-            アドレス再利用が不可能。hash original-keys 2 テーブルは対象外（①Stage 2 が正解、guard は COW 安定性と干渉）。
-            レバー C 残（単一脱出/汎用捕捉）も合流。
+            残対象 = array 型メタ・container defaults・shaped dims・grep-view。Weak が ArcInner を pin ＝
+            アドレス再利用が不可能。レバー C 残（単一脱出/汎用捕捉）も合流。
 - [ ] **トラック C — 並行 / lever B（共有セル）** ＝ 並行（A と独立。要素セルは B と共有基盤なので B に弱依存）
       - [ ] `clone_for_thread` のスナップショットコピー → 共有すべき lexical/state/global を `Arc<Mutex>` ライブセルへ
             （ANALYSIS §8.3/§2.2。`start` 間で `$counter`/`state $n` 共有）。

--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -130,6 +130,29 @@ Concrete steps:
 Array/Set/Bag/Mix have the SAME Arc-ptr side tables (array_type_metadata, …) and
 the same flaky; apply the same wrapper (ArrayData, …) after the hash one lands.
 
+### Stage 3 — Set/Bag/Mix type metadata embedded (DONE, 2026-06-13)
+
+`SetData`/`BagData`/`MixData` already existed as wrapper structs (with
+`original_keys`), so no `Value` variant change was needed: added
+`value_type`/`key_type`/`declared_type` + `has_type_meta()` to each,
+extended `tag_container_metadata` with Set/Bag/Mix arms (same skip-if-same
+COW guard preserving `.WHICH`), migrated the four QuantHash writer sites
+(`SetHash[T].new` type_args, `.MixHash` coerces ×2, `is SetHash/...` var
+trait) to tag + write-back, pointed `container_type_metadata` at the
+embedded fields, replaced the one raw-id reader (`set_type_metadata_get`),
+and deleted the three side tables. The Hash/Set/Bag/Mix arms of
+`register_container_type_metadata` are a shared `debug_assert` tripwire.
+
+**Remaining: ArrayData only.** `Value::Array(Arc<Vec<Value>>, ArrayKind)`
+has no wrapper yet — that is the real Stage-1a-scale migration (Deref
+absorbs reads; structural sites: `Arc::new`, `Arc::make_mut`, `Arc::ptr_eq`,
+and CRITICALLY every `Arc::as_ptr(..) as *mut Vec<Value>` unsafe in-place
+site, which becomes UB against a wrapper — see "Latent UB found & fixed").
+Until it lands, `array_type_metadata` stays on the Weak-guarded
+`PtrKeyedMap` (#2953). Candidates to embed alongside type metadata in
+`ArrayData`: the array `is default(...)` value and the shaped-array dims
+(both currently pointer-keyed side tables).
+
 ## Why staged this way
 
 Stage 1a (wrapper, intended-invariant) is the mechanical foundation; 1b (embed +

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -105,8 +105,8 @@ impl Interpreter {
                     } else {
                         result
                     };
-                    self.register_container_type_metadata(
-                        &result,
+                    let result = self.tag_container_metadata(
+                        result,
                         ContainerTypeInfo {
                             value_type: "Real".to_string(),
                             key_type: None,

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2536,8 +2536,8 @@ impl Interpreter {
                     } else {
                         Value::set(elems)
                     };
-                    // Register type metadata for parameterized SetHash[T]
-                    if let Some(ref ta) = type_args
+                    // Embed type metadata for parameterized SetHash[T]
+                    let result = if let Some(ref ta) = type_args
                         && let Some(constraint) = ta.first()
                     {
                         let info = crate::runtime::ContainerTypeInfo {
@@ -2545,8 +2545,10 @@ impl Interpreter {
                             key_type: Some(constraint.clone()),
                             declared_type: Some(class_name.resolve()),
                         };
-                        self.register_container_type_metadata(&result, info);
-                    }
+                        self.tag_container_metadata(result, info)
+                    } else {
+                        result
+                    };
                     return Ok(result);
                 }
                 "Bag" | "BagHash" => {
@@ -2794,16 +2796,18 @@ impl Interpreter {
                     } else {
                         Value::mix(weights)
                     };
-                    if is_hash_variant {
-                        self.register_container_type_metadata(
-                            &result,
+                    let result = if is_hash_variant {
+                        self.tag_container_metadata(
+                            result,
                             ContainerTypeInfo {
                                 value_type: "Real".to_string(),
                                 key_type: None,
                                 declared_type: Some("MixHash".to_string()),
                             },
-                        );
-                    }
+                        )
+                    } else {
+                        result
+                    };
                     return Ok(result);
                 }
                 "Complex" => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1031,14 +1031,9 @@ pub struct Interpreter {
     var_hash_key_constraints: HashMap<String, String>,
     /// Type metadata for Array values (pointer-keyed, Weak-guarded).
     array_type_metadata: PtrKeyedMap<Vec<Value>, ContainerTypeInfo>,
-    /// Type metadata for Mix values (pointer-keyed, Weak-guarded).
-    mix_type_metadata: PtrKeyedMap<crate::value::MixData, ContainerTypeInfo>,
-    /// Type metadata for Set values (pointer-keyed, Weak-guarded).
-    set_type_metadata: PtrKeyedMap<crate::value::SetData, ContainerTypeInfo>,
-    /// Type metadata for Bag values (pointer-keyed, Weak-guarded).
-    bag_type_metadata: PtrKeyedMap<crate::value::BagData, ContainerTypeInfo>,
-    // Object-hash original keys are embedded in `HashData.original_keys`
-    // (Stage 2) — no side table.
+    // Hash/Set/Bag/Mix type metadata and object-hash original keys are
+    // embedded in their backing data structs (HashData/SetData/BagData/
+    // MixData) — no side tables.
     /// Type metadata for instance values keyed by stable instance id.
     instance_type_metadata: HashMap<u64, ContainerTypeInfo>,
     let_saves: Vec<(String, Value, bool)>,
@@ -3130,9 +3125,6 @@ impl Interpreter {
             hash_defaults: PtrKeyedMap::new(),
             var_hash_key_constraints: HashMap::new(),
             array_type_metadata: PtrKeyedMap::new(),
-            mix_type_metadata: PtrKeyedMap::new(),
-            set_type_metadata: PtrKeyedMap::new(),
-            bag_type_metadata: PtrKeyedMap::new(),
             instance_type_metadata: HashMap::new(),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
@@ -4602,41 +4594,59 @@ impl Interpreter {
         })
     }
 
-    /// Write a `ContainerTypeInfo`'s type fields into a hash's embedded metadata.
-    fn apply_type_info_to_hashdata(hd: &mut crate::value::HashData, info: &ContainerTypeInfo) {
-        hd.value_type = (!info.value_type.is_empty()).then(|| info.value_type.clone());
-        hd.key_type = info.key_type.clone();
-        hd.declared_type = info.declared_type.clone();
-    }
-
     /// Attach container type metadata to `value`, returning the (possibly
-    /// rebuilt) value. For hashes the metadata is embedded in the `HashData`
-    /// (via copy-on-write `Arc::make_mut`), so callers MUST use the returned
-    /// value — store it back into the env/local slot it came from. For other
-    /// container types this defers to the Arc-pointer side tables (unchanged)
-    /// and returns the value untouched.
+    /// rebuilt) value. For hashes and Set/Bag/Mix the metadata is embedded in
+    /// the backing data struct (via copy-on-write `Arc::make_mut`), so callers
+    /// MUST use the returned value — store it back into the env/local slot it
+    /// came from. For other container types this defers to the Arc-pointer
+    /// side tables (unchanged) and returns the value untouched.
     pub(crate) fn tag_container_metadata(
         &mut self,
         value: Value,
         info: ContainerTypeInfo,
     ) -> Value {
+        // Skip the copy-on-write clone when the metadata is already present.
+        // `Arc::make_mut` on a shared container clones the backing data, which
+        // changes the container's identity (`.WHICH` is pointer-based) — so a
+        // no-op re-tag of e.g. `$map.Map` would otherwise break
+        // `$map.Map === $map`.
+        macro_rules! embed_type_info {
+            ($arc:ident, $info:ident) => {{
+                let new_vt = (!$info.value_type.is_empty()).then(|| $info.value_type.clone());
+                if $arc.value_type != new_vt
+                    || $arc.key_type != $info.key_type
+                    || $arc.declared_type != $info.declared_type
+                {
+                    let data = Arc::make_mut(&mut $arc);
+                    data.value_type = new_vt;
+                    data.key_type = $info.key_type.clone();
+                    data.declared_type = $info.declared_type.clone();
+                }
+            }};
+        }
         match value {
             Value::Hash(mut arc) => {
-                // Skip the copy-on-write clone when the metadata is already
-                // present. `Arc::make_mut` on a shared hash clones the backing
-                // `HashData`, which changes the hash's identity (`.WHICH` is
-                // pointer-based) — so a no-op re-tag of e.g. `$map.Map` would
-                // otherwise break `$map.Map === $map`.
-                let new_vt = (!info.value_type.is_empty()).then(|| info.value_type.clone());
-                if arc.value_type != new_vt
-                    || arc.key_type != info.key_type
-                    || arc.declared_type != info.declared_type
-                {
-                    Self::apply_type_info_to_hashdata(Arc::make_mut(&mut arc), &info);
-                }
+                embed_type_info!(arc, info);
                 Value::Hash(arc)
             }
-            Value::Mixin(inner, m) if matches!(inner.as_ref(), Value::Hash(_)) => {
+            Value::Set(mut arc, m) => {
+                embed_type_info!(arc, info);
+                Value::Set(arc, m)
+            }
+            Value::Bag(mut arc, m) => {
+                embed_type_info!(arc, info);
+                Value::Bag(arc, m)
+            }
+            Value::Mix(mut arc, m) => {
+                embed_type_info!(arc, info);
+                Value::Mix(arc, m)
+            }
+            Value::Mixin(inner, m)
+                if matches!(
+                    inner.as_ref(),
+                    Value::Hash(_) | Value::Set(..) | Value::Bag(..) | Value::Mix(..)
+                ) =>
+            {
                 let tagged = self.tag_container_metadata((*inner).clone(), info);
                 Value::Mixin(Arc::new(tagged), m)
             }
@@ -4654,18 +4664,17 @@ impl Interpreter {
     ) {
         match value {
             Value::Array(items, ..) => self.array_type_metadata.insert(items, info),
-            Value::Mix(items, _) => self.mix_type_metadata.insert(items, info),
-            Value::Set(items, _) => self.set_type_metadata.insert(items, info),
-            Value::Bag(items, _) => self.bag_type_metadata.insert(items, info),
-            Value::Hash(_) => {
-                // Hash type metadata is embedded in `HashData` — see
-                // `tag_container_metadata`. Reaching here means a hash flowed
-                // through the by-reference register path, which cannot embed
-                // (it has no owning slot to write back). Such sites are migrated
-                // to `tag_container_metadata`; this arm is intentionally a no-op.
+            Value::Hash(_) | Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+                // Hash/Set/Bag/Mix type metadata is embedded in the backing
+                // data struct — see `tag_container_metadata`. Reaching here
+                // means such a value flowed through the by-reference register
+                // path, which cannot embed (it has no owning slot to write
+                // back). Such sites are migrated to `tag_container_metadata`;
+                // this arm is intentionally a no-op.
                 debug_assert!(
                     false,
-                    "register_container_type_metadata called on a Hash; use tag_container_metadata"
+                    "register_container_type_metadata called on a {}; use tag_container_metadata",
+                    crate::value::what_type_name(value)
                 );
             }
             Value::Instance { id, .. } => {
@@ -4695,10 +4704,6 @@ impl Interpreter {
         {
             self.register_container_type_metadata(&arr, info.clone());
         }
-    }
-
-    pub(crate) fn set_type_metadata_get(&self, id: usize) -> Option<ContainerTypeInfo> {
-        self.set_type_metadata.get(id).cloned()
     }
 
     /// Capture a container's pointer-keyed metadata (type info + `is default`)
@@ -4762,11 +4767,25 @@ impl Interpreter {
     }
 
     pub(crate) fn container_type_metadata(&self, value: &Value) -> Option<ContainerTypeInfo> {
+        // Embedded-metadata readers for Set/Bag/Mix (mirrors `hashdata_type_info`).
+        macro_rules! embedded_type_info {
+            ($data:ident) => {
+                if $data.has_type_meta() {
+                    Some(ContainerTypeInfo {
+                        value_type: $data.value_type.clone().unwrap_or_default(),
+                        key_type: $data.key_type.clone(),
+                        declared_type: $data.declared_type.clone(),
+                    })
+                } else {
+                    None
+                }
+            };
+        }
         match value {
             Value::Array(items, ..) => self.array_type_metadata.get_arc(items).cloned(),
-            Value::Mix(items, _) => self.mix_type_metadata.get_arc(items).cloned(),
-            Value::Set(items, _) => self.set_type_metadata.get_arc(items).cloned(),
-            Value::Bag(items, _) => self.bag_type_metadata.get_arc(items).cloned(),
+            Value::Mix(items, _) => embedded_type_info!(items),
+            Value::Set(items, _) => embedded_type_info!(items),
+            Value::Bag(items, _) => embedded_type_info!(items),
             Value::Hash(items) => Self::hashdata_type_info(items),
             Value::Instance { id, .. } => self.instance_type_metadata.get(id).cloned(),
             Value::Mixin(inner, _) => self.container_type_metadata(inner),
@@ -5529,9 +5548,6 @@ impl Interpreter {
             hash_defaults: self.hash_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),
             array_type_metadata: self.array_type_metadata.clone(),
-            mix_type_metadata: self.mix_type_metadata.clone(),
-            set_type_metadata: self.set_type_metadata.clone(),
-            bag_type_metadata: self.bag_type_metadata.clone(),
             instance_type_metadata: self.instance_type_metadata.clone(),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -230,6 +230,15 @@ pub(crate) struct BagData {
     /// Maps string keys back to original Values (e.g. Int(2), Bool(false)).
     /// Only populated when the Bag is created from mixed-type data.
     pub original_keys: Option<HashMap<String, Value>>,
+    /// Element value-type constraint (e.g. `Int` for `BagHash[Int]`), if any.
+    pub value_type: Option<String>,
+    /// Key-type constraint for parameterized QuantHashes, if any.
+    pub key_type: Option<String>,
+    /// Declared container type name (e.g. `BagHash`, `Bag[Int]`), if any.
+    /// Embedded here (not in a pointer-keyed side table) so it travels with
+    /// the container through copy-on-write and can never be inherited by an
+    /// unrelated container via Arc-pointer reuse.
+    pub declared_type: Option<String>,
 }
 
 impl BagData {
@@ -237,6 +246,9 @@ impl BagData {
         BagData {
             counts,
             original_keys: None,
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
     }
 
@@ -247,7 +259,15 @@ impl BagData {
         BagData {
             counts,
             original_keys: Some(original_keys),
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
+    }
+
+    /// Whether container *type* metadata (element/key/declared type) is attached.
+    pub fn has_type_meta(&self) -> bool {
+        self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
     }
 
     /// Get the original Value for a key, falling back to Str.
@@ -288,6 +308,15 @@ pub(crate) struct SetData {
     /// Maps string keys back to original Values (e.g. Int(2), Bool(false)).
     /// Only populated when the Set is created from mixed-type data.
     pub original_keys: Option<HashMap<String, Value>>,
+    /// Element value-type constraint (e.g. `Str` for `SetHash[Str]`), if any.
+    pub value_type: Option<String>,
+    /// Key-type constraint for parameterized QuantHashes, if any.
+    pub key_type: Option<String>,
+    /// Declared container type name (e.g. `SetHash`, `Set[Int]`), if any.
+    /// Embedded here (not in a pointer-keyed side table) so it travels with
+    /// the container through copy-on-write and can never be inherited by an
+    /// unrelated container via Arc-pointer reuse.
+    pub declared_type: Option<String>,
 }
 
 impl SetData {
@@ -295,6 +324,9 @@ impl SetData {
         SetData {
             elements,
             original_keys: None,
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
     }
 
@@ -305,7 +337,15 @@ impl SetData {
         SetData {
             elements,
             original_keys: Some(original_keys),
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
+    }
+
+    /// Whether container *type* metadata (element/key/declared type) is attached.
+    pub fn has_type_meta(&self) -> bool {
+        self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
     }
 
     /// Get the original Value for a key, falling back to Str.
@@ -346,6 +386,15 @@ pub(crate) struct MixData {
     /// Maps string keys back to original Values (e.g. Int(2), Bool(false)).
     /// Only populated when the Mix is created from mixed-type data.
     pub original_keys: Option<HashMap<String, Value>>,
+    /// Element value-type constraint (e.g. `Real` for `MixHash`), if any.
+    pub value_type: Option<String>,
+    /// Key-type constraint for parameterized QuantHashes, if any.
+    pub key_type: Option<String>,
+    /// Declared container type name (e.g. `MixHash`, `Mix[Int]`), if any.
+    /// Embedded here (not in a pointer-keyed side table) so it travels with
+    /// the container through copy-on-write and can never be inherited by an
+    /// unrelated container via Arc-pointer reuse.
+    pub declared_type: Option<String>,
 }
 
 impl MixData {
@@ -353,6 +402,9 @@ impl MixData {
         MixData {
             weights,
             original_keys: None,
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
     }
 
@@ -363,7 +415,15 @@ impl MixData {
         MixData {
             weights,
             original_keys: Some(original_keys),
+            value_type: None,
+            key_type: None,
+            declared_type: None,
         }
+    }
+
+    /// Whether container *type* metadata (element/key/declared type) is attached.
+    pub fn has_type_meta(&self) -> bool {
+        self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
     }
 
     /// Get the original Value for a key, falling back to Str.

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1089,15 +1089,14 @@ impl VM {
                         }
                     }
                 }
-                // Register container type metadata so assignment operations
+                // Embed container type metadata so assignment operations
                 // know to coerce back to BagHash/SetHash/etc.
                 let info = crate::runtime::ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,
                     declared_type: Some(trait_name.clone()),
                 };
-                self.interpreter
-                    .register_container_type_metadata(&instance, info);
+                let instance = self.interpreter.tag_container_metadata(instance, info);
                 self.locals_set_by_name(code, &name_str, instance.clone());
                 self.set_env_with_main_alias(&name_str, instance.clone());
                 // Set type constraint so future assignments are coerced correctly

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3021,40 +3021,38 @@ impl VM {
                 // Type check for parameterized SetHash[T] element binding.
                 // Only applies when the declared type is explicitly parameterized
                 // (e.g. SetHash[Str]), not when the constraint is just `is SetHash`.
-                if let Some(Value::Set(set, _)) = self.interpreter.env().get(&var_name) {
-                    let set_id = Arc::as_ptr(set) as usize;
-                    if let Some(info) = self.interpreter.set_type_metadata_get(set_id)
-                        && info
-                            .declared_type
-                            .as_deref()
-                            .is_some_and(|t| t.contains('['))
-                        && !info.value_type.is_empty()
-                        && info.value_type != "Any"
-                        && info.value_type != "Mu"
-                        && !self.interpreter.type_matches_value(&info.value_type, &idx)
-                    {
-                        let got_type = crate::value::what_type_name(&idx);
-                        let got_repr = idx.to_string_value();
-                        let msg = format!(
-                            "Type check failed in binding; expected {} but got {} (\"{}\")",
-                            info.value_type, got_type, got_repr,
-                        );
-                        let mut attrs = std::collections::HashMap::new();
-                        attrs.insert("message".to_string(), Value::str(msg.clone()));
-                        attrs.insert("operation".to_string(), Value::str_from("bind"));
-                        attrs.insert("got".to_string(), idx.clone());
-                        attrs.insert(
-                            "expected".to_string(),
-                            Value::Package(crate::symbol::Symbol::intern(&info.value_type)),
-                        );
-                        let ex = Value::make_instance(
-                            crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
-                            attrs,
-                        );
-                        let mut err = RuntimeError::new(msg);
-                        err.exception = Some(Box::new(ex));
-                        return Err(err);
-                    }
+                if let Some(set_val @ Value::Set(..)) = self.interpreter.env().get(&var_name)
+                    && let Some(info) = self.interpreter.container_type_metadata(set_val)
+                    && info
+                        .declared_type
+                        .as_deref()
+                        .is_some_and(|t| t.contains('['))
+                    && !info.value_type.is_empty()
+                    && info.value_type != "Any"
+                    && info.value_type != "Mu"
+                    && !self.interpreter.type_matches_value(&info.value_type, &idx)
+                {
+                    let got_type = crate::value::what_type_name(&idx);
+                    let got_repr = idx.to_string_value();
+                    let msg = format!(
+                        "Type check failed in binding; expected {} but got {} (\"{}\")",
+                        info.value_type, got_type, got_repr,
+                    );
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("message".to_string(), Value::str(msg.clone()));
+                    attrs.insert("operation".to_string(), Value::str_from("bind"));
+                    attrs.insert("got".to_string(), idx.clone());
+                    attrs.insert(
+                        "expected".to_string(),
+                        Value::Package(crate::symbol::Symbol::intern(&info.value_type)),
+                    );
+                    let ex = Value::make_instance(
+                        crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+                        attrs,
+                    );
+                    let mut err = RuntimeError::new(msg);
+                    err.exception = Some(Box::new(ex));
+                    return Err(err);
                 }
                 // When the container is an Instance of a Hash subclass (e.g.
                 // `class MyHash is Hash {}`), convert it to a plain Hash


### PR DESCRIPTION
## Summary

Track B / Q2 wrapper rollout, step 1 of 2: apply the HashData playbook (#2952) to the three QuantHash containers.

`SetData`/`BagData`/`MixData` already wrap their backing collections (and carry `original_keys`), so **no `Value` variant change is needed**: add `value_type`/`key_type`/`declared_type` + `has_type_meta()` to each struct and delete the three Arc-pointer-keyed side tables (`set/bag/mix_type_metadata`). The metadata now travels with the container through copy-on-write, so a freshly built Set/Bag/Mix can never inherit a dead typed container's metadata via pointer reuse (the Q2 flaky class).

## Changes

- `tag_container_metadata` gains Set/Bag/Mix arms (same skip-if-unchanged guard as the Hash arm — a no-op re-tag does not relocate the data and break `.WHICH`); the Mixin arm recurses for all four embedded-container types.
- Writer sites migrated to tag + write-back: parameterized `SetHash[T]`-style `.new` (type_args), the two `.MixHash` coerce registrations, and the `is SetHash`/`is BagHash` variable trait.
- `register_container_type_metadata`'s Hash/Set/Bag/Mix arms = shared `debug_assert` tripwire (catches any missed by-reference writer in debug runs).
- Reads go through the embedded fields; the one raw-id reader (`set_type_metadata_get`) replaced with `container_type_metadata` on the live value and deleted.
- Docs: hashdata-migration-plan Stage 3 notes (remaining = ArrayData only, with the `*mut Vec<Value>` UB audit warning), PLAN.md track B updated.

## Verification

- `cargo test` 466; `make test` 727 files / 6588 — **zero tripwire hits** under the debug build
- Set/Bag/Mix roast sweep (set/bag/mix/*-iterator/baggy/set_* operators/calling_sets/pair: 17 files, 9190 tests) PASS
- `sethash.t`/`baghash.t`/`mixhash.t` (non-whitelisted) TAP output byte-identical to main (pre-existing failures unchanged)
- `SetHash[Str]` element type check, `is SetHash` semantics, `.MixHash`/`.BagHash` coerce smoke matches raku

Next: ArrayData wrapper (the final and largest one) on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)