### PR TITLE
feat(await): broken-Promise exception does X::Await::Died

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -1567,6 +1567,40 @@ impl Interpreter {
     }
 
     /// `await` — block until Promise(s) resolve, then return their results.
+    /// Build the `RuntimeError` carrying an `X::Await::Died` exception for a
+    /// broken Promise observed by `await`. Raku mixes the `X::Await::Died` role
+    /// INTO the original failure cause (`.^name` is e.g. `X::AdHoc+{X::Await::Died}`),
+    /// so it keeps its class, message and backtrace while also doing
+    /// `X::Await::Died`. We mirror that: when the cause is an exception instance,
+    /// mark it with `__mutsu_does_await_died` (recognized by `isa_check`) and
+    /// re-raise it unchanged, preserving its gist/backtrace. A plain (non-instance)
+    /// cause is wrapped in a fresh `X::Await::Died`.
+    fn await_died_error(cause: Value) -> RuntimeError {
+        let msg = match &cause {
+            Value::Instance { attributes, .. } => {
+                attributes.insert("__mutsu_does_await_died".to_string(), Value::Bool(true));
+                attributes
+                    .as_map()
+                    .get("message")
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| cause.to_string_value())
+            }
+            other => other.to_string_value(),
+        };
+        let mut err = RuntimeError::new(msg.clone());
+        let exc = if matches!(cause, Value::Instance { .. }) {
+            cause
+        } else {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("message".to_string(), Value::str(msg.clone()));
+            attrs.insert("payload".to_string(), Value::str(msg));
+            attrs.insert("__mutsu_does_await_died".to_string(), Value::Bool(true));
+            Value::make_instance(Symbol::intern("X::Await::Died"), attrs)
+        };
+        err.exception = Some(Box::new(exc));
+        err
+    }
+
     pub(super) fn builtin_await(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.is_empty() {
             return Err(RuntimeError::new(
@@ -1606,33 +1640,8 @@ impl Interpreter {
                     }
                     if shared.status() == "Broken" {
                         self.sync_shared_vars_to_env();
-                        let msg = result.to_string_value();
-                        let mut err = RuntimeError::new(msg);
-                        // Preserve exception object if it's already an exception instance
-                        match &result {
-                            Value::Instance { class_name, .. }
-                                if class_name.resolve().starts_with("X::")
-                                    || class_name == "Exception"
-                                    || class_name.resolve().ends_with("Exception") =>
-                            {
-                                err.exception = Some(Box::new(result));
-                            }
-                            _ => {
-                                // Wrap in X::AdHoc
-                                let mut attrs = std::collections::HashMap::new();
-                                attrs.insert(
-                                    "payload".to_string(),
-                                    Value::str(result.to_string_value()),
-                                );
-                                attrs.insert(
-                                    "message".to_string(),
-                                    Value::str(result.to_string_value()),
-                                );
-                                let ex = Value::make_instance(Symbol::intern("X::AdHoc"), attrs);
-                                err.exception = Some(Box::new(ex));
-                            }
-                        }
-                        return Err(err);
+                        // Raku wraps the broken Promise's cause in X::Await::Died.
+                        return Err(Self::await_died_error(result));
                     }
                     // Replay deferred Proc::Async taps
                     if let Value::Instance {
@@ -1671,8 +1680,7 @@ impl Interpreter {
                                 self.output_sink_mut().stderr_output.push_str(&stderr);
                                 if shared.status() == "Broken" {
                                     self.sync_shared_vars_to_env();
-                                    let msg = result.to_string_value();
-                                    return Err(RuntimeError::new(msg));
+                                    return Err(Self::await_died_error(result));
                                 }
                                 let result = Self::unwrap_async_status_result(result)?;
                                 results.push(result);

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -222,6 +222,18 @@ impl Interpreter {
         if let Value::Scalar(inner) = value {
             return self.type_matches_value(constraint, inner.as_ref());
         }
+        // X::Await::Died role mixed into an exception by `await` of a broken
+        // Promise (see `await_died_error`): the cause keeps its own class but
+        // also does X::Await::Died.
+        if constraint == "X::Await::Died"
+            && let Value::Instance { attributes, .. } = value
+            && matches!(
+                attributes.as_map().get("__mutsu_does_await_died"),
+                Some(Value::Bool(true))
+            )
+        {
+            return true;
+        }
         if constraint == "Inf" {
             return matches!(value, Value::Num(n) if n.is_infinite() && n.is_sign_positive());
         }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -613,6 +613,18 @@ impl Value {
         if my_type == type_name {
             return true;
         }
+        // The X::Await::Died role is mixed into the original exception when
+        // `await` observes a broken Promise (see `await_died_error`): the cause
+        // keeps its own class but also does X::Await::Died.
+        if type_name == "X::Await::Died"
+            && let Value::Instance { attributes, .. } = self
+            && matches!(
+                attributes.as_map().get("__mutsu_does_await_died"),
+                Some(Value::Bool(true))
+            )
+        {
+            return true;
+        }
         // Perl6::Metamodel:: and Metamodel:: are equivalent namespaces
         if let Some(short) = my_type.strip_prefix("Perl6::")
             && short == type_name

--- a/t/await-died-exception.t
+++ b/t/await-died-exception.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Awaiting a broken Promise throws an exception that does X::Await::Died (Raku
+# mixes the X::Await::Died role into the original cause). The original message
+# and, for a thrown exception, its backtrace are preserved.
+
+plan 8;
+
+# Broken with a plain string cause.
+{
+    my $p = Promise.new;
+    $p.break("golly!");
+    my $caught;
+    try { await $p; CATCH { default { $caught = $_ } } }
+    ok $caught.does(X::Await::Died), 'await of string-broken Promise does X::Await::Died';
+    ok $caught ~~ Exception, 'and is an Exception';
+    like ~$caught, /golly/, 'gist contains the original message';
+}
+
+# Broken by a die inside a start block: original exception type and backtrace
+# are preserved while also doing X::Await::Died.
+{
+    sub deep-failer { die "kaboom" }
+    my $p = start { deep-failer() };
+    my $caught;
+    try { await $p; CATCH { default { $caught = $_ } } }
+    ok $caught.does(X::Await::Died), 'await of die-broken Promise does X::Await::Died';
+    like ~$caught, /kaboom/, 'gist contains the original die message';
+    like $caught.backtrace.Str, /deep\-failer/, 'backtrace keeps the throwing location';
+}
+
+# Awaiting several promises where one dies still surfaces X::Await::Died.
+{
+    my $ok = Promise.new; $ok.keep(1);
+    my $bad = start { die "nope" };
+    my $caught;
+    try { await $ok, $bad; CATCH { default { $caught = $_ } } }
+    ok $caught.does(X::Await::Died), 'await of a list with one broken does X::Await::Died';
+    like ~$caught, /nope/, 'gist contains the failing promise message';
+}


### PR DESCRIPTION
## Summary

Awaiting a broken Promise must surface an exception that `.does(X::Await::Died)` — Raku mixes the `X::Await::Died` role into the original failure cause (`.^name` is e.g. `X::AdHoc+{X::Await::Died}`). mutsu threw a bare `X::AdHoc`, so `.does(X::Await::Died)` was False.

## What changed

- `await_died_error`: when the broken cause is an exception **instance**, mark it with `__mutsu_does_await_died` and re-raise it **unchanged** — preserving its class, message and backtrace while also doing `X::Await::Died`. A plain (non-instance) cause is wrapped in a fresh `X::Await::Died` carrying the message.
- `type_matches_value` and `isa_check` recognize the marker, so `.does(X::Await::Died)` / `~~ X::Await::Died` return True without losing the original type.

Both `await $broken` and `await @list-with-one-broken` use this path.

Preserving the original instance (rather than wrapping) keeps `S17-promise/start.t`'s backtrace assertions passing. Fixes the "does X::Await::Died" subtests in `roast/S17-promise/nonblocking-await.t`.

## Testing
- New `t/await-died-exception.t` (8 subtests).
- `make test` passes.
- No regression: `S17-promise/start.t` stays at its pre-existing 3 failures (45/53/58); `S32-exceptions/misc2.t` still fully passes.
- clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)