### PR TITLE
feat(Track B): VM-native `push` on the CallMethodMut path (captured / multi-arg)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -28,10 +28,11 @@
 | ~~`vm_call_method_mut_ops.rs` plain `@`-array mutators~~ | ~~append/prepend/unshift/pop/shift~~ | — | **✅消化 (③ PR-5)**: `try_native_array_mut` で VM ネイティブ。typed/shaped/lazy/shared/constrained は interpreter 維持 |
 | ~~`vm_call_method_mut_ops.rs` mutable Buf write methods~~ | ~~write-bits/write-ubits/write-num*/write-int*/write-uint*~~ | — | **✅消化 (③ PR-7)**: `try_native_buf_mut` で VM ネイティブ。pure 変換は `builtins/{buf_bits,buf_write_num,buf_write_int}` に一本化。type-object/Blob/malformed-arity は interpreter 維持 |
 | ~~`vm_call_method_mut_ops.rs` 単純 array-backed Iterator~~ | ~~pull-one/skip-one/skip-at-least/skip-at-least-pull-one/sink-all~~ | — | **✅消化 (③ PR-9)**: `try_native_iterator` で VM ネイティブ（`$it.pull-one` は CallMethodMut＝mut パス）。`items`+`index` 自己完結のみ。squish（コールバック）/ lazy（gather/coroutine, `is_lazy`）/ push-*（外部バッファ）/ count-only/bool-only は interpreter 維持 |
-| `vm_call_method_mut_ops.rs` array-backed instance | `is Array` storage の push/pop/shift | MEDIUM | 第一級コンテナ Phase 2 |
+| ~~`vm_call_method_mut_ops.rs` array-backed instance~~ | ~~`is Array` storage の push/pop/shift~~ | — | **✅消化 (#3058)**: `native_array_storage_mut` で `is Array`-backed instance の backing storage への push/pop/shift/unshift/append/prepend を VM ネイティブ化。`write_back_array_storage_instance` で instance 再構築。richer メソッド（join/sort/map/splice/AT-POS 等）は interpreter 維持 |
 | `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B（共有セル所有） |
 | `vm_data_ops.rs` shaped push | shaped 配列 push | MEDIUM | shaped 次元メタ検査の VM 化 |
-| `vm_data_ops.rs` non-simple push | closure-captured / 非Array push | MEDIUM | 第一級コンテナ Phase 2（ContainerRef） |
+| `vm_data_ops.rs` non-simple push | 非Array/非ContainerRef な ArrayPush ターゲット（cold） | LOW | **probe で cold 確認 (2026-06-14)**: ArrayPush opcode は単一引数 push かつ *local* array 限定で emit。closure-captured / multi-arg push は CallMethodMut へ流れ **#3060 で native 化済**（下記）。残る ArrayPush 非Array 分岐は whitelist で発火例ゼロ＝cold |
+| ~~`vm_call_method_mut_ops.rs` CallMethodMut push~~ | ~~closure-captured / multi-arg `@a.push`~~ | — | **✅消化 (#3060)**: `try_native_array_mut` に `push` arm を追加。`@a.push(x)` は単一引数 local のみ ArrayPush opcode、それ以外（captured / multi-arg）は CallMethodMut で来るのを VM ネイティブ化。typed/shaped/lazy/shared/constrained は interpreter 維持 |
 | ~~`vm_smart_match.rs` key-method~~ | ~~smartmatch のキーメソッド抽出~~ | — | **✅消化 (PR2)**: 統一 compiled-first へ |
 | ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`（list-like 受け手）~~ | — | **✅消化 (③ PR-8)**: `try_native_quanthash_coerce` で VM ネイティブ。pure 折り畳みは `builtins/quanthash_coerce` に一本化。`.MixHash`（型メタ登録）/ Instance/Package 受け手は interpreter 維持 |
 | `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1479,7 +1479,10 @@ impl VM {
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if !matches!(method, "append" | "prepend" | "unshift" | "pop" | "shift") {
+        if !matches!(
+            method,
+            "push" | "append" | "prepend" | "unshift" | "pop" | "shift"
+        ) {
             return None;
         }
         // A plain `@`-sigiled variable whose value is a real `[...]` array
@@ -1519,6 +1522,15 @@ impl VM {
             return None;
         };
         let result = match method {
+            "push" => {
+                // `@a.push` compiles to `ArrayPush` only for single-arg pushes on
+                // a *local* array; the captured-closure and multi-arg forms reach
+                // here as `CallMethodMut`. Mirror the `ArrayPush` opcode's env-bound
+                // branch (`normalize_push_unshift_args` then extend).
+                let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
+                Arc::make_mut(arc_items).extend(norm);
+                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+            }
             "append" | "prepend" => {
                 let flat = crate::runtime::flatten_append_args(args.to_vec());
                 let items = Arc::make_mut(arc_items);

--- a/t/native-callmethod-push.t
+++ b/t/native-callmethod-push.t
@@ -1,0 +1,92 @@
+use Test;
+
+# `@a.push` compiles to the `ArrayPush` opcode only for a single-arg push on a
+# *local* array. The captured-closure form and the multi-arg form reach the VM
+# as `CallMethodMut`; this pins the VM-native fast path for those (push added to
+# `try_native_array_mut`).
+
+plan 18;
+
+# multi-arg push on a local array (CallMethodMut, not ArrayPush)
+my @a;
+@a.push(1, 2, 3);
+is @a.join(','), '1,2,3', 'multi-arg push on local array';
+@a.push(4);
+is @a.join(','), '1,2,3,4', 'subsequent push grows';
+
+# captured-closure single-arg push
+my @b;
+my $c = { @b.push($_) };
+$c(10);
+$c(20);
+$c(30);
+is @b.join(','), '10,20,30', 'captured single-arg push accumulates';
+
+# captured-closure multi-arg push
+my @d;
+my $e = { @d.push($_, $_ * 2) };
+$e(5);
+$e(6);
+is @d.join(','), '5,10,6,12', 'captured multi-arg push';
+
+# push via map closure
+my @f;
+(1..3).map({ @f.push($_ * 100) });
+is @f.join(','), '100,200,300', 'push inside map closure';
+
+# Slip flattening
+my @g;
+@g.push(|(7, 8, 9));
+is @g.join(','), '7,8,9', 'push flattens a Slip argument';
+
+# Empty pushes nothing
+my @h;
+@h.push(Empty);
+is @h.elems, 0, 'push Empty adds nothing';
+@h.push(1);
+@h.push(Empty);
+is @h.elems, 1, 'push Empty after a real element is a no-op';
+
+# push returns the array
+my @z;
+my $ret = @z.push(99);
+is $ret.^name, 'Array', 'push returns the Array';
+is $ret.elems, 1, 'returned array has the pushed element';
+
+# Typed array push still type-checks (falls through to the interpreter)
+my Int @t;
+@t.push(1, 2);
+is @t.join(','), '1,2', 'typed array multi-arg push works';
+my $threw = False;
+{
+    @t.push("not an int");
+    CATCH { default { $threw = True } }
+}
+ok $threw, 'typed array push rejects a wrong-typed value';
+
+# Captured typed array push also type-checks
+my Int @u;
+my $up = { @u.push($_) };
+$up(1);
+$up(2);
+is @u.join(','), '1,2', 'captured typed array push works';
+
+# Mix of itemized and plain arguments
+my @v;
+@v.push(1, $(2, 3), 4);
+is @v.elems, 3, 'itemized argument pushed as a single element';
+is @v[1].elems, 2, 'itemized element preserved';
+
+# Nested array values are pushed as-is (no flattening of a non-Slip Array arg)
+my @w;
+my @inner = 1, 2, 3;
+@w.push(@inner);
+is @w.elems, 1, 'pushing an array adds one element';
+is @w[0].elems, 3, 'pushed array element keeps its contents';
+
+# Loop pushes
+my @s;
+@s.push($_) for 1..5;
+is @s.join(','), '1,2,3,4,5', 'for-loop push accumulates';
+
+done-testing;


### PR DESCRIPTION
## Summary

Phase I close-out (Track B): VM-natives the captured-closure and multi-arg `@a.push` forms.

`@a.push($x)` compiles to the dedicated `ArrayPush` opcode **only** for a single-arg push on a *local* array. The captured-closure form (`{ @a.push($_) }`) and the multi-arg form (`@a.push(1, 2, 3)`) reach the VM as `CallMethodMut`, where `push` was the one simple array mutator still excluded from `try_native_array_mut` — so every such push routed through the tree-walking interpreter.

## What changed

- Added a `push` arm to `try_native_array_mut`, mirroring the `ArrayPush` opcode's env-bound branch exactly (`normalize_push_unshift_args` then `extend`).
- Conservative fall-through unchanged: typed/shaped/lazy/shared/type-constrained arrays still go to the interpreter, preserving element type checks, shaped-dimension errors, and shared-cell semantics → behavior-invariant.

## Probe finding

A whitelist probe confirmed the sibling `vm_data_ops.rs` `ArrayPush` **non-simple branch** (non-`Array` / non-`ContainerRef` target) is **cold** — it never fires across the whitelist, because `ArrayPush` is only emitted for single-arg local pushes. The ledger entry is reclassified `MEDIUM` → `LOW (cold)` accordingly.

## Verification

- `t/native-callmethod-push.t` (18) — multi-arg/local, captured single + multi, map-closure, Slip flatten, `Empty`, return value, itemized args, nested-array element, typed-array type checks (both direct and captured). All pass; verified identical under `raku`.
- `MUTSU_VM_STATS=1`: closure-captured push no longer appears in the method-fallback breakdown (`push=6` → `0`).
- `make test`: 792 files / 7380 tests, all pass.

Ledger: consumes the `CallMethodMut push` fallback and updates the already-merged array-backed-instance entry (#3058).

🤖 Generated with [Claude Code](https://claude.com/claude-code)