### PR TITLE
refactor(③): lift instance_type_metadata behind a shared Arc<RwLock> handle

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -144,8 +144,13 @@ VM→interpreter 委譲は carrier / concurrency(Track C) / niche のみ。**env
 - [ ] **Track C — 並行（共有セル）**（**2〜4 PR**）— スライス 1〜5 landed（共有スカラ/state/compound-assign/
       hash-elem/**array-elem index 代入 #3063**）。残: `state @`/`%` 共有（Track B 基盤依存）、unsafe aliasing 撤廃
       （ANALYSIS §2.3 `Arc::as_ptr as *mut` 11 箇所）。
-- [ ] **cool side-table の handle 移管（任意）**（**1〜3 PR**）— `instance_type_metadata` 等を VM handle 化。
+- [~] **cool side-table の handle 移管（任意）**（**1〜3 PR**）— `instance_type_metadata` 等を VM handle 化。
       CP-3 の畳み込み面を減らす（CP-3 に同梱可）。
+      - [x] **PR-1: `instance_type_metadata` を `Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>` へ shaping**
+            （`current_package`/`io_handles` の共有ハンドル playbook）。`clone_for_thread` を明示スナップショット
+            （Arc 共有ではなく map deep-copy）化して per-thread 意味論を保存。挙動不変。
+      - [ ] **PR-2（任意・要 VM-native consumer）**: VM peer field + `instance_type_metadata_handle()` で
+            `container_type_metadata`（instance read）を VM ネイティブ化し interpreter バウンス除去。
 - [ ] **perf（独立）** — 正規表現コンパイルキャッシュは #3064（`Arc<RegexPattern>` で per-match deep clone 除去、
       ~1.6x）/ #3065（単一マッチ早期終了、catastrophic backtracking 抑制）で大半 landed。残＝量指定子反復ごとの
       `RegexCaptures.clone()` 削減。他に NaN-boxing（下記 Q4）。

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1033,8 +1033,15 @@ pub struct Interpreter {
     // Array/Hash/Set/Bag/Mix type metadata and object-hash original keys are
     // embedded in their backing data structs (ArrayData/HashData/SetData/
     // BagData/MixData) — no side tables.
-    /// Type metadata for instance values keyed by stable instance id.
-    instance_type_metadata: HashMap<u64, ContainerTypeInfo>,
+    /// Type metadata for instance values keyed by stable instance id. Lifted
+    /// behind `Arc<RwLock>` (the same shared-handle playbook used for
+    /// `current_package` / `io_handles`) so the VM and Interpreter can reach it
+    /// as peers and CP-3 can fold it by handle transfer rather than ownership
+    /// reasoning. Like those handles it is a *per-thread snapshot*, not
+    /// live-shared: `clone_for_thread` deep-copies the map into a fresh `Arc`,
+    /// so the lock never contends across threads. Collapses to a plain VM field
+    /// once the Interpreter execution path is removed (PLAN.md ④/⑤).
+    instance_type_metadata: Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>,
     let_saves: Vec<(String, Value, bool)>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
     pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, std::time::Instant)>>,
@@ -3134,7 +3141,7 @@ impl Interpreter {
             atomic_var_seen: false,
             var_defaults: HashMap::new(),
             var_hash_key_constraints: HashMap::new(),
-            instance_type_metadata: HashMap::new(),
+            instance_type_metadata: Arc::new(RwLock::new(HashMap::new())),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
@@ -4713,7 +4720,7 @@ impl Interpreter {
                 );
             }
             Value::Instance { id, .. } => {
-                self.instance_type_metadata.insert(*id, info);
+                self.instance_type_metadata.write().unwrap().insert(*id, info);
             }
             Value::Mixin(inner, _) => self.register_container_type_metadata(inner, info),
             _ => {}
@@ -4784,7 +4791,9 @@ impl Interpreter {
             Value::Set(items, _) => embedded_type_info!(items),
             Value::Bag(items, _) => embedded_type_info!(items),
             Value::Hash(items) => Self::hashdata_type_info(items),
-            Value::Instance { id, .. } => self.instance_type_metadata.get(id).cloned(),
+            Value::Instance { id, .. } => {
+                self.instance_type_metadata.read().unwrap().get(id).cloned()
+            }
             Value::Mixin(inner, _) => self.container_type_metadata(inner),
             _ => None,
         }
@@ -5586,7 +5595,12 @@ impl Interpreter {
             atomic_var_seen: self.atomic_var_seen,
             var_defaults: self.var_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),
-            instance_type_metadata: self.instance_type_metadata.clone(),
+            // Per-thread snapshot (not a shared-handle clone): deep-copy the map
+            // into a fresh `Arc` so the child thread's instance type metadata is
+            // independent of the parent's, mirroring `io_handles`/`current_package`.
+            instance_type_metadata: Arc::new(RwLock::new(
+                self.instance_type_metadata.read().unwrap().clone(),
+            )),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4720,7 +4720,10 @@ impl Interpreter {
                 );
             }
             Value::Instance { id, .. } => {
-                self.instance_type_metadata.write().unwrap().insert(*id, info);
+                self.instance_type_metadata
+                    .write()
+                    .unwrap()
+                    .insert(*id, info);
             }
             Value::Mixin(inner, _) => self.register_container_type_metadata(inner, info),
             _ => {}


### PR DESCRIPTION
## What

`instance_type_metadata: HashMap<u64, ContainerTypeInfo>` was a plain Interpreter-owned side table holding type metadata for `Instance` values (keyed by stable instance id). This PR lifts it behind `Arc<RwLock>`, following the same shared-handle playbook already used for `current_package` / `io_handles` / `output_sink`.

Implements PR-1 of PLAN.md's **"cool side-table の handle 移管"** item: shape the side table as a shared handle so the VM and Interpreter can reach it as peers and CP-3 can fold it by handle transfer rather than ownership reasoning.

## Details

- Field: `HashMap<u64, ContainerTypeInfo>` → `Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>`.
- The two access sites (`register_container_type_metadata` insert / `container_type_metadata` read) take short `write()`/`read()` guards confined to the call — never held across re-entry.
- **`clone_for_thread` now explicitly deep-copies the map into a fresh `Arc`** (was a plain map clone). It is a *per-thread snapshot*, not live-shared — Arc-cloning the field instead would have wrongly made the table live-shared across threads. Mirrors `io_handles` / `current_package`.

## Behaviour

Behaviour-identical. `make test` green (797 files / 7425 tests / Failed: 0). Locally verified: `roast/S09-typed-arrays/arrays.t`, `roast/S02-names-vars/perl.t`, `t/native-array-mut.t`, `t/whole-container-bind.t` all pass.

## Follow-up (not in this PR)

PR-2 (optional, needs a real VM-native consumer): add a VM peer field + `instance_type_metadata_handle()` accessor and make `container_type_metadata` instance reads VM-native to remove the interpreter bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)