### PR TITLE
fix(with): alias a container-element topic so `with %h<k> { .push }` propagates

### DIFF
--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -2228,11 +2228,23 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // container topic through `given`, so `with @a { .push }` propagates the
     // mutation back to `@a` (the `given` opcode treats `@`/`%` topics as
     // read-only-for-reassign but writes container mutations back to the source).
+    // A container *element* subscript on a simple variable (`with %h<k>` /
+    // `with @a[i]`) is an lvalue: routing it through `given` makes the `given`
+    // element-source writeback propagate both `$_ = ...` and `.push` back to the
+    // element (the element topic is rw, unlike a whole-container topic).
+    let topic_is_element_lvalue = matches!(
+        &cond_expr,
+        Expr::Index { target, .. }
+            if matches!(
+                target.as_ref(),
+                Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
+            )
+    );
     let use_given_alias = param_name.is_none()
-        && matches!(
+        && (matches!(
             &cond_expr,
             Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
-        );
+        ) || topic_is_element_lvalue);
     // Topicalize `$_` for the body. For a literal, wrap it in a Mixin marked
     // read-only so in-place mutation of `$_` throws X::Assignment::RO. Otherwise
     // reuse the `$tmp` holding the (once-evaluated) condition value.

--- a/t/with-element-topic.t
+++ b/t/with-element-topic.t
@@ -1,0 +1,84 @@
+use Test;
+
+# `with %h<k> { ... }` / `with @a[i] { ... }` topicalize a container *element*
+# by alias (same as `given` on an element): the element is an lvalue, so BOTH a
+# whole reassign (`$_ = ...`) and a container mutation (`.push`) through `$_`
+# propagate back to that element. `with` only runs the body when the element is
+# defined.
+
+plan 12;
+
+# --- hash element: mutate and reassign -----------------------------------
+{
+    my %h = k => [1, 2];
+    with %h<k> { .push(3) }
+    is %h<k>.gist, '[1 2 3]', 'with %h<k> { .push } propagates to the element';
+}
+{
+    my %h = k => 10;
+    with %h<k> { $_ = 99 }
+    is %h<k>, 99, 'with %h<k> { $_ = v } assigns the element';
+}
+
+# --- array element: mutate and reassign ----------------------------------
+{
+    my @a = [1], [2];
+    with @a[0] { .push(9) }
+    is @a[0].gist, '[1 9]', 'with @a[i] { .push } propagates to the element';
+}
+{
+    my @a = 1, 2, 3;
+    with @a[1] { $_ = 50 }
+    is @a.gist, '[1 50 3]', 'with @a[i] { $_ = v } assigns the element';
+}
+
+# --- runtime (variable) subscripts ---------------------------------------
+{
+    my %h = foo => [1];
+    my $k = 'foo';
+    with %h{$k} { .push(2) }
+    is %h<foo>.gist, '[1 2]', 'with %h{$k} (variable key) propagates';
+}
+{
+    my @a = [1], [2];
+    my $i = 1;
+    with @a[$i] { .push(8) }
+    is @a[1].gist, '[2 8]', 'with @a[$i] (variable index) propagates';
+}
+
+# --- with only runs when the element is defined --------------------------
+{
+    my %u;
+    my $ran = 0;
+    with %u<missing> { $ran = 1 }
+    is $ran, 0, 'with undefined element skips the body';
+}
+{
+    my %d = k => 5;
+    my $ran = 0;
+    without %d<k> { $ran = 1 }
+    is $ran, 0, 'without defined element does not run';
+}
+
+# --- the element topic is rw (not read-only) -----------------------------
+{
+    my @a = 1, 2, 3;
+    lives-ok { with @a[0] { $_ = 100 } },
+        'with @a[i] { $_ = v } is rw (element is an lvalue)';
+}
+
+# --- read-only usage leaves the element unchanged ------------------------
+{
+    my %h = x => 5;
+    my $sum = 0;
+    with %h<x> { $sum += $_ }
+    is %h<x>, 5, 'read-only with element leaves the element unchanged';
+    is $sum, 5, 'read-only with element still reads the topic';
+}
+
+# --- scalar holding a container, element topic ---------------------------
+{
+    my $h = { y => [7] };
+    with $h<y> { .push(8) }
+    is $h<y>.gist, '[7 8]', 'with $h<k> (scalar holding hash) propagates';
+}


### PR DESCRIPTION
## What

`with %h<k> { ... }` / `with @a[i] { ... }` now topicalize a container
**element** by alias, like `given` on an element (#3015). Because an element is
an lvalue, **both** a whole reassign (`$_ = ...`) and a container mutation
(`.push`) through `$_` propagate back to that element.

```raku
my %h = k => [1, 2];
with %h<k> { .push(3) }
say %h<k>;            # before: [1 2]   after: [1 2 3]   (raku)

my @a = 1, 2, 3;
with @a[1] { $_ = 50 }
say @a;               # [1 50 3]
```

`with` still only runs the body when the element is defined.

## Why / How

`with`/`without` already route simple-variable topics (`with $x`, `with @a`,
`with %h`) through a `given` block (`use_given_alias`) to get aliasing
(#3012/#3014). The fix extends that gate to a **container-element subscript on a
simple variable** (`%h<k>`, `@a[i]`, `$h<k>`), so the `given` element-source
writeback (#3015) propagates the mutated `$_` back to the element. Parser-only
change in `with_stmt`.

Verified against `raku` for: hash/array elements, literal & runtime (variable)
subscripts, scalars holding a container (`$h<k>`), defined-gating, read-only
usage (no-op), and rw `$_ = ...`.

## Out of scope

Pointy-param aliasing (`with %h<k> -> $p { $p.push }`) — a separate
parameter-aliasing mechanism.

## Tests

`t/with-element-topic.t` (12 subtests), all matching `raku`. `make test` green
(6961). Whitelisted control-flow roast (`with`/`given`/`when`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)