### PR TITLE
feat(vm): convert user-code Rust panics into catchable X:: at a VM boundary

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -205,7 +205,6 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
 
 #### Phase I/II と並行で随時消化できる独立タスク（critical path 外）
 
-- [ ] **VM の panic→`X::` 変換境界を `run()` に設置**（ANALYSIS §2.1）— 安定性。依存なし・いつでも可（Q4 前倒し）。
 - [ ] **正規表現のコンパイル済みキャッシュ**（ANALYSIS §8.4）— perf（raku 比 8.6x 遅）。撤去とは独立。
 
 関連: 🟣第2優先「第一級コンテナ」＝トラック B の本体（レバー C ＝ Phase 1 の一部、Q2 の Arc-pointer flaky を吸収）。
@@ -511,8 +510,6 @@ NaN-boxing で payload 8byte 化。**各ステップで int.t 等の重量級 ro
       `start` ブロック間で `$counter`/`state $n` が共有されない (mutsu 1/0、raku 4/3)。
 - [ ] **`unsafe` の "single-threaded 前提" を是正** (ANALYSIS §2.3) — `Arc::as_ptr as *mut` での
       エイリアス書き換え 11 箇所がスレッド生成と矛盾し UB の余地。配列/ハッシュを共有セル化して撤廃。
-- [ ] **VM の panic→`X::` 変換境界を `run()` に設置** (ANALYSIS §2.1, §5) — ユーザコード起因の
-      Rust パニックを Raku 例外に変換し、プロセスクラッシュを防ぐ (Q4 「panic/crash を 0 に」の前倒し)。
 - [ ] **正規表現のコンパイル済みキャッシュ導入** (ANALYSIS §8.4) — `Value::Regex(Arc<String>)` が
       毎マッチ再パース。実測 raku 比 8.6x 遅 (変数束縛でも改善せず)。パターン→構造のキャッシュを追加。
 - [ ] **コンテナ型メタデータを生 Arc ポインタ keying から安定コンテナ ID へ移す**（間欠 flaky の根本原因。

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,30 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### 安定性: VM の panic→`X::` 変換境界（ANALYSIS §2.1）
+
+ユーザコード起因の Rust パニック（整数オーバーフロー・`Vec` capacity overflow・index OOB・`unwrap`/`unreachable!`
+等）は、これまでプロセス全体をクラッシュさせていた（exit 101 / core dump）。これを VM 内の境界で捕捉し、
+catchable な `X::AdHoc`（`Internal error: <payload>`）に変換するようにした。クラッシュ → 通常のエラー経路
+（メッセージ表示・exit 1・`try`/`CATCH` で捕捉可能）へ。
+
+- **二段の境界**:
+  - `VM::run` を `catch_unwind` でラップ（ループ本体を `&mut self` の `run_inner` に切り出し、`self` の
+    move-return を排除して `catch_unwind(AssertUnwindSafe)` 可能に）。トップレベル文（`try` の外）の
+    パニックの安全網。EVAL / サブ VM も `VM::run` 経由なので自動的にカバー。
+  - `try`/`CATCH` のボディ実行に `run_range_guarded` を使用。これにより、try 内で何重にネストした
+    （未ガードの `run_range`/`run_reuse` を貫く）パニックも、アンワインドがこの単一境界まで巻き戻って
+    `Err` に変換され、既存の例外機構経由で CATCH ハンドラへ流れる。中間フレームはガード不要。
+- **perf 影響なし**: ホットなループ本体の `run_range` は未ガードのまま。境界は `try` ブロックとトップレベル
+  のみ。
+- **stderr のバックトレース抑制**: `thread_local` フラグ + カスタム panic フックで、境界内のパニックの
+  デフォルトバックトレース出力を抑制（`RUST_BACKTRACE`/`MUTSU_TRACE` 指定時は従来どおり表示し、本物の
+  内部バグのデバッグ性を維持）。
+- **スコープ外**: スタックオーバーフロー（`sub f { f() }; f()`）は unwind せず `abort` するため対象外
+  （別途、再帰深度ガードが必要）。巨大アロケーション（`"x" x 2**62`）も allocator abort で対象外。
+- テスト: `t/vm-panic-boundary.t`（9 サブテスト — try 生存・`X::AdHoc` 化・メッセージ保持・`$!` 設定・
+  `dies-ok`・深いネスト・通常配列成長は無影響）。
+
 ### トラック C: react/supply 駆動ループの単一エンジン統合（Stage 1 完了, #3027 / #3029 / #3031）
 
 react/supply ランタイムの「駆動ループ（source 解決 → イベント poll → body 実行 → done/last/quit/close）」は

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -16,6 +16,49 @@ use num_traits::{Signed, Zero};
 
 type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
 
+thread_local! {
+    /// Set while execution is inside the `VM::run` catch_unwind boundary, so the
+    /// custom panic hook can stay quiet for panics that we are about to convert
+    /// into a catchable `X::` error (instead of dumping a Rust backtrace).
+    static IN_VM_PANIC_BOUNDARY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+static VM_PANIC_HOOK_INIT: std::sync::Once = std::sync::Once::new();
+
+/// Install (once) a panic hook that suppresses the default backtrace dump for
+/// panics caught at the `VM::run` boundary, unless the user opted into details
+/// via `RUST_BACKTRACE`/`MUTSU_TRACE`. Panics outside the boundary (genuine
+/// internal bugs) still print normally.
+fn install_vm_panic_hook() {
+    VM_PANIC_HOOK_INIT.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let suppress = IN_VM_PANIC_BOUNDARY.with(|f| f.get());
+            let want_details = std::env::var("RUST_BACKTRACE")
+                .map(|v| !v.is_empty() && v != "0")
+                .unwrap_or(false)
+                || std::env::var("MUTSU_TRACE")
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false);
+            if suppress && !want_details {
+                return;
+            }
+            default_hook(info);
+        }));
+    });
+}
+
+/// Extract a human-readable message from a caught panic payload.
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
 /// Pre-computed fast dispatch entry for compiled methods.
 /// Caches all the information needed to skip intermediate dispatch steps
 /// (wrap chain check, compiled_code extraction, fast-path eligibility checks).
@@ -623,14 +666,57 @@ impl VM {
 
     /// Run the compiled bytecode. Always returns the interpreter back
     /// (even on error) so the caller can restore it.
+    ///
+    /// The actual exec loop runs inside a `catch_unwind` boundary so that a Rust
+    /// `panic!`/`unwrap`/index-OOB/capacity-overflow triggered by user code is
+    /// converted into a catchable `X::AdHoc` `RuntimeError` (exit 1, flows through
+    /// `try`/`CATCH`) instead of crashing the whole process (exit 101). This also
+    /// covers EVAL and sub-VMs, which run through `VM::run`. Stack overflow
+    /// `abort`s rather than unwinding, so it is out of scope here.
     pub(crate) fn run(
         mut self,
         code: &CompiledCode,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> (Interpreter, Result<Option<Value>, RuntimeError>) {
-        if let Err(e) = Self::validate_labels(code) {
-            return (self.interpreter, Err(e));
-        }
+        install_vm_panic_hook();
+        // Save/restore the flag so nested `VM::run` calls (EVAL, sub-VMs) don't
+        // clobber an outer boundary's state.
+        let prev = IN_VM_PANIC_BOUNDARY.with(|f| f.replace(true));
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.run_inner(code, compiled_fns)
+        }));
+        IN_VM_PANIC_BOUNDARY.with(|f| f.set(prev));
+        let result = match caught {
+            Ok(r) => r,
+            Err(payload) => Err(Self::vm_panic_error(panic_payload_message(
+                payload.as_ref(),
+            ))),
+        };
+        (self.interpreter, result)
+    }
+
+    /// Build a catchable `X::AdHoc` error from a caught panic message.
+    fn vm_panic_error(message: String) -> RuntimeError {
+        let message = format!("Internal error: {message}");
+        let mut err = RuntimeError::new(message.clone());
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        err.exception = Some(Box::new(Value::make_instance(
+            Symbol::intern("X::AdHoc"),
+            attrs,
+        )));
+        err
+    }
+
+    /// The exec loop, borrowing `&mut self` so the `catch_unwind` closure in
+    /// `run` does not move `self.interpreter` out (the caller must always get the
+    /// interpreter back, even on panic).
+    fn run_inner(
+        &mut self,
+        code: &CompiledCode,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<Option<Value>, RuntimeError> {
+        Self::validate_labels(code)?;
         // Initialize local variable slots
         self.locals = vec![Value::Nil; code.locals.len()];
         for (i, name) in code.locals.iter().enumerate() {
@@ -674,14 +760,14 @@ impl VM {
                 if e.is_return && self.interpreter.routine_stack().is_empty() {
                     let inner_err = RuntimeError::controlflow_return(true);
                     if self.check_phaser_depth > 0 {
-                        return (self.interpreter, Err(Self::wrap_in_begin_time(inner_err)));
+                        return Err(Self::wrap_in_begin_time(inner_err));
                     }
-                    return (self.interpreter, Err(inner_err));
+                    return Err(inner_err);
                 }
                 if self.check_phaser_depth > 0 {
-                    return (self.interpreter, Err(Self::wrap_in_begin_time(e)));
+                    return Err(Self::wrap_in_begin_time(e));
                 }
-                return (self.interpreter, Err(e));
+                return Err(e);
             }
             if self.interpreter.is_halted() {
                 break;
@@ -693,8 +779,8 @@ impl VM {
         // callers (e.g. eval_block_value) can observe side effects.
         self.sync_env_from_locals(code);
         let last_stack_value = self.stack.last().cloned();
-        let fallback = self.last_topic_value;
-        (self.interpreter, Ok(last_stack_value.or(fallback)))
+        let fallback = self.last_topic_value.clone();
+        Ok(last_stack_value.or(fallback))
     }
 
     /// Invoke a callable value using the VM fast paths when available and
@@ -858,6 +944,36 @@ impl VM {
     }
 
     /// Execute opcodes in [start..end), used by loop compound opcodes.
+    /// Like `run_range`, but installs a `catch_unwind` boundary so a Rust panic
+    /// (unwrap/index-OOB/overflow/...) raised anywhere inside the executed range
+    /// — however deeply nested through other (unguarded) `run_range`/`run_reuse`
+    /// frames — is converted into a catchable `X::AdHoc` `RuntimeError` rather
+    /// than crashing the process. Used for the `try`/`CATCH` body so user error
+    /// handlers can catch otherwise-fatal internal panics. The intermediate
+    /// frames need no guard: Rust unwinding propagates through them up to this
+    /// boundary, where it becomes a normal `Err` and flows through the existing
+    /// exception machinery.
+    pub(crate) fn run_range_guarded(
+        &mut self,
+        code: &CompiledCode,
+        start: usize,
+        end: usize,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<(), RuntimeError> {
+        install_vm_panic_hook();
+        let prev = IN_VM_PANIC_BOUNDARY.with(|f| f.replace(true));
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.run_range(code, start, end, compiled_fns)
+        }));
+        IN_VM_PANIC_BOUNDARY.with(|f| f.set(prev));
+        match caught {
+            Ok(r) => r,
+            Err(payload) => Err(Self::vm_panic_error(panic_payload_message(
+                payload.as_ref(),
+            ))),
+        }
+    }
+
     fn run_range(
         &mut self,
         code: &CompiledCode,

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2742,7 +2742,10 @@ impl VM {
         if has_control {
             self.interpreter.control_handler_depth += 1;
         }
-        let body_result = self.run_range(code, body_start, catch_begin, compiled_fns);
+        // Guard the protected body with a panic->X:: boundary so an internal
+        // Rust panic (overflow/OOB/unwrap) raised anywhere inside it becomes a
+        // catchable exception routed to the CATCH handler, instead of crashing.
+        let body_result = self.run_range_guarded(code, body_start, catch_begin, compiled_fns);
         if has_control {
             self.interpreter.control_handler_depth -= 1;
         }

--- a/t/vm-panic-boundary.t
+++ b/t/vm-panic-boundary.t
@@ -1,0 +1,93 @@
+# A Rust-level panic triggered by user code (integer overflow, capacity
+# overflow, index out of bounds in a native op, etc.) must NOT crash the whole
+# process. The VM installs a panic->X:: boundary that converts such an
+# otherwise-fatal panic into a catchable X::AdHoc exception (exit 1 + message),
+# so it flows through the normal try/CATCH machinery.
+#
+# Stack overflow (`sub f { f() }; f()`) aborts rather than unwinds and is out of
+# scope for this boundary.
+use Test;
+
+plan 9;
+
+# 1-2: try {} catches the panic; the process survives and execution continues.
+{
+    my $survived = False;
+    try {
+        my @a;
+        @a[2**64 - 1] = 1;   # "attempt to add with overflow" in the native op
+    }
+    $survived = True;
+    ok $survived, 'try {} survives an overflow panic';
+}
+
+{
+    my $survived = False;
+    try {
+        my @a;
+        @a[2**64 - 2] = 1;   # Vec capacity-overflow panic
+    }
+    $survived = True;
+    ok $survived, 'try {} survives a capacity-overflow panic';
+}
+
+# 3-4: the caught error is a real, introspectable exception.
+{
+    my $caught;
+    try {
+        my @a;
+        @a[2**64 - 1] = 1;
+        CATCH { default { $caught = $_ } }
+    }
+    ok $caught.defined, 'CATCH receives an exception object';
+    isa-ok $caught, X::AdHoc, 'panic surfaces as X::AdHoc';
+}
+
+# 5: the message is preserved (prefixed with "Internal error:").
+{
+    my $msg;
+    try {
+        my @a;
+        @a[2**64 - 1] = 1;
+        CATCH { default { $msg = .message } }
+    }
+    ok $msg.contains('Internal error'), 'message carries the internal-error prefix';
+}
+
+# 6: $! is populated after a caught panic, like any other exception.
+{
+    try {
+        my @a;
+        @a[2**64 - 1] = 1;
+    }
+    isa-ok $!, X::AdHoc, '$! holds the converted exception';
+}
+
+# 7: dies-ok treats it as a throwing block.
+dies-ok {
+    my @a;
+    @a[2**64 - 1] = 1;
+}, 'dies-ok sees the panic as a thrown exception';
+
+# 8: a panic nested deep inside loops/blocks within the try is still caught by
+# the single try-body boundary (unwinding propagates through inner frames).
+{
+    my $count = 0;
+    try {
+        for ^3 {
+            for ^3 {
+                my @a;
+                @a[2**64 - 1] = 1;
+            }
+        }
+    }
+    $count = 1;
+    ok $count == 1, 'deeply-nested panic is caught by the enclosing try';
+}
+
+# 9: a normal (non-panic) lives block is unaffected by the boundary.
+lives-ok {
+    my @a;
+    @a[3] = 1;
+    @a[10] = 2;
+}, 'ordinary array growth is unaffected';


### PR DESCRIPTION
## What

A Rust panic triggered from **user code** (integer overflow, `Vec` capacity overflow, index out of bounds in a native op, `unwrap`/`unreachable!`, …) previously killed the whole process (**exit 101 / core dump**). This installs a panic→`X::` boundary in the VM so such an otherwise-fatal panic becomes a **catchable `X::AdHoc`** (`Internal error: <payload>`) that flows through the normal error path: printed as an error, **exit 1**, catchable by `try`/`CATCH`.

Implements the PLAN.md「VM の panic→`X::` 変換境界」independent stability task (ANALYSIS §2.1/§5/§8.2).

## How

Two boundaries:

- **`VM::run`** is wrapped in `catch_unwind`. Its exec loop is factored into a `&mut self` `run_inner` so the closure does not move `self.interpreter` out (the caller must always get the interpreter back, even on panic). Top-level safety net for statements outside any `try`; covers EVAL / sub-VMs for free.
- **`try`/`CATCH` body** runs via the new `run_range_guarded`. A panic raised anywhere inside the `try` — however deeply nested through other (unguarded) `run_range`/`run_reuse` frames — unwinds up to this single boundary, becomes a normal `Err`, and is routed to the CATCH handler by the existing exception machinery. Intermediate frames need no guard, so the **hot per-iteration `run_range` stays unguarded (no perf impact)**.

A `thread_local` flag + custom panic hook suppresses the default Rust backtrace for caught panics, unless `RUST_BACKTRACE`/`MUTSU_TRACE` is set (preserves debuggability of genuine internal bugs).

## Out of scope

Stack overflow (`sub f { f() }; f()`) **aborts** rather than unwinds → needs a separate recursion-depth guard. Huge allocations (`"x" x 2**62`) abort in the allocator.

## Behavior

```
$ mutsu -e 'my @a; @a[2**64-1] = 1'              # before: backtrace + exit 101
Runtime error: Internal error: attempt to add with overflow   # now: exit 1

$ mutsu -e 'try { my @a; @a[2**64-1]=1 }; say "survived"'      # now: survived
$ mutsu -e 'my @a; @a[2**64-1]=1; CATCH { default { say .^name } }'  # X::AdHoc
```

## Tests

- `t/vm-panic-boundary.t` (9 subtests): try survives, `X::AdHoc` surfacing, message preservation, `$!` population, `dies-ok`, deep nesting, normal array growth unaffected.
- `make test` PASS (774 files / 7138 tests, Failed: 0).
- Exception roast suite (`S04-exception-handlers/*`, `S04-exceptions/*`, `S32-exceptions/misc2.t`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)