### PR TITLE
fix(with): alias the container topic so `with @a { .push }` propagates

### DIFF
--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -2224,8 +2224,15 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // semantics). This lets in-place mutations through `$_` (e.g. `.=uc`,
     // `$_ = ...`) write back to the original container, while `$_` stays writable
     // exactly as in `given`. The `.defined` condition is still evaluated
-    // separately via `$tmp`.
-    let use_given_alias = param_name.is_none() && matches!(&cond_expr, Expr::Var(_));
+    // separately via `$tmp`. Container variables (`@a` / `%h`) also alias their
+    // container topic through `given`, so `with @a { .push }` propagates the
+    // mutation back to `@a` (the `given` opcode treats `@`/`%` topics as
+    // read-only-for-reassign but writes container mutations back to the source).
+    let use_given_alias = param_name.is_none()
+        && matches!(
+            &cond_expr,
+            Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
+        );
     // Topicalize `$_` for the body. For a literal, wrap it in a Mixin marked
     // read-only so in-place mutation of `$_` throws X::Assignment::RO. Otherwise
     // reuse the `$tmp` holding the (once-evaluated) condition value.

--- a/t/with-topic-alias.t
+++ b/t/with-topic-alias.t
@@ -1,0 +1,88 @@
+use Test;
+
+# `with @container { ... }` topicalizes the container by alias (same as
+# `given`): a container *mutation* through `$_` (`.push`, element assign)
+# propagates to the source. The topic is read-only, so `$_ = ...` (whole
+# reassign) must fail. A bare scalar variable (`with $x`) aliases `$x` rw.
+# `with` only runs the body when the topic is defined.
+
+plan 13;
+
+# --- container mutation through the topic propagates ----------------------
+{
+    my @a = 1, 2, 3;
+    with @a { .push(4) }
+    is @a.gist, '[1 2 3 4]', 'with @a { .push } propagates';
+}
+{
+    my @a = 1, 2, 3;
+    with @a { $_[0] = 99 }
+    is @a.gist, '[99 2 3]', 'with @a { $_[0] = v } propagates';
+}
+{
+    my %h = a => 1;
+    with %h { $_<b> = 2 }
+    is %h.sort.gist, '(a => 1 b => 2)', 'with %h { $_<k> = v } propagates';
+}
+{
+    my %h = a => 1;
+    with %h { .{'b'} = 2 }
+    is %h.sort.gist, '(a => 1 b => 2)', 'with %h { .{k} = v } propagates';
+}
+
+# --- the topic is read-only: whole reassign must die ----------------------
+{
+    my @a = 1, 2;
+    dies-ok { with @a { $_ = (7, 8, 9) } },
+        'with @container { $_ = ... } dies (read-only topic)';
+}
+
+# --- a bare scalar variable topic is rw (aliases the variable) ------------
+{
+    my $x = 5;
+    with $x { $_ = 99 }
+    is $x, 99, 'with $x { $_ = v } is rw and propagates to $x';
+}
+
+# --- read-only with leaves the source unchanged and still reads -----------
+{
+    my @a = 1, 2, 3;
+    my $sum = 0;
+    with @a { $sum += .sum }
+    is @a.gist, '[1 2 3]', 'read-only with leaves the source unchanged';
+    is $sum, 6, 'read-only with still reads the topic';
+}
+
+# --- with only runs when the topic is defined -----------------------------
+{
+    my $u;
+    my $ran = 0;
+    with $u { $ran = 1 }
+    is $ran, 0, 'with undefined scalar skips the body';
+}
+
+# --- a defined (even empty) array always runs with / never runs without ---
+{
+    my @e;
+    my $ran = 0;
+    with @e { $ran = 1 }
+    is $ran, 1, 'with defined (empty) array runs the body';
+}
+{
+    my @e;
+    my $ran = 0;
+    without @e { $ran = 1 }
+    is $ran, 0, 'without defined array does not run';
+}
+
+# --- nested with keeps inner/outer topics distinct ------------------------
+{
+    my @outer = 1, 2;
+    my @inner = 10, 20;
+    with @outer {
+        with @inner { .push(30) }
+        .push(3);
+    }
+    is @outer.gist, '[1 2 3]', 'nested with: outer push propagates';
+    is @inner.gist, '[10 20 30]', 'nested with: inner push propagates';
+}


### PR DESCRIPTION
## What

`with @container { ... }` now topicalizes the container **by alias**, exactly
like `given` (#3012): a container *mutation* through `$_` (`.push`, element
assign) propagates back to the source, while a whole reassign (`$_ = ...`)
dies because the container topic is read-only-for-reassign.

```raku
my @a = 1, 2, 3;
with @a { .push(4) }
say @a;            # before: [1 2 3]   after: [1 2 3 4]  (raku)

my %h = a => 1;
with %h { $_<b> = 2 }
say %h.sort;       # (a => 1 b => 2)
```

## Why / How

`with`/`without` already routed **bare scalar** variable topics (`with $x`)
through a `given` block (`use_given_alias`) to get rw aliasing. The fix simply
extends that gate to **container variables** (`@a` / `%h`), so they reuse the
`given` opcode's container-topic writeback and read-only-for-reassign
semantics landed in #3012. One-line parser change in `with_stmt`.

Verified against `raku` for: container push/element-assign propagation,
`$_ = ...` dies, scalar `with $x` stays rw, `with`/`without` defined-gating,
and nested `with`.

## Out of scope (separate mechanisms, divergent and tracked)

- **Element-source topics** (`with %h<k> { .push }`, `given @a[i] { .push }`,
  `for %h<k>.values { ... }`) — needs an element-source writeback target
  (container var + index path); next Track B slice.
- **Pointy-param aliasing** (`with @c -> @p { @p.push }`) — Raku aliases the
  pointy `@p` param (like #3003 parameter aliasing); not handled here.

## Tests

`t/with-topic-alias.t` (13 subtests), all matching `raku`. `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)