### PR TITLE
feat(③ ctor): VM-native `Buf`/`Blob` construction

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -770,6 +770,98 @@ impl Interpreter {
         }
     }
 
+    /// True for the buf/blob type names `build_native_buf_value` constructs as a
+    /// pure byte overlay — every `Buf`/`Blob` flavour (`Buf`, `buf8`..`buf64`,
+    /// `Blob`, `blob8`..`blob64`, and the parametric `Buf[uintN]`/`Blob[uintN]`
+    /// forms) EXCEPT `utf8`/`utf16`, which `dispatch_new` builds via a different
+    /// (unmasked) arm and must keep on the interpreter. Used by the VM to route
+    /// `Buf.new(...)` to the native builder instead of the generic dispatch.
+    pub(crate) fn is_native_buf_constructible(cn: &str) -> bool {
+        cn != "utf8" && cn != "utf16" && crate::runtime::utils::is_buf_or_blob_class(cn)
+    }
+
+    /// Build a `Buf`/`Blob` instance from `.new` arguments as pure data: flatten
+    /// each argument into a byte sequence, mask every value to the element width
+    /// inferred from the type name (`uint8`/`16`/`32`/`64`), and tag the
+    /// canonical parametric class name (`buf8` -> `Buf[uint8]`, …). Touches no
+    /// env / registry, so the VM constructs these directly (see
+    /// `is_native_buf_constructible`) without entering generic dispatch, while
+    /// `dispatch_new`'s Buf/Blob arm calls the same helper — keeping the two
+    /// byte-identical. `utf8`/`utf16` are intentionally NOT handled here.
+    pub(crate) fn build_native_buf_value(class_name: Symbol, args: &[Value]) -> Value {
+        let cn = class_name.resolve();
+        let raw_vals: Vec<Value> = args
+            .iter()
+            .flat_map(|a| match a {
+                Value::Int(i) => vec![Value::Int(*i)],
+                Value::Array(items, ..) => items.to_vec(),
+                Value::Seq(items) => items.to_vec(),
+                Value::Slip(items) => items.to_vec(),
+                Value::Range(start, end) => (*start..=*end).map(Value::Int).collect(),
+                Value::RangeExcl(start, end) => (*start..*end).map(Value::Int).collect(),
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if class_name == "Buf"
+                    || class_name == "Blob"
+                    || class_name == "utf8"
+                    || class_name == "utf16"
+                    || class_name.resolve().starts_with("Buf[")
+                    || class_name.resolve().starts_with("Blob[")
+                    || class_name.resolve().starts_with("buf")
+                    || class_name.resolve().starts_with("blob") =>
+                {
+                    if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
+                        items.to_vec()
+                    } else {
+                        Vec::new()
+                    }
+                }
+                Value::BigInt(_) => vec![a.clone()],
+                other => vec![Value::Int(to_int(other))],
+            })
+            .collect();
+        // Mask values to unsigned range based on element size. For uint64, use
+        // BigInt-aware conversion to preserve values > i64::MAX.
+        let byte_vals: Vec<Value> = raw_vals
+            .into_iter()
+            .map(|v| {
+                if cn.contains("64") {
+                    let u = match &v {
+                        Value::BigInt(n) => {
+                            use num_traits::ToPrimitive;
+                            n.as_ref().to_u64().unwrap_or(to_int(&v) as u64)
+                        }
+                        _ => to_int(&v) as u64,
+                    };
+                    Value::Int(u as i64)
+                } else if cn.contains("32") {
+                    Value::Int(to_int(&v) as u32 as i64)
+                } else if cn.contains("16") {
+                    Value::Int(to_int(&v) as u16 as i64)
+                } else {
+                    Value::Int(to_int(&v) as u8 as i64)
+                }
+            })
+            .collect();
+        let mut attrs = HashMap::new();
+        attrs.insert("bytes".to_string(), Value::array(byte_vals));
+        // Normalize short buf/blob names to canonical forms.
+        let canonical_name = match cn.as_str() {
+            "buf8" => Symbol::intern("Buf[uint8]"),
+            "buf16" => Symbol::intern("Buf[uint16]"),
+            "buf32" => Symbol::intern("Buf[uint32]"),
+            "buf64" => Symbol::intern("Buf[uint64]"),
+            "blob8" => Symbol::intern("Blob[uint8]"),
+            "blob16" => Symbol::intern("Blob[uint16]"),
+            "blob32" => Symbol::intern("Blob[uint32]"),
+            "blob64" => Symbol::intern("Blob[uint64]"),
+            _ => class_name,
+        };
+        Value::make_instance(canonical_name, attrs)
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,
@@ -2485,82 +2577,9 @@ impl Interpreter {
                 }
                 "Buf" | "buf8" | "Buf[uint8]" | "Blob" | "blob8" | "Blob[uint8]" | "buf16"
                 | "buf32" | "buf64" | "blob16" | "blob32" | "blob64" => {
-                    let cn = class_name.resolve();
-                    let raw_vals: Vec<Value> = args
-                        .iter()
-                        .flat_map(|a| match a {
-                            Value::Int(i) => vec![Value::Int(*i)],
-                            Value::Array(items, ..) => items.to_vec(),
-                            Value::Seq(items) => items.to_vec(),
-                            Value::Slip(items) => items.to_vec(),
-                            Value::Range(start, end) => (*start..=*end).map(Value::Int).collect(),
-                            Value::RangeExcl(start, end) => {
-                                (*start..*end).map(Value::Int).collect()
-                            }
-                            Value::Instance {
-                                class_name,
-                                attributes,
-                                ..
-                            } if class_name == "Buf"
-                                || class_name == "Blob"
-                                || class_name == "utf8"
-                                || class_name == "utf16"
-                                || class_name.resolve().starts_with("Buf[")
-                                || class_name.resolve().starts_with("Blob[")
-                                || class_name.resolve().starts_with("buf")
-                                || class_name.resolve().starts_with("blob") =>
-                            {
-                                if let Some(Value::Array(items, ..)) =
-                                    attributes.as_map().get("bytes")
-                                {
-                                    items.to_vec()
-                                } else {
-                                    Vec::new()
-                                }
-                            }
-                            Value::BigInt(_) => vec![a.clone()],
-                            other => vec![Value::Int(to_int(other))],
-                        })
-                        .collect();
-                    // Mask values to unsigned range based on element size.
-                    // For uint64, use BigInt-aware conversion to preserve
-                    // values > i64::MAX (e.g. 18446744073709551615).
-                    let byte_vals: Vec<Value> = raw_vals
-                        .into_iter()
-                        .map(|v| {
-                            if cn.contains("64") {
-                                let u = match &v {
-                                    Value::BigInt(n) => {
-                                        use num_traits::ToPrimitive;
-                                        n.as_ref().to_u64().unwrap_or(to_int(&v) as u64)
-                                    }
-                                    _ => to_int(&v) as u64,
-                                };
-                                Value::Int(u as i64)
-                            } else if cn.contains("32") {
-                                Value::Int(to_int(&v) as u32 as i64)
-                            } else if cn.contains("16") {
-                                Value::Int(to_int(&v) as u16 as i64)
-                            } else {
-                                Value::Int(to_int(&v) as u8 as i64)
-                            }
-                        })
-                        .collect();
-                    let mut attrs = HashMap::new();
-                    attrs.insert("bytes".to_string(), Value::array(byte_vals));
-                    // Normalize short buf/blob names to canonical forms
-                    let canonical_name = match cn.as_str() {
-                        "buf8" => Symbol::intern("Buf[uint8]"),
-                        "buf16" => Symbol::intern("Buf[uint16]"),
-                        "buf32" => Symbol::intern("Buf[uint32]"),
-                        "buf64" => Symbol::intern("Buf[uint64]"),
-                        "blob8" => Symbol::intern("Blob[uint8]"),
-                        "blob16" => Symbol::intern("Blob[uint16]"),
-                        "blob32" => Symbol::intern("Blob[uint32]"),
-                        "blob64" => Symbol::intern("Blob[uint64]"),
-                        _ => *class_name,
-                    };
-                    return Ok(Value::make_instance(canonical_name, attrs));
+                    // Shared with the VM's native fast path (the byte-overlay
+                    // build is pure data; see `build_native_buf_value`).
+                    return Ok(Self::build_native_buf_value(*class_name, &args));
                 }
                 "Rat" => {
                     use num_bigint::BigInt;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -113,6 +113,19 @@ impl VM {
             self.method_dispatch_pure = true;
             return result;
         }
+        // Native `Buf`/`Blob` construction: a byte-overlay build of pure data
+        // (flatten args -> bytes, mask to element width). The VM builds it
+        // directly instead of routing through the interpreter's `dispatch_new`.
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && crate::runtime::Interpreter::is_native_buf_constructible(&class_name.resolve())
+        {
+            self.method_dispatch_pure = true;
+            return Ok(crate::runtime::Interpreter::build_native_buf_value(
+                *class_name,
+                &args,
+            ));
+        }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
@@ -1478,6 +1491,17 @@ impl VM {
             // Pure construction: fresh instance, no caller-env write (Slice 6.3).
             self.method_dispatch_pure = true;
             return result;
+        }
+        // Native `Buf`/`Blob` construction (mut path twin of the above).
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && crate::runtime::Interpreter::is_native_buf_constructible(&class_name.resolve())
+        {
+            self.method_dispatch_pure = true;
+            return Ok(crate::runtime::Interpreter::build_native_buf_value(
+                *class_name,
+                &args,
+            ));
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();

--- a/t/native-buf-construct.t
+++ b/t/native-buf-construct.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# `Buf`/`Blob` construction (`Buf.new(...)`, `buf8.new(...)`, parametric
+# `Buf[uintN].new(...)`) is a pure byte-overlay build — flatten the arguments to
+# a byte sequence and mask each to the element width. The VM now builds these
+# directly through the shared `build_native_buf_value` helper instead of routing
+# `.new` through the interpreter's generic `dispatch_new`. The interpreter's
+# Buf/Blob arm calls the same helper, so the two stay byte-identical.
+# `utf8`/`utf16` keep their own (unmasked) construction arm on the interpreter.
+
+plan 18;
+
+# --- basic Buf/Blob ---
+is Buf.new(1, 2, 3).elems, 3, 'Buf.new from a list';
+is Buf.new(1, 2, 3)[1], 2, 'Buf element access';
+is Blob.new(255, 256, 257).list, (255, 0, 1), 'Blob masks to uint8';
+
+# --- aliases ---
+is buf8.new(10, 20, 30).list, (10, 20, 30), 'buf8.new';
+is blob8.new(0 xx 4).list, (0, 0, 0, 0), 'blob8.new with a repeat list';
+
+# --- element-width masking ---
+is buf16.new(0x1FFFF)[0], 0xFFFF, 'buf16 masks to uint16';
+is buf32.new(0x1FFFFFFFF)[0], 0xFFFFFFFF, 'buf32 masks to uint32';
+
+# --- parametric type names ---
+is Buf[uint8].new(10, 20).list, (10, 20), 'Buf[uint8].new';
+is Blob[uint16].new(70000)[0], 70000 +& 0xFFFF, 'Blob[uint16] masks';
+is Buf[uint8].new(1, 2).^name, 'Buf[uint8]', 'parametric name preserved';
+
+# --- ranges and arrays flatten ---
+is Buf.new(1..3).list, (1, 2, 3), 'Buf.new from an inclusive range';
+is Buf.new(^4).list, (0, 1, 2, 3), 'Buf.new from an exclusive range';
+my @a = 10, 20, 30;
+is buf8.new(@a).list, (10, 20, 30), 'buf8.new from an array';
+
+# --- constructing from another buf copies its bytes ---
+my $src = buf8.new(5, 6, 7);
+is buf8.new($src).list, (5, 6, 7), 'buf8.new from another buf';
+is Buf.new($src).list, (5, 6, 7), 'Buf.new from a buf8';
+
+# --- empty ---
+is Buf.new.elems, 0, 'Buf.new with no args is empty';
+is buf8.new.elems, 0, 'buf8.new with no args is empty';
+
+# --- canonical name normalization ---
+is buf8.new(1).^name, 'Buf[uint8]', 'buf8 normalizes to Buf[uint8]';


### PR DESCRIPTION
## Summary

`Buf.new(...)`, `buf8.new(...)` and the parametric `Buf[uintN]`/`Blob[uintN]` forms construct as a pure byte overlay: flatten each argument into a byte sequence and mask every value to the element width inferred from the type name. This carries no user code, yet `.new` on these built-in types round-tripped through the interpreter's generic `dispatch_new` — it is the **single largest remaining `new` method fallback** (`roast/S03-buf/read-write-bits.t` alone hits it thousands of times in a loop).

This extracts that Buf/Blob arm of `dispatch_new` into a shared, self-contained `build_native_buf_value(class_name, args)` helper (no env / registry access) and adds a VM fast path (both the value and mut-receiver `.new` call sites) gated on `is_native_buf_constructible` — every `Buf`/`Blob` flavour **except `utf8`/`utf16`**, which take a different (unmasked) arm and stay on the interpreter. The interpreter's arm now calls the same helper, so the two are byte-identical by construction.

## Behavior-invariance

- **interpreter** — a before/after `diff` over all flavours (basic, masked uint8/16/32/64, parametric, range/array/buf sources, empty) is identical.
- **raku** — matches, except one pre-existing divergence (a `uint64` value > `i64::MAX` rendering as `-1` under `.perl`) that lives in the extracted logic verbatim and is out of scope.
- `MUTSU_VM_STATS` confirms `buf8.new(...)` in a 1000-iteration loop now reports **0 interpreter fallbacks** (was 1000).

## Tests

- `t/native-buf-construct.t` (18) — passes on raku and mutsu.
- All `roast/S03-buf/*.t` pass; `S32-str/encode.t` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)