### PR TITLE
feat(container): reflect bound container type in .VAR.^name (Track B)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -242,8 +242,12 @@ STATUS で撤回済み。
 
 各項目は深い。**ROI が明確なとき**（特定 whitelist 候補ファイルが残り 1–2 subtest で、原因が該当バグ）にだけ着手する。
 
-- [ ] **`.VAR.^name` 束縛コンテナ反映** — `my $l := (1,2,3); $l.VAR.^name` が `Scalar`（raku `List`）。
-      格納時コンテナ status が要る。
+- [x] **`.VAR.^name` 束縛コンテナ反映 (DONE)** — `my $l := (1,2,3); $l.VAR.^name` を `List`（旧 `Scalar`）に。
+      scalar `:=`-bound to a container（`@a`/`%h`/`(1,2,3)`/Set/Bag/Mix）は Scalar コンテナを持たず
+      コンテナを直接 alias するため `.VAR` は束縛値自体を返す。`__mutsu_bound_decont` marker を Hash/Set/Bag/Mix/
+      ContainerRef へ拡張し、VAR ハンドラ（methods_mut.rs）が marker を見て target を返す。scalar rebind
+      （`$r := ...`、VarDecl でないので `__scalar_bind` 無し）も `MarkScalarBindContext` を emit して marker 維持。
+      `t/var-name-bind.t`(16)。
 - [ ] **配列/ハッシュ要素のセル化（COW）= Phase 2 残り** — 深い `>>++`・`deepmap(++*)`（hyper.t 330-333）。
       最ホット表現に触る大改修。下記「設計の鍵」を適用。（`is rw` 共有セル #2928・take-rw #2930・
       束縛要素セル #2902-#2925 は landed）

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1124,6 +1124,14 @@ impl Compiler {
                 if matches!(op, AssignOp::Bind) {
                     if effective_name.starts_with('@') {
                         self.code.emit(OpCode::MarkBindContext);
+                    } else if !effective_name.starts_with('%') && !effective_name.starts_with('&') {
+                        // A scalar rebind (`$r := ...`) is still a bind: mark it
+                        // so SetLocal records the bound-decont marker (it has no
+                        // `__scalar_bind` trait like a `my $r := ...` VarDecl
+                        // does). Without this the rebind is seen as a plain
+                        // assignment and clears the marker, so `$r.VAR.^name`
+                        // would wrongly report Scalar and `@a = $r` would itemize.
+                        self.code.emit(OpCode::MarkScalarBindContext);
                     }
                     // Signal rebind context for cleanup of old bind pairs.
                     self.code.emit(OpCode::MarkRebindContext);

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1748,6 +1748,21 @@ impl Interpreter {
                     return Ok(target);
                 }
             }
+            // A scalar `:=`-bound to a container (`my $r := @a` / `:= %h` /
+            // `:= (1,2,3)`) has no Scalar container of its own — the binding
+            // aliases the container directly — so `.VAR` returns the bound value
+            // itself and `.VAR.^name` reflects the container type (List/Array/
+            // Hash/...), not Scalar. The `__mutsu_bound_decont` marker records
+            // such binds.
+            if !target_var.starts_with('@')
+                && !target_var.starts_with('%')
+                && !target_var.starts_with('&')
+            {
+                let decont_key = format!("__mutsu_bound_decont::{}", target_var);
+                if matches!(self.env.get(&decont_key), Some(Value::Bool(true))) {
+                    return Ok(target);
+                }
+            }
             let class_name = if target_var.starts_with('@') {
                 "Array"
             } else if target_var.starts_with('%') {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -938,7 +938,11 @@ impl VM {
             return;
         }
         if is_bind {
-            let is_positional = match val {
+            // A scalar bound to a container (`$x := @a` / `:= %h` / `:= (1,2,3)`)
+            // is not a Scalar container of its own: it aliases the container, so
+            // `@a = $bound` flattens (ItemizeVar) and `$bound.VAR.^name` reflects
+            // the container type (List/Array/Hash/Set/Bag/Mix) rather than Scalar.
+            let is_container = match &val {
                 Value::Array(_, k) => !k.is_itemized(),
                 Value::Seq(_)
                 | Value::Slip(_)
@@ -946,10 +950,24 @@ impl VM {
                 | Value::Range(..)
                 | Value::RangeExcl(..)
                 | Value::RangeExclStart(..)
-                | Value::RangeExclBoth(..) => true,
+                | Value::RangeExclBoth(..)
+                | Value::Hash(_)
+                | Value::Set(..)
+                | Value::Bag(..)
+                | Value::Mix(..) => true,
+                // A `:=` bind to a whole-container `@`/`%` variable holds a
+                // shared cell whose inner value is the container.
+                Value::ContainerRef(cell) => matches!(
+                    &*cell.lock().unwrap(),
+                    Value::Array(..)
+                        | Value::Hash(_)
+                        | Value::Set(..)
+                        | Value::Bag(..)
+                        | Value::Mix(..)
+                ),
                 _ => false,
             };
-            if is_positional {
+            if is_container {
                 let key = format!("__mutsu_bound_decont::{}", name);
                 self.interpreter.env_mut().insert(key, Value::Bool(true));
                 self.bound_decont_active = true;

--- a/t/var-name-bind.t
+++ b/t/var-name-bind.t
@@ -1,0 +1,80 @@
+use Test;
+
+# `.VAR.^name` reflects the container a variable lives in. A scalar `:=`-bound
+# to a container (`my $r := @a` / `:= %h` / `:= (1,2,3)`) aliases that container
+# directly and so has no Scalar container of its own — `.VAR.^name` must report
+# the underlying container type, not "Scalar". An assigned scalar (`my $s = ...`)
+# IS a Scalar container.
+
+plan 16;
+
+# --- Assigned scalars are Scalar containers ---
+{
+    my $s = 5;
+    is $s.VAR.^name, 'Scalar', 'assigned Int scalar .VAR is Scalar';
+    my $a = (1, 2, 3);
+    is $a.VAR.^name, 'Scalar', 'assigned List scalar .VAR is Scalar';
+}
+
+# --- @ / % variables report their container type (unchanged) ---
+{
+    my @a = 1, 2, 3;
+    is @a.VAR.^name, 'Array', '@-variable .VAR is Array';
+    my %h = a => 1;
+    is %h.VAR.^name, 'Hash', '%-variable .VAR is Hash';
+}
+
+# --- A scalar bound to a List literal reflects List ---
+{
+    my $l := (1, 2, 3);
+    is $l.VAR.^name, 'List', 'scalar bound to a List literal .VAR is List';
+    is (1, 2, 3).VAR.^name, 'List', 'List literal .VAR is List';
+}
+
+# --- A scalar bound to a whole @ / % variable reflects Array / Hash ---
+{
+    my @a = 1, 2, 3;
+    my $b := @a;
+    is $b.VAR.^name, 'Array', 'scalar bound to @a .VAR is Array';
+    my %h = a => 1;
+    my $hr := %h;
+    is $hr.VAR.^name, 'Hash', 'scalar bound to %h .VAR is Hash';
+}
+
+# --- Bound scalars still flatten on @-assignment (ItemizeVar semantics) ---
+{
+    my @a = 1, 2, 3;
+    my $b := @a;
+    my @c = $b;
+    is @c.elems, 3, 'scalar bound to an array flattens on @-assignment';
+    my $l := (4, 5, 6);
+    my @d = $l;
+    is @d.elems, 3, 'scalar bound to a List flattens on @-assignment';
+    # An assigned scalar itemizes (does NOT flatten).
+    my $s = (7, 8, 9);
+    my @e = $s;
+    is @e.elems, 1, 'assigned List scalar itemizes on @-assignment';
+}
+
+# --- .VAR.name still returns the variable name ---
+{
+    my $x = 5;
+    is $x.VAR.name, '$x', '.VAR.name returns the sigil-qualified variable name';
+}
+
+# --- Set / Bag bound scalars reflect their type ---
+{
+    my $s := <a b c>.Set;
+    is $s.VAR.^name, 'Set', 'scalar bound to a Set .VAR is Set';
+    my $bag := <a a b>.Bag;
+    is $bag.VAR.^name, 'Bag', 'scalar bound to a Bag .VAR is Bag';
+}
+
+# --- A re-bound scalar updates its reflected container ---
+{
+    my @a = 1, 2;
+    my $r := @a;
+    is $r.VAR.^name, 'Array', 'bound scalar reflects Array before rebind';
+    $r := (1, 2, 3);
+    is $r.VAR.^name, 'List', 'rebound scalar reflects List after rebind';
+}


### PR DESCRIPTION
## Summary

Track B (first-class container). A scalar `:=`-bound to a container
(`my $r := @a` / `:= %h` / `:= (1,2,3)`) aliases that container directly and has
no Scalar container of its own, so `.VAR` must return the bound value itself and
`.VAR.^name` reflect the container type — not `Scalar`:

```raku
my $l := (1, 2, 3);          say $l.VAR.^name;   # was Scalar → now List
my @a = 1,2,3; my $b := @a;  say $b.VAR.^name;   # was Scalar → now Array
my %h = a=>1;  my $hr := %h; say $hr.VAR.^name;  # was Scalar → now Hash
```

An assigned scalar (`my $s = ...`) is still a Scalar container.

## What changed

- `update_bound_decont_marker` now records the bound-decont marker for Hash /
  Set / Bag / Mix / whole-container `ContainerRef` sources too (previously only
  List / Array / Seq / Range / Slip / LazyList).
- the `.VAR` handler (`methods_mut.rs`) returns the bound value directly when the
  `__mutsu_bound_decont` marker is set, instead of synthesizing a `Scalar`
  container purely from the sigil.
- a scalar rebind (`$r := …`, an `Assign{op:Bind}` with no `__scalar_bind`
  trait) now emits `MarkScalarBindContext` so the marker is maintained across
  rebinding (and `@a = $r` keeps flattening); previously the rebind was treated
  as a plain assignment and cleared the marker, so `$r.VAR.^name` wrongly
  reported `Scalar` again.

## Tests

- New `t/var-name-bind.t` (16 subtests): assigned vs bound scalars, `@`/`%`
  variables, List-literal binds, whole-`@`/`%` binds, Set/Bag binds, rebind,
  `.VAR.name`, and the preserved `@a = $bound` flattening / assigned-scalar
  itemization semantics.
- `cargo test` 461/0; `t/` binding suite + VAR-using roast
  (`S02-names/name.t`, `is_dynamic.t`, `S32-scalar/perl.t`, `sethash.t`) green.
  Relying on CI for the full `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)