### PR TITLE
docs: record ctor native-construction 2nd wave (#3028-3036) + re-measurement

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -319,6 +319,23 @@
   cargo test 461/0、make test PASS。**残: coercion 型・native 型・typed `@`/`%`・`is Type`・shaped・同名再宣言・
   does-Role 属性・CUnion・custom BUILDALL/new は依然 interpreter。**
 
+- **2026-06-14 (③ ctor 第2波 = post-assembly フェーズ方式, #3028〜3036)**: 「pure-data only」原則を破り、pure-data
+  組み立て後に **submethod 実行 / 制約検証 / role mixin を post-assembly フェーズ**として走らせて user-code-running shape も
+  native 化。`.new` 本経路の各フェーズを共有ヘルパに抽出（`run_tweak_phase`/`run_build_phase`/`enforce_attribute_where_constraints`/
+  `apply_attribute_does_role_mixins`）し interpreter/native 両方から呼んで byte-identical 保証。**TWEAK(#3028)**（`TWEAK(:$y)`
+  引数渡し＝コンストラクタ2系統で扱い違い）→ **where(#3030)**（TWEAK 前後両方で enforce＝assignment-time セマンティクス）→
+  **BUILD(#3032)**（`fail`→Failure / カスタム BUILD で named-arg 自動代入抑制 / positional 拒否＝`S.new("pos")` pre-existing バグ
+  も修正）→ **is-rw(#3034)**（`ClassAttributeDef` pos3=is_rw を is_required と誤読していたバグ修正、未提供 is-rw が native 化＋
+  `@`/`%` required 強制も正しく）→ **does-Role(#3036)**（role を属性値に mixin、raku 非準拠の文書化済み近似なので native==interpreter
+  で検証）。各 pin テスト（`t/native-{tweak,where,build,isrw,doesrole}-construct.t`）。S12/S14 whitelist 全緑、make test PASS。
+  **★再計測（重要）**: ctor 5スライス後も whitelist sample の `new` method fallback はほぼ不変（5230→5225）。**大半（4686）は
+  単一テスト `S03-buf/read-write-bits.t` の `Buf.new`＝組み込み型コンストラクタ**（`is_native_default_constructible` は user 定義
+  `registry().classes` のみ対象なので正しく対象外）。**＝ユーザークラス ctor native 化は完遂。これ以上 ctor を削っても `new`
+  fallback 数は動かない。** 次の実質ターゲットは別カテゴリ: **組み込み型 `.new`**（Buf.new 等）/ **`name`=3257（MOP）** /
+  **`op`=1418（Routine 値 lexical &-var `&infix:<(|)>` 束縛、今回の Sub/WeakSub 限定 fix の除外分）** / iterator push-* protocol
+  （Track B）/ coercion（builtins 降ろし）。残る ctor 難ケース: required-after-BUILD / 未設定 class-typed + BUILD / `is built`/
+  MOP set_build / BUILDALL / custom new / CUnion。
+
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
 すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -507,9 +507,33 @@ interpreter に委ね behavior-invariant（対象は raku ではなく現 interp
   クラッシュ regression（finalize pass を leaf まで再帰）②is-Type provided coercion（`has @.a is Buf` 提供値を
   `coerce_value_to_is_type` で declared 型へ）。
 
-**§1 ctor の結論**: pure-data で構築できる属性 shape（untyped/typed `$`・`@`/`%`・native 型・coercion 型・required）は
-カバー完了。残る shape（is-Type/shaped/where/native-element-container）は**いずれも interpreter method dispatch /
-user code 実行に依存**し、保守的 pure-data 原則では native 化できない → phase ④（method dispatch 自体の native 化）後。
+**§1 ctor の結論（#2826〜2844 時点）**: pure-data で構築できる属性 shape（untyped/typed `$`・`@`/`%`・native 型・
+coercion 型・required）はカバー完了。残る shape（is-Type/shaped/where/native-element-container）は当時「interpreter
+method dispatch / user code 実行に依存し pure-data 原則では native 化できない」と判断 → phase ④ 待ちとした。
+
+### Package.new コンストラクタの native 化 第2波: post-assembly フェーズ方式（#3028〜3036, 2026-06-14）
+上記の「pure-data only 原則」を破り、**インスタンスを pure-data 組み立てした後に submethod 実行・制約検証・role mixin を
+post-assembly フェーズとして走らせる**手法を確立。これで user code を走らせる shape も native 化できた。`.new` 本経路の
+各フェーズを共有ヘルパに抽出（dedup）し interpreter/native 両方から呼んで byte-identical を保証。
+- **TWEAK (#3028)**: `submethod TWEAK` を `run_tweak_phase` で post-assembly 実行。`TWEAK(:$y)` への引数渡しが
+  必要（コンストラクタ経路は2系統＝`self.bless`/`.new` 本体で引数の扱いが違う）。
+- **where (#3030)**: `enforce_attribute_where_constraints` を post-check。**TWEAK の前（代入時）と後の両方**でチェック
+  （raku/interpreter 一致＝where は assignment-time セマンティクス）。
+- **BUILD (#3032)**: `run_build_phase`（`fail`→Failure 返し）。**カスタム BUILD ありで named 引数の属性自動代入は抑制**
+  （`P.new(:666x)` で x=42 のまま）＋**positional 引数は `.new` が拒否**（pre-existing バグ `S.new("pos")` 誤受理も修正）。
+- **is rw (#3034)**: `ClassAttributeDef` タプルのフィールド取り違え修正（pos3=is_rw を is_required と誤読していた）。
+  未提供 is-rw が native 化、付随的に `@`/`%` の `is required` 強制も正しく。
+- **does Role (#3036)**: `apply_attribute_does_role_mixins` で role を属性値に mixin。**mutsu の does-Role は raku 非準拠の
+  文書化済み近似**（raku は immutable コンテナに mixin）なので検証は native==interpreter で実施。
+
+**第2波の結論**: ユーザークラスの `.new` 主要 shape（BUILD/TWEAK/where/is-rw/does-Role）はほぼ native 化完了。
+**再計測（セッション末）**: whitelist サンプルの `new` method fallback はほぼ不変（5230→5225）だが、その大半（4686）は
+**`Buf.new`＝組み込み型コンストラクタ**（`read-write-bits.t`）でユーザークラスではない。＝ユーザークラス ctor の native 化は
+完遂、これ以上 ctor を削っても `new` fallback 数は動かない。次の実質ターゲットは別カテゴリ（組み込み型 `.new` / MOP `name`
+=3257 / Routine 値 lexical &-var `op`=1418 / iterator push-* protocol / coercion）。
+
+**旧 §1 ctor の結論（#2826〜2844 時点）の残 shape**: is-Type/shaped/native-element-container は依然 interpreter
+（型/Array の `.new` ディスパッチ依存）。where は #3030 で解決済み。
 
 **重要な現状認識**: §1/§2 の「安い native 化」は枯渇した。残るフォールバックは全て構造的ブロッカー
 （③ state 所有 / 第一級コンテナ Phase 2 / lever B 並行）が前提。次の実質進捗はこれら 3 つの構造リファクタであり、


### PR DESCRIPTION
Docs-only. Records the post-assembly-phase constructor native-ization campaign (TWEAK/where/BUILD/is-rw/does-Role, #3028–3036) in `news/2026-06.md` and the fallback ledger.

Key finding from the session-end re-measurement: user-class `.new` native-ization is effectively complete — the remaining bulk of the `new` method fallback (4686 of 5225 in the whitelist sample) is `Buf.new`, a **builtin-type** constructor, not a user class (`is_native_default_constructible` correctly only covers user-defined `registry().classes`). The doc notes the next real targets: builtin-type `.new`, MOP `name`, Routine-valued lexical `&`-var (`op`), iterator push-* protocol, and coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)