### PR TITLE
refactor(value): Stage 1a — ArrayData wrapper for list-backing Vec

### DIFF
--- a/src/builtins/comb.rs
+++ b/src/builtins/comb.rs
@@ -111,5 +111,5 @@ pub(crate) fn native_comb_method(
     };
     let matcher = positional.first().copied();
 
-    comb_pure(&text, matcher, limit).map(|items| Ok(Value::Seq(std::sync::Arc::new(items))))
+    comb_pure(&text, matcher, limit).map(|items| Ok(Value::Seq(std::sync::Arc::new(items.into()))))
 }

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -174,7 +174,7 @@ fn native_sprintf(args: &[Value], z_mode: bool) -> Option<Result<Value, RuntimeE
     let flattened: Vec<Value>;
     let actual_args = if rest.len() == 1 {
         if let Value::Array(items, ..) = &rest[0] {
-            flattened = items.as_ref().clone();
+            flattened = items.as_ref().to_vec();
             &flattened[..]
         } else {
             rest
@@ -311,18 +311,18 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             let items = match arg {
                 Value::Int(n) => {
                     if *n < 0 {
-                        return Some(Ok(Value::Seq(Vec::new().into())));
+                        return Some(Ok(Value::Seq(Value::array_arc(Vec::new()))));
                     }
                     let items: Vec<Value> = (0..*n).map(Value::Int).collect();
-                    return Some(Ok(Value::Seq(
-                        super::methods_0arg::collection::combinations_all(&items).into(),
-                    )));
+                    return Some(Ok(Value::Seq(Value::array_arc(
+                        super::methods_0arg::collection::combinations_all(&items),
+                    ))));
                 }
                 _ => runtime::value_to_list(arg),
             };
-            Some(Ok(Value::Seq(
-                super::methods_0arg::collection::combinations_all(&items).into(),
-            )))
+            Some(Ok(Value::Seq(Value::array_arc(
+                super::methods_0arg::collection::combinations_all(&items),
+            ))))
         }
         "permutations" => {
             // permutations($n) where $n is Int => (0, 1, ..., $n-1).permutations
@@ -330,7 +330,9 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             let items = match arg {
                 Value::Int(n) => {
                     if *n <= 0 {
-                        return Some(Ok(Value::Seq(vec![Value::array(Vec::new())].into())));
+                        return Some(Ok(Value::Seq(Value::array_arc(vec![Value::array(
+                            Vec::new(),
+                        )]))));
                     }
                     if *n > 20 {
                         // For large n, return a lazy list that knows its count (n!)
@@ -351,9 +353,9 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
                     let items: Vec<Value> = (0..*n).map(Value::Int).collect();
-                    return Some(Ok(Value::Seq(
-                        super::methods_0arg::collection::all_permutations(&items).into(),
-                    )));
+                    return Some(Ok(Value::Seq(Value::array_arc(
+                        super::methods_0arg::collection::all_permutations(&items),
+                    ))));
                 }
                 _ => runtime::value_to_list(arg),
             };
@@ -374,9 +376,9 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }
-            Some(Ok(Value::Seq(
-                super::methods_0arg::collection::all_permutations(&items).into(),
-            )))
+            Some(Ok(Value::Seq(Value::array_arc(
+                super::methods_0arg::collection::all_permutations(&items),
+            ))))
         }
         "srand" => {
             let seed = match arg {
@@ -434,7 +436,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 .split_whitespace()
                 .map(|p| Value::str(p.to_string()))
                 .collect();
-            Some(Ok(Value::Seq(std::sync::Arc::new(parts))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(parts.into()))))
         }
         "chars" => Some(Ok(Value::Int(
             arg.to_string_value().graphemes(true).count() as i64,
@@ -893,12 +895,12 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 Value::Array(items, ..) => {
                     let mut reversed = (**items).clone();
                     reversed.reverse();
-                    Value::array(reversed)
+                    Value::array(reversed.to_vec())
                 }
                 Value::Seq(items) | Value::Slip(items) => {
                     let mut reversed = (**items).clone();
                     reversed.reverse();
-                    Value::array(reversed)
+                    Value::array(reversed.to_vec())
                 }
                 Value::Range(..)
                 | Value::RangeExcl(..)
@@ -923,7 +925,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 Value::Array(items, ..) => {
                     let mut sorted = (**items).clone();
                     sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                    Value::array(sorted)
+                    Value::array(sorted.to_vec())
                 }
                 _ => Value::Nil,
             }))
@@ -968,7 +970,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
         "flat" => {
             if crate::runtime::utils::is_shaped_array(arg) {
                 let leaves = crate::runtime::utils::shaped_array_leaves(arg);
-                return Some(Ok(Value::Seq(std::sync::Arc::new(leaves))));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(leaves.into()))));
             }
             if is_infinite_range(arg) {
                 return Some(Ok(arg.clone()));
@@ -978,7 +980,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             // top-level arrays (including @a in `flat (6, @a)`) are
             // flattened, while nested arrays inside [...] are preserved.
             flat_val(arg, &mut flat, true);
-            Some(Ok(Value::Seq(std::sync::Arc::new(flat))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(flat.into()))))
         }
         "first" => Some(Ok(match arg {
             Value::Array(items, ..) => items.first().cloned().unwrap_or(Value::Nil),
@@ -1373,7 +1375,7 @@ fn native_function_2arg(
             if let Some(n) = limit {
                 words.truncate(n);
             }
-            Some(Ok(Value::Seq(std::sync::Arc::new(words))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(words.into()))))
         }
         "uniprop" => {
             // uniprop(target, property_name)
@@ -1619,7 +1621,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             };
             let lists: Vec<Vec<Value>> = raw_inputs.iter().map(runtime::value_to_list).collect();
             if lists.is_empty() {
-                return Some(Ok(Value::Seq(std::sync::Arc::new(vec![]))));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(vec![].into()))));
             }
             let max_expand: usize = 1_000;
             let min_len = lists
@@ -1649,7 +1651,7 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
             for arg in args {
                 flat_val(arg, &mut result, true);
             }
-            Some(Ok(Value::Seq(std::sync::Arc::new(result))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(result.into()))))
         }
         "sum" => {
             // If any argument (or element inside an array arg) is a Junction,
@@ -1882,12 +1884,12 @@ fn builtin_times() -> Result<Value, RuntimeError> {
             let user = usage.ru_utime.tv_sec as f64 + usage.ru_utime.tv_usec as f64 / 1_000_000.0;
             let sys = usage.ru_stime.tv_sec as f64 + usage.ru_stime.tv_usec as f64 / 1_000_000.0;
             Ok(Value::Array(
-                vec![Value::Num(user), Value::Num(sys)].into(),
+                Value::array_arc(vec![Value::Num(user), Value::Num(sys)]),
                 ArrayKind::List,
             ))
         } else {
             Ok(Value::Array(
-                vec![Value::Num(0.0), Value::Num(0.0)].into(),
+                Value::array_arc(vec![Value::Num(0.0), Value::Num(0.0)]),
                 ArrayKind::List,
             ))
         }
@@ -1895,7 +1897,7 @@ fn builtin_times() -> Result<Value, RuntimeError> {
     #[cfg(not(unix))]
     {
         Ok(Value::Array(
-            vec![Value::Num(0.0), Value::Num(0.0)].into(),
+            Value::array_arc(vec![Value::Num(0.0), Value::Num(0.0)]),
             ArrayKind::List,
         ))
     }
@@ -1958,7 +1960,7 @@ fn builtin_localtime_gmtime(name: &str, args: &[Value]) -> Result<Value, Runtime
         } else {
             // List context: return the 9-element list
             Ok(Value::Array(
-                vec![
+                Value::array_arc(vec![
                     Value::Int(sec as i64),
                     Value::Int(min as i64),
                     Value::Int(hour as i64),
@@ -1968,8 +1970,7 @@ fn builtin_localtime_gmtime(name: &str, args: &[Value]) -> Result<Value, Runtime
                     Value::Int(wday as i64),
                     Value::Int(yday as i64),
                     Value::Int(isdst as i64),
-                ]
-                .into(),
+                ]),
                 ArrayKind::List,
             ))
         }

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -205,10 +205,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::LazyList(ll) => {
                 if ll.scan_spec.is_some() {
                     let items = ll.force_scan_to(200_000);
-                    Some(Ok(Value::Slip(std::sync::Arc::new(items))))
+                    Some(Ok(Value::Slip(std::sync::Arc::new(items.into()))))
                 } else {
                     let items = ll.cache.lock().unwrap().clone().unwrap_or_default();
-                    Some(Ok(Value::Slip(std::sync::Arc::new(items))))
+                    Some(Ok(Value::Slip(std::sync::Arc::new(items.into()))))
                 }
             }
             Value::Range(..)
@@ -244,7 +244,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     )))
                 } else {
                     Some(Ok(Value::Array(
-                        std::sync::Arc::new(Vec::new()),
+                        std::sync::Arc::new(Vec::new().into()),
                         crate::value::ArrayKind::List,
                     )))
                 }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -192,7 +192,7 @@ fn invert_value(target: &Value) -> Option<Value> {
         }
         _ => return None,
     }
-    Some(Value::Seq(result.into()))
+    Some(Value::Seq(Value::array_arc(result)))
 }
 
 fn push_permutations(
@@ -401,10 +401,12 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     };
                     Some(Ok(Value::array(keys)))
                 }
-                Value::Pair(key, _) => {
-                    Some(Ok(Value::Seq(Arc::new(vec![Value::str(key.clone())]))))
+                Value::Pair(key, _) => Some(Ok(Value::Seq(Arc::new(
+                    vec![Value::str(key.clone())].into(),
+                )))),
+                Value::ValuePair(key, _) => {
+                    Some(Ok(Value::Seq(Arc::new(vec![*key.clone()].into()))))
                 }
-                Value::ValuePair(key, _) => Some(Ok(Value::Seq(Arc::new(vec![*key.clone()])))),
                 Value::Nil => Some(Ok(Value::array(Vec::new()))),
                 Value::Set(s, _) => {
                     Some(Ok(Value::array(s.iter().map(|k| s.typed_key(k)).collect())))
@@ -438,7 +440,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     Some(Ok(Value::array(values)))
                 }
                 Value::Pair(_, value) | Value::ValuePair(_, value) => {
-                    Some(Ok(Value::Seq(Arc::new(vec![*value.clone()]))))
+                    Some(Ok(Value::Seq(Arc::new(vec![*value.clone()].into()))))
                 }
                 Value::Nil => Some(Ok(Value::array(Vec::new()))),
                 Value::Set(s, _) => Some(Ok(Value::array(
@@ -491,13 +493,12 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     }
                     Some(Ok(Value::array(kv)))
                 }
-                Value::Pair(key, value) => Some(Ok(Value::Seq(Arc::new(vec![
-                    Value::str(key.clone()),
-                    *value.clone(),
-                ])))),
-                Value::ValuePair(key, value) => {
-                    Some(Ok(Value::Seq(Arc::new(vec![*key.clone(), *value.clone()]))))
-                }
+                Value::Pair(key, value) => Some(Ok(Value::Seq(Arc::new(
+                    vec![Value::str(key.clone()), *value.clone()].into(),
+                )))),
+                Value::ValuePair(key, value) => Some(Ok(Value::Seq(Arc::new(
+                    vec![*key.clone(), *value.clone()].into(),
+                )))),
                 Value::Nil => Some(Ok(Value::array(Vec::new()))),
                 Value::Set(s, _) => {
                     let mut kv = Vec::new();
@@ -523,10 +524,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     }
                     Some(Ok(Value::array(kv)))
                 }
-                Value::Enum { key, value, .. } => Some(Ok(Value::Seq(Arc::new(vec![
-                    Value::str(key.resolve()),
-                    value.to_value(),
-                ])))),
+                Value::Enum { key, value, .. } => Some(Ok(Value::Seq(Arc::new(
+                    vec![Value::str(key.resolve()), value.to_value()].into(),
+                )))),
                 Value::Package(_) => None, // let runtime handle (may be enum type)
                 Value::LazyIoLines { handle, words, .. } => {
                     // Wrap the lazy IO lines with kv flag so the for-loop can
@@ -611,7 +611,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
         }
         "pairup" => match target {
-            Value::Package(name) if name == "Any" => Some(Ok(Value::Seq(Vec::new().into()))),
+            Value::Package(name) if name == "Any" => {
+                Some(Ok(Value::Seq(Value::array_arc(Vec::new()))))
+            }
             _ => {
                 let items = crate::runtime::utils::value_to_list(target);
                 if !items.len().is_multiple_of(2) {
@@ -638,7 +640,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         Value::ValuePair(Box::new(chunk[0].clone()), Box::new(chunk[1].clone()))
                     })
                     .collect();
-                Some(Ok(Value::Seq(pairs.into())))
+                Some(Ok(Value::Seq(Value::array_arc(pairs))))
             }
         },
         "antipairs" => {
@@ -1066,7 +1068,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         result.push(item.clone());
                     }
                 }
-                Some(Ok(Value::Seq(std::sync::Arc::new(result))))
+                Some(Ok(Value::Seq(std::sync::Arc::new(result.into()))))
             }
             _ => None,
         },
@@ -1097,7 +1099,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }
-            Some(Ok(Value::Seq(all_permutations(&items).into())))
+            Some(Ok(Value::Seq(Value::array_arc(all_permutations(&items)))))
         }
         "combinations" => {
             let items = if crate::runtime::utils::is_shaped_array(target) {
@@ -1108,7 +1110,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     .map(|items| items.to_vec())
                     .unwrap_or_else(|| runtime::value_to_list(target))
             };
-            Some(Ok(Value::Seq(combinations_all(&items).into())))
+            Some(Ok(Value::Seq(Value::array_arc(combinations_all(&items)))))
         }
         "cache" => {
             let items = target

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -34,9 +34,10 @@ pub(super) fn dispatch(
         "clone" => {
             match target {
                 Value::Package(_) | Value::Nil => Some(Some(Ok(target.clone()))),
-                Value::Array(items, kind) => {
-                    Some(Some(Ok(Value::Array(Arc::new(items.to_vec()), *kind))))
-                }
+                Value::Array(items, kind) => Some(Some(Ok(Value::Array(
+                    Arc::new(items.to_vec().into()),
+                    *kind,
+                )))),
                 Value::Hash(map) => Some(Some(Ok(Value::Hash(Value::hash_arc((**map).clone()))))),
                 Value::Set(data, mutable) => {
                     Some(Some(Ok(Value::Set(Arc::new((**data).clone()), *mutable))))

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -39,7 +39,7 @@ pub(super) fn dispatch(
         "flat" => Some(match target {
             Value::Array(_, crate::value::ArrayKind::Shaped) => {
                 let leaves = crate::runtime::utils::shaped_array_leaves(target);
-                Some(Ok(Value::Seq(Arc::new(leaves))))
+                Some(Ok(Value::Seq(Arc::new(leaves.into()))))
             }
             other if is_infinite_range(other) => Some(Ok(other.clone())),
             Value::LazyList(_) => Some(Ok(target.clone())), // flat of a lazy list is still lazy
@@ -53,7 +53,7 @@ pub(super) fn dispatch(
                 // `false` for Seq children and so left them un-flattened.
                 let mut result = Vec::new();
                 crate::builtins::flat_val(target, &mut result, true);
-                Some(Ok(Value::Seq(Arc::new(result))))
+                Some(Ok(Value::Seq(Arc::new(result.into()))))
             }
         }),
         "sort" => Some(match target {
@@ -63,7 +63,7 @@ pub(super) fn dispatch(
                 {
                     crate::runtime::utils::shaped_array_leaves(target)
                 } else {
-                    (**items).clone()
+                    (**items).to_vec()
                 };
                 sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
                 Some(Ok(Value::array(sorted)))
@@ -99,7 +99,7 @@ pub(super) fn dispatch(
                     let mut reversed = crate::runtime::utils::value_to_list(target);
                     reversed.reverse();
                     Some(Ok(Value::Array(
-                        std::sync::Arc::new(reversed),
+                        std::sync::Arc::new(reversed.into()),
                         crate::value::ArrayKind::List,
                     )))
                 }
@@ -111,7 +111,7 @@ pub(super) fn dispatch(
                 if end_is_neg_inf {
                     // Empty range -- reverse is empty
                     return Some(Some(Ok(Value::Array(
-                        std::sync::Arc::new(Vec::new()),
+                        std::sync::Arc::new(Vec::new().into()),
                         crate::value::ArrayKind::List,
                     ))));
                 }
@@ -124,7 +124,7 @@ pub(super) fn dispatch(
                     let mut reversed = items;
                     reversed.reverse();
                     Some(Ok(Value::Array(
-                        std::sync::Arc::new(reversed),
+                        std::sync::Arc::new(reversed.into()),
                         crate::value::ArrayKind::List,
                     )))
                 }

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -623,7 +623,7 @@ pub(super) fn dispatch(
             }
             // Single-threaded: materialize and wrap in HyperSeq/RaceSeq
             let items = runtime::value_to_list(target);
-            let arc = std::sync::Arc::new(items);
+            let arc = std::sync::Arc::new(crate::value::ArrayData::new(items));
             let result = if method == "hyper" {
                 Value::HyperSeq(arc)
             } else {

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -19,7 +19,7 @@ pub(super) fn dispatch(
                 .split_whitespace()
                 .map(|w| Value::str(w.to_string()))
                 .collect();
-            Some(Some(Ok(Value::Seq(std::sync::Arc::new(words)))))
+            Some(Some(Ok(Value::Seq(std::sync::Arc::new(words.into())))))
         }
         "codes" => {
             let s = target.to_string_value();
@@ -40,7 +40,7 @@ pub(super) fn dispatch(
                 .into_iter()
                 .map(Value::str)
                 .collect();
-            Some(Some(Ok(Value::Seq(Arc::new(lines)))))
+            Some(Some(Ok(Value::Seq(Arc::new(lines.into())))))
         }
         "trim" => Some(Some(Ok(Value::str(
             target.to_string_value().trim().to_string(),
@@ -132,7 +132,7 @@ pub(super) fn dispatch(
                 return Some(Some(Ok(target.clone())));
             }
             let items = if let Some(items) = target.as_list_items() {
-                items.as_ref().clone()
+                items.to_vec()
             } else if matches!(
                 target,
                 Value::Range(..)
@@ -199,7 +199,7 @@ pub(super) fn dispatch(
                 .graphemes(true)
                 .map(|g| Value::str(g.to_string()))
                 .collect();
-            Some(Some(Ok(Value::Seq(std::sync::Arc::new(parts)))))
+            Some(Some(Ok(Value::Seq(std::sync::Arc::new(parts.into())))))
         }
         "fmt" => {
             // .fmt() with no arguments: use default format and separator

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -346,7 +346,7 @@ pub(crate) fn native_method_0arg(
     if method == "pending" {
         let failures = crate::value::get_pending_failures();
         return Some(Ok(Value::Array(
-            std::sync::Arc::new(failures),
+            std::sync::Arc::new(failures.into()),
             crate::value::ArrayKind::List,
         )));
     }
@@ -456,7 +456,7 @@ pub(crate) fn native_method_0arg(
             }
             "comb" => {
                 let parts: Vec<Value> = text.chars().map(|c| Value::str(c.to_string())).collect();
-                return Some(Ok(Value::Seq(std::sync::Arc::new(parts))));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(parts.into()))));
             }
             "Str" => {
                 use unicode_normalization::UnicodeNormalization;
@@ -606,14 +606,14 @@ fn dispatch_capture(
                 positional: positional.to_vec(),
                 named: named.clone(),
             };
-            Some(Ok(Value::Seq(Arc::new(vec![cap]))))
+            Some(Ok(Value::Seq(Arc::new(vec![cap].into()))))
         }
         "Seq" | "List" => {
             let cap = Value::Capture {
                 positional: positional.to_vec(),
                 named: named.clone(),
             };
-            Some(Ok(Value::Seq(Arc::new(vec![cap]))))
+            Some(Ok(Value::Seq(Arc::new(vec![cap].into()))))
         }
         _ => None,
     }

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -403,7 +403,7 @@ fn flatten_target(target: &Value, depth: Option<usize>, flatten_arrays: bool) ->
     } else {
         flatten_with_depth(target, depth, &mut flat, flatten_arrays);
     }
-    Value::Seq(Arc::new(flat))
+    Value::Seq(Arc::new(flat.into()))
 }
 
 pub(crate) fn fmt_joinable_target(target: &Value) -> bool {
@@ -1119,7 +1119,7 @@ pub(crate) fn native_method_1arg(
                             .into_iter()
                             .map(Value::str)
                             .collect();
-                    return Some(Ok(Value::Seq(std::sync::Arc::new(lines))));
+                    return Some(Ok(Value::Seq(std::sync::Arc::new(lines.into()))));
                 }
                 return None;
             }
@@ -1141,7 +1141,7 @@ pub(crate) fn native_method_1arg(
                 lines.truncate(n);
             }
             let lines: Vec<Value> = lines.into_iter().map(Value::str).collect();
-            Some(Ok(Value::Seq(std::sync::Arc::new(lines))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(lines.into()))))
         }
         "words" => {
             let s = target.to_string_value();
@@ -1164,7 +1164,7 @@ pub(crate) fn native_method_1arg(
             if let Some(n) = limit {
                 words.truncate(n);
             }
-            Some(Ok(Value::Seq(std::sync::Arc::new(words))))
+            Some(Ok(Value::Seq(std::sync::Arc::new(words.into()))))
         }
         "join" => {
             // Shaped arrays: join over leaves
@@ -1317,19 +1317,18 @@ pub(crate) fn native_method_1arg(
                 .map(|items| items.to_vec())
                 .unwrap_or_else(|| runtime::value_to_list(target));
             match arg {
-                Value::Range(a, b) => Some(Ok(Value::Seq(
-                    super::methods_0arg::collection::combinations_range(&items, *a, *b).into(),
-                ))),
-                Value::RangeExcl(a, b) => Some(Ok(Value::Seq(
-                    super::methods_0arg::collection::combinations_range(&items, *a, *b - 1).into(),
-                ))),
-                Value::RangeExclStart(a, b) => Some(Ok(Value::Seq(
-                    super::methods_0arg::collection::combinations_range(&items, *a + 1, *b).into(),
-                ))),
-                Value::RangeExclBoth(a, b) => Some(Ok(Value::Seq(
-                    super::methods_0arg::collection::combinations_range(&items, *a + 1, *b - 1)
-                        .into(),
-                ))),
+                Value::Range(a, b) => Some(Ok(Value::Seq(Value::array_arc(
+                    super::methods_0arg::collection::combinations_range(&items, *a, *b),
+                )))),
+                Value::RangeExcl(a, b) => Some(Ok(Value::Seq(Value::array_arc(
+                    super::methods_0arg::collection::combinations_range(&items, *a, *b - 1),
+                )))),
+                Value::RangeExclStart(a, b) => Some(Ok(Value::Seq(Value::array_arc(
+                    super::methods_0arg::collection::combinations_range(&items, *a + 1, *b),
+                )))),
+                Value::RangeExclBoth(a, b) => Some(Ok(Value::Seq(Value::array_arc(
+                    super::methods_0arg::collection::combinations_range(&items, *a + 1, *b - 1),
+                )))),
                 Value::GenericRange {
                     start,
                     end,
@@ -1344,19 +1343,18 @@ pub(crate) fn native_method_1arg(
                     if *excl_end {
                         hi -= 1;
                     }
-                    Some(Ok(Value::Seq(
-                        super::methods_0arg::collection::combinations_range(&items, lo, hi).into(),
-                    )))
+                    Some(Ok(Value::Seq(Value::array_arc(
+                        super::methods_0arg::collection::combinations_range(&items, lo, hi),
+                    ))))
                 }
                 _ => {
                     let k = runtime::to_int(arg);
                     if k < 0 {
-                        Some(Ok(Value::Seq(Vec::new().into())))
+                        Some(Ok(Value::Seq(Value::array_arc(Vec::new()))))
                     } else {
-                        Some(Ok(Value::Seq(
-                            super::methods_0arg::collection::combinations_k(&items, k as usize)
-                                .into(),
-                        )))
+                        Some(Ok(Value::Seq(Value::array_arc(
+                            super::methods_0arg::collection::combinations_k(&items, k as usize),
+                        ))))
                     }
                 }
             }
@@ -1387,7 +1385,7 @@ pub(crate) fn native_method_1arg(
                 .chunks(n)
                 .map(|chunk| Value::array(chunk.to_vec()))
                 .collect();
-            Some(Ok(Value::Seq(batches.into())))
+            Some(Ok(Value::Seq(Value::array_arc(batches))))
         }
         "rindex" => {
             // Fall through to runtime dispatch for arrays (list of needles)
@@ -1651,7 +1649,7 @@ pub(crate) fn native_method_1arg(
             };
             let (non_repeating, repeating) = rat_base_repeating(n, d, radix);
             Some(Ok(Value::Array(
-                Arc::new(vec![Value::str(non_repeating), Value::str(repeating)]),
+                Arc::new(vec![Value::str(non_repeating), Value::str(repeating)].into()),
                 ArrayKind::List,
             )))
         }
@@ -2061,7 +2059,7 @@ pub(crate) fn native_method_1arg(
             if let Value::Set(items, _) = target {
                 let keys: Vec<&String> = items.iter().collect();
                 if keys.is_empty() {
-                    return Some(Ok(Value::Seq(Arc::new(Vec::new()))));
+                    return Some(Ok(Value::Seq(Arc::new(Vec::new().into()))));
                 }
                 if count.is_none() {
                     let generated = 131_072usize;
@@ -2080,7 +2078,7 @@ pub(crate) fn native_method_1arg(
                 }
                 let count = count.unwrap_or(0);
                 if count == 0 {
-                    return Some(Ok(Value::Seq(Arc::new(Vec::new()))));
+                    return Some(Ok(Value::Seq(Arc::new(Vec::new().into()))));
                 }
                 let mut result = Vec::with_capacity(count);
                 for _ in 0..count {

--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -57,7 +57,7 @@ impl SplitOpts {
             let mut attrs = HashMap::new();
             attrs.insert("what".to_string(), Value::str("split".to_string()));
             attrs.insert("source".to_string(), Value::str(source.to_string()));
-            attrs.insert("nogo".to_string(), Value::Seq(Arc::new(nogo)));
+            attrs.insert("nogo".to_string(), Value::Seq(Arc::new(nogo.into())));
             let msg = format!(
                 "Only one of :v, :k, :kv, :p may be specified on {}.split",
                 source
@@ -425,7 +425,7 @@ pub(crate) fn native_split_method(
     };
 
     let result = apply_split_opts(parts, &opts);
-    Some(Ok(Value::Seq(Arc::new(result))))
+    Some(Ok(Value::Seq(Arc::new(result.into()))))
 }
 
 /// Perform string split as function: split($splitter, $string, ...).
@@ -457,5 +457,5 @@ pub(crate) fn native_split_function(args: &[Value]) -> Option<Result<Value, Runt
     };
 
     let result = apply_split_opts(parts, &opts);
-    Some(Ok(Value::Seq(Arc::new(result))))
+    Some(Ok(Value::Seq(Arc::new(result.into()))))
 }

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -351,7 +351,7 @@ impl Compiler {
             let mut flags: Vec<Value> = chain.iter().map(|(_, p)| Value::Bool(*p)).collect();
             flags.push(Value::Bool(outer_positional));
             let positional_flags_idx = self.code.add_constant(Value::Array(
-                Arc::new(flags),
+                Arc::new(flags.into()),
                 crate::value::ArrayKind::Array,
             ));
             // Stack order: [value, idx_outermost, ..., idx_innermost]

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -570,7 +570,7 @@ pub(super) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     if let Ok(r) = try_kw("Nil", Value::Nil) {
         return Ok(r);
     }
-    if let Ok(r) = try_kw("Empty", Value::Slip(std::sync::Arc::new(vec![]))) {
+    if let Ok(r) = try_kw("Empty", Value::Slip(std::sync::Arc::new(vec![].into()))) {
         return Ok(r);
     }
     if let Ok(r) = try_kw("Any", Value::Package(Symbol::intern("Any"))) {

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1173,7 +1173,7 @@ impl Interpreter {
             dispatcher_env.insert(
                 "__mutsu_multi_dispatch_candidates".to_string(),
                 Value::Array(
-                    std::sync::Arc::new(candidate_subs),
+                    std::sync::Arc::new(candidate_subs.into()),
                     crate::value::ArrayKind::List,
                 ),
             );

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -353,13 +353,16 @@ impl Interpreter {
             "__mutsu_bind_index_value" => Ok(Value::Pair(
                 "__mutsu_bind_index_value".to_string(),
                 Box::new(Value::Array(
-                    std::sync::Arc::new(vec![
-                        args.first().cloned().unwrap_or(Value::Nil),
-                        args.get(1).cloned().unwrap_or(Value::Array(
-                            std::sync::Arc::new(Vec::new()),
-                            crate::value::ArrayKind::List,
-                        )),
-                    ]),
+                    std::sync::Arc::new(
+                        vec![
+                            args.first().cloned().unwrap_or(Value::Nil),
+                            args.get(1).cloned().unwrap_or(Value::Array(
+                                std::sync::Arc::new(Vec::new().into()),
+                                crate::value::ArrayKind::List,
+                            )),
+                        ]
+                        .into(),
+                    ),
                     crate::value::ArrayKind::List,
                 )),
             )),
@@ -614,7 +617,7 @@ impl Interpreter {
                 } else {
                     // take with multiple args creates a single list element
                     Value::Array(
-                        std::sync::Arc::new(args.clone()),
+                        std::sync::Arc::new(args.clone().into()),
                         crate::value::ArrayKind::List,
                     )
                 };

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -610,7 +610,7 @@ impl Interpreter {
             if !shared.contains_key(&atomic_key) {
                 drop(shared);
                 let arr = self.env.get(&arr_name).cloned().unwrap_or(Value::Array(
-                    std::sync::Arc::new(Vec::new()),
+                    std::sync::Arc::new(Vec::new().into()),
                     crate::value::ArrayKind::Array,
                 ));
                 let mut shared = self.shared_vars.write().unwrap();
@@ -625,7 +625,7 @@ impl Interpreter {
         {
             let mut shared = self.shared_vars.write().unwrap();
             let arr = shared.get(&atomic_key).cloned().unwrap_or(Value::Array(
-                std::sync::Arc::new(Vec::new()),
+                std::sync::Arc::new(Vec::new().into()),
                 crate::value::ArrayKind::Array,
             ));
             if let Value::Array(ref elements, kind) = arr {
@@ -694,7 +694,7 @@ impl Interpreter {
             if !shared.contains_key(&atomic_key) {
                 drop(shared);
                 let arr = self.env.get(&arr_name).cloned().unwrap_or(Value::Array(
-                    std::sync::Arc::new(Vec::new()),
+                    std::sync::Arc::new(Vec::new().into()),
                     crate::value::ArrayKind::Array,
                 ));
                 let mut shared = self.shared_vars.write().unwrap();
@@ -709,7 +709,7 @@ impl Interpreter {
         {
             let mut shared = self.shared_vars.write().unwrap();
             let arr = shared.get(&atomic_key).cloned().unwrap_or(Value::Array(
-                std::sync::Arc::new(Vec::new()),
+                std::sync::Arc::new(Vec::new().into()),
                 crate::value::ArrayKind::Array,
             ));
             // Navigate to the element using the dimension indices

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -717,7 +717,7 @@ impl Interpreter {
         };
 
         if items.is_empty() {
-            return Ok(Value::Seq(std::sync::Arc::new(vec![])));
+            return Ok(Value::Seq(std::sync::Arc::new(vec![].into())));
         }
 
         // Find all indices matching the extremum
@@ -735,11 +735,11 @@ impl Interpreter {
                     .iter()
                     .map(|&i| Value::Int(i as i64))
                     .collect();
-                Ok(Value::Seq(std::sync::Arc::new(keys)))
+                Ok(Value::Seq(std::sync::Arc::new(keys.into())))
             }
             "v" => {
                 let vals: Vec<Value> = matching_indices.iter().map(|&i| items[i].clone()).collect();
-                Ok(Value::Seq(std::sync::Arc::new(vals)))
+                Ok(Value::Seq(std::sync::Arc::new(vals.into())))
             }
             "kv" => {
                 let mut kvs = Vec::new();
@@ -747,7 +747,7 @@ impl Interpreter {
                     kvs.push(Value::Int(i as i64));
                     kvs.push(items[i].clone());
                 }
-                Ok(Value::Seq(std::sync::Arc::new(kvs)))
+                Ok(Value::Seq(std::sync::Arc::new(kvs.into())))
             }
             "p" => {
                 let pairs: Vec<Value> = matching_indices
@@ -756,7 +756,7 @@ impl Interpreter {
                         Value::ValuePair(Box::new(Value::Int(i as i64)), Box::new(items[i].clone()))
                     })
                     .collect();
-                Ok(Value::Seq(std::sync::Arc::new(pairs)))
+                Ok(Value::Seq(std::sync::Arc::new(pairs.into())))
             }
             _ => Ok(result),
         }
@@ -1097,12 +1097,12 @@ impl Interpreter {
         // copy unconditionally flattened nested `[...]`, which over-flattened
         // `flat(1, [2, [3, 4]], (5, 6))` (raku keeps the inner `[3 4]`).
         let list = Value::Array(
-            std::sync::Arc::new(args.to_vec()),
+            std::sync::Arc::new(args.to_vec().into()),
             crate::value::ArrayKind::List,
         );
         let mut result = Vec::new();
         crate::builtins::flat_val(&list, &mut result, true);
-        Ok(Value::Seq(std::sync::Arc::new(result)))
+        Ok(Value::Seq(std::sync::Arc::new(result.into())))
     }
 
     pub(super) fn builtin_slip(&self, args: &[Value]) -> Result<Value, RuntimeError> {
@@ -1142,7 +1142,7 @@ impl Interpreter {
                 lines.push(Value::str(line));
             }
             lines.reverse();
-            return Ok(Value::Array(Arc::new(lines), ArrayKind::List));
+            return Ok(Value::Array(Arc::new(lines.into()), ArrayKind::List));
         }
         // Single arg: delegate to the single shared native `reverse` (Array / Seq
         // / Slip / Range / 1-D shaped / Str), instead of a drifting second copy
@@ -2072,10 +2072,10 @@ impl Interpreter {
                     {
                         match single {
                             Value::Array(items, _) => {
-                                values = items.as_ref().clone();
+                                values = items.as_ref().to_vec();
                             }
                             Value::Seq(items) | Value::Slip(items) => {
-                                values = items.as_ref().clone();
+                                values = items.as_ref().to_vec();
                             }
                             _ => {}
                         }
@@ -2120,7 +2120,7 @@ impl Interpreter {
 
     pub(super) fn builtin_roundrobin(&self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.is_empty() {
-            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
         }
 
         // Implement Raku's single-arg rule (+@lol): when called with a single
@@ -2137,7 +2137,7 @@ impl Interpreter {
         };
 
         if effective_args.is_empty() {
-            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
         }
 
         let streams: Vec<Vec<Value>> = effective_args
@@ -2176,7 +2176,7 @@ impl Interpreter {
             rounds.push(Value::array(tuple));
         }
 
-        Ok(Value::Seq(std::sync::Arc::new(rounds)))
+        Ok(Value::Seq(std::sync::Arc::new(rounds.into())))
     }
 
     /// `duckmap(&block, \obj)` — apply block to each element; on type mismatch
@@ -2234,7 +2234,7 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(Value::Seq(std::sync::Arc::new(result)))
+                Ok(Value::Seq(std::sync::Arc::new(result.into())))
             }
             Value::Hash(map) => {
                 let mut result = std::collections::HashMap::new();
@@ -2309,7 +2309,7 @@ impl Interpreter {
                 } else {
                     crate::value::ArrayKind::List
                 };
-                Ok(Value::Array(std::sync::Arc::new(result), arr_kind))
+                Ok(Value::Array(std::sync::Arc::new(result.into()), arr_kind))
             }
             Value::Seq(items) => {
                 let mut result = Vec::new();
@@ -2323,11 +2323,11 @@ impl Interpreter {
                 if itemize_result {
                     // Itemize the result as a list
                     Ok(Value::Array(
-                        std::sync::Arc::new(result),
+                        std::sync::Arc::new(result.into()),
                         crate::value::ArrayKind::ItemList,
                     ))
                 } else {
-                    Ok(Value::Seq(std::sync::Arc::new(result)))
+                    Ok(Value::Seq(std::sync::Arc::new(result.into())))
                 }
             }
             Value::Hash(map) => {
@@ -2418,7 +2418,7 @@ impl Interpreter {
                         for item in items.iter() {
                             result.push(self.duckmap_element(block, item)?);
                         }
-                        Ok(Value::Seq(std::sync::Arc::new(result)))
+                        Ok(Value::Seq(std::sync::Arc::new(result.into())))
                     }
                     Value::Hash(map) => {
                         let mut result = std::collections::HashMap::new();

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -168,7 +168,7 @@ impl Interpreter {
         match args {
             [] => None,
             [single] => Some(single.clone()),
-            _ => Some(Value::Slip(std::sync::Arc::new(args.to_vec()))),
+            _ => Some(Value::Slip(std::sync::Arc::new(args.to_vec().into()))),
         }
     }
 
@@ -367,21 +367,21 @@ impl Interpreter {
                     for item in items.iter() {
                         mapped.push(apply_hyper_prefix(interp, routine, item.clone())?);
                     }
-                    Ok(Value::Array(std::sync::Arc::new(mapped), kind))
+                    Ok(Value::Array(std::sync::Arc::new(mapped.into()), kind))
                 }
                 Value::Seq(items) => {
                     let mut mapped = Vec::with_capacity(items.len());
                     for item in items.iter() {
                         mapped.push(apply_hyper_prefix(interp, routine, item.clone())?);
                     }
-                    Ok(Value::Seq(std::sync::Arc::new(mapped)))
+                    Ok(Value::Seq(std::sync::Arc::new(mapped.into())))
                 }
                 Value::Slip(items) => {
                     let mut mapped = Vec::with_capacity(items.len());
                     for item in items.iter() {
                         mapped.push(apply_hyper_prefix(interp, routine, item.clone())?);
                     }
-                    Ok(Value::Slip(std::sync::Arc::new(mapped)))
+                    Ok(Value::Slip(std::sync::Arc::new(mapped.into())))
                 }
                 other => interp.call_function(routine, vec![other]),
             }
@@ -411,7 +411,7 @@ impl Interpreter {
             for item in items.iter() {
                 results.push(apply_hyper_prefix(self, &routine, item.clone())?);
             }
-            let result = Value::Array(std::sync::Arc::new(results), *kind);
+            let result = Value::Array(std::sync::Arc::new(results.into()), *kind);
             if mutating {
                 self.overwrite_array_bindings_by_identity(items, result.clone());
             }

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -3,7 +3,7 @@ use super::*;
 impl Interpreter {
     pub(super) fn builtin_make(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let value = if args.len() > 1 {
-            Value::Slip(std::sync::Arc::new(args.to_vec()))
+            Value::Slip(std::sync::Arc::new(args.to_vec().into()))
         } else {
             args.first().cloned().unwrap_or(Value::Nil)
         };

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -81,14 +81,14 @@ impl Interpreter {
         }
         let count = crate::runtime::to_int(&args[0]);
         if count <= 0 {
-            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
         }
         let thunk = args[1].clone();
         let mut values = Vec::with_capacity(count as usize);
         for _ in 0..count {
             values.push(self.eval_call_on_value(thunk.clone(), Vec::new())?);
         }
-        Ok(Value::Seq(std::sync::Arc::new(values)))
+        Ok(Value::Seq(std::sync::Arc::new(values.into())))
     }
 
     pub(super) fn builtin_reverse_andthen(
@@ -351,12 +351,12 @@ impl Interpreter {
                 let val = self.eval_call_on_value(thunk.clone(), Vec::new())?;
                 let items = crate::runtime::value_to_list(&val);
                 if i >= items.len() {
-                    return Ok(Value::Seq(std::sync::Arc::new(out)));
+                    return Ok(Value::Seq(std::sync::Arc::new(out.into())));
                 }
                 repeated.push(items.into_iter().nth(i).unwrap_or(Value::Nil));
             }
-            out.push(Value::Seq(std::sync::Arc::new(repeated)));
+            out.push(Value::Seq(std::sync::Arc::new(repeated.into())));
         }
-        Ok(Value::Seq(std::sync::Arc::new(out)))
+        Ok(Value::Seq(std::sync::Arc::new(out.into())))
     }
 }

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -639,7 +639,7 @@ impl Interpreter {
             }
             changed.push(path_value.clone());
         }
-        Ok(Value::Array(changed.into(), ArrayKind::List))
+        Ok(Value::Array(Value::array_arc(changed), ArrayKind::List))
     }
 
     pub(super) fn builtin_mkdir(&self, args: &[Value]) -> Result<Value, RuntimeError> {
@@ -1191,7 +1191,7 @@ impl Interpreter {
             if close_after {
                 self.close_handle_value(&handle)?;
             }
-            return Ok(Value::Seq(std::sync::Arc::new(lines)));
+            return Ok(Value::Seq(std::sync::Arc::new(lines.into())));
         }
         Ok(Value::array(Vec::new()))
     }
@@ -1252,7 +1252,7 @@ impl Interpreter {
             if close_after {
                 self.close_handle_value(&handle)?;
             }
-            return Ok(Value::Seq(std::sync::Arc::new(words)));
+            return Ok(Value::Seq(std::sync::Arc::new(words.into())));
         }
         // Non-handle argument: delegate to string-splitting words (native function)
         if !args.is_empty()

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -96,7 +96,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
     }
     // List/Array as index means "multiple indices in this dimension"
     if let Value::Array(idx_items, ..) = head {
-        let idx_list: Vec<Value> = idx_items.as_ref().clone();
+        let idx_list: Vec<Value> = idx_items.as_ref().to_vec();
         let mut out = Vec::with_capacity(idx_list.len());
         for idx in &idx_list {
             let mut sub_indices = vec![idx.clone()];
@@ -171,7 +171,10 @@ pub(super) fn make_key_tuple(indices: &[Value]) -> Value {
     if indices.len() == 1 {
         return indices[0].clone();
     }
-    Value::Array(std::sync::Arc::new(indices.to_vec()), ArrayKind::List)
+    Value::Array(
+        std::sync::Arc::new(indices.to_vec().into()),
+        ArrayKind::List,
+    )
 }
 
 /// Collect (path, value) leaves from a multi-dimensional array,

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -67,11 +67,14 @@ impl Interpreter {
                 if exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(vec![key, v]),
+                        std::sync::Arc::new(vec![key, v].into()),
                         ArrayKind::List,
                     ))
                 } else {
-                    Ok(Value::Array(std::sync::Arc::new(vec![]), ArrayKind::List))
+                    Ok(Value::Array(
+                        std::sync::Arc::new(vec![].into()),
+                        ArrayKind::List,
+                    ))
                 }
             }
             "p" => {
@@ -94,11 +97,14 @@ impl Interpreter {
                 if !exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(vec![key, v]),
+                        std::sync::Arc::new(vec![key, v].into()),
                         ArrayKind::List,
                     ))
                 } else {
-                    Ok(Value::Array(std::sync::Arc::new(vec![]), ArrayKind::List))
+                    Ok(Value::Array(
+                        std::sync::Arc::new(vec![].into()),
+                        ArrayKind::List,
+                    ))
                 }
             }
             "not-p" => {
@@ -271,11 +277,14 @@ impl Interpreter {
             "kv" => {
                 if raw_exists {
                     Ok(Value::Array(
-                        std::sync::Arc::new(vec![key, Value::Bool(exists)]),
+                        std::sync::Arc::new(vec![key, Value::Bool(exists)].into()),
                         ArrayKind::List,
                     ))
                 } else {
-                    Ok(Value::Array(std::sync::Arc::new(vec![]), ArrayKind::List))
+                    Ok(Value::Array(
+                        std::sync::Arc::new(vec![].into()),
+                        ArrayKind::List,
+                    ))
                 }
             }
             "p" => {
@@ -546,11 +555,14 @@ impl Interpreter {
                 if exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(vec![key, v]),
+                        std::sync::Arc::new(vec![key, v].into()),
                         ArrayKind::List,
                     ))
                 } else {
-                    Ok(Value::Array(std::sync::Arc::new(vec![]), ArrayKind::List))
+                    Ok(Value::Array(
+                        std::sync::Arc::new(vec![].into()),
+                        ArrayKind::List,
+                    ))
                 }
             }
             "p" => {
@@ -654,11 +666,14 @@ impl Interpreter {
             "kv" => {
                 if raw_exists {
                     Ok(Value::Array(
-                        std::sync::Arc::new(vec![key, Value::Bool(exists)]),
+                        std::sync::Arc::new(vec![key, Value::Bool(exists)].into()),
                         ArrayKind::List,
                     ))
                 } else {
-                    Ok(Value::Array(std::sync::Arc::new(vec![]), ArrayKind::List))
+                    Ok(Value::Array(
+                        std::sync::Arc::new(vec![].into()),
+                        ArrayKind::List,
+                    ))
                 }
             }
             "p" => {

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -118,7 +118,7 @@ impl Interpreter {
                             results.push(v);
                         }
                         return Ok(Value::Array(
-                            std::sync::Arc::new(results),
+                            std::sync::Arc::new(results.into()),
                             crate::value::ArrayKind::List,
                         ));
                     }
@@ -201,7 +201,7 @@ impl Interpreter {
                                 results.push(v);
                             }
                             return Ok(Value::Array(
-                                std::sync::Arc::new(results),
+                                std::sync::Arc::new(results.into()),
                                 crate::value::ArrayKind::List,
                             ));
                         }
@@ -1019,7 +1019,7 @@ impl Interpreter {
                 for rhs in &args[1..] {
                     if !crate::runtime::types::value_is_defined(&acc) {
                         // Return Empty (empty Slip) when LHS is not defined
-                        return Ok(Value::Slip(std::sync::Arc::new(vec![])));
+                        return Ok(Value::Slip(std::sync::Arc::new(vec![].into())));
                     }
                     acc = rhs.clone();
                 }
@@ -1416,7 +1416,7 @@ impl Interpreter {
                 result
             }
             // Seq → List when used as xx LHS (Raku caches/listifies Seq on repeat)
-            Value::Seq(items) => Ok(Value::array(items.as_ref().clone())),
+            Value::Seq(items) => Ok(Value::array(items.as_ref().to_vec())),
             // xx thunks the LHS: each repetition must be an independent copy
             Value::Array(items, kind) => Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind)),
             Value::Hash(map) => Ok(Value::Hash(Value::hash_arc(map.as_ref().clone()))),
@@ -1544,7 +1544,7 @@ impl Interpreter {
                         let count = Self::repeat_logical_count(rhs);
                         Self::make_repeat_lazy_cache_counted(items, count)
                     } else {
-                        Value::Seq(std::sync::Arc::new(items))
+                        Value::Seq(std::sync::Arc::new(items.into()))
                     };
                 }
                 _ => unreachable!(),
@@ -1818,7 +1818,7 @@ impl Interpreter {
         let right_is_array = matches!(right, Value::Array(_, crate::value::ArrayKind::Array));
         if !left_is_array && !right_is_array {
             Ok(Value::Array(
-                std::sync::Arc::new(results),
+                std::sync::Arc::new(results.into()),
                 crate::value::ArrayKind::List,
             ))
         } else {

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -23,7 +23,7 @@ impl Interpreter {
         let flattened: Vec<Value>;
         let actual_args = if rest.len() == 1 {
             if let Value::Array(items, ..) = &rest[0] {
-                flattened = items.as_ref().clone();
+                flattened = items.as_ref().to_vec();
                 &flattened
             } else {
                 rest
@@ -154,7 +154,7 @@ impl Interpreter {
         let text = target.to_string_value();
         let parts = self.split_with_splitter(&text, &splitter, opts.limit)?;
         let result = apply_split_opts(parts, &opts);
-        Ok(Value::Seq(std::sync::Arc::new(result)))
+        Ok(Value::Seq(std::sync::Arc::new(result.into())))
     }
 
     /// Handle split() function with full support for regex splitters.
@@ -180,7 +180,7 @@ impl Interpreter {
         let text = target.to_string_value();
         let parts = self.split_with_splitter(&text, &splitter, opts.limit)?;
         let result = apply_split_opts(parts, &opts);
-        Ok(Value::Seq(std::sync::Arc::new(result)))
+        Ok(Value::Seq(std::sync::Arc::new(result.into())))
     }
 
     /// Core split implementation that handles string, regex, and list splitters.

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -82,7 +82,7 @@ impl Interpreter {
         // Second arg is the type check cache (array of types)
         let cache = if let Some(cache_val) = args.get(1) {
             match cache_val {
-                Value::Array(items, _) => Some(items.as_ref().clone()),
+                Value::Array(items, _) => Some(items.to_vec()),
                 _ => None,
             }
         } else {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -179,7 +179,7 @@ pub(super) fn multidim_assign_pos(
         }
         updated[i] = new_child;
     }
-    Ok(Value::Array(std::sync::Arc::new(updated), *arr_kind))
+    Ok(Value::Array(std::sync::Arc::new(updated.into()), *arr_kind))
 }
 
 /// Recursively bind value at indices. The innermost slot is stored as
@@ -215,7 +215,7 @@ pub(super) fn multidim_bind_pos(
         }
         updated[i] = new_child;
     }
-    Ok(Value::Array(std::sync::Arc::new(updated), *arr_kind))
+    Ok(Value::Array(std::sync::Arc::new(updated.into()), *arr_kind))
 }
 
 /// Recursively delete the innermost slot. Returns (deleted_value, updated_outer_array).
@@ -257,7 +257,7 @@ pub(super) fn multidim_delete_pos(
     }
     Ok((
         deleted,
-        Value::Array(std::sync::Arc::new(updated), *arr_kind),
+        Value::Array(std::sync::Arc::new(updated.into()), *arr_kind),
     ))
 }
 
@@ -382,7 +382,7 @@ impl Interpreter {
                         }
                         pulled_items.push(val);
                     }
-                    let new_seq = Value::Seq(std::sync::Arc::new(pulled_items));
+                    let new_seq = Value::Seq(std::sync::Arc::new(pulled_items.into()));
                     // Transfer cached state from old Seq to new Seq
                     if crate::value::seq_is_cached(&items_arc)
                         && let Value::Seq(new_items) = &new_seq
@@ -1070,7 +1070,7 @@ impl Interpreter {
                                 if let Some(existing) = map.get(&key) {
                                     // Key exists: create itemized array
                                     let arr = Value::Array(
-                                        Arc::new(vec![existing.clone(), *v]),
+                                        Arc::new(vec![existing.clone(), *v].into()),
                                         crate::value::ArrayKind::ItemArray,
                                     );
                                     map.insert(key, arr);
@@ -1083,7 +1083,7 @@ impl Interpreter {
                                 let map = &mut (*ptr).map;
                                 if let Some(existing) = map.get(&key) {
                                     let arr = Value::Array(
-                                        Arc::new(vec![existing.clone(), *v]),
+                                        Arc::new(vec![existing.clone(), *v].into()),
                                         crate::value::ArrayKind::ItemArray,
                                     );
                                     map.insert(key, arr);
@@ -1105,7 +1105,7 @@ impl Interpreter {
                         let key = k.as_str().to_string();
                         if let Some(existing) = new_map.get(&key) {
                             let arr = Value::Array(
-                                Arc::new(vec![existing.clone(), *v]),
+                                Arc::new(vec![existing.clone(), *v].into()),
                                 crate::value::ArrayKind::ItemArray,
                             );
                             new_map.insert(key, arr);
@@ -1117,7 +1117,7 @@ impl Interpreter {
                         let key = k.to_string_value();
                         if let Some(existing) = new_map.get(&key) {
                             let arr = Value::Array(
-                                Arc::new(vec![existing.clone(), *v]),
+                                Arc::new(vec![existing.clone(), *v].into()),
                                 crate::value::ArrayKind::ItemArray,
                             );
                             new_map.insert(key, arr);
@@ -1244,13 +1244,13 @@ impl Interpreter {
                     }
                     "path" => {
                         if is_win32 {
-                            return Ok(Value::Seq(
-                                std::sync::Arc::new(Self::win32_path_from_env()),
-                            ));
+                            return Ok(Value::Seq(std::sync::Arc::new(
+                                Self::win32_path_from_env().into(),
+                            )));
                         }
                         let path_env = std::env::var("PATH").unwrap_or_default();
                         if path_env.is_empty() {
-                            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+                            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
                         }
                         let parts: Vec<Value> = path_env
                             .split(':')
@@ -1262,7 +1262,7 @@ impl Interpreter {
                                 }
                             })
                             .collect();
-                        return Ok(Value::Seq(std::sync::Arc::new(parts)));
+                        return Ok(Value::Seq(std::sync::Arc::new(parts.into())));
                     }
                     "splitpath" => {
                         let mut positional: Vec<&Value> = Vec::new();
@@ -1304,11 +1304,10 @@ impl Interpreter {
                                 }
                             };
                             return Ok(Value::Array(
-                                std::sync::Arc::new(vec![
-                                    Value::str(volume),
-                                    Value::str(dir),
-                                    Value::str(file),
-                                ]),
+                                std::sync::Arc::new(
+                                    vec![Value::str(volume), Value::str(dir), Value::str(file)]
+                                        .into(),
+                                ),
                                 crate::value::ArrayKind::List,
                             ));
                         }
@@ -1326,11 +1325,14 @@ impl Interpreter {
                                 ("", path.as_str())
                             };
                         return Ok(Value::Array(
-                            std::sync::Arc::new(vec![
-                                Value::str_from(""),
-                                Value::str(dir.to_string()),
-                                Value::str(file.to_string()),
-                            ]),
+                            std::sync::Arc::new(
+                                vec![
+                                    Value::str_from(""),
+                                    Value::str(dir.to_string()),
+                                    Value::str(file.to_string()),
+                                ]
+                                .into(),
+                            ),
                             crate::value::ArrayKind::List,
                         ));
                     }
@@ -1487,7 +1489,7 @@ impl Interpreter {
                             .unwrap_or_default();
                         if path.is_empty() {
                             return Ok(Value::Array(
-                                std::sync::Arc::new(vec![Value::str_from("")]),
+                                std::sync::Arc::new(vec![Value::str_from("")].into()),
                                 crate::value::ArrayKind::List,
                             ));
                         }
@@ -1499,7 +1501,7 @@ impl Interpreter {
                             path.split('/').map(|s| Value::str(s.to_string())).collect()
                         };
                         return Ok(Value::Array(
-                            std::sync::Arc::new(parts),
+                            std::sync::Arc::new(parts.into()),
                             crate::value::ArrayKind::List,
                         ));
                     }
@@ -2375,7 +2377,7 @@ impl Interpreter {
                         updated.resize(index + 1, Value::Package(Symbol::intern("Any")));
                     }
                     updated[index] = value.clone();
-                    let replacement = Value::Array(std::sync::Arc::new(updated), *arr_kind);
+                    let replacement = Value::Array(std::sync::Arc::new(updated.into()), *arr_kind);
                     if let Some(ref shape) = shape {
                         crate::runtime::utils::mark_shaped_array(&replacement, Some(shape));
                     }
@@ -2399,7 +2401,7 @@ impl Interpreter {
                         updated.resize(index + 1, Value::Package(Symbol::intern("Any")));
                     }
                     updated[index] = Value::Scalar(Box::new(value.clone()));
-                    let replacement = Value::Array(std::sync::Arc::new(updated), *arr_kind);
+                    let replacement = Value::Array(std::sync::Arc::new(updated.into()), *arr_kind);
                     if let Some(ref shape) = shape {
                         crate::runtime::utils::mark_shaped_array(&replacement, Some(shape));
                     }
@@ -2430,7 +2432,7 @@ impl Interpreter {
                     } else {
                         Value::Nil
                     };
-                    let replacement = Value::Array(std::sync::Arc::new(updated), *arr_kind);
+                    let replacement = Value::Array(std::sync::Arc::new(updated.into()), *arr_kind);
                     if let Some(ref shape) = shape {
                         crate::runtime::utils::mark_shaped_array(&replacement, Some(shape));
                     }
@@ -2439,7 +2441,7 @@ impl Interpreter {
                 }
                 ("clone", _) => {
                     let cloned = items.to_vec();
-                    return Ok(Value::Array(Arc::new(cloned), *arr_kind));
+                    return Ok(Value::Array(Arc::new(cloned.into()), *arr_kind));
                 }
                 _ => {}
             }
@@ -2941,7 +2943,7 @@ impl Interpreter {
                 return Err(RuntimeError::typed("X::Invalid::Value", attrs));
             }
             let items = value_to_list(&target);
-            let arc = std::sync::Arc::new(items);
+            let arc = std::sync::Arc::new(crate::value::ArrayData::new(items));
             return Ok(if method == "hyper" {
                 Value::HyperSeq(arc)
             } else {
@@ -2965,9 +2967,9 @@ impl Interpreter {
                     let result = self.call_method_with_values(array_target, method, args)?;
                     let result_items = value_to_list(&result);
                     return Ok(if is_hyper {
-                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                        Value::HyperSeq(std::sync::Arc::new(result_items.into()))
                     } else {
-                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                        Value::RaceSeq(std::sync::Arc::new(result_items.into()))
                     });
                 }
                 _ => {
@@ -2993,7 +2995,7 @@ impl Interpreter {
             if !matches!(method, "elems" | "hyper" | "race") {
                 self.env = saved_env;
             }
-            let seq = Value::Seq(std::sync::Arc::new(items));
+            let seq = Value::Seq(std::sync::Arc::new(items.into()));
             return self.call_method_with_values(seq, method, args);
         }
 

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -228,12 +228,12 @@ impl Interpreter {
                 "prepend" => flatten_append_args(args),
                 _ => unreachable!(),
             };
-            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
             unsafe {
                 if matches!(method, "unshift" | "prepend") {
                     let mut combined = vals;
-                    combined.append(&mut (*ptr));
-                    *ptr = combined;
+                    combined.append(&mut (*ptr).items);
+                    (*ptr).items = combined;
                 } else {
                     (*ptr).extend(vals);
                 }
@@ -252,12 +252,12 @@ impl Interpreter {
             "push" => {
                 let normalized = Self::normalize_push_args_for_copy(args);
                 items.extend(normalized);
-                Ok(Value::Array(Arc::new(items), kind))
+                Ok(Value::Array(Arc::new(items.into()), kind))
             }
             "append" => {
                 let flat = flatten_append_args(args);
                 items.extend(flat);
-                Ok(Value::Array(Arc::new(items), kind))
+                Ok(Value::Array(Arc::new(items.into()), kind))
             }
             "pop" => {
                 if !args.is_empty() {
@@ -270,10 +270,10 @@ impl Interpreter {
                     return Err(RuntimeError::cannot_lazy("pop"));
                 }
                 if items.is_empty() {
-                    Ok(Value::Array(Arc::new(items), kind))
+                    Ok(Value::Array(Arc::new(items.into()), kind))
                 } else {
                     items.pop();
-                    Ok(Value::Array(Arc::new(items), kind))
+                    Ok(Value::Array(Arc::new(items.into()), kind))
                 }
             }
             "shift" => {
@@ -284,10 +284,10 @@ impl Interpreter {
                     )));
                 }
                 if items.is_empty() {
-                    Ok(Value::Array(Arc::new(items), kind))
+                    Ok(Value::Array(Arc::new(items.into()), kind))
                 } else {
                     items.remove(0);
-                    Ok(Value::Array(Arc::new(items), kind))
+                    Ok(Value::Array(Arc::new(items.into()), kind))
                 }
             }
             "unshift" | "prepend" => {
@@ -295,7 +295,7 @@ impl Interpreter {
                 for (i, arg) in normalized.into_iter().enumerate() {
                     items.insert(i, arg);
                 }
-                Ok(Value::Array(Arc::new(items), kind))
+                Ok(Value::Array(Arc::new(items.into()), kind))
             }
             "splice" => {
                 // On a bare Array value (not a named variable) there is no

--- a/src/runtime/methods_collection_ops/collation_temporal.rs
+++ b/src/runtime/methods_collection_ops/collation_temporal.rs
@@ -93,9 +93,9 @@ impl Interpreter {
             .unwrap_or_default();
 
         match target {
-            Value::Package(class_name) if class_name == "Supply" => {
-                Ok(Value::Seq(Arc::new(vec![Value::Package(class_name)])))
-            }
+            Value::Package(class_name) if class_name == "Supply" => Ok(Value::Seq(Arc::new(
+                vec![Value::Package(class_name)].into(),
+            ))),
             Value::Instance {
                 class_name,
                 attributes,
@@ -112,13 +112,12 @@ impl Interpreter {
                 attrs.insert("live".to_string(), Value::Bool(false));
                 Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
             }
-            Value::Array(items, ..) => Ok(Value::Seq(Arc::new(collate_sort(
-                items.to_vec(),
-                &settings,
-            )))),
+            Value::Array(items, ..) => Ok(Value::Seq(Arc::new(
+                collate_sort(items.to_vec(), &settings).into(),
+            ))),
             other => {
                 let values = Self::value_to_list(&other);
-                Ok(Value::Seq(Arc::new(collate_sort(values, &settings))))
+                Ok(Value::Seq(Arc::new(collate_sort(values, &settings).into())))
             }
         }
     }

--- a/src/runtime/methods_collection_ops/encoding_rotor_toggle.rs
+++ b/src/runtime/methods_collection_ops/encoding_rotor_toggle.rs
@@ -278,7 +278,7 @@ impl Interpreter {
         }
 
         if rotor_specs.is_empty() {
-            return Ok(Value::Seq(Arc::new(Vec::new())));
+            return Ok(Value::Seq(Arc::new(Vec::new().into())));
         }
 
         // Get the items to rotor over (force LazyList if needed)
@@ -294,7 +294,7 @@ impl Interpreter {
         };
 
         if items.is_empty() {
-            return Ok(Value::Seq(Arc::new(Vec::new())));
+            return Ok(Value::Seq(Arc::new(Vec::new().into())));
         }
 
         let mut result: Vec<Value> = Vec::new();
@@ -379,7 +379,7 @@ impl Interpreter {
             }
         }
 
-        Ok(Value::Seq(Arc::new(result)))
+        Ok(Value::Seq(Arc::new(result.into())))
     }
 
     /// Implements the `.toggle` method.
@@ -453,6 +453,6 @@ impl Interpreter {
             }
         }
 
-        Ok(Value::Seq(Arc::new(result)))
+        Ok(Value::Seq(Arc::new(result.into())))
     }
 }

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -185,7 +185,7 @@ impl Interpreter {
         fn flatten_to_list(v: &Value) -> Vec<Value> {
             match v {
                 Value::Array(items, ..) | Value::Seq(items) | Value::Slip(items) => {
-                    items.as_ref().clone()
+                    items.as_ref().to_vec()
                 }
                 Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
                 _ => vec![v.clone()],

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -287,7 +287,8 @@ impl Interpreter {
             Value::Array(items, arr_kind) => {
                 let (filtered, mutated_items) =
                     self.eval_grep_over_items_with_mutated(args.first().cloned(), items.to_vec())?;
-                let updated_source = std::sync::Arc::new(mutated_items);
+                let updated_source =
+                    std::sync::Arc::new(crate::value::ArrayData::new(mutated_items));
                 self.overwrite_array_bindings_by_identity(
                     &items,
                     Value::Array(updated_source.clone(), arr_kind),

--- a/src/runtime/methods_collection_ops/minmax_extrema.rs
+++ b/src/runtime/methods_collection_ops/minmax_extrema.rs
@@ -65,13 +65,13 @@ impl Interpreter {
                     ));
                 }
             }
-            Value::Seq(Arc::new(out))
+            Value::Seq(Arc::new(out.into()))
         };
         Ok(match target {
             Value::Array(items, ..) => to_pairs(&items),
             Value::Set(ref set, ..) => {
                 if set.elements.is_empty() {
-                    Value::Seq(Arc::new(Vec::new()))
+                    Value::Seq(Arc::new(Vec::new().into()))
                 } else {
                     // All Set weights are True, so min == max == all elements
                     let out: Vec<Value> = set
@@ -79,12 +79,12 @@ impl Interpreter {
                         .iter()
                         .map(|k| Value::Pair(k.clone(), Box::new(Value::Bool(true))))
                         .collect();
-                    Value::Seq(Arc::new(out))
+                    Value::Seq(Arc::new(out.into()))
                 }
             }
             Value::Bag(ref bag, ..) => {
                 if bag.is_empty() {
-                    Value::Seq(Arc::new(Vec::new()))
+                    Value::Seq(Arc::new(Vec::new().into()))
                 } else {
                     let mut best_count: Option<i64> = None;
                     let mut out: Vec<Value> = Vec::new();
@@ -105,12 +105,12 @@ impl Interpreter {
                             out.push(Value::Pair(key.clone(), Box::new(Value::Int(*count))));
                         }
                     }
-                    Value::Seq(Arc::new(out))
+                    Value::Seq(Arc::new(out.into()))
                 }
             }
             Value::Mix(ref mix, ..) => {
                 if mix.is_empty() {
-                    Value::Seq(Arc::new(Vec::new()))
+                    Value::Seq(Arc::new(Vec::new().into()))
                 } else {
                     let mut best_weight: Option<f64> = None;
                     let mut out: Vec<Value> = Vec::new();
@@ -139,12 +139,12 @@ impl Interpreter {
                             ));
                         }
                     }
-                    Value::Seq(Arc::new(out))
+                    Value::Seq(Arc::new(out.into()))
                 }
             }
             Value::Hash(ref hash) => {
                 if hash.is_empty() {
-                    Value::Seq(Arc::new(Vec::new()))
+                    Value::Seq(Arc::new(Vec::new().into()))
                 } else {
                     // For Hash, compare values
                     let mut best: Option<&Value> = None;
@@ -169,13 +169,12 @@ impl Interpreter {
                             out.push(Value::Pair(key.clone(), Box::new(value.clone())));
                         }
                     }
-                    Value::Seq(Arc::new(out))
+                    Value::Seq(Arc::new(out.into()))
                 }
             }
-            other => Value::Seq(Arc::new(vec![Value::ValuePair(
-                Box::new(Value::Int(0)),
-                Box::new(other),
-            )])),
+            other => Value::Seq(Arc::new(
+                vec![Value::ValuePair(Box::new(Value::Int(0)), Box::new(other))].into(),
+            )),
         })
     }
 

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -538,7 +538,7 @@ pub(crate) fn sort_value_generic(
                     )))
                 } else {
                     sort_items_generic(caller, &mut leaves, callable_ref, arity);
-                    Ok(Value::Seq(Arc::new(leaves)))
+                    Ok(Value::Seq(Arc::new(leaves.into())))
                 }
             } else {
                 let Value::Array(mut items, ..) = target else {
@@ -554,7 +554,7 @@ pub(crate) fn sort_value_generic(
                     )))
                 } else {
                     sort_items_generic(caller, items_mut, callable_ref, arity);
-                    Ok(Value::Seq(Arc::new(items_mut.to_vec())))
+                    Ok(Value::Seq(Arc::new(items_mut.to_vec().into())))
                 }
             }
         }
@@ -587,7 +587,7 @@ pub(crate) fn sort_value_generic(
                 )))
             } else {
                 sort_items_generic(caller, &mut sorted, callable_ref, arity);
-                Ok(Value::Seq(Arc::new(sorted)))
+                Ok(Value::Seq(Arc::new(sorted.into())))
             }
         }
         Value::Hash(map) => {

--- a/src/runtime/methods_collection_ops/unique_squish.rs
+++ b/src/runtime/methods_collection_ops/unique_squish.rs
@@ -230,7 +230,7 @@ impl Interpreter {
         let source_items = items.clone();
 
         if items.is_empty() {
-            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
         }
 
         let env_before_callbacks = if as_func.is_some() || with_func.is_some() {
@@ -268,7 +268,7 @@ impl Interpreter {
             prev_key = key;
         }
 
-        let result = Value::Seq(std::sync::Arc::new(squished_items));
+        let result = Value::Seq(std::sync::Arc::new(squished_items.into()));
         if (as_func.is_some() || with_func.is_some())
             && let Value::Seq(items) = &result
         {

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -214,12 +214,12 @@ impl Interpreter {
         if let Some(lim) = limit
             && lim <= 0
         {
-            return Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new()))));
+            return Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new().into()))));
         }
 
         let matcher = positional.first().copied();
 
-        let make_seq = |items: Vec<Value>| Value::Seq(std::sync::Arc::new(items));
+        let make_seq = |items: Vec<Value>| Value::Seq(std::sync::Arc::new(items.into()));
 
         match matcher {
             // Pure Int-chunk / Str-fixed split: single shared impl in

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -158,12 +158,12 @@ impl Interpreter {
                 // Seq.slice(@indices) — return elements at the given indices as a Seq.
                 // Seq.slice() with no args returns an empty Seq.
                 let items = if let Value::Seq(ref arc) = target {
-                    arc.as_ref().clone()
+                    arc.to_vec()
                 } else {
                     crate::runtime::utils::value_to_list(&target)
                 };
                 if args.is_empty() {
-                    Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new()))))
+                    Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new().into()))))
                 } else {
                     let mut result = Vec::with_capacity(args.len());
                     for arg in &args {
@@ -178,7 +178,7 @@ impl Interpreter {
                             result.push(items[i].clone());
                         }
                     }
-                    Some(Ok(Value::Seq(std::sync::Arc::new(result))))
+                    Some(Ok(Value::Seq(Value::array_arc(result))))
                 }
             }
             "iterator" if args.is_empty() => Some(self.dispatch_iterator_method(target)),
@@ -199,7 +199,7 @@ impl Interpreter {
                             other => flat_items.push(other),
                         }
                     }
-                    Value::Seq(std::sync::Arc::new(flat_items))
+                    Value::Seq(std::sync::Arc::new(flat_items.into()))
                 }))
             }
             "duckmap" => {
@@ -503,7 +503,10 @@ impl Interpreter {
         let mut env = self.env.clone();
         env.insert(
             "__mutsu_lazy_map_items".to_string(),
-            Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List),
+            Value::Array(
+                std::sync::Arc::new(items.into()),
+                crate::value::ArrayKind::List,
+            ),
         );
         env.insert(
             "__mutsu_lazy_map_func".to_string(),
@@ -600,7 +603,7 @@ impl Interpreter {
         if let Value::Package(name) = &target
             && name == "Supply"
         {
-            return Ok(Value::Seq(std::sync::Arc::new(vec![target])));
+            return Ok(Value::Seq(std::sync::Arc::new(vec![target].into())));
         }
         let mut caller = crate::runtime::methods_collection_ops::sort::InterpCaller(self);
         crate::runtime::methods_collection_ops::sort::sort_value_generic(&mut caller, target, &args)

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -350,7 +350,7 @@ impl Interpreter {
             return Some(Ok(if grabbed.len() == 1 && args.is_empty() {
                 grabbed.into_iter().next().unwrap()
             } else {
-                Value::Seq(Arc::new(grabbed))
+                Value::Seq(Arc::new(grabbed.into()))
             }));
         }
         // BagHash.grab: select and remove random element(s)
@@ -382,7 +382,7 @@ impl Interpreter {
             }
         };
         if mix.is_empty() || count == 0 {
-            return Some(Ok(Value::Seq(Arc::new(Vec::new()))));
+            return Some(Ok(Value::Seq(Arc::new(Vec::new().into()))));
         }
         use crate::builtins::rng::builtin_rand;
         let mut grabbed = Vec::new();
@@ -399,7 +399,7 @@ impl Interpreter {
             grabbed.push(Value::Pair(key, Box::new(weight_val)));
         }
         // TODO: compile to bytecode - should mutate the original variable
-        Some(Ok(Value::Seq(Arc::new(grabbed))))
+        Some(Ok(Value::Seq(Arc::new(grabbed.into()))))
     }
 
     /// Helper for BagHash.grab (works on a clone, does not mutate the original).
@@ -421,7 +421,7 @@ impl Interpreter {
             if args.is_empty() {
                 return Ok(Value::Nil);
             }
-            return Ok(Value::Seq(Arc::new(Vec::new())));
+            return Ok(Value::Seq(Arc::new(Vec::new().into())));
         }
         let mut grabbed = Vec::new();
         let mut remaining = bag.clone();
@@ -454,7 +454,7 @@ impl Interpreter {
         Ok(if grabbed.len() == 1 && args.is_empty() {
             grabbed.into_iter().next().unwrap()
         } else {
-            Value::Seq(Arc::new(grabbed))
+            Value::Seq(Arc::new(grabbed.into()))
         })
     }
 
@@ -474,7 +474,7 @@ impl Interpreter {
             }
         };
         if bag.is_empty() || count == 0 {
-            return Ok(Value::Seq(Arc::new(Vec::new())));
+            return Ok(Value::Seq(Arc::new(Vec::new().into())));
         }
         let mut grabbed = Vec::new();
         let mut remaining = bag.clone();
@@ -488,7 +488,7 @@ impl Interpreter {
             let val = remaining.remove(&key).unwrap_or(0);
             grabbed.push(Value::Pair(key, Box::new(Value::Int(val))));
         }
-        Ok(Value::Seq(Arc::new(grabbed)))
+        Ok(Value::Seq(Arc::new(grabbed.into())))
     }
 
     /// Dispatch the "skip" method.
@@ -518,7 +518,7 @@ impl Interpreter {
             args[0].to_f64().max(0.0) as usize
         };
         let result: Vec<Value> = items.into_iter().skip(n).collect();
-        Ok(Value::Seq(Arc::new(result)))
+        Ok(Value::Seq(Arc::new(result.into())))
     }
 
     /// Dispatch the "join" method.
@@ -756,7 +756,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let items = crate::runtime::utils::value_to_list(&target);
         if args.is_empty() {
-            return Ok(Value::Seq(Arc::new(Vec::new())));
+            return Ok(Value::Seq(Arc::new(Vec::new().into())));
         }
         // Collect all indices from args (flattening lists/arrays)
         let mut indices: Vec<usize> = Vec::new();
@@ -787,6 +787,6 @@ impl Interpreter {
             .into_iter()
             .map(|i| items.get(i).cloned().unwrap_or(Value::Nil))
             .collect();
-        Ok(Value::Seq(Arc::new(result)))
+        Ok(Value::Seq(Arc::new(result.into())))
     }
 }

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -1,7 +1,6 @@
 use crate::runtime::Interpreter;
 use crate::value::{RuntimeError, Value};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Parse a JSON string into a Value::Hash.
@@ -616,7 +615,7 @@ impl Interpreter {
         // Find candidates and pick the highest matching version.
         let candidates = match self.cur_inst_candidates(prefix, &depspec)? {
             Value::Array(arr, _) => arr,
-            _ => Arc::new(Vec::new()),
+            _ => crate::value::Value::array_arc(Vec::new()),
         };
         let dist_meta = |dist: &Value| -> Value {
             match dist {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -90,7 +90,7 @@ impl Interpreter {
                             rule_args = positional.clone();
                         }
                         Value::Array(arr, _) => {
-                            rule_args = arr.as_ref().clone();
+                            rule_args = arr.as_ref().to_vec();
                         }
                         other => {
                             rule_args = vec![other.clone()];
@@ -380,7 +380,10 @@ impl Interpreter {
                             self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?;
                         updated_items.push(updated_item);
                     }
-                    updated_named.insert(child_name, Value::Array(Arc::new(updated_items), *meta));
+                    updated_named.insert(
+                        child_name,
+                        Value::Array(Arc::new(updated_items.into()), *meta),
+                    );
                 } else {
                     let dispatch_name =
                         Self::get_action_name(&child_match).unwrap_or_else(|| child_name.clone());

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -178,7 +178,9 @@ impl Interpreter {
                     }
                     "List" if args.is_empty() => return Ok(Value::array(items)),
                     "Slip" if args.is_empty() => return Ok(Value::slip(items)),
-                    "Seq" if args.is_empty() => return Ok(Value::Seq(std::sync::Arc::new(items))),
+                    "Seq" if args.is_empty() => {
+                        return Ok(Value::Seq(std::sync::Arc::new(items.into())));
+                    }
                     "append" if args.len() == 1 => {
                         items.extend(iterationbuffer_values(&args[0]));
                         return Ok(update_items(items));
@@ -1644,11 +1646,11 @@ impl Interpreter {
                         }
                     }
                     new_items.append(items);
-                    *items = new_items;
+                    **items = new_items;
                 }
                 _ => {}
             }
-            Ok(Value::real_array(items.clone()))
+            Ok(Value::real_array(items.to_vec()))
         } else {
             Err(RuntimeError::new(format!(
                 "Cannot call '{}' on non-Array attribute",

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -254,7 +254,7 @@ impl Interpreter {
 
     pub(crate) fn overwrite_array_bindings_by_identity(
         &mut self,
-        needle: &std::sync::Arc<Vec<Value>>,
+        needle: &std::sync::Arc<crate::value::ArrayData>,
         replacement: Value,
     ) {
         let keys: Vec<Symbol> = self
@@ -296,7 +296,7 @@ impl Interpreter {
     /// share the same array container.
     pub(crate) fn propagate_shared_array_in_instances(
         &mut self,
-        needle: &std::sync::Arc<Vec<Value>>,
+        needle: &std::sync::Arc<crate::value::ArrayData>,
         replacement: &Value,
     ) {
         let mut updates: Vec<(Symbol, String)> = Vec::new();
@@ -707,7 +707,7 @@ impl Interpreter {
                 let mut updated = items.to_vec();
                 if idx < updated.len() {
                     updated[idx] = value.clone();
-                    let replacement = Value::Array(std::sync::Arc::new(updated), *kind);
+                    let replacement = Value::Array(std::sync::Arc::new(updated.into()), *kind);
                     if let Some(var_name) = target_var {
                         self.env.insert(var_name.to_string(), replacement);
                     }
@@ -724,7 +724,7 @@ impl Interpreter {
             let idx = if method == "head" { 0 } else { items.len() - 1 };
             let mut updated = items.to_vec();
             updated[idx] = value.clone();
-            let replacement = Value::Array(std::sync::Arc::new(updated), *kind);
+            let replacement = Value::Array(std::sync::Arc::new(updated.into()), *kind);
             if let Some(var_name) = target_var {
                 self.env.insert(var_name.to_string(), replacement);
             }
@@ -886,7 +886,7 @@ impl Interpreter {
                     return Ok(value);
                 }
                 let mut selected_hash: Option<std::sync::Arc<crate::value::HashData>> = None;
-                let mut selected_array: Option<std::sync::Arc<Vec<Value>>> = None;
+                let mut selected_array: Option<std::sync::Arc<crate::value::ArrayData>> = None;
 
                 if let Some(var_name) = target_var
                     && let Some(Value::Hash(candidate)) = self.env.get(var_name)
@@ -949,7 +949,7 @@ impl Interpreter {
                     let mut updated = (*source_array).clone();
                     if i < updated.len() {
                         updated[i] = value.clone();
-                        let replacement = Value::array(updated);
+                        let replacement = Value::array(updated.to_vec());
                         self.overwrite_array_bindings_by_identity(&source_array, replacement);
                         return Ok(value);
                     }
@@ -2579,7 +2579,7 @@ impl Interpreter {
                     } else {
                         items.extend(normalized_args);
                     }
-                    let result = Value::Array(Arc::new(items), array_flag);
+                    let result = Value::Array(Arc::new(items.into()), array_flag);
                     self.env.insert(key, result.clone());
                     return Ok(result);
                 }
@@ -2614,7 +2614,7 @@ impl Interpreter {
                         items.pop().unwrap_or(Value::Nil)
                     };
                     self.env
-                        .insert(key, Value::Array(Arc::new(items), array_flag));
+                        .insert(key, Value::Array(Arc::new(items.into()), array_flag));
                     return Ok(out);
                 }
                 "unshift" => {
@@ -2633,7 +2633,7 @@ impl Interpreter {
                     for (i, arg) in normalized_args.iter().enumerate() {
                         items.insert(i, arg.clone());
                     }
-                    let result = Value::Array(Arc::new(items), array_flag);
+                    let result = Value::Array(Arc::new(items.into()), array_flag);
                     self.env.insert(key, result.clone());
                     return Ok(result);
                 }
@@ -2652,9 +2652,9 @@ impl Interpreter {
                     };
                     let mut pref: Vec<Value> = flat_values;
                     pref.extend(items);
-                    let result = Value::Array(Arc::new(pref.clone()), array_flag);
+                    let result = Value::Array(Arc::new(pref.clone().into()), array_flag);
                     self.env
-                        .insert(key, Value::Array(Arc::new(pref), array_flag));
+                        .insert(key, Value::Array(Arc::new(pref.into()), array_flag));
                     return Ok(result);
                 }
                 "shift" => {
@@ -2683,7 +2683,7 @@ impl Interpreter {
                         items.remove(0)
                     };
                     self.env
-                        .insert(key, Value::Array(Arc::new(items), array_flag));
+                        .insert(key, Value::Array(Arc::new(items.into()), array_flag));
                     return Ok(out);
                 }
                 _ => {}
@@ -2753,7 +2753,7 @@ impl Interpreter {
                 if method == "grab" && args.is_empty() {
                     return Ok(Value::Nil);
                 }
-                return Ok(Value::Seq(Arc::new(Vec::new())));
+                return Ok(Value::Seq(Arc::new(Vec::new().into())));
             }
             use crate::builtins::rng::builtin_rand;
             let mut grabbed = Vec::new();
@@ -2776,7 +2776,7 @@ impl Interpreter {
                 if grabbed.len() == 1 && args.is_empty() && method == "grab" {
                     grabbed.into_iter().next().unwrap()
                 } else {
-                    Value::Seq(Arc::new(grabbed))
+                    Value::Seq(Arc::new(grabbed.into()))
                 },
             );
         }
@@ -2836,7 +2836,7 @@ impl Interpreter {
                 if method == "grab" && args.is_empty() {
                     return Ok(Value::Nil);
                 }
-                return Ok(Value::Seq(Arc::new(Vec::new())));
+                return Ok(Value::Seq(Arc::new(Vec::new().into())));
             }
             use crate::builtins::rng::builtin_rand;
             let mut grabbed = Vec::new();
@@ -2887,7 +2887,7 @@ impl Interpreter {
             return Ok(if grabbed.len() == 1 && args.is_empty() {
                 grabbed.into_iter().next().unwrap()
             } else {
-                Value::Seq(Arc::new(grabbed))
+                Value::Seq(Arc::new(grabbed.into()))
             });
         }
 
@@ -2942,7 +2942,7 @@ impl Interpreter {
             };
             let keys: Vec<String> = mix.keys().cloned().collect();
             if keys.is_empty() || count == 0 {
-                return Ok(Value::Seq(Arc::new(Vec::new())));
+                return Ok(Value::Seq(Arc::new(Vec::new().into())));
             }
             use crate::builtins::rng::builtin_rand;
             let mut grabbed = Vec::new();
@@ -2969,7 +2969,7 @@ impl Interpreter {
             return Ok(if grabbed.len() == 1 && args.is_empty() {
                 grabbed.into_iter().next().unwrap()
             } else {
-                Value::Seq(Arc::new(grabbed))
+                Value::Seq(Arc::new(grabbed.into()))
             });
         }
 
@@ -3118,7 +3118,7 @@ impl Interpreter {
                                 let mut next = existing.to_vec();
                                 next.extend(collected);
                                 let updated_array =
-                                    Value::Array(std::sync::Arc::new(next), *arr_kind);
+                                    Value::Array(std::sync::Arc::new(next.into()), *arr_kind);
                                 self.overwrite_array_bindings_by_identity(existing, updated_array);
                             }
                             Value::str_from("IterationEnd")
@@ -3180,7 +3180,7 @@ impl Interpreter {
                                 let mut next = existing.to_vec();
                                 next.extend(collected.clone());
                                 let updated_array =
-                                    Value::Array(std::sync::Arc::new(next), *arr_kind);
+                                    Value::Array(std::sync::Arc::new(next.into()), *arr_kind);
                                 self.overwrite_array_bindings_by_identity(existing, updated_array);
                             }
                             if collected.len() >= want {
@@ -3261,7 +3261,8 @@ impl Interpreter {
                     if let Some(Value::Array(existing, arr_kind)) = args.first() {
                         let mut next = existing.to_vec();
                         next.extend(vals.iter().cloned());
-                        let updated_array = Value::Array(std::sync::Arc::new(next), *arr_kind);
+                        let updated_array =
+                            Value::Array(std::sync::Arc::new(next.into()), *arr_kind);
                         self.overwrite_array_bindings_by_identity(existing, updated_array);
                     }
                 };

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -549,7 +549,7 @@ impl Interpreter {
             let inner = inner.trim().to_string();
             let items = match Self::coerce_attr_value_by_sigil(value, '@') {
                 Value::Array(items, _) => (*items).clone(),
-                other => vec![other],
+                other => vec![other].into(),
             };
             if inner.starts_with(char::is_uppercase) {
                 for it in &items {
@@ -560,7 +560,7 @@ impl Interpreter {
                     }
                 }
             }
-            let arr = Value::real_array(items);
+            let arr = Value::real_array(items.to_vec());
             self.register_container_type_metadata(
                 &arr,
                 super::ContainerTypeInfo {
@@ -1461,7 +1461,7 @@ impl Interpreter {
                         if matches!(iterator, Value::Instance { .. })
                             && self.type_matches_value("PredictiveIterator", iterator)
                         {
-                            let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                            let seq = Value::Seq(std::sync::Arc::new(Vec::new().into()));
                             if let Value::Seq(items) = &seq {
                                 let seq_id = std::sync::Arc::as_ptr(items) as usize;
                                 // Store off the scoped env so the association
@@ -1479,13 +1479,13 @@ impl Interpreter {
                             if let Some(Value::Array(items, ..)) =
                                 map.get("items").or_else(|| map.get("stuff"))
                             {
-                                return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
+                                return Ok(Value::Seq(std::sync::Arc::new(items.to_vec().into())));
                             }
                         }
                         // Register deferred iterator: don't pull eagerly.
                         // Raku's Seq.new(iterator) creates a lazy Seq; pulling
                         // happens only when the Seq is actually consumed/iterated.
-                        let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                        let seq = Value::Seq(std::sync::Arc::new(Vec::new().into()));
                         if let Value::Seq(items) = &seq {
                             crate::value::seq_register_deferred_iter(items, iterator.clone());
                         }
@@ -1495,7 +1495,7 @@ impl Interpreter {
                     // This matches Raku: Seq.new() has no iterator, so it's
                     // immediately consumed. This is what .raku returns for
                     // consumed Seqs ("Seq.new()") so the EVAL roundtrip works.
-                    let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                    let seq = Value::Seq(std::sync::Arc::new(Vec::new().into()));
                     if let Value::Seq(items) = &seq {
                         let _ = crate::value::seq_consume(items);
                     }
@@ -3435,7 +3435,7 @@ impl Interpreter {
                     {
                         let items = match val {
                             Value::Array(items, _) => (**items).clone(),
-                            _ => vec![val.clone()],
+                            _ => vec![val.clone()].into(),
                         };
                         let shaped = Value::Array(std::sync::Arc::new(items), ArrayKind::Shaped);
                         crate::runtime::utils::mark_shaped_array(&shaped, Some(&dims));

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -39,7 +39,7 @@ impl Interpreter {
         }
 
         let Some(body_callable) = positional.first().cloned() else {
-            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new().into())));
         };
         let cond_callable = positional.get(1).cloned();
         let step_callable = positional.get(2).cloned();
@@ -54,7 +54,7 @@ impl Interpreter {
             let iter =
                 Value::make_instance(crate::symbol::Symbol::intern("FromLoopIterator"), attrs);
             // Wrap in a deferred-iterator Seq
-            let arc = std::sync::Arc::new(Vec::<Value>::new());
+            let arc = std::sync::Arc::new(crate::value::ArrayData::new(Vec::<Value>::new()));
             crate::value::seq_register_deferred_iter(&arc, iter.clone());
             crate::value::seq_mark_lazy(&arc);
             return Ok(Value::Seq(arc));
@@ -104,6 +104,6 @@ impl Interpreter {
             }
         }
 
-        Ok(Value::Seq(std::sync::Arc::new(items)))
+        Ok(Value::Seq(std::sync::Arc::new(items.into())))
     }
 }

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1196,13 +1196,13 @@ impl Interpreter {
 
     pub(crate) fn overwrite_array_items_by_identity_for_vm(
         &mut self,
-        needle: &std::sync::Arc<Vec<Value>>,
+        needle: &std::sync::Arc<crate::value::ArrayData>,
         updated_items: Vec<Value>,
         kind: ArrayKind,
     ) {
         self.overwrite_array_bindings_by_identity(
             needle,
-            Value::Array(std::sync::Arc::new(updated_items), kind),
+            Value::Array(std::sync::Arc::new(updated_items.into()), kind),
         );
     }
 }

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -1281,7 +1281,7 @@ impl Interpreter {
             }
         }
         Ok(Value::Array(
-            std::sync::Arc::new(results),
+            std::sync::Arc::new(results.into()),
             crate::value::ArrayKind::List,
         ))
     }

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -29,11 +29,11 @@ impl Interpreter {
                     } else {
                         Vec::new()
                     };
-                Value::Seq(std::sync::Arc::new(values))
+                Value::Seq(std::sync::Arc::new(values.into()))
             }
             Value::LazyList(ll) => {
                 let items = self.force_lazy_list_bridge(&ll)?;
-                Value::Seq(std::sync::Arc::new(items))
+                Value::Seq(std::sync::Arc::new(items.into()))
             }
             other @ (Value::Range(..)
             | Value::RangeExcl(..)
@@ -41,7 +41,7 @@ impl Interpreter {
             | Value::RangeExclBoth(..)
             | Value::GenericRange { .. }) => {
                 let items = Self::value_to_list(&other);
-                Value::Seq(std::sync::Arc::new(items))
+                Value::Seq(std::sync::Arc::new(items.into()))
             }
             Value::Instance {
                 class_name,
@@ -62,10 +62,10 @@ impl Interpreter {
                 if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
                     Value::Seq(items.clone())
                 } else {
-                    Value::Seq(std::sync::Arc::new(Vec::new()))
+                    Value::Seq(std::sync::Arc::new(Vec::new().into()))
                 }
             }
-            other => Value::Seq(std::sync::Arc::new(vec![other])),
+            other => Value::Seq(std::sync::Arc::new(vec![other].into())),
         })
     }
 
@@ -91,14 +91,14 @@ impl Interpreter {
                     return Ok(Value::Array(items.clone(), crate::value::ArrayKind::List));
                 }
                 return Ok(Value::Array(
-                    std::sync::Arc::new(Vec::new()),
+                    std::sync::Arc::new(Vec::new().into()),
                     crate::value::ArrayKind::List,
                 ));
             }
         }
         let items = Self::value_to_list(&target);
         Ok(Value::Array(
-            std::sync::Arc::new(items),
+            std::sync::Arc::new(items.into()),
             crate::value::ArrayKind::List,
         ))
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1024,13 +1024,13 @@ pub struct Interpreter {
     var_defaults: HashMap<String, Value>,
     /// Array element defaults for `is default(...)`, keyed by Arc pointer
     /// identity with a Weak guard against pointer reuse (see `ptr_keyed`).
-    array_defaults: PtrKeyedMap<Vec<Value>, Value>,
+    array_defaults: PtrKeyedMap<crate::value::ArrayData, Value>,
     /// Hash element defaults for `is default(...)` (guarded; see `ptr_keyed`).
     hash_defaults: PtrKeyedMap<crate::value::HashData, Value>,
     /// Optional hash key type constraints (e.g. `%h{Str}`).
     var_hash_key_constraints: HashMap<String, String>,
     /// Type metadata for Array values (pointer-keyed, Weak-guarded).
-    array_type_metadata: PtrKeyedMap<Vec<Value>, ContainerTypeInfo>,
+    array_type_metadata: PtrKeyedMap<crate::value::ArrayData, ContainerTypeInfo>,
     // Hash/Set/Bag/Mix type metadata and object-hash original keys are
     // embedded in their backing data structs (HashData/SetData/BagData/
     // MixData) — no side tables.

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -744,7 +744,7 @@ impl Interpreter {
                 if let Some(n) = limit {
                     parts.truncate(n);
                 }
-                Ok(Value::Seq(std::sync::Arc::new(parts)))
+                Ok(Value::Seq(std::sync::Arc::new(parts.into())))
             }
             "words" => {
                 let content = fs::read_to_string(&path_buf)
@@ -766,7 +766,7 @@ impl Interpreter {
                 if let Some(n) = limit {
                     parts.truncate(n);
                 }
-                Ok(Value::Seq(std::sync::Arc::new(parts)))
+                Ok(Value::Seq(std::sync::Arc::new(parts.into())))
             }
             "comb" => {
                 let content = fs::read_to_string(&path_buf)
@@ -780,7 +780,7 @@ impl Interpreter {
                     .collect();
                 match self.dispatch_comb_with_args(Value::str(content), &comb_args) {
                     Some(res) => res,
-                    None => Ok(Value::Seq(std::sync::Arc::new(Vec::new()))),
+                    None => Ok(Value::Seq(std::sync::Arc::new(Vec::new().into()))),
                 }
             }
             "slurp" => {
@@ -2499,7 +2499,7 @@ impl Interpreter {
                     if close_after {
                         self.close_handle_value(&target_val)?;
                     }
-                    Ok(Value::Seq(std::sync::Arc::new(lines)))
+                    Ok(Value::Seq(std::sync::Arc::new(lines.into())))
                 } else {
                     // No limit: return a lazy IO lines iterator so that
                     // consumers (e.g. for-loop) can read on demand and
@@ -2559,7 +2559,7 @@ impl Interpreter {
                 if close_after {
                     self.close_handle_value(&target_val)?;
                 }
-                Ok(Value::Seq(std::sync::Arc::new(words)))
+                Ok(Value::Seq(std::sync::Arc::new(words.into())))
             }
             "read" => {
                 // .read() always returns a Buf (Buf[uint8]) in Raku
@@ -2848,7 +2848,7 @@ impl Interpreter {
                 }
                 match self.dispatch_comb_with_args(Value::str(text), &comb_args) {
                     Some(res) => res,
-                    None => Ok(Value::Seq(std::sync::Arc::new(Vec::new()))),
+                    None => Ok(Value::Seq(std::sync::Arc::new(Vec::new().into()))),
                 }
             }
             "Supply" => self.handle_supply(target, &args),

--- a/src/runtime/native_methods/socket_helpers.rs
+++ b/src/runtime/native_methods/socket_helpers.rs
@@ -223,7 +223,7 @@ impl Interpreter {
             }
             lines.push(line);
         }
-        Ok(Value::Seq(Arc::new(lines)))
+        Ok(Value::Seq(Arc::new(lines.into())))
     }
 
     /// Create a Buf instance from raw bytes

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -426,7 +426,7 @@ impl Interpreter {
                     proc_attrs.insert(
                         "command".to_string(),
                         Value::Array(
-                            std::sync::Arc::new(cmd_arr_clone),
+                            std::sync::Arc::new(cmd_arr_clone.into()),
                             crate::value::ArrayKind::List,
                         ),
                     );

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1057,7 +1057,7 @@ impl Interpreter {
                     out.push(Self::apply_reduction_op(inner_op, l, r)?);
                 }
             }
-            return Ok(Value::Seq(std::sync::Arc::new(out)));
+            return Ok(Value::Seq(std::sync::Arc::new(out.into())));
         }
         if let Some(inner_op) = op.strip_prefix('Z')
             && !inner_op.is_empty()
@@ -1073,7 +1073,7 @@ impl Interpreter {
                     &right_list[i],
                 )?);
             }
-            return Ok(Value::Seq(std::sync::Arc::new(out)));
+            return Ok(Value::Seq(std::sync::Arc::new(out.into())));
         }
         match op {
             "+" => {
@@ -1136,7 +1136,7 @@ impl Interpreter {
                     Ok(right.clone())
                 } else {
                     // Return Empty (empty Slip) when left is undefined
-                    Ok(Value::Slip(std::sync::Arc::new(vec![])))
+                    Ok(Value::Slip(std::sync::Arc::new(vec![].into())))
                 }
             }
             "xor" => {
@@ -1575,7 +1575,7 @@ impl Interpreter {
                         crate::value::LazyList::new_cached(items),
                     )))
                 } else {
-                    Ok(Value::Seq(std::sync::Arc::new(items)))
+                    Ok(Value::Seq(std::sync::Arc::new(items.into())))
                 }
             }
             "," => {

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3761,7 +3761,7 @@ impl Interpreter {
                                         self.env.get(&env_key).cloned().unwrap_or(Value::Nil);
                                     let elements = match &value {
                                         Value::Array(arr, _) => arr.as_ref().clone(),
-                                        _ => vec![value],
+                                        _ => vec![value].into(),
                                     };
                                     let mut alt_patterns = Vec::new();
                                     for elt in &elements {
@@ -5039,7 +5039,7 @@ impl Interpreter {
                             .unwrap_or(Value::Nil);
                         let elements = match &value {
                             Value::Array(arr, _) => arr.as_ref().clone(),
-                            _ => vec![value],
+                            _ => vec![value].into(),
                         };
                         let mut alts = Vec::new();
                         for elt in &elements {
@@ -5075,7 +5075,7 @@ impl Interpreter {
                         .unwrap_or(Value::Nil);
                     let elements = match &value {
                         Value::Array(arr, _) => arr.as_ref().clone(),
-                        _ => vec![value],
+                        _ => vec![value].into(),
                     };
                     let mut alts = Vec::new();
                     for elt in &elements {
@@ -5110,7 +5110,7 @@ impl Interpreter {
                     let val = self.eval_string_as_source(&expr_str);
                     let elements = match &val {
                         Value::Array(arr, _) => arr.as_ref().clone(),
-                        _ => vec![val],
+                        _ => vec![val].into(),
                     };
                     let mut alts = Vec::new();
                     for elt in elements.iter() {

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -953,8 +953,8 @@ impl Interpreter {
                 let expr = variants[0].1.as_ref().unwrap();
                 let v = self.eval_block_value(&[Stmt::Expr(expr.clone())])?;
                 let raw_items: Vec<Value> = match &v {
-                    Value::Array(items, _) => items.as_ref().clone(),
-                    Value::Slip(items) => items.as_ref().clone(),
+                    Value::Array(items, _) => items.as_ref().to_vec(),
+                    Value::Slip(items) => items.as_ref().to_vec(),
                     Value::Hash(map) => map
                         .iter()
                         .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
@@ -966,7 +966,7 @@ impl Interpreter {
                     .into_iter()
                     .flat_map(|item| match item {
                         Value::Slip(inner) => inner.as_ref().clone(),
-                        other => vec![other],
+                        other => vec![other].into(),
                     })
                     .collect();
                 expanded = items

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -491,7 +491,7 @@ impl Interpreter {
                     self.env.insert(
                         "/".to_string(),
                         Value::Array(
-                            std::sync::Arc::new(Vec::new()),
+                            std::sync::Arc::new(Vec::new().into()),
                             crate::value::ArrayKind::List,
                         ),
                     );
@@ -502,7 +502,7 @@ impl Interpreter {
                         self.env.insert(
                             "/".to_string(),
                             Value::Array(
-                                std::sync::Arc::new(Vec::new()),
+                                std::sync::Arc::new(Vec::new().into()),
                                 crate::value::ArrayKind::List,
                             ),
                         );
@@ -1148,15 +1148,18 @@ impl Interpreter {
                             let vt = &info.value_type;
                             if let Some(ref kt) = info.key_type {
                                 if vt != "Any" || kt != "Str" {
-                                    return Some(vec![
-                                        Value::Package(crate::symbol::Symbol::intern(vt)),
-                                        Value::Package(crate::symbol::Symbol::intern(kt)),
-                                    ]);
+                                    return Some(
+                                        vec![
+                                            Value::Package(crate::symbol::Symbol::intern(vt)),
+                                            Value::Package(crate::symbol::Symbol::intern(kt)),
+                                        ]
+                                        .into(),
+                                    );
                                 }
                             } else if vt != "Any" && vt != "Mu" {
-                                return Some(vec![Value::Package(crate::symbol::Symbol::intern(
-                                    vt,
-                                ))]);
+                                return Some(
+                                    vec![Value::Package(crate::symbol::Symbol::intern(vt))].into(),
+                                );
                             }
                         }
                         None
@@ -1166,9 +1169,9 @@ impl Interpreter {
                         if let Some(info) = self.container_type_metadata(left_value) {
                             let vt = &info.value_type;
                             if vt != "Any" && vt != "Mu" {
-                                return Some(vec![Value::Package(crate::symbol::Symbol::intern(
-                                    vt,
-                                ))]);
+                                return Some(
+                                    vec![Value::Package(crate::symbol::Symbol::intern(vt))].into(),
+                                );
                             }
                         }
                         None
@@ -1617,7 +1620,7 @@ impl Interpreter {
     /// Extract list items from a value, expanding ranges.
     fn extract_list_items(v: &Value) -> Vec<Value> {
         if let Some(items) = v.as_list_items() {
-            items.as_ref().clone()
+            items.as_ref().to_vec()
         } else if v.is_range() {
             Self::value_to_list(v)
         } else {

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -1443,7 +1443,7 @@ impl Interpreter {
 
             // Collect results, avoiding duplicates at segment boundaries
             let items: Option<Vec<Value>> = match &seg_result {
-                Value::Array(items, ..) => Some(items.as_ref().clone()),
+                Value::Array(items, ..) => Some(items.as_ref().to_vec()),
                 Value::LazyList(ll) => ll.cache.lock().unwrap().clone(),
                 _ => None,
             };

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -297,7 +297,7 @@ impl Interpreter {
             && let Ok(forced) = self.force_lazy_io_lines(handle, *words)
         {
             let items = crate::runtime::utils::value_to_list(&forced);
-            return Value::Seq(std::sync::Arc::new(items));
+            return Value::Seq(std::sync::Arc::new(items.into()));
         }
         v
     }
@@ -306,7 +306,7 @@ impl Interpreter {
         match v {
             Value::Seq(items) => Value::Array(items.clone(), ArrayKind::List),
             Value::LazyList(list) => match self.force_lazy_list(list) {
-                Ok(items) => Value::Array(std::sync::Arc::new(items), ArrayKind::List),
+                Ok(items) => Value::Array(std::sync::Arc::new(items.into()), ArrayKind::List),
                 Err(_) => v.clone(),
             },
             // A lazy IO words/lines iterator must be drained before comparison so
@@ -315,7 +315,7 @@ impl Interpreter {
                 match self.force_lazy_io_lines(handle, *words) {
                     Ok(forced) => {
                         let items = crate::runtime::utils::value_to_list(&forced);
-                        Value::Array(std::sync::Arc::new(items), ArrayKind::List)
+                        Value::Array(std::sync::Arc::new(items.into()), ArrayKind::List)
                     }
                     Err(_) => v.clone(),
                 }

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -459,7 +459,7 @@ impl Interpreter {
                         _ => {}
                     }
                 }
-                Value::Array(Arc::new(vec![Value::bag(map)]), *kind)
+                Value::Array(Arc::new(vec![Value::bag(map)].into()), *kind)
             }
             _ => expected_expanded.clone(),
         };

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -247,7 +247,7 @@ impl Interpreter {
             }
             Value::Pair(name, boxed) if self.registry().roles.contains_key(name) => {
                 if let Value::Array(args, ..) = boxed.as_ref() {
-                    Some((name.clone(), args.as_ref().clone()))
+                    Some((name.clone(), args.as_ref().to_vec()))
                 } else {
                     None
                 }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -855,14 +855,14 @@ impl Interpreter {
                     let Value::Array(actual_args, ..) = mixin_value else {
                         continue;
                     };
-                    let comparable_actual_args = if actual_base == constraint_base {
-                        actual_args.as_ref().clone()
+                    let comparable_actual_args: Vec<Value> = if actual_base == constraint_base {
+                        actual_args.to_vec()
                     } else if let Some(parent_args) =
                         self.role_parent_args_for(actual_base, actual_args, &constraint_base)
                     {
                         parent_args
                     } else if self.role_is_subtype(actual_base, &constraint_base) {
-                        actual_args.as_ref().clone()
+                        actual_args.to_vec()
                     } else {
                         continue;
                     };

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -80,9 +80,9 @@ pub(crate) fn make_empty_array_failure_what(op: &str, what: &str) -> Value {
     failure_attrs.insert("handled".to_string(), Value::Bool(false));
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
-type GrepViewBinding = (Arc<Vec<Value>>, Vec<usize>, ArrayKind);
-type GrepViewMap = PtrKeyedMap<Vec<Value>, GrepViewBinding>;
-type ShapedArrayIds = PtrKeyedMap<Vec<Value>, Vec<usize>>;
+type GrepViewBinding = (Arc<crate::value::ArrayData>, Vec<usize>, ArrayKind);
+type GrepViewMap = PtrKeyedMap<crate::value::ArrayData, GrepViewBinding>;
+type ShapedArrayIds = PtrKeyedMap<crate::value::ArrayData, Vec<usize>>;
 
 fn shaped_array_ids() -> &'static Mutex<ShapedArrayIds> {
     static SHAPED_ARRAY_IDS: OnceLock<Mutex<ShapedArrayIds>> = OnceLock::new();
@@ -130,13 +130,13 @@ fn grep_view_bindings() -> &'static Mutex<GrepViewMap> {
     GREP_VIEW_BINDINGS.get_or_init(|| Mutex::new(PtrKeyedMap::new()))
 }
 
-fn shaped_array_key(items: &Arc<Vec<Value>>) -> usize {
+fn shaped_array_key(items: &Arc<crate::value::ArrayData>) -> usize {
     crate::runtime::ptr_keyed::ptr_key(items)
 }
 
 pub(crate) fn register_grep_view_binding(
-    filtered: &Arc<Vec<Value>>,
-    source: &Arc<Vec<Value>>,
+    filtered: &Arc<crate::value::ArrayData>,
+    source: &Arc<crate::value::ArrayData>,
     source_indices: Vec<usize>,
     source_is_array: ArrayKind,
 ) {
@@ -146,8 +146,8 @@ pub(crate) fn register_grep_view_binding(
 }
 
 pub(crate) fn get_grep_view_binding(
-    filtered: &Arc<Vec<Value>>,
-) -> Option<(Arc<Vec<Value>>, Vec<usize>, ArrayKind)> {
+    filtered: &Arc<crate::value::ArrayData>,
+) -> Option<(Arc<crate::value::ArrayData>, Vec<usize>, ArrayKind)> {
     let bindings = grep_view_bindings().lock().ok()?;
     bindings.get_arc(filtered).cloned()
 }
@@ -241,7 +241,10 @@ pub(crate) fn mark_shaped_array(value: &Value, shape: Option<&[usize]>) {
     mark_shaped_array_items(items, shape);
 }
 
-pub(crate) fn mark_shaped_array_items(items: &Arc<Vec<Value>>, shape: Option<&[usize]>) {
+pub(crate) fn mark_shaped_array_items(
+    items: &Arc<crate::value::ArrayData>,
+    shape: Option<&[usize]>,
+) {
     if shape.is_none() {
         return;
     }
@@ -589,19 +592,19 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         }
         Value::Range(a, b) => {
             let items: Vec<Value> = (a..=b).map(Value::Int).collect();
-            coerce_to_hash(Value::Array(items.into(), ArrayKind::List))
+            coerce_to_hash(Value::Array(Value::array_arc(items), ArrayKind::List))
         }
         Value::RangeExcl(a, b) => {
             let items: Vec<Value> = (a..b).map(Value::Int).collect();
-            coerce_to_hash(Value::Array(items.into(), ArrayKind::List))
+            coerce_to_hash(Value::Array(Value::array_arc(items), ArrayKind::List))
         }
         Value::RangeExclStart(a, b) => {
             let items: Vec<Value> = (a + 1..=b).map(Value::Int).collect();
-            coerce_to_hash(Value::Array(items.into(), ArrayKind::List))
+            coerce_to_hash(Value::Array(Value::array_arc(items), ArrayKind::List))
         }
         Value::RangeExclBoth(a, b) => {
             let items: Vec<Value> = (a + 1..b).map(Value::Int).collect();
-            coerce_to_hash(Value::Array(items.into(), ArrayKind::List))
+            coerce_to_hash(Value::Array(Value::array_arc(items), ArrayKind::List))
         }
         Value::Nil => Value::hash(HashMap::new()),
         Value::Instance {
@@ -679,7 +682,7 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
 const MAX_ARRAY_EXPAND: i64 = 100_000;
 
 pub(crate) fn coerce_to_array(value: Value) -> Value {
-    fn metadata_shape_for_items(items: &Arc<Vec<Value>>) -> Option<Vec<usize>> {
+    fn metadata_shape_for_items(items: &Arc<crate::value::ArrayData>) -> Option<Vec<usize>> {
         shaped_array_ids()
             .lock()
             .ok()
@@ -771,7 +774,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
         Value::GenericRange { ref end, .. } => {
             let end_f = end.to_f64();
             if end_f.is_infinite() && end_f.is_sign_positive() {
-                Value::Array(Arc::new(value_to_list(&value)), ArrayKind::Lazy)
+                Value::Array(Arc::new(value_to_list(&value).into()), ArrayKind::Lazy)
             } else {
                 Value::real_array(value_to_list(&value))
             }
@@ -1684,9 +1687,9 @@ pub(crate) fn reduction_identity(op: &str) -> Value {
         "(-)" | "∖" | "(|)" | "∪" | "(&)" | "∩" | "(^)" | "⊖" => Value::set(HashSet::new()),
         "(.)" | "⊍" | "(+)" | "⊎" => Value::bag(HashMap::new()),
         // Comma: empty list
-        "," => Value::Array(std::sync::Arc::new(Vec::new()), ArrayKind::List),
+        "," => Value::Array(std::sync::Arc::new(Vec::new().into()), ArrayKind::List),
         // Zip: empty Seq (Raku returns a Seq for arity-0 Z)
-        "Z" => Value::Seq(std::sync::Arc::new(Vec::new())),
+        "Z" => Value::Seq(std::sync::Arc::new(Vec::new().into())),
         _ => {
             // Hyper operator forms: >>op<<, >>op>>, <<op<<, <<op>>
             if let Some(inner) = strip_hyper_delimiters_for_identity(op) {

--- a/src/runtime/value_iterator.rs
+++ b/src/runtime/value_iterator.rs
@@ -22,7 +22,10 @@ use std::sync::Arc;
 /// A pull source over `Value` elements.
 pub(crate) enum ValueIterator {
     /// Already-materialized elements (Array / Seq / Slip). Shares the source `Arc`.
-    Slice { items: Arc<Vec<Value>>, idx: usize },
+    Slice {
+        items: Arc<crate::value::ArrayData>,
+        idx: usize,
+    },
     /// Lazy integer counter. `end == i64::MAX` with `inclusive` represents an
     /// open-ended (infinite) range and must never be eagerly collected.
     IntRange { cur: i64, end: i64, inclusive: bool },

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -12,18 +12,18 @@ use num_bigint::BigInt as NumBigInt;
 use num_integer::Integer;
 use num_traits::{Signed, ToPrimitive, Zero};
 /// Global list tracking consumed Seq instances via Weak references.
-/// Uses Weak<Vec<Value>> so that when the Seq is dropped, the Weak expires
+/// Uses Weak<ArrayData> so that when the Seq is dropped, the Weak expires
 /// and won't cause false positives from address reuse.
-static CONSUMED_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
+static CONSUMED_SEQS: OnceLock<Mutex<Vec<Weak<ArrayData>>>> = OnceLock::new();
 
-fn consumed_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
+fn consumed_seqs() -> &'static Mutex<Vec<Weak<ArrayData>>> {
     CONSUMED_SEQS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 /// Global set tracking "cached" Seq instances (have called .cache).
-static CACHED_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
+static CACHED_SEQS: OnceLock<Mutex<Vec<Weak<ArrayData>>>> = OnceLock::new();
 
-fn cached_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
+fn cached_seqs() -> &'static Mutex<Vec<Weak<ArrayData>>> {
     CACHED_SEQS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
@@ -36,14 +36,14 @@ fn deferred_seq_iters() -> &'static Mutex<HashMap<usize, Value>> {
 }
 
 /// Global set tracking lazy Seq instances (e.g. from Seq.from-loop without condition).
-static LAZY_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
+static LAZY_SEQS: OnceLock<Mutex<Vec<Weak<ArrayData>>>> = OnceLock::new();
 
-fn lazy_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
+fn lazy_seqs() -> &'static Mutex<Vec<Weak<ArrayData>>> {
     LAZY_SEQS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 /// Mark a Seq as lazy (infinite, from Seq.from-loop without condition).
-pub(crate) fn seq_mark_lazy(arc_ptr: &Arc<Vec<Value>>) {
+pub(crate) fn seq_mark_lazy(arc_ptr: &Arc<ArrayData>) {
     let mut list = lazy_seqs().lock().unwrap();
     let target_ptr = Arc::as_ptr(arc_ptr);
     list.retain(|w| w.strong_count() > 0);
@@ -58,7 +58,7 @@ pub(crate) fn seq_mark_lazy(arc_ptr: &Arc<Vec<Value>>) {
 }
 
 /// Check if a Seq has been marked as lazy.
-pub(crate) fn seq_is_lazy(arc_ptr: &Arc<Vec<Value>>) -> bool {
+pub(crate) fn seq_is_lazy(arc_ptr: &Arc<ArrayData>) -> bool {
     let list = lazy_seqs().lock().unwrap();
     let target_ptr = Arc::as_ptr(arc_ptr);
     for w in list.iter() {
@@ -79,21 +79,21 @@ fn consumed_lazylists() -> &'static Mutex<Vec<Weak<LazyList>>> {
 }
 
 /// Register a deferred iterator for a Seq. Called by Seq.new(iterator).
-pub(crate) fn seq_register_deferred_iter(arc_ptr: &Arc<Vec<Value>>, iterator: Value) {
+pub(crate) fn seq_register_deferred_iter(arc_ptr: &Arc<ArrayData>, iterator: Value) {
     let key = Arc::as_ptr(arc_ptr) as usize;
     let mut map = deferred_seq_iters().lock().unwrap();
     map.insert(key, iterator);
 }
 
 /// Take the deferred iterator for a Seq (if any). Removes and returns it.
-pub(crate) fn seq_take_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> Option<Value> {
+pub(crate) fn seq_take_deferred_iter(arc_ptr: &Arc<ArrayData>) -> Option<Value> {
     let key = Arc::as_ptr(arc_ptr) as usize;
     let mut map = deferred_seq_iters().lock().unwrap();
     map.remove(&key)
 }
 
 /// Check if a Seq has a deferred iterator.
-pub(crate) fn seq_has_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> bool {
+pub(crate) fn seq_has_deferred_iter(arc_ptr: &Arc<ArrayData>) -> bool {
     let key = Arc::as_ptr(arc_ptr) as usize;
     let map = deferred_seq_iters().lock().unwrap();
     map.contains_key(&key)
@@ -130,7 +130,7 @@ pub(crate) fn lazylist_is_consumed(arc_ptr: &Arc<LazyList>) -> bool {
 }
 
 /// Mark a Seq as cached (called .cache on it). Cached Seqs do not get consumed.
-pub(crate) fn seq_mark_cached(arc_ptr: &Arc<Vec<Value>>) {
+pub(crate) fn seq_mark_cached(arc_ptr: &Arc<ArrayData>) {
     let mut list = cached_seqs().lock().unwrap();
     let target_ptr = Arc::as_ptr(arc_ptr);
     list.retain(|w| w.strong_count() > 0);
@@ -145,7 +145,7 @@ pub(crate) fn seq_mark_cached(arc_ptr: &Arc<Vec<Value>>) {
 }
 
 /// Check if a Seq has been marked as cached.
-pub(crate) fn seq_is_cached(arc_ptr: &Arc<Vec<Value>>) -> bool {
+pub(crate) fn seq_is_cached(arc_ptr: &Arc<ArrayData>) -> bool {
     let list = cached_seqs().lock().unwrap();
     let target_ptr = Arc::as_ptr(arc_ptr);
     for w in list.iter() {
@@ -175,7 +175,7 @@ pub(crate) fn seq_consumed_error() -> RuntimeError {
 /// Mark a Seq (identified by its Arc) as consumed.
 /// Returns Err if the Seq was already consumed.
 #[allow(clippy::result_large_err)]
-pub(crate) fn seq_consume(arc_ptr: &Arc<Vec<Value>>) -> Result<(), RuntimeError> {
+pub(crate) fn seq_consume(arc_ptr: &Arc<ArrayData>) -> Result<(), RuntimeError> {
     let mut list = consumed_seqs().lock().unwrap();
     // Clean up expired Weak references and check for duplicates
     let target_ptr = Arc::as_ptr(arc_ptr);
@@ -192,7 +192,7 @@ pub(crate) fn seq_consume(arc_ptr: &Arc<Vec<Value>>) -> Result<(), RuntimeError>
 }
 
 /// Check if a Seq (identified by its Arc) has been consumed.
-pub(crate) fn seq_is_consumed(arc_ptr: &Arc<Vec<Value>>) -> bool {
+pub(crate) fn seq_is_consumed(arc_ptr: &Arc<ArrayData>) -> bool {
     let list = consumed_seqs().lock().unwrap();
     let target_ptr = Arc::as_ptr(arc_ptr);
     for w in list.iter() {
@@ -207,7 +207,7 @@ pub(crate) fn seq_is_consumed(arc_ptr: &Arc<Vec<Value>>) -> bool {
 
 /// For sink: if cached, do nothing; if consumed, do nothing (re-sink is ok);
 /// if not cached and not consumed, mark as consumed.
-pub(crate) fn seq_sink(arc_ptr: &Arc<Vec<Value>>) {
+pub(crate) fn seq_sink(arc_ptr: &Arc<ArrayData>) {
     if seq_is_cached(arc_ptr) {
         seq_take_deferred_iter(arc_ptr); // discard deferred iter if any
         return;
@@ -1331,6 +1331,100 @@ impl PartialEq for HashData {
     }
 }
 
+/// Backing storage for the list-like `Value` variants (`Array`, `Seq`,
+/// `HyperSeq`, `RaceSeq`, `Slip`). Bundles the element `Vec` with its container
+/// type metadata (element value-type / declared container type), so the
+/// metadata travels WITH the array through copy-on-write — replacing the
+/// fragile `Arc::as_ptr`-keyed `array_type_metadata` side table (the last
+/// Arc-pointer-identity flaky source). `Deref`s to the inner `Vec` so the
+/// overwhelming majority of read sites (`.iter()`/`.len()`/indexing/…) are
+/// unchanged; only structural mutation/rebuild sites touch the wrapper.
+///
+/// Only `Array` ever carries metadata; `Seq`/`Slip`/`HyperSeq`/`RaceSeq` leave
+/// the metadata fields `None`. (Stage 1a: the fields exist but the
+/// `array_type_metadata` side table remains authoritative; Stage 1b wires them
+/// and deletes the table.)
+#[derive(Debug, Clone, Default)]
+pub struct ArrayData {
+    pub items: Vec<Value>,
+    /// Element value-type constraint (e.g. `int` for `my int @a`), if any.
+    /// Mirrors `ContainerTypeInfo::value_type`.
+    pub value_type: Option<String>,
+    /// Declared container type name (e.g. `array[int]`, `Array[Int]`), if any.
+    /// Mirrors `ContainerTypeInfo::declared_type`.
+    pub declared_type: Option<String>,
+}
+
+impl ArrayData {
+    pub fn new(items: Vec<Value>) -> Self {
+        ArrayData {
+            items,
+            value_type: None,
+            declared_type: None,
+        }
+    }
+
+    /// Whether any container *type* metadata is attached.
+    pub fn has_type_meta(&self) -> bool {
+        self.value_type.is_some() || self.declared_type.is_some()
+    }
+
+    /// Clear all container type metadata (used when re-tagging in place).
+    pub fn clear_type_meta(&mut self) {
+        self.value_type = None;
+        self.declared_type = None;
+    }
+}
+
+impl std::ops::Deref for ArrayData {
+    type Target = Vec<Value>;
+    fn deref(&self) -> &Vec<Value> {
+        &self.items
+    }
+}
+
+impl std::ops::DerefMut for ArrayData {
+    fn deref_mut(&mut self) -> &mut Vec<Value> {
+        &mut self.items
+    }
+}
+
+impl From<Vec<Value>> for ArrayData {
+    fn from(items: Vec<Value>) -> Self {
+        ArrayData::new(items)
+    }
+}
+
+impl FromIterator<Value> for ArrayData {
+    fn from_iter<I: IntoIterator<Item = Value>>(iter: I) -> Self {
+        ArrayData::new(iter.into_iter().collect())
+    }
+}
+
+impl IntoIterator for ArrayData {
+    type Item = Value;
+    type IntoIter = std::vec::IntoIter<Value>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ArrayData {
+    type Item = &'a Value;
+    type IntoIter = std::slice::Iter<'a, Value>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+/// Array equality ignores container metadata — only the element vec matters
+/// (preserves the prior `Arc<Vec<Value>>` PartialEq semantics).
+impl PartialEq for ArrayData {
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+    }
+}
+
 /// Value stored in an enum variant: an integer, a string, or an arbitrary Value.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum EnumValue {
@@ -1387,7 +1481,7 @@ pub enum Value {
         excl_end: bool,
     },
     /// Distinguishes Array, List, and their itemized (Scalar-wrapped) variants.
-    Array(Arc<Vec<Value>>, ArrayKind),
+    Array(Arc<ArrayData>, ArrayKind),
     Hash(Arc<HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),
@@ -1446,12 +1540,12 @@ pub enum Value {
         kind: JunctionKind,
         values: Arc<Vec<Value>>,
     },
-    Seq(Arc<Vec<Value>>),
+    Seq(Arc<ArrayData>),
     /// HyperSeq: result of `.hyper` — preserves order, single-threaded implementation.
-    HyperSeq(Arc<Vec<Value>>),
+    HyperSeq(Arc<ArrayData>),
     /// RaceSeq: result of `.race` — unordered parallel, single-threaded implementation.
-    RaceSeq(Arc<Vec<Value>>),
-    Slip(Arc<Vec<Value>>),
+    RaceSeq(Arc<ArrayData>),
+    Slip(Arc<ArrayData>),
     LazyList(Arc<LazyList>),
     Version {
         parts: Vec<VersionPart>,
@@ -1541,7 +1635,7 @@ pub enum Value {
     /// Reading this value returns the current value at the index (or Nil).
     /// Assigning to it writes back to the parent array via interior mutation.
     ArraySlotRef {
-        array: Arc<Vec<Value>>,
+        array: Arc<ArrayData>,
         index: usize,
     },
     /// A deferred hash access path for binding. Acts as Any for reads.
@@ -2239,7 +2333,7 @@ impl PartialEq for SharedChannel {
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        let match_equals_pair_array = |attrs: &Arc<InstanceAttrs>, arr: &Arc<Vec<Value>>| {
+        let match_equals_pair_array = |attrs: &Arc<InstanceAttrs>, arr: &Arc<ArrayData>| {
             if arr.len() != 2 {
                 return false;
             }
@@ -2595,15 +2689,23 @@ impl Value {
         }
     }
     pub fn array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(items), ArrayKind::List)
+        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::List)
     }
     /// Create a true Array value (from [...] literals).
     pub fn real_array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(items), ArrayKind::Array)
+        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Array)
     }
     /// Create a shaped (multidimensional) Array value.
     pub fn shaped_array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(items), ArrayKind::Shaped)
+        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Shaped)
+    }
+
+    /// Build an `Arc<ArrayData>` from a bare `Vec`. Lets call sites that
+    /// constructed `Value::Array(Arc::new(v), kind)` keep their shape as
+    /// `Value::Array(Value::array_arc(v), kind)` after the variant moved to
+    /// `ArrayData`.
+    pub fn array_arc(items: Vec<Value>) -> Arc<ArrayData> {
+        Arc::new(ArrayData::new(items))
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)
     /// or a `HashData` (a cloned/rebuilt hash whose container metadata is then
@@ -2893,7 +2995,7 @@ impl Value {
     /// concurrent reads/writes to the same Arc.
     pub fn array_push_in_place(&self, val: Value) -> bool {
         if let Value::Array(arc, _) = self {
-            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            let ptr = Arc::as_ptr(arc) as *mut ArrayData;
             unsafe {
                 (*ptr).push(val);
             }
@@ -2936,7 +3038,7 @@ impl Value {
     pub fn array_slot_ref(&self, idx: usize, terminal: bool) -> Option<Value> {
         if let Value::Array(arc, _kind) = self {
             // SAFETY: mutsu is single-threaded.
-            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+            let ptr = Arc::as_ptr(arc) as *mut ArrayData;
             unsafe {
                 while (&(*ptr)).len() <= idx {
                     (&mut (*ptr)).push(Value::Nil);
@@ -2978,7 +3080,7 @@ impl Value {
     /// Write a value to an ArraySlotRef's parent array at the stored index.
     pub fn array_slot_write(&self, val: Value) {
         if let Value::ArraySlotRef { array, index } = self {
-            let ptr = Arc::as_ptr(array) as *mut Vec<Value>;
+            let ptr = Arc::as_ptr(array) as *mut ArrayData;
             unsafe {
                 while (&(*ptr)).len() <= *index {
                     (&mut (*ptr)).push(Value::Nil);
@@ -3115,7 +3217,7 @@ impl Value {
         )
     }
     pub fn slip(items: Vec<Value>) -> Self {
-        Value::Slip(Arc::new(items))
+        Value::Slip(Arc::new(items.into()))
     }
     pub fn junction(kind: JunctionKind, values: Vec<Value>) -> Self {
         Value::Junction {
@@ -3613,7 +3715,7 @@ impl Value {
 
     /// Check if this value is a numeric type (Int, Num, Rat, FatRat, BigInt).
     /// Returns the inner items if this value is an Array, Seq, or Slip.
-    pub(crate) fn as_list_items(&self) -> Option<&Arc<Vec<Value>>> {
+    pub(crate) fn as_list_items(&self) -> Option<&Arc<ArrayData>> {
         match self {
             Value::Array(items, _) | Value::Seq(items) | Value::Slip(items) => Some(items),
             _ => None,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -137,7 +137,11 @@ pub(crate) struct VM {
     /// for-loop iterable is a grep result with a registered grep-view binding,
     /// this holds (source array Arc, per-filtered-index source indices, kind)
     /// so the loop can write modified topics back to the original array slots.
-    for_grep_view: Option<(Arc<Vec<Value>>, Vec<usize>, crate::value::ArrayKind)>,
+    for_grep_view: Option<(
+        Arc<crate::value::ArrayData>,
+        Vec<usize>,
+        crate::value::ArrayKind,
+    )>,
     /// Names of multi-param for-loop bindings (`-> %a, %b`) whose `%`/`@` params
     /// must preserve a QuantHash (Set/Bag/Mix) value rather than coercing it to
     /// a plain Hash, matching Raku's parameter-binding semantics.
@@ -1612,13 +1616,13 @@ impl VM {
                                 raw_val
                             } else {
                                 Value::Array(
-                                    std::sync::Arc::new(vec![raw_val]),
+                                    std::sync::Arc::new(vec![raw_val].into()),
                                     crate::value::ArrayKind::List,
                                 )
                             }
                         }
                         other => Value::Array(
-                            std::sync::Arc::new(vec![other]),
+                            std::sync::Arc::new(vec![other].into()),
                             crate::value::ArrayKind::List,
                         ),
                     }
@@ -2671,7 +2675,7 @@ impl VM {
                     // Comma lists and other non-real arrays become Lists.
                     Value::Array(items, _) => Value::Array(items, crate::value::ArrayKind::List),
                     Value::Seq(items) => Value::Array(
-                        std::sync::Arc::new(items.to_vec()),
+                        std::sync::Arc::new(items.to_vec().into()),
                         crate::value::ArrayKind::List,
                     ),
                     // Hash values are flattened to pairs for constant @.
@@ -2680,7 +2684,10 @@ impl VM {
                             .iter()
                             .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
                             .collect();
-                        Value::Array(std::sync::Arc::new(pairs), crate::value::ArrayKind::List)
+                        Value::Array(
+                            std::sync::Arc::new(pairs.into()),
+                            crate::value::ArrayKind::List,
+                        )
                     }
                     // Instance objects: check if Positional; if so keep as-is,
                     // otherwise call .cache for coercion (constant @ semantics).
@@ -2752,18 +2759,18 @@ impl VM {
                                     Value::Array(items, crate::value::ArrayKind::List)
                                 }
                                 Value::Seq(items) => Value::Array(
-                                    std::sync::Arc::new(items.to_vec()),
+                                    std::sync::Arc::new(items.to_vec().into()),
                                     crate::value::ArrayKind::List,
                                 ),
                                 other => Value::Array(
-                                    std::sync::Arc::new(vec![other]),
+                                    std::sync::Arc::new(vec![other].into()),
                                     crate::value::ArrayKind::List,
                                 ),
                             }
                         }
                     }
                     other => Value::Array(
-                        std::sync::Arc::new(vec![other]),
+                        std::sync::Arc::new(vec![other].into()),
                         crate::value::ArrayKind::List,
                     ),
                 };
@@ -3252,7 +3259,7 @@ impl VM {
                 if let Some(val) = self.get_env_with_main_alias(name) {
                     match &val {
                         Value::Array(arc, _) => {
-                            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
                             unsafe { (*ptr).clear() };
                         }
                         Value::Hash(arc) => {
@@ -3266,7 +3273,7 @@ impl VM {
                 if let Some(slot) = self.find_local_slot(code, name) {
                     match &self.locals[slot] {
                         Value::Array(arc, _) => {
-                            let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
                             unsafe { (*ptr).clear() };
                         }
                         Value::Hash(arc) => {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -78,8 +78,8 @@ impl VM {
         let actual_n = n.min(items.len());
         let result = if is_shift {
             let rest = items.split_off(actual_n);
-            let shifted = items;
-            items = rest;
+            let shifted = std::mem::take(&mut items.items);
+            items.items = rest;
             shifted
         } else {
             // pop
@@ -905,11 +905,11 @@ impl VM {
             let n = n.max(0) as usize;
             // Fast path: @var.shift xx N or @var.pop xx N — bulk drain
             if let Some(items) = self.try_bulk_shift_pop(&data, n)? {
-                self.stack.push(Value::Seq(Arc::new(items)));
+                self.stack.push(Value::Seq(Arc::new(items.into())));
                 return Ok(());
             }
             let items = self.vm_xx_repeat_thunk(data.as_ref(), n)?;
-            self.stack.push(Value::Seq(Arc::new(items)));
+            self.stack.push(Value::Seq(Arc::new(items.into())));
             return Ok(());
         }
 
@@ -965,7 +965,7 @@ impl VM {
             let count = crate::runtime::Interpreter::repeat_logical_count(&right);
             crate::runtime::Interpreter::make_repeat_lazy_cache_counted(items, count)
         } else {
-            Value::Seq(Arc::new(items))
+            Value::Seq(Arc::new(items.into()))
         };
         self.stack.push(result);
         Ok(())

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -125,7 +125,7 @@ impl VM {
                 }
                 // Create HyperSeq/RaceSeq
                 let items = crate::runtime::value_to_list(&target);
-                let arc = std::sync::Arc::new(items);
+                let arc = std::sync::Arc::new(crate::value::ArrayData::new(items));
                 let result = if method == "hyper" {
                     Value::HyperSeq(arc)
                 } else {
@@ -191,9 +191,9 @@ impl VM {
                         let result_val = call_result?;
                         let result_items = crate::runtime::value_to_list(&result_val);
                         let wrapped = if is_hyper {
-                            Value::HyperSeq(Arc::new(result_items))
+                            Value::HyperSeq(Arc::new(result_items.into()))
                         } else {
-                            Value::RaceSeq(Arc::new(result_items))
+                            Value::RaceSeq(Arc::new(result_items.into()))
                         };
                         self.stack.push(wrapped);
                         self.env_dirty = true;
@@ -401,7 +401,7 @@ impl VM {
             if !matches!(method.as_str(), "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
                 *self.interpreter.env_mut() = saved_env;
             }
-            Value::Seq(std::sync::Arc::new(items))
+            Value::Seq(std::sync::Arc::new(items.into()))
         } else {
             target
         };
@@ -774,7 +774,7 @@ impl VM {
                 return Err(RuntimeError::typed("X::Invalid::Value", attrs));
             }
             let items = crate::runtime::value_to_list(&target);
-            let arc = std::sync::Arc::new(items);
+            let arc = std::sync::Arc::new(crate::value::ArrayData::new(items));
             let result = if method == "hyper" {
                 Value::HyperSeq(arc)
             } else {
@@ -834,9 +834,9 @@ impl VM {
                     let result_val = call_result?;
                     let result_items = crate::runtime::value_to_list(&result_val);
                     let wrapped = if is_hyper {
-                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                        Value::HyperSeq(std::sync::Arc::new(result_items.into()))
                     } else {
-                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                        Value::RaceSeq(std::sync::Arc::new(result_items.into()))
                     };
                     self.stack.push(wrapped);
                     self.env_dirty = true;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -555,7 +555,7 @@ impl VM {
             if !matches!(method, "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
                 *self.interpreter.env_mut() = saved_env;
             }
-            Value::Seq(std::sync::Arc::new(items))
+            Value::Seq(std::sync::Arc::new(items.into()))
         } else {
             target
         };
@@ -609,7 +609,7 @@ impl VM {
             }
             // Materialize and wrap
             let items = crate::runtime::value_to_list(&target);
-            let arc = std::sync::Arc::new(items);
+            let arc = std::sync::Arc::new(crate::value::ArrayData::new(items));
             let result = if method == "hyper" {
                 Value::HyperSeq(arc)
             } else {
@@ -706,9 +706,9 @@ impl VM {
                         let result =
                             self.exec_hyper_race_map_grep(&items_arc, block, is_map, is_hyper)?;
                         let wrapped = if is_hyper {
-                            Value::HyperSeq(Arc::new(result))
+                            Value::HyperSeq(Arc::new(result.into()))
                         } else {
-                            Value::RaceSeq(Arc::new(result))
+                            Value::RaceSeq(Arc::new(result.into()))
                         };
                         self.stack.push(wrapped);
                         self.env_dirty = true;
@@ -968,7 +968,7 @@ impl VM {
                         "ords" if args.is_empty() => {
                             return Err(RuntimeError::warn_signal_with_resume(
                                 "Use of Nil in string context".to_string(),
-                                Value::Seq(Arc::new(vec![])),
+                                Value::Seq(Arc::new(vec![].into())),
                             ));
                         }
                         "chrs" if args.is_empty() => {
@@ -1102,7 +1102,7 @@ impl VM {
                                 .collect();
                             // Pure array transform: env-pure.
                             self.method_dispatch_pure = true;
-                            Ok(Value::Slip(std::sync::Arc::new(converted)))
+                            Ok(Value::Slip(std::sync::Arc::new(converted.into())))
                         } else if let Some(native_result) =
                             self.try_native_method(&target, Symbol::intern(method), &args)
                         {
@@ -1156,9 +1156,9 @@ impl VM {
                 {
                     let result_items = crate::runtime::value_to_list(&result);
                     let wrapped = if is_hyper {
-                        Value::HyperSeq(std::sync::Arc::new(result_items))
+                        Value::HyperSeq(std::sync::Arc::new(result_items.into()))
                     } else {
-                        Value::RaceSeq(std::sync::Arc::new(result_items))
+                        Value::RaceSeq(std::sync::Arc::new(result_items.into()))
                     };
                     self.stack.push(wrapped);
                 }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1850,7 +1850,7 @@ impl VM {
         }
         let mut updated = items.to_vec();
         updated[actual_idx] = current_topic;
-        let updated_value = Value::Array(std::sync::Arc::new(updated), kind);
+        let updated_value = Value::Array(std::sync::Arc::new(updated.into()), kind);
         self.set_env_with_main_alias(source, updated_value.clone());
         self.update_local_if_exists(code, source, &updated_value);
     }
@@ -1945,7 +1945,7 @@ impl VM {
                 {
                     let mut updated = items.to_vec();
                     updated[idx] = val;
-                    let updated_value = Value::Array(std::sync::Arc::new(updated), kind);
+                    let updated_value = Value::Array(std::sync::Arc::new(updated.into()), kind);
                     self.set_env_with_main_alias(source, updated_value.clone());
                     self.update_local_if_exists(code, source, &updated_value);
                 }
@@ -1960,7 +1960,7 @@ impl VM {
                         updated[base + j] = val;
                     }
                 }
-                let updated_value = Value::Array(std::sync::Arc::new(updated), kind);
+                let updated_value = Value::Array(std::sync::Arc::new(updated.into()), kind);
                 self.set_env_with_main_alias(source, updated_value.clone());
                 self.update_local_if_exists(code, source, &updated_value);
             } else {
@@ -1974,7 +1974,7 @@ impl VM {
                 }
                 let mut updated = items.to_vec();
                 updated[idx] = current_val;
-                let updated_value = Value::Array(std::sync::Arc::new(updated), kind);
+                let updated_value = Value::Array(std::sync::Arc::new(updated.into()), kind);
                 self.set_env_with_main_alias(source, updated_value.clone());
                 self.update_local_if_exists(code, source, &updated_value);
             }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -94,7 +94,7 @@ impl VM {
                     &right_list[i],
                 )?);
             }
-            return Ok(Value::Seq(std::sync::Arc::new(results)));
+            return Ok(Value::Seq(std::sync::Arc::new(results.into())));
         }
         // Hyper operator forms: >>op<<, >>op>>, <<op<<, <<op>>
         // Apply inner op element-wise to two lists.

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -861,7 +861,7 @@ impl VM {
                         }
                     } else {
                         match self.vm_call_on_value(func, vec![elem], None)? {
-                            Value::Slip(items) => items.as_ref().clone(),
+                            Value::Slip(items) => items.as_ref().to_vec(),
                             v => vec![v],
                         }
                     };
@@ -1065,7 +1065,7 @@ impl VM {
     fn force_lazy_if_needed(&mut self, val: Value) -> Result<Value, RuntimeError> {
         if let Value::LazyList(ll) = &val {
             let items = self.force_lazy_list_vm(ll)?;
-            Ok(Value::Seq(std::sync::Arc::new(items)))
+            Ok(Value::Seq(std::sync::Arc::new(items.into())))
         } else {
             Ok(val)
         }
@@ -1360,7 +1360,7 @@ impl VM {
                     other => other.clone(),
                 })
                 .collect();
-            Value::Array(std::sync::Arc::new(resolved), kind)
+            Value::Array(std::sync::Arc::new(resolved.into()), kind)
         } else {
             val
         }

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -484,7 +484,7 @@ impl VM {
             Value::Array(_, kind) if kind.is_real_array() && !method_is_nodal => ArrayKind::Array,
             _ => ArrayKind::List,
         };
-        let result = Value::Array(std::sync::Arc::new(results), result_kind);
+        let result = Value::Array(std::sync::Arc::new(results.into()), result_kind);
         // A per-element native method raised a resumable warn: re-raise it once,
         // carrying the whole hyper result as the resume value, so an enclosing
         // `CONTROL { .resume }` (or the default warn handler) resumes the entire
@@ -521,8 +521,8 @@ impl VM {
                     mutated.push(m);
                 }
                 Ok((
-                    Value::Array(std::sync::Arc::new(results), *kind),
-                    Value::Array(std::sync::Arc::new(mutated), *kind),
+                    Value::Array(std::sync::Arc::new(results.into()), *kind),
+                    Value::Array(std::sync::Arc::new(mutated.into()), *kind),
                 ))
             }
             Value::Seq(elems) | Value::Slip(elems) => {
@@ -535,8 +535,8 @@ impl VM {
                     mutated.push(m);
                 }
                 Ok((
-                    Value::Array(std::sync::Arc::new(results), ArrayKind::List),
-                    Value::Array(std::sync::Arc::new(mutated), ArrayKind::List),
+                    Value::Array(std::sync::Arc::new(results.into()), ArrayKind::List),
+                    Value::Array(std::sync::Arc::new(mutated.into()), ArrayKind::List),
                 ))
             }
             Value::Hash(map) => {
@@ -782,8 +782,10 @@ impl VM {
             Value::Array(_, kind) if kind.is_real_array() => ArrayKind::Array,
             _ => ArrayKind::List,
         };
-        self.stack
-            .push(Value::Array(std::sync::Arc::new(results), result_kind));
+        self.stack.push(Value::Array(
+            std::sync::Arc::new(results.into()),
+            result_kind,
+        ));
         Ok(())
     }
 }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -729,7 +729,7 @@ impl VM {
                 return Ok(());
             }
             let items = self.force_lazy_list_vm(ll)?;
-            Value::Seq(std::sync::Arc::new(items))
+            Value::Seq(std::sync::Arc::new(items.into()))
         } else {
             val
         };
@@ -1405,7 +1405,7 @@ impl VM {
                         shaped_items.resize(shape[0], Value::Nil);
                     }
                     assigned = Value::Array(
-                        std::sync::Arc::new(shaped_items),
+                        std::sync::Arc::new(shaped_items.into()),
                         crate::value::ArrayKind::Shaped,
                     );
                     crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
@@ -1776,7 +1776,7 @@ impl VM {
                     prefix.push(item);
                     out.push(Value::array(prefix.clone()));
                 }
-                self.stack.push(Value::Seq(std::sync::Arc::new(out)));
+                self.stack.push(Value::Seq(std::sync::Arc::new(out.into())));
             } else {
                 self.stack.push(Value::array(list));
             }
@@ -1798,7 +1798,8 @@ impl VM {
 
         if scan {
             if list.is_empty() {
-                self.stack.push(Value::Seq(std::sync::Arc::new(Vec::new())));
+                self.stack
+                    .push(Value::Seq(std::sync::Arc::new(Vec::new().into())));
                 return Ok(());
             }
             if list.len() == 1 {
@@ -1808,7 +1809,8 @@ impl VM {
                 } else {
                     list[0].clone()
                 };
-                self.stack.push(Value::Seq(std::sync::Arc::new(vec![val])));
+                self.stack
+                    .push(Value::Seq(std::sync::Arc::new(vec![val].into())));
                 return Ok(());
             }
             let out = match assoc {
@@ -1897,7 +1899,7 @@ impl VM {
                                     let inner_op = &base_op[1..];
                                     let items = runtime::value_to_list(&list[0]);
                                     if items.is_empty() {
-                                        Value::Seq(std::sync::Arc::new(vec![]))
+                                        Value::Seq(std::sync::Arc::new(vec![].into()))
                                     } else {
                                         let mut acc0 = items[0].clone();
                                         for item in items.iter().skip(1) {
@@ -1905,7 +1907,7 @@ impl VM {
                                                 inner_op, &acc0, item,
                                             )?;
                                         }
-                                        Value::Seq(std::sync::Arc::new(vec![acc0]))
+                                        Value::Seq(std::sync::Arc::new(vec![acc0].into()))
                                     }
                                 } else {
                                     // Apply the Z/X op to all prefix elements
@@ -1931,7 +1933,7 @@ impl VM {
                                 let zx_prefix = (base_op.starts_with('Z') && base_op.len() > 1)
                                     || (base_op.starts_with('X') && base_op.len() > 1);
                                 if zx_prefix {
-                                    acc = Value::Seq(std::sync::Arc::new(vec![acc]));
+                                    acc = Value::Seq(std::sync::Arc::new(vec![acc].into()));
                                 } else if base_op == "minmax" {
                                     // [minmax](x) = x..x for scalars,
                                     // or min(x)..max(x) for array/list x.
@@ -1966,7 +1968,7 @@ impl VM {
                     out
                 }
             };
-            self.stack.push(Value::Seq(std::sync::Arc::new(out)));
+            self.stack.push(Value::Seq(std::sync::Arc::new(out.into())));
             return Ok(());
         }
         // [^^] and [xor] are list-associative: they check that exactly one element
@@ -2160,7 +2162,8 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         if thunks.is_empty() {
             if scan {
-                self.stack.push(Value::Seq(std::sync::Arc::new(Vec::new())));
+                self.stack
+                    .push(Value::Seq(std::sync::Arc::new(Vec::new().into())));
             } else {
                 // Identity values
                 let identity = match op {
@@ -2230,7 +2233,8 @@ impl VM {
                 last_val
             };
             if scan {
-                self.stack.push(Value::Seq(std::sync::Arc::new(results)));
+                self.stack
+                    .push(Value::Seq(std::sync::Arc::new(results.into())));
             } else {
                 self.stack.push(final_result);
             }
@@ -2284,7 +2288,7 @@ impl VM {
                         if runtime::types::value_is_defined(&acc) {
                             val
                         } else {
-                            Value::Slip(std::sync::Arc::new(vec![]))
+                            Value::Slip(std::sync::Arc::new(vec![].into()))
                         }
                     }
                     _ => val,
@@ -2295,7 +2299,8 @@ impl VM {
             }
         }
         if scan {
-            self.stack.push(Value::Seq(std::sync::Arc::new(results)));
+            self.stack
+                .push(Value::Seq(std::sync::Arc::new(results.into())));
         } else {
             self.stack.push(acc);
         }
@@ -3168,7 +3173,8 @@ impl VM {
                 }
                 Err(e) if e.is_next && has_label && Self::label_matches(&e.label, &label) => {
                     self.stack.truncate(stack_base);
-                    self.stack.push(Value::Slip(std::sync::Arc::new(vec![])));
+                    self.stack
+                        .push(Value::Slip(std::sync::Arc::new(vec![].into())));
                     break Ok(());
                 }
                 Err(e)
@@ -3180,7 +3186,7 @@ impl VM {
                     self.stack.truncate(stack_base);
                     self.stack.push(
                         e.return_value
-                            .unwrap_or(Value::Slip(std::sync::Arc::new(vec![]))),
+                            .unwrap_or(Value::Slip(std::sync::Arc::new(vec![].into()))),
                     );
                     break Ok(());
                 }
@@ -3188,7 +3194,7 @@ impl VM {
                     self.stack.truncate(stack_base);
                     self.stack.push(
                         e.return_value
-                            .unwrap_or(Value::Slip(std::sync::Arc::new(vec![]))),
+                            .unwrap_or(Value::Slip(std::sync::Arc::new(vec![].into()))),
                     );
                     break Ok(());
                 }
@@ -3322,7 +3328,7 @@ impl VM {
         match val {
             Value::Array(arc_vec, kind) => {
                 let copied: Vec<Value> = arc_vec.iter().map(Self::deep_copy_value).collect();
-                Value::Array(std::sync::Arc::new(copied), *kind)
+                Value::Array(std::sync::Arc::new(copied.into()), *kind)
             }
             Value::Hash(arc_map) => {
                 let copied: std::collections::HashMap<String, Value> = arc_map

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -201,11 +201,12 @@ impl VM {
             match self.force_lazy_list_vm(ll) {
                 Ok(items) => {
                     let val = match method_name.as_str() {
-                        "Slip" => Value::Slip(std::sync::Arc::new(items)),
-                        "List" => {
-                            Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
-                        }
-                        "Seq" => Value::Seq(std::sync::Arc::new(items)),
+                        "Slip" => Value::Slip(std::sync::Arc::new(items.into())),
+                        "List" => Value::Array(
+                            std::sync::Arc::new(items.into()),
+                            crate::value::ArrayKind::List,
+                        ),
+                        "Seq" => Value::Seq(std::sync::Arc::new(items.into())),
                         "Array" => Value::real_array(items),
                         _ => unreachable!(),
                     };
@@ -330,7 +331,7 @@ impl VM {
                     if let Value::LazyList(ll) = arg {
                         match self.force_lazy_list_vm(ll) {
                             Ok(items) => {
-                                forced_args.push(Value::Seq(std::sync::Arc::new(items)));
+                                forced_args.push(Value::Seq(std::sync::Arc::new(items.into())));
                             }
                             Err(e) => return Some(Err(e)),
                         }

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -215,7 +215,7 @@ impl VM {
         // On a real array, mutsu's `.map` yields a List-kind array (matching the
         // interpreter's return shape).
         Some(Ok(Value::Array(
-            std::sync::Arc::new(result),
+            std::sync::Arc::new(result.into()),
             ArrayKind::List,
         )))
     }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -829,7 +829,7 @@ impl VM {
                                 }
                             })
                             .collect();
-                        let new_arr = Value::Array(Arc::new(replaced), kind);
+                        let new_arr = Value::Array(Arc::new(replaced.into()), kind);
                         self.interpreter
                             .set_container_default(&new_arr, default_value.clone());
                         self.locals_set_by_name(code, &name, new_arr.clone());

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -1482,7 +1482,7 @@ impl VM {
             let right_is_array = matches!(right, Value::Array(_, crate::value::ArrayKind::Array));
             return if !left_is_array && !right_is_array {
                 Ok(Value::Array(
-                    std::sync::Arc::new(results),
+                    std::sync::Arc::new(results.into()),
                     crate::value::ArrayKind::List,
                 ))
             } else {
@@ -1767,7 +1767,10 @@ impl VM {
             if both_scalar && items.len() == 1 {
                 items.into_iter().next().unwrap()
             } else if !left_is_array && !right_is_array {
-                Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+                Value::Array(
+                    std::sync::Arc::new(items.into()),
+                    crate::value::ArrayKind::List,
+                )
             } else {
                 Value::real_array(items)
             }
@@ -2098,7 +2101,7 @@ impl VM {
                         results,
                     )))
                 } else if results.is_empty() {
-                    Value::Seq(std::sync::Arc::new(Vec::new()))
+                    Value::Seq(std::sync::Arc::new(Vec::new().into()))
                 } else {
                     Value::array(results)
                 }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -219,7 +219,7 @@ impl VM {
         // Bare Whatever (*) in array subscript means all indices: 0, 1, ..., len-1
         if matches!(idx, Value::Whatever) {
             let indices: Vec<Value> = (0..len).map(Value::Int).collect();
-            return Value::Array(Arc::new(indices), crate::value::ArrayKind::List);
+            return Value::Array(Arc::new(indices.into()), crate::value::ArrayKind::List);
         }
         if let Value::Sub(ref data) = idx {
             let mut sub_env = data.env.clone();
@@ -265,7 +265,7 @@ impl VM {
                         resolved.push(item.clone());
                     }
                 }
-                return Value::Array(Arc::new(resolved), kind);
+                return Value::Array(Arc::new(resolved.into()), kind);
             }
         }
         idx
@@ -367,7 +367,7 @@ impl VM {
     fn replace_array_refs_in_value(
         v: &mut Value,
         old_ptr: usize,
-        new_array: &Arc<Vec<Value>>,
+        new_array: &Arc<crate::value::ArrayData>,
         kind: ArrayKind,
         seen_hashes: &mut Vec<usize>,
     ) {
@@ -466,8 +466,8 @@ impl VM {
                     new_items.push(v.clone());
                 }
             }
-            let result_arc = Arc::new(new_items);
-            let items_ptr = Arc::as_ptr(&result_arc) as *mut Vec<Value>;
+            let result_arc = Arc::new(crate::value::ArrayData::new(new_items));
+            let items_ptr = Arc::as_ptr(&result_arc) as *mut crate::value::ArrayData;
             // SAFETY: We just created result_arc and hold the only reference,
             // so no other thread can access it.
             unsafe {
@@ -875,7 +875,7 @@ impl VM {
 
     fn assignment_rhs_values(&mut self, val: &Value) -> Result<Vec<Value>, RuntimeError> {
         Ok(match val {
-            Value::Array(v, ..) => v.as_ref().clone(),
+            Value::Array(v, ..) => v.as_ref().to_vec(),
             Value::Seq(v) | Value::Slip(v) => v.iter().cloned().collect(),
             Value::Range(a, b) => {
                 let end = (*b).min(a.saturating_add(Self::MAX_ASSIGN_SLICE_EXPAND));
@@ -1075,7 +1075,7 @@ impl VM {
                 &coercion_target,
                 explicit_initializer,
             )?;
-            return Ok(Value::Array(Arc::new(coerced_items), kind));
+            return Ok(Value::Array(Arc::new(coerced_items.into()), kind));
         }
 
         if var_name.starts_with('%')
@@ -1227,7 +1227,7 @@ impl VM {
                     coercion_target,
                     explicit_initializer,
                 )?;
-                coerced_items.push(Value::Array(Arc::new(sub_coerced), *sub_kind));
+                coerced_items.push(Value::Array(Arc::new(sub_coerced.into()), *sub_kind));
                 continue;
             }
             let target_type = coercion_target(constraint).unwrap_or_else(|| constraint.to_string());
@@ -1930,7 +1930,7 @@ impl VM {
                         // matching the behavior of index assignment.
                         // SAFETY: mutsu is single-threaded.
                         let use_inplace = Arc::strong_count(arr) > 1 && !name.starts_with('@');
-                        let a: &mut Vec<Value> = if use_inplace {
+                        let a: &mut crate::value::ArrayData = if use_inplace {
                             unsafe { &mut *(Arc::as_ptr(arr) as *mut _) }
                         } else {
                             Arc::make_mut(arr)
@@ -2448,19 +2448,19 @@ impl VM {
             Value::Slip(items) => Value::Array(items, crate::value::ArrayKind::List),
             Value::Range(a, b) if expand_range => {
                 let items: Vec<Value> = (a..=b).map(Value::Int).collect();
-                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+                Value::Array(Arc::new(items.into()), crate::value::ArrayKind::List)
             }
             Value::RangeExcl(a, b) if expand_range => {
                 let items: Vec<Value> = (a..b).map(Value::Int).collect();
-                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+                Value::Array(Arc::new(items.into()), crate::value::ArrayKind::List)
             }
             Value::RangeExclStart(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..=b).map(Value::Int).collect();
-                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+                Value::Array(Arc::new(items.into()), crate::value::ArrayKind::List)
             }
             Value::RangeExclBoth(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..b).map(Value::Int).collect();
-                Value::Array(Arc::new(items), crate::value::ArrayKind::List)
+                Value::Array(Arc::new(items.into()), crate::value::ArrayKind::List)
             }
             other => other,
         };
@@ -3235,7 +3235,7 @@ impl VM {
                                     // SAFETY: mutsu is single-threaded.
                                     let use_inplace =
                                         Arc::strong_count(items) > 1 && !var_name.starts_with('@');
-                                    let arr: &mut Vec<Value> = if use_inplace {
+                                    let arr: &mut crate::value::ArrayData = if use_inplace {
                                         unsafe { &mut *(Arc::as_ptr(items) as *mut _) }
                                     } else {
                                         Arc::make_mut(items)
@@ -3734,7 +3734,7 @@ impl VM {
                         // Use interior mutation when the inner array is shared
                         // (e.g., by an ArraySlotRef from := binding).
                         if Arc::strong_count(inner_arr) > 1 {
-                            let ptr = Arc::as_ptr(inner_arr) as *mut Vec<Value>;
+                            let ptr = Arc::as_ptr(inner_arr) as *mut crate::value::ArrayData;
                             unsafe {
                                 let v = &mut *ptr;
                                 while v.len() <= j {
@@ -3830,7 +3830,7 @@ impl VM {
                 if let Ok(i) = outer_key.parse::<usize>() {
                     if Arc::strong_count(arr) > 1 {
                         // SAFETY: mutsu is single-threaded.
-                        let ptr = Arc::as_ptr(arr) as *mut Vec<Value>;
+                        let ptr = Arc::as_ptr(arr) as *mut crate::value::ArrayData;
                         unsafe {
                             let v = &mut *ptr;
                             while v.len() <= i {
@@ -4200,7 +4200,7 @@ impl VM {
                 // Interior mutation: write into the array via raw pointer
                 // so the change is visible to all holders of the same Arc.
                 if let Ok(i) = key.parse::<usize>() {
-                    let ptr = Arc::as_ptr(arc) as *mut Vec<Value>;
+                    let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
                     unsafe {
                         let v = &mut *ptr;
                         while v.len() <= i {
@@ -5170,17 +5170,23 @@ impl VM {
                     Value::Array(items, kind) if kind.is_real_array() => Value::Array(items, kind),
                     Value::Array(items, _) => Value::Array(items, crate::value::ArrayKind::List),
                     Value::Seq(items) => Value::Array(
-                        std::sync::Arc::new(items.to_vec()),
+                        std::sync::Arc::new(items.to_vec().into()),
                         crate::value::ArrayKind::List,
                     ),
                     Value::LazyList(list) => {
                         let items = self.force_lazy_list_vm(&list)?;
-                        Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+                        Value::Array(
+                            std::sync::Arc::new(items.into()),
+                            crate::value::ArrayKind::List,
+                        )
                     }
                     Value::LazyIoLines { .. } => {
                         let forced = self.force_if_lazy_io_lines(raw_popped)?;
                         let items = runtime::value_to_list(&forced);
-                        Value::Array(std::sync::Arc::new(items), crate::value::ArrayKind::List)
+                        Value::Array(
+                            std::sync::Arc::new(items.into()),
+                            crate::value::ArrayKind::List,
+                        )
                     }
                     Value::Instance { ref class_name, .. } => {
                         // Check if Instance does Positional — if so, keep as-is.
@@ -5255,18 +5261,18 @@ impl VM {
                                     Value::Array(items, crate::value::ArrayKind::List)
                                 }
                                 Value::Seq(items) => Value::Array(
-                                    std::sync::Arc::new(items.to_vec()),
+                                    std::sync::Arc::new(items.to_vec().into()),
                                     crate::value::ArrayKind::List,
                                 ),
                                 other => Value::Array(
-                                    std::sync::Arc::new(vec![other]),
+                                    std::sync::Arc::new(vec![other].into()),
                                     crate::value::ArrayKind::List,
                                 ),
                             }
                         }
                     }
                     other => Value::Array(
-                        std::sync::Arc::new(vec![other]),
+                        std::sync::Arc::new(vec![other].into()),
                         crate::value::ArrayKind::List,
                     ),
                 }
@@ -5392,7 +5398,7 @@ impl VM {
                     shaped_items.resize(shape[0], Value::Nil);
                 }
                 assigned = Value::Array(
-                    std::sync::Arc::new(shaped_items),
+                    std::sync::Arc::new(shaped_items.into()),
                     crate::value::ArrayKind::Shaped,
                 );
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(&shape));
@@ -5455,7 +5461,7 @@ impl VM {
                     .iter()
                     .map(|v| if is_hole(v) { def.clone() } else { v.clone() })
                     .collect();
-                val = Value::Array(Arc::new(replaced), kind);
+                val = Value::Array(Arc::new(replaced.into()), kind);
             }
         }
         // Skip typed container coercion for `:=` binding — it would create
@@ -6475,8 +6481,8 @@ impl VM {
 
         let key_list = match keys {
             Value::Array(items, ..) => items,
-            Value::Seq(items) => Arc::new(items.to_vec()),
-            _ => Arc::new(vec![keys]),
+            Value::Seq(items) => items,
+            _ => crate::value::Value::array_arc(vec![keys]),
         };
 
         let mut current = target;

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -80,7 +80,7 @@ impl VM {
             // A user-declared type named `Empty` shadows the empty-Slip term
             // (it is resolved to a Package by the `has_type` branch below).
             // `Inf`/`NaN` are numeric literals and are not shadowable.
-            Value::Slip(std::sync::Arc::new(vec![]))
+            Value::Slip(std::sync::Arc::new(vec![].into()))
         } else if name == "GLOBALish" {
             // GLOBALish is the per-compunit alias for the GLOBAL package.
             Value::Package(Symbol::intern("GLOBAL"))

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -241,7 +241,7 @@ impl VM {
         }
         match source {
             Value::Array(_, kind) if kind.is_real_array() => Value::array(items),
-            _ => Value::Seq(Arc::new(items)),
+            _ => Value::Seq(Arc::new(items.into())),
         }
     }
 
@@ -715,7 +715,7 @@ impl VM {
                     let end = end.min(items.len().saturating_sub(1));
                     items[start..=end].to_vec()
                 };
-                Value::Seq(Arc::new(slice))
+                Value::Seq(Arc::new(slice.into()))
             }
             (Value::Seq(items), Value::RangeExcl(a, b)) => {
                 let start = a.max(0) as usize;
@@ -730,7 +730,7 @@ impl VM {
                         items[start..end_excl].to_vec()
                     }
                 };
-                Value::Seq(Arc::new(slice))
+                Value::Seq(Arc::new(slice.into()))
             }
             // WhateverCode index on Seq: (1,2,3).Seq[*-1]
             (Value::Seq(items), Value::Sub(ref data)) => {
@@ -1601,7 +1601,7 @@ impl VM {
             // Role parameterization: e.g. R1[C1] → ParametricRole
             (Value::Package(name), idx) if self.interpreter.is_role(&name.resolve()) => {
                 let type_args = match idx {
-                    Value::Array(items, ..) => items.as_ref().clone(),
+                    Value::Array(items, ..) => items.as_ref().to_vec(),
                     other => vec![other],
                 };
                 Value::ParametricRole {
@@ -1620,7 +1620,7 @@ impl VM {
             (Value::Package(name), idx) => {
                 let type_args = match idx {
                     Value::Array(items, ..) => items.as_ref().clone(),
-                    other => vec![other],
+                    other => vec![other].into(),
                 };
                 let args = type_args
                     .into_iter()
@@ -1803,7 +1803,7 @@ impl VM {
     /// to a sublist (slice). Returns `None` if the index is not a range.
     pub(super) fn resolve_range_index_slice(
         idx: &Value,
-        items: &std::sync::Arc<Vec<Value>>,
+        items: &std::sync::Arc<crate::value::ArrayData>,
         kind: crate::value::ArrayKind,
         _len: i64,
         vm: &mut VM,

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -148,7 +148,7 @@ impl VM {
 
     pub(super) fn resolve_array_entry(
         &self,
-        items: &Arc<Vec<Value>>,
+        items: &Arc<crate::value::ArrayData>,
         kind: ArrayKind,
         idx: usize,
         default: Value,


### PR DESCRIPTION
## What

Introduce `ArrayData { items, value_type, declared_type }` as the backing store for all list-like `Value` variants (`Array`, `Seq`, `HyperSeq`, `RaceSeq`, `Slip`) and `ArraySlotRef`, replacing the bare `Arc<Vec<Value>>`. `ArrayData` `Deref`/`DerefMut`s to the inner `Vec<Value>`, so the overwhelming majority of read/mutate sites are unchanged; only structural sites (construction, `Arc::as_ptr` interior mutation, explicit type annotations, `PtrKeyedMap` generics) are touched.

## Why

This is the mechanical foundation (mirrors HashData Stage 1a from #2952) for the **last** Arc-pointer-keyed side-table removal called out in PLAN.md Q2: embedding array container type metadata IN the value so it travels with COW, then deleting the `array_type_metadata` side table — the final intermittent Arc-pointer-identity flaky source.

**This PR is behavior-preserving.** The metadata fields exist but are NOT yet wired: `array_type_metadata` / `array_defaults` / shaped-array / grep-view `PtrKeyedMap`s remain authoritative. Stage 1b wires the fields and deletes the type-metadata side table.

## Critical detail (per the HashData layout-UB lesson)

Every `Arc::as_ptr(..) as *mut Vec<Value>` interior-mutation site was retargeted to `*mut ArrayData` (ops auto-deref through `DerefMut`); the two whole-Vec replacement sites (`*ptr = combined`, `Arc::new(new_items)`) operate on `.items` explicitly. `seq_*` lazy/cached/consumed pointer tracking and the PtrKeyedMaps now key on `Arc<ArrayData>` — pointer identity is preserved.

## Testing

- `make test` (727 files, 6588 tests) green.
- Whitelisted array/set/bag/mix/typed-array/seq/gather/range tests pass locally.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)