### PR TITLE
feat(await): append the await call-site to a broken Promise's backtrace

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -1575,7 +1575,54 @@ impl Interpreter {
     /// mark it with `__mutsu_does_await_died` (recognized by `isa_check`) and
     /// re-raise it unchanged, preserving its gist/backtrace. A plain (non-instance)
     /// cause is wrapped in a fresh `X::Await::Died`.
-    fn await_died_error(cause: Value) -> RuntimeError {
+    /// Format the current routine stack (the point where `await` was called) as
+    /// a Raku-style backtrace string, innermost frame first. Used to append the
+    /// await/re-throw location to a broken-Promise exception's backtrace.
+    fn await_site_backtrace(&self) -> String {
+        let stack = self.routine_stack();
+        let mut lines = Vec::new();
+        for frame in stack.iter().rev() {
+            let loc = match (frame.file.as_deref(), frame.line) {
+                (Some(f), Some(l)) => format!(" at {} line {}", f, l),
+                (Some(f), None) => format!(" at {}", f),
+                _ => String::new(),
+            };
+            if frame.is_block || frame.name.is_empty() || frame.name == "<unit>" {
+                lines.push(format!("  in block <unit>{}", loc));
+            } else {
+                lines.push(format!("  in sub {}{}", frame.name, loc));
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn await_died_error(&self, cause: Value) -> RuntimeError {
+        // Append the await call-site to the exception's backtrace, so the gist
+        // surfaces both where the Promise's code died (preserved) and where it
+        // was awaited (the re-throw location) — matching Raku's X::Await::Died.
+        if let Value::Instance { attributes, .. } = &cause {
+            let await_bt = self.await_site_backtrace();
+            if !await_bt.is_empty()
+                && let Some(Value::Instance {
+                    class_name: bt_cn,
+                    attributes: bt_attrs,
+                    ..
+                }) = attributes.as_map().get("backtrace").cloned()
+                && bt_cn == "Backtrace"
+            {
+                let old = bt_attrs
+                    .as_map()
+                    .get("text")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default();
+                let combined = if old.is_empty() {
+                    await_bt
+                } else {
+                    format!("{old}\n{await_bt}")
+                };
+                bt_attrs.insert("text".to_string(), Value::str(combined));
+            }
+        }
         let msg = match &cause {
             Value::Instance { attributes, .. } => {
                 attributes.insert("__mutsu_does_await_died".to_string(), Value::Bool(true));
@@ -1657,7 +1704,7 @@ impl Interpreter {
                     if shared.status() == "Broken" {
                         self.sync_shared_vars_to_env();
                         // Raku wraps the broken Promise's cause in X::Await::Died.
-                        return Err(Self::await_died_error(result));
+                        return Err(self.await_died_error(result));
                     }
                     // Replay deferred Proc::Async taps
                     if let Value::Instance {
@@ -1696,7 +1743,7 @@ impl Interpreter {
                                 self.output_sink_mut().stderr_output.push_str(&stderr);
                                 if shared.status() == "Broken" {
                                     self.sync_shared_vars_to_env();
-                                    return Err(Self::await_died_error(result));
+                                    return Err(self.await_died_error(result));
                                 }
                                 let result = Self::unwrap_async_status_result(result)?;
                                 results.push(result);

--- a/t/await-site-backtrace.t
+++ b/t/await-site-backtrace.t
@@ -1,0 +1,34 @@
+use Test;
+
+# When `await` rethrows a broken Promise, the exception's gist/backtrace must
+# contain BOTH where the Promise's code died (the throwing location) and where
+# it was awaited (the re-throw / await-site location) — matching Raku's
+# X::Await::Died.
+
+plan 4;
+
+sub death-bar { die "golly!" }
+sub make-it { start { death-bar() } }
+
+sub waiting-for-it {
+    await make-it();
+    CATCH {
+        default {
+            like .gist, /golly/,           'gist contains the original message';
+            like .gist, /death\-bar/,      'gist contains the throwing location';
+            like .gist, /waiting\-for\-it/, 'gist contains the await-site location';
+        }
+    }
+}
+waiting-for-it;
+
+# The await-site frame is also present on the structured backtrace.
+{
+    sub inner { die "boom" }
+    sub spawner { start { inner() } }
+    sub awaiter {
+        await spawner();
+        CATCH { default { like .backtrace.Str, /awaiter/, 'backtrace string includes the awaiter' } }
+    }
+    awaiter;
+}


### PR DESCRIPTION
## Summary

When `await` rethrows a broken Promise, Raku's `X::Await::Died` gist shows **both** where the Promise's code died and where it was awaited (the re-throw location). mutsu preserved only the original (thread-side) backtrace, so the await call-site was missing from the gist.

`await_died_error` now formats the current routine stack (the await call-site) and appends it to the exception's `Backtrace` object text, so both `.gist` and `.backtrace.Str` surface the awaiting routine. The original frames are kept (the text is appended in place).

Example — gist now contains `death-bar` (threw) **and** `waiting-for-it` (awaited):
```
golly!
  in sub death-bar at … line 1
  …
  in sub waiting-for-it at … line 4
```

## Impact
- **`roast/S17-promise/nonblocking-await.t`: all 28 pass** (was 2 failing).
- **`S17-promise/start.t`**: the "re-throwing location" subtest now passes (down to 2 unrelated pre-existing failures: `$/` over-sharing and parallel grammar parsing).

## Note on whitelisting
`nonblocking-await.t` is **not** added to the whitelist: it runs ~35s (mutsu's `Supply.interval` is much slower than rakudo's ~4s), too slow to gate CI on. A supply-timing perf follow-up is separate.

## Testing
- New `t/await-site-backtrace.t` (4 subtests).
- `make test` passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)