### PR TITLE
feat(deepmap): pass leaves as containers; mutations write through (Stage 2)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2263,6 +2263,27 @@ impl Interpreter {
         self.deepmap_iterate_inner(block, target, false)
     }
 
+    /// Call the deepmap block on a leaf element through a transient
+    /// `ContainerRef` cell, so a mutating callable (`++*`, `*--`, `$_++`)
+    /// writes through — Raku's `deepmap` passes each leaf as a *container*
+    /// and mutations are visible in the source structure. Returns the
+    /// block's (decontainerized) result plus the cell's post-call value for
+    /// the caller to write back into the source slot.
+    fn deepmap_leaf_call(
+        &mut self,
+        block: &Value,
+        leaf: &Value,
+    ) -> Result<(Value, Value), RuntimeError> {
+        let cell = std::sync::Arc::new(std::sync::Mutex::new(leaf.clone()));
+        let res = self.call_sub_value(
+            block.clone(),
+            vec![Value::ContainerRef(cell.clone())],
+            false,
+        )?;
+        let new_val = cell.lock().unwrap().clone();
+        Ok((res.deref_container(), new_val))
+    }
+
     /// Inner recursive helper. `itemize_result` is true for nested calls
     /// so that sublists get wrapped in Scalar containers.
     fn deepmap_iterate_inner(
@@ -2281,7 +2302,34 @@ impl Interpreter {
                 // `[1,[2,3]].deepmap(*+1)` -> `[2, [3, 4]]`.
                 let child_itemize = !kind.is_real_array();
                 let mut result = Vec::new();
-                for item in items.iter() {
+                for (idx, item) in items.iter().enumerate() {
+                    let is_leaf = !matches!(
+                        item,
+                        Value::Package(_) | Value::Array(..) | Value::Seq(_) | Value::Hash(_)
+                    );
+                    if is_leaf {
+                        match self.deepmap_leaf_call(block, item) {
+                            Ok((v, new_src)) => {
+                                if new_src != *item {
+                                    // Write the mutated leaf back into the
+                                    // source array in place so all holders of
+                                    // the Arc see it (Raku container
+                                    // semantics). SAFETY: mutsu is
+                                    // single-threaded; same pattern as the
+                                    // other interior-mutation sites.
+                                    let ptr = std::sync::Arc::as_ptr(items)
+                                        as *mut crate::value::ArrayData;
+                                    unsafe {
+                                        (&mut *ptr).items[idx] = new_src;
+                                    }
+                                }
+                                result.push(v);
+                            }
+                            Err(e) if e.is_next => continue,
+                            Err(e) => return Err(e),
+                        }
+                        continue;
+                    }
                     match self.deepmap_iterate_inner(block, item, child_itemize) {
                         Ok(v) => result.push(v),
                         Err(e) if e.is_next => continue,
@@ -2335,6 +2383,31 @@ impl Interpreter {
             Value::Hash(map) => {
                 let mut result = std::collections::HashMap::new();
                 for (k, v) in map.iter() {
+                    let is_leaf = !matches!(
+                        v,
+                        Value::Package(_) | Value::Array(..) | Value::Seq(_) | Value::Hash(_)
+                    );
+                    if is_leaf {
+                        match self.deepmap_leaf_call(block, v) {
+                            Ok((Value::Slip(items), _)) if items.is_empty() => continue,
+                            Ok((val, new_src)) => {
+                                if new_src != *v {
+                                    // Write the mutated leaf back into the
+                                    // source hash in place (see the Array arm).
+                                    // SAFETY: mutsu is single-threaded.
+                                    let ptr =
+                                        std::sync::Arc::as_ptr(map) as *mut crate::value::HashData;
+                                    unsafe {
+                                        (&mut *ptr).map.insert(k.clone(), new_src);
+                                    }
+                                }
+                                result.insert(k.clone(), val);
+                            }
+                            Err(e) if e.is_next => continue,
+                            Err(e) => return Err(e),
+                        }
+                        continue;
+                    }
                     match self.deepmap_iterate_inner(block, v, true) {
                         Ok(Value::Slip(items)) if items.is_empty() => {
                             // Empty slip means the block returned Empty;
@@ -2350,8 +2423,9 @@ impl Interpreter {
                 }
                 Ok(Value::Hash(Value::hash_arc(result)))
             }
-            // Leaf value: apply the block
-            _ => self.call_sub_value(block.clone(), vec![target.clone()], false),
+            // Leaf value: apply the block (through a transient container so
+            // mutating callables write through to a bare top-level leaf too).
+            _ => self.deepmap_leaf_call(block, target).map(|(v, _)| v),
         }
     }
 

--- a/t/deepmap-container.t
+++ b/t/deepmap-container.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 16;
+
+# deepmap passes each leaf as a container: a mutating callable writes
+# through to the source structure (hyper.t 330-333 regression tests).
+
+{
+    my @a = (1, { a => 2, b => 3 }, 4);
+    my @r = @a.deepmap(++*);
+    is @r[0], 2, 'prefix ++ result: plain element';
+    is @r[1]<a>, 3, 'prefix ++ result: hash value';
+    is @r[2], 5, 'prefix ++ result: trailing element';
+    is @a[0], 2, 'prefix ++ mutates source: plain element';
+    is @a[1]<a>, 3, 'prefix ++ mutates source: hash value';
+    is @a[1]<b>, 4, 'prefix ++ mutates source: hash value b';
+    is @a[2], 5, 'prefix ++ mutates source: trailing element';
+}
+
+{
+    my @a = (10, { x => 20 });
+    my @r = @a.deepmap(*--);
+    is @r[0], 10, 'postfix -- returns old value';
+    is @r[1]<x>, 20, 'postfix -- returns old hash value';
+    is @a[0], 9, 'postfix -- mutates source';
+    is @a[1]<x>, 19, 'postfix -- mutates source hash value';
+}
+
+{
+    # Nested arrays mutate through too.
+    my @a = [1, [2, 3]];
+    @a.deepmap(++*);
+    is @a[0], 2, 'nested: top element mutated';
+    is @a[1][0], 3, 'nested: inner element mutated';
+}
+
+{
+    # Non-mutating blocks still work and do NOT touch the source.
+    my @a = (1, { a => 2 }, 4);
+    my @r = @a.deepmap(-*);
+    is @r[0], -1, 'pure block result';
+    is @a[0], 1, 'pure block leaves source untouched';
+    # A block returning its argument must not leak a container.
+    my @s = @a.deepmap({ $_ });
+    is @s[0], 1, 'identity block returns plain value';
+}


### PR DESCRIPTION
## Summary

container-identity Stage 2, slice 1: Raku's `deepmap` passes each leaf element as a **container**, so a mutating callable (`++*`, `*--`, `$_++`) writes through to the source structure. mutsu passed plain values — `@a.deepmap(++*)` produced the right result list but left the source untouched, which is exactly why `hyper.t` 330-333 failed (the `*--` group depends on the preceding `++*` having mutated the source).

## Changes

- Each leaf call goes through a transient `ContainerRef` cell (the Phase 2 element-cell read/write chokepoints make the cell transparent to the callable); after the call, the cell's value is written back into the source Array/Hash slot in place (single-threaded interior-mutation house pattern).
- The block result is decontainerized, so an identity block (`{ $_ }`) cannot leak the cell into the result.
- The cell is transient — nothing persists in the source structure (no "cells everywhere" leak).

## Verification

- `hyper.t`: 12 → 9 failures (330-333 fixed; the remaining 9 are unrelated nodal/callable features)
- New `t/deepmap-container.t` (16 tests, output verified against raku — including source mutation, postfix old-value semantics, nested arrays, pure blocks leaving the source untouched, and identity-block non-leak)
- `make test` 727 files / 6588 PASS; whitelisted `S32-list/deepmap.t` + `duckmap.t` + `t/deepmap-nodemap-nodal.t` + `S15-nfg/concat-stable.t` PASS; `element-bind-cell` / `nested.t` / `let.t` PASS; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)