### PR TITLE
perf(vm): drop redundant env_dirty marks in exec-call ops; revert unsafe eager reconcile (CP-2 shrink slice 4)

### DIFF
--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -24,31 +24,53 @@ map; record each slice's before/after here.
 > path (slot perf on `fib` etc.). **Therefore CP-3 (carrier removal) does NOT
 > unblock full deletion of `sync_locals_from_env` — that primitive is permanent.**
 >
-> **Achievable CP-2 (revised target).** Delete the *lazy flag* layer
-> (`env_dirty`, `ensure_locals_synced`, `saved_env_dirty`, and the `VmCallFrame`
-> dirty fields), converting every `env_dirty = true` setter (166 sites) into one
-> of:
->   1. **nothing** — the op is provably env-pure (native methods on by-value
->      targets, pure value/reflection branches). *(This file's first slice:
->      spurious pure-method marks in `vm_call_method_ops.rs`.)*
->   2. **surgical local update** — a VM-native by-name write whose name is known:
->      mirror into the matching slot (`update_local_if_exists`) instead of flagging.
->   3. **eager-precise reconcile** — a carrier (`loan_env!`) that may have written
->      arbitrary names: call `sync_locals_from_env(code)` immediately *iff a
->      carrier actually ran* (track it like `pending_local_updates` /
->      `method_dispatch_pure`), instead of the deferred flag.
-> Once every setter is converted, `env_dirty` + `ensure_locals_synced` +
-> `saved_env_dirty` are dead and deleted. **`sync_locals_from_env` is kept** as
-> the eager EVAL/carrier reconcile primitive (consider renaming to
-> `reconcile_locals_from_env`). The hot per-call paths already use the precise
-> `method_dispatch_pure` flag (Slice 6.3) and stay perf-neutral; the cold/carrier
-> sites move from lazy-flag to eager-precise.
+> **DEEPER CORRECTION (2026-06-15, after the `t/element-bind-cell.t` regression).**
+> The "delete the lazy flag" target above is **also fundamentally blocked**, for
+> the same class of reason. The flag's job is to *defer* the env→locals pull to a
+> safe barrier (every `GetLocal` calls `ensure_locals_synced`). It is NOT merely a
+> perf knob: the deferral is **load-bearing for correctness**. `sync_locals_from_env`
+> overwrites `locals[i]` with the env copy of the name; when a later op makes an
+> **in-place cell mutation** to a local (e.g. a cyclic `:=` bind, `$s[..] := $s[..]`)
+> that env does not yet reflect, pulling at the *wrong time* clobbers the fresh
+> local with the stale env value. The flag-deferred pull happens only once env is
+> fresh again, so it is safe; an **eager `sync_locals_from_env` at a carrier site is
+> NOT** (proven: converting the `exec_call_values` carriers to eager reconcile broke
+> `t/element-bind-cell.t` cyclic-bind subtests 46–47).
 >
-> **User direction (2026-06-15):** pursue CP-3 (carrier VM-native-ization) in
-> parallel where it removes whole carrier categories, but the dual-store *flag*
-> deletion above is the concrete, independently-shippable CP-2 campaign. Easy
-> `try_native_*` method/function-dispatch wins are already exhausted (benchmarks
-> show ~0% method fallback), so remaining CP-3 is the hard ③ state-ownership work.
+> Consequences:
+> - **Category 3 (carrier → eager reconcile) is unsafe and abandoned.** Carriers
+>   (EVAL / `exec_call_values` / regex `{}` / subset `where`) must keep the
+>   `env_dirty` flag.
+> - Since carriers permanently set the flag, and deleting the flag would force an
+>   unconditional pull at every `GetLocal` (the `fib` hot-path perf regression),
+>   **`env_dirty` is itself permanent** — exactly like `sync_locals_from_env`. It is
+>   already the minimal mechanism (one global "a carrier dirtied env since the last
+>   sync" bit).
+> - **CP-2 as "delete the dual-store machinery" is therefore not achievable** while
+>   slot-indexed `locals` and arbitrary-by-name carriers (EVAL) coexist. The only
+>   deletion path is eliminating `locals` as a separate store (env-only), which
+>   regresses the hottest path. This is the same wall the `sync_locals_from_env`
+>   analysis hit, now shown to also bind the flag.
+>
+> **What IS achievable — footprint reduction (perf, not deletion).** Convert only:
+>   1. **pure ops → no mark** — provably env-pure (native methods on by-value
+>      targets, pure value/reflection branches). Safe; shipped: #3080 (hyper/race),
+>      #3083 (.emit/Deprecation/hash-sentinel/Nil), and the `vm_call_exec_ops`
+>      native-call drops below.
+>   2. **redundant blanket → rely on the precise internal signal** — e.g. a blanket
+>      `env_dirty = true` right after `call_compiled_function_named` (which already
+>      sets `env_dirty` precisely from its return merge) only *defeats* that
+>      precision; drop it to match the hot `vm_call_func_ops` path.
+>   3. **surgical local update** — a VM-native by-name write whose name is known may
+>      `update_local_if_exists` instead of flagging (still TODO; lower priority).
+> These shrink spurious pulls (perf) but the flag, `ensure_locals_synced`,
+> `saved_env_dirty`, and `sync_locals_from_env` all **remain**.
+>
+> **REVERTED:** the slice-2 module-load eager-reconcile (#3081) used the now-
+> disproven category-3 pattern; it passed full roast only because module loads run
+> at scope entry, before any in-place cell mutation. Reverted to the `env_dirty`
+> flag for principled correctness (in the `vm_call_exec_ops`/`vm_register_ops`
+> follow-up).
 
 > **Correction (2026-06-05).** The slice notes below repeatedly cite
 > `t/wrap.t`, `t/placeholder.t`, and `t/tail-function.t` as "pre-existing"

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -70,7 +70,10 @@ impl VM {
                 self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name);
             self.interpreter.set_pending_call_arg_sources(None);
             call_result?;
-            self.env_dirty = true;
+            // No blanket mark: call_compiled_function_named already signals
+            // env_dirty precisely from its return merge (matches the hot
+            // vm_call_func_ops path). A blanket `= true` here would defeat that
+            // precision. See docs/vm-dual-store.md "CP-2 status & corrected plan".
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             native_result?;
         } else {
@@ -78,6 +81,11 @@ impl VM {
             let exec_result = loan_env!(self, exec_call_values(&name, args));
             self.interpreter.set_pending_call_arg_sources(None);
             exec_result?;
+            // Carrier may write the caller env by name (e.g. EVAL'd lexicals). Keep
+            // the env_dirty flag rather than an eager sync_locals_from_env here: an
+            // eager pull at a function-call site can clobber an in-place cell
+            // mutation a later op made to a local (cyclic `:=` bind), which the
+            // flag-deferred barrier pull avoids by running only once env is fresh.
             self.env_dirty = true;
         }
         Ok(())
@@ -107,16 +115,15 @@ impl VM {
         if let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args) {
             let pkg = self.current_package().to_string();
             self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name)?;
-            self.env_dirty = true;
+            // call_compiled_function_named signals env_dirty precisely; no blanket.
             return Ok(());
         }
-        // Try native function
+        // Try native function (env-pure: no env_dirty mark).
         if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             native_result?;
-            self.env_dirty = true;
             return Ok(());
         }
-        // Fall back to interpreter
+        // Carrier fallback: keep the env_dirty flag (see exec_exec_call_op).
         loan_env!(self, exec_call_pairs_values(&name, args))?;
         self.env_dirty = true;
         Ok(())
@@ -161,16 +168,15 @@ impl VM {
         if let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args) {
             let pkg = self.current_package().to_string();
             self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name)?;
-            self.env_dirty = true;
+            // call_compiled_function_named signals env_dirty precisely; no blanket.
             return Ok(());
         }
-        // Try native function (same as non-slip call path)
+        // Try native function (env-pure: no env_dirty mark).
         if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             self.stack.push(native_result?);
-            self.env_dirty = true;
             return Ok(());
         }
-        // Fall back to interpreter
+        // Carrier fallback: keep the env_dirty flag (see exec_exec_call_op).
         loan_env!(self, exec_call_pairs_values(&name, args))?;
         self.env_dirty = true;
         Ok(())

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -671,13 +671,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        // CP-2 eager reconcile: a module load writes imported symbols into env by
-        // name. Reconcile them into locals now rather than deferring via the
-        // env_dirty flag. GetLocal is itself a barrier (it calls
-        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
-        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
-        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
-        self.sync_locals_from_env(code);
+        // A module load writes imported symbols into env by name; flag the env so
+        // the next GetLocal barrier reconciles them into locals. (An eager
+        // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
+        // cell mutation of a local that env does not yet reflect -- see the
+        // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
+        // flag-deferred barrier pull, which runs once env is fresh, is correct.)
+        self.env_dirty = true;
         Ok(())
     }
 
@@ -705,13 +705,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        // CP-2 eager reconcile: a module load writes imported symbols into env by
-        // name. Reconcile them into locals now rather than deferring via the
-        // env_dirty flag. GetLocal is itself a barrier (it calls
-        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
-        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
-        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
-        self.sync_locals_from_env(code);
+        // A module load writes imported symbols into env by name; flag the env so
+        // the next GetLocal barrier reconciles them into locals. (An eager
+        // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
+        // cell mutation of a local that env does not yet reflect -- see the
+        // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
+        // flag-deferred barrier pull, which runs once env is fresh, is correct.)
+        self.env_dirty = true;
         Ok(())
     }
 
@@ -726,13 +726,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        // CP-2 eager reconcile: a module load writes imported symbols into env by
-        // name. Reconcile them into locals now rather than deferring via the
-        // env_dirty flag. GetLocal is itself a barrier (it calls
-        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
-        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
-        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
-        self.sync_locals_from_env(code);
+        // A module load writes imported symbols into env by name; flag the env so
+        // the next GetLocal barrier reconciles them into locals. (An eager
+        // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
+        // cell mutation of a local that env does not yet reflect -- see the
+        // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
+        // flag-deferred barrier pull, which runs once env is fresh, is correct.)
+        self.env_dirty = true;
         Ok(())
     }
 
@@ -747,13 +747,13 @@ impl VM {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
-        // CP-2 eager reconcile: a module load writes imported symbols into env by
-        // name. Reconcile them into locals now rather than deferring via the
-        // env_dirty flag. GetLocal is itself a barrier (it calls
-        // ensure_locals_synced), so moving the pull earlier is behavior-preserving.
-        // sync_locals_from_env is the permanent EVAL/carrier reconcile primitive
-        // (see docs/vm-dual-store.md "CP-2 status & corrected plan").
-        self.sync_locals_from_env(code);
+        // A module load writes imported symbols into env by name; flag the env so
+        // the next GetLocal barrier reconciles them into locals. (An eager
+        // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
+        // cell mutation of a local that env does not yet reflect -- see the
+        // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
+        // flag-deferred barrier pull, which runs once env is fresh, is correct.)
+        self.env_dirty = true;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fourth slice of the CP-2 `env_dirty` footprint-reduction work, **plus an important correction to the campaign's premise**.

### `vm_call_exec_ops.rs` (safe, behavior-preserving)

- Drop the `env_dirty` mark after a **native** function call in the pairs/slip ExecCall paths. Native functions are env-pure, and the main `exec_call_op` native branch already omits the mark (removes that inconsistency).
- Drop the **blanket** `env_dirty` mark after `call_compiled_function_named` in all three ExecCall paths. That routine already signals `env_dirty` *precisely* from its return merge (the hot `vm_call_func_ops` path relies on exactly this and adds no blanket); the blanket `= true` only **defeated** that precision. Statement-level compiled calls are now as precise as the hot path.

### Correction (docs/vm-dual-store.md): eager reconcile is unsafe → CP-2 deletion is blocked

The planned "category 3 = convert carriers to eager `sync_locals_from_env`" is **unsafe and abandoned**. An eager reconcile at a carrier site clobbers a fresh in-place cell mutation of a local that `env` does not yet reflect — **proven**: it broke `t/element-bind-cell.t` cyclic-`:=`-bind subtests 46–47. The flag-deferred pull is correct because it runs only once `env` is fresh again.

Consequently carriers must keep the `env_dirty` flag, which makes **the flag itself permanent** (deleting it would force an unconditional pull at every `GetLocal` — the `fib` hot-path regression). So **CP-2 "delete the dual-store machinery" is not achievable** while slot-locals and arbitrary-by-name carriers (`EVAL`) coexist; only spurious-mark / precision footprint reduction is. The slice-2 module-load eager-reconcile (#3081) used the same disproven pattern and is **reverted here** to the flag (it passed roast only because module loads precede cell mutations).

## Testing

- `make test` PASS (802 files / 7460 tests)
- `t/element-bind-cell.t`, module, and EVAL tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)