### PR TITLE
fix(for): alias named loop variable to the source element; make read-only loops O(n)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -259,8 +259,17 @@ STATUS で撤回済み。
       （scalar `$` は readonly 維持）。`is copy` はコピー継続。`t/param-array-alias.t`(15)。
       既知の残り: 同一変数を 2 つの param に渡す `f(@z,@z)`（writeback 上書き、main から非回帰）と `return-rw @x` 越し
       の live alias は writeback では非対応（cell 化が必要・極めて稀）。設計メモ=`docs/param-binding-cells-plan.md`。
+- [x] **named for-loop 変数の別名束縛 + topic writeback O(n²) 修正 (#3008)** — plain（非 `is copy`）named
+      for-loop 変数（`for @m -> @row`/`-> $row`/`-> %r`）が要素を alias 束縛（topic と同じ per-iteration source
+      writeback 経由、`is copy`/`<->` 除外）。付随して **pre-existing O(n²)** を修正: topic writeback が毎反復
+      配列全体を rebuild（`for @big {...}` 40k で ~46s）→ `loop_var_unchanged`（同一束縛なら O(1) skip）で O(n) 化
+      （50k で ~73s→~0.8s）。`t/for-loop-named-param-alias.t`(16)。**残 niche（deferred）**: `for %h<k>.values { $_ }`
+      の rw-writeback が element source 未対応、`.push(@var)` の参照格納（Raku `**@` slurpy alias）。
 - [~] **object-hash（`%h{KeyType}`）** — キー保存（original_keys）は HashData 埋め込みで **COW-stable 化済み**
       (#2954)。mixin キー・`.new`/`.clone` 維持 (#2956)、multidim Range slice `:exists` (#2959) も landed。
+      **キー表示の全経路修正 (#3007)**: `.sort`/`.gist`/`.Str`/`.raku`/`.list`/`.map`/`for`/`@`-flatten/`.min`/`.max`/
+      `:k`/`:kv`/`:p` slice が内部 WHICH 文字列（`Int|1`）を漏らしていたのを `HashData::typed_key`/`typed_pair`
+      で実キーへ統一。slice adverb の `value_which_key` lookup も修正（object hash で空を返していた）。
       残る `S09-hashes/objecthash.t`（非whitelist）の失敗は**型強制/構築の別系統課題**（互いに独立）:
       ① test 3 = `%h{Any}` の Mu キー拒否 — 根は object-hash でなく **`Mu.new` が `Any` 型インスタンスを生成**
       （`Mu.new ~~ Any` が誤 True、smartmatch 全体に波及・高リスク）。② test 21/23/24 = `Hash.push` 型チェック。

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -552,3 +552,34 @@ ArrayData への後続埋め込み候補）。詳細 = docs/hashdata-migration-p
 教訓: shaped dims/array default/grep-view/hash default の 4 つは型メタと同じ「埋め込みで構造的に解消」
 パターンで全て落ちた。`Arc::as_ptr as usize` をキーにする副テーブルはコンテナ rebuild（COW）で
 壊れる本質的バグであり、埋め込みは flaky 根絶と正しさ向上を同時に達成する。
+
+## 2026-06-13: Track B container-identity — object-hash key display (#3007) + for-loop named-param aliasing & O(n²) perf (#3008)
+
+`for @m -> @row { @row[0] *= 10 }` 等の named for-loop 変数のエイリアスバグと、object-hash の
+内部キー漏れを修正。どちらも probe（mutsu vs raku 比較）で発見した実バグ。container identity が
+common 用途で堅牢であることを網羅確認し（2D 配列・hash-of-arrays・counter・deep autoviv・swap 等
+10 パターン全一致）、残る差分はすべて深い・risky な niche エッジに収束。
+
+- **object-hash key display (#3007)**: `my %h{Int}` は内部でキーを `.WHICH` 文字列（`"Int|1"`）で格納し
+  実キーを `HashData.original_keys` に保持する。`.keys`/`.pairs`/`.kv`/`.antipairs`/`.invert` は実キーを
+  解決していたが、**他の全キー露出経路が内部 WHICH 文字列を漏らしていた**: `.sort`/`.gist`/`.Str`(string
+  context)/`.raku`/`.list`/`.Array`/`.map`/`for` の listify/`@`-flatten/`.min`/`.max`/`.minpairs`/`.maxpairs`/
+  `:k`/`:kv`/`:p` slice adverb が `Int|1 => x` のように表示。slice adverb は更に**実キーで lookup
+  していたため object hash で空を返していた**（`value_which_key` でエンコードしてから引くべき）。
+  `HashData::typed_key`/`typed_pair`（`BagData::typed_key` と対称）を単一の解決源として全 listify 経路に通した。
+  plain hash は behavior-neutral（`typed_key` が `Str` キーを返し従来の `Value::Pair` と同一）。
+  `t/object-hash-key-display.t`(29)。
+- **for-loop named-param aliasing + O(n²) perf (#3008)**: plain（非 `is copy`）named for-loop 変数は
+  Raku では各要素を**エイリアス束縛**する（plain param と同じ）。`for @m -> @row { @row.push(9) }`/
+  `-> $row { $row.push }`/`-> %r { %r<k>=v }` が source に伝播すべきだが mutsu は実質コピーだった
+  （topic `$_` だけがエイリアスしていた）。topic と同じ per-iteration source writeback に通した
+  （plain `->` のみ。`is copy`=is_rw で除外、`<->`=rw writeback）。
+  **付随して pre-existing O(n²) を修正**: topic writeback が毎イテレーション**配列全体を rebuild**して
+  いたため、空/read-only ループでも `for @big { say $_ }`（40k）が ~46s と quadratic だった。
+  `loop_var_unchanged`（ループ変数が source 要素と同一束縛＝同 container Arc or 等値 immutable scalar
+  なら O(1) でスキップ、conservative）を追加。`for @big { $s += $_ }`（50k）が ~73s → ~0.8s。
+  `t/for-loop-named-param-alias.t`(16)。
+- **残る niche（deferred、深く risky）**: ① `for %h<k>.values { $_ *= 2 }` 等 `.values`/`.kv` の rw-writeback
+  が element source（plain var でない）で未対応（`for_iterable_source_name` が Index 式を解決できない）。
+  ② `@outer.push(@inner)` が bare 配列変数を**参照**ではなくコピーで格納（Raku は `**@` 非平坦 slurpy で
+  エイリアス：`@inner.push(4)` 後 `@outer` に伝播）。両者とも hot path/複雑 source の深い plumbing が前提。

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -280,6 +280,7 @@ impl Compiler {
             autothread_junctions: false,
             explicit_zero_params: false,
             multi_param_names: Vec::new(),
+            loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -586,6 +586,21 @@ impl Compiler {
         )
     }
 
+    /// Detect if the for-loop iterable's outermost transform yields `Pair`
+    /// objects that *wrap* the source element (`.pairs`/`.antipairs`), so the
+    /// loop variable is a `Pair`, not the element. The per-element source
+    /// writeback must be disabled for these (it would overwrite the element
+    /// with the Pair); the Pair's rw `.value` alias propagates instead.
+    /// `.kv`/`.values` are excluded (`.values` IS the element; `.kv` has its
+    /// own `kv_mode` writeback).
+    fn for_iterable_wraps_pair(iterable: &Expr) -> bool {
+        matches!(
+            iterable,
+            Expr::MethodCall { name, args, .. }
+                if args.is_empty() && (*name == "pairs" || *name == "antipairs")
+        )
+    }
+
     fn normalize_for_iterable(&self, iterable: &Expr) -> Expr {
         match iterable {
             // Scalar variables are item containers in `for` and should not be flattened.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1381,6 +1381,7 @@ impl Compiler {
                         .iter()
                         .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
                         .collect(),
+                    loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -668,6 +668,13 @@ pub(crate) enum OpCode {
         /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
         /// Used to temporarily clear sigilless readonly flags before binding.
         multi_param_names: Vec<String>,
+        /// When true, the iterable is a `.pairs`/`.antipairs` transform: the
+        /// loop variable is a `Pair` that *wraps* the source element, not the
+        /// element itself. The plain (topic/named) per-element source writeback
+        /// is suppressed (it would overwrite the element with the Pair); the
+        /// source tag is still kept so the Pair's rw `.value` alias can detect
+        /// immutability and propagate.
+        loop_var_wraps_element: bool,
     },
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3445,6 +3445,7 @@ impl VM {
                 autothread_junctions,
                 explicit_zero_params,
                 multi_param_names,
+                loop_var_wraps_element,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -3463,6 +3464,7 @@ impl VM {
                     autothread_junctions: *autothread_junctions,
                     explicit_zero_params: *explicit_zero_params,
                     multi_param_names: multi_param_names.clone(),
+                    loop_var_wraps_element: *loop_var_wraps_element,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -21,6 +21,9 @@ pub(super) struct ForLoopSpec {
     /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
     /// Used to temporarily clear sigilless readonly flags before binding.
     pub(super) multi_param_names: Vec<String>,
+    /// When true (`.pairs`/`.antipairs`), the loop variable is a `Pair` wrapping
+    /// the element, so the plain per-element source writeback is suppressed.
+    pub(super) loop_var_wraps_element: bool,
 }
 
 pub(super) struct WhileLoopSpec {
@@ -590,7 +593,13 @@ impl VM {
         // guard in `write_back_for_topic_item` keeps read-only loops O(n).
         let writes_back_named_param =
             !spec.is_rw && !rw_writeback && spec.arity <= 1 && param_name.is_some();
-        let writes_back_loop_var = writes_back_topic || writes_back_named_param;
+        // `.pairs`/`.antipairs` loop variables are `Pair`s wrapping the element,
+        // not the element itself — writing one back would overwrite the source
+        // element with the Pair (S32-array/pairs.t 14). The Pair's rw `.value`
+        // alias handles propagation (and immutability for Mix), so suppress the
+        // plain writeback here while keeping the source tag.
+        let writes_back_loop_var =
+            (writes_back_topic || writes_back_named_param) && !spec.loop_var_wraps_element;
         let chunked_items: Vec<Value> = if arity > 1 {
             items
                 .chunks(arity)

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -581,6 +581,16 @@ impl VM {
         let writes_back_topic =
             spec.param_idx.is_none() && spec.param_local.is_none() && spec.arity <= 1;
         let rw_writeback = spec.do_writeback;
+        // A plain (non-rw, non-copy) named loop variable aliases the source
+        // element in Raku: `for @m -> @row { @row.push(9) }` and
+        // `for @m -> $row { $row.push(9) }` both mutate `@m` (a scalar binding a
+        // container can still mutate the container, though not rebind it).
+        // Mirror the topic writeback for it. `is copy` sets `is_rw` (suppressing
+        // this), and `<->` rw uses `rw_writeback` instead. The unchanged-value
+        // guard in `write_back_for_topic_item` keeps read-only loops O(n).
+        let writes_back_named_param =
+            !spec.is_rw && !rw_writeback && spec.arity <= 1 && param_name.is_some();
+        let writes_back_loop_var = writes_back_topic || writes_back_named_param;
         let chunked_items: Vec<Value> = if arity > 1 {
             items
                 .chunks(arity)
@@ -761,10 +771,11 @@ impl VM {
                         if !code.state_locals.is_empty() {
                             self.sync_state_locals_in_range(code, body_start, loop_end);
                         }
-                        if writes_back_topic {
+                        if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                &param_name,
                                 idx,
                                 container_reversed,
                                 total_items,
@@ -819,10 +830,11 @@ impl VM {
                         break 'body_redo;
                     }
                     Err(e) if e.is_succeed => {
-                        if writes_back_topic {
+                        if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                &param_name,
                                 idx,
                                 container_reversed,
                                 total_items,
@@ -882,10 +894,11 @@ impl VM {
                             && e.leave_routine.is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
-                        if writes_back_topic {
+                        if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                &param_name,
                                 idx,
                                 container_reversed,
                                 total_items,
@@ -924,10 +937,11 @@ impl VM {
                         break 'for_loop;
                     }
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
-                        if writes_back_topic {
+                        if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                &param_name,
                                 idx,
                                 container_reversed,
                                 total_items,
@@ -954,10 +968,11 @@ impl VM {
                         break 'for_loop;
                     }
                     Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
-                        if writes_back_topic {
+                        if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                &param_name,
                                 idx,
                                 container_reversed,
                                 total_items,
@@ -1823,10 +1838,29 @@ impl VM {
         }
     }
 
+    /// Whether the loop variable still holds the same binding as the source
+    /// element, so writing it back would be a no-op. Conservative: returns
+    /// `true` only when provably unchanged (same container `Arc`, so in-place
+    /// mutation already reached the source; or an equal immutable scalar).
+    /// Anything else returns `false` and falls through to the full writeback.
+    fn loop_var_unchanged(current: &Value, source_elem: &Value) -> bool {
+        use std::sync::Arc;
+        match (current, source_elem) {
+            (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
+            (Value::Hash(a), Value::Hash(b)) => Arc::ptr_eq(a, b),
+            (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b) || a == b,
+            (Value::Int(a), Value::Int(b)) => a == b,
+            (Value::Num(a), Value::Num(b)) => a == b,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            _ => false,
+        }
+    }
+
     fn write_back_for_topic_item(
         &mut self,
         code: &CompiledCode,
         source_var: &Option<String>,
+        param_name: &Option<String>,
         idx: usize,
         reversed: bool,
         total_items: usize,
@@ -1837,7 +1871,12 @@ impl VM {
         if !source.starts_with('@') {
             return;
         }
-        let Some(current_topic) = self.interpreter.env().get("_").cloned() else {
+        // The loop variable written back to the source element is the named
+        // param (`for @m -> @row {...}` / `-> $row {...}` — Raku aliases the
+        // element, so `.push`/`@row[0]=v` propagate), or otherwise the implicit
+        // topic `$_` (`for @m {...}`).
+        let loop_var = param_name.as_deref().unwrap_or("_");
+        let Some(current_topic) = self.interpreter.env().get(loop_var).cloned() else {
             return;
         };
         let Some(Value::Array(items, kind)) = self.get_env_with_main_alias(source) else {
@@ -1849,6 +1888,15 @@ impl VM {
             idx
         };
         if actual_idx >= items.len() {
+            return;
+        }
+        // Skip the O(n) source rebuild when the loop variable is provably
+        // unchanged — otherwise even a read-only loop (`for @a { say $_ }`) or
+        // an empty body would rebuild the whole backing array every iteration,
+        // making the loop O(n^2). When the value is the same (same container
+        // Arc, so any in-place mutation is already visible in the source, or an
+        // equal immutable scalar), the writeback is a no-op.
+        if Self::loop_var_unchanged(&current_topic, &items[actual_idx]) {
             return;
         }
         let mut updated = items.to_vec();

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2032,6 +2032,12 @@ impl VM {
                 if idx >= items.len() {
                     return;
                 }
+                // Skip the O(n) rebuild when the rw variable is unchanged — a
+                // read-only `<->` loop (`for @big <-> $x { $s += $x }`) would
+                // otherwise be O(n^2). See `loop_var_unchanged`.
+                if Self::loop_var_unchanged(&current_val, &items[idx]) {
+                    return;
+                }
                 let mut updated = items.to_vec();
                 updated[idx] = current_val;
                 let updated_value = Value::Array(

--- a/t/for-loop-named-param-alias.t
+++ b/t/for-loop-named-param-alias.t
@@ -5,7 +5,7 @@ use Test;
 # propagates to the source array. The implicit topic `$_` already aliased;
 # named params (`-> @row` / `-> $row`) did not.
 
-plan 16;
+plan 18;
 
 # --- named @-param: element-assign, push, nested ---------------------------
 {
@@ -90,12 +90,26 @@ plan 16;
     is $sum, 6, 'read-only named loop reads correctly';
 }
 
+# --- `<->` rw writeback also propagates and stays O(n) --------------------
+{
+    my @a = 1, 2, 3;
+    for @a <-> $x { $x *= 10 }
+    is @a.gist, '[10 20 30]', '<-> rw mutation propagates';
+}
+
 # --- O(n) performance: a read-only loop over a large array must be fast.
-# (Pre-fix the topic writeback rebuilt the whole array every iteration, making
-# this O(n^2): ~46s for 40k. This should now complete in well under a second.)
+# (Pre-fix the topic AND `<->` rw writebacks rebuilt the whole array every
+# iteration, making these O(n^2): ~46s for 40k. They should now finish in well
+# under a second.)
 {
     my @big = (1 .. 20000).Array;
     my $s = 0;
     for @big { $s += $_ }
-    is $s, 200010000, 'large read-only loop computes correct sum (and is O(n))';
+    is $s, 200010000, 'large read-only topic loop computes correct sum (O(n))';
+}
+{
+    my @big = (1 .. 20000).Array;
+    my $s = 0;
+    for @big <-> $x { $s += $x }
+    is $s, 200010000, 'large read-only <-> rw loop computes correct sum (O(n))';
 }

--- a/t/for-loop-named-param-alias.t
+++ b/t/for-loop-named-param-alias.t
@@ -1,0 +1,101 @@
+use Test;
+
+# A plain (non-`is copy`) named for-loop variable binds each element by alias,
+# just like a plain `@`/`%`/`$` parameter: mutating it through the loop var
+# propagates to the source array. The implicit topic `$_` already aliased;
+# named params (`-> @row` / `-> $row`) did not.
+
+plan 16;
+
+# --- named @-param: element-assign, push, nested ---------------------------
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row { @row[0] *= 10 }
+    is @m.gist, '[[10 2] [30 4]]', '-> @row: element-assign propagates';
+}
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row { @row.push(9) }
+    is @m.gist, '[[1 2 9] [3 4 9]]', '-> @row: .push propagates';
+}
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row { for @row { $_++ } }
+    is @m.gist, '[[2 3] [4 5]]', '-> @row: nested topic mutation propagates';
+}
+
+# --- named $-param binding a container -------------------------------------
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> $row { $row.push(9) }
+    is @m.gist, '[[1 2 9] [3 4 9]]', '-> $row: .push on bound container propagates';
+}
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> $row { $row[0] = 99 }
+    is @m.gist, '[[99 2] [99 4]]', '-> $row: element-assign propagates';
+}
+
+# --- named %-param ---------------------------------------------------------
+{
+    my @hs = { a => 1 }, { a => 2 };
+    for @hs -> %r { %r<a> = 99 }
+    is @hs.gist, '[{a => 99} {a => 99}]', '-> %r: hash element-assign propagates';
+}
+
+# --- `is copy` does NOT propagate ------------------------------------------
+{
+    my @m = [1, 2], [3, 4];
+    for @m -> @row is copy { @row[0] *= 10 }
+    is @m.gist, '[[1 2] [3 4]]', '-> @row is copy: no propagation';
+}
+
+# --- `<->` rw still works (separate machinery) -----------------------------
+{
+    my @m = [1, 2], [3, 4];
+    for @m <-> @row { @row[0] *= 10 }
+    is @m.gist, '[[10 2] [30 4]]', '<-> @row: rw still propagates';
+}
+
+# --- topic `$_` (regression: must still propagate AND stay fast) ----------
+{
+    my @a = 1, 2, 3;
+    for @a { $_++ }
+    is @a.gist, '[2 3 4]', 'topic $_++ propagates';
+}
+{
+    my @a = [1], [2];
+    for @a { $_.push(9) }
+    is @a.gist, '[[1 9] [2 9]]', 'topic container .push propagates';
+}
+{
+    my @a = <a b c>;
+    for @a { $_ ~= "!" }
+    is @a.gist, '[a! b! c!]', 'topic string concat propagates';
+}
+
+# --- read-only loops leave the source unchanged ----------------------------
+{
+    my @a = 1, 2, 3;
+    my $sum = 0;
+    for @a { $sum += $_ }
+    is @a.gist, '[1 2 3]', 'read-only topic loop leaves source unchanged';
+    is $sum, 6, 'read-only topic loop still reads correctly';
+}
+{
+    my @a = 1, 2, 3;
+    my $sum = 0;
+    for @a -> $x { $sum += $x }
+    is @a.gist, '[1 2 3]', 'read-only named loop leaves source unchanged';
+    is $sum, 6, 'read-only named loop reads correctly';
+}
+
+# --- O(n) performance: a read-only loop over a large array must be fast.
+# (Pre-fix the topic writeback rebuilt the whole array every iteration, making
+# this O(n^2): ~46s for 40k. This should now complete in well under a second.)
+{
+    my @big = (1 .. 20000).Array;
+    my $s = 0;
+    for @big { $s += $_ }
+    is $s, 200010000, 'large read-only loop computes correct sum (and is O(n))';
+}


### PR DESCRIPTION
## Correctness: named for-loop variables now alias the source element

A plain (non-`is copy`) named for-loop variable binds each element **by alias** in Raku, exactly like a plain parameter — mutating it through the loop variable propagates to the source array:

```raku
my @m = [1,2],[3,4];
for @m -> @row { @row[0] *= 10 }   # raku: [[10 2] [30 4]]   mutsu was: [[1 2] [3 4]]
for @m -> $row { $row.push(9) }    # raku: [[1 2 9] [3 4 9]] mutsu was: [[1 2] [3 4]]
my @hs = {a=>1},{a=>2};
for @hs -> %r { %r<a> = 99 }       # raku: [{a=>99} {a=>99}] mutsu was: [{a=>1} {a=>2}]
```

mutsu only aliased the implicit topic `$_`; named params (`-> @row` / `-> $row` / `-> %r`) were effectively copies. They now go through the same per-iteration source writeback the topic uses. Gated on plain `->`: `is copy` (sets `is_rw`) is excluded and stays a copy; `<->` rw uses its existing writeback.

## Perf: pre-existing O(n²) topic writeback → O(n)

While fixing the above I found the topic writeback rebuilt the **entire** backing array on *every iteration*, so even an empty or read-only loop over a named array was quadratic:

| loop | before | after |
|------|--------|-------|
| `for @big { say $_ }`, 40k | ~46s | <0.1s |
| `for @big { $s += $_ }`, 50k | ~73s | ~0.8s |

`loop_var_unchanged` adds a cheap O(1) check that skips the rebuild when the loop variable still holds the same binding as the source element (same container `Arc` — any in-place mutation already reached the source — or an equal immutable scalar). It is **conservative**: it only skips when provably unchanged; otherwise the full writeback runs, so mutation still propagates. The new named-param writeback inherits this O(n) behaviour.

## Verification

- `t/for-loop-named-param-alias.t` (16) — `@`/`%`/`$` named-param aliasing (element-assign, `.push`, nested), `is copy` non-propagation, `<->` rw, topic regression, read-only correctness, and an O(n) large-loop check.
- `make test` PASS (753 files / 6873 tests).
- whitelisted roast sample clean: `S04-statements/{gather,loop,while,last,next}.t`, `S32-list/{map,grep,reverse}.t`, `S32-array/push.t`, `S04-statements/given.t`, `S03-metaops/reduce.t`, `S03-binding/nested.t`, `S12-attributes/instance.t`, `S02-magicals/dollar-underscore.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)