### PR TITLE
perf(regex): cache compiled patterns as Arc to avoid a deep clone per match

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -387,10 +387,14 @@ say f();         # mutsu => 0     raku => 3
 | mutsu (`my $rx = rx/.../;` で事前コンパイル) | **3.51 s** (改善せず) |
 | raku | **0.40 s** |
 
-→ mutsu は raku の約 **8.6 倍遅く**、しかも regex を変数に束ねても速くならない。
+→ (当時) mutsu は raku の約 **8.6 倍遅く**、しかも regex を変数に束ねても速くならなかった。
 これは `Value::Regex(Arc<String>)` (生文字列) が**マッチのたびに `parse_regex` で
-構造を再構築している**ことを定量的に裏付ける (5 章)。
-**改善**: パターン文字列 → コンパイル済み構造 (`RegexAtom` ツリー) のキャッシュを導入。
+構造を再構築している**ことを定量的に裏付けていた (5 章)。
+**改善 (実施済み)**: static パターン → コンパイル済み `RegexPattern` ツリーの memo キャッシュ
+(`REGEX_PARSE_CACHE`) を導入済み。さらに #3064 でキャッシュヒットを `Arc<RegexPattern>` の
+refcount bump 化し、毎マッチの deep tree clone を除去。現状 release ~0.56s (raku 0.36s ＝
+~1.6x)。**残るギャップはマッチャ本体**: `regex_match_ends_from_caps_in_pkg` が全 end 位置の
+`RegexCaptures` を構築→sort するアロケーションコスト (別の深い最適化対象)。
 
 ### 8.5 根本原因 → roast ブロッカーの対応 (`TODO_roast/BLOCKERS.md`)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -230,7 +230,13 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
 
 #### Phase I/II と並行で随時消化できる独立タスク（critical path 外）
 
-- [ ] **正規表現のコンパイル済みキャッシュ**（ANALYSIS §8.4）— perf（raku 比 8.6x 遅）。撤去とは独立。
+- [~] **正規表現のコンパイル済みキャッシュ**（ANALYSIS §8.4）— perf。撤去とは独立。
+      static パターンの parse 結果は `REGEX_PARSE_CACHE` で memo 済み。#3064 で**キャッシュヒットを
+      owned `RegexPattern` の deep clone → `Arc<RegexPattern>` の refcount bump 化**（毎マッチの
+      ツリー clone を除去）。ベンチ `~~ /(\w+) \s+ (\w+) \s+ (\d+)/` ×20000 は release ~0.56s
+      （raku 0.36s ＝ ~1.6x、ANALYSIS 当時の 8.6x から大幅改善）。**残るギャップはマッチャ本体**
+      （`regex_match_ends_from_caps_in_pkg` が全 end 位置の `RegexCaptures` を構築→sort する
+      アロケーション）で、これは別の深い最適化。
 
 関連: 🟣第2優先「第一級コンテナ」＝トラック B の本体（レバー C ＝ Phase 1 の一部、Q2 の Arc-pointer flaky を吸収）。
 

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -110,7 +110,7 @@ impl Interpreter {
         &self,
         atom: &RegexAtom,
         pkg: &str,
-    ) -> Option<(RegexPattern, String)> {
+    ) -> Option<(std::sync::Arc<RegexPattern>, String)> {
         let RegexAtom::Named(name) = atom else {
             return None;
         };

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -17,7 +17,11 @@ thread_local! {
     /// so it is safe to cache and reuse across calls. This avoids re-parsing the
     /// same (potentially large) pattern on every step of a match — e.g. a token
     /// with dozens of alternations called once per input character.
-    static REGEX_PARSE_CACHE: RefCell<HashMap<String, RegexPattern>> = RefCell::new(HashMap::new());
+    /// Cached as `Arc<RegexPattern>` so a cache hit is a cheap refcount bump
+    /// rather than a deep clone of the whole token tree — the hot match loop
+    /// re-fetches the same compiled pattern on every step / every iteration.
+    static REGEX_PARSE_CACHE: RefCell<HashMap<String, std::sync::Arc<RegexPattern>>> =
+        RefCell::new(HashMap::new());
 }
 
 /// A pattern is cacheable iff parsing it does not depend on runtime variable
@@ -1813,27 +1817,37 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn parse_regex(&self, pattern: &str) -> Option<RegexPattern> {
-        self.parse_regex_with_mode(pattern, RegexParseMode::Match)
-    }
-
-    fn parse_regex_with_mode(&self, pattern: &str, mode: RegexParseMode) -> Option<RegexPattern> {
-        // Fast path: reuse a previously-parsed result for static patterns.
-        // Only the runtime `Match` mode caches: `Validate` produces opaque
-        // (un-interpolated, un-resolved) structures that must never leak into
-        // the runtime cache.
-        if mode == RegexParseMode::Match && regex_pattern_is_static(pattern) {
+    /// Parse a runtime (`Match`-mode) regex pattern, returning a shared
+    /// `Arc<RegexPattern>`. For a static pattern the compiled tree is memoized
+    /// in `REGEX_PARSE_CACHE`, so a repeat call (the hot match loop re-fetches
+    /// the same pattern on every step / iteration) is a refcount bump rather
+    /// than a deep clone of the whole token tree (the previous owned-`RegexPattern`
+    /// cache cloned the tree on every hit — ANALYSIS §8.4).
+    pub(super) fn parse_regex(&self, pattern: &str) -> Option<std::sync::Arc<RegexPattern>> {
+        if regex_pattern_is_static(pattern) {
             if let Some(cached) = REGEX_PARSE_CACHE.with(|c| c.borrow().get(pattern).cloned()) {
                 return Some(cached);
             }
-            let parsed = self.parse_regex_uncached(pattern, mode);
+            let parsed = self
+                .parse_regex_uncached(pattern, RegexParseMode::Match)
+                .map(std::sync::Arc::new);
             if let Some(ref p) = parsed {
                 REGEX_PARSE_CACHE.with(|c| {
-                    c.borrow_mut().insert(pattern.to_string(), p.clone());
+                    c.borrow_mut()
+                        .insert(pattern.to_string(), std::sync::Arc::clone(p));
                 });
             }
             return parsed;
         }
+        self.parse_regex_uncached(pattern, RegexParseMode::Match)
+            .map(std::sync::Arc::new)
+    }
+
+    /// Owned-`RegexPattern` parse used by the parser's own recursion (sub-pattern
+    /// parsing while building the token tree) and by non-`Match` (`Validate`)
+    /// callers. Sub-patterns live inside their parent's tree, so they are not
+    /// top-level cached here; the parent as a whole is cached by `parse_regex`.
+    fn parse_regex_with_mode(&self, pattern: &str, mode: RegexParseMode) -> Option<RegexPattern> {
         self.parse_regex_uncached(pattern, mode)
     }
 
@@ -4549,12 +4563,13 @@ impl Interpreter {
                         for _ in 0..sep_atom_str.chars().count() {
                             chars.next();
                         }
-                        Self::parse_regex(self, sep_atom_str.trim()).map(|pattern| {
-                            Box::new(RegexSeparatorSpec {
-                                pattern,
-                                allow_trailing,
+                        self.parse_regex_with_mode(sep_atom_str.trim(), mode)
+                            .map(|pattern| {
+                                Box::new(RegexSeparatorSpec {
+                                    pattern,
+                                    allow_trailing,
+                                })
                             })
-                        })
                     } else {
                         None
                     }


### PR DESCRIPTION
## Summary

The static-pattern parse cache (`REGEX_PARSE_CACHE`) stored an owned `RegexPattern`, so every cache hit — and the hot match loop re-fetches the same compiled pattern on **every step / every iteration** — deep-cloned the whole token tree (`Vec<RegexToken>`, nested alternation/group sub-patterns, char classes). This stores and returns `Arc<RegexPattern>` instead, so a hit is a refcount bump rather than a tree clone. Addresses the clone half of ANALYSIS §8.4.

## Change

- `parse_regex` now returns `Option<Arc<RegexPattern>>` and owns the static `Match`-mode Arc cache directly.
- `parse_regex_with_mode` reverts to returning an owned `RegexPattern`: it is used only by the parser's own recursion (sub-pattern parsing while building the token tree) and by `Validate`-mode callers, where the result is moved into the parent tree. Sub-patterns are not separately top-level cached; the parent as a whole is cached by `parse_regex`.
- Match-path callers use the result by reference, so `Arc` is transparent via deref coercion; only `try_resolve_named_to_pattern`'s return type and the separator-spec builder (which keeps an owned `RegexPattern`) needed touching.

## Measurement

`"hello world 123" ~~ /(\w+) \s+ (\w+) \s+ (\d+)/` x20000:
- debug **2.47s → 2.37s** (apples-to-apples, ~4%)
- release ~**0.56s** (vs raku 0.36s)

Strictly better by construction — an `Arc` clone replaces a deep tree clone on every match — and reduces allocator churn in the matcher. (The parse cache itself already existed; this refines cache *hits* from O(tree) to O(1).)

## Verification

- `make test` green.
- Whitelisted S05 regex/grammar tests pass (25 checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)