### PR TITLE
feat(③ ctor): VM-native `Complex.new` construction

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -935,6 +935,31 @@ impl Interpreter {
         }
     }
 
+    /// Coerce one `Complex.new` positional argument to its `f64` component
+    /// (Int/Num/Rat directly, anything else via `to_float_value`). Mirrors the
+    /// interpreter's `Complex` constructor arm exactly.
+    fn complex_component(v: Option<&Value>) -> f64 {
+        match v {
+            Some(Value::Int(i)) => *i as f64,
+            Some(Value::Num(f)) => *f,
+            Some(Value::Rat(n, d)) if *d != 0 => *n as f64 / *d as f64,
+            Some(v) => to_float_value(v).unwrap_or(0.0),
+            _ => 0.0,
+        }
+    }
+
+    /// Build a `Complex` from `.new` arguments as pure data: `Complex.new(re,
+    /// im)` -> `re + im*i`, each component coerced via `complex_component`
+    /// (missing components default to `0`). Behaviour matches the interpreter
+    /// (which is more lenient than raku — raku requires exactly two `Real`
+    /// arguments, mutsu accepts 0/1/2 — a pre-existing divergence preserved here).
+    pub(crate) fn build_native_complex_value(args: &[Value]) -> Value {
+        Value::Complex(
+            Self::complex_component(args.first()),
+            Self::complex_component(args.get(1)),
+        )
+    }
+
     /// Build a `Duration` instance from `.new` arguments as pure data: the
     /// seconds argument is stored as a `Rational` (matching Rakudo, where
     /// `Duration.new(...).tai` is always a `Rat`); `Inf`/`-Inf`/`NaN` map to the
@@ -1035,6 +1060,8 @@ impl Interpreter {
             Some(Ok(Self::version_from_value(
                 args.first().cloned().unwrap_or(Value::Nil),
             )))
+        } else if cn == "Complex" {
+            Some(Ok(Self::build_native_complex_value(args)))
         } else if cn == "Duration" {
             Some(Self::build_native_duration_value(args))
         } else if cn == "StrDistance" {
@@ -3119,21 +3146,8 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "Complex" => {
-                    let re = match args.first() {
-                        Some(Value::Int(i)) => *i as f64,
-                        Some(Value::Num(f)) => *f,
-                        Some(Value::Rat(n, d)) if *d != 0 => *n as f64 / *d as f64,
-                        Some(v) => to_float_value(v).unwrap_or(0.0),
-                        _ => 0.0,
-                    };
-                    let im = match args.get(1) {
-                        Some(Value::Int(i)) => *i as f64,
-                        Some(Value::Num(f)) => *f,
-                        Some(Value::Rat(n, d)) if *d != 0 => *n as f64 / *d as f64,
-                        Some(v) => to_float_value(v).unwrap_or(0.0),
-                        _ => 0.0,
-                    };
-                    return Ok(Value::Complex(re, im));
+                    // Shared with the VM's native fast path (pure component build).
+                    return Ok(Self::build_native_complex_value(&args));
                 }
                 "Backtrace" => {
                     let file = self

--- a/t/native-complex-construct.t
+++ b/t/native-complex-construct.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# `Complex.new(re, im)` is pure data — it builds a `Value::Complex` with each
+# component coerced to f64 — yet `.new` routed through the interpreter's generic
+# `dispatch_new`. It now constructs through the shared
+# `try_native_builtin_construct` entry (joining Buf/utf8/Uni/Version/Duration/…),
+# so the VM builds it directly. The interpreter arm calls the same
+# `build_native_complex_value` helper, keeping the two byte-identical.
+
+plan 12;
+
+is Complex.new(3, 4).Str, '3+4i', 'Complex.new(re, im)';
+is Complex.new(3, 4).re, 3, 'real part';
+is Complex.new(3, 4).im, 4, 'imaginary part';
+is Complex.new(3, 4).reals, (3, 4), 'reals list';
+ok Complex.new(3, 4) ~~ Complex, 'is a Complex';
+is Complex.new(3, 4).WHAT.^name, 'Complex', 'WHAT is Complex';
+
+# --- component coercions ---
+is Complex.new(1.5, 2.5).Str, '1.5+2.5i', 'Num components';
+is Complex.new(1/2, 3).Str, '0.5+3i', 'Rat component coerces to f64';
+
+# --- defaults (mutsu is more lenient than raku here; matches the interpreter) ---
+is Complex.new.Str, '0+0i', 'Complex.new with no args is 0+0i';
+is Complex.new(3).Str, '3+0i', 'Complex.new with one arg defaults im to 0';
+is Complex.new(0, 0).Str, '0+0i', 'zero Complex';
+
+# --- arithmetic on a freshly constructed Complex ---
+is (Complex.new(1, 2) + Complex.new(3, 4)).Str, '4+6i',
+    'arithmetic on constructed Complex values';


### PR DESCRIPTION
## Summary

`Complex.new(re, im)` builds a `Value::Complex` with each component coerced to f64 — pure data, no env/registry/user code — yet `.new` on `Complex` round-tripped through the interpreter's generic `dispatch_new` on every call (the root cause of the `Complex.new(...)` method fallback I found while probing native-method dispatch; the `.gist`/`.reals` on the resulting `Value::Complex` were already native).

This extracts the `Complex` arm of `dispatch_new` into a shared `build_native_complex_value(args)` helper (with a `complex_component` coercion matching the interpreter's Int/Num/Rat/`to_float_value` handling) and adds `Complex` to `try_native_builtin_construct`, joining Buf/Blob/utf8/utf16/Uni/Version/Duration/StrDistance/Stash. The interpreter arm calls the same helper.

## Behavior-invariance

An interpreter-vs-native before/after `diff` over re/im, Num/Rat components, defaults, `.reals`/`.WHAT`/`~~ Complex`, and arithmetic is identical. (mutsu accepts 0/1/2 args where raku requires exactly two `Real` arguments — a pre-existing leniency preserved by the verbatim extraction.) `MUTSU_VM_STATS` confirms `Complex.new(...)` in a loop drops to **0** interpreter fallbacks; `roast/S32-num/complex.t` passes.

## Tests

- `t/native-complex-construct.t` (12) — passes on mutsu (and on raku for the 2-arg cases; raku rejects the 1-arg form mutsu accepts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)