### PR TITLE
feat(③ ctor): native-construct TWEAK-only classes

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -444,6 +444,44 @@ impl Interpreter {
                 attributes = updated;
             }
         }
+        // `self.bless(...)` runs BUILD/TWEAK with no extra args (the named
+        // attributes were already folded into `attributes` above); preserve
+        // that by passing an empty TWEAK arg list.
+        let attributes = self.run_tweak_phase(class_name, attributes, &[])?;
+        Ok(Value::make_instance(class_name, attributes))
+    }
+
+    /// Run the TWEAK phase of construction: invoke every TWEAK submethod (own and
+    /// role-composed) across the MRO in base-first order, threading the
+    /// (possibly mutated) attribute map through each call. `tweak_args` are the
+    /// constructor's named arguments, passed through to each TWEAK so a
+    /// `submethod TWEAK(:$y)` signature binds them (the `.new` path passes the
+    /// original args; `self.bless` passes none). Extracted so the native default
+    /// constructor can reuse the exact same TWEAK ordering/dispatch instead of
+    /// duplicating it (Track A ③ ctor: a class whose only non-simple feature is
+    /// TWEAK is native-default constructible, then runs TWEAK here).
+    pub(crate) fn run_tweak_phase(
+        &mut self,
+        class_name: Symbol,
+        mut attributes: HashMap<String, Value>,
+        tweak_args: &[Value],
+    ) -> Result<HashMap<String, Value>, RuntimeError> {
+        let cn = class_name.resolve();
+        let mro = self.class_mro(&cn);
+        let class_lang_rev = self
+            .type_metadata
+            .get(&cn)
+            .and_then(|m| m.get("language-revision"))
+            .map(|v| v.to_string_value())
+            .unwrap_or_else(|| {
+                let version = crate::parser::current_language_version();
+                if let Some(rest) = version.strip_prefix("6.") {
+                    rest.chars().next().unwrap_or('c').to_string()
+                } else {
+                    "c".to_string()
+                }
+            });
+        let class_is_6e = class_lang_rev != "c";
         for mro_class in mro.iter().rev() {
             if mro_class == "Any" || mro_class == "Mu" {
                 continue;
@@ -480,11 +518,11 @@ impl Interpreter {
                     continue;
                 }
                 let (_v, updated) = self.run_instance_method_resolved(
-                    &class_name.resolve(),
+                    &cn,
                     &role_name,
                     method_def,
                     attributes.clone(),
-                    Vec::new(),
+                    tweak_args.to_vec(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
                 attributes = updated;
@@ -507,13 +545,13 @@ impl Interpreter {
                     mro_class,
                     attributes.clone(),
                     "TWEAK",
-                    Vec::new(),
+                    tweak_args.to_vec(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
                 attributes = updated;
             }
         }
-        Ok(Value::make_instance(class_name, attributes))
+        Ok(attributes)
     }
 
     /// Dispatch Enum .new — should throw X::Constructor::BadType.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -99,8 +99,13 @@ impl Interpreter {
                 // A non-class entry in the MRO (e.g. a role) — be conservative.
                 return false;
             };
+            // A `TWEAK` submethod is allowed: the native path assembles the
+            // instance as usual, then runs the TWEAK phase via the shared
+            // `run_tweak_phase` helper (same ordering/dispatch as the full
+            // constructor). `BUILD`/`BUILDALL`/custom `new` still fall through —
+            // BUILD runs *before* attribute defaults are finalized, which the
+            // native assembly order does not reproduce.
             let simple = !class_def.methods.contains_key("BUILD")
-                && !class_def.methods.contains_key("TWEAK")
                 && !class_def.methods.contains_key("BUILDALL")
                 && !class_def.methods.contains_key("new")
                 && class_def.native_methods.is_empty()
@@ -507,6 +512,25 @@ impl Interpreter {
         }
         // Add alias metadata for `has $x` (no twigil) attributes
         self.add_alias_attribute_metadata(cn_resolved, &mut attrs);
+        // Run the TWEAK phase if any class in the MRO declares one. The gate
+        // (`is_native_default_constructible`) allows TWEAK-only classes; the
+        // instance is fully assembled at this point, so running TWEAK here
+        // matches the full constructor (which runs it after attribute init).
+        // Cheap MRO check first so the common no-TWEAK case pays nothing extra.
+        let has_tweak = self.mro_readonly(cn_resolved).iter().any(|cls| {
+            self.registry()
+                .classes
+                .get(cls)
+                .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
+        });
+        if has_tweak {
+            // Pass the original constructor args so a `submethod TWEAK(:$y)`
+            // signature binds them, matching the full `.new` path.
+            match self.run_tweak_phase(class_name, attrs, args) {
+                Ok(updated) => attrs = updated,
+                Err(e) => return Some(Err(e)),
+            }
+        }
         Some(Ok(Value::make_instance(class_name, attrs)))
     }
 

--- a/t/native-tweak-construct.t
+++ b/t/native-tweak-construct.t
@@ -1,0 +1,75 @@
+use v6;
+use Test;
+
+# VM-native default construction now covers classes whose only non-simple
+# feature is a `TWEAK` submethod (Track A ③ constructor). The instance is
+# assembled natively (named args + attribute defaults), then the TWEAK phase
+# runs via the shared `run_tweak_phase` helper — the same ordering/dispatch the
+# full constructor uses. These pin the semantics that must survive the move.
+
+plan 16;
+
+# --- basic derived attribute in TWEAK ---
+class Temp {
+    has $.celsius;
+    has $.fahrenheit;
+    submethod TWEAK { $!fahrenheit //= $!celsius * 9/5 + 32 }
+}
+is Temp.new(celsius => 100).fahrenheit, 212, 'TWEAK computes a derived attribute';
+is Temp.new(celsius => 0, fahrenheit => 50).fahrenheit, 50,
+    'a provided value is kept when TWEAK only defaults it';
+
+# --- TWEAK mutates a typed scalar attribute with a default ---
+class B { has Int $.x = 5; submethod TWEAK { $!x = $!x * 2 } }
+is B.new.x, 10, 'TWEAK mutates a defaulted typed attribute';
+is B.new(x => 7).x, 14, 'TWEAK mutates a provided typed attribute';
+
+# --- coercion-typed attribute is coerced before TWEAK observes it ---
+class A { has Int() $.n; method kind { $!n.WHAT.^name } }
+class A2 { has Int() $.n; has $.seen; submethod TWEAK { $!seen = $!n.WHAT.^name } }
+is A.new(n => "42").n, 42, 'coercion-typed attribute coerces in the native path';
+is A2.new(n => "42").seen, 'Int', 'TWEAK sees the coerced value, not the raw Str';
+
+# --- TWEAK that dies propagates the exception ---
+class C { has $.age; submethod TWEAK { die "negative age" if $!age < 0 } }
+dies-ok { C.new(age => -1) }, 'a dying TWEAK propagates out of .new';
+is C.new(age => 3).age, 3, 'a non-dying TWEAK constructs normally';
+
+# --- TWEAK derives one attribute from another provided one ---
+class F { has $.a; has $.b; submethod TWEAK { $!b = $!a + 1 } }
+is F.new(a => 10).b, 11, 'TWEAK derives an attribute from a provided one';
+
+# --- inheritance: base + child TWEAK both run, base-first ---
+class Base { has @.order is rw; }
+class Mid is Base { submethod TWEAK { self.order.push("Mid") } }
+class Leaf is Mid { submethod TWEAK { self.order.push("Leaf") } }
+is Leaf.new.order.join(","), "Mid,Leaf",
+    'TWEAK runs base-first across the inheritance chain';
+
+# --- typed container attribute is finalized before TWEAK ---
+class E { has Int @.nums; has $.total; submethod TWEAK { $!total = @!nums.sum } }
+is E.new(nums => [1, 2, 3]).total, 6, 'TWEAK sees a finalized typed container';
+
+# --- an empty TWEAK is a no-op ---
+class N { has $.v = 9; submethod TWEAK { } }
+is N.new.v, 9, 'an empty TWEAK leaves attributes untouched';
+
+# --- TWEAK coexisting with BUILD still runs through the full constructor ---
+class G {
+    has $.a;
+    has $.b;
+    submethod BUILD(:$a) { $!a = $a // 1 }
+    submethod TWEAK { $!b = $!a * 10 }
+}
+is G.new(a => 5).b, 50, 'BUILD+TWEAK class constructs correctly (full path)';
+is G.new.b, 10, 'BUILD+TWEAK class uses BUILD defaults then TWEAK';
+
+# --- TWEAK with a named-arg signature receives the constructor args ---
+class H { has $.y; submethod TWEAK(:$y) { $!y = 2 * $y } }
+is H.new(y => 3).y, 6, 'TWEAK(:$y) binds the named constructor argument';
+
+# --- parent TWEAK and child TWEAK(:$y) both see the args, base-first ---
+class PT { has $.x; submethod TWEAK { $!x *= 2 } }
+class CT is PT { has $.y; submethod TWEAK(:$y) { $!y = 2 * $y } }
+my $ct = CT.new(x => 1, y => 2);
+is "{$ct.x},{$ct.y}", "2,4", 'parent and child TWEAK(:$y) both bind args base-first';


### PR DESCRIPTION
## Summary

Track A ③ constructor (the env-ownership 本丸). `Package.new` is the dominant method-call interpreter fallback, and a `submethod TWEAK` was the single biggest shape excluded from the native default constructor. This PR makes a class whose **only** non-simple feature is a `TWEAK` submethod native-default constructible.

```raku
class Temp {
    has $.celsius;
    has $.fahrenheit;
    submethod TWEAK { $!fahrenheit //= $!celsius * 9/5 + 32 }
}
Temp.new(celsius => 100).fahrenheit   # 212 — now 0 `new` interpreter fallbacks
```

## How

- The VM assembles the instance natively as before (named args + attribute defaults + coercion + typed-container finalization), then runs the **TWEAK phase**.
- `BUILD` still falls through: it runs *before* attribute defaults are finalized, which the native assembly order does not reproduce. `BUILDALL`/custom `new`/`where`/shaped/`does Role` also keep the full path.
- The TWEAK loop is extracted from `dispatch_bless` into a shared `run_tweak_phase` (base-first MRO walk, own + role-composed TWEAK submethods, 6.c/6.e revision rules) so there's no duplicated ordering logic.
- **Args threading:** `run_tweak_phase` takes the constructor's named args and passes them to each TWEAK, so `submethod TWEAK(:$y)` binds them. The native builder passes the original args (matching the full `.new` path); `self.bless(...)` passes none (preserving its prior behavior).

## Verification

Behavior byte-identical to raku: coercion-typed (`Int()`) and typed-container (`Int @.x`) attributes are finalized *before* TWEAK observes them, base-first ordering across inheritance, role-composed TWEAK, a dying TWEAK propagates, and `TWEAK(:$y)` binds the named arg.

New `t/native-tweak-construct.t` (16 subtests). `make test` PASS. `roast/S12-construction/{TWEAK,construction,named-params-in-BUILD,roles-6e}.t` match raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)