### PR TITLE
feat(C track): VM-native atomic shared hash element-assign across threads

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -187,8 +187,17 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
             アトミック RMW。`await (^100).map: { start { for ^100 { $c += 1 } } }` が決定的に 10000。
             **要点**: 融合 rhs は `compile_expr` でコンパイル（`compile_call_arg` はスカラ被演算子を
             itemize/escape-box して captured-outer 伝播を壊す）。テスト `t/concurrent-compound-assign.t`。
-            **残**: `state @`/`%`（配列/ハッシュ）のスレッド共有（要素セル＝Track B 依存）、
-            lexical `@`/`%` 共有・複合代入のアトミック化（同 Track B 依存）。
+            **スライス 4 LANDED（PR #3061）**: スレッド間の**ハッシュ要素代入**（`%h{$k} = $v`）。
+            `my %h; await (^50).map: -> $i { start { %h{$i} = $i*$i } }` が 0（スナップショットの
+            last-writer-wins で書き込み消失）→ 決定的 50（raku 一致）。`assign_hash_elem_to_shared_var`
+            （`shared_vars` ロック保持下で get→`Arc::make_mut`→insert＝`.push` と同じ要素単位アトミック）を
+            `exec_index_assign_expr_named_op` 先頭の `shared_vars_active` 早期 return ガード
+            （`try_shared_hash_element_assign`）から呼ぶ。単一スレッドは早期 return で挙動不変。
+            `@a.push` は元から動作（`push_to_shared_var`）、壊れていたのは `@a[i]=`／`%h{k}=`。
+            テスト `t/concurrent-hash-assign.t`。
+            **残**: スレッド間の**配列要素 index 代入**（`@a[$i] = $v`、スライス 4 の直接の続き＝
+            `assign_array_elem_to_shared_var`、index 強制・resize・ArrayKind を要す）、
+            `state @`/`%`（配列/ハッシュ）のスレッド共有（要素セル＝Track B 依存）。
       - [x] **react/supply ランタイムの VM ネイティブ化 — 完了（Stage 1+2+3, #3010〜#3039, 2026-06、
             詳細は [news/2026-06.md](news/2026-06.md)）**。駆動ループの 4 箇所二重化を単一エンジンへ統合し
             （Stage 1）、ループ所有権を `impl Interpreter`→`impl VM`（`vm/vm_react_loop.rs`）へ逆転して

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -132,7 +132,32 @@ raku は `+=` のアトミック性を保証しないが、mutsu はスライス
 
 検証: `t/concurrent-compound-assign.t`（新規, 8 tests）、回帰アンカー `t/method-env-dirty.t`（24/24）・
 `t/test-util-test-iter-opt.t`（3/3）、`make test` green、3M ローカルループは ~baseline（local は非融合）。
-**残**: `state @`/`%`・lexical `@`/`%` の共有（要素セル＝Track B 依存）、unsafe aliasing 撤廃。
+
+### トラック C 共有セル スライス 4: スレッド間のハッシュ要素代入（`%h{$k} = $v`）（#3061, 2026-06-14）
+
+スライス 3 に続き、`start` ブロック内の**ハッシュ要素代入**を共有セル経由に。
+
+```raku
+my %h;
+await (^50).map: -> $i { start { %h{$i} = $i * $i } };
+say %h.elems;   # 50（従来は 0 — スナップショットの last-writer-wins で各スレッドの書き込みが消失）
+```
+
+raku は 50。mutsu も決定的に一致するようになった。`@a.push` のスレッド間共有は元から動いていた
+（`push_to_shared_var`）が、`@a[i]=`／`%h{k}=` の**要素/インデックス代入**は壊れていた。
+
+- `Interpreter::assign_hash_elem_to_shared_var`（`push_to_existing_shared_array` の隣）は
+  `shared_vars` ロックを get→`Arc::make_mut`→insert の全体で保持するので、別キーを書く 2 スレッドが
+  互いの更新を失わない（`.push` と同じ要素単位アトミック性）。thread-clone は env の私的 Arc を落として
+  in-place mutate、`__mutsu_shared_dirty::` マーカーで一度だけ dirty mark。親は env も更新。
+- `VM::try_shared_hash_element_assign` は `exec_index_assign_expr_named_op` 先頭の安価な
+  `shared_vars_active` 早期 return ガード。`try_fast_hash_element_assign` と同じ単純性ガード
+  （型/キー制約・default・bound index・複雑 index を拒否）を適用し、共有ハッシュでなければ素通り。
+
+単一スレッド（`shared_vars_active == false`）は新経路を完全にスキップするので挙動不変。検証:
+`t/concurrent-hash-assign.t`（新規 7: 別キー50・値の正しさ・pre-seed 生存・20×50 重競合1000）、
+`make test` green、`roast/S02-types/hash.t` 112/112。**残**: 配列要素 index 代入（`@a[$i]=$v`、
+直接の続き）、`state @`/`%` の共有（要素セル＝Track B 依存）、unsafe aliasing 撤廃。
 
 ### トラック A §2: lexical `&`-var 名呼びの VM ネイティブ dispatch 完結（#2949 / #3021 / #3022 / #3024）
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5744,6 +5744,52 @@ impl Interpreter {
         Some(result)
     }
 
+    /// Track C: assign a single hash element (`%h{$k} = $v`) through the shared
+    /// cell so concurrent `start { %h{...} = ... }` blocks all land instead of
+    /// each mutating a private snapshot (last-writer-wins). Holds the
+    /// `shared_vars` lock for the whole get-make_mut-insert so two threads
+    /// writing different keys can't lose each other's update — the same
+    /// per-element atomicity `push_to_existing_shared_var` gives `.push`.
+    ///
+    /// Returns `Some(value)` if it wrote through the shared hash, `None` if the
+    /// variable is not a shared hash (caller falls back to the normal path).
+    pub(crate) fn assign_hash_elem_to_shared_var(
+        &mut self,
+        key: &str,
+        elem_key: String,
+        value: Value,
+    ) -> Option<Value> {
+        if !key.starts_with('%') || !self.shared_vars_active {
+            return None;
+        }
+        let is_thread_clone = self.is_thread_clone();
+        if is_thread_clone {
+            // Drop env's private copy so the shared cell holds the only Arc and
+            // make_mut mutates in place (the thread's env is discarded anyway).
+            self.env.remove(key);
+        }
+        let mut sv = self.shared_vars.write().unwrap();
+        let Some(Value::Hash(arc)) = sv.get_mut(key) else {
+            return None;
+        };
+        Value::hash_insert_through(&mut Arc::make_mut(arc).map, elem_key, value.clone());
+        let result = Value::Hash(Arc::clone(arc));
+        drop(sv);
+        if is_thread_clone {
+            // Mark dirty once per key (a per-key env marker avoids re-locking the
+            // dirty set on every element write).
+            let dirty_marker = format!("__mutsu_shared_dirty::{key}");
+            if !self.env.contains_key(&dirty_marker) {
+                self.mark_shared_var_dirty(key);
+                self.env.insert(dirty_marker, Value::Bool(true));
+            }
+        } else {
+            self.mark_shared_var_dirty(key);
+            self.env.insert(key.to_string(), result);
+        }
+        Some(value)
+    }
+
     /// Read a shared variable. If the variable is in shared_vars, return
     /// the shared version (which may have been mutated by another thread).
     #[allow(dead_code)]

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2276,6 +2276,97 @@ impl VM {
         Ok(())
     }
 
+    /// Track C: route a simple `%h{$k} = $v` through the shared cell when a
+    /// thread is active, so concurrent `start` blocks accumulate into one hash
+    /// instead of each mutating a private snapshot (last-writer-wins).
+    /// Applies the same simplicity guards as `try_fast_hash_element_assign`
+    /// (rejecting type constraints, defaults, bound indices, complex indices).
+    /// Returns `Some(Ok)` when it wrote through the shared hash, else `None`.
+    fn try_shared_hash_element_assign(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Option<Result<(), RuntimeError>> {
+        // Cheap early-out: only meaningful while a thread shares this env.
+        if !self.interpreter.shared_vars_active {
+            return None;
+        }
+        if !self.local_bind_pairs.is_empty() {
+            return None;
+        }
+        let var_name = Self::const_str(code, name_idx);
+        if !var_name.starts_with('%') {
+            return None;
+        }
+        let stack_len = self.stack.len();
+        if stack_len < 2 {
+            return None;
+        }
+        let idx_ref = &self.stack[stack_len - 1];
+        let val_ref = &self.stack[stack_len - 2];
+        // Reject complex index types (slices/ranges/junctions need the full path).
+        if matches!(
+            idx_ref,
+            Value::Array(..)
+                | Value::Junction { .. }
+                | Value::GenericRange { .. }
+                | Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::Nil
+                | Value::Seq(..)
+                | Value::Slip(..)
+        ) {
+            return None;
+        }
+        // Reject bind-mode markers and Nil values (need default/type handling).
+        if matches!(val_ref, Value::Pair(name, _) if name == "__mutsu_bind_index_value")
+            || matches!(val_ref, Value::Nil)
+        {
+            return None;
+        }
+        // Reject when type/key constraints, defaults, readonly, or bound indices
+        // exist — those need the full assignment path's healing.
+        if self
+            .interpreter
+            .var_type_constraint_fast(var_name)
+            .is_some()
+            || self.interpreter.var_default(var_name).is_some()
+            || self.interpreter.var_hash_key_constraint_fast(var_name)
+            || self.interpreter.readonly_vars().contains(var_name)
+        {
+            return None;
+        }
+        {
+            let bound_key = format!("__mutsu_bound_index::{}", var_name);
+            if self.interpreter.env().contains_key(&bound_key) {
+                return None;
+            }
+        }
+        let var_name = var_name.to_string();
+        let key = idx_ref.to_string_value();
+        // Commit: pop idx then val and write through the shared cell.
+        let idx = self.stack.pop().unwrap();
+        let val = self.stack.pop().unwrap();
+        match self
+            .interpreter
+            .assign_hash_elem_to_shared_var(&var_name, key, val.clone())
+        {
+            Some(_) => {
+                self.stack.push(val);
+                Some(Ok(()))
+            }
+            None => {
+                // Not a shared hash after all (e.g. not yet seeded): restore the
+                // [val, idx] stack order and fall through to the normal path.
+                self.stack.push(val);
+                self.stack.push(idx);
+                None
+            }
+        }
+    }
+
     /// Fast path for simple hash element assignment: `%h{$key} = $val`.
     ///
     /// Returns `Some(Ok(()))` if the fast path handled the assignment,
@@ -2291,7 +2382,6 @@ impl VM {
     /// - No type constraints, no key constraints, no var defaults
     /// - Variable is not readonly (not bound via `:=`)
     /// - No container type metadata on the hash
-    #[inline]
     fn try_fast_hash_element_assign(
         &mut self,
         code: &CompiledCode,
@@ -2484,6 +2574,12 @@ impl VM {
         name_idx: u32,
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
+        // --- Track C: shared hash element assignment across threads ---
+        // `%h{$k} = $v` inside a `start` block must write through the shared
+        // cell so concurrent threads all land (snapshot semantics lose updates).
+        if let Some(result) = self.try_shared_hash_element_assign(code, name_idx) {
+            return result;
+        }
         // --- Fast path for simple hash element assignment ---
         // Handles the common case: %h{$key} = $val with no type constraints,
         // no binding, no special containers. Skips ~16 HashMap lookups.

--- a/t/concurrent-hash-assign.t
+++ b/t/concurrent-hash-assign.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# Track C: scalar hash element assignment (`%h{$k} = $v`) inside a `start` block
+# writes through the shared cell, so concurrent threads all land instead of each
+# mutating a private snapshot (last-writer-wins). See memory track-c-shared-thread-cells.
+
+plan 7;
+
+# --- 50 threads each writing one distinct key -> 50 elements ---
+for ^3 {
+    my %h;
+    await (^50).map: -> $i { start { %h{$i} = $i * $i } };
+    is %h.elems, 50, 'concurrent distinct-key hash writes all land';
+}
+
+# --- values are correct, not just the count ---
+{
+    my %h;
+    await (^50).map: -> $i { start { %h{$i} = $i * $i } };
+    is %h{7}, 49, 'concurrent hash write stores the correct value';
+    is ([+] %h.values), 40425, 'sum of all concurrently-written values is exact';
+}
+
+# --- pre-seeded hash: parent element survives alongside thread writes ---
+{
+    my %h;
+    %h<seed> = -1;
+    await (^50).map: -> $i { start { %h{$i} = $i } };
+    is %h.elems, 51, 'pre-seeded element survives concurrent writes';
+}
+
+# --- heavy contention: 20 threads x 50 keys each -> 1000 elements ---
+{
+    my %h;
+    await (^20).map: -> $t { start { for ^50 -> $k { %h{"$t-$k"} = $t * $k } } };
+    is %h.elems, 1000, 'heavy multi-key contention loses no updates';
+}


### PR DESCRIPTION
## Summary

Track C (shared cells): a scalar hash element assignment (`%h{\$k} = \$v`) inside a `start` block now writes through the shared cell, so concurrent threads accumulate into one hash instead of each mutating a private snapshot (last-writer-wins).

```raku
my %h;
await (^50).map: -> $i { start { %h{$i} = $i * $i } };
say %h.elems;   # 50 (was 0 — thread writes were lost)
```

raku gives 50 here; mutsu now matches deterministically. This is the hash counterpart to the existing shared-`.push` path; array element index-assign (`@a[\$i] = \$v`, also snapshot-only today) is a follow-up slice.

## Design

- **`Interpreter::assign_hash_elem_to_shared_var`** holds the `shared_vars` lock across the whole `get → Arc::make_mut → insert`, so two threads writing different keys can't lose each other's update — the same per-element atomicity `push_to_existing_shared_array` gives `.push`. In a thread clone it drops env's private Arc (so `make_mut` mutates in place) and marks the key dirty once via a `__mutsu_shared_dirty::` env marker; in the parent it also updates env.
- **`VM::try_shared_hash_element_assign`** is a cheap early-out (`shared_vars_active`) guard ahead of the existing fast/slow hash-assign paths. It applies the same simplicity guards as `try_fast_hash_element_assign` (no type/key constraints, defaults, bound indices, or complex indices) and routes through the shared helper, falling through untouched when the variable is not a shared hash.

Single-threaded code (`shared_vars_active == false`) skips the new path entirely, so behavior is unchanged.

## Verification

- `t/concurrent-hash-assign.t` (new): distinct keys → 50 ×3, value correctness vs raku, pre-seeded element survival → 51, heavy 20×50 multi-key contention → 1000.
- `make test` green; `roast/S02-types/hash.t` 112/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)