### PR TITLE
docs: record Track C Stage 1 (react/supply drive-loop unification) complete

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -180,52 +180,22 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             **残**: `state @`/`%`（配列/ハッシュ）のスレッド共有（要素セル＝Track B 依存）、
             lexical `@`/`%` 共有・複合代入（`+=`）のアトミック化。
       - [ ] **react/supply ランタイムの VM ネイティブ化**（`run_react_event_loop[_drain]` /
-            `run_whenever_with_value`）。**調査済み（2026-06-13、次セッションで実装）**:
-            - **重複の実態**: 「source 解決→event poll→body 実行→done/last/quit/close phaser」の駆動ループが
-              **4 箇所に二重化**: ① `run_react_event_loop`（`subtest.rs:180`、`ReactSubscription` struct）=
-              `react{}`、② `supply_promise_on_demand`（`native_supply_methods.rs:3542`、`SupplyPromiseSub`）=
-              `await $supply`、③ `native_supply` tap/act（同 515）、④ `native_supply_mut` tap/act（同 2663、
-              `$s.tap` が実際に効く方）。`native_supply_methods.rs` は 4070 行でその大半がこの二重化。
-            - **台帳の前提を訂正**: 「blocked-by: async state ownership (lever B)」は**部分的に誤り**。
-              supplier レジストリ・channel（`register_supplier_tap`/`supplier_snapshot`/`take_supply_channel`）は
-              `OnceLock` ベースの**プロセスグローバル static**（`native_methods/state.rs`/`state_supplier.rs`）で
-              Interpreter 非所有 ＝ VM から直接触れる。ループが Interpreter に縛られている真因は
-              `call_sub_value`（compiled body 実行）と `supply_emit_buffer`（emit 捕捉/subscription staging の Vec）
-              **だけ**。body callback は既に compiled sub。
-            - **既知のハング/バグ（2026-06-14、perf で診断）**:
-              - **[FIXED] on-demand supply + 内側 `done` の無限スピン**: `my $s = supply { whenever
-                Supply.interval(0.001) { done } }; react { whenever $s { } }` が単一 tap でも 100% CPU で
-                無限ループ（raku はミリ秒で完了）。これが `S17-supply/syntax.t` のテスト 71
-                （"No races/crashes around interval that emits done"、line 540-550 の 2000-react stress）の
-                ハング元で、debug でも release でも再現する**真の無限ループ**だった（メモリの「debug 限定の遅さ」
-                は誤り）。**真因**: parser の `rewrite_supply_body` が `supply{}` 内の `done` を
-                `$emitter.done()` に書き換える（正しい Raku セマンティクス＝その supply を完了）。
-                `run_react_event_loop` の on-demand 分岐は内側 whenever subscription をフラット化して直接
-                ポーリングするが、`run_on_demand_body(..., None)` と emitter_supplier_id を渡しておらず、
-                `$emitter.done()` が捨てられる Supplier の no-op になりループが止まらなかった。
-                **修正**（subtest.rs）: on-demand 分岐で emitter_supplier_id を採番し
-                `supplier_register_promise` で done-signal promise を事前登録（`supplier_done` が reset 前に
-                解決する＝Promise パスと同じ仕組み）、フラット化した各 `ReactSubscription` に
-                `on_demand_done` promise を紐付け、poll ループで `is_resolved()` を見て LAST 発火＋done。
-                検証: `t/supply-ondemand-interval-done.t`（mutsu/raku 両方 4/4）、whitelist S17-supply 53本(720)、
-                make test 461。syntax.t は 70→79 まで到達するように。
-              - **[残・別機能] 同期無限 supply body の backpressure**: syntax.t テスト 77-80+
-                （line 644-701、`supply { loop { emit(++$) } }` を `done if $n>=5` で消費）はまだ
-                ハング/失敗。on-demand body を**同期的に最後まで実行してバッファに集める**現方式では無限
-                ループになる。消費側が done したら次の `emit` で body を止める streaming/backpressure が必要で、
-                上記の async interval 修正とは構造的に別。Stage 2（VM 所有境界・streaming emit）で対応。
-            - **段階プラン**:
-              - **Stage 1（最初の PR・着手点）**: 4 駆動ループを**単一エンジン**へ統合。完了ポリシーを enum 化
-                （`React`=全 done まで / `Promise`=last value で resolve / `Tap`=永続 tap 登録）。
-                `native_supply`↔`native_supply_mut` の tap/act 二重化を削除し、`supply_promise_on_demand` と
-                `run_react_event_loop` を共有コアへ畳む。**削除機構＝2〜3 コピー分**（arch-first の主目的＝重複削除）。
-                VM 化の前提（4 コピーは移行できない、まず 1 つに）。既存 S17 ＋ `t/supply-await-static-whenever.t`/
-                `t/done-paren-stmt-modifier.t` で検証。高 blast-radius なので release CI を最終安全網に。
-              - **Stage 2**: 統合エンジンを VM 所有境界へ。ループが `Interpreter::call_sub_value` ではなく VM の
-                compiled-function dispatch を直接呼ぶ形にし、`supply_emit_buffer` staging を VM/グローバル側へ。
-                `ReactScope`/`WheneverScope` opcode が tree-walk 非経由で駆動 → 台帳から `run_react_event_loop`/
-                `run_whenever_with_value` 真フォールバック行を削除。
-              - **Stage 3**: `vm_register_ops.rs:1670` の `// TODO: compile to bytecode` 除去・台帳/PLAN 更新。
+            `run_whenever_with_value`）。**Stage 1 完了（#3027/#3029/#3031, 2026-06、詳細は
+            [news/2026-06.md](news/2026-06.md)）**: 4 箇所に二重化していた駆動ループを単一エンジンへ統合
+            （tap×2→1 #3010、react↔await-promise を `SupplyDrivePolicy { React, Promise }` enum +
+            `drive_react_subscriptions` へ #3027）、`SupplyPromiseSub` + 重複ポーリングループ削除、
+            `native_supply_methods.rs`(3671行)を6サブモジュールへ分割 #3031。残りは:
+            - **Stage 2（VM 所有境界・残）**: 精査済み(2026-06-14) — **ループ所有権の逆転**が必要。whenever body は
+              現状 `Stmt::Block` の AST のまま subscription に登録され `call_sub_value`→`eval_block_value` で
+              tree-walk される（これが消すべき真フォールバック）。native `.map` の前例
+              （VM 側ループが `VM::call_compiled_closure` で closure のバイトコードを実行）に倣う:
+              ① `exec_whenever_scope_op` で body を `CompiledCode` へコンパイルし `compiled_code` 付き SubData を作る、
+              ② `ReactSubscription` がその compiled SubData を保持、③ `drive_react_subscriptions` を VM 側へ移動し
+              `call_compiled_closure` で各 body を実行、④ `supply_emit_buffer`（Interpreter field, ~43 箇所）を
+              VM/グローバル側へ（supplier レジストリは既に OnceLock global ＝整合）、⑤ supplier-registry tap
+              callback も同様。複数PR規模・高リスク（並行コア）。詳細は台帳
+              [vm-interpreter-fallback-ledger.md](docs/vm-interpreter-fallback-ledger.md) の react-loop 行。
+            - **Stage 3**: `vm_register_ops.rs` の `// TODO: compile to bytecode` 除去・台帳/PLAN 更新。
       - [ ] **unsafe aliasing 撤廃**（ANALYSIS §2.3, `Arc::as_ptr as *mut` 11 箇所）— B の要素セル基盤の上で。
 
 #### Phase II（収束・逐次）: state 移管 → carrier 確定 → dual-store 削除 → Interpreter 撤去

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -35,7 +35,7 @@
 | ~~`vm_smart_match.rs` key-method~~ | ~~smartmatch のキーメソッド抽出~~ | — | **✅消化 (PR2)**: 統一 compiled-first へ |
 | ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`（list-like 受け手）~~ | — | **✅消化 (③ PR-8)**: `try_native_quanthash_coerce` で VM ネイティブ。pure 折り畳みは `builtins/quanthash_coerce` に一本化。`.MixHash`（型メタ登録）/ Instance/Package 受け手は interpreter 維持 |
 | `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |
-| `vm_register_ops.rs` react loop | `run_react_event_loop[_drain]` / `run_whenever_with_value` | MEDIUM-HARD | **訂正(2026-06-13)**: async レジストリはプロセスグローバル static で VM から触れる＝lever B 非依存。真因は `call_sub_value`＋`supply_emit_buffer` のみ。駆動ループが **4 箇所に二重化**（react / await-promise / tap×2）。Stage 1=単一エンジンへ統合（重複削除）→ Stage 2=VM 所有境界へ。詳細 [PLAN.md](../PLAN.md) Track C「react/supply ランタイムの VM ネイティブ化」 |
+| `vm_register_ops.rs` react loop | `run_react_event_loop[_drain]` / `run_whenever_with_value` | MEDIUM-HARD | **訂正(2026-06-13)**: async レジストリはプロセスグローバル static で VM から触れる＝lever B 非依存。真因は `call_sub_value`＋`supply_emit_buffer` のみ。駆動ループが **4 箇所に二重化**（react / await-promise / tap×2）。**Stage 1 = DONE（単一エンジン統合）**: tap×2→1 (#3010)、react↔await-promise を `SupplyDrivePolicy { React, Promise }` enum + `drive_react_subscriptions` へ統合 (#3027)、`SupplyPromiseSub` + 重複ポーリングループ削除。**Stage 2 = VM 所有境界（残）**: 精査済み(2026-06-14) — **ループ所有権の逆転**が必要。whenever body は現状 `Stmt::Block` の AST のまま登録され `eval_block_value` で tree-walk。native `.map` の前例(`VM::call_compiled_closure`)に倣い、body をコンパイル→ループを VM 側へ移動→`supply_emit_buffer` を global 側へ。複数PR規模・高リスク。詳細 [PLAN.md](../PLAN.md) Track C「react/supply ランタイムの VM ネイティブ化」 |
 
 ## §2 — 関数ディスパッチの真フォールバック（`call_function` / `call_function_fallback`）
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,29 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### トラック C: react/supply 駆動ループの単一エンジン統合（Stage 1 完了, #3027 / #3029 / #3031）
+
+react/supply ランタイムの「駆動ループ（source 解決 → イベント poll → body 実行 → done/last/quit/close）」は
+**4 箇所に二重実装**されていた（react / await-promise / tap×2）。これを単一エンジンへ統合する Stage 1 を完了。
+
+- **react↔await-promise 統合（#3027）**: 完了ポリシーを表す `enum SupplyDrivePolicy { React, Promise }` を
+  導入し、react のイベントループを `drive_react_subscriptions(subs, policy)` として抽出。`run_react_event_loop`
+  は subscription を組み立てて `Policy::React` で委譲、`supply_promise_on_demand`（`await $supply`）は
+  `ReactSubscription` を組み立てて `Policy::Promise` で委譲する。Promise 専用の独自ポーリングループと
+  `SupplyPromiseSub` 構造体（約90行）を削除。`React` は全 subscription を `run_react_consumer`（done/next/last
+  をマップ）で完了まで駆動し CLOSE phaser を発火、`Promise` は supply body の内側 `done` が supplier レジストリ
+  経由で promise を keep するか deadline まで駆動し最後の emit 値で keep する。
+- **ボイラープレート削減（#3029）**: `ReactSubscription` の構築8箇所が全15フィールドを毎回列挙していたのを
+  `ReactSubscription::new(callback)` + struct-update 構文へ（−56行）。
+- **god-file 分割（#3031）**: 3671行に肥大化した `native_supply_methods.rs` を機能別6サブモジュール
+  （dispatch / supplier / supply_mut / classify / promise / transform）へ分割し、共有ヘルパー + `QuitOutcome`
+  のみ189行で残した。純粋な move（メソッド数 26=26、private `fn`→`pub(super) fn` のみ）。
+
+**Stage 2（VM 所有境界）は精査済み・未着手**: whenever body が AST のまま tree-walk される真フォールバックを
+消すには、native `.map` の前例（`VM::call_compiled_closure`）に倣って **駆動ループを VM 側へ移動**する
+所有権逆転が必要で、複数PR規模・高リスク。台帳 [vm-interpreter-fallback-ledger.md](../docs/vm-interpreter-fallback-ledger.md)
+の react-loop 行に5ステップの実装計画を記録。
+
 ### トラック A §2: lexical `&`-var 名呼びの VM ネイティブ dispatch 完結（#2949 / #3021 / #3022 / #3024）
 
 `-> &op {...}` / `my &f = ...` のようにレキシカル束縛された Callable を `op(...)` と名前で呼ぶ経路を


### PR DESCRIPTION
## Summary

Records the react/supply VM-native **Stage 1** work that landed this session across the project docs.

- **news/2026-06.md** — new Track C highlight: the `SupplyDrivePolicy` drive-loop unification (#3027), `ReactSubscription::new` cleanup (#3029), and the `native_supply_methods.rs` split (#3031).
- **PLAN.md** — trims the now-completed Stage 1 detail (moved to news per the "PLAN = future tasks only" rule), keeps Stage 2/3 as remaining work, updated with the 2026-06-14 investigation finding: Stage 2 requires a loop-ownership inversion following the native `.map` / `call_compiled_closure` precedent.
- **vm-interpreter-fallback-ledger.md** — marks the react-loop row Stage 1 done and records the concrete 5-step Stage 2 plan.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)