### PR TITLE
feat(③ ctor): VM-native `Rat.new`/`FatRat.new`/`Pair.new` construction

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -960,6 +960,83 @@ impl Interpreter {
         )
     }
 
+    /// Build a `Rat` from `.new(numerator, denominator)` as pure data
+    /// (defaults `0/1`). A `BigInt` argument routes through `make_big_rat` to
+    /// avoid truncation; otherwise the components are `to_int`-coerced.
+    pub(crate) fn build_native_rat_value(args: &[Value]) -> Value {
+        use num_bigint::BigInt;
+        let has_big = args.iter().take(2).any(|v| matches!(v, Value::BigInt(_)));
+        if has_big {
+            let a = match args.first() {
+                Some(Value::BigInt(bi)) => (**bi).clone(),
+                Some(v) => BigInt::from(to_int(v)),
+                None => BigInt::from(0),
+            };
+            let b = match args.get(1) {
+                Some(Value::BigInt(bi)) => (**bi).clone(),
+                Some(v) => BigInt::from(to_int(v)),
+                None => BigInt::from(1),
+            };
+            return crate::value::make_big_rat(a, b);
+        }
+        let a = args.first().map(to_int).unwrap_or(0);
+        let b = args.get(1).map(to_int).unwrap_or(1);
+        make_rat(a, b)
+    }
+
+    /// Build a `FatRat` from `.new(numerator, denominator)` as pure data
+    /// (defaults `0/1`), always via the BigInt path (`make_big_fat_rat`).
+    pub(crate) fn build_native_fatrat_value(args: &[Value]) -> Value {
+        use crate::value::make_big_fat_rat;
+        use num_bigint::BigInt;
+        let a = match args.first() {
+            Some(Value::BigInt(bi)) => (**bi).clone(),
+            Some(v) => BigInt::from(to_int(v)),
+            None => BigInt::from(0),
+        };
+        let b = match args.get(1) {
+            Some(Value::BigInt(bi)) => (**bi).clone(),
+            Some(v) => BigInt::from(to_int(v)),
+            None => BigInt::from(1),
+        };
+        match make_big_fat_rat(a, b) {
+            Value::Rat(n, d) => Value::FatRat(n, d),
+            Value::BigRat(n, d) => Value::BigRat(n, d),
+            other => other,
+        }
+    }
+
+    /// Build a `Pair` from `.new(:key, :value)` or `.new(key, value)` as pure
+    /// data. A `Str` key uses `Pair` (string-keyed); any other key type uses
+    /// `ValuePair`, mirroring the `=>` operator and positional `Pair.new`.
+    pub(crate) fn build_native_pair_value(args: &[Value]) -> Value {
+        let mut named_key: Option<Value> = None;
+        let mut named_value: Option<Value> = None;
+        let mut positional = Vec::new();
+        for a in args {
+            match a {
+                Value::Pair(k, v) if k == "key" => named_key = Some((**v).clone()),
+                Value::Pair(k, v) if k == "value" => named_value = Some((**v).clone()),
+                _ => positional.push(a.clone()),
+            }
+        }
+        let (key, value) = if named_key.is_some() || named_value.is_some() {
+            (
+                named_key.unwrap_or(Value::Nil),
+                named_value.unwrap_or(Value::Nil),
+            )
+        } else {
+            (
+                positional.first().cloned().unwrap_or(Value::Nil),
+                positional.get(1).cloned().unwrap_or(Value::Nil),
+            )
+        };
+        match &key {
+            Value::Str(_) => Value::Pair(key.to_string_value(), Box::new(value)),
+            _ => Value::ValuePair(Box::new(key), Box::new(value)),
+        }
+    }
+
     /// Build a `Date` from `.new` arguments as pure data: parse named
     /// (`year`/`month`/`day`/`formatter`) and positional args (a date string, a
     /// `DateTime`/`Instant` to take the date of, or `y, m, d`), validate, and
@@ -1406,6 +1483,12 @@ impl Interpreter {
             )))
         } else if cn == "Complex" {
             Some(Ok(Self::build_native_complex_value(args)))
+        } else if cn == "Rat" {
+            Some(Ok(Self::build_native_rat_value(args)))
+        } else if cn == "FatRat" {
+            Some(Ok(Self::build_native_fatrat_value(args)))
+        } else if cn == "Pair" {
+            Some(Ok(Self::build_native_pair_value(args)))
         } else if cn == "Date" {
             // A `:formatter` renders a user Callable (`render_date_formatter`,
             // self-dependent) — fall through to the interpreter for that case;
@@ -2730,85 +2813,16 @@ impl Interpreter {
                     return Ok(Self::build_native_buf_value(*class_name, &args));
                 }
                 "Rat" => {
-                    use num_bigint::BigInt;
-                    // Handle BigInt args to avoid truncation
-                    let has_big = args.iter().take(2).any(|v| matches!(v, Value::BigInt(_)));
-                    if has_big {
-                        let a = match args.first() {
-                            Some(Value::BigInt(bi)) => (**bi).clone(),
-                            Some(v) => BigInt::from(to_int(v)),
-                            None => BigInt::from(0),
-                        };
-                        let b = match args.get(1) {
-                            Some(Value::BigInt(bi)) => (**bi).clone(),
-                            Some(v) => BigInt::from(to_int(v)),
-                            None => BigInt::from(1),
-                        };
-                        return Ok(crate::value::make_big_rat(a, b));
-                    }
-                    let a = match args.first() {
-                        Some(v) => to_int(v),
-                        None => 0,
-                    };
-                    let b = match args.get(1) {
-                        Some(v) => to_int(v),
-                        None => 1,
-                    };
-                    return Ok(make_rat(a, b));
+                    // Shared with the VM's native fast path (pure component build).
+                    return Ok(Self::build_native_rat_value(&args));
                 }
                 "FatRat" => {
-                    use crate::value::make_big_fat_rat;
-                    use num_bigint::BigInt;
-                    let a = match args.first() {
-                        Some(Value::BigInt(bi)) => (**bi).clone(),
-                        Some(v) => BigInt::from(to_int(v)),
-                        None => BigInt::from(0),
-                    };
-                    let b = match args.get(1) {
-                        Some(Value::BigInt(bi)) => (**bi).clone(),
-                        Some(v) => BigInt::from(to_int(v)),
-                        None => BigInt::from(1),
-                    };
-                    return Ok(match make_big_fat_rat(a, b) {
-                        Value::Rat(n, d) => Value::FatRat(n, d),
-                        Value::BigRat(n, d) => Value::BigRat(n, d),
-                        other => other,
-                    });
+                    // Shared with the VM's native fast path.
+                    return Ok(Self::build_native_fatrat_value(&args));
                 }
                 "Pair" => {
-                    // Pair.new(:key<foo>, :value<bar>) or Pair.new(key, value)
-                    let mut named_key: Option<Value> = None;
-                    let mut named_value: Option<Value> = None;
-                    let mut positional = Vec::new();
-                    for a in args.iter() {
-                        match a {
-                            Value::Pair(k, v) if k == "key" => {
-                                named_key = Some((**v).clone());
-                            }
-                            Value::Pair(k, v) if k == "value" => {
-                                named_value = Some((**v).clone());
-                            }
-                            _ => positional.push(a.clone()),
-                        }
-                    }
-                    if named_key.is_some() || named_value.is_some() {
-                        let key = named_key.unwrap_or(Value::Nil);
-                        let value = named_value.unwrap_or(Value::Nil);
-                        // Preserve the original key type: a string key uses Pair,
-                        // any other key type uses ValuePair (mirrors the `=>` and
-                        // positional Pair.new behavior).
-                        return Ok(match &key {
-                            Value::Str(_) => Value::Pair(key.to_string_value(), Box::new(value)),
-                            _ => Value::ValuePair(Box::new(key), Box::new(value)),
-                        });
-                    }
-                    let key = positional.first().cloned().unwrap_or(Value::Nil);
-                    let value = positional.get(1).cloned().unwrap_or(Value::Nil);
-                    // A string positional key also uses Pair for consistent display.
-                    return Ok(match &key {
-                        Value::Str(_) => Value::Pair(key.to_string_value(), Box::new(value)),
-                        _ => Value::ValuePair(Box::new(key), Box::new(value)),
-                    });
+                    // Shared with the VM's native fast path.
+                    return Ok(Self::build_native_pair_value(&args));
                 }
                 "Set" | "SetHash" => {
                     // Check for lazy inputs

--- a/t/native-rat-pair-construct.t
+++ b/t/native-rat-pair-construct.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# `Rat.new(n, d)`, `FatRat.new(n, d)` and `Pair.new(...)` are pure data
+# constructors — yet `.new` routed through the interpreter's generic
+# `dispatch_new` on every call. They now build through the shared
+# `try_native_builtin_construct` entry via `build_native_{rat,fatrat,pair}_value`
+# helpers that the interpreter arms also call, keeping the two byte-identical.
+
+plan 16;
+
+# --- Rat ---
+is Rat.new(1, 2), 0.5, 'Rat.new(1, 2)';
+is Rat.new(3, 4).nude, (3, 4), 'Rat.new keeps numerator/denominator';
+is Rat.new(6, 4).nude, (3, 2), 'Rat.new normalizes';
+is Rat.new(5).nude, (5, 1), 'Rat.new(n) defaults denominator to 1';
+is Rat.new.nude, (0, 1), 'Rat.new with no args is 0/1';
+is Rat.new(10000000000000000000, 3).nude,
+    (10000000000000000000, 3), 'Rat.new with a BigInt numerator';
+
+# --- FatRat ---
+is FatRat.new(1, 3).WHAT.^name, 'FatRat', 'FatRat.new produces a FatRat';
+is FatRat.new(2, 4).nude, (1, 2), 'FatRat.new normalizes';
+
+# --- Pair (positional) ---
+is Pair.new("a", 1).key, 'a', 'Pair.new positional key';
+is Pair.new("a", 1).value, 1, 'Pair.new positional value';
+is Pair.new("a", 1).gist, 'a => 1', 'Pair.new gist';
+
+# --- Pair (named) ---
+is Pair.new(key => "k", value => 42).key, 'k', 'Pair.new(:key) key';
+is Pair.new(key => "k", value => 42).value, 42, 'Pair.new(:value) value';
+
+# --- a non-string key yields a ValuePair-style pair ---
+is Pair.new(5, "v").key, 5, 'Pair.new with a numeric key';
+is Pair.new(5, "v").value, 'v', 'Pair.new numeric-key value';
+
+# --- arithmetic on constructed Rats ---
+is (Rat.new(1, 2) + Rat.new(1, 3)), Rat.new(5, 6), 'arithmetic on constructed Rats';


### PR DESCRIPTION
## Summary

`Rat.new(n, d)`, `FatRat.new(n, d)` and `Pair.new(...)` are pure data constructors (numerator/denominator coercion via `to_int`/BigInt; a Str key → `Pair`, otherwise `ValuePair`) — yet `.new` on them round-tripped through the interpreter's generic `dispatch_new` on every call.

This extracts each `dispatch_new` arm into a shared helper (`build_native_rat_value`, `build_native_fatrat_value`, `build_native_pair_value` — free of env/registry/self) and adds `Rat`/`FatRat`/`Pair` to `try_native_builtin_construct`. The interpreter arms call the same helpers.

## Behavior-invariance

An interpreter-vs-native before/after `diff` (Rat normalize, BigInt numerator, Rat defaults, FatRat, positional/named Pair, numeric-key ValuePair, arithmetic) is identical, and matches raku. `MUTSU_VM_STATS` confirms each `.new` in a loop drops to **0** interpreter fallbacks. `roast/S02-types/pair.t` and `roast/S32-num/rat.t` pass.

## Tests

- `t/native-rat-pair-construct.t` (16) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)