### PR TITLE
fix(exceptions): untyped caught errors surface as X::AdHoc, not the abstract Exception

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -90,7 +90,9 @@ impl Interpreter {
                 let default_exception = || {
                     let mut attrs = std::collections::HashMap::new();
                     attrs.insert("message".to_string(), Value::str("Failed".to_string()));
-                    Value::make_instance(Symbol::intern("Exception"), attrs)
+                    // `Failure.new` with no explicit exception defaults to
+                    // X::AdHoc in Raku, not the abstract base Exception.
+                    Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
                 };
                 let raw_exception = args
                     .first()

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2760,7 +2760,11 @@ impl VM {
                         let bt_val = Self::backtrace_value_from_string(bt);
                         exc_attrs.insert("backtrace".to_string(), bt_val);
                     }
-                    Value::make_instance(Symbol::intern("Exception"), exc_attrs)
+                    // An untyped runtime error surfaces as X::AdHoc in Raku (the
+                    // class a bare `die "msg"` produces), not the abstract base
+                    // Exception. X::AdHoc IS-A Exception, so `throws-like
+                    // ..., Exception` / `isa-ok $!, Exception` still match.
+                    Value::make_instance(Symbol::intern("X::AdHoc"), exc_attrs)
                 };
                 let saved_topic = self.interpreter.env().get("_").cloned();
                 self.interpreter

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2888,7 +2888,8 @@ impl VM {
             } else {
                 let mut exc_attrs = std::collections::HashMap::new();
                 exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                Value::make_instance(crate::symbol::Symbol::intern("Exception"), exc_attrs)
+                // Untyped runtime error -> X::AdHoc (see vm_control_ops.rs).
+                Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), exc_attrs)
             };
             self.interpreter
                 .env_mut()
@@ -2945,7 +2946,8 @@ impl VM {
                 } else {
                     let mut exc_attrs = std::collections::HashMap::new();
                     exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                    Value::make_instance(crate::symbol::Symbol::intern("Exception"), exc_attrs)
+                    // Untyped runtime error -> X::AdHoc (see vm_control_ops.rs).
+                    Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), exc_attrs)
                 };
                 self.interpreter
                     .env_mut()

--- a/t/untyped-error-adhoc.t
+++ b/t/untyped-error-adhoc.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 9;
+
+# An untyped runtime error (one that mutsu raises without an attached typed
+# exception) surfaces as X::AdHoc -- the class a bare `die "msg"` produces in
+# Raku -- not the abstract base Exception. X::AdHoc IS-A Exception, so the
+# Exception-level checks must keep matching too.
+
+# Bare string die.
+{
+    my $ex;
+    try { die "boom"; CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::AdHoc, 'die "str" -> X::AdHoc';
+    isa-ok $ex, Exception, 'X::AdHoc IS-A Exception';
+    is $ex.message, 'boom', 'message preserved';
+}
+
+# Failure.new with no explicit exception.
+{
+    my $f = Failure.new;
+    isa-ok $f.exception, X::AdHoc, 'Failure.new default exception is X::AdHoc';
+}
+
+# A POST-style / phaser-visible $! also carries X::AdHoc.
+{
+    my $ex;
+    try {
+        die "in-block";
+        CATCH { default { $ex = $! } }
+    };
+    isa-ok $ex, X::AdHoc, '$! from untyped die is X::AdHoc';
+}
+
+# A *typed* error keeps its specific type (regression guard: the default must
+# only apply when no typed exception is attached).
+{
+    my $ex;
+    try { my Int $x = "nope"; CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::TypeCheck::Assignment, 'typed assignment error keeps its type';
+    nok $ex.isa(X::AdHoc), 'typed error is not downgraded to X::AdHoc';
+}
+
+# throws-like at the Exception level still matches an untyped die.
+throws-like { die "x" }, Exception, 'throws-like Exception matches untyped die';
+throws-like { die "x" }, X::AdHoc, 'throws-like X::AdHoc matches untyped die';


### PR DESCRIPTION
## Summary

When mutsu raised a runtime error **without** an attached typed exception (a plain `die "msg"`, or internal messages like "Required named parameter …"), the `try`/`CATCH` / phaser `$!` fallback — and `Failure.new`'s default exception — wrapped the message in the abstract base class `Exception`. Rakudo produces **`X::AdHoc`** for exactly these cases:

```raku
try { die "boom"; CATCH { default { say .^name } } }   # Raku: X::AdHoc
say Failure.new.exception.^name                          # Raku: X::AdHoc
```

`X::AdHoc` IS-A `Exception`, so `throws-like …, Exception` and `isa-ok $!, Exception` keep matching, while `isa-ok $!, X::AdHoc` / `throws-like …, X::AdHoc` now match as in Raku.

## Changes

All four untyped-error → exception-`Value` fallback sites:

- `vm/vm_control_ops.rs` — `try`/`CATCH` `$!` fallback (keeps line/backtrace attrs)
- `vm/vm_misc_ops.rs` ×2 — LEAVE/UNDO and POST phaser `$!` fallback
- `runtime/methods_dispatch_new.rs` — `Failure.new` default exception

The default only applies when no typed exception is attached, so typed errors (`X::TypeCheck::Assignment`, etc.) keep their specific class — covered by a regression guard.

## Tests

Adds `t/untyped-error-adhoc.t` (9 subtests): bare `die`, `Failure.new`, phaser-visible `$!`, the typed-error regression guard, and `throws-like` at both the `Exception` and `X::AdHoc` levels.

`make test` green (731 files). Exception/CATCH-heavy whitelist (94 files) and S12/S17/S03/S26 (324 files) pass — the only failure was the documented timing-flaky `S17-scheduler/every.t` (PASS/Fail-1/Fail-2 across reruns; no exception-class checks involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)