### PR TITLE
feat(track-a): dispatch lexical &-var slip calls VM-natively

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -516,6 +516,15 @@ impl VM {
             self.env_dirty = true;
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             self.stack.push(native_result?);
+        } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), &name) {
+            // Pure lexical `&name` callable invoked with a slip (`op(|@args)`):
+            // dispatch VM-natively via vm_call_on_value, same as the non-slip
+            // case in `dispatch_func_call_inner` (Track A). Builtin priority is
+            // preserved because try_native_function already ran above, and
+            // lexical_amp_var_callable excludes builtin / package-sub names.
+            let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
+            self.stack.push(result);
+            self.env_dirty = true;
         } else {
             // Sync VM locals to env before spawning threads so closures capture them
             if name == "start" {

--- a/t/lexical-amp-var-slip-vm.t
+++ b/t/lexical-amp-var-slip-vm.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+# VM-native dispatch of a pure lexical &-var call made with a *slip*
+# (`op(|@args)`) — Track A follow-up. The slip call path
+# (`exec_call_func_slip_op`) used to reach the tree-walking interpreter
+# terminal (`call_function_compiled_first`) for a `&op` parameter; it now
+# dispatches through `vm_call_on_value`, the same as the non-slip case. The
+# cases below pin the semantics that must survive: slip expansion position,
+# dynamic-var visibility, lexotic control flow, and instance mutation.
+
+plan 6;
+
+# --- basic slurpy slip through a &-param ---
+sub apply(&op, *@args) { op(|@args) }
+is apply({ $^a + $^b }, 3, 4), 7,
+    'placeholder block via &-param with slip args';
+
+# --- slip in the middle, regular args around it ---
+sub mid(&op) { op(1, |(2, 3), 4) }
+is mid(-> *@a { @a.join("-") }), "1-2-3-4",
+    'slip expands at its position with regular args on both sides';
+
+# --- dynamic var rebinding visible through a slip call ---
+class FakeIO {
+    has @!lines;
+    method print(*@stuff) { @!lines.push(@stuff.join); True }
+    method lines() { @!lines }
+}
+sub cap(&code, @args) {
+    my $*ERR = FakeIO.new;
+    code(|@args);
+    $*ERR.lines.join("|");
+}
+is cap(-> $m { note $m }, ["hi"]), "hi\n",
+    'note inside a slip &-param call writes to the caller-rebound $*ERR';
+
+# --- lexotic control flow through the slip call ---
+sub invoke(&c, @a) { c(|@a); "after" }
+sub g {
+    invoke(-> $x { return "early:$x" }, [9]);
+    "late";
+}
+is g(), "early:9", 'return inside a slip &-param block exits the enclosing routine';
+
+# --- take propagates through the slip call into gather ---
+sub trampoline(&c, @a) { c(|@a) }
+my @vals = gather trampoline(-> $n { take $_ for 1..$n }, [3]);
+is @vals.join(","), "1,2,3", 'take propagates through a slip &-param call';
+
+# --- instance mutation inside the slip closure (cell visibility) ---
+class Counter {
+    has $.n is rw = 0;
+    method add($d) { $!n += $d }
+}
+sub run(&f, @a) {
+    my $c = Counter.new;
+    f($c, |@a);
+    f($c, |@a);
+    $c.n;
+}
+is run(-> $c, $d { $c.add($d) }, [5]), 10,
+    'instance attr mutation inside a slip &-param call is visible in caller';


### PR DESCRIPTION
## Summary

Track A follow-up ②. A pure lexical `&op` parameter invoked with a **slip** (`op(|@args)`) compiles to `CallFuncSlip`, whose `exec_call_func_slip_op` fell through to the tree-walking interpreter terminal (`call_function_compiled_first`). The non-slip case in `dispatch_func_call_inner` was already moved to `vm_call_on_value` in #2949; this PR routes the slip case the same way by hooking `lexical_amp_var_callable` (designed reusable for exactly this) before the final fallback.

## Safety / precedence

Builtin and package-sub priority is preserved: the compiled-function, user-function-shadow, and `try_native_function` arms all run first, and `lexical_amp_var_callable` itself excludes builtin / `has_function` / `has_proto` / `has_multi` names. So only a genuine lexical `&op` (with no same-named package sub) reaches the new branch.

`function-call interpreter_fallbacks` for `apply({...}, 3, 4)`-style slip calls drop 2→0.

## Tests

New `t/lexical-amp-var-slip-vm.t` (6 subtests): slip expansion position (`op(1, |(2,3), 4)`), caller-rebound dynamic-var visibility (`note` → rebound `$*ERR`), lexotic control flow (`return`/`take` through the slip call), and instance-attr mutation visibility across frames. All match `raku`. `make test` PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)