### PR TITLE
fix(subscript): expand a Range dimension in multi-dim subscript adverbs

### DIFF
--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -380,9 +380,23 @@ impl Interpreter {
         target: &Value,
         indices: &[Value],
     ) -> Result<Vec<Value>, RuntimeError> {
+        // A Range (or Seq) in a subscript dimension is a multi-key slice
+        // (`%h{1;1..3}`), so expand it to its element list up front — then the
+        // existing multi-index path (`has_multi_indices` / collect-leaves) walks
+        // each key, exactly as it already does for a comma list (`%h{1;2,3}`).
+        let indices: Vec<Value> = indices
+            .iter()
+            .map(|idx| {
+                if idx.is_range() || matches!(idx, Value::Seq(_)) {
+                    Value::array(crate::runtime::utils::value_to_list(idx))
+                } else {
+                    idx.clone()
+                }
+            })
+            .collect();
         let mut resolved = Vec::with_capacity(indices.len());
         let mut current = target.clone();
-        for idx in indices {
+        for idx in &indices {
             match idx {
                 Value::Sub(..) => {
                     // WhateverCode: call with array length


### PR DESCRIPTION
`%h{1;1..3}:exists` returned a single `False` instead of the per-key list
`(False, True, False)`. `resolve_multidim_indices` passed a `Range` dimension
through untouched, so `has_multi_indices` didn't treat it as a slice and the
single-result path ran. A comma list in the same spot (`%h{1;2,3}:exists`)
already worked (it arrives as a `Value::Array`).

Fix: expand a `Range`/`Seq` subscript dimension to its element list up front, so
it flows through the existing multi-index (`collect-leaves`) path just like a
comma list. Covers `:exists`, `:delete`, and dynamic adverbs (shared
`resolve_multidim_indices`).

This is the root-cause fix for `S09-hashes/objecthash.t` test 55
(`%a{1;1..3}:exists`).

## Verification
- `make test` 6588/6588 green
- clippy clean
- 417-file container whitelist sweep (S02/S04/S09/S12/S14/S32) green — no regression

## Note
objecthash.t test 55 itself stays unreached until that file's earlier list→hash
flatten abort (rakudo #5165 block) is fixed — which needs itemization tracking to
distinguish a bare `%h` (flattens into a hash) from an itemized `$h` (does not);
that's a larger change, deferred. This fix is the correct, general fix for the
Range case regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)