### PR TITLE
feat(③ Track A): VM-native `.gist` on bare native-data instances (Buf/Blob/Uni)

### DIFF
--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -8,14 +8,29 @@ impl VM {
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
         fn collection_contains_instance(value: &Value) -> bool {
+            // Recursive: does any element (transitively) carry an Instance whose
+            // `.gist` may need interpreter dispatch?
+            fn contains_instance(value: &Value) -> bool {
+                match value {
+                    Value::Instance { .. } => true,
+                    v if v.as_list_items().is_some() => {
+                        v.as_list_items().unwrap().iter().any(contains_instance)
+                    }
+                    Value::Hash(map) => map.values().any(contains_instance),
+                    _ => false,
+                }
+            }
+            // Only a *collection* receiver triggers the gist bypass. A bare
+            // instance (e.g. a `Buf`, whose gist `native_method_0arg` renders
+            // purely via `dispatch_core_repr`) is dispatched normally — the
+            // builtins layer itself defers a collection whose elements may have a
+            // user `method gist`, so bypassing a bare instance here only forced a
+            // pure native gist (Buf/Blob/Uni) onto the interpreter for nothing.
             match value {
-                Value::Instance { .. } => true,
-                v if v.as_list_items().is_some() => v
-                    .as_list_items()
-                    .unwrap()
-                    .iter()
-                    .any(collection_contains_instance),
-                Value::Hash(map) => map.values().any(collection_contains_instance),
+                v if v.as_list_items().is_some() => {
+                    v.as_list_items().unwrap().iter().any(contains_instance)
+                }
+                Value::Hash(map) => map.values().any(contains_instance),
                 _ => false,
             }
         }

--- a/t/native-buf-gist.t
+++ b/t/native-buf-gist.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# `.gist` on a bare native-data instance (`Buf`/`Blob`/`Uni`) is pure
+# formatting handled by `dispatch_core_repr`, yet the VM's "collection gist
+# bypass" treated *any* Instance receiver — including a bare Buf — as a
+# collection that might contain a user `method gist`, and forced it onto the
+# interpreter. The bypass is now narrowed to actual collection receivers
+# (list/array/hash); a bare instance dispatches natively, while a collection
+# whose elements may carry a custom gist still defers (the builtins layer
+# already does that itself). Byte-identical to the interpreter — these assert
+# the rendered gist is unchanged and correct.
+
+plan 9;
+
+# --- Buf / Blob gist ---
+is Buf.new(1, 2, 255).gist, 'Buf:0x<01 02 FF>', 'Buf.gist hex rendering';
+is Blob.new(16, 32).gist, 'Blob:0x<10 20>', 'Blob.gist hex rendering';
+is buf16.new(0x1234, 0xABCD).gist, 'Buf[uint16]:0x<1234 ABCD>',
+    'buf16.gist uses 4-wide hex';
+
+# --- Uni gist ---
+is Uni.new(72, 105).gist, 'Uni:0x<0048 0069>', 'Uni.gist hex rendering';
+
+# --- a collection that contains instances still gists its elements ---
+my @bufs = Buf.new(1, 2), Buf.new(3, 4);
+is @bufs.gist, '[Buf:0x<01 02> Buf:0x<03 04>]', 'a list of Bufs gists each element';
+
+# --- a user instance with a custom gist still dispatches the method ---
+class P { has $.x; method gist { "P<{$!x}>" } }
+is P.new(x => 7).gist, 'P<7>', 'a user method gist is honored on a bare instance';
+
+# --- a list mixing a custom-gist instance still honors it ---
+my @mix = Buf.new(9), P.new(x => 1);
+is @mix.gist, '[Buf:0x<09> P<1>]', 'a mixed list gists Buf natively and P via its method';
+
+# --- a hash with Buf values ---
+my %h = k => Buf.new(7, 8);
+is %h.gist, '{k => Buf:0x<07 08>}', 'a hash gist renders a Buf value';
+
+# --- gist of a Buf inside say still works end to end ---
+is Buf.new(0xDE, 0xAD).gist, 'Buf:0x<DE AD>', 'Buf.gist uppercase hex';


### PR DESCRIPTION
## Summary

`.gist` on a bare `Buf`/`Blob`/`Uni` instance is pure formatting handled by `dispatch_core_repr` (the same impl the interpreter uses), but the VM's "collection gist bypass" in `try_native_method` treated **any** `Value::Instance` receiver — including a bare Buf — as a collection that might contain a user-defined `method gist`, and forced it onto the interpreter on every call.

The bypass exists so a *collection* (list/array/hash) whose elements may carry a custom gist defers to per-element method dispatch. A bare instance is not a collection: `native_method_0arg` renders a Buf/Blob/Uni gist purely, and the builtins layer (`dispatch_core_repr`) already defers a collection-with-instances on its own. So this narrows `collection_contains_instance` to only fire for an actual collection receiver — a bare instance now dispatches natively (Buf/Blob/Uni gist) or falls through normally (a user instance returns `None` and reaches the interpreter as before).

## Behavior-invariance

An interpreter-vs-native before/after `diff` over Buf/Blob/Uni gist, lists/hashes of Bufs, user instances with and without a custom `method gist`, and mixed collections is identical (both the native and fallback paths call the same `dispatch_core_repr`). `MUTSU_VM_STATS` confirms `Buf.gist` in a loop drops from 100% to **0** interpreter fallbacks; user-instance gist still falls back. All `roast/S03-buf/*.t` pass.

(Track A — §1 native receiver method dispatch.)

## Tests

- `t/native-buf-gist.t` (9) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)