### PR TITLE
fix(supply): run LAST phaser in whenever on done; route its emit

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -220,6 +220,13 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             name,
             body: rewrite_supply_body(body, emitter_name),
         },
+        // Phaser bodies (LAST/QUIT/FIRST/NEXT/...) inside a supply/whenever
+        // can also `emit`/`done`; rewrite them to the emitter just like the
+        // main body so e.g. `LAST { emit "done" }` forwards to the supply.
+        Stmt::Phaser { kind, body } => Stmt::Phaser {
+            kind,
+            body: rewrite_supply_body(body, emitter_name),
+        },
         Stmt::Label { name, stmt } => Stmt::Label {
             name,
             stmt: Box::new(rewrite_supply_stmt(*stmt, emitter_name)),

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -658,6 +658,21 @@ impl Interpreter {
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(supplier_id, qf.clone());
                                 }
+                                // Register the whenever's own LAST phaser
+                                // callbacks (arr[2]) as done callbacks on the
+                                // inner supplier, BEFORE the group marker, so
+                                // that when the inner supplier signals done the
+                                // LAST blocks run first. Their `emit` routes to
+                                // the supply block's emitter (and out to the
+                                // outer tap) just like the main body's emit.
+                                if let Value::Array(last_arr, ..) = &arr[2] {
+                                    for last_cb in last_arr.iter() {
+                                        register_supplier_done_callback(
+                                            supplier_id,
+                                            last_cb.clone(),
+                                        );
+                                    }
+                                }
                                 // Register done callback: use the group marker
                                 // so done only fires when ALL whenevers complete.
                                 if let Some(ref marker) = done_group_marker {
@@ -2625,6 +2640,21 @@ impl Interpreter {
                                 }
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(supplier_id, qf.clone());
+                                }
+                                // Register the whenever's own LAST phaser
+                                // callbacks (arr[2]) as done callbacks on the
+                                // inner supplier, BEFORE the group marker, so
+                                // that when the inner supplier signals done the
+                                // LAST blocks run first. Their `emit` routes to
+                                // the supply block's emitter (and out to the
+                                // outer tap) just like the main body's emit.
+                                if let Value::Array(last_arr, ..) = &arr[2] {
+                                    for last_cb in last_arr.iter() {
+                                        register_supplier_done_callback(
+                                            supplier_id,
+                                            last_cb.clone(),
+                                        );
+                                    }
                                 }
                                 // Register done callback: use the group marker
                                 // so done only fires when ALL whenevers complete.

--- a/t/whenever-last-phaser.t
+++ b/t/whenever-last-phaser.t
@@ -1,0 +1,57 @@
+use Test;
+plan 4;
+
+# A LAST phaser inside a `whenever` block must run when the source supply
+# is done, and any `emit` inside it must forward to the enclosing supply.
+# See roast/S17-supply/syntax.t ("Value from LAST block correct").
+
+{
+    my $trigger = Supplier.new;
+    my $s = supply {
+        whenever $trigger -> $value {
+            emit $value;
+            LAST { emit "END"; }
+        }
+    }
+    my @got;
+    $s.tap({ @got.push($_) });
+    $trigger.emit("a");
+    $trigger.emit("b");
+    $trigger.done();
+    is @got, ["a", "b", "END"], 'LAST phaser emit forwards to supply on done';
+}
+
+# LAST runs even with a done callback present on the tap.
+{
+    my $trigger = Supplier.new;
+    my $done = 0;
+    my $s = supply {
+        whenever $trigger -> $value {
+            emit $value;
+            LAST { emit "fin"; }
+        }
+    }
+    my @got;
+    $s.tap({ @got.push($_) }, done => { $done++ });
+    $trigger.emit(1);
+    $trigger.done();
+    is @got, [1, "fin"], 'LAST emit forwards with a done tap callback';
+    is $done, 1, 'done callback still fires once after LAST';
+}
+
+# A LAST phaser that only runs side effects (no emit) still executes.
+{
+    my $trigger = Supplier.new;
+    my $ran = 0;
+    my $s = supply {
+        whenever $trigger -> $value {
+            emit $value;
+            LAST { $ran++; }
+        }
+    }
+    my @got;
+    $s.tap({ @got.push($_) });
+    $trigger.emit("x");
+    $trigger.done();
+    is $ran, 1, 'LAST side-effect block runs on done';
+}


### PR DESCRIPTION
## Summary

A `LAST` phaser inside a `whenever` block did not work on the on-demand supply path:

```raku
my $trigger = Supplier.new;
my $s = supply {
    whenever $trigger -> $value {
        emit $value;
        LAST { emit "END"; }   # never ran, and its emit never forwarded
    }
}
my @got;
$s.tap({ @got.push($_) });
$trigger.emit("a"); $trigger.emit("b");
$trigger.done();
say @got;   # was [a b], Rakudo gives [a b END]
```

Two independent gaps:

1. **LAST callbacks were dropped.** When the inner supplier signalled `done`, only the whenever-done *group marker* fired; the whenever's own LAST blocks (`arr[2]` of the subscription record) were never registered as done callbacks.
2. **`emit` inside a phaser body was not rewritten.** `rewrite_supply_body` recursed into loops/blocks/`whenever`, but not into `Stmt::Phaser`, so `emit "END"` inside `LAST { … }` stayed a bare `emit` call and never forwarded to the supply emitter.

## Fix

- `native_supply_methods`: register the whenever's LAST callbacks as done callbacks on the inner supplier, **ahead of** the group marker, on both on-demand paths (`tap` and `supply_promise_on_demand`).
- `rewrite_supply_body`: recurse into `Stmt::Phaser` bodies so `emit`/`done` inside `LAST`/`QUIT`/etc. is rewritten to the supply emitter like the main body.

### Verified

- `roast/S17-supply/syntax.t` tests **26 & 29** now pass (`whenever loop produced three values` / `Value from LAST block correct`).
- `make test` PASS (6783 tests); `t/emit-method.t`, `t/react-whenever.t`, `t/supply-act.t`, `S04-statements/gather.t` unaffected.
- New regression test `t/whenever-last-phaser.t` (LAST with/without a done tap callback, emit-forwarding and side-effect-only LAST).

The remaining `syntax.t` failures (multiple-whenever done propagation, QUIT/CLOSE phasers, `react whenever Supply.interval`) are separate deeper supply-runtime gaps. Test 53 in that file is pre-existing concurrency flakiness (passes on retry), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)