### PR TITLE
fix(hyper): lvalue-precise writeback for hyper mutation on a variable (Track B)

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -370,11 +370,21 @@ impl Compiler {
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
+        // For a plain `@`/`%` variable target, record its name so a mutating
+        // hyper (`@a>>++`) writes back precisely to that binding rather than to
+        // every Arc-identity-sharing binding (which corrupts COW copies like
+        // `my @x = @a`).
+        let target_name_idx = match target {
+            Expr::ArrayVar(n) => Some(self.code.add_constant(Value::str(format!("@{}", n)))),
+            Expr::HashVar(n) => Some(self.code.add_constant(Value::str(format!("%{}", n)))),
+            _ => None,
+        };
         self.code.emit(OpCode::HyperMethodCall {
             name_idx,
             arity,
             modifier_idx,
             quoted,
+            target_name_idx,
         });
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -818,6 +818,12 @@ pub(crate) enum OpCode {
         arity: u32,
         modifier_idx: Option<u32>,
         quoted: bool,
+        /// The lvalue variable name when the hyper target is a plain `@`/`%`
+        /// variable (`@a>>++`), so a mutating hyper writes back *precisely* to
+        /// that binding (cell-write if bound, COW-detach otherwise) instead of
+        /// the Arc-identity scan that over-reaches COW-shared copies. `None` for
+        /// non-variable targets (`@b[0]>>++`, `(1,2,3)>>.uc`).
+        target_name_idx: Option<u32>,
     },
     HyperMethodCallDynamic {
         arity: u32,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3843,6 +3843,7 @@ impl VM {
                 arity,
                 modifier_idx,
                 quoted,
+                target_name_idx,
             } => {
                 match self.exec_hyper_method_call_op(
                     code,
@@ -3850,6 +3851,7 @@ impl VM {
                     *arity,
                     *modifier_idx,
                     *quoted,
+                    *target_name_idx,
                 ) {
                     Ok(()) => {}
                     Err(e) => {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -2,6 +2,29 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl VM {
+    /// Write a mutating hyper's result back to its *named* `@`/`%` target
+    /// variable precisely. If the variable is bound (holds a shared
+    /// `ContainerRef` cell, e.g. `$b := @a`), write through the cell so all
+    /// aliases observe the change; otherwise replace the binding (COW-detach) so
+    /// a copy (`my @x = @a`) keeps its own backing and is not corrupted. This is
+    /// the lvalue-precise alternative to the Arc-identity binding scan, which
+    /// cannot tell a bound alias from a COW copy.
+    fn write_back_hyper_target_var(&mut self, code: &CompiledCode, var: &str, new_val: Value) {
+        if let Some(Value::ContainerRef(cell)) = self.interpreter.env().get(var) {
+            *cell.lock().unwrap() = new_val;
+            return;
+        }
+        if let Some(slot) = self.find_local_slot(code, var)
+            && let Value::ContainerRef(cell) = &self.locals[slot]
+        {
+            *cell.lock().unwrap() = new_val;
+            return;
+        }
+        self.set_env_with_main_alias(var, new_val.clone());
+        self.locals_set_by_name(code, var, new_val);
+        self.env_dirty = true;
+    }
+
     pub(super) fn exec_hyper_method_call_op(
         &mut self,
         code: &CompiledCode,
@@ -9,8 +32,11 @@ impl VM {
         arity: u32,
         modifier_idx: Option<u32>,
         quoted: bool,
+        target_name_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let method_raw = Self::const_str(code, name_idx);
+        let target_var: Option<String> =
+            target_name_idx.map(|idx| Self::const_str(code, idx).to_string());
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
@@ -358,25 +384,38 @@ impl VM {
             }
         }
         if let Value::Array(existing, kind) = &target {
-            // In-place write back through the target's `Arc<ArrayData>` so a
-            // hyper mutation on a *nested* element (`@b[0]>>++`, `%h<a>>>++`,
-            // `$r>>++` where `$r := @a`) reaches the element: the read shares the
-            // inner Arc with the slot that holds it, so mutating the Arc's items
-            // is observed there. The by-identity binding scan below only reaches
-            // top-level variable bindings (it misses array/hash elements).
-            // SAFETY: mutsu is single-threaded; no immutable borrow into this
-            // ArrayData is alive across the write.
-            {
-                let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
-                unsafe {
-                    (*ptr).items = items.clone();
+            if let Some(var) = &target_var {
+                // Precise writeback to the *named* `@`-variable's binding only.
+                // A bound variable holds a shared `ContainerRef` cell (e.g.
+                // `$b := @a`): write the new array through the cell so aliases
+                // observe it. A plain array binding is replaced (COW-detach), so
+                // a copy `my @x = @a` keeps its own Arc and is NOT corrupted —
+                // unlike the Arc-identity scan, which over-reaches COW copies.
+                let new_arr = Value::Array(
+                    std::sync::Arc::new(crate::value::ArrayData::new(items.clone())),
+                    *kind,
+                );
+                self.write_back_hyper_target_var(code, var, new_arr);
+            } else {
+                // Non-variable target (`@b[0]>>++`, `(1,2,3)>>.uc`): write back
+                // in place through the target's `Arc<ArrayData>` so a hyper
+                // mutation on a *nested* element reaches it (the read shares the
+                // inner Arc with the slot holding it), plus the by-identity scan
+                // for any top-level binding that COW-detached.
+                // SAFETY: mutsu is single-threaded; no immutable borrow into
+                // this ArrayData is alive across the write.
+                {
+                    let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
+                    unsafe {
+                        (*ptr).items = items.clone();
+                    }
                 }
+                self.interpreter.overwrite_array_items_by_identity_for_vm(
+                    existing,
+                    items.clone(),
+                    *kind,
+                );
             }
-            self.interpreter.overwrite_array_items_by_identity_for_vm(
-                existing,
-                items.clone(),
-                *kind,
-            );
             if let Some(gv) = existing.grep_source.as_deref() {
                 let mut source_items = gv.source.to_vec();
                 for (filtered_idx, source_idx) in gv.indices.iter().enumerate() {
@@ -403,8 +442,15 @@ impl VM {
             for (key, item) in keys.iter().zip(items.iter()) {
                 map.insert(key.clone(), item.clone());
             }
-            self.interpreter
-                .overwrite_hash_bindings_by_identity(existing, Value::Hash(Value::hash_arc(map)));
+            let new_hash = Value::Hash(Value::hash_arc(map));
+            if let Some(var) = &target_var {
+                // Precise writeback to the named `%`-variable (see the Array
+                // arm); avoids corrupting a COW copy `my %g = %h`.
+                self.write_back_hyper_target_var(code, var, new_hash);
+            } else {
+                self.interpreter
+                    .overwrite_hash_bindings_by_identity(existing, new_hash);
+            }
             self.env_dirty = true;
         }
         // Preserve the container type of the target for QuantHash types.

--- a/t/hyper-nested-writeback.t
+++ b/t/hyper-nested-writeback.t
@@ -6,7 +6,7 @@ use Test;
 # variable bindings by Arc identity, missing nested elements, so `@b[0]>>++`
 # left `@b[0]` unchanged. (Track B element-cell: deep `>>++`.)
 
-plan 10;
+plan 13;
 
 # --- Hyper increment on an array element that is itself an array ---
 {
@@ -63,4 +63,23 @@ plan 10;
     my $inner := @b[0];
     @b[0]>>++;
     is-deeply $inner, [2, 3], 'a separate bind to @b[0] sees the hyper mutation';
+}
+
+# --- A whole-variable hyper mutation must NOT corrupt a copy ---
+# (lvalue-precise writeback: `@a>>++` writes to @a's binding, not to every
+# Arc-identity-sharing binding, so the independent copy `@x` is preserved.)
+{
+    my @a = 1, 2, 3;
+    my @x = @a;
+    @a>>++;
+    is-deeply @x, [1, 2, 3], 'copy is not corrupted by hyper ++ on the source';
+    is-deeply @a, [2, 3, 4], 'source is incremented';
+}
+
+# --- A whole-container `:=` bound alias DOES see the hyper mutation ---
+{
+    my @a = 1, 2, 3;
+    my $b := @a;
+    @a>>++;
+    is-deeply $b, [2, 3, 4], 'bound alias sees hyper ++ through the shared cell';
 }


### PR DESCRIPTION
## Summary

Track B (first-class container). A mutating hyper (`@a>>++`) on a whole `@`/`%`
variable wrote its result back to *every* binding sharing the array's `Arc` (the
by-identity scan), corrupting an independent copy:

```raku
my @a = 1,2,3;  my @x = @a;  @a>>++;  say @x;   # was [2 3 4] → now [1 2 3]
```

## Fix

When the hyper target is a named `@`/`%` variable, write the result back
**precisely** to that binding (new `HyperMethodCall.target_name_idx`):

- a bound variable holds a shared `ContainerRef` cell (`my $b := @a`) → write
  through the cell so aliases observe it;
- a plain array binding is replaced (COW-detach) → an independent copy keeps its
  own backing and is not corrupted.

`None` for non-variable targets (`@b[0]>>++`, `(1,2,3)>>.uc`), which keep the
in-place + by-identity path that reaches nested elements (#2996).

## Behavior note

This also makes a hyper mutation through an array **parameter**
(`sub f(@x){ @x>>++ }`) behave like every other mutation through that parameter
in mutsu — e.g. `.push` — which does **not** propagate to the caller. The old
by-identity propagation for `>>++` alone was an inconsistent accident. True
caller propagation for array/hash parameters (raku binds them by alias) is a
separate, deeper item (**parameter-binding cells**); mutsu currently copies them
for all other mutations.

## Tests

- `t/hyper-nested-writeback.t` 10 → 13 (copy-not-corrupted, bound-alias-sees).
- `roast/S03-metaops/hyper.t` unchanged; `cargo test` 461/0; clippy clean.
  Relying on CI for the full `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)