### PR TITLE
feat(③ ctor): native-construct classes with :D/:U/:_ smiley attributes

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -304,6 +304,20 @@
   （pin 作成中に **連続 bare block `} { ` のパース不可**と **クラス名 `Q` のクォート演算子衝突**という 2 つの
   pre-existing パーサ制約に遭遇＝テストをトップレベル構造＋非衝突名に変更して回避。本 slice とは無関係。）
   **残: where・coercion 型・native 型・typed `@`/`%`・`is Type`・shaped は依然 interpreter。**
+- **2026-06-14 (③ ctor, §1 = native construction を定義性 smiley `:D`/`:U`/`:_` 属性へ拡張)**: TWEAK(#3028)/
+  where(#3030)/BUILD(#3032) に続く ctor slice。従来ゲートが `attribute_smileys.is_empty()` で reject していた
+  `has Int:D $.x` 等を native 構築。ゲートから smiley 検査を外し、build path で `enforce_attribute_smiley_constraints`
+  （full path と同一ヘルパ）を **where と同じ位置＝post-assembly/pre-BUILD で 1 回 + post-BUILD で再チェック**。
+  **interpreter baseline に厳密一致（raku ではなく）**: ① `:U` 提供 defined / `:D` 提供 undefined は die
+  （"default value of attribute" メッセージ＝interpreter の既存挙動。raku は "assignment to" だが本 slice の対象外の
+  pre-existing 差）、② **BUILD が smiley 違反 → die（post-BUILD 再チェック、full path 3929 に一致）**、
+  ③ **TWEAK が smiley 違反 → die しない**（interpreter は post-TWEAK で smiley を再チェックせず代入時チェックも
+  しないため、native も再チェックしない＝baseline 一致。raku は die）。bare `:D`（default 無し・required 無し）は
+  parse time に `X::Syntax::Variable::MissingInitializer` で弾かれ構築に到達しない。pin
+  `t/native-ctor-smiley-attrs.t`(21, `:D`/`:U`/`:_` × default/required/provided/継承/mixed/BUILD-dies/TWEAK-lives/
+  Str:D)。S12-attributes/smiley.t(54) + S12-class/attributes-required.t(11) 含む構築系 whitelist 118 件全緑、
+  cargo test 461/0、make test PASS。**残: coercion 型・native 型・typed `@`/`%`・`is Type`・shaped・同名再宣言・
+  does-Role 属性・CUnion・custom BUILDALL/new は依然 interpreter。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -184,8 +184,14 @@ impl Interpreter {
                     Self::is_simple_native_ctor_constraint(tc)
                         || Self::native_scalar_default(tc).is_some()
                         || Self::is_native_coercion_ctor_constraint(tc)
-                })
-                && class_def.attribute_smileys.is_empty();
+                });
+            // A definedness smiley (`:D`/`:U`/`:_`) on an attribute is allowed:
+            // the native builder runs `enforce_attribute_smiley_constraints`
+            // (the same predicate the full constructor uses) post-assembly and
+            // again after BUILD, matching the full path's enforcement points. A
+            // bare `:D` with no default and no `is required` is already a
+            // parse-time error (`X::Syntax::Variable::MissingInitializer`), so it
+            // never reaches here.
             if !simple {
                 return false;
             }
@@ -568,6 +574,21 @@ impl Interpreter {
         {
             return Some(Err(e));
         }
+        // Enforce definedness smileys (`:D`/`:U`) at the same point as `where`
+        // (post-assembly, pre-BUILD/TWEAK): a provided/defaulted value whose
+        // definedness does not match its `:D`/`:U` smiley is rejected here, exactly
+        // as the full constructor does (`enforce_attribute_smiley_constraints`,
+        // which itself skips `is required` attributes). `:_` imposes no constraint.
+        let has_smiley = self.mro_readonly(cn_resolved).iter().any(|cls| {
+            self.registry()
+                .classes
+                .get(cls)
+                .is_some_and(|cd| !cd.attribute_smileys.is_empty())
+        });
+        if has_smiley && let Err(e) = self.enforce_attribute_smiley_constraints(cn_resolved, &attrs)
+        {
+            return Some(Err(e));
+        }
         if has_build {
             // Pass the original constructor args so `submethod BUILD(:$x)` binds
             // them. A `fail` inside BUILD yields a `Failure` instance to return.
@@ -575,6 +596,18 @@ impl Interpreter {
                 Ok(Ok(updated)) => attrs = updated,
                 Ok(Err(failure)) => return Some(Ok(failure)),
                 Err(e) => return Some(Err(e)),
+            }
+            // Re-check smileys after BUILD but BEFORE TWEAK, exactly where the full
+            // constructor does (its post-BUILD pass) — a BUILD that mutates a
+            // `:D`/`:U` attribute into a definedness violation is rejected
+            // identically. The interpreter does NOT re-check smileys after TWEAK
+            // (it relies on the assignment-time check there, which mutsu's
+            // interpreter does not currently perform), so neither do we — a TWEAK
+            // that violates a smiley is left untouched to match the baseline.
+            if has_smiley
+                && let Err(e) = self.enforce_attribute_smiley_constraints(cn_resolved, &attrs)
+            {
+                return Some(Err(e));
             }
         }
         if has_tweak {

--- a/t/native-ctor-smiley-attrs.t
+++ b/t/native-ctor-smiley-attrs.t
@@ -1,0 +1,72 @@
+use Test;
+
+# Native default construction for classes whose attributes carry a definedness
+# smiley (`:D` / `:U` / `:_`). These used to fall through to the interpreter;
+# the native default constructor now enforces the smiley as a post-assembly
+# phase (the same `enforce_attribute_smiley_constraints` the full path uses).
+
+plan 21;
+
+# --- :D with a default (the default makes it defined) ---
+class CDef { has Int:D $.x = 9 }
+is CDef.new.x, 9, ':D attr with a default constructs natively';
+is CDef.new(:x(5)).x, 5, ':D attr accepts a provided defined value';
+
+# --- :D is required ---
+class CReq { has Int:D $.x is required }
+is CReq.new(:x(7)).x, 7, ':D required attr with a provided value';
+dies-ok { CReq.new }, ':D required attr without a value dies';
+
+# --- :D provided an undefined value dies ---
+class CUndef { has Int:D $.x = 1 }
+dies-ok { CUndef.new(:x(Int)) }, ':D attr rejects a provided type object';
+
+# --- :U ---
+class CU { has Int:U $.x }
+nok CU.new.x.defined, ':U attr defaults to a type object (undefined)';
+dies-ok { CU.new(:x(5)) }, ':U attr rejects a provided defined value';
+
+# --- :_ (no definedness constraint) ---
+class CAny { has Int:_ $.x }
+nok CAny.new.x.defined, ':_ attr defaults to a type object';
+is CAny.new(:x(3)).x, 3, ':_ attr accepts a defined value';
+
+# --- mixed: a plain attr alongside a :D attr ---
+class CMix { has $.name; has Int:D $.age = 0 }
+my $c = CMix.new(:name<bob>, :age(42));
+is $c.name, 'bob', 'mixed: plain attr set';
+is $c.age, 42, 'mixed: :D attr set';
+
+# --- inheritance: :D attr in a parent ---
+class P { has Int:D $.id = 1 }
+class Child is P { has $.tag }
+my $q = Child.new(:id(10), :tag<t>);
+is $q.id, 10, 'inherited :D attr set';
+is $q.tag, 't', 'child attr set';
+dies-ok { Child.new(:id(Int)) }, 'inherited :D attr rejects undefined';
+
+# --- :D with BUILD/TWEAK (smiley enforced before and after the phasers) ---
+class CTweak { has Int:D $.x = 1; submethod TWEAK { $!x = 100 } }
+is CTweak.new.x, 100, ':D attr with a TWEAK that keeps it defined';
+
+# A TWEAK that violates a :D attr is NOT re-checked (matches the interpreter
+# baseline, which relies on an assignment-time check mutsu does not perform).
+class CTweakBad { has Int:D $.x = 1; submethod TWEAK { $!x = Int } }
+lives-ok { CTweakBad.new }, 'TWEAK violating a :D attr is not re-checked (baseline parity)';
+
+class CBuild { has Int:D $.x = 1; submethod BUILD(:$y = 5) { $!x = $y } }
+is CBuild.new(:y(8)).x, 8, ':D attr with a BUILD that keeps it defined';
+
+# A BUILD that mutates a :D attribute into a violation is rejected (smileys are
+# re-checked after BUILD, matching the full constructor's post-BUILD pass).
+class CBuildBad { has Int:D $.x = 1; submethod BUILD { $!x = Int } }
+dies-ok { CBuildBad.new }, 'BUILD violating a :D attr dies (post-BUILD smiley re-check)';
+
+# --- :U constructs natively ---
+class CU2 { has Int:U $.x }
+isa-ok CU2.new, CU2, ':U attr constructs natively';
+
+# --- str:D native-typed smiley ---
+class CStr { has Str:D $.s = "hi" }
+is CStr.new.s, "hi", 'Str:D attr with a default';
+is CStr.new(:s<bye>).s, 'bye', 'Str:D attr provided';


### PR DESCRIPTION
## Summary

Following the TWEAK (#3028), `where` (#3030), and BUILD (#3032) constructor slices, a definedness smiley (`:D` / `:U` / `:_`) on an attribute was the next shape excluded from the native default constructor. Now a class whose only non-simple feature is a smiley (and/or `where` / BUILD / TWEAK) constructs natively (Track A ③ ctor — the dominant `Package.new` interpreter fallback).

The native builder enforces the smiley with the same `enforce_attribute_smiley_constraints` the full `.new` path uses, run at the same points: once post-assembly (alongside `where`, before BUILD/TWEAK) and again after BUILD. `:_` imposes no constraint; `is required` attributes are skipped by the helper itself.

## Matched against the interpreter baseline (not raku) per the dedup rule

- A provided defined value on `:U`, or a provided/defaulted undefined value on `:D`, **dies** with the interpreter's existing `"...default value of attribute..."` message (raku says `"...assignment to..."` — a pre-existing wording gap, out of scope here since the native path delegates to the same helper).
- A **BUILD** that mutates a `:D`/`:U` attribute into a violation **is rejected** (post-BUILD re-check, matching the full path's post-BUILD pass at `methods_object.rs:3929`).
- A **TWEAK** that violates a smiley is **NOT re-checked**: the interpreter does not re-enforce smileys after TWEAK and does not type-check the attribute assignment there, so the native path leaves it untouched to match the baseline (verified by stashing the change and comparing — interpreter prints `(Int)`, does not die).

A bare `:D` with no default and no `is required` never reaches construction — it is a parse-time `X::Syntax::Variable::MissingInitializer`.

## Tests

New `t/native-ctor-smiley-attrs.t` (21 subtests): `:D`/`:U`/`:_` with default / required / provided / inheritance / mixed attrs, BUILD-dies, TWEAK-lives, and `Str:D`. The whitelisted `S12-attributes/smiley.t` (54) and `S12-class/attributes-required.t` (11) — which directly exercise this path — stay green; construction-related whitelist (118 files) clean, `cargo test` 461/0, `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)