### PR TITLE
feat(③ Track A): VM-native built-in class-method dispatch (Instant.from-posix)

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -986,12 +986,12 @@ impl Interpreter {
                     }
                 })
                 .collect();
-            if name == "Instant" && normalized_method == "from_posix" {
-                let secs = args.first().and_then(to_float_value).unwrap_or(0.0);
-                let tai = crate::builtins::methods_0arg::temporal::posix_to_instant(secs);
-                let mut attrs = HashMap::new();
-                attrs.insert("value".to_string(), Value::Num(tai));
-                return Ok(Value::make_instance(Symbol::intern("Instant"), attrs));
+            if name == "Instant"
+                && normalized_method == "from_posix"
+                && let Some(result) = Self::try_native_builtin_class_method(*name, method, &args)
+            {
+                // Shared with the VM's native class-method fast path.
+                return result;
             }
             if name == "Supply" && method == "interval" {
                 let seconds = args.first().map_or(1.0, |value| match value {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1441,6 +1441,30 @@ impl Interpreter {
         }
     }
 
+    /// VM-native dispatch for a built-in *class* method (a method on a type
+    /// object other than `.new`) whose result is pure data assembly — no env /
+    /// registry / user code. Currently `Instant.from-posix(secs)`, which maps a
+    /// POSIX timestamp to TAI seconds and wraps it in an `Instant`. Returns
+    /// `Some` when handled, else `None` so the caller falls through to the
+    /// interpreter's class-method dispatch. The interpreter calls the same arm,
+    /// so the two stay byte-identical. The method name is matched dash-
+    /// insensitively (`from-posix` == `from_posix`), as the interpreter does.
+    pub(crate) fn try_native_builtin_class_method(
+        class_name: Symbol,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let cn = class_name.resolve();
+        if cn == "Instant" && method.replace('-', "_") == "from_posix" {
+            let secs = args.first().and_then(to_float_value).unwrap_or(0.0);
+            let tai = crate::builtins::methods_0arg::temporal::posix_to_instant(secs);
+            let mut attrs = HashMap::new();
+            attrs.insert("value".to_string(), Value::Num(tai));
+            return Some(Ok(Value::make_instance(Symbol::intern("Instant"), attrs)));
+        }
+        None
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -125,6 +125,19 @@ impl VM {
             self.method_dispatch_pure = true;
             return result;
         }
+        // Native built-in *class* method (a pure type-object method other than
+        // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
+        // through the interpreter's class-method dispatch.
+        if let Value::Package(class_name) = &target
+            && let Some(result) = crate::runtime::Interpreter::try_native_builtin_class_method(
+                *class_name,
+                method,
+                &args,
+            )
+        {
+            self.method_dispatch_pure = true;
+            return result;
+        }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
             // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
@@ -1496,6 +1509,17 @@ impl VM {
             && let Value::Package(class_name) = &target
             && let Some(result) =
                 crate::runtime::Interpreter::try_native_builtin_construct(*class_name, &args)
+        {
+            self.method_dispatch_pure = true;
+            return result;
+        }
+        // Native built-in class method (mut path twin of the above).
+        if let Value::Package(class_name) = &target
+            && let Some(result) = crate::runtime::Interpreter::try_native_builtin_class_method(
+                *class_name,
+                method,
+                &args,
+            )
         {
             self.method_dispatch_pure = true;
             return result;

--- a/t/native-instant-from-posix.t
+++ b/t/native-instant-from-posix.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# `Instant.from-posix(secs)` is a pure *class* method (a type-object method
+# other than `.new`): it maps a POSIX timestamp to TAI seconds and wraps it in
+# an `Instant`. It now dispatches through the new VM-native class-method hook
+# `try_native_builtin_class_method` instead of routing through the interpreter's
+# generic class-method dispatch. The interpreter calls the same arm, so the two
+# are byte-identical. (This hook is the scaffold for native-izing further pure
+# built-in class methods.) `.to-posix` returns `(posix, leap-second-flag)`.
+
+plan 7;
+
+is Instant.from-posix(0).to-posix[0], 0, 'epoch instant round-trips to posix 0';
+is Instant.from-posix(1000000000).to-posix[0], 1000000000,
+    'a large posix timestamp round-trips';
+is Instant.from-posix(1.5).to-posix[0], 1.5, 'fractional seconds preserved';
+is Instant.from-posix(1000).WHAT.^name, 'Instant', 'produces an Instant';
+
+# --- arithmetic between instants yields the elapsed seconds ---
+is (Instant.from-posix(100) - Instant.from-posix(40)), 60,
+    'difference of two instants is the elapsed seconds';
+
+# --- conversion to DateTime ---
+is Instant.from-posix(1600000000).DateTime.year, 2020,
+    'Instant -> DateTime carries the right year';
+
+# --- negative posix (before epoch) ---
+is Instant.from-posix(-86400).to-posix[0], -86400, 'a pre-epoch instant';


### PR DESCRIPTION
## Summary

Introduces a VM-native fast path for built-in **class** methods — a method on a type object other than `.new` whose result is pure data assembly. The first is `Instant.from-posix(secs)`, which maps a POSIX timestamp to TAI seconds and wraps it in an `Instant`; it previously round-tripped through the interpreter's generic class-method dispatch (`dispatch_instance_and_fallback`) on every call.

Adds `try_native_builtin_class_method(class_name, method, args)` (sibling of `try_native_builtin_construct`) and calls it from the VM's two `Package`-receiver method sites (value and mut paths), right after the `.new` fast path. The interpreter's `Instant.from-posix` arm now calls the same helper. The method name is matched dash-insensitively (`from-posix` == `from_posix`), as the interpreter does.

This is the **scaffold** for native-izing further pure built-in class methods (the class-method dispatch path that `.new`'s `try_native_builtin_construct` did not cover).

## Behavior-invariance

An interpreter-vs-native before/after `diff` (to-posix round-trips, fractional/negative seconds, instant arithmetic, `.DateTime`) is identical and matches raku. `MUTSU_VM_STATS` confirms `Instant.from-posix(...)` in a loop drops to **0** interpreter fallbacks. `roast/S32-temporal/DateTime-Instant-Duration.t` passes.

## Tests

- `t/native-instant-from-posix.t` (7) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)