### PR TITLE
fix(hash): flatten a Hash list element into its pairs in hash construction

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -645,6 +645,19 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                 }
                 map.insert(str_key, *boxed_val);
             }
+            // A hash appearing as a list element (e.g. `my %c = (%h,)` or
+            // `%c = %a, %b`) contributes its key/value pairs, not a single odd
+            // element. Object-hash original keys are carried along.
+            Value::Hash(h) => {
+                for (k, v) in h.map.iter() {
+                    map.insert(k.clone(), v.clone());
+                }
+                if let Some(ok) = h.original_keys.as_ref() {
+                    for (k, orig) in ok.iter() {
+                        original_keys.insert(k.clone(), orig.clone());
+                    }
+                }
+            }
             other => {
                 let Some(value) = iter.next() else {
                     let message = format!(


### PR DESCRIPTION
`my %c = (%h,)` (or `%c = %a, %b`) threw **"Odd number of elements found where
hash initializer expected"** and aborted: `build_hash_from_items` treated a bare
`Value::Hash` list element as a single key looking for a following value. In raku
a hash in list/hash-initializer context contributes its key/value pairs.

Added a `Value::Hash` arm that merges the hash's entries (carrying object-hash
`original_keys` along). General fix — a plain `my %c = (%n,)` was equally broken,
not just object hashes.

## Impact
Unblocks `S09-hashes/objecthash.t`, which previously **aborted at test 36**
(rakudo #5165 block): it now runs all **62 tests (8 fail vs 26 previously unrun)**
— the `%a{1;2}:exists` multidim block (tests 37–54) all pass.

## Verification
- `make test` 6588/6588 green
- clippy clean
- 417-file container whitelist sweep (S02/S04/S09/S12/S14/S32) green — no regression

## Remaining objecthash.t (separate follow-ups)
test 3/4 (`Mu.new` mistyped as `Any` → `Mu.new ~~ Any` wrongly True), 21/23/24
(`Hash.push` checks), 55 (multidim slice with a `Range` not expanded), 61
(object-hash `is-deeply`), 62 (`Int(Str)` coercion-key throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)