### PR TITLE
refactor(grep): embed grep rw-view binding into ArrayData (remove side table)

### DIFF
--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -305,15 +305,23 @@ impl Interpreter {
                             scan_from = absolute.saturating_add(1);
                         }
                     }
-                    if !indices.is_empty() {
-                        crate::runtime::utils::register_grep_view_binding(
-                            filtered_items,
-                            &updated_source,
-                            indices.clone(),
-                            arr_kind,
-                        );
-                    }
                 }
+                // Embed the rw-view binding into the filtered ArrayData so it
+                // travels with the value through copy-on-write (no Arc-pointer
+                // side table). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array
+                // in `transform_result`, which naturally drops the binding.
+                let filtered = match filtered {
+                    Value::Array(filtered_items, fkind) if !indices.is_empty() => {
+                        let mut data = (*filtered_items).clone();
+                        data.grep_source = Some(Box::new(crate::value::GrepView {
+                            source: updated_source.clone(),
+                            indices: indices.clone(),
+                            source_kind: arr_kind,
+                        }));
+                        Value::Array(std::sync::Arc::new(data), fkind)
+                    }
+                    other => other,
+                };
                 grep_adverb.transform_result(filtered, &indices)
             }
             Value::Range(..)

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1,8 +1,7 @@
 use crate::symbol::Symbol;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
-use crate::runtime::ptr_keyed::PtrKeyedMap;
 use crate::value::{ArrayKind, EnumValue, JunctionKind, RuntimeError, Value};
 use num_bigint::BigInt;
 use num_integer::Integer;
@@ -80,9 +79,6 @@ pub(crate) fn make_empty_array_failure_what(op: &str, what: &str) -> Value {
     failure_attrs.insert("handled".to_string(), Value::Bool(false));
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
-type GrepViewBinding = (Arc<crate::value::ArrayData>, Vec<usize>, ArrayKind);
-type GrepViewMap = PtrKeyedMap<crate::value::ArrayData, GrepViewBinding>;
-
 /// Embed original (non-string) keys for an object hash into its `HashData`,
 /// returning the (possibly rebuilt) value. The map travels WITH the hash
 /// through copy-on-write — replacing the old Arc-pointer-keyed side tables, so
@@ -117,29 +113,6 @@ pub(crate) fn hash_typed_key(hash: &Value, str_key: &str) -> Value {
         return orig.clone();
     }
     Value::str(str_key.to_string())
-}
-
-fn grep_view_bindings() -> &'static Mutex<GrepViewMap> {
-    static GREP_VIEW_BINDINGS: OnceLock<Mutex<GrepViewMap>> = OnceLock::new();
-    GREP_VIEW_BINDINGS.get_or_init(|| Mutex::new(PtrKeyedMap::new()))
-}
-
-pub(crate) fn register_grep_view_binding(
-    filtered: &Arc<crate::value::ArrayData>,
-    source: &Arc<crate::value::ArrayData>,
-    source_indices: Vec<usize>,
-    source_is_array: ArrayKind,
-) {
-    if let Ok(mut bindings) = grep_view_bindings().lock() {
-        bindings.insert(filtered, (source.clone(), source_indices, source_is_array));
-    }
-}
-
-pub(crate) fn get_grep_view_binding(
-    filtered: &Arc<crate::value::ArrayData>,
-) -> Option<(Arc<crate::value::ArrayData>, Vec<usize>, ArrayKind)> {
-    let bindings = grep_view_bindings().lock().ok()?;
-    bindings.get_arc(filtered).cloned()
 }
 
 /// Check if an array is a shaped (multidimensional) array.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1359,6 +1359,27 @@ pub struct ArrayData {
     /// `Arc::as_ptr`-keyed `ShapedArrayIds` side table) so the shape travels
     /// with the container through copy-on-write.
     pub shape: Option<Vec<usize>>,
+    /// rw aggregate-view binding for `for @a.grep(...) { $_++ }`. A grep result
+    /// over an array carries the source array and the matched source indices so
+    /// the for-loop can write modified topics back to the original slots.
+    /// Embedded (replacing the former `Arc::as_ptr`-keyed grep-view side table)
+    /// so the binding travels with the filtered value through copy-on-write and
+    /// can never be inherited by an unrelated array via pointer reuse. A `=`
+    /// assignment / any rebuild via `array_data_like` drops it (the named-array
+    /// copy owns its elements and must not leak writeback into the source).
+    pub grep_source: Option<Box<GrepView>>,
+}
+
+/// The source binding embedded in a grep result so `for @a.grep(...) { $_++ }`
+/// can mirror modified topics back to the original array's matched slots.
+#[derive(Debug, Clone)]
+pub struct GrepView {
+    /// The (post-grep) source array whose slots the filtered elements alias.
+    pub source: Arc<ArrayData>,
+    /// For each filtered element, its 0-based index in `source`.
+    pub indices: Vec<usize>,
+    /// The source array's kind (preserved through writeback).
+    pub source_kind: ArrayKind,
 }
 
 impl ArrayData {
@@ -1370,6 +1391,7 @@ impl ArrayData {
             declared_type: None,
             default: None,
             shape: None,
+            grep_source: None,
         }
     }
 
@@ -2703,6 +2725,8 @@ impl Value {
             declared_type: like.declared_type.clone(),
             default: like.default.clone(),
             shape: like.shape.clone(),
+            // A rebuilt array never inherits a stale grep rw-view binding.
+            grep_source: None,
         })
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -407,7 +407,10 @@ impl VM {
         // iterable carries a registered grep-view binding, remember the source
         // array + matched indices so the loop can write modified topics back.
         self.for_grep_view = match &iterable {
-            Value::Array(items, _) => crate::runtime::utils::get_grep_view_binding(items),
+            Value::Array(items, _) => items
+                .grep_source
+                .as_deref()
+                .map(|gv| (gv.source.clone(), gv.indices.clone(), gv.source_kind)),
             _ => None,
         };
 

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -363,19 +363,17 @@ impl VM {
                 items.clone(),
                 *kind,
             );
-            if let Some((source, indices, source_kind)) =
-                crate::runtime::utils::get_grep_view_binding(existing)
-            {
-                let mut source_items = source.to_vec();
-                for (filtered_idx, source_idx) in indices.iter().enumerate() {
+            if let Some(gv) = existing.grep_source.as_deref() {
+                let mut source_items = gv.source.to_vec();
+                for (filtered_idx, source_idx) in gv.indices.iter().enumerate() {
                     if filtered_idx < items.len() && *source_idx < source_items.len() {
                         source_items[*source_idx] = items[filtered_idx].clone();
                     }
                 }
                 self.interpreter.overwrite_array_items_by_identity_for_vm(
-                    &source,
+                    &gv.source,
                     source_items,
-                    source_kind,
+                    gv.source_kind,
                 );
             }
             self.env_dirty = true;


### PR DESCRIPTION
## Summary

`for @a.grep(...) { \$_++ }` writes modified topics back to the source array's matched slots. This binding (source array + matched indices + kind) was tracked in a global `Arc::as_ptr`-keyed side table (`GREP_VIEW_BINDINGS`) — the **last array-side user of `PtrKeyedMap`** after typed-container / `default` / `shape` metadata were already embedded into `ArrayData`.

This PR embeds the binding directly into `ArrayData` as `grep_source: Option<Box<GrepView>>`, matching the established `default`/`shape` embedding pattern. The binding now travels with the filtered value through copy-on-write and can never be inherited by an unrelated array via pointer reuse (the unsoundness that #2953 had to defend with a `Weak` guard).

## Behavior preservation

Identical to the side table:
- The for-loop reads the binding from the iterable's `ArrayData` (guarded by `container_binding.is_none()` for the named-variable case).
- The hyper-method writeback (`@a.grep(...)>>.++`) reads it the same way.
- `:k`/`:kv`/`:p` adverbs rebuild a fresh array in `transform_result`, naturally dropping the binding.
- Any rebuild via `array_data_like` (e.g. `=` decontainerize) drops it.

Verified equivalent on `[1 3 3 5]` (direct rw), named-grep non-writeback, typed-array grep rw, and the pre-existing chained-grep / named-then-hyper edge cases (both behave identically to `main`).

## Removed

- `register_grep_view_binding` / `get_grep_view_binding` / `grep_view_bindings`
- the `GrepViewMap` = `PtrKeyedMap<ArrayData, ...>` side table
- `Mutex`/`OnceLock`/`PtrKeyedMap` imports in `utils.rs`

`PtrKeyedMap` itself stays (still used by `hash_defaults`).

## Test

- `t/grep-rw-view.t`, `t/grep-regressions.t`, `t/grep-lazy-range.t` pass
- whitelisted `roast/S32-list/grep.t`, `roast/S17-supply/grep.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)