### PR TITLE
feat(③ ctor): VM-native `Date.new` construction (no-formatter case)

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -960,6 +960,103 @@ impl Interpreter {
         )
     }
 
+    /// Build a `Date` from `.new` arguments as pure data: parse named
+    /// (`year`/`month`/`day`/`formatter`) and positional args (a date string, a
+    /// `DateTime`/`Instant` to take the date of, or `y, m, d`), validate, and
+    /// construct the `Date` value (with any `:formatter` embedded). Returns the
+    /// date plus the formatter that still needs *rendering* — rendering runs a
+    /// user `Callable` (`render_date_formatter`, the only `self`-dependent step),
+    /// so a `Some` formatter makes the VM fall through to the interpreter while
+    /// the common no-formatter case stays native. All the parsing/validation
+    /// (`temporal::*`) is free of env/registry/self. Shared by both paths.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn build_native_date(
+        args: &[Value],
+    ) -> Result<(Value, Option<Value>), RuntimeError> {
+        use crate::builtins::methods_0arg::temporal;
+        let mut year: i64 = 1970;
+        let mut month: i64 = 1;
+        let mut day: i64 = 1;
+        let mut positional = Vec::new();
+        let mut has_named = false;
+        let mut formatter: Option<Value> = None;
+        for arg in args {
+            match arg {
+                Value::Pair(key, value) => match key.as_str() {
+                    "year" => {
+                        year = to_int(value);
+                        has_named = true;
+                    }
+                    "month" => {
+                        month = to_int(value);
+                        has_named = true;
+                    }
+                    "day" => {
+                        day = to_int(value);
+                        has_named = true;
+                    }
+                    "formatter" => {
+                        formatter = Some(*value.clone());
+                    }
+                    _ => {}
+                },
+                other => positional.push(other),
+            }
+        }
+        // Positional args: a date string, a DateTime/Instant, or y/m/d.
+        if let Some(v) = positional.first() {
+            match v {
+                Value::Str(s) if positional.len() == 1 => {
+                    let (y, m, d) = temporal::parse_date_string(s)?;
+                    year = y;
+                    month = m;
+                    day = d;
+                }
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if class_name == "DateTime" => {
+                    let (y, m, d, _, _, _, _) = temporal::datetime_attrs(&attributes.as_map());
+                    year = y;
+                    month = m;
+                    day = d;
+                }
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if class_name == "Instant" => {
+                    let tai = attributes
+                        .as_map()
+                        .get("value")
+                        .and_then(crate::runtime::to_float_value)
+                        .unwrap_or(0.0);
+                    let posix = temporal::instant_to_posix(tai);
+                    let epoch_days = (posix / 86400.0).floor() as i64;
+                    let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
+                    year = y;
+                    month = m;
+                    day = d;
+                }
+                _ => {
+                    year = to_int(v);
+                    if let Some(v2) = positional.get(1) {
+                        month = to_int(v2);
+                    }
+                    if let Some(v3) = positional.get(2) {
+                        day = to_int(v3);
+                    }
+                }
+            }
+        } else if !has_named {
+            return Err(RuntimeError::new("Date.new requires arguments"));
+        }
+        temporal::validate_date(year, month, day)?;
+        let date = temporal::make_date_with_formatter(year, month, day, formatter.clone());
+        Ok((date, formatter))
+    }
+
     /// Build a `Duration` instance from `.new` arguments as pure data: the
     /// seconds argument is stored as a `Rational` (matching Rakudo, where
     /// `Duration.new(...).tai` is always a `Rat`); `Inf`/`-Inf`/`NaN` map to the
@@ -1062,6 +1159,15 @@ impl Interpreter {
             )))
         } else if cn == "Complex" {
             Some(Ok(Self::build_native_complex_value(args)))
+        } else if cn == "Date" {
+            // A `:formatter` renders a user Callable (`render_date_formatter`,
+            // self-dependent) — fall through to the interpreter for that case;
+            // the common no-formatter date is built natively.
+            match Self::build_native_date(args) {
+                Ok((date, None)) => Some(Ok(date)),
+                Ok((_, Some(_))) => None,
+                Err(e) => Some(Err(e)),
+            }
         } else if cn == "Duration" {
             Some(Self::build_native_duration_value(args))
         } else if cn == "StrDistance" {
@@ -1995,90 +2101,9 @@ impl Interpreter {
                     return Ok(Self::build_native_strdistance_value(&args));
                 }
                 "Date" => {
-                    use crate::builtins::methods_0arg::temporal;
-                    let mut year: i64 = 1970;
-                    let mut month: i64 = 1;
-                    let mut day: i64 = 1;
-                    let mut positional = Vec::new();
-                    let mut has_named = false;
-                    let mut formatter: Option<Value> = None;
-                    for arg in &args {
-                        match arg {
-                            Value::Pair(key, value) => match key.as_str() {
-                                "year" => {
-                                    year = to_int(value);
-                                    has_named = true;
-                                }
-                                "month" => {
-                                    month = to_int(value);
-                                    has_named = true;
-                                }
-                                "day" => {
-                                    day = to_int(value);
-                                    has_named = true;
-                                }
-                                "formatter" => {
-                                    formatter = Some(*value.clone());
-                                }
-                                _ => {}
-                            },
-                            other => positional.push(other),
-                        }
-                    }
-                    // Handle positional args: can be string, DateTime, or y/m/d
-                    if let Some(v) = positional.first() {
-                        match v {
-                            // Single string arg: parse as date string
-                            Value::Str(s) if positional.len() == 1 => {
-                                let (y, m, d) = temporal::parse_date_string(s)?;
-                                year = y;
-                                month = m;
-                                day = d;
-                            }
-                            Value::Instance {
-                                class_name,
-                                attributes,
-                                ..
-                            } if class_name == "DateTime" => {
-                                let (y, m, d, _, _, _, _) =
-                                    temporal::datetime_attrs(&(attributes).as_map());
-                                year = y;
-                                month = m;
-                                day = d;
-                            }
-                            Value::Instance {
-                                class_name,
-                                attributes,
-                                ..
-                            } if class_name == "Instant" => {
-                                let tai = attributes
-                                    .as_map()
-                                    .get("value")
-                                    .and_then(crate::runtime::to_float_value)
-                                    .unwrap_or(0.0);
-                                let posix = temporal::instant_to_posix(tai);
-                                let epoch_days = (posix / 86400.0).floor() as i64;
-                                let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
-                                year = y;
-                                month = m;
-                                day = d;
-                            }
-                            _ => {
-                                year = to_int(v);
-                                if let Some(v2) = positional.get(1) {
-                                    month = to_int(v2);
-                                }
-                                if let Some(v3) = positional.get(2) {
-                                    day = to_int(v3);
-                                }
-                            }
-                        }
-                    } else if !has_named {
-                        return Err(RuntimeError::new("Date.new requires arguments"));
-                    }
-                    temporal::validate_date(year, month, day)?;
-                    let date =
-                        temporal::make_date_with_formatter(year, month, day, formatter.clone());
+                    // Shared with the VM's native fast path. Only the formatter
+                    // case needs `self` (it renders a user Callable).
+                    let (date, formatter) = Self::build_native_date(&args)?;
                     if let Some(formatter_value) = formatter {
                         return self.render_date_formatter(date, formatter_value);
                     }

--- a/t/native-date-construct.t
+++ b/t/native-date-construct.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# `Date.new(...)` is pure data — parse named/positional args (a date string, a
+# DateTime/Instant to take the date of, or y/m/d), validate, and build the Date
+# — except a `:formatter`, which renders a user Callable. It now constructs
+# through the shared `try_native_builtin_construct` entry via
+# `build_native_date`, so the common (no-formatter) case is VM-native; a
+# `:formatter` falls through to the interpreter (the only self-dependent step).
+# The interpreter arm calls the same helper, keeping them byte-identical.
+
+plan 14;
+
+is Date.new(2020, 1, 1).Str, '2020-01-01', 'Date.new(y, m, d)';
+is Date.new(2020, 2, 29).Str, '2020-02-29', 'leap day is valid';
+is Date.new("2021-06-15").Str, '2021-06-15', 'Date.new from a string';
+is Date.new(year => 2000, month => 12, day => 25).Str, '2000-12-25',
+    'Date.new from named args';
+
+my $d = Date.new(2020, 3, 15);
+is $d.year, 2020, '.year';
+is $d.month, 3, '.month';
+is $d.day, 15, '.day';
+is $d.WHAT.^name, 'Date', 'WHAT is Date';
+
+# --- from a DateTime ---
+is Date.new(DateTime.new(2020, 5, 5, 10, 30, 0)).Str, '2020-05-05',
+    'Date.new from a DateTime takes its date';
+
+# --- validation errors ---
+dies-ok { Date.new(2020, 13, 1) }, 'invalid month dies';
+dies-ok { Date.new(2021, 2, 29) }, 'invalid leap day dies';
+dies-ok { Date.new }, 'Date.new with no args dies';
+
+# --- day-of-week is computed ---
+is Date.new(2020, 1, 1).day-of-week, 3, '2020-01-01 is a Wednesday';
+
+# --- a :formatter still works (falls through to the interpreter) ---
+is Date.new(2020, 1, 1, formatter => { sprintf "%04d!", .year }).Str, '2020!',
+    'a :formatter renders via the interpreter';


### PR DESCRIPTION
## Summary

`Date.new(...)` parses named/positional args (a date string, a DateTime/Instant to take the date of, or y/m/d), validates, and builds the Date — all pure `temporal::*` logic — except a `:formatter`, which renders a user `Callable` (`render_date_formatter`, the only `self`-dependent step). Yet `Date.new` round-tripped through the interpreter's generic `dispatch_new` on every call (its *methods* are already native; only construction fell back).

This extracts the parse/validate/build into a shared `build_native_date(args) -> (Value, Option<formatter>)` helper (free of env/registry/self) and adds `Date` to `try_native_builtin_construct`: a no-formatter date builds natively, while a `:formatter` returns the formatter and the VM falls through to the interpreter to render it. The interpreter arm calls the same helper.

## Behavior-invariance

An interpreter-vs-native before/after `diff` (y/m/d, string, named, from-DateTime, validation errors, day-of-week, and the `:formatter` case) is identical, and matches raku. `MUTSU_VM_STATS` confirms `Date.new(y,m,d)` in a loop drops to **0** interpreter fallbacks (the `:formatter` case still falls back, as intended). `roast/S32-temporal/{Date,DateTime,DateTime-Instant-Duration}.t` pass.

Follow-up: `DateTime.new`/`Instant.from-posix` are the same pattern (pure except formatter) and fall back similarly — next slices.

## Tests

- `t/native-date-construct.t` (14) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)