### PR TITLE
feat(③ ctor): native-construct classes with does Role attributes

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -76,16 +76,10 @@ impl Interpreter {
                 }
             }
         }
-        // An attribute with a `does Role` trait mixes the role into its value at
-        // construction (full path only) — fall through.
-        if self.mro_readonly(cn_resolved).iter().any(|cls| {
-            self.registry()
-                .class_attribute_does_roles
-                .keys()
-                .any(|(c, _)| c == cls)
-        }) {
-            return false;
-        }
+        // A `has $.x does Role` attribute is allowed: the native builder mixes
+        // the declared role(s) into the attribute value via the shared
+        // `apply_attribute_does_role_mixins` helper (same approximation as the
+        // full constructor), as a post-assembly phase.
         let mut has_attribute = false;
         for cls in self.mro_readonly(cn_resolved) {
             if cls == "Any" || cls == "Mu" || cls == "Cool" {
@@ -595,7 +589,43 @@ impl Interpreter {
         {
             return Some(Err(e));
         }
+        // Mix `has $.x does Role` roles into the final attribute values — the
+        // full constructor does this last (after BUILD/TWEAK), so do the same.
+        self.apply_attribute_does_role_mixins(cn_resolved, &mut attrs);
         Some(Ok(Value::make_instance(class_name, attrs)))
+    }
+
+    /// Apply `has $.x does Role` attribute traits: mix each declared role into
+    /// the attribute's value so `$o.x` does the role and `$o.x.method` dispatches
+    /// into it. (raku mixes into the Scalar *container*; mutsu has no
+    /// per-attribute container, so the value carries the mixin — enough for
+    /// method dispatch. This is a documented, pre-existing approximation; the
+    /// native and interpreter constructors share this helper so they stay
+    /// byte-identical.) Mixins are keyed `__mutsu_role__<Name>` with a marker
+    /// value; method dispatch resolves the role from the registry by that name.
+    pub(crate) fn apply_attribute_does_role_mixins(
+        &mut self,
+        class_key: &str,
+        attrs: &mut HashMap<String, Value>,
+    ) {
+        let mro = self.class_mro(class_key);
+        let does_attrs: Vec<(String, Vec<String>)> = self
+            .registry()
+            .class_attribute_does_roles
+            .iter()
+            .filter(|((c, _), _)| mro.contains(c))
+            .map(|((_, a), roles)| (a.clone(), roles.clone()))
+            .collect();
+        for (attr_name, roles) in does_attrs {
+            let Some(base) = attrs.get(&attr_name).cloned() else {
+                continue;
+            };
+            let mut mixins = HashMap::new();
+            for role in &roles {
+                mixins.insert(format!("__mutsu_role__{}", role), Value::Bool(true));
+            }
+            attrs.insert(attr_name, Value::mixin(base, mixins));
+        }
     }
 
     /// The `is Type` trait declared on an `@`/`%` attribute (`has @.a is Buf`),
@@ -4160,34 +4190,9 @@ impl Interpreter {
                         attrs.insert(attr_name.clone(), tagged);
                     }
                 }
-                // Apply `has $.x does Role` attribute traits: mix each declared
-                // role into the attribute's value so `$o.x` does the role and
-                // `$o.x.method` dispatches into it. (raku mixes into the Scalar
-                // *container*; mutsu has no per-attribute container, so the value
-                // carries the mixin — enough for method dispatch.)
-                {
-                    let mro = self.class_mro(class_key);
-                    let does_attrs: Vec<(String, Vec<String>)> = self
-                        .registry()
-                        .class_attribute_does_roles
-                        .iter()
-                        .filter(|((c, _), _)| mro.contains(c))
-                        .map(|((_, a), roles)| (a.clone(), roles.clone()))
-                        .collect();
-                    for (attr_name, roles) in does_attrs {
-                        let Some(base) = attrs.get(&attr_name).cloned() else {
-                            continue;
-                        };
-                        // Role mixins are keyed `__mutsu_role__<Name>` with a marker
-                        // value; method dispatch resolves the role from the registry
-                        // by that name (mirrors the `does`/role-pun construction).
-                        let mut mixins = HashMap::new();
-                        for role in &roles {
-                            mixins.insert(format!("__mutsu_role__{}", role), Value::Bool(true));
-                        }
-                        attrs.insert(attr_name, Value::mixin(base, mixins));
-                    }
-                }
+                // Apply `has $.x does Role` attribute traits (shared with the
+                // native default constructor).
+                self.apply_attribute_does_role_mixins(class_key, &mut attrs);
                 let mut instance = Value::make_instance(*class_name, attrs);
                 if let Some(type_args) = type_args.as_ref() {
                     if self.class_mro(class_key).iter().any(|n| n == "Array") {

--- a/t/native-doesrole-construct.t
+++ b/t/native-doesrole-construct.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# VM-native default construction now covers `has $.x does Role` attributes
+# (Track A ③ constructor). The native builder mixes each declared role into the
+# attribute's value via the shared `apply_attribute_does_role_mixins` helper —
+# the same approximation the full constructor uses (mutsu mixes into the value,
+# not the Scalar container; enough for method dispatch and `~~ Role`). The
+# native and interpreter paths share the helper, so they stay byte-identical.
+#
+# NOTE: this pins mutsu's *documented approximation*, NOT raku conformance.
+# Raku mixes the role into the (immutable) Scalar container, so providing or
+# defaulting a value on a `does Role` attribute raises "Cannot assign to an
+# immutable value" in raku. mutsu has no per-attribute container and carries the
+# mixin on the value instead, so it accepts the value. This test asserts that
+# mutsu's native constructor reproduces mutsu's interpreter behavior exactly.
+
+plan 11;
+
+role R1 { method m1 { "m1" } }
+role R2 { method m2 { "m2" } }
+
+# --- a single role mixed into an attribute value ---
+class A { has $.x does R1; }
+my $a = A.new(x => 42);
+is $a.x, 42, 'does-Role attribute keeps its provided value';
+is $a.x.m1, "m1", 'a role method dispatches into the attribute value';
+ok $a.x ~~ R1, 'the attribute value does the role';
+
+# --- multiple roles on one attribute ---
+class B { has $.y does R1 does R2; }
+my $b = B.new(y => "v");
+is $b.y.m1 ~ $b.y.m2, "m1m2", 'both roles are mixed into the attribute';
+ok $b.y ~~ R1 && $b.y ~~ R2, 'the value does both roles';
+
+# --- does-Role with a default value ---
+class C { has $.z does R1 = 100; }
+is C.new.z, 100, 'does-Role attribute uses its default';
+is C.new.z.m1, "m1", 'the default value still does the role';
+
+# --- does-Role alongside plain attributes ---
+class D { has $.a; has $.b does R1; }
+my $d = D.new(a => 1, b => 2);
+is $d.a, 1, 'a plain attribute is unaffected';
+is $d.b, 2, 'the does-Role attribute keeps its value';
+is $d.b.m1, "m1", 'only the does-Role attribute carries the mixin';
+nok $d.a ~~ R1, 'the plain attribute does not do the role';


### PR DESCRIPTION
## Summary

A `has $.x does Role` attribute was excluded from the native default constructor (Track A ③ ctor). Now such a class constructs natively: the native builder mixes the declared role(s) into the attribute value as a post-assembly phase, via a shared `apply_attribute_does_role_mixins` helper extracted from the full `.new` path. Both constructors call the same helper, so the native and interpreter results are **byte-identical** (verified: single role, multiple roles, default value, and alongside plain attributes all match the interpreter baseline exactly).

## Behavior-invariance (not raku conformance)

This preserves mutsu's existing, **documented approximation** of `does Role` attributes: raku mixes the role into the (immutable) Scalar *container*, while mutsu has no per-attribute container and carries the mixin on the value instead — enough for method dispatch (`$o.x.meth`) and `~~ Role`. The slice is behavior-invariant against the interpreter (the design principle); the raku divergence (raku raises "Cannot assign to an immutable value" when a `does Role` attribute is given or defaulted a value) is pre-existing and unchanged.

## Details

Removes the `class_attribute_does_roles` gate exclusion; the role mixin runs last (after BUILD/TWEAK/where), matching the full constructor's ordering. Zero `new` interpreter fallback for does-Role class construction.

New `t/native-doesrole-construct.t` (11 subtests, pinning the native==interpreter behavior — its header documents the raku divergence). `make test` PASS; the full S12/S14-roles whitelist class suite is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)