### PR TITLE
perf(vm): drop spurious env_dirty marks on pure hyper/race/reflection branches (CP-2 shrink slice 1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -146,8 +146,14 @@ VM→interpreter 委譲は carrier / concurrency(Track C) / niche のみ。**env
 
 #### 後続（CP-1 後・逐次）
 
-- [ ] **CP-2: dual-store 機構の削除**（**2〜4 PR**）— env が VM 単一所有になったら `env_dirty`/`saved_env_dirty`/
-      `ensure_locals_synced`/`sync_locals_from_env`（現状 **241 参照**）+ `VmCallFrame` の dirty/bind 群を撤去。
+- [~] **CP-2: dual-store *遅延フラグ* 機構の削除**（多 PR キャンペーン）— **スコープ訂正 (2026-06-15、依存調査の結論。
+      詳細 = [docs/vm-dual-store.md](docs/vm-dual-store.md) 冒頭「CP-2 status & corrected plan」)**: `sync_locals_from_env`
+      は **`EVAL`（仕様上の永続 by-name lexical writer）が存在する限り削除不可**＝env→locals name→slot 再構築は本質的に必須。
+      よって達成可能 CP-2 = **遅延フラグ層**（`env_dirty` / `saved_env_dirty` / `ensure_locals_synced` + `VmCallFrame` の
+      dirty フィールド）の撤去。166 個の `env_dirty = true` setter を ①pure→無マーク ②native by-name→surgical local 更新
+      ③carrier→eager-precise reconcile に変換しきってから削除。`sync_locals_from_env` は eager reconcile primitive として残す。
+      - [x] **slice 1**: `vm_call_method_ops.rs` の pure な hyper/race wrap + reflection 分岐の spurious mark を撤去
+            （pin = `t/hyper-reflection-env.t` / `t/say-env-roundtrip.t`）。
 - [ ] **CP-3: Interpreter を carrier-only へ縮退 → 撤去**（**4〜8 PR**）— 残る **86 フィールド**を VM へ畳むか撤去、
       ping-pong 撤去、carrier（subset-where/regex-`{}`）を VM-native 化して carrier 面を縮小 → **Interpreter 削除**。
 

--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -5,6 +5,51 @@ Tracking design for the highest-leverage VM-decoupling task
 so it is staged into small, individually-shippable slices. This file is the
 map; record each slice's before/after here.
 
+> ## CP-2 status & corrected plan (2026-06-15) — READ FIRST
+>
+> **CP-1 done**: `env` is now VM-owned (`VM.env`, PR #3075); carriers borrow it
+> via `loan_env!`. PLAN.md then lists **CP-2 = delete the dual-store machinery**
+> (`env_dirty` / `saved_env_dirty` / `ensure_locals_synced` / `sync_locals_from_env`
+> + the `VmCallFrame` dirty/bind group), estimated "2–4 PR, before CP-3".
+>
+> **Correction after a full dependency survey (this session).** That estimate and
+> ordering were optimistic. The machinery survives because **carriers write the
+> caller `env` by arbitrary name**, after which the slot-indexed `locals` are
+> stale and must be reconciled name→slot (`sync_locals_from_env`). The decisive
+> finding: **`EVAL` is a permanent, spec-mandated by-name lexical writer** — it
+> compiles+runs a sub-program that can assign any caller lexical. So as long as
+> slot-indexed `locals` and `EVAL` coexist, the env→locals name→slot reconcile is
+> *fundamentally required* and cannot be deleted. Deleting it outright would mean
+> eliminating `locals` as a separate store (env-only), which regresses the hottest
+> path (slot perf on `fib` etc.). **Therefore CP-3 (carrier removal) does NOT
+> unblock full deletion of `sync_locals_from_env` — that primitive is permanent.**
+>
+> **Achievable CP-2 (revised target).** Delete the *lazy flag* layer
+> (`env_dirty`, `ensure_locals_synced`, `saved_env_dirty`, and the `VmCallFrame`
+> dirty fields), converting every `env_dirty = true` setter (166 sites) into one
+> of:
+>   1. **nothing** — the op is provably env-pure (native methods on by-value
+>      targets, pure value/reflection branches). *(This file's first slice:
+>      spurious pure-method marks in `vm_call_method_ops.rs`.)*
+>   2. **surgical local update** — a VM-native by-name write whose name is known:
+>      mirror into the matching slot (`update_local_if_exists`) instead of flagging.
+>   3. **eager-precise reconcile** — a carrier (`loan_env!`) that may have written
+>      arbitrary names: call `sync_locals_from_env(code)` immediately *iff a
+>      carrier actually ran* (track it like `pending_local_updates` /
+>      `method_dispatch_pure`), instead of the deferred flag.
+> Once every setter is converted, `env_dirty` + `ensure_locals_synced` +
+> `saved_env_dirty` are dead and deleted. **`sync_locals_from_env` is kept** as
+> the eager EVAL/carrier reconcile primitive (consider renaming to
+> `reconcile_locals_from_env`). The hot per-call paths already use the precise
+> `method_dispatch_pure` flag (Slice 6.3) and stay perf-neutral; the cold/carrier
+> sites move from lazy-flag to eager-precise.
+>
+> **User direction (2026-06-15):** pursue CP-3 (carrier VM-native-ization) in
+> parallel where it removes whole carrier categories, but the dual-store *flag*
+> deletion above is the concrete, independently-shippable CP-2 campaign. Easy
+> `try_native_*` method/function-dispatch wins are already exhausted (benchmarks
+> show ~0% method fallback), so remaining CP-3 is the hard ③ state-ownership work.
+
 > **Correction (2026-06-05).** The slice notes below repeatedly cite
 > `t/wrap.t`, `t/placeholder.t`, and `t/tail-function.t` as "pre-existing"
 > failures used to validate "my change didn't break anything." That framing was

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -609,7 +609,7 @@ impl VM {
                 Value::RaceSeq(arc)
             };
             self.stack.push(result);
-            self.env_dirty = true;
+            // Pure value wrap (no env write): no env_dirty mark needed.
             return Ok(());
         }
         // HyperSeq/RaceSeq delegation: unwrap, dispatch on inner list, wrap back for map/grep
@@ -621,7 +621,7 @@ impl VM {
                         _ => unreachable!(),
                     };
                     self.stack.push(Value::HyperSeq(items_arc));
-                    self.env_dirty = true;
+                    // Pure rewrap (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "race" => {
@@ -630,12 +630,12 @@ impl VM {
                         _ => unreachable!(),
                     };
                     self.stack.push(Value::RaceSeq(items_arc));
-                    self.env_dirty = true;
+                    // Pure rewrap (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "is-lazy" => {
                     self.stack.push(Value::Bool(false));
-                    self.env_dirty = true;
+                    // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "^name" => {
@@ -645,7 +645,7 @@ impl VM {
                         "RaceSeq"
                     };
                     self.stack.push(Value::str(name.to_string()));
-                    self.env_dirty = true;
+                    // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "WHAT" => {
@@ -655,7 +655,7 @@ impl VM {
                         "RaceSeq"
                     };
                     self.stack.push(Value::Package(Symbol::intern(name)));
-                    self.env_dirty = true;
+                    // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "isa" | "does" => {
@@ -671,12 +671,12 @@ impl VM {
                     // Delegate to isa_check which handles the full type hierarchy
                     let result = target.isa_check(&type_name);
                     self.stack.push(Value::Bool(result));
-                    self.env_dirty = true;
+                    // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "defined" => {
                     self.stack.push(Value::Bool(true));
-                    self.env_dirty = true;
+                    // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "map" | "grep" => {

--- a/t/hyper-reflection-env.t
+++ b/t/hyper-reflection-env.t
@@ -1,0 +1,43 @@
+# Pin test for CP-2 shrink slice 1: dropping spurious `env_dirty` marks on the
+# pure hyper/race wrap + reflection (is-lazy/^name/WHAT/isa/does/defined)
+# method branches in vm_call_method_ops.rs. These ops are env-pure, so they must
+# not force an env->locals pull. Interleave them with local mutations/reads to
+# confirm no stale read is introduced (and no value is lost).
+use Test;
+
+plan 10;
+
+# Pure hyper/race wrap interleaved with a local read.
+{
+    my $x = 7;
+    my @r = (1, 2, 3).hyper.map(* + $x);   # block reads captured $x = 7
+    is @r.sort.join(","), "8,9,10", "hyper.map reads captured local correctly";
+    is $x, 7, "local intact after hyper.map";
+}
+
+# Reflection methods on hyper/race, then read a freshly-mutated local.
+{
+    my $n = 1;
+    my $h = (1, 2, 3).hyper;
+    is $h.WHAT.^name, "HyperSeq", "hyper.WHAT then ...";
+    $n = $n + 40;
+    is $n, 41, "local mutation observed after hyper.WHAT";
+    is $h.is-lazy, False, "hyper.is-lazy is False";
+    is $h.defined, True, "hyper.defined is True";
+    is $h.^name, "HyperSeq", "hyper.^name";
+}
+
+# race wrap/rewrap and a subsequent local read
+{
+    my $acc = 0;
+    my @out = (1, 2, 3, 4).race.grep(* %% 2);
+    $acc = @out.elems;
+    is @out.sort.join(","), "2,4", "race.grep result";
+    is $acc, 2, "local assigned from race result";
+}
+
+# isa/does on a hyper value
+{
+    my $h = (1, 2).hyper;
+    ok $h.isa(Any), "hyper isa Any";
+}

--- a/t/say-env-roundtrip.t
+++ b/t/say-env-roundtrip.t
@@ -1,0 +1,58 @@
+# Pin test for the Say/Put/Print/Note dual-store round-trip removal (CP-3 slice 1).
+# Exercises the actual Say/Put/Print/Note opcodes (via captured stdout/stderr)
+# along the paths the old pre-Say `sync_env_from_locals` / post-Say
+# `env_dirty = true` round-trip was meant to protect.
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 7;
+
+# 1. say of a freshly-mutated local: the arg comes from the stack, must print 10.
+is_run(
+    'my $x = 5; $x = 10; say $x;',
+    { out => "10\n", status => 0 },
+    'say of mutated local prints current value',
+);
+
+# 2. custom .gist reading a dynamic var via say
+is_run(
+    'class G { method gist { "G:" ~ $*GREETING } }; my $*GREETING = "hi"; say G.new;',
+    { out => "G:hi\n", status => 0 },
+    'say with custom .gist reading dynamic var',
+);
+
+# 3. .gist side-effect on a dynamic var; caller observes it after the say
+is_run(
+    'class S { method gist { $*SEEN = "yes"; "se" } }; my $*SEEN = "no"; say S.new; say $*SEEN;',
+    { out => "se\nyes\n", status => 0 },
+    'caller observes dynamic-var write done inside .gist during say',
+);
+
+# 4. put of a list local
+is_run(
+    'my @a = 1, 2, 3; put @a;',
+    { out => "1 2 3\n", status => 0 },
+    'put of array local',
+);
+
+# 5. print (no newline) of a mutated local
+is_run(
+    'my $n = 1; $n = $n + 41; print $n;',
+    { out => "42", status => 0 },
+    'print of mutated local',
+);
+
+# 6. note goes to stderr
+is_run(
+    'note "warned";',
+    { err => "warned\n", status => 0 },
+    'note writes to stderr',
+);
+
+# 7. say inside a loop reading a per-iteration local
+is_run(
+    'for 1..3 -> $i { my $sq = $i * $i; say $sq; }',
+    { out => "1\n4\n9\n", status => 0 },
+    'say of loop-local in each iteration',
+);


### PR DESCRIPTION
## Summary

First slice of the **CP-2 dual-store flag removal** campaign.

A full dependency survey this session corrects the PLAN's CP-2 premise: `sync_locals_from_env` **cannot** be deleted, because `EVAL` is a spec-mandated, permanent by-name caller-lexical writer — the env→locals name→slot reconcile is fundamentally required as long as slot-indexed `locals` exist. So the achievable CP-2 is the **lazy flag layer** (`env_dirty` / `saved_env_dirty` / `ensure_locals_synced` + `VmCallFrame` dirty fields); `sync_locals_from_env` survives as the eager carrier/EVAL reconcile primitive. Recorded in `docs/vm-dual-store.md` ("CP-2 status & corrected plan") and `PLAN.md`.

## This slice — category (1): provably env-pure ops → no mark

The pure hyper/race wrap/rewrap and the `is-lazy` / `^name` / `WHAT` / `isa`/`does` / `defined` reflection branches in `vm_call_method_ops.rs` write nothing to env, yet unconditionally set `env_dirty = true`, forcing a redundant no-op env→locals pull at the next barrier. Dropping the mark is **behavior-preserving**: a dropped mark cannot cause a stale read (a genuinely diverging prior op sets its own mark; this op leaves `env_dirty` untouched). Carrier branches (hyper `map`/`grep` runs user blocks; `Regex.Bool` smartmatch runs regex `{}` code) keep their mark.

## Testing

- `make test` PASS (801 files / 7454 tests)
- hyper/race roast (`S07-hyperrace/{for,stress}.t`, `S03-metaops/eager-hyper.t`, `S32-hash/hyperslice.t`, `S02-types/hyperwhatever.t`) green
- New pins: `t/hyper-reflection-env.t` (10), `t/say-env-roundtrip.t` (7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)