### PR TITLE
refactor(vm): run eval_block_value pure-expr blocks in-place via run_nested (CP-3 collapse)

### DIFF
--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1709,21 +1709,18 @@ impl Interpreter {
         result
     }
 
-    pub(crate) fn eval_block_value(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
-        if body.is_empty() {
-            return Ok(Value::Nil);
-        }
-        let let_mark = self.let_saves_len();
-        let saved_functions = self.registry().functions.clone();
-        let saved_proto_subs = self.registry().proto_subs.clone();
-        let saved_proto_functions = self.registry().proto_functions.clone();
-        let saved_operator_assoc = self.operator_assoc.clone();
-        let saved_code_env: std::collections::HashMap<Symbol, Value> = self
-            .env
-            .iter()
-            .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
-            .map(|(k, v)| (*k, v.clone()))
-            .collect();
+    /// Compile a block with `eval_block_value`'s compiler context (routine
+    /// scope, `$?PACKAGE`/`$?DISTRIBUTION`) without executing it. Pure
+    /// compilation — touches no `env`, runs no user code — so the VM can call it
+    /// (no env loan) and run the result in-place via `VM::run_nested` instead of
+    /// the `mem::take`/`VM::new` ping-pong (CP-3 collapse).
+    pub(crate) fn compile_block_value(
+        &self,
+        body: &[Stmt],
+    ) -> (
+        crate::opcode::CompiledCode,
+        std::collections::HashMap<String, crate::opcode::CompiledFunction>,
+    ) {
         let mut compiler = crate::compiler::Compiler::new();
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
@@ -1743,7 +1740,25 @@ impl Interpreter {
                 .get(&self.current_package())
                 .cloned()
         });
-        let (code, compiled_fns) = compiler.compile(body);
+        compiler.compile(body)
+    }
+
+    pub(crate) fn eval_block_value(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
+        if body.is_empty() {
+            return Ok(Value::Nil);
+        }
+        let let_mark = self.let_saves_len();
+        let saved_functions = self.registry().functions.clone();
+        let saved_proto_subs = self.registry().proto_subs.clone();
+        let saved_proto_functions = self.registry().proto_functions.clone();
+        let saved_operator_assoc = self.operator_assoc.clone();
+        let saved_code_env: std::collections::HashMap<Symbol, Value> = self
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let (code, compiled_fns) = self.compile_block_value(body);
         self.block_scope_depth += 1;
         let result = self.run_compiled_block(&code, &compiled_fns);
         let trailing_sub_value = match body.last() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1246,8 +1246,28 @@ impl VM {
         result.map(|_| ())
     }
 
-    #[inline]
     pub(crate) fn vm_eval_block_value(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
+        if body.is_empty() {
+            return Ok(Value::Nil);
+        }
+        // CP-3 collapse: when the block is pure expression statements (no sub/
+        // proto/operator declarations and no trailing-sub value), the registry +
+        // code-env save/restore that `Interpreter::eval_block_value` performs is a
+        // no-op, so run the block in-place via `run_nested` (no `mem::take`/
+        // `VM::new` ping-pong) and only replicate the cheap scope bookkeeping
+        // (block-scope depth + let/temp restore + DESTROY pass). All current
+        // callers pass a single `Stmt::Expr` (registration-time default / enum /
+        // role-arg evaluation). Any other shape falls back to the interpreter.
+        if body.iter().all(|s| matches!(s, Stmt::Expr(_))) {
+            let (code, compiled_fns) = self.interpreter.compile_block_value(body);
+            let let_mark = self.interpreter.let_saves_len();
+            self.interpreter.push_block_scope_depth();
+            let result = self.run_nested(&code, &compiled_fns);
+            self.interpreter.pop_block_scope_depth();
+            self.interpreter.restore_let_saves(let_mark);
+            self.loan_env_for(|i| i.run_pending_instance_destroys())?;
+            return result.map(|v| v.unwrap_or(Value::Nil));
+        }
         self.loan_env_for(|i| i.eval_block_value(body))
     }
 


### PR DESCRIPTION
## Summary

Second carrier converted off the ping-pong (after `run_block_raw` in #3095).

**Note on direction:** the intended target was `call_sub_value`, but
investigation showed the VM already has a native, ping-pong-free Sub-value path
(`call_compiled_closure`) — `vm_call_sub_value` is only a fallback at 3 sites for
wrap-chains / lexical-override edge cases (complex, narrow). The cleaner, real
next carrier following the `run_block_raw` pattern is `eval_block_value`.

All 4 VM callers of `vm_eval_block_value` pass a single `Stmt::Expr`:
registration-time attribute-default / enum-value / parametric-role-arg / trait-arg
evaluation. For pure expression statements, `eval_block_value`'s function/proto/
operator registry clone + `&`-var code-env save/restore is a no-op, and there's
no trailing-sub value.

## Changes

- `vm_eval_block_value`: when the body is all `Stmt::Expr`, compile via the new
  `compile_block_value` helper (pure, no env) and run in-place via `run_nested`
  instead of the `mem::take`/`VM::new` ping-pong. Replicates only the cheap scope
  bookkeeping that matters (block-scope depth + let/temp restore + DESTROY pass).
  Non-expr bodies still fall back to the interpreter.
- Dedups `eval_block_value`'s compiler-context setup into `compile_block_value`
  (shared by interpreter + VM — 1 op = 1 impl).

## Verification

- A/B vs baseline **byte-identical** (attribute defaults, enum values +
  auto-increment, parametric roles, constants, sub-referencing defaults).
- `make test` PASS (806 files / 7519 tests); enum + attribute roast green;
  clippy clean.

## Campaign status

run_nested now drives 2 carriers (run_block_raw, eval_block_value). Remaining
ping-pong `loan_env_for` sites: `type_matches_value` (subset-where eval),
`call_function`/`call_method_with_values` (complex dispatch — much already native
via `call_compiled_closure`), `call_sub_value` (wrap/lexical fallback only),
`use_module`, `run_instance_method`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)