### PR TITLE
docs: record container/element topic aliasing (#3014/#3015/#3016)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -292,15 +292,20 @@ STATUS で撤回済み。
       `given %h { $_<k>=v }` が伝播（`@`/`%` topic を `write_back_given_topic` で source 書き戻し、#3008 の
       `loop_var_unchanged` guard 流用）。`Given` opcode に `topic_readonly` フラグ追加し `given @a { $_=... }`・
       `given 42 { $_=9 }` を raku 同様 die（`given $x` は rw 維持）。`t/given-topic-alias.t`(12)。
-- [ ] **Track B 残 niche（次セッション候補・優先度＝ROI 順、すべて深い別 feature 前提。詳細 = メモリ
-      `project_track_b_phase2_element_cells` NEXT SESSION resume map）**:
-      ① **element-source topic/iter writeback**（最汎用・複数バグ一括）: `given %h<k>{.push}`・`given @a[i]{.push}`・
-      `for %h<k>.values{$_*=2}`・`for @a[i].values{$_}` が伝播しない共通根 = source が Index 式のとき
-      `for_iterable_source_name`/given compiler が None → TagContainerRef 非発行。writeback ターゲットを
-      「var名」でなく「container var + index path」で表現＋nested index-assign 化。
-      ② **`with` topic aliasing**: `with @a {.push}`（`with` は defined-check `__with_tmp_N` へ compile され Given opcode
-      非経由）→ with を Given 経路へ寄せる。③ **`.push(@var)` 参照格納**（Raku `**@` slurpy alias、COW detach するので
-      cell 昇格＝#2990 機構が必要・hot push path）。
+- [x] **whole-container `with` topic + element-source topic（given/with）の別名束縛 (#3014/#3015/#3016)** —
+      ① **#3014**: `with @a {.push}`・`with %h {$_<k>=v}` が伝播（`use_given_alias` を `@`/`%` に拡張し #3012 の
+      given 機構へルート）。② **#3015**: `given %h<k>{.push}`・`given @a[i]{$_=v}` が伝播（新 `OpCode::TagElementSource`
+      で element を lvalue topic 化＋`write_back_element_source` で `assign_into_nested_container` 経由 書き戻し。
+      **element は lvalue ＝完全 rw**＝whole-container topic の read-only-for-reassign と非対称）。③ **#3016**: `with %h<k>`
+      も `use_given_alias` を simple-var target の `Expr::Index` に拡張して #3015 機構へルート。
+      `t/with-topic-alias.t`(13)/`t/given-element-topic.t`(16)/`t/with-element-topic.t`(12)。
+- [ ] **Track B 残 niche（深い別 feature・ROI 低。詳細 = メモリ `project_track_b_phase2_element_cells`）**:
+      ① **`for %h<k>.values{$_*=2}` の element-source rw writeback**（element-source topic 最後の穴）: for-loop は
+      `container_binding`（String var名）駆動の per-iteration writeback で、element source は `%h<k>[idx]=$_` の 2 段
+      nested writeback ＋ `for %h<k>` の itemization 修正が必要・**最ホット path で多機構が絡み高リスク**（#3008 教訓:
+      for-loop writeback は full roast 必須）。② **`.push(@var)` 参照格納**（Raku `**@` slurpy alias、COW detach するので
+      cell 昇格＝#2990 機構が必要・hot push path）。③ **with/given の `-> $p` pointy-param aliasing**（param aliasing
+      #3003 系、for-loop named param は #3008 済だが with/given は未対応）。
 - [~] **object-hash（`%h{KeyType}`）** — キー保存（original_keys）は HashData 埋め込みで **COW-stable 化済み**
       (#2954)。mixin キー・`.new`/`.clone` 維持 (#2956)、multidim Range slice `:exists` (#2959) も landed。
       **キー表示の全経路修正 (#3007)**: `.sort`/`.gist`/`.Str`/`.raku`/`.list`/`.map`/`for`/`@`-flatten/`.min`/`.max`/

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -596,3 +596,36 @@ source に伝播する（mutsu はコピー扱いで `.push` が消失）。`@`/
 コンテナ変異（`.push`）は引き続き伝播。`t/given-topic-alias.t`(12)、given-ro が raku 完全一致。
 **残 gap（deferred）**: element-source topic（`given %h<k>`/`given @a[i]` は TagContainerRef 非発行）と
 `with`（defined-check へ compile され Given opcode を通らない）は未伝播。
+
+## 2026-06-14: container/element topic aliasing 完了 (#3014/#3015/#3016)
+
+#3012（given topic alias）の残 gap だった **whole-container `with`** と **element-source topic**
+（given/with の両方）を実装・マージ。これで topic aliasing は for-loop の `.values` を除き完成。
+
+- **#3014 = whole-container `with` topic alias**: `with @a { .push }` / `with %h { $_<k>=v }` が source に
+  伝播。parser `with_stmt` の `use_given_alias`（既に `with $x` を `given` ブロックへルートして rw alias を
+  得ていた）を `ArrayVar`/`HashVar` にも拡張し、#3012 の `given` 機構（read-only-for-reassign + container
+  mutation writeback）を流用。1 行変更。`t/with-topic-alias.t`(13)。
+
+- **#3015 = `given` element-source topic alias**: `given %h<k> { .push }` / `given @a[i] { $_ = v }` が
+  element に伝播。**element は lvalue なので whole-container topic（read-only-for-reassign）と非対称＝完全 rw**
+  （`$_ = ...` も `.push` も伝播、raku 実機確認）。新 `OpCode::TagElementSource { container_idx, positional }`
+  が index を pop→`container[index]` を標準 index op で読み→topic として push→`(container, index, positional)`
+  を VM field `element_source` に記録。`exec_given_op` が body 後に `$_` を `write_back_element_source`
+  （`assign_into_nested_container` 経由）で element へ書き戻し。compiler は element-source topic で
+  `topic_readonly = false`。literal/variable subscript・hash/array・scalar 保持コンテナ・nested・when/default
+  全対応。`t/given-element-topic.t`(16)。
+
+- **#3016 = `with` element-source topic alias**: `with %h<k> { .push }` / `with @a[i] { $_ = v }` が伝播。
+  parser `use_given_alias` を **simple-var target の `Expr::Index`**（`%h<k>`/`@a[i]`/`$h<k>`）にも拡張
+  （`topic_is_element_lvalue`）し #3015 の given element-source writeback へルート。parser-only。
+  `t/with-element-topic.t`(12)。
+
+**設計教訓**: ①raku 実機確認で element topic は whole-container topic と**非対称**（element=lvalue で完全 rw、
+whole-container=read-only-for-reassign）。②`given`/`for` は cell をコピーで deref する（`my $r:=%h<k>; $r.push`
+は効くが `given $r { .push }` は効かない）→ cell 経由 desugar 不可・明示 writeback が正攻法。③PR スタッキングは
+避け依存 PR がマージされてから clean main で次を作る（#3016 は #3014+#3015 両方が main に必要だった）。
+
+**残 deferred（深い・ROI 低）**: ① `for %h<k>.values { $_*=2 }` の element-source rw writeback（for-loop は
+最ホット path で多機構が絡み、`for %h<k>` の itemization バグ＋per-iteration nested writeback の両方が必要・
+#3008 教訓で full roast 必須）、② `.push(@var)` の参照格納、③ with/given の `-> $p` pointy-param aliasing。


### PR DESCRIPTION
Record the completion of **whole-container `with` topic aliasing** and
**element-source topic aliasing** (given + with) from #3014/#3015/#3016.

- `news/2026-06.md`: new section summarizing the three PRs, design lessons
  (element topic is rw — asymmetric with the read-only-for-reassign
  whole-container topic; cells deref on copy so explicit writeback is the right
  approach; avoid PR stacking), and the remaining deferred niche.
- `PLAN.md` Track B backlog: mark the topic-aliasing items done and re-scope the
  remaining deferred niche to `for %h<k>.values` rw writeback, `.push(@var)`
  reference storage, and with/given pointy-param aliasing.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)