### PR TITLE
fix(exceptions): missing required named parameter throws X::AdHoc, not bare Exception

### DIFF
--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -771,10 +771,14 @@ impl Interpreter {
                         bind_named_rename_sub_signature(self, sub_params, &Box::new(value))?;
                     }
                 } else if !found && pd.required {
-                    return Err(RuntimeError::new(format!(
-                        "Required named parameter '{}' not passed",
-                        pd.name
-                    )));
+                    // A missing required named parameter is a runtime X::AdHoc in
+                    // Raku (not the compile-time arity X::TypeCheck::Argument that
+                    // a missing positional yields). Carry the typed exception so it
+                    // surfaces as X::AdHoc instead of the bare "Exception" default.
+                    return Err(RuntimeError::typed_msg(
+                        "X::AdHoc",
+                        format!("Required named parameter '{}' not passed", pd.name),
+                    ));
                 } else if !found && !pd.name.is_empty() {
                     // Only bind a default if the env doesn't already have a value
                     // (e.g. BUILD/TWEAK attribute bindings pre-populate the env).

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -1235,10 +1235,13 @@ impl VM {
                     self.interpreter.set_env(caller_env);
                     self.locals = saved_locals;
                     self.env_dirty = saved_env_dirty;
-                    return Err(RuntimeError::new(format!(
-                        "Required named parameter '{}' not passed",
-                        param_name
-                    )));
+                    // Missing required named parameter is a runtime X::AdHoc in
+                    // Raku (see binding.rs); carry the typed exception so it does
+                    // not fall back to the bare "Exception" default.
+                    return Err(RuntimeError::typed_msg(
+                        "X::AdHoc",
+                        format!("Required named parameter '{}' not passed", param_name),
+                    ));
                 } else {
                     None
                 }

--- a/t/named-required-param-adhoc.t
+++ b/t/named-required-param-adhoc.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+# A missing required named parameter throws X::AdHoc at runtime (NOT the
+# compile-time arity X::TypeCheck::Argument that a missing positional yields).
+
+# Simple all-named sub (VM light-call path).
+{
+    my $ex;
+    sub f(:$x!) { }
+    try { f(); CATCH { default { $ex = $_ } } };
+    ok $ex.defined, 'missing required named param dies';
+    isa-ok $ex, X::AdHoc, 'it is an X::AdHoc';
+    is $ex.message, q{Required named parameter 'x' not passed}, 'message is correct';
+}
+
+# Typed named param (heavy bind path).
+{
+    my $ex;
+    sub g(Int :$x!) { }
+    try { g(); CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::AdHoc, 'typed required named param -> X::AdHoc';
+}
+
+# One of several required named params missing.
+{
+    my $ex;
+    sub h(:$x!, :$y!) { }
+    try { h(:x(1)); CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::AdHoc, 'second missing required named -> X::AdHoc';
+    is $ex.message, q{Required named parameter 'y' not passed}, 'names the missing param';
+}
+
+# A missing required *positional* is still X::TypeCheck::Argument (regression guard).
+{
+    my $ex;
+    sub p($x) { }
+    try { p(); CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::TypeCheck::Argument, 'missing positional -> X::TypeCheck::Argument';
+    is $ex.signature, '($x)', 'positional error carries .signature';
+}


### PR DESCRIPTION
## Summary

Follow-up to #2975. A missing required **named** parameter (`sub f(:\$x!){}; f()`) threw a plain `RuntimeError` carrying no exception object, so the `try`/`CATCH` fallback wrapped it in the generic `Exception` class:

```raku
sub f(:$x!) {}; try { f(); CATCH { default { say .^name; say .isa(X::AdHoc) } } }
# before: Exception / False
# after:  X::AdHoc / True   (matches Rakudo)
```

Rakudo reports `X::AdHoc` with message `Required named parameter 'x' not passed`.

This is the named-parameter analogue of the missing-positional gap fixed in #2975: there a missing **mandatory positional** became a typed `X::TypeCheck::Argument` (a compile-time-style arity error); a missing required **named** param is instead a runtime `X::AdHoc`. Both binding sites now carry the typed exception via `RuntimeError::typed_msg("X::AdHoc", ...)`:

- `runtime/types/binding.rs` — heavy `bind_function_args_values` path
- `vm/vm_call_dispatch.rs` — `call_compiled_function_light` (all-named subs)

## Tests

Adds `t/named-required-param-adhoc.t` (8 subtests) covering both binding paths, the multi-named case, and a regression guard that a missing **positional** stays `X::TypeCheck::Argument` with `.signature`.

`make test` green (731 files); whitelisted S06 (87) and S32-exceptions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)