### PR TITLE
feat(③ ctor): native-construct where-constrained classes

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -121,8 +121,8 @@ impl Interpreter {
                     p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
-                    |(name, _, _, _is_required, type_constraint, sigil, where_constraint)| {
-                        // No `where` clause, and a constructible sigil/type shape:
+                    |(name, _, _, _is_required, type_constraint, sigil, _where_constraint)| {
+                        // A constructible sigil/type shape:
                         // - `$`: a type constraint is allowed only when it is a
                         //   plain `type_matches_value`-checkable class/role/subset
                         //   type (see `is_simple_native_ctor_constraint`); native /
@@ -133,8 +133,10 @@ impl Interpreter {
                         // `is required` is allowed through: an unprovided required
                         // attribute falls through at build time (the interpreter
                         // raises X::Attribute::Required).
-                        where_constraint.is_none()
-                            && match sigil {
+                        // A `where` clause is allowed: the native builder runs
+                        // `enforce_attribute_where_constraints` as a post-assembly
+                        // phase (same predicate dispatch as the full constructor).
+                        match sigil {
                                 '$' => match type_constraint {
                                     None => true,
                                     Some(inner) => inner.as_deref().is_some_and(|tc| {
@@ -523,12 +525,34 @@ impl Interpreter {
                 .get(cls)
                 .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
         });
+        // Enforce `where` constraints at attribute-assignment time, i.e. *before*
+        // TWEAK runs — both raku and the interpreter reject a provided/defaulted
+        // value that fails its `where` at this point (a later TWEAK that would
+        // "fix" it never gets to run). `class_attrs` is the same
+        // `ClassAttributeDef` slice the interpreter uses, so the predicate
+        // dispatch is identical.
+        let has_where = class_attrs.iter().any(|(.., where_c)| where_c.is_some());
+        if has_where
+            && let Err(e) =
+                self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
+        {
+            return Some(Err(e));
+        }
         if has_tweak {
             // Pass the original constructor args so a `submethod TWEAK(:$y)`
             // signature binds them, matching the full `.new` path.
             match self.run_tweak_phase(class_name, attrs, args) {
                 Ok(updated) => attrs = updated,
                 Err(e) => return Some(Err(e)),
+            }
+            // Re-check `where` after TWEAK: the full constructor enforces
+            // constraints again post-TWEAK, so a TWEAK that mutates an attribute
+            // into a `where` violation is rejected identically.
+            if has_where
+                && let Err(e) =
+                    self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
+            {
+                return Some(Err(e));
             }
         }
         Some(Ok(Value::make_instance(class_name, attrs)))

--- a/t/native-where-construct.t
+++ b/t/native-where-construct.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# VM-native default construction now covers classes with `where`-constrained
+# attributes (Track A ③ constructor). The instance is assembled natively, then
+# `where` predicates are enforced as a post-assembly phase — at attribute
+# *assignment* time (before TWEAK), matching the full constructor and raku.
+
+plan 14;
+
+# --- a satisfied / violated where ---
+class Pos { has Int $.n where * > 0; }
+is Pos.new(n => 5).n, 5, 'a value satisfying its where is accepted';
+ok (try Pos.new(n => 3)).defined, 'positive value constructs';
+nok (try Pos.new(n => -1)).defined, 'a value failing its where is rejected';
+
+# --- where on a defaulted attribute ---
+class D { has Int $.x where * >= 0 = 10; }
+is D.new.x, 10, 'a default value that satisfies where is accepted';
+ok (try D.new).defined, 'defaulted where-attribute constructs';
+
+# --- untyped where ---
+class U { has $.s where *.chars > 2; }
+is U.new(s => "abc").s, "abc", 'untyped where on a string attribute';
+nok (try U.new(s => "a")).defined, 'short string fails the where';
+
+# --- multiple attributes, one constrained ---
+class M { has $.a; has Int $.b where * %% 2; }
+is M.new(a => 1, b => 4).b, 4, 'an even value satisfies %%2';
+nok (try M.new(a => 1, b => 3)).defined, 'an odd value fails %%2';
+
+# --- where is checked BEFORE TWEAK runs (assignment-time semantics) ---
+class T { has Int $.v where * > 100; submethod TWEAK { $!v = $!v * 1000 } }
+nok (try T.new(v => 1)).defined,
+    'where rejects at assignment time; a fixing TWEAK never runs';
+
+# --- a valid initial value lets TWEAK run, post-TWEAK still satisfies where ---
+class T2 { has Int $.v where * > 100; submethod TWEAK { $!v = $!v + 1 } }
+is T2.new(v => 200).v, 201, 'TWEAK runs when the initial value passes where';
+ok (try T2.new(v => 200)).defined, 'where + TWEAK constructs with a valid value';
+
+# --- a TWEAK that mutates INTO a violation is rejected post-TWEAK ---
+class T3 { has Int $.v where * > 100; submethod TWEAK { $!v = 1 } }
+nok (try T3.new(v => 200)).defined, 'TWEAK mutating into a where violation is rejected';
+
+# --- subset-typed attribute (where via a subset) ---
+subset Even of Int where * %% 2;
+class S { has Even $.e; }
+is S.new(e => 8).e, 8, 'subset-typed attribute accepts a matching value';


### PR DESCRIPTION
## Summary

Following the TWEAK constructor slice (#3028), a class with a `where`-constrained attribute was the next shape excluded from the native default constructor. Now it constructs natively (Track A ③ ctor).

```raku
class Pos { has Int $.n where * > 0; }
Pos.new(n => 5).n   # 5 — now 0 `new` interpreter fallbacks
Pos.new(n => -1)    # rejected
```

## How

- The gate (`is_native_default_constructible`) drops the `where_constraint.is_none()` requirement (the sigil/type shape must still be simple).
- The native builder runs `enforce_attribute_where_constraints` — the same predicate dispatch the full constructor uses — as a post-assembly phase.

## Ordering (matches raku + interpreter baseline)

`where` is enforced at attribute-**assignment** time, i.e. **before** TWEAK runs (a provided value that fails its `where` is rejected immediately; a "fixing" TWEAK never runs), and **re-checked after** TWEAK (a TWEAK that mutates an attribute into a violation is rejected post-TWEAK). I verified both orderings against raku and the pre-change interpreter baseline. The error message text is identical to the interpreter baseline (behavior-invariant; raku's exact wording differs but acceptance/rejection matches).

## Tests

New `t/native-where-construct.t` (14 subtests, all match raku including the before/after-TWEAK ordering and a subset-typed attribute). `make test` PASS. `S12-subset/subtypes.t` (non-whitelisted) keeps its identical pre-existing 13/90 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)