### PR TITLE
perf(regex): stop backtracking DFS at the first complete single match

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -393,8 +393,11 @@ say f();         # mutsu => 0     raku => 3
 **改善 (実施済み)**: static パターン → コンパイル済み `RegexPattern` ツリーの memo キャッシュ
 (`REGEX_PARSE_CACHE`) を導入済み。さらに #3064 でキャッシュヒットを `Arc<RegexPattern>` の
 refcount bump 化し、毎マッチの deep tree clone を除去。現状 release ~0.56s (raku 0.36s ＝
-~1.6x)。**残るギャップはマッチャ本体**: `regex_match_ends_from_caps_in_pkg` が全 end 位置の
-`RegexCaptures` を構築→sort するアロケーションコスト (別の深い最適化対象)。
+~1.6x)。さらに #3065 で**単一マッチ経路 (`~~`/anchored) の早期終了**を追加: バックトラック DFS は
+最初に見つかる完全マッチが最高優先 (greedy/leftmost) なので、`matches[0]` しか使わない caller は
+そこで `break`。**catastrophic backtracking を抑制** — `"aaaa…(20)…b" ~~ /(\w+) (\w+) (\w+) b/`
+×3000 が 22.8s→0.52s (~44x)。**残るギャップ**: 非曖昧パターンのトークン候補リスト構築＋量指定子
+反復ごとの `RegexCaptures.clone()` (バックトラックスナップショット) アロケーション (別の深い最適化対象)。
 
 ### 8.5 根本原因 → roast ブロッカーの対応 (`TODO_roast/BLOCKERS.md`)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -234,9 +234,13 @@ interp から降ろした。WhateverCode/regex 結合な部分は `runtime/` に
       static パターンの parse 結果は `REGEX_PARSE_CACHE` で memo 済み。#3064 で**キャッシュヒットを
       owned `RegexPattern` の deep clone → `Arc<RegexPattern>` の refcount bump 化**（毎マッチの
       ツリー clone を除去）。ベンチ `~~ /(\w+) \s+ (\w+) \s+ (\d+)/` ×20000 は release ~0.56s
-      （raku 0.36s ＝ ~1.6x、ANALYSIS 当時の 8.6x から大幅改善）。**残るギャップはマッチャ本体**
-      （`regex_match_ends_from_caps_in_pkg` が全 end 位置の `RegexCaptures` を構築→sort する
-      アロケーション）で、これは別の深い最適化。
+      （raku 0.36s ＝ ~1.6x、ANALYSIS 当時の 8.6x から大幅改善）。
+      #3065 で**単一マッチ経路（`~~`/anchored）の早期終了**: バックトラック DFS は greedy/最高優先を
+      先に訪れ end を未ソート DFS 順で返すので、`matches[0]` を取る単一マッチ caller は最初の完全マッチで
+      `break`（`first_only` フラグ、`matches[0]` バイト同一＝意味保存）。**catastrophic backtracking を
+      抑制**: `"aaaa…(20)…b" ~~ /(\w+) (\w+) (\w+) b/` ×3000 が 22.8s→0.52s（~44x）。
+      **残るギャップ**: 非曖昧パターンのトークン候補リスト構築＋量指定子反復ごとの `RegexCaptures.clone()`
+      （バックトラックスナップショット）。clone 削減が次の（より深い）最適化。
 
 関連: 🟣第2優先「第一級コンテナ」＝トラック B の本体（レバー C ＝ Phase 1 の一部、Q2 の Arc-pointer flaky を吸収）。
 

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -264,7 +264,13 @@ impl Interpreter {
         start: usize,
         pkg: &str,
     ) -> Option<(usize, RegexCaptures)> {
-        self.regex_match_ends_from_caps_in_pkg(pattern, chars, start, pkg)
+        // Only the first (highest-priority / greedy) complete match is needed
+        // here, and the backtracking DFS already discovers it first (matches are
+        // returned in DFS-completion order, unsorted), so stop as soon as one is
+        // found instead of exploring the whole backtracking tree. `matches[0]` is
+        // byte-identical to the all-ends result's first element, so this is
+        // semantics-preserving — it just skips work the `.next()` would discard.
+        self.regex_match_ends_from_caps_in_pkg_impl(pattern, chars, start, pkg, true)
             .into_iter()
             .next()
     }
@@ -276,6 +282,22 @@ impl Interpreter {
         start: usize,
         pkg: &str,
     ) -> Vec<(usize, RegexCaptures)> {
+        self.regex_match_ends_from_caps_in_pkg_impl(pattern, chars, start, pkg, false)
+    }
+
+    /// Backtracking match returning the complete-match end positions (with
+    /// captures) at `start`, in DFS-completion order (highest priority first).
+    /// When `first_only` is true the DFS stops after the first complete match —
+    /// `matches[0]` is unchanged, so callers that only take `.next()` get the
+    /// same answer for far less work.
+    fn regex_match_ends_from_caps_in_pkg_impl(
+        &self,
+        pattern: &RegexPattern,
+        chars: &[char],
+        start: usize,
+        pkg: &str,
+        first_only: bool,
+    ) -> Vec<(usize, RegexCaptures)> {
         // When :m (ignoremark) is set on the pattern, strip combining marks
         // from both text and pattern, match on the stripped versions, then
         // map positions back to the original text.
@@ -284,8 +306,13 @@ impl Interpreter {
             let text_slice = &chars[start..];
             let (stripped_chars, pos_map) = strip_marks_text(text_slice);
             let stripped_pattern = strip_marks_pattern(pattern);
-            let mut results =
-                self.regex_match_ends_from_caps_in_pkg(&stripped_pattern, &stripped_chars, 0, pkg);
+            let mut results = self.regex_match_ends_from_caps_in_pkg_impl(
+                &stripped_pattern,
+                &stripped_chars,
+                0,
+                pkg,
+                first_only,
+            );
             let orig_len = text_slice.len();
             for (end, caps) in &mut results {
                 *end = map_pos(*end, &pos_map, orig_len) + start;
@@ -477,6 +504,13 @@ impl Interpreter {
             if idx == pattern.tokens.len() {
                 if !pattern.anchor_end || pos == chars.len() {
                     matches.push((pos, caps));
+                    // Single-match callers (`regex_match_end_from_caps_in_pkg`)
+                    // only use `matches[0]`; the DFS visits highest priority
+                    // first, so the first complete match IS that element — stop
+                    // exploring the rest of the backtracking tree.
+                    if first_only {
+                        break;
+                    }
                 }
                 continue;
             }

--- a/t/regex-backtrack-early-exit.t
+++ b/t/regex-backtrack-early-exit.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# A `~~` / single-match regex only needs the first (greedy, highest-priority)
+# complete match. The backtracking DFS discovers that match first, so it now
+# stops there instead of exploring the entire backtracking tree. This both
+# preserves match/capture semantics and bounds catastrophic backtracking on
+# ambiguous patterns (e.g. `(\w+) (\w+) (\w+) b` over a long run, which would
+# otherwise explore exponentially many splits).
+
+plan 9;
+
+# --- ambiguous multi-group greedy split: leftmost-greedy wins ---
+ok "aaaaaaaaaaaaaaaaaaaab" ~~ /(\w+) (\w+) (\w+) b/, 'ambiguous pattern matches';
+is $0, 'aaaaaaaaaaaaaaaaaa', 'first group is greedy (16 of the a-run)';
+is $1, 'a', 'second group gets one char';
+is $2, 'a', 'third group gets one char';
+
+# --- greedy vs frugal still behave ---
+ok "abc123" ~~ /(\w+?)(\d+)/, 'frugal+greedy matches';
+is ~$/, 'abc123', 'frugal first group yields the full overall match';
+
+# --- anchored ambiguous split keeps greedy semantics ---
+ok "aaa" ~~ /^(a+)(a+)$/, 'anchored ambiguous split matches';
+is $0, 'aa', 'anchored greedy first group';
+
+# --- a pattern that without early-exit would explode but still must match ---
+ok "xxxxxxxxxxxxxxxxxxxxy" ~~ /(\w+) (\w+) (\w+) (\w+) y/,
+    'four-group ambiguous pattern matches without hanging';


### PR DESCRIPTION
## Summary

`regex_match_end_from_caps_in_pkg` — the single-match entry used by `~~`, anchored matches, and the per-start scan in `regex_match_with_captures_core` — called the all-ends `regex_match_ends_from_caps_in_pkg` and took `.next()`. But that built the **entire backtracking tree** (every alternative split of every quantifier) before discarding all but the first element.

The DFS already visits the highest-priority (greedy / leftmost) match first and returns ends in DFS-completion order (unsorted), so `matches[0]` is the first complete match found. This adds a `first_only` flag that breaks the DFS loop the moment the first complete match is pushed. `matches[0]` is byte-identical, so the change is **semantics-preserving** — it only skips work that `.next()` would throw away.

## Impact

Bounds catastrophic backtracking on ambiguous patterns. `"aaaa…(20)…b" ~~ /(\w+) (\w+) (\w+) b/` x3000:

| | time |
|---|---|
| before | **22.8 s** |
| after | **0.52 s** (~44x) |

Capture semantics verified identical to rakudo across greedy / frugal / anchored-ambiguous cases (`(\w+) (\w+) (\w+) b`, `(\w+?)(\d+)`, `^(a+)(a+)$`, `(a?)(b?)`). The plain `"hello world 123" ~~ /(\w+) \s+ (\w+) \s+ (\d+)/` micro-bench is unchanged (it has no post-match ambiguity to prune).

The all-ends consumers — alternation / quantifier backtracking inside the matcher that genuinely need every end — are unchanged (`first_only = false`).

## Verification

- `t/regex-backtrack-early-exit.t` (new): ambiguous greedy split, frugal, anchored-ambiguous, four-group non-hang.
- `make test` green; whitelisted S05 regex/grammar tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)