### PR TITLE
feat(③ ctor): VM-native `IterationBuffer.new` construction

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1068,6 +1068,40 @@ impl Interpreter {
         }
     }
 
+    /// Build an `IterationBuffer` from `.new(...)` as pure data: flatten each
+    /// argument (an Array/Seq/Slip is spread, another IterationBuffer's items
+    /// are taken, anything else is a single element) into the buffer's
+    /// `__mutsu_iterationbuffer_items` array.
+    pub(crate) fn build_native_iterationbuffer_value(class_name: Symbol, args: &[Value]) -> Value {
+        let mut items = Vec::new();
+        for arg in args {
+            match arg {
+                Value::Array(vals, ..) => items.extend(vals.iter().cloned()),
+                Value::Seq(vals) | Value::Slip(vals) => items.extend(vals.iter().cloned()),
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if class_name == "IterationBuffer" => {
+                    match attributes.as_map().get("__mutsu_iterationbuffer_items") {
+                        Some(Value::Array(vals, ..)) => items.extend(vals.iter().cloned()),
+                        Some(Value::Seq(vals)) | Some(Value::Slip(vals)) => {
+                            items.extend(vals.iter().cloned())
+                        }
+                        _ => {}
+                    }
+                }
+                other => items.push(other.clone()),
+            }
+        }
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "__mutsu_iterationbuffer_items".to_string(),
+            Value::real_array(items),
+        );
+        Value::make_instance(class_name, attrs)
+    }
+
     /// Build a `Date` from `.new` arguments as pure data: parse named
     /// (`year`/`month`/`day`/`formatter`) and positional args (a date string, a
     /// `DateTime`/`Instant` to take the date of, or `y, m, d`), validate, and
@@ -1527,6 +1561,10 @@ impl Interpreter {
             Some(Ok(Value::str(String::new())))
         } else if cn == "Slip" {
             Some(Ok(Value::slip(args.to_vec())))
+        } else if cn == "IterationBuffer" {
+            Some(Ok(Self::build_native_iterationbuffer_value(
+                class_name, args,
+            )))
         } else if cn == "Rat" {
             Some(Ok(Self::build_native_rat_value(args)))
         } else if cn == "FatRat" {
@@ -2108,37 +2146,8 @@ impl Interpreter {
             }
             match base_class_name {
                 "IterationBuffer" => {
-                    let mut items = Vec::new();
-                    for arg in &args {
-                        match arg {
-                            Value::Array(vals, ..) => items.extend(vals.iter().cloned()),
-                            Value::Seq(vals) | Value::Slip(vals) => {
-                                items.extend(vals.iter().cloned())
-                            }
-                            Value::Instance {
-                                class_name,
-                                attributes,
-                                ..
-                            } if class_name == "IterationBuffer" => {
-                                match attributes.as_map().get("__mutsu_iterationbuffer_items") {
-                                    Some(Value::Array(vals, ..)) => {
-                                        items.extend(vals.iter().cloned())
-                                    }
-                                    Some(Value::Seq(vals)) | Some(Value::Slip(vals)) => {
-                                        items.extend(vals.iter().cloned())
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            other => items.push(other.clone()),
-                        }
-                    }
-                    let mut attrs = HashMap::new();
-                    attrs.insert(
-                        "__mutsu_iterationbuffer_items".to_string(),
-                        Value::real_array(items),
-                    );
-                    return Ok(Value::make_instance(*class_name, attrs));
+                    // Shared with the VM's native fast path.
+                    return Ok(Self::build_native_iterationbuffer_value(*class_name, &args));
                 }
                 "Array" | "List" | "Positional" | "array" => {
                     // native `array` requires a type parameter (e.g. array[int].new)

--- a/t/native-iterationbuffer-construct.t
+++ b/t/native-iterationbuffer-construct.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+# `IterationBuffer.new(...)` flattens its arguments into the buffer's items —
+# pure data — yet `.new` round-tripped through the interpreter's `dispatch_new`.
+# It now builds through the shared `try_native_builtin_construct` entry via
+# `build_native_iterationbuffer_value`, which the interpreter arm also calls.
+#
+# NOTE: raku's IterationBuffer.new only takes named args (a positional dies);
+# mutsu's constructor is leniently positional. This test pins mutsu's
+# (interpreter-matching, byte-identical) behavior — it is not run against raku.
+
+plan 6;
+
+is IterationBuffer.new(1, 2, 3).elems, 3, 'IterationBuffer.new from elements';
+is IterationBuffer.new.elems, 0, 'empty IterationBuffer.new';
+is IterationBuffer.new([10, 20], 30).elems, 3, 'an Array argument is spread';
+my $c = IterationBuffer.new(1, 2);
+$c.push(3);
+is $c.elems, 3, 'push works on a natively-built buffer';
+is IterationBuffer.new($c).elems, 3, 'another IterationBuffer is copied in';
+is IterationBuffer.new.WHAT.^name, 'IterationBuffer', 'WHAT is IterationBuffer';


### PR DESCRIPTION
## Summary

`IterationBuffer.new(...)` flattens its arguments (an Array/Seq/Slip is spread, another IterationBuffer's items are taken, anything else is a single element) into the buffer's `__mutsu_iterationbuffer_items` array — pure data — yet `.new` round-tripped through the interpreter's generic `dispatch_new`.

Extracts that `dispatch_new` arm into a shared `build_native_iterationbuffer_value(class_name, args)` helper and adds `IterationBuffer` to `try_native_builtin_construct`; the interpreter arm calls the same helper.

## Behavior-invariance

An interpreter-vs-native before/after `diff` (elements, empty, a spread Array, push on the result, copying another buffer) is identical. `MUTSU_VM_STATS` confirms `IterationBuffer.new(...)` in a loop drops to **0** interpreter fallbacks. (mutsu's constructor is leniently positional where raku's takes only named args — a pre-existing leniency preserved by the verbatim extraction; the pin documents this and is not run against raku.)

## Tests

- `t/native-iterationbuffer-construct.t` (6) — passes on mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)