### PR TITLE
feat(③ ctor): native-construct `repr('CUnion')` classes

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -246,6 +246,17 @@ impl Interpreter {
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
         let cn_resolved = class_name.resolve();
+        // A `repr('CUnion')` class constructs via a byte overlay
+        // (`construct_cunion_instance`): its native-int fields share the same
+        // underlying bytes. The interpreter's `dispatch_new` does *nothing else*
+        // for a CUnion class (no BUILD/TWEAK/required), so run that exact shared
+        // helper here and skip the interpreter round-trip. `is_native_default_
+        // constructible` still rejects CUnion classes, keeping
+        // `build_native_default_instance` (plain per-attribute assignment) from
+        // ever touching the byte overlay.
+        if self.registry().cunion_classes.contains(&cn_resolved) {
+            return Some(self.construct_cunion_instance(&cn_resolved, args));
+        }
         if !self.is_native_default_constructible(&cn_resolved) {
             return None;
         }

--- a/t/native-cunion-construct.t
+++ b/t/native-cunion-construct.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# VM-native default construction now also covers `repr('CUnion')` classes
+# (Track A ③ constructor). A CUnion lays all its native-int fields over the
+# same little-endian bytes, so it constructs through the dedicated
+# `construct_cunion_instance` byte-overlay helper. The interpreter's
+# `dispatch_new` does nothing else for a CUnion class (no BUILD/TWEAK/required),
+# so the native fast path runs that exact shared helper and skips the
+# interpreter round-trip — byte-identical to the interpreter and to raku.
+
+plan 11;
+
+class U is repr('CUnion') {
+    has uint8  $.byte;
+    has uint16 $.word;
+    has uint32 $.dword;
+}
+
+# --- the widest field sets the shared bytes; narrower fields read low bytes ---
+my $a = U.new(dword => 0x12345678);
+is $a.dword, 0x12345678, 'dword reads the full value';
+is $a.word, 0x5678, 'word reads the low 16 bits';
+is $a.byte, 0x78, 'byte reads the low 8 bits';
+
+# --- setting the narrowest field overlays just the low byte ---
+my $b = U.new(byte => 0xFF);
+is $b.byte, 0xFF, 'byte field set';
+is $b.word, 0xFF, 'word shares the low byte';
+is $b.dword, 0xFF, 'dword shares the low byte';
+
+# --- no argument: all fields are zero ---
+my $z = U.new;
+is $z.byte, 0, 'unset byte is 0';
+is $z.word, 0, 'unset word is 0';
+is $z.dword, 0, 'unset dword is 0';
+
+# --- a 16-bit write leaves the high bytes of the 32-bit view clear ---
+my $c = U.new(word => 0xABCD);
+is $c.word, 0xABCD, 'word field set';
+is $c.dword, 0xABCD, 'dword sees only the low 16 bits';


### PR DESCRIPTION
## Summary

A `repr('CUnion')` class lays all its native-int fields over the same little-endian bytes, so it constructs through the dedicated `construct_cunion_instance` byte-overlay helper rather than plain per-attribute assignment. The interpreter's `dispatch_new` does **nothing else** for a CUnion class (no BUILD/TWEAK/required), so the native fast path (`try_native_default_construct`) now runs that exact shared helper and returns, skipping the interpreter round-trip.

`is_native_default_constructible` still rejects CUnion classes, so `build_native_default_instance` (plain per-attribute data assembly) never touches the byte overlay — the CUnion branch sits ahead of that gate.

## Behavior-invariance

The native path calls the same `construct_cunion_instance` the interpreter does, so the produced instance is byte-identical (verified by a before/after `diff` and against raku). `roast/S02-types/int-uint.t` (the only CUnion roast test, whitelisted) still passes, as do `signed-unsigned-native.t` and `S12-attributes/native.t`.

## Tests

- `t/native-cunion-construct.t` (11) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)