### PR TITLE
perf(vm): drop more spurious env_dirty marks on env-pure method branches (CP-2 shrink slice 3)

### DIFF
--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -239,7 +239,7 @@ impl VM {
             if let Some(buf) = self.interpreter.supply_emit_buffer.last_mut() {
                 buf.push(target);
                 self.stack.push(Value::Nil);
-                self.env_dirty = true;
+                // Buffering into the supply emit buffer touches no env: no mark.
                 return Ok(());
             }
             return Err(RuntimeError::emit_signal(target));
@@ -341,7 +341,7 @@ impl VM {
                 None => Value::Nil,
             };
             self.stack.push(result);
-            self.env_dirty = true;
+            // Reads/clears global deprecation state, not env: no mark.
             return Ok(());
         }
 
@@ -864,8 +864,9 @@ impl VM {
                             && let Some(native_result) =
                                 self.try_native_method(&storage, Symbol::intern(method), &args)
                         {
+                            // Native method on the by-value backing storage is
+                            // env-pure: no env_dirty mark needed.
                             self.stack.push(native_result?);
-                            self.env_dirty = true;
                             return Ok(());
                         }
                         let result =
@@ -968,8 +969,8 @@ impl VM {
                             ));
                         }
                         _ => {
+                            // Nil-absorbing method returns Nil and touches no env.
                             self.stack.push(Value::Nil);
-                            self.env_dirty = true;
                             return Ok(());
                         }
                     }
@@ -1061,14 +1062,15 @@ impl VM {
                             self.try_native_method(&resolved, Symbol::intern(method), &args)
                         {
                             let result = native_result;
+                            // Native method on a by-value resolved hash is env-pure
+                            // (see the sibling native-method branches below that set
+                            // method_dispatch_pure): no env_dirty mark needed.
                             match modifier {
                                 Some("?") => {
                                     self.stack.push(result.unwrap_or(Value::Nil));
-                                    self.env_dirty = true;
                                 }
                                 _ => {
                                     self.stack.push(result?);
-                                    self.env_dirty = true;
                                 }
                             }
                             return Ok(());


### PR DESCRIPTION
## Summary

Third slice of the **CP-2 dual-store flag-removal** campaign (category 1: provably env-pure ops → no mark; follows #3080, #3081).

Removes the conservative `env_dirty = true` from six more early-return special-case branches in `vm_call_method_ops.rs` that write nothing to env:

- `.emit` buffering into the supply emit buffer (interpreter field, not env)
- `Deprecation.report` (reads/clears global deprecation state, returns a Str)
- the hash-sentinel native-method branch (native method on a by-value resolved hash, env-pure like the sibling branches that set `method_dispatch_pure`)
- the array-subclass native-delegation branch (native method on the by-value backing storage)
- the Nil-absorbing generic method fallback (returns Nil, touches no env)

Each is an early-return branch, so dropping the mark is behavior-preserving: a dropped mark cannot cause a stale read (a genuinely diverging prior op sets its own mark; `GetLocal` is itself a barrier via `ensure_locals_synced`). Carrier/mutating branches (`.*` / `.+` all-method dispatch, compiled-method delegation, autoviv writeback, proxy-subclass mutate) keep their mark.

## Testing

- `make test` PASS (802 files / 7460 tests)
- supply roast green (`S17-supply/{Channel,Promise,Seq,act}.t`)

Out of scope (noted in passing): `is Array` subclass `AT-POS` reads `Nil` instead of the backing-storage element on **both** this branch and `main` — a pre-existing indexing bug unrelated to `env_dirty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)