### PR TITLE
feat(concurrency): share scalar state variables across threads (Track C slice 2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -152,8 +152,17 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             ④ box 時に stale な `shared_vars` スナップショットをセルに張り替え
             （mainline `start` 後の `sync_shared_vars_to_env` writeback がセルを clobber する回帰を防止）。
             `await (^N).map: { start { $c++ } }` が正しく N を返す。テスト `t/concurrent-shared-cell.t`。
-            **残**: `state $n` のスレッド間共有（`state_vars`/`closure_captured_state` は clone_for_thread で
-            リセットされる別機構 — 次スライス）。`@`/`%` 共有・複合代入（`+=`）のアトミック化。
+            **スライス 2 LANDED**: スカラ `state $n` のスレッド間共有。`StateVarInit` が
+            `shared_vars_active` の間、user `state` 変数を `shared_vars` 内の共有 `ContainerRef` セル
+            （正規化キー `__mutsu_shared_state::{normalize_state_key(scoped_key)}`）に格納。
+            キー正規化は mutsu の二重コンパイル（registered body `&f` と OTF `&f/0`）で分岐する
+            `@<ip>`／`/<n>` を剥がし、`start f()` と直接 `f()` が同一セルを引くようにする。
+            `clone_for_thread` がスレッド前の親 state を共有セルへ移行（`f();f();start{f()}` を解く）。
+            増減は ① のアトミック ContainerRef RMW を流用（決定的）。`StateVarInit` は genuine `state`
+            宣言のみに出るので `ff`/`fff`/smart-match の内部 state（`set_state_var` 直接・非セル）は不変。
+            テスト `t/concurrent-state-var.t`。
+            **残**: `state @`/`%`（配列/ハッシュ）のスレッド共有（要素セル＝Track B 依存）、
+            lexical `@`/`%` 共有・複合代入（`+=`）のアトミック化。
       - [ ] `run_react_event_loop[_drain]` を VM ネイティブ実行へ（react/supply の async 状態所有）。
       - [ ] **unsafe aliasing 撤廃**（ANALYSIS §2.3, `Arc::as_ptr as *mut` 11 箇所）— B の要素セル基盤の上で。
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -669,6 +669,25 @@ impl Interpreter {
         self.state_vars.insert(key, value);
     }
 
+    /// Track C: get-or-create a shared `ContainerRef` cell for a `state` variable
+    /// in `shared_vars` (the cross-thread store), keyed by `key`. Used while a
+    /// thread is running so that concurrent calls to the same routine — e.g.
+    /// `await (^3).map: { start f() }` where `f` has `state $n` — share one live
+    /// cell instead of each thread initializing its own snapshot. The get-or-init
+    /// is atomic under the `shared_vars` write lock, so the first caller seeds the
+    /// cell (from `initial`) and the rest observe it. Returns the cell value.
+    pub(crate) fn get_or_init_shared_state_cell(&self, key: &str, initial: Value) -> Value {
+        let mut sv = self.shared_vars.write().unwrap();
+        if let Some(existing) = sv.get(key)
+            && matches!(existing, Value::ContainerRef(_))
+        {
+            return existing.clone();
+        }
+        let cell = initial.into_container_ref();
+        sv.insert(key.to_string(), cell.clone());
+        cell
+    }
+
     /// Read per-closure-instance captured-variable state (hot closure-call path).
     pub(crate) fn get_closure_captured_state(&self, id: u64, name: Symbol) -> Option<&Value> {
         self.closure_captured_state.get(&(id, name))

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5324,6 +5324,35 @@ impl Interpreter {
         id
     }
 
+    /// Normalize a scoped `state`-variable storage key into a form stable across
+    /// mutsu's two compilations of the same routine (the registered body `&f` and
+    /// the on-the-fly multi-candidate body `&f/0` reach `state $n` under different
+    /// `current_package` suffixes and opcode positions). Used as the cross-thread
+    /// shared-cell key so `start f()` and a direct `f()` agree (Track C). Strips a
+    /// trailing `@<digits>` (opcode position) and any `/<digits>` candidate suffix.
+    pub(crate) fn normalize_state_key(key: &str) -> String {
+        let trimmed = match key.rfind('@') {
+            Some(pos)
+                if pos + 1 < key.len() && key[pos + 1..].bytes().all(|b| b.is_ascii_digit()) =>
+            {
+                &key[..pos]
+            }
+            _ => key,
+        };
+        let mut out = String::with_capacity(trimmed.len());
+        let mut chars = trimmed.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '/' && chars.peek().is_some_and(|n| n.is_ascii_digit()) {
+                while chars.peek().is_some_and(|n| n.is_ascii_digit()) {
+                    chars.next();
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`
@@ -5363,6 +5392,21 @@ impl Interpreter {
                 // Only insert if not already present — existing values may have
                 // been updated by earlier threads that are already running.
                 sv.entry(key.resolve()).or_insert_with(|| val.clone());
+            }
+            // Track C: migrate the parent's existing `state` variables into shared
+            // cells (keyed by their normalized cross-compilation key) so a routine
+            // whose `state` was already mutated before the first thread spawned
+            // (`f(); f(); start { f() }`) carries that value into the threads
+            // instead of re-initializing from the declaration. Only seeds cells
+            // that don't exist yet; the value becomes the cell's initial content.
+            for (skey, sval) in &self.state_vars {
+                if matches!(sval, Value::ContainerRef(_)) {
+                    continue;
+                }
+                let shared_key =
+                    format!("__mutsu_shared_state::{}", Self::normalize_state_key(skey));
+                sv.entry(shared_key)
+                    .or_insert_with(|| sval.clone().into_container_ref());
             }
         }
         self.shared_vars_active = true;

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2794,7 +2794,50 @@ impl VM {
         let scoped_key = self.scoped_state_key(base_key);
         let slot_idx = slot as usize;
         let name = &code.locals[slot_idx];
-        let val = if let Some(stored) = self.interpreter.get_state_var(&scoped_key) {
+        // Track C: while a thread is running, a user `state` variable lives in a
+        // shared `ContainerRef` cell (keyed in shared_vars) so concurrent calls
+        // to the same routine across threads — `await (^3).map: { start f() }`
+        // where `f` has `state $n` — share one live cell. The cell makes the
+        // increment atomic (the ContainerRef inc/dec chokepoint) and visible to
+        // the parent after `await`. `StateVarInit` is emitted only for genuine
+        // `state` declarations, so `ff`/`fff`/smart-match internal state (which
+        // uses `set_state_var` directly, never a cell) is unaffected.
+        let val = if self.interpreter.shared_vars_active {
+            let coerced_initial = if name.starts_with('@') {
+                runtime::coerce_to_array(init_val)
+            } else if name.starts_with('%') {
+                runtime::coerce_to_hash(init_val)
+            } else {
+                init_val
+            };
+            // Seed the shared cell from any value the local snapshot already
+            // holds (state mutated before the first thread spawned), else from
+            // this declaration's initializer.
+            let initial = self
+                .interpreter
+                .get_state_var(&scoped_key)
+                .cloned()
+                .unwrap_or(coerced_initial);
+            // The cross-thread cell key must be stable across mutsu's two
+            // compilations of the same routine (the registered body `&f` and the
+            // on-the-fly multi-candidate body `&f/0` reach `state $n` under
+            // different `current_package` suffixes and opcode positions, so
+            // `scoped_key` alone differs between `start f()` and a direct `f()`).
+            // Normalize away the `/<n>` candidate suffix and the trailing
+            // `@<ip>` position so both paths share one cell.
+            let shared_key = format!(
+                "__mutsu_shared_state::{}",
+                crate::runtime::Interpreter::normalize_state_key(&scoped_key)
+            );
+            let cell = self
+                .interpreter
+                .get_or_init_shared_state_cell(&shared_key, initial);
+            // Keep the local store pointing at the cell too, so the exit-time
+            // writeback and any non-cell reader observe the same Arc.
+            self.interpreter
+                .set_state_var(scoped_key.clone(), cell.clone());
+            cell
+        } else if let Some(stored) = self.interpreter.get_state_var(&scoped_key) {
             stored.clone()
         } else {
             // Coerce @ variables to Array and % variables to Hash,

--- a/t/concurrent-state-var.t
+++ b/t/concurrent-state-var.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Track C (concurrency / shared live cells), slice 2: a scalar `state` variable
+# is shared across threads. A routine's `state $n` lives on the routine, so
+# concurrent calls from `start` blocks must accumulate into one shared cell
+# instead of each thread initializing its own snapshot. mutsu stores the state
+# in a shared `ContainerRef` cell and increments it under the cell lock, so the
+# result is deterministic (unlike a plain racy `++`).
+
+plan 5;
+
+# Canonical case: state counter incremented from spawned threads.
+{
+    sub f { state $n = 0; $n++ }
+    await (^3).map: { start f() };
+    is f(), 3, 'state $n accumulates across start blocks';
+}
+
+# State mutated BEFORE the first thread spawns must carry into the threads.
+{
+    sub g { state $n = 0; $n++ }
+    g(); g();                 # n -> 2 (pre-thread)
+    await (start { g() });    # thread: n 2 -> 3
+    is g(), 3, 'pre-thread state value carries into the shared cell';
+}
+
+# Larger fan-out stays exact thanks to the atomic read-modify-write.
+{
+    sub h { state $n = 0; $n++ }
+    await (^100).map: { start h() };
+    is h(), 100, 'atomic state increment keeps a large fan-out exact';
+}
+
+# Decrement through the shared state cell works too.
+{
+    sub d { state $n = 50; $n-- }
+    await (^10).map: { start d() };
+    is d(), 40, 'shared state decrement accumulates';
+}
+
+# A non-threaded state variable is completely unaffected (no cell).
+{
+    sub plain { state $c = 10; $c++ }
+    my @r = (plain(), plain(), plain());
+    is @r, [10, 11, 12], 'non-threaded state still increments normally';
+}


### PR DESCRIPTION
## Summary

Second slice of **PLAN.md Track C** (concurrency / shared live cells). A scalar `state` variable is now shared across threads, so concurrent calls from `start` blocks accumulate into one cell.

Before: `sub f { state $n = 0; $n++ }; await (^3).map: { start f() }; say f()` → **0** (mutsu) vs **3** (raku).
After: → **3** (and exact for large fan-out, since the increment is atomic).

## What changed

1. **`StateVarInit` uses a shared `ContainerRef` cell while a thread is running** (`shared_vars_active`), keyed in `shared_vars`. Concurrent calls across threads share one live cell; the increment reuses slice 1's atomic ContainerRef RMW (deterministic where raku's bare `++` races).
2. **Cross-thread cell key normalization** (`Interpreter::normalize_state_key`): strips the `@<ip>` opcode-position disambiguator and any `/<n>` multi-candidate suffix. mutsu compiles the same routine under two scope names (registered body `&f` and on-the-fly `&f/0`) with different opcode layouts, so `start f()` and a direct `f()` otherwise reach `state $n` under different keys and never share. Normalization makes both agree.
3. **`clone_for_thread` migrates the parent's existing `state` values** into shared cells before spawning, so state mutated before the first thread (`f(); f(); start { f() }`) carries into the threads instead of resetting.

Non-threaded `state` is completely unchanged (no cell path). `StateVarInit` is emitted only for genuine `state` declarations, so `ff`/`fff`/smart-match internal state (uses `set_state_var` directly, never a cell) is unaffected.

## Still snapshot-only (follow-up)
- `state @`/`%` (array/hash state needs element-cell sharing — Track B).
- lexical `@`/`%` and compound-assign (`+=`) atomicity.

## Testing
- New `t/concurrent-state-var.t` (5 subtests).
- `make test` passes.
- Whitelisted `roast/S04-declarations/state.t`, `once.t`, `loop.t` pass; `S17-promise/start.t` unchanged (pre-existing 45/53/58).
- clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)