### PR TITLE
feat(C track): VM-native atomic scalar compound-assign ($x OP= rhs)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -177,8 +177,18 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             増減は ① のアトミック ContainerRef RMW を流用（決定的）。`StateVarInit` は genuine `state`
             宣言のみに出るので `ff`/`fff`/smart-match の内部 state（`set_state_var` 直接・非セル）は不変。
             テスト `t/concurrent-state-var.t`。
+            **スライス 3 LANDED（PR #3059）**: スカラ複合代入（`$x OP= rhs`）のアトミック化。
+            融合オペコード `OpCode::AtomicCompoundVar { name_idx, op: CompoundBaseOp }` を
+            コンパイラのチョークポイント（`compile_expr_assign`／`Stmt::Assign` 末尾）で
+            **平の env 名前付きスカラのみ**に発行（local スロット／twigil は除外＝ホットな
+            リテラル `$x = $x + y` own-local ループは融合しない）。非セル書き込みは `++` の
+            env 書き戻し末尾を抽出した `store_named_scalar_rmw_result` を `++`/`--` と共用するので
+            METHOD captured-outer 伝播が `++` と構造的に同一。ContainerRef セル分岐はロック保持下の
+            アトミック RMW。`await (^100).map: { start { for ^100 { $c += 1 } } }` が決定的に 10000。
+            **要点**: 融合 rhs は `compile_expr` でコンパイル（`compile_call_arg` はスカラ被演算子を
+            itemize/escape-box して captured-outer 伝播を壊す）。テスト `t/concurrent-compound-assign.t`。
             **残**: `state @`/`%`（配列/ハッシュ）のスレッド共有（要素セル＝Track B 依存）、
-            lexical `@`/`%` 共有・複合代入（`+=`）のアトミック化。
+            lexical `@`/`%` 共有・複合代入のアトミック化（同 Track B 依存）。
       - [x] **react/supply ランタイムの VM ネイティブ化 — 完了（Stage 1+2+3, #3010〜#3039, 2026-06、
             詳細は [news/2026-06.md](news/2026-06.md)）**。駆動ループの 4 箇所二重化を単一エンジンへ統合し
             （Stage 1）、ループ所有権を `impl Interpreter`→`impl VM`（`vm/vm_react_loop.rs`）へ逆転して

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -98,6 +98,42 @@ tree-walk runtime で対象外）。検証: `t/supply-quit-handler.t`(7 — when
 whitelist S17-supply 代表 6 ファイル(119) PASS、make test。react 形式 `react { whenever {...QUIT...} }` の
 チャネル quit ハングは**変更前から存在する別バグ**でスコープ外。
 
+### トラック C 共有セル スライス 3: スカラ複合代入（`$x OP= rhs`）のアトミック化（#3059, 2026-06-14）
+
+スライス 1（`start` 捕捉スカラ → 共有 `ContainerRef` セル、`++`/`--` のアトミック RMW）、
+スライス 2（`state $n` スレッド共有）に続き、スカラ**複合代入**（`+= -= *= /= ~= min= +&= …`）を
+共有セル上のアトミック read-modify-write に一般化。`start` 捕捉 lexical がスレッド間で決定的に積算される:
+
+```raku
+my $c = 0;
+await (^100).map: { start { for ^100 { $c += 1 } } };
+say $c;   # 10000（従来は ~4000、lost-update でレース）
+```
+
+raku は `+=` のアトミック性を保証しないが、mutsu はスライス 1 の `++` と同様に意図的に決定的。
+
+**設計**:
+- 新オペコード `OpCode::AtomicCompoundVar { name_idx, op: CompoundBaseOp }` を
+  コンパイラのチョークポイント（`compile_expr_assign`／`Stmt::Assign` 末尾）で
+  **平の env 名前付きスカラのみ**に発行。local スロット・twigil/特殊ターゲットは除外するので、
+  ホットなリテラル `$x = $x + y` own-local ループは融合しない（融合すると 3M ループが 31.6s→41s+ に退行した）。
+- mutation/escape 解析（`op_name_const_idx`／`op_name_write_const_idx`／`has_env_writes`）に登録し、
+  `$c` が共有 `ContainerRef` セルに box され続けるようにする。
+- 非セル書き込みは `exec_post_increment_op_inner` から抽出した `store_named_scalar_rmw_result`（`++` の
+  env 書き戻し末尾）を `++`/`--` と共用 → METHOD captured-outer スカラ伝播が `++` と構造的に同一。
+- ContainerRef セル分岐はロックを RMW 全体で保持（アトミック）。Proxy 分岐は fetch/op/store。
+- `apply_compound_base_op` は平の `Binary` 経路と同じ `exec_*_op` を流用（演算子セマンティクス・強制・
+  ユーザ `infix` オーバーロードが一致）。
+
+**最初の（リバートされた）試行が突き当たった壁の正体**は、事後分析が予測した「SetGlobal ストア末尾の再利用
+リファクタ」ではなく、コンパイラの 1 行だった: 融合 rhs を `compile_expr` でコンパイルする（`compile_call_arg`
+ではない）。`compile_call_arg` はスカラ被演算子を itemize/escape-box してしまい、rhs が変数参照
+（`$acc += $!step` をメソッド内で）のとき captured-outer の env 伝播を壊していた。
+
+検証: `t/concurrent-compound-assign.t`（新規, 8 tests）、回帰アンカー `t/method-env-dirty.t`（24/24）・
+`t/test-util-test-iter-opt.t`（3/3）、`make test` green、3M ローカルループは ~baseline（local は非融合）。
+**残**: `state @`/`%`・lexical `@`/`%` の共有（要素セル＝Track B 依存）、unsafe aliasing 撤廃。
+
 ### トラック A §2: lexical `&`-var 名呼びの VM ネイティブ dispatch 完結（#2949 / #3021 / #3022 / #3024）
 
 `-> &op {...}` / `my &f = ...` のようにレキシカル束縛された Callable を `op(...)` と名前で呼ぶ経路を

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -46,6 +46,14 @@ impl Compiler {
             });
             self.code.emit(OpCode::Pop); // discard the accessor result
         }
+        // Fuse `$x OP= rhs` (parsed as `$x = $x OP rhs`) into an atomic RMW for
+        // plain env-named scalars; the fused op leaves the new value on the
+        // stack, exactly what expression context wants.
+        if self.try_compile_fused_compound_assign(name, expr) {
+            let name_idx = self.code.add_constant(Value::str(name.to_string()));
+            self.code.emit(OpCode::TagContainerRef(name_idx));
+            return;
+        }
         self.compile_expr(expr);
         if let Some(&slot) = self.local_map.get(name) {
             self.code.emit(OpCode::AssignExprLocal(slot));

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -54,6 +54,58 @@ impl Compiler {
         }
     }
 
+    /// True if `name` is a plain env-named scalar suitable for fused
+    /// compound-assignment (`$x OP= rhs`). Excludes twigil/attribute/special
+    /// forms and package-qualified names; bare `$_` (name `_`) is allowed.
+    fn is_plain_compound_target(name: &str) -> bool {
+        match name.chars().next() {
+            None => false,
+            Some(first) => {
+                !matches!(first, '.' | '!' | '~' | '?' | '&' | '*' | '^' | ':')
+                    && !name.contains("::")
+            }
+        }
+    }
+
+    /// If `expr` is `Var(name) OP rhs` with a fusable base operator and `name`
+    /// is a plain env-named scalar (not a local slot), compile the rhs and emit
+    /// a fused `OpCode::AtomicCompoundVar`, leaving the new value on the stack;
+    /// returns `true`. This gives `$x OP= rhs` (parsed as `$x = $x OP rhs`)
+    /// cross-thread-atomic read-modify-write semantics on a shared `ContainerRef`
+    /// cell (Track C), mirroring the slice-1 `++`/`--` path. Local slots and a
+    /// literal `$x = $x + y` are deliberately NOT fused: own locals are ~never
+    /// shared cells, and fusing them regressed a hot 3M-iter loop.
+    pub(super) fn try_compile_fused_compound_assign(&mut self, name: &str, expr: &Expr) -> bool {
+        if self.local_map.contains_key(name) || !Self::is_plain_compound_target(name) {
+            return false;
+        }
+        let Expr::Binary { left, op, right } = expr else {
+            return false;
+        };
+        let Expr::Var(left_name) = left.as_ref() else {
+            return false;
+        };
+        if left_name != name {
+            return false;
+        }
+        let Some(base_op) = Self::binary_opcode(op) else {
+            return false;
+        };
+        let Some(compound_op) = crate::opcode::CompoundBaseOp::from_opcode(&base_op) else {
+            return false;
+        };
+        // Compile the rhs as a plain expression (matching the `Binary` path the
+        // unfused `$x = $x OP rhs` would take); a call-arg compile can itemize /
+        // escape-box the operand, which is wrong for a scalar binary operand.
+        self.compile_expr(right);
+        let name_idx = self.code.add_constant(Value::str(name.to_string()));
+        self.code.emit(OpCode::AtomicCompoundVar {
+            name_idx,
+            op: compound_op,
+        });
+        true
+    }
+
     pub(super) fn binary_opcode(op: &TokenKind) -> Option<OpCode> {
         match op {
             TokenKind::Plus => Some(OpCode::Add),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1137,6 +1137,14 @@ impl Compiler {
                     self.code.emit(OpCode::MarkRebindContext);
                     self.compile_call_arg(expr);
                 } else {
+                    // Fuse `$x OP= rhs` (parsed as `$x = $x OP rhs`) into an
+                    // atomic RMW for plain env-named scalars (Track C). The fused
+                    // op leaves the result on the stack; statement context wants
+                    // nothing, so discard it.
+                    if self.try_compile_fused_compound_assign(effective_name, expr) {
+                        self.code.emit(OpCode::Pop);
+                        return;
+                    }
                     self.compile_assignment_rhs_for_target(effective_name, expr);
                 }
                 self.emit_set_named_var(effective_name);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -27,6 +27,62 @@ pub(crate) fn reflective_name_access_possible() -> bool {
     REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed)
 }
 
+/// Base binary operation for a fused compound-assignment opcode
+/// (`$x OP= rhs`). Each variant maps to the same `exec_*_op` the plain
+/// `Binary` path uses, so the fused op shares exact operator semantics.
+/// See `OpCode::AtomicCompoundVar`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompoundBaseOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Pow,
+    Concat,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitShiftLeft,
+    BitShiftRight,
+    IntDiv,
+    IntMod,
+    Gcd,
+    Lcm,
+    InfixMin,
+    InfixMax,
+    StringRepeat,
+}
+
+impl CompoundBaseOp {
+    /// Map a base binary `OpCode` to its fusable `CompoundBaseOp`, or `None`
+    /// if compound-assignment fusion is not supported for that operator.
+    pub(crate) fn from_opcode(op: &OpCode) -> Option<CompoundBaseOp> {
+        Some(match op {
+            OpCode::Add => CompoundBaseOp::Add,
+            OpCode::Sub => CompoundBaseOp::Sub,
+            OpCode::Mul => CompoundBaseOp::Mul,
+            OpCode::Div => CompoundBaseOp::Div,
+            OpCode::Mod => CompoundBaseOp::Mod,
+            OpCode::Pow => CompoundBaseOp::Pow,
+            OpCode::Concat => CompoundBaseOp::Concat,
+            OpCode::BitAnd => CompoundBaseOp::BitAnd,
+            OpCode::BitOr => CompoundBaseOp::BitOr,
+            OpCode::BitXor => CompoundBaseOp::BitXor,
+            OpCode::BitShiftLeft => CompoundBaseOp::BitShiftLeft,
+            OpCode::BitShiftRight => CompoundBaseOp::BitShiftRight,
+            OpCode::IntDiv => CompoundBaseOp::IntDiv,
+            OpCode::IntMod => CompoundBaseOp::IntMod,
+            OpCode::Gcd => CompoundBaseOp::Gcd,
+            OpCode::Lcm => CompoundBaseOp::Lcm,
+            OpCode::InfixMin => CompoundBaseOp::InfixMin,
+            OpCode::InfixMax => CompoundBaseOp::InfixMax,
+            OpCode::StringRepeat => CompoundBaseOp::StringRepeat,
+            _ => return None,
+        })
+    }
+}
+
 /// Bytecode operations for the VM.
 #[derive(Debug, Clone)]
 pub(crate) enum OpCode {
@@ -604,6 +660,17 @@ pub(crate) enum OpCode {
     AssignExpr(u32),
     /// Assignment as expression for local variable (indexed slot)
     AssignExprLocal(u32),
+    /// Fused compound assignment to a NAMED (env) scalar: `$x OP= rhs`.
+    /// The rhs has already been compiled and sits on top of the stack.
+    /// Performs a read-modify-write of the named variable (`old OP rhs`),
+    /// using an atomic locked RMW when the variable holds a shared
+    /// `ContainerRef` cell (Track C cross-thread atomicity), and leaves the
+    /// new value on the stack. Emitted only for plain env-named scalars
+    /// (local slots and literal `$x = $x + y` are excluded for perf).
+    AtomicCompoundVar {
+        name_idx: u32,
+        op: CompoundBaseOp,
+    },
     /// Nested index assignment: `var[outer][inner] = value` (sigil included in name).
     /// `outer_positional` is true if the outer subscript was `[...]` (positional),
     /// false if `{...}` / `<...>` (associative). `inner_positional` is the same
@@ -1407,7 +1474,8 @@ impl CompiledCode {
             | OpCode::PreDecrement(idx)
             | OpCode::GetArrayVar(idx)
             | OpCode::GetHashVar(idx)
-            | OpCode::AssignExpr(idx) => Some(*idx),
+            | OpCode::AssignExpr(idx)
+            | OpCode::AtomicCompoundVar { name_idx: idx, .. } => Some(*idx),
             _ => None,
         }
     }
@@ -1426,7 +1494,8 @@ impl CompiledCode {
             | OpCode::PostDecrement(idx)
             | OpCode::PreIncrement(idx)
             | OpCode::PreDecrement(idx)
-            | OpCode::AssignExpr(idx) => Some(*idx),
+            | OpCode::AssignExpr(idx)
+            | OpCode::AtomicCompoundVar { name_idx: idx, .. } => Some(*idx),
             _ => None,
         }
     }
@@ -1594,6 +1663,7 @@ impl CompiledCode {
                     | OpCode::SetGlobalRaw(_)
                     | OpCode::AssignExpr(_)
                     | OpCode::AssignExprLocal(_)
+                    | OpCode::AtomicCompoundVar { .. }
                     | OpCode::IndexAssignExprNamed { .. }
                     | OpCode::IndexAssignExprNested { .. }
                     | OpCode::IndexAssignDeepNested { .. }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3552,6 +3552,10 @@ impl VM {
                 self.exec_assign_expr_op(code, *name_idx)?;
                 *ip += 1;
             }
+            OpCode::AtomicCompoundVar { name_idx, op } => {
+                self.exec_atomic_compound_var_op(code, *name_idx, *op)?;
+                *ip += 1;
+            }
 
             // -- Loops --
             OpCode::WhileLoop {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1616,6 +1616,154 @@ impl VM {
         }
     }
 
+    /// Store the result of a read-modify-write on a NAMED (env) scalar, mirroring
+    /// the non-cell write-back tail of `exec_post_increment_op_inner`. Applies
+    /// native-int wrapping and the type constraint, writes the value into env
+    /// (with main-alias), the anonymous-state shadow, this code's local slot, any
+    /// `:=`-bound sibling slots, the sigilless-alias chain, and — when the target
+    /// is the topic `$_` — back to the topic source variable. Does NOT push to the
+    /// stack; the caller decides what to leave there. Returns the (possibly
+    /// native-int-wrapped) stored value. Shared by `++`/`--` and the fused
+    /// compound-assignment op so their propagation is identical by construction.
+    pub(super) fn store_named_scalar_rmw_result(
+        &mut self,
+        code: &CompiledCode,
+        name: &str,
+        new_val: Value,
+    ) -> Result<Value, RuntimeError> {
+        let new_val = Self::maybe_wrap_native_int(&self.interpreter, name, new_val);
+        self.check_incdec_type_constraint(name, &new_val)?;
+        self.set_env_with_main_alias(name, new_val.clone());
+        self.sync_anon_state_value(name, &new_val);
+        self.update_local_if_exists(code, name, &new_val);
+        // Propagate via local_bind_pairs (for `:=` bindings within this scope
+        // or cross-scope bindings resolved by resolve_pending_alias_binds).
+        if let Some(source_idx) = code.locals.iter().position(|n| n == name) {
+            let mut env_updates = Vec::new();
+            for &(src, tgt) in &self.local_bind_pairs {
+                if src == source_idx {
+                    self.locals[tgt] = new_val.clone();
+                    env_updates.push((code.locals[tgt].clone(), new_val.clone()));
+                }
+            }
+            // Also update env so ensure_locals_synced doesn't overwrite
+            // with stale data.
+            for (target_name, val) in env_updates {
+                self.set_env_with_main_alias(&target_name, val);
+            }
+        }
+        // Propagate the new value along the sigilless alias chain and into self's
+        // shared cell for an attribute-twigil alias.
+        self.propagate_sigilless_alias_chain(code, name, &new_val);
+        // Write back to source variable when the target is `$_` bound to a container.
+        if name == "_"
+            && let Some(ref source_var) = self.topic_source_var
+            && !source_var.starts_with('@')
+            && !source_var.starts_with('%')
+        {
+            let sv = source_var.clone();
+            self.set_env_with_main_alias(&sv, new_val.clone());
+            self.update_local_if_exists(code, &sv, &new_val);
+        }
+        Ok(new_val)
+    }
+
+    /// Apply a fused compound-assignment base operator to `left OP right` by
+    /// reusing the exact `exec_*_op` the plain `Binary` path runs (so operator
+    /// semantics, coercions, and user-`infix` overloads are identical). The
+    /// operands are pushed left-then-right (matching the stack order each
+    /// `exec_*_op` pops) and the result is popped back off.
+    fn apply_compound_base_op(
+        &mut self,
+        op: crate::opcode::CompoundBaseOp,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
+        use crate::opcode::CompoundBaseOp as B;
+        self.stack.push(left);
+        self.stack.push(right);
+        match op {
+            B::Add => self.exec_add_op()?,
+            B::Sub => self.exec_sub_op()?,
+            B::Mul => self.exec_mul_op()?,
+            B::Div => self.exec_div_op()?,
+            B::Mod => self.exec_mod_op()?,
+            B::Pow => self.exec_pow_op()?,
+            B::Concat => self.exec_concat_op(),
+            B::BitAnd => self.exec_bit_and_op(),
+            B::BitOr => self.exec_bit_or_op(),
+            B::BitXor => self.exec_bit_xor_op(),
+            B::BitShiftLeft => self.exec_bit_shift_left_op(),
+            B::BitShiftRight => self.exec_bit_shift_right_op(),
+            B::IntDiv => self.exec_int_div_op()?,
+            B::IntMod => self.exec_int_mod_op()?,
+            B::Gcd => self.exec_gcd_op(),
+            B::Lcm => self.exec_lcm_op(),
+            B::InfixMin => self.exec_infix_min_op(),
+            B::InfixMax => self.exec_infix_max_op(),
+            B::StringRepeat => self.exec_string_repeat_op()?,
+        }
+        Ok(self.stack.pop().unwrap())
+    }
+
+    /// Execute a fused compound assignment to a NAMED (env) scalar: `$x OP= rhs`.
+    /// The rhs is already on the stack. Structurally mirrors
+    /// `exec_post_increment_op_inner`: a `ContainerRef` cell gets an atomic
+    /// locked read-modify-write (Track C cross-thread atomicity), a `Proxy` is
+    /// fetched/op'd/stored, and a plain env scalar is written through the shared
+    /// `store_named_scalar_rmw_result` tail so propagation is identical to `++`.
+    /// Leaves the new value on the stack.
+    pub(super) fn exec_atomic_compound_var_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        op: crate::opcode::CompoundBaseOp,
+    ) -> Result<(), RuntimeError> {
+        let rhs = self.stack.pop().unwrap();
+        self.resolve_pending_alias_binds(code);
+        let name = Self::const_str(code, name_idx);
+        self.interpreter.check_readonly_for_increment(name)?;
+        // Default to Nil (NOT Int(0) like `++`) so `my $w; $w ~= "z"` yields "z",
+        // not "0z"; the binary op descalarizes/numifies/stringifies Nil itself.
+        let raw_val = self
+            .get_env_with_main_alias(name)
+            .or_else(|| self.anon_state_value(name))
+            .unwrap_or(Value::Nil);
+        // ContainerRef cell: atomic RMW under the cell lock so concurrent
+        // `start { $shared += n }` blocks don't lose updates (Track C).
+        if let Value::ContainerRef(ref arc) = raw_val {
+            let arc = arc.clone();
+            // Hold the cell lock across the whole read-modify-write so concurrent
+            // threads can't interleave and lose updates. `rhs` was already popped
+            // (a concrete value), and the base op operates only on `old`/`rhs`, so
+            // it never re-enters this cell — no deadlock.
+            let mut guard = arc.lock().unwrap();
+            let old = guard.clone();
+            let new_val = self.apply_compound_base_op(op, old, rhs)?;
+            *guard = new_val.clone();
+            drop(guard);
+            self.stack.push(new_val);
+            return Ok(());
+        }
+        // Proxy: FETCH -> op -> STORE.
+        if let Value::Proxy { storer, .. } = &raw_val
+            && !matches!(storer.as_ref(), Value::Nil)
+        {
+            let fetched = self.interpreter.auto_fetch_proxy(&raw_val)?;
+            let new_val = self.apply_compound_base_op(op, fetched, rhs)?;
+            self.interpreter
+                .assign_proxy_lvalue(raw_val, new_val.clone())?;
+            self.stack.push(new_val);
+            return Ok(());
+        }
+        // Plain env scalar: compute old OP rhs, store via the shared `++` tail so
+        // METHOD captured-outer propagation is identical to `++` by construction.
+        let new_val = self.apply_compound_base_op(op, raw_val, rhs)?;
+        let stored = self.store_named_scalar_rmw_result(code, name, new_val)?;
+        self.stack.push(stored);
+        Ok(())
+    }
+
     pub(super) fn exec_post_increment_op(
         &mut self,
         code: &CompiledCode,
@@ -1708,40 +1856,7 @@ impl VM {
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.increment_value_smart(&val)?;
-        let new_val = Self::maybe_wrap_native_int(&self.interpreter, name, new_val);
-        self.check_incdec_type_constraint(name, &new_val)?;
-        self.set_env_with_main_alias(name, new_val.clone());
-        self.sync_anon_state_value(name, &new_val);
-        self.update_local_if_exists(code, name, &new_val);
-        // Propagate via local_bind_pairs (for `:=` bindings within this scope
-        // or cross-scope bindings resolved by resolve_pending_alias_binds).
-        if let Some(source_idx) = code.locals.iter().position(|n| n == name) {
-            let mut env_updates = Vec::new();
-            for &(src, tgt) in &self.local_bind_pairs {
-                if src == source_idx {
-                    self.locals[tgt] = new_val.clone();
-                    env_updates.push((code.locals[tgt].clone(), new_val.clone()));
-                }
-            }
-            // Also update env so ensure_locals_synced doesn't overwrite
-            // with stale data.
-            for (target_name, val) in env_updates {
-                self.set_env_with_main_alias(&target_name, val);
-            }
-        }
-        // Propagate the new value along the sigilless alias chain and into self's
-        // shared cell for an attribute-twigil alias.
-        self.propagate_sigilless_alias_chain(code, name, &new_val);
-        // Write back to source variable when incrementing $_ bound to a container
-        if name == "_"
-            && let Some(ref source_var) = self.topic_source_var
-            && !source_var.starts_with('@')
-            && !source_var.starts_with('%')
-        {
-            let sv = source_var.clone();
-            self.set_env_with_main_alias(&sv, new_val.clone());
-            self.update_local_if_exists(code, &sv, &new_val);
-        }
+        self.store_named_scalar_rmw_result(code, name, new_val)?;
         self.stack.push(val);
         Ok(())
     }
@@ -1814,14 +1929,7 @@ impl VM {
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.decrement_value_smart(&val)?;
-        let new_val = Self::maybe_wrap_native_int(&self.interpreter, name, new_val);
-        self.check_incdec_type_constraint(name, &new_val)?;
-        self.set_env_with_main_alias(name, new_val.clone());
-        self.sync_anon_state_value(name, &new_val);
-        self.update_local_if_exists(code, name, &new_val);
-        // Propagate the new value along the sigilless alias chain and into self's
-        // shared cell for an attribute-twigil alias.
-        self.propagate_sigilless_alias_chain(code, name, &new_val);
+        self.store_named_scalar_rmw_result(code, name, new_val)?;
         self.stack.push(val);
         Ok(())
     }

--- a/t/concurrent-compound-assign.t
+++ b/t/concurrent-compound-assign.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+# Track C slice 3: scalar compound assignment (`$x OP= rhs`) on a `start`-captured
+# lexical is an atomic read-modify-write on the shared cell, so concurrent threads
+# don't lose updates. raku itself does NOT guarantee atomic `+=`; mutsu is
+# deterministic here on purpose (matching the slice-1 `++` "more deterministic
+# than raku" choice). See memory next-compound-assign-atomicity.
+
+plan 8;
+
+# --- `+=` accumulation across 100 threads x 100 iterations -> 10000 ---
+for ^3 {
+    my $c = 0;
+    await (^100).map: { start { for ^100 { $c += 1 } } };
+    is $c, 10000, 'concurrent += accumulates without lost updates';
+}
+
+# --- `-=` from a base, exact ---
+{
+    my $c = 10000;
+    await (^100).map: { start { for ^100 { $c -= 1 } } };
+    is $c, 0, 'concurrent -= is exact';
+}
+
+# --- `*=` doubling, serialized count -> 2 ** 10 ---
+{
+    my $c = 1;
+    await (^10).map: { start { $c *= 2 } };
+    is $c, 1024, 'concurrent *= doubling reaches 2 ** 10';
+}
+
+# --- single-threaded sanity: a mix of compound ops ---
+{
+    my $x = 10;
+    $x += 5;   # 15
+    $x -= 3;   # 12
+    $x *= 2;   # 24
+    is $x, 24, 'single-threaded numeric compound chain';
+}
+
+# --- string concat compound on an undefined scalar ---
+{
+    my $s;
+    $s ~= "a";
+    $s ~= "b";
+    is $s, "ab", 'concat compound on initially-undefined scalar';
+}
+
+# --- compound assign inside a method mutating a captured-outer scalar,
+#     with a variable rhs (the env-propagation case) ---
+{
+    my $acc = 0;
+    my $step = 3;
+    class CompoundPusher { method go() { $acc += $step } }
+    my $p = CompoundPusher.new;
+    $p.go(); $p.go();
+    is $acc, 6, 'compound assign in method propagates captured-outer scalar';
+}


### PR DESCRIPTION
## Summary

Track C slice 3: generalize the slice-1 `++`/`--` shared-cell atomic read-modify-write to scalar **compound assignment** (`+= -= *= /= ~= min= +&= ...`), so a `start`-captured lexical accumulates deterministically across threads.

```raku
my $c = 0;
await (^100).map: { start { for ^100 { $c += 1 } } };
say $c;   # 10000 (was ~4000, racy lost-update)
```

raku does not guarantee atomic `+=`; mutsu being deterministic here is intentional, matching the slice-1 `++` choice.

## Design (the clean approach)

- New `OpCode::AtomicCompoundVar { name_idx, op: CompoundBaseOp }`, emitted at the compiler chokepoints (`compile_expr_assign`, the `Stmt::Assign` tail) **only for plain env-named scalars**. Local slots and twigil/special targets are excluded, so the hot literal `$x = $x + y` own-local loop is *not* fused (fusing it regressed a 3M-iter loop 31.6s→41s+).
- Registered in the mutation/escape analysis (`op_name_const_idx`, `op_name_write_const_idx`, `has_env_writes`) so `$c` is still boxed into a shared `ContainerRef` cell.
- The non-cell write **reuses the exact `++` env write-back tail**: extracted `store_named_scalar_rmw_result` from `exec_post_increment_op_inner` and routed both `++`/`--` and the fused op through it, so METHOD captured-outer scalar propagation is identical to `++` by construction.
- ContainerRef cell branch holds the lock across the whole RMW (atomic); Proxy branch fetch/op/stores.
- `apply_compound_base_op` reuses the same `exec_*_op` the plain `Binary` path runs, so operator semantics / coercions / user-`infix` overloads match.

The key fix over the first (reverted) attempt: the fused rhs is compiled with `compile_expr`, **not** `compile_call_arg` — a call-arg compile itemizes/escape-boxes a scalar operand, corrupting captured-outer env propagation when the rhs is a variable reference (`$acc += \$!step` in a method). That was the wall.

## Verification

- `t/concurrent-compound-assign.t` (new): `+=`→10000 ×3, `-=`→exact, `*=`→1024, single-threaded matrix, method captured-outer.
- Regression anchors: `t/method-env-dirty.t` (24/24), `t/test-util-test-iter-opt.t` (3/3).
- `make test` green. Perf: 3M-iter local loop stays ~baseline (locals not fused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)