### PR TITLE
feat(③ ctor): VM-native utf8/utf16/Uni construction + unified built-in entry

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -862,6 +862,102 @@ impl Interpreter {
         Value::make_instance(canonical_name, attrs)
     }
 
+    /// Build a `utf8`/`utf16` instance from `.new` arguments as pure data:
+    /// flatten each argument into a code-unit sequence (no masking) and store it
+    /// as the `bytes` attribute. Unlike `build_native_buf_value` this keeps the
+    /// literal class name and drops arguments it cannot turn into code units
+    /// (the interpreter's `utf8`/`utf16` arm did the same), so the two stay
+    /// byte-identical.
+    pub(crate) fn build_native_utf_value(class_name: Symbol, args: &[Value]) -> Value {
+        let elems: Vec<Value> = args
+            .iter()
+            .flat_map(|a| match a {
+                Value::Int(i) => vec![Value::Int(*i)],
+                Value::Array(items, ..) => items.to_vec(),
+                Value::Seq(items) | Value::Slip(items) => items.to_vec(),
+                Value::Range(start, end) => (*start..=*end).map(Value::Int).collect(),
+                Value::RangeExcl(start, end) => (*start..*end).map(Value::Int).collect(),
+                Value::Instance {
+                    class_name: cn,
+                    attributes: ia,
+                    ..
+                } if crate::runtime::utils::is_buf_or_blob_class(&cn.resolve()) => {
+                    if let Some(Value::Array(items, ..)) = ia.as_map().get("bytes") {
+                        items.to_vec()
+                    } else {
+                        vec![]
+                    }
+                }
+                _ => vec![],
+            })
+            .collect();
+        let mut attrs = HashMap::new();
+        attrs.insert("bytes".to_string(), Value::array(elems));
+        Value::make_instance(class_name, attrs)
+    }
+
+    /// Build a `Uni` value from `.new` arguments as pure data: flatten each
+    /// argument into a sequence of codepoints and collect them as a string.
+    /// (Flattening now also covers `Range`s — `Uni.new(65..67)` -> "ABC" — which
+    /// the old interpreter arm missed, leaving it to stringify the whole Range;
+    /// the shared helper fixes that to match raku and the sibling `utf8` arm.)
+    pub(crate) fn build_native_uni_value(args: &[Value]) -> Value {
+        let mut flat_args: Vec<Value> = Vec::new();
+        for a in args {
+            match a {
+                Value::Array(items, ..) => flat_args.extend(items.iter().cloned()),
+                Value::Seq(items) | Value::Slip(items) => {
+                    flat_args.extend(items.iter().cloned());
+                }
+                Value::Range(start, end) => {
+                    flat_args.extend((*start..=*end).map(Value::Int));
+                }
+                Value::RangeExcl(start, end) => {
+                    flat_args.extend((*start..*end).map(Value::Int));
+                }
+                other => flat_args.push(other.clone()),
+            }
+        }
+        let text: String = flat_args
+            .iter()
+            .filter_map(|a| {
+                let cp = match a {
+                    Value::Int(i) => *i as u32,
+                    Value::Num(f) => *f as u32,
+                    other => other.to_string_value().parse::<u32>().unwrap_or(0),
+                };
+                char::from_u32(cp)
+            })
+            .collect();
+        Value::Uni {
+            form: String::new(),
+            text,
+        }
+    }
+
+    /// VM-native construction for a built-in type whose `.new(...)` is pure data
+    /// assembly (no env / registry / user code): `Buf`/`Blob` (byte overlay),
+    /// `utf8`/`utf16` (code units) and `Uni` (codepoints). Returns `Some` with
+    /// the constructed value when `class_name` is one of these, else `None` so
+    /// the caller falls through to the generic constructor. The interpreter's
+    /// `dispatch_new` arms call the same per-type helpers, so the native path is
+    /// byte-identical.
+    pub(crate) fn try_native_builtin_construct(
+        class_name: Symbol,
+        args: &[Value],
+    ) -> Option<Value> {
+        let cn = class_name.resolve();
+        if Self::is_native_buf_constructible(&cn) {
+            Some(Self::build_native_buf_value(class_name, args))
+        } else if cn == "utf8" || cn == "utf16" {
+            Some(Self::build_native_utf_value(class_name, args))
+        } else if cn == "Uni" {
+            Some(Self::build_native_uni_value(args))
+        } else {
+            None
+        }
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,
@@ -1714,38 +1810,8 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "Uni" => {
-                    // Flatten array arguments so Uni.new(@codes) works
-                    let mut flat_args: Vec<&Value> = Vec::new();
-                    for a in &args {
-                        match a {
-                            Value::Array(items, ..) => {
-                                for item in items.iter() {
-                                    flat_args.push(item);
-                                }
-                            }
-                            Value::Seq(items) | Value::Slip(items) => {
-                                for item in items.iter() {
-                                    flat_args.push(item);
-                                }
-                            }
-                            other => flat_args.push(other),
-                        }
-                    }
-                    let text: String = flat_args
-                        .iter()
-                        .filter_map(|a| {
-                            let cp = match a {
-                                Value::Int(i) => *i as u32,
-                                Value::Num(f) => *f as u32,
-                                other => other.to_string_value().parse::<u32>().unwrap_or(0),
-                            };
-                            char::from_u32(cp)
-                        })
-                        .collect();
-                    return Ok(Value::Uni {
-                        form: String::new(),
-                        text,
-                    });
+                    // Shared with the VM's native fast path (pure codepoint build).
+                    return Ok(Self::build_native_uni_value(&args));
                 }
                 "Seq" => {
                     // Seq.new(iterator) — pull all items from the iterator
@@ -2547,33 +2613,8 @@ impl Interpreter {
                     return Ok(Value::make_instance(*class_name, attrs));
                 }
                 "utf8" | "utf16" => {
-                    let elems: Vec<Value> = args
-                        .iter()
-                        .flat_map(|a| match a {
-                            Value::Int(i) => vec![Value::Int(*i)],
-                            Value::Array(items, ..) => items.to_vec(),
-                            Value::Seq(items) | Value::Slip(items) => items.to_vec(),
-                            Value::Range(start, end) => (*start..=*end).map(Value::Int).collect(),
-                            Value::RangeExcl(start, end) => {
-                                (*start..*end).map(Value::Int).collect()
-                            }
-                            Value::Instance {
-                                class_name: cn,
-                                attributes: ia,
-                                ..
-                            } if crate::runtime::utils::is_buf_or_blob_class(&cn.resolve()) => {
-                                if let Some(Value::Array(items, ..)) = ia.as_map().get("bytes") {
-                                    items.to_vec()
-                                } else {
-                                    vec![]
-                                }
-                            }
-                            _ => vec![],
-                        })
-                        .collect();
-                    let mut attrs = HashMap::new();
-                    attrs.insert("bytes".to_string(), Value::array(elems));
-                    return Ok(Value::make_instance(*class_name, attrs));
+                    // Shared with the VM's native fast path (pure code-unit build).
+                    return Ok(Self::build_native_utf_value(*class_name, &args));
                 }
                 "Buf" | "buf8" | "Buf[uint8]" | "Blob" | "blob8" | "Blob[uint8]" | "buf16"
                 | "buf32" | "buf64" | "blob16" | "blob32" | "blob64" => {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -113,18 +113,16 @@ impl VM {
             self.method_dispatch_pure = true;
             return result;
         }
-        // Native `Buf`/`Blob` construction: a byte-overlay build of pure data
-        // (flatten args -> bytes, mask to element width). The VM builds it
-        // directly instead of routing through the interpreter's `dispatch_new`.
+        // Native built-in construction: `Buf`/`Blob` (byte overlay), `utf8`/
+        // `utf16` (code units), `Uni` (codepoints) — pure data builds the VM
+        // performs directly instead of routing through `dispatch_new`.
         if method == "new"
             && let Value::Package(class_name) = &target
-            && crate::runtime::Interpreter::is_native_buf_constructible(&class_name.resolve())
+            && let Some(v) =
+                crate::runtime::Interpreter::try_native_builtin_construct(*class_name, &args)
         {
             self.method_dispatch_pure = true;
-            return Ok(crate::runtime::Interpreter::build_native_buf_value(
-                *class_name,
-                &args,
-            ));
+            return Ok(v);
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
@@ -1492,16 +1490,14 @@ impl VM {
             self.method_dispatch_pure = true;
             return result;
         }
-        // Native `Buf`/`Blob` construction (mut path twin of the above).
+        // Native built-in construction (mut path twin of the above).
         if method == "new"
             && let Value::Package(class_name) = &target
-            && crate::runtime::Interpreter::is_native_buf_constructible(&class_name.resolve())
+            && let Some(v) =
+                crate::runtime::Interpreter::try_native_builtin_construct(*class_name, &args)
         {
             self.method_dispatch_pure = true;
-            return Ok(crate::runtime::Interpreter::build_native_buf_value(
-                *class_name,
-                &args,
-            ));
+            return Ok(v);
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();

--- a/t/native-builtin-utf-uni-construct.t
+++ b/t/native-builtin-utf-uni-construct.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# VM-native construction for the byte/codepoint built-in types whose `.new(...)`
+# is pure data assembly: `utf8`/`utf16` (code units, no masking) and `Uni`
+# (codepoints). These join `Buf`/`Blob` under the shared
+# `try_native_builtin_construct` entry, so the VM builds them directly instead
+# of routing `.new` through the interpreter's generic `dispatch_new`. The
+# interpreter's arms call the same per-type helpers, keeping them byte-identical.
+
+plan 16;
+
+# --- utf8.new ---
+is utf8.new(72, 105).decode, 'Hi', 'utf8.new decodes to text';
+is utf8.new(72, 105).elems, 2, 'utf8.new elem count';
+is utf8.new(72, 105).list, (72, 105), 'utf8.new byte list';
+is utf8.new(0xE2, 0x82, 0xAC).decode, '€', 'utf8.new multi-byte codepoint';
+is utf8.new(65 .. 67).decode, 'ABC', 'utf8.new flattens a range';
+my @a = 65, 66, 67;
+is utf8.new(@a).decode, 'ABC', 'utf8.new flattens an array';
+my $b = buf8.new(72, 73);
+is utf8.new($b).decode, 'HI', 'utf8.new from a buf';
+is utf8.new.elems, 0, 'utf8.new with no args is empty';
+
+# --- utf16.new ---
+is utf16.new(72, 105).elems, 2, 'utf16.new elem count';
+is utf16.new(72, 105).list, (72, 105), 'utf16.new unit list';
+
+# --- Uni.new ---
+is Uni.new(72, 105).Str, 'Hi', 'Uni.new from codepoints';
+is Uni.new(0x263A).Str, '☺', 'Uni.new from a single codepoint';
+my @c = 72, 101, 108, 108, 111;
+is Uni.new(@c).Str, 'Hello', 'Uni.new flattens an array';
+is Uni.new.Str.chars, 0, 'Uni.new with no args is empty';
+
+# --- Uni.new now flattens ranges too (was a pre-existing bug; the shared helper
+#     fixes it to match raku and the sibling utf8 arm) ---
+is Uni.new(65 .. 67).Str, 'ABC', 'Uni.new flattens an inclusive range';
+is Uni.new(65 ..^ 68).Str, 'ABC', 'Uni.new flattens an exclusive range';


### PR DESCRIPTION
## Summary

Extends VM-native built-in construction (started for `Buf`/`Blob` in #3044) to the other pure-data byte/codepoint constructors:

- `utf8`/`utf16` — flatten args into a code-unit sequence (no masking).
- `Uni` — flatten args into codepoints and collect to a string.

Each `dispatch_new` arm is extracted into a self-contained helper (`build_native_utf_value`, `build_native_uni_value`); the interpreter arms call them, and a single new entry `try_native_builtin_construct(class_name, args)` dispatches `Buf`/`Blob`/`utf8`/`utf16`/`Uni` by name. The VM's two `.new` call sites now call that one entry instead of the inline Buf-only check #3044 added, so all five built-in constructors are native through one consolidated path.

## Behavior-invariance (+ one bug fix)

The Buf/utf16 paths are byte-identical to the interpreter (before/after `diff`). The `Uni` path additionally **fixes a pre-existing bug**: `Uni.new(65..67)` flattened arrays but not ranges, so it stringified the whole `Range` to codepoint 0; the shared helper flattens `Range`/`RangeExcl` too — matching raku and the sibling `utf8` arm. That is the only before/after output change.

`MUTSU_VM_STATS` confirms `utf8.new(...)`/`Uni.new(...)` in a loop now report **0 interpreter fallbacks**. `S15-nfg/*` and `S03-buf/*` suites are unaffected (the one `S15-nfg` FAIL, `GraphemeBreakTest-3.t`, is pre-existing and non-whitelisted).

## Tests

- `t/native-builtin-utf-uni-construct.t` (16) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)