### PR TITLE
feat(③ ctor): native-construct classes with a BUILD submethod

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -554,6 +554,124 @@ impl Interpreter {
         Ok(attributes)
     }
 
+    /// Run the BUILD phase of construction: invoke every BUILD submethod (own and
+    /// role-composed) across the MRO in base-first order, threading the
+    /// (possibly mutated) attribute map and passing the constructor's named args.
+    /// Mirrors the BUILD loop in the full `.new` path, including its `fail`
+    /// semantics: a `fail` inside BUILD does not propagate as an error but yields
+    /// a `Failure` instance to return from `.new`. The result is therefore
+    /// `Ok(Ok(attrs))` on success, `Ok(Err(failure))` when a BUILD failed (the
+    /// caller returns that `Failure` value), or `Err(e)` for a real error.
+    /// Extracted so the native default constructor can reuse it (Track A ③ ctor).
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn run_build_phase(
+        &mut self,
+        class_name: Symbol,
+        mut attributes: HashMap<String, Value>,
+        build_args: &[Value],
+    ) -> Result<Result<HashMap<String, Value>, Value>, RuntimeError> {
+        let cn = class_name.resolve();
+        let mro = self.class_mro(&cn);
+        let class_lang_rev = self
+            .type_metadata
+            .get(&cn)
+            .and_then(|m| m.get("language-revision"))
+            .map(|v| v.to_string_value())
+            .unwrap_or_else(|| {
+                let version = crate::parser::current_language_version();
+                if let Some(rest) = version.strip_prefix("6.") {
+                    rest.chars().next().unwrap_or('c').to_string()
+                } else {
+                    "c".to_string()
+                }
+            });
+        let class_is_6e = class_lang_rev != "c";
+        for mro_class in mro.iter().rev() {
+            if mro_class == "Any" || mro_class == "Mu" {
+                continue;
+            }
+            if self.registry().roles.contains_key(mro_class)
+                && !self.registry().classes.contains_key(mro_class)
+            {
+                continue;
+            }
+            let class_has_own_build = self
+                .registry()
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get("BUILD"))
+                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                .unwrap_or(false);
+            let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
+            for (role_name, method_def) in role_order {
+                let role_base = role_name
+                    .split_once('[')
+                    .map(|(b, _)| b)
+                    .unwrap_or(&role_name);
+                let role_lang_rev = self
+                    .type_metadata
+                    .get(role_base)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "c".to_string());
+                if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
+                    continue;
+                }
+                let (_v, updated) = self.run_instance_method_resolved(
+                    &cn,
+                    &role_name,
+                    method_def,
+                    attributes.clone(),
+                    build_args.to_vec(),
+                    Some(Value::make_instance(class_name, attributes.clone())),
+                )?;
+                attributes = updated;
+            }
+            let has_non_submethod_build = self
+                .registry()
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get("BUILD"))
+                .map(|overloads| {
+                    overloads
+                        .iter()
+                        .any(|md| md.role_origin.is_none() || !md.is_my)
+                })
+                .unwrap_or(false);
+            if has_non_submethod_build {
+                match self.run_instance_method(
+                    mro_class,
+                    attributes.clone(),
+                    "BUILD",
+                    build_args.to_vec(),
+                    Some(Value::make_instance(class_name, attributes.clone())),
+                ) {
+                    Ok((_v, updated)) => {
+                        attributes = updated;
+                    }
+                    Err(err) if err.is_fail => {
+                        // `fail` inside BUILD yields a Failure, not an error.
+                        let ex = if let Some(exception) = err.exception {
+                            *exception
+                        } else {
+                            let mut ex_attrs = HashMap::new();
+                            ex_attrs.insert("message".to_string(), Value::str(err.message));
+                            Value::make_instance(Symbol::intern("X::AdHoc"), ex_attrs)
+                        };
+                        let mut failure_attrs = HashMap::new();
+                        failure_attrs.insert("exception".to_string(), ex);
+                        return Ok(Err(Value::make_instance(
+                            Symbol::intern("Failure"),
+                            failure_attrs,
+                        )));
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+        Ok(Ok(attributes))
+    }
+
     /// Dispatch Enum .new — should throw X::Constructor::BadType.
     /// Returns Some(err) if target is an enum, None otherwise.
     pub(super) fn dispatch_enum_new_check(

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -99,14 +99,17 @@ impl Interpreter {
                 // A non-class entry in the MRO (e.g. a role) — be conservative.
                 return false;
             };
-            // A `TWEAK` submethod is allowed: the native path assembles the
-            // instance as usual, then runs the TWEAK phase via the shared
-            // `run_tweak_phase` helper (same ordering/dispatch as the full
-            // constructor). `BUILD`/`BUILDALL`/custom `new` still fall through —
-            // BUILD runs *before* attribute defaults are finalized, which the
-            // native assembly order does not reproduce.
-            let simple = !class_def.methods.contains_key("BUILD")
-                && !class_def.methods.contains_key("BUILDALL")
+            // `TWEAK` and `BUILD` submethods are allowed: the native path
+            // assembles the instance as usual (defaults first, matching the
+            // interpreter's `.new` which also applies defaults before BUILD),
+            // then runs the BUILD and TWEAK phases via the shared
+            // `run_build_phase` / `run_tweak_phase` helpers (same ordering /
+            // dispatch / `fail` semantics as the full constructor). A custom
+            // `BUILDALL` (replaces the whole build plan) or custom `new` still
+            // fall through. A class with an unprovided `is required` or unset
+            // class-typed attribute also falls through at build time (it may be
+            // set by BUILD, which the conservative native path does not assume).
+            let simple = !class_def.methods.contains_key("BUILDALL")
                 && !class_def.methods.contains_key("new")
                 && class_def.native_methods.is_empty()
                 // No custom per-attribute build closure (`is built` trait or a
@@ -261,6 +264,16 @@ impl Interpreter {
         cn_resolved: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
+        // The default `.new` accepts only named arguments (`method new(*%_)`); a
+        // positional argument is an error (`X::Constructor::Positional`). The
+        // native path only consumes `Pair` (named) args, so a positional would be
+        // silently ignored — fall through to the interpreter, whose `.new`
+        // signature binding raises the proper error. (This also covers a BUILD
+        // with a positional parameter: `.new` strips positionals before BUILD, so
+        // `Foo.new('x', :y)` must die rather than feed 'x' to BUILD.)
+        if args.iter().any(|a| !matches!(a, Value::Pair(..))) {
+            return None;
+        }
         let class_attrs = self.collect_class_attributes(cn_resolved);
         // Attribute type constraints (MRO-wide) live in `attribute_types`, not in
         // the `ClassAttributeDef` tuple's constraint slot — and the gate already
@@ -276,8 +289,25 @@ impl Interpreter {
                 .unwrap_or('$')
         };
 
+        // A custom BUILD replaces the default named-argument → attribute binding:
+        // with a BUILD present, a provided `:attr(value)` is NOT auto-assigned to
+        // `$!attr` — only BUILD decides what gets set (via its signature's
+        // `:$!attr` params or explicit assignment in its body). So
+        // `class P { has $.x = 42; submethod BUILD() {} }; P.new(:666x).x` is 42.
+        // Skip the auto-assignment loop when the class has a BUILD; defaults are
+        // still filled below and BUILD runs afterward.
+        let has_build = self.mro_readonly(cn_resolved).iter().any(|cls| {
+            self.registry()
+                .classes
+                .get(cls)
+                .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+        });
+
         let mut attrs = HashMap::new();
         for arg in args {
+            if has_build {
+                break;
+            }
             if let Value::Pair(key, val) = arg
                 && self.is_attribute_buildable(cn_resolved, key)
             {
@@ -514,11 +544,12 @@ impl Interpreter {
         }
         // Add alias metadata for `has $x` (no twigil) attributes
         self.add_alias_attribute_metadata(cn_resolved, &mut attrs);
-        // Run the TWEAK phase if any class in the MRO declares one. The gate
-        // (`is_native_default_constructible`) allows TWEAK-only classes; the
-        // instance is fully assembled at this point, so running TWEAK here
-        // matches the full constructor (which runs it after attribute init).
-        // Cheap MRO check first so the common no-TWEAK case pays nothing extra.
+        // The gate (`is_native_default_constructible`) allows BUILD/TWEAK-only
+        // classes; the instance is assembled (defaults first) at this point, so
+        // running BUILD then TWEAK here matches the full `.new` path (which also
+        // applies defaults before BUILD). `has_build` was computed above (it
+        // gates the named-arg auto-assignment); the TWEAK check is cheap so the
+        // common no-submethod case pays nothing extra.
         let has_tweak = self.mro_readonly(cn_resolved).iter().any(|cls| {
             self.registry()
                 .classes
@@ -526,11 +557,10 @@ impl Interpreter {
                 .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
         });
         // Enforce `where` constraints at attribute-assignment time, i.e. *before*
-        // TWEAK runs — both raku and the interpreter reject a provided/defaulted
-        // value that fails its `where` at this point (a later TWEAK that would
-        // "fix" it never gets to run). `class_attrs` is the same
-        // `ClassAttributeDef` slice the interpreter uses, so the predicate
-        // dispatch is identical.
+        // BUILD/TWEAK run (matches the interpreter's pre-BUILD enforcement): a
+        // provided/defaulted value that fails its `where` is rejected here, and a
+        // later BUILD/TWEAK that would "fix" it never runs. `class_attrs` is the
+        // same `ClassAttributeDef` slice the interpreter uses.
         let has_where = class_attrs.iter().any(|(.., where_c)| where_c.is_some());
         if has_where
             && let Err(e) =
@@ -538,22 +568,32 @@ impl Interpreter {
         {
             return Some(Err(e));
         }
+        if has_build {
+            // Pass the original constructor args so `submethod BUILD(:$x)` binds
+            // them. A `fail` inside BUILD yields a `Failure` instance to return.
+            match self.run_build_phase(class_name, attrs, args) {
+                Ok(Ok(updated)) => attrs = updated,
+                Ok(Err(failure)) => return Some(Ok(failure)),
+                Err(e) => return Some(Err(e)),
+            }
+        }
         if has_tweak {
-            // Pass the original constructor args so a `submethod TWEAK(:$y)`
-            // signature binds them, matching the full `.new` path.
+            // Pass the original constructor args so `submethod TWEAK(:$y)` binds
+            // them, matching the full `.new` path.
             match self.run_tweak_phase(class_name, attrs, args) {
                 Ok(updated) => attrs = updated,
                 Err(e) => return Some(Err(e)),
             }
-            // Re-check `where` after TWEAK: the full constructor enforces
-            // constraints again post-TWEAK, so a TWEAK that mutates an attribute
-            // into a `where` violation is rejected identically.
-            if has_where
-                && let Err(e) =
-                    self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
-            {
-                return Some(Err(e));
-            }
+        }
+        // Re-check `where` after BUILD/TWEAK: the full constructor enforces
+        // constraints again post-construction, so a BUILD/TWEAK that mutates an
+        // attribute into a `where` violation is rejected identically.
+        if has_where
+            && (has_build || has_tweak)
+            && let Err(e) =
+                self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
+        {
+            return Some(Err(e));
         }
         Some(Ok(Value::make_instance(class_name, attrs)))
     }

--- a/t/native-build-construct.t
+++ b/t/native-build-construct.t
@@ -1,0 +1,73 @@
+use v6;
+use Test;
+
+# VM-native default construction now covers classes with a `BUILD` submethod
+# (Track A ③ constructor). The instance is assembled natively (defaults first,
+# matching the interpreter which also applies defaults before BUILD), then the
+# BUILD phase runs via the shared `run_build_phase` helper — same ordering /
+# dispatch / `fail` semantics as the full constructor. A custom BUILDALL/new
+# still falls through, as does a positional argument (`.new` is named-only).
+
+plan 17;
+
+# --- BUILD assigns from a named arg, with a default ---
+class P {
+    has $.a;
+    has $.b;
+    submethod BUILD(:$a = 1) { $!a = $a; $!b = $a + 100 }
+}
+is P.new(a => 5).a, 5, 'BUILD binds a provided named arg';
+is P.new(a => 5).b, 105, 'BUILD derives another attribute';
+is P.new.a, 1, 'BUILD uses its parameter default when arg omitted';
+is P.new.b, 101, 'BUILD-derived attribute with the default';
+
+# --- defaults are applied before BUILD; BUILD overrides ---
+class Y { has $.c = 99; submethod BUILD { $!c = 7 } }
+is Y.new.c, 7, 'BUILD overrides an attribute default';
+
+# --- an attribute BUILD does not touch keeps its default ---
+class DK { has $.a; has $.b = "kept"; submethod BUILD(:$a) { $!a = $a } }
+is DK.new(a => 1).b, "kept", 'a default BUILD does not touch is preserved';
+
+# --- `fail` inside BUILD yields a Failure, not a thrown error ---
+class F { has $.x; submethod BUILD(:$x) { fail "bad" if $x < 0; $!x = $x } }
+ok (try F.new(x => 5)).defined, 'BUILD succeeds for a valid value';
+my $r = F.new(x => -1);
+ok $r ~~ Failure, 'a `fail` inside BUILD returns a Failure';
+nok $r.defined, 'the returned Failure is undefined';
+
+# --- BUILD then TWEAK, in that order ---
+class BT {
+    has $.a;
+    has $.b;
+    submethod BUILD(:$a) { $!a = $a }
+    submethod TWEAK { $!b = $!a * 10 }
+}
+is BT.new(a => 3).b, 30, 'BUILD runs before TWEAK';
+
+# --- inheritance: base BUILD then child BUILD, base-first ---
+class Base2 { has $.tag; submethod BUILD { $!tag = "B" } }
+class Der is Base2 { submethod BUILD { } }
+is Der.new.tag, "B", 'base-class BUILD runs for a derived class';
+
+# --- a positional argument to .new is rejected (named-only constructor) ---
+class S { has $.x; }
+nok (try S.new("pos")).defined, 'a positional arg to .new is rejected';
+class Foo9 {
+    has $.a;
+    has $.b;
+    submethod BUILD($foo, :$bar) { $!a = $foo; $!b = $bar }
+}
+dies-ok { Foo9.new('pos', bar => 'd') },
+    'a positional to .new dies even when BUILD has a positional param';
+
+# --- named-only construction is unaffected ---
+class N2 { has $.v; submethod BUILD(:$v = 99) { $!v = $v } }
+is N2.new.v, 99, 'BUILD parameter default when omitted';
+is N2.new(v => 7).v, 7, 'BUILD parameter from a provided named arg';
+
+# --- a custom BUILD suppresses default named-arg -> attribute binding ---
+class Keep { has $.x = 42; submethod BUILD() { } }
+is Keep.new.x, 42, 'BUILD class keeps the attribute default';
+is Keep.new(x => 666).x, 42,
+    'explicitly setting an attr is ignored when BUILD does not bind it';


### PR DESCRIPTION
## Summary

Following the TWEAK (#3028) and where (#3030) constructor slices, a `submethod BUILD` was the next shape excluded from the native default constructor. Now a class whose only non-simple feature is BUILD (and/or TWEAK / where) constructs natively (Track A ③ ctor — the dominant `Package.new` interpreter fallback).

The native builder assembles the instance (defaults first — the interpreter's `.new` also applies defaults before BUILD), runs the BUILD phase, then TWEAK, with `where` enforced before and after. The BUILD loop is extracted from the full `.new` path into a shared `run_build_phase` helper, preserving its `fail` semantics (a `fail` inside BUILD yields a `Failure` instance, not a thrown error).

## Two subtle constructor semantics (each verified vs raku + interpreter baseline)

- **Named args are NOT auto-bound to attributes when a class has a custom BUILD.** Only BUILD decides what gets set, so `class P { has $.x = 42; submethod BUILD() {} }; P.new(:666x).x` is **42**, not 666. The native builder skips its named-arg auto-assignment loop when a BUILD is present. (Without this, the slice regresses the whitelisted `S12-construction/BUILD.t`.)

- **A positional argument to `.new` is rejected.** The default `.new` is named-only (`method new(*%_)`); a positional is `X::Constructor::Positional`. The native path only consumed `Pair` args, silently ignoring a positional — it now falls through so the interpreter's `.new` signature raises the proper error. This also fixes a **pre-existing** bug for simple native classes (`class S { has $.x }; S.new("pos")` wrongly succeeded) and makes `Foo.new('x', :y)` die when BUILD has a positional param.

A custom `BUILDALL`/`new`, an unprovided `is required` / unset class-typed attribute, and `is rw` attributes still fall through conservatively.

## Tests

New `t/native-build-construct.t` (17 subtests): named-arg binding & defaults, BUILD overriding defaults, `fail`→Failure, BUILD-before-TWEAK, inheritance, positional rejection, and the named-arg-suppression semantics. `make test` PASS; `S12-construction/BUILD.t` and the full S12/S14/S02-types whitelist class suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)