### PR TITLE
feat(③ Track A): VM-native Failure `.exception` / `.handled` accessors

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -362,6 +362,35 @@ pub(crate) fn native_method_0arg(
         return Some(Ok(Value::Nil));
     }
 
+    // Failure safe accessors: `.exception` (the stored exception object) and
+    // `.handled` (read of the global handled flag). Both are in the
+    // interpreter's no-explode safe list, so dispatching them natively is
+    // correct — a *non*-safe method (e.g. `.message`) is not handled here, so it
+    // returns `None` and reaches the interpreter, which explodes an unhandled
+    // Failure. (The `.handled = ...` setter is the 1-arg form, handled
+    // elsewhere; this only covers the 0-arg read.)
+    if let Value::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target
+        && class_name == "Failure"
+    {
+        match method {
+            "exception" => {
+                return Some(Ok(attributes
+                    .as_map()
+                    .get("exception")
+                    .cloned()
+                    .unwrap_or(Value::Nil)));
+            }
+            "handled" => {
+                return Some(Ok(Value::Bool(target.is_failure_handled())));
+            }
+            _ => {}
+        }
+    }
+
     // For Mixin values, handle Bool/WHICH method specially, then delegate to inner.
     if let Value::Mixin(inner, mixins) = target {
         if method == "Bool"

--- a/t/native-failure-accessors.t
+++ b/t/native-failure-accessors.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# `.exception` (the stored exception object) and `.handled` (read of the global
+# handled flag) on a `Failure` are in the interpreter's no-explode "safe" list,
+# so they dispatch natively via `native_method_0arg` instead of routing through
+# the interpreter. Crucially, a *non*-safe method on an unhandled Failure (e.g.
+# `.succ`/`.Int`) still returns `None` from the native layer and reaches the
+# interpreter, which explodes the Failure — so the native accessors do not
+# weaken Failure's defining behavior. Byte-identical to the interpreter.
+
+plan 10;
+
+# --- .handled read (unhandled -> False; does not explode) ---
+my $f = Failure.new("oops");
+is $f.handled, False, '.handled on an unhandled Failure is False (no explosion)';
+
+# --- .exception read returns the stored exception (does not explode) ---
+is $f.exception.message, 'oops', '.exception returns the stored exception';
+is $f.exception.WHAT.^name, 'X::AdHoc', '.exception is an X::AdHoc';
+
+# --- mark handled, then .handled reads True ---
+$f.handled = True;
+is $f.handled, True, '.handled reflects the global handled flag after setting';
+is $f.exception.message, 'oops', '.exception still works after handling';
+
+# --- a non-safe method on an unhandled Failure still explodes ---
+my $g = Failure.new("boom");
+my $lived = (try { $g.Int; True }) // False;
+is $lived, False, 'a non-safe method (.Int) on an unhandled Failure explodes';
+
+my $h = Failure.new("bang");
+my $lived2 = (try { $h.succ; True }) // False;
+is $lived2, False, 'a non-safe method (.succ) on an unhandled Failure explodes';
+
+# --- a handled Failure does NOT explode on a non-safe method ---
+my $k = Failure.new("ok");
+$k.handled = True;
+my $lived3 = (try { $k.defined; True }) // False;
+is $lived3, True, 'a handled Failure does not explode';
+
+# --- .exception/.handled on a handled Failure ---
+is $k.handled, True, '.handled True on a handled Failure';
+is $k.exception.message, 'ok', '.exception on a handled Failure';


### PR DESCRIPTION
## Summary

`.exception` (the stored exception object) and `.handled` (a read of the global handled flag, `is_failure_handled`) on a `Failure` are in the interpreter's no-explode "safe" method list, so they carry no special control flow — yet they round-tripped through the interpreter on every call.

This handles them in `native_method_0arg` (the pure builtins layer the VM and interpreter share): for a `Failure` instance, `.exception` returns the `exception` attribute and `.handled` (0-arg read) returns `target.is_failure_handled()`.

This is safe precisely because **only those two safe accessors are added** — a *non*-safe method (`.Int`, `.succ`, `.message`, …) is not matched here, returns `None`, and reaches the interpreter, which still explodes an unhandled Failure. The `.handled = ...` setter is the 1-arg form and keeps its existing interpreter path.

## Behavior-invariance

An interpreter-vs-native before/after `diff` over `.handled`/`.exception` reads, the handled setter, and explosion-on-non-safe-method is identical. (The one raku divergence — a Failure not auto-marked handled after an explosion is caught — is pre-existing in the interpreter and unrelated.) `MUTSU_VM_STATS` confirms `.handled`/`.exception` in a loop drop to **0** interpreter fallbacks (only the setter remains). Whitelisted S04/S32 exception suites pass.

(Track A — §1 native receiver method dispatch.)

## Tests

- `t/native-failure-accessors.t` (10) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)