### PR TITLE
fix(hyper): write back hyper mutations to nested elements (Track B)

### DIFF
--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -358,6 +358,20 @@ impl VM {
             }
         }
         if let Value::Array(existing, kind) = &target {
+            // In-place write back through the target's `Arc<ArrayData>` so a
+            // hyper mutation on a *nested* element (`@b[0]>>++`, `%h<a>>>++`,
+            // `$r>>++` where `$r := @a`) reaches the element: the read shares the
+            // inner Arc with the slot that holds it, so mutating the Arc's items
+            // is observed there. The by-identity binding scan below only reaches
+            // top-level variable bindings (it misses array/hash elements).
+            // SAFETY: mutsu is single-threaded; no immutable borrow into this
+            // ArrayData is alive across the write.
+            {
+                let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
+                unsafe {
+                    (*ptr).items = items.clone();
+                }
+            }
             self.interpreter.overwrite_array_items_by_identity_for_vm(
                 existing,
                 items.clone(),
@@ -714,6 +728,15 @@ impl VM {
             }
         }
         if let Value::Array(existing, kind) = &target {
+            // In-place write back through the target's `Arc<ArrayData>` so a
+            // nested-element hyper mutation reaches the element (see the twin
+            // site in `exec_hyper_method_call_op`). SAFETY: single-threaded.
+            {
+                let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
+                unsafe {
+                    (*ptr).items = items.clone();
+                }
+            }
             self.interpreter.overwrite_array_items_by_identity_for_vm(
                 existing,
                 items.clone(),

--- a/t/hyper-nested-writeback.t
+++ b/t/hyper-nested-writeback.t
@@ -1,0 +1,66 @@
+use Test;
+
+# A hyper postfix/method mutation (`>>++`, `>>.=method`) on a *nested* element
+# (an array element, a hash value, or a scalar bound to a container) must write
+# back to that element. Before the fix the runtime only wrote back to top-level
+# variable bindings by Arc identity, missing nested elements, so `@b[0]>>++`
+# left `@b[0]` unchanged. (Track B element-cell: deep `>>++`.)
+
+plan 10;
+
+# --- Hyper increment on an array element that is itself an array ---
+{
+    my @b = [1, 2], [3, 4];
+    @b[0]>>++;
+    is-deeply @b, [[2, 3], [3, 4]], 'hyper ++ on @b[0] writes back to the element';
+    @b[1]>>++;
+    is-deeply @b, [[2, 3], [4, 5]], 'hyper ++ on @b[1] writes back to the element';
+}
+
+# --- Hyper increment on a hash value that is an array ---
+{
+    my %h = a => [1, 2], b => [3, 4];
+    %h<a>>>++;
+    is-deeply %h<a>, [2, 3], 'hyper ++ on %h<a> writes back to the value';
+    is-deeply %h<b>, [3, 4], 'sibling hash value untouched';
+}
+
+# --- Hyper increment through a scalar bound to a whole array ---
+{
+    my @a = 1, 2, 3;
+    my $r := @a;
+    $r>>++;
+    is-deeply @a, [2, 3, 4], 'hyper ++ through scalar-bound array writes to source';
+}
+
+# --- Whole-variable hyper increment still works (regression guard) ---
+{
+    my @a = 1, 2, 3;
+    @a>>++;
+    is-deeply @a, [2, 3, 4], 'hyper ++ on whole @-variable still works';
+    my %h = a => 1, b => 2;
+    %h>>++;
+    is-deeply %h, {a => 2, b => 3}, 'hyper ++ on whole %-variable still works';
+}
+
+# --- Hyper .=method mutation on a nested element ---
+{
+    my @b = ["a", "b"], ["c", "d"];
+    @b[0]>>.=uc;
+    is-deeply @b, [["A", "B"], ["c", "d"]], 'hyper .=uc on @b[0] writes back';
+}
+
+# --- deepmap-style nested increment (whole structure) ---
+{
+    my @a = [1, 2], [3, 4];
+    deepmap(++*, @a);
+    is-deeply @a, [[2, 3], [4, 5]], 'deepmap(++*) mutates nested elements';
+}
+
+# --- A bound element of @b stays shared after hyper mutation ---
+{
+    my @b = [1, 2], [3, 4];
+    my $inner := @b[0];
+    @b[0]>>++;
+    is-deeply $inner, [2, 3], 'a separate bind to @b[0] sees the hyper mutation';
+}


### PR DESCRIPTION
## Summary

Track B (first-class container, deep `>>++`). A hyper postfix/method mutation on
a **nested** element — `@b[0]>>++`, `%h<a>>>++`, or `$r>>++` where `$r := @a` —
left the element unchanged:

```raku
my @b = [1,2],[3,4];  @b[0]>>++;  say @b;   # was [[1 2] [3 4]] → now [[2 3] [3 4]]
my %h = a=>[1,2];     %h<a>>>++;  say %h<a>; # was [1 2] → now [2 3]
my @a = 1,2,3; my $r := @a; $r>>++; say @a;  # was [1 2 3] → now [2 3 4]
```

The hyper writeback only reached *top-level* variable bindings by `Arc` identity
(`overwrite_array_items_by_identity_for_vm`), which never visits array/hash
elements, so a nested target was silently dropped.

## Fix

Also write the mutated items in place through the target's own
`Arc<ArrayData>`. A hyper target read from an element shares that inner Arc with
the slot holding it, so the in-place update is observed at the element (and at
any other alias of the same container). The by-identity scan is kept for
top-level bindings that may have COW-detached. Applied at both hyper writeback
sites (`exec_hyper_method_call_op` and the recursive helper).

## Tests

- New `t/hyper-nested-writeback.t` (10 subtests): `@b[i]>>++`, `%h<k>>>++`,
  scalar-bound `$r>>++`, whole-variable regression guards, `>>.=uc` on an
  element, `deepmap(++*)`, and a separate bind to `@b[0]` observing the mutation.
- `roast/S03-metaops/hyper.t` unchanged (399 ok / 9 pre-existing nodality
  failures); `cargo test` 461/0; whitelisted `S02-literals/adverbs.t` (TODO-aware
  PASS) and `S03-operators/subscript-adverbs.t` (110/0) green. Relying on CI for
  the full `make roast`.

## Note (out of scope)

A separate, pre-existing issue remains where `my @x = @a; @a>>++` also mutates
the COW-shared `@x` (the by-identity scan over-reaches assignment copies). That
is assignment-copy semantics, orthogonal to this element-writeback fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)