### PR TITLE
fix(track-a): lexical &op shadow wins over package sub in slip calls

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -486,6 +486,26 @@ impl VM {
         let args = self.normalize_call_args_for_target(&name, args);
         let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
         self.interpreter.set_pending_callsite_line(callsite_line);
+        // A lexical `&name` parameter (or `my &name`) that shadows a same-named
+        // package sub wins over the package sub, even when the call slips its
+        // args (`op(|@args)`). This mirrors the `lexical_override` handling in
+        // `exec_call_func_op`; without it the `find_compiled_function` branch
+        // below would pick the package sub and ignore the shadow. Only grabbed
+        // when a same-named package sub actually exists (otherwise the
+        // pure-lexical path in the final `else` handles it).
+        if self.has_function(&name) && !self.has_proto(&name) && !self.has_multi_candidates(&name) {
+            let ampname = format!("&{}", name);
+            let from_local = self.locals_get_by_name(code, &ampname);
+            let candidate = from_local.or_else(|| self.interpreter.env().get(&ampname).cloned());
+            if let Some(callable) =
+                candidate.filter(|v| Self::env_callable_is_lexical_override(v, &name))
+            {
+                let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
+                self.stack.push(result);
+                self.env_dirty = true;
+                return Ok(());
+            }
+        }
         if !self.has_proto(&name)
             && let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args)
         {

--- a/t/lexical-amp-var-slip-vm.t
+++ b/t/lexical-amp-var-slip-vm.t
@@ -9,12 +9,18 @@ use Test;
 # cases below pin the semantics that must survive: slip expansion position,
 # dynamic-var visibility, lexotic control flow, and instance mutation.
 
-plan 6;
+plan 7;
 
 # --- basic slurpy slip through a &-param ---
 sub apply(&op, *@args) { op(|@args) }
 is apply({ $^a + $^b }, 3, 4), 7,
     'placeholder block via &-param with slip args';
+
+# --- a slip call where &op shadows a same-named package sub ---
+sub op($a, $b, $c) { "package-op" }
+sub useit(&op, @args) { op(|@args) }
+is useit(-> $a, $b, $c { "$a$b$c" }, [1, 2, 3]), "123",
+    'slip &op shadows the same-named package sub';
 
 # --- slip in the middle, regular args around it ---
 sub mid(&op) { op(1, |(2, 3), 4) }


### PR DESCRIPTION
## Summary

A `&op` parameter (or `my &op`) that shadows a same-named package sub must win even when the call **slips** its args (`op(|@args)`). `exec_call_func_slip_op` had no lexical-override detection, so the `find_compiled_function` branch picked up the package sub and ignored the shadow:

```raku
sub op($a, $b, $c) { "package-op" }
sub useit(&op, @args) { op(|@args) }
say useit(-> $a, $b, $c { "$a$b$c" }, [1, 2, 3]);
# raku: 123    mutsu before: package-op    mutsu after: 123
```

The non-slip path (`exec_call_func_op`) already had this via its `lexical_override` computation; the slip path was missing it (pre-existing gap, surfaced while finishing the Track A lexical &-var VM-dispatch work).

## Fix

Mirror the `lexical_override` handling: before the compiled-function branch, detect a `&name` local/env value whose identity differs from the named package sub (`env_callable_is_lexical_override`) and dispatch it via `vm_call_on_value`. Only triggered when a same-named package sub actually exists (`has_function && !has_proto && !has_multi`); the pure-lexical slip case is still handled by the existing final-`else` hook.

## Tests

Extends `t/lexical-amp-var-slip-vm.t` with the shadow+slip case. All subtests match `raku`. `make test` PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)