### PR TITLE
fix(object-hash): show original typed keys, not internal WHICH strings

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -993,7 +993,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             Value::Hash(items) => items
                 .iter()
                 .min_by(|(ak, _), (bk, _)| ak.cmp(bk))
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .map(|(k, v)| items.typed_pair(k, v.clone()))
                 .unwrap_or(Value::Nil),
             Value::Array(items, ..) => items
                 .iter()
@@ -1009,7 +1009,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             Value::Hash(items) => items
                 .iter()
                 .max_by(|(ak, _), (bk, _)| ak.cmp(bk))
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .map(|(k, v)| items.typed_pair(k, v.clone()))
                 .unwrap_or(Value::Nil),
             Value::Array(items, ..) => items
                 .iter()

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -484,7 +484,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Hash(map) => {
                 let pairs: Vec<Value> = map
                     .iter()
-                    .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                    .map(|(k, v)| map.typed_pair(k, v.clone()))
                     .collect();
                 Some(Ok(Value::array(pairs)))
             }

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -674,7 +674,12 @@ pub(super) fn dispatch(
                 sorted_keys.sort();
                 let parts: Vec<String> = sorted_keys
                     .iter()
-                    .map(|k| format!("{} => {}", k, runtime::gist_value(&map[*k])))
+                    .map(|k| {
+                        // Object hashes store `.WHICH` string keys; show the
+                        // original typed key (e.g. `a`, not `Str|a`).
+                        let key_disp = runtime::gist_value(&map.typed_key(k));
+                        format!("{} => {}", key_disp, runtime::gist_value(&map[*k]))
+                    })
                     .collect();
                 Some(Ok(Value::str(format!("{{{}}}", parts.join(", ")))))
             }

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -495,11 +495,23 @@ pub fn raku_value(v: &Value) -> String {
                 .iter()
                 .map(|k| {
                     let v = &map[*k];
-                    let is_ident = !k.is_empty()
-                        && k.starts_with(|c: char| c.is_alphabetic() || c == '_')
-                        && k.chars()
-                            .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+                    // Object hashes store `.WHICH` string keys (e.g. `"Int|1"`);
+                    // serialize the original typed key. A `Str` typed key keeps
+                    // the colon-pair / ident logic; a non-`Str` key (object hash)
+                    // uses the general `key => value` form.
+                    let typed = map.typed_key(k);
+                    let key_str: Option<String> = match &typed {
+                        Value::Str(s) => Some((**s).clone()),
+                        _ => None,
+                    };
+                    let is_ident = key_str.as_deref().is_some_and(|k| {
+                        !k.is_empty()
+                            && k.starts_with(|c: char| c.is_alphabetic() || c == '_')
+                            && k.chars()
+                                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+                    });
                     if is_ident {
+                        let k = key_str.as_deref().unwrap();
                         if let Value::Bool(true) = v {
                             format!(":{}", k)
                         } else if let Value::Bool(false) = v {
@@ -519,7 +531,7 @@ pub fn raku_value(v: &Value) -> String {
                         } else {
                             raku_value(v)
                         };
-                        format!("{} => {}", raku_value(&Value::str(k.to_string())), repr)
+                        format!("{} => {}", raku_value(&typed), repr)
                     }
                 })
                 .collect();

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -548,14 +548,16 @@ impl Interpreter {
         let mut best_key: Option<Value> = None;
 
         for (k, v) in map.as_ref().iter() {
-            let pair = Value::Pair(k.clone(), Box::new(v.clone()));
+            // Object hashes store `.WHICH` string keys; expose the original
+            // typed key both in the resulting Pair and in the default ordering.
+            let pair = map.typed_pair(k, v.clone());
             let key = if let Some(by_callable) = &by {
                 match self.call_sub_value(by_callable.clone(), vec![pair.clone()], true) {
                     Ok(value) => value,
                     Err(_) => v.clone(),
                 }
             } else {
-                Value::str(k.clone())
+                map.typed_key(k)
             };
 
             let replace = if let Some(current_key) = &best_key {

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -861,10 +861,18 @@ impl Interpreter {
                             .map(|t| Value::Package(Symbol::intern(&t)))
                     })
                     .unwrap_or_else(|| Value::Package(Symbol::intern("Any")));
+                // Object hashes (`my %h{Int}`) store `.WHICH`-encoded keys, so
+                // the subscript value must be encoded the same way to find the
+                // entry; the *displayed* key is the original typed subscript.
+                let is_object_hash = map.key_type.is_some();
                 for idx in &indices {
-                    let key_str = idx.to_string_value();
-                    let key =
-                        super::builtins_collection::builtin_val(&[Value::str(key_str.clone())]);
+                    let (key_str, key) = if is_object_hash {
+                        (crate::runtime::utils::value_which_key(idx), idx.clone())
+                    } else {
+                        let s = idx.to_string_value();
+                        let k = super::builtins_collection::builtin_val(&[Value::str(s.clone())]);
+                        (s, k)
+                    };
                     let exists = map.contains_key(&key_str);
                     let value = map
                         .get(&key_str)

--- a/src/runtime/methods_collection_ops/minmax_extrema.rs
+++ b/src/runtime/methods_collection_ops/minmax_extrema.rs
@@ -164,9 +164,9 @@ impl Interpreter {
                         if replace {
                             best = Some(value);
                             out.clear();
-                            out.push(Value::Pair(key.clone(), Box::new(value.clone())));
+                            out.push(hash.typed_pair(key, value.clone()));
                         } else if ord == std::cmp::Ordering::Equal {
-                            out.push(Value::Pair(key.clone(), Box::new(value.clone())));
+                            out.push(hash.typed_pair(key, value.clone()));
                         }
                     }
                     Value::Seq(Arc::new(out))

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -593,7 +593,7 @@ pub(crate) fn sort_value_generic(
         Value::Hash(map) => {
             let items: Vec<Value> = map
                 .iter()
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .map(|(k, v)| map.typed_pair(k, v.clone()))
                 .collect();
             sort_value_generic(caller, Value::array(items), args)
         }

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -209,7 +209,7 @@ impl Interpreter {
     /// Dispatch .raku/.perl on constrained Hash.
     pub(super) fn dispatch_constrained_hash_raku(
         &mut self,
-        map: &std::collections::HashMap<String, Value>,
+        map: &crate::value::HashData,
         info: &ContainerTypeInfo,
     ) -> Result<Value, RuntimeError> {
         let mut sorted_keys: Vec<&String> = map.keys().collect();
@@ -232,14 +232,21 @@ impl Interpreter {
                             .unwrap_or_else(|_| format!("{:?}", v))
                     }
                 };
+                // Object hashes store `.WHICH` string keys; serialize the
+                // original typed key (`1`, not `Int|1`; `a`, not `Str|a`).
+                let typed = map.typed_key(k);
+                let key_disp = match &typed {
+                    Value::Str(s) => (**s).clone(),
+                    _ => crate::builtins::methods_0arg::raku_value(&typed),
+                };
                 if use_arrow {
-                    format!("{} => {}", k, value_repr())
+                    format!("{} => {}", key_disp, value_repr())
                 } else if let Value::Bool(true) = v {
-                    format!(":{}", k)
+                    format!(":{}", key_disp)
                 } else if let Value::Bool(false) = v {
-                    format!(":!{}", k)
+                    format!(":!{}", key_disp)
                 } else {
-                    format!(":{}({})", k, value_repr())
+                    format!(":{}({})", key_disp, value_repr())
                 }
             })
             .collect();

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1624,7 +1624,7 @@ impl Interpreter {
             Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
             Value::Hash(items) => items
                 .iter()
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .map(|(k, v)| items.typed_pair(k, v.clone()))
                 .collect(),
             Value::Range(a, b) => {
                 let end = (*b).min(*a + 1_000_000);

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -766,7 +766,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             // Hash assigned to @-var: flatten into pairs
             let pairs: Vec<Value> = map
                 .iter()
-                .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                .map(|(k, v)| map.typed_pair(k, v.clone()))
                 .collect();
             Value::real_array(pairs)
         }
@@ -1753,7 +1753,7 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
         Value::Hash(items) => items
             .iter()
-            .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+            .map(|(k, v)| items.typed_pair(k, v.clone()))
             .collect(),
         Value::Range(a, b) => {
             let end = (*b).min(*a + MAX_RANGE_EXPAND);

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -464,7 +464,15 @@ impl Value {
                 SEEN_HASH_PTRS.with(|seen| seen.borrow_mut().push(ptr));
                 let mut pairs: Vec<_> = items
                     .iter()
-                    .map(|(k, v)| format!("{}\t{}", k, v.to_string_value()))
+                    .map(|(k, v)| {
+                        // Object hashes store `.WHICH` string keys; show the
+                        // original typed key (e.g. `1`, not `Int|1`).
+                        format!(
+                            "{}\t{}",
+                            items.typed_key(k).to_string_value(),
+                            v.to_string_value()
+                        )
+                    })
                     .collect();
                 pairs.sort();
                 SEEN_HASH_PTRS.with(|seen| {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1309,6 +1309,31 @@ impl HashData {
         self.key_type = None;
         self.declared_type = None;
     }
+
+    /// Get the original (typed) key Value for a stored string key. For object
+    /// hashes (`my %h{Int}`) the stored key is a `.WHICH` string (e.g.
+    /// `"Int|1"`); this returns the real key object (`Int(1)`). Plain hashes
+    /// have no `original_keys`, so this returns a `Str`. Mirrors
+    /// `BagData::typed_key`.
+    pub fn typed_key(&self, str_key: &str) -> Value {
+        if let Some(ref orig) = self.original_keys
+            && let Some(v) = orig.get(str_key)
+        {
+            return v.clone();
+        }
+        Value::Str(Arc::new(str_key.to_string()))
+    }
+
+    /// Build a `Pair` for a hash entry, using the original typed key for object
+    /// hashes. Plain string keys yield `Value::Pair`; non-string typed keys
+    /// (object hashes) yield `Value::ValuePair`. Behaviour-neutral for plain
+    /// hashes (returns `Value::Pair(str_key, value)` as before).
+    pub fn typed_pair(&self, str_key: &str, value: Value) -> Value {
+        match self.typed_key(str_key) {
+            Value::Str(s) => Value::Pair((*s).clone(), Box::new(value)),
+            other => Value::ValuePair(Box::new(other), Box::new(value)),
+        }
+    }
 }
 
 impl std::ops::Deref for HashData {

--- a/t/object-hash-key-display.t
+++ b/t/object-hash-key-display.t
@@ -1,0 +1,60 @@
+use Test;
+
+# Object hashes (`my %h{Type}`) store keys by `.WHICH` internally, but every
+# place that exposes a key (pairs from .sort/.map/listification, gist, .raku,
+# string context, .min/.max, slice adverbs) must show the *original* typed key,
+# not the internal WHICH string (e.g. `1`, not `Int|1`).
+
+plan 29;
+
+# --- Int-keyed object hash ------------------------------------------------
+my %i{Int};
+%i{1} = "x"; %i{2} = "y"; %i{3} = "z";
+
+is %i.sort.gist,          '(1 => x 2 => y 3 => z)', '.sort uses typed key';
+is %i.gist,               '{1 => x, 2 => y, 3 => z}', '.gist uses typed key';
+is %i.Str,                "1\tx\n2\ty\n3\tz",       '.Str uses typed key';
+is %i.raku,               '(my Any %{Int} = 1 => "x", 2 => "y", 3 => "z")', '.raku uses typed key';
+is %i.list.sort.gist,     '(1 => x 2 => y 3 => z)', '.list uses typed key';
+is %i.pairs.sort.gist,    '(1 => x 2 => y 3 => z)', '.pairs uses typed key';
+is %i.map({ "{.key}={.value}" }).sort.gist, '(1=x 2=y 3=z)', '.map sees typed key';
+is %i.min.gist,           '1 => x',                 '.min returns typed-key pair';
+is %i.max.gist,           '3 => z',                 '.max returns typed-key pair';
+is %i.minpairs.gist,      '(1 => x)',               '.minpairs typed key';
+is %i.maxpairs.gist,      '(3 => z)',               '.maxpairs typed key';
+
+# keys / values themselves stay correct
+is %i.keys.sort.gist,     '(1 2 3)',                '.keys typed';
+is %i.values.sort.gist,   '(x y z)',                '.values';
+
+# iteration yields the typed key
+my @collected;
+for %i.sort -> $p { @collected.push($p.key) }
+is @collected.gist,       '[1 2 3]',                'for-iteration sees typed key';
+
+# @-flattening preserves typed key in pairs
+my @flat = %i;
+is @flat.sort.gist,       '(1 => x 2 => y 3 => z)', '@-flatten uses typed key';
+
+# --- slice adverbs on object hashes --------------------------------------
+is (%i{1,2}).gist,        '(x y)',                  'plain slice';
+is (%i{1,2}:exists).gist, '(True True)',            ':exists slice';
+is (%i{1,2}:k).gist,      '(1 2)',                  ':k slice typed';
+is (%i{1,2}:kv).gist,     '(1 x 2 y)',              ':kv slice typed';
+is (%i{1,2}:p).gist,      '(1 => x 2 => y)',        ':p slice typed';
+is (%i{2}:delete).gist,   'y',                      ':delete single';
+is %i.keys.sort.gist,     '(1 3)',                  ':delete removed entry';
+
+# --- Str-keyed object hash ------------------------------------------------
+my %s{Str};
+%s<alpha> = 1; %s<beta> = 2;
+is %s.sort.gist,          '(alpha => 1 beta => 2)', 'Str object hash .sort';
+is %s.raku,               '(my Any %{Str} = :alpha(1), :beta(2))', 'Str object hash .raku';
+is %s.gist,               '{alpha => 1, beta => 2}', 'Str object hash .gist';
+
+# --- plain hash is unaffected --------------------------------------------
+my %p = a => 1, b => 2;
+is %p.sort.gist,          '(a => 1 b => 2)',        'plain hash .sort';
+is %p.raku,               '{:a(1), :b(2)}',         'plain hash .raku';
+is %p.gist,               '{a => 1, b => 2}',       'plain hash .gist';
+is %p.map({ .key }).sort.gist, '(a b)',             'plain hash .map';


### PR DESCRIPTION
## Problem

Object hashes (`my %h{Int}`) store keys by `.WHICH` internally (e.g. `"Int|1"`), keeping the real key object in `HashData.original_keys`. `.keys`/`.pairs`/`.kv`/`.antipairs`/`.invert` already resolved the original key, but **every other key-exposing path leaked the internal WHICH string**:

```raku
my %i{Int}; %i{1} = "x"; %i{2} = "y";
say %i.sort;     # was: (Int|1 => x Int|2 => y)   now: (1 => x 2 => y)
say %i.gist;     # was: {Int|1 => x, ...}         now: {1 => x, 2 => y}
say %i.raku;     # was: ... = Int|1 => "x", ...   now: ... = 1 => "x", ...
print %i;        # was: Int|1\tx ...              now: 1\tx ...
say %i{1,2}:p;   # was: ()  (lookup missed!)      now: (1 => x 2 => y)
```

Affected: `.sort`, `.gist`, `.Str`/string context, `.raku`, `.list`/`.Array` coercion, `.map`/`for`/`@`-flatten listification, `.min`/`.max`, `.minpairs`/`.maxpairs`, and `:k`/`:kv`/`:p` slice adverbs. The slice adverbs additionally **returned empty** for object hashes because they looked the key up by its plain string form (`"1"`) instead of the WHICH-encoded storage key (`"Int|1"`).

## Fix

Add `HashData::typed_key` / `typed_pair` (mirrors the existing `BagData::typed_key`) as the single source for resolving a stored key to its original typed value, and route every hash→pair listification through it. For slice adverbs, encode the subscript via `value_which_key` for object hashes so the lookup hits the stored entry while the displayed key stays the original typed value.

Behaviour-neutral for plain hashes: `typed_key` returns the `Str` key, yielding the same `Value::Pair` as before (verified — plain-hash subtests included).

## Verification

- `t/object-hash-key-display.t` (29) — Int- and Str-keyed object hashes across all the above paths, plus plain-hash no-regression cases.
- `make test` PASS (751 files / 6871 tests).
- roast sample clean: `S02-types/hash.t`, `S09-typed-arrays/hashes.t`, `S02-types/mix.t`, `S32-hash/{keys_values,pairs,slice,delete-adverb}.t`, `S32-list/{sort,categorize}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)