### PR TITLE
refactor(CP-1 1b): route all src/vm env access through VM seam accessors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -115,17 +115,13 @@ VM→interpreter 委譲は carrier / concurrency(Track C) / niche のみ。**env
       **方式 A（env は VM.env に住み、carrier 呼び前後で `mem::swap` 貸借／snapshot carrier は clone 借りのみ）を採用**、
       方式 B（`&mut Env` 引数渡し）は runtime/ 全域結合のため却下。全 carrier の env read/write/再入タイミングを表に
       （live: EVAL/subset-where/call_*/eval_block/run_block / snapshot: thread/regex補間）。VM env アクセス実測 = 513 サイト。
-- [~] **1b. VM env seam を導入**（**3〜4 PR**・モジュール群ごとに分割）
-      - `VM::env()` / `VM::env_mut()` アクセサを新設（当面は `self.interpreter.env()` へ forward＝**挙動不変**）。
-      - 481 の `self.interpreter.env`/`env_mut` を、**borrow 衝突しないサイトから**順に accessor へ移行
-        （順序例: vm_var_get/assign → vm_call_* → vm_data/misc/helpers → 残り）。`grep -rc self.interpreter.env src/vm`
-        で残数を追い、1 PR = 1 モジュール群。
-      - **PR #1 = DONE 2026-06-15**: `src/vm/` 内部の全 env アクセス（513 サイト `env()`/`env_mut()` + `clone_env`/
-        `set_env`/`take_env`）を VM seam アクセサ経由に一括移行。borrow 衝突は **わずか2件**（`env_mut().insert(_, self.locals[idx].clone())`）で
-        ローカル束縛切り出しで即解消＝**1c は実質ここに畳んだ**。`make test` PASS / clippy 緑 / env 系 roast（let/subset/eval/
-        pointy-rw/given/sort）緑。残: 外部 driver サイト（`runtime/resolution.rs` の `vm.interpreter().env()` / `vm.interpreter_mut().env_insert()`
-        ＝ map/sort reuse carrier）を `vm.env()`/`vm.env_mut()` へ揃える PR #2。
-- [x] **1c. borrow 衝突サイトを解消**（1b PR #1 に畳み込み済 — 衝突は2件のみだった）。
+- [x] **1b. VM env seam を導入** — **DONE 2026-06-15**（borrow 衝突が2件のみで、当初 3〜4 PR 想定を 1 PR に集約）。
+      `VM::env()`/`env_mut()`/`clone_env()`/`set_env()`/`take_env()` アクセサを新設（当面 `self.interpreter` へ forward＝挙動不変）。
+      - **内部**: `src/vm/` の全 env アクセス（513 サイト `env()`/`env_mut()` + clone_env/set_env/take_env）を seam アクセサ経由に一括移行。
+      - **外部 driver**: `runtime/resolution.rs` の map/sort `run_reuse` carrier（`vm.interpreter().env()` 読み 6 + `vm.interpreter_mut().env_insert()` 書き）も
+        `vm.env()`/`vm.env_mut()` へ揃え、未使用化した `VM::interpreter_mut` を削除。**これで VM env アクセスは 100% seam 経由**。
+      - 検証: `make test` PASS（797 files / 7425 tests）/ clippy 緑 / env 系 roast（let/subset 6c/6e/eval_lex/in-eval/pointy-rw/given/sort/proto/class）緑。
+- [x] **1c. borrow 衝突サイトを解消**（1b に畳み込み済 — 衝突は2件のみだった）。
 - [ ] **1d. interpreter 側 carrier の env 借用点を整理**（**1〜2 PR**）
       - 1a で列挙した carrier が `self.env` を読む箇所を、メソッド境界で env を出し入れできる形に整理
         （env を引数 or 一時 swap で受け取れるよう carrier 経路をリファクタ）。挙動不変。

--- a/PLAN.md
+++ b/PLAN.md
@@ -115,14 +115,17 @@ VM→interpreter 委譲は carrier / concurrency(Track C) / niche のみ。**env
       **方式 A（env は VM.env に住み、carrier 呼び前後で `mem::swap` 貸借／snapshot carrier は clone 借りのみ）を採用**、
       方式 B（`&mut Env` 引数渡し）は runtime/ 全域結合のため却下。全 carrier の env read/write/再入タイミングを表に
       （live: EVAL/subset-where/call_*/eval_block/run_block / snapshot: thread/regex補間）。VM env アクセス実測 = 513 サイト。
-- [ ] **1b. VM env seam を導入**（**3〜4 PR**・モジュール群ごとに分割）
+- [~] **1b. VM env seam を導入**（**3〜4 PR**・モジュール群ごとに分割）
       - `VM::env()` / `VM::env_mut()` アクセサを新設（当面は `self.interpreter.env()` へ forward＝**挙動不変**）。
       - 481 の `self.interpreter.env`/`env_mut` を、**borrow 衝突しないサイトから**順に accessor へ移行
         （順序例: vm_var_get/assign → vm_call_* → vm_data/misc/helpers → 残り）。`grep -rc self.interpreter.env src/vm`
         で残数を追い、1 PR = 1 モジュール群。
-- [ ] **1c. borrow 衝突サイトを解消**（**1〜2 PR**）
-      - env 読みと他 self フィールドが交錯し、accessor の `&self` 全体借用が衝突するサイトを、ローカル束縛への
-        切り出し / スコープ分割で個別に解消（1b で後回しにした分）。完了時点で VM 側 env アクセスは 100% seam 経由。
+      - **PR #1 = DONE 2026-06-15**: `src/vm/` 内部の全 env アクセス（513 サイト `env()`/`env_mut()` + `clone_env`/
+        `set_env`/`take_env`）を VM seam アクセサ経由に一括移行。borrow 衝突は **わずか2件**（`env_mut().insert(_, self.locals[idx].clone())`）で
+        ローカル束縛切り出しで即解消＝**1c は実質ここに畳んだ**。`make test` PASS / clippy 緑 / env 系 roast（let/subset/eval/
+        pointy-rw/given/sort）緑。残: 外部 driver サイト（`runtime/resolution.rs` の `vm.interpreter().env()` / `vm.interpreter_mut().env_insert()`
+        ＝ map/sort reuse carrier）を `vm.env()`/`vm.env_mut()` へ揃える PR #2。
+- [x] **1c. borrow 衝突サイトを解消**（1b PR #1 に畳み込み済 — 衝突は2件のみだった）。
 - [ ] **1d. interpreter 側 carrier の env 借用点を整理**（**1〜2 PR**）
       - 1a で列挙した carrier が `self.env` を読む箇所を、メソッド境界で env を出し入れできる形に整理
         （env を引数 or 一時 swap で受け取れるよう carrier 経路をリファクタ）。挙動不変。

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -2108,29 +2108,30 @@ impl Interpreter {
                     return Err(RuntimeError::new("Not enough elements for map block arity"));
                 }
                 {
-                    let interp = vm.interpreter_mut();
                     let assumed_count = data.assumed_positional.len();
                     // Bind assumed positional args first
                     for (idx, val) in data.assumed_positional.iter().enumerate() {
                         if let Some(p) = data.params.get(idx) {
-                            interp.env_insert(p.clone(), val.clone());
+                            vm.env_mut().insert(p.clone(), val.clone());
                         }
                     }
                     if arity == 1 {
                         let item = list_items[i].clone();
                         if let Some(p) = data.params.get(assumed_count) {
-                            interp.env_insert(p.clone(), item.clone());
+                            vm.env_mut().insert(p.clone(), item.clone());
                         }
-                        interp.env_insert(underscore.clone(), item.clone());
-                        interp.env_insert(dollar_topic.clone(), item);
+                        vm.env_mut().insert(underscore.clone(), item.clone());
+                        vm.env_mut().insert(dollar_topic.clone(), item);
                     } else {
                         for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                             if i + idx < list_items.len() {
-                                interp.env_insert(p.clone(), list_items[i + idx].clone());
+                                vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
                             }
                         }
-                        interp.env_insert(underscore.clone(), list_items[i].clone());
-                        interp.env_insert(dollar_topic.clone(), list_items[i].clone());
+                        vm.env_mut()
+                            .insert(underscore.clone(), list_items[i].clone());
+                        vm.env_mut()
+                            .insert(dollar_topic.clone(), list_items[i].clone());
                     }
                 }
                 match vm.run_reuse(&code, &compiled_fns) {
@@ -2138,7 +2139,7 @@ impl Interpreter {
                         let val = vm
                             .last_stack_value()
                             .cloned()
-                            .or_else(|| vm.interpreter().env().get("_").cloned())
+                            .or_else(|| vm.env().get("_").cloned())
                             .unwrap_or(Value::Nil);
                         match val {
                             Value::Slip(elems) => result.extend(elems.iter().cloned()),
@@ -2343,30 +2344,31 @@ impl Interpreter {
                     return Err(RuntimeError::new("Not enough elements for map block arity"));
                 }
                 {
-                    let interp = vm.interpreter_mut();
                     let assumed_count = data.assumed_positional.len();
                     for (idx, val) in data.assumed_positional.iter().enumerate() {
                         if let Some(p) = data.params.get(idx) {
-                            interp.env_insert(p.clone(), val.clone());
+                            vm.env_mut().insert(p.clone(), val.clone());
                         }
                     }
                     // Clear the topic tracker before each iteration
-                    interp.env_mut().remove(topic_key);
+                    vm.env_mut().remove(topic_key);
                     if arity == 1 {
                         let item = list_items[i].clone();
                         if let Some(p) = data.params.get(assumed_count) {
-                            interp.env_insert(p.clone(), item.clone());
+                            vm.env_mut().insert(p.clone(), item.clone());
                         }
-                        interp.env_insert(underscore.clone(), item.clone());
-                        interp.env_insert(dollar_topic.clone(), item);
+                        vm.env_mut().insert(underscore.clone(), item.clone());
+                        vm.env_mut().insert(dollar_topic.clone(), item);
                     } else {
                         for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                             if i + idx < list_items.len() {
-                                interp.env_insert(p.clone(), list_items[i + idx].clone());
+                                vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
                             }
                         }
-                        interp.env_insert(underscore.clone(), list_items[i].clone());
-                        interp.env_insert(dollar_topic.clone(), list_items[i].clone());
+                        vm.env_mut()
+                            .insert(underscore.clone(), list_items[i].clone());
+                        vm.env_mut()
+                            .insert(dollar_topic.clone(), list_items[i].clone());
                     }
                 }
                 match vm.run_reuse(&code, &compiled_fns) {
@@ -2374,11 +2376,11 @@ impl Interpreter {
                         let val = vm
                             .last_stack_value()
                             .cloned()
-                            .or_else(|| vm.interpreter().env().get("_").cloned())
+                            .or_else(|| vm.env().get("_").cloned())
                             .unwrap_or(Value::Nil);
                         // Write back topic mutation if it happened
                         if arity == 1
-                            && let Some(mutated) = vm.interpreter().env().get(topic_key).cloned()
+                            && let Some(mutated) = vm.env().get(topic_key).cloned()
                         {
                             list_items[i] = mutated;
                         }
@@ -2389,14 +2391,14 @@ impl Interpreter {
                     }
                     Err(e) if e.is_next => {
                         if arity == 1
-                            && let Some(mutated) = vm.interpreter().env().get(topic_key).cloned()
+                            && let Some(mutated) = vm.env().get(topic_key).cloned()
                         {
                             list_items[i] = mutated;
                         }
                     }
                     Err(e) if e.is_last => {
                         if arity == 1
-                            && let Some(mutated) = vm.interpreter().env().get(topic_key).cloned()
+                            && let Some(mutated) = vm.env().get(topic_key).cloned()
                         {
                             list_items[i] = mutated;
                         }
@@ -2533,28 +2535,28 @@ impl Interpreter {
                 };
                 'body_redo: loop {
                     {
-                        let interp = vm.interpreter_mut();
                         let assumed_count = data.assumed_positional.len();
                         for (idx, val) in data.assumed_positional.iter().enumerate() {
                             if let Some(p) = data.params.get(idx) {
-                                interp.env_insert(p.clone(), val.clone());
+                                vm.env_mut().insert(p.clone(), val.clone());
                             }
                         }
                         if arity == 1 {
                             if let Some(p) = data.params.get(assumed_count) {
-                                interp.env_insert(p.clone(), chunk[0].clone());
+                                vm.env_mut().insert(p.clone(), chunk[0].clone());
                             }
-                            interp.env_insert(underscore.clone(), chunk[0].clone());
-                            interp.env_insert(dollar_topic.clone(), chunk[0].clone());
-                            interp.env_insert(topic_source_key.clone(), chunk[0].clone());
+                            vm.env_mut().insert(underscore.clone(), chunk[0].clone());
+                            vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
+                            vm.env_mut()
+                                .insert(topic_source_key.clone(), chunk[0].clone());
                         } else {
                             for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                                 if idx < chunk.len() {
-                                    interp.env_insert(p.clone(), chunk[idx].clone());
+                                    vm.env_mut().insert(p.clone(), chunk[idx].clone());
                                 }
                             }
-                            interp.env_insert(underscore.clone(), chunk[0].clone());
-                            interp.env_insert(dollar_topic.clone(), chunk[0].clone());
+                            vm.env_mut().insert(underscore.clone(), chunk[0].clone());
+                            vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
                         }
                     }
                     vm.set_topic_source_var((arity == 1).then_some(topic_source_key.clone()));
@@ -2563,7 +2565,7 @@ impl Interpreter {
                             let pred = vm
                                 .last_stack_value()
                                 .cloned()
-                                .or_else(|| vm.interpreter().env().get("_").cloned())
+                                .or_else(|| vm.env().get("_").cloned())
                                 .unwrap_or(Value::Nil);
                             let updated_item = if arity == 1 {
                                 vm.interpreter()

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -720,7 +720,7 @@ impl VM {
         // Initialize local variable slots
         self.locals = vec![Value::Nil; code.locals.len()];
         for (i, name) in code.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(name) {
+            if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -806,7 +806,7 @@ impl VM {
         // Initialize local variable slots
         self.locals.resize(code.locals.len(), Value::Nil);
         for (i, name) in code.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(name) {
+            if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
             } else {
                 self.locals[i] = Value::Nil;
@@ -918,6 +918,51 @@ impl VM {
     /// Get a reference to the interpreter (for reading env values).
     pub(crate) fn interpreter(&self) -> &Interpreter {
         &self.interpreter
+    }
+
+    /// Read access to the variable store (env) through the VM's own seam.
+    ///
+    /// CP-1 (env-loan, step 1b): the env physically still lives in
+    /// `self.interpreter` and this accessor forwards there, so the change is
+    /// behavior-invariant. The point of routing every VM env read through this
+    /// single method now is that step 1e can flip the body to `&self.env` (env
+    /// moved into the VM) in one place. See docs/vm-state-ownership.md
+    /// "CP-1 env-loan 設計".
+    #[inline]
+    pub(crate) fn env(&self) -> &Env {
+        self.interpreter.env()
+    }
+
+    /// Write access to the variable store (env) through the VM's own seam.
+    /// Forwards to `self.interpreter` for now (CP-1 step 1b, behavior-invariant);
+    /// step 1e flips it to `&mut self.env`. See [`VM::env`].
+    #[inline]
+    pub(crate) fn env_mut(&mut self) -> &mut Env {
+        self.interpreter.env_mut()
+    }
+
+    /// Clone the env for capture across a call/block/thread boundary, through the
+    /// VM seam. Forwards to `self.interpreter.clone_env()` (CP-1 step 1b);
+    /// step 1e flips it to `self.env.flattened()`. See [`VM::env`].
+    #[inline]
+    pub(crate) fn clone_env(&self) -> Env {
+        self.interpreter.clone_env()
+    }
+
+    /// Replace the entire env, through the VM seam. Forwards to
+    /// `self.interpreter.set_env()` (CP-1 step 1b); step 1e flips it to
+    /// `self.env = env`. See [`VM::env`].
+    #[inline]
+    pub(crate) fn set_env(&mut self, env: Env) {
+        self.interpreter.set_env(env);
+    }
+
+    /// Take the env out, replacing it with an empty `Env`, through the VM seam.
+    /// Forwards to `self.interpreter.take_env()` (CP-1 step 1b); step 1e flips it
+    /// to `std::mem::take(&mut self.env)`. See [`VM::env`].
+    #[inline]
+    pub(crate) fn take_env(&mut self) -> Env {
+        self.interpreter.take_env()
     }
 
     /// Get a mutable reference to the interpreter (for setting env values).
@@ -1424,7 +1469,7 @@ impl VM {
                     .or_else(|| {
                         // Fallback: check bare name in env (for closures capturing params)
                         name.strip_prefix('@')
-                            .and_then(|bare| self.interpreter.env().get(bare).cloned())
+                            .and_then(|bare| self.env().get(bare).cloned())
                     })
                     .or_else(|| {
                         // Fallback for fast-path method dispatch (skip_env_setup=true):
@@ -1503,7 +1548,7 @@ impl VM {
                     .or_else(|| self.get_local_by_bare_name(code, name))
                     .or_else(|| {
                         name.strip_prefix('%')
-                            .and_then(|bare| self.interpreter.env().get(bare).cloned())
+                            .and_then(|bare| self.env().get(bare).cloned())
                     })
                     .or_else(|| {
                         // Fallback for fast-path method dispatch (skip_env_setup=true):
@@ -1594,19 +1639,16 @@ impl VM {
                         .is_none()
                     && !self.interpreter.is_readonly(name_str)
                     && !matches!(self.stack.last(), Some(Value::Capture { .. }))
-                    && !matches!(
-                        self.interpreter.env().get(name_str),
-                        Some(Value::ContainerRef(_))
-                    )
+                    && !matches!(self.env().get(name_str), Some(Value::ContainerRef(_)))
                 {
                     let val = self.stack.pop().unwrap_or(Value::Nil);
                     // Preserve `$` state persistence across closure calls.
                     self.sync_anon_state_value("__ANON_STATE__", &val);
                     let sym = Symbol::intern("__ANON_STATE__");
-                    if let Some(slot) = self.interpreter.env_mut().get_mut_sym(sym) {
+                    if let Some(slot) = self.env_mut().get_mut_sym(sym) {
                         *slot = val;
                     } else {
-                        self.interpreter.env_mut().insert_sym(sym, val);
+                        self.env_mut().insert_sym(sym, val);
                     }
                     *ip += 1;
                     return Ok(());
@@ -1634,7 +1676,7 @@ impl VM {
                 }
                 if self.interpreter.strict_mode
                     && !name.contains("::")
-                    && !self.interpreter.env().contains_key(&name)
+                    && !self.env().contains_key(&name)
                 {
                     return Err(self.strict_undeclared_error(&name));
                 }
@@ -1661,7 +1703,7 @@ impl VM {
                 if let Some(constraint) = self.interpreter.var_type_constraint(&name) {
                     let base = constraint.split('[').next().unwrap_or(&constraint);
                     if matches!(base, "Mix" | "Set" | "Bag")
-                        && let Some(existing) = self.interpreter.env().get(&name)
+                        && let Some(existing) = self.env().get(&name)
                         && matches!(
                             existing,
                             Value::Mix(_, false) | Value::Set(_, false) | Value::Bag(_, false)
@@ -1686,7 +1728,7 @@ impl VM {
                     && !name.starts_with('%')
                     && !name.starts_with('&')
                     && !name.contains("::")
-                    && matches!(self.interpreter.env().get(&name), Some(Value::Package(_)))
+                    && matches!(self.env().get(&name), Some(Value::Package(_)))
                     && self.interpreter.has_class(&name)
                 {
                     return Err(RuntimeError::new(format!(
@@ -1820,10 +1862,8 @@ impl VM {
                 }
                 let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
                 let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-                if matches!(
-                    self.interpreter.env().get(&readonly_key),
-                    Some(Value::Bool(true))
-                ) && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
+                if matches!(self.env().get(&readonly_key), Some(Value::Bool(true)))
+                    && !matches!(self.env().get(&alias_key), Some(Value::Str(_)))
                 {
                     return Err(RuntimeError::assignment_ro(None));
                 }
@@ -1832,7 +1872,7 @@ impl VM {
                     let mut seen = std::collections::HashSet::new();
                     while seen.insert(resolved_source.clone()) {
                         let key = format!("__mutsu_sigilless_alias::{}", resolved_source);
-                        let Some(Value::Str(next)) = self.interpreter.env().get(&key) else {
+                        let Some(Value::Str(next)) = self.env().get(&key) else {
                             break;
                         };
                         resolved_source = next.to_string();
@@ -1874,7 +1914,7 @@ impl VM {
                         {
                             let reverse_key = format!("__mutsu_sigilless_alias::!{}", name);
                             if let Some(Value::Str(ref target)) =
-                                self.interpreter.env().get(&reverse_key).cloned()
+                                self.env().get(&reverse_key).cloned()
                                 && target.as_str() == name
                             {
                                 let priv_key = format!("!{}", name);
@@ -1944,9 +1984,7 @@ impl VM {
                 // Return early to avoid overwriting the ContainerRef in env with a plain value.
                 if !is_rebind && !raw_mode {
                     // Check env directly (not through alias resolution to avoid circular lookups)
-                    if let Some(Value::ContainerRef(arc)) =
-                        self.interpreter.env().get(&name).cloned()
-                    {
+                    if let Some(Value::ContainerRef(arc)) = self.env().get(&name).cloned() {
                         arc.lock().unwrap().clone_from(&val);
                         *ip += 1;
                         return Ok(());
@@ -1954,9 +1992,9 @@ impl VM {
                     // Also check alias target for sigilless attributes
                     let alias_key_check = format!("__mutsu_sigilless_alias::{}", name);
                     if let Some(Value::Str(alias_target)) =
-                        self.interpreter.env().get(&alias_key_check).cloned()
+                        self.env().get(&alias_key_check).cloned()
                         && let Some(Value::ContainerRef(arc)) =
-                            self.interpreter.env().get(alias_target.as_str()).cloned()
+                            self.env().get(alias_target.as_str()).cloned()
                     {
                         arc.lock().unwrap().clone_from(&val);
                         *ip += 1;
@@ -1966,7 +2004,7 @@ impl VM {
                 if raw_mode && name.starts_with('@') {
                     // For `constant @x`, bypass set_shared_var's List→Array
                     // normalization so the container type (List) is preserved.
-                    self.interpreter.env_mut().insert(name.clone(), val.clone());
+                    self.env_mut().insert(name.clone(), val.clone());
                 } else {
                     self.set_env_with_main_alias(&name, val.clone());
                 }
@@ -1988,7 +2026,7 @@ impl VM {
                 if !(raw_mode && name.starts_with('@')) {
                     self.interpreter.set_shared_var(&name, val.clone());
                 }
-                let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+                let mut alias_name = self.env().get(&alias_key).and_then(|v| {
                     if let Value::Str(name) = v {
                         Some(name.to_string())
                     } else {
@@ -2007,7 +2045,7 @@ impl VM {
                     // the sigilless attr sees the new value (Phase 3 Stage 2c (ii)).
                     self.write_self_attr_cell(&current_alias, val.clone());
                     let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-                    alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                    alias_name = self.env().get(&next_key).and_then(|v| {
                         if let Value::Str(name) = v {
                             Some(name.to_string())
                         } else {
@@ -2068,8 +2106,7 @@ impl VM {
                 // Exception: if the constraint is "Nil", keep the value as Value::Nil
                 // (the Nil type object is Value::Nil, not Value::Package("Nil")).
                 if !name.starts_with('@') && !name.starts_with('%') && constraint != "Nil" {
-                    let is_nil =
-                        matches!(self.interpreter.env().get(&name), Some(Value::Nil) | None);
+                    let is_nil = matches!(self.env().get(&name), Some(Value::Nil) | None);
                     if is_nil {
                         // Native types get zero/empty defaults instead of type objects.
                         let init_val =
@@ -2114,7 +2151,7 @@ impl VM {
             OpCode::SetTopic => {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 self.last_topic_value = Some(val.clone());
-                self.interpreter.env_mut().insert("_".to_string(), val);
+                self.env_mut().insert("_".to_string(), val);
                 *ip += 1;
             }
             OpCode::SaveTopic => {
@@ -2129,7 +2166,7 @@ impl VM {
             }
             OpCode::RestoreTopic => {
                 if let Some(saved) = self.topic_save_stack.pop() {
-                    self.interpreter.env_mut().insert("_".to_string(), saved);
+                    self.env_mut().insert("_".to_string(), saved);
                 }
                 *ip += 1;
             }
@@ -2211,7 +2248,7 @@ impl VM {
                         _ => "",
                     };
                     let key = format!("__mutsu_bound_decont::{}", var_name);
-                    matches!(self.interpreter.env().get(&key), Some(Value::Bool(true)))
+                    matches!(self.env().get(&key), Some(Value::Bool(true)))
                 } else {
                     false
                 };
@@ -3622,10 +3659,10 @@ impl VM {
                 if let Some((name, saved_val)) = self.for_param_restore_stack.pop() {
                     match saved_val {
                         Some(v) => {
-                            self.interpreter.env_mut().insert(name, v);
+                            self.env_mut().insert(name, v);
                         }
                         None => {
-                            self.interpreter.env_mut().remove(&name);
+                            self.env_mut().remove(&name);
                         }
                     }
                 }
@@ -3705,7 +3742,7 @@ impl VM {
                 // die() with empty array (from parsing die() with parens) should
                 // check $! first, falling back to "Died" default
                 let val = if matches!(&val, Value::Array(items, _) if items.is_empty()) {
-                    let current = self.interpreter.env().get("!").cloned();
+                    let current = self.env().get("!").cloned();
                     if let Some(ref c) = current
                         && !matches!(c, Value::Nil)
                     {
@@ -3781,7 +3818,7 @@ impl VM {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 // Check if &return has been lexically rebound; if so, call
                 // the rebound function instead of performing a built-in return.
-                if let Some(rebound) = self.interpreter.env().get("&return").cloned()
+                if let Some(rebound) = self.env().get("&return").cloned()
                     && matches!(
                         &rebound,
                         Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
@@ -4241,7 +4278,7 @@ impl VM {
                         // This ensures side effects from gather bodies propagate
                         // to outer-scope variables (e.g., `$was-lazy = 0`).
                         for (i, name) in code.locals.iter().enumerate() {
-                            if let Some(v) = self.interpreter.env().get(name)
+                            if let Some(v) = self.env().get(name)
                                 && i < self.locals.len()
                             {
                                 self.locals[i] = v.clone();
@@ -4441,10 +4478,7 @@ impl VM {
                 // in a closure).  The readonly_vars set is scope-local
                 // and gets restored on frame pop, but the env key persists.
                 let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-                if matches!(
-                    self.interpreter.env().get(&readonly_key),
-                    Some(Value::Bool(true))
-                ) {
+                if matches!(self.env().get(&readonly_key), Some(Value::Bool(true))) {
                     return Err(RuntimeError::assignment_ro(Some(name)));
                 }
                 *ip += 1;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -965,11 +965,6 @@ impl VM {
         self.interpreter.take_env()
     }
 
-    /// Get a mutable reference to the interpreter (for setting env values).
-    pub(crate) fn interpreter_mut(&mut self) -> &mut Interpreter {
-        &mut self.interpreter
-    }
-
     pub(crate) fn last_stack_value(&self) -> Option<&Value> {
         if self.stack.len() == 1 {
             self.stack.last()

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -66,7 +66,7 @@ impl VM {
             .interpreter
             .env()
             .get(&arr_key)
-            .or_else(|| self.interpreter.env().get(&var_name))
+            .or_else(|| self.env().get(&var_name))
             .cloned();
         let Value::Array(arc_items, kind) = target_val.unwrap_or(Value::Nil) else {
             return Ok(None);
@@ -88,7 +88,7 @@ impl VM {
             crate::value::ArrayData::new(popped)
         };
         // Write the mutated array back
-        let lookup_key = if self.interpreter.env().contains_key(&arr_key) {
+        let lookup_key = if self.env().contains_key(&arr_key) {
             &arr_key
         } else {
             &var_name
@@ -112,17 +112,17 @@ impl VM {
         let touched_keys: Vec<String> = data.env.keys().map(|k| k.resolve()).collect();
         let saved: Vec<(String, Option<Value>)> = touched_keys
             .iter()
-            .map(|k| (k.clone(), self.interpreter.env().get(k).cloned()))
+            .map(|k| (k.clone(), self.env().get(k).cloned()))
             .collect();
 
         // Install captured env
         for (k, v) in data.env.iter() {
-            if matches!(self.interpreter.env().get_sym(*k), Some(Value::Array(..)))
+            if matches!(self.env().get_sym(*k), Some(Value::Array(..)))
                 && matches!(v, Value::Array(..))
             {
                 continue;
             }
-            self.interpreter.env_mut().insert_sym(*k, v.clone());
+            self.env_mut().insert_sym(*k, v.clone());
         }
 
         // Compile the thunk body
@@ -153,10 +153,10 @@ impl VM {
                     for (k, orig) in saved {
                         match orig {
                             Some(v) => {
-                                self.interpreter.env_mut().insert(k, v);
+                                self.env_mut().insert(k, v);
                             }
                             None => {
-                                self.interpreter.env_mut().remove(&k);
+                                self.env_mut().remove(&k);
                             }
                         }
                     }
@@ -172,7 +172,7 @@ impl VM {
         for (k, orig) in saved {
             // If the thunk mutated an array variable (e.g. via .shift),
             // keep the mutated version instead of restoring the original.
-            let current = self.interpreter.env().get(&k).cloned();
+            let current = self.env().get(&k).cloned();
             let should_keep_current = matches!(
                 (&orig, &current),
                 (Some(Value::Array(..)), Some(Value::Array(..)))
@@ -182,10 +182,10 @@ impl VM {
             }
             match orig {
                 Some(v) => {
-                    self.interpreter.env_mut().insert(k, v);
+                    self.env_mut().insert(k, v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove(&k);
+                    self.env_mut().remove(&k);
                 }
             }
         }

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -439,7 +439,7 @@ impl VM {
     /// Find an instance in the environment by class name and id.
     /// Used to refresh a target after mutation during auto-threading.
     fn find_instance_in_env(&self, class_name: &str, id: u64) -> Option<Value> {
-        for v in self.interpreter.env().values() {
+        for v in self.env().values() {
             if let Value::Instance {
                 class_name: cn,
                 id: vid,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -15,7 +15,7 @@ impl VM {
                 .unwrap_or_default();
             let line = cl
                 .or_else(|| {
-                    self.interpreter.env().get("?LINE").and_then(|v| match v {
+                    self.env().get("?LINE").and_then(|v| match v {
                         Value::Int(i) => Some(*i),
                         _ => None,
                     })
@@ -325,7 +325,7 @@ impl VM {
             // when the prefix package is visible in the current scope.
             if found_key.is_none() && pkg != "GLOBAL" {
                 let prefix_visible = if let Some((pkg_prefix, _)) = name.rsplit_once("::") {
-                    self.interpreter.env().get(pkg_prefix).is_some()
+                    self.env().get(pkg_prefix).is_some()
                         || self
                             .interpreter
                             .env()
@@ -498,15 +498,15 @@ impl VM {
         let caller_env: Option<Env> = if use_scoped {
             // Chain a child over the whole caller env (itself possibly scoped):
             // no flatten, so nested fast calls don't pay the O(env) merge.
-            let parent = self.interpreter.env().clone();
+            let parent = self.env().clone();
             let scoped = crate::env::Env::scoped_child(parent);
-            Some(std::mem::replace(self.interpreter.env_mut(), scoped))
+            Some(std::mem::replace(self.env_mut(), scoped))
         } else {
             None
         };
         let saved_env = if !use_scoped && has_locals {
             crate::vm::vm_stats::record_clone_env();
-            Some(self.interpreter.clone_env())
+            Some(self.clone_env())
         } else {
             None
         };
@@ -517,8 +517,8 @@ impl VM {
 
         // Raku: routines get their own $_ initialized to (Any).
         let saved_topic = if cf.code.is_routine {
-            let old = self.interpreter.env().get("_").cloned();
-            self.interpreter.env_mut().insert(
+            let old = self.env().get("_").cloned();
+            self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(crate::symbol::Symbol::intern("Any")),
             );
@@ -532,7 +532,7 @@ impl VM {
         self.locals.clear();
         self.locals.resize(num_locals, Value::Nil);
         for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(local_name) {
+            if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -628,7 +628,7 @@ impl VM {
                 } else {
                     cf.code.locals.iter().map(|s| s.as_str()).collect()
                 };
-            let scoped = std::mem::replace(self.interpreter.env_mut(), caller_env);
+            let scoped = std::mem::replace(self.env_mut(), caller_env);
             let mut changed = false;
             for (k, v) in scoped.overlay_iter() {
                 // The callee's private topic / arg array / routine-id must not
@@ -637,7 +637,7 @@ impl VM {
                     continue;
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
-                    self.interpreter.env_mut().insert_sym(*k, v.clone());
+                    self.env_mut().insert_sym(*k, v.clone());
                     changed = true;
                 }
             }
@@ -647,7 +647,7 @@ impl VM {
                 self.env_dirty = true;
             }
         } else if let Some(saved_env) = saved_env {
-            if saved_env.ptr_eq(self.interpreter.env()) {
+            if saved_env.ptr_eq(self.env()) {
                 // No env changes, nothing to merge
             } else {
                 // Use declared_locals to only filter out function-local vars.
@@ -659,12 +659,12 @@ impl VM {
                         cf.code.locals.iter().map(|s| s.as_str()).collect()
                     };
                 let mut restored_env = saved_env;
-                for (k, v) in self.interpreter.env().iter() {
+                for (k, v) in self.env().iter() {
                     if !k.with_str(|s| local_names.contains(s)) {
                         restored_env.insert_sym(*k, v.clone());
                     }
                 }
-                *self.interpreter.env_mut() = restored_env;
+                *self.env_mut() = restored_env;
                 // Mark env as dirty so caller re-syncs its locals from env.
                 // This is needed when captured outer variables were modified
                 // by the function (e.g. $a++ where $a is from the caller's scope).
@@ -691,10 +691,10 @@ impl VM {
         if cf.code.is_routine && !use_scoped {
             match saved_topic {
                 Some(v) => {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
             }
         }
@@ -883,11 +883,8 @@ impl VM {
         // This replaces the previous name-keyed save/restore juggling
         // (saved_env_locals / saved_param_env) with a single O(callee-writes)
         // merge -- the function's own params/locals never pollute the caller env.
-        let parent = self.interpreter.env().clone();
-        let caller_env = std::mem::replace(
-            self.interpreter.env_mut(),
-            crate::env::Env::scoped_child(parent),
-        );
+        let parent = self.env().clone();
+        let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
 
         let num_locals = cf.code.locals.len();
         self.locals.clear();
@@ -897,7 +894,7 @@ impl VM {
         // local that shadows a same-named caller variable, matching the prior
         // env().get() semantics.
         for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(local_name) {
+            if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -917,7 +914,7 @@ impl VM {
                     && !Self::fast_type_check(&val, tc)
                 {
                     self.interpreter.restore_readonly_vars(saved_readonly);
-                    self.interpreter.set_env(caller_env);
+                    self.set_env(caller_env);
                     self.locals = saved_locals;
                     self.env_dirty = saved_env_dirty;
                     {
@@ -940,7 +937,7 @@ impl VM {
                     || matches!(val, Value::Nil)
                     || cf.code.needs_env_sync.get(*slot).copied().unwrap_or(true);
                 if needs_env {
-                    self.interpreter.env_mut().insert(param_name.clone(), val);
+                    self.env_mut().insert(param_name.clone(), val);
                 }
                 self.interpreter
                     .mark_readonly(&cf.param_defs[param_idx].name);
@@ -1020,7 +1017,7 @@ impl VM {
                 } else {
                     cf.code.locals.iter().map(|s| s.as_str()).collect()
                 };
-            let scoped = std::mem::replace(self.interpreter.env_mut(), caller_env);
+            let scoped = std::mem::replace(self.env_mut(), caller_env);
             for (k, v) in scoped.overlay_iter() {
                 // The callee's private topic / arg array / routine id, and the
                 // per-frame contextual vars (`?LINE`/`?FILE`/...), must not
@@ -1036,7 +1033,7 @@ impl VM {
                     continue;
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
-                    self.interpreter.env_mut().insert_sym(*k, v.clone());
+                    self.env_mut().insert_sym(*k, v.clone());
                     self.env_dirty = true;
                 }
             }
@@ -1132,11 +1129,8 @@ impl VM {
         // land in a fresh map and are discarded by dropping the overlay on return
         // (callee-local names) or merged overlay-only (captured-outer writes),
         // replacing the per-key save/restore the `modified_env_keys` list did.
-        let parent = self.interpreter.env().clone();
-        let caller_env = std::mem::replace(
-            self.interpreter.env_mut(),
-            crate::env::Env::scoped_child(parent),
-        );
+        let parent = self.env().clone();
+        let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
 
         let num_locals = cf.code.locals.len();
         self.locals = vec![Value::Nil; num_locals];
@@ -1232,7 +1226,7 @@ impl VM {
                     }
                     Some(v)
                 } else if pd.required {
-                    self.interpreter.set_env(caller_env);
+                    self.set_env(caller_env);
                     self.locals = saved_locals;
                     self.env_dirty = saved_env_dirty;
                     // Missing required named parameter is a runtime X::AdHoc in
@@ -1259,7 +1253,7 @@ impl VM {
                     positional_idx += 1;
                     Some(val)
                 } else if pd.required {
-                    self.interpreter.set_env(caller_env);
+                    self.set_env(caller_env);
                     self.locals = saved_locals;
                     self.env_dirty = saved_env_dirty;
                     return Err(RuntimeError::new(format!(
@@ -1344,7 +1338,7 @@ impl VM {
                         if let Some(slot) = cf.code.locals.iter().position(|n| *n == bare) {
                             self.locals[slot] = val.clone();
                         }
-                        self.interpreter.env_mut().insert(bare, val);
+                        self.env_mut().insert(bare, val);
                     }
                 }
             }
@@ -1353,7 +1347,7 @@ impl VM {
         // For any locals not yet set from params, try to initialize from env
         for (i, local_name) in cf.code.locals.iter().enumerate() {
             if matches!(self.locals[i], Value::Nil)
-                && let Some(val) = self.interpreter.env().get(local_name)
+                && let Some(val) = self.env().get(local_name)
             {
                 self.locals[i] = val.clone();
             }
@@ -1431,7 +1425,7 @@ impl VM {
                 } else {
                     cf.code.locals.iter().map(|s| s.as_str()).collect()
                 };
-            let scoped = std::mem::replace(self.interpreter.env_mut(), caller_env);
+            let scoped = std::mem::replace(self.env_mut(), caller_env);
             for (k, v) in scoped.overlay_iter() {
                 if *k == "_"
                     || *k == "@_"
@@ -1442,7 +1436,7 @@ impl VM {
                     continue;
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
-                    self.interpreter.env_mut().insert_sym(*k, v.clone());
+                    self.env_mut().insert_sym(*k, v.clone());
                     self.env_dirty = true;
                 }
             }
@@ -1502,7 +1496,7 @@ impl VM {
             false,
             // Flatten: this Sub is pushed for callframe().code introspection and
             // must expose the full lexical view, not a scoped overlay.
-            self.interpreter.clone_env(),
+            self.clone_env(),
         );
         self.interpreter.push_block(sub_val);
 
@@ -1512,7 +1506,7 @@ impl VM {
         // overlay; on return the merge iterates it overlay-only into the restored
         // caller env. frame.saved_env holds the flat caller for restoration.
         {
-            let parent = self.interpreter.env().clone();
+            let parent = self.env().clone();
             self.interpreter
                 .set_env(crate::env::Env::scoped_child(parent));
         }
@@ -1547,7 +1541,7 @@ impl VM {
             // the missing/None case correctly. This avoids triggering
             // Arc::make_mut deep clone on the CoW env for simple functions.
             if resolved_callable_id != 0 {
-                self.interpreter.env_mut().insert(
+                self.env_mut().insert(
                     "__mutsu_callable_id".to_string(),
                     Value::Int(resolved_callable_id),
                 );
@@ -1571,7 +1565,7 @@ impl VM {
             self.stack.truncate(saved_stack_depth);
             let frame = self.pop_call_frame();
             // Drop the scoped overlay, restoring the caller env.
-            self.interpreter.set_env(frame.saved_env);
+            self.set_env(frame.saved_env);
             return Err(Interpreter::reject_args_for_empty_sig(&args));
         }
 
@@ -1586,7 +1580,7 @@ impl VM {
         // into the current env so where-constraint expressions can access them.
         if !fn_name.is_empty() && cf.param_defs.iter().any(|pd| pd.where_constraint.is_some()) {
             let ampname = format!("&{}", fn_name);
-            if let Some(Value::Sub(ref sub_data)) = self.interpreter.env().get(&ampname).cloned() {
+            if let Some(Value::Sub(ref sub_data)) = self.env().get(&ampname).cloned() {
                 for (k, v) in &sub_data.env {
                     // Skip internal variables, parameters, and sigiled variables
                     // that belong to the calling scope. Only merge simple lexical
@@ -1598,7 +1592,7 @@ impl VM {
                         && k != "@_"
                         && k != "%_"
                     {
-                        self.interpreter.env_mut().insert_sym(*k, v.clone());
+                        self.env_mut().insert_sym(*k, v.clone());
                     }
                 }
             }
@@ -1621,7 +1615,7 @@ impl VM {
                     self.interpreter.pop_caller_env();
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
-                    *self.interpreter.env_mut() = frame.saved_env;
+                    *self.env_mut() = frame.saved_env;
                     return Err(Interpreter::enhance_binding_error(
                         e,
                         fn_name,
@@ -1652,7 +1646,7 @@ impl VM {
 
         // Raku: routines get their own $_ initialized to (Any).
         if cf.code.is_routine && !cf.param_defs.iter().any(|pd| pd.name == "_") {
-            self.interpreter.env_mut().insert(
+            self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(crate::symbol::Symbol::intern("Any")),
             );
@@ -1660,7 +1654,7 @@ impl VM {
 
         self.locals = vec![Value::Nil; cf.code.locals.len()];
         for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(local_name) {
+            if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -1781,7 +1775,7 @@ impl VM {
                 body.clone(),
                 *is_rw,
                 // Flatten: a Sub returned as a value is dispatched cross-scope.
-                self.interpreter.clone_env(),
+                self.clone_env(),
             );
         }
 
@@ -1821,7 +1815,7 @@ impl VM {
         let mut changed = false;
         // Fast path: if the env wasn't mutated during the call (Arc still shared),
         // we can skip the expensive env merge and just restore directly.
-        if restored_env.ptr_eq(self.interpreter.env()) {
+        if restored_env.ptr_eq(self.env()) {
             self.interpreter.pop_caller_env();
         } else {
             let mut restored_env = restored_env;
@@ -1847,7 +1841,7 @@ impl VM {
                 } else {
                     cf.code.locals.iter().map(|s| s.as_str()).collect()
                 };
-            for (k, v) in self.interpreter.env().iter() {
+            for (k, v) in self.env().iter() {
                 if *k == "_" || *k == "@_" || *k == "%_" {
                     continue;
                 }
@@ -1869,7 +1863,7 @@ impl VM {
                     restored_env.insert_sym(*k, v.clone());
                 }
             }
-            *self.interpreter.env_mut() = restored_env;
+            *self.env_mut() = restored_env;
         }
         // A raw/Proxy return aliases a caller container in a way the value merge
         // above does not see; keep the conservative mark for those.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -88,7 +88,7 @@ impl VM {
         let ampname = format!("&{}", name);
         let candidate = code
             .and_then(|c| self.locals_get_by_name(c, &ampname))
-            .or_else(|| self.interpreter.env().get(&ampname).cloned());
+            .or_else(|| self.env().get(&ampname).cloned());
         candidate.filter(|v| matches!(v, Value::Sub(_) | Value::WeakSub(_)))
     }
 
@@ -273,8 +273,7 @@ impl VM {
                 let ampname = format!("&{}", name_str);
                 // First check local slots (parameter bindings live here).
                 let from_local = self.locals_get_by_name(code, &ampname);
-                let candidate =
-                    from_local.or_else(|| self.interpreter.env().get(&ampname).cloned());
+                let candidate = from_local.or_else(|| self.env().get(&ampname).cloned());
                 candidate.filter(|v| Self::env_callable_is_lexical_override(v, name_str))
             }
         };
@@ -496,7 +495,7 @@ impl VM {
         if self.has_function(&name) && !self.has_proto(&name) && !self.has_multi_candidates(&name) {
             let ampname = format!("&{}", name);
             let from_local = self.locals_get_by_name(code, &ampname);
-            let candidate = from_local.or_else(|| self.interpreter.env().get(&ampname).cloned());
+            let candidate = from_local.or_else(|| self.env().get(&ampname).cloned());
             if let Some(callable) =
                 candidate.filter(|v| Self::env_callable_is_lexical_override(v, &name))
             {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -229,7 +229,7 @@ impl VM {
             .get(&temp_name)
             .cloned()
             .unwrap_or_else(|| item.clone());
-        self.interpreter.env_mut().remove(&temp_name);
+        self.env_mut().remove(&temp_name);
         Ok((result, updated))
     }
 
@@ -253,7 +253,7 @@ impl VM {
             .get(&temp_name)
             .cloned()
             .unwrap_or_else(|| item.clone());
-        self.interpreter.env_mut().remove(&temp_name);
+        self.env_mut().remove(&temp_name);
         Ok((result, updated))
     }
 }

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1896,7 +1896,7 @@ impl VM {
                     self.locals[*slot] = val.clone();
                     continue;
                 }
-                if let Some(val) = self.interpreter.env().get(name) {
+                if let Some(val) = self.env().get(name) {
                     self.locals[*slot] = val.clone();
                 }
             }
@@ -2019,8 +2019,8 @@ impl VM {
             && let Some(persisted) = self.interpreter.get_closure_env_override(wid)
         {
             for (k, v) in persisted.iter() {
-                if self.interpreter.env().contains_key_sym(*k) {
-                    self.interpreter.env_mut().insert_sym(*k, v.clone());
+                if self.env().contains_key_sym(*k) {
+                    self.env_mut().insert_sym(*k, v.clone());
                 }
             }
             self.env_dirty = true;

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -388,7 +388,7 @@ impl VM {
                 && (matches!(method.as_str(), "map" | "grep")
                     || Self::lazy_pipe_preserving_coercion(&method)))
         {
-            let saved_env = self.interpreter.env().clone();
+            let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(&method, &args) {
@@ -405,7 +405,7 @@ impl VM {
             // legitimate and must persist (unlike gather coroutine corruption,
             // which the env restore undoes).
             if !matches!(method.as_str(), "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
             }
             Value::Seq(std::sync::Arc::new(items))
         } else {
@@ -1097,7 +1097,7 @@ impl VM {
                         // BOUND_HASH_REF_SENTINEL back-reference.
                         let mut bind_source_install: Option<(String, Value)> = None;
                         if let Some(var_name) = source_var {
-                            let cell = match self.interpreter.env().get(&var_name) {
+                            let cell = match self.env().get(&var_name) {
                                 Some(Value::ContainerRef(cell)) => cell.clone(),
                                 _ => {
                                     let cell = Arc::new(std::sync::Mutex::new(value.clone()));
@@ -1138,7 +1138,7 @@ impl VM {
                         let mut new_map = std::collections::HashMap::new();
                         let mut bind_source_install: Option<(String, Value)> = None;
                         if let Some(var_name) = source_var {
-                            let cell = match self.interpreter.env().get(&var_name) {
+                            let cell = match self.env().get(&var_name) {
                                 Some(Value::ContainerRef(cell)) => cell.clone(),
                                 _ => {
                                     let cell = Arc::new(std::sync::Mutex::new(value.clone()));
@@ -1151,7 +1151,7 @@ impl VM {
                         } else {
                             new_map.insert(key, value.clone());
                         }
-                        self.interpreter.env_mut().insert(
+                        self.env_mut().insert(
                             target_name.to_string(),
                             Value::Hash(Value::hash_arc(new_map)),
                         );
@@ -1363,12 +1363,11 @@ impl VM {
                                 )
                             })?;
                         // Read back the (potentially mutated) storage
-                        if let Some(updated_storage) =
-                            self.interpreter.env().get("__mutsu_array_tmp").cloned()
+                        if let Some(updated_storage) = self.env().get("__mutsu_array_tmp").cloned()
                         {
                             storage = updated_storage;
                         }
-                        self.interpreter.env_mut().remove("__mutsu_array_tmp");
+                        self.env_mut().remove("__mutsu_array_tmp");
                         // Update the instance with the new storage
                         self.write_back_array_storage_instance(
                             &target_name,
@@ -1490,10 +1489,7 @@ impl VM {
         // variable bound to a whole array container (`my $r := @a`), which holds
         // a shared `ContainerRef` cell that `env_root_descended_mut` below
         // unwraps so the mutation still writes through the shared array.
-        let is_bound_cell = matches!(
-            self.interpreter.env().get(target_name),
-            Some(Value::ContainerRef(_))
-        );
+        let is_bound_cell = matches!(self.env().get(target_name), Some(Value::ContainerRef(_)));
         if (!target_name.starts_with('@') && !is_bound_cell)
             || !matches!(target, Value::Array(_, crate::value::ArrayKind::Array))
         {
@@ -1698,10 +1694,7 @@ impl VM {
         // (ArrayKind::Array), excluding List/Item/Shaped/Lazy — OR a scalar bound
         // to a whole array container (`my $r := @a`), unwrapped via
         // `env_root_descended_mut` below.
-        let is_bound_cell = matches!(
-            self.interpreter.env().get(target_name),
-            Some(Value::ContainerRef(_))
-        );
+        let is_bound_cell = matches!(self.env().get(target_name), Some(Value::ContainerRef(_)));
         if (!target_name.starts_with('@') && !is_bound_cell)
             || !matches!(target, Value::Array(_, crate::value::ArrayKind::Array))
         {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -536,7 +536,7 @@ impl VM {
             && !(ll.lazy_pipe.is_some()
                 && (matches!(method, "map" | "grep") || Self::lazy_pipe_preserving_coercion(method)))
         {
-            let saved_env = self.interpreter.env().clone();
+            let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(method, &args) {
@@ -553,7 +553,7 @@ impl VM {
             // callback via `vm_call_on_value` in this VM, so its side effects on
             // enclosing variables are legitimate and must persist.
             if !matches!(method, "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
             }
             Value::Seq(std::sync::Arc::new(items))
         } else {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -215,7 +215,7 @@ impl VM {
         // writeback iterates this overlay (overlay-only) = exactly the closure's
         // own mutations, which is what it must propagate back to the caller.
         {
-            let parent = self.interpreter.env().clone();
+            let parent = self.env().clone();
             self.interpreter
                 .set_env(crate::env::Env::scoped_child(parent));
         }
@@ -229,7 +229,7 @@ impl VM {
         // don't-overwrite default would otherwise hide this closure's own cell.
         for (k, v) in data.env.iter() {
             if matches!(v, Value::ContainerRef(_)) {
-                self.interpreter.env_mut().insert_sym(*k, v.clone());
+                self.env_mut().insert_sym(*k, v.clone());
             } else {
                 self.interpreter
                     .env_mut()
@@ -248,7 +248,7 @@ impl VM {
         // accumulated state still wins on later calls. See PLAN.md lever C.
         for sym in &data.owned_captures {
             if let Some(val) = data.env.get_sym(*sym).cloned() {
-                self.interpreter.env_mut().insert_sym(*sym, val);
+                self.env_mut().insert_sym(*sym, val);
             }
         }
         // Override with persisted per-closure-instance captured variable state.
@@ -276,7 +276,7 @@ impl VM {
             })
             .collect();
         for (k, val) in cap_overrides {
-            self.interpreter.env_mut().insert_sym(k, val);
+            self.env_mut().insert_sym(k, val);
         }
 
         self.interpreter.push_caller_env();
@@ -303,7 +303,7 @@ impl VM {
             source_file: data.source_file.clone(),
             owned_captures: data.owned_captures.clone(),
         });
-        self.interpreter.env_mut().insert(
+        self.env_mut().insert(
             "&?BLOCK".to_string(),
             Value::WeakSub(std::sync::Arc::downgrade(&block_arc)),
         );
@@ -332,7 +332,7 @@ impl VM {
                 call_file,
             );
         }
-        self.interpreter.env_mut().insert(
+        self.env_mut().insert(
             "__mutsu_callable_id".to_string(),
             Value::Int(data.id as i64),
         );
@@ -343,7 +343,7 @@ impl VM {
             self.interpreter.pop_caller_env();
             self.stack.truncate(saved_stack_depth);
             let frame = self.pop_call_frame();
-            *self.interpreter.env_mut() = frame.saved_env;
+            *self.env_mut() = frame.saved_env;
             return Err(Interpreter::reject_args_for_empty_sig(&args));
         }
 
@@ -360,7 +360,7 @@ impl VM {
                     self.interpreter.pop_caller_env();
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
-                    *self.interpreter.env_mut() = frame.saved_env;
+                    *self.env_mut() = frame.saved_env;
                     return Err(Interpreter::enhance_binding_error(
                         e,
                         &data.name.resolve(),
@@ -386,13 +386,13 @@ impl VM {
         } else if data.params.is_empty() && args.is_empty() && data.name.is_empty() {
             let caller_topic = self.call_frames.last().unwrap().saved_env.get("_").cloned();
             if let Some(topic) = caller_topic {
-                self.interpreter.env_mut().insert("_".to_string(), topic);
+                self.env_mut().insert("_".to_string(), topic);
             }
         }
 
         // Raku: routines get their own $_ initialized to (Any).
         if cc.is_routine && !data.param_defs.iter().any(|pd| pd.name == "_") {
-            self.interpreter.env_mut().insert(
+            self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(crate::symbol::Symbol::intern("Any")),
             );
@@ -411,7 +411,7 @@ impl VM {
         // param — to the element value. Applied after the routine-`$_` reset so
         // it wins, and before the locals load so the slot picks it up.
         if let Some(topic) = explicit_topic {
-            let env = self.interpreter.env_mut();
+            let env = self.env_mut();
             env.insert("_".to_string(), topic.clone());
             env.insert("$_".to_string(), topic.clone());
             // A single simple positional param consumes the topic too (e.g.
@@ -441,7 +441,7 @@ impl VM {
 
         self.locals = vec![Value::Nil; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(local_name) {
+            if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -466,7 +466,7 @@ impl VM {
         let free_at_entry: Vec<Option<Value>> = cc
             .free_var_syms
             .iter()
-            .map(|k| self.interpreter.env().get_sym(*k).cloned())
+            .map(|k| self.env().get_sym(*k).cloned())
             .collect();
         // A captured variable that lives in a local slot is flushed to env on
         // exit (above) rather than written through env during the body, so its
@@ -602,7 +602,7 @@ impl VM {
                 .position(|n| n == "_")
                 .map(|i| self.locals[i].clone());
             self.rw_map_topic_capture = local_topic
-                .or_else(|| self.interpreter.env().get("_").cloned())
+                .or_else(|| self.env().get("_").cloned())
                 .or_else(|| {
                     self.interpreter
                         .env()
@@ -655,7 +655,7 @@ impl VM {
         // Mirror of `cap_overrides` above: only free variables can be mutated by
         // the body, so only those need persisting.
         for k in &cc.free_var_syms {
-            if let Some(val) = self.interpreter.env().get_sym(*k).cloned() {
+            if let Some(val) = self.env().get_sym(*k).cloned() {
                 self.interpreter
                     .set_closure_captured_state(data.id, *k, val);
             }
@@ -720,7 +720,7 @@ impl VM {
             .free_var_syms
             .iter()
             .zip(free_at_entry.iter())
-            .any(|(k, old)| self.interpreter.env().get_sym(*k) != old.as_ref());
+            .any(|(k, old)| self.env().get_sym(*k) != old.as_ref());
         // A writable parameter (sigilless `\a`, `is rw`, or `is raw`) bound to a
         // caller-provided container writes the mutation into this frame's env
         // under the *source container's* name (e.g. the synthetic `__mutsu_*`
@@ -762,7 +762,7 @@ impl VM {
                 cc.locals_sym.iter().copied().collect();
             let underscore_sym = Symbol::intern("_");
             let at_underscore_sym = Symbol::intern("@_");
-            for (k, v) in self.interpreter.env().iter() {
+            for (k, v) in self.env().iter() {
                 if *k != underscore_sym
                     && *k != at_underscore_sym
                     && !rw_sources.contains(k)
@@ -796,16 +796,16 @@ impl VM {
             for captured_sym in &cc.free_var_syms {
                 let captured_name = captured_sym.resolve();
                 let readonly_key = format!("__mutsu_sigilless_readonly::{}", captured_name);
-                if let Some(v) = self.interpreter.env().get(&readonly_key).cloned() {
+                if let Some(v) = self.env().get(&readonly_key).cloned() {
                     restored_env.insert(readonly_key, v);
                 }
                 let alias_key = format!("__mutsu_sigilless_alias::{}", captured_name);
-                if let Some(v) = self.interpreter.env().get(&alias_key).cloned() {
+                if let Some(v) = self.env().get(&alias_key).cloned() {
                     restored_env.insert(alias_key, v);
                 }
             }
             self.interpreter
-                .merge_sigilless_alias_writes(&mut restored_env, self.interpreter.env());
+                .merge_sigilless_alias_writes(&mut restored_env, self.env());
         }
 
         // Only run the state-variable sync and cleanup when the closure
@@ -820,8 +820,8 @@ impl VM {
             // StateVarInit in the declaring scope).
             for k in &cc.free_var_syms {
                 let meta_key = format!("__mutsu_state_key::{}", k);
-                if let Some(Value::Str(state_key)) = self.interpreter.env().get(&meta_key).cloned()
-                    && let Some(val) = self.interpreter.env().get_sym(*k).cloned()
+                if let Some(Value::Str(state_key)) = self.env().get(&meta_key).cloned()
+                    && let Some(val) = self.env().get_sym(*k).cloned()
                 {
                     self.interpreter.set_state_var(state_key.to_string(), val);
                 }
@@ -840,7 +840,7 @@ impl VM {
             }
         }
 
-        *self.interpreter.env_mut() = restored_env;
+        *self.env_mut() = restored_env;
 
         // After a closure returns, update captured envs of END phasers for
         // variables that the closure captures (and may have modified).  This
@@ -853,7 +853,7 @@ impl VM {
                 captured_strs.iter().map(|s| s.as_str()).collect();
             // Flatten: END phasers run at program exit with this captured env;
             // it must hold the full lexical view, not a transient scoped overlay.
-            let current = self.interpreter.clone_env();
+            let current = self.clone_env();
             self.interpreter
                 .update_end_phaser_envs_for_keys(&captured_names, &current);
         }

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -579,7 +579,7 @@ impl VM {
         let mut seen = std::collections::HashSet::new();
         while seen.insert(current.clone()) {
             let key = format!("__mutsu_sigilless_alias::{}", current);
-            if let Some(Value::Str(next)) = self.interpreter.env().get(&key) {
+            if let Some(Value::Str(next)) = self.env().get(&key) {
                 current = next.to_string();
             } else {
                 break;
@@ -701,7 +701,7 @@ impl VM {
         let sep_pos = encoded.find("\x00idx\x00")?;
         let var_name = &encoded[..sep_pos];
         let idx_str = &encoded[sep_pos + 5..];
-        match self.interpreter.env().get(var_name) {
+        match self.env().get(var_name) {
             Some(Value::Array(items, _)) => {
                 let i = idx_str.parse::<usize>().ok()?;
                 items.get(i).cloned()
@@ -1220,7 +1220,7 @@ impl VM {
         // *this* match's embedded `{ }` code blocks wrote a caller variable by name
         // (the engine records them there but nothing consumes the log otherwise).
         self.interpreter.pending_local_updates.clear();
-        let saved_topic = self.interpreter.env().get("_").cloned();
+        let saved_topic = self.env().get("_").cloned();
         self.interpreter
             .env_mut()
             .insert("_".to_string(), left.clone());
@@ -1251,9 +1251,9 @@ impl VM {
         if lhs_is_literal && (was_substitution || was_transliterate) && right.truthy() {
             // Restore the topic before propagating the error.
             if let Some(v) = saved_topic {
-                self.interpreter.env_mut().insert("_".to_string(), v);
+                self.env_mut().insert("_".to_string(), v);
             } else {
-                self.interpreter.env_mut().remove("_");
+                self.env_mut().remove("_");
             }
             return Err(RuntimeError::assignment_ro(Some("Str")));
         }
@@ -1273,9 +1273,9 @@ impl VM {
             self.update_local_if_exists(code, var_name, &modified_topic);
         }
         if let Some(v) = saved_topic {
-            self.interpreter.env_mut().insert("_".to_string(), v);
+            self.env_mut().insert("_".to_string(), v);
         } else {
-            self.interpreter.env_mut().remove("_");
+            self.env_mut().remove("_");
         }
         // When RHS was a transliterate (tr///), return the result directly.
         // In Raku, $x ~~ tr/a/b/ returns a StrDistance that stringifies to the after-string.

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -132,7 +132,7 @@ impl VM {
                 // `saved` only holds names that shadowed an existing outer binding
                 // (recorded in exec_set_local_op), so restoring the captured value
                 // re-exposes the outer `$x` clobbered by the loop body's `my $x`.
-                self.interpreter.env_mut().insert(name.clone(), val.clone());
+                self.env_mut().insert(name.clone(), val.clone());
                 // Restore the local slot too: loop bodies mark every local
                 // `needs_env_sync`, so the shadowing `my` wrote the outer var's
                 // shared slot. `GetLocal`'s fast path returns a non-Nil slot value
@@ -221,7 +221,7 @@ impl VM {
                 break;
             }
             let topic_before_body = if spec.isolate_topic {
-                Some(self.interpreter.env().get("_").cloned())
+                Some(self.env().get("_").cloned())
             } else {
                 None
             };
@@ -235,9 +235,9 @@ impl VM {
                         }
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                         }
                         if let Some(ref mut coll) = collected {
@@ -258,9 +258,9 @@ impl VM {
                     Err(e) if e.is_succeed => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                         }
                         break 'body_redo;
@@ -268,9 +268,9 @@ impl VM {
                     Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                         }
                         continue 'body_redo;
@@ -285,7 +285,7 @@ impl VM {
                             if let Some(ref mut coll) = collected {
                                 Self::collect_loop_value(coll, v.clone());
                             } else {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             }
                         }
                         break 'while_loop;
@@ -296,9 +296,9 @@ impl VM {
                     Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                         }
                         break 'body_redo;
@@ -617,7 +617,7 @@ impl VM {
         let mut deferred_container_refs: Vec<(usize, String)> = Vec::new();
         let saved_topic = spec
             .restore_topic
-            .then(|| self.interpreter.env().get("_").cloned())
+            .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
         let saved_quanthash_bind = std::mem::take(&mut self.quanthash_bind_params);
@@ -662,10 +662,10 @@ impl VM {
             .multi_param_names
             .iter()
             .map(|name| {
-                let val = self.interpreter.env().get(name).cloned();
+                let val = self.env().get(name).cloned();
                 let was_readonly = self.interpreter.readonly_vars().contains(name);
                 let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
-                let sigilless_ro = self.interpreter.env().get(&sigilless_key).cloned();
+                let sigilless_ro = self.env().get(&sigilless_key).cloned();
                 (name.clone(), val, was_readonly, sigilless_ro)
             })
             .collect();
@@ -677,7 +677,7 @@ impl VM {
         let saved_param: Option<(String, Option<Value>)> = param_name
             .as_ref()
             .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| (name.clone(), self.interpreter.env().get(name).cloned()));
+            .map(|name| (name.clone(), self.env().get(name).cloned()));
         // Track loop-body declarations for per-iteration closure capture
         // (owned_captures). Balanced by pop on every exit.
         self.push_loop_local_scope();
@@ -769,7 +769,7 @@ impl VM {
                 self.interpreter.unmark_readonly(mp_name);
                 // Clear sigilless readonly flag
                 let key = format!("__mutsu_sigilless_readonly::{}", mp_name);
-                self.interpreter.env_mut().insert(key, Value::Bool(false));
+                self.env_mut().insert(key, Value::Bool(false));
             }
             'body_redo: loop {
                 match self.run_range(code, body_start, loop_end, compiled_fns) {
@@ -1033,10 +1033,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1059,10 +1059,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic.clone() {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1110,9 +1110,9 @@ impl VM {
         // Restore saved multi-param values and readonly state
         for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {
             if let Some(v) = saved_val {
-                self.interpreter.env_mut().insert(name.clone(), v);
+                self.env_mut().insert(name.clone(), v);
             } else {
-                self.interpreter.env_mut().remove(&name);
+                self.env_mut().remove(&name);
             }
             if was_readonly {
                 self.interpreter.mark_readonly(&name);
@@ -1121,9 +1121,9 @@ impl VM {
             }
             let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
             if let Some(ro_val) = sigilless_ro {
-                self.interpreter.env_mut().insert(sigilless_key, ro_val);
+                self.env_mut().insert(sigilless_key, ro_val);
             } else {
-                self.interpreter.env_mut().remove(&sigilless_key);
+                self.env_mut().remove(&sigilless_key);
             }
         }
         // Defer restoring the single named loop param's prior binding until
@@ -1144,10 +1144,10 @@ impl VM {
         if spec.restore_topic {
             match saved_topic {
                 Some(v) => {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
             }
         }
@@ -1187,7 +1187,7 @@ impl VM {
             });
         let saved_topic = spec
             .restore_topic
-            .then(|| self.interpreter.env().get("_").cloned())
+            .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
         let was_topic_readonly = self.interpreter.readonly_vars().contains("_");
@@ -1204,7 +1204,7 @@ impl VM {
         let saved_param: Option<(String, Option<Value>)> = param_name
             .as_ref()
             .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| (name.clone(), self.interpreter.env().get(name).cloned()));
+            .map(|name| (name.clone(), self.env().get(name).cloned()));
 
         // Track loop-body declarations so closures created in the body capture
         // them per-iteration (owned_captures). Balanced by pop on every exit.
@@ -1343,10 +1343,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1366,10 +1366,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic.clone() {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1400,10 +1400,10 @@ impl VM {
         if spec.restore_topic {
             match saved_topic {
                 Some(v) => {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
             }
         }
@@ -1472,7 +1472,7 @@ impl VM {
             });
         let saved_topic = spec
             .restore_topic
-            .then(|| self.interpreter.env().get("_").cloned())
+            .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
         let was_topic_readonly = self.interpreter.readonly_vars().contains("_");
@@ -1576,10 +1576,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1597,10 +1597,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic.clone() {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1625,10 +1625,10 @@ impl VM {
         if spec.restore_topic {
             match saved_topic {
                 Some(v) => {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
             }
         }
@@ -1661,7 +1661,7 @@ impl VM {
             spec.param_idx.is_none() && spec.param_local.is_none() && spec.arity <= 1;
         let saved_topic = spec
             .restore_topic
-            .then(|| self.interpreter.env().get("_").cloned())
+            .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
@@ -1790,10 +1790,10 @@ impl VM {
                         if spec.restore_topic {
                             match saved_topic.clone() {
                                 Some(v) => {
-                                    self.interpreter.env_mut().insert("_".to_string(), v);
+                                    self.env_mut().insert("_".to_string(), v);
                                 }
                                 None => {
-                                    self.interpreter.env_mut().remove("_");
+                                    self.env_mut().remove("_");
                                 }
                             }
                         }
@@ -1816,10 +1816,10 @@ impl VM {
         if spec.restore_topic {
             match saved_topic {
                 Some(v) => {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
             }
         }
@@ -1838,10 +1838,10 @@ impl VM {
         param_name: &Option<String>,
     ) -> Option<Value> {
         if writes_back_topic {
-            self.interpreter.env().get("_").cloned()
+            self.env().get("_").cloned()
         } else if rw_writeback {
             let var = param_name.as_deref().unwrap_or("_");
-            self.interpreter.env().get(var).cloned()
+            self.env().get(var).cloned()
         } else {
             None
         }
@@ -1868,7 +1868,7 @@ impl VM {
         // (`@p` after `@p.push`); otherwise the topic `$_`.
         let current = match pointy_param {
             Some(p) => self.get_env_with_main_alias(p),
-            None => self.interpreter.env().get("_").cloned(),
+            None => self.env().get("_").cloned(),
         };
         let Some(current) = current else {
             return;
@@ -1898,7 +1898,7 @@ impl VM {
         // otherwise the topic `$_`.
         let current = match pointy_param {
             Some(p) => self.get_env_with_main_alias(p),
-            None => self.interpreter.env().get("_").cloned(),
+            None => self.env().get("_").cloned(),
         };
         let Some(current) = current else {
             return;
@@ -1954,7 +1954,7 @@ impl VM {
         // element, so `.push`/`@row[0]=v` propagate), or otherwise the implicit
         // topic `$_` (`for @m {...}`).
         let loop_var = param_name.as_deref().unwrap_or("_");
-        let Some(current_topic) = self.interpreter.env().get(loop_var).cloned() else {
+        let Some(current_topic) = self.env().get(loop_var).cloned() else {
             return;
         };
         let Some(Value::Array(items, kind)) = self.get_env_with_main_alias(source) else {
@@ -2000,7 +2000,7 @@ impl VM {
             return;
         }
         let var_name = param_name.as_deref().unwrap_or("_");
-        let Some(current_val) = self.interpreter.env().get(var_name).cloned() else {
+        let Some(current_val) = self.env().get(var_name).cloned() else {
             return;
         };
         let target = &source_var_names[idx];
@@ -2041,8 +2041,8 @@ impl VM {
                     // For %hash.kv -> $key, $val is rw: read $key and $val, update hash
                     let key_name = &rw_param_names[0];
                     let val_name = &rw_param_names[1];
-                    if let Some(key) = self.interpreter.env().get(key_name).cloned()
-                        && let Some(val) = self.interpreter.env().get(val_name).cloned()
+                    if let Some(key) = self.env().get(key_name).cloned()
+                        && let Some(val) = self.env().get(val_name).cloned()
                         && let Some(Value::Hash(hash_items)) = self.get_env_with_main_alias(source)
                     {
                         let mut updated = hash_items.as_ref().clone();
@@ -2056,7 +2056,7 @@ impl VM {
                     // %hash.values -> $val is rw: positional writeback using pre-captured key order
                     let var_name = param_name.as_deref().unwrap_or("_");
                     if let Some(keys) = hash_keys
-                        && let Some(val) = self.interpreter.env().get(var_name).cloned()
+                        && let Some(val) = self.env().get(var_name).cloned()
                         && let Some(Value::Hash(hash_items)) = self.get_env_with_main_alias(source)
                         && idx < keys.len()
                     {
@@ -2072,7 +2072,7 @@ impl VM {
             if kv_mode && arity > 1 && rw_param_names.len() >= 2 {
                 // .kv mode: chunk is [key, val]. Write back val at key position.
                 let val_name = &rw_param_names[1];
-                if let Some(val) = self.interpreter.env().get(val_name).cloned()
+                if let Some(val) = self.env().get(val_name).cloned()
                     && idx < items.len()
                 {
                     let mut updated = items.to_vec();
@@ -2090,7 +2090,7 @@ impl VM {
                 let mut updated = items.to_vec();
                 for (j, pname) in rw_param_names.iter().enumerate() {
                     if base + j < updated.len()
-                        && let Some(val) = self.interpreter.env().get(pname).cloned()
+                        && let Some(val) = self.env().get(pname).cloned()
                     {
                         updated[base + j] = val;
                     }
@@ -2104,7 +2104,7 @@ impl VM {
             } else {
                 // Single-param rw: read the named param (or $_) and write back
                 let var_name = param_name.as_deref().unwrap_or("_");
-                let Some(current_val) = self.interpreter.env().get(var_name).cloned() else {
+                let Some(current_val) = self.env().get(var_name).cloned() else {
                     return;
                 };
                 if idx >= items.len() {
@@ -2134,7 +2134,7 @@ impl VM {
             if kv_mode && arity > 1 && rw_param_names.len() >= 2 {
                 if let Some(existing) = self.get_env_with_main_alias(source) {
                     let val_name = &rw_param_names[1];
-                    if let Some(val) = self.interpreter.env().get(val_name).cloned() {
+                    if let Some(val) = self.env().get(val_name).cloned() {
                         let writeback_val = match existing {
                             Value::Pair(key, _) => Value::Pair(key, Box::new(val)),
                             Value::ValuePair(key, _) => Value::ValuePair(key, Box::new(val)),
@@ -2147,7 +2147,7 @@ impl VM {
                 return;
             }
             let var_name = param_name.as_deref().unwrap_or("_");
-            let Some(current_val) = self.interpreter.env().get(var_name).cloned() else {
+            let Some(current_val) = self.env().get(var_name).cloned() else {
                 return;
             };
             // If the source variable holds a Pair, update only the pair's value
@@ -2247,7 +2247,7 @@ impl VM {
                             if let Some(ref mut coll) = collected {
                                 Self::collect_loop_value(coll, v.clone());
                             } else {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             }
                         }
                         break 'c_loop;
@@ -2325,7 +2325,7 @@ impl VM {
         let end = body_end as usize;
         let stack_base = self.stack.len();
 
-        let saved_topic = self.interpreter.env().get("_").cloned();
+        let saved_topic = self.env().get("_").cloned();
         let saved_when = self.interpreter.when_matched();
         let saved_topic_source = self.topic_source_var.take();
         let saved_element_source = self.element_source.take();
@@ -2338,7 +2338,7 @@ impl VM {
         if element_source.is_none() {
             self.topic_source_var = container_binding.clone();
         }
-        self.interpreter.env_mut().insert("_".to_string(), topic);
+        self.env_mut().insert("_".to_string(), topic);
         self.interpreter.set_when_matched(false);
         // A read-only topic (`given @a` / `given 42` / `given expr()`) forbids
         // `$_ = ...`; container *mutation* (`.push`) is still allowed and is
@@ -2445,9 +2445,9 @@ impl VM {
         let body_start = *ip + 1;
         let end = body_end as usize;
 
-        let saved_topic = self.interpreter.env().get("_").cloned();
+        let saved_topic = self.env().get("_").cloned();
         let saved_when = self.interpreter.when_matched();
-        self.interpreter.env_mut().insert("_".to_string(), topic);
+        self.env_mut().insert("_".to_string(), topic);
         self.interpreter.set_when_matched(false);
 
         let mut last = Value::Nil;
@@ -2470,9 +2470,9 @@ impl VM {
             Err(e) => {
                 self.interpreter.set_when_matched(saved_when);
                 if let Some(v) = saved_topic {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 } else {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
                 return Err(e);
             }
@@ -2480,9 +2480,9 @@ impl VM {
 
         self.interpreter.set_when_matched(saved_when);
         if let Some(v) = saved_topic {
-            self.interpreter.env_mut().insert("_".to_string(), v);
+            self.env_mut().insert("_".to_string(), v);
         } else {
-            self.interpreter.env_mut().remove("_");
+            self.env_mut().remove("_");
         }
         self.stack.push(last);
         self.env_dirty = true;
@@ -2663,7 +2663,7 @@ impl VM {
                             && Self::label_matches(&e.label, label) =>
                     {
                         if let Some(v) = e.return_value {
-                            self.interpreter.env_mut().insert("_".to_string(), v);
+                            self.env_mut().insert("_".to_string(), v);
                         }
                         break 'repeat_loop;
                     }
@@ -2772,7 +2772,7 @@ impl VM {
                 self.interpreter.discard_let_saves(let_mark);
                 if control_begin < end {
                     self.stack.truncate(saved_depth);
-                    let saved_topic = self.interpreter.env().get("_").cloned();
+                    let saved_topic = self.env().get("_").cloned();
                     if let Some(signal_topic) = Self::control_signal_topic_value(&e) {
                         self.interpreter
                             .env_mut()
@@ -2793,9 +2793,9 @@ impl VM {
                     }
                     self.interpreter.set_when_matched(saved_when);
                     if let Some(v) = saved_topic {
-                        self.interpreter.env_mut().insert("_".to_string(), v);
+                        self.env_mut().insert("_".to_string(), v);
                     } else {
-                        self.interpreter.env_mut().remove("_");
+                        self.env_mut().remove("_");
                     }
                     *ip = end;
                     Ok(())
@@ -2846,7 +2846,7 @@ impl VM {
             {
                 self.interpreter.discard_let_saves(let_mark);
                 self.stack.truncate(saved_depth);
-                let saved_topic = self.interpreter.env().get("_").cloned();
+                let saved_topic = self.env().get("_").cloned();
                 let saved_when = self.interpreter.when_matched();
                 let mut pending_err = e;
                 loop {
@@ -2875,9 +2875,9 @@ impl VM {
                         Err(ce) => {
                             self.interpreter.set_when_matched(saved_when);
                             if let Some(v) = saved_topic {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                             return Err(ce);
                         }
@@ -2887,9 +2887,9 @@ impl VM {
                         Some(resume_point) => {
                             self.interpreter.set_when_matched(saved_when);
                             if let Some(v) = saved_topic.clone() {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                             // A resumable *warn* raised mid-expression (e.g. a Nil
                             // coercion: `Nil.ords`, `Nil.Int`) carries the value
@@ -2940,9 +2940,9 @@ impl VM {
                 }
                 self.interpreter.set_when_matched(saved_when);
                 if let Some(v) = saved_topic {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 } else {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
                 *ip = end;
                 Ok(())
@@ -2975,11 +2975,11 @@ impl VM {
                     // ..., Exception` / `isa-ok $!, Exception` still match.
                     Value::make_instance(Symbol::intern("X::AdHoc"), exc_attrs)
                 };
-                let saved_topic = self.interpreter.env().get("_").cloned();
+                let saved_topic = self.env().get("_").cloned();
                 self.interpreter
                     .env_mut()
                     .insert("!".to_string(), err_val.clone());
-                self.interpreter.env_mut().insert("_".to_string(), err_val);
+                self.env_mut().insert("_".to_string(), err_val);
                 let saved_when = self.interpreter.when_matched();
                 self.interpreter.set_when_matched(false);
                 let catch_stack_base = self.stack.len();
@@ -2999,9 +2999,9 @@ impl VM {
                             self.stack.truncate(catch_stack_base);
                             self.interpreter.set_when_matched(saved_when);
                             if let Some(v) = saved_topic {
-                                self.interpreter.env_mut().insert("_".to_string(), v);
+                                self.env_mut().insert("_".to_string(), v);
                             } else {
-                                self.interpreter.env_mut().remove("_");
+                                self.env_mut().remove("_");
                             }
                             // Resume from the instruction after die
                             if let Some(resume_point) = self.resume_ip.take() {
@@ -3023,9 +3023,9 @@ impl VM {
                 self.interpreter
                     .set_when_matched(saved_when || when_handled);
                 if let Some(v) = saved_topic {
-                    self.interpreter.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert("_".to_string(), v);
                 } else {
-                    self.interpreter.env_mut().remove("_");
+                    self.env_mut().remove("_");
                 }
                 // If there's an explicit CATCH block but no `when`/`default`
                 // matched, re-throw the exception (Raku semantics).

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -430,7 +430,7 @@ impl VM {
         // dimension metadata check in VM. See ledger §1.
         // Check for shaped arrays — must fall back to interpreter
         // (push is illegal on fixed-dimension arrays)
-        if let Some(Value::Array(_, kind)) = self.interpreter.env().get(target_name)
+        if let Some(Value::Array(_, kind)) = self.env().get(target_name)
             && *kind == crate::value::ArrayKind::Shaped
         {
             let val = self.stack.pop().unwrap_or(Value::Nil);
@@ -530,9 +530,7 @@ impl VM {
             self.locals[slot] = Value::Nil;
         }
 
-        let result = if let Some(Value::Array(arr, kind)) =
-            self.interpreter.env_mut().get_mut(target_name)
-        {
+        let result = if let Some(Value::Array(arr, kind)) = self.env_mut().get_mut(target_name) {
             let items = Arc::make_mut(arr);
             match &val {
                 Value::Slip(slip_items) => items.extend(slip_items.iter().cloned()),

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -19,9 +19,9 @@ impl VM {
     /// that captures or iterates it overlay-only. See docs/vm-dual-store.md (Slice 6).
     #[inline]
     pub(super) fn flatten_scoped_env(&mut self) {
-        if self.interpreter.env().is_scoped() {
-            let flat = self.interpreter.env().flattened();
-            *self.interpreter.env_mut() = flat;
+        if self.env().is_scoped() {
+            let flat = self.env().flattened();
+            *self.env_mut() = flat;
         }
     }
 
@@ -35,7 +35,7 @@ impl VM {
         // pay the per-call O(env) flatten. Long-lived captures (Sub closures, END
         // phasers, threads) still flatten via `clone_env` at the capture site.
         let frame = VmCallFrame {
-            saved_env: self.interpreter.env().clone(),
+            saved_env: self.env().clone(),
             saved_readonly: Some(self.interpreter.save_readonly_vars()),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
@@ -51,7 +51,7 @@ impl VM {
     pub(super) fn push_light_call_frame(&mut self) {
         crate::vm::vm_stats::record_clone_env();
         let frame = VmCallFrame {
-            saved_env: self.interpreter.env().clone(),
+            saved_env: self.env().clone(),
             saved_readonly: None,
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
@@ -188,7 +188,7 @@ impl VM {
         // lexical variables take precedence over shared_vars. Without this,
         // recursive `start` blocks can read stale parameter values from
         // shared_vars instead of the locally-bound ones.
-        if let Some(val) = self.interpreter.env().get(name) {
+        if let Some(val) = self.env().get(name) {
             return Some(val.clone());
         }
         // Anonymous scalar placeholders (from bare `$`) are invocation-local.
@@ -202,29 +202,29 @@ impl VM {
         }
         // Follow binding aliases ($CALLER::target := $source)
         if let Some(resolved) = self.interpreter.resolve_binding(name)
-            && let Some(val) = self.interpreter.env().get(resolved)
+            && let Some(val) = self.env().get(resolved)
         {
             return Some(val.clone());
         }
         if let Some(alias) = Self::twigil_dynamic_alias(name) {
-            return self.interpreter.env().get(&alias).cloned();
+            return self.env().get(&alias).cloned();
         }
         if let Some(alias) = Self::main_unqualified_name(name) {
-            return self.interpreter.env().get(&alias).cloned();
+            return self.env().get(&alias).cloned();
         }
         if let Some(qualified) = Self::main_qualified_name(name) {
-            return self.interpreter.env().get(&qualified).cloned();
+            return self.env().get(&qualified).cloned();
         }
         // Strip GLOBAL::, OUR::, MY:: pseudo-package qualifiers to find
         // the variable under its bare name in the environment.
         if let Some(bare) = Self::pseudo_package_unqualified_name(name) {
-            return self.interpreter.env().get(&bare).cloned();
+            return self.env().get(&bare).cloned();
         }
         // Placeholder block parameters are stored as "^name". Allow lexical
         // access by the de-careted name inside the same block.
         if !name.starts_with('^') {
             let placeholder = format!("^{name}");
-            if let Some(val) = self.interpreter.env().get(&placeholder) {
+            if let Some(val) = self.env().get(&placeholder) {
                 return Some(val.clone());
             }
             if let Some(val) = self.interpreter.get_shared_var(&placeholder) {
@@ -247,20 +247,20 @@ impl VM {
         value: Value,
     ) {
         if name.starts_with("__ANON_STATE_") {
-            self.interpreter.env_mut().insert(name.to_string(), value);
+            self.env_mut().insert(name.to_string(), value);
             return;
         }
         if !name.starts_with('^') {
             let placeholder = format!("^{name}");
-            if self.interpreter.env().contains_key(&placeholder) {
+            if self.env().contains_key(&placeholder) {
                 self.interpreter.set_shared_var(&placeholder, value.clone());
-                self.interpreter.env_mut().insert(placeholder, value);
+                self.env_mut().insert(placeholder, value);
                 return;
             }
         }
         self.interpreter.set_shared_var(name, value.clone());
         if let Some(alias) = Self::twigil_dynamic_alias(name) {
-            self.interpreter.env_mut().insert(alias, value.clone());
+            self.env_mut().insert(alias, value.clone());
         }
         if let Some(inner) = name
             .strip_prefix("&infix:<")
@@ -273,23 +273,23 @@ impl VM {
                 .insert(format!("&{}", op_name), value.clone());
         }
         if let Some(alias) = Self::main_unqualified_name(name) {
-            self.interpreter.env_mut().insert(alias, value);
+            self.env_mut().insert(alias, value);
             return;
         }
         if let Some(qualified) = Self::main_qualified_name(name)
-            && self.interpreter.env().contains_key(&qualified)
+            && self.env().contains_key(&qualified)
         {
-            self.interpreter.env_mut().insert(qualified, value);
+            self.env_mut().insert(qualified, value);
             return;
         }
         // Write through GLOBAL::, OUR::, MY:: pseudo-package qualifiers to the
         // bare variable name in the environment.
         if let Some(bare) = Self::pseudo_package_unqualified_name(name) {
-            self.interpreter.env_mut().insert(bare, value);
+            self.env_mut().insert(bare, value);
         } else if let Some(bare) = name.strip_prefix("GLOBAL::")
-            && self.interpreter.env().contains_key(bare)
+            && self.env().contains_key(bare)
         {
-            self.interpreter.env_mut().insert(bare.to_string(), value);
+            self.env_mut().insert(bare.to_string(), value);
         }
     }
 
@@ -307,7 +307,7 @@ impl VM {
             if name.starts_with('!') {
                 continue;
             }
-            if let Some(val) = self.interpreter.env().get(name) {
+            if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
                 continue;
             }
@@ -316,7 +316,7 @@ impl VM {
                 .or_else(|| name.strip_prefix('@'))
                 .or_else(|| name.strip_prefix('%'))
                 .or_else(|| name.strip_prefix('&'))
-                && let Some(val) = self.interpreter.env().get(bare)
+                && let Some(val) = self.env().get(bare)
             {
                 self.locals[i] = val.clone();
             }
@@ -344,7 +344,7 @@ impl VM {
             // block scopes) from being prematurely introduced into the env,
             // which would cause bare-word class name resolution to fail when
             // a later block declares `my $x` and the class is named `x`.
-            if !self.interpreter.env().contains_key(name) {
+            if !self.env().contains_key(name) {
                 continue;
             }
             self.set_env_with_main_alias(name, self.locals[i].clone());

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -409,7 +409,7 @@ impl VM {
         // write-through (`flush_local_to_env`), so no explicit flush is needed
         // here; we restore locals directly on return.
         crate::vm::vm_stats::record_clone_env();
-        let saved_env = self.interpreter.clone_env();
+        let saved_env = self.clone_env();
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
         let saved_env_dirty = self.env_dirty;
@@ -419,7 +419,7 @@ impl VM {
         // own writes land in a fresh born-owned overlay (no fork of `list.env`).
         // The merge below iterates the overlay (overlay-only) = the body's writes.
         // See docs/vm-dual-store.md (Slice 6).
-        *self.interpreter.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
+        *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
 
         // Push gather items collector
         let saved_gather_len = self.interpreter.gather_items_len();
@@ -429,7 +429,7 @@ impl VM {
         // Initialize locals for the compiled code
         self.locals = vec![Value::Nil; cc.locals.len()];
         for (i, name) in cc.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(name) {
+            if let Some(val) = self.env().get(name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -493,7 +493,7 @@ impl VM {
         // This prevents nested gather closures from corrupting each other's
         // captured variables (e.g., `$n` in nested grep-div calls), while
         // still propagating genuine side effects (e.g., `$x += 1`).
-        let gather_result_env = self.interpreter.env().clone();
+        let gather_result_env = self.env().clone();
         let mut merged_env = saved_env.clone();
         for (k, v) in gather_result_env.iter() {
             if !saved_env.contains_key_sym(*k) {
@@ -512,11 +512,11 @@ impl VM {
                 merged_env.insert_sym(*k, v.clone());
             }
         }
-        *self.interpreter.env_mut() = merged_env;
+        *self.env_mut() = merged_env;
 
         // Check whether the merged env actually changed any outer-scope variables.
         let env_actually_changed = {
-            let merged = self.interpreter.env();
+            let merged = self.env();
             saved_env.iter().any(|(k, old_val)| {
                 merged
                     .get_sym(*k)
@@ -594,7 +594,7 @@ impl VM {
 
         // Save current VM state
         crate::vm::vm_stats::record_clone_env();
-        let saved_env = self.interpreter.clone_env();
+        let saved_env = self.clone_env();
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
         let saved_env_dirty = self.env_dirty;
@@ -610,7 +610,7 @@ impl VM {
                 ip = coro.ip;
                 self.locals = coro.locals.clone();
                 self.stack = coro.stack.clone();
-                *self.interpreter.env_mut() = coro.env.clone();
+                *self.env_mut() = coro.env.clone();
                 self.gather_for_loop_resume = coro.for_loop_resume.clone();
                 has_prior_state = true;
             } else {
@@ -620,10 +620,10 @@ impl VM {
                 // preserves overlay+parent+tombstones), so the body's writes
                 // accumulate across takes without forking `list.env`.
                 ip = 0;
-                *self.interpreter.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
+                *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
                 self.locals = vec![Value::Nil; cc.locals.len()];
                 for (i, name) in cc.locals.iter().enumerate() {
-                    if let Some(val) = self.interpreter.env().get(name) {
+                    if let Some(val) = self.env().get(name) {
                         self.locals[i] = val.clone();
                     }
                 }
@@ -633,10 +633,10 @@ impl VM {
         } else {
             // Fresh start (no coroutine slot yet)
             ip = 0;
-            *self.interpreter.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
+            *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
             self.locals = vec![Value::Nil; cc.locals.len()];
             for (i, name) in cc.locals.iter().enumerate() {
-                if let Some(val) = self.interpreter.env().get(name) {
+                if let Some(val) = self.env().get(name) {
                     self.locals[i] = val.clone();
                 }
             }
@@ -731,7 +731,7 @@ impl VM {
                 ip,
                 locals: self.locals.clone(),
                 stack: self.stack.clone(),
-                env: self.interpreter.env().clone(),
+                env: self.env().clone(),
                 finished: false,
                 for_loop_resume,
             };
@@ -746,7 +746,7 @@ impl VM {
         }
 
         // Merge env changes back to outer scope
-        let gather_result_env = self.interpreter.env().clone();
+        let gather_result_env = self.env().clone();
         let initial_env = &list.env;
         let mut merged_env = saved_env.clone();
         for (k, v) in gather_result_env.iter() {
@@ -761,10 +761,10 @@ impl VM {
                 merged_env.insert_sym(*k, v.clone());
             }
         }
-        *self.interpreter.env_mut() = merged_env;
+        *self.env_mut() = merged_env;
 
         let env_actually_changed = {
-            let merged = self.interpreter.env();
+            let merged = self.env();
             saved_env.iter().any(|(k, old_val)| {
                 merged
                     .get_sym(*k)

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -10,7 +10,7 @@ impl VM {
     /// the lvalue-precise alternative to the Arc-identity binding scan, which
     /// cannot tell a bound alias from a COW copy.
     fn write_back_hyper_target_var(&mut self, code: &CompiledCode, var: &str, new_val: Value) {
-        if let Some(Value::ContainerRef(cell)) = self.interpreter.env().get(var) {
+        if let Some(Value::ContainerRef(cell)) = self.env().get(var) {
             *cell.lock().unwrap() = new_val;
             return;
         }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -20,7 +20,7 @@ impl VM {
     ) -> Result<(Value, HashMap<String, Value>, bool), RuntimeError> {
         // Check for `is DEPRECATED` trait on the method
         if let Some(ref msg) = method_def.deprecated_message {
-            let cl = self.interpreter.env().get("?LINE").and_then(|v| match v {
+            let cl = self.env().get("?LINE").and_then(|v| match v {
                 Value::Int(i) => Some(*i),
                 _ => None,
             });
@@ -156,7 +156,7 @@ impl VM {
         // it overlay-only (the method's own writes). No closure/thread body runs
         // under the overlay.
         if cc.closure_compiled_codes.is_empty() {
-            let parent = self.interpreter.env().clone();
+            let parent = self.env().clone();
             self.interpreter
                 .set_env(crate::env::Env::scoped_child(parent));
         }
@@ -182,17 +182,17 @@ impl VM {
         };
 
         // Set ::?CLASS / ::?ROLE
-        self.interpreter.env_mut().insert(
+        self.env_mut().insert(
             "?CLASS".to_string(),
             Value::Package(crate::symbol::Symbol::intern(owner_class)),
         );
         if let Some(role_name) = role_context {
-            self.interpreter.env_mut().insert(
+            self.env_mut().insert(
                 "?ROLE".to_string(),
                 Value::Package(crate::symbol::Symbol::intern(&role_name)),
             );
         } else {
-            self.interpreter.env_mut().remove("?ROLE");
+            self.env_mut().remove("?ROLE");
         }
 
         // Set current_package so class-scoped subs are found during method execution.
@@ -214,7 +214,7 @@ impl VM {
         // $_ in a method body is Any unless the invocant is explicitly named $_
         // (e.g. `method foo ($_: ) { ... }`). The invocant binding loop below
         // will set $_ back to self if the invocant param is named "_".
-        self.interpreter.env_mut().insert(
+        self.env_mut().insert(
             "_".to_string(),
             Value::Package(crate::symbol::Symbol::intern("Any")),
         );
@@ -227,7 +227,7 @@ impl VM {
         // Assign a unique callable ID for this method invocation so that
         // non-local returns from blocks defined inside this method can target it.
         let method_callable_id = crate::value::next_instance_id();
-        self.interpreter.env_mut().insert(
+        self.env_mut().insert(
             "__mutsu_callable_id".to_string(),
             Value::Int(method_callable_id as i64),
         );
@@ -312,7 +312,7 @@ impl VM {
                             self.set_current_package(saved_package.clone());
                             self.stack.truncate(saved_stack_depth);
                             let frame = self.pop_call_frame();
-                            *self.interpreter.env_mut() = frame.saved_env;
+                            *self.env_mut() = frame.saved_env;
                             // :D/:U smiley mismatch → X::Parameter::InvalidConcreteness
                             if constraint.ends_with(":D") || constraint.ends_with(":U") {
                                 let (base_type, _) =
@@ -360,20 +360,20 @@ impl VM {
                     // routing's alias-table lookup (Phase 3 Stage 2c (ii)).
                     self.interpreter.sigilless_attrs_active = true;
                     // Set up bidirectional alias: !x ↔ alias_name
-                    self.interpreter.env_mut().insert(
+                    self.env_mut().insert(
                         format!("__mutsu_sigilless_alias::!{}", actual_attr),
                         Value::str(source_name.to_string()),
                     );
-                    self.interpreter.env_mut().insert(
+                    self.env_mut().insert(
                         format!("__mutsu_sigilless_readonly::!{}", actual_attr),
                         Value::Bool(false),
                     );
                     // Reverse alias: alias_name → !attr so writing to $x updates $!x
-                    self.interpreter.env_mut().insert(
+                    self.env_mut().insert(
                         format!("__mutsu_sigilless_alias::{}", source_name),
                         Value::str(format!("!{}", actual_attr)),
                     );
-                    self.interpreter.env_mut().insert(
+                    self.env_mut().insert(
                         format!("__mutsu_sigilless_readonly::{}", source_name),
                         Value::Bool(false),
                     );
@@ -440,7 +440,7 @@ impl VM {
                     self.set_current_package(saved_package.clone());
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
-                    *self.interpreter.env_mut() = frame.saved_env;
+                    *self.env_mut() = frame.saved_env;
                     return Err(e);
                 }
             };
@@ -448,7 +448,7 @@ impl VM {
         // Initialize locals from env
         self.locals = vec![Value::Nil; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
-            if let Some(val) = self.interpreter.env().get(local_name) {
+            if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
             }
         }
@@ -645,7 +645,7 @@ impl VM {
                         .cloned()
                         .or_else(|| {
                             let qualified = format!("{}::{}", owner_class, param_name);
-                            self.interpreter.env().get(&qualified).cloned()
+                            self.env().get(&qualified).cloned()
                         })
                         .map(|val| (source_name.clone(), val))
                 })
@@ -655,7 +655,7 @@ impl VM {
             // saved caller env, take the live callee env) so merge_method_env can
             // mutate the caller env in place without a deep copy.
             let frame = self.pop_call_frame();
-            let current_env = self.interpreter.take_env();
+            let current_env = self.take_env();
             let (mut merged_env, wrote_caller) =
                 merge_method_env(frame.saved_env, current_env, &method_local_keys);
             // Precise dirty signal (Slice 6.3): the caller only needs an
@@ -680,7 +680,7 @@ impl VM {
             self.interpreter.pop_routine();
             self.interpreter.pop_method_class();
             self.set_current_package(saved_package.clone());
-            *self.interpreter.env_mut() = merged_env;
+            *self.env_mut() = merged_env;
         }
 
         if can_skip_merge {
@@ -688,7 +688,7 @@ impl VM {
             self.method_dispatch_pure = true;
             self.set_current_package(saved_package);
             let frame = self.pop_call_frame();
-            *self.interpreter.env_mut() = frame.saved_env;
+            *self.env_mut() = frame.saved_env;
         }
 
         let final_result = match result {
@@ -851,7 +851,7 @@ impl VM {
         if let Some(slot) = code.locals.iter().position(|n| n == name) {
             return Some(self.locals[slot].clone());
         }
-        self.interpreter.env().get(name).cloned()
+        self.env().get(name).cloned()
     }
 
     /// Phase 3 Stage 2c (i): mirror attributive parameters (`$!x`/`@!a`/`%!h`)
@@ -915,9 +915,9 @@ impl VM {
         // iterates the scoped env for a full lexical view.
         let use_scoped = cc.closure_compiled_codes.is_empty();
         if use_scoped {
-            let parent = self.interpreter.env().clone();
+            let parent = self.env().clone();
             let scoped = crate::env::Env::scoped_child(parent);
-            self.interpreter.set_env(scoped);
+            self.set_env(scoped);
         }
         let saved_var_bindings = self.interpreter.take_var_bindings();
         self.interpreter.push_method_class(owner_class.to_string());
@@ -961,7 +961,7 @@ impl VM {
                     self.set_current_package(saved_package);
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
-                    self.interpreter.set_env(frame.saved_env);
+                    self.set_env(frame.saved_env);
                     return Err(RuntimeError::typecheck_binding_parameter(
                         param_name,
                         constraint,
@@ -987,7 +987,7 @@ impl VM {
         // method-local vars since all reads go through GetLocal.
         let skip_env_setup = can_skip_merge && cc.closure_compiled_codes.is_empty();
         if skip_env_setup {
-            let env = self.interpreter.env_mut();
+            let env = self.env_mut();
             env.insert("self".to_string(), base.clone());
             env.insert("__ANON_STATE__".to_string(), base.clone());
             env.insert("?CLASS".to_string(), class_val.clone());
@@ -1004,7 +1004,7 @@ impl VM {
                 env.insert(param_name.to_string(), param_val.clone());
             }
         } else {
-            let env = self.interpreter.env_mut();
+            let env = self.env_mut();
             env.insert("self".to_string(), base.clone());
             env.insert("__ANON_STATE__".to_string(), base.clone());
             env.insert("?CLASS".to_string(), class_val.clone());
@@ -1076,7 +1076,7 @@ impl VM {
                         attributes.get(&name[2..]).cloned().unwrap_or(Value::Nil)
                     }
                     // Outer env (read-only, no deep clone)
-                    else if let Some(val) = self.interpreter.env().get(name) {
+                    else if let Some(val) = self.env().get(name) {
                         val.clone()
                     } else {
                         Value::Nil
@@ -1249,16 +1249,16 @@ impl VM {
             // slots stay coherent, opcode skips the env_dirty mark).
             self.method_dispatch_pure = true;
             let frame = self.pop_call_frame();
-            self.interpreter.set_env(frame.saved_env);
+            self.set_env(frame.saved_env);
         } else {
             // Inner calls may have modified env (globals, dynamics).
             // Check if env was actually changed; if so, merge the changes
             // into the saved env before restoring.
             let frame = self.pop_call_frame();
-            if self.interpreter.env().ptr_eq(&frame.saved_env) {
+            if self.env().ptr_eq(&frame.saved_env) {
                 // Env object unchanged -> nothing merged back (pure).
                 self.method_dispatch_pure = true;
-                self.interpreter.set_env(frame.saved_env);
+                self.set_env(frame.saved_env);
             } else {
                 // Build method_local_keys set (keys that should NOT leak to caller)
                 let mut method_local_keys: HashSet<String> = HashSet::from_iter([
@@ -1289,13 +1289,13 @@ impl VM {
                 }
                 // Own both envs (frame already popped above; take the live callee
                 // env) so the merge mutates the caller env in place, no deep copy.
-                let current_env = self.interpreter.take_env();
+                let current_env = self.take_env();
                 let (merged, wrote_caller) =
                     merge_method_env(frame.saved_env, current_env, &method_local_keys);
                 // Precise dirty signal (Slice 6.3): re-sync the caller's locals
                 // only when the method merged a caller-visible write.
                 self.method_dispatch_pure = !wrote_caller;
-                self.interpreter.set_env(merged);
+                self.set_env(merged);
             }
         }
 

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -306,7 +306,7 @@ impl VM {
         {
             return Some(callable);
         }
-        if let Some(callable) = self.interpreter.env().get(&format!("&{}", op)).cloned()
+        if let Some(callable) = self.env().get(&format!("&{}", op)).cloned()
             && matches!(
                 callable,
                 Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } | Value::Instance { .. }
@@ -951,7 +951,7 @@ impl VM {
             self.flush_local_to_env(code, slot);
             // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
             let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+            let mut alias_name = self.env().get(&alias_key).and_then(|v| {
                 if let Value::Str(n) = v {
                     Some(n.to_string())
                 } else {
@@ -966,7 +966,7 @@ impl VM {
                 self.set_env_with_main_alias(&current_alias, new_val.clone());
                 self.update_local_if_exists(code, &current_alias, &new_val);
                 let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                alias_name = self.env().get(&next_key).and_then(|v| {
                     if let Value::Str(n) = v {
                         Some(n.to_string())
                     } else {
@@ -1049,7 +1049,7 @@ impl VM {
             self.flush_local_to_env(code, slot);
             // Propagate via sigilless alias chain (e.g. `$!attr := outer_var`).
             let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-            let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+            let mut alias_name = self.env().get(&alias_key).and_then(|v| {
                 if let Value::Str(n) = v {
                     Some(n.to_string())
                 } else {
@@ -1064,7 +1064,7 @@ impl VM {
                 self.set_env_with_main_alias(&current_alias, new_val.clone());
                 self.update_local_if_exists(code, &current_alias, &new_val);
                 let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-                alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+                alias_name = self.env().get(&next_key).and_then(|v| {
                     if let Value::Str(n) = v {
                         Some(n.to_string())
                     } else {
@@ -1105,10 +1105,10 @@ impl VM {
 
     pub(super) fn exec_get_capture_var_op(&mut self, code: &CompiledCode, name_idx: u32) {
         let name = Self::const_str(code, name_idx);
-        let val = if let Some(v) = self.interpreter.env().get(name).cloned() {
+        let val = if let Some(v) = self.env().get(name).cloned() {
             v
         } else if let Some(key) = name.strip_prefix('<').and_then(|s| s.strip_suffix('>'))
-            && let Some(match_val) = self.interpreter.env().get("/").cloned()
+            && let Some(match_val) = self.env().get("/").cloned()
         {
             match &match_val {
                 Value::Hash(map) => map.get(key).cloned().unwrap_or(Value::Nil),
@@ -1152,13 +1152,10 @@ impl VM {
             && !name.contains("::")
             && !name.starts_with('?')
             && !name.starts_with('*')
-            && matches!(
-                self.interpreter.env().get("__mutsu_in_eval"),
-                Some(Value::Bool(true))
-            )
+            && matches!(self.env().get("__mutsu_in_eval"), Some(Value::Bool(true)))
         {
             let env_key = format!("&{}", name);
-            let is_declared = self.interpreter.env().contains_key(&env_key);
+            let is_declared = self.env().contains_key(&env_key);
             if !is_declared {
                 let suggestions = self.interpreter.suggest_routine_names(name);
                 return Err(RuntimeError::undeclared_routine_symbols(
@@ -1334,7 +1331,7 @@ impl VM {
         }
         if name.starts_with('&') && !name.contains("::") {
             let bare = name.trim_start_matches('&');
-            let has_variable_slot = self.interpreter.env().contains_key(&name);
+            let has_variable_slot = self.env().contains_key(&name);
             let is_routine_symbol = self.has_function(bare)
                 || self.has_multi_function(bare)
                 || self.has_proto(bare)
@@ -1428,7 +1425,7 @@ impl VM {
                 .or_else(|| {
                     // Also check declared shape metadata for multi-dim
                     let key = format!("__mutsu_shaped_array_dims::{}", name);
-                    self.interpreter.env().get(&key).and_then(|v| {
+                    self.env().get(&key).and_then(|v| {
                         if let Value::Array(dims, ..) = v {
                             Some(
                                 dims.iter()
@@ -1531,10 +1528,8 @@ impl VM {
             };
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        if matches!(
-            self.interpreter.env().get(&readonly_key),
-            Some(Value::Bool(true))
-        ) && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
+        if matches!(self.env().get(&readonly_key), Some(Value::Bool(true)))
+            && !matches!(self.env().get(&alias_key), Some(Value::Str(_)))
         {
             return Err(RuntimeError::assignment_ro(None));
         }
@@ -1543,7 +1538,7 @@ impl VM {
             let mut seen = std::collections::HashSet::new();
             while seen.insert(resolved_source.clone()) {
                 let key = format!("__mutsu_sigilless_alias::{}", resolved_source);
-                let Some(Value::Str(next)) = self.interpreter.env().get(&key) else {
+                let Some(Value::Str(next)) = self.env().get(&key) else {
                     break;
                 };
                 resolved_source = next.to_string();
@@ -1644,7 +1639,7 @@ impl VM {
                 .env_mut()
                 .insert("__mutsu_rw_map_topic__".to_string(), val.clone());
         }
-        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+        let mut alias_name = self.env().get(&alias_key).and_then(|v| {
             if let Value::Str(name) = v {
                 Some(name.to_string())
             } else {
@@ -1661,7 +1656,7 @@ impl VM {
                 .env_mut()
                 .insert(current_alias.clone(), val.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+            alias_name = self.env().get(&next_key).and_then(|v| {
                 if let Value::Str(name) = v {
                     Some(name.to_string())
                 } else {
@@ -1705,7 +1700,7 @@ impl VM {
 
     pub(super) fn exec_get_env_index_op(&mut self, code: &CompiledCode, key_idx: u32) {
         let key = Self::const_str(code, key_idx);
-        let val = if let Some(Value::Hash(env_hash)) = self.interpreter.env().get("%*ENV") {
+        let val = if let Some(Value::Hash(env_hash)) = self.env().get("%*ENV") {
             env_hash.get(key).cloned().unwrap_or_else(|| {
                 std::env::var_os(key)
                     .map(|v| {
@@ -1727,7 +1722,7 @@ impl VM {
 
     pub(super) fn exec_exists_env_index_op(&mut self, code: &CompiledCode, key_idx: u32) {
         let key = Self::const_str(code, key_idx);
-        let exists = if let Some(Value::Hash(env_hash)) = self.interpreter.env().get("%*ENV") {
+        let exists = if let Some(Value::Hash(env_hash)) = self.env().get("%*ENV") {
             env_hash.contains_key(key) || std::env::var_os(key).is_some()
         } else {
             std::env::var_os(key).is_some()
@@ -2450,12 +2445,12 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let body_end = body_end as usize;
         let saved = self.current_package().to_string();
-        let saved_env = self.interpreter.env().clone();
+        let saved_env = self.env().clone();
         let saved_locals = self.locals.clone();
         self.set_current_package(name);
         self.run_range(code, *ip + 1, body_end, compiled_fns)?;
         self.set_current_package(saved);
-        let current_env = self.interpreter.env().clone();
+        let current_env = self.env().clone();
         let mut restored_env = saved_env.clone();
         for (k, v) in current_env.iter() {
             if saved_env.contains_key_sym(*k) || k.contains_str("::") {
@@ -2468,7 +2463,7 @@ impl VM {
                 self.locals[idx] = val;
             }
         }
-        *self.interpreter.env_mut() = restored_env;
+        *self.env_mut() = restored_env;
         *ip = body_end;
         Ok(())
     }
@@ -2859,18 +2854,18 @@ impl VM {
         // This avoids triggering Arc::make_mut deep clone on the CoW env when
         // the state variable is already initialized with the same value (common
         // case in tight loops).
-        let needs_env_insert = self.interpreter.env().get(&name) != Some(&val);
+        let needs_env_insert = self.env().get(&name) != Some(&val);
         if needs_env_insert {
-            self.interpreter.env_mut().insert(name.clone(), val);
+            self.env_mut().insert(name.clone(), val);
         }
         // Store metadata mapping variable name to its state storage key.
         // Closures that capture this variable can use this to update state
         // storage when they modify the variable.
         let meta_key = format!("__mutsu_state_key::{}", name);
         let scoped_key_val = Value::str(scoped_key.clone());
-        let needs_meta_insert = self.interpreter.env().get(&meta_key) != Some(&scoped_key_val);
+        let needs_meta_insert = self.env().get(&meta_key) != Some(&scoped_key_val);
         if needs_meta_insert {
-            self.interpreter.env_mut().insert(meta_key, scoped_key_val);
+            self.env_mut().insert(meta_key, scoped_key_val);
         }
     }
 
@@ -2899,7 +2894,7 @@ impl VM {
         let post_start = post_start as usize;
         let end = end as usize;
         let routine_snapshot = self.interpreter.snapshot_routine_registry();
-        let saved_env = self.interpreter.env().clone();
+        let saved_env = self.env().clone();
         let saved_locals = self.locals.clone();
         let once_scope = self.interpreter.next_once_scope_id();
         // Track variables declared within this block scope.
@@ -3029,11 +3024,11 @@ impl VM {
         // so they see the final values of block-scoped variables (which will
         // be removed from env when the block scope is restored below).
         if self.interpreter.end_phaser_count() > end_phaser_count_before {
-            let current = self.interpreter.env().clone();
+            let current = self.env().clone();
             self.interpreter
                 .update_end_phaser_envs(end_phaser_count_before, &current);
         }
-        let current_env = self.interpreter.env().clone();
+        let current_env = self.env().clone();
         let mut restored_env = saved_env.clone();
         for (k, v) in current_env {
             // Package-qualified names (e.g. Test1::ns, Foo::Bar) are package-global
@@ -3113,16 +3108,16 @@ impl VM {
                 restored_env.insert(local_name.clone(), val);
             }
         }
-        *self.interpreter.env_mut() = restored_env;
+        *self.env_mut() = restored_env;
         // After block scope restoration, sync `:=` alias bindings.
         // If a local variable was modified inside the block and has a
         // sigilless alias (e.g. `my $a := $_`), propagate the local's
         // current value to the alias target in env so they stay in sync.
         for (idx, name) in code.locals.iter().enumerate() {
             let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-            if let Some(Value::Str(target)) = self.interpreter.env().get(&alias_key).cloned() {
+            if let Some(Value::Str(target)) = self.env().get(&alias_key).cloned() {
                 let local_val = &self.locals[idx];
-                if let Some(env_val) = self.interpreter.env().get(target.as_str())
+                if let Some(env_val) = self.env().get(target.as_str())
                     && local_val != env_val
                 {
                     self.interpreter
@@ -3250,7 +3245,7 @@ impl VM {
         self.interpreter.push_once_scope(once_scope);
         self.interpreter.push_enum_scope();
         let saved_env = if scope_isolate {
-            Some((self.interpreter.env().clone(), self.locals.clone()))
+            Some((self.env().clone(), self.locals.clone()))
         } else {
             None
         };
@@ -3304,7 +3299,7 @@ impl VM {
             // `:into(my %h := :{})`) remain visible in the outer scope.
             // Only hash variables are preserved to avoid side effects
             // on other container types.
-            let current_env = self.interpreter.env().clone();
+            let current_env = self.env().clone();
             let mut new_vars: Vec<(Symbol, Value)> = Vec::new();
             for (name, value) in current_env.iter() {
                 if !name.starts_with("%") || name.starts_with("%*") {
@@ -3322,10 +3317,10 @@ impl VM {
                 }
             }
             let restored_env = saved_env.clone();
-            *self.interpreter.env_mut() = restored_env;
+            *self.env_mut() = restored_env;
             // Re-insert newly declared user variables
             for (name, value) in new_vars {
-                self.interpreter.env_mut().insert_sym(name, value);
+                self.env_mut().insert_sym(name, value);
             }
             self.locals = saved_locals;
             // Re-read locals from env for variables that use env as the primary
@@ -3339,7 +3334,7 @@ impl VM {
                     // Simple locals: env may be stale; saved_locals is correct.
                     continue;
                 }
-                if let Some(val) = self.interpreter.env().get(name).cloned() {
+                if let Some(val) = self.env().get(name).cloned() {
                     self.locals[idx] = val;
                 }
             }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -5,7 +5,7 @@ use crate::symbol::Symbol;
 impl VM {
     /// Get the current source line number from the interpreter env.
     pub(super) fn current_source_line(&self) -> Option<u32> {
-        self.interpreter.env().get("?LINE").and_then(|v| match v {
+        self.env().get("?LINE").and_then(|v| match v {
             Value::Int(n) => Some(*n as u32),
             _ => None,
         })
@@ -13,7 +13,7 @@ impl VM {
 
     /// Get the current source file from the interpreter env.
     pub(super) fn current_source_file(&self) -> Option<String> {
-        self.interpreter.env().get("?FILE").and_then(|v| match v {
+        self.env().get("?FILE").and_then(|v| match v {
             Value::Str(s) => Some(s.to_string()),
             _ => None,
         })
@@ -26,7 +26,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::Block(body) = stmt {
-            let mut env = self.interpreter.env().clone();
+            let mut env = self.env().clone();
             env.insert(
                 "__mutsu_lazylist_from_gather".to_string(),
                 Value::Bool(true),
@@ -98,7 +98,7 @@ impl VM {
                 // possibly from a different scope, and its captured env is seeded
                 // overlay-only at dispatch -- so it must hold the full lexical view
                 // now, not a scoped overlay whose parent tier would be lost.
-                env: self.interpreter.clone_env(),
+                env: self.clone_env(),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
@@ -140,7 +140,7 @@ impl VM {
             let owned_captures = self.compute_owned_captures(&compiled_code);
             // Flatten: closure env captured into a Value::Sub for later (possibly
             // cross-scope) dispatch must hold the full lexical view (see above).
-            let mut env = self.interpreter.clone_env();
+            let mut env = self.clone_env();
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -351,7 +351,7 @@ impl VM {
             let owned_captures = self.compute_owned_captures(&compiled_code);
             // Flatten: closure env captured into a Value::Sub for later (possibly
             // cross-scope) dispatch must hold the full lexical view (see above).
-            let mut env = self.interpreter.clone_env();
+            let mut env = self.clone_env();
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -418,7 +418,7 @@ impl VM {
                 is_rw: false,
                 is_raw: false,
                 // Flatten: long-lived closure capture (see above).
-                env: self.interpreter.clone_env(),
+                env: self.clone_env(),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
@@ -500,7 +500,7 @@ impl VM {
                 // be dropped when the module scope exits. Capture it so `import`
                 // can restore the trait-modified value.
                 let code_var_key = format!("&{}", resolved_name);
-                if let Some(val @ Value::Mixin(..)) = self.interpreter.env().get(&code_var_key) {
+                if let Some(val @ Value::Mixin(..)) = self.env().get(&code_var_key) {
                     self.interpreter.record_exported_sub_value(
                         pkg,
                         resolved_name.clone(),
@@ -615,7 +615,7 @@ impl VM {
                         param_defs.clone(),
                         body.clone(),
                         false,
-                        self.interpreter.clone_env(),
+                        self.clone_env(),
                     );
                     let named_arg = Value::Pair(trait_name.clone(), Box::new(Value::Bool(true)));
                     let result = self
@@ -761,7 +761,7 @@ impl VM {
             attrs.insert("next-repo".to_string(), prev);
             let repo =
                 Value::make_instance(Symbol::intern("CompUnit::Repository::Installation"), attrs);
-            self.interpreter.env_mut().insert("*REPO".to_string(), repo);
+            self.env_mut().insert("*REPO".to_string(), repo);
         }
         self.interpreter.add_lib_path(path);
         Ok(())
@@ -1298,7 +1298,7 @@ impl VM {
             }
             // Register the class name in the lexical env so that
             // ::("ClassName") indirect lookups can find it in the current scope.
-            let env = self.interpreter.env_mut();
+            let env = self.env_mut();
             env.insert(
                 "_".to_string(),
                 Value::Package(Symbol::intern(&qualified_name)),
@@ -1323,7 +1323,7 @@ impl VM {
                 self.interpreter.suppress_name(&resolved_name);
                 // Register the short name in the lexical env so it resolves
                 // within the enclosing class scope (e.g. `Frog` inside `Forest`).
-                let env = self.interpreter.env_mut();
+                let env = self.env_mut();
                 env.insert(
                     resolved_name.clone(),
                     Value::Package(Symbol::intern(&qualified_name)),
@@ -1343,7 +1343,7 @@ impl VM {
                 // Do not shadow built-in types (e.g. `my class X::Roast::Channel`
                 // must not make the bare name `Channel` resolve to the user class).
                 if !short.is_empty() && short != qualified_name && !Self::is_builtin_type(&short) {
-                    self.interpreter.env_mut().entry_or_insert_with(short, || {
+                    self.env_mut().entry_or_insert_with(short, || {
                         Value::Package(Symbol::intern(&qualified_name))
                     });
                 }
@@ -1491,16 +1491,16 @@ impl VM {
                 .store_language_revision_from_version(&qualified_name, language_version);
             // Compile role method bodies to bytecode
             self.interpreter.compile_role_methods(&qualified_name);
-            self.interpreter.env_mut().insert(
+            self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(Symbol::intern(&qualified_name)),
             );
-            self.interpreter.env_mut().insert(
+            self.env_mut().insert(
                 qualified_name.clone(),
                 Value::Package(Symbol::intern(&qualified_name)),
             );
             if qualified_name != name_str && !name_str.contains("::") {
-                self.interpreter.env_mut().insert(
+                self.env_mut().insert(
                     name_str.clone(),
                     Value::Package(Symbol::intern(&qualified_name)),
                 );
@@ -1516,7 +1516,7 @@ impl VM {
                     .map(|(_, s)| s.to_string())
                     .unwrap_or_else(|| qualified_name.clone());
                 if !short.is_empty() && short != qualified_name {
-                    self.interpreter.env_mut().entry_or_insert_with(short, || {
+                    self.env_mut().entry_or_insert_with(short, || {
                         Value::Package(Symbol::intern(&qualified_name))
                     });
                 }

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -861,7 +861,7 @@ impl VM {
             } else {
                 Value::Nil
             };
-            self.interpreter.env_mut().insert("/".to_string(), slash);
+            self.env_mut().insert("/".to_string(), slash);
             self.stack.push(Value::str(text));
             return Ok(());
         }
@@ -1106,9 +1106,9 @@ impl VM {
         samespace: bool,
     ) -> String {
         // Snapshot the env entries we overwrite so we can restore them after.
-        let saved_slash = self.interpreter.env().get("/").cloned();
+        let saved_slash = self.env().get("/").cloned();
         let saved_caps: Vec<Option<Value>> = (0..10)
-            .map(|n| self.interpreter.env().get(&n.to_string()).cloned())
+            .map(|n| self.env().get(&n.to_string()).cloned())
             .collect();
 
         let mut out = String::new();
@@ -1145,7 +1145,7 @@ impl VM {
                         .env_mut()
                         .insert(n.to_string(), Value::str(cap.clone()));
                 } else {
-                    self.interpreter.env_mut().remove(&n.to_string());
+                    self.env_mut().remove(&n.to_string());
                 }
             }
 
@@ -1184,19 +1184,19 @@ impl VM {
         // by the caller after this returns).
         match saved_slash {
             Some(v) => {
-                self.interpreter.env_mut().insert("/".to_string(), v);
+                self.env_mut().insert("/".to_string(), v);
             }
             None => {
-                self.interpreter.env_mut().remove("/");
+                self.env_mut().remove("/");
             }
         }
         for (n, saved) in saved_caps.into_iter().enumerate() {
             match saved {
                 Some(v) => {
-                    self.interpreter.env_mut().insert(n.to_string(), v);
+                    self.env_mut().insert(n.to_string(), v);
                 }
                 None => {
-                    self.interpreter.env_mut().remove(&n.to_string());
+                    self.env_mut().remove(&n.to_string());
                 }
             }
         }
@@ -1658,7 +1658,7 @@ impl VM {
             let mut found = None;
             for key in [format!("&{}", bare), bare.to_string()] {
                 if let Some(v @ (Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. })) =
-                    self.interpreter.env().get(&key)
+                    self.env().get(&key)
                 {
                     found = Some(v.clone());
                     break;
@@ -1769,7 +1769,7 @@ impl VM {
             };
             if do_writeback {
                 let synth = format!("__mutsu_hyperfn_lv_{}", i);
-                self.interpreter.env_mut().insert(synth.clone(), l.clone());
+                self.env_mut().insert(synth.clone(), l.clone());
                 let varref =
                     crate::runtime::types::make_varref_value(synth.clone(), l.clone(), None);
                 let call_args = vec![varref, r.clone()];
@@ -1780,8 +1780,8 @@ impl VM {
                     compiled_fns,
                 )?;
                 results.push(result);
-                let updated = self.interpreter.env().get(&synth).cloned().unwrap_or(l);
-                self.interpreter.env_mut().remove(&synth);
+                let updated = self.env().get(&synth).cloned().unwrap_or(l);
+                self.env_mut().remove(&synth);
                 mutated_left.push(updated);
             } else {
                 let call_args = vec![l, r.clone()];
@@ -1931,13 +1931,13 @@ impl VM {
             };
             if do_writeback {
                 let synth = format!("__mutsu_hyperfn_lvh_{}", key);
-                self.interpreter.env_mut().insert(synth.clone(), l.clone());
+                self.env_mut().insert(synth.clone(), l.clone());
                 let varref =
                     crate::runtime::types::make_varref_value(synth.clone(), l.clone(), None);
                 let call_args = vec![varref, r];
                 let v = self.dispatch_hyper_func_call(name, func_value, call_args, compiled_fns)?;
-                let updated = self.interpreter.env().get(&synth).cloned().unwrap_or(l);
-                self.interpreter.env_mut().remove(&synth);
+                let updated = self.env().get(&synth).cloned().unwrap_or(l);
+                self.env_mut().remove(&synth);
                 result.insert(key.clone(), v);
                 mutated.insert(key, updated);
             } else {
@@ -2326,7 +2326,7 @@ impl VM {
     }
 
     fn flip_flop_scope_key(&self) -> String {
-        if let Some(Value::Int(id)) = self.interpreter.env().get("__mutsu_callable_id") {
+        if let Some(Value::Int(id)) = self.env().get("__mutsu_callable_id") {
             return format!("callable:{id}");
         }
         if let Some(frame) = self.interpreter.routine_stack_top() {
@@ -2570,12 +2570,12 @@ impl VM {
                     }
                     if let Some(op_name) = infix_name {
                         let op_env_name = format!("&{}", op_name);
-                        if let Some(code_val) = self.interpreter.env().get(&op_env_name).cloned() {
+                        if let Some(code_val) = self.env().get(&op_env_name).cloned() {
                             return self.vm_call_on_value(code_val, Vec::new(), None);
                         }
                     }
                     let bare_env_name = format!("&{}", name);
-                    if let Some(code_val) = self.interpreter.env().get(&bare_env_name).cloned() {
+                    if let Some(code_val) = self.env().get(&bare_env_name).cloned() {
                         return self.vm_call_on_value(code_val, Vec::new(), None);
                     }
                     let method_name = name
@@ -2605,12 +2605,12 @@ impl VM {
                 } else {
                     if let Some(op_name) = infix_name {
                         let op_env_name = format!("&{}", op_name);
-                        if let Some(code_val) = self.interpreter.env().get(&op_env_name).cloned() {
+                        if let Some(code_val) = self.env().get(&op_env_name).cloned() {
                             return self.vm_call_on_value(code_val, call_args, None);
                         }
                     }
                     let bare_env_name = format!("&{}", name);
-                    if let Some(code_val) = self.interpreter.env().get(&bare_env_name).cloned() {
+                    if let Some(code_val) = self.env().get(&bare_env_name).cloned() {
                         self.vm_call_on_value(code_val, call_args, None)
                     } else {
                         let method_name = name
@@ -2709,14 +2709,14 @@ impl VM {
                     if let Ok((stmts, _)) = parsed {
                         // Save $_ before evaluating the code block, as
                         // eval_block_value may clobber the topic variable.
-                        let saved_topic = self.interpreter.env().get("_").cloned();
+                        let saved_topic = self.env().get("_").cloned();
                         let val = self
                             .interpreter
                             .eval_block_value(&stmts)
                             .unwrap_or(Value::Nil);
                         // Restore $_ so the substitution can find the target
                         if let Some(topic) = saved_topic {
-                            self.interpreter.env_mut().insert("_".to_string(), topic);
+                            self.env_mut().insert("_".to_string(), topic);
                         }
                         out.push_str(&val.to_string_value());
                     } else {

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -453,7 +453,7 @@ impl VM {
             return crate::builtins::collation::CollationSettings::from_value(&val);
         }
         // Also check with $* prefix
-        if let Some(val) = self.interpreter.env().get("$*COLLATION") {
+        if let Some(val) = self.env().get("$*COLLATION") {
             return crate::builtins::collation::CollationSettings::from_value(val);
         }
         crate::builtins::collation::CollationSettings::default()

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -177,7 +177,7 @@ impl VM {
             let var_name = &source_name[..sep_pos];
             let idx_str = &source_name[sep_pos + 5..];
             if let Ok(i) = idx_str.parse::<usize>() {
-                let Some(container) = self.interpreter.env_mut().get_mut(var_name) else {
+                let Some(container) = self.env_mut().get_mut(var_name) else {
                     return Err(RuntimeError::assignment_ro(None));
                 };
                 if let Value::Array(items, ..) = container {
@@ -189,7 +189,7 @@ impl VM {
                     return Ok(());
                 }
             }
-            if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(source_name) {
+            if let Some(Value::Hash(hash)) = self.env_mut().get_mut(source_name) {
                 let h = Arc::make_mut(hash);
                 h.insert(idx_str.to_string(), value);
                 return Ok(());
@@ -197,7 +197,7 @@ impl VM {
             return Err(RuntimeError::assignment_ro(None));
         }
         if let Some(i) = source_index {
-            let Some(container) = self.interpreter.env_mut().get_mut(source_name) else {
+            let Some(container) = self.env_mut().get_mut(source_name) else {
                 return Err(RuntimeError::assignment_ro(None));
             };
             let Value::Array(items, ..) = container else {
@@ -235,13 +235,13 @@ impl VM {
             for p in &data.params {
                 sub_env.insert(p.to_string(), Value::Int(len));
             }
-            let saved_env = std::mem::take(self.interpreter.env_mut());
-            *self.interpreter.env_mut() = sub_env;
+            let saved_env = std::mem::take(self.env_mut());
+            *self.env_mut() = sub_env;
             let result = self
                 .interpreter
                 .eval_block_value(&data.body)
                 .unwrap_or(Value::Nil);
-            *self.interpreter.env_mut() = saved_env;
+            *self.env_mut() = saved_env;
             return result;
         }
         // Resolve Array of WhateverCode indices: @a[*-3, *-2, *-1]
@@ -261,13 +261,13 @@ impl VM {
                         for p in &data.params {
                             sub_env.insert(p.to_string(), Value::Int(len));
                         }
-                        let saved_env = std::mem::take(self.interpreter.env_mut());
-                        *self.interpreter.env_mut() = sub_env;
+                        let saved_env = std::mem::take(self.env_mut());
+                        *self.env_mut() = sub_env;
                         let result = self
                             .interpreter
                             .eval_block_value(&data.body)
                             .unwrap_or(Value::Nil);
-                        *self.interpreter.env_mut() = saved_env;
+                        *self.env_mut() = saved_env;
                         resolved.push(result);
                     } else {
                         resolved.push(item.clone());
@@ -592,7 +592,7 @@ impl VM {
             // Only coerce if the variable IS a QuantHash container (declared via `is`),
             // not when the constraint is a value type (declared via `of`).
             // Check: if the current value is already a QuantHash, it's an `is` trait.
-            let current = self.interpreter.env().get(name).cloned();
+            let current = self.env().get(name).cloned();
             let is_quanthash_container = matches!(
                 current,
                 Some(Value::Bag(_, _) | Value::Mix(_, _) | Value::Set(_, _))
@@ -621,7 +621,7 @@ impl VM {
             ) {
                 return Ok(value);
             }
-            let trait_name = match self.interpreter.env().get(name) {
+            let trait_name = match self.env().get(name) {
                 Some(Value::Set(_, _)) => Some("SetHash"),
                 Some(Value::Bag(_, _)) => Some("BagHash"),
                 Some(Value::Mix(_, _)) => Some("MixHash"),
@@ -969,14 +969,14 @@ impl VM {
             };
             if is_container {
                 let key = format!("__mutsu_bound_decont::{}", name);
-                self.interpreter.env_mut().insert(key, Value::Bool(true));
+                self.env_mut().insert(key, Value::Bool(true));
                 self.bound_decont_active = true;
                 return;
             }
         }
         if self.bound_decont_active {
             let key = format!("__mutsu_bound_decont::{}", name);
-            self.interpreter.env_mut().remove(&key);
+            self.env_mut().remove(&key);
         }
     }
 
@@ -1020,7 +1020,7 @@ impl VM {
         let mut seen = std::collections::HashSet::new();
         while seen.insert(resolved.clone()) {
             let key = format!("__mutsu_sigilless_alias::{}", resolved);
-            let Some(Value::Str(next)) = self.interpreter.env().get(&key) else {
+            let Some(Value::Str(next)) = self.env().get(&key) else {
                 break;
             };
             resolved = next.to_string();
@@ -1590,7 +1590,7 @@ impl VM {
     /// with the bidirectional `x ↔ !x` alias table.
     fn propagate_sigilless_alias_chain(&mut self, code: &CompiledCode, name: &str, val: &Value) {
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+        let mut alias_name = self.env().get(&alias_key).and_then(|v| {
             if let Value::Str(n) = v {
                 Some(n.to_string())
             } else {
@@ -1606,7 +1606,7 @@ impl VM {
             self.update_local_if_exists(code, &current_alias, val);
             self.write_self_attr_cell(&current_alias, val.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+            alias_name = self.env().get(&next_key).and_then(|v| {
                 if let Value::Str(n) = v {
                     Some(n.to_string())
                 } else {
@@ -2102,9 +2102,7 @@ impl VM {
         // Modify the container in-place in the env to preserve Arc sharing
         // (e.g. when two variables reference the same array via Arc).
         // First try to modify via env_mut().get_mut() to avoid clone.
-        let modified_in_place = if let Some(container_value) =
-            self.interpreter.env_mut().get_mut(&name)
-        {
+        let modified_in_place = if let Some(container_value) = self.env_mut().get_mut(&name) {
             match container_value {
                 Value::Hash(h) => {
                     Value::hash_insert_through(
@@ -2223,7 +2221,7 @@ impl VM {
         };
         if modified_in_place {
             // Update local slot to match the modified env value
-            if let Some(val) = self.interpreter.env().get(&name).cloned() {
+            if let Some(val) = self.env().get(&name).cloned() {
                 self.update_local_if_exists(code, &name, &val);
             }
         } else {
@@ -2263,7 +2261,7 @@ impl VM {
                 self.interpreter
                     .env_mut()
                     .insert(name.clone(), new_container);
-                if let Some(val) = self.interpreter.env().get(&name).cloned() {
+                if let Some(val) = self.env().get(&name).cloned() {
                     self.update_local_if_exists(code, &name, &val);
                 }
             }
@@ -2340,7 +2338,7 @@ impl VM {
         }
         {
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
-            if self.interpreter.env().contains_key(&bound_key) {
+            if self.env().contains_key(&bound_key) {
                 return None;
             }
         }
@@ -2418,9 +2416,7 @@ impl VM {
         {
             let shaped_key = format!("__mutsu_shaped_array_dims::{}", var_name);
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
-            if self.interpreter.env().contains_key(&shaped_key)
-                || self.interpreter.env().contains_key(&bound_key)
-            {
+            if self.env().contains_key(&shaped_key) || self.env().contains_key(&bound_key) {
                 return None;
             }
         }
@@ -2525,13 +2521,13 @@ impl VM {
         // (e.g. `%h<a> := $foo` makes element writes propagate to $foo)
         {
             let bound_key = format!("__mutsu_bound_index::{}", var_name);
-            if self.interpreter.env().contains_key(&bound_key) {
+            if self.env().contains_key(&bound_key) {
                 return None;
             }
         }
         // Check that the variable exists in env as a plain Hash
         // and that it has no container type metadata
-        let env = self.interpreter.env();
+        let env = self.env();
         match env.get(var_name) {
             Some(Value::Hash(hash_arc)) => {
                 let strong_count = Arc::strong_count(hash_arc);
@@ -2577,7 +2573,7 @@ impl VM {
                 if let Some(slot) = local_slot {
                     self.locals[slot] = Value::Nil;
                 }
-                if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(var_name) {
+                if let Some(Value::Hash(hash)) = self.env_mut().get_mut(var_name) {
                     Value::hash_insert_through(
                         &mut Arc::make_mut(hash).map,
                         key.clone(),
@@ -2586,7 +2582,7 @@ impl VM {
                 }
                 // Restore the local slot to point to the (now mutated) env Arc
                 if let Some(slot) = local_slot
-                    && let Some(env_val) = self.interpreter.env().get(var_name).cloned()
+                    && let Some(env_val) = self.env().get(var_name).cloned()
                 {
                     self.locals[slot] = env_val;
                 }
@@ -2706,7 +2702,7 @@ impl VM {
         // (the read op has no variable name to fall back on), so a stale/lost
         // entry silently degrades them to string-keyed lookups returning Nil.
         if let Some(info) = saved_type_meta_outer
-            && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
+            && let Some(container) = self.env().get(&save_var_name).cloned()
             && self
                 .interpreter
                 .container_type_metadata(&container)
@@ -2724,7 +2720,7 @@ impl VM {
             self.locals_set_by_name(code, &save_var_name, tagged);
         }
         if let Some(def) = saved_default_outer
-            && let Some(container) = self.interpreter.env().get(&save_var_name).cloned()
+            && let Some(container) = self.env().get(&save_var_name).cloned()
             && self.interpreter.container_default(&container).is_none()
         {
             let tagged = self.interpreter.tag_container_default(container, def);
@@ -2749,7 +2745,7 @@ impl VM {
         // operate on `%a` directly so in-place mutations are visible.
         let sigilless_alias_target = {
             let alias_key = format!("__mutsu_sigilless_alias::{}", original_var_name);
-            self.interpreter.env().get(&alias_key).and_then(|v| {
+            self.env().get(&alias_key).and_then(|v| {
                 if let Value::Str(target) = v {
                     Some(target.to_string())
                 } else {
@@ -2770,7 +2766,7 @@ impl VM {
         // Capture the old Arc pointer before any mutation so the post-mutation
         // sync code can distinguish stale COW copies from unrelated containers.
         let old_container_arc_ptr: Option<usize> =
-            if let Some(container) = self.interpreter.env().get(&var_name) {
+            if let Some(container) = self.env().get(&var_name) {
                 match container {
                     Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
                     Value::Hash(arc) => Some(Arc::as_ptr(arc) as usize),
@@ -2789,9 +2785,9 @@ impl VM {
         let _target_is_baghash = declared_type.as_deref().is_some_and(|t| t == "BagHash");
         let _target_is_sethash = declared_type.as_deref().is_some_and(|t| t == "SetHash");
         let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
-        let has_declared_shape = self.interpreter.env().contains_key(&declared_shape_key);
+        let has_declared_shape = self.env().contains_key(&declared_shape_key);
         let idx = self.stack.pop().unwrap_or(Value::Nil);
-        let index_target = self.interpreter.env().get(&var_name).cloned();
+        let index_target = self.env().get(&var_name).cloned();
         let idx = self.resolve_whatever_index_for_target(idx, index_target.as_ref());
         // Normalize Seq/Slip/Range index to Array for uniform handling in assignment.
         // For hash variables, expand Range indices into individual keys so that
@@ -2908,7 +2904,7 @@ impl VM {
         // When `my Mix $m; $m<key> = val`, the variable is undefined (Nil or
         // type object) but has an immutable type constraint.
         {
-            let current_val = self.interpreter.env().get(&var_name).cloned();
+            let current_val = self.env().get(&var_name).cloned();
             let is_undefined = current_val.is_none()
                 || matches!(&current_val, Some(Value::Nil))
                 || matches!(&current_val, Some(Value::Package(_)));
@@ -2925,7 +2921,7 @@ impl VM {
             }
         }
         // Immutable List/Range containers - prevent assignment and binding
-        if let Some(target_val) = self.interpreter.env().get(&var_name) {
+        if let Some(target_val) = self.env().get(&var_name) {
             let is_immutable = matches!(
                 target_val,
                 Value::Array(_, crate::value::ArrayKind::List)
@@ -3009,14 +3005,14 @@ impl VM {
             // for an existing non-cell element is stale (e.g. the binding was
             // broken by splice or an array reset) — clean it up; the write
             // proceeds either way (cell writes go through the cell arm).
-            if let Some(Value::Array(items, ..)) = self.interpreter.env().get(&var_name)
+            if let Some(Value::Array(items, ..)) = self.env().get(&var_name)
                 && let Some(i) = Self::index_to_usize(&idx)
                 && matches!(items.get(i), Some(v) if !v.is_container_ref())
             {
                 self.remove_bound_index(&var_name, &encoded_idx);
             }
         }
-        if !self.interpreter.env().contains_key(&var_name)
+        if !self.env().contains_key(&var_name)
             && let Some(slot) = self.find_local_slot(code, &var_name)
         {
             self.set_env_with_main_alias(&var_name, self.locals[slot].clone());
@@ -3037,21 +3033,19 @@ impl VM {
                 let v = junc_vals.get(i).cloned().unwrap_or(Value::Nil);
                 let k = key.to_string_value();
                 if var_name.starts_with('%') {
-                    if !matches!(self.interpreter.env().get(&var_name), Some(Value::Hash(_))) {
-                        self.interpreter.env_mut().insert(
+                    if !matches!(self.env().get(&var_name), Some(Value::Hash(_))) {
+                        self.env_mut().insert(
                             var_name.clone(),
                             Value::hash(std::collections::HashMap::new()),
                         );
                     }
-                    if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(&var_name) {
+                    if let Some(Value::Hash(hash)) = self.env_mut().get_mut(&var_name) {
                         let h = Arc::make_mut(hash);
                         h.insert(k, v);
                     }
                 } else if let Some(idx_usize) = Self::index_to_usize(key) {
                     // For array variables with junction index, use numeric indices
-                    if let Some(Value::Array(items, ..)) =
-                        self.interpreter.env_mut().get_mut(&var_name)
-                    {
+                    if let Some(Value::Array(items, ..)) = self.env_mut().get_mut(&var_name) {
                         let arr = Arc::make_mut(items);
                         if idx_usize >= arr.len() {
                             let fill = native_fill.clone();
@@ -3179,8 +3173,8 @@ impl VM {
                         }
                     }
                 }
-                if !matches!(self.interpreter.env().get(&var_name), Some(Value::Hash(_))) {
-                    self.interpreter.env_mut().insert(
+                if !matches!(self.env().get(&var_name), Some(Value::Hash(_))) {
+                    self.env_mut().insert(
                         var_name.clone(),
                         Value::hash(std::collections::HashMap::new()),
                     );
@@ -3203,7 +3197,7 @@ impl VM {
                         } else if let Some(Some(source_name)) = bind_sources.get(i)
                             && !source_name.contains('\0')
                         {
-                            match self.interpreter.env().get(source_name) {
+                            match self.env().get(source_name) {
                                 Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                                 _ => Some((
                                     Some(source_name.clone()),
@@ -3218,7 +3212,7 @@ impl VM {
                 }
                 let mut pending_source_cells: Vec<(String, Arc<std::sync::Mutex<Value>>)> =
                     Vec::new();
-                if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(&var_name) {
+                if let Some(Value::Hash(hash)) = self.env_mut().get_mut(&var_name) {
                     let h = Arc::make_mut(hash);
                     for (i, key) in keys.iter().enumerate() {
                         let k = if slice_is_object_hash {
@@ -3328,8 +3322,7 @@ impl VM {
                 // Resolve GenericRange with WhateverCode endpoints (e.g. @a[*-4 .. *-1] = ...)
                 let resolved_idx;
                 let idx_for_slice = if let Value::GenericRange { .. } = &idx {
-                    let array_len = if let Some(Value::Array(items, ..)) =
-                        self.interpreter.env().get(&var_name)
+                    let array_len = if let Some(Value::Array(items, ..)) = self.env().get(&var_name)
                     {
                         items.len()
                     } else {
@@ -3364,7 +3357,7 @@ impl VM {
                         }
                     }
                 }
-                if let Some(current) = self.interpreter.env().get(&var_name).cloned()
+                if let Some(current) = self.env().get(&var_name).cloned()
                     && let Value::Mixin(inner, mixins) = current
                 {
                     let mut updated_mixins = (*mixins).clone();
@@ -3397,7 +3390,7 @@ impl VM {
                         }
                     }
                     if assigned_object_slot {
-                        self.interpreter.env_mut().insert(
+                        self.env_mut().insert(
                             var_name.clone(),
                             Value::Mixin(inner, Arc::new(updated_mixins)),
                         );
@@ -3428,7 +3421,7 @@ impl VM {
                     } else if let Some(Some(source_name)) = bind_sources.first()
                         && !source_name.contains('\0')
                     {
-                        match self.interpreter.env().get(source_name) {
+                        match self.env().get(source_name) {
                             Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                             _ => Some((
                                 Some(source_name.clone()),
@@ -3449,7 +3442,7 @@ impl VM {
                 // Type check for parameterized SetHash[T] element binding.
                 // Only applies when the declared type is explicitly parameterized
                 // (e.g. SetHash[Str]), not when the constraint is just `is SetHash`.
-                if let Some(set_val @ Value::Set(..)) = self.interpreter.env().get(&var_name)
+                if let Some(set_val @ Value::Set(..)) = self.env().get(&var_name)
                     && let Some(info) = self.interpreter.container_type_metadata(set_val)
                     && info
                         .declared_type
@@ -3491,7 +3484,7 @@ impl VM {
                     class_name,
                     attributes,
                     ..
-                }) = self.interpreter.env().get(&var_name)
+                }) = self.env().get(&var_name)
                     && self
                         .interpreter
                         .is_container_subclass(&class_name.resolve())
@@ -3515,7 +3508,7 @@ impl VM {
                     if let Some(type_name) = effective_type
                         && matches!(type_name, "MixHash" | "BagHash" | "SetHash")
                         && matches!(
-                            self.interpreter.env().get(&var_name),
+                            self.env().get(&var_name),
                             Some(Value::Nil) | Some(Value::Package(_)) | None
                         )
                     {
@@ -3551,7 +3544,7 @@ impl VM {
                             .insert(var_name.clone(), new_container);
                         self.stack.push(val);
                         // Update local slot
-                        if let Some(new_val) = self.interpreter.env().get(&var_name).cloned() {
+                        if let Some(new_val) = self.env().get(&var_name).cloned() {
                             self.update_local_if_exists(code, &var_name, &new_val);
                         }
                         return Ok(());
@@ -3920,7 +3913,7 @@ impl VM {
         // sync the modified container back to the alias variable so reads
         // of the sigilless variable see the updated value.
         if let Some(ref alias_target) = sigilless_alias_target
-            && let Some(updated_container) = self.interpreter.env().get(alias_target).cloned()
+            && let Some(updated_container) = self.env().get(alias_target).cloned()
         {
             self.interpreter
                 .env_mut()
@@ -3935,7 +3928,7 @@ impl VM {
         if let Some(old_ptr) = old_container_arc_ptr {
             let current = self
                 .get_env_with_main_alias(&var_name)
-                .or_else(|| self.interpreter.env().get(&original_var_name).cloned());
+                .or_else(|| self.env().get(&original_var_name).cloned());
             if let Some(ref container) = current {
                 let new_arc_ptr = match container {
                     Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
@@ -4120,7 +4113,7 @@ impl VM {
             }
         }
 
-        if !self.interpreter.env().contains_key(&var_name) {
+        if !self.env().contains_key(&var_name) {
             // Autovivify the variable as Array if the inner subscript was
             // positional (`[...]`), otherwise as Hash. For sigiled vars
             // (`@x`, `%h`) the sigil already constrains the kind, so this
@@ -4134,7 +4127,7 @@ impl VM {
             } else {
                 Value::hash(std::collections::HashMap::new())
             };
-            self.interpreter.env_mut().insert(var_name.clone(), init);
+            self.env_mut().insert(var_name.clone(), init);
         }
 
         // Handle Array-as-outer-container (e.g. `@array[42][23] = 17`,
@@ -4338,7 +4331,7 @@ impl VM {
     /// mutex data, kept alive by the `Arc` stored in env (see
     /// `descend_container_ref`).
     pub(crate) fn env_root_descended_mut(&mut self, var_name: &str) -> Option<&mut Value> {
-        let root = self.interpreter.env_mut().get_mut(var_name)? as *mut Value;
+        let root = self.env_mut().get_mut(var_name)? as *mut Value;
         let descended = unsafe { Self::descend_container_ref(root) };
         Some(unsafe { &mut *descended })
     }
@@ -4444,7 +4437,7 @@ impl VM {
         }
 
         // Ensure the root variable exists
-        if !self.interpreter.env().contains_key(&var_name) {
+        if !self.env().contains_key(&var_name) {
             let init = if var_name.starts_with('@') {
                 Value::real_array(Vec::new())
             } else if var_name.starts_with('%') {
@@ -4454,13 +4447,13 @@ impl VM {
             } else {
                 Value::hash(std::collections::HashMap::new())
             };
-            self.interpreter.env_mut().insert(var_name.clone(), init);
+            self.env_mut().insert(var_name.clone(), init);
         }
 
         // Walk down the chain of indices, autovivifying containers as needed.
         // We need a mutable reference to the current container at each level.
         // Use raw pointer traversal to avoid borrow checker issues with nested mutation.
-        let root: *mut Value = self.interpreter.env_mut().get_mut(&var_name).unwrap() as *mut Value;
+        let root: *mut Value = self.env_mut().get_mut(&var_name).unwrap() as *mut Value;
 
         let mut current: *mut Value = root;
 
@@ -4669,7 +4662,7 @@ impl VM {
         } else if let Some(source_name) = &bind_source
             && !source_name.contains('\0')
         {
-            match self.interpreter.env().get(source_name) {
+            match self.env().get(source_name) {
                 Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                 _ => Some((
                     Some(source_name.clone()),
@@ -4828,7 +4821,7 @@ impl VM {
                     } else {
                         format!("{pkg}::{key_name}")
                     };
-                    self.interpreter.env_mut().insert(fq, val.clone());
+                    self.env_mut().insert(fq, val.clone());
                 }
                 self.stack.push(val);
             }
@@ -5035,7 +5028,7 @@ impl VM {
         let mut seen = std::collections::HashSet::new();
         while seen.insert(current.clone()) {
             let key = format!("__mutsu_sigilless_alias::{}", current);
-            match self.interpreter.env().get(&key) {
+            match self.env().get(&key) {
                 Some(Value::Str(next)) => {
                     let next = next.to_string();
                     if Self::attr_twigil_base(&next).is_some() {
@@ -5279,7 +5272,7 @@ impl VM {
         let name = code.locals.get(idx).cloned().unwrap_or_default();
         if let Some(bound_to) = self.interpreter.resolve_binding(&name) {
             let bound_to = bound_to.to_string();
-            if let Some(val) = self.interpreter.env().get(&bound_to).cloned() {
+            if let Some(val) = self.env().get(&bound_to).cloned() {
                 self.stack.push(val);
                 return Ok(());
             }
@@ -5288,7 +5281,7 @@ impl VM {
         // value since sync_locals_from_env skips !-prefixed names for performance.
         if name.starts_with('!')
             && self.interpreter.is_shared_var_dirty(&name)
-            && let Some(val) = self.interpreter.env().get(&name).cloned()
+            && let Some(val) = self.env().get(&name).cloned()
         {
             self.locals[idx] = val.clone();
             self.stack.push(val);
@@ -5349,7 +5342,7 @@ impl VM {
                     | Value::Sub(..)
                     | Value::Instance { .. }
             )
-            && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(&name).cloned()
+            && let Some(Value::ContainerRef(arc)) = self.env().get(&name).cloned()
         {
             self.locals[idx] = Value::ContainerRef(arc);
         }
@@ -5398,11 +5391,7 @@ impl VM {
             // in the env (when skip_env_setup is active) but are still valid.
             let is_private_attr =
                 name.starts_with('!') && name.len() > 1 && !name.starts_with("__");
-            if !is_internal
-                && !is_special
-                && !is_private_attr
-                && !self.interpreter.env().contains_key(&name)
-            {
+            if !is_internal && !is_special && !is_private_attr && !self.env().contains_key(&name) {
                 return Err(RuntimeError::new(format!(
                     "X::Undeclared::Symbols: Variable '{name}' is not declared"
                 )));
@@ -5501,19 +5490,16 @@ impl VM {
             // Clear the deleted-index tracker left over from a previous
             // same-named variable in an outer scope.
             let deleted_key = format!("__mutsu_deleted_index::{}", name);
-            self.interpreter.env_mut().remove(&deleted_key);
+            self.env_mut().remove(&deleted_key);
             // Clear any sigilless-readonly flag inherited from an outer
             // scope (e.g. a for-loop `\result` shouldn't block `my $result`
             // in a called sub).
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-            self.interpreter.env_mut().remove(&readonly_key);
+            self.env_mut().remove(&readonly_key);
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it.
-            if matches!(
-                self.interpreter.env().get(name),
-                Some(Value::ContainerRef(_))
-            ) {
+            if matches!(self.env().get(name), Some(Value::ContainerRef(_))) {
                 self.interpreter
                     .env_mut()
                     .insert(name.to_string(), Value::Nil);
@@ -5543,7 +5529,7 @@ impl VM {
             if !is_rebind
                 && !self.locals[idx].is_container_ref()
                 && !is_vardecl
-                && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
+                && let Some(Value::ContainerRef(arc)) = self.env().get(name).cloned()
             {
                 self.locals[idx] = Value::ContainerRef(arc);
             }
@@ -5648,7 +5634,7 @@ impl VM {
                 self.local_bind_pairs.retain(|&(source, _)| source != idx);
                 let mut aliases_to_remove = Vec::new();
                 let prefix = "__mutsu_sigilless_alias::";
-                for (k, v) in self.interpreter.env().iter() {
+                for (k, v) in self.env().iter() {
                     if let Some(_var_name) = k.strip_prefix_str(prefix)
                         && let Value::Str(target) = v
                         && target.as_str() == name
@@ -5657,7 +5643,7 @@ impl VM {
                     }
                 }
                 for k in aliases_to_remove {
-                    self.interpreter.env_mut().remove_sym(k);
+                    self.env_mut().remove_sym(k);
                 }
             }
             // Propagate value to variables bound to this one via `:=` binding.
@@ -5675,7 +5661,7 @@ impl VM {
             // the source is an env variable like `$_`).
             {
                 let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-                if let Some(Value::Str(target)) = self.interpreter.env().get(&alias_key).cloned() {
+                if let Some(Value::Str(target)) = self.env().get(&alias_key).cloned() {
                     let is_co_local = code.locals.iter().any(|n| n == target.as_str());
                     if !is_co_local {
                         self.interpreter
@@ -5686,10 +5672,9 @@ impl VM {
             }
             // Track topic mutations for map rw writeback
             if name == "_" {
-                self.interpreter.env_mut().insert(
-                    "__mutsu_rw_map_topic__".to_string(),
-                    self.locals[idx].clone(),
-                );
+                let topic = self.locals[idx].clone();
+                self.env_mut()
+                    .insert("__mutsu_rw_map_topic__".to_string(), topic);
             }
             self.flush_local_to_env(code, idx);
             return Ok(());
@@ -6151,11 +6136,8 @@ impl VM {
         // declaration (my $x = ...).  A `my` decl creates a fresh variable
         // that shadows the sigilless one, so it must not be blocked.
         if !is_vardecl
-            && matches!(
-                self.interpreter.env().get(&readonly_key),
-                Some(Value::Bool(true))
-            )
-            && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
+            && matches!(self.env().get(&readonly_key), Some(Value::Bool(true)))
+            && !matches!(self.env().get(&alias_key), Some(Value::Str(_)))
         {
             return Err(RuntimeError::assignment_ro(None));
         }
@@ -6171,7 +6153,7 @@ impl VM {
             // so GetLocal alias-following doesn't read the new value.
             let mut aliases_to_remove = Vec::new();
             let prefix = "__mutsu_sigilless_alias::";
-            for (k, v) in self.interpreter.env().iter() {
+            for (k, v) in self.env().iter() {
                 if let Some(_var_name) = k.strip_prefix_str(prefix)
                     && let Value::Str(target) = v
                     && target.as_str() == name
@@ -6180,7 +6162,7 @@ impl VM {
                 }
             }
             for k in aliases_to_remove {
-                self.interpreter.env_mut().remove_sym(k);
+                self.env_mut().remove_sym(k);
             }
         }
         if let Some(source_name) = bind_source {
@@ -6221,7 +6203,7 @@ impl VM {
                 // the bound value in a fresh cell.
                 let cell = match &val {
                     Value::ContainerRef(arc) => arc.clone(),
-                    _ => match self.interpreter.env().get(&resolved_source) {
+                    _ => match self.env().get(&resolved_source) {
                         Some(Value::ContainerRef(arc)) => arc.clone(),
                         _ => std::sync::Arc::new(std::sync::Mutex::new(val.clone())),
                     },
@@ -6340,7 +6322,7 @@ impl VM {
                 // binding sigilless `$x`, also update `!x` so attribute writeback picks it up).
                 let alias_key_for_target = format!("__mutsu_sigilless_alias::{}", name);
                 if let Some(Value::Str(alias_target)) =
-                    self.interpreter.env().get(&alias_key_for_target).cloned()
+                    self.env().get(&alias_key_for_target).cloned()
                     && let Some(alias_idx) =
                         code.locals.iter().rposition(|n| n == alias_target.as_str())
                 {
@@ -6377,7 +6359,7 @@ impl VM {
                     | Value::Sub(..)
                     | Value::Instance { .. }
             )
-            && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
+            && let Some(Value::ContainerRef(arc)) = self.env().get(name).cloned()
         {
             self.locals[idx] = Value::ContainerRef(arc);
         }
@@ -6535,7 +6517,7 @@ impl VM {
                     .insert(format!("{pkg}::term:<{symbol}>"), val.clone());
             }
         }
-        let mut alias_name = self.interpreter.env().get(&alias_key).and_then(|v| {
+        let mut alias_name = self.env().get(&alias_key).and_then(|v| {
             if let Value::Str(name) = v {
                 Some(name.to_string())
             } else {
@@ -6555,7 +6537,7 @@ impl VM {
             // self's shared cell (no-op for non-attribute aliases). Stage 2c (ii).
             self.write_self_attr_cell(&current_alias, val.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
-            alias_name = self.interpreter.env().get(&next_key).and_then(|v| {
+            alias_name = self.env().get(&next_key).and_then(|v| {
                 if let Value::Str(name) = v {
                     Some(name.to_string())
                 } else {
@@ -6633,7 +6615,7 @@ impl VM {
         // first-iteration value. Genuine body-local shadows (`for {...{ my @a }}`)
         // always get a slot, so this distinguishes the two reliably.
         if !self.loop_cond_active
-            && let Some(prev) = self.interpreter.env().get(name).cloned()
+            && let Some(prev) = self.env().get(name).cloned()
         {
             // Only record a *genuine, live* enclosing binding for restoration.
             // The restore writes back both env and the local slot, so the value
@@ -6678,7 +6660,7 @@ impl VM {
         // `&name = Any` before the RHS runs makes `EVAL(q[sub name() { ... }])`
         // look like a routine redeclaration instead of producing a callable to
         // bind into `my &name = ...`.
-        if !name.starts_with('&') && !self.interpreter.env().contains_key(name) {
+        if !name.starts_with('&') && !self.env().contains_key(name) {
             let default = if name.starts_with('@') {
                 Value::real_array(Vec::new())
             } else if name.starts_with('%') {
@@ -6686,7 +6668,7 @@ impl VM {
             } else {
                 Value::Package(crate::symbol::Symbol::intern("Any"))
             };
-            self.interpreter.env_mut().insert(name.to_string(), default);
+            self.env_mut().insert(name.to_string(), default);
         }
         // Track this variable as declared within the current block scope.
         // BlockScope restoration uses this to avoid propagating block-local
@@ -6747,7 +6729,7 @@ impl VM {
                         | Value::Sub(..)
                         | Value::Instance { .. }
                 )
-                && let Some(Value::ContainerRef(arc)) = self.interpreter.env().get(name).cloned()
+                && let Some(Value::ContainerRef(arc)) = self.env().get(name).cloned()
             {
                 self.locals[idx] = Value::ContainerRef(arc);
             }
@@ -6815,10 +6797,9 @@ impl VM {
             }
             // Track topic mutations for map rw writeback
             if name == "_" {
-                self.interpreter.env_mut().insert(
-                    "__mutsu_rw_map_topic__".to_string(),
-                    self.locals[idx].clone(),
-                );
+                let topic = self.locals[idx].clone();
+                self.env_mut()
+                    .insert("__mutsu_rw_map_topic__".to_string(), topic);
             }
             self.flush_local_to_env(code, idx);
             return Ok(());
@@ -6898,10 +6879,8 @@ impl VM {
         }
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        if matches!(
-            self.interpreter.env().get(&readonly_key),
-            Some(Value::Bool(true))
-        ) && !matches!(self.interpreter.env().get(&alias_key), Some(Value::Str(_)))
+        if matches!(self.env().get(&readonly_key), Some(Value::Bool(true)))
+            && !matches!(self.env().get(&alias_key), Some(Value::Str(_)))
         {
             return Err(RuntimeError::assignment_ro(None));
         }
@@ -6939,7 +6918,7 @@ impl VM {
         }
         self.locals[idx] = val.clone();
         self.set_env_with_main_alias(name, val.clone());
-        if let Some(alias_name) = self.interpreter.env().get(&alias_key).and_then(|v| {
+        if let Some(alias_name) = self.env().get(&alias_key).and_then(|v| {
             if let Value::Str(name) = v {
                 Some(name.to_string())
             } else {
@@ -6947,7 +6926,7 @@ impl VM {
             }
         }) {
             self.update_local_if_exists(code, &alias_name, &val);
-            self.interpreter.env_mut().insert(alias_name, val.clone());
+            self.env_mut().insert(alias_name, val.clone());
         }
         if let Some(attr) = name.strip_prefix('.') {
             self.interpreter
@@ -6968,7 +6947,7 @@ impl VM {
             // OUTER:: is lexical, not package-based. Expose captured lexical vars
             // from the current interpreter environment as stash entries.
             let mut entries: HashMap<String, Value> = HashMap::new();
-            for (key, val) in self.interpreter.env().iter() {
+            for (key, val) in self.env().iter() {
                 let key_str = key.resolve();
                 if self.interpreter.should_hide_from_my_global_stash(&key_str) {
                     continue;
@@ -7005,7 +6984,7 @@ impl VM {
             let key = Self::add_sigil_prefix(var_name);
             entries.insert(key, val);
         }
-        for (key, val) in self.interpreter.env().iter() {
+        for (key, val) in self.env().iter() {
             let key_str = key.resolve();
             if self.interpreter.should_hide_from_my_global_stash(&key_str) {
                 continue;
@@ -7021,7 +7000,7 @@ impl VM {
     pub(super) fn build_pseudo_stash(&mut self, code: &CompiledCode, name: &str) -> Value {
         if name == "OUTER" {
             let mut entries: HashMap<String, Value> = HashMap::new();
-            for (key, val) in self.interpreter.env().iter() {
+            for (key, val) in self.env().iter() {
                 let key_str = key.resolve();
                 if self.interpreter.should_hide_from_my_global_stash(&key_str) {
                     continue;
@@ -7050,7 +7029,7 @@ impl VM {
             let key = Self::add_sigil_prefix(var_name);
             entries.insert(key, val);
         }
-        for (key, val) in self.interpreter.env().iter() {
+        for (key, val) in self.env().iter() {
             let key_str = key.resolve();
             if self.interpreter.should_hide_from_my_global_stash(&key_str) {
                 continue;
@@ -7314,7 +7293,7 @@ impl VM {
                 // initial value is correct (the closure may have set the
                 // target via SetGlobal but locals are stale from the frame
                 // restore).
-                let source_val = if let Some(v) = self.interpreter.env().get(&source_name) {
+                let source_val = if let Some(v) = self.env().get(&source_name) {
                     v.clone()
                 } else {
                     self.locals[source_idx].clone()

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -16,13 +16,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let resolved = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 resolved
             }
             Value::Array(items, ..) => {
@@ -62,7 +62,7 @@ impl VM {
             .interpreter
             .var_type_constraint(var_name)
             .unwrap_or_default();
-        let env = self.interpreter.env_mut();
+        let env = self.env_mut();
         let Some(container) = env.get_mut(var_name) else {
             return;
         };
@@ -120,7 +120,7 @@ impl VM {
         {
             return None;
         }
-        let env = self.interpreter.env();
+        let env = self.env();
         match env.get(var_name) {
             Some(Value::Hash(hash_arc)) => {
                 let strong_count = Arc::strong_count(hash_arc);
@@ -142,14 +142,13 @@ impl VM {
                 if let Some(slot) = local_slot {
                     self.locals[slot] = Value::Nil;
                 }
-                let removed =
-                    if let Some(Value::Hash(hash)) = self.interpreter.env_mut().get_mut(var_name) {
-                        Arc::make_mut(hash).remove(&key).unwrap_or(Value::Nil)
-                    } else {
-                        Value::Nil
-                    };
+                let removed = if let Some(Value::Hash(hash)) = self.env_mut().get_mut(var_name) {
+                    Arc::make_mut(hash).remove(&key).unwrap_or(Value::Nil)
+                } else {
+                    Value::Nil
+                };
                 if let Some(slot) = local_slot
-                    && let Some(env_val) = self.interpreter.env().get(var_name).cloned()
+                    && let Some(env_val) = self.env().get(var_name).cloned()
                 {
                     self.locals[slot] = env_val;
                 }
@@ -171,17 +170,17 @@ impl VM {
         // back through the cell (so every alias observes the delete) and restore
         // the cell in env and the local slot.
         let var_name = Self::const_str(code, name_idx).to_string();
-        let bound_cell = match self.interpreter.env().get(&var_name) {
+        let bound_cell = match self.env().get(&var_name) {
             Some(Value::ContainerRef(cell)) => Some(cell.clone()),
             _ => None,
         };
         if let Some(ref cell) = bound_cell {
             let inner = cell.lock().unwrap().clone();
-            self.interpreter.env_mut().insert(var_name.clone(), inner);
+            self.env_mut().insert(var_name.clone(), inner);
         }
         let result = self.exec_delete_index_named_op_inner(code, name_idx);
         if let Some(cell) = bound_cell {
-            if let Some(mutated) = self.interpreter.env().get(&var_name).cloned() {
+            if let Some(mutated) = self.env().get(&var_name).cloned() {
                 *cell.lock().unwrap() = mutated;
             }
             let cell_val = Value::ContainerRef(cell);
@@ -294,7 +293,7 @@ impl VM {
             None
         };
         // Resolve WhateverCode indices (e.g. *-1) for array targets
-        let idx = if let Some(container) = self.interpreter.env().get(&var_name).cloned() {
+        let idx = if let Some(container) = self.env().get(&var_name).cloned() {
             self.resolve_delete_index_for_array(idx, &container)
         } else {
             idx
@@ -315,7 +314,7 @@ impl VM {
                 // Convert index value to a Str containing the WHICH key
                 let which = crate::runtime::utils::value_which_key(&idx);
                 // Check if the hash uses WHICH keys or encoded keys
-                if let Some(Value::Hash(map)) = self.interpreter.env().get(&var_name) {
+                if let Some(Value::Hash(map)) = self.env().get(&var_name) {
                     if map.contains_key(&which) {
                         Value::str(which)
                     } else {
@@ -331,7 +330,7 @@ impl VM {
                     .iter()
                     .map(|k| {
                         let which = crate::runtime::utils::value_which_key(k);
-                        if let Some(Value::Hash(map)) = self.interpreter.env().get(&var_name)
+                        if let Some(Value::Hash(map)) = self.env().get(&var_name)
                             && map.contains_key(&which)
                         {
                             Value::str(which)
@@ -347,7 +346,7 @@ impl VM {
             };
         // Save idx for unmark step (idx is consumed by delete_from_container)
         let idx_for_unmark = idx.clone();
-        let result = if let Some(container) = self.interpreter.env_mut().get_mut(&var_name) {
+        let result = if let Some(container) = self.env_mut().get_mut(&var_name) {
             // Check immutability for Set/Bag/Mix (immutable variants)
             match container {
                 Value::Mix(_, is_mutable) if !*is_mutable => {
@@ -391,7 +390,7 @@ impl VM {
         // embed metadata in `HashData`, so the re-tagged value is written back
         // (no-op Arc for array/instance side-table containers).
         if let Some(info) = saved_meta
-            && let Some(container) = self.interpreter.env().get(&var_name)
+            && let Some(container) = self.env().get(&var_name)
             && self
                 .interpreter
                 .container_type_metadata(container)
@@ -409,16 +408,16 @@ impl VM {
         // don't inherit a leaked default from a same-named variable in an
         // outer scope.
         if let Some(def) = saved_default
-            && let Some(container) = self.interpreter.env().get(&var_name).cloned()
+            && let Some(container) = self.env().get(&var_name).cloned()
             && self.interpreter.container_default(&container).is_none()
         {
             let tagged = self.interpreter.tag_container_default(container, def);
-            self.interpreter.env_mut().insert(var_name.clone(), tagged);
+            self.env_mut().insert(var_name.clone(), tagged);
         }
         // Sync env value to locals so reads through locals see the
         // updated container after delete (Arc::make_mut may have changed
         // the container pointer).
-        if let Some(container) = self.interpreter.env().get(&var_name).cloned() {
+        if let Some(container) = self.env().get(&var_name).cloned() {
             self.locals_set_by_name(code, &var_name, container);
         }
         self.stack.push(result);

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -88,7 +88,7 @@ impl VM {
             // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to
             // Package values so that .WHO/.WHAT etc. work correctly.
             Value::Package(Symbol::intern(name))
-        } else if let Some(v) = self.interpreter.env().get(name) {
+        } else if let Some(v) = self.env().get(name) {
             if matches!(v, Value::Enum { .. } | Value::Nil)
                 || matches!(v, Value::Package(pkg) if pkg.resolve() != name)
             {
@@ -161,7 +161,7 @@ impl VM {
             || Self::is_type_with_smiley(name, &self.interpreter)
         {
             Value::Package(Symbol::intern(Self::resolve_type_alias(name)))
-        } else if let Some(callable) = self.interpreter.env().get(&format!("&{name}")).cloned()
+        } else if let Some(callable) = self.env().get(&format!("&{name}")).cloned()
             && matches!(
                 callable,
                 Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -589,13 +589,13 @@ impl VM {
                             for p in &data.params {
                                 sub_env.insert(p.to_string(), Value::Int(len));
                             }
-                            let saved_env = std::mem::take(self.interpreter.env_mut());
-                            *self.interpreter.env_mut() = sub_env;
+                            let saved_env = std::mem::take(self.env_mut());
+                            *self.env_mut() = sub_env;
                             let result = self
                                 .interpreter
                                 .eval_block_value(&data.body)
                                 .unwrap_or(Value::Nil);
-                            *self.interpreter.env_mut() = saved_env;
+                            *self.env_mut() = saved_env;
                             Some(result)
                         } else {
                             None
@@ -743,13 +743,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 let i = match &idx {
                     Value::Int(i) => Some(*i),
                     Value::Num(n) => Some(*n as i64),
@@ -836,13 +836,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 match &idx {
                     Value::Int(i) if *i < 0 => Self::make_out_of_range_failure(*i),
                     Value::Int(i) => {
@@ -1174,13 +1174,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 let i = match &idx {
                     Value::Int(i) => Some(*i),
                     Value::Num(n) => Some(*n as i64),
@@ -1344,13 +1344,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 // If the WhateverCode returned a Range, use it to slice the array
                 if idx.is_range() {
                     let indices = crate::runtime::utils::value_to_list(&idx);
@@ -1409,13 +1409,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 let i = match &idx {
                     Value::Int(i) => Some(*i),
                     Value::Num(n) => Some(*n as i64),
@@ -1459,13 +1459,13 @@ impl VM {
                             for p in &data.params {
                                 sub_env.insert(p.to_string(), Value::Int(len));
                             }
-                            let saved_env = std::mem::take(self.interpreter.env_mut());
-                            *self.interpreter.env_mut() = sub_env;
+                            let saved_env = std::mem::take(self.env_mut());
+                            *self.env_mut() = sub_env;
                             let result = self
                                 .interpreter
                                 .eval_block_value(&data.body)
                                 .unwrap_or(Value::Nil);
-                            *self.interpreter.env_mut() = saved_env;
+                            *self.env_mut() = saved_env;
                             match result {
                                 Value::Int(i) => i,
                                 _ => 0,
@@ -1505,13 +1505,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(len));
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 let i = match &idx {
                     Value::Int(i) => Some(*i),
                     Value::Num(n) => Some(*n as i64),
@@ -1711,13 +1711,13 @@ impl VM {
                 for p in &data.params {
                     sub_env.insert(p.to_string(), Value::Int(1)); // elems = 1
                 }
-                let saved_env = std::mem::take(self.interpreter.env_mut());
-                *self.interpreter.env_mut() = sub_env;
+                let saved_env = std::mem::take(self.env_mut());
+                *self.env_mut() = sub_env;
                 let idx = self
                     .interpreter
                     .eval_block_value(&data.body)
                     .unwrap_or(Value::Nil);
-                *self.interpreter.env_mut() = saved_env;
+                *self.env_mut() = saved_env;
                 let i = match &idx {
                     Value::Int(i) => Some(*i),
                     Value::Num(n) => Some(*n as i64),

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -220,13 +220,13 @@ impl VM {
             for p in &data.params {
                 sub_env.insert(p.to_string(), Value::Int(len));
             }
-            let saved_env = std::mem::take(self.interpreter.env_mut());
-            *self.interpreter.env_mut() = sub_env;
+            let saved_env = std::mem::take(self.env_mut());
+            *self.env_mut() = sub_env;
             let result = self
                 .interpreter
                 .eval_block_value(&data.body)
                 .unwrap_or(Value::Nil);
-            *self.interpreter.env_mut() = saved_env;
+            *self.env_mut() = saved_env;
             return Some(result);
         }
         if let Value::Rat(n, d) = dim {
@@ -282,7 +282,7 @@ impl VM {
 
         // Check if target is a shaped array - use bounds-checked assignment
         let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
-        let has_declared_shape = self.interpreter.env().contains_key(&declared_shape_key);
+        let has_declared_shape = self.env().contains_key(&declared_shape_key);
         let is_shaped = has_declared_shape
             || self
                 .interpreter
@@ -298,7 +298,7 @@ impl VM {
             .and_then(|v| self.interpreter.container_type_metadata(v));
 
         // Get mutable reference to the target variable
-        if let Some(container) = self.interpreter.env_mut().get_mut(&var_name) {
+        if let Some(container) = self.env_mut().get_mut(&var_name) {
             if is_shaped {
                 // For shaped arrays, use bounds-checked assignment
                 Self::assign_array_multidim(container, &dims, value.clone())?;
@@ -311,7 +311,7 @@ impl VM {
         // pre-assignment copy from locals into env. Without this, shaped
         // array element writes like `@a[i;j] = v` can be silently lost
         // before a closure captures the env (e.g. `start { ... }`).
-        if let Some(updated) = self.interpreter.env().get(&var_name).cloned() {
+        if let Some(updated) = self.env().get(&var_name).cloned() {
             self.update_local_if_exists(code, &var_name, &updated);
         }
 
@@ -319,7 +319,7 @@ impl VM {
         // embed metadata in `HashData`, so the re-tagged value must be written
         // back (no-op Arc for array/instance side-table containers).
         if let Some(info) = old_type_info
-            && let Some(updated) = self.interpreter.env().get(&var_name).cloned()
+            && let Some(updated) = self.env().get(&var_name).cloned()
         {
             let tagged = self.interpreter.tag_container_metadata(updated, info);
             self.interpreter

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -595,7 +595,7 @@ impl VM {
 
     pub(super) fn is_bound_index(&self, var_name: &str, encoded: &str) -> bool {
         let key = format!("__mutsu_bound_index::{}", var_name);
-        if let Some(Value::Hash(map)) = self.interpreter.env().get(&key) {
+        if let Some(Value::Hash(map)) = self.env().get(&key) {
             map.contains_key(encoded)
         } else {
             false
@@ -604,19 +604,19 @@ impl VM {
 
     pub(super) fn mark_bound_index(&mut self, var_name: &str, encoded: String) {
         let key = format!("__mutsu_bound_index::{}", var_name);
-        if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+        if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
             Arc::make_mut(map).insert(encoded, Value::Bool(true));
             return;
         }
         let mut map = std::collections::HashMap::new();
         map.insert(encoded, Value::Bool(true));
-        self.interpreter.env_mut().insert(key, Value::hash(map));
+        self.env_mut().insert(key, Value::hash(map));
     }
 
     /// Remove a bound-index marker (e.g. after splice breaks the binding).
     pub(super) fn remove_bound_index(&mut self, var_name: &str, encoded: &str) {
         let key = format!("__mutsu_bound_index::{}", var_name);
-        if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+        if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
             Arc::make_mut(map).remove(encoded);
         }
     }
@@ -626,18 +626,18 @@ impl VM {
         // `:exists` checks report the slot as present again.
         {
             let deleted_key = format!("__mutsu_deleted_index::{}", var_name);
-            if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&deleted_key) {
+            if let Some(Value::Hash(map)) = self.env_mut().get_mut(&deleted_key) {
                 Arc::make_mut(map).remove(&encoded);
             }
         }
         let key = format!("__mutsu_initialized_index::{}", var_name);
-        if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+        if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
             Arc::make_mut(map).insert(encoded, Value::Bool(true));
             return;
         }
         let mut map = std::collections::HashMap::new();
         map.insert(encoded, Value::Bool(true));
-        self.interpreter.env_mut().insert(key, Value::hash(map));
+        self.env_mut().insert(key, Value::hash(map));
     }
 
     /// Mark the given indices as deleted. `:exists` on an array consults
@@ -645,14 +645,14 @@ impl VM {
     /// as missing even though the slot value is not `Nil`.
     pub(super) fn mark_deleted_indices(&mut self, var_name: &str, idx: &Value) {
         let key = format!("__mutsu_deleted_index::{}", var_name);
-        let map = if let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) {
+        let map = if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
             Arc::make_mut(map)
         } else {
             let m = std::collections::HashMap::new();
             self.interpreter
                 .env_mut()
                 .insert(key.clone(), Value::hash(m));
-            match self.interpreter.env_mut().get_mut(&key) {
+            match self.env_mut().get_mut(&key) {
                 Some(Value::Hash(map)) => Arc::make_mut(map),
                 _ => return,
             }
@@ -663,7 +663,7 @@ impl VM {
     #[allow(dead_code)]
     pub(super) fn unmark_deleted_indices(&mut self, var_name: &str, idx: &Value) {
         let key = format!("__mutsu_deleted_index::{}", var_name);
-        let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) else {
+        let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
             return;
         };
         let m = Arc::make_mut(map);
@@ -673,7 +673,7 @@ impl VM {
     pub(super) fn is_deleted_index(&self, var_name: &str, idx: i64) -> bool {
         let key = format!("__mutsu_deleted_index::{}", var_name);
         matches!(
-            self.interpreter.env().get(&key),
+            self.env().get(&key),
             Some(Value::Hash(map)) if map.contains_key(&idx.to_string())
         )
     }
@@ -711,7 +711,7 @@ impl VM {
     /// This must be called after array element deletion to sever bindings.
     pub(super) fn unmark_bound_indices(&mut self, var_name: &str, idx: &Value) {
         let key = format!("__mutsu_bound_index::{}", var_name);
-        let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) else {
+        let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
             return;
         };
         let m = Arc::make_mut(map);
@@ -724,7 +724,7 @@ impl VM {
     /// as holes and can be trimmed.
     pub(super) fn unmark_initialized_indices(&mut self, var_name: &str, idx: &Value) {
         let key = format!("__mutsu_initialized_index::{}", var_name);
-        let Some(Value::Hash(map)) = self.interpreter.env_mut().get_mut(&key) else {
+        let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
             return;
         };
         let m = Arc::make_mut(map);


### PR DESCRIPTION
## CP-1 step 1b (PR #1) — VM env seam

Second slice of CP-1 (env-loan). Introduces the **seam** that every VM env access goes through, so step 1e can flip the env home to a VM-owned field in one place.

### What changed (behavior-invariant)
- Add 5 forwarding accessors on `VM`: `env()`, `env_mut()`, `clone_env()`, `set_env()`, `take_env()` — all forward to `self.interpreter` for now.
- Migrate **every** env access inside `src/vm/` (513 `self.interpreter.env()`/`env_mut()` sites + `clone_env`/`set_env`/`take_env`) to the accessors.
- Only **2 borrow conflicts** surfaced (`env_mut().insert(_, self.locals[idx].clone())`); fixed by hoisting the value into a local. This folds the planned step 1c into this PR.

Since the accessors still return `&self.interpreter.env`, there is **no runtime behavior change**.

### Verification
- `cargo build` + `cargo clippy --lib` clean.
- `make test` PASS (797 files / 7425 tests; cargo test 461 passed / 0 failed).
- Targeted env-heavy roast green: `let`, `subset-6c`/`6e`, `eval_lex`, `in-eval`, `pointy-rw`, `given`, `class/basic`, `sort`, `multi/proto`, `magicals/sub`, `modifier/pos`. (The only failing file in the sample, `S17-supply/syntax.t`, is non-whitelisted unimplemented Supply concurrency, fails identically and unrelated to env access.)

### Deferred to 1b follow-up
External driver sites in `runtime/resolution.rs` (`vm.interpreter().env()` / `vm.interpreter_mut().env_insert()` in the map/sort `run_reuse` loops) still reach env through the interpreter; they move to `vm.env()`/`vm.env_mut()` before the 1e flip.

Design: `docs/vm-state-ownership.md` → "CP-1 env-loan 設計（確定）".

🤖 Generated with [Claude Code](https://claude.com/claude-code)