### PR TITLE
fix(quanthash): eat named arguments in Set/Bag/Mix.new

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -189,7 +189,12 @@
 - [ ] roast/S02-types/baghash.t
   - 268/270 pass then aborts at 270 (plan 344). Fixed weight=0 removal + Str→X::Str::Numeric
     on `%h is BagHash`/scalar BagHash element assign (quanthash-element-assign fix).
-  - Remaining before abort: 206 (`does` add wrong-type croak), 268 (named arg eaten by `.new`).
+  - Remaining before abort: 206 (`does` add wrong-type croak).
+  - DONE: 268 (named arg eaten by `.new`) — `Bag/Set/Mix.new` (and the Hash variants) now
+    drop top-level `Value::Pair` args (bareword `a => 1` reaches `.new` un-containerized as
+    `Value::Pair`, while positional pair literals are `ValuePair` and array-flattened pairs
+    stay inside their Array). Hash/Map intentionally keep named-as-data to satisfy
+    hash.t's rakudo-issue-#3211 test. See `strip_named_pair_args` in methods_object.rs.
   - Abort blocker: writable `.values`/`.pairs`/`.kv` aliases into the bag weights need
     Proxy-style writeback into the QuantHash internal counts (container identity). Hard.
 - [ ] roast/S02-types/bag-iterator.t

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1627,6 +1627,27 @@ impl Interpreter {
         None
     }
 
+    /// Drop *named* arguments from a Hash/QuantHash constructor's argument list.
+    ///
+    /// A bareword `key => value` argument is a named argument that `.new`
+    /// silently eats — it does NOT become an element (`Bag.new(a => 1).elems`
+    /// is 0, while `Bag.new("a" => 1).elems` is 1). mutsu keeps the
+    /// named/positional distinction in the value form: a named argument reaches
+    /// here un-containerized as a `Value::Pair`, whereas a positional pair
+    /// literal (`(a => 1)`, `"a" => 1`) is a `Value::ValuePair`, and pairs
+    /// flattened out of an array/variable remain inside their `Array`. So
+    /// dropping top-level `Value::Pair`s strips exactly the named arguments
+    /// while preserving every positional pair.
+    fn strip_named_pair_args(args: Vec<Value>) -> Vec<Value> {
+        if args.iter().any(|a| matches!(a, Value::Pair(..))) {
+            args.into_iter()
+                .filter(|a| !matches!(a, Value::Pair(..)))
+                .collect()
+        } else {
+            args
+        }
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,
@@ -2376,6 +2397,12 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "Hash" | "Map" => {
+                    // NOTE: Hash/Map deliberately do NOT strip named args here.
+                    // rakudo eats them (`Hash.new(:42a) eqv {}`), but roast
+                    // hash.t (rakudo issue #3211) asserts `Hash.new(:42a, :666b)`
+                    // equals the positional `Hash.new((:42a, :666b))` — i.e. the
+                    // named args should become data. mutsu already does that, so
+                    // keep it (only the QuantHash constructors eat named args).
                     let mut flat = Vec::new();
                     for arg in &args {
                         flat.extend(Self::value_to_list(arg));
@@ -2875,6 +2902,7 @@ impl Interpreter {
                     return Ok(Self::build_native_pair_value(&args));
                 }
                 "Set" | "SetHash" => {
+                    let args = Self::strip_named_pair_args(args);
                     // Check for lazy inputs
                     for a in &args {
                         if Self::is_lazy_for_coerce(a) {
@@ -2998,6 +3026,7 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "Bag" | "BagHash" => {
+                    let args = Self::strip_named_pair_args(args);
                     // Check for lazy inputs
                     for a in &args {
                         if Self::is_lazy_for_coerce(a) {
@@ -3130,6 +3159,7 @@ impl Interpreter {
                     });
                 }
                 "Mix" | "MixHash" => {
+                    let args = Self::strip_named_pair_args(args);
                     // MixHash.new treats all positional arguments as elements
                     // to count. Pairs are NOT decomposed into key=>weight;
                     // they are stringified and treated as individual elements.


### PR DESCRIPTION
## Summary

In Raku a bareword `key => value` argument to a constructor is a **named** argument, which `.new` silently consumes — it does *not* become an element:

```raku
BagHash.new(a => 1).elems      # 0  (named, eaten)
BagHash.new("a" => 1).elems    # 1  (positional Pair)
BagHash.new((a => 1)).elems    # 1  (positional Pair)
```

mutsu was counting the named argument as data (`elems == 1`) for every QuantHash constructor.

## How

mutsu already preserves the named/positional distinction in the value form (this is what makes `sub f(*@a, *%h)` slurpy binding work): a named argument reaches `dispatch_new` un-containerized as a `Value::Pair`, whereas a positional pair literal is a `Value::ValuePair`, and pairs flattened out of an array/variable remain inside their `Array`.

So dropping **top-level `Value::Pair`** args (new `strip_named_pair_args` helper) strips exactly the named arguments while preserving every positional pair. Applied to `Set`/`SetHash`, `Bag`/`BagHash`, `Mix`/`MixHash` `.new`.

**Hash/Map are intentionally left unchanged:** roast `hash.t` (rakudo issue #3211) asserts `Hash.new(:42a, :666b)` *equals* the positional `Hash.new((:42a, :666b))`, i.e. the named args should become entries. rakudo itself fails that test; mutsu already implements the desired behavior, so eating named args there would regress the whitelisted `hash.t`.

## Results

- `roast/S02-types/baghash.t`: test 268 ("named argument is happily eaten by .new method") now **passes**.
- Verified against `raku` across named / positional-pair-literal / array-of-pairs / single-pair-var / mixed cases — all match.
- No regression to whitelisted `hash.t` / `mix.t`. `make test` clean (only the known-flaky async-socket `t/io-socket-async-listen.t`, which passes 3/3 on retry and is non-fatal in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)