### PR TITLE
feat(exceptions): populate X::TypeCheck::Argument fields on proto dispatch failure

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1306,8 +1306,39 @@ impl Interpreter {
                             .collect::<Vec<_>>()
                             .join(", ")
                     ));
+                    let signature = format!(
+                        "({})",
+                        def.param_defs
+                            .iter()
+                            .map(|p| {
+                                // Type-only params (`Str`) carry a synthetic name;
+                                // render just the type constraint.
+                                if p.name.starts_with("__") {
+                                    return p
+                                        .type_constraint
+                                        .as_deref()
+                                        .unwrap_or("Any")
+                                        .to_string();
+                                }
+                                if let Some(tc) = &p.type_constraint {
+                                    format!("{} {}", tc, p.name)
+                                } else {
+                                    p.name.clone()
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
                     let mut attrs = std::collections::HashMap::new();
                     attrs.insert("message".to_string(), Value::str(err.message.clone()));
+                    attrs.insert("objname".to_string(), Value::str(proto_name.to_string()));
+                    attrs.insert("signature".to_string(), Value::str(signature));
+                    attrs.insert(
+                        "arguments".to_string(),
+                        Value::array(type_names.iter().cloned().map(Value::str).collect()),
+                    );
+                    // This dispatch failure is against a `proto` signature.
+                    attrs.insert("protoguilt".to_string(), Value::Bool(true));
                     err.exception = Some(Box::new(Value::make_instance(
                         Symbol::intern("X::TypeCheck::Argument"),
                         attrs,


### PR DESCRIPTION
## What

When a `proto` sub rejects a call (`proto sub foo(Str) {*}; foo 42`), the resulting `X::TypeCheck::Argument` now carries the standard accessor fields — `protoguilt` (True, since the failure is against a proto signature), `objname`, `signature` (type-only params render as just their type, e.g. `(Str)`), and `arguments` — in addition to the existing `message`. Previously only `message` was set, so `.protoguilt`/`.signature`/`.arguments` read as Nil.

## Testing

- Fixes `S32-exceptions/misc.t` test 10 (**43 → 44**).
- `make test` (729 files, 6623 tests) green; whitelisted proto/multi roast tests pass.
- `cargo clippy -- -D warnings` clean.

## Follow-up (documented, not in this PR)

The regular-sub VM fast path (`vm_call_dispatch.rs`) and the missing-required-arg case still throw `X::TypeCheck::Argument` without these fields (misc.t tests 11/13). Fixing those needs threading the callee name through the VM dispatch path and unifying the 3-4 construction sites behind one shared helper — a deliberate anti-duplication follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)