### PR TITLE
feat(concurrency): share thread-captured lexical cells across start blocks (Track C slice 1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -141,8 +141,19 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             **残の ptr-keyed（Weak-guard #2953 で防御中）**: container defaults・shaped dims・grep-view —
             ArrayData への後続埋め込み候補。レバー C 残（単一脱出/汎用捕捉）も合流。
 - [ ] **トラック C — 並行 / lever B（共有セル）** ＝ 並行（A と独立。要素セルは B と共有基盤なので B に弱依存）
-      - [ ] `clone_for_thread` のスナップショットコピー → 共有すべき lexical/state/global を `Arc<Mutex>` ライブセルへ
-            （ANALYSIS §8.3/§2.2。`start` 間で `$counter`/`state $n` 共有）。
+      - [~] `clone_for_thread` のスナップショットコピー → 共有すべき lexical/global を `ContainerRef`
+            （`Arc<Mutex<Value>>`）ライブセルへ（ANALYSIS §8.3/§2.2）。**スライス 1 LANDED**:
+            `start` で捕捉・変異される lexical scalar をエスケープ解析でセル化し、スレッド間で同一 Arc を共有。
+            ① `start` 引数を escaping position 化（`compile_call_arg_with_escape`）、
+            ② エスケープ信号をネストした非エスケープクロージャ越しに親へ伝播（`needs_cell_free_vars` —
+            `map { start { $outer++ } }` のような中間 map ブロック越しの捕捉を解く）、
+            ③ `++`/`--` を ContainerRef のロック保持下でアトミック RMW 化（`atomic_container_incdec` —
+            並列加算が lost-update しない。raku より決定的）、
+            ④ box 時に stale な `shared_vars` スナップショットをセルに張り替え
+            （mainline `start` 後の `sync_shared_vars_to_env` writeback がセルを clobber する回帰を防止）。
+            `await (^N).map: { start { $c++ } }` が正しく N を返す。テスト `t/concurrent-shared-cell.t`。
+            **残**: `state $n` のスレッド間共有（`state_vars`/`closure_captured_state` は clone_for_thread で
+            リセットされる別機構 — 次スライス）。`@`/`%` 共有・複合代入（`+=`）のアトミック化。
       - [ ] `run_react_event_loop[_drain]` を VM ネイティブ実行へ（react/supply の async 状態所有）。
       - [ ] **unsafe aliasing 撤廃**（ANALYSIS §2.3, `Arc::as_ptr as *mut` 11 箇所）— B の要素セル基盤の上で。
 

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -883,8 +883,13 @@ impl Compiler {
             } else {
                 let arity = args.len() as u32;
                 let arg_sources_idx = self.add_arg_sources_constant(args);
+                // `start { ... }` spawns a thread: its block argument outlives
+                // the call frame, so captured-and-mutated locals must become
+                // shared `ContainerRef` cells (escape analysis). Compile its
+                // args in an escaping position.
+                let escaping_args = name.resolve() == "start";
                 for arg in args {
-                    self.compile_call_arg(arg);
+                    self.compile_call_arg_with_escape(arg, escaping_args);
                 }
                 let name_idx = self.code.add_constant(Value::str(name.resolve()));
                 self.code.emit(OpCode::CallFunc {

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -162,11 +162,21 @@ impl Compiler {
     }
 
     pub(super) fn compile_call_arg(&mut self, arg: &Expr) {
-        // A call argument's value is passed to the callee, not stored in the
-        // caller frame, so a closure argument is conservatively NON-escaping
-        // (the #2746 guard: `map {...}` / `lives-ok {...}` must not box even when
-        // the whole call sits in an escaping position like `my @r = map {...}`).
-        self.with_escape(false, |c| {
+        self.compile_call_arg_with_escape(arg, false);
+    }
+
+    /// Like `compile_call_arg` but lets the caller force the argument into an
+    /// escaping position. Used for thread-spawning constructs (`start`) whose
+    /// block argument genuinely outlives the call frame (it is stored in a
+    /// Promise and run later on another thread), so the locals it captures and
+    /// mutates must be promoted to shared `ContainerRef` cells (escape analysis).
+    pub(super) fn compile_call_arg_with_escape(&mut self, arg: &Expr, escaping: bool) {
+        // A call argument's value is normally passed to the callee, not stored
+        // in the caller frame, so a closure argument is conservatively
+        // NON-escaping (the #2746 guard: `map {...}` / `lives-ok {...}` must not
+        // box even when the whole call sits in an escaping position like
+        // `my @r = map {...}`). `start` overrides this with `escaping = true`.
+        self.with_escape(escaping, |c| {
             c.with_suppress_pair_capture(true, |c| c.compile_expr(arg))
         });
         if Self::needs_decont(arg) {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1132,6 +1132,17 @@ pub(crate) struct CompiledCode {
     /// call args / control blocks) non-boxed, avoiding the broad-boxing
     /// perf/correctness regression (see #2749).
     pub(crate) needs_cell_locals: Vec<Symbol>,
+    /// Free variables (names NOT in this code's own locals) that must become a
+    /// shared `ContainerRef` cell in whichever *ancestor* frame declares them,
+    /// because they are captured-and-mutated by an ESCAPING closure somewhere in
+    /// this code's closure subtree. This bubbles the escape signal up through
+    /// intermediate NON-escaping closures (e.g. a `map {...}` block — itself an
+    /// immediately-invoked call arg — that contains `start { $outer++ }`): the
+    /// `start` escapes, so `$outer` needs a cell, but the enclosing `map` block
+    /// doesn't escape and would otherwise hide that requirement. The ancestor
+    /// that owns the local folds these into its own `needs_cell_locals`
+    /// (see `compute_free_vars`).
+    pub(crate) needs_cell_free_vars: Vec<Symbol>,
     /// True if this code contains any call opcode (function/method/closure
     /// invocation). Set during `emit()`. The closure exit-writeback skip uses
     /// this as the "is this a leaf closure" test: a non-leaf closure may have a
@@ -1164,6 +1175,7 @@ impl CompiledCode {
             free_var_writes: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
+            needs_cell_free_vars: Vec::new(),
             has_calls: false,
         }
     }
@@ -1464,14 +1476,37 @@ impl CompiledCode {
         let mut captured_mutated: std::collections::HashSet<Symbol> =
             std::collections::HashSet::new();
         let mut needs_cell: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        // Free vars that must be cells in an ancestor (escape bubbling up through
+        // this frame's NON-escaping closures — see `needs_cell_free_vars`).
+        let mut needs_cell_free: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
         for (i, nested) in self.closure_compiled_codes.iter().enumerate() {
             let escapes = self.closure_escapes.get(i).copied().unwrap_or(false);
             for sym in &nested.free_var_syms {
-                if sym.with_str(|s| own.contains(s)) && self_mutated.contains(sym) {
+                let is_own = sym.with_str(|s| own.contains(s));
+                if is_own && self_mutated.contains(sym) {
                     captured_mutated.insert(*sym);
                     if escapes {
                         needs_cell.insert(*sym);
                     }
+                }
+                // An escaping child closure that captures-and-mutates a var which
+                // is NOT our local: that var needs a cell in the ancestor that
+                // owns it. Bubble it up. (Mutation is checked against the union
+                // of free-var writes folded in above.)
+                if escapes && !is_own && free_writes.contains(sym) {
+                    needs_cell_free.insert(*sym);
+                }
+            }
+            // Bubble cell requirements that originated deeper in the subtree.
+            for sym in &nested.needs_cell_free_vars {
+                if sym.with_str(|s| own.contains(s)) {
+                    // We declare this local; it must be a shared cell here.
+                    captured_mutated.insert(*sym);
+                    needs_cell.insert(*sym);
+                } else {
+                    // Still a free var here; keep bubbling toward the owner.
+                    needs_cell_free.insert(*sym);
                 }
             }
         }
@@ -1479,6 +1514,7 @@ impl CompiledCode {
         self.free_var_writes = free_writes.into_iter().collect();
         self.captured_mutated_locals = captured_mutated.into_iter().collect();
         self.needs_cell_locals = needs_cell.into_iter().collect();
+        self.needs_cell_free_vars = needs_cell_free.into_iter().collect();
     }
 
     /// Store a compiled closure body and return its index. `escapes` records

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -934,6 +934,9 @@ impl VM {
         {
             // ContainerRef: increment through the shared arc (e.g. `$!attr := outer_var`).
             if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                if self.atomic_container_incdec(arc, name, true, false) {
+                    return Ok(());
+                }
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.increment_value_smart(&val)?;
@@ -982,6 +985,9 @@ impl VM {
         // closures over this lexical observe the change and the smart string/Int
         // increment semantics are preserved (the slot holds the same Arc).
         if let Value::ContainerRef(ref arc) = val {
+            if self.atomic_container_incdec(arc, name, true, false) {
+                return Ok(());
+            }
             let inner = arc.lock().unwrap().clone();
             let v = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.increment_value_smart(&v)?;
@@ -1026,6 +1032,9 @@ impl VM {
         {
             // ContainerRef: decrement through the shared arc (e.g. `$!attr := outer_var`).
             if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                if self.atomic_container_incdec(arc, name, false, false) {
+                    return Ok(());
+                }
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.decrement_value_smart(&val)?;
@@ -1074,6 +1083,9 @@ impl VM {
         // closures over this lexical observe the change and the smart string/Int
         // decrement semantics are preserved (the slot holds the same Arc).
         if let Value::ContainerRef(ref arc) = val {
+            if self.atomic_container_incdec(arc, name, false, false) {
+                return Ok(());
+            }
             let inner = arc.lock().unwrap().clone();
             let v = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.decrement_value_smart(&v)?;

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -313,6 +313,17 @@ impl VM {
                 self.interpreter
                     .env_mut()
                     .insert(s.to_string(), container.clone());
+                // Track C: if a thread is already running (shared_vars active) and a
+                // stale plain snapshot of this name lives in `shared_vars` (seeded
+                // by an earlier `start` before this local was boxed), replace it
+                // with the cell. Otherwise the stale value, marked dirty, would be
+                // written back over the cell by `sync_shared_vars_to_env` after the
+                // next await — disconnecting the parent from the shared cell.
+                // `set_shared_var` only updates entries that already exist, so this
+                // is a no-op when the name was never snapshotted.
+                if self.interpreter.shared_vars_active {
+                    self.interpreter.set_shared_var(s, container.clone());
+                }
             });
         }
     }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1517,6 +1517,39 @@ impl VM {
         Ok(())
     }
 
+    /// Atomically read-modify-write a shared `ContainerRef` scalar cell for an
+    /// in-place `++`/`--`, holding the cell lock across the whole RMW so that
+    /// concurrent `start { $shared++ }` blocks (Track C: shared lexical cells)
+    /// don't lose updates the way a separate lock-read / lock-write would.
+    /// `increment` selects `++` vs `--`; `post` selects which value to push
+    /// (post-inc/dec pushes the old value, pre-inc/dec the new one).
+    /// Returns `true` if it handled the op atomically. Instance cells run a
+    /// user-defined `.succ`/`.pred`, which can't be dispatched while the cell
+    /// lock is held (reentrancy), so for those it returns `false` and the
+    /// caller falls back to the (non-atomic) smart path.
+    pub(super) fn atomic_container_incdec(
+        &mut self,
+        arc: &std::sync::Arc<std::sync::Mutex<Value>>,
+        name: &str,
+        increment: bool,
+        post: bool,
+    ) -> bool {
+        let mut guard = arc.lock().unwrap();
+        if matches!(&*guard, Value::Instance { .. }) {
+            return false;
+        }
+        let old = self.normalize_incdec_source_with_type(name, guard.clone());
+        let new_val = if increment {
+            Self::increment_value(&old)
+        } else {
+            Self::decrement_value(&old)
+        };
+        *guard = new_val.clone();
+        drop(guard);
+        self.stack.push(if post { old } else { new_val });
+        true
+    }
+
     /// Decrement a value, calling .pred() on Instance values with custom methods.
     pub(super) fn decrement_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
         // Route user-defined `.pred` through the VM's unified compiled-first
@@ -1605,6 +1638,9 @@ impl VM {
         {
             // ContainerRef: increment through the shared arc (e.g. `$!attr := outer_var`).
             if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                if self.atomic_container_incdec(arc, name, true, true) {
+                    return Ok(());
+                }
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.increment_value_smart(&val)?;
@@ -1627,8 +1663,13 @@ impl VM {
             .get_env_with_main_alias(name)
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
-        // ContainerRef: deref for increment, write back through the shared container
+        // ContainerRef: deref for increment, write back through the shared container.
+        // Use an atomic read-modify-write under the cell lock so concurrent
+        // `start { $shared++ }` blocks don't lose updates (Track C).
         if let Value::ContainerRef(ref arc) = raw_val {
+            if self.atomic_container_incdec(arc, name, true, true) {
+                return Ok(());
+            }
             let inner = arc.lock().unwrap().clone();
             let val = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.increment_value_smart(&val)?;
@@ -1715,6 +1756,9 @@ impl VM {
         {
             // ContainerRef: decrement through the shared arc (e.g. `$!attr := outer_var`).
             if let Value::ContainerRef(ref arc) = self.locals[slot].clone() {
+                if self.atomic_container_incdec(arc, name, false, true) {
+                    return Ok(());
+                }
                 let inner = arc.lock().unwrap().clone();
                 let val = self.normalize_incdec_source_with_type(name, inner);
                 let new_val = self.decrement_value_smart(&val)?;
@@ -1737,8 +1781,12 @@ impl VM {
             .get_env_with_main_alias(name)
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
-        // ContainerRef: deref for decrement, write back through the shared container
+        // ContainerRef: deref for decrement, write back through the shared container.
+        // Atomic RMW under the cell lock for concurrent `start` blocks (Track C).
         if let Value::ContainerRef(ref arc) = raw_val {
+            if self.atomic_container_incdec(arc, name, false, true) {
+                return Ok(());
+            }
             let inner = arc.lock().unwrap().clone();
             let val = self.normalize_incdec_source_with_type(name, inner);
             let new_val = self.decrement_value_smart(&val)?;

--- a/t/concurrent-shared-cell.t
+++ b/t/concurrent-shared-cell.t
@@ -1,0 +1,65 @@
+use Test;
+
+# Track C (concurrency / shared live cells): a lexical scalar captured and
+# mutated by a `start` block must be a SHARED container cell, so increments from
+# the spawned threads accumulate into the parent's variable instead of each
+# thread mutating its own snapshot copy. mutsu performs the in-place `++` under
+# the cell's lock, so the result is deterministic (unlike a plain racy `++`).
+
+plan 7;
+
+# Single start block writes back through the shared cell.
+{
+    my $counter = 0;
+    await (start { $counter++ });
+    is $counter, 1, 'single start block increment is visible to parent';
+}
+
+# Serialized start blocks accumulate (no race, pure sharing).
+{
+    my $counter = 0;
+    for ^4 {
+        await (start { $counter++ });
+    }
+    is $counter, 4, 'serialized start blocks accumulate into shared cell';
+}
+
+# `start` directly in a loop body: all spawned threads share one cell.
+{
+    my $counter = 0;
+    my @p;
+    for ^10 { @p.push: start { $counter++ } }
+    await @p;
+    is $counter, 10, 'parallel start blocks in loop body share one cell';
+}
+
+# Canonical reproducer: `start` nested inside an immediately-invoked `map`
+# block. The escape signal must bubble up through the (non-escaping) map block
+# so the outer `$counter` still becomes a shared cell.
+{
+    my $counter = 0;
+    await (^10).map: { start { $counter++ } };
+    is $counter, 10, 'start nested in map block shares the outer cell';
+}
+
+# Larger fan-out stays exact thanks to the atomic read-modify-write.
+{
+    my $counter = 0;
+    await (^200).map: { start { $counter++ } };
+    is $counter, 200, 'atomic increment keeps a large fan-out exact';
+}
+
+# Decrement through the shared cell works too.
+{
+    my $counter = 100;
+    await (^10).map: { start { $counter-- } };
+    is $counter, 90, 'shared-cell decrement accumulates';
+}
+
+# A non-thread sibling-closure capture (escape analysis baseline) is unaffected.
+{
+    my $v = 0;
+    my @cbs = (^5).map: { -> { $v++ } };
+    $_() for @cbs;
+    is $v, 5, 'sibling closures still share their captured cell';
+}


### PR DESCRIPTION
## Summary

First slice of **PLAN.md Track C** (concurrency / shared live cells). A lexical scalar captured and mutated by a `start` block now becomes a **shared `ContainerRef` cell** so mutations from spawned threads accumulate into the parent's variable instead of each thread mutating its own snapshot copy.

Before: `await (^4).map: { start { $counter++ } }` → **1** (mutsu) vs **4** (raku).
After: → **4** (and exact for large fan-out, since the increment is atomic).

## What changed

1. **`start` block argument is an escaping position** (`compile_call_arg_with_escape`). The block outlives the call frame (stored in a Promise, run on a thread), so its captured-and-mutated locals must be cells. Other call args (`map`/`lives-ok` blocks) stay non-escaping (#2746 perf guard).
2. **Escape signal bubbles through intermediate non-escaping closures** (`CompiledCode::needs_cell_free_vars`). Solves the canonical `map { start { $outer++ } }` where the enclosing map block doesn't escape but the inner `start` does.
3. **Atomic `++`/`--` on a `ContainerRef`** (`atomic_container_incdec`): read-modify-write under the cell lock, so concurrent `start { $shared++ }` don't lose updates. Deterministic where raku's bare `++` races. Instance cells (custom `.succ`/`.pred`) keep the non-atomic path.
4. **Stale `shared_vars` snapshot fix**: when boxing a local into a cell while a thread is running, replace any stale plain snapshot of that name with the cell, so `sync_shared_vars_to_env` writeback doesn't clobber the cell after a later await.

## Still snapshot-only (follow-up slices)
- `state $n` cross-thread sharing (separate `state_vars`/`closure_captured_state` mechanism, reset in `clone_for_thread`).
- `@`/`%` and compound-assign (`+=`) atomicity.

## Testing
- New `t/concurrent-shared-cell.t` (7 subtests).
- `make test` passes (734 files).
- `roast/S04-statements/for.t` (closure+loop heavy): **identical** failures on this branch and `main` (zero regression).
- clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)