### PR TITLE
perf(vm): convert module-load ops to eager reconcile (CP-2 shrink slice 2)

### DIFF
--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -671,7 +671,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        self.env_dirty = true;
+        // CP-2 eager reconcile: a module load writes imported symbols into env by
+        // name. Reconcile them into locals now rather than deferring via the
+        // env_dirty flag. GetLocal is itself a barrier (it calls
+        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
+        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
+        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
+        self.sync_locals_from_env(code);
         Ok(())
     }
 
@@ -699,7 +705,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        self.env_dirty = true;
+        // CP-2 eager reconcile: a module load writes imported symbols into env by
+        // name. Reconcile them into locals now rather than deferring via the
+        // env_dirty flag. GetLocal is itself a barrier (it calls
+        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
+        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
+        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
+        self.sync_locals_from_env(code);
         Ok(())
     }
 
@@ -714,7 +726,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        self.env_dirty = true;
+        // CP-2 eager reconcile: a module load writes imported symbols into env by
+        // name. Reconcile them into locals now rather than deferring via the
+        // env_dirty flag. GetLocal is itself a barrier (it calls
+        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
+        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
+        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
+        self.sync_locals_from_env(code);
         Ok(())
     }
 
@@ -729,7 +747,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        self.env_dirty = true;
+        // CP-2 eager reconcile: a module load writes imported symbols into env by
+        // name. Reconcile them into locals now rather than deferring via the
+        // env_dirty flag. GetLocal is itself a barrier (it calls
+        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
+        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
+        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
+        self.sync_locals_from_env(code);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Second slice of the **CP-2 dual-store flag-removal** campaign (category 3: carrier → eager-precise reconcile).

The four module-load ops (`use`/`import`/`no`/`need`) write imported symbols into env by name and then set `env_dirty = true` to defer the env→locals pull to the next barrier. This replaces that with an immediate `sync_locals_from_env(code)`.

## Why behavior-preserving

`GetLocal` is itself a barrier: both `exec_get_local_op` and `exec_get_local_raw_op` call `ensure_locals_synced` at entry. So whether the pull happens lazily (at the next `GetLocal`) or eagerly (here), the next slot read observes the same fresh locals. Moving the pull earlier just drops one flag setter toward the eventual deletion of `env_dirty` / `ensure_locals_synced` / `saved_env_dirty`. `sync_locals_from_env` itself is the permanent EVAL/carrier reconcile primitive and is kept (see `docs/vm-dual-store.md` "CP-2 status & corrected plan", added in #3080).

The reactive scope ops (`subtest`/`react`/`whenever`) are intentionally left on the flag for now — they run user blocks and `exec_react_scope_op` already calls `sync_locals_from_env`; converting them needs a dedicated, carefully-tested slice.

## Testing

- `make test` PASS (799 files / 7437 tests)
- module roast/t green (`t/import-statement.t`, `t/module-export-import.t`, `t/nested-module-package-vars.t`, `t/strict-use-and-eval.t`, `t/use-newline.t`, `t/grammar-in-module.t`, `t/user-type-shadows-term.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)