### PR TITLE
feat(③ ctor): native-construct unset class-typed and required attributes

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -127,9 +127,10 @@ impl Interpreter {
                         // - `@`/`%`: only untyped with no `is Type` trait — typed
                         //   elements need container type metadata and `is Type`
                         //   builds a typed container, both interpreter-owned.
-                        // `is required` is allowed through: an unprovided required
-                        // attribute falls through at build time (the interpreter
-                        // raises X::Attribute::Required).
+                        // `is required` is allowed through: the native builder
+                        // raises `X::Attribute::Required` itself for an unprovided
+                        // required attribute (before defaults when there is no
+                        // BUILD, or after BUILD when there is one).
                         // A `where` clause is allowed: the native builder runs
                         // `enforce_attribute_where_constraints` as a post-assembly
                         // phase (same predicate dispatch as the full constructor).
@@ -342,31 +343,35 @@ impl Interpreter {
                 }
             }
         }
-        // A required attribute that was not provided is `X::Attribute::Required`
-        // — let the interpreter raise it. The required flag is tuple field 4
-        // (`Option<Option<String>>`: `Some` when `is required`); field 3 is
+        // A required attribute not supplied as a named arg. Without a BUILD it
+        // can never be set, so raise `X::Attribute::Required` now — exactly the
+        // interpreter's pre-defaults required check. With a BUILD, defer: BUILD
+        // may set it, and the post-BUILD required check below enforces it. The
+        // required flag is tuple field 4 (`Option<Option<String>>`: `Some` when
+        // `is required`, the inner value being the optional reason); field 3 is
         // `is_rw`, which must NOT gate construction (an unprovided `is rw`
         // attribute just gets its normal default, so it stays native).
-        for (attr_name, _, _, _is_rw, is_required, _, _) in &class_attrs {
-            if is_required.is_some() && !attrs.contains_key(attr_name) {
-                return None;
+        if !has_build {
+            for (attr_name, _, _, _is_rw, is_required, _, _) in &class_attrs {
+                if let Some(reason) = is_required
+                    && !attrs.contains_key(attr_name)
+                {
+                    let attr_full_name = format!("$!{}", attr_name);
+                    return Some(Err(RuntimeError::attribute_required(
+                        &attr_full_name,
+                        reason.as_deref(),
+                    )));
+                }
             }
         }
         // A class-typed `$` attribute that is neither provided nor defaulted is
-        // initialized to its *type object* (e.g. `Int`), not `Nil`. Let the
-        // interpreter synthesize it. Native-typed attributes (`int`/`num`/`str`)
-        // are the exception: they default to a native zero (handled in the fill
-        // loop below), not a type object, so they stay native.
-        for (attr_name, _, default_expr, _, _, _, _) in &class_attrs {
-            if default_expr.is_none()
-                && !attrs.contains_key(attr_name)
-                && type_constraints
-                    .get(attr_name)
-                    .is_some_and(|c| Self::native_scalar_default(c).is_none())
-            {
-                return None;
-            }
-        }
+        // stored as `Nil` (exactly as the interpreter does); the attribute
+        // accessor synthesizes the declared *type object* (e.g. `Int`) from the
+        // stored `Nil` at read time, so the native instance behaves identically.
+        // The empty-fill loop below stores that `Nil` (native-typed `int`/`num`/
+        // `str` attributes get their native zero there instead). A `where` /
+        // `:D`/`:U` / element type check all skip a `Nil` value, matching the
+        // interpreter, so nothing further is needed here.
         // An `@`/`%` attribute with a default expression may be shaped (the
         // shape is encoded in the default, e.g. `has @.a[2]`) or otherwise need
         // the interpreter's construction — fall through whether or not it was
@@ -593,6 +598,22 @@ impl Interpreter {
                 Ok(Ok(updated)) => attrs = updated,
                 Ok(Err(failure)) => return Some(Ok(failure)),
                 Err(e) => return Some(Err(e)),
+            }
+            // Enforce required attributes after BUILD ran (BUILD may set them),
+            // exactly where the full constructor does its post-BUILD required
+            // check. A still-unset attribute (`None` or `Nil`) raises
+            // `X::Attribute::Required` with the same message and reason.
+            for (attr_name, _, _, _, is_required, _, _) in &class_attrs {
+                if let Some(reason) = is_required {
+                    let is_set = !matches!(attrs.get(attr_name), Some(Value::Nil) | None);
+                    if !is_set {
+                        let attr_full_name = format!("$!{}", attr_name);
+                        return Some(Err(RuntimeError::attribute_required(
+                            &attr_full_name,
+                            reason.as_deref(),
+                        )));
+                    }
+                }
             }
             // Re-check smileys after BUILD but BEFORE TWEAK, exactly where the full
             // constructor does (its post-BUILD pass) — a BUILD that mutates a

--- a/t/native-required-classtyped-construct.t
+++ b/t/native-required-classtyped-construct.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# VM-native default construction now covers two more attribute shapes
+# (Track A ③ constructor):
+#   1. A class-typed `$` attribute left unprovided and undefaulted — stored as
+#      `Nil`, with the declared *type object* synthesized at read time, exactly
+#      as the interpreter does (and as raku does).
+#   2. An `is required` attribute — the native builder raises
+#      `X::Attribute::Required` itself: before defaults when there is no BUILD,
+#      and after BUILD when a BUILD submethod has a chance to set it.
+
+plan 21;
+
+# --- class-typed `$` unset -> declared type object, undefined ---
+class C1 { has Int $.x; }
+is C1.new.x.^name, 'Int', 'unset Int attribute reads as its type object';
+nok C1.new.x.defined, 'unset Int attribute is undefined';
+
+class C2 { has Str $.s; has Int $.n; }
+my $o = C2.new;
+is $o.s.^name, 'Str', 'unset Str attribute type object';
+is $o.n.^name, 'Int', 'unset Int attribute type object';
+nok $o.s.defined, 'unset Str undefined';
+
+# --- subtype/class type unset ---
+class C3 { has Numeric $.v; }
+is C3.new.v.^name, 'Numeric', 'unset Numeric attribute type object';
+
+# --- mixed: one provided, one unset ---
+class C4 { has Int $.a; has Int $.b; }
+my $m = C4.new(a => 7);
+is $m.a, 7, 'provided typed attribute';
+is $m.b.^name, 'Int', 'sibling unset typed attribute is a type object';
+nok $m.b.defined, 'sibling unset typed attribute undefined';
+
+# --- inheritance: parent class-typed attr unset ---
+class PBase { has Str $.name; }
+class QDer is PBase { has Int $.age; }
+my $q = QDer.new(age => 5);
+is $q.name.^name, 'Str', 'inherited unset typed attribute type object';
+is $q.age, 5, 'own provided typed attribute';
+
+# --- introspect the stored value is the type object (read synthesis) ---
+class C5 { has Int $.k; method peek() { $!k.^name } }
+is C5.new.peek, 'Int', 'attribute read inside a method synthesizes the type object';
+
+# --- required, no BUILD: not provided dies; provided lives ---
+class R1 { has $.r is required; }
+dies-ok { R1.new }, 'unprovided required attribute (no BUILD) dies';
+is R1.new(r => 9).r, 9, 'provided required attribute constructs';
+
+# --- required failure names the attribute and is the right exception type ---
+# (mutsu does not currently thread the optional `is required(reason)` text into
+# the message — a pre-existing parser limitation shared by the interpreter — so
+# we assert the attribute name and exception type, which the native path does
+# preserve byte-identically.)
+class R2 { has $.x is required; }
+my $err = (try { R2.new; "" }) // $!;
+like $!.message, /'$!x'/, 'required failure names the attribute';
+isa-ok $!, X::Attribute::Required, 'required failure is X::Attribute::Required';
+
+# --- required + BUILD that sets it -> lives ---
+class B1 { has $.x is required; submethod BUILD(:$x) { $!x = $x // 5 } }
+is B1.new.x, 5, 'BUILD satisfies a required attribute (default)';
+is B1.new(x => 8).x, 8, 'BUILD satisfies a required attribute (provided)';
+
+# --- required + BUILD that does NOT set it -> dies after BUILD ---
+class B2 { has $.x is required; submethod BUILD() { } }
+dies-ok { B2.new }, 'required attribute unset by BUILD dies post-BUILD';
+
+# --- required + TWEAK (no BUILD): required still enforced pre-TWEAK ---
+class T1 { has $.x is required; submethod TWEAK() { } }
+dies-ok { T1.new }, 'required attribute with only a TWEAK still dies';
+
+# --- required typed attribute provided ---
+class R3 { has Int $.n is required; }
+is R3.new(n => 3).n, 3, 'required typed attribute provided constructs';


### PR DESCRIPTION
## Summary

Two more attribute shapes now build through the **native default constructor** (Track A ③ constructor) instead of falling through to the interpreter:

1. **Unset class-typed `$`** (`has Int \$.x`, `C.new`) — stored as `Nil`, exactly as the interpreter does. The accessor synthesizes the declared type object (`Int`) from `Nil` at read time, and every post-assembly check (`where`, `:D`/`:U`, element type) already skips `Nil`, so the native instance is byte-identical. Native scalars (`int`/`num`/`str`) keep their native-zero default.

2. **`is required`** — now enforced by the native builder itself:
   - **no BUILD** → raises `X::Attribute::Required` before defaults (the interpreter's pre-defaults check).
   - **with BUILD** → defers, then re-checks after BUILD ran (BUILD may set it), matching the full constructor's post-BUILD required check (including the `None`/`Nil` "unset" test).

## Behavior-invariance

The optional `is required(reason)` text is still dropped from the message — a pre-existing parser limitation **shared by the interpreter** — so this stays behavior-invariant against the current interpreter (verified by an interpreter-vs-native `diff` across all edge cases). The only raku divergence exercised (a `where`-constrained unset attribute) is a pre-existing interpreter bug reproduced identically on both paths.

## Tests

- `t/native-required-classtyped-construct.t` (21) — passes on both raku and mutsu.
- Existing whitelisted suites (`S12-class/attributes-required.t`, `S12-class/attributes.t`, `S12-attributes/*`, `S12-construction/*`, `S02-types/int-uint.t`, `signed-unsigned-native.t`) all still pass; the two pre-existing non-whitelisted FAILs (`S12-attributes/class.t`, `trusts.t`) are unchanged (same failing subtests before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)