### PR TITLE
feat(Track B): VM-native array mutators on `is Array`-backed instances

### DIFF
--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1323,9 +1323,28 @@ impl VM {
                             .get("__mutsu_array_storage")
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));
+                        // VM-native fast path: simple mutators on the plain
+                        // untyped backing array are performed in Rust and the
+                        // updated storage written back, with no interpreter
+                        // dispatch. Richer methods fall through below.
+                        if let Some(result) =
+                            Self::native_array_storage_mut(&mut storage, &method, &args)
+                        {
+                            let result = result?;
+                            self.write_back_array_storage_instance(
+                                &target_name,
+                                inst_class,
+                                attributes,
+                                inst_id,
+                                storage,
+                            );
+                            self.stack.push(result);
+                            self.env_dirty = true;
+                            return Ok(());
+                        }
                         // Perform the operation on the backing array
                         // TODO: compile to bytecode — Array-backed instance method
-                        // (push/pop/shift on `is Array` storage). See ledger §1.
+                        // (non-simple methods on `is Array` storage). See ledger §1.
                         crate::vm::vm_stats::record_method_fallback(&method);
                         let result = self
                             .interpreter
@@ -1351,22 +1370,13 @@ impl VM {
                         }
                         self.interpreter.env_mut().remove("__mutsu_array_tmp");
                         // Update the instance with the new storage
-                        let new_attrs = crate::value::InstanceAttrs::clone(attributes);
-                        new_attrs.insert("__mutsu_array_storage".to_string(), storage);
-                        let updated_instance = Value::Instance {
-                            class_name: *inst_class,
-                            attributes: Arc::new(crate::value::InstanceAttrs::new(
-                                *inst_class,
-                                (new_attrs).to_map(),
-                                inst_id,
-                                true,
-                            )),
-                            id: inst_id,
-                        };
-                        self.interpreter
-                            .env_mut()
-                            .insert(target_name.to_string(), updated_instance);
-                        self.env_dirty = true;
+                        self.write_back_array_storage_instance(
+                            &target_name,
+                            inst_class,
+                            attributes,
+                            inst_id,
+                            storage,
+                        );
                         self.stack.push(result);
                         self.env_dirty = true;
                         return Ok(());
@@ -1546,6 +1556,107 @@ impl VM {
             _ => unreachable!(),
         };
         Some(Ok(result))
+    }
+
+    /// VM-native simple array mutators (push/pop/shift/unshift/append/prepend)
+    /// applied directly to an `is Array`-backed instance's backing storage
+    /// `Value` (ledger §1: array-backed instance dispatch -> VM-native).
+    ///
+    /// Mirrors the interpreter's plain, non-shared env-keyed mutator branch
+    /// (`methods_mut.rs`): the `__mutsu_array_storage` value is a plain untyped
+    /// `real_array`, so `push`/`append`/`unshift`/`prepend` extend/insert the
+    /// normalized arguments and `pop`/`shift` remove an element (returning a
+    /// typed empty Failure when empty). `storage` is mutated in place and the
+    /// method's result value is returned. Returns `None` (fall through to the
+    /// interpreter) for any other method, a non-plain `ArrayKind`, or an
+    /// arity-erroring `pop`/`shift` so the interpreter owns the richer cases.
+    fn native_array_storage_mut(
+        storage: &mut Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let Value::Array(arc_items, crate::value::ArrayKind::Array) = storage else {
+            return None;
+        };
+        let result = match method {
+            "push" => {
+                let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
+                Arc::make_mut(arc_items).extend(norm);
+                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+            }
+            "append" => {
+                let flat = crate::runtime::flatten_append_args(args.to_vec());
+                Arc::make_mut(arc_items).extend(flat);
+                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+            }
+            "unshift" => {
+                let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
+                let items = Arc::make_mut(arc_items);
+                for (i, v) in norm.into_iter().enumerate() {
+                    items.insert(i, v);
+                }
+                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+            }
+            "prepend" => {
+                let flat = crate::runtime::flatten_append_args(args.to_vec());
+                let items = Arc::make_mut(arc_items);
+                for (i, v) in flat.into_iter().enumerate() {
+                    items.insert(i, v);
+                }
+                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+            }
+            "pop" => {
+                if !args.is_empty() {
+                    return None;
+                }
+                if arc_items.is_empty() {
+                    crate::runtime::utils::make_empty_array_failure_what("pop", "Array")
+                } else {
+                    Arc::make_mut(arc_items).pop().unwrap_or(Value::Nil)
+                }
+            }
+            "shift" => {
+                if !args.is_empty() {
+                    return None;
+                }
+                if arc_items.is_empty() {
+                    crate::runtime::utils::make_empty_array_failure_what("shift", "Array")
+                } else {
+                    Arc::make_mut(arc_items).remove(0)
+                }
+            }
+            _ => return None,
+        };
+        Some(Ok(result))
+    }
+
+    /// Rebuild an `is Array`-backed instance with its `__mutsu_array_storage`
+    /// attribute replaced by `storage` and write it back into `target_name`.
+    /// Shared by the VM-native mutator fast path and the interpreter fallback.
+    fn write_back_array_storage_instance(
+        &mut self,
+        target_name: &str,
+        inst_class: &Symbol,
+        attributes: &Arc<crate::value::InstanceAttrs>,
+        inst_id: u64,
+        storage: Value,
+    ) {
+        let new_attrs = crate::value::InstanceAttrs::clone(attributes);
+        new_attrs.insert("__mutsu_array_storage".to_string(), storage);
+        let updated_instance = Value::Instance {
+            class_name: *inst_class,
+            attributes: Arc::new(crate::value::InstanceAttrs::new(
+                *inst_class,
+                new_attrs.to_map(),
+                inst_id,
+                true,
+            )),
+            id: inst_id,
+        };
+        self.interpreter
+            .env_mut()
+            .insert(target_name.to_string(), updated_instance);
+        self.env_dirty = true;
     }
 
     /// VM-native `splice` on a plain, untyped `@`-array bound to `target_name`

--- a/t/native-array-backed-instance.t
+++ b/t/native-array-backed-instance.t
@@ -1,0 +1,70 @@
+use Test;
+
+# VM-native simple array mutators (push/pop/shift/unshift/append/prepend)
+# on an `is Array`-backed instance's backing storage.
+
+plan 20;
+
+class Stack is Array {
+}
+
+# push (single + multiple args)
+my $s = Stack.new;
+$s.push(1);
+is $s.elems, 1, 'push single grows storage';
+$s.push(2, 3);
+is $s.elems, 3, 'push multiple args';
+is $s.join(','), '1,2,3', 'push order correct';
+
+# pop returns the removed element and shrinks
+is $s.pop, 3, 'pop returns last element';
+is $s.elems, 2, 'pop shrinks storage';
+is $s.join(','), '1,2', 'pop leaves the rest';
+
+# shift returns the first element and shrinks
+is $s.shift, 1, 'shift returns first element';
+is $s.elems, 1, 'shift shrinks storage';
+is $s.join(','), '2', 'shift leaves the rest';
+
+# unshift prepends
+$s.unshift(0);
+is $s.join(','), '0,2', 'unshift prepends';
+
+# append (one-arg flattening rule)
+$s.append(9, 10);
+is $s.join(','), '0,2,9,10', 'append multiple args';
+$s.append((11, 12));
+is $s.join(','), '0,2,9,10,11,12', 'append flattens a single list arg';
+
+# prepend
+$s.prepend(-1);
+is $s.join(','), '-1,0,2,9,10,11,12', 'prepend prepends';
+
+# pop/shift on empty storage returns an undefined Failure
+my $empty = Stack.new;
+my $p = $empty.pop;
+nok $p.defined, 'pop on empty is undefined';
+my $sh = $empty.shift;
+nok $sh.defined, 'shift on empty is undefined';
+
+# Slip flattening on push
+my $t = Stack.new;
+$t.push(|(4, 5, 6));
+is $t.join(','), '4,5,6', 'push flattens a Slip';
+
+# Mutations persist across multiple method calls on the same variable
+my $u = Stack.new;
+$u.push($_) for 1..5;
+is $u.elems, 5, 'repeated push in a loop accumulates';
+is $u.join(','), '1,2,3,4,5', 'loop push order';
+
+# A subclass with extra methods keeps working
+class Counter is Array {
+    method total { self.elems }
+}
+my $c = Counter.new;
+$c.push(10, 20, 30);
+is $c.total, 3, 'custom method sees native-pushed elements';
+is $c.join('+'), '10+20+30', 'native mutation visible to custom method';
+
+done-testing;


### PR DESCRIPTION
## Summary

Phase I close-out (Track B): VM-natives the last clean dispatch fallback for **array-backed instances**.

When an `Instance`'s class inherits from `Array`, mutating Array methods are delegated to its `__mutsu_array_storage` attribute. Previously this delegation always routed through the tree-walking interpreter (`call_method_mut_with_values` on a temporary env slot). This PR adds a VM-native fast path for the simple mutators.

## What changed

- New `native_array_storage_mut(storage, method, args)` — performs `push`/`pop`/`shift`/`unshift`/`append`/`prepend` directly on the plain untyped backing `Value::Array` in Rust, mirroring the interpreter's non-shared env-keyed mutator branch exactly (`normalize_push_unshift_args` / `flatten_append_args`, typed empty `Failure` for `pop`/`shift` on empty).
- New `write_back_array_storage_instance(...)` helper — rebuilds the instance with updated storage and writes it back. Extracted from the existing fallback so both the native fast path and the interpreter fallback share one writeback.
- Conservative fall-through: richer methods (`join`/`sort`/`map`/`splice`/`AT-POS`/...), non-plain `ArrayKind`, and arity-erroring `pop`/`shift` continue to the interpreter unchanged → behavior-invariant.

## Verification

- `t/native-array-backed-instance.t` (20) — push/pop/shift/unshift/append/prepend, Slip flatten, empty-Failure, loop accumulation, custom-method visibility. All pass.
- `MUTSU_VM_STATS=1`: `push`/`pop`/`shift`/... no longer appear in the method-fallback breakdown for `is Array` instances (only read-only `join`/`elems` and the `new` ctor remain, which are separate ledger items).
- `make test`: 791 files / 7362 tests, all pass.

Ledger: removes the `vm_call_method_mut_ops.rs` "array-backed instance" §1 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)