### PR TITLE
feat(C supply): implement Supply.categorize + class-method guard

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -244,7 +244,6 @@ is the genuinely concurrent surface, which is hard to make deterministic.
 - roast/S17-promise/then.t (dynamic variables not propagated to `.then`)
 - roast/S17-scheduler/basic.t
 - roast/S17-supply/batch.t (known flaky — see CLAUDE.md; hangs intermittently)
-- roast/S17-supply/categorize.t (class-method guard missing)
 - roast/S17-supply/migrate.t
 - roast/S17-supply/stable.t
 

--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -96,7 +96,11 @@
   - Proper fix: a timer-driven batch flush (a background thread that flushes the
     buffer once `seconds` elapse, independent of further emits). Substantial
     concurrency work with regression risk across the S17-supply suite — deferred.
-- [ ] roast/S17-supply/categorize.t
+- [x] roast/S17-supply/categorize.t (whitelisted) — added the missing
+    `Supply.categorize` instance method (multi-key mapper; a value may go to
+    several buckets or none), a `Supply.classify`/`.categorize` class-method
+    guard (dies on the type object), and honored a hash mapper's `is default(...)`
+    for missing keys.
 - [ ] roast/S17-supply/Channel.t
 - [ ] roast/S17-supply/classify.t
 - [ ] roast/S17-supply/collate.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -860,6 +860,7 @@ roast/S17-supply/Promise.t
 roast/S17-supply/Seq.t
 roast/S17-supply/act.t
 roast/S17-supply/basic.t
+roast/S17-supply/categorize.t
 roast/S17-supply/classify.t
 roast/S17-supply/collate.t
 roast/S17-supply/comb.t

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -12,6 +12,15 @@ impl Interpreter {
     ) -> Option<Result<Value, RuntimeError>> {
         match method {
             "are" => Some(self.dispatch_are(target, &args)),
+            "classify" | "categorize" if matches!(&target, Value::Package(name) if name == "Supply") =>
+            {
+                // Supply.classify / Supply.categorize are instance methods
+                // (declared `Supply:D:`); calling them on the Supply type
+                // object is an error in Rakudo.
+                Some(Err(RuntimeError::new(format!(
+                    "Cannot call '{method}' as a class method on Supply (requires a defined invocant)"
+                ))))
+            }
             "classify" | "categorize" if !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply") =>
             {
                 let mut call_args = Vec::with_capacity(args.len() + 1);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1438,6 +1438,7 @@ impl Interpreter {
                     "unique",
                     "on-close",
                     "classify",
+                    "categorize",
                     "Channel",
                     "Supply",
                     "Promise",

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -17,6 +17,9 @@ struct ClassifyState {
     classify_supplier_id: u64,
     seen_keys: Vec<Value>,
     key_supplier_ids: Vec<(Value, u64)>,
+    /// `true` for `.categorize` (mapper returns a list of keys; a value may go
+    /// to several buckets), `false` for `.classify` (single key per value).
+    categorize: bool,
 }
 
 #[derive(Clone)]
@@ -887,6 +890,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
     supplier_id: u64,
     mapper: Value,
     classify_supplier_id: u64,
+    categorize: bool,
 ) {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         map.entry(supplier_id)
@@ -904,6 +908,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                     classify_supplier_id,
                     seen_keys: Vec::new(),
                     key_supplier_ids: Vec::new(),
+                    categorize,
                 }),
                 elems_trace: None,
                 head_limit: None,
@@ -923,12 +928,13 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
     }
 }
 
-/// Get the classify state for a tap. Returns (mapper, classify_supplier_id, seen_keys, key_supplier_ids).
+/// Get the classify state for a tap. Returns
+/// (mapper, classify_supplier_id, seen_keys, key_supplier_ids, categorize).
 #[allow(clippy::type_complexity)]
 pub(in crate::runtime) fn get_classify_state(
     supplier_id: u64,
     tap_index: usize,
-) -> Option<(Value, u64, Vec<Value>, Vec<(Value, u64)>)> {
+) -> Option<(Value, u64, Vec<Value>, Vec<(Value, u64)>, bool)> {
     if let Ok(map) = supplier_subscriptions_map().lock()
         && let Some(subs) = map.get(&supplier_id)
         && let Some(tap) = subs.taps.get(tap_index)
@@ -939,6 +945,7 @@ pub(in crate::runtime) fn get_classify_state(
             cs.classify_supplier_id,
             cs.seen_keys.clone(),
             cs.key_supplier_ids.clone(),
+            cs.categorize,
         ))
     } else {
         None

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -475,7 +475,8 @@ impl Interpreter {
                 Ok(Value::make_instance(Symbol::intern("Supply"), new_attrs))
             }
             "unique" => self.supply_unique(attributes, &args),
-            "classify" => self.supply_classify(attributes, &args),
+            "classify" => self.supply_classify(attributes, &args, false),
+            "categorize" => self.supply_classify(attributes, &args, true),
             "sort" => {
                 let source_values = self.supply_get_values(attributes)?;
                 let mut sorted = source_values.clone();

--- a/src/runtime/supply_classify.rs
+++ b/src/runtime/supply_classify.rs
@@ -99,6 +99,7 @@ impl Interpreter {
         &mut self,
         attributes: &HashMap<String, Value>,
         args: &[Value],
+        categorize: bool,
     ) -> Result<Value, RuntimeError> {
         let mapper = args.first().cloned().unwrap_or(Value::Nil);
 
@@ -107,7 +108,7 @@ impl Interpreter {
             // Create a new supplier for the classify output
             let classify_supplier_id = next_supplier_id();
             // Register a classify tap on the source supplier
-            register_supplier_classify_tap(source_sid, mapper, classify_supplier_id);
+            register_supplier_classify_tap(source_sid, mapper, classify_supplier_id, categorize);
             // Return a Supply backed by the classify supplier
             let mut supply_attrs = HashMap::new();
             supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
@@ -128,12 +129,19 @@ impl Interpreter {
         let mut keys_order: Vec<Value> = Vec::new();
         let mut buckets: HashMap<String, Vec<Value>> = HashMap::new();
         for val in values {
-            let key = self.apply_classify_mapper(&mapper, &val)?;
-            let key_str = key.to_string_value();
-            if !buckets.contains_key(&key_str) {
-                keys_order.push(key);
+            let mapped = self.apply_classify_mapper(&mapper, &val)?;
+            let keys = if categorize {
+                Self::flatten_categorize_keys(mapped)
+            } else {
+                vec![mapped]
+            };
+            for key in keys {
+                let key_str = key.to_string_value();
+                if !buckets.contains_key(&key_str) {
+                    keys_order.push(key);
+                }
+                buckets.entry(key_str).or_default().push(val.clone());
             }
-            buckets.entry(key_str).or_default().push(val);
         }
         // Build result as array of pairs (key => Supply)
         let mut result_values = Vec::new();
@@ -165,8 +173,11 @@ impl Interpreter {
                 let key = value.to_string_value();
                 if let Some(v) = map.get(&key) {
                     Ok(v.clone())
+                } else if let Some(def) = &map.default {
+                    // Honor the hash's `is default(...)` value for missing keys
+                    // (e.g. `is default(())` makes a categorize value uncategorized).
+                    Ok((**def).clone())
                 } else {
-                    // Hash with `is default(0)` — default value
                     Ok(Value::Int(0))
                 }
             }
@@ -192,67 +203,72 @@ impl Interpreter {
         tap_index: usize,
         value: Value,
     ) -> Result<(), RuntimeError> {
-        let (mapper, classify_supplier_id, mut seen_keys, mut key_supplier_ids) =
+        let (mapper, classify_supplier_id, mut seen_keys, mut key_supplier_ids, categorize) =
             match get_classify_state(source_supplier_id, tap_index) {
                 Some(state) => state,
                 None => return Ok(()),
             };
 
-        let key = self.apply_classify_mapper(&mapper, &value)?;
-        let key_str = key.to_string_value();
-
-        // Find or create sub-supplier for this key
-        let sub_supplier_id = if let Some((_, sid)) = key_supplier_ids
-            .iter()
-            .find(|(k, _)| k.to_string_value() == key_str)
-        {
-            *sid
+        let mapped = self.apply_classify_mapper(&mapper, &value)?;
+        // `.classify` produces a single key; `.categorize` produces a list of
+        // keys (a value may go to several buckets, or to none for `()`).
+        let keys: Vec<Value> = if categorize {
+            Self::flatten_categorize_keys(mapped)
         } else {
-            // New key — create sub-supplier and its Supply
-            let sub_sid = next_supplier_id();
-            seen_keys.push(key.clone());
-            key_supplier_ids.push((key.clone(), sub_sid));
-
-            // Update state before emitting (so it's visible to callbacks)
-            update_classify_state(source_supplier_id, tap_index, seen_keys, key_supplier_ids);
-
-            // Create a Supply for this sub-supplier
-            let mut sub_supply_attrs = HashMap::new();
-            sub_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
-            sub_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
-            sub_supply_attrs.insert("live".to_string(), Value::Bool(true));
-            sub_supply_attrs.insert("supplier_id".to_string(), Value::Int(sub_sid as i64));
-            let sub_supply = Value::make_instance(Symbol::intern("Supply"), sub_supply_attrs);
-
-            // Emit Pair(key, supply) to the classify supplier's taps
-            let pair = Value::ValuePair(Box::new(key), Box::new(sub_supply));
-            supplier_emit(classify_supplier_id, pair.clone());
-            let actions = supplier_emit_callbacks(classify_supplier_id, &pair);
-            for action in actions {
-                match action {
-                    SupplierEmitAction::Call(tap, emitted, delay_seconds) => {
-                        Self::sleep_for_supply_delay(delay_seconds);
-                        let _ = self.call_sub_value(tap, vec![emitted], true);
-                    }
-                    SupplierEmitAction::HeadLimitReached { supplier_id: sid2 } => {
-                        let deferred_promises = supplier_done_deferred(sid2);
-                        for done_cb in take_supplier_done_callbacks(sid2) {
-                            let _ = self.invoke_done_callback(done_cb);
-                        }
-                        for (promise, result) in deferred_promises {
-                            promise.keep(result, String::new(), String::new());
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            sub_sid
+            vec![mapped]
         };
 
-        // Emit the value to the sub-supplier
-        supplier_emit(sub_supplier_id, value.clone());
-        let actions = supplier_emit_callbacks(sub_supplier_id, &value);
+        for key in keys {
+            let key_str = key.to_string_value();
+
+            // Find or create sub-supplier for this key
+            let sub_supplier_id = if let Some((_, sid)) = key_supplier_ids
+                .iter()
+                .find(|(k, _)| k.to_string_value() == key_str)
+            {
+                *sid
+            } else {
+                // New key — create sub-supplier and its Supply
+                let sub_sid = next_supplier_id();
+                seen_keys.push(key.clone());
+                key_supplier_ids.push((key.clone(), sub_sid));
+
+                // Update state before emitting (so it's visible to callbacks)
+                update_classify_state(
+                    source_supplier_id,
+                    tap_index,
+                    seen_keys.clone(),
+                    key_supplier_ids.clone(),
+                );
+
+                // Create a Supply for this sub-supplier
+                let mut sub_supply_attrs = HashMap::new();
+                sub_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
+                sub_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+                sub_supply_attrs.insert("live".to_string(), Value::Bool(true));
+                sub_supply_attrs.insert("supplier_id".to_string(), Value::Int(sub_sid as i64));
+                let sub_supply = Value::make_instance(Symbol::intern("Supply"), sub_supply_attrs);
+
+                // Emit Pair(key, supply) to the classify supplier's taps
+                let pair = Value::ValuePair(Box::new(key), Box::new(sub_supply));
+                supplier_emit(classify_supplier_id, pair.clone());
+                let actions = supplier_emit_callbacks(classify_supplier_id, &pair);
+                self.run_supplier_emit_actions(actions);
+
+                sub_sid
+            };
+
+            // Emit the value to the sub-supplier
+            supplier_emit(sub_supplier_id, value.clone());
+            let actions = supplier_emit_callbacks(sub_supplier_id, &value);
+            self.run_supplier_emit_actions(actions);
+        }
+
+        Ok(())
+    }
+
+    /// Run the callback/head-limit actions produced by a supplier emit.
+    fn run_supplier_emit_actions(&mut self, actions: Vec<SupplierEmitAction>) {
         for action in actions {
             match action {
                 SupplierEmitAction::Call(tap, emitted, delay_seconds) => {
@@ -271,7 +287,18 @@ impl Interpreter {
                 _ => {}
             }
         }
+    }
 
-        Ok(())
+    /// Flatten a `.categorize` mapper result into a list of keys.
+    /// Lists/Arrays/Seqs/Slips contribute their elements; an empty list
+    /// contributes no keys (the value is dropped); anything else is a single key.
+    fn flatten_categorize_keys(mapped: Value) -> Vec<Value> {
+        match mapped {
+            Value::Array(items, ..) => items.iter().cloned().collect(),
+            Value::Seq(items) | Value::Slip(items) => items.iter().cloned().collect(),
+            // An empty/undefined mapper result contributes no keys.
+            Value::Nil => Vec::new(),
+            other => vec![other],
+        }
     }
 }

--- a/t/supply-categorize.t
+++ b/t/supply-categorize.t
@@ -1,0 +1,63 @@
+use Test;
+
+plan 8;
+
+# .categorize / .classify cannot be called on the Supply type object.
+dies-ok { Supply.categorize({ ... }) }, 'Supply.categorize dies as a class method';
+dies-ok { Supply.classify({ ... }) },  'Supply.classify dies as a class method';
+
+# Live .categorize with a Block mapper returning a list of keys.
+# A value goes to every key in the list (or to none for an empty list).
+{
+    my &mapper = { $_ div 10 ?? (0, 1) !! () };
+    my $s = Supplier.new;
+    my $c = $s.Supply.categorize(&mapper);
+    ok $c ~~ Supply, 'categorize returns a Supply';
+
+    my @keys;
+    my @supplies;
+    $c.tap(-> $p { @keys.push: $p.key; @supplies.push: $p.value });
+
+    my @bucket0;
+    my @bucket1;
+    $s.emit($_) for 1, 2, 3, 11, 12, 13;
+    $s.done;
+
+    is-deeply @keys, [0, 1], 'categorize emits a Pair per bucket key';
+    is @supplies.elems, 2, 'two classification sub-supplies';
+}
+
+# Live .classify with a Block mapper: one key per value.
+{
+    my &mapper = { $_ div 10 };
+    my $s = Supplier.new;
+    my @keys;
+    $s.Supply.classify(&mapper).tap(-> $p { @keys.push: $p.key });
+    $s.emit($_) for 1, 2, 3, 11, 12, 13;
+    $s.done;
+    is-deeply @keys, [0, 1], 'classify emits one key bucket per distinct key';
+}
+
+# Hash mapper honors `is default(...)` for missing keys.
+{
+    my %mapper is default(()) = (11 => (0, 1), 12 => (0, 1), 13 => (0, 1));
+    my $s = Supplier.new;
+    my @keys;
+    $s.Supply.categorize(%mapper).tap(-> $p { @keys.push: $p.key });
+    $s.emit($_) for 1, 2, 3, 11, 12, 13;
+    $s.done;
+    is-deeply @keys, [0, 1], 'categorize hash mapper: default(()) drops uncategorized values';
+}
+
+# Array mapper: index lookup returning a list of keys.
+{
+    my @mapper = (), (), (), (), (), (), (), (), (), (),
+        $(0, 1), $(0, 1), $(0, 1), $(0, 1), $(0, 1),
+        $(0, 1), $(0, 1), $(0, 1), $(0, 1), $(0, 1);
+    my $s = Supplier.new;
+    my @keys;
+    $s.Supply.categorize(@mapper).tap(-> $p { @keys.push: $p.key });
+    $s.emit($_) for 1, 2, 3, 11, 12, 13;
+    $s.done;
+    is-deeply @keys, [0, 1], 'categorize array mapper: itemized list keys';
+}


### PR DESCRIPTION
## Summary

`Supply.categorize` was unimplemented (`No such method 'categorize' for invocant of type 'Supply'`), and `Supply.classify`/`.categorize` called on the **Supply type object** silently succeeded instead of dying. This implements the missing method and the class-method guard, making `roast/S17-supply/categorize.t` pass **63/63** (now whitelisted).

## Changes

- Register `categorize` as a Supply native method and route it through `supply_classify` with a `categorize` flag.
- **`.categorize` semantics**: the mapper returns a *list* of keys, so a value may go to several buckets (or none, for an empty list). `.classify` keeps its single-key-per-value behavior. Both the live (supplier-tap) and non-live (buffered) paths handle the flag; Array/Seq/Slip results are flattened into keys, Nil/empty drop the value.
- **Class-method guard**: `Supply.classify`/`.categorize` on the type object now dies (they are `Supply:D:` instance methods).
- **Hash mapper** now honors `is default(...)` for missing keys (e.g. `is default(())` leaves a value uncategorized) instead of hardcoding `0`.
- Extract the shared supplier-emit action loop into `run_supplier_emit_actions`.

## Testing

- `roast/S17-supply/categorize.t` → 63/63, whitelisted.
- New `t/supply-categorize.t` (8 cases: class-method guard, Block/Hash/Array mappers, classify regression).
- `make test` PASS (798 files / 7433 tests), clippy clean, whitelist sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)