### PR TITLE
fix(given): alias a container-element topic so `given %h<k> { .push }` propagates

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -144,6 +144,20 @@ impl Compiler {
             .any(|s| matches!(s, Stmt::Catch(_) | Stmt::Control(_)))
     }
 
+    /// The env key for the container variable an element subscript targets, used
+    /// when topicalizing an element (`given %h<k>` / `given @a[i]`) so the
+    /// mutated `$_` can be written back. Returns `%name` for a hash variable,
+    /// `@name` for an array variable, and the bare name for a scalar variable
+    /// (holding a container). `None` for any other (non-simple-var) target.
+    pub(super) fn container_var_name(target: &Expr) -> Option<String> {
+        match target {
+            Expr::HashVar(name) => Some(format!("%{}", name)),
+            Expr::ArrayVar(name) => Some(format!("@{}", name)),
+            Expr::Var(name) => Some(name.clone()),
+            _ => None,
+        }
+    }
+
     pub(super) fn body_mutates_topic(stmts: &[Stmt]) -> bool {
         // Only check if the *first* non-SetLine statement assigns `$_` directly.
         // This detects `with`-style topic switches (where the parser inserts a

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1670,20 +1670,44 @@ impl Compiler {
             }
             // Given/When/Default
             Stmt::Given { topic, body } => {
-                self.compile_expr(topic);
-                if let Some(source_name) = match topic {
-                    Expr::Var(name) => Some(name.clone()),
-                    Expr::ArrayVar(name) => Some(format!("@{}", name)),
-                    Expr::HashVar(name) => Some(format!("%{}", name)),
+                // An lvalue container *element* topic (`given %h<k>` /
+                // `given @a[i]`) aliases that element rw: both `$_ = ...` and
+                // container mutations (`.push`) propagate to the element. Push
+                // the element value and tag the (container, index) source so the
+                // body's final `$_` is written back. `topic_readonly` is false.
+                let element_source = match topic {
+                    Expr::Index {
+                        target,
+                        index,
+                        is_positional,
+                    } => Self::container_var_name(target).map(|c| (c, index, *is_positional)),
                     _ => None,
-                } {
-                    let name_idx = self.code.add_constant(Value::str(source_name));
-                    self.code.emit(OpCode::TagContainerRef(name_idx));
+                };
+                let topic_readonly;
+                if let Some((container, index, is_positional)) = element_source {
+                    self.compile_expr(index);
+                    let container_idx = self.code.add_constant(Value::str(container));
+                    self.code.emit(OpCode::TagElementSource {
+                        container_idx,
+                        positional: is_positional,
+                    });
+                    topic_readonly = false;
+                } else {
+                    self.compile_expr(topic);
+                    if let Some(source_name) = match topic {
+                        Expr::Var(name) => Some(name.clone()),
+                        Expr::ArrayVar(name) => Some(format!("@{}", name)),
+                        Expr::HashVar(name) => Some(format!("%{}", name)),
+                        _ => None,
+                    } {
+                        let name_idx = self.code.add_constant(Value::str(source_name));
+                        self.code.emit(OpCode::TagContainerRef(name_idx));
+                    }
+                    // The topic is read-only unless it is a bare scalar variable
+                    // (`given $x` aliases `$x` rw). `given @a` / `given 42` /
+                    // `given expr()` are read-only (Raku errors on `$_ = ...`).
+                    topic_readonly = !matches!(topic, Expr::Var(_));
                 }
-                // The topic is read-only unless it is a bare scalar variable
-                // (`given $x` aliases `$x` rw). `given @a` / `given 42` /
-                // `given expr()` are read-only (Raku errors on `$_ = ...`).
-                let topic_readonly = !matches!(topic, Expr::Var(_));
                 let given_idx = self.code.emit(OpCode::Given {
                     body_end: 0,
                     topic_readonly,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -553,6 +553,16 @@ pub(crate) enum OpCode {
     TagContainerRef(u32),
     /// Tag the current value as coming from a reversed named container (for `@a.reverse` writeback)
     TagContainerRefReversed(u32),
+    /// Topicalize a container *element* (`given %h<k>` / `given @a[i]`) as an
+    /// lvalue: pop the index from the stack, read element `container[index]`,
+    /// push it as the topic value, and record the (container, index) source so
+    /// the `given`/`with` body's final `$_` (after `$_ = ...` or `.push`) is
+    /// written back to that element. `positional` is true for `@a[i]`, false for
+    /// `%h<k>`. The operand is the constant index of the container variable name.
+    TagElementSource {
+        container_idx: u32,
+        positional: bool,
+    },
 
     /// Clear an aggregate variable (@/%) in-place so references see the change.
     UndefineAggregate(u32),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -133,6 +133,11 @@ pub(crate) struct VM {
     container_ref_reversed: bool,
     /// Source variable name for topic binding in for loops
     topic_source_var: Option<String>,
+    /// Element source for an lvalue container-element topic (`given %h<k>` /
+    /// `given @a[i]`): (container var name, resolved index, positional). After
+    /// the `given`/`with` body runs, the final `$_` is written back to this
+    /// element so `$_ = ...` and container mutations (`.push`) propagate.
+    element_source: Option<(String, Value, bool)>,
     /// rw aggregate view writeback for `for @a.grep(...) { $_++ }`: when the
     /// for-loop iterable is a grep result with a registered grep-view binding,
     /// this holds (source array Arc, per-filtered-index source indices, kind)
@@ -451,6 +456,7 @@ impl VM {
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,
+            element_source: None,
             for_grep_view: None,
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
@@ -3264,6 +3270,25 @@ impl VM {
                 let name = Self::const_str(code, *name_idx).to_string();
                 self.container_ref_var = Some(name);
                 self.container_ref_reversed = true;
+                *ip += 1;
+            }
+            OpCode::TagElementSource {
+                container_idx,
+                positional,
+            } => {
+                let container = Self::const_str(code, *container_idx).to_string();
+                let positional = *positional;
+                let index = self.stack.pop().unwrap_or(Value::Nil);
+                // Read the element value `container[index]` and push it as the
+                // topic, reusing the standard index op so all container shapes
+                // (Array/Hash/ContainerRef/typed) are handled uniformly.
+                let cval = self
+                    .get_env_with_main_alias(&container)
+                    .unwrap_or(Value::Nil);
+                self.stack.push(cval);
+                self.stack.push(index.clone());
+                self.exec_index_op_with_positional(positional)?;
+                self.element_source = Some((container, index, positional));
                 *ip += 1;
             }
 

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1871,6 +1871,29 @@ impl VM {
         self.update_local_if_exists(code, source, &current);
     }
 
+    /// Write the final `$_` back to an lvalue container element (`given %h<k>`
+    /// / `given @a[i]`). The element source is `(container var, index,
+    /// positional)`. This makes both `$_ = ...` (whole reassign) and container
+    /// mutations (`.push`) propagate to the original element, matching Raku's
+    /// aliasing of an element topic.
+    fn write_back_element_source(&mut self, code: &CompiledCode, src: &(String, Value, bool)) {
+        let (container, index, _positional) = src;
+        let Some(current) = self.interpreter.env().get("_").cloned() else {
+            return;
+        };
+        let key = match index {
+            Value::Int(i) => i.to_string(),
+            Value::Str(s) => s.as_ref().clone(),
+            other => other.to_string_value(),
+        };
+        let Some(mut cval) = self.get_env_with_main_alias(container) else {
+            return;
+        };
+        Self::assign_into_nested_container(&mut cval, &key, current);
+        self.set_env_with_main_alias(container, cval.clone());
+        self.update_local_if_exists(code, container, &cval);
+    }
+
     /// Whether the loop variable still holds the same binding as the source
     /// element, so writing it back would be a no-op. Conservative: returns
     /// `true` only when provably unchanged (same container `Arc`, so in-place
@@ -2273,13 +2296,22 @@ impl VM {
         let saved_topic = self.interpreter.env().get("_").cloned();
         let saved_when = self.interpreter.when_matched();
         let saved_topic_source = self.topic_source_var.take();
+        let saved_element_source = self.element_source.take();
         let container_binding = self.container_ref_var.take();
-        self.topic_source_var = container_binding.clone();
+        // An element-source topic (`given %h<k>` / `given @a[i]`) aliases an
+        // lvalue element: the final `$_` is written back to that element below,
+        // so `$_ = ...` (whole reassign) AND `.push` both propagate. Don't set
+        // `topic_source_var` (that is for whole-variable writeback).
+        let element_source = saved_element_source.clone();
+        if element_source.is_none() {
+            self.topic_source_var = container_binding.clone();
+        }
         self.interpreter.env_mut().insert("_".to_string(), topic);
         self.interpreter.set_when_matched(false);
         // A read-only topic (`given @a` / `given 42` / `given expr()`) forbids
         // `$_ = ...`; container *mutation* (`.push`) is still allowed and is
-        // written back to the source below. A bare scalar var (`given $x`) is rw.
+        // written back to the source below. A bare scalar var (`given $x`) is rw,
+        // and an element source (handled above) is rw too.
         let mark_ro = topic_readonly && !self.interpreter.readonly_vars().contains("_");
         if mark_ro {
             self.interpreter.mark_readonly("_");
@@ -2290,7 +2322,11 @@ impl VM {
                 this.interpreter.unmark_readonly("_");
             }
             if write_back {
-                this.write_back_given_topic(code, &container_binding);
+                if let Some(src) = &element_source {
+                    this.write_back_element_source(code, src);
+                } else {
+                    this.write_back_given_topic(code, &container_binding);
+                }
             }
             this.interpreter.set_when_matched(saved_when);
             if let Some(v) = saved_topic.clone() {
@@ -2299,6 +2335,7 @@ impl VM {
                 this.interpreter.env_mut().remove("_");
             }
             this.topic_source_var = saved_topic_source.clone();
+            this.element_source = saved_element_source.clone();
         };
 
         let mut inner_ip = body_start;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3982,7 +3982,7 @@ impl VM {
     /// assign so that a write to a container-valued bound element
     /// (`%h<key><inner> = ...` where `%h<key>` is a cell) mutates the shared,
     /// held container in place instead of being silently dropped.
-    fn assign_into_nested_container(target: &mut Value, outer_key: &str, val: Value) {
+    pub(super) fn assign_into_nested_container(target: &mut Value, outer_key: &str, val: Value) {
         match target {
             Value::ContainerRef(cell) => {
                 let mut guard = cell.lock().unwrap();

--- a/t/given-element-topic.t
+++ b/t/given-element-topic.t
@@ -1,0 +1,108 @@
+use Test;
+
+# `given %h<k> { ... }` / `given @a[i] { ... }` topicalize a container *element*
+# by alias: the element is an lvalue, so BOTH a whole reassign (`$_ = ...`) and
+# a container mutation (`.push`) through `$_` propagate back to that element.
+# (This differs from a whole-container topic `given @a`, which is read-only for
+# reassign.) The final `$_` is written back to the element after the body.
+
+plan 16;
+
+# --- hash element: reassign and mutate -----------------------------------
+{
+    my %h = k => 10;
+    given %h<k> { $_ = 99 }
+    is %h<k>, 99, 'given %h<k> { $_ = v } assigns the element';
+}
+{
+    my %h = k => [1, 2];
+    given %h<k> { .push(3) }
+    is %h<k>.gist, '[1 2 3]', 'given %h<k> { .push } propagates to the element';
+}
+
+# --- array element: reassign and mutate ----------------------------------
+{
+    my @a = 1, 2, 3;
+    given @a[1] { $_ = 50 }
+    is @a.gist, '[1 50 3]', 'given @a[i] { $_ = v } assigns the element';
+}
+{
+    my @a = [1], [2], [3];
+    given @a[1] { .push(22) }
+    is @a[1].gist, '[2 22]', 'given @a[i] { .push } propagates to the element';
+}
+
+# --- runtime (variable) subscripts ---------------------------------------
+{
+    my %h = foo => [1, 2];
+    my $k = 'foo';
+    given %h{$k} { .push(3) }
+    is %h<foo>.gist, '[1 2 3]', 'given %h{$k} (variable key) propagates';
+}
+{
+    my @a = [1], [2], [3];
+    my $i = 2;
+    given @a[$i] { .push(9) }
+    is @a[2].gist, '[3 9]', 'given @a[$i] (variable index) propagates';
+}
+
+# --- the element topic is rw: $_ assign is allowed (not read-only) --------
+{
+    my @a = 1, 2, 3;
+    lives-ok { given @a[0] { $_ = 100 } },
+        'given @a[i] { $_ = v } is rw (element is an lvalue)';
+}
+
+# --- read-only usage leaves the element unchanged ------------------------
+{
+    my %h = x => 5;
+    my $sum = 0;
+    given %h<x> { $sum += $_ }
+    is %h<x>, 5, 'read-only given element leaves the element unchanged';
+    is $sum, 5, 'read-only given element still reads the topic';
+}
+
+# --- nested given over distinct elements ---------------------------------
+{
+    my %m = a => [1], b => [2];
+    given %m<a> {
+        given %m<b> { .push(20) }
+        .push(10);
+    }
+    is %m<a>.gist, '[1 10]', 'nested given element: outer propagates';
+    is %m<b>.gist, '[2 20]', 'nested given element: inner propagates';
+}
+
+# --- scalar holding a container, element topic ---------------------------
+{
+    my $h = { y => [7] };
+    given $h<y> { .push(8) }
+    is $h<y>.gist, '[7 8]', 'given $h<k> (scalar holding hash) propagates';
+}
+
+# --- given element with when/default dispatch still works -----------------
+{
+    my %w = k => 5;
+    my $res = do given %w<k> {
+        when * > 3 { "big" }
+        default { "small" }
+    };
+    is $res, 'big', 'given %h<k> { when ... } dispatch works';
+}
+
+# --- the element value is the topic (single item, not flattened) ----------
+{
+    my @a = <a b c>;
+    my @nested = @a, <d e>;
+    my @seen;
+    given @nested[0] { @seen.push(.elems) }
+    is @seen.gist, '[3]', 'given @a[i] topicalizes the element as one item';
+}
+
+# --- mutating the element does not disturb siblings -----------------------
+{
+    my @a = [1, 2], [3, 4];
+    given @a[0] { .push(99) }
+    is @a[0].gist, '[1 2 99]', 'sibling element untouched: target updated';
+    is @a[1].gist, '[3 4]', 'sibling element untouched: other unchanged';
+}


### PR DESCRIPTION
## What

`given %h<k> { ... }` / `given @a[i] { ... }` now topicalize a container
**element** by alias. Because an element is an lvalue, **both** a whole reassign
(`$_ = ...`) and a container mutation (`.push`) through `$_` propagate back to
that element — unlike a whole-container topic (`given @a`), which is read-only
for reassign.

```raku
my %h = k => [1, 2];
given %h<k> { .push(3) }
say %h<k>;            # before: [1 2]   after: [1 2 3]   (raku)

my @a = 1, 2, 3;
given @a[1] { $_ = 50 }
say @a;               # [1 50 3]
```

## Why / How

mutsu previously only tagged **simple-variable** topics (`given @a` / `given %h`)
for writeback (`TagContainerRef`). An `Expr::Index` topic produced no source
tag, so the body's `$_` mutations were silently lost.

- New `OpCode::TagElementSource { container_idx, positional }`: pops the
  (once-evaluated) index, reads `container[index]` via the standard index op (so
  all container shapes — Array/Hash/typed/ContainerRef — are handled), pushes it
  as the topic, and records the `(container, index, positional)` element source.
- `Stmt::Given` compiles an element-source topic through this opcode and marks
  the topic **rw** (`topic_readonly = false`), since the element is an lvalue.
- `exec_given_op` saves/restores `element_source` and, on success, writes the
  final `$_` back to the element via `assign_into_nested_container`
  (`write_back_element_source`).

Verified against `raku` for: hash/array elements, literal & runtime (variable)
subscripts, scalars holding a container (`$h<k>`), nested element topics,
read-only usage (no-op), and `when`/`default` dispatch.

## Out of scope (separate code paths; follow-ups)

- **`with %h<k>`** element topic — needs the `with`→`given` routing
  (`use_given_alias`) extended to `Expr::Index`; deferred so it doesn't conflict
  with the just-merged #3014.
- **`for %h<k>.values { ... }`** rw writeback — for-loop element source (a
  different opcode path).

## Tests

`t/given-element-topic.t` (16 subtests), all matching `raku`. `make test` green
(6936). Whitelisted control-flow roast (`given`/`with`/`when`/`do`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)