### PR TITLE
fix(given/with): alias container/scalar pointy parameters to the topic source

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -299,13 +299,18 @@ STATUS で撤回済み。
       **element は lvalue ＝完全 rw**＝whole-container topic の read-only-for-reassign と非対称）。③ **#3016**: `with %h<k>`
       も `use_given_alias` を simple-var target の `Expr::Index` に拡張して #3015 機構へルート。
       `t/with-topic-alias.t`(13)/`t/given-element-topic.t`(16)/`t/with-element-topic.t`(12)。
+- [x] **with/given の pointy-param aliasing (#3020)** — `given @a -> @p { @p.push }` / `with @a -> @p { @p[0]=v }`
+      （`-> %p` / `-> $p`・element-source `given %h<k> -> @p`・`when`/`default` body・whole reassign `@p=(...)`）が
+      source へ伝播。`is copy` は flatten した fresh copy で非伝播。parser が `@p := $_` に desugar→compiler が
+      `Given { pointy_param_idx }` に bound 名を載せ→writeback が param の最終値を source へ。`with` は given にルート。
+      道中 3 バグ修正（pre-existing readonly leak / element_source 1-shot leak / stale-alias 越境汚染）。
+      `t/with-given-pointy-alias.t`(28)。
 - [ ] **Track B 残 niche（深い別 feature・ROI 低。詳細 = メモリ `project_track_b_phase2_element_cells`）**:
       ① **`for %h<k>.values{$_*=2}` の element-source rw writeback**（element-source topic 最後の穴）: for-loop は
       `container_binding`（String var名）駆動の per-iteration writeback で、element source は `%h<k>[idx]=$_` の 2 段
       nested writeback ＋ `for %h<k>` の itemization 修正が必要・**最ホット path で多機構が絡み高リスク**（#3008 教訓:
       for-loop writeback は full roast 必須）。② **`.push(@var)` 参照格納**（Raku `**@` slurpy alias、COW detach するので
-      cell 昇格＝#2990 機構が必要・hot push path）。③ **with/given の `-> $p` pointy-param aliasing**（param aliasing
-      #3003 系、for-loop named param は #3008 済だが with/given は未対応）。
+      cell 昇格＝#2990 機構が必要・hot push path）。
 - [~] **object-hash（`%h{KeyType}`）** — キー保存（original_keys）は HashData 埋め込みで **COW-stable 化済み**
       (#2954)。mixin キー・`.new`/`.clone` 維持 (#2956)、multidim Range slice `:exists` (#2959) も landed。
       **キー表示の全経路修正 (#3007)**: `.sort`/`.gist`/`.Str`/`.raku`/`.list`/`.map`/`for`/`@`-flatten/`.min`/`.max`/

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1708,9 +1708,31 @@ impl Compiler {
                     // `given expr()` are read-only (Raku errors on `$_ = ...`).
                     topic_readonly = !matches!(topic, Expr::Var(_));
                 }
+                // A pointy block (`given @a -> @p { ... }`) is desugared by the
+                // parser into `@p := $_` at the body head. Record that bound
+                // parameter so the topic-source writeback reads its final value
+                // (e.g. after `@p.push`) instead of `$_`, propagating the
+                // mutation back to the source. `is copy` desugars to `@p = $_`
+                // (an Assign, not a Bind), so it is not detected here and does
+                // not write back.
+                let pointy_param_idx = match body.first() {
+                    Some(Stmt::Assign {
+                        name,
+                        op: AssignOp::Bind,
+                        expr: Expr::Var(topic),
+                    }) if topic == "_"
+                        && !name.starts_with('!')
+                        && !name.starts_with('.')
+                        && !name.starts_with('&') =>
+                    {
+                        Some(self.code.add_constant(Value::str(name.clone())))
+                    }
+                    _ => None,
+                };
                 let given_idx = self.code.emit(OpCode::Given {
                     body_end: 0,
                     topic_readonly,
+                    pointy_param_idx,
                 });
                 if Self::has_catch_or_control(body) {
                     self.compile_try(body, &None);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -711,6 +711,13 @@ pub(crate) enum OpCode {
         /// `given expr()` are all read-only in Raku (container *mutation* like
         /// `.push` is still allowed and propagates).
         topic_readonly: bool,
+        /// For a pointy block (`given @a -> @p { ... }`), the env name of the
+        /// parameter aliased to the topic. When set, the topic-source writeback
+        /// reads this parameter's final value (instead of `$_`) and writes it
+        /// back to the source, so `@p.push` / `@p[0]=v` propagate to `@a`. The
+        /// parser desugars `-> @p` into `@p := $_` at the body head and the
+        /// compiler records the bound name here. `None` for non-pointy `given`.
+        pointy_param_idx: Option<u32>,
     },
     When {
         body_end: u32,

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -2139,22 +2139,63 @@ pub(super) fn given_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws(r)?;
         let (r, pd) = parse_pointy_param(r)?;
         let (r, _) = ws(r)?;
-        (r, Some(pd.name.clone()))
+        (r, Some(pd))
     } else {
         (rest, None)
     };
     let (rest, mut body) = block(rest)?;
-    if let Some(param_name) = pointy_param {
-        body.insert(
-            0,
-            Stmt::Assign {
-                name: param_name,
-                op: AssignOp::Bind,
-                expr: Expr::Var("_".to_string()),
-            },
-        );
+    if let Some(pd) = pointy_param {
+        body.insert(0, pointy_topic_bind(&pd));
     }
     Ok((rest, Stmt::Given { topic, body }))
+}
+
+/// Build the head statement that binds a pointy-block parameter to the topic.
+///
+/// A plain (aliasing) parameter uses `:=` so the compiler/VM writes the
+/// parameter's final value back to the topic source — `given @a -> @p { @p.push }`
+/// aliases `@a`, matching Raku. `is copy` uses `=` (a fresh copy) so nothing is
+/// written back. The compiler only treats a `:=`-to-`$_` head as a pointy alias.
+fn pointy_topic_bind(pd: &ParamDef) -> Stmt {
+    let topic = Expr::Var("_".to_string());
+    if pd.traits.iter().any(|t| t == "copy") {
+        // `is copy` is a fresh, writable copy with no link to the source. Use a
+        // plain assignment (not `:=`, so the compiler does not treat it as a
+        // writeback alias). For `@`/`%` params flatten the topic first
+        // (`@p = $_.list` / `%p = $_.hash`) so a copy of an array/hash topic
+        // does not nest inside a single element (`$_` is an itemized container).
+        let expr = if pd.name.starts_with('@') {
+            method_call(topic, "list")
+        } else if pd.name.starts_with('%') {
+            method_call(topic, "hash")
+        } else {
+            topic
+        };
+        Stmt::Assign {
+            name: pd.name.clone(),
+            op: AssignOp::Assign,
+            expr,
+        }
+    } else {
+        // Aliasing parameter: `:=` so the compiler/VM writes the parameter's
+        // final value back to the topic source.
+        Stmt::Assign {
+            name: pd.name.clone(),
+            op: AssignOp::Bind,
+            expr: topic,
+        }
+    }
+}
+
+/// Build a zero-argument method call expression (`$expr.NAME`).
+fn method_call(target: Expr, name: &str) -> Expr {
+    Expr::MethodCall {
+        target: Box::new(target),
+        name: Symbol::intern(name),
+        args: Vec::new(),
+        modifier: None,
+        quoted: false,
+    }
 }
 
 pub(super) fn when_stmt(input: &str) -> PResult<'_, Stmt> {
@@ -2240,11 +2281,28 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
             )
     );
-    let use_given_alias = param_name.is_none()
-        && (matches!(
-            &cond_expr,
-            Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
-        ) || topic_is_element_lvalue);
+    let cond_is_lvalue = matches!(
+        &cond_expr,
+        Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
+    ) || topic_is_element_lvalue;
+    // A container/scalar pointy parameter on an lvalue condition is routed
+    // through `given` so it shares `given`'s topic semantics: a plain `-> @p`
+    // aliases the source (writeback of `@p.push` / `@p[0]=v`), while `-> @p is
+    // copy` becomes a flattened fresh copy (see `pointy_topic_bind`). Exclude
+    // sub-signatures, sigilless `\x`, callables, and attributive (`$!x`/`$.x`)
+    // params — those keep the copy-style VarDecl binding below.
+    let pointy_routes_through_given = param_def
+        .as_ref()
+        .map(|pd| {
+            pd.sub_signature.is_none()
+                && !pd.sigilless
+                && !pd.name.is_empty()
+                && !pd.name.starts_with('&')
+                && !pd.name.starts_with('!')
+                && !pd.name.starts_with('.')
+        })
+        .unwrap_or(false);
+    let use_given_alias = cond_is_lvalue && (param_name.is_none() || pointy_routes_through_given);
     // Topicalize `$_` for the body. For a literal, wrap it in a Mixin marked
     // read-only so in-place mutation of `$_` throws X::Assignment::RO. Otherwise
     // reuse the `$tmp` holding the (once-evaluated) condition value.
@@ -2265,8 +2323,13 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     } else {
         vec![topic_assign]
     };
-    // If a named parameter was given (-> $param), also assign it
-    if let Some(ref pname) = param_name {
+    // If a named parameter was given (-> $param), also assign it. A
+    // container/scalar pointy param is handled by the `given` routing below
+    // (it prepends the alias/copy bind to the given body), so skip the VarDecl
+    // here for those.
+    if let Some(ref pname) = param_name
+        && !(use_given_alias && pointy_routes_through_given)
+    {
         // Attributive parameter (`-> $!foo` / `-> $.foo`): bind the value to
         // self's attribute via an attribute assignment. This must be checked
         // first (an attributive param never has a sub-signature), and it must be
@@ -2378,9 +2441,17 @@ pub(super) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
         }
     }
     if use_given_alias {
+        let mut given_body = body;
+        // For a container/scalar pointy param, prepend the alias/copy bind
+        // (`@p := $_` for aliasing, `@p = $_.list` for `is copy`) so the `given`
+        // mechanism handles topic-source writeback (alias) or a flattened fresh
+        // copy (matching `given @a -> @p`).
+        if pointy_routes_through_given && let Some(ref pd) = param_def {
+            given_body.insert(0, pointy_topic_bind(pd));
+        }
         with_body = vec![Stmt::Given {
             topic: cond_expr.clone(),
-            body,
+            body: given_body,
         }];
     } else {
         with_body.extend(body);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3531,8 +3531,16 @@ impl VM {
             OpCode::Given {
                 body_end,
                 topic_readonly,
+                pointy_param_idx,
             } => {
-                self.exec_given_op(code, *body_end, *topic_readonly, ip, compiled_fns)?;
+                self.exec_given_op(
+                    code,
+                    *body_end,
+                    *topic_readonly,
+                    *pointy_param_idx,
+                    ip,
+                    compiled_fns,
+                )?;
             }
             OpCode::When { body_end } => {
                 self.exec_when_op(code, *body_end, ip, compiled_fns)?;

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1852,14 +1852,25 @@ impl VM {
     /// mutation through `$_` must propagate. Only for `@`/`%`-sigil sources
     /// (whole-container topicalization); skipped when the topic is unchanged
     /// (same `Arc`) so a read-only `given` stays a no-op.
-    fn write_back_given_topic(&mut self, code: &CompiledCode, source: &Option<String>) {
+    fn write_back_given_topic(
+        &mut self,
+        code: &CompiledCode,
+        source: &Option<String>,
+        pointy_param: &Option<String>,
+    ) {
         let Some(source) = source else {
             return;
         };
         if !source.starts_with('@') && !source.starts_with('%') {
             return;
         }
-        let Some(current) = self.interpreter.env().get("_").cloned() else {
+        // For a pointy block, write back the bound parameter's final value
+        // (`@p` after `@p.push`); otherwise the topic `$_`.
+        let current = match pointy_param {
+            Some(p) => self.get_env_with_main_alias(p),
+            None => self.interpreter.env().get("_").cloned(),
+        };
+        let Some(current) = current else {
             return;
         };
         if let Some(orig) = self.get_env_with_main_alias(source)
@@ -1876,9 +1887,20 @@ impl VM {
     /// positional)`. This makes both `$_ = ...` (whole reassign) and container
     /// mutations (`.push`) propagate to the original element, matching Raku's
     /// aliasing of an element topic.
-    fn write_back_element_source(&mut self, code: &CompiledCode, src: &(String, Value, bool)) {
+    fn write_back_element_source(
+        &mut self,
+        code: &CompiledCode,
+        src: &(String, Value, bool),
+        pointy_param: &Option<String>,
+    ) {
         let (container, index, _positional) = src;
-        let Some(current) = self.interpreter.env().get("_").cloned() else {
+        // For a pointy block, write back the bound parameter's final value;
+        // otherwise the topic `$_`.
+        let current = match pointy_param {
+            Some(p) => self.get_env_with_main_alias(p),
+            None => self.interpreter.env().get("_").cloned(),
+        };
+        let Some(current) = current else {
             return;
         };
         let key = match index {
@@ -2285,10 +2307,20 @@ impl VM {
         code: &CompiledCode,
         body_end: u32,
         topic_readonly: bool,
+        pointy_param_idx: Option<u32>,
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let topic = self.stack.pop().unwrap();
+        // For a pointy block (`given @a -> @p { ... }`), the writeback reads the
+        // bound parameter's final value rather than `$_` (Raku binds `@p` to the
+        // topic but leaves `$_` undefined). `is copy` is not recorded here, so it
+        // copies and does not write back.
+        let pointy_param: Option<String> =
+            pointy_param_idx.map(|idx| match &code.constants[idx as usize] {
+                Value::Str(s) => s.to_string(),
+                other => other.to_string_value(),
+            });
         let body_start = *ip + 1;
         let end = body_end as usize;
         let stack_base = self.stack.len();
@@ -2312,7 +2344,15 @@ impl VM {
         // `$_ = ...`; container *mutation* (`.push`) is still allowed and is
         // written back to the source below. A bare scalar var (`given $x`) is rw,
         // and an element source (handled above) is rw too.
-        let mark_ro = topic_readonly && !self.interpreter.readonly_vars().contains("_");
+        //
+        // A pointy block (`given @a -> @p`) leaves `$_` undefined in Raku and
+        // makes `@p` a fully-writable alias of the source (`@p = (...)`,
+        // `@p[0]=v`, and `@p.push` all propagate). So when a pointy param is
+        // present, don't mark `$_` read-only: that would propagate read-only to
+        // `@p` through its `@p := $_` bind and block element assignment.
+        let mark_ro = topic_readonly
+            && pointy_param.is_none()
+            && !self.interpreter.readonly_vars().contains("_");
         if mark_ro {
             self.interpreter.mark_readonly("_");
         }
@@ -2323,9 +2363,9 @@ impl VM {
             }
             if write_back {
                 if let Some(src) = &element_source {
-                    this.write_back_element_source(code, src);
+                    this.write_back_element_source(code, src, &pointy_param);
                 } else {
-                    this.write_back_given_topic(code, &container_binding);
+                    this.write_back_given_topic(code, &container_binding, &pointy_param);
                 }
             }
             this.interpreter.set_when_matched(saved_when);
@@ -2334,8 +2374,34 @@ impl VM {
             } else {
                 this.interpreter.env_mut().remove("_");
             }
+            // A pointy parameter (`-> @p`) is block-scoped in Raku, but mutsu
+            // desugars it to a global `@p := $_` whose alias/bound markers would
+            // otherwise leak past this block. Clear them so a later block reusing
+            // the name (e.g. `given @c -> @p is copy { ... }`, a plain assign that
+            // would otherwise follow the stale `__mutsu_sigilless_alias::@p` and
+            // corrupt `$_`) starts clean. Done after the writeback above, which
+            // still reads the parameter's final value.
+            if let Some(p) = &pointy_param {
+                this.interpreter
+                    .env_mut()
+                    .remove(&format!("__mutsu_sigilless_alias::{}", p));
+                this.interpreter
+                    .env_mut()
+                    .remove(&format!("__mutsu_sigilless_readonly::{}", p));
+                this.interpreter
+                    .env_mut()
+                    .remove(&format!("__mutsu_bound_decont::{}", p));
+                this.interpreter.unmark_readonly(p);
+            }
             this.topic_source_var = saved_topic_source.clone();
-            this.element_source = saved_element_source.clone();
+            // `element_source` is a one-shot signal set by `TagElementSource`
+            // immediately before this `Given`, so consuming it must clear it (not
+            // restore the just-set value). Re-setting `saved_element_source` here
+            // leaked the element source to the next `given`, which then routed its
+            // whole-container writeback through `write_back_element_source` and
+            // dropped the mutation (a non-element `given @a -> @p` after a
+            // `given %h<k>` would not propagate `@p.push`).
+            this.element_source = None;
         };
 
         let mut inner_ip = body_start;

--- a/t/with-given-pointy-alias.t
+++ b/t/with-given-pointy-alias.t
@@ -1,0 +1,159 @@
+use Test;
+
+# `given`/`with` with a pointy parameter (`-> @p` / `-> %p` / `-> $p`) aliases
+# the topic source, exactly like `given @a { ... }` aliases `@a`. Container
+# mutations through the parameter propagate back to the source. `is copy`
+# parameters get a fresh copy and do not propagate.
+
+plan 28;
+
+# --- given: whole-container array param ---
+{
+    my @a = 1, 2, 3;
+    given @a -> @p { @p.push(4) }
+    is-deeply @a, [1, 2, 3, 4], 'given @a -> @p { .push }';
+}
+{
+    my @a = 1, 2, 3;
+    given @a -> @p { @p[0] = 99 }
+    is-deeply @a, [99, 2, 3], 'given @a -> @p { @p[0] = v }';
+}
+{
+    my @a = 1, 2, 3;
+    given @a -> @p { @p = (7, 8, 9) }
+    is-deeply @a, [7, 8, 9], 'given @a -> @p { @p = (...) } (reassign propagates)';
+}
+
+# --- given: hash param ---
+{
+    my %h = a => 1;
+    given %h -> %q { %q<b> = 2 }
+    is-deeply %h, {a => 1, b => 2}, 'given %h -> %q { %q<k> = v }';
+}
+
+# --- given: scalar param binding a container ---
+{
+    my @a = 1, 2, 3;
+    given @a -> $p { $p.push(4) }
+    is-deeply @a, [1, 2, 3, 4], 'given @a -> $p { $p.push }';
+}
+
+# --- with: whole-container ---
+{
+    my @a = 1, 2, 3;
+    with @a -> @p { @p.push(4) }
+    is-deeply @a, [1, 2, 3, 4], 'with @a -> @p { .push }';
+}
+{
+    my @a = 1, 2, 3;
+    with @a -> @p { @p[0] = 99 }
+    is-deeply @a, [99, 2, 3], 'with @a -> @p { @p[0] = v }';
+}
+{
+    my %h = a => 1;
+    with %h -> %q { %q<b> = 2 }
+    is-deeply %h, {a => 1, b => 2}, 'with %h -> %q { %q<k> = v }';
+}
+{
+    my @a = 1, 2, 3;
+    with @a -> $p { $p.push(8) }
+    is-deeply @a, [1, 2, 3, 8], 'with @a -> $p { $p.push }';
+}
+
+# --- element-source topics ---
+{
+    my %e = k => [1, 2, 3];
+    with %e<k> -> @p { @p.push(4) }
+    is-deeply %e<k>, [1, 2, 3, 4], 'with %e<k> -> @p { .push }';
+}
+{
+    my @f = [1, 2], [3, 4];
+    given @f[1] -> @p { @p.push(9) }
+    is-deeply @f, [[1, 2], [3, 4, 9]], 'given @a[i] -> @p { .push }';
+}
+{
+    my %g = k => [1, 2];
+    given %g<k> -> $p { $p.push(5) }
+    is-deeply %g<k>, [1, 2, 5], 'given %h<k> -> $p { $p.push }';
+}
+
+# --- is copy: fresh flattened copy, no propagation ---
+{
+    my @c = 1, 2, 3;
+    my @inner;
+    given @c -> @p is copy { @p.push(4); @inner = @p }
+    is-deeply @inner, [1, 2, 3, 4], 'given @c -> @p is copy: inner is a flattened copy';
+    is-deeply @c, [1, 2, 3], 'given @c -> @p is copy { .push } (no propagation)';
+}
+{
+    my @c = 1, 2, 3;
+    my @inner;
+    with @c -> @p is copy { @p.push(4); @inner = @p }
+    is-deeply @inner, [1, 2, 3, 4], 'with @c -> @p is copy: inner is a flattened copy';
+    is-deeply @c, [1, 2, 3], 'with @c -> @p is copy { .push } (no propagation)';
+}
+
+# --- when / default inside a pointy given ---
+{
+    my @w = 1, 2, 3;
+    given @w -> @p { when * { @p.push(7) } }
+    is-deeply @w, [1, 2, 3, 7], 'given @a -> @p { when * { .push } }';
+}
+{
+    my @w = 1, 2, 3;
+    given @w -> @p { default { @p.push(7) } }
+    is-deeply @w, [1, 2, 3, 7], 'given @a -> @p { default { .push } }';
+}
+
+# --- nested pointy with ---
+{
+    my @big = 1, 2, 3;
+    with @big -> @outer { with @outer -> @inner { @inner.push(99) } }
+    is-deeply @big, [1, 2, 3, 99], 'nested with -> @p propagates through both levels';
+}
+
+# --- sequential reuse of the same parameter name (no leak) ---
+{
+    my @a = 1, 2, 3;
+    with @a -> @p { @p.push(4) }
+    my @b = 1, 2, 3;
+    given @b -> @p { @p[0] = 9 }
+    is-deeply @a, [1, 2, 3, 4], 'sequential reuse: first block intact';
+    is-deeply @b, [9, 2, 3], 'sequential reuse: second block intact';
+}
+
+# --- aliasing then is copy on the same name (no stale-alias corruption) ---
+{
+    my @a = 1, 2, 3;
+    with @a -> @p { @p.push(4) }
+    my @c = 1, 2, 3;
+    given @c -> @p is copy { @p.push(4) }
+    is-deeply @a, [1, 2, 3, 4], 'alias-then-copy: aliased source intact';
+    is-deeply @c, [1, 2, 3], 'alias-then-copy: copy source unchanged';
+}
+
+# --- element-source given followed by whole-container given (element_source not leaked) ---
+{
+    my %g = k => [1, 2];
+    given %g<k> -> @p { @p.push(3) }
+    my @w = 1, 2, 3;
+    given @w -> @p { @p.push(4) }
+    is-deeply %g<k>, [1, 2, 3], 'element-then-whole: element source intact';
+    is-deeply @w, [1, 2, 3, 4], 'element-then-whole: whole-container propagates';
+}
+
+# --- value/topic still usable; read-only loops are no-ops ---
+{
+    my @a = 1, 2, 3;
+    my $sum = 0;
+    given @a -> @p { $sum += $_ for @p }
+    is $sum, 6, 'read-only pointy given does not corrupt the source';
+    is-deeply @a, [1, 2, 3], 'read-only pointy given leaves the source unchanged';
+}
+
+# --- without: false branch never runs the alias body ---
+{
+    my $ran = False;
+    without 42 -> $p { $ran = True }
+    is $ran, False, 'without with defined value does not run the body';
+}


### PR DESCRIPTION
## Summary

`given @a -> @p { ... }` / `with @a -> @p { ... }` (and `-> %p` / `-> $p`) now **alias the topic source**, just like `given @a { ... }` aliases `@a`. Container mutations through the parameter propagate back to the source:

- `@p.push(x)`, `@p[0] = v`, whole reassign `@p = (...)`, hash `%p<k> = v`
- scalar pointy binding a container: `given @a -> $p { $p.push }`
- element-source topics: `given %h<k> -> @p`, `with @a[i] -> @p`
- `when` / `default` bodies inside a pointy `given`
- `is copy` parameters get a fresh, **flattened** copy and do **not** propagate

This is Track B residual item #3 (with/given pointy-param aliasing), the natural follow-up to the container/element topic aliasing landed in #3012/#3014/#3015/#3016.

## Mechanism

- Parser desugars `-> @p` into `@p := $_` at the body head.
- Compiler records that bound name on the `Given` opcode (`pointy_param_idx`).
- `exec_given_op`'s topic-source writeback reads the parameter's final value instead of `$_`.
- `with` routes container/scalar pointy params (on an lvalue condition) through `given` so it shares the same machinery.
- `is copy` desugars to a flattened assign (`@p = $_.list` / `%p = $_.hash`) that the compiler does **not** treat as a writeback alias.

## Bugs fixed along the way

- A pointy block left `$_` read-only (`given @a` topic semantics), which propagated read-only to `@p` through its bind and blocked `@p[0]=v`. Skip the `$_` read-only mark when a pointy param is present (Raku leaves `$_` undefined and makes `@p` fully writable, so `@p=(...)` also propagates). **This was a pre-existing bug** — sequential `given @a -> @p { ... }; given @b -> @p { ... }` failed with "Cannot assign to a readonly variable (@p)" on `main`.
- `element_source` was a one-shot signal that `exec_given_op` re-set on restore instead of clearing, leaking it to the next `given`.
- The pointy parameter desugars to a global whose alias/bound markers leaked past the block; clear them on restore so a later block reusing the name does not follow a stale alias.

## Testing

- `t/with-given-pointy-alias.t` — 28 cases, all verified to pass under real `raku` as well.
- `make test` PASS (760 files, 6989 tests).
- Related suites pass: `given-topic-alias`, `with-topic-alias`, `given-element-topic`, `with-element-topic`, `for-loop-named-param-alias`, `orwith`; roast `S04-statements/{given,with,when}.t`, `S03-binding/{arrays,hashes}.t`, `S03-smartmatch/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)