### PR TITLE
feat(await): support awaiting Channels and Supplies

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -1601,6 +1601,19 @@ impl Interpreter {
         err
     }
 
+    /// Normalize a single `await` target. A `Supply` is awaited via its
+    /// `.Promise` (kept with the last emitted value when the supply completes,
+    /// broken if it quits) — `await $supply` ≡ `await $supply.Promise`. All other
+    /// values pass through unchanged (Promises and Channels are handled inline).
+    fn await_normalize(&mut self, v: Value) -> Result<Value, RuntimeError> {
+        if let Value::Instance { class_name, .. } = &v
+            && class_name == "Supply"
+        {
+            return self.call_method_with_values(v, "Promise", vec![]);
+        }
+        Ok(v)
+    }
+
     pub(super) fn builtin_await(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.is_empty() {
             return Err(RuntimeError::new(
@@ -1609,11 +1622,14 @@ impl Interpreter {
         }
         let mut await_targets: Vec<Value> = Vec::new();
         for arg in args {
-            match arg {
-                _ if arg.as_list_items().is_some() => {
-                    await_targets.extend(arg.as_list_items().unwrap().iter().cloned());
+            if let Some(items) = arg.as_list_items() {
+                let items: Vec<Value> = items.to_vec();
+                for it in items {
+                    await_targets.push(self.await_normalize(it)?);
                 }
-                other => await_targets.push(other.clone()),
+            } else {
+                let normalized = self.await_normalize(arg.clone())?;
+                await_targets.push(normalized);
             }
         }
         let mut results = Vec::new();
@@ -1701,6 +1717,19 @@ impl Interpreter {
                         }
                     }
                 }
+                // `await $channel` blocks for the next value (like `.receive`):
+                // returns it, or throws X::Channel::ReceiveOnClosed when the
+                // channel is drained and closed, or the failure cause when failed.
+                Value::Channel(ch) => match ch.receive_result() {
+                    Ok(Value::Nil) => return Err(Self::channel_receive_closed_error()),
+                    Ok(value) => results.push(value),
+                    Err(cause) => {
+                        let ex = Self::as_exception_value(cause);
+                        let mut err = RuntimeError::new(ex.to_string_value());
+                        err.exception = Some(Box::new(ex));
+                        return Err(err);
+                    }
+                },
                 _ => results.push(arg.clone()),
             }
         }

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -29,7 +29,7 @@ impl Interpreter {
         err
     }
 
-    fn channel_receive_closed_error() -> RuntimeError {
+    pub(crate) fn channel_receive_closed_error() -> RuntimeError {
         let mut err = RuntimeError::new("Cannot receive on a closed channel");
         err.exception = Some(Box::new(Value::make_instance(
             Symbol::intern("X::Channel::ReceiveOnClosed"),

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -3349,9 +3349,28 @@ impl Interpreter {
                 match sub.receiver.recv_timeout(poll_timeout) {
                     Ok(SupplyEvent::Emit(value)) => {
                         any_active = true;
-                        let _ = self.call_sub_value(sub.callback.clone(), vec![value], true);
-                        // Check if promise was resolved during callback
+                        let cb_result = self.call_sub_value(sub.callback.clone(), vec![value], true);
+                        // `done`/`last` etc. inside the whenever resolve the
+                        // promise via the Supplier.done handler.
                         if promise.is_resolved() {
+                            return Ok(());
+                        }
+                        // A `die` inside the whenever block quits the supply: break
+                        // the awaited promise with the cause (otherwise the poll
+                        // loop would spin to its deadline — a hang). Control-flow
+                        // signals (done/last/next/redo) are not failures.
+                        if let Err(err) = cb_result
+                            && !err.is_react_done
+                            && !err.is_last
+                            && !err.is_next
+                            && !err.is_redo
+                        {
+                            let cause = err
+                                .exception
+                                .as_deref()
+                                .cloned()
+                                .unwrap_or_else(|| Value::str(err.message.clone()));
+                            promise.break_with(cause, String::new(), String::new());
                             return Ok(());
                         }
                     }

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -3349,7 +3349,8 @@ impl Interpreter {
                 match sub.receiver.recv_timeout(poll_timeout) {
                     Ok(SupplyEvent::Emit(value)) => {
                         any_active = true;
-                        let cb_result = self.call_sub_value(sub.callback.clone(), vec![value], true);
+                        let cb_result =
+                            self.call_sub_value(sub.callback.clone(), vec![value], true);
                         // `done`/`last` etc. inside the whenever resolve the
                         // promise via the Supplier.done handler.
                         if promise.is_resolved() {

--- a/t/await-channel-supply.t
+++ b/t/await-channel-supply.t
@@ -1,0 +1,64 @@
+use Test;
+
+# `await` on a Channel receives the next value (blocking); `await` on a Supply
+# runs it to completion and returns the last emitted value (broken if it quits).
+
+plan 8;
+
+# await on a Channel returns the next sent value.
+{
+    my $c = Channel.new;
+    $c.send(42);
+    is await($c), 42, 'await Channel receives the sent value';
+}
+
+# Two awaits drain two values in order.
+{
+    my $c = Channel.new;
+    $c.send(1); $c.send(2);
+    is (await($c) + await($c)), 3, 'sequential awaits drain the channel';
+}
+
+# await on a closed, drained Channel throws X::Channel::ReceiveOnClosed.
+{
+    my $c = Channel.new;
+    $c.close;
+    throws-like { await($c) }, X::Channel::ReceiveOnClosed,
+        'await on a closed empty Channel throws';
+}
+
+# await on a supply block returns the last value emitted before done.
+{
+    is (await supply { emit 1; emit 2; emit 7; done }), 7,
+        'await supply block returns the last emitted value';
+}
+
+# await on a supply driven by Supply.interval returns its emitted value.
+{
+    is (await supply { whenever Supply.interval(0.01) { emit 99; done } }), 99,
+        'await supply with interval returns the emitted value';
+}
+
+# A die inside a whenever quits the supply; await rethrows the cause
+# (instead of hanging until the poll deadline).
+{
+    throws-like { await supply { whenever Supply.interval(0.01) { die 'strewth' } } },
+        Exception, message => 'strewth',
+        'await of a dying supply rethrows the cause';
+}
+
+# Many outstanding awaits over supplies in parallel start blocks all complete.
+{
+    my @proms = (1..20).map: -> $i {
+        start { await supply { whenever Supply.interval(0.001 * $i) { emit $i; done } } }
+    };
+    is ([+] await @proms), (1..20).sum, 'many outstanding supply awaits complete';
+}
+
+# Many outstanding awaits over a shared channel in parallel start blocks.
+{
+    my $c = Channel.new;
+    my @proms = (1..20).map: { start { await($c) } };
+    for 1..20 { $c.send($_) }
+    is ([+] await @proms), (1..20).sum, 'many outstanding channel awaits complete';
+}


### PR DESCRIPTION
## Summary

`await` ignored `Channel` and `Supply` arguments — `await $channel` returned the Channel itself and `await $supply` returned the Supply — so the "hundred outstanding awaits on supplies/channels" cases in `nonblocking-await.t` hung or gave wrong answers.

## What changed

- **`await $channel`**: block for the next value (like `.receive`); throw `X::Channel::ReceiveOnClosed` when the channel is drained and closed, or the failure cause when failed.
- **`await $supply`**: normalize to `$supply.Promise` (kept with the last emitted value when the supply completes, broken if it quits) before waiting — `await $supply` ≡ `await $supply.Promise`.
- **Fix a hang** in the on-demand supply poll loop: a `die` inside a `whenever` block was swallowed (`let _ = …`), so the awaited promise was never broken and the loop spun to its 30s deadline. Now a non-control-flow error breaks the promise with the cause, so awaiting a dying supply rethrows immediately.

## Note on "non-blocking"

mutsu spawns a real OS thread per `start` (no bounded thread pool), so a blocking `await` never starves the scheduler — the deep await-trees and 100-outstanding-await cases work without a non-blocking scheduler. The remaining 2 `nonblocking-await.t` failures need await-site backtrace locations (a separate backtrace feature).

## Testing
- New `t/await-channel-supply.t` (8 subtests).
- `roast/S17-promise/nonblocking-await.t`: 6 failures → **2**.
- `make test` passes; S17 supply/channel suite (throttle/grab/map/list/channel-basic) green; `S17-promise/start.t` unchanged (3 pre-existing).
- clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)