### PR TITLE
fix(parser): allow a parenthesized listop in a ternary then-branch

### DIFF
--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -195,13 +195,20 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
         let result = normalize_chained_zip_meta(first);
         // Wrap in Grouped so the compiler's chain-flattener can
         // distinguish `(1|2)|3` from `1|2|3` for junction operators.
+        //
+        // A lone parenthesized bareword (a listop term such as `(done)`) is also
+        // wrapped: the parens close off the listop so it cannot gobble a trailing
+        // operator, which lets `1 ?? (done) !! 2` parse (matching Rakudo). Without
+        // the wrapper the ternary then-branch check would reject the naked
+        // `BareWord`, conflating `(done)` with the gobbling `done`.
         let result = if matches!(
             &result,
             Expr::Binary {
                 op: TokenKind::Pipe | TokenKind::Ampersand | TokenKind::Caret,
                 ..
             }
-        ) {
+        ) || matches!(&result, Expr::BareWord(_))
+        {
             Expr::Grouped(Box::new(result))
         } else {
             result

--- a/t/known-call-ternary.t
+++ b/t/known-call-ternary.t
@@ -1,9 +1,23 @@
 use Test;
 
-plan 3;
+plan 6;
 
 is do { defined(42) ?? 1 !! 2 }, 1, 'ternary after known call parses in do block';
 
 sub optional($p?) { defined($p) ?? $p !! 'undef' }
 is optional('abc'), 'abc', 'ternary after known call parses in sub body';
 is optional(), 'undef', 'optional arg + ternary else branch works';
+
+# A naked listop term (e.g. `done`) in the then-branch would gobble the `!!`,
+# so Rakudo requires parenthesizing it. The parens must let it parse and the
+# else-branch must still be reachable.
+sub picks-else { my $r = 'init'; 0 ?? (done) !! ($r = 'else'); $r }
+is picks-else(), 'else', 'parenthesized `(done)` in then-branch keeps ternary intact';
+
+# A parenthesized control-flow term in the then-branch fires when selected.
+sub picks-then { for 1..5 { $_ == 2 ?? (last) !! Nil }; 'returned' }
+is picks-then(), 'returned', 'parenthesized `(last)` in then-branch parses and runs';
+
+# The explicit call form `done()` has always parsed; keep it covered.
+sub call-form { my $r = 'init'; 0 ?? done() !! ($r = 'else'); $r }
+is call-form(), 'else', 'ternary then-branch `done()` call parses';


### PR DESCRIPTION
## Summary

A naked listop term such as `done` in the then-branch of a ternary `?? !!` gobbles the `!!`. Rakudo rejects `1 ?? done !! 2` with *"Your !! was gobbled by the expression in the middle; please parenthesize"* — and mutsu correctly rejects it too. The Rakudo escape hatch is to parenthesize the term: `1 ?? (done) !! 2`.

mutsu wrongly rejected the **parenthesized** form as well, because `(done)` collapsed to a bare `Expr::BareWord("done")` in the AST — indistinguishable from the naked `done` — so the ternary then-branch gobble-check fired anyway.

## Fix

In `paren_expr`, wrap a lone parenthesized bareword in `Expr::Grouped` (already a transparent wrapper in the compiler, so runtime behavior is unchanged). This preserves the fact that the parens closed off the listop, letting `1 ?? (done) !! 2` parse while still rejecting the naked `1 ?? done !! 2`.

### Verified

- `1 ?? (done) !! 2`, `1 ?? done() !! 2` parse; `1 ?? done !! 2` still rejected (matches Rakudo).
- `(foo)()`, `(Int)`, `(C).new.m` unchanged (and `(foo)()` matches Rakudo's `CALL-ME` error).
- `roast/S03-operators/ternary.t` 28/28 PASS; `make test` PASS.

Note: the diagnostic for the *unparenthesized* gobble case is still mutsu's generic "expected statement" cascade rather than Rakudo's typed `X::Syntax::ConditionalOperator::SecondPartGobbled`; improving that message is left as separate follow-up (ternary.t's `throws-like` case already passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)