### PR TITLE
fix(supply): `done` as an expression term completes the supply (no 30s spin)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -848,6 +848,7 @@ roast/S17-promise/in.t
 roast/S17-promise/lock-async-stress.t
 roast/S17-promise/lock-async-stress2.t
 roast/S17-promise/lock-async.t
+roast/S17-promise/nonblocking-await.t
 roast/S17-promise/single-assignment.t
 roast/S17-promise/stress.t
 roast/S17-scheduler/at.t

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -83,6 +83,14 @@ impl Compiler {
                 let name_idx = self.code.add_constant(Value::str(var_name));
                 self.code.emit(OpCode::GetHashVar(name_idx));
             }
+            Expr::BareWord(name) if name == "done" => {
+                // `done` as a bare term in expression position (e.g. the `!!`
+                // branch of `$cond ?? die !! done`) is the supply/react
+                // completion control flow, not an ordinary bareword. Emit
+                // ReactDone so it signals instead of evaluating to a no-op string
+                // (which left `whenever ... { ... !! done }` never completing).
+                self.code.emit(OpCode::ReactDone);
+            }
             Expr::BareWord(name) => {
                 // Only resolve to GetLocal for sigilless bindings (e.g. `my \Foo = ...`)
                 // or builtin-type-safe locals.  `$`-sigiled variables whose `$` was

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -3331,6 +3331,9 @@ impl Interpreter {
         // with the last emitted value.
         let poll_timeout = Duration::from_millis(10);
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        // The supply's result is the last value it emitted before completing.
+        // Seed it from any values emitted synchronously before the subscriptions.
+        let mut last_value = plain_values.last().cloned().unwrap_or(Value::Nil);
         loop {
             // Check if promise was resolved (by supplier_done via Supplier.done handler)
             if promise.is_resolved() {
@@ -3349,30 +3352,37 @@ impl Interpreter {
                 match sub.receiver.recv_timeout(poll_timeout) {
                     Ok(SupplyEvent::Emit(value)) => {
                         any_active = true;
+                        // Capture values the whenever block `emit`s so a later
+                        // `done` resolves the promise with the last one.
+                        self.supply_emit_buffer.push(Vec::new());
                         let cb_result =
                             self.call_sub_value(sub.callback.clone(), vec![value], true);
-                        // `done`/`last` etc. inside the whenever resolve the
-                        // promise via the Supplier.done handler.
+                        let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
+                        if let Some(last) = emitted.last() {
+                            last_value = last.clone();
+                        }
                         if promise.is_resolved() {
                             return Ok(());
                         }
-                        // A `die` inside the whenever block quits the supply: break
-                        // the awaited promise with the cause (otherwise the poll
-                        // loop would spin to its deadline — a hang). Control-flow
-                        // signals (done/last/next/redo) are not failures.
-                        if let Err(err) = cb_result
-                            && !err.is_react_done
-                            && !err.is_last
-                            && !err.is_next
-                            && !err.is_redo
-                        {
-                            let cause = err
-                                .exception
-                                .as_deref()
-                                .cloned()
-                                .unwrap_or_else(|| Value::str(err.message.clone()));
-                            promise.break_with(cause, String::new(), String::new());
-                            return Ok(());
+                        if let Err(err) = cb_result {
+                            // `done` (and `last`) inside the whenever complete the
+                            // supply: keep the promise with the last emitted value
+                            // immediately, instead of spinning to the poll deadline.
+                            if err.is_react_done || err.is_last {
+                                promise.keep(last_value.clone(), String::new(), String::new());
+                                return Ok(());
+                            }
+                            // `next`/`redo` are loop control, not completion.
+                            if !err.is_next && !err.is_redo {
+                                // A `die` quits the supply: break with the cause.
+                                let cause = err
+                                    .exception
+                                    .as_deref()
+                                    .cloned()
+                                    .unwrap_or_else(|| Value::str(err.message.clone()));
+                                promise.break_with(cause, String::new(), String::new());
+                                return Ok(());
+                            }
                         }
                     }
                     Ok(SupplyEvent::Done) => {

--- a/t/supply-done-expression.t
+++ b/t/supply-done-expression.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `done` used as a bare term in expression position (e.g. the `!!` branch of a
+# ternary inside a `whenever`) must signal supply/react completion, exactly like
+# the statement form. Previously it parsed to a no-op bareword, so an on-demand
+# supply never completed and `await` spun to the poll deadline (~30s).
+
+plan 4;
+
+# `done` in the else branch of a ternary completes the supply promptly.
+{
+    my $start = now;
+    await supply {
+        whenever Supply.interval(0.01) {
+            False ?? emit(1) !! done
+        }
+    };
+    ok now - $start < 5, 'await of supply whose whenever runs `done` (else branch) returns promptly';
+}
+
+# emit-then-done returns the last emitted value.
+{
+    is (await supply { whenever Supply.interval(0.01) { emit 42; done } }), 42,
+        'emit then done returns the emitted value';
+}
+
+# A whenever that dies (then branch) breaks the awaited promise promptly.
+{
+    my $start = now;
+    my $threw = False;
+    try {
+        await supply { whenever Supply.interval(0.01) { True ?? die('boom') !! done } };
+        CATCH { default { $threw = True } }
+    }
+    ok $threw && now - $start < 5, 'a dying whenever breaks the await promptly';
+}
+
+# A mix of done and die across many parallel supplies completes promptly.
+{
+    my $start = now;
+    my @proms = (1..40).map: -> $i {
+        start {
+            await supply {
+                whenever Supply.interval(0.001) {
+                    $i > 20 ?? die 'boom' !! done
+                }
+            }
+        }
+    };
+    my $threw = False;
+    try { await @proms; CATCH { default { $threw = True } } }
+    ok $threw && now - $start < 10,
+        'parallel supplies that done/die complete promptly without spinning';
+}


### PR DESCRIPTION
## Summary

`done` written as a bare term in **expression** position — e.g. the `!!` branch of `$i > 50 ?? die 'x' !! done` inside a `whenever` — parsed to `Expr::BareWord` and compiled to a no-op evaluating to the string `"done"`, instead of the supply/react completion control flow. So an on-demand supply whose `whenever` completed via such a `done` never resolved its promise, and `await` spun in the poll loop until its **30-second deadline**.

## What changed

- Compile a bare `done` term as `OpCode::ReactDone`, matching the statement form (`Expr::BareWord("done")`). In Raku a bare `done` is always the completion keyword.
- In the on-demand supply poll loop (`supply_promise_on_demand`), track the last emitted value and, when a `whenever` callback signals react-done / `last`, keep the promise with it immediately instead of waiting for the deadline.

## Impact

`roast/S17-promise/nonblocking-await.t`: **~35s → ~7s** (release), fast enough to whitelist. **Added to `roast-whitelist.txt`** (all 28 subtests pass).

## Testing
- New `t/supply-done-expression.t` (4 subtests).
- `make test` passes; S17 supply suite (grab/map/throttle/list) + gather green; whitelist sorted; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)