### PR TITLE
perf(value): box Uni/RegexWithAdverbs/CustomType, shrink Value 56→48 (§5 PR3)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -133,8 +133,8 @@ pub(super) fn dispatch(
             );
             let which_str = match target {
                 Value::Package(name) => format!("{}|U{}", name.resolve(), name.id()),
-                Value::CustomType { name, id, .. } => {
-                    format!("{}|U{}", name.resolve(), id)
+                Value::CustomType(c) => {
+                    format!("{}|U{}", c.name.resolve(), c.id)
                 }
                 Value::Int(n) => format!("Int|{}", n),
                 Value::BigInt(n) => format!("Int|{}", n),
@@ -187,8 +187,8 @@ pub(super) fn dispatch(
                 Value::Regex(pattern) => {
                     format!("Regex|{:p}", Arc::as_ptr(pattern))
                 }
-                Value::RegexWithAdverbs { pattern, .. } => {
-                    format!("Regex|{:p}", Arc::as_ptr(pattern))
+                Value::RegexWithAdverbs(a) => {
+                    format!("Regex|{:p}", Arc::as_ptr(&a.pattern))
                 }
                 Value::Instance { id, .. } => {
                     format!("{}|{}", runtime::utils::value_type_name(target), id)

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -640,10 +640,7 @@ pub(super) fn dispatch(
                 "NFKC" => s.nfkc().collect(),
                 _ => s.nfkd().collect(),
             };
-            Some(Some(Ok(Value::Uni {
-                form: method.to_string(),
-                text: normalized,
-            })))
+            Some(Some(Ok(Value::uni(method.to_string(), normalized))))
         }
         _ => None,
     }

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -512,7 +512,12 @@ pub(super) fn dispatch(
             Value::Package(name) if name.resolve() == "Hash" || name.resolve() == "Array" => {
                 Some(Ok(Value::Package(Symbol::intern("Mu"))))
             }
-            Value::Package(name) | Value::CustomType { name, .. } => {
+            Value::Package(_) | Value::CustomType(_) => {
+                let name = match target {
+                    Value::Package(name) => *name,
+                    Value::CustomType(c) => c.name,
+                    _ => unreachable!(),
+                };
                 let n = name.resolve();
                 if matches!(n.as_ref(), "Bag" | "BagHash")
                     || n.starts_with("Bag[")
@@ -545,7 +550,12 @@ pub(super) fn dispatch(
                 None
             }
             Value::Hash(_) => None,
-            Value::Package(name) | Value::CustomType { name, .. } => {
+            Value::Package(_) | Value::CustomType(_) => {
+                let name = match target {
+                    Value::Package(name) => *name,
+                    Value::CustomType(c) => c.name,
+                    _ => unreachable!(),
+                };
                 let n = name.resolve();
                 if let Some(bracket_pos) = n.find('[') {
                     let base = &n[..bracket_pos];

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -478,7 +478,8 @@ pub(crate) fn native_method_0arg(
         return Some(raku_repr::native_int_coerce_method(target, method));
     }
     // Uni types: override .chars, .codes, .comb to work on codepoints
-    if let Value::Uni { text, .. } = target {
+    if let Value::Uni(u) = target {
+        let text = &u.text;
         match method {
             "chars" | "codes" => {
                 return Some(Ok(Value::Int(text.chars().count() as i64)));
@@ -523,10 +524,7 @@ pub(crate) fn native_method_0arg(
                     "NFKC" => text.nfkc().collect(),
                     _ => text.nfkd().collect(),
                 };
-                return Some(Ok(Value::Uni {
-                    form: method.to_string(),
-                    text: normalized,
-                }));
+                return Some(Ok(Value::uni(method.to_string(), normalized)));
             }
             _ => {}
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -150,16 +150,8 @@ impl Compiler {
         };
         matches!(
             regex,
-            Value::RegexWithAdverbs { global: true, .. }
-                | Value::RegexWithAdverbs { overlap: true, .. }
-                | Value::RegexWithAdverbs {
-                    exhaustive: true,
-                    ..
-                }
-                | Value::RegexWithAdverbs {
-                    repeat: Some(_),
-                    ..
-                }
+            Value::RegexWithAdverbs(a)
+                if a.global || a.overlap || a.exhaustive || a.repeat.is_some()
         )
     }
 

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -566,26 +566,16 @@ mod tests {
         assert_eq!(rest1, "");
         assert!(matches!(
             expr1,
-            Expr::MatchRegex(Value::RegexWithAdverbs {
-                pattern: ref s,
-                exhaustive: false,
-                repeat: Some(2),
-                perl5: false,
-                ..
-            }) if s.as_str() == "ab"
+            Expr::MatchRegex(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == "ab" && !a.exhaustive && a.repeat == Some(2) && !a.perl5
         ));
 
         let (rest2, expr2) = primary("m:x(2)/ab/").unwrap();
         assert_eq!(rest2, "");
         assert!(matches!(
             expr2,
-            Expr::MatchRegex(Value::RegexWithAdverbs {
-                pattern: ref s,
-                exhaustive: false,
-                repeat: Some(2),
-                perl5: false,
-                ..
-            }) if s.as_str() == "ab"
+            Expr::MatchRegex(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == "ab" && !a.exhaustive && a.repeat == Some(2) && !a.perl5
         ));
     }
 
@@ -621,22 +611,16 @@ mod tests {
         assert_eq!(rest1, "");
         assert!(matches!(
             expr1,
-            Expr::MatchRegex(Value::RegexWithAdverbs {
-                pattern: ref s,
-                perl5: true,
-                ..
-            }) if s.as_str() == "(?<name>.+)"
+            Expr::MatchRegex(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == "(?<name>.+)" && a.perl5
         ));
 
         let (rest2, expr2) = primary("rx:P5/a/").unwrap();
         assert_eq!(rest2, "");
         assert!(matches!(
             expr2,
-            Expr::Literal(Value::RegexWithAdverbs {
-                pattern: ref s,
-                perl5: true,
-                ..
-            }) if s.as_str() == "a"
+            Expr::Literal(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == "a" && a.perl5
         ));
     }
 
@@ -646,11 +630,8 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::MatchRegex(Value::RegexWithAdverbs {
-                pattern: ref s,
-                sigspace: true,
-                ..
-            }) if s.as_str() == ":s ab cd"
+            Expr::MatchRegex(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == ":s ab cd" && a.sigspace
         ));
     }
 
@@ -660,13 +641,8 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             expr,
-            Expr::MatchRegex(Value::RegexWithAdverbs {
-                pattern: ref s,
-                exhaustive: true,
-                repeat: None,
-                perl5: false,
-                ..
-            }) if s.as_str() == " s o+ "
+            Expr::MatchRegex(Value::RegexWithAdverbs(ref a))
+                if a.pattern.as_str() == " s o+ " && a.exhaustive && a.repeat.is_none() && !a.perl5
         ));
     }
 

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -740,7 +740,7 @@ fn adverbs_need_value(adverbs: &MatchAdverbs) -> bool {
 
 /// Build a RegexWithAdverbs Value from parsed adverbs.
 fn build_regex_with_adverbs(pattern: String, adverbs: &MatchAdverbs) -> Value {
-    Value::RegexWithAdverbs {
+    Value::RegexWithAdverbs(Box::new(crate::value::RegexAdverbs {
         pattern: Arc::new(pattern),
         global: adverbs.global,
         exhaustive: adverbs.exhaustive,
@@ -754,7 +754,7 @@ fn build_regex_with_adverbs(pattern: String, adverbs: &MatchAdverbs) -> Value {
         sigspace: adverbs.sigspace,
         samecase: adverbs.samecase,
         samespace: adverbs.samespace,
-    }
+    }))
 }
 
 /// Parse comma-separated call arguments inside parens.

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -921,13 +921,7 @@ fn parse_nf_form<'a>(rest_after_nf: &'a str, nf_name: &str) -> PResult<'a, Expr>
         "NFKC" => content.nfkc().collect(),
         _ => content.nfkd().collect(),
     };
-    Ok((
-        rest,
-        Expr::Literal(Value::Uni {
-            form: form_upper,
-            text: normalized,
-        }),
-    ))
+    Ok((rest, Expr::Literal(Value::uni(form_upper, normalized))))
 }
 
 /// Parse heredoc with flags (supports :c, :w adverbs on heredoc).

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -110,10 +110,7 @@ impl Interpreter {
                     _ => value.to_string_value().parse::<u32>().unwrap_or(0),
                 };
                 let text: String = char::from_u32(cp).into_iter().collect();
-                Value::Uni {
-                    form: String::new(),
-                    text,
-                }
+                Value::uni(String::new(), text)
             }
             _ => Value::Nil,
         };

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -191,9 +191,8 @@ impl Interpreter {
         limit: Option<usize>,
     ) -> Result<Vec<(String, Option<SplitMatch>)>, RuntimeError> {
         match splitter {
-            Value::Regex(pattern) | Value::RegexWithAdverbs { pattern, .. } => {
-                self.split_by_regex(text, pattern, limit)
-            }
+            Value::Regex(pattern) => self.split_by_regex(text, pattern, limit),
+            Value::RegexWithAdverbs(a) => self.split_by_regex(text, &a.pattern, limit),
             Value::Array(items, _) => {
                 // Check if any item is a regex
                 let has_regex = items
@@ -327,7 +326,12 @@ impl Interpreter {
 
             for (idx, splitter) in splitters.iter().enumerate() {
                 match splitter {
-                    Value::Regex(pattern) | Value::RegexWithAdverbs { pattern, .. } => {
+                    Value::Regex(_) | Value::RegexWithAdverbs(_) => {
+                        let pattern: &str = match splitter {
+                            Value::Regex(p) => p,
+                            Value::RegexWithAdverbs(a) => &a.pattern,
+                            _ => unreachable!(),
+                        };
                         if let Some((from, to)) = self.regex_find_first_from(pattern, text, pos) {
                             let matched: String = chars[from..to].iter().collect();
                             let is_better = match &best {

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -55,12 +55,12 @@ impl Interpreter {
             },
         );
 
-        Ok(Value::CustomType {
-            how: Box::new(how),
+        Ok(Value::custom_type(
+            Box::new(how),
             repr,
-            name: Symbol::intern(""),
+            Symbol::intern(""),
             id,
-        })
+        ))
     }
 
     /// Metamodel::Primitives.configure_type_checking($type, @cache, :$authoritative, :$call_accepts)
@@ -71,7 +71,7 @@ impl Interpreter {
             .ok_or_else(|| RuntimeError::new("configure_type_checking requires a type argument"))?;
 
         let id = match &type_val {
-            Value::CustomType { id, .. } => *id,
+            Value::CustomType(c) => c.id,
             _ => {
                 return Err(RuntimeError::new(
                     "configure_type_checking: first argument must be a custom type",
@@ -119,7 +119,7 @@ impl Interpreter {
             .ok_or_else(|| RuntimeError::new("compose_type requires a type argument"))?;
 
         let id = match &type_val {
-            Value::CustomType { id, .. } => *id,
+            Value::CustomType(c) => c.id,
             _ => {
                 return Err(RuntimeError::new(
                     "compose_type: first argument must be a custom type",
@@ -144,9 +144,9 @@ impl Interpreter {
         let target_type = &args[1];
 
         match (obj, target_type) {
-            (Value::CustomTypeInstance(d), Value::CustomType { how, .. }) => {
+            (Value::CustomTypeInstance(d), Value::CustomType(c)) => {
                 // Store the new HOW in the rebless map so .HOW returns the new type
-                self.rebless_map.insert(d.id, *how.clone());
+                self.rebless_map.insert(d.id, (*c.how).clone());
                 Ok(obj.clone())
             }
             _ => Ok(args[0].clone()),

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -707,17 +707,11 @@ impl Interpreter {
     /// Dispatch the CREATE method for CustomType and Package targets.
     pub(super) fn dispatch_create(&self, target: &Value) -> Option<Result<Value, RuntimeError>> {
         match target {
-            Value::CustomType {
-                how,
-                repr,
-                name,
-                id,
-                ..
-            } => Some(Ok(Value::custom_type_instance(
-                *id,
-                how.clone(),
-                repr.clone(),
-                *name,
+            Value::CustomType(c) => Some(Ok(Value::custom_type_instance(
+                c.id,
+                c.how.clone(),
+                c.repr.clone(),
+                c.name,
                 std::sync::Arc::new(HashMap::new()),
                 crate::value::next_instance_id(),
             ))),

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -100,11 +100,11 @@ impl Interpreter {
             Value::Whatever => "Whatever",
             Value::HyperWhatever => "HyperWhatever",
             Value::Capture { .. } => "Capture",
-            Value::Uni { form, .. } => {
-                if form.is_empty() {
+            Value::Uni(u) => {
+                if u.form.is_empty() {
                     "Uni"
                 } else {
-                    form.as_str()
+                    u.form.as_str()
                 }
             }
             Value::Mixin(inner, mixins) => {
@@ -120,8 +120,8 @@ impl Interpreter {
                 return Ok(Value::Package(*name));
             }
             Value::Proxy { .. } => "Proxy",
-            Value::CustomType { name, .. } => {
-                return Ok(Value::Package(*name));
+            Value::CustomType(c) => {
+                return Ok(Value::Package(c.name));
             }
             Value::CustomTypeInstance(d) => {
                 return Ok(Value::Package(d.type_name));
@@ -308,8 +308,8 @@ impl Interpreter {
         if let Value::Instance { class_name, .. } = target {
             return Ok(self.package_stash_value(&class_name.resolve()));
         }
-        if let Value::CustomType { name, .. } = target {
-            return Ok(self.package_stash_value(&name.resolve()));
+        if let Value::CustomType(c) = target {
+            return Ok(self.package_stash_value(&c.name.resolve()));
         }
         Ok(Value::Hash(Value::hash_arc(HashMap::new())))
     }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -929,10 +929,7 @@ impl Interpreter {
                 char::from_u32(cp)
             })
             .collect();
-        Value::Uni {
-            form: String::new(),
-            text,
-        }
+        Value::uni(String::new(), text)
     }
 
     /// Coerce one `Complex.new` positional argument to its `f64` component

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -651,15 +651,20 @@ impl Interpreter {
         };
 
         match pattern {
-            Value::Regex(pat) | Value::RegexWithAdverbs { pattern: pat, .. } => {
-                let is_p5 = matches!(pattern, Value::RegexWithAdverbs { perl5: true, .. });
+            Value::Regex(_) | Value::RegexWithAdverbs(_) => {
+                let pat: &str = match pattern {
+                    Value::Regex(p) => p,
+                    Value::RegexWithAdverbs(a) => &a.pattern,
+                    _ => unreachable!(),
+                };
+                let is_p5 = matches!(pattern, Value::RegexWithAdverbs(a) if a.perl5);
                 let pat = if is_p5 {
                     self.interpolate_regex_pattern(pat)
                 } else {
                     pat.to_string()
                 };
                 let pat_global =
-                    matches!(pattern, Value::RegexWithAdverbs { global: true, .. }) || global;
+                    matches!(pattern, Value::RegexWithAdverbs(a) if a.global) || global;
                 let all_captures = if is_p5 {
                     #[cfg(feature = "pcre2")]
                     {

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -50,7 +50,7 @@ impl Interpreter {
         };
         match val {
             Value::Regex(pat) => Some(pat.to_string()),
-            Value::RegexWithAdverbs { pattern, .. } => Some(pattern.to_string()),
+            Value::RegexWithAdverbs(a) => Some(a.pattern.to_string()),
             Value::Routine {
                 is_regex: true,
                 name,
@@ -69,7 +69,7 @@ impl Interpreter {
                     .iter()
                     .map(|v| match v {
                         Value::Regex(pat) => pat.to_string(),
-                        Value::RegexWithAdverbs { pattern, .. } => pattern.to_string(),
+                        Value::RegexWithAdverbs(a) => a.pattern.to_string(),
                         other => {
                             let s = other.to_string_value();
                             // Quote as regex literal using single quotes
@@ -88,7 +88,7 @@ impl Interpreter {
                     .iter()
                     .map(|v| match v {
                         Value::Regex(pat) => pat.to_string(),
-                        Value::RegexWithAdverbs { pattern, .. } => pattern.to_string(),
+                        Value::RegexWithAdverbs(a) => a.pattern.to_string(),
                         other => {
                             let s = other.to_string_value();
                             // Quote as regex literal using single quotes

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3711,9 +3711,7 @@ impl Interpreter {
                                     };
                                     let pat_str = match &value {
                                         Value::Regex(pat) => pat.to_string(),
-                                        Value::RegexWithAdverbs { pattern, .. } => {
-                                            pattern.to_string()
-                                        }
+                                        Value::RegexWithAdverbs(a) => a.pattern.to_string(),
                                         other => other.to_string_value(),
                                     };
                                     // Check for longname alias first
@@ -3781,9 +3779,7 @@ impl Interpreter {
                                     for elt in &elements {
                                         let pat_str = match elt {
                                             Value::Regex(pat) => pat.to_string(),
-                                            Value::RegexWithAdverbs { pattern, .. } => {
-                                                pattern.to_string()
-                                            }
+                                            Value::RegexWithAdverbs(a) => a.pattern.to_string(),
                                             other => other.to_string_value(),
                                         };
                                         if let Some(parsed) =
@@ -5064,9 +5060,7 @@ impl Interpreter {
                         for elt in &elements {
                             match elt {
                                 Value::Regex(pat) => alts.push(pat.to_string()),
-                                Value::RegexWithAdverbs { pattern, .. } => {
-                                    alts.push(pattern.to_string())
-                                }
+                                Value::RegexWithAdverbs(a) => alts.push(a.pattern.to_string()),
                                 other => alts.push(Self::escape_regex_scalar_literal(
                                     &other.to_string_value(),
                                 )),
@@ -5100,9 +5094,7 @@ impl Interpreter {
                     for elt in &elements {
                         match elt {
                             Value::Regex(pat) => alts.push(pat.to_string()),
-                            Value::RegexWithAdverbs { pattern, .. } => {
-                                alts.push(pattern.to_string())
-                            }
+                            Value::RegexWithAdverbs(a) => alts.push(a.pattern.to_string()),
                             other => alts
                                 .push(Self::escape_regex_scalar_literal(&other.to_string_value())),
                         }
@@ -5135,9 +5127,7 @@ impl Interpreter {
                     for elt in elements.iter() {
                         match elt {
                             Value::Regex(pat) => alts.push(pat.to_string()),
-                            Value::RegexWithAdverbs { pattern, .. } => {
-                                alts.push(pattern.to_string())
-                            }
+                            Value::RegexWithAdverbs(a) => alts.push(a.pattern.to_string()),
                             other => alts
                                 .push(Self::escape_regex_scalar_literal(&other.to_string_value())),
                         }
@@ -5202,7 +5192,7 @@ impl Interpreter {
         match value {
             Value::Nil => out.push_str("<!>"),
             Value::Regex(pat) => out.push_str(pat),
-            Value::RegexWithAdverbs { pattern, .. } => out.push_str(pattern),
+            Value::RegexWithAdverbs(a) => out.push_str(&a.pattern),
             Value::Junction { values, .. } => {
                 // Expand junction values as alternation [v1|v2|...]
                 out.push('[');
@@ -5212,7 +5202,7 @@ impl Interpreter {
                     }
                     match v {
                         Value::Regex(pat) => out.push_str(pat),
-                        Value::RegexWithAdverbs { pattern, .. } => out.push_str(pattern),
+                        Value::RegexWithAdverbs(a) => out.push_str(&a.pattern),
                         other => out
                             .push_str(&Self::escape_regex_scalar_literal(&other.to_string_value())),
                     }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -235,15 +235,10 @@ impl Interpreter {
                 }
             }
             // :nth(...) and ordinal forms (:1st, :2nd, :3rd, :4th, ...)
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern,
-                    nth: Some(raw_nth),
-                    perl5,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a)) if a.nth.is_some() => {
+                let pattern = &a.pattern;
+                let raw_nth = a.nth.as_ref().unwrap();
+                let perl5 = &a.perl5;
                 let text = left.to_string_value();
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
@@ -367,17 +362,10 @@ impl Interpreter {
                 true
             }
             // :c/:continue -- search from $/.to (or 0) onwards (non-anchored)
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern: pat,
-                    continue_: true,
-                    global: false,
-                    exhaustive: false,
-                    overlap: false,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a))
+                if a.continue_ && !a.global && !a.exhaustive && !a.overlap =>
+            {
+                let pat = &a.pattern;
                 let text = left.to_string_value();
                 let pat = pat.to_string();
                 let start_pos = self.get_match_to_position();
@@ -390,17 +378,10 @@ impl Interpreter {
                 false
             }
             // :pos/:p anchored match (non-exhaustive/non-global) -- match at $/.to (or 0)
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern: pat,
-                    pos: true,
-                    global: false,
-                    exhaustive: false,
-                    overlap: false,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a))
+                if a.pos && !a.global && !a.exhaustive && !a.overlap =>
+            {
+                let pat = &a.pattern;
                 let text = left.to_string_value();
                 let pat = pat.to_string();
                 let start_pos = self.get_match_to_position();
@@ -413,18 +394,12 @@ impl Interpreter {
             }
             // :x(N) without :g/:ex/:ov -- require at least N non-overlapping matches,
             // return first N in $/.
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern,
-                    global: false,
-                    exhaustive: false,
-                    overlap: false,
-                    repeat: Some(needed),
-                    perl5,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a))
+                if !a.global && !a.exhaustive && !a.overlap && a.repeat.is_some() =>
+            {
+                let pattern = &a.pattern;
+                let needed = &a.repeat.unwrap();
+                let perl5 = &a.perl5;
                 let text = left.to_string_value();
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
@@ -454,18 +429,10 @@ impl Interpreter {
                 true
             }
             // :g (global) -- find all non-overlapping matches
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern,
-                    global: true,
-                    overlap: false,
-                    exhaustive: false,
-                    repeat,
-                    perl5,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a)) if a.global && !a.overlap && !a.exhaustive => {
+                let pattern = &a.pattern;
+                let repeat = &a.repeat;
+                let perl5 = &a.perl5;
                 let text = left.to_string_value();
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
@@ -522,15 +489,9 @@ impl Interpreter {
                 true
             }
             // :ov (overlap) -- find longest match at each starting position
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern,
-                    overlap: true,
-                    perl5,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a)) if a.overlap => {
+                let pattern = &a.pattern;
+                let perl5 = &a.perl5;
                 let text = left.to_string_value();
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
@@ -570,16 +531,10 @@ impl Interpreter {
                 true
             }
             // :ex (exhaustive) -- find ALL possible matches
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern,
-                    exhaustive: true,
-                    repeat,
-                    perl5,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a)) if a.exhaustive => {
+                let pattern = &a.pattern;
+                let repeat = &a.repeat;
+                let perl5 = &a.perl5;
                 let text = left.to_string_value();
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
@@ -617,7 +572,7 @@ impl Interpreter {
                 true
             }
             // Array/List ~~ Regex: iterate elements, match each individually
-            (Value::Array(items, ..), Value::Regex(_) | Value::RegexWithAdverbs { .. }) => {
+            (Value::Array(items, ..), Value::Regex(_) | Value::RegexWithAdverbs(_)) => {
                 for item in items.iter() {
                     if self.smart_match(item, right) {
                         return true;
@@ -628,7 +583,7 @@ impl Interpreter {
             }
             (
                 Value::Seq(items) | Value::Slip(items),
-                Value::Regex(_) | Value::RegexWithAdverbs { .. },
+                Value::Regex(_) | Value::RegexWithAdverbs(_),
             ) => {
                 for item in items.iter() {
                     if self.smart_match(item, right) {
@@ -639,7 +594,7 @@ impl Interpreter {
                 false
             }
             // Hash ~~ Regex: iterate keys, match each individually
-            (Value::Hash(map), Value::Regex(_) | Value::RegexWithAdverbs { .. }) => {
+            (Value::Hash(map), Value::Regex(_) | Value::RegexWithAdverbs(_)) => {
                 for key in map.keys() {
                     let key_val = Value::str(key.clone());
                     if self.smart_match(&key_val, right) {
@@ -650,18 +605,19 @@ impl Interpreter {
                 false
             }
             // Single match: plain Regex or RegexWithAdverbs without multi-match flags
-            (_, Value::Regex(pat))
-            | (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern: pat,
-                    global: false,
-                    exhaustive: false,
-                    overlap: false,
-                    perl5: false,
-                    ..
-                },
-            ) => {
+            (_, Value::Regex(_)) | (_, Value::RegexWithAdverbs(_))
+                if matches!(right, Value::Regex(_))
+                    || matches!(
+                        right,
+                        Value::RegexWithAdverbs(a)
+                            if !a.global && !a.exhaustive && !a.overlap && !a.perl5
+                    ) =>
+            {
+                let pat: &str = match right {
+                    Value::Regex(p) => p,
+                    Value::RegexWithAdverbs(a) => &a.pattern,
+                    _ => unreachable!(),
+                };
                 let text = left.to_string_value();
                 let pat = pat.to_string();
                 // Set $_ to the match target so $( $_ ) works inside regex
@@ -778,17 +734,10 @@ impl Interpreter {
                 false
             }
             // P5 regex single match
-            (
-                _,
-                Value::RegexWithAdverbs {
-                    pattern: pat,
-                    global: false,
-                    exhaustive: false,
-                    overlap: false,
-                    perl5: true,
-                    ..
-                },
-            ) => {
+            (_, Value::RegexWithAdverbs(a))
+                if !a.global && !a.exhaustive && !a.overlap && a.perl5 =>
+            {
+                let pat = &a.pattern;
                 let text = left.to_string_value();
                 let pat = self.interpolate_regex_pattern(pat);
                 #[cfg(feature = "pcre2")]
@@ -986,10 +935,12 @@ impl Interpreter {
                 map.contains_key(&key)
             }),
             // Regex ~~ Hash: check if any key matches the regex
-            (
-                Value::Regex(pat) | Value::RegexWithAdverbs { pattern: pat, .. },
-                Value::Hash(map),
-            ) => {
+            (Value::Regex(_) | Value::RegexWithAdverbs(_), Value::Hash(map)) => {
+                let pat: &str = match left {
+                    Value::Regex(p) => p,
+                    Value::RegexWithAdverbs(a) => &a.pattern,
+                    _ => unreachable!(),
+                };
                 for key in map.keys() {
                     if self.regex_find_first(pat, key).is_some() {
                         return true;
@@ -1198,9 +1149,11 @@ impl Interpreter {
                     .all(|(lhs, rhs)| self.parametric_arg_subtypes(lhs, rhs))
             }
             // When RHS is a CustomType, use Raku type checking protocol
-            (_, Value::CustomType { id, how, .. }) => self.custom_type_check(left, *id, how),
+            (_, Value::CustomType(c)) => self.custom_type_check(left, c.id, &c.how),
             // When LHS is a CustomType (type object), check type cache or HOW.type_check
-            (Value::CustomType { how, id, .. }, _) => {
+            (Value::CustomType(c), _) => {
+                let how = &c.how;
+                let id = &c.id;
                 if let Value::Package(_) = right {
                     // After compose: check the type check cache
                     let data = self.custom_type_data.get(id).cloned();
@@ -1415,10 +1368,10 @@ impl Interpreter {
                     Value::Junction { .. }
                         | Value::Sub(_)
                         | Value::Regex(_)
-                        | Value::RegexWithAdverbs { .. }
+                        | Value::RegexWithAdverbs(_)
                         | Value::Routine { .. }
                         | Value::Package(_)
-                        | Value::CustomType { .. }
+                        | Value::CustomType(_)
                         | Value::ParametricRole { .. }
                 ) =>
             {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1560,7 +1560,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
             }
             "Capture"
         }
-        Value::Uni { form, .. } => match form.as_str() {
+        Value::Uni(u) => match u.form.as_str() {
             "NFC" => "NFC",
             "NFD" => "NFD",
             "NFKC" => "NFKC",
@@ -2305,7 +2305,7 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
                 y, mo, d, h, mi, s, tz,
             ))
         }
-        Value::Uni { ref text, .. } => Value::Int(text.chars().count() as i64),
+        Value::Uni(u) => Value::Int(u.text.chars().count() as i64),
         Value::Capture { ref positional, .. } => Value::Int(positional.len() as i64),
         _ => Value::Int(0),
     }
@@ -3499,7 +3499,7 @@ pub(crate) fn value_which_key(value: &Value) -> String {
         Value::Complex(r, i) => format!("Complex|{}+{}i", r, i),
         Value::Nil => format!("Nil|U{}", Symbol::intern("Nil").id()),
         Value::Package(name) => format!("{}|U{}", name.resolve(), name.id()),
-        Value::CustomType { name, id, .. } => format!("{}|U{}", name.resolve(), id),
+        Value::CustomType(c) => format!("{}|U{}", c.name.resolve(), c.id),
         Value::Instance { id, .. } => {
             format!("{}|{}", value_type_name(value), id)
         }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -447,7 +447,7 @@ impl Value {
             }
             Value::LazyList(_) => "LazyList".to_string(),
             Value::LazyIoLines { .. } => "(...)".to_string(),
-            Value::Uni { text, .. } => text.clone(),
+            Value::Uni(u) => u.text.clone(),
             Value::Hash(items) => {
                 // Cycle detection for recursive hash structures
                 thread_local! {
@@ -844,20 +844,18 @@ impl Value {
                 format!("{}({})", kind_str, elems)
             }
             Value::Regex(pattern) => format!("/{}/", pattern),
-            Value::RegexWithAdverbs {
-                pattern,
-                global,
-                exhaustive,
-                overlap,
-                repeat,
-                nth,
-                perl5,
-                ignore_case,
-                sigspace,
-                samecase,
-                samespace,
-                ..
-            } => {
+            Value::RegexWithAdverbs(a) => {
+                let pattern = &a.pattern;
+                let global = &a.global;
+                let exhaustive = &a.exhaustive;
+                let overlap = &a.overlap;
+                let repeat = &a.repeat;
+                let nth = &a.nth;
+                let perl5 = &a.perl5;
+                let ignore_case = &a.ignore_case;
+                let sigspace = &a.sigspace;
+                let samecase = &a.samecase;
+                let samespace = &a.samespace;
                 let mut prefix = String::new();
                 if *ignore_case {
                     prefix.push_str(":i");
@@ -943,11 +941,11 @@ impl Value {
                 }
             }
             Value::Proxy { .. } => "Proxy".to_string(),
-            Value::CustomType { name, .. } => {
-                if name.is_empty() {
+            Value::CustomType(c) => {
+                if c.name.is_empty() {
                     "(CustomType)".to_string()
                 } else {
-                    format!("({})", name)
+                    format!("({})", c.name)
                 }
             }
             Value::CustomTypeInstance(d) => format!("{}()", d.type_name),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1561,21 +1561,9 @@ pub enum Value {
         index: usize,
     },
     Regex(Arc<String>),
-    RegexWithAdverbs {
-        pattern: Arc<String>,
-        global: bool,
-        exhaustive: bool,
-        overlap: bool,
-        repeat: Option<usize>,
-        nth: Option<Arc<String>>,
-        perl5: bool,
-        pos: bool,
-        continue_: bool,
-        ignore_case: bool,
-        sigspace: bool,
-        samecase: bool,
-        samespace: bool,
-    },
+    /// A regex literal carrying adverbs. Boxed payload to keep `Value` small
+    /// (this variant has 13 fields).
+    RegexWithAdverbs(Box<RegexAdverbs>),
     Sub(Arc<SubData>),
     /// A weak reference to a Sub (used for &?BLOCK self-references to break cycles).
     /// Upgrade to the strong value when accessed; returns Nil if expired.
@@ -1618,11 +1606,8 @@ pub enum Value {
     },
     /// Unicode normalization form types (NFC, NFD, NFKC, NFKD).
     /// `form` is one of "NFC", "NFD", "NFKC", "NFKD".
-    /// `text` is the normalized string.
-    Uni {
-        form: String,
-        text: String,
-    },
+    /// `text` is the normalized string. Boxed to keep `Value` small.
+    Uni(Box<UniData>),
     /// A Proxy container with FETCH and STORE callbacks.
     Proxy {
         fetcher: Box<Value>,
@@ -1639,13 +1624,9 @@ pub enum Value {
         type_args: Vec<Value>,
     },
     /// A type object created by Metamodel::Primitives.create_type.
-    /// `how` is the meta-object (HOW), `repr` is the REPR name, `name` is the type name.
-    CustomType {
-        how: Box<Value>,
-        repr: String,
-        name: Symbol,
-        id: u64,
-    },
+    /// `how` is the meta-object (HOW), `repr` is the REPR name, `name` is the type
+    /// name. Boxed payload to keep `Value` small.
+    CustomType(Box<CustomTypeData>),
     /// An instance of a custom type (created by .CREATE on a CustomType).
     /// Boxed payload to keep `Value` small (this variant has six fields).
     CustomTypeInstance(Box<CustomTypeInstanceData>),
@@ -1697,6 +1678,40 @@ pub struct CustomTypeInstanceData {
     pub type_name: Symbol,
     pub attributes: Arc<HashMap<String, Value>>,
     pub id: u64,
+}
+
+/// Boxed payload of [`Value::CustomType`] (a type object from create_type).
+#[derive(Debug, Clone)]
+pub struct CustomTypeData {
+    pub how: Box<Value>,
+    pub repr: String,
+    pub name: Symbol,
+    pub id: u64,
+}
+
+/// Boxed payload of [`Value::Uni`] (a Uni in a normalization form).
+#[derive(Debug, Clone)]
+pub struct UniData {
+    pub form: String,
+    pub text: String,
+}
+
+/// Boxed payload of [`Value::RegexWithAdverbs`] (a regex literal carrying adverbs).
+#[derive(Debug, Clone)]
+pub struct RegexAdverbs {
+    pub pattern: Arc<String>,
+    pub global: bool,
+    pub exhaustive: bool,
+    pub overlap: bool,
+    pub repeat: Option<usize>,
+    pub nth: Option<Arc<String>>,
+    pub perl5: bool,
+    pub pos: bool,
+    pub continue_: bool,
+    pub ignore_case: bool,
+    pub sigspace: bool,
+    pub samecase: bool,
+    pub samespace: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -2521,51 +2536,20 @@ impl PartialEq for Value {
                 },
             ) => at == bt && ak == bk,
             (Value::Regex(a), Value::Regex(b)) => a == b,
-            (
-                Value::RegexWithAdverbs {
-                    pattern: ap,
-                    global: ag,
-                    exhaustive: aex,
-                    overlap: aov,
-                    repeat: ar,
-                    nth: anth,
-                    perl5: ap5,
-                    pos: apos,
-                    continue_: ac,
-                    ignore_case: aic,
-                    sigspace: ass,
-                    samecase: asc,
-                    samespace: asp,
-                },
-                Value::RegexWithAdverbs {
-                    pattern: bp,
-                    global: bg,
-                    exhaustive: bex,
-                    overlap: bov,
-                    repeat: br,
-                    nth: bnth,
-                    perl5: bp5,
-                    pos: bpos,
-                    continue_: bc,
-                    ignore_case: bic,
-                    sigspace: bss,
-                    samecase: bsc,
-                    samespace: bsp,
-                },
-            ) => {
-                ap == bp
-                    && ag == bg
-                    && aex == bex
-                    && aov == bov
-                    && ar == br
-                    && anth == bnth
-                    && ap5 == bp5
-                    && apos == bpos
-                    && ac == bc
-                    && aic == bic
-                    && ass == bss
-                    && asc == bsc
-                    && asp == bsp
+            (Value::RegexWithAdverbs(a), Value::RegexWithAdverbs(b)) => {
+                a.pattern == b.pattern
+                    && a.global == b.global
+                    && a.exhaustive == b.exhaustive
+                    && a.overlap == b.overlap
+                    && a.repeat == b.repeat
+                    && a.nth == b.nth
+                    && a.perl5 == b.perl5
+                    && a.pos == b.pos
+                    && a.continue_ == b.continue_
+                    && a.ignore_case == b.ignore_case
+                    && a.sigspace == b.sigspace
+                    && a.samecase == b.samecase
+                    && a.samespace == b.samespace
             }
             (
                 Value::Routine {
@@ -2677,9 +2661,7 @@ impl PartialEq for Value {
                     false
                 }
             }
-            (Value::Uni { form: af, text: at }, Value::Uni { form: bf, text: bt }) => {
-                af == bf && at == bt
-            }
+            (Value::Uni(a), Value::Uni(b)) => a.form == b.form && a.text == b.text,
             // ContainerRef: deref and compare inner values.
             // Check Arc pointer identity first to avoid deadlock on same-Arc comparison.
             (Value::ContainerRef(a), Value::ContainerRef(b)) => {
@@ -2760,10 +2742,10 @@ impl Value {
         Value::BigRat(Box::new(num), Box::new(den))
     }
     /// The HOW (meta-object) of a `CustomType` or `CustomTypeInstance`, if this
-    /// is one. Centralizes access now that `CustomTypeInstance` is a boxed payload.
+    /// is one. Centralizes access now that both are boxed payloads.
     pub fn custom_how(&self) -> Option<&Value> {
         match self {
-            Value::CustomType { how, .. } => Some(how),
+            Value::CustomType(d) => Some(&d.how),
             Value::CustomTypeInstance(d) => Some(&d.how),
             _ => None,
         }
@@ -2771,10 +2753,23 @@ impl Value {
     /// The REPR name of a `CustomType` or `CustomTypeInstance`, if this is one.
     pub fn custom_repr(&self) -> Option<&str> {
         match self {
-            Value::CustomType { repr, .. } => Some(repr),
+            Value::CustomType(d) => Some(&d.repr),
             Value::CustomTypeInstance(d) => Some(&d.repr),
             _ => None,
         }
+    }
+    /// Create a CustomType value (boxed payload).
+    pub fn custom_type(how: Box<Value>, repr: String, name: Symbol, id: u64) -> Self {
+        Value::CustomType(Box::new(CustomTypeData {
+            how,
+            repr,
+            name,
+            id,
+        }))
+    }
+    /// Create a Uni value (boxed payload).
+    pub fn uni(form: String, text: String) -> Self {
+        Value::Uni(Box::new(UniData { form, text }))
     }
     /// Create a CustomTypeInstance value (boxed payload).
     pub fn custom_type_instance(
@@ -3983,11 +3978,11 @@ mod value_size_guard {
         // Oversized variants used to hold their payloads inline, making `Value`
         // 72 bytes (every clone/move pays for the largest variant). Boxing the
         // big payloads shrank it: Capture+BigRat (72->64), CustomTypeInstance
-        // (64->56). Remaining 48-byte variants (Uni, RegexWithAdverbs,
-        // CustomType) + their missing niche are boxed in follow-up steps to
-        // reach the next tier. Guard against layout regressions.
+        // (64->56), Uni+RegexWithAdverbs+CustomType (56->48). Remaining 40-byte
+        // variants (Proxy, Enum, ...) are boxed in follow-up steps. Guard against
+        // layout regressions.
         let sz = std::mem::size_of::<Value>();
-        assert!(sz <= 56, "size_of::<Value>() = {sz}, expected <= 56");
+        assert!(sz <= 48, "size_of::<Value>() = {sz}, expected <= 48");
     }
 }
 

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -185,34 +185,20 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             index: *index,
         }),
         Value::Regex(s) => Ok(SerValue::Regex((**s).clone())),
-        Value::RegexWithAdverbs {
-            pattern,
-            global,
-            exhaustive,
-            overlap,
-            repeat,
-            nth,
-            perl5,
-            pos,
-            continue_,
-            ignore_case,
-            sigspace,
-            samecase,
-            samespace,
-        } => Ok(SerValue::RegexWithAdverbs {
-            pattern: (**pattern).clone(),
-            global: *global,
-            exhaustive: *exhaustive,
-            overlap: *overlap,
-            repeat: *repeat,
-            nth: nth.as_ref().map(|v| (**v).clone()),
-            perl5: *perl5,
-            pos: *pos,
-            continue_: *continue_,
-            ignore_case: *ignore_case,
-            sigspace: *sigspace,
-            samecase: *samecase,
-            samespace: *samespace,
+        Value::RegexWithAdverbs(a) => Ok(SerValue::RegexWithAdverbs {
+            pattern: (*a.pattern).clone(),
+            global: a.global,
+            exhaustive: a.exhaustive,
+            overlap: a.overlap,
+            repeat: a.repeat,
+            nth: a.nth.as_ref().map(|v| (**v).clone()),
+            perl5: a.perl5,
+            pos: a.pos,
+            continue_: a.continue_,
+            ignore_case: a.ignore_case,
+            sigspace: a.sigspace,
+            samecase: a.samecase,
+            samespace: a.samespace,
         }),
         Value::Junction { kind, values } => {
             let ser_kind = match kind {
@@ -277,9 +263,9 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 named: ser_named?,
             })
         }
-        Value::Uni { form, text } => Ok(SerValue::Uni {
-            form: form.clone(),
-            text: text.clone(),
+        Value::Uni(u) => Ok(SerValue::Uni {
+            form: u.form.clone(),
+            text: u.text.clone(),
         }),
         Value::ParametricRole {
             base_name,
@@ -394,7 +380,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             sigspace,
             samecase,
             samespace,
-        } => Value::RegexWithAdverbs {
+        } => Value::RegexWithAdverbs(Box::new(crate::value::RegexAdverbs {
             pattern: Arc::new(pattern),
             global,
             exhaustive,
@@ -408,7 +394,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             sigspace,
             samecase,
             samespace,
-        },
+        })),
         SerValue::Junction { kind, values } => {
             let jk = match kind {
                 SerJunctionKind::Any => JunctionKind::Any,
@@ -459,7 +445,7 @@ fn ser_to_value(sv: SerValue) -> Value {
                 .map(|(k, v)| (k, ser_to_value(v)))
                 .collect(),
         ),
-        SerValue::Uni { form, text } => Value::Uni { form, text },
+        SerValue::Uni { form, text } => Value::uni(form, text),
         SerValue::ParametricRole {
             base_name,
             type_args,

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -453,7 +453,7 @@ impl Value {
             Value::Whatever => true,
             Value::HyperWhatever => true,
             Value::Capture { positional, named } => !positional.is_empty() || !named.is_empty(),
-            Value::Uni { text, .. } => !text.is_empty(),
+            Value::Uni(u) => !u.text.is_empty(),
             Value::Mixin(inner, mixins) => {
                 if let Some(bool_val) = mixins.get("Bool") {
                     bool_val.truthy()
@@ -567,7 +567,7 @@ impl Value {
             Value::Whatever => "Whatever",
             Value::HyperWhatever => "HyperWhatever",
             Value::Capture { .. } => "Capture",
-            Value::Uni { form, .. } => form.as_str(),
+            Value::Uni(u) => u.form.as_str(),
             Value::Mixin(inner, mixins) => {
                 // Check allomorphic type names (IntStr, NumStr, RatStr, ComplexStr, Allomorph)
                 if matches!(
@@ -591,8 +591,8 @@ impl Value {
             Value::ParametricRole { base_name, .. } => {
                 return base_name.resolve() == type_name;
             }
-            Value::CustomType { name, .. } => {
-                return name.resolve() == type_name;
+            Value::CustomType(c) => {
+                return c.name.resolve() == type_name;
             }
             Value::CustomTypeInstance(d) => {
                 return d.type_name.resolve() == type_name;
@@ -909,8 +909,8 @@ pub(crate) fn what_type_name(val: &Value) -> String {
         Value::Regex(_) => "Regex".to_string(),
         Value::Junction { .. } => "Junction".to_string(),
         Value::Slip(_) => "Slip".to_string(),
-        Value::Uni { form, .. } if !form.is_empty() => form.clone(),
-        Value::Uni { .. } => "Uni".to_string(),
+        Value::Uni(u) if !u.form.is_empty() => u.form.clone(),
+        Value::Uni(_) => "Uni".to_string(),
         Value::Mixin(inner, mixins) => {
             allomorph_type_name(inner, mixins).unwrap_or_else(|| what_type_name(inner))
         }

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -508,8 +508,8 @@ impl VM {
         };
 
         // Uni: check exists based on codepoint count
-        if let Value::Uni { text, .. } = &target {
-            let len = text.chars().count() as i64;
+        if let Value::Uni(u) = &target {
+            let len = u.text.chars().count() as i64;
             if indices.len() == 1 && !is_zen {
                 let i = indices[0];
                 let exists = i >= 0 && i < len;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1490,16 +1490,16 @@ impl VM {
                 Value::array(slice)
             }
             // Uni/NFC/NFD/NFKC/NFKD indexing: returns integer codepoint values
-            (Value::Uni { ref text, .. }, Value::Int(i)) => {
-                let chars: Vec<char> = text.chars().collect();
+            (Value::Uni(u), Value::Int(i)) => {
+                let chars: Vec<char> = u.text.chars().collect();
                 if i < 0 || (i as usize) >= chars.len() {
                     Value::Nil
                 } else {
                     Value::Int(chars[i as usize] as i64)
                 }
             }
-            (Value::Uni { ref text, .. }, Value::Sub(ref data)) => {
-                let chars: Vec<char> = text.chars().collect();
+            (Value::Uni(u), Value::Sub(ref data)) => {
+                let chars: Vec<char> = u.text.chars().collect();
                 let len = chars.len() as i64;
                 let mut sub_env = data.env.clone();
                 for p in &data.params {
@@ -1524,8 +1524,8 @@ impl VM {
                     _ => Value::Nil,
                 }
             }
-            (Value::Uni { ref text, .. }, Value::Array(indices, ..)) => {
-                let chars: Vec<char> = text.chars().collect();
+            (Value::Uni(u), Value::Array(indices, ..)) => {
+                let chars: Vec<char> = u.text.chars().collect();
                 Value::array(
                     indices
                         .iter()
@@ -1543,8 +1543,8 @@ impl VM {
                         .collect(),
                 )
             }
-            (Value::Uni { ref text, .. }, Value::Range(a, b)) => {
-                let chars: Vec<char> = text.chars().collect();
+            (Value::Uni(u), Value::Range(a, b)) => {
+                let chars: Vec<char> = u.text.chars().collect();
                 let start = a.max(0) as usize;
                 let end = if Self::range_end_is_unbounded(b) {
                     chars.len().saturating_sub(1)
@@ -1559,8 +1559,8 @@ impl VM {
                     .collect();
                 Value::array(slice)
             }
-            (Value::Uni { ref text, .. }, Value::RangeExcl(a, b)) => {
-                let chars: Vec<char> = text.chars().collect();
+            (Value::Uni(u), Value::RangeExcl(a, b)) => {
+                let chars: Vec<char> = u.text.chars().collect();
                 let start = a.max(0) as usize;
                 let end_excl = if Self::range_end_is_unbounded(b) {
                     chars.len()


### PR DESCRIPTION
## Summary

Continues the `Value`-size reduction (ANALYSIS §5). After PR2 (#3074, 64→56), the 48-byte struct variants `Uni`, `RegexWithAdverbs` (13 fields), and `CustomType` capped `Value` at 56 (48-byte payload + an 8-byte discriminant with no spare niche). Boxing all three drops **Value 56 → 48**.

## Changes

- New payload structs `UniData` / `RegexAdverbs` / `CustomTypeData`; variants become `Uni(Box<UniData>)`, `RegexWithAdverbs(Box<RegexAdverbs>)`, `CustomType(Box<CustomTypeData>)`. Added `Value::uni(..)` / `Value::custom_type(..)` constructors (RegexWithAdverbs built inline).
- Updated `custom_how()` / `custom_repr()` accessors for the now-boxed `CustomType`; OR-patterns that bound a field shared with `CustomTypeInstance` route through them.
- ~70 match/construction sites across ~20 files adapted (struct patterns → `(payload)` + field access; serde both directions; in-crate `matches!` regex-adverb tests).

## Testing

- `size_of::<Value>()` 56 → 48; `value_size_guard` tightened to `<= 48`. **Cumulative §5 so far: 72 → 48 (-33%).**
- Roast green: `S05-modifier/{global,counted,exhaustive,ignorecase}.t`, `S15-normalization/nfc-10.t`. NFC/NFD codes, `m:g`/`m:i`, `Metamodel::ClassHOW.new_type` verified identical to rakudo.
- `make test` PASS (799 files / 7437 tests), clippy clean (`--all-targets`).

Follow-up (PR4): box the 40-byte tier (`Proxy`, `Enum`) to reach ~40 or below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)