### PR TITLE
feat(bind): share a cell for scalar := whole-container binds (Track B)

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -769,6 +769,21 @@ impl Compiler {
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
                     self.bind_terminal = false;
+                } else if scalar_bind_decont && matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
+                {
+                    // A scalar `:=` bind to a *whole* container variable
+                    // (`my $ref := @a` / `my $ref := %h`) must alias the same
+                    // container, not snapshot it (so `$ref.push` mutates `@a`).
+                    // Route through compile_call_arg so WrapVarRef is emitted and
+                    // SetLocal's whole-container bind path shares one cell, just
+                    // like `my @b := @a`. (Scalar binds normally take the
+                    // assignment path below, which only Arc-shares — a COW push
+                    // would then detach the alias.)
+                    self.scalar_bind_autovivify = true;
+                    self.bind_terminal = true;
+                    self.compile_call_arg(expr);
+                    self.scalar_bind_autovivify = false;
+                    self.bind_terminal = false;
                 } else {
                     let rhs_expr = if has_default_trait
                         && !name.starts_with('@')

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1472,9 +1472,16 @@ impl VM {
         if !matches!(method, "append" | "prepend" | "unshift" | "pop" | "shift") {
             return None;
         }
-        // Only a plain `@`-sigiled variable whose value is a real `[...]` array
-        // (ArrayKind::Array). This excludes List/Item/Shaped/Lazy kinds.
-        if !target_name.starts_with('@')
+        // A plain `@`-sigiled variable whose value is a real `[...]` array
+        // (ArrayKind::Array), excluding List/Item/Shaped/Lazy kinds — OR a scalar
+        // variable bound to a whole array container (`my $r := @a`), which holds
+        // a shared `ContainerRef` cell that `env_root_descended_mut` below
+        // unwraps so the mutation still writes through the shared array.
+        let is_bound_cell = matches!(
+            self.interpreter.env().get(target_name),
+            Some(Value::ContainerRef(_))
+        );
+        if (!target_name.starts_with('@') && !is_bound_cell)
             || !matches!(target, Value::Array(_, crate::value::ArrayKind::Array))
         {
             return None;
@@ -1564,9 +1571,15 @@ impl VM {
         if method != "splice" {
             return None;
         }
-        // Only a plain `@`-sigiled variable whose value is a real `[...]` array
-        // (ArrayKind::Array). This excludes List/Item/Shaped/Lazy kinds.
-        if !target_name.starts_with('@')
+        // A plain `@`-sigiled variable whose value is a real `[...]` array
+        // (ArrayKind::Array), excluding List/Item/Shaped/Lazy — OR a scalar bound
+        // to a whole array container (`my $r := @a`), unwrapped via
+        // `env_root_descended_mut` below.
+        let is_bound_cell = matches!(
+            self.interpreter.env().get(target_name),
+            Some(Value::ContainerRef(_))
+        );
+        if (!target_name.starts_with('@') && !is_bound_cell)
             || !matches!(target, Value::Array(_, crate::value::ArrayKind::Array))
         {
             return None;

--- a/t/whole-container-bind.t
+++ b/t/whole-container-bind.t
@@ -6,7 +6,7 @@ use Test;
 # fix, the two slots only shared the inner Arc and a COW mutation (`.push`)
 # detached them.
 
-plan 26;
+plan 33;
 
 # --- Array: push through either alias propagates both ways ---
 {
@@ -134,4 +134,28 @@ plan 26;
     my Int %a;
     my Cool %b := %a;
     is %b.of, Int, 'bound hash keeps the source declared element type';
+}
+
+# --- Scalar bound to a whole container (`my $r := @a`) shares it too ---
+{
+    my @a = 1, 2, 3;
+    my $r := @a;
+    $r.push(4);
+    is-deeply @a, [1, 2, 3, 4], 'push via scalar-bound array propagates to source';
+    @a.push(5);
+    is-deeply $r, [1, 2, 3, 4, 5], 'push via source propagates to scalar alias';
+    $r[0] = 99;
+    is-deeply @a, [99, 2, 3, 4, 5], 'index assign via scalar alias';
+    $r.pop;
+    is-deeply @a, [99, 2, 3, 4], 'pop via scalar alias propagates to source';
+    $r.splice(1, 1);
+    is-deeply @a, [99, 3, 4], 'splice via scalar alias propagates to source';
+}
+{
+    my %h = a => 1;
+    my $hr := %h;
+    $hr<b> = 2;
+    is %h<b>, 2, 'hash element assign via scalar alias propagates to source';
+    $hr<a>:delete;
+    is-deeply %h.keys.sort, ('b',), 'hash delete via scalar alias seen by source';
 }


### PR DESCRIPTION
## Summary

Follow-up to #2990. A scalar `:=` bind to a *whole* container variable
(`my $r := @a` / `my $r := %h`) now aliases the same container instead of
snapshotting it, so mutations through either side propagate — matching the
`@b := @a` behavior #2990 landed:

```raku
my @a = 1, 2, 3;
my $r := @a;
$r.push(4);
say @a;   # was [1 2 3]  →  now [1 2 3 4]
```

## What changed

- **compiler** (`stmt.rs`): route a scalar `:=` bind whose RHS is a whole `@`/`%`
  variable through `compile_call_arg`, so `WrapVarRef` is emitted and SetLocal's
  whole-container bind path (from #2990) shares one `ContainerRef` cell. Scalar
  binds otherwise take the assignment path, which only shares the inner `Arc` —
  a COW `.push` then detaches the alias. Scalar-to-scalar (`$x := $y`) and
  scalar-to-element (`$e := %h<k>` / `$el := @a[0]`) binds are untouched (the new
  branch only matches `Expr::ArrayVar`/`HashVar` RHS).
- **vm** (`vm_call_method_mut_ops.rs`): relax the native array-mut and `splice`
  fast paths to also accept a scalar variable bound to a whole array (env holds a
  `ContainerRef`), unwrapped via `env_root_descended_mut` so
  pop/shift/unshift/append/prepend/splice write through the shared cell. (push,
  index-assign, hash element assign and `:delete` already worked via the
  cell-descending paths.)

## Tests

- `t/whole-container-bind.t` extended to 33 subtests (scalar push/pop/splice/
  index/hash-assign/delete through the alias).
- `cargo test` + local `prove t/` PASS; `cargo clippy -D warnings` clean.
  Scalar-to-scalar and scalar-to-element binds verified unchanged. Relying on CI
  for the full `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)