### PR TITLE
fix(control): emit/done outside supply throw X::ControlFlow

### DIFF
--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -252,8 +252,25 @@ impl RuntimeError {
     }
 
     pub(crate) fn react_done_signal() -> Self {
+        // When `done` propagates unhandled (no enclosing supply/react), it
+        // becomes X::ControlFlow with illegal=>"done", enclosing=>"supply or
+        // react". Pre-set the exception so throws-like / CATCH can match the
+        // correct type; the supply/react runtime consumes the `is_react_done`
+        // flag before this exception is ever observed.
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("illegal".to_string(), Value::str("done".to_string()));
+        attrs.insert(
+            "enclosing".to_string(),
+            Value::str("supply or react".to_string()),
+        );
+        attrs.insert(
+            "message".to_string(),
+            Value::str("done without supply or react".to_string()),
+        );
+        let xcf = Self::typed("X::ControlFlow", attrs);
         Self {
             is_react_done: true,
+            exception: xcf.exception,
             ..Self::new("")
         }
     }
@@ -297,10 +314,27 @@ impl RuntimeError {
     }
 
     pub(crate) fn emit_signal(value: Value) -> Self {
+        // When CX::Emit propagates unhandled (no enclosing supply/react), it
+        // becomes X::ControlFlow with illegal=>"emit", enclosing=>"supply or
+        // react". Pre-set the exception so throws-like / CATCH can match the
+        // correct type; the supply/react runtime consumes the `is_emit` flag
+        // before this exception is ever observed.
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("illegal".to_string(), Value::str("emit".to_string()));
+        attrs.insert(
+            "enclosing".to_string(),
+            Value::str("supply or react".to_string()),
+        );
+        attrs.insert(
+            "message".to_string(),
+            Value::str("emit without supply or react".to_string()),
+        );
+        let xcf = Self::typed("X::ControlFlow", attrs);
         Self {
             message: "CX::Emit".to_string(),
             is_emit: true,
             return_value: Some(value),
+            exception: xcf.exception,
             ..Self::new("")
         }
     }

--- a/t/emit-done-controlflow.t
+++ b/t/emit-done-controlflow.t
@@ -1,0 +1,29 @@
+use Test;
+plan 5;
+
+# `emit` / `done` used outside any supply/react block must raise
+# X::ControlFlow (illegal => 'emit'/'done', enclosing => 'supply or react'),
+# matching Rakudo. See roast/S17-supply/syntax.t.
+
+throws-like 'emit 42', X::ControlFlow, illegal => 'emit',
+    enclosing => 'supply or react',
+    'bare emit outside supply throws X::ControlFlow';
+throws-like 'done', X::ControlFlow, illegal => 'done',
+    enclosing => 'supply or react',
+    'bare done outside supply throws X::ControlFlow';
+
+throws-like 'emit 42', X::ControlFlow,
+    message => 'emit without supply or react',
+    'emit X::ControlFlow message matches Rakudo';
+throws-like 'done', X::ControlFlow,
+    message => 'done without supply or react',
+    'done X::ControlFlow message matches Rakudo';
+
+# Sanity: emit/done inside a supply are still ordinary control flow,
+# not exceptions — `done` stops the block after the first emit.
+{
+    my @got;
+    my $s = supply { emit 1; done; emit 2; }
+    $s.tap({ @got.push($_) });
+    is @got, [1], 'emit/done inside supply remain normal control flow';
+}


### PR DESCRIPTION
## Summary

`emit` and `done` used outside any enclosing `supply`/`react` block must raise **X::ControlFlow** in Rakudo:

- `illegal => 'emit'` / `'done'`
- `enclosing => 'supply or react'`
- message `"emit without supply or react"` / `"done without supply or react"`

mutsu let the raw `CX::Emit` / `CX::Done` control signal escape **untyped**, so `throws-like 'emit 42', X::ControlFlow` failed on the exception type. This fixes `roast/S17-supply/syntax.t` tests 54 & 55.

## Fix

Pre-set the `X::ControlFlow` exception on `emit_signal` / `react_done_signal`, exactly as `take_signal` already does for `take`-without-gather. The supply/react/gather runtime keys off the `is_emit` / `is_react_done` flags and consumes the signal **before** this exception is ever observed, so normal in-supply control flow is unchanged.

### Verified

- `roast/S17-supply/syntax.t` tests 54/55 now pass (the rest of that file's failures are unrelated deeper supply-runtime gaps — LAST/CLOSE/QUIT phasers, `Supply.interval` in `react` — out of scope here).
- `supply { emit 1; done; emit 2 }` still yields `[1]`; `react`/`whenever`, `gather`/`take`, and whitelisted `S32-exceptions/misc2.t` unaffected.
- `make test` PASS (6772 tests). New regression test `t/emit-done-controlflow.t`.

Note: catching these via `try`/`CATCH` directly (vs `throws-like`'s EVAL boundary) is a separate, pre-existing gap that also affects `take`; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)