### PR TITLE
feat(whatever): X/Z meta-operator Whatever-currying

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -336,22 +336,17 @@
 - [x] roast/S02-types/version-stress.t
 - [x] roast/S02-types/version.t
 - [ ] roast/S02-types/whatever.t
-  - 126/131 tests run, 93/126 pass. Blockers:
+  - 130/131 tests run. Blockers:
     - Tests 52-53: Nested WhateverCode currying with user-defined operators (3+ `*` across nested calls)
     - Tests 75-76: `&infix:<+>(*, 42)` should die, not Whatever-curry
-    - Tests 77-92: X+/Z+ meta-operators with Whatever-currying not implemented.
-      Currently the abort point (test 77, `1 X+ * X+ 3` must be a WhateverCode).
-      NOTE (2026-06-15): enabling X/Z in `contains_whatever`/`count_whatever`
-      (parser/expr/mod.rs, currently `meta == "R"` only) makes the scalar cases
-      (`1 X+ *`, `* X+ *`, `1 Z+ *`) curry correctly — but REGRESSES the whitelisted
-      `S03-metaops/zip.t`/`cross.t`: a trailing `*` in a comma-list operand is a list
-      *extender* (`1,2,3,* Z 10,20,30` repeats the 3), not a curry placeholder. mutsu's
-      parser splits `1,2,3,* Z 10` into `1,2,3,(* Z 10)` (Z binds the bare `*` tighter
-      than the comma) so `contains_whatever` can't tell extend from curry at the MetaOp
-      node. The no-whatever path gathers the full list operand (`MetaOp{Z,[1,2,3],...}`);
-      the real fix is making the X/Z operand parse gather the trailing-`*` list the same
-      way (then an `ArrayLiteral` operand can be excluded from currying). Deep parser
-      precedence work — do NOT ship the contains_whatever change alone.
+    - Tests 77-92: X+/Z+ meta-operator Whatever-currying — DONE (#3094). Curry
+      decision in parser/primary/container.rs after the comma-list lift: a standalone
+      `*` operand curries, a trailing `*` in a comma-list operand extends (zip/cross
+      repeats the last element). `contains_whatever` stays R-gated (non-paren contexts
+      untouched); only `count_whatever` learned X/Z for arity. Also fixed a pre-existing
+      lift bug where X/Z chains of >2 list operands dropped every column past the second
+      (now left-folded into nested meta-ops; plain non-Whatever Z chains keep the lazy
+      `zip` Call form).
     - Tests 108-109: `*++`/`++*` WhateverCode with rw parameters
     - Test 110: `*(42)` should throw X::Method::NotFound
     - Test 111: Code.ACCEPTS does not preserve container (`=:=`)

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -773,10 +773,16 @@ fn count_whatever(expr: &Expr) -> usize {
         Expr::InfixFunc { left, right, .. } => {
             count_whatever(left) + right.iter().map(count_whatever).sum::<usize>()
         }
-        // R meta-operators
+        // R/X/Z meta-operators. R always curries on a Whatever operand; X/Z
+        // currying is decided at parse time in `container.rs` (a standalone `*`
+        // operand curries, a trailing `*` in a comma-list operand extends), but
+        // once the decision to wrap is made we must count placeholders here so
+        // the WhateverCode gets the right arity.
         Expr::MetaOp {
             meta, left, right, ..
-        } if meta == "R" => count_whatever(left) + count_whatever(right),
+        } if matches!(meta.as_str(), "R" | "X" | "Z") => {
+            count_whatever(left) + count_whatever(right)
+        }
         _ => 0,
     }
 }

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -5,7 +5,9 @@ use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::Value;
 
-use super::super::expr::{expression, expression_no_sequence};
+use super::super::expr::{
+    contains_whatever, expression, expression_no_sequence, wrap_whatevercode,
+};
 use super::super::helpers::{is_non_breaking_space, split_angle_words, ws};
 use super::super::stmt::keyword;
 use super::quote_adverbs::QuoteFlags;
@@ -192,7 +194,13 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
         } else {
             first
         };
-        let result = normalize_chained_zip_meta(first);
+        // Curry BEFORE normalizing chained Z meta-ops: `1 Z+ * Z+ 3` must become
+        // a WhateverCode wrapping the nested meta-op, not a (non-curryable) `zip`
+        // call. A non-currying meta-op still normalizes as before.
+        let result = match maybe_curry_xz_metaop(first) {
+            curried @ (Expr::Lambda { .. } | Expr::AnonSubParams { .. }) => curried,
+            other => normalize_chained_zip_meta(other),
+        };
         // Wrap in Grouped so the compiler's chain-flattener can
         // distinguish `(1|2)|3` from `1|2|3` for junction operators.
         //
@@ -317,9 +325,65 @@ fn finalize_paren_list(items: Vec<Expr>) -> Expr {
         && (matches!(&lifted[0], Expr::MetaOp { .. })
             || matches!(&lifted[0], Expr::Call { name, .. } if *name == Symbol::intern("zip")))
     {
-        return lifted.into_iter().next().unwrap();
+        return maybe_curry_xz_metaop(lifted.into_iter().next().unwrap());
     }
+    // A standalone X/Z meta-op element with Whatever operands curries into a
+    // WhateverCode (e.g. `(* X+ *, 5)`); list-operand metaops were already folded
+    // by the lift above and left as plain (extending) MetaOps.
+    let lifted = lifted.into_iter().map(maybe_curry_xz_metaop).collect();
     Expr::ArrayLiteral(lifted)
+}
+
+/// Whatever-curry an X/Z meta-op when (and only when) a *standalone* `*` operand
+/// makes it a WhateverCode. A `*` that is merely the trailing element of a
+/// comma-list operand is a list *extender* (zip/cross repeats the last element),
+/// not a curry placeholder, so an `ArrayLiteral` operand never triggers currying.
+fn maybe_curry_xz_metaop(expr: Expr) -> Expr {
+    if matches!(&expr, Expr::MetaOp { meta, .. } if meta == "X" || meta == "Z")
+        && xz_metaop_curries(&expr)
+    {
+        wrap_whatevercode(&expr)
+    } else {
+        expr
+    }
+}
+
+/// True when an X/Z meta-op (possibly a left-nested chain of them) has a
+/// standalone Whatever operand that should curry.
+fn xz_metaop_curries(expr: &Expr) -> bool {
+    if let Expr::MetaOp {
+        meta, left, right, ..
+    } = expr
+        && (meta == "X" || meta == "Z")
+    {
+        operand_curries(left) || operand_curries(right)
+    } else {
+        false
+    }
+}
+
+/// An operand curries when it carries a standalone Whatever placeholder. A
+/// comma-list operand (`ArrayLiteral`) is an extender, never a curry. Nested
+/// X/Z meta-ops recurse (so `1 X+ * X+ 3` curries through the inner op even
+/// though the global `contains_whatever` deliberately ignores X/Z).
+fn operand_curries(e: &Expr) -> bool {
+    match e {
+        Expr::ArrayLiteral(_) => false,
+        Expr::MetaOp { meta, .. } if meta == "X" || meta == "Z" => xz_metaop_curries(e),
+        _ => {
+            contains_whatever(e)
+                || matches!(
+                    e,
+                    Expr::Lambda {
+                        is_whatever_code: true,
+                        ..
+                    } | Expr::AnonSubParams {
+                        is_whatever_code: true,
+                        ..
+                    }
+                )
+        }
+    }
 }
 
 fn lift_minmax_in_paren_list(items: &[Expr]) -> Option<Expr> {
@@ -554,17 +618,22 @@ fn lift_meta_ops_in_paren_list(items: Vec<Expr>) -> Vec<Expr> {
         columns_rev.push(first_col);
         columns_rev.reverse();
 
-        let lifted_expr = if *meta == "Z" && columns_rev.len() > 2 {
-            let mut args: Vec<Expr> = columns_rev
-                .into_iter()
-                .map(|col| {
-                    if col.len() == 1 {
-                        col.into_iter().next().unwrap()
-                    } else {
-                        Expr::ArrayLiteral(col)
-                    }
-                })
-                .collect();
+        let col_to_expr = |col: Vec<Expr>| {
+            if col.len() == 1 {
+                col.into_iter().next().unwrap()
+            } else {
+                Expr::ArrayLiteral(col)
+            }
+        };
+        // A standalone `*` column (`(1,2 Z~ * Z~ 3,4)`) makes the whole chain a
+        // WhateverCode. We must keep it as a nested meta-op so the curry logic in
+        // `maybe_curry_xz_metaop` can wrap it; the lazy multi-arg `zip` call form
+        // (used for plain `Z` chains to preserve laziness) is not curryable.
+        let has_standalone_whatever = columns_rev
+            .iter()
+            .any(|col| col.len() == 1 && matches!(col[0], Expr::Whatever));
+        let lifted_expr = if *meta == "Z" && columns_rev.len() > 2 && !has_standalone_whatever {
+            let mut args: Vec<Expr> = columns_rev.into_iter().map(col_to_expr).collect();
             args.push(Expr::Binary {
                 left: Box::new(Expr::Literal(Value::str_from("with"))),
                 op: TokenKind::FatArrow,
@@ -575,25 +644,20 @@ fn lift_meta_ops_in_paren_list(items: Vec<Expr>) -> Vec<Expr> {
                 args,
             }
         } else {
-            let mut iter = columns_rev.into_iter();
-            let lhs = iter.next().unwrap_or_default();
-            let rhs = iter.next().unwrap_or_default();
-            let lhs = if lhs.len() == 1 {
-                lhs.into_iter().next().unwrap()
-            } else {
-                Expr::ArrayLiteral(lhs)
-            };
-            let rhs = if rhs.len() == 1 {
-                rhs.into_iter().next().unwrap()
-            } else {
-                Expr::ArrayLiteral(rhs)
-            };
-            Expr::MetaOp {
-                meta: meta.clone(),
-                op: op.clone(),
-                left: Box::new(lhs),
-                right: Box::new(rhs),
+            // Left-fold the columns into a nested meta-op chain. This handles X
+            // chains of any arity (`a X~ b X~ c` => `(a X~ b) X~ c`, previously
+            // the trailing columns were dropped) and curryable Z chains alike.
+            let mut iter = columns_rev.into_iter().map(col_to_expr);
+            let mut acc = iter.next().unwrap_or(Expr::ArrayLiteral(Vec::new()));
+            for col in iter {
+                acc = Expr::MetaOp {
+                    meta: meta.clone(),
+                    op: op.clone(),
+                    left: Box::new(acc),
+                    right: Box::new(col),
+                };
             }
+            acc
         };
 
         let mut result = vec![lifted_expr];

--- a/t/whatever-xz-currying.t
+++ b/t/whatever-xz-currying.t
@@ -1,0 +1,63 @@
+use Test;
+
+# X/Z meta-operator Whatever-currying.
+# A standalone `*` operand of an X/Z meta-op makes a WhateverCode; a trailing
+# `*` in a comma-list operand is a list extender, not a curry placeholder.
+
+plan 19;
+
+# --- single standalone * curries (X) ---
+{
+    my $f = (1 X+ * X+ 3);
+    isa-ok $f, Code, '1 X+ * X+ 3 curries';
+    is $f(2), 6, '... applied (2 -> 6)';
+    is $f(-4), 0, '... applied (-4 -> 0)';
+}
+
+# --- two standalone * curry to a 2-arg WhateverCode (X) ---
+{
+    my $f = (* X+ *);
+    isa-ok $f, Code, '* X+ * curries (2 args)';
+    is $f(41, 43), 84, '... applied';
+    is $f(-1, 1), 0, '... applied';
+}
+
+# --- list operands with standalone * middle operand (X cross) ---
+{
+    my $f = (1, 2 X~ * X~ 3, 4);
+    isa-ok $f, Code, '1,2 X~ * X~ 3,4 curries';
+    is $f(<a b>).join(' '), '1a3 1a4 1b3 1b4 2a3 2a4 2b3 2b4', '... cross product';
+}
+
+# --- single standalone * curries (Z) ---
+{
+    my $f = (1 Z+ * Z+ 3);
+    isa-ok $f, Code, '1 Z+ * Z+ 3 curries';
+    is $f(2), 6, '... applied (2 -> 6)';
+    is $f(-4), 0, '... applied (-4 -> 0)';
+}
+
+# --- two standalone * curry to a 2-arg WhateverCode (Z) ---
+{
+    my $f = (* Z+ *);
+    isa-ok $f, Code, '* Z+ * curries (2 args)';
+    is $f(41, 43), 84, '... applied';
+}
+
+# --- list operands with standalone * middle operand (Z zip) ---
+{
+    my $f = (1, 2 Z~ * Z~ 3, 4);
+    isa-ok $f, Code, '1,2 Z~ * Z~ 3,4 curries';
+    is $f(<a b>).join(' '), '1a3 2b4', '... zip';
+}
+
+# --- EXTEND: a trailing * in a comma-list operand is NOT a curry ---
+is (1, 2, 3, * Z 10, 20, 30, 40, 50).join('|'),
+    '1 10|2 20|3 30|3 40|3 50', 'trailing * extends left zip argument';
+is (1, 2, 3, * Z+ 10, 20, 30, 40, 50).join(' '),
+    '11 22 33 43 53', 'trailing * extends (Z+)';
+
+# --- plain X/Z chains (no Whatever) keep working, including >2 operands ---
+is (1, 2 X~ 3, 4 X~ 5, 6).join(' '),
+    '135 136 145 146 235 236 245 246', 'X~ chain of three list operands';
+is (1, 2 Z~ 3, 4 Z~ 5, 6).join(' '), '135 246', 'Z~ chain of three list operands';


### PR DESCRIPTION
## Summary

Implements Whatever-currying for the `X` and `Z` meta-operators, so
`(1 X+ * X+ 3)`, `(* Z+ *)`, `(1, 2 Z~ * Z~ 3, 4)` etc. now produce a
`WhateverCode`, while a trailing `*` in a comma-list operand still **extends**
(zip/cross repeats the last element).

This clears the long-standing abort in `roast/S02-types/whatever.t` at test 77
(`1 X+ * X+ 3` evaluated to a `List` and `$f(2)` died with "No such method
CALL-ME for List"). The file now runs **130/131** (was aborting after 77), and
the whole X+/Z+ curry cluster (tests 77–92) passes.

## The crux: curry vs extend

The two forms are syntactically indistinguishable at the meta-op node level:

- `(* Z 10, 20, 30)` — a **standalone** `*` operand → curries to a `WhateverCode`.
- `(1, 2, 3, * Z 10, 20, 30)` — a `*` that is the **trailing element of a
  comma-list operand** → extends (the `*` is a plain Whatever value the zip
  truncates against), **not** a curry.

When the parser first sees `* Z 10, 20, 30`, the left operand is just `*` in
both cases — the surrounding `1, 2, 3` are separate comma items. Only
`lift_meta_ops_in_paren_list` (in `parser/primary/container.rs`) folds the
preceding items into the meta-op's left operand. So the curry decision is made
**right after the lift**, where a list operand is an `ArrayLiteral` (extend) and
a standalone `*` is bare `Whatever` (curry).

`contains_whatever` is deliberately **kept R-gated** (X/Z excluded) so non-paren
contexts are untouched; only `count_whatever` learns X/Z, so a meta-op we decide
to wrap gets the right arity.

## Drive-by fix

The lift dropped every column past the second for an `X` (or curryable `Z`)
chain of >2 list operands: `(1, 2 X~ 3, 4 X~ 5, 6)` gave `(13 14 23 24)` instead
of the full 8-element cross product. The lift now left-folds columns into a
nested meta-op. Plain (non-Whatever) `Z` chains still use the lazy multi-arg
`zip` call form to preserve the laziness behavior `zip.t` checks.

## Tests

- New `t/whatever-xz-currying.t` (19 subtests) covering curry, extend, and plain
  >2-operand chains.
- `roast/S03-metaops/zip.t` and `cross.t` (whitelisted regression gates) stay green.
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)