### PR TITLE
feat(track-a): dispatch lexical &-var shadow overrides VM-natively

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -412,9 +412,17 @@ impl VM {
         }
 
         // Lexical `&name` binding (e.g. from `sub callit(&foo) { foo(1) }`)
-        // takes precedence over package-level compiled subs.
+        // takes precedence over package-level compiled subs. Dispatch
+        // VM-natively via `vm_call_on_value` (same as the pure-lexical case in
+        // `dispatch_func_call_inner`, Track A): `call_compiled_closure` roots
+        // the closure frame at the live caller env (scoped_child) so dynamic
+        // vars (`my $*ERR` in the caller) stay visible, and first-class
+        // instance cells make mutating methods on caller-held instances visible
+        // across frames. The override value is always a `Value::Sub`
+        // (`env_callable_is_lexical_override`), so this never reaches the
+        // interpreter terminal.
         if let Some(callable) = lexical_override {
-            let result = self.interpreter.call_sub_value(callable, args, false)?;
+            let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
             self.stack.push(result);
             self.env_dirty = true;
             return Ok(());

--- a/t/lexical-amp-var-shadow-vm.t
+++ b/t/lexical-amp-var-shadow-vm.t
@@ -1,0 +1,83 @@
+use v6;
+use Test;
+
+# VM-native dispatch of a lexical &-var that *shadows* a same-named package
+# sub (Track A follow-up). When a `&foo` parameter (or `my &foo`) shadows an
+# existing package `sub foo`, the call used to reach the tree-walking
+# interpreter terminal via `call_sub_value`; it now dispatches through
+# `vm_call_on_value` just like the pure-lexical case. The cases below pin the
+# semantics that must survive the move: argument passing, lexotic control flow,
+# dynamic-var visibility, and instance-mutation visibility across frames.
+
+plan 8;
+
+# --- a lexical &-param shadows a package sub of the same name ---
+sub foo() { "package-foo" }
+sub callit(&foo) { foo() }
+is callit(-> { "lexical-foo" }), "lexical-foo",
+    'anon block bound to &foo shadows the package sub foo';
+
+# --- argument passing through the shadowed call ---
+sub add($a, $b) { $a + $b }
+sub useadd(&add) { add(10, 20) }
+is useadd(-> $x, $y { $x * $y }), 200,
+    'args flow to the shadowing lexical, not the package sub';
+
+# --- a named sub with a *different* name bound to the param ---
+sub orig() { "orig" }
+sub other() { "other" }
+sub run(&orig) { orig() }
+is run(&other), "other",
+    'a differently-named package sub bound to &orig shadows orig';
+
+# --- dynamic var rebinding visible inside the shadowed call ---
+class FakeIO {
+    has @!lines;
+    method print(*@stuff) { @!lines.push(@stuff.join); True }
+    method lines() { @!lines }
+}
+sub greet() { "package-greet" }
+sub cap(&greet) {
+    my $*ERR = FakeIO.new;
+    note greet();
+    $*ERR.lines.join("|");
+}
+is cap(-> { "lexical-greet" }), "lexical-greet\n",
+    'note inside the shadowing call writes to the caller-rebound $*ERR';
+
+# --- lexotic control flow through the shadowed call ---
+sub stepper() { }
+sub invoke(&stepper) { stepper(); "after" }
+sub g {
+    invoke(-> { return "early" });
+    "late";
+}
+is g(), "early", 'return inside a shadowing block exits the enclosing routine';
+
+my @seen;
+sub probe() { }
+sub run-once(&probe) { probe() }
+for 1..5 -> $i {
+    run-once(-> { last if $i == 3; @seen.push($i) });
+}
+is @seen.join(","), "1,2",
+    'last inside a shadowing block breaks the enclosing loop';
+
+sub gen() { 0 }
+sub trampoline(&gen) { gen() }
+my @vals = gather trampoline(-> { take $_ for 1..3 });
+is @vals.join(","), "1,2,3", 'take propagates through the shadowing call';
+
+# --- instance mutation inside the shadowing closure (cell visibility) ---
+class Counter {
+    has $.n is rw = 0;
+    method bump() { $!n++ }
+}
+sub step() { }
+sub driver(&step) {
+    my $c = Counter.new;
+    step($c); step($c);
+    $c.n;
+}
+is driver(-> $c { $c.bump }), 2,
+    'instance attr mutation inside the shadowing call is visible in caller';


### PR DESCRIPTION
## Summary

Track A follow-up ①. When a `&foo` parameter (or `my &foo`) **shadows** a same-named package sub, `exec_call_func_op` resolved the lexical override but still dispatched it through the tree-walking interpreter (`interpreter.call_sub_value`). The *pure*-lexical case (no package sub to shadow) was already moved to `vm_call_on_value` in #2949; this PR routes the shadow case the same way, removing the last `call_sub_value` dependency on this path.

## Why it's safe now

- First-class instance cells (#2872–#2947) make mutating methods on caller-held instances visible across frames (the old `overwrite_instance_bindings_by_identity` writeback gap that originally blocked Track A is gone).
- `call_compiled_closure` roots the closure frame at the live caller env (`scoped_child`), so caller-rebound dynamic vars (`my $*ERR` for `note`) stay visible.
- The override value is always a `Value::Sub` (`env_callable_is_lexical_override`), so dispatch never reaches the interpreter terminal.

## Tests

New `t/lexical-amp-var-shadow-vm.t` (8 subtests) pins: argument passing through the shadowing call, lexotic control flow (`return`/`last`/`take`), caller-rebound dynamic-var visibility (`note` → rebound `$*ERR`), and instance-attr mutation visibility across frames. All match `raku`. `make test` PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)