### PR TITLE
fix(supply): run whenever QUIT phaser; handled exception completes with done

### DIFF
--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -49,13 +49,13 @@ pub(in crate::runtime) use state_supplier::{
     register_supplier_flat_tap, register_supplier_lines_tap, register_supplier_produce_tap,
     register_supplier_quit_callback, register_supplier_start_tap, register_supplier_tap,
     register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    register_supplier_words_tap, register_supplier_zip_latest_tap, register_supplier_zip_tap,
-    register_zip_latest_state, register_zip_state, supplier_emit_callbacks,
-    supplier_produce_update_acc, supplier_tap_count, supplier_unique_get_seen,
-    supplier_unique_mark_seen, take_supplier_done_callbacks, take_supplier_quit_callbacks,
-    update_classify_state, whenever_done_group_decrement, zip_buffer_value,
-    zip_latest_buffer_value, zip_latest_source_done, zip_latest_state_info, zip_source_done,
-    zip_state_info,
+    register_supplier_whenever_quit_callback, register_supplier_words_tap,
+    register_supplier_zip_latest_tap, register_supplier_zip_tap, register_zip_latest_state,
+    register_zip_state, supplier_emit_callbacks, supplier_produce_update_acc, supplier_tap_count,
+    supplier_unique_get_seen, supplier_unique_mark_seen, take_supplier_done_callbacks,
+    take_supplier_quit_callbacks, take_supplier_whenever_quit_callbacks, update_classify_state,
+    whenever_done_group_decrement, zip_buffer_value, zip_latest_buffer_value,
+    zip_latest_source_done, zip_latest_state_info, zip_source_done, zip_state_info,
 };
 
 use super::*;

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -112,6 +112,11 @@ struct SupplierSubscriptions {
     taps: Vec<SupplierTapSubscription>,
     done_callbacks: Vec<Value>,
     quit_callbacks: Vec<Value>,
+    /// QUIT phaser bodies from `whenever` blocks. Unlike `quit_callbacks`
+    /// (the downstream tap's `quit =>` handler), these run *first* when the
+    /// source quits: if a QUIT phaser handles the exception the supply
+    /// completes with `done` and the downstream quit is suppressed.
+    whenever_quit_callbacks: Vec<Value>,
 }
 
 type SupplierSubscriptionsMap = std::sync::Mutex<HashMap<u64, SupplierSubscriptions>>;
@@ -151,6 +156,7 @@ pub(in crate::runtime) fn close_all_supplier_taps(supplier_id: u64) {
         }
         subs.done_callbacks.clear();
         subs.quit_callbacks.clear();
+        subs.whenever_quit_callbacks.clear();
     }
 }
 
@@ -1032,6 +1038,30 @@ pub(in crate::runtime) fn register_supplier_quit_callback(supplier_id: u64, quit
         map.entry(supplier_id)
             .or_default()
             .quit_callbacks
+            .push(quit_cb);
+    }
+}
+
+pub(in crate::runtime) fn take_supplier_whenever_quit_callbacks(supplier_id: u64) -> Vec<Value> {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        if let Some(subs) = map.get_mut(&supplier_id) {
+            std::mem::take(&mut subs.whenever_quit_callbacks)
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    }
+}
+
+pub(in crate::runtime) fn register_supplier_whenever_quit_callback(
+    supplier_id: u64,
+    quit_cb: Value,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .whenever_quit_callbacks
             .push(quit_cb);
     }
 }

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -79,6 +79,30 @@ impl Interpreter {
         }
     }
 
+    /// Run a single `whenever` QUIT phaser body with `reason` bound as `$_`.
+    /// Returns true if the phaser handled the exception — a `when`/`default`
+    /// matched, or it called `done`/`succeed` — meaning the supply should
+    /// complete with `done` and the downstream quit handler is suppressed.
+    /// A QUIT that matched nothing (ran to completion without a match) or
+    /// rethrew leaves the exception unhandled.
+    pub(super) fn run_whenever_quit_phaser(&mut self, quit_cb: Value, reason: Value) -> bool {
+        let saved_when = self.when_matched();
+        self.set_when_matched(false);
+        let result = self.call_sub_value(quit_cb, vec![reason], true);
+        let matched = self.when_matched();
+        self.set_when_matched(saved_when);
+        match result {
+            Ok(_) => matched,
+            // `done`/`succeed` inside the phaser means it is handling the
+            // exception and completing the supply. A `done` is rewritten to
+            // `$emitter.done()` + return, so it surfaces as is_return (the
+            // return unwinds the when-scope, so `matched` is no longer visible
+            // here — the done itself is the handled signal).
+            Err(err) if err.is_react_done || err.is_succeed || err.is_return => true,
+            Err(_) => false,
+        }
+    }
+
     pub(super) fn native_supply(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -670,6 +694,19 @@ impl Interpreter {
                                         register_supplier_done_callback(
                                             supplier_id,
                                             last_cb.clone(),
+                                        );
+                                    }
+                                }
+                                // Register the whenever's own QUIT phaser
+                                // callbacks (arr[3]) as whenever-quit handlers.
+                                // On quit they run before the downstream quit
+                                // handler; if one handles the exception the
+                                // supply completes with done instead of quit.
+                                if let Value::Array(quit_arr, ..) = &arr[3] {
+                                    for qcb in quit_arr.iter() {
+                                        register_supplier_whenever_quit_callback(
+                                            supplier_id,
+                                            qcb.clone(),
                                         );
                                     }
                                 }
@@ -2028,11 +2065,28 @@ impl Interpreter {
                     }
                     let (_, _, quit_reason) = supplier_snapshot(supplier_id);
                     if let Some(reason) = quit_reason {
-                        for quit_cb in take_supplier_quit_callbacks(supplier_id) {
-                            self.call_supply_quit_handler(quit_cb, reason.clone())?;
+                        // Run any `whenever` QUIT phasers first. If one handles
+                        // the exception, the supply completes with done and the
+                        // downstream quit handler is suppressed.
+                        let mut handled = false;
+                        for qcb in take_supplier_whenever_quit_callbacks(supplier_id) {
+                            if self.run_whenever_quit_phaser(qcb, reason.clone()) {
+                                handled = true;
+                            }
                         }
+                        if handled {
+                            for done_cb in take_supplier_done_callbacks(supplier_id) {
+                                let _ = self.invoke_done_callback(done_cb);
+                            }
+                        } else {
+                            for quit_cb in take_supplier_quit_callbacks(supplier_id) {
+                                self.call_supply_quit_handler(quit_cb, reason.clone())?;
+                            }
+                            let _ = take_supplier_done_callbacks(supplier_id);
+                        }
+                    } else {
+                        let _ = take_supplier_done_callbacks(supplier_id);
                     }
-                    let _ = take_supplier_done_callbacks(supplier_id);
                     close_all_supplier_taps(supplier_id);
                     supplier_reset_keep_quit(supplier_id);
                 }
@@ -2369,10 +2423,26 @@ impl Interpreter {
                     for (tap, emitted) in flush_supplier_words_taps(sid) {
                         self.call_sub_value(tap, vec![emitted], true)?;
                     }
-                    for quit_cb in take_supplier_quit_callbacks(sid) {
-                        self.call_supply_quit_handler(quit_cb, reason.clone())?;
+                    // Run any `whenever` QUIT phasers first. If one handles the
+                    // exception (a when/default matched, or it called done), the
+                    // supply completes with done and the downstream quit handler
+                    // is suppressed.
+                    let mut handled = false;
+                    for qcb in take_supplier_whenever_quit_callbacks(sid) {
+                        if self.run_whenever_quit_phaser(qcb, reason.clone()) {
+                            handled = true;
+                        }
                     }
-                    let _ = take_supplier_done_callbacks(sid);
+                    if handled {
+                        for done_cb in take_supplier_done_callbacks(sid) {
+                            let _ = self.invoke_done_callback(done_cb);
+                        }
+                    } else {
+                        for quit_cb in take_supplier_quit_callbacks(sid) {
+                            self.call_supply_quit_handler(quit_cb, reason.clone())?;
+                        }
+                        let _ = take_supplier_done_callbacks(sid);
+                    }
                     close_all_supplier_taps(sid);
                     supplier_reset_keep_quit(sid);
                 }
@@ -2653,6 +2723,19 @@ impl Interpreter {
                                         register_supplier_done_callback(
                                             supplier_id,
                                             last_cb.clone(),
+                                        );
+                                    }
+                                }
+                                // Register the whenever's own QUIT phaser
+                                // callbacks (arr[3]) as whenever-quit handlers.
+                                // On quit they run before the downstream quit
+                                // handler; if one handles the exception the
+                                // supply completes with done instead of quit.
+                                if let Value::Array(quit_arr, ..) = &arr[3] {
+                                    for qcb in quit_arr.iter() {
+                                        register_supplier_whenever_quit_callback(
+                                            supplier_id,
+                                            qcb.clone(),
                                         );
                                     }
                                 }

--- a/t/whenever-quit-phaser.t
+++ b/t/whenever-quit-phaser.t
@@ -1,0 +1,62 @@
+use Test;
+plan 6;
+
+# A QUIT phaser inside a `whenever` runs when the source quits. If it handles
+# the exception (a when/default matches), the supply completes with `done` and
+# the downstream quit handler is suppressed; an emit inside it forwards to the
+# supply. See roast/S17-supply/syntax.t.
+
+# QUIT default handles any exception -> supply is done, no quit.
+{
+    my $trigger = Supplier.new;
+    my $d = 0; my $q = 0;
+    my $s = supply {
+        whenever $trigger { QUIT { default { } } }
+    }
+    $s.tap(done => { $d++ }, quit => { $q++ });
+    $trigger.quit(Exception.new);
+    is $d, 1, 'handled QUIT (default) completes the supply with done';
+    is $q, 0, 'handled QUIT does not fire the downstream quit';
+}
+
+# emit inside a QUIT block forwards to the supply's tap.
+{
+    my class OMGBears is Exception { }
+    my $trigger = Supplier.new;
+    my @got;
+    my $s = supply {
+        whenever $trigger {
+            emit $_;
+            QUIT { when OMGBears { emit "Run!"; } }
+        }
+    }
+    $s.tap({ @got.push($_) });
+    $trigger.emit("A");
+    $trigger.emit("B");
+    $trigger.quit(OMGBears.new);
+    is @got, ["A", "B", "Run!"], 'emit inside a matched QUIT block forwards to the supply';
+}
+
+# An unmatched QUIT still quits (the exception is not handled).
+{
+    my class Useless is Exception { }
+    my $trigger = Supplier.new;
+    my $d = 0; my $q = 0;
+    my $s = supply {
+        whenever $trigger { QUIT { when Useless { } } }
+    }
+    $s.tap(done => { $d++ }, quit => { $q++ });
+    $trigger.quit(Exception.new);
+    is $q, 1, 'unmatched QUIT still quits';
+    is $d, 0, '...and does not run done';
+}
+
+# A whenever with no QUIT phaser propagates the quit to the tap.
+{
+    my $trigger = Supplier.new;
+    my $q = 0;
+    my $s = supply { whenever $trigger { } }
+    $s.tap(quit => { $q++ });
+    $trigger.quit('boom');
+    is $q, 1, 'quit propagates when there is no QUIT phaser';
+}


### PR DESCRIPTION
## Summary

A `QUIT` phaser inside a `whenever` block did not work on the on-demand supply path. Its callbacks (`arr[3]` of the subscription record) were never registered, so when the source quit:

- the QUIT phaser never executed,
- an `emit` inside it never forwarded to the supply,
- and a *handled* exception still surfaced as a `quit` instead of completing the supply with `done`.

```raku
my $trigger = Supplier.new;
my $s = supply {
    whenever $trigger { QUIT { default { } } }
}
my $d = 0; my $q = 0;
$s.tap(done => { $d++ }, quit => { $q++ });
$trigger.quit(Exception.new);
# was: d=0 q=1   — Rakudo: d=1 q=0 (handled -> done)
```

## Fix

- **state_supplier**: add a `whenever_quit_callbacks` list (distinct from the downstream tap's `quit_callbacks`) with register/take helpers.
- **native_supply_methods**: register the whenever's QUIT phaser bodies on the inner supplier (both on-demand loops). On quit, run them first via the new `run_whenever_quit_phaser`; if one handles the exception (a `when`/`default` matched, or it called `done`/`succeed`) the supply fires its done callbacks and the downstream quit is suppressed; otherwise the quit propagates as before.

This builds on #2997 (which made `rewrite_supply_body` recurse into phaser bodies, so `emit` inside QUIT now forwards to the supply emitter).

### Verified

- `roast/S17-supply/syntax.t`: **44, 47, 48 now pass** (emit in a QUIT block; handled quit completes with done; no spurious quit). Unmatched QUIT still quits (test ~49-50 stays correct). syntax.t failures 19 → 16.
- `make test` PASS (6815 tests). New regression test `t/whenever-quit-phaser.t`.

### Known remaining (follow-up)

Tests **45/46** (`when X { emit; done }` — an explicit `done` inside a *matched* QUIT) still quit. `done` rewrites to `$emitter.done()` + return, and the return unwinds the when-scope so the when-match is no longer observable at the dispatch site (the `interpreter.when_matched` flag is not set by VM-compiled phaser subs). Fixing that needs when-match propagation across the VM phaser-sub boundary — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)