### PR TITLE
feat(bind): share a cell for whole-container := binds (Track B)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -131,8 +131,15 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
 - [ ] **トラック B — 第一級コンテナ Phase 2（要素セル）** ＝ データ表現（A と完全独立）
       設計・段階導入は 🟣第2優先「第一級コンテナ」セクション参照（Phase 1 = landed）。
       - [ ] Phase 0.5 第2段（スタック不変条件 + lvalue opcode）を Phase 2 と同一 PR で。
-      - [ ] 配列/ハッシュ要素の COW セル化 → array-backed mut・shaped/non-simple push・hyper temp・
+      - [~] 配列/ハッシュ要素の COW セル化 → array-backed mut・shaped/non-simple push・hyper temp・
             深い `>>++` を解く（take-rw は #2930、`@a[0]:=`/束縛要素セルは #2902-#2925 で landed）。
+            - [x] **whole-container `:=` bind 共有（`my @b := @a` / `my %g := %h`）**: 両変数が単一の
+                  共有 `ContainerRef` cell を持ち、push/pop/shift/unshift/splice/index-assign/slice-assign/
+                  delete の変異が双方向に伝播（旧実装は inner Arc 共有のみで COW push が detach していた）。
+                  GetArrayVar/GetHashVar がトップレベル cell を decont（Phase 0.5 第2段の読み側）、bind 経路が
+                  cell を生成、変異 op（native array mut/splice・delete）が `env_root_descended_mut` で
+                  cell を descend。`t/whole-container-bind.t`(26)。**残**: スカラー `$ref := @a`（`$`-bind は
+                  bind_vardecl=false で WrapVarRef 非 emit → コンパイラ変更が前提・別 PR）。
       - [x] **Q2 の型メタ Arc-ptr flaky の構造的除去 = 完全吸収 DONE（2026-06-12〜13）**:
             Hash = HashData (#2952、original_keys = #2954)、Set/Bag/Mix = 既存 *Data 埋め込み (#2957)、
             **Array = ArrayData wrapper（2026-06-13）— 全 5 コンテナ型の型メタがコンテナ値に埋め込まれ、

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1328,6 +1328,12 @@ impl VM {
                             Value::Nil
                         }
                     });
+                // A whole-container `:=` bind (`my @b := @a`) stores a shared
+                // `ContainerRef` cell in the slot so both aliases observe
+                // mutations. Decontainerize the top-level cell here so the read
+                // yields the inner Array/Hash (the cell is a binding alias, not
+                // an array element). Element-level cells are handled at Index.
+                let val = val.into_deref();
                 // When @-sigil dereferences a Hash, convert to a list of pairs
                 let val = match val {
                     Value::Hash(ref map) => {
@@ -1394,7 +1400,10 @@ impl VM {
                         }
                     });
                 match val {
-                    Some(v) => self.stack.push(v),
+                    // Decontainerize a top-level `ContainerRef` cell from a
+                    // whole-container `:=` bind (`my %h2 := %h`); the read
+                    // yields the inner Hash.
+                    Some(v) => self.stack.push(v.into_deref()),
                     None => {
                         // %ENV (without * twigil) is not declared in Raku;
                         // only %*ENV is valid. Throw an undeclared error for %ENV specifically.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1493,9 +1493,11 @@ impl VM {
             return None;
         }
         // The receiver must be exactly the array currently bound to this name, so
-        // an in-place `Arc::make_mut` writeback is correct.
+        // an in-place `Arc::make_mut` writeback is correct. Descend through a
+        // whole-container `:=` bound cell (`my @x := @a`) so the mutation writes
+        // back through the shared cell (every alias observes it).
         let Some(Value::Array(arc_items, crate::value::ArrayKind::Array)) =
-            self.interpreter.env_mut().get_mut(target_name)
+            self.env_root_descended_mut(target_name)
         else {
             return None;
         };
@@ -1613,9 +1615,10 @@ impl VM {
         }
         // The receiver must be exactly the array currently bound to this name, so
         // an in-place `Arc::make_mut` writeback is correct. Compute the splice
-        // bounds from the live binding's length (not `target`).
+        // bounds from the live binding's length (not `target`). Descend through a
+        // whole-container `:=` bound cell so the splice writes through the cell.
         let Some(Value::Array(arc_items, crate::value::ArrayKind::Array)) =
-            self.interpreter.env_mut().get_mut(target_name)
+            self.env_root_descended_mut(target_name)
         else {
             return None;
         };

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2779,7 +2779,11 @@ impl VM {
                         }
                     }
                 }
-                if let Some(container) = self.interpreter.env_mut().get_mut(&var_name)
+                // Descend through a whole-container `:=` bound cell (`my @x :=
+                // @a`) so an array slice assignment mutates the shared inner
+                // Array (every alias observes it) instead of falling through to
+                // the hash-slice path below.
+                if let Some(container) = self.env_root_descended_mut(&var_name)
                     && matches!(container, Value::Array(..))
                 {
                     let is_shaped =
@@ -4028,7 +4032,7 @@ impl VM {
     /// SAFETY: single-threaded; the returned reference points into the cell's
     /// mutex data, kept alive by the `Arc` stored in env (see
     /// `descend_container_ref`).
-    fn env_root_descended_mut(&mut self, var_name: &str) -> Option<&mut Value> {
+    pub(crate) fn env_root_descended_mut(&mut self, var_name: &str) -> Option<&mut Value> {
         let root = self.interpreter.env_mut().get_mut(var_name)? as *mut Value;
         let descended = unsafe { Self::descend_container_ref(root) };
         Some(unsafe { &mut *descended })
@@ -5882,15 +5886,6 @@ impl VM {
             self.interpreter
                 .env_mut()
                 .insert(readonly_key, Value::Bool(false));
-            // Record local-slot binding pair for write propagation.
-            // Only record if the source is also a local in the same code unit,
-            // so cross-scope name collisions do not cause spurious propagation.
-            if is_vardecl
-                && let Some(source_idx) = code.locals.iter().position(|n| n == &resolved_source)
-                && source_idx != idx
-            {
-                self.local_bind_pairs.push((source_idx, idx));
-            }
             // Create a shared ContainerRef for cross-scope binding (source in
             // outer call frame) OR same-scope rebinding (`:=` on existing vars).
             // ContainerRef ensures bidirectional container sharing: writing to
@@ -5900,6 +5895,96 @@ impl VM {
                 .iter()
                 .any(|f| f.saved_env.contains_key(&resolved_source));
             let source_in_same_scope = code.locals.iter().any(|n| n == &resolved_source);
+            // Whole-container `:=` bind (`my @b := @a`, `my %h2 := %h`,
+            // `my $ref := @a`): share a single `ContainerRef` cell between the
+            // source and target so mutations through either alias (push,
+            // element assignment) are observed by both, as in Raku. Without
+            // this the two slots only share the inner `Arc`, and a COW mutation
+            // (`.push`) detaches them. (Mirrors the element-bind cell pattern in
+            // the index-assign path; the cell IS the alias so no
+            // `local_bind_pairs` entry is recorded.)
+            let val_is_container = matches!(
+                val,
+                Value::Array(..) | Value::Hash(..) | Value::ContainerRef(_)
+            );
+            if val_is_container
+                && (source_in_same_scope || source_in_outer_frame)
+                && !name.starts_with('&')
+            {
+                // Reuse the source's existing cell if it already has one (so a
+                // third alias `my @c := @b` joins the same cell); otherwise wrap
+                // the bound value in a fresh cell.
+                let cell = match &val {
+                    Value::ContainerRef(arc) => arc.clone(),
+                    _ => match self.interpreter.env().get(&resolved_source) {
+                        Some(Value::ContainerRef(arc)) => arc.clone(),
+                        _ => std::sync::Arc::new(std::sync::Mutex::new(val.clone())),
+                    },
+                };
+                // A bound `@`/`%` variable adopts the *source* container's
+                // declared element/key type, not its own (`my Int %a; my Cool
+                // %b := %a` ⇒ `%b.of` is `Int`). Propagate the inner container's
+                // embedded type metadata to this variable's constraint (same as
+                // the typed-bind propagation at the end of the slow path, which
+                // the early return below skips).
+                if name.starts_with('@') || name.starts_with('%') {
+                    let inner = cell.lock().unwrap().clone();
+                    if let Some(info) = self.interpreter.container_type_metadata(&inner)
+                        && !info.value_type.is_empty()
+                    {
+                        let constraint_str = if name.starts_with('%') {
+                            if let Some(ref kt) = info.key_type {
+                                format!("{}{{{}}}", info.value_type, kt)
+                            } else {
+                                info.value_type.clone()
+                            }
+                        } else {
+                            info.value_type.clone()
+                        };
+                        self.interpreter
+                            .set_var_type_constraint(name, Some(constraint_str));
+                    } else {
+                        // Untyped source: clear any declared constraint inherited
+                        // from this variable's own declaration so it does not
+                        // over-constrain the shared container.
+                        self.interpreter.set_var_type_constraint(name, None);
+                    }
+                }
+                let container = Value::ContainerRef(cell);
+                self.locals[idx] = container.clone();
+                if let Some(source_idx) = code.locals.iter().rposition(|n| n == &resolved_source) {
+                    self.locals[source_idx] = container.clone();
+                    self.flush_local_to_env(code, source_idx);
+                }
+                self.set_env_with_main_alias(&resolved_source, container.clone());
+                // Propagate the shared cell into saved call frames so the
+                // binding survives method returns (env restore) without
+                // reverting to a stale value (same as the scalar path below).
+                for frame in self.call_frames.iter_mut().rev() {
+                    if frame.saved_env.contains_key(&resolved_source) {
+                        frame
+                            .saved_env
+                            .insert(resolved_source.clone(), container.clone());
+                    }
+                    for (i, local_name) in code.locals.iter().enumerate() {
+                        if local_name == &resolved_source && i < frame.saved_locals.len() {
+                            frame.saved_locals[i] = container.clone();
+                        }
+                    }
+                }
+                self.set_env_with_main_alias(name, container.clone());
+                self.flush_local_to_env(code, idx);
+                return Ok(());
+            }
+            // Record local-slot binding pair for write propagation.
+            // Only record if the source is also a local in the same code unit,
+            // so cross-scope name collisions do not cause spurious propagation.
+            if is_vardecl
+                && let Some(source_idx) = code.locals.iter().position(|n| n == &resolved_source)
+                && source_idx != idx
+            {
+                self.local_bind_pairs.push((source_idx, idx));
+            }
             // Only use ContainerRef for same-scope rebind when the value is a
             // simple scalar (not a type object, array, hash, etc.)
             let val_is_simple_scalar = !matches!(

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -164,6 +164,40 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // A whole-container `:=` bound variable (`my %g := %h`) holds a shared
+        // `ContainerRef` cell. The delete logic operates on plain Hash/Array
+        // values read from env, so temporarily unwrap the cell's inner container
+        // into env for the duration of the op, then write the mutated result
+        // back through the cell (so every alias observes the delete) and restore
+        // the cell in env and the local slot.
+        let var_name = Self::const_str(code, name_idx).to_string();
+        let bound_cell = match self.interpreter.env().get(&var_name) {
+            Some(Value::ContainerRef(cell)) => Some(cell.clone()),
+            _ => None,
+        };
+        if let Some(ref cell) = bound_cell {
+            let inner = cell.lock().unwrap().clone();
+            self.interpreter.env_mut().insert(var_name.clone(), inner);
+        }
+        let result = self.exec_delete_index_named_op_inner(code, name_idx);
+        if let Some(cell) = bound_cell {
+            if let Some(mutated) = self.interpreter.env().get(&var_name).cloned() {
+                *cell.lock().unwrap() = mutated;
+            }
+            let cell_val = Value::ContainerRef(cell);
+            self.interpreter
+                .env_mut()
+                .insert(var_name.clone(), cell_val.clone());
+            self.locals_set_by_name(code, &var_name, cell_val);
+        }
+        result
+    }
+
+    fn exec_delete_index_named_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
         let var_name = Self::const_str(code, name_idx).to_string();
         let idx = self.stack.pop().unwrap_or(Value::Nil);
         // Fast path for simple hash delete

--- a/t/whole-container-bind.t
+++ b/t/whole-container-bind.t
@@ -1,0 +1,137 @@
+use Test;
+
+# Whole-container `:=` bind (`my @b := @a` / `my %g := %h`) makes the two
+# variables share a single container, so mutations through either alias are
+# observed by both (Track B element-cell: array-backed mutation). Before the
+# fix, the two slots only shared the inner Arc and a COW mutation (`.push`)
+# detached them.
+
+plan 26;
+
+# --- Array: push through either alias propagates both ways ---
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    @b.push(4);
+    is-deeply @a, [1, 2, 3, 4], 'push via bound alias propagates to source';
+    @a.push(5);
+    is-deeply @b, [1, 2, 3, 4, 5], 'push via source propagates to bound alias';
+}
+
+# --- Array: single + slice + nested index assignment ---
+{
+    my @a = 1, 2, 3;
+    my @x := @a;
+    @x[0] = 99;
+    is-deeply @a, [99, 2, 3], 'single index assign via alias';
+    @a[1] = 88;
+    is-deeply @x, [99, 88, 3], 'single index assign via source';
+    @x[1, 2] = 10, 20;
+    is-deeply @a, [99, 10, 20], 'slice assign via alias';
+}
+{
+    my @a = [1, 2], [3, 4];
+    my @x := @a;
+    @x[0][1] = 99;
+    is-deeply @a, [[1, 99], [3, 4]], 'nested index assign via alias';
+}
+
+# --- Array: pop / shift / unshift / splice through alias ---
+{
+    my @a = 1, 2, 3, 4, 5;
+    my @b := @a;
+    @a.pop;
+    is-deeply @b, [1, 2, 3, 4], 'pop via source seen by alias';
+    @a.shift;
+    is-deeply @b, [2, 3, 4], 'shift via source seen by alias';
+    @a.unshift(0);
+    is-deeply @b, [0, 2, 3, 4], 'unshift via source seen by alias';
+    @a.splice(1, 1);
+    is-deeply @b, [0, 3, 4], 'splice via source seen by alias';
+    @b.push(99);
+    is-deeply @a, [0, 3, 4, 99], 'push via alias seen by source';
+}
+
+# --- Array: delete through alias ---
+{
+    my @a = 1, 2, 3, 4;
+    my @b := @a;
+    @a[1]:delete;
+    is-deeply @b, [1, Any, 3, 4], 'delete via source seen by alias';
+}
+
+# --- Array: bind then plain reassign source ---
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    @a = (4, 5, 6);
+    is-deeply @b, [4, 5, 6], 'plain reassign of source seen by alias';
+}
+
+# --- Array: rebind source detaches the old alias ---
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    my @c = 7, 8, 9;
+    @a := @c;
+    @a.push(10);
+    is-deeply @b, [1, 2, 3], 'rebound source no longer affects old alias';
+    is-deeply @a, [7, 8, 9, 10], 'rebound source tracks new container';
+}
+
+# --- Array: three-way chained alias shares one container ---
+{
+    my @a = 1, 2;
+    my @b := @a;
+    my @c := @b;
+    @c.push(3);
+    is-deeply @a, [1, 2, 3], 'chained alias: source sees push';
+    is-deeply @b, [1, 2, 3], 'chained alias: middle sees push';
+}
+
+# --- Array: cross-frame parameter alias ---
+{
+    sub mutate(@arr) {
+        my @local := @arr;
+        @local.push(99);
+    }
+    my @a = 1, 2, 3;
+    mutate(@a);
+    is-deeply @a, [1, 2, 3, 99], 'bound alias inside sub mutates caller array';
+}
+
+# --- Array: bind to a literal (no source variable) still mutable ---
+{
+    my @b := [1, 2, 3];
+    @b.push(4);
+    is-deeply @b, [1, 2, 3, 4], 'bind to array literal is mutable';
+}
+
+# --- Hash: bidirectional element assign + delete through alias ---
+{
+    my %h = a => 1, b => 2;
+    my %g := %h;
+    %g<c> = 3;
+    is %h<c>, 3, 'hash element assign via alias propagates to source';
+    %h<d> = 4;
+    is %g<d>, 4, 'hash element assign via source propagates to alias';
+    %g<b>:delete;
+    is-deeply %h.keys.sort, ('a', 'c', 'd'), 'hash delete via alias seen by source';
+}
+
+# --- Iteration / read methods over a bound alias decontainerize ---
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    @a.push(4);
+    is ([+] @b), 10, 'reduce over bound alias sees latest';
+    is @b.elems, 4, 'elems over bound alias';
+    is @b[2], 3, 'index read over bound alias';
+}
+
+# --- A bound container adopts the source's declared element type ---
+{
+    my Int %a;
+    my Cool %b := %a;
+    is %b.of, Int, 'bound hash keeps the source declared element type';
+}


### PR DESCRIPTION
## Summary

Track B (first-class container, element cells): a whole-container `:=` bind
(`my @b := @a`, `my %g := %h`) now makes both variables share a single mutable
`ContainerRef` cell, so mutations through either alias are observed by both —
matching Raku's binding semantics.

Before this change the two slots only shared the inner `Arc`, so a copy-on-write
mutation (`.push`) detached them and the alias silently stopped tracking:

```raku
my @a = 1, 2, 3;
my @b := @a;
@b.push(4);
say @a;   # was [1 2 3]  →  now [1 2 3 4]  (raku)
```

## What changed

- **Read side (Phase 0.5 第2段, read half)**: `GetArrayVar` / `GetHashVar`
  decontainerize a top-level `ContainerRef` cell, so reading a bound `@`/`%`
  variable yields the inner Array/Hash. (Behavior-neutral before this PR since
  `@`/`%` variables never held a cell; the bind path explicitly excluded them.)
- **Bind path**: a whole-container `:=` bind wraps the source container in a
  shared cell (reusing the source's existing cell, so `my @c := @b` joins the
  same one) and binds both source and target to it, propagating the cell into
  saved call frames (cross-frame param binds). A bound container also adopts the
  *source's* declared element type (`my Int %a; my Cool %b := %a` ⇒ `%b.of` is
  `Int`).
- **Mutation paths**: native array mut (`pop`/`shift`/`unshift`/`append`/
  `prepend`), native `splice`, and `:delete` descend the cell via
  `env_root_descended_mut` so the mutation writes through the shared cell. Array
  slice-assign (`@x[1,2] = ...`) likewise descends (it previously fell through to
  the hash-slice path and produced garbage pairs). Single/nested index-assign and
  `push` already descended.

## Tests

- New `t/whole-container-bind.t` (26 subtests): push/pop/shift/unshift/splice/
  delete/index/slice/iteration through aliases, plain reassign, rebind detach,
  three-way chained alias, cross-frame param bind, literal bind, typed `.of`.
- `make test` PASS (6722). `roast/S03-binding/{arrays,hashes,nested,scalars}.t`
  all green. `int.t` perf unchanged (0.15s). Broad array/hash roast sample shows
  zero new failures vs `main` (splice.t's 245 self-reference failures are
  pre-existing and identical on `main`).

## Out of scope (follow-up)

Scalar-to-container bind (`my $ref := @a`) still snapshots: the `$`-sigil bind
takes `bind_vardecl=false` and never emits `WrapVarRef`, so it doesn't reach the
shared-cell path. Fixing it needs a compiler change (emit `WrapVarRef` for scalar
`:=` to a container source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)