### PR TITLE
fix(given): make `-> $_ is copy` a writable, non-writeback topic

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,10 +196,15 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 170/191 pass. **NOT whitelistable as written**: reference rakudo itself
+  - 179/191 pass. **NOT whitelistable as written**: reference rakudo itself
     fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
     file cannot reach a clean pass. Remaining mutsu failures span several distinct
     (mostly regex-internal) features:
+  - ABORT FIXED: the file previously aborted mid-run at the `s[...] OP= ...`
+    block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`). `given LITERAL -> $_ is
+    copy` marked `$_` read-only (the `$_ = $_` copy-head desugar then died on the
+    RO topic). Now a `-> $_ is copy` pointy head sets `topic_readonly = false` and
+    suppresses the source-writeback tag (a detached copy). All 191 tests now run.
   - 85, 86 (FIXED): `s///` / `ss///` against a *matching* string literal
     (`'abc' ~~ s/b/g/`) now throws X::Assignment::RO; a non-matching attempt stays
     a no-op. (SmartMatchExpr carries an `lhs_is_literal` flag.)
@@ -228,8 +233,11 @@
   - 184, 186: `:x(1..3)` range argument to `:x` in operator/method form (opcode
     `x_count` is a single `u32`, cannot carry a range); `.subst` does not set
     `$/` to a List of matches for multi-match adverbs.
-  - 187-190: placeholder params (`$^a`) inside `S{...}=...` are captured by the
-    substitution's synthetic closure instead of the enclosing block.
+  - 187-190: placeholder params (`$^a`) inside `[3,4].map:{ S{...}=$^a }`. Root
+    cause: a block with explicit placeholders should leave `$_` bound to the
+    *outer* lexical topic, but mutsu leaves `$_` undefined inside the placeholder
+    block (raku keeps the enclosing `$_`). The substitution then operates on the
+    wrong/empty topic. Broader fix in block topicalization, not subst-local.
   - Fixed in this pass: `:g`/`:x`/multi-`:nth` now return a List of Match in `$/`
     (single `:nth(N)` stays a Match even with `:g`); `s:g[...] = expr` with
     captures/`$/`/`$0` on the RHS evaluated per match; multi-value `:nth(a,b)`

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1670,6 +1670,18 @@ impl Compiler {
             }
             // Given/When/Default
             Stmt::Given { topic, body } => {
+                // A pointy `-> $_ is copy` block is desugared by the parser into a
+                // `$_ = $_` head (see `pointy_topic_bind`): the topic becomes a
+                // fresh, writable copy with NO writeback to the source. Detect that
+                // head so the topic is not marked read-only (`given 42 -> $_ is copy`
+                // must allow `$_ = ...`) and so a bare-variable topic is not tagged
+                // for writeback (`given $x -> $_ is copy { $_ = ... }` leaves `$x`
+                // untouched).
+                let is_copy_topic = matches!(
+                    body.first(),
+                    Some(Stmt::Assign { name, op: AssignOp::Assign, expr: Expr::Var(t) })
+                        if name == "_" && t == "_"
+                );
                 // An lvalue container *element* topic (`given %h<k>` /
                 // `given @a[i]`) aliases that element rw: both `$_ = ...` and
                 // container mutations (`.push`) propagate to the element. Push
@@ -1694,19 +1706,27 @@ impl Compiler {
                     topic_readonly = false;
                 } else {
                     self.compile_expr(topic);
-                    if let Some(source_name) = match topic {
-                        Expr::Var(name) => Some(name.clone()),
-                        Expr::ArrayVar(name) => Some(format!("@{}", name)),
-                        Expr::HashVar(name) => Some(format!("%{}", name)),
-                        _ => None,
-                    } {
+                    // `is copy` makes a detached copy, so suppress the
+                    // source-writeback tag even for a bare-variable topic.
+                    let source_name = if is_copy_topic {
+                        None
+                    } else {
+                        match topic {
+                            Expr::Var(name) => Some(name.clone()),
+                            Expr::ArrayVar(name) => Some(format!("@{}", name)),
+                            Expr::HashVar(name) => Some(format!("%{}", name)),
+                            _ => None,
+                        }
+                    };
+                    if let Some(source_name) = source_name {
                         let name_idx = self.code.add_constant(Value::str(source_name));
                         self.code.emit(OpCode::TagContainerRef(name_idx));
                     }
                     // The topic is read-only unless it is a bare scalar variable
-                    // (`given $x` aliases `$x` rw). `given @a` / `given 42` /
-                    // `given expr()` are read-only (Raku errors on `$_ = ...`).
-                    topic_readonly = !matches!(topic, Expr::Var(_));
+                    // (`given $x` aliases `$x` rw) or an `is copy` writable copy.
+                    // `given @a` / `given 42` / `given expr()` are read-only (Raku
+                    // errors on `$_ = ...`).
+                    topic_readonly = !is_copy_topic && !matches!(topic, Expr::Var(_));
                 }
                 // A pointy block (`given @a -> @p { ... }`) is desugared by the
                 // parser into `@p := $_` at the body head. Record that bound

--- a/t/given-pointy-is-copy.t
+++ b/t/given-pointy-is-copy.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 7;
+
+# `given LITERAL -> $_ is copy` makes $_ a fresh writable copy.
+given "a 2 3" -> $_ is copy {
+    $_ = "x";
+    is $_, "x", 'given literal -> $_ is copy allows $_ = ...';
+}
+
+# `is copy` over a substitution-assignment (the subst.t case).
+given 'a 2 3' -> $_ is copy {
+    s[\d] += 5;
+    is $_, 'a 7 3', 's[...] += 5 inside given -> $_ is copy';
+}
+
+# `is copy` over a variable topic must NOT write back to the source.
+{
+    my $x = "orig";
+    given $x -> $_ is copy {
+        $_ = "changed";
+    }
+    is $x, "orig", 'given $x -> $_ is copy does not write back';
+}
+
+# Plain `given $x { ... }` (no pointy) still topicalizes writably.
+{
+    my $y = "orig";
+    given $y {
+        $_ = "changed";
+    }
+    is $y, "changed", 'given $x { $_ = ... } still works';
+}
+
+# Aliasing pointy array param still writes back through .push.
+{
+    my @a = 1, 2;
+    given @a -> @p {
+        @p.push(3);
+    }
+    is-deeply @a, [1, 2, 3], 'given @a -> @p { @p.push } writes back';
+}
+
+# `is copy` array param is a detached copy.
+{
+    my @a = 1, 2;
+    given @a -> @p is copy {
+        @p.push(3);
+    }
+    is-deeply @a, [1, 2], 'given @a -> @p is copy does not write back';
+}
+
+# Named scalar `is copy` param still works.
+{
+    my $x = 5;
+    given $x -> $n is copy {
+        $n = 99;
+    }
+    is $x, 5, 'given $x -> $n is copy leaves source untouched';
+}


### PR DESCRIPTION
## Problem

`given LITERAL -> $_ is copy { ... }` died at runtime with
`Cannot assign to a readonly variable (_) or a value`.

The parser desugars a `-> $_ is copy` pointy block into a `$_ = $_`
copy-head at the body start (so `$_` becomes a fresh writable copy). But
the Given compiler marked any non-variable topic read-only, so that copy
head — and every later `$_ = ...` — was rejected.

This caused `roast/S05-substitution/subst.t` to **abort mid-file** at the
`s[...] OP= ...` block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`).

## Fix

In the Given compiler, detect the `$_ = $_` copy-head and:

- set `topic_readonly = false` so `$_` is a writable copy, and
- suppress the source-writeback tag even for a bare-variable topic, so
  `given $x -> $_ is copy { $_ = ... }` leaves `$x` untouched — matching
  Raku's detached-copy semantics (verified against reference `raku`).

Aliasing pointy params (`-> @p`, desugared to a `:=` bind) are unaffected
and still write back.

## Impact

`roast/S05-substitution/subst.t` now runs all **191** tests (**179 pass**)
instead of aborting at test 135 (was 134 passing). The file is still not
whitelistable (reference rakudo itself fails 2; remaining 12 are separate
regex-internal / placeholder-topic features documented in `TODO_roast/S05.md`).

## Tests

New `t/given-pointy-is-copy.t` (7 cases: literal/var `is copy`, no
writeback, aliasing writeback still works, named scalar copy). Full
`make test` passes (803 files, 7467 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)