### PR TITLE
fix(parser): parse `done()` with a statement modifier as a single statement

### DIFF
--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 
 use super::super::add_parse_warning;
 use super::super::expr::expression;
-use super::super::helpers::{is_loop_label_name, ws, ws1};
+use super::super::helpers::{is_loop_label_name, skip_balanced_parens, ws, ws1};
 use super::super::parse_result::{PError, PResult, merge_expected_messages, opt_char, parse_char};
 
 use crate::ast::{Expr, PhaserKind, Stmt};
@@ -1983,6 +1983,17 @@ pub(super) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
         }
     }
     if name == "done" {
+        // `done()` is the explicit call form (it takes no payload). Consume the
+        // empty argument list so a trailing statement modifier applies to the
+        // whole `done`, not to a stray `()` term: `done() if $_ == 3` must parse
+        // as `(done()) if $_ == 3`, not `done; () if $_ == 3`.
+        let rest = if !had_ws && rest.starts_with('(') {
+            let after = skip_balanced_parens(rest);
+            let (after, _) = ws(after)?;
+            after
+        } else {
+            rest
+        };
         // Support statement modifiers like `done if $v >= 2`
         return parse_statement_modifier(rest, Stmt::ReactDone);
     }

--- a/t/done-paren-stmt-modifier.t
+++ b/t/done-paren-stmt-modifier.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `done()` (explicit call form) followed by a statement modifier must parse as
+# `(done()) if COND`, not `done; () if COND`. Previously the bare `done` was
+# split off as an unconditional control statement and the trailing `()` became a
+# separate term carrying the modifier, so `done() if $_ == N` fired on every
+# value.
+
+plan 4;
+
+# Blockless react with `done() if` — should iterate until the condition holds.
+{
+    my $i = 0;
+    react whenever Supply.from-list(0, 1, 2, 3, 4, 5) {
+        done() if $_ == 3;
+        $i++;
+    }
+    is $i, 3, 'done() if in blockless react iterates until the condition';
+}
+
+# Block form behaves the same.
+{
+    my $i = 0;
+    react {
+        whenever Supply.from-list(0, 1, 2, 3, 4, 5) {
+            done() if $_ == 3;
+            $i++;
+        }
+    }
+    is $i, 3, 'done() if in block react iterates until the condition';
+}
+
+# `done()` with no modifier still completes immediately.
+{
+    my $i = 0;
+    react {
+        whenever Supply.from-list(10, 20, 30) {
+            $i++;
+            done();
+        }
+    }
+    is $i, 1, 'bare done() completes the react after the first value';
+}
+
+# `done if` (no parens) keeps working.
+{
+    my $i = 0;
+    react whenever Supply.from-list(0, 1, 2, 3, 4) {
+        done if $_ == 2;
+        $i++;
+    }
+    is $i, 2, 'done if (no parens) still parses the modifier correctly';
+}


### PR DESCRIPTION
## Summary

`done() if COND` parsed as **two** statements: a bare, unconditional `done` (`Stmt::ReactDone`) followed by a separate `() if COND` term carrying the modifier. So `done() if $_ == 3` fired `done` on *every* value.

Concretely, a blockless `react whenever Supply.interval(...) { done() if $_ == 3; $i++ }` completed after the very first emission (`$i` stayed `0`).

The `done` keyword maps to the control-flow statement `Stmt::ReactDone` and takes no payload, but the explicit call form `done()` must still consume its (empty) argument list before a trailing statement modifier is applied. This consumes a balanced `()` after `done` (when there is no preceding whitespace), so the modifier attaches to the whole `done()`.

AST before / after for `done() if $_ == 3; say "x"`:

```
# before                          # after
ReactDone,                        If { cond: $_ == 3,
If { cond: $_ == 3,                    then: [ ReactDone ] },
     then: [ ArrayLiteral([]) ] }, Say("x")
Say("x")
```

`done if COND` (no parens) was already correct and is unchanged.

## Roast impact

Fixes `roast/S17-supply/syntax.t` test `'blockless react/whenever works'` (line 339).

## Tests

- New: `t/done-paren-stmt-modifier.t` (4 cases: blockless & block `done() if`, bare `done()`, `done if` regression).
- `cargo test --lib parser`: 343 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)