### PR TITLE
fix(given): alias the container topic; enforce read-only topic semantics

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -583,3 +583,16 @@ common 用途で堅牢であることを網羅確認し（2D 配列・hash-of-ar
   が element source（plain var でない）で未対応（`for_iterable_source_name` が Index 式を解決できない）。
   ② `@outer.push(@inner)` が bare 配列変数を**参照**ではなくコピーで格納（Raku は `**@` 非平坦 slurpy で
   エイリアス：`@inner.push(4)` 後 `@outer` に伝播）。両者とも hot path/複雑 source の深い plumbing が前提。
+
+## 2026-06-14: given/with topic aliasing + read-only topic 意味論 (#3009)
+
+`given @a { .push(4) }` は Raku ではコンテナをエイリアス topicalize し、`$_` 経由のコンテナ変異が
+source に伝播する（mutsu はコピー扱いで `.push` が消失）。`@`/`%` container topic を `given` が既に
+`TagContainerRef` で張る per-iteration source writeback に通した（#3008 の `write_back_given_topic`＋
+`loop_var_unchanged` guard 再利用、read-only given は no-op）。さらに **given topic は read-only**
+（bare scalar var `given $x { $_=9 }` だけ rw で `$x` に伝播）だが mutsu は全 topic で `$_=...` を許して
+いた → `Given` opcode に `topic_readonly` フラグ追加（compiler が bare scalar `Var` 以外で true）し
+`$_` を read-only マーク。`given @a { $_ = (7,8,9) }`・`given 42 { $_ = 9 }` が Raku 同様エラーに、
+コンテナ変異（`.push`）は引き続き伝播。`t/given-topic-alias.t`(12)、given-ro が raku 完全一致。
+**残 gap（deferred）**: element-source topic（`given %h<k>`/`given @a[i]` は TagContainerRef 非発行）と
+`with`（defined-check へ compile され Given opcode を通らない）は未伝播。

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1680,7 +1680,14 @@ impl Compiler {
                     let name_idx = self.code.add_constant(Value::str(source_name));
                     self.code.emit(OpCode::TagContainerRef(name_idx));
                 }
-                let given_idx = self.code.emit(OpCode::Given { body_end: 0 });
+                // The topic is read-only unless it is a bare scalar variable
+                // (`given $x` aliases `$x` rw). `given @a` / `given 42` /
+                // `given expr()` are read-only (Raku errors on `$_ = ...`).
+                let topic_readonly = !matches!(topic, Expr::Var(_));
+                let given_idx = self.code.emit(OpCode::Given {
+                    body_end: 0,
+                    topic_readonly,
+                });
                 if Self::has_catch_or_control(body) {
                     self.compile_try(body, &None);
                     self.code.emit(OpCode::Pop);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -695,6 +695,12 @@ pub(crate) enum OpCode {
     // -- Given/When/Default (compound opcodes) --
     Given {
         body_end: u32,
+        /// When true, the topic (`$_`) is read-only: assigning to it (`$_ = ...`)
+        /// must fail. True for every topic except a bare scalar variable
+        /// (`given $x { $_ = 9 }` aliases `$x` rw); `given @a`/`given 42`/
+        /// `given expr()` are all read-only in Raku (container *mutation* like
+        /// `.push` is still allowed and propagates).
+        topic_readonly: bool,
     },
     When {
         body_end: u32,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3503,8 +3503,11 @@ impl VM {
             }
 
             // -- Given/When/Default --
-            OpCode::Given { body_end } => {
-                self.exec_given_op(code, *body_end, ip, compiled_fns)?;
+            OpCode::Given {
+                body_end,
+                topic_readonly,
+            } => {
+                self.exec_given_op(code, *body_end, *topic_readonly, ip, compiled_fns)?;
             }
             OpCode::When { body_end } => {
                 self.exec_when_op(code, *body_end, ip, compiled_fns)?;

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1847,6 +1847,30 @@ impl VM {
         }
     }
 
+    /// Write a mutated whole-container topic back to its source variable after a
+    /// `given`/`with` block: `given @a { .push(4) }` aliases `@a`, so a container
+    /// mutation through `$_` must propagate. Only for `@`/`%`-sigil sources
+    /// (whole-container topicalization); skipped when the topic is unchanged
+    /// (same `Arc`) so a read-only `given` stays a no-op.
+    fn write_back_given_topic(&mut self, code: &CompiledCode, source: &Option<String>) {
+        let Some(source) = source else {
+            return;
+        };
+        if !source.starts_with('@') && !source.starts_with('%') {
+            return;
+        }
+        let Some(current) = self.interpreter.env().get("_").cloned() else {
+            return;
+        };
+        if let Some(orig) = self.get_env_with_main_alias(source)
+            && Self::loop_var_unchanged(&current, &orig)
+        {
+            return;
+        }
+        self.set_env_with_main_alias(source, current.clone());
+        self.update_local_if_exists(code, source, &current);
+    }
+
     /// Whether the loop variable still holds the same binding as the source
     /// element, so writing it back would be a no-op. Conservative: returns
     /// `true` only when provably unchanged (same container `Arc`, so in-place
@@ -2237,6 +2261,7 @@ impl VM {
         &mut self,
         code: &CompiledCode,
         body_end: u32,
+        topic_readonly: bool,
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
@@ -2252,6 +2277,29 @@ impl VM {
         self.topic_source_var = container_binding.clone();
         self.interpreter.env_mut().insert("_".to_string(), topic);
         self.interpreter.set_when_matched(false);
+        // A read-only topic (`given @a` / `given 42` / `given expr()`) forbids
+        // `$_ = ...`; container *mutation* (`.push`) is still allowed and is
+        // written back to the source below. A bare scalar var (`given $x`) is rw.
+        let mark_ro = topic_readonly && !self.interpreter.readonly_vars().contains("_");
+        if mark_ro {
+            self.interpreter.mark_readonly("_");
+        }
+
+        let restore = |this: &mut Self, write_back: bool| {
+            if mark_ro {
+                this.interpreter.unmark_readonly("_");
+            }
+            if write_back {
+                this.write_back_given_topic(code, &container_binding);
+            }
+            this.interpreter.set_when_matched(saved_when);
+            if let Some(v) = saved_topic.clone() {
+                this.interpreter.env_mut().insert("_".to_string(), v);
+            } else {
+                this.interpreter.env_mut().remove("_");
+            }
+            this.topic_source_var = saved_topic_source.clone();
+        };
 
         let mut inner_ip = body_start;
         while inner_ip < end {
@@ -2261,23 +2309,11 @@ impl VM {
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
                     }
-                    self.interpreter.set_when_matched(saved_when);
-                    if let Some(v) = saved_topic.clone() {
-                        self.interpreter.env_mut().insert("_".to_string(), v);
-                    } else {
-                        self.interpreter.env_mut().remove("_");
-                    }
-                    self.topic_source_var = saved_topic_source;
+                    restore(self, true);
                     *ip = end;
                     return Ok(());
                 }
-                self.interpreter.set_when_matched(saved_when);
-                if let Some(v) = saved_topic {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
-                } else {
-                    self.interpreter.env_mut().remove("_");
-                }
-                self.topic_source_var = saved_topic_source;
+                restore(self, false);
                 return Err(e);
             }
             if self.interpreter.when_matched() || self.interpreter.is_halted() {
@@ -2290,13 +2326,7 @@ impl VM {
             self.stack.push(last);
         }
 
-        self.interpreter.set_when_matched(saved_when);
-        if let Some(v) = saved_topic {
-            self.interpreter.env_mut().insert("_".to_string(), v);
-        } else {
-            self.interpreter.env_mut().remove("_");
-        }
-        self.topic_source_var = saved_topic_source;
+        restore(self, true);
         *ip = end;
         Ok(())
     }

--- a/t/given-topic-alias.t
+++ b/t/given-topic-alias.t
@@ -1,0 +1,79 @@
+use Test;
+
+# `given @container { ... }` topicalizes the container by alias: a container
+# *mutation* through `$_` (`.push`, element assign) propagates to the source.
+# The topic is read-only, so `$_ = ...` (whole reassign) must fail — except a
+# bare scalar variable (`given $x`), which aliases `$x` rw.
+
+plan 12;
+
+# --- container mutation through the topic propagates ----------------------
+{
+    my @a = 1, 2, 3;
+    given @a { .push(4) }
+    is @a.gist, '[1 2 3 4]', 'given @a { .push } propagates';
+}
+{
+    my @a = 1, 2, 3;
+    given @a { $_[0] = 99 }
+    is @a.gist, '[99 2 3]', 'given @a { $_[0] = v } propagates';
+}
+{
+    my %h = a => 1;
+    given %h { $_<b> = 2 }
+    is %h.sort.gist, '(a => 1 b => 2)', 'given %h { $_<k> = v } propagates';
+}
+
+# --- the topic is read-only: whole reassign must die ----------------------
+{
+    my @a = 1, 2;
+    dies-ok { given @a { $_ = (7, 8, 9) } },
+        'given @container { $_ = ... } dies (read-only topic)';
+}
+{
+    dies-ok { given 42 { $_ = 99 } },
+        'given <literal> { $_ = ... } dies (read-only topic)';
+}
+
+# --- a bare scalar variable topic is rw (aliases the variable) ------------
+{
+    my $x = 5;
+    given $x { $_ = 99 }
+    is $x, 99, 'given $x { $_ = v } is rw and propagates to $x';
+}
+
+# --- read-only given leaves the source unchanged and still reads ----------
+{
+    my @a = 1, 2, 3;
+    my $sum = 0;
+    given @a { $sum += .sum }
+    is @a.gist, '[1 2 3]', 'read-only given leaves the source unchanged';
+    is $sum, 6, 'read-only given still reads the topic';
+}
+
+# --- given/when dispatch is unaffected ------------------------------------
+{
+    my $r = do given 5 {
+        when * > 3 { "big" }
+        default { "small" }
+    };
+    is $r, 'big', 'given/when dispatch still works';
+}
+{
+    my @a = <a b c>;
+    my @seen;
+    given @a { @seen.push(.elems) }
+    is @seen.gist, '[3]', 'given @a topicalizes the whole array (1 item)';
+}
+
+# --- nested given keeps inner/outer topics distinct -----------------------
+{
+    my @outer = 1, 2;
+    my @inner = 10, 20;
+    given @outer {
+        given @inner { .push(30) }
+        .push(3);
+    }
+    is @outer.gist, '[1 2 3]', 'nested given: outer push propagates';
+    is @inner.gist, '[10 20 30]', 'nested given: inner push propagates';
+}


### PR DESCRIPTION
## Container topic aliasing

`given @a { .push(4) }` topicalizes `@a` **by alias** in Raku, so a container mutation through `$_` propagates to the source. mutsu treated the topic as a copy, so `.push` (and other container mutations) were lost:

```raku
my @a = 1,2,3;
given @a { .push(4) }          # raku: [1 2 3 4]   mutsu was: [1 2 3]
my %h = a => 1;
given %h { $_<b> = 2 }         # raku: {a=>1,b=>2} mutsu was: {a=>1}
```

Route the `@`/`%` container topic through the same per-element source writeback `given` already wires up via `TagContainerRef`, reusing `write_back_given_topic` + the `loop_var_unchanged` guard (from #3008) so a read-only `given` stays a no-op.

## Read-only topic semantics

The `given` topic is **read-only** — except a bare scalar variable (`given $x` aliases `$x` rw). mutsu wrongly allowed `$_ = ...` for every topic:

```raku
given @a { $_ = (7,8,9) }      # raku: dies   mutsu was: lived
given 42 { $_ = 9 }            # raku: dies   mutsu was: lived
given $x { $_ = 9 }            # raku: $x = 9 (rw)  — preserved
```

Add a `topic_readonly` flag to the `Given` opcode (compiler sets it for any topic that is not a bare scalar `Var`) and mark `$_` read-only for the block. Container *mutation* (`.push`) is still allowed and propagates; only whole reassignment fails.

## Known gaps (deferred)

- Element-source topics (`given %h<k>` / `given @a[i]`) don't tag a source, so they don't propagate yet.
- `with` compiles to a defined-check rather than the `Given` opcode, so `with @a { .push }` doesn't propagate yet.

## Verification

- `t/given-topic-alias.t` (12) — container `.push`/element-assign propagation, read-only `$_ = ...` dies, scalar-var rw, read-only no-op, given/when dispatch, nested given. Matches raku.
- `make test` PASS (754 files / 6887 tests). `S04-statements/{given,when,with}.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)