### PR TITLE
feat(parser): X::Syntax::Term::MissingInitializer for sigilless term decl without initializer

### DIFF
--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -5,7 +5,7 @@ use super::super::{keyword, qualified_ident};
 use super::constant_subset::constant_decl;
 use super::helpers::{parse_sigilless_decl_name, register_term_symbol_from_decl_name};
 use super::my_decl_assign::parse_colon_args;
-use super::{parse_decl_type_constraint, parse_statement_modifier, typed_default_expr};
+use super::{parse_decl_type_constraint, parse_statement_modifier};
 use crate::ast::{Expr, Stmt};
 use crate::symbol::Symbol;
 use crate::value::Value;
@@ -129,22 +129,18 @@ pub(super) fn parse_sigilless_decl(
         }
         return Ok((r, stmt));
     }
-    Ok((
-        r,
-        Stmt::VarDecl {
-            name,
-            expr: type_constraint
-                .as_deref()
-                .map_or(Expr::Literal(Value::Nil), typed_default_expr),
-            type_constraint,
-            is_state,
-            is_our,
-            is_dynamic: false,
-            is_export: false,
-            export_tags: Vec::new(),
-            custom_traits: Vec::new(),
-            where_constraint: None,
-        },
+    // A sigilless term declaration (`my \foo`) requires an initializer; there
+    // is no implicit default like a sigilled variable has. rakudo rejects this
+    // at compile time with X::Syntax::Term::MissingInitializer.
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert(
+        "message".to_string(),
+        Value::str("Term definition requires an initializer".to_string()),
+    );
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Term::MissingInitializer"), attrs);
+    Err(PError::fatal_with_exception(
+        "Term definition requires an initializer".to_string(),
+        Box::new(ex),
     ))
 }
 


### PR DESCRIPTION
## What

A sigilless term declaration must have an initializer (`my \foo = expr` / `:=` / `::=` / `.=`); unlike a sigilled variable it has no implicit default. `my \foo` with **no** initializer now raises a compile-time `X::Syntax::Term::MissingInitializer` (message *\"Term definition requires an initializer\"*), matching rakudo. Previously mutsu silently accepted it as a Nil-initialized term.

## How

The no-initializer fallthrough in `parse_sigilless_decl` now returns `PError::fatal_with_exception` carrying an `X::Syntax::Term::MissingInitializer` instance — the same typed-parse-error mechanism `has_decl.rs` already uses for `X::Syntax::Variable::MissingInitializer` (`:D` attribute without default). The exception type was already registered. All initializer forms (`=`, `:=`, `::=`, `.=`, with or without a type constraint) are unaffected.

## Testing

- Fixes `S32-exceptions/misc.t` test 32.
- `my \foo = 5`, `my \foo := $x`, `my Int \foo = 3` all still work; `my \foo` errors.
- `make test` (728 files, 6604 tests) green.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)