### PR TITLE
fix(supply): stop on-demand react over interval+done from busy-spinning forever

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -187,6 +187,28 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
               Interpreter 非所有 ＝ VM から直接触れる。ループが Interpreter に縛られている真因は
               `call_sub_value`（compiled body 実行）と `supply_emit_buffer`（emit 捕捉/subscription staging の Vec）
               **だけ**。body callback は既に compiled sub。
+            - **既知のハング/バグ（2026-06-14、perf で診断）**:
+              - **[FIXED] on-demand supply + 内側 `done` の無限スピン**: `my $s = supply { whenever
+                Supply.interval(0.001) { done } }; react { whenever $s { } }` が単一 tap でも 100% CPU で
+                無限ループ（raku はミリ秒で完了）。これが `S17-supply/syntax.t` のテスト 71
+                （"No races/crashes around interval that emits done"、line 540-550 の 2000-react stress）の
+                ハング元で、debug でも release でも再現する**真の無限ループ**だった（メモリの「debug 限定の遅さ」
+                は誤り）。**真因**: parser の `rewrite_supply_body` が `supply{}` 内の `done` を
+                `$emitter.done()` に書き換える（正しい Raku セマンティクス＝その supply を完了）。
+                `run_react_event_loop` の on-demand 分岐は内側 whenever subscription をフラット化して直接
+                ポーリングするが、`run_on_demand_body(..., None)` と emitter_supplier_id を渡しておらず、
+                `$emitter.done()` が捨てられる Supplier の no-op になりループが止まらなかった。
+                **修正**（subtest.rs）: on-demand 分岐で emitter_supplier_id を採番し
+                `supplier_register_promise` で done-signal promise を事前登録（`supplier_done` が reset 前に
+                解決する＝Promise パスと同じ仕組み）、フラット化した各 `ReactSubscription` に
+                `on_demand_done` promise を紐付け、poll ループで `is_resolved()` を見て LAST 発火＋done。
+                検証: `t/supply-ondemand-interval-done.t`（mutsu/raku 両方 4/4）、whitelist S17-supply 53本(720)、
+                make test 461。syntax.t は 70→79 まで到達するように。
+              - **[残・別機能] 同期無限 supply body の backpressure**: syntax.t テスト 77-80+
+                （line 644-701、`supply { loop { emit(++$) } }` を `done if $n>=5` で消費）はまだ
+                ハング/失敗。on-demand body を**同期的に最後まで実行してバッファに集める**現方式では無限
+                ループになる。消費側が done したら次の `emit` で body を止める streaming/backpressure が必要で、
+                上記の async interval 修正とは構造的に別。Stage 2（VM 所有境界・streaming emit）で対応。
             - **段階プラン**:
               - **Stage 1（最初の PR・着手点）**: 4 駆動ループを**単一エンジン**へ統合。完了ポリシーを enum 化
                 （`React`=全 done まで / `Promise`=last value で resolve / `Tap`=永続 tap 登録）。

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -114,6 +114,7 @@ impl Interpreter {
                     emit_count: 0,
                     channel: None,
                     promise: None,
+                    on_demand_done: None,
                 });
             }
             if let Some(Value::Int(sid)) = attributes.as_map().get("supplier_id") {
@@ -140,6 +141,7 @@ impl Interpreter {
                     emit_count: 0,
                     channel: None,
                     promise: None,
+                    on_demand_done: None,
                 });
             }
         }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::runtime::native_methods::{
-    SupplyEvent, supplier_snapshot, take_promise_combinator_sources, take_supply_channel,
+    SupplyEvent, next_supplier_id, supplier_register_promise, supplier_snapshot,
+    take_promise_combinator_sources, take_supply_channel,
 };
 use crate::symbol::Symbol;
 use std::sync::mpsc;
@@ -27,6 +28,15 @@ pub(crate) struct ReactSubscription {
     /// Direct Channel source (for `whenever $channel { ... }`)
     pub channel: Option<crate::value::SharedChannel>,
     pub promise: Option<crate::value::SharedPromise>,
+    /// When this subscription was flattened out of an on-demand `supply { ... }`
+    /// body, a promise that resolves when the body's emitter is done. The inner
+    /// `whenever`'s `done` is rewritten to `$emitter.done()`, which marks the
+    /// emitter done (and resolves this promise) rather than raising the
+    /// react-done signal — and the emitter's done state is reset immediately
+    /// afterwards, so the loop cannot observe it by polling the supplier. The
+    /// promise survives that reset, so the event loop watches it to complete
+    /// the subscription once the emitter is done.
+    pub on_demand_done: Option<crate::value::SharedPromise>,
 }
 
 impl Interpreter {
@@ -236,6 +246,7 @@ impl Interpreter {
                                 emit_count: 0,
                                 channel: None,
                                 promise: None,
+                                on_demand_done: None,
                             });
                             continue;
                         }
@@ -267,15 +278,31 @@ impl Interpreter {
                                 emit_count: 0,
                                 channel: None,
                                 promise: None,
+                                on_demand_done: None,
                             });
                             continue;
                         }
                         // Handle on-demand supplies: execute the callback to produce values
                         if let Some(on_demand_cb) = attributes.as_map().get("on_demand_callback") {
-                            // Execute the on-demand callback, which calls emit on the emitter.
-                            // If the callback dies, propagate as X::React::Died.
-                            let (od_res, emitted, _) =
-                                self.run_on_demand_body(on_demand_cb.clone(), None);
+                            // Execute the on-demand callback, which calls emit on the
+                            // emitter. Use a tracked emitter supplier id so that `done`
+                            // inside the supply block (rewritten to `$emitter.done()`)
+                            // marks this emitter done instead of raising the react-done
+                            // signal; the event loop below watches it to complete the
+                            // flattened subscriptions. If the callback dies, propagate
+                            // as X::React::Died.
+                            let emitter_supplier_id = next_supplier_id();
+                            // Register a done-signal promise on the emitter BEFORE
+                            // running the body. `$emitter.done()` resolves all pending
+                            // promises (line in supplier_done) and only then resets the
+                            // supplier's done flag, so this promise is the only thing
+                            // that survives to tell the loop the supply completed.
+                            let done_promise = crate::value::SharedPromise::new();
+                            supplier_register_promise(emitter_supplier_id, done_promise.clone());
+                            let (od_res, emitted, _) = self.run_on_demand_body(
+                                on_demand_cb.clone(),
+                                Some(emitter_supplier_id),
+                            );
                             if let Err(od_err) = od_res
                                 && !od_err.is_react_done
                             {
@@ -283,10 +310,13 @@ impl Interpreter {
                             }
                             // The emitted items may include subscription registrations
                             // from `whenever` inside the supply body. Convert them to
-                            // ReactSubscriptions for the event loop.
+                            // ReactSubscriptions for the event loop, tagging each with
+                            // the done-signal promise so the loop can complete them
+                            // when the supply body calls `done`.
                             for v in emitted {
                                 if Self::is_supply_subscription_registration(&v) {
-                                    if let Some(rsub) = self.value_to_react_subscription(&v) {
+                                    if let Some(mut rsub) = self.value_to_react_subscription(&v) {
+                                        rsub.on_demand_done = Some(done_promise.clone());
                                         react_subs.push(rsub);
                                     }
                                 } else {
@@ -334,6 +364,7 @@ impl Interpreter {
                             emit_count: 0,
                             channel: None,
                             promise: Some(shared.clone()),
+                            on_demand_done: None,
                         });
                     }
                     // Channel source: poll values directly from the channel
@@ -357,6 +388,7 @@ impl Interpreter {
                             emit_count: 0,
                             channel: Some(ch.clone()),
                             promise: None,
+                            on_demand_done: None,
                         });
                     }
                     _ => {}
@@ -377,6 +409,27 @@ impl Interpreter {
                     continue;
                 }
                 all_done = false;
+                // On-demand supply completion: a `done` inside the `supply { ... }`
+                // body was rewritten to `$emitter.done()`, which resolves this
+                // subscription's done-signal promise rather than raising the
+                // react-done signal. Once that resolves the flattened subscription
+                // is complete, so fire its LAST callbacks and stop polling it
+                // (otherwise an infinite source like `Supply.interval` would spin
+                // forever — see S17-supply/syntax.t).
+                if let Some(done_promise) = sub.on_demand_done.clone()
+                    && done_promise.is_resolved()
+                {
+                    for callback in &sub.last_callbacks {
+                        match self.call_sub_value(callback.clone(), Vec::new(), true) {
+                            Err(e) if e.is_react_done => break 'react_loop,
+                            other => {
+                                other?;
+                            }
+                        }
+                    }
+                    sub.done = true;
+                    continue;
+                }
                 // Handle Channel sources: poll values directly
                 if let Some(ref ch) = sub.channel {
                     match ch.poll_result() {

--- a/t/supply-ondemand-interval-done.t
+++ b/t/supply-ondemand-interval-done.t
@@ -1,0 +1,48 @@
+use Test;
+
+# Regression: `react { whenever $s { } }` over an on-demand supply whose body
+# is `whenever Supply.interval(...) { done }` used to busy-spin forever. The
+# inner `done` is rewritten to `$emitter.done()` (it completes the inner supply,
+# it does not raise the react-done signal), and the react event loop never
+# observed that completion, so it kept polling the infinite interval source.
+# See S17-supply/syntax.t ("No races/crashes around interval that emits done").
+
+plan 4;
+
+# 1. A single tap of an on-demand supply that completes via `done` terminates.
+{
+    my $s = supply { whenever Supply.interval(0.001) { done } }
+    lives-ok {
+        react { whenever $s { } }
+    }, 'react over on-demand supply with inner interval+done terminates';
+}
+
+# 2. Re-tapping the same on-demand supply works (the second tap must not hang).
+{
+    my $s = supply { whenever Supply.interval(0.001) { done } }
+    lives-ok {
+        react { whenever $s { } }
+        react { whenever $s { } }
+    }, 're-tapping the same on-demand supply terminates';
+}
+
+# 3. The inner `done` stops the supply after the first emission, so the
+#    consumer sees exactly one value.
+{
+    my @received;
+    react {
+        whenever (supply { whenever Supply.interval(0.001) { @received.push($_); done } }) {
+        }
+    }
+    is @received.elems, 1, 'inner done stops the interval after one emission';
+}
+
+# 4. Many sequential taps complete (the original stress shape, scaled down).
+{
+    my $s = supply { whenever Supply.interval(0.001) { done } }
+    lives-ok {
+        for ^50 {
+            react { whenever $s { } }
+        }
+    }, '50 sequential reacts over the same on-demand supply complete';
+}


### PR DESCRIPTION
## Summary

`my \$s = supply { whenever Supply.interval(0.001) { done } }; react { whenever \$s { } }` busy-spun at **100% CPU forever**, even for a single tap (raku completes it in milliseconds). This was the real cause of `S17-supply/syntax.t` test 71 ("No races/crashes around interval that emits done", the 2000-react stress at line 540-550) hanging — a **genuine infinite loop in both debug and release** builds, diagnosed with `perf`.

## Root cause

The parser's `rewrite_supply_body` rewrites `done` inside a `supply { ... }` block to `\$emitter.done()` — the correct Raku semantics: it completes *that supply*, it does **not** raise the react-done signal. The react event loop's on-demand branch flattens the inner `whenever` subscription and polls it directly, but:

1. ran the on-demand body with **no emitter supplier id**, so `\$emitter.done()` was a no-op on a discarded `Supplier` and the loop never observed completion; and
2. even with an id, `Supplier.done` calls `supplier_reset` immediately after propagating done, so polling the supplier's done state always reads `false`.

So the loop kept polling the infinite `Supply.interval` source forever.

## Fix

Allocate an emitter supplier id for the on-demand body and **register a done-signal promise** on it before running the body (`supplier_done` resolves pending promises *before* the reset — the same mechanism the `await`/`.Promise` path already relies on). Tag each flattened `ReactSubscription` with this promise via a new `on_demand_done` field, and complete the subscription (firing its `LAST` callbacks) once the promise resolves.

## Tests

- Adds `t/supply-ondemand-interval-done.t` — passes on **both mutsu and raku**.
- Whitelisted `S17-supply` (53 files, 720 tests): pass.
- `make test`: pass (6912 tests).
- `syntax.t` now progresses from test 70 → 79 (was hanging at 71).

The remaining `syntax.t` hang at tests 77-80+ is a **separate, harder feature** — backpressure for synchronously-infinite supply bodies (`supply { loop { emit(++\$) } }`). Recorded in `PLAN.md` for Track C Stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)