### PR TITLE
feat(supply): fire Supply.on-demand `closing` callback in react

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -145,12 +145,26 @@
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
   - 88/90 deterministic (3 debug runs: same 2 fails, no hang/flaky tail in
-    debug — #3018 cleared the busy-spin). Remaining 2: test 75 (`Supply.on-demand
-    (..., closing => {})` close callback not fired when a nested on-demand supply
-    is done) and test 90 (two `whenever`s each doing `last` + a `whenever start`
-    feeding both via a Supplier::Preserving, with cross-whenever LAST ordering —
-    the hard case). Whitelist still gated on release/CI stability of the
-    2000-react interval-done stress (lines 543-550).
+    debug — #3018 cleared the busy-spin). Remaining 2: test 75 and test 90.
+    Whitelist still gated on release/CI stability of the 2000-react interval-done
+    stress (lines 543-550).
+  - test 75 (`Supply.on-demand(..., closing => {})`): the `closing` callback is
+    now captured (dispatch_supply_on_demand stores it as `on_close_callbacks`)
+    and fired by the **react event-loop** on-demand branch — synchronous body
+    (`-> $s { $s.emit; $s.done }`) fires it inline via `body_ran_done`; an async
+    `start { ... }` body registers a source-less subscription so
+    run_react_close_callbacks fires it at react end. Both work standalone
+    (t/supply-on-demand-closing.t). **test 75 itself still fails** because there
+    the `whenever $sod` is NESTED inside `whenever Supply.interval { ... }`: a
+    nested whenever registers while supply_emit_buffer is empty (the loop already
+    popped it) → run_whenever_with_value takes the NON-react `.tap` path
+    (native_supply_mut tap/act ~2300-2730), NOT the react loop. To pass test 75
+    the tapped on-demand supply's own `on_close_callbacks` must be fired from the
+    TAP path when its (async start-block) body completes — that path currently
+    only collects on_close from INNER whenevers (`whenever_on_close`), not the
+    tapped supply itself. Deeper (tap path + async start + close-marker).
+  - test 90 (two `whenever`s each `last` + a `whenever start` feeding both via a
+    Supplier::Preserving, cross-whenever LAST ordering) — the hard case; deferred.
   - `last`/`next` inside a `whenever` in a `react` (tests 72, 84-87): the react
     loop now maps the body's control signals via `run_react_consumer` (`done`
     ends react, `next` skips the value, `last` stops just that whenever + fires

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -312,6 +312,20 @@ impl Interpreter {
         attrs.insert("taps".to_string(), Value::array(Vec::new()));
         attrs.insert("live".to_string(), Value::Bool(false));
         attrs.insert("on_demand_callback".to_string(), callback);
+        // `Supply.on-demand(..., closing => { ... })`: the `closing` callback runs
+        // when the supply is closed (its tap is closed, or it sends `done`).
+        // Store it on the on-close list so the react runtime fires it on
+        // completion (see run_react_event_loop's on-demand branch).
+        for arg in args.iter().skip(1) {
+            if let Value::Pair(key, value) = arg
+                && key == "closing"
+            {
+                attrs.insert(
+                    "on_close_callbacks".to_string(),
+                    Value::array(vec![(**value).clone()]),
+                );
+            }
+        }
         Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
     }
 

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -406,7 +406,7 @@ impl Interpreter {
                                 consumer_cb: callback.clone(),
                                 done: false,
                             });
-                            let (od_res, emitted, _) = self.run_on_demand_body(
+                            let (od_res, emitted, body_ran_done) = self.run_on_demand_body(
                                 on_demand_cb.clone(),
                                 Some(emitter_supplier_id),
                             );
@@ -450,6 +450,41 @@ impl Interpreter {
                                     }
                                 } else {
                                     let _ = self.call_sub_value(callback.clone(), vec![v], true);
+                                }
+                            }
+                            // Supply.on-demand(..., closing => { ... }): the
+                            // `closing` callback runs when the supply is closed.
+                            let close_cbs =
+                                Self::extract_supply_on_close_callbacks(&attributes.as_map());
+                            if !close_cbs.is_empty() {
+                                if body_ran_done {
+                                    // Synchronous body that ran `done` — closed now.
+                                    for close_cb in close_cbs {
+                                        let _ = self.call_sub_value(close_cb, Vec::new(), true);
+                                    }
+                                } else {
+                                    // Async body (e.g. `start { emit; done }`): the
+                                    // supply closes later. Register a source-less
+                                    // subscription carrying the close callbacks so
+                                    // run_react_close_callbacks fires them when the
+                                    // react ends.
+                                    react_subs.push(ReactSubscription {
+                                        receiver: None,
+                                        supplier_id: None,
+                                        supplier_next_index: 0,
+                                        callback: callback.clone(),
+                                        close_callbacks: close_cbs,
+                                        last_callbacks: Vec::new(),
+                                        quit_callbacks: Vec::new(),
+                                        done: false,
+                                        is_lines: false,
+                                        line_buffer: String::new(),
+                                        head_limit: None,
+                                        emit_count: 0,
+                                        channel: None,
+                                        promise: None,
+                                        on_demand_done: None,
+                                    });
                                 }
                             }
                         } else {

--- a/t/supply-on-demand-closing.t
+++ b/t/supply-on-demand-closing.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# `Supply.on-demand(..., closing => { ... })`: the `closing` callback runs when
+# the supply is closed (it sends `done`, or its tap is closed).
+
+plan 4;
+
+# Synchronous body that emits then sends done.
+{
+    my $closed = 0;
+    my $sod = Supply.on-demand:
+        -> $s { $s.emit(42); $s.done },
+        closing => { $closed++ };
+    react whenever $sod -> $v { }
+    is $closed, 1, 'closing fires when a synchronous on-demand supply is done';
+}
+
+# Asynchronous body (start block) that emits then sends done.
+{
+    my $closed = 0;
+    my $sod = Supply.on-demand:
+        -> $s { start { $s.emit(1); $s.done } },
+        closing => { $closed++ };
+    react {
+        whenever $sod -> $v { }
+        whenever Promise.in(0.5) { done }
+    }
+    ok $closed, 'closing fires for an async (start-block) on-demand supply';
+}
+
+# The emitted value still reaches the consumer before closing.
+{
+    my @got;
+    my $closed = 0;
+    my $sod = Supply.on-demand:
+        -> $s { $s.emit('a'); $s.emit('b'); $s.done },
+        closing => { $closed++ };
+    react whenever $sod -> $v { @got.push($v) }
+    is-deeply @got, ['a', 'b'], 'consumer sees all emitted values';
+    is $closed, 1, 'closing fires once after the values';
+}


### PR DESCRIPTION
## Summary

`Supply.on-demand(..., closing => { ... })` ignored the `closing` named arg, so the callback never ran. This captures it (`dispatch_supply_on_demand` stores it as `on_close_callbacks`) and fires it from the react event loop's on-demand branch when the supply closes:

- a **synchronous** body that runs `done` (`-> $s { $s.emit($x); $s.done }`) fires `closing` inline (via the body-ran-done signal);
- an **async** `start { ... }` body registers a source-less subscription so the callback fires when the react ends.

## Tests

- New: `t/supply-on-demand-closing.t` (sync + async cases, all matching rakudo)
- `make test` green (461 cargo + 7035 prove); all 53 whitelisted `S17-supply/*` (720 tests) pass

## Scope note

This is **partial** for S17-supply/syntax.t test 75. There the `whenever $sod` is nested inside `whenever Supply.interval { ... }`, so it registers while the react's `supply_emit_buffer` is already popped and takes the non-react `.tap` path (`native_supply_mut` tap/act) instead of the react loop. Firing the tapped supply's *own* `on_close` from that path (it currently only collects `on_close` from inner whenevers) is left for a follow-up and recorded in `TODO_roast/S17.md`. syntax.t stays at 88/90 (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)