### PR TITLE
refactor(supply): add ReactSubscription::new to drop field boilerplate

### DIFF
--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -3217,20 +3217,7 @@ impl Interpreter {
                     {
                         react_subs.push(crate::runtime::subtest::ReactSubscription {
                             receiver: Some(rx),
-                            supplier_id: None,
-                            supplier_next_index: 0,
-                            callback,
-                            close_callbacks: Vec::new(),
-                            last_callbacks: Vec::new(),
-                            quit_callbacks: Vec::new(),
-                            done: false,
-                            is_lines: false,
-                            line_buffer: String::new(),
-                            head_limit: None,
-                            emit_count: 0,
-                            channel: None,
-                            promise: None,
-                            on_demand_done: None,
+                            ..crate::runtime::subtest::ReactSubscription::new(callback)
                         });
                         continue;
                     }

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -101,20 +101,12 @@ impl Interpreter {
                     .unwrap_or_default();
                 return Some(ReactSubscription {
                     receiver: Some(rx),
-                    supplier_id: None,
-                    supplier_next_index: 0,
-                    callback,
                     close_callbacks: Self::extract_supply_on_close_cbs(&(attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
-                    done: false,
                     is_lines,
-                    line_buffer: String::new(),
                     head_limit,
-                    emit_count: 0,
-                    channel: None,
-                    promise: None,
-                    on_demand_done: None,
+                    ..ReactSubscription::new(callback)
                 });
             }
             if let Some(Value::Int(sid)) = attributes.as_map().get("supplier_id") {
@@ -127,21 +119,13 @@ impl Interpreter {
                     .and_then(Self::react_value_array_items)
                     .unwrap_or_default();
                 return Some(ReactSubscription {
-                    receiver: None,
                     supplier_id: Some(*sid as u64),
-                    supplier_next_index: 0,
-                    callback,
                     close_callbacks: Self::extract_supply_on_close_cbs(&(attributes).as_map()),
                     last_callbacks: last_cbs,
                     quit_callbacks: quit_cbs,
-                    done: false,
                     is_lines,
-                    line_buffer: String::new(),
                     head_limit,
-                    emit_count: 0,
-                    channel: None,
-                    promise: None,
-                    on_demand_done: None,
+                    ..ReactSubscription::new(callback)
                 });
             }
         }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -39,6 +39,32 @@ pub(crate) struct ReactSubscription {
     pub on_demand_done: Option<crate::value::SharedPromise>,
 }
 
+impl ReactSubscription {
+    /// A subscription with no source wired up and no phasers: every field at
+    /// its inert default except `callback`. Callers fill in the source field
+    /// (`receiver` / `supplier_id` / `channel` / `promise`) and any collected
+    /// phaser callbacks via struct-update syntax (`..ReactSubscription::new(cb)`).
+    pub(crate) fn new(callback: Value) -> Self {
+        ReactSubscription {
+            receiver: None,
+            supplier_id: None,
+            supplier_next_index: 0,
+            callback,
+            close_callbacks: Vec::new(),
+            last_callbacks: Vec::new(),
+            quit_callbacks: Vec::new(),
+            done: false,
+            is_lines: false,
+            line_buffer: String::new(),
+            head_limit: None,
+            emit_count: 0,
+            channel: None,
+            promise: None,
+            on_demand_done: None,
+        }
+    }
+}
+
 /// A streaming consumer for an on-demand `supply { ... }` body driven by `react`.
 /// While registered (keyed by the emitter's `supplier_id`), each `emit` in the
 /// supply body delivers its value to `consumer_cb` synchronously rather than
@@ -344,22 +370,14 @@ impl Interpreter {
                                 .unwrap_or_default();
                             react_subs.push(ReactSubscription {
                                 receiver: Some(rx),
-                                supplier_id: None,
-                                supplier_next_index: 0,
-                                callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
                                     &(attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
-                                done: false,
                                 is_lines,
-                                line_buffer: String::new(),
                                 head_limit,
-                                emit_count: 0,
-                                channel: None,
-                                promise: None,
-                                on_demand_done: None,
+                                ..ReactSubscription::new(callback)
                             });
                             continue;
                         }
@@ -375,23 +393,15 @@ impl Interpreter {
                                 .and_then(Self::value_array_items)
                                 .unwrap_or_default();
                             react_subs.push(ReactSubscription {
-                                receiver: None,
                                 supplier_id: Some(*supplier_id as u64),
-                                supplier_next_index: 0,
-                                callback,
                                 close_callbacks: Self::extract_supply_on_close_callbacks(
                                     &(attributes).as_map(),
                                 ),
                                 last_callbacks,
                                 quit_callbacks,
-                                done: false,
                                 is_lines,
-                                line_buffer: String::new(),
                                 head_limit,
-                                emit_count: 0,
-                                channel: None,
-                                promise: None,
-                                on_demand_done: None,
+                                ..ReactSubscription::new(callback)
                             });
                             continue;
                         }
@@ -489,21 +499,8 @@ impl Interpreter {
                                     // run_react_close_callbacks fires them when the
                                     // react ends.
                                     react_subs.push(ReactSubscription {
-                                        receiver: None,
-                                        supplier_id: None,
-                                        supplier_next_index: 0,
-                                        callback: callback.clone(),
                                         close_callbacks: close_cbs,
-                                        last_callbacks: Vec::new(),
-                                        quit_callbacks: Vec::new(),
-                                        done: false,
-                                        is_lines: false,
-                                        line_buffer: String::new(),
-                                        head_limit: None,
-                                        emit_count: 0,
-                                        channel: None,
-                                        promise: None,
-                                        on_demand_done: None,
+                                        ..ReactSubscription::new(callback.clone())
                                     });
                                 }
                             }
@@ -549,20 +546,8 @@ impl Interpreter {
                         });
                         react_subs.push(ReactSubscription {
                             receiver: Some(rx),
-                            supplier_id: None,
-                            supplier_next_index: 0,
-                            callback,
-                            close_callbacks: Vec::new(),
-                            last_callbacks: Vec::new(),
-                            quit_callbacks: Vec::new(),
-                            done: false,
-                            is_lines: false,
-                            line_buffer: String::new(),
-                            head_limit: None,
-                            emit_count: 0,
-                            channel: None,
                             promise: Some(shared.clone()),
-                            on_demand_done: None,
+                            ..ReactSubscription::new(callback)
                         });
                     }
                     // Channel source: poll values directly from the channel
@@ -572,21 +557,9 @@ impl Interpreter {
                             .and_then(Self::value_array_items)
                             .unwrap_or_default();
                         react_subs.push(ReactSubscription {
-                            receiver: None,
-                            supplier_id: None,
-                            supplier_next_index: 0,
-                            callback,
-                            close_callbacks: Vec::new(),
                             last_callbacks,
-                            quit_callbacks: Vec::new(),
-                            done: false,
-                            is_lines: false,
-                            line_buffer: String::new(),
-                            head_limit: None,
-                            emit_count: 0,
                             channel: Some(ch.clone()),
-                            promise: None,
-                            on_demand_done: None,
+                            ..ReactSubscription::new(callback)
                         });
                     }
                     _ => {}


### PR DESCRIPTION
## Summary

Follow-up cleanup to #3027. Every `ReactSubscription` construction site repeated all 15 struct fields, the great majority set to their inert default (`None` / `Vec::new()` / `0` / `false`). This introduces a `ReactSubscription::new(callback)` constructor returning that inert base and rewrites the 8 construction sites with struct-update syntax (`..ReactSubscription::new(cb)`), so each site lists only the source field (`receiver` / `supplier_id` / `channel` / `promise`) and the phaser callbacks it actually sets.

Pure cleanup, no behavior change — every elided field had the exact value `new()` now supplies.

Net **-56 lines** across `subtest.rs`, `react_died.rs`, `native_supply_methods.rs`.

## Verification

- `cargo build` + `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- `t/` supply/react/await suites — 13 files / 79 tests, PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)