### PR TITLE
feat(③ ctor): VM-native `Int.new`/`Num.new`/`Str.new`/`Slip.new` construction

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -960,6 +960,37 @@ impl Interpreter {
         )
     }
 
+    /// Build an `Int` from `.new(value)` as pure data: `to_int`-coerce the
+    /// argument (default `0`). A type-object argument is an error, matching the
+    /// interpreter's basic-type `.new` arm.
+    pub(crate) fn build_native_int_value(args: &[Value]) -> Result<Value, RuntimeError> {
+        if matches!(args.first(), Some(Value::Package(_))) {
+            return Err(RuntimeError::new("Cannot convert type object to Int"));
+        }
+        Ok(Value::Int(args.first().map_or(0, crate::runtime::to_int)))
+    }
+
+    /// Build a `Num` from `.new(value)` as pure data: coerce the argument to
+    /// f64 (default `0e0`). A type-object or non-coercible argument is an error,
+    /// matching the interpreter's basic-type `.new` arm.
+    pub(crate) fn build_native_num_value(args: &[Value]) -> Result<Value, RuntimeError> {
+        if let Some(arg) = args.first() {
+            if matches!(arg, Value::Package(_)) {
+                return Err(RuntimeError::new(
+                    "Cannot coerce to Num: no .Num method found",
+                ));
+            }
+            match crate::runtime::to_float_value(arg) {
+                Some(f) => Ok(Value::Num(f)),
+                None => Err(RuntimeError::new(
+                    "Cannot coerce to Num: no .Num method found",
+                )),
+            }
+        } else {
+            Ok(Value::Num(0.0))
+        }
+    }
+
     /// Build a `Rat` from `.new(numerator, denominator)` as pure data
     /// (defaults `0/1`). A `BigInt` argument routes through `make_big_rat` to
     /// avoid truncation; otherwise the components are `to_int`-coerced.
@@ -1483,6 +1514,19 @@ impl Interpreter {
             )))
         } else if cn == "Complex" {
             Some(Ok(Self::build_native_complex_value(args)))
+        } else if cn == "Int" {
+            Some(Self::build_native_int_value(args))
+        } else if cn == "Num" {
+            Some(Self::build_native_num_value(args))
+        } else if cn == "Str" {
+            // The default Str constructor ignores positional args and yields the
+            // empty string (mutsu is lenient where raku rejects a positional).
+            // (`Bool` is intentionally NOT native-ized: it is an enum, so
+            // `Bool.new` errors in `dispatch_new` before the basic-type arm —
+            // the native path must preserve that, so it falls through.)
+            Some(Ok(Value::str(String::new())))
+        } else if cn == "Slip" {
+            Some(Ok(Value::slip(args.to_vec())))
         } else if cn == "Rat" {
             Some(Ok(Self::build_native_rat_value(args)))
         } else if cn == "FatRat" {
@@ -3232,7 +3276,8 @@ impl Interpreter {
                     return Ok(Value::make_instance(*class_name, attrs));
                 }
                 "Slip" => {
-                    return Ok(Value::slip(args.clone()));
+                    // Shared with the VM's native fast path.
+                    return Ok(Value::slip(args.to_vec()));
                 }
                 "Match" => {
                     // Match.new(:orig("..."), :from(N), :pos(N), :list(...), :hash(...))
@@ -4484,32 +4529,10 @@ impl Interpreter {
             Value::Package(name) => {
                 // Built-in type objects: .new creates a default defined instance
                 match name.resolve().as_str() {
-                    "Int" => {
-                        if matches!(args.first(), Some(Value::Package(_))) {
-                            return Err(RuntimeError::new("Cannot convert type object to Int"));
-                        }
-                        let int_val = args.first().map_or(0, crate::runtime::to_int);
-                        Ok(Value::Int(int_val))
-                    }
+                    // Shared with the VM's native fast path.
+                    "Int" => Self::build_native_int_value(&args),
                     "Str" => Ok(Value::str(String::new())),
-                    "Num" => {
-                        if let Some(arg) = args.first() {
-                            // Type objects (e.g. anonymous class {}) cannot coerce to Num
-                            if matches!(arg, Value::Package(_)) {
-                                return Err(RuntimeError::new(
-                                    "Cannot coerce to Num: no .Num method found",
-                                ));
-                            }
-                            match crate::runtime::to_float_value(arg) {
-                                Some(f) => Ok(Value::Num(f)),
-                                None => Err(RuntimeError::new(
-                                    "Cannot coerce to Num: no .Num method found",
-                                )),
-                            }
-                        } else {
-                            Ok(Value::Num(0.0))
-                        }
-                    }
+                    "Num" => Self::build_native_num_value(&args),
                     "Bool" => Ok(Value::Bool(false)),
                     "Attribute" => {
                         // Attribute.new(:name<...>, :type(Int), :package<Foo>)

--- a/t/native-int-num-str-slip-construct.t
+++ b/t/native-int-num-str-slip-construct.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# `Int.new(v)`, `Num.new(v)`, `Str.new` and `Slip.new(...)` are pure data
+# constructors — yet `.new` routed through the interpreter's generic
+# `dispatch_new`. They now build through the shared `try_native_builtin_construct`
+# entry (Int/Num via `build_native_{int,num}_value`, Str/Slip inline) that the
+# interpreter arms also use, keeping them byte-identical. `Bool` is deliberately
+# left on the interpreter (it is an enum, so `Bool.new` errors before the
+# basic-type arm — the native path preserves that by falling through).
+
+plan 13;
+
+# --- Int ---
+is Int.new(5), 5, 'Int.new(5)';
+is Int.new, 0, 'Int.new defaults to 0';
+is Int.new(3.9), 3, 'Int.new truncates a Num';
+is Int.new(-7), -7, 'Int.new negative';
+dies-ok { Int.new(Int) }, 'Int.new on a type object dies';
+
+# --- Num ---
+is Num.new(1.5), 1.5e0, 'Num.new(1.5)';
+is Num.new, 0e0, 'Num.new defaults to 0e0';
+is Num.new(3), 3e0, 'Num.new from an Int';
+dies-ok { Num.new(Int) }, 'Num.new on a type object dies';
+
+# --- Str ---
+is Str.new, '', 'Str.new is the empty string';
+
+# --- Slip ---
+is Slip.new(1, 2, 3).elems, 3, 'Slip.new from elements';
+is (Slip.new(1, 2), 3).elems, 3, 'a Slip flattens into a surrounding list';
+
+# --- arithmetic on a constructed Int ---
+is (Int.new(10) + 5), 15, 'arithmetic on a constructed Int';


### PR DESCRIPTION
## Summary

`Int.new(v)` (`to_int`-coerce, type-object errors), `Num.new(v)` (f64-coerce, type-object/non-coercible errors), `Str.new` (the empty string) and `Slip.new(...)` (a Slip of the args) are pure data constructors — yet `.new` round-tripped through the interpreter's generic `dispatch_new` on every call.

Adds `Int`/`Num`/`Str`/`Slip` to `try_native_builtin_construct` (Int/Num via new shared `build_native_{int,num}_value` helpers the interpreter's basic-type arms also call; Str/Slip are trivial inline constructors mirrored in both places).

`Bool` is deliberately **NOT** native-ized: it is an enum, so `Bool.new` errors in `dispatch_new` *before* the (dead-code) basic-type `Bool` arm — native-izing it to `False` would diverge, so it falls through to preserve the error. (Caught by the interpreter-vs-native diff.)

## Behavior-invariance

An interpreter-vs-native before/after `diff` (Int coerce/default/negative/type-object error, Num coerce/default/error, Str empty, Slip elems + flattening, Bool still erroring, arithmetic) is identical, and matches raku (mutsu's lenient `Str.new(positional)` and enum `Bool.new` aside). `MUTSU_VM_STATS` confirms each `.new` drops to **0** interpreter fallbacks; `roast/S02-types/num.t` and `S02-literals/numeric.t` pass.

## Tests

- `t/native-int-num-str-slip-construct.t` (13) — passes on raku and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)