### PR TITLE
feat(react): handle `last` and `next` inside a `whenever` block

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -144,9 +144,19 @@
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
-  - All deterministic failures fixed; remaining failures are the flaky
-    concurrency tail only (test 53 cross-thread await ~4/5 pass; lines 543-550
-    the 2000-react interval-done stress, release/CI only). Do NOT whitelist.
+  - 88/90 deterministic (3 debug runs: same 2 fails, no hang/flaky tail in
+    debug — #3018 cleared the busy-spin). Remaining 2: test 75 (`Supply.on-demand
+    (..., closing => {})` close callback not fired when a nested on-demand supply
+    is done) and test 90 (two `whenever`s each doing `last` + a `whenever start`
+    feeding both via a Supplier::Preserving, with cross-whenever LAST ordering —
+    the hard case). Whitelist still gated on release/CI stability of the
+    2000-react interval-done stress (lines 543-550).
+  - `last`/`next` inside a `whenever` in a `react` (tests 72, 84-87): the react
+    loop now maps the body's control signals via `run_react_consumer` (`done`
+    ends react, `next` skips the value, `last` stops just that whenever + fires
+    its LAST phaser with the triggering value as topic). The static-source path
+    `replay_static_supply` handles them too and fires its own LAST. Tests
+    `t/react-whenever-last-next.t`.
   - Streaming synchronous emit (tests 77-82): a `react` consuming an on-demand
     `supply { ... }` whose body emits synchronously (`loop { emit(++$) }` /
     `until my $done { emit(...) } CLOSE { $done = True }`) now delivers each emit

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -241,6 +241,45 @@ impl Interpreter {
         let _ = self.supply_emit_buffer.pop();
     }
 
+    /// Deliver one value to a `whenever` subscription's callback, mapping the
+    /// loop-control signals a `whenever` body may raise:
+    /// - `done` (`is_react_done`) ends the whole react — returns `Ok(true)` so
+    ///   the caller breaks the event loop.
+    /// - `next` (`is_next`) skips the rest of the body for this value — the
+    ///   callback already unwound, so just continue (`Ok(false)`).
+    /// - `last` (`is_last`) stops only this `whenever`: fire its LAST phasers
+    ///   (with the triggering value as topic) and mark the subscription done.
+    ///   The react keeps driving any other subscriptions.
+    ///
+    /// Any other error propagates.
+    fn run_react_consumer(
+        &mut self,
+        sub: &mut ReactSubscription,
+        value: Value,
+    ) -> Result<bool, RuntimeError> {
+        match self.call_sub_value(sub.callback.clone(), vec![value.clone()], true) {
+            Ok(_) => Ok(false),
+            Err(e) if e.is_react_done => Ok(true),
+            Err(e) if e.is_next => Ok(false),
+            Err(e) if e.is_last => {
+                for cb in sub.last_callbacks.clone() {
+                    match self.call_sub_value(cb, vec![value.clone()], true) {
+                        Err(le) if le.is_react_done => {
+                            sub.done = true;
+                            return Ok(true);
+                        }
+                        other => {
+                            other?;
+                        }
+                    }
+                }
+                sub.done = true;
+                Ok(false)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     pub(crate) fn run_react_event_loop(&mut self) -> Result<(), RuntimeError> {
         // Take the subscriptions collected during the react body
         let subscriptions = self.supply_emit_buffer.pop().unwrap_or_default();
@@ -414,10 +453,24 @@ impl Interpreter {
                                 }
                             }
                         } else {
-                            // No channel, no on-demand - replay static values
-                            self.replay_static_supply(&(attributes).as_map(), &callback)?;
+                            // No channel, no on-demand - replay static values.
+                            // replay_static_supply handles `last`/`next`/`done`
+                            // in the whenever body and fires this whenever's LAST
+                            // phasers itself, so skip the shared post-LAST below.
+                            let last_cbs = items
+                                .get(2)
+                                .and_then(Self::value_array_items)
+                                .unwrap_or_default();
+                            if self.replay_static_supply(
+                                &(attributes).as_map(),
+                                &callback,
+                                &last_cbs,
+                            )? {
+                                return Ok(());
+                            }
+                            continue;
                         }
-                        // Fire LAST callbacks after static/on-demand supply completes
+                        // Fire LAST callbacks after the on-demand supply completes
                         let last_cbs = items
                             .get(2)
                             .and_then(Self::value_array_items)
@@ -524,11 +577,8 @@ impl Interpreter {
                 if let Some(ref ch) = sub.channel {
                     match ch.poll_result() {
                         Ok(Some(value)) => {
-                            match self.call_sub_value(sub.callback.clone(), vec![value], true) {
-                                Err(e) if e.is_react_done => break 'react_loop,
-                                other => {
-                                    other?;
-                                }
+                            if self.run_react_consumer(sub, value)? {
+                                break 'react_loop;
                             }
                             sub.emit_count += 1;
                         }
@@ -569,15 +619,11 @@ impl Interpreter {
                             while let Some(pos) = sub.line_buffer.find('\n') {
                                 let line = sub.line_buffer[..pos].to_string();
                                 sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
-                                match self.call_sub_value(
-                                    sub.callback.clone(),
-                                    vec![Value::str(line)],
-                                    true,
-                                ) {
-                                    Err(e) if e.is_react_done => break 'react_loop,
-                                    other => {
-                                        other?;
-                                    }
+                                if self.run_react_consumer(sub, Value::str(line))? {
+                                    break 'react_loop;
+                                }
+                                if sub.done {
+                                    break;
                                 }
                                 sub.emit_count += 1;
                                 if let Some(limit) = sub.head_limit
@@ -591,11 +637,13 @@ impl Interpreter {
                                 }
                             }
                         } else {
-                            match self.call_sub_value(sub.callback.clone(), vec![value], true) {
-                                Err(e) if e.is_react_done => break 'react_loop,
-                                other => {
-                                    other?;
-                                }
+                            if self.run_react_consumer(sub, value)? {
+                                break 'react_loop;
+                            }
+                            // `last` in the body marked this whenever done; stop
+                            // pulling further values from the source.
+                            if sub.done {
+                                break;
                             }
                             sub.emit_count += 1;
                             if let Some(limit) = sub.head_limit
@@ -665,24 +713,15 @@ impl Interpreter {
                             while let Some(pos) = sub.line_buffer.find('\n') {
                                 let line = sub.line_buffer[..pos].to_string();
                                 sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
-                                match self.call_sub_value(
-                                    sub.callback.clone(),
-                                    vec![Value::str(line)],
-                                    true,
-                                ) {
-                                    Err(e) if e.is_react_done => break 'react_loop,
-                                    other => {
-                                        other?;
-                                    }
+                                if self.run_react_consumer(sub, Value::str(line))? {
+                                    break 'react_loop;
+                                }
+                                if sub.done {
+                                    break;
                                 }
                             }
-                        } else {
-                            match self.call_sub_value(sub.callback.clone(), vec![value], true) {
-                                Err(e) if e.is_react_done => break 'react_loop,
-                                other => {
-                                    other?;
-                                }
-                            }
+                        } else if self.run_react_consumer(sub, value)? {
+                            break 'react_loop;
                         }
                     }
                     Ok(SupplyEvent::Done) => {
@@ -778,17 +817,46 @@ impl Interpreter {
     }
 
     /// Replay static supply values (non-streaming supplies)
+    /// Replay a static supply's values through a `whenever` callback, honouring
+    /// the loop-control signals the body may raise: `done` ends the react
+    /// (returns `Ok(true)`), `next` skips to the next value, `last` stops the
+    /// whenever early. This whenever's LAST phasers are fired here — with the
+    /// triggering value as topic when stopped via `last`, otherwise with no
+    /// topic on natural completion. Returns `Ok(true)` iff `done` was signalled.
     fn replay_static_supply(
         &mut self,
         attributes: &HashMap<String, Value>,
         callback: &Value,
-    ) -> Result<(), RuntimeError> {
+        last_callbacks: &[Value],
+    ) -> Result<bool, RuntimeError> {
+        let mut last_topic: Option<Value> = None;
         if let Some(Value::Array(values, ..)) = attributes.get("values") {
             for v in values.iter() {
-                self.call_sub_value(callback.clone(), vec![v.clone()], true)?;
+                match self.call_sub_value(callback.clone(), vec![v.clone()], true) {
+                    Ok(_) => {}
+                    Err(e) if e.is_react_done => return Ok(true),
+                    Err(e) if e.is_next => continue,
+                    Err(e) if e.is_last => {
+                        last_topic = Some(v.clone());
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
-        Ok(())
+        for cb in last_callbacks {
+            let args = match &last_topic {
+                Some(v) => vec![v.clone()],
+                None => Vec::new(),
+            };
+            match self.call_sub_value(cb.clone(), args, true) {
+                Err(e) if e.is_react_done => return Ok(true),
+                other => {
+                    other?;
+                }
+            }
+        }
+        Ok(false)
     }
 
     pub(crate) fn run_whenever_with_value(

--- a/t/react-whenever-last-next.t
+++ b/t/react-whenever-last-next.t
@@ -1,0 +1,88 @@
+use v6;
+use Test;
+
+# `last` and `next` inside a `whenever` block in a `react`:
+# - `next` skips the rest of the body for the current value and continues.
+# - `last` stops just that `whenever` (firing its LAST phaser with the
+#   triggering value as topic) without ending the whole react or throwing.
+# See roast/S17-supply/syntax.t.
+
+plan 8;
+
+# next skips values
+{
+    my @got;
+    react whenever Supply.from-list(1..6) {
+        next if $_ %% 2;
+        @got.push($_);
+    }
+    is-deeply @got, [1, 3, 5], 'next skips matching values in a whenever';
+}
+
+# next does not throw
+{
+    lives-ok {
+        react whenever Supply.from-list(1..4) { next if $_ > 2 }
+    }, 'next inside a whenever does not die';
+}
+
+# last stops the whenever and fires LAST with the triggering value as topic
+{
+    my @got;
+    react whenever Supply.from-list(1..10) {
+        last if $_ > 3;
+        @got.push($_);
+        LAST { @got.push("last $_") }
+    }
+    is-deeply @got, [1, 2, 3, "last 4"],
+        'last stops the whenever and LAST runs with the triggering topic';
+}
+
+# last does not throw, even without a LAST block
+{
+    lives-ok {
+        react whenever Supply.from-list(1..6) {
+            last if $_ > 2;
+            die "ran past last at $_" if $_ > 3;
+        }
+    }, 'last inside a whenever does not die (no LAST block)';
+}
+
+# last on a single whenever sees all values up to (but excluding) the trigger
+{
+    my @got;
+    react whenever Supply.from-list(1..7) {
+        last if $_ > 4;
+        @got.push($_);
+    }
+    is-deeply @got, [1, 2, 3, 4], 'last lets through values before the trigger';
+}
+
+# next inside a whenever over an on-demand supply
+{
+    my @got;
+    react whenever supply { .emit for ^10 } {
+        next if $_ > 4;
+        @got.push($_);
+    }
+    is-deeply @got, [0, 1, 2, 3, 4], 'next works over an on-demand supply';
+}
+
+# last inside a whenever over an on-demand supply
+{
+    my @got;
+    react whenever supply { .emit for ^10 } {
+        last if $_ >= 3;
+        @got.push($_);
+    }
+    is-deeply @got, [0, 1, 2], 'last works over an on-demand supply';
+}
+
+# A whenever that runs to completion still fires LAST (no topic required)
+{
+    my $ran = 0;
+    react whenever Supply.from-list(1..3) {
+        LAST { $ran++ }
+    }
+    is $ran, 1, 'LAST fires once on natural completion of the supply';
+}


### PR DESCRIPTION
## Summary

`last`/`next` inside a `whenever` body within a `react` used to propagate as an uncaught control exception, aborting the whole react (S17-supply/syntax.t tests 72, 84–87 threw / produced wrong output).

This maps the body's loop-control signals in both the react event loop and the static-source replay path:

- **`done`** (`is_react_done`) — ends the whole react (unchanged).
- **`next`** (`is_next`) — skips the rest of the body for the current value and continues with the next one.
- **`last`** (`is_last`) — stops just that `whenever`: fire its LAST phasers **with the triggering value as topic**, mark the subscription done, and keep driving any other subscriptions.

A new `run_react_consumer` helper centralizes this across the channel / supplier / receiver dispatch sites (including the line-buffered variants). `replay_static_supply` — the path `react whenever Supply.from-list(...)` takes — now honours the same signals and fires its own LAST phasers (trigger value as topic on `last`, no topic on natural completion).

## Result

syntax.t: **88/90** now pass (was 83/90, and one test that previously never emitted now runs). The two remaining are deferred:

- test 75 — `Supply.on-demand(..., closing => {})` close callback not fired when a nested on-demand supply is done.
- test 90 — two `whenever`s each doing `last` plus a `whenever start` feeding both via a `Supplier::Preserving`, with cross-whenever LAST ordering (the hard case).

## Tests

- New: `t/react-whenever-last-next.t` (8 deterministic single-whenever cases, all matching rakudo)
- `make test` green (461 cargo + 7016 prove); all 53 whitelisted `S17-supply/*` (720 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)