### PR TITLE
perf(value): box CustomTypeInstance payload, shrink Value 64→56 (ANALYSIS §5 PR2)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -15,7 +15,7 @@ fn gist_needs_method_dispatch(v: &Value) -> bool {
     match v {
         Value::Instance { .. }
         | Value::CustomType { .. }
-        | Value::CustomTypeInstance { .. }
+        | Value::CustomTypeInstance(_)
         | Value::Package(..) => true,
         Value::Array(items, _) => items.iter().any(gist_needs_method_dispatch),
         Value::Seq(items) | Value::Slip(items) => items.iter().any(gist_needs_method_dispatch),

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -144,9 +144,9 @@ impl Interpreter {
         let target_type = &args[1];
 
         match (obj, target_type) {
-            (Value::CustomTypeInstance { id, .. }, Value::CustomType { how, .. }) => {
+            (Value::CustomTypeInstance(d), Value::CustomType { how, .. }) => {
                 // Store the new HOW in the rebless map so .HOW returns the new type
-                self.rebless_map.insert(*id, *how.clone());
+                self.rebless_map.insert(d.id, *how.clone());
                 Ok(obj.clone())
             }
             _ => Ok(args[0].clone()),

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2091,7 +2091,7 @@ impl Interpreter {
                     // through `.gist` would add a spurious paren layer.)
                     Value::Instance { .. }
                     | Value::CustomType { .. }
-                    | Value::CustomTypeInstance { .. }
+                    | Value::CustomTypeInstance(_)
                     | Value::Package(..) => true,
                     _ if value.as_list_items().is_some() => value
                         .as_list_items()
@@ -3158,10 +3158,9 @@ impl Interpreter {
                 | "put"
                 | "note"
                 | "new"
-        ) && let Value::CustomType { ref how, .. } | Value::CustomTypeInstance { ref how, .. } =
-            target
+        ) && let Some(how) = target.custom_how()
         {
-            let how_clone = *how.clone();
+            let how_clone = how.clone();
             let found = self.call_method_with_values(
                 how_clone,
                 "find_method",

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -713,14 +713,14 @@ impl Interpreter {
                 name,
                 id,
                 ..
-            } => Some(Ok(Value::CustomTypeInstance {
-                type_id: *id,
-                how: how.clone(),
-                repr: repr.clone(),
-                type_name: *name,
-                attributes: std::sync::Arc::new(HashMap::new()),
-                id: crate::value::next_instance_id(),
-            })),
+            } => Some(Ok(Value::custom_type_instance(
+                *id,
+                how.clone(),
+                repr.clone(),
+                *name,
+                std::sync::Arc::new(HashMap::new()),
+                crate::value::next_instance_id(),
+            ))),
             Value::Package(class_name) => {
                 Some(Ok(Value::make_instance(*class_name, HashMap::new())))
             }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1437,15 +1437,15 @@ impl Interpreter {
                     self.class_mro(&pkg_name).contains(&target_name),
                 ))
             }
-            "REPR" if args.is_empty() => match target {
-                Value::CustomType { repr, .. } | Value::CustomTypeInstance { repr, .. } => {
-                    Ok(Value::str(repr))
-                }
-                Value::Package(name) if self.registry().classes.contains_key(&name.resolve()) => {
+            "REPR" if args.is_empty() => {
+                // CustomType/CustomTypeInstance report their stored REPR; every
+                // other type is P6opaque.
+                if let Some(repr) = target.custom_repr() {
+                    Ok(Value::str_from(repr))
+                } else {
                     Ok(Value::str_from("P6opaque"))
                 }
-                _ => Ok(Value::str_from("P6opaque")),
-            },
+            }
             "Str" | "Stringy" if args.is_empty() => match &target {
                 Value::Package(_) => Ok(Value::str(String::new())),
                 Value::Instance { class_name, .. } => {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -123,8 +123,8 @@ impl Interpreter {
             Value::CustomType { name, .. } => {
                 return Ok(Value::Package(*name));
             }
-            Value::CustomTypeInstance { type_name: tn, .. } => {
-                return Ok(Value::Package(*tn));
+            Value::CustomTypeInstance(d) => {
+                return Ok(Value::Package(d.type_name));
             }
             Value::ParametricRole {
                 base_name,
@@ -194,13 +194,13 @@ impl Interpreter {
         }
         // Return custom HOW for CustomType/CustomTypeInstance
         // Check rebless map first for reblessed instances
-        if let Value::CustomTypeInstance { id, .. } = target
-            && let Some(new_how) = self.rebless_map.get(id).cloned()
+        if let Value::CustomTypeInstance(d) = target
+            && let Some(new_how) = self.rebless_map.get(&d.id).cloned()
         {
             return Ok(new_how);
         }
-        if let Value::CustomType { how, .. } | Value::CustomTypeInstance { how, .. } = target {
-            return Ok(*how.clone());
+        if let Some(how) = target.custom_how() {
+            return Ok(how.clone());
         }
         // Return CurriedRoleHOW for parameterized roles
         if let Value::ParametricRole {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1583,7 +1583,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Proxy { .. } => "Proxy",
         Value::ParametricRole { .. } => "Package",
         Value::CustomType { .. } => "CustomType",
-        Value::CustomTypeInstance { .. } => "CustomTypeInstance",
+        Value::CustomTypeInstance(_) => "CustomTypeInstance",
         Value::Scalar(inner) => value_type_name(inner),
         Value::LazyThunk(thunk_data) => {
             let cache = thunk_data.cache.lock().unwrap();

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -950,7 +950,7 @@ impl Value {
                     format!("({})", name)
                 }
             }
-            Value::CustomTypeInstance { type_name, .. } => format!("{}()", type_name),
+            Value::CustomTypeInstance(d) => format!("{}()", d.type_name),
             Value::Scalar(inner) => inner.to_string_value(),
             Value::ContainerRef(_) => self.with_deref(Value::to_string_value),
             Value::LazyThunk(thunk_data) => {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1647,14 +1647,8 @@ pub enum Value {
         id: u64,
     },
     /// An instance of a custom type (created by .CREATE on a CustomType).
-    CustomTypeInstance {
-        type_id: u64,
-        how: Box<Value>,
-        repr: String,
-        type_name: Symbol,
-        attributes: Arc<HashMap<String, Value>>,
-        id: u64,
-    },
+    /// Boxed payload to keep `Value` small (this variant has six fields).
+    CustomTypeInstance(Box<CustomTypeInstanceData>),
     /// A Scalar container wrapping a value (from `.item` or `$()`).
     /// Prevents one level of flattening in list/array context.
     Scalar(Box<Value>),
@@ -1691,6 +1685,18 @@ pub enum Value {
         /// The key for the nested access
         key: String,
     },
+}
+
+/// Boxed payload of [`Value::CustomTypeInstance`] (an instance of a type created
+/// via Metamodel::Primitives.create_type + `.CREATE`). Boxed to keep `Value` small.
+#[derive(Debug, Clone)]
+pub struct CustomTypeInstanceData {
+    pub type_id: u64,
+    pub how: Box<Value>,
+    pub repr: String,
+    pub type_name: Symbol,
+    pub attributes: Arc<HashMap<String, Value>>,
+    pub id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -2752,6 +2758,41 @@ impl Value {
     /// stores them behind `Box` to keep `Value` small).
     pub fn bigrat(num: NumBigInt, den: NumBigInt) -> Self {
         Value::BigRat(Box::new(num), Box::new(den))
+    }
+    /// The HOW (meta-object) of a `CustomType` or `CustomTypeInstance`, if this
+    /// is one. Centralizes access now that `CustomTypeInstance` is a boxed payload.
+    pub fn custom_how(&self) -> Option<&Value> {
+        match self {
+            Value::CustomType { how, .. } => Some(how),
+            Value::CustomTypeInstance(d) => Some(&d.how),
+            _ => None,
+        }
+    }
+    /// The REPR name of a `CustomType` or `CustomTypeInstance`, if this is one.
+    pub fn custom_repr(&self) -> Option<&str> {
+        match self {
+            Value::CustomType { repr, .. } => Some(repr),
+            Value::CustomTypeInstance(d) => Some(&d.repr),
+            _ => None,
+        }
+    }
+    /// Create a CustomTypeInstance value (boxed payload).
+    pub fn custom_type_instance(
+        type_id: u64,
+        how: Box<Value>,
+        repr: String,
+        type_name: Symbol,
+        attributes: Arc<HashMap<String, Value>>,
+        id: u64,
+    ) -> Self {
+        Value::CustomTypeInstance(Box::new(CustomTypeInstanceData {
+            type_id,
+            how,
+            repr,
+            type_name,
+            attributes,
+            id,
+        }))
     }
     /// Create a true Array value (from [...] literals).
     pub fn real_array(items: Vec<Value>) -> Self {
@@ -3939,13 +3980,14 @@ mod value_size_guard {
     use super::*;
     #[test]
     fn value_stays_small() {
-        // `Capture` and `BigRat` previously held their large payloads inline,
-        // making `Value` 72 bytes. Boxing them dropped it to 64. Guard against
-        // regressing the layout (every `Value` clone/move pays for the largest
-        // variant). Remaining 64-byte variants (CustomTypeInstance, ...) are
-        // boxed in follow-up steps to shrink this further.
+        // Oversized variants used to hold their payloads inline, making `Value`
+        // 72 bytes (every clone/move pays for the largest variant). Boxing the
+        // big payloads shrank it: Capture+BigRat (72->64), CustomTypeInstance
+        // (64->56). Remaining 48-byte variants (Uni, RegexWithAdverbs,
+        // CustomType) + their missing niche are boxed in follow-up steps to
+        // reach the next tier. Guard against layout regressions.
         let sz = std::mem::size_of::<Value>();
-        assert!(sz <= 64, "size_of::<Value>() = {sz}, expected <= 64");
+        assert!(sz <= 56, "size_of::<Value>() = {sz}, expected <= 56");
     }
 }
 

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -303,7 +303,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         | Value::Channel(_)
         | Value::Proxy { .. }
         | Value::CustomType { .. }
-        | Value::CustomTypeInstance { .. }
+        | Value::CustomTypeInstance(_)
         | Value::LazyThunk(_)
         | Value::LazyIoLines { .. }
         | Value::HashSlotRef { .. }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -463,7 +463,7 @@ impl Value {
             }
             Value::Proxy { .. } => true,
             Value::CustomType { .. } => false,
-            Value::CustomTypeInstance { .. } => true,
+            Value::CustomTypeInstance(_) => true,
             Value::Scalar(inner) => inner.truthy(),
             Value::ContainerRef(_) => self.with_deref(Value::truthy),
             Value::LazyThunk(thunk_data) => {
@@ -594,8 +594,8 @@ impl Value {
             Value::CustomType { name, .. } => {
                 return name.resolve() == type_name;
             }
-            Value::CustomTypeInstance { type_name: tn, .. } => {
-                return tn.resolve() == type_name;
+            Value::CustomTypeInstance(d) => {
+                return d.type_name.resolve() == type_name;
             }
             Value::Scalar(inner) => return inner.isa_check(type_name),
             Value::ContainerRef(_) => return self.with_deref(|inner| inner.isa_check(type_name)),

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -8,7 +8,7 @@ fn needs_method_dispatch(v: &Value) -> bool {
     match v {
         Value::Instance { .. }
         | Value::CustomType { .. }
-        | Value::CustomTypeInstance { .. }
+        | Value::CustomTypeInstance(_)
         | Value::Mixin(..)
         | Value::Proxy { .. }
         | Value::Junction { .. } => true,
@@ -41,7 +41,7 @@ fn element_needs_method_dispatch(v: &Value) -> bool {
     match v {
         Value::Instance { .. }
         | Value::CustomType { .. }
-        | Value::CustomTypeInstance { .. }
+        | Value::CustomTypeInstance(_)
         | Value::Package(..) => true,
         Value::Array(items, _) => items.iter().any(element_needs_method_dispatch),
         Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) | Value::Slip(items) => {


### PR DESCRIPTION
## Summary

Continues the `Value`-size reduction (ANALYSIS §5). After PR1 (#3073, 72→64 by boxing Capture + BigRat), the 6-field 64-byte struct variant `CustomTypeInstance` was the remaining 64-byte driver. This boxes its whole payload → **Value 64 → 56**.

## Changes

- New `CustomTypeInstanceData` struct; `Value::CustomTypeInstance(Box<CustomTypeInstanceData>)` + a `Value::custom_type_instance(..)` constructor.
- Added `Value::custom_how()` / `Value::custom_repr()` accessors. Several sites previously used OR-patterns binding a field shared between `CustomType` (struct variant) and `CustomTypeInstance` (`{ how, .. } | { how, .. }`); that no longer works once one side is a boxed tuple, so those go through the accessors. `.REPR` simplified (every non-custom type is `P6opaque`).
- 15 match/construction sites updated.

## Testing

- `size_of::<Value>()` 64 → 56; `value_size_guard` test tightened to `<= 56`.
- `S12-meta/primitives.t` + `classhow.t` green; `Metamodel::ClassHOW.new_type` / `.CREATE` / `.^name` / `.REPR` verified identical to rakudo.
- `make test` PASS (799 files / 7437 tests), clippy clean.

Follow-up (PR3): box the 48-byte tier (`Uni`, `RegexWithAdverbs`, `CustomType`) — those + a missing niche currently cap `Value` at 56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)