### PR TITLE
feat(Track A): VM-native gist/Str/raku for Instant and Duration

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -295,6 +295,14 @@ pub(super) fn dispatch(
                     Some(Err(RuntimeError::new("Failed")))
                 }
             }
+            // Instant/Duration `.Str` is the same pure rendering as their gist
+            // (`value/display.rs::to_string_value`), so handle it natively
+            // instead of falling through to the interpreter.
+            Value::Instance { class_name, .. }
+                if class_name == "Instant" || class_name == "Duration" =>
+            {
+                Some(Ok(Value::str(target.to_string_value())))
+            }
             Value::Package(_) | Value::Instance { .. } => None,
             Value::LazyList(_) => None, // fall through to runtime to force the list
             Value::Enum { .. } => None, // fall through to enum dispatch for string enum support

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -299,32 +299,42 @@ pub(super) fn dispatch(
             class_name,
             attributes,
             ..
-        } if class_name == "Instant" && (method == "raku" || method == "perl") => {
-            let tai = attributes
-                .as_map()
-                .get("value")
-                .map(|v| v.to_f64())
-                .unwrap_or(0.0);
-            let posix = crate::builtins::methods_0arg::temporal::instant_to_posix(tai);
-            Some(Ok(Value::str(format!(
-                "Instant.from-posix({})",
-                format_temporal_num(posix)
-            ))))
+        } if class_name == "Instant" => {
+            if method == "gist" {
+                // `Instant:<tai>` — identical to the Str/gist rendering in
+                // `value/display.rs::to_string_value`.
+                Some(Ok(Value::str(target.to_string_value())))
+            } else {
+                let tai = attributes
+                    .as_map()
+                    .get("value")
+                    .map(|v| v.to_f64())
+                    .unwrap_or(0.0);
+                let posix = crate::builtins::methods_0arg::temporal::instant_to_posix(tai);
+                Some(Ok(Value::str(format!(
+                    "Instant.from-posix({})",
+                    format_temporal_num(posix)
+                ))))
+            }
         }
         Value::Instance {
             class_name,
             attributes,
             ..
-        } if class_name == "Duration" && (method == "raku" || method == "perl") => {
-            let val = attributes
-                .as_map()
-                .get("value")
-                .cloned()
-                .unwrap_or(Value::Num(0.0));
-            Some(Ok(Value::str(format!(
-                "Duration.new({})",
-                format_temporal_num(val.to_f64())
-            ))))
+        } if class_name == "Duration" => {
+            if method == "gist" {
+                Some(Ok(Value::str(target.to_string_value())))
+            } else {
+                let val = attributes
+                    .as_map()
+                    .get("value")
+                    .cloned()
+                    .unwrap_or(Value::Num(0.0));
+                Some(Ok(Value::str(format!(
+                    "Duration.new({})",
+                    format_temporal_num(val.to_f64())
+                ))))
+            }
         }
         Value::Bag(b, mutable) => {
             let type_name = if *mutable { "BagHash" } else { "Bag" };

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -114,10 +114,24 @@ impl VM {
                 if cn == "Supplier" && method_sym == "Supply" && args.is_empty() {
                     return None;
                 }
-                // Numeric bridge
-                if self.interpreter.type_matches_value("Real", target)
-                    || self.interpreter.type_matches_value("Numeric", target)
-                    || self.interpreter.has_user_method(&cn, "Bridge")
+                // Numeric bridge — Real/Numeric instances route through the
+                // interpreter's Numeric bridge for arithmetic and coercion.
+                // Exception: pure-render methods (gist/Str/raku/...) don't need
+                // the bridge, so let `native_method_0arg` render the known
+                // builtin numeric instances (Instant/Duration) directly. A
+                // user numeric class that overrides one of these keeps the
+                // bypass so its method runs; unknown numeric instances return
+                // `None` from native and still fall through to the interpreter.
+                let is_pure_render = matches!(
+                    method_name.as_str(),
+                    "gist" | "Str" | "Stringy" | "raku" | "perl"
+                );
+                let render_overridden =
+                    is_pure_render && self.interpreter.has_user_method(&cn, &method_name);
+                if (!is_pure_render || render_overridden)
+                    && (self.interpreter.type_matches_value("Real", target)
+                        || self.interpreter.type_matches_value("Numeric", target)
+                        || self.interpreter.has_user_method(&cn, "Bridge"))
                 {
                     return None;
                 }

--- a/t/native-instant-duration-render.t
+++ b/t/native-instant-duration-render.t
@@ -1,0 +1,46 @@
+use Test;
+
+# VM-native gist/Str/raku rendering for Instant and Duration instances
+# (Track A native-method dispatch). Previously these fell through to the
+# interpreter — Instant because the dispatch arms only covered raku/perl, and
+# Duration additionally because the VM's Numeric-bridge bypass diverted every
+# method on a Real instance to the interpreter.
+
+plan 14;
+
+# --- Instant ---
+my $i = Instant.from-posix(1000000);
+is $i.gist, 'Instant:1000010', 'Instant.gist';
+is $i.Str, 'Instant:1000010', 'Instant.Str';
+is ~$i, 'Instant:1000010', 'Instant in string context';
+is $i.raku, 'Instant.from-posix(1000000.0)', 'Instant.raku';
+
+# --- Duration (integer) ---
+my $d = DateTime.new(2020, 1, 1, 0, 0, 30) - DateTime.new(2020, 1, 1, 0, 0, 0);
+is $d.^name, 'Duration', 'subtracting DateTimes yields a Duration';
+is $d.gist, '30', 'Duration.gist (integer)';
+is $d.Str, '30', 'Duration.Str (integer)';
+is $d.raku, 'Duration.new(30.0)', 'Duration.raku (integer)';
+
+# --- Duration (fractional) ---
+my $df = DateTime.new(2020, 1, 1, 0, 0, 30.5) - DateTime.new(2020, 1, 1, 0, 0, 0);
+is $df.gist, '30.5', 'Duration.gist (fractional)';
+is $df.Str, '30.5', 'Duration.Str (fractional)';
+
+# Duration arithmetic still bridges through Numeric (bypass preserved for
+# non-render methods)
+ok ($d + 0) == 30, 'Duration still participates in numeric ops';
+is $d.Int, 30, 'Duration.Int via the Numeric bridge';
+
+# A user class that does Real (no custom render) renders via the Numeric bridge
+# and still participates in arithmetic — the bypass relaxation does not change
+# its behavior.
+class Plain does Real {
+    has $.n;
+    method Bridge { $!n.Num }
+}
+my $p = Plain.new(n => 7);
+is $p.gist, '7', 'user Real class default gist bridges to the number';
+ok ($p + 5) == 12, 'user Real class still bridges arithmetic';
+
+done-testing;


### PR DESCRIPTION
## Summary

Track A native-method dispatch: `gist`/`Str`/`raku` on `Instant` and `Duration` instances were routing through the tree-walking interpreter. Two distinct causes, both fixed:

1. **Instant** — `native_method_0arg` only covered `raku`/`perl`; `gist`/`Str` had no arm. Added a `gist` branch to the Instant/Duration arm in `dispatch_core_repr.rs` and an Instant/Duration arm to the `"Str"|"Stringy"` match in `dispatch_core_coerce.rs`, both returning `target.to_string_value()` (the same pure rendering as `value/display.rs`).
2. **Duration** — additionally blocked by the VM's **Numeric-bridge bypass** (`vm_native_dispatch.rs`), which diverts *every* method on a `Real`/`Numeric` instance to the interpreter. Pure-render methods (gist/Str/Stringy/raku/perl) don't need the bridge, so the bypass now skips them — **unless** the class overrides that render method (`has_user_method`), keeping the bypass so the custom method runs.

## Safety / behavior-invariance

- Unknown numeric instances still return `None` from native → fall through to the interpreter (same as before).
- A user `does Real` class with a custom `gist`/`Str` keeps the bypass → its method runs.
- Arithmetic/coercion methods (`.Int`, `+`, …) keep the bypass.
- Byte-identical to `raku`: `Instant.raku` = `Instant.from-posix(N.0)`, `Duration.raku` = `Duration.new(N.0)`.

## Verification

- `t/native-instant-duration-render.t` (14) — Instant/Duration gist/Str/raku (integer + fractional), Numeric-bridge arithmetic still works, user `does Real` class default render + arithmetic. All pass; verified identical under `raku`.
- `MUTSU_VM_STATS=1`: Instant/Duration `gist`/`Str`/`raku` fallback 100% → 0.
- All whitelisted `S32-temporal/*` tests pass (incl. `DateTime-Instant-Duration.t`); `cargo test` 461/0; numeric-render sanity (`Complex`/`Rat`/`Num`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)