### PR TITLE
perf(value): box Capture and BigRat payloads to shrink Value 72→64 (ANALYSIS §5)

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -165,7 +165,7 @@ fn to_big_rat_parts(value: &Value) -> Option<(NumBigInt, NumBigInt)> {
         Value::Int(i) => Some((NumBigInt::from(*i), NumBigInt::from(1))),
         Value::BigInt(i) => Some(((**i).clone(), NumBigInt::from(1))),
         Value::Rat(n, d) | Value::FatRat(n, d) => Some((NumBigInt::from(*n), NumBigInt::from(*d))),
-        Value::BigRat(n, d) => Some((n.clone(), d.clone())),
+        Value::BigRat(n, d) => Some(((**n).clone(), (**d).clone())),
         _ => None,
     }
 }
@@ -1267,9 +1267,9 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                         Value::BigRat(bn, bd) => {
                             // Check if denom fits in i64 (numerator can be big)
                             if let Some(d64) = bd.to_i64() {
-                                Value::BigRat(bn, NumBigInt::from(d64))
+                                Value::bigrat(*bn, NumBigInt::from(d64))
                             } else {
-                                Value::Num(bigint_ratio_to_f64(&bn, &bd))
+                                Value::Num(bigint_ratio_to_f64(bn.as_ref(), bd.as_ref()))
                             }
                         }
                         other => other,
@@ -1287,9 +1287,9 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                         Value::Rat(rn, rd) => Value::Rat(rn, rd),
                         Value::BigRat(bn, bd) => {
                             if let Some(d64) = bd.to_i64() {
-                                Value::BigRat(bn, NumBigInt::from(d64))
+                                Value::bigrat(*bn, NumBigInt::from(d64))
                             } else {
-                                Value::Num(bigint_ratio_to_f64(&bn, &bd))
+                                Value::Num(bigint_ratio_to_f64(bn.as_ref(), bd.as_ref()))
                             }
                         }
                         other => other,
@@ -1447,9 +1447,9 @@ pub(crate) fn arith_negate(val: Value) -> Result<Value, RuntimeError> {
         }
         Value::BigRat(ref n, ref d) => {
             if is_fat_rat_like(&val) {
-                Ok(make_big_fat_rat(-n.clone(), d.clone()))
+                Ok(make_big_fat_rat(-(**n).clone(), (**d).clone()))
             } else {
-                Ok(make_big_rat_arith(-n.clone(), d.clone()))
+                Ok(make_big_rat_arith(-(**n).clone(), (**d).clone()))
             }
         }
         Value::Complex(r, i) => {

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -10,14 +10,14 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
         "numerator" => match target {
             Value::Rat(n, _) => Some(Ok(Value::Int(*n))),
             Value::FatRat(n, _) => Some(Ok(Value::Int(*n))),
-            Value::BigRat(n, _) => Some(Ok(Value::BigInt(std::sync::Arc::new(n.clone())))),
+            Value::BigRat(n, _) => Some(Ok(Value::BigInt(std::sync::Arc::new((**n).clone())))),
             Value::Int(i) => Some(Ok(Value::Int(*i))),
             _ => Some(Ok(Value::Int(0))),
         },
         "denominator" => match target {
             Value::Rat(_, d) => Some(Ok(Value::Int(*d))),
             Value::FatRat(_, d) => Some(Ok(Value::Int(*d))),
-            Value::BigRat(_, d) => Some(Ok(Value::BigInt(std::sync::Arc::new(d.clone())))),
+            Value::BigRat(_, d) => Some(Ok(Value::BigInt(std::sync::Arc::new((**d).clone())))),
             Value::Int(_) => Some(Ok(Value::Int(1))),
             _ => Some(Ok(Value::Int(1))),
         },
@@ -31,8 +31,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Value::Rat(n, d) => Some(Ok(Value::array(vec![Value::Int(*n), Value::Int(*d)]))),
             Value::FatRat(n, d) => Some(Ok(Value::array(vec![Value::Int(*n), Value::Int(*d)]))),
             Value::BigRat(n, d) => Some(Ok(Value::array(vec![
-                Value::BigInt(std::sync::Arc::new(n.clone())),
-                Value::BigInt(std::sync::Arc::new(d.clone())),
+                Value::BigInt(std::sync::Arc::new((**n).clone())),
+                Value::BigInt(std::sync::Arc::new((**d).clone())),
             ]))),
             Value::Int(i) => Some(Ok(Value::array(vec![Value::Int(*i), Value::Int(1)]))),
             _ => Some(Ok(Value::array(vec![Value::Int(0), Value::Int(1)]))),
@@ -43,9 +43,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Value::Rat(nn, dd) => Value::FatRat(nn, dd),
                 other => other,
             })),
-            Value::BigRat(n, d) => Some(Ok(match make_big_fat_rat(n.clone(), d.clone()) {
+            Value::BigRat(n, d) => Some(Ok(match make_big_fat_rat((**n).clone(), (**d).clone()) {
                 Value::Rat(nn, dd) => Value::FatRat(nn, dd),
-                Value::BigRat(nn, dd) => Value::BigRat(nn, dd),
+                Value::BigRat(nn, dd) => Value::bigrat(*nn, *dd),
                 other => other,
             })),
             Value::Int(i) => Some(Ok(Value::FatRat(*i, 1))),
@@ -126,11 +126,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 num_traits::ToPrimitive::to_f64(n.as_ref()).unwrap_or(f64::INFINITY),
                 0.0,
             ))),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => Some(Ok(Value::Complex(
-                num_traits::ToPrimitive::to_f64(n).unwrap_or(0.0)
-                    / num_traits::ToPrimitive::to_f64(d).unwrap_or(1.0),
-                0.0,
-            ))),
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => {
+                Some(Ok(Value::Complex(
+                    num_traits::ToPrimitive::to_f64(n.as_ref()).unwrap_or(0.0)
+                        / num_traits::ToPrimitive::to_f64(d.as_ref()).unwrap_or(1.0),
+                    0.0,
+                )))
+            }
             _ => Some(Ok(Value::Complex(0.0, 0.0))),
         },
         "Pair" => match target {
@@ -588,6 +590,7 @@ pub(crate) fn value_is_prime(target: &Value) -> Result<Value, RuntimeError> {
             Ok(Value::Bool(is_prime_i64(int_val)))
         }
         Value::BigRat(n, d) => {
+            let (n, d) = (n.as_ref(), d.as_ref());
             use num_traits::Zero;
             if d.is_zero() {
                 return Ok(Value::Bool(false));
@@ -670,19 +673,13 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             let mut named = HashMap::new();
             named.insert("key".to_string(), Value::str(k.clone()));
             named.insert("value".to_string(), *v.clone());
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         Value::ValuePair(k, v) => {
             let mut named = HashMap::new();
             named.insert("key".to_string(), *k.clone());
             named.insert("value".to_string(), *v.clone());
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Set.Capture → named args where each key maps to True
         Value::Set(s, _) => {
@@ -690,10 +687,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             for k in s.iter() {
                 named.insert(k.clone(), Value::Bool(true));
             }
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Bag.Capture → named args where each key maps to its count
         Value::Bag(b, _) => {
@@ -701,10 +695,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             for (k, v) in b.iter() {
                 named.insert(k.clone(), Value::Int(*v));
             }
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Mix.Capture → named args where each key maps to its weight
         Value::Mix(m, _) => {
@@ -718,10 +709,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                 };
                 named.insert(k.clone(), val);
             }
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Hash.Capture → named args from hash entries
         Value::Hash(map) => {
@@ -729,10 +717,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             for (k, v) in map.iter() {
                 named.insert(k.clone(), v.clone());
             }
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Lazy arrays must throw X::Cannot::Lazy
         Value::Array(_, kind) if kind.is_lazy() => Err(RuntimeError::cannot_lazy_with_action(
@@ -754,7 +739,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                     _ => positional.push(item.clone()),
                 }
             }
-            Ok(Value::Capture { positional, named })
+            Ok(Value::capture(positional, named))
         }
         Value::Seq(items) | Value::Slip(items) => {
             let mut positional = vec![];
@@ -770,7 +755,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                     _ => positional.push(item.clone()),
                 }
             }
-            Ok(Value::Capture { positional, named })
+            Ok(Value::capture(positional, named))
         }
         Value::LazyList(ll) => {
             // A LazyList is considered lazy if it has a body or compiled code
@@ -796,7 +781,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                         _ => positional.push(item.clone()),
                     }
                 }
-                Ok(Value::Capture { positional, named })
+                Ok(Value::capture(positional, named))
             }
         }
         // Range.Capture → Mu.Capture semantics (named args from attributes)
@@ -822,10 +807,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                 )),
             );
             named.insert("is-int".to_string(), Value::Bool(true));
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         Value::GenericRange {
             start,
@@ -841,16 +823,10 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             let is_int = matches!(&**start, Value::Int(_) | Value::BigInt(_))
                 && matches!(&**end, Value::Int(_) | Value::BigInt(_));
             named.insert("is-int".to_string(), Value::Bool(is_int));
-            Ok(Value::Capture {
-                positional: vec![],
-                named,
-            })
+            Ok(Value::capture(vec![], named))
         }
         // Nil.Capture → empty capture
-        Value::Nil => Ok(Value::Capture {
-            positional: vec![],
-            named: HashMap::new(),
-        }),
+        Value::Nil => Ok(Value::capture(vec![], HashMap::new())),
         // Types whose .Capture throws X::Cannot::Capture
         Value::Bool(_)
         | Value::Str(_)
@@ -870,17 +846,11 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             match type_name.as_str() {
                 "IntStr" | "NumStr" | "RatStr" | "ComplexStr" | "WhateverCode" | "Signature"
                 | "Version" => Err(cannot_capture(&type_name)),
-                _ => Ok(Value::Capture {
-                    positional: vec![target.clone()],
-                    named: HashMap::new(),
-                }),
+                _ => Ok(Value::capture(vec![target.clone()], HashMap::new())),
             }
         }
         // Default: wrap in a single-positional capture
-        _ => Ok(Value::Capture {
-            positional: vec![target.clone()],
-            named: HashMap::new(),
-        }),
+        _ => Ok(Value::capture(vec![target.clone()], HashMap::new())),
     }
 }
 

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -387,7 +387,7 @@ pub(super) fn dispatch(
                 }
                 Value::BigRat(n, d) if !d.is_zero() => {
                     use num_traits::ToPrimitive;
-                    Value::Int((n / d).to_i64().unwrap_or(i64::MAX))
+                    Value::Int((n.as_ref() / d.as_ref()).to_i64().unwrap_or(i64::MAX))
                 }
                 Value::Str(s) => {
                     if let Some(v) = parse_raku_int_from_str(s) {

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -314,6 +314,7 @@ pub(super) fn dispatch(
                 Some(Ok(raku_round_to_value(f)))
             }
             Value::BigRat(n, d) if !d.is_zero() => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 use num_bigint::BigInt;
                 use num_integer::Integer;
                 // round = floor(x + 0.5) for Raku semantics
@@ -350,7 +351,7 @@ pub(super) fn dispatch(
             Value::Int(i) => Some(Ok(Value::Int(*i))),
             Value::BigInt(_) => Some(Ok(target.clone())),
             Value::Rat(n, d) if *d != 0 => Some(Ok(Value::Int(*n / *d))),
-            Value::BigRat(n, d) if !d.is_zero() => Some(Ok(Value::bigint(n / d))),
+            Value::BigRat(n, d) if !d.is_zero() => Some(Ok(Value::bigint(n.as_ref() / d.as_ref()))),
             Value::FatRat(n, d) if *d != 0 => Some(Ok(Value::Int(*n / *d))),
             Value::Complex(re, im) => Some(Ok(Value::Complex(re.trunc(), im.trunc()))),
             Value::Rat(_, d) if *d == 0 => Some(Ok(

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -179,7 +179,7 @@ pub(super) fn dispatch(
             Value::Complex(r, i) => Some(Ok(Value::Complex(r + 1.0, *i))),
             Value::Rat(n, d) => Some(Ok(make_rat(n + d, *d))),
             Value::FatRat(n, d) => Some(Ok(Value::FatRat(n + d, *d))),
-            Value::BigRat(n, d) => Some(Ok(Value::BigRat(n + d, d.clone()))),
+            Value::BigRat(n, d) => Some(Ok(Value::bigrat(n.as_ref() + d.as_ref(), (**d).clone()))),
             Value::Bool(_) => Some(Ok(Value::Bool(true))),
             Value::Str(s) => Some(Ok(Value::str(crate::builtins::str_increment::string_succ(
                 s,
@@ -193,7 +193,7 @@ pub(super) fn dispatch(
             Value::Complex(r, i) => Some(Ok(Value::Complex(r - 1.0, *i))),
             Value::Rat(n, d) => Some(Ok(make_rat(n - d, *d))),
             Value::FatRat(n, d) => Some(Ok(Value::FatRat(n - d, *d))),
-            Value::BigRat(n, d) => Some(Ok(Value::BigRat(n - d, d.clone()))),
+            Value::BigRat(n, d) => Some(Ok(Value::bigrat(n.as_ref() - d.as_ref(), (**d).clone()))),
             Value::Bool(_) => Some(Ok(Value::Bool(false))),
             Value::Str(s) => Some(Ok(Value::str(crate::builtins::str_increment::string_pred(
                 s,
@@ -205,9 +205,9 @@ pub(super) fn dispatch(
             Value::BigInt(i) => Some(Ok(Value::Num(i.to_f64().unwrap_or(f64::INFINITY).ln()))),
             Value::Num(f) => Some(Ok(Value::Num(f.ln()))),
             Value::Rat(n, d) if *d != 0 => Some(Ok(Value::Num((*n as f64 / *d as f64).ln()))),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => Some(Ok(Value::Num(
-                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).ln(),
-            ))),
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => Some(Ok(
+                Value::Num((n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).ln()),
+            )),
             Value::Complex(r, i) => {
                 let mag = (r * r + i * i).sqrt().ln();
                 let arg = i.atan2(*r);
@@ -220,9 +220,9 @@ pub(super) fn dispatch(
             Value::BigInt(i) => Some(Ok(Value::Num(i.to_f64().unwrap_or(f64::INFINITY).log2()))),
             Value::Num(f) => Some(Ok(Value::Num(f.log2()))),
             Value::Rat(n, d) if *d != 0 => Some(Ok(Value::Num((*n as f64 / *d as f64).log2()))),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => Some(Ok(Value::Num(
-                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).log2(),
-            ))),
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => Some(Ok(
+                Value::Num((n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).log2()),
+            )),
             Value::Complex(r, i) => {
                 let mag = (r * r + i * i).sqrt().ln();
                 let arg = i.atan2(*r);
@@ -236,9 +236,9 @@ pub(super) fn dispatch(
             Value::BigInt(i) => Some(Ok(Value::Num(i.to_f64().unwrap_or(f64::INFINITY).log10()))),
             Value::Num(f) => Some(Ok(Value::Num(f.log10()))),
             Value::Rat(n, d) if *d != 0 => Some(Ok(Value::Num((*n as f64 / *d as f64).log10()))),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => Some(Ok(Value::Num(
-                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).log10(),
-            ))),
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => Some(Ok(
+                Value::Num((n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).log10()),
+            )),
             Value::Complex(r, i) => {
                 let mag = (r * r + i * i).sqrt().ln();
                 let arg = i.atan2(*r);
@@ -252,9 +252,9 @@ pub(super) fn dispatch(
             Value::BigInt(i) => Some(Ok(Value::Num(i.to_f64().unwrap_or(f64::INFINITY).exp()))),
             Value::Num(f) => Some(Ok(Value::Num(f.exp()))),
             Value::Rat(n, d) if *d != 0 => Some(Ok(Value::Num((*n as f64 / *d as f64).exp()))),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => Some(Ok(Value::Num(
-                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).exp(),
-            ))),
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => Some(Ok(
+                Value::Num((n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)).exp()),
+            )),
             Value::Complex(r, i) => {
                 // exp(a+bi) = exp(a) * (cos(b) + i*sin(b))
                 let ea = r.exp();
@@ -270,7 +270,7 @@ pub(super) fn dispatch(
                 Value::Num(f) => *f,
                 Value::Rat(n, d) if *d != 0 => *n as f64 / *d as f64,
                 Value::FatRat(n, d) if *d != 0 => *n as f64 / *d as f64,
-                Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => {
+                Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                     n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)
                 }
                 Value::Str(s) => match s.parse::<f64>() {
@@ -295,7 +295,7 @@ pub(super) fn dispatch(
                 Value::Num(f) => *f,
                 Value::Rat(n, d) if *d != 0 => *n as f64 / *d as f64,
                 Value::FatRat(n, d) if *d != 0 => *n as f64 / *d as f64,
-                Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => {
+                Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                     n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)
                 }
                 Value::Str(s) => match s.parse::<f64>() {
@@ -474,7 +474,7 @@ pub(super) fn dispatch(
                 let rat = str_to_rat(s);
                 match rat {
                     Value::Rat(n, d) => Some(Ok(Value::FatRat(n, d))),
-                    Value::BigRat(n, d) => Some(Ok(crate::value::make_big_fat_rat(n, d))),
+                    Value::BigRat(n, d) => Some(Ok(crate::value::make_big_fat_rat(*n, *d))),
                     _ => Some(Ok(Value::FatRat(0, 1))),
                 }
             }

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -90,7 +90,7 @@ pub(super) fn dispatch(
             use num_traits::Zero;
             if d.is_zero() && (method == "gist" || method == "Str") {
                 Some(Err(RuntimeError::numeric_divide_by_zero_with(Some(
-                    Value::from_bigint(n.clone()),
+                    Value::from_bigint((**n).clone()),
                 ))))
             } else if method == "gist" {
                 Some(Ok(Value::str(target.to_string_value())))

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -622,26 +622,17 @@ fn dispatch_capture(
             Some(Ok(Value::str(format!("\\({})", parts.join(", ")))))
         }
         "gist" | "Str" => {
-            let target = Value::Capture {
-                positional: positional.to_vec(),
-                named: named.clone(),
-            };
+            let target = Value::capture(positional.to_vec(), named.clone());
             Some(Ok(Value::str(target.to_string_value())))
         }
         "Bool" => Some(Ok(Value::Bool(!positional.is_empty() || !named.is_empty()))),
         "WHAT" => Some(Ok(Value::Package(Symbol::intern("Capture")))),
         "flat" => {
-            let cap = Value::Capture {
-                positional: positional.to_vec(),
-                named: named.clone(),
-            };
+            let cap = Value::capture(positional.to_vec(), named.clone());
             Some(Ok(Value::Seq(Arc::new(vec![cap]))))
         }
         "Seq" | "List" => {
-            let cap = Value::Capture {
-                positional: positional.to_vec(),
-                named: named.clone(),
-            };
+            let cap = Value::capture(positional.to_vec(), named.clone());
             Some(Ok(Value::Seq(Arc::new(vec![cap]))))
         }
         _ => None,

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -370,6 +370,7 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         Value::BigRat(n, d) => {
+            let (n, d) = (n.as_ref(), d.as_ref());
             if d == &num_bigint::BigInt::from(0) {
                 if n == &num_bigint::BigInt::from(0) {
                     "NaN".to_string()
@@ -607,7 +608,7 @@ pub fn raku_value(v: &Value) -> String {
         }
         Value::Capture { positional, named } => {
             let mut parts = Vec::new();
-            for v in positional {
+            for v in positional.iter() {
                 // Pairs appearing as positional items in a Capture are rendered
                 // with quoted key syntax ("key" => value) to distinguish them
                 // from named arguments which use colonpair syntax (:key(value)).

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -1481,7 +1481,7 @@ fn negate_angle_numeric(val: Value) -> Value {
         Value::Num(n) => Value::Num(-n),
         Value::Rat(n, d) => Value::Rat(-n, d),
         Value::FatRat(n, d) => Value::FatRat(-n, d),
-        Value::BigRat(n, d) => Value::BigRat(-n, d),
+        Value::BigRat(n, d) => Value::bigrat(-(*n), *d),
         other => other,
     }
 }

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -64,7 +64,7 @@ fn negate_literal_value(value: &Value) -> Option<Value> {
         Value::Num(n) => Some(Value::Num(-n)),
         Value::Rat(n, d) => Some(crate::value::make_rat(-n, *d)),
         Value::FatRat(n, d) => Some(Value::FatRat(-n, *d)),
-        Value::BigRat(n, d) => Some(crate::value::make_big_rat(-n.clone(), d.clone())),
+        Value::BigRat(n, d) => Some(crate::value::make_big_rat(-(**n).clone(), (**d).clone())),
         Value::Complex(re, im) => Some(Value::Complex(-re, -im)),
         _ => None,
     }

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1346,7 +1346,7 @@ impl Interpreter {
                     ));
                 }
                 use num_traits::ToPrimitive;
-                Ok(Some((n / d).to_i64().unwrap_or(i64::MAX)))
+                Ok(Some((n.as_ref() / d.as_ref()).to_i64().unwrap_or(i64::MAX)))
             }
             Value::Str(s) => {
                 let parsed = s.trim().parse::<f64>().map_err(|_| {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3058,10 +3058,7 @@ impl Interpreter {
             let mut named = std::collections::HashMap::new();
             named.insert("__mutsu_varref_name".to_string(), Value::str(source_name));
             named.insert("__mutsu_varref_value".to_string(), source_value);
-            return Ok(Value::Capture {
-                positional: Vec::new(),
-                named,
-            });
+            return Ok(Value::capture(Vec::new(), named));
         }
 
         // .join on LazyList

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -207,7 +207,7 @@ impl Interpreter {
             list_items.to_vec()
         } else {
             match target {
-                Value::Capture { positional, .. } => positional,
+                Value::Capture { positional, .. } => *positional,
                 Value::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
                 _ => return Ok(Value::Nil),
             }
@@ -220,9 +220,9 @@ impl Interpreter {
             Some(Value::Int(i)) => *i,
             Some(Value::Num(n)) => *n as i64,
             Some(Value::Rat(n, d)) if *d != 0 => *n / *d,
-            Some(Value::BigRat(n, d)) if *d != num_bigint::BigInt::from(0) => {
+            Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                 use num_traits::ToPrimitive;
-                (n / d).to_i64().unwrap_or(1)
+                (n.as_ref() / d.as_ref()).to_i64().unwrap_or(1)
             }
             Some(other) => other.to_string_value().parse::<i64>().unwrap_or(1),
             None => 1,

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -665,7 +665,7 @@ impl Interpreter {
     fn dispatch_values_method(&self, target: Value) -> Result<Value, RuntimeError> {
         match target {
             Value::Capture { positional, named } => {
-                let mut vals = positional.clone();
+                let mut vals = *positional;
                 vals.extend(named.values().cloned());
                 Ok(Value::array(vals))
             }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -87,7 +87,7 @@ impl Interpreter {
                             positional,
                             named: _,
                         } => {
-                            rule_args = positional.clone();
+                            rule_args = (**positional).clone();
                         }
                         Value::Array(arr, _) => {
                             rule_args = arr.as_ref().clone().items;

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -663,8 +663,8 @@ impl Interpreter {
     pub(super) fn capture_to_call_args(value: &Value) -> Vec<Value> {
         match value {
             Value::Capture { positional, named } => {
-                let mut args = positional.clone();
-                for (k, v) in named {
+                let mut args = (**positional).clone();
+                for (k, v) in named.iter() {
                     args.push(Value::Pair(k.clone(), Box::new(v.clone())));
                 }
                 args

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -717,7 +717,7 @@ impl Interpreter {
                         },
                     ));
                 }
-                Ok(Some((n / d).to_i64().unwrap_or(i64::MAX)))
+                Ok(Some((n.as_ref() / d.as_ref()).to_i64().unwrap_or(i64::MAX)))
             }
             Value::Str(s) => {
                 let parsed = s.trim().parse::<f64>().map_err(|_| {

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1648,8 +1648,8 @@ impl Interpreter {
             Value::Seq(items) => items.to_vec(),
             Value::Slip(items) => items.to_vec(),
             Value::Capture { positional, named } => {
-                let mut args = positional;
-                for (k, v) in named {
+                let mut args = *positional;
+                for (k, v) in *named {
                     args.push(Value::Pair(k, Box::new(v)));
                 }
                 args

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -76,7 +76,9 @@ impl Interpreter {
         value: &Value,
     ) -> Option<(Vec<Value>, HashMap<String, Value>)> {
         match value {
-            Value::Capture { positional, named } => Some((positional.clone(), named.clone())),
+            Value::Capture { positional, named } => {
+                Some(((**positional).clone(), (**named).clone()))
+            }
             Value::Hash(map) => Some((Vec::new(), map.map.clone())),
             Value::Set(items, _) => Some((
                 Vec::new(),

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -4,7 +4,7 @@ use crate::symbol::Symbol;
 impl Interpreter {
     fn normalize_sequence_arg(value: &Value) -> Value {
         match value {
-            Value::Capture { positional, .. } => Value::array(positional.clone()),
+            Value::Capture { positional, .. } => Value::array((**positional).clone()),
             other => other.clone(),
         }
     }

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -167,9 +167,9 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             Some(Value::Num(f)) => *f as i64,
             Some(Value::Rat(n, d)) if *d != 0 => *n / *d,
             Some(Value::FatRat(n, d)) if *d != 0 => *n / *d,
-            Some(Value::BigRat(n, d)) if *d != num_bigint::BigInt::from(0) => {
+            Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                 use num_traits::ToPrimitive;
-                (n / d).to_i64().unwrap_or(0)
+                (n.as_ref() / d.as_ref()).to_i64().unwrap_or(0)
             }
             Some(Value::Str(s)) => s
                 .trim()
@@ -185,7 +185,9 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             Some(Value::Num(f)) => BigInt::from(*f as i64),
             Some(Value::Rat(n, d)) if *d != 0 => BigInt::from(*n / *d),
             Some(Value::FatRat(n, d)) if *d != 0 => BigInt::from(*n / *d),
-            Some(Value::BigRat(n, d)) if *d != num_bigint::BigInt::from(0) => n / d,
+            Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
+                n.as_ref() / d.as_ref()
+            }
             Some(Value::Str(s)) => s
                 .trim()
                 .parse::<BigInt>()
@@ -199,9 +201,9 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             Some(Value::Num(f)) => *f,
             Some(Value::Rat(n, d)) if *d != 0 => *n as f64 / *d as f64,
             Some(Value::FatRat(n, d)) if *d != 0 => *n as f64 / *d as f64,
-            Some(Value::BigRat(n, d)) if *d != num_bigint::BigInt::from(0) => {
+            Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                 use num_traits::ToPrimitive;
-                let result = n * BigInt::from(1_000_000_000i64) / d;
+                let result = n.as_ref() * BigInt::from(1_000_000_000i64) / d.as_ref();
                 result.to_f64().unwrap_or(0.0) / 1_000_000_000.0
             }
             Some(Value::Str(s)) => s.trim().parse::<f64>().unwrap_or(0.0),

--- a/src/runtime/sprintf_helpers.rs
+++ b/src/runtime/sprintf_helpers.rs
@@ -24,7 +24,9 @@ pub(super) fn format_rat_fixed(
     let (numer, denom) = match arg {
         Some(Value::Rat(n, d)) if *d != 0 => (BigInt::from(*n), BigInt::from(*d)),
         Some(Value::FatRat(n, d)) if *d != 0 => (BigInt::from(*n), BigInt::from(*d)),
-        Some(Value::BigRat(n, d)) if *d != num_bigint::BigInt::from(0) => (n.clone(), d.clone()),
+        Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
+            ((**n).clone(), (**d).clone())
+        }
         _ => return None,
     };
     let is_neg = numer < BigInt::from(0);

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -138,7 +138,7 @@ impl Interpreter {
                                 positional.push(arg);
                             }
                         }
-                        Some(Value::Capture { positional, named })
+                        Some(Value::capture(positional, named))
                     } else {
                         // For single-star slurpy (*@), flatten list arguments but preserve
                         // itemized Arrays ($[...] / .item) as single positional values.

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -412,7 +412,7 @@ impl Interpreter {
                             named.insert(key, *val);
                         }
                     }
-                    let capture_value = Value::Capture { positional, named };
+                    let capture_value = Value::capture(positional, named);
                     if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, capture_value.clone());
                         self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -123,7 +123,7 @@ pub(in crate::runtime) fn coerce_value(target: &str, value: Value) -> Value {
             Value::Rat(n, d) if *d != 0 => Value::Complex(*n as f64 / *d as f64, 0.0),
             Value::FatRat(n, d) if *d != 0 => Value::Complex(*n as f64 / *d as f64, 0.0),
             Value::BigInt(n) => Value::Complex(n.to_f64().unwrap_or(0.0), 0.0),
-            Value::BigRat(n, d) if d != &num_bigint::BigInt::from(0) => {
+            Value::BigRat(n, d) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                 Value::Complex(n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0), 0.0)
             }
             Value::Str(s) => match crate::runtime::str_numeric::parse_raku_str_to_numeric(s) {

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(in crate::runtime) fn positional_values_from_unpack_target(value: &Value) -> Vec<Value> {
     match value {
-        Value::Capture { positional, .. } => positional.clone(),
+        Value::Capture { positional, .. } => (**positional).clone(),
         other => crate::runtime::value_to_list(other),
     }
 }
@@ -159,10 +159,7 @@ pub(crate) fn make_varref_value(name: String, value: Value, source_index: Option
     if let Some(i) = source_index {
         named.insert("__mutsu_varref_index".to_string(), Value::Int(i as i64));
     }
-    Value::Capture {
-        positional: Vec::new(),
-        named,
-    }
+    Value::capture(Vec::new(), named)
 }
 
 pub(in crate::runtime) fn sigilless_alias_key(name: &str) -> String {
@@ -177,7 +174,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
     value: &Value,
 ) -> std::collections::HashMap<String, Value> {
     match value {
-        Value::Capture { named, .. } => named.clone(),
+        Value::Capture { named, .. } => (**named).clone(),
         Value::Hash(map) => map.map.clone(),
         Value::Pair(key, val) => {
             let mut out = std::collections::HashMap::new();
@@ -544,7 +541,7 @@ pub(in crate::runtime) fn sub_signature_target_from_remaining_args(args: &[Value
             other => positional.push(other.clone()),
         }
     }
-    Value::Capture { positional, named }
+    Value::capture(positional, named)
 }
 
 pub(in crate::runtime) fn callable_signature_info(

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1786,7 +1786,9 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
                     Value::Num(f) => Some(Value::Num(*f + 1.0)),
                     Value::Rat(n, d) => Some(crate::value::make_rat(n + d, *d)),
                     Value::FatRat(n, d) => Some(Value::FatRat(n + d, *d)),
-                    Value::BigRat(n, d) => Some(Value::BigRat(n + d, d.clone())),
+                    Value::BigRat(n, d) => {
+                        Some(Value::bigrat(n.as_ref() + d.as_ref(), (**d).clone()))
+                    }
                     other if other.is_numeric() => Some(Value::Num(other.to_f64() + 1.0)),
                     _ => None,
                 }
@@ -2937,7 +2939,7 @@ pub(crate) fn to_big_rat_parts(val: &Value) -> Option<(BigInt, BigInt)> {
         Value::Int(i) => Some((BigInt::from(*i), BigInt::from(1))),
         Value::BigInt(i) => Some(((**i).clone(), BigInt::from(1))),
         Value::Rat(n, d) | Value::FatRat(n, d) => Some((BigInt::from(*n), BigInt::from(*d))),
-        Value::BigRat(n, d) => Some((n.clone(), d.clone())),
+        Value::BigRat(n, d) => Some(((**n).clone(), (**d).clone())),
         _ => None,
     }
 }
@@ -3049,6 +3051,7 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
             }
         }
         Value::BigRat(n, d) => {
+            let (n, d) = (n.as_ref(), d.as_ref());
             if !d.is_zero() {
                 if let (Some(nn), Some(dd)) = (n.to_f64(), d.to_f64())
                     && nn.is_finite()

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -520,6 +520,7 @@ impl Value {
                 }
             }
             Value::BigRat(n, d) => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 if d.is_zero() {
                     if n.is_zero() {
                         "NaN".to_string()
@@ -915,7 +916,7 @@ impl Value {
             Value::HyperWhatever => "**".to_string(),
             Value::Capture { positional, named } => {
                 let mut parts = Vec::new();
-                for v in positional {
+                for v in positional.iter() {
                     match v {
                         Value::Str(s) => parts.push(format!("\"{}\"", s)),
                         _ => parts.push(v.to_string_value()),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1053,7 +1053,7 @@ pub fn make_big_rat(num: NumBigInt, den: NumBigInt) -> Value {
     if let (Some(n_i64), Some(d_i64)) = (n.to_i64(), d.to_i64()) {
         Value::Rat(n_i64, d_i64)
     } else {
-        Value::BigRat(n, d)
+        Value::bigrat(n, d)
     }
 }
 
@@ -1087,7 +1087,7 @@ pub fn make_big_rat_arith(num: NumBigInt, den: NumBigInt) -> Value {
         // The bits() check is a redundant safety net for d.to_u64().
         Value::Num(bigrat_to_f64(&n, &d))
     } else {
-        Value::BigRat(n, d)
+        Value::bigrat(n, d)
     }
 }
 
@@ -1114,7 +1114,7 @@ pub fn make_big_fat_rat(num: NumBigInt, den: NumBigInt) -> Value {
     if let (Some(n_i64), Some(d_i64)) = (n.to_i64(), d.to_i64()) {
         Value::Rat(n_i64, d_i64)
     } else {
-        Value::BigRat(n, d)
+        Value::bigrat(n, d)
     }
 }
 
@@ -1534,7 +1534,7 @@ pub enum Value {
     Hash(Arc<HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),
-    BigRat(NumBigInt, NumBigInt),
+    BigRat(Box<NumBigInt>, Box<NumBigInt>),
     Complex(f64, f64),
     /// Set (immutable) or SetHash (mutable). The bool is `true` for mutable (SetHash).
     Set(Arc<SetData>, bool),
@@ -1609,10 +1609,12 @@ pub enum Value {
     /// A value with mixin overrides from the `but` operator.
     /// Inner value is the original; the HashMap maps type names (e.g. "Bool") to override values.
     Mixin(Arc<Value>, Arc<HashMap<String, Value>>),
-    /// A Capture: positional args + named args
+    /// A Capture: positional args + named args.
+    /// Both fields are boxed to keep `Value` small (the inline `Vec` + `HashMap`
+    /// otherwise made this the largest variant, inflating every `Value`).
     Capture {
-        positional: Vec<Value>,
-        named: HashMap<String, Value>,
+        positional: Box<Vec<Value>>,
+        named: Box<HashMap<String, Value>>,
     },
     /// Unicode normalization form types (NFC, NFD, NFKC, NFKD).
     /// `form` is one of "NFC", "NFD", "NFKC", "NFKD".
@@ -2442,15 +2444,18 @@ impl PartialEq for Value {
             }
             (Value::BigRat(an, ad), Value::BigRat(bn, bd)) => an == bn && ad == bd,
             (Value::BigRat(n, d), Value::Int(i)) | (Value::Int(i), Value::BigRat(n, d)) => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 !d.is_zero() && *n == NumBigInt::from(*i) * d
             }
             (Value::BigRat(n, d), Value::Rat(rn, rd))
             | (Value::Rat(rn, rd), Value::BigRat(n, d)) => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 !d.is_zero()
                     && *rd != 0
                     && n.clone() * NumBigInt::from(*rd) == NumBigInt::from(*rn) * d
             }
             (Value::BigRat(n, d), Value::Num(f)) | (Value::Num(f), Value::BigRat(n, d)) => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 if d.is_zero() {
                     return false;
                 }
@@ -2475,6 +2480,7 @@ impl PartialEq for Value {
             }
             (Value::Complex(r, i), Value::BigRat(n, d))
             | (Value::BigRat(n, d), Value::Complex(r, i)) => {
+                let (n, d) = (n.as_ref(), d.as_ref());
                 !d.is_zero()
                     && *i == 0.0
                     && *r == (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0))
@@ -2733,6 +2739,19 @@ impl Value {
     }
     pub fn array(items: Vec<Value>) -> Self {
         Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::List)
+    }
+    /// Create a Capture value. Boxes the positional/named payloads (the variant
+    /// stores them behind `Box` to keep `Value` small).
+    pub fn capture(positional: Vec<Value>, named: HashMap<String, Value>) -> Self {
+        Value::Capture {
+            positional: Box::new(positional),
+            named: Box::new(named),
+        }
+    }
+    /// Create a BigRat value. The numerator/denominator are boxed (the variant
+    /// stores them behind `Box` to keep `Value` small).
+    pub fn bigrat(num: NumBigInt, den: NumBigInt) -> Self {
+        Value::BigRat(Box::new(num), Box::new(den))
     }
     /// Create a true Array value (from [...] literals).
     pub fn real_array(items: Vec<Value>) -> Self {
@@ -3879,7 +3898,7 @@ impl Value {
             }
             Value::BigRat(n, d) => {
                 if !d.is_zero() {
-                    n / d
+                    n.as_ref() / d.as_ref()
                 } else {
                     NumBigInt::from(0)
                 }
@@ -3914,6 +3933,21 @@ const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Value>();
 };
+
+#[cfg(test)]
+mod value_size_guard {
+    use super::*;
+    #[test]
+    fn value_stays_small() {
+        // `Capture` and `BigRat` previously held their large payloads inline,
+        // making `Value` 72 bytes. Boxing them dropped it to 64. Guard against
+        // regressing the layout (every `Value` clone/move pays for the largest
+        // variant). Remaining 64-byte variants (CustomTypeInstance, ...) are
+        // boxed in follow-up steps to shrink this further.
+        let sz = std::mem::size_of::<Value>();
+        assert!(sz <= 64, "size_of::<Value>() = {sz}, expected <= 64");
+    }
+}
 
 #[cfg(test)]
 mod hash_chokepoint_tests {

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -150,7 +150,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         }
         Value::Rat(n, d) => Ok(SerValue::Rat(*n, *d)),
         Value::FatRat(n, d) => Ok(SerValue::FatRat(*n, *d)),
-        Value::BigRat(n, d) => Ok(SerValue::BigRat(n.clone(), d.clone())),
+        Value::BigRat(n, d) => Ok(SerValue::BigRat((**n).clone(), (**d).clone())),
         Value::Complex(r, i) => Ok(SerValue::Complex(*r, *i)),
         Value::Set(s, _) => Ok(SerValue::Set(s.elements.clone())),
         Value::Bag(b, _) => Ok(SerValue::Bag(b.counts.clone())),
@@ -348,7 +348,7 @@ fn ser_to_value(sv: SerValue) -> Value {
         ),
         SerValue::Rat(n, d) => Value::Rat(n, d),
         SerValue::FatRat(n, d) => Value::FatRat(n, d),
-        SerValue::BigRat(n, d) => Value::BigRat(n, d),
+        SerValue::BigRat(n, d) => Value::bigrat(n, d),
         SerValue::Complex(r, i) => Value::Complex(r, i),
         SerValue::Set(s) => Value::set(s),
         SerValue::Bag(b) => Value::bag(b),
@@ -452,13 +452,13 @@ fn ser_to_value(sv: SerValue) -> Value {
                     .collect(),
             ),
         ),
-        SerValue::Capture { positional, named } => Value::Capture {
-            positional: positional.into_iter().map(ser_to_value).collect(),
-            named: named
+        SerValue::Capture { positional, named } => Value::capture(
+            positional.into_iter().map(ser_to_value).collect(),
+            named
                 .into_iter()
                 .map(|(k, v)| (k, ser_to_value(v)))
                 .collect(),
-        },
+        ),
         SerValue::Uni { form, text } => Value::Uni { form, text },
         SerValue::ParametricRole {
             base_name,

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -457,8 +457,8 @@ impl VM {
             Value::Slip(items) => (*items).to_vec(),
             Value::Seq(items) => (*items).to_vec(),
             Value::Capture { positional, named } => {
-                let mut items = positional.clone();
-                for (k, v) in named {
+                let mut items = (**positional).clone();
+                for (k, v) in named.iter() {
                     items.push(Value::Pair(k.clone(), Box::new(v.clone())));
                 }
                 items

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -65,8 +65,8 @@ impl VM {
                 args.extend(elements.iter().cloned());
             }
             Value::Capture { positional, named } => {
-                args.extend(positional);
-                for (k, v) in named {
+                args.extend(*positional);
+                for (k, v) in *named {
                     args.push(Value::Pair(k, Box::new(v)));
                 }
             }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -38,10 +38,7 @@ impl VM {
                 positional.push(a.clone());
             }
         }
-        let capture = Value::Capture {
-            positional,
-            named: std::collections::HashMap::new(),
-        };
+        let capture = Value::capture(positional, std::collections::HashMap::new());
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("message".to_string(), Value::str(message.clone()));
         attrs.insert("capture".to_string(), capture);

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -67,7 +67,7 @@ fn check_rat_divide_by_zero(v: &Value) -> Result<(), RuntimeError> {
             Value::Int(*n),
         ))),
         Value::BigRat(n, d) if d.is_zero() => Err(RuntimeError::numeric_divide_by_zero_with(Some(
-            Value::from_bigint(n.clone()),
+            Value::from_bigint((**n).clone()),
         ))),
         _ => Ok(()),
     }
@@ -263,8 +263,8 @@ impl VM {
                     named: n,
                 } => {
                     // Flatten inner capture (from |capture slip)
-                    positional.extend(p);
-                    named.extend(n);
+                    positional.extend(*p);
+                    named.extend(*n);
                 }
                 Value::Slip(items) => {
                     for item in items.iter() {
@@ -279,7 +279,7 @@ impl VM {
                 other => positional.push(other),
             }
         }
-        self.stack.push(Value::Capture { positional, named });
+        self.stack.push(Value::capture(positional, named));
     }
 
     pub(super) fn exec_say_op(&mut self, n: u32) -> Result<(), RuntimeError> {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1692,10 +1692,7 @@ impl VM {
         let mut named = std::collections::HashMap::new();
         named.insert("__mutsu_varref_name".to_string(), Value::str(name));
         named.insert("__mutsu_varref_value".to_string(), value);
-        self.stack.push(Value::Capture {
-            positional: Vec::new(),
-            named,
-        });
+        self.stack.push(Value::capture(Vec::new(), named));
     }
 
     pub(super) fn exec_get_env_index_op(&mut self, code: &CompiledCode, key_idx: u32) {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -160,10 +160,7 @@ impl VM {
         if let Some(i) = source_index {
             named.insert("__mutsu_varref_index".to_string(), Value::Int(i as i64));
         }
-        Value::Capture {
-            positional: Vec::new(),
-            named,
-        }
+        Value::capture(Vec::new(), named)
     }
 
     fn assign_varref_target(


### PR DESCRIPTION
## Summary

ANALYSIS §5: every `Value` is sized to its largest variant, so oversized variants tax every clone/move and `Vec<Value>`. Measured `size_of::<Value>() = 72`. The drivers were `Capture { Vec, HashMap }` (72B) and `BigRat(BigInt, BigInt)` (64B payload, +8 discriminant → 72B). This boxes both, dropping `Value` to **64 bytes**.

## Changes

- **`Capture`** now boxes its two fields (`Box<Vec<Value>>`, `Box<HashMap<String, Value>>`); added a `Value::capture(positional, named)` constructor. Match patterns keep working via deref coercion; only construction / owned-move sites changed (~84 sites).
- **`BigRat(Box<NumBigInt>, Box<NumBigInt>)`** with a `Value::bigrat(num, den)` constructor. Arithmetic/comparison sites deref the boxes (`.as_ref()`, or `let (n, d) = (n.as_ref(), d.as_ref())` arm rebinds). Numeric semantics unchanged.
- Added a `value_size_guard` unit test asserting `size_of::<Value>() <= 64` to prevent layout regressions.

## Why only 72→64 (not lower)

The two 64-byte variants `CustomTypeInstance` and the 48B tier (`CustomType`, `Uni`, `RegexWithAdverbs`, `Proxy`, `Version`) still cap `Value` at 64. Boxing those is left to **follow-up PRs** (this one is already large at ~110 mechanical sites; keeping it reviewable). The size only drops when the *max* variant drops, so the tiers must be peeled in order.

## Testing

- Numeric correctness verified against rakudo (`.nude`, `+`/`-`/`*`, `<`, `.floor`, `.Num`) for BigRats with denominators exceeding i64.
- Numeric roast green: `S02-types/num.t`, `S02-types/fatrat.t`, `S32-num/rat.t`. `capture.t` unchanged (same pre-existing abort point).
- `make test` PASS (799 files / 7437 tests, incl. the size guard), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)