### PR TITLE
feat(exceptions): X::TypeCheck::Argument fields + mandatory-positional check on VM light path

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,10 +125,14 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 42/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 44/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: X::Undeclared now carries `post` and `highexpect` attributes, so the bare-`$k`
     case (`throws-like '$k', X::Undeclared, post => '$k', highexpect => &not`) passes.
+  - Done: X::TypeCheck::Argument now carries `objname`/`signature`/`arguments` from the VM
+    positional-light dispatch path (type-mismatch AND missing-mandatory-positional). The
+    light path now enforces mandatory positionals (`sub f($x){}; f()` throws) and shares a
+    `type_check_argument_attrs` helper with `Interpreter::enhance_binding_error`.
   - Major remaining blockers (each is a distinct feature, not specific to this file):
     - mutsu does NOT do compile-time undeclared-symbol checking for normal (non-EVAL)
       programs: `say $undeclared` just yields Nil instead of throwing X::Undeclared /

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -461,20 +461,12 @@ impl Interpreter {
         Ok(())
     }
 
-    /// Enhance a binding error with function name, call profile, and signature info.
-    pub(crate) fn enhance_binding_error(
-        err: RuntimeError,
-        func_name: &str,
-        param_defs: &[crate::ast::ParamDef],
-        args: &[Value],
-    ) -> RuntimeError {
-        // Don't enhance errors that are already enhanced or are control flow
-        if err.is_return || err.is_last || err.is_next || func_name.is_empty() {
-            return err;
-        }
-        // Build call profile: func_name(Type1, Type2, ...)
-        let arg_types: Vec<String> = args
-            .iter()
+    /// Build the positional/named argument type-name list used for the
+    /// `arguments` attribute of `X::TypeCheck::Argument` (and call profiles).
+    /// Skips the internal callsite-line pair and all named (Pair) arguments,
+    /// matching Rakudo's `.arguments` which lists only positional argument types.
+    pub(crate) fn arg_type_names(args: &[Value]) -> Vec<String> {
+        args.iter()
             .filter(|a| {
                 !matches!(
                     a,
@@ -483,10 +475,13 @@ impl Interpreter {
             })
             .filter(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
             .map(|a| super::value_type_name(a).to_string())
-            .collect();
-        let call_profile = format!("{}({})", func_name, arg_types.join(", "));
+            .collect()
+    }
 
-        // Build signature string: (Type $name, ...)
+    /// Build the Raku signature string `(Type $name, ...)` from parameter
+    /// definitions, used for the `signature` attribute of
+    /// `X::TypeCheck::Argument` and in enhanced error messages.
+    pub(crate) fn build_signature_string(param_defs: &[crate::ast::ParamDef]) -> String {
         let sig_parts: Vec<String> = param_defs
             .iter()
             .filter(|pd| !pd.traits.iter().any(|t| t == "invocant"))
@@ -517,7 +512,26 @@ impl Interpreter {
                 }
             })
             .collect();
-        let signature = format!("({})", sig_parts.join(", "));
+        format!("({})", sig_parts.join(", "))
+    }
+
+    /// Enhance a binding error with function name, call profile, and signature info.
+    pub(crate) fn enhance_binding_error(
+        err: RuntimeError,
+        func_name: &str,
+        param_defs: &[crate::ast::ParamDef],
+        args: &[Value],
+    ) -> RuntimeError {
+        // Don't enhance errors that are already enhanced or are control flow
+        if err.is_return || err.is_last || err.is_next || func_name.is_empty() {
+            return err;
+        }
+        // Build call profile: func_name(Type1, Type2, ...)
+        let arg_types: Vec<String> = Self::arg_type_names(args);
+        let call_profile = format!("{}({})", func_name, arg_types.join(", "));
+
+        // Build signature string: (Type $name, ...)
+        let signature = Self::build_signature_string(param_defs);
 
         // Enhance the error message, preserving the original for exception type matching
         let enhanced_msg = format!(

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -816,29 +816,60 @@ impl VM {
     /// callable_id lookup, and full bind_function_args_values. Parameters are
     /// bound directly to pre-computed local slots AND written to env so that
     /// closures and dynamic lookups work correctly.
+    /// Build the common `X::TypeCheck::Argument` attribute map (message,
+    /// objname, signature, arguments) shared by the positional-light arity and
+    /// type-mismatch error paths. Type-mismatch callers additionally insert
+    /// `expected`/`got`. Mirrors the interpreter path in
+    /// `Interpreter::enhance_binding_error`.
+    fn type_check_argument_attrs(
+        func_name: &str,
+        param_defs: &[crate::ast::ParamDef],
+        args: &[Value],
+        message: String,
+    ) -> std::collections::HashMap<String, Value> {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message));
+        attrs.insert("objname".to_string(), Value::str(func_name.to_string()));
+        attrs.insert(
+            "signature".to_string(),
+            Value::str(crate::runtime::Interpreter::build_signature_string(
+                param_defs,
+            )),
+        );
+        let arg_type_values: Vec<Value> = crate::runtime::Interpreter::arg_type_names(args)
+            .into_iter()
+            .map(Value::str)
+            .collect();
+        attrs.insert("arguments".to_string(), Value::array(arg_type_values));
+        attrs
+    }
+
     pub(super) fn call_compiled_function_positional_light(
         &mut self,
         cf: &CompiledFunction,
         args: &[Value],
         compiled_fns: &HashMap<String, CompiledFunction>,
+        func_name: &str,
     ) -> Result<Value, RuntimeError> {
         self.record_cf_deprecation(cf);
         let param_slots = cf.param_local_slots.as_ref().unwrap();
         let positional_count = param_slots.len();
         let actual_count = args.len();
 
+        // Every positional-light-eligible parameter is a mandatory positional
+        // (no default, optional `?`, or slurpy -- see
+        // `is_positional_light_call_eligible`), so any shortfall is a "too few
+        // positionals" arity error. Report it as a typed X::TypeCheck::Argument
+        // carrying objname/signature/arguments, matching the interpreter path.
         if actual_count < positional_count {
-            let required = cf
-                .param_defs
-                .iter()
-                .filter(|pd| !pd.named && pd.required)
-                .count();
-            if actual_count < required {
-                return Err(RuntimeError::new(format!(
-                    "Too few positionals passed; expected {} arguments but got {}",
-                    positional_count, actual_count
-                )));
-            }
+            let msg = format!(
+                "Too few positionals passed; expected {} arguments but got {}",
+                positional_count, actual_count
+            );
+            return Err(RuntimeError::typed(
+                "X::TypeCheck::Argument",
+                Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
+            ));
         }
 
         let saved_locals = std::mem::take(&mut self.locals);
@@ -896,10 +927,10 @@ impl VM {
                             "Type check failed in binding ${}: expected {}, got {}",
                             param_name, tc, got
                         );
-                        let mut attrs = std::collections::HashMap::new();
+                        let mut attrs =
+                            Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg);
                         attrs.insert("expected".to_string(), Value::str(tc.to_string()));
                         attrs.insert("got".to_string(), Value::str(got.to_string()));
-                        attrs.insert("message".to_string(), Value::str(msg.clone()));
                         return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
                     }
                 }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -129,6 +129,7 @@ impl VM {
                                 cf,
                                 &args,
                                 compiled_fns,
+                                name_str,
                             )?;
                             self.stack.push(result);
                             // Compiled path: positional_light's scoped-overlay
@@ -208,7 +209,12 @@ impl VM {
                         let result = if Self::is_light_call_eligible(&cf, name_str) {
                             self.call_compiled_function_light(&cf, args, compiled_fns)
                         } else if Self::is_positional_light_call_eligible(&cf, name_str) {
-                            self.call_compiled_function_positional_light(&cf, &args, compiled_fns)
+                            self.call_compiled_function_positional_light(
+                                &cf,
+                                &args,
+                                compiled_fns,
+                                name_str,
+                            )
                         } else {
                             let pkg = self.current_package().to_string();
                             self.interpreter.push_samewith_context(name_str, None);
@@ -710,7 +716,7 @@ impl VM {
                         }
                     }
                     let result =
-                        self.call_compiled_function_positional_light(cf, &args, compiled_fns);
+                        self.call_compiled_function_positional_light(cf, &args, compiled_fns, name);
                     return self.interpreter.maybe_fetch_rw_proxy(result?, true);
                 }
                 // Try light call path for simple functions in tight loops.


### PR DESCRIPTION
## Summary

The VM positional-light dispatch path threw `X::TypeCheck::Argument` for a parameter type mismatch but populated only `expected`/`got`/`message`, so `.signature`/`.objname`/`.arguments` came back `Nil`. It also did **not** enforce mandatory positional parameters at all: `sub f($x){}; f()` silently ran with `$x` unbound, because the arity guard keyed on `pd.required` (true only for an explicit `!` suffix), which is never set for an ordinary mandatory positional.

Every positional-light-eligible parameter is a mandatory positional (no default/optional `?`/slurpy — see `is_positional_light_call_eligible`), so a shortfall is unambiguously a "too few positionals" arity error. We now throw it as a typed `X::TypeCheck::Argument` carrying `objname`/`signature`/`arguments`, and add the same fields to the type-mismatch path.

## Refactor

Both error paths share a new `type_check_argument_attrs` helper built on two reusable pieces extracted from `Interpreter::enhance_binding_error`:
- `build_signature_string(param_defs)` — `(Int \$x, Str \$y)`
- `arg_type_names(args)` — positional argument type names for `.arguments`

This removes the duplicated signature/arg-type formatting between the interpreter and VM dispatch paths.

## Impact

`roast/S32-exceptions/misc.t` 42 → 44 (the missing-mandatory-arg and two-arg-mismatch `X::TypeCheck::Argument` cases). `make test` green (730 files); whitelisted S06 (87 files) and S04/S32 spot-checks show no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)