### PR TITLE
fix(when): record the match when a when block exits via control flow

### DIFF
--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2368,7 +2368,14 @@ impl VM {
                     self.interpreter.set_when_matched(true);
                     return Err(e);
                 }
-                Err(e) => return Err(e),
+                // The `when` matched, so record the match before propagating any
+                // other control signal (e.g. an is_return produced by `done`
+                // inside the block). Otherwise a `when` body that exits via a
+                // control flow signal would lose the fact that it matched.
+                Err(e) => {
+                    self.interpreter.set_when_matched(true);
+                    return Err(e);
+                }
             }
             if !did_proceed {
                 self.interpreter.set_when_matched(true);

--- a/t/whenever-quit-phaser.t
+++ b/t/whenever-quit-phaser.t
@@ -1,5 +1,5 @@
 use Test;
-plan 6;
+plan 9;
 
 # A QUIT phaser inside a `whenever` runs when the source quits. If it handles
 # the exception (a when/default matches), the supply completes with `done` and
@@ -59,4 +59,26 @@ plan 6;
     $s.tap(quit => { $q++ });
     $trigger.quit('boom');
     is $q, 1, 'quit propagates when there is no QUIT phaser';
+}
+
+# A QUIT that matches with an explicit `done` inside: emit forwards, the
+# supply completes with done, and no quit fires. (The `when` match must be
+# recorded even though the block exits via the `done` control flow.)
+{
+    my class OMGBears is Exception { }
+    my $trigger = Supplier.new;
+    my @got; my $d = 0; my $q = 0;
+    my $s = supply {
+        whenever $trigger {
+            emit $_;
+            QUIT { when OMGBears { emit "Run!"; done; } }
+        }
+    }
+    $s.tap({ @got.push($_) }, done => { $d++ }, quit => { $q++ });
+    $trigger.emit("A");
+    $trigger.emit("B");
+    $trigger.quit(OMGBears.new);
+    is @got, ["A", "B", "Run!"], 'emit before and inside a matched QUIT all come out';
+    is $d, 1, 'done inside a matched QUIT completes the supply';
+    is $q, 0, 'a handled QUIT with done does not fire the downstream quit';
 }


### PR DESCRIPTION
## Summary

Completes the `whenever` QUIT phaser cluster (follows #2997, #2998).

`exec_when_op` set `when_matched = true` only when the matched block completed normally or issued a `succeed`. Any *other* control signal leaving the block — notably the `is_return` produced by `done` (which `rewrite_supply_body` turns into `$emitter.done()` + `return`) — propagated **without** recording that the `when` had matched.

As a result `QUIT { when X { emit ...; done } }` looked *unhandled* at the supply quit dispatch (`run_whenever_quit_phaser` reads `when_matched` on the Ok path), so the supply quit instead of completing with `done`:

```raku
my $s = supply {
    whenever $trigger {
        emit $_;
        QUIT { when OMGBears { emit "Run!"; done; } }
    }
}
# was: done=0 quit=1   — Rakudo: collected=[…, Run!] done=1 quit=0
```

## Fix

Set `when_matched = true` before propagating the control signal — the match already happened regardless of how the body exits. This mirrors the existing `is_succeed` arm.

### Verified

- `roast/S17-supply/syntax.t` tests **45 & 46** now pass (`done inside of matched QUIT block worked` / `did not produce a quit, since exception handled`). syntax.t failures 16 → 14; the whole QUIT cluster (44–48) now passes.
- `roast/S04-statements/given.t`, `when.t`, `gather.t` PASS; `make test` PASS (6818 tests).
- Extended `t/whenever-quit-phaser.t` with the emit+done case.

Remaining syntax.t failures are unrelated clusters: multiple-whenever done propagation (31–37), `react whenever Supply.interval` (52), CLOSE phaser (60–63), and phasers seeing outer scope when the whenever never iterated (64–68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)