### PR TITLE
refactor(array): embed shaped-array dims in ArrayData, delete ShapedArrayIds side table

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -82,12 +82,6 @@ pub(crate) fn make_empty_array_failure_what(op: &str, what: &str) -> Value {
 }
 type GrepViewBinding = (Arc<crate::value::ArrayData>, Vec<usize>, ArrayKind);
 type GrepViewMap = PtrKeyedMap<crate::value::ArrayData, GrepViewBinding>;
-type ShapedArrayIds = PtrKeyedMap<crate::value::ArrayData, Vec<usize>>;
-
-fn shaped_array_ids() -> &'static Mutex<ShapedArrayIds> {
-    static SHAPED_ARRAY_IDS: OnceLock<Mutex<ShapedArrayIds>> = OnceLock::new();
-    SHAPED_ARRAY_IDS.get_or_init(|| Mutex::new(PtrKeyedMap::new()))
-}
 
 /// Embed original (non-string) keys for an object hash into its `HashData`,
 /// returning the (possibly rebuilt) value. The map travels WITH the hash
@@ -130,10 +124,6 @@ fn grep_view_bindings() -> &'static Mutex<GrepViewMap> {
     GREP_VIEW_BINDINGS.get_or_init(|| Mutex::new(PtrKeyedMap::new()))
 }
 
-fn shaped_array_key(items: &Arc<crate::value::ArrayData>) -> usize {
-    crate::runtime::ptr_keyed::ptr_key(items)
-}
-
 pub(crate) fn register_grep_view_binding(
     filtered: &Arc<crate::value::ArrayData>,
     source: &Arc<crate::value::ArrayData>,
@@ -171,7 +161,6 @@ pub(crate) fn shaped_array_shape(value: &Value) -> Option<Vec<usize>> {
     if *kind != ArrayKind::Shaped {
         return None;
     }
-    let key = shaped_array_key(items);
 
     fn shape_matches_structure(value: &Value, shape: &[usize]) -> bool {
         if shape.is_empty() {
@@ -195,15 +184,16 @@ pub(crate) fn shaped_array_shape(value: &Value) -> Option<Vec<usize>> {
         return None;
     }
 
-    fn infer_shape_from_array(items: &[Value], ids: &ShapedArrayIds) -> Option<Vec<usize>> {
+    // Infer this array's shape from its children's embedded shapes.
+    fn infer_shape_from_array(items: &[Value]) -> Option<Vec<usize>> {
         let first = items.first()?;
         let Value::Array(first_items, ..) = first else {
             return None;
         };
-        let first_shape = ids.get(shaped_array_key(first_items))?;
+        let first_shape = first_items.shape.as_ref()?;
         if !items.iter().all(|child| {
             if let Value::Array(child_items, ..) = child {
-                ids.get(shaped_array_key(child_items)) == Some(first_shape)
+                child_items.shape.as_ref() == Some(first_shape)
             } else {
                 false
             }
@@ -216,21 +206,19 @@ pub(crate) fn shaped_array_shape(value: &Value) -> Option<Vec<usize>> {
         Some(shape)
     }
 
-    let ids = shaped_array_ids().lock().ok()?;
-    let cached_shape = ids.get(key).cloned();
-    if let Some(cached_shape) = cached_shape
-        && shape_matches_structure(value, &cached_shape)
+    // Prefer the shape embedded on this array's `ArrayData`, validated against
+    // the current element structure (a stale cached shape after restructuring
+    // is rejected and re-inferred).
+    if let Some(cached_shape) = &items.shape
+        && shape_matches_structure(value, cached_shape)
     {
-        return Some(cached_shape);
+        return Some(cached_shape.clone());
     }
-    let inferred_shape = infer_shape_from_array(items.as_ref(), &ids)?;
+    let inferred_shape = infer_shape_from_array(items.as_ref())?;
     if !shape_matches_structure(value, &inferred_shape) {
         return None;
     }
-    drop(ids);
-    if let Ok(mut ids) = shaped_array_ids().lock() {
-        ids.insert(items, inferred_shape.clone());
-    }
+    mark_shaped_array_items(items, Some(&inferred_shape));
     Some(inferred_shape)
 }
 
@@ -245,17 +233,20 @@ pub(crate) fn mark_shaped_array_items(
     items: &Arc<crate::value::ArrayData>,
     shape: Option<&[usize]>,
 ) {
-    if shape.is_none() {
+    let Some(shape) = shape else {
+        return;
+    };
+    if items.shape.as_deref() == Some(shape) {
         return;
     }
-    let key = shaped_array_key(items);
-    if let Ok(mut ids) = shaped_array_ids().lock() {
-        if let Some(current_shape) = ids.get(key)
-            && shape.is_some_and(|s| current_shape.as_slice() == s)
-        {
-            return;
-        }
-        ids.insert(items, shape.unwrap_or(&[]).to_vec());
+    // SAFETY: mutsu is single-threaded. The shape is metadata about this one
+    // logical array, shared by every holder of the `Arc` — matching the prior
+    // pointer-keyed side-table semantics (any holder of the same pointer saw
+    // the shape). Interior mutation preserves "mark after the array Value is
+    // already placed" without requiring a write-back through the caller.
+    let ptr = Arc::as_ptr(items) as *mut crate::value::ArrayData;
+    unsafe {
+        (*ptr).shape = Some(shape.to_vec());
     }
 }
 
@@ -695,10 +686,7 @@ const MAX_ARRAY_EXPAND: i64 = 100_000;
 
 pub(crate) fn coerce_to_array(value: Value) -> Value {
     fn metadata_shape_for_items(items: &Arc<crate::value::ArrayData>) -> Option<Vec<usize>> {
-        shaped_array_ids()
-            .lock()
-            .ok()
-            .and_then(|ids| ids.get_arc(items).cloned())
+        items.shape.clone()
     }
 
     match value {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1354,6 +1354,11 @@ pub struct ArrayData {
     /// whenever the backing Arc was rebuilt), and so pure value-level code
     /// (e.g. the Array→Slip coercion materializing holes) can read it.
     pub default: Option<Box<Value>>,
+    /// Dimensions of a shaped (multidimensional) array (`my @a[2;3]`). `Some`
+    /// only on `ArrayKind::Shaped` arrays. Embedded (replacing the former
+    /// `Arc::as_ptr`-keyed `ShapedArrayIds` side table) so the shape travels
+    /// with the container through copy-on-write.
+    pub shape: Option<Vec<usize>>,
 }
 
 impl ArrayData {
@@ -1364,6 +1369,7 @@ impl ArrayData {
             key_type: None,
             declared_type: None,
             default: None,
+            shape: None,
         }
     }
 
@@ -2703,6 +2709,7 @@ impl Value {
             key_type: like.key_type.clone(),
             declared_type: like.declared_type.clone(),
             default: like.default.clone(),
+            shape: like.shape.clone(),
         })
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)


### PR DESCRIPTION
## What

Move multidimensional-array shape (`my @a[2;3]`) from the `Arc::as_ptr`-keyed `ShapedArrayIds` side table into a new `ArrayData.shape: Option<Vec<usize>>` field, completing the array-metadata embedding started in #2962 (type metadata + `is default`). This deletes the **last shaped-array Arc-pointer-keyed table**.

## Why

The shape now travels WITH the container through copy-on-write (it is `Clone`d into rebuilds via `array_data_like`), eliminating the pointer-identity fragility that the Weak-guard in #2953 only *contained*. Measures the north-star directly: one more Arc-ptr special-case mechanism deleted.

## How (minimal blast radius)

The public API (`is_shaped_array` / `shaped_array_shape` / `mark_shaped_array` / `mark_shaped_array_items`) is unchanged, so all ~85 call sites are untouched — only four internal helpers in `runtime/utils.rs` are rewritten:

- `shaped_array_shape` reads the embedded `items.shape`, validated against the current element structure (a stale shape after restructuring is rejected and re-inferred).
- `infer_shape_from_array` reads children's embedded `.shape` instead of the global table.
- `mark_shaped_array_items` interior-mutates `items.shape` via the existing single-threaded `Arc::as_ptr as *mut ArrayData` pattern (same "mark after the array Value is placed" semantics as the side table, no caller write-back).
- `coerce_to_array`'s `metadata_shape_for_items` reads `items.shape`.

## Testing

- Shaped 1-D/2-D/3-D indexing, `.shape`, and copy-preserves-shape all match `raku`.
- `make test` (727 files, 6588 tests) green.
- Whitelisted `S09-typed-arrays/*` + `multidimensional.t` + `multidim-assignment.t` pass.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)