### PR TITLE
feat(bind): alias plain @/% positional params to the caller's container

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -252,10 +252,13 @@ STATUS で撤回済み。
       whole-container `:=` bind 共有（`@b:=@a`/`$r:=@a` #2990/#2993）、nested-element hyper writeback
       （`@b[0]>>++` #2996）、hyper lvalue-precise writeback（`@a>>++` が COW コピーを破壊しない #2999）。
       （`is rw` 共有セル #2928・take-rw #2930・束縛要素セル #2902-#2925 も landed）
-- [ ] **配列/ハッシュ param の別名束縛（parameter-binding cells）= 残る最大の container 正しさ項目** —
-      raku は plain `@x`/`%h` param を caller に alias 束縛（`sub f(@x){@x.push}` が伝播）。**mutsu は配列 param を
-      コピー**（hash param と `is raw` は既に alias 動作）。全関数呼び出しに影響する大改修・高 blast radius のため
-      **専用セッション**で。設計・調査・現状の事実表は **`docs/param-binding-cells-plan.md`**。
+- [x] **配列/ハッシュ param の別名束縛（parameter aliasing）= 残る最大の container 正しさ項目 (DONE)** —
+      plain `@x`/`%h` positional param を caller に alias 束縛。`@x.push`・`@x[0]=v`・`@x>>++`・`splice`・
+      whole-container `@x=(...)`/`%h=(...)` が全て伝播。手法=`is rw`/`is raw` の writeback 機構
+      （`apply_rw_bindings_to_env`）へ plain `@`/`%` positional param を載せ、`readonly_vars` から `@`/`%` を除外
+      （scalar `$` は readonly 維持）。`is copy` はコピー継続。`t/param-array-alias.t`(15)。
+      既知の残り: 同一変数を 2 つの param に渡す `f(@z,@z)`（writeback 上書き、main から非回帰）と `return-rw @x` 越し
+      の live alias は writeback では非対応（cell 化が必要・極めて稀）。設計メモ=`docs/param-binding-cells-plan.md`。
 - [~] **object-hash（`%h{KeyType}`）** — キー保存（original_keys）は HashData 埋め込みで **COW-stable 化済み**
       (#2954)。mixin キー・`.new`/`.clone` 維持 (#2956)、multidim Range slice `:exists` (#2959) も landed。
       残る `S09-hashes/objecthash.t`（非whitelist）の失敗は**型強制/構築の別系統課題**（互いに独立）:

--- a/docs/param-binding-cells-plan.md
+++ b/docs/param-binding-cells-plan.md
@@ -1,9 +1,10 @@
 # Parameter aliasing for array/hash params — design plan (handoff)
 
-> **Status: NOT STARTED. This is a handoff for a fresh session.** It is the
-> largest remaining Track B / first-class-container correctness gap. It changes
-> core function-call argument binding (high blast radius), so it deserves its
-> own session with CI as the safety net.
+> **Status: DONE (2026-06-13).** Implemented via the writeback approach, not the
+> cell approach sketched in §3 below. Plain `@`/`%` positional params now bind
+> the caller's container by alias: `.push`, element assign, `>>++`, `splice`,
+> and whole-container `=` assignment all propagate; `is copy` copies; scalar `$`
+> params stay readonly. See §6 for what shipped.
 >
 > Read alongside `docs/container-identity.md` (Phase 2 element cells) and the
 > memory file `project_track_b_phase2_element_cells.md`. The cell machinery this
@@ -117,3 +118,40 @@ All MERGED unless noted (2026-06-13):
 Remaining Track B after param aliasing: write-autoviv `HashSlotRef` (concluded
 **not removable** — deferred-token + `is raw` reduce lvalue-read semantics);
 that campaign is effectively complete.
+
+---
+
+## 6. What shipped (2026-06-13)
+
+Chose the **writeback approach over the cell approach** of §3. The caller's
+variable is not reachable at bind time (it lives in the saved call frame /
+caller VM locals, restored only at return), so promoting it to a live shared
+cell during binding is impractical. The proven `is rw`/`is raw` writeback
+machinery already propagates a param's final container value to the caller at
+return — and that handles `.push`, element assign, `splice`, `>>++`, and
+whole-container `=` uniformly, because they all leave the param holding the
+correct final value. Two small edits in `src/runtime/types/binding.rs`:
+
+1. In the positional-param loop, push plain `@`/`%` positional params (not
+   `is copy`/`is rw`/`is raw`, not slurpy/`onearg`/invocant, no sub-signature,
+   not an attribute twigil) with a caller lvalue source onto `rw_bindings`, so
+   `apply_rw_bindings_to_env` writes the final value back at return.
+2. In the readonly-marking loop, exclude `@`/`%` params from `readonly_vars`
+   (scalar `$` stays readonly). Raku array/hash params are writable containers:
+   `@x = (...)` / `%h = (...)` / `.push` are allowed; only `:=` rebinding is
+   forbidden (a separate signature-bound check).
+
+Propagates through every dispatch path (VM, `dispatch.rs`, `calls.rs`,
+`class.rs`, closures, …) because they all call `apply_rw_bindings_to_env`.
+Tests: `t/param-array-alias.t` (15). `make test` clean; whitelisted S06/S12/S02/
+S03/S29/S17 roast samples clean.
+
+**Known limitations (writeback ≠ live cell), both pre-existing, not regressions:**
+- `f(@z, @z)` — same caller var bound to two params, mutate one: the
+  unmutated param's writeback clobbers the mutated one (last write wins). raku:
+  live alias → both see it.
+- `return-rw @x` of a param, then mutate the returned alias after the call: the
+  writeback already fired at return, so later mutations don't propagate.
+
+Both need true shared-cell aliasing (caller var promoted to a cell at the call
+site, in the VM arg-eval path) and are extremely rare; deferred.

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -850,6 +850,30 @@ impl Interpreter {
                                 .and_then(|name| name.as_ref())
                                 .cloned()
                         });
+                    // Plain positional `@`/`%` params bind the caller's container
+                    // by alias (Raku readonly-container semantics): element
+                    // assignment, `.push`, `splice`, and whole-container `=`
+                    // assignment all propagate to the caller, while `is copy`
+                    // copies and `:=` rebinding is forbidden. mutsu reaches this
+                    // by routing the param through the same writeback machinery
+                    // `is rw`/`is raw` use: at return `apply_rw_bindings_to_env`
+                    // writes the param's final container value back to the
+                    // caller's variable. Scalar `$` params remain readonly.
+                    let is_copy = pd.traits.iter().any(|t| t == "copy");
+                    let alias_plain_container = !is_rw
+                        && !is_raw
+                        && !is_copy
+                        && !pd.slurpy
+                        && !pd.double_slurpy
+                        && !pd.onearg
+                        && !pd.is_invocant
+                        && pd.sub_signature.is_none()
+                        && (pd.name.starts_with('@') || pd.name.starts_with('%'))
+                        // Exclude attribute-binding twigil params (@!x, %.y, ...).
+                        && !pd.name[1..].starts_with(['!', '.']);
+                    if alias_plain_container && let Some(source_name) = &source_name {
+                        rw_bindings.push((pd.name.clone(), source_name.clone()));
+                    }
                     let source_type_constraint = source_name.as_deref().and_then(|source_name| {
                         self.var_type_constraint(source_name).or_else(|| {
                             self.var_type_constraint(
@@ -1469,7 +1493,16 @@ impl Interpreter {
                 .traits
                 .iter()
                 .any(|t| t == "rw" || t == "copy" || t == "raw");
-            if !has_mutable_trait || raw_nonlvalue_params.contains(&pd.name) {
+            // Plain `@`/`%` params are NOT readonly the way `$` params are: the
+            // bound container is writable (element/whole-container assignment and
+            // `.push` are allowed and propagate to the caller); only `:=`
+            // rebinding is forbidden. So keep `$` scalar params readonly but let
+            // array/hash params through. (`@!attr`/`%.attr` twigil params are
+            // attribute binds, already skipped above.)
+            let is_container_param = pd.name.starts_with('@') || pd.name.starts_with('%');
+            if !is_container_param
+                && (!has_mutable_trait || raw_nonlvalue_params.contains(&pd.name))
+            {
                 self.readonly_vars.insert(pd.name.clone());
             }
         }

--- a/t/param-array-alias.t
+++ b/t/param-array-alias.t
@@ -1,0 +1,120 @@
+use Test;
+
+# A plain positional `@`/`%` parameter binds the caller's container by alias:
+# element assignment, `.push`/`splice`, and whole-container `=` assignment all
+# propagate to the caller. `is copy` copies; `is raw` already aliased.
+
+plan 15;
+
+# --- array: .push propagates ---
+{
+    sub a-push(@x) { @x.push(9) }
+    my @a = 1, 2, 3;
+    a-push(@a);
+    is-deeply @a, [1, 2, 3, 9], 'push through plain array param propagates';
+}
+
+# --- array: element assignment propagates ---
+{
+    sub a-elem(@x) { @x[0] = 99 }
+    my @b = 1, 2, 3;
+    a-elem(@b);
+    is-deeply @b, [99, 2, 3], 'element assign through plain array param propagates';
+}
+
+# --- array: whole-container assignment propagates ---
+{
+    sub a-whole(@x) { @x = (7, 8, 9) }
+    my @c = 1, 2, 3;
+    a-whole(@c);
+    is-deeply @c, [7, 8, 9], 'whole-container assign through plain array param propagates';
+}
+
+# --- array: splice propagates ---
+{
+    sub a-splice(@x) { @x.splice(1, 1, 'a', 'b') }
+    my @d = 1, 2, 3;
+    a-splice(@d);
+    is-deeply @d, [1, 'a', 'b', 3], 'splice through plain array param propagates';
+}
+
+# --- array: .= mutation propagates ---
+{
+    sub a-dotmap(@x) { @x .= map(* + 1) }
+    my @e = 1, 2, 3;
+    a-dotmap(@e);
+    is-deeply @e, [2, 3, 4], '.=map through plain array param propagates';
+}
+
+# --- array: nested := inside the sub propagates ---
+{
+    sub a-rebind(@x) { my @y := @x; @y.push(5) }
+    my @f = 1, 2, 3;
+    a-rebind(@f);
+    is-deeply @f, [1, 2, 3, 5], 'transitive := bind inside sub propagates';
+}
+
+# --- is copy does NOT propagate ---
+{
+    sub a-copy(@x is copy) { @x.push(9); @x[0] = 99 }
+    my @g = 1, 2, 3;
+    a-copy(@g);
+    is-deeply @g, [1, 2, 3], 'is copy array param does not propagate';
+}
+
+# --- is raw still propagates ---
+{
+    sub a-raw(@x is raw) { @x.push(9) }
+    my @h = 1, 2, 3;
+    a-raw(@h);
+    is-deeply @h, [1, 2, 3, 9], 'is raw array param propagates';
+}
+
+# --- two distinct array params stay independent ---
+{
+    sub a-two(@x, @y) { @x.push(@y.elems) }
+    my @p = 1, 2;
+    my @q = 3, 4, 5;
+    a-two(@p, @q);
+    is-deeply @p, [1, 2, 3], 'first array param mutated';
+    is-deeply @q, [3, 4, 5], 'second array param untouched';
+}
+
+# --- hash: element assignment propagates ---
+{
+    sub h-elem(%h) { %h<k> = 5 }
+    my %m = a => 1;
+    h-elem(%m);
+    is-deeply %m, {a => 1, k => 5}, 'element assign through plain hash param propagates';
+}
+
+# --- hash: whole-container assignment propagates ---
+{
+    sub h-whole(%h) { %h = (m => 1, n => 2) }
+    my %n = a => 1;
+    h-whole(%n);
+    is-deeply %n, {m => 1, n => 2}, 'whole-container assign through plain hash param propagates';
+}
+
+# --- hash is copy does NOT propagate ---
+{
+    sub h-copy(%h is copy) { %h<k> = 5 }
+    my %o = a => 1;
+    h-copy(%o);
+    is-deeply %o, {a => 1}, 'is copy hash param does not propagate';
+}
+
+# --- array literal arg: container is writable inside (no propagation target) ---
+{
+    sub a-lit(@x) { @x.push(9); @x[0] = 100 }
+    lives-ok { a-lit([1, 2, 3]) }, 'plain array param bound to a literal is writable';
+}
+
+# --- methods: array attribute passed to a plain param mutates in place ---
+{
+    sub take(@x) { @x.push(42) }
+    my @r = 10, 20;
+    take(@r);
+    take(@r);
+    is-deeply @r, [10, 20, 42, 42], 'repeated calls accumulate on the caller container';
+}


### PR DESCRIPTION
## Summary

In Raku a plain positional **array/hash parameter binds the caller's container by alias** — mutation through the parameter is visible in the caller. mutsu previously **copied** plain `@` params (mutations didn't propagate) and rejected whole-container `=` on `@`/`%` params as readonly. This was the largest remaining Track B / first-class-container correctness gap (see `docs/param-binding-cells-plan.md`).

```raku
sub a1(@x) { @x.push(9) }
my @a = 1,2,3; a1(@a); say @a;   # was: [1 2 3]   now: [1 2 3 9]  ✓
sub a2(@x) { @x[0] = 99 }
my @b = 1,2,3; a2(@b); say @b;   # was: [1 2 3]   now: [99 2 3]   ✓
sub a3(@x) { @x = (7,8,9) }
my @c = 1,2,3; a3(@c); say @c;   # was: RO error  now: [7 8 9]    ✓
```

## Approach

Routes plain `@`/`%` positional params through the same **writeback machinery** `is rw`/`is raw` already use: at return `apply_rw_bindings_to_env` writes the param's final container value back to the caller's variable. This handles `.push`, element assign, `splice`, `>>++`, and whole-container `=` uniformly (they all leave the param holding the correct final value) and propagates through every dispatch path (VM, `dispatch.rs`, `calls.rs`, `class.rs`, closures).

Two edits in `src/runtime/types/binding.rs`:
1. Push plain `@`/`%` positional params (not `is copy`/`rw`/`raw`, not slurpy/`onearg`/invocant, no sub-signature, not an attribute twigil) with a caller lvalue source onto `rw_bindings`.
2. Exclude `@`/`%` params from `readonly_vars` so `=`/`.push` are allowed; scalar `$` params stay readonly. Only `:=` rebinding remains forbidden.

`is copy` continues to copy. `>>++` on an array param now propagates (matching `.push`), consistent with raku.

## Known limitations (writeback ≠ live cell, both pre-existing, not regressions)
- `f(@z, @z)` — same caller var bound to two params, mutate one: the unmutated param's writeback clobbers the mutated one.
- `return-rw @x` of a param, then mutate the returned alias after the call.

Both need true shared-cell aliasing and are very rare; deferred (documented in the plan).

## Tests
- New `t/param-array-alias.t` (15): push / element / whole-assign / splice / `.=map` / transitive `:=` / `is copy` / `is raw` / two params / hash element+whole / literal arg / repeated calls.
- `make test` clean; whitelisted S06/S12/S02/S03/S29/S17 roast samples clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)