### PR TITLE
feat(supply): stream synchronous on-demand emit so an infinite body terminates on done

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -144,14 +144,25 @@
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
-  - Down to 1 failing subtest (was ~19): blockless `react whenever
-    Supply.interval(...)` (line 340) never iterates the interval into the react
-    loop. Remaining blocker is the interval/timer + react driver, not phasers.
+  - All deterministic failures fixed; remaining failures are the flaky
+    concurrency tail only (test 53 cross-thread await ~4/5 pass; lines 543-550
+    the 2000-react interval-done stress, release/CI only). Do NOT whitelist.
+  - Streaming synchronous emit (tests 77-82): a `react` consuming an on-demand
+    `supply { ... }` whose body emits synchronously (`loop { emit(++$) }` /
+    `until my $done { emit(...) } CLOSE { $done = True }`) now delivers each emit
+    to the consumer live via a `supply_stream_consumers` sink, terminating the
+    body on emit-to-dead-consumer (one emit past the consumer's `done`). Needed
+    a parser fix too: `while/until my $x { ... }` was mis-parsed (the body `{ }`
+    was eaten as a `$x{ }` subscript on the inline declaration), and a bare
+    `my $done` loop condition is now hoisted to declare once at loop entry.
+    Tests `t/supply-sync-infinite-emit.t`, `t/while-until-my-decl.t`.
   - Phaser/done clusters fixed across recent PRs (LAST/QUIT/CLOSE, multi-whenever
-    done, when-via-control-flow). Latest: `await (supply { whenever
-    Supply.from-list(...) { ... } })` now replays the static source on the
-    Promise path, runs the LAST phaser (or QUIT on a dying source), and resolves
-    with the last emitted value (tests 64,65,67,68).
+    done, when-via-control-flow). `await (supply { whenever
+    Supply.from-list(...) { ... } })` replays the static source on the Promise
+    path, runs the LAST phaser (or QUIT on a dying source), and resolves with the
+    last emitted value (tests 64,65,67,68).
+  - Remaining non-flaky gap: blockless `react whenever Supply.interval(...)`
+    (line 340) — interval/timer + react driver, not phasers.
 - [ ] roast/S17-supply/tail.t
 - [ ] roast/S17-supply/throttle.t
 - [ ] roast/S17-supply/unique.t

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2529,6 +2529,13 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     | Expr::DoStmt(_)
                     | Expr::Grouped(_)
             )
+            // An inline `my`/`our`/`state` declaration must not be hash-
+            // subscripted: the declaration parser consumes the whitespace after
+            // the variable name, so `while my $done { ... }` would otherwise eat
+            // the loop body `{ ... }` as a `$done{ ... }` subscript. A bare
+            // declaration is never subscripted in expression context — wrap it in
+            // parens (`(my %h){key}`) for that, which parses as Grouped.
+            && !matches!(&expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
         {
             let r = &rest[1..];
             let (r, _) = ws(r)?;

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -71,10 +71,33 @@ fn supply_method_call(body: Vec<Stmt>) -> Expr {
 }
 
 fn rewrite_supply_body(stmts: Vec<Stmt>, emitter_name: &str) -> Vec<Stmt> {
-    stmts
-        .into_iter()
-        .map(|stmt| rewrite_supply_stmt(stmt, emitter_name))
-        .collect()
+    // Phasers are set up at block entry, not when control textually reaches them.
+    // Hoist top-level CLOSE phaser registrations to the front of the body so a
+    // CLOSE that appears after a (potentially non-terminating) loop is still
+    // registered before the loop runs — e.g.
+    //   supply { until my $done { emit(...) } CLOSE { $done = True } }
+    // relies on the CLOSE phaser being able to break the loop.
+    let mut closes = Vec::new();
+    let mut rest = Vec::new();
+    for stmt in stmts {
+        let lowered = rewrite_supply_stmt(stmt, emitter_name);
+        if is_close_registration(&lowered) {
+            closes.push(lowered);
+        } else {
+            rest.push(lowered);
+        }
+    }
+    closes.extend(rest);
+    closes
+}
+
+/// True if `stmt` is the registration call a CLOSE phaser is lowered to.
+fn is_close_registration(stmt: &Stmt) -> bool {
+    matches!(
+        stmt,
+        Stmt::Expr(Expr::MethodCall { name, .. })
+            if name.resolve().as_str() == "__mutsu_register_close_phaser"
+    )
 }
 
 fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -37,6 +37,37 @@ fn condition_has_assignment_tail(rest: &str) -> bool {
         || super::assign::parse_custom_compound_assign_op(rest).is_some()
 }
 
+/// Split an inline no-initializer declaration out of a `while`/`until`
+/// condition so it is declared once at loop entry instead of re-declared (and
+/// reset to its default) on every iteration. `until my $done { ... CLOSE {
+/// $done = True } }` relies on `$done` persisting across iterations.
+///
+/// Only the no-initializer form is hoisted: `while my $x = expr { }` must keep
+/// re-running `= expr` each iteration (that is the whole point of the idiom), so
+/// it is left as-is. Returns the hoisted declaration (if any) and the condition
+/// to test each iteration (a plain read of the declared variable).
+fn split_loop_cond_decl(cond: Expr) -> (Option<Stmt>, Expr) {
+    if let Expr::DoStmt(boxed) = &cond
+        && let Stmt::VarDecl {
+            name,
+            custom_traits,
+            ..
+        } = boxed.as_ref()
+        && !custom_traits.iter().any(|(t, _)| t == "__has_initializer")
+    {
+        let read = if let Some(rest) = name.strip_prefix('@') {
+            Expr::ArrayVar(rest.to_string())
+        } else if let Some(rest) = name.strip_prefix('%') {
+            Expr::HashVar(rest.to_string())
+        } else {
+            Expr::Var(name.clone())
+        };
+        let decl = (**boxed).clone();
+        return (Some(decl), read);
+    }
+    (None, cond)
+}
+
 fn condition_expr(input: &str) -> PResult<'_, Expr> {
     match expression(input) {
         Ok((rest, cond)) => {
@@ -1702,6 +1733,11 @@ pub(super) fn while_stmt(input: &str) -> PResult<'_, Stmt> {
     };
     let (rest, _) = ws(rest)?;
     let (rest, body) = block(rest)?;
+    let (hoisted_decl, cond) = if param_binding.is_none() {
+        split_loop_cond_decl(cond)
+    } else {
+        (None, cond)
+    };
     let while_stmt = Stmt::While {
         cond: if let Some(ref param) = param_binding {
             Expr::AssignExpr {
@@ -1715,6 +1751,9 @@ pub(super) fn while_stmt(input: &str) -> PResult<'_, Stmt> {
         body,
         label: None,
     };
+    if let Some(decl) = hoisted_decl {
+        return Ok((rest, Stmt::Block(vec![decl, while_stmt])));
+    }
     if let Some(param) = param_binding {
         Ok((
             rest,
@@ -1757,6 +1796,11 @@ pub(super) fn until_stmt(input: &str) -> PResult<'_, Stmt> {
     };
     let (rest, _) = ws(rest)?;
     let (rest, body) = block(rest)?;
+    let (hoisted_decl, cond) = if param_binding.is_none() {
+        split_loop_cond_decl(cond)
+    } else {
+        (None, cond)
+    };
     let cond_expr = if let Some(ref param) = param_binding {
         Expr::AssignExpr {
             name: param.clone(),
@@ -1774,6 +1818,9 @@ pub(super) fn until_stmt(input: &str) -> PResult<'_, Stmt> {
         body,
         label: None,
     };
+    if let Some(decl) = hoisted_decl {
+        return Ok((rest, Stmt::Block(vec![decl, while_stmt])));
+    }
     if let Some(param) = param_binding {
         Ok((
             rest,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1032,6 +1032,13 @@ pub struct Interpreter {
     let_saves: Vec<(String, Value, bool)>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
     pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, std::time::Instant)>>,
+    /// Active streaming consumers for on-demand `supply { ... }` bodies driven by
+    /// `react`. When a stream consumer is registered for an emitter's
+    /// `supplier_id`, `emit` delivers the value to the consumer callback
+    /// synchronously (instead of buffering into `supply_emit_buffer`), so an
+    /// infinite synchronous body (`supply { loop { emit(...) } }`) can be
+    /// terminated by the consumer's `done` on emit-to-dead-consumer.
+    pub(super) supply_stream_consumers: Vec<crate::runtime::subtest::StreamConsumer>,
     /// Shared variables between threads. When `start` spawns a thread,
     /// variables are stored here so both parent and child can see mutations.
     shared_vars: Arc<RwLock<HashMap<String, Value>>>,
@@ -3125,6 +3132,7 @@ impl Interpreter {
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
+            supply_stream_consumers: Vec::new(),
             shared_vars: Arc::new(RwLock::new(HashMap::new())),
             shared_vars_active: false,
             sigilless_attrs_active: false,
@@ -5576,6 +5584,7 @@ impl Interpreter {
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
+            supply_stream_consumers: Vec::new(),
             shared_vars: Arc::clone(&self.shared_vars),
             shared_vars_active: true,
             sigilless_attrs_active: self.sigilless_attrs_active,

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1455,6 +1455,12 @@ impl Interpreter {
                 if Self::supply_is_terminated(attributes) {
                     return Ok(Value::Nil);
                 }
+                // Streaming on-demand react path (see native_supplier_mut emit).
+                if let Some(sid) = supplier_id_from_attrs(attributes)
+                    && let Some(res) = self.try_stream_emit(sid, &value)
+                {
+                    return res.map(|_| Value::Nil);
+                }
                 if let Some(buf) = self.supply_emit_buffer.last_mut() {
                     buf.push(value.clone());
                 }
@@ -1807,6 +1813,14 @@ impl Interpreter {
                 let value = args.first().cloned().unwrap_or(Value::Nil);
                 if Self::supply_is_terminated(&attrs) {
                     return Ok((Value::Nil, attrs));
+                }
+                // Streaming on-demand react path: deliver synchronously to the
+                // consumer instead of buffering, so an infinite synchronous body
+                // can be terminated on emit-to-dead-consumer.
+                if let Some(sid) = supplier_id_from_attrs(&attrs)
+                    && let Some(res) = self.try_stream_emit(sid, &value)
+                {
+                    return res.map(|_| (Value::Nil, attrs));
                 }
                 // Push to supply_emit_buffer if active
                 if let Some(buf) = self.supply_emit_buffer.last_mut() {

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -39,6 +39,60 @@ pub(crate) struct ReactSubscription {
     pub on_demand_done: Option<crate::value::SharedPromise>,
 }
 
+/// A streaming consumer for an on-demand `supply { ... }` body driven by `react`.
+/// While registered (keyed by the emitter's `supplier_id`), each `emit` in the
+/// supply body delivers its value to `consumer_cb` synchronously rather than
+/// buffering. This lets a synchronously infinite body be terminated when the
+/// consumer signals `done`: the consumer's `done` marks the stream `done`, and
+/// the next `emit` to a `done` consumer unwinds the body.
+pub(crate) struct StreamConsumer {
+    pub supplier_id: u64,
+    pub consumer_cb: Value,
+    pub done: bool,
+}
+
+impl Interpreter {
+    /// If a streaming consumer is registered for `supplier_id`, deliver `value`
+    /// to it synchronously and return `Some(result)`; otherwise return `None`
+    /// so the caller falls back to the normal buffering path.
+    ///
+    /// - If the consumer is already `done`, this is an emit-to-dead-consumer:
+    ///   return a benign react-done signal that unwinds the supply body.
+    /// - Otherwise run the consumer callback. If it signals `done`, mark the
+    ///   stream done and fire the body's CLOSE phasers synchronously (so e.g.
+    ///   `until my $done { ... } CLOSE { $done = True }` terminates cleanly),
+    ///   then return `Ok` so the current `emit` completes normally.
+    pub(super) fn try_stream_emit(
+        &mut self,
+        supplier_id: u64,
+        value: &Value,
+    ) -> Option<Result<(), RuntimeError>> {
+        let idx = self
+            .supply_stream_consumers
+            .iter()
+            .position(|c| c.supplier_id == supplier_id)?;
+        if self.supply_stream_consumers[idx].done {
+            return Some(Err(RuntimeError::supply_terminate_signal()));
+        }
+        let cb = self.supply_stream_consumers[idx].consumer_cb.clone();
+        match self.call_sub_value(cb, vec![value.clone()], true) {
+            Err(e) if e.is_react_done => {
+                self.supply_stream_consumers[idx].done = true;
+                for close_cb in
+                    crate::runtime::native_methods::take_supplier_close_callbacks(supplier_id)
+                {
+                    if let Err(ce) = self.call_sub_value(close_cb, Vec::new(), true) {
+                        return Some(Err(ce));
+                    }
+                }
+                Some(Ok(()))
+            }
+            Err(e) => Some(Err(e)),
+            Ok(_) => Some(Ok(())),
+        }
+    }
+}
+
 impl Interpreter {
     fn split_whenever_body_phasers(body: &[Stmt]) -> (Vec<Stmt>, Vec<Vec<Stmt>>, Vec<Vec<Stmt>>) {
         let mut main = Vec::new();
@@ -299,14 +353,50 @@ impl Interpreter {
                             // that survives to tell the loop the supply completed.
                             let done_promise = crate::value::SharedPromise::new();
                             supplier_register_promise(emitter_supplier_id, done_promise.clone());
+                            // Register a streaming consumer so that `emit` inside
+                            // the supply body delivers values to this whenever's
+                            // callback synchronously. This lets a synchronously
+                            // infinite body (`supply { loop { emit(...) } }`) be
+                            // terminated when the consumer signals `done`, instead
+                            // of buffering every emitted value (which would never
+                            // return). Direct emits stream live; inner `whenever`
+                            // registrations still flow through `supply_emit_buffer`
+                            // and are set up as ReactSubscriptions below.
+                            self.supply_stream_consumers.push(StreamConsumer {
+                                supplier_id: emitter_supplier_id,
+                                consumer_cb: callback.clone(),
+                                done: false,
+                            });
                             let (od_res, emitted, _) = self.run_on_demand_body(
                                 on_demand_cb.clone(),
                                 Some(emitter_supplier_id),
                             );
+                            let streamed_done = self
+                                .supply_stream_consumers
+                                .pop()
+                                .map(|c| c.done)
+                                .unwrap_or(false);
                             if let Err(od_err) = od_res
                                 && !od_err.is_react_done
                             {
                                 return Err(Self::wrap_react_died(od_err));
+                            }
+                            // If the streaming consumer signalled `done`, the
+                            // whole react has been satisfied by this supply — fire
+                            // its LAST callbacks and stop (don't set up the inner
+                            // subscriptions or keep polling).
+                            if streamed_done {
+                                let last_cbs = items
+                                    .get(2)
+                                    .and_then(Self::value_array_items)
+                                    .unwrap_or_default();
+                                for last_cb in &last_cbs {
+                                    match self.call_sub_value(last_cb.clone(), Vec::new(), true) {
+                                        Err(e) if e.is_react_done => return Ok(()),
+                                        _ => {}
+                                    }
+                                }
+                                return Ok(());
                             }
                             // The emitted items may include subscription registrations
                             // from `whenever` inside the supply body. Convert them to

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -244,6 +244,18 @@ impl RuntimeError {
         }
     }
 
+    /// A benign control signal that unwinds a synchronously-running on-demand
+    /// `supply { ... }` body when it emits to a consumer that has already
+    /// signalled `done`. Carries `is_react_done` (so the react runtime treats it
+    /// as normal completion) but no `X::ControlFlow` exception, so it never
+    /// surfaces to user code.
+    pub(crate) fn supply_terminate_signal() -> Self {
+        Self {
+            is_react_done: true,
+            ..Self::new("")
+        }
+    }
+
     pub(crate) fn resume_signal() -> Self {
         Self {
             is_resume: true,

--- a/t/supply-sync-infinite-emit.t
+++ b/t/supply-sync-infinite-emit.t
@@ -1,0 +1,84 @@
+use v6;
+use Test;
+
+# A `react`/`whenever` consuming an on-demand `supply { ... }` whose body emits
+# synchronously must stream values to the consumer and terminate the body when
+# the consumer signals `done` (emit-to-dead-consumer). See S17-supply/syntax.t.
+
+plan 8;
+
+# Infinite `loop { emit }` body: terminates one emit past the consumer's done.
+{
+    my $pre-emits = 0;
+    my $post-emits = 0;
+    sub make-supply() {
+        supply {
+            loop {
+                $pre-emits++;
+                emit(++$);
+                $post-emits++;
+            }
+        }
+    }
+
+    my @received;
+    react {
+        whenever make-supply() -> $n {
+            push @received, $n;
+            done if $n >= 5;
+        }
+    }
+
+    is @received, [1, 2, 3, 4, 5], 'infinite synchronous supply streams values';
+    is $pre-emits, 6, 'body runs one emit past the dead consumer';
+    is $post-emits, 5, 'body terminates on emit to dead consumer';
+}
+
+# `until my $done { ... } CLOSE { $done = True }`: the CLOSE phaser (registered
+# at block entry, even though it textually follows the loop) fires when the
+# consumer signals `done`, setting $done so the loop exits without an extra emit.
+{
+    my @pre-emit;
+    my $ran-close = False;
+    sub make-supply() {
+        supply {
+            until my $done {
+                @pre-emit.push('x');
+                emit(++$);
+            }
+            CLOSE { $ran-close = True; $done = True }
+        }
+    }
+
+    my @received;
+    react {
+        whenever make-supply() -> $n {
+            push @received, $n;
+            done if $n >= 5;
+        }
+    }
+
+    is @received, [1, 2, 3, 4, 5], 'until-loop supply streams values';
+    ok $ran-close, 'CLOSE phaser in source supply ran';
+    is @pre-emit, ['x', 'x', 'x', 'x', 'x'], 'CLOSE breaks the loop, no extra emit';
+}
+
+# A finite synchronous supply still works through the streaming path.
+{
+    my @received;
+    react {
+        whenever supply { emit 10; emit 20; emit 30 } -> $n {
+            push @received, $n;
+        }
+    }
+    is @received, [10, 20, 30], 'finite synchronous supply delivers all values';
+}
+
+# Consumer that never signals done drains a finite supply fully.
+{
+    my $sum = 0;
+    react {
+        whenever supply { emit $_ for 1..4 } -> $n { $sum += $n }
+    }
+    is $sum, 10, 'finite supply with for-emit sums correctly';
+}

--- a/t/while-until-my-decl.t
+++ b/t/while-until-my-decl.t
@@ -1,0 +1,77 @@
+use v6;
+use Test;
+
+# `while`/`until` with a bare `my`/`our`/`state` declaration in the condition.
+# The declaration must run once at loop entry, not be re-declared (and reset)
+# on each iteration — otherwise a body that mutates the variable can never make
+# the condition true. Regression for `until my $done { ... }`.
+
+plan 7;
+
+# until my $done — body sets $done to terminate
+{
+    my $i = 0;
+    until my $done {
+        $i++;
+        $done = True if $i >= 3;
+    }
+    is $i, 3, 'until my $done loops until body sets the declared variable';
+}
+
+# while my $done — runs while the declared variable is false
+{
+    my $i = 0;
+    while my $done {
+        $i++;
+    }
+    is $i, 0, 'while my $done does not run while the declared variable is false';
+}
+
+# until my $done with a later body that flips it
+{
+    my @log;
+    until my $stop {
+        @log.push(@log.elems);
+        $stop = True if @log.elems == 4;
+    }
+    is @log, [0, 1, 2, 3], 'until my keeps the declared variable across iterations';
+}
+
+# The with-initializer idiom must keep re-running the initializer each iteration.
+{
+    my @data = 1, 2, 3;
+    my $idx = 0;
+    my @got;
+    while my $x = @data[$idx++] {
+        @got.push($x);
+    }
+    is @got, [1, 2, 3], 'while my $x = expr re-runs the initializer each iteration';
+}
+
+# A genuine hash subscript on an already-declared variable still parses.
+{
+    my %h = a => 1, b => 2;
+    is %h{'a'}, 1, 'hash subscript on a declared variable still works';
+}
+
+# The body of a `my`-declaration loop condition must still parse normally,
+# including hash subscripts inside the body (the declaration's trailing block is
+# the loop body, but subscripts elsewhere are unaffected).
+{
+    my %h = a => 0;
+    until my $done {
+        %h{'a'} = %h{'a'} + 1;
+        $done = True if %h{'a'} >= 3;
+    }
+    is %h{'a'}, 3, 'hash subscripts inside a my-condition loop body still work';
+}
+
+# until my $done with no body mutation but an external break via last
+{
+    my $n = 0;
+    until my $never {
+        $n++;
+        last if $n == 10;
+    }
+    is $n, 10, 'until my with last works';
+}


### PR DESCRIPTION
## Summary

A `react` consuming an on-demand `supply { ... }` whose body emits **synchronously** hung forever in mutsu (S17-supply/syntax.t tests 77–82):

```raku
supply { loop { $pre++; emit(++$); $post++ } }
# consumed by:  react { whenever $s -> $n { push @r, $n; done if $n >= 5 } }
```

The old runtime ran the supply body to completion into `supply_emit_buffer` before delivering any value, so an infinite body never returned.

## What changed

**Streaming emit (Stage 2 of the VM-native react/supply plan).** While a react on-demand supply runs, a `supply_stream_consumers` sink is registered keyed by the emitter's `supplier_id`. `emit` then delivers each value to the `whenever` consumer **synchronously**:

- when the consumer signals `done`, the stream is marked done and the body's **CLOSE phasers fire immediately**;
- the next `emit` to the now-dead consumer unwinds the body with a benign `supply_terminate_signal`.

This reproduces Rakudo's exact counts (`pre-emits=6`, `post-emits=5` — one emit past the consumer's `done`; and CLOSE breaking an `until my $done` loop before the next emit, so `@pre-emit` stays at 5).

**Two parser fixes** were required for the `until`-loop variant:

- `while/until my $x { ... }` was mis-parsed — the declaration parser consumes the whitespace after the variable name, so the loop body `{ ... }` was eaten as a `$x{ ... }` hash subscript on the inline `DoStmt(VarDecl)`. Inline declarations are now excluded from brace-subscripting in the postfix parser.
- a bare `my $done` loop condition is now **hoisted** to declare the variable once at loop entry instead of re-declaring (and resetting) it every iteration. The with-initializer idiom `while my $x = expr { }` is left as-is (it must re-run the initializer each iteration).

Top-level supply-block CLOSE phasers are also hoisted to the front of the body so a CLOSE registered after a non-terminating loop still runs at block entry.

## Tests

- New: `t/supply-sync-infinite-emit.t`, `t/while-until-my-decl.t`
- syntax.t tests 77–82 now match rakudo output exactly
- `make test` green (461 cargo + 6980 prove); all 53 whitelisted `S17-supply/*` (720 tests) pass; `S04-statements/{while,until,loop}.t` and `S02-types/hash.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)