### PR TITLE
refactor(supply): unify react/promise drive loops behind a policy enum

### DIFF
--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -3110,7 +3110,7 @@ impl Interpreter {
         attributes: &HashMap<String, Value>,
         promise: &crate::value::SharedPromise,
     ) -> Result<(), RuntimeError> {
-        use crate::runtime::native_methods::{SupplyEvent, take_supply_channel};
+        use crate::runtime::native_methods::take_supply_channel;
         use std::time::Duration;
 
         let on_demand_cb = match attributes.get("on_demand_callback") {
@@ -3179,11 +3179,7 @@ impl Interpreter {
         // dies) and capturing emitted values. This makes
         // `await (supply { whenever Supply.from-list(...) { ... } })` resolve
         // with the last emitted value even when the whenever never iterates.
-        struct SupplyPromiseSub {
-            receiver: std::sync::mpsc::Receiver<SupplyEvent>,
-            callback: Value,
-        }
-        let mut subs: Vec<SupplyPromiseSub> = Vec::new();
+        let mut react_subs: Vec<crate::runtime::subtest::ReactSubscription> = Vec::new();
         let mut static_last_value: Option<Value> = None;
         for sub_val in &subscriptions {
             if let Value::Array(items, ..) = sub_val
@@ -3219,9 +3215,22 @@ impl Interpreter {
                     if let Some(sid) = supply_id
                         && let Some(rx) = take_supply_channel(sid)
                     {
-                        subs.push(SupplyPromiseSub {
-                            receiver: rx,
+                        react_subs.push(crate::runtime::subtest::ReactSubscription {
+                            receiver: Some(rx),
+                            supplier_id: None,
+                            supplier_next_index: 0,
                             callback,
+                            close_callbacks: Vec::new(),
+                            last_callbacks: Vec::new(),
+                            quit_callbacks: Vec::new(),
+                            done: false,
+                            is_lines: false,
+                            line_buffer: String::new(),
+                            head_limit: None,
+                            emit_count: 0,
+                            channel: None,
+                            promise: None,
+                            on_demand_done: None,
                         });
                         continue;
                     }
@@ -3238,7 +3247,7 @@ impl Interpreter {
             }
         }
 
-        if subs.is_empty() {
+        if react_subs.is_empty() {
             // No live channels: resolve with the last value emitted by the
             // static sources (or any plain synchronously-emitted value).
             let result = static_last_value
@@ -3248,89 +3257,23 @@ impl Interpreter {
             return Ok(());
         }
 
-        // Custom event loop: poll channels until the promise is resolved.
-        // When the supply block calls `done`, the Supplier.done handler
-        // calls supplier_done() which keeps pending promises (including ours)
-        // with the last emitted value.
-        let poll_timeout = Duration::from_millis(10);
-        let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        // The supply's result is the last value it emitted before completing.
-        // Seed it from any values emitted synchronously before the subscriptions.
-        let mut last_value = static_last_value
+        // Drive the channel-backed subscriptions through the shared react loop
+        // under the Promise policy: it polls until the supply block's `done`
+        // keeps this promise (via the Supplier.done handler / supplier registry)
+        // or the deadline elapses, keeping the promise with the last emitted
+        // value. Seed that value from anything emitted synchronously before the
+        // subscriptions.
+        let seed = static_last_value
             .or_else(|| plain_values.last().cloned())
             .unwrap_or(Value::Nil);
-        loop {
-            // Check if promise was resolved (by supplier_done via Supplier.done handler)
-            if promise.is_resolved() {
-                return Ok(());
-            }
-
-            // Check timeout to prevent infinite hangs
-            if std::time::Instant::now() >= deadline {
-                promise.keep(Value::Nil, String::new(), String::new());
-                return Ok(());
-            }
-
-            // Poll all channel subscriptions
-            let mut any_active = false;
-            for sub in &subs {
-                match sub.receiver.recv_timeout(poll_timeout) {
-                    Ok(SupplyEvent::Emit(value)) => {
-                        any_active = true;
-                        // Capture values the whenever block `emit`s so a later
-                        // `done` resolves the promise with the last one.
-                        self.supply_emit_buffer.push(Vec::new());
-                        let cb_result =
-                            self.call_sub_value(sub.callback.clone(), vec![value], true);
-                        let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
-                        if let Some(last) = emitted.last() {
-                            last_value = last.clone();
-                        }
-                        if promise.is_resolved() {
-                            return Ok(());
-                        }
-                        if let Err(err) = cb_result {
-                            // `done` (and `last`) inside the whenever complete the
-                            // supply: keep the promise with the last emitted value
-                            // immediately, instead of spinning to the poll deadline.
-                            if err.is_react_done || err.is_last {
-                                promise.keep(last_value.clone(), String::new(), String::new());
-                                return Ok(());
-                            }
-                            // `next`/`redo` are loop control, not completion.
-                            if !err.is_next && !err.is_redo {
-                                // A `die` quits the supply: break with the cause.
-                                let cause = err
-                                    .exception
-                                    .as_deref()
-                                    .cloned()
-                                    .unwrap_or_else(|| Value::str(err.message.clone()));
-                                promise.break_with(cause, String::new(), String::new());
-                                return Ok(());
-                            }
-                        }
-                    }
-                    Ok(SupplyEvent::Done) => {
-                        // Inner supply done
-                    }
-                    Ok(SupplyEvent::Quit(_)) => {
-                        // Inner supply quit
-                    }
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        // Channel closed
-                    }
-                    Err(_) => {
-                        // Timeout, continue polling
-                        any_active = true;
-                    }
-                }
-            }
-            if !any_active {
-                // All channels disconnected
-                promise.keep(Value::Nil, String::new(), String::new());
-                return Ok(());
-            }
-        }
+        self.drive_react_subscriptions(
+            react_subs,
+            crate::runtime::subtest::SupplyDrivePolicy::Promise {
+                promise: promise.clone(),
+                deadline: std::time::Instant::now() + Duration::from_secs(30),
+                last_value: seed,
+            },
+        )
     }
 
     /// On the `await`/`.Promise` path, replay a finite/static `whenever` source

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -51,6 +51,26 @@ pub(crate) struct StreamConsumer {
     pub done: bool,
 }
 
+/// Completion policy for the shared subscription drive loop
+/// (`drive_react_subscriptions`).
+///
+/// The same poll loop backs both `react { ... }` and `await $supply` /
+/// `$supply.Promise`; they differ only in how a `whenever` value is dispatched
+/// and when the loop terminates:
+/// - `React` runs every subscription to completion via `run_react_consumer`
+///   (which maps `done`/`next`/`last`), then fires the CLOSE phasers.
+/// - `Promise` drives the subscriptions only until the awaited promise resolves
+///   — the supply body's inner `done` keeps it through the supplier registry —
+///   or the deadline elapses, keeping it with the last emitted value.
+pub(crate) enum SupplyDrivePolicy {
+    React,
+    Promise {
+        promise: crate::value::SharedPromise,
+        deadline: std::time::Instant,
+        last_value: Value,
+    },
+}
+
 impl Interpreter {
     /// If a streaming consumer is registered for `supplier_id`, deliver `value`
     /// to it synchronously and return `Some(result)`; otherwise return `None`
@@ -574,13 +594,48 @@ impl Interpreter {
             }
         }
 
+        self.drive_react_subscriptions(react_subs, SupplyDrivePolicy::React)
+    }
+
+    /// Shared subscription drive loop backing both `react { ... }` and the
+    /// `await $supply` / `$supply.Promise` paths. `react`-built and
+    /// promise-built subscriptions poll through here; `policy` selects how each
+    /// emitted value is dispatched and when the loop completes (see
+    /// [`SupplyDrivePolicy`]).
+    pub(crate) fn drive_react_subscriptions(
+        &mut self,
+        mut react_subs: Vec<ReactSubscription>,
+        mut policy: SupplyDrivePolicy,
+    ) -> Result<(), RuntimeError> {
         if react_subs.is_empty() {
+            if let SupplyDrivePolicy::Promise {
+                promise, last_value, ..
+            } = &policy
+                && !promise.is_resolved()
+            {
+                promise.keep(last_value.clone(), String::new(), String::new());
+            }
             return Ok(());
         }
 
         // Event loop: poll all subscriptions
         let timeout = Duration::from_millis(10);
         'react_loop: loop {
+            if let SupplyDrivePolicy::Promise {
+                promise, deadline, ..
+            } = &policy
+            {
+                // The supply body's inner `done` keeps this promise through the
+                // supplier registry; once that happens the await is satisfied.
+                if promise.is_resolved() {
+                    return Ok(());
+                }
+                // Bound the wait so a stalled source cannot hang the await.
+                if std::time::Instant::now() >= *deadline {
+                    promise.keep(Value::Nil, String::new(), String::new());
+                    return Ok(());
+                }
+            }
             let mut all_done = true;
             for sub in react_subs.iter_mut() {
                 if sub.done {
@@ -741,53 +796,109 @@ impl Interpreter {
                 }
                 // Try to receive with a short timeout
                 match receiver.recv_timeout(timeout) {
-                    Ok(SupplyEvent::Emit(value)) => {
-                        if sub.is_lines {
-                            let chunk = value.to_string_value();
-                            sub.line_buffer.push_str(&chunk);
-                            while let Some(pos) = sub.line_buffer.find('\n') {
-                                let line = sub.line_buffer[..pos].to_string();
-                                sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
-                                if self.run_react_consumer(sub, Value::str(line))? {
-                                    break 'react_loop;
+                    Ok(SupplyEvent::Emit(value)) => match &mut policy {
+                        SupplyDrivePolicy::Promise {
+                            promise, last_value, ..
+                        } => {
+                            // Capture values the whenever block `emit`s so a
+                            // later `done` resolves the promise with the last one.
+                            self.supply_emit_buffer.push(Vec::new());
+                            let cb_result =
+                                self.call_sub_value(sub.callback.clone(), vec![value], true);
+                            let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
+                            if let Some(last) = emitted.last() {
+                                *last_value = last.clone();
+                            }
+                            if promise.is_resolved() {
+                                return Ok(());
+                            }
+                            if let Err(err) = cb_result {
+                                // `done`/`last` inside the whenever complete the
+                                // supply: keep the promise with the last emitted
+                                // value immediately rather than spinning to the
+                                // deadline.
+                                if err.is_react_done || err.is_last {
+                                    promise.keep(
+                                        last_value.clone(),
+                                        String::new(),
+                                        String::new(),
+                                    );
+                                    return Ok(());
                                 }
-                                if sub.done {
-                                    break;
+                                // `next`/`redo` are loop control, not completion.
+                                if !err.is_next && !err.is_redo {
+                                    // A `die` quits the supply: break with the cause.
+                                    let cause = err
+                                        .exception
+                                        .as_deref()
+                                        .cloned()
+                                        .unwrap_or_else(|| Value::str(err.message.clone()));
+                                    promise.break_with(cause, String::new(), String::new());
+                                    return Ok(());
                                 }
                             }
-                        } else if self.run_react_consumer(sub, value)? {
-                            break 'react_loop;
                         }
-                    }
+                        SupplyDrivePolicy::React => {
+                            if sub.is_lines {
+                                let chunk = value.to_string_value();
+                                sub.line_buffer.push_str(&chunk);
+                                while let Some(pos) = sub.line_buffer.find('\n') {
+                                    let line = sub.line_buffer[..pos].to_string();
+                                    sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
+                                    if self.run_react_consumer(sub, Value::str(line))? {
+                                        break 'react_loop;
+                                    }
+                                    if sub.done {
+                                        break;
+                                    }
+                                }
+                            } else if self.run_react_consumer(sub, value)? {
+                                break 'react_loop;
+                            }
+                        }
+                    },
                     Ok(SupplyEvent::Done) => {
-                        if sub.is_lines && !sub.line_buffer.is_empty() {
-                            let remaining = std::mem::take(&mut sub.line_buffer);
-                            match self.call_sub_value(
-                                sub.callback.clone(),
-                                vec![Value::str(remaining)],
-                                true,
-                            ) {
-                                Err(e) if e.is_react_done => break 'react_loop,
-                                other => {
-                                    other?;
+                        if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
+                            // Inner supply done: the promise resolves through the
+                            // supplier registry, not the channel close — just
+                            // retire this receiver.
+                            sub.done = true;
+                        } else {
+                            if sub.is_lines && !sub.line_buffer.is_empty() {
+                                let remaining = std::mem::take(&mut sub.line_buffer);
+                                match self.call_sub_value(
+                                    sub.callback.clone(),
+                                    vec![Value::str(remaining)],
+                                    true,
+                                ) {
+                                    Err(e) if e.is_react_done => break 'react_loop,
+                                    other => {
+                                        other?;
+                                    }
                                 }
                             }
+                            for callback in &sub.last_callbacks {
+                                self.call_sub_value(callback.clone(), Vec::new(), true)?;
+                            }
+                            sub.done = true;
                         }
-                        for callback in &sub.last_callbacks {
-                            self.call_sub_value(callback.clone(), Vec::new(), true)?;
-                        }
-                        sub.done = true;
                     }
                     Ok(SupplyEvent::Quit(error)) => {
-                        let mut handled = false;
-                        for quit_cb in &sub.quit_callbacks {
-                            self.call_supply_quit_handler(quit_cb.clone(), error.clone())?;
-                            handled = true;
-                        }
-                        sub.done = true;
-                        if !handled {
-                            let ch_quit_err = Self::runtime_error_from_supply_reason(error);
-                            return Err(Self::wrap_react_died(ch_quit_err));
+                        if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
+                            // On the await path an inner quit just retires the
+                            // receiver; the promise is resolved/broken elsewhere.
+                            sub.done = true;
+                        } else {
+                            let mut handled = false;
+                            for quit_cb in &sub.quit_callbacks {
+                                self.call_supply_quit_handler(quit_cb.clone(), error.clone())?;
+                                handled = true;
+                            }
+                            sub.done = true;
+                            if !handled {
+                                let ch_quit_err = Self::runtime_error_from_supply_reason(error);
+                                return Err(Self::wrap_react_died(ch_quit_err));
+                            }
                         }
                     }
                     Err(mpsc::RecvTimeoutError::Timeout) => {}
@@ -796,8 +907,24 @@ impl Interpreter {
                     }
                 }
             }
-            if all_done || react_subs.iter().all(|s| s.done) {
-                break;
+            match &policy {
+                SupplyDrivePolicy::React => {
+                    if all_done || react_subs.iter().all(|s| s.done) {
+                        break;
+                    }
+                }
+                SupplyDrivePolicy::Promise { promise, .. } => {
+                    if promise.is_resolved() {
+                        return Ok(());
+                    }
+                    // All channels closed without the promise resolving:
+                    // complete the await with Nil (matching the legacy
+                    // supply_promise_on_demand loop).
+                    if all_done || react_subs.iter().all(|s| s.done) {
+                        promise.keep(Value::Nil, String::new(), String::new());
+                        return Ok(());
+                    }
+                }
             }
         }
 

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -609,7 +609,9 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         if react_subs.is_empty() {
             if let SupplyDrivePolicy::Promise {
-                promise, last_value, ..
+                promise,
+                last_value,
+                ..
             } = &policy
                 && !promise.is_resolved()
             {
@@ -798,7 +800,9 @@ impl Interpreter {
                 match receiver.recv_timeout(timeout) {
                     Ok(SupplyEvent::Emit(value)) => match &mut policy {
                         SupplyDrivePolicy::Promise {
-                            promise, last_value, ..
+                            promise,
+                            last_value,
+                            ..
                         } => {
                             // Capture values the whenever block `emit`s so a
                             // later `done` resolves the promise with the last one.
@@ -818,11 +822,7 @@ impl Interpreter {
                                 // value immediately rather than spinning to the
                                 // deadline.
                                 if err.is_react_done || err.is_last {
-                                    promise.keep(
-                                        last_value.clone(),
-                                        String::new(),
-                                        String::new(),
-                                    );
+                                    promise.keep(last_value.clone(), String::new(), String::new());
                                     return Ok(());
                                 }
                                 // `next`/`redo` are loop control, not completion.


### PR DESCRIPTION
## Summary

Phase B of the react/supply VM-native plan ([[react-supply-vm-native-plan]]). The "poll subscriptions until completion" drive loop was reimplemented twice — once in `run_react_event_loop` (`react {}`) and once in `supply_promise_on_demand` (`await $supply` / `$supply.Promise`). This folds both behind a single shared engine selected by a completion-policy enum.

## Changes

- Introduce `SupplyDrivePolicy { React, Promise { promise, deadline, last_value } }`. The policy selects how each emitted value is dispatched and when the loop terminates:
  - **React** runs every subscription to completion via `run_react_consumer` (mapping `done`/`next`/`last`), then fires the CLOSE phasers.
  - **Promise** drives until the supply body's inner `done` keeps the promise (through the supplier registry) or the 30s deadline elapses, keeping it with the last emitted value.
- Extract the react event loop into `drive_react_subscriptions(react_subs, policy)`. Promise-policy subscriptions are receiver-only, so only the receiver branch runs for them; the `Emit`/`Done`/`Quit` arms and the termination check branch on the policy.
- `supply_promise_on_demand` now builds `ReactSubscription` records and delegates to the shared engine, deleting its private `SupplyPromiseSub` struct and ~90 lines of duplicated poll loop.

## Verification

Behavior-preserving:
- `make test` — 767 files / 7035 tests, PASS
- all whitelisted `S17-supply` + `S17-promise` — 64 files / 872 tests, PASS
- `t/` supply/await/react suites — 18 files / 107 tests, PASS
- `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)