### PR TITLE
feat(whatever): curry chained comparisons (whatever.t test 125)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -338,7 +338,13 @@
 - [ ] roast/S02-types/whatever.t
   - 130/131 tests run. Blockers:
     - Tests 52-53: Nested WhateverCode currying with user-defined operators (3+ `*` across nested calls)
-    - Tests 75-76: `&infix:<+>(*, 42)` should die, not Whatever-curry
+    - Tests 75-76, 126(subtest 5+): `*` passed as a *call argument* (`&infix:<+>(*, 42)`,
+      `$sub(*)`) should be a Whatever *value*, not a curry placeholder. mutsu over-curries
+      via the CallOn args branch of contains_whatever/count_whatever/replace_whatever_*.
+      Naively dropping args from those branches REGRESSES many cases (tests 12, 44-53,
+      112-113, 118, 127-129, `*²(3)`) — CallOn arg-currying is load-bearing for non-call
+      WhateverCode forms that mutsu also represents as CallOn. Needs a narrower
+      "call to a code *value*" distinction. Do NOT blanket-drop CallOn args.
     - Tests 77-92: X+/Z+ meta-operator Whatever-currying — DONE (#3094). Curry
       decision in parser/primary/container.rs after the comma-list lift: a standalone
       `*` operand curries, a trailing `*` in a comma-list operand extends (zip/cross
@@ -352,8 +358,16 @@
     - Test 111: Code.ACCEPTS does not preserve container (`=:=`)
     - Test 115: is_run no-warning check for WhateverCode passed as arg
     - Test 119: `none 2 ...^ * > expr` precedence (none as list prefix vs sequence op)
-    - Test 121: `Mu ~~ (*)` should return True (parenthesized Whatever distinction)
-    - Tests 122-131 don't run: depend on `where`+`is default`, `BEGIN`, regex curry, etc.
+    - Test 121: `Mu ~~ (*)` should return True (parenthesized Whatever is a value →
+      ACCEPTS → True), but bare `Mu ~~ *` autoprimes to a WhateverCode. The VM
+      autoprime (`smart_match_op` in vm_helpers.rs) keys on `Value::Whatever`, so both
+      forms look identical at runtime — needs a parse-time marker for parenthesized `(*)`.
+    - Tests 125: chained-comparison Whatever-curry (`1 < *+1 < 5`, `22 + *.flip < *² ... < *`)
+      — DONE. The chain expands to `(a OP m) && (m OP b)`; count_whatever/replace_whatever_numbered
+      now dedup the structurally-equal shared middle `m` so arity = number of distinct
+      operands (was double-counting the middle).
+    - Tests 122-124, 126-131 don't run/fail: depend on `where`+`is default`/`BEGIN`
+      compile-time WhateverCode eval, regex `/<$_>/` curry, call-arg Whatever (see 75-76).
     - Tests 42, 114, 117 also fail on raku (todo'd)
 - [ ] roast/S02-types/WHICH.t
   - 1652/1657 pass. Remaining: Nil.raku/gist returns "(Any)" instead of "Nil" (mutsu uses Value::Nil for both Nil and uninitialized Any); subtest using EVAL/start/supply not implemented

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -719,10 +719,14 @@ fn count_whatever(expr: &Expr) -> usize {
                     ..
                 },
             ) = (left.as_ref(), right.as_ref())
-                && is_whatever(lr)
-                && is_whatever(rl)
+                && exprs_structurally_eq(lr, rl)
+                && count_whatever(lr) > 0
             {
-                return count_whatever(ll) + 1 + count_whatever(rr);
+                // Chained comparison `a OP m OP b` is expanded to
+                // `(a OP m) && (m OP b)` with the middle `m` duplicated. Count the
+                // shared middle's placeholders once so the WhateverCode arity is
+                // the number of distinct operands, not double the middle.
+                return count_whatever(ll) + count_whatever(lr) + count_whatever(rr);
             }
             count_whatever(left) + count_whatever(right)
         }
@@ -787,6 +791,14 @@ fn count_whatever(expr: &Expr) -> usize {
     }
 }
 
+/// Structural equality of two expressions, used to detect the shared middle
+/// term of an expanded chained comparison (`a OP m OP b` => `(a OP m) && (m OP
+/// b)`). `Expr` cannot derive `PartialEq` (it embeds `Value`), and this only runs
+/// while wrapping a WhateverCode, so a `Debug`-string comparison is sufficient.
+fn exprs_structurally_eq(a: &Expr, b: &Expr) -> bool {
+    format!("{a:?}") == format!("{b:?}")
+}
+
 /// Replace Whatever expressions with numbered parameter variables.
 /// `counter` tracks the next parameter index to assign.
 fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
@@ -813,22 +825,27 @@ fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
                     right: rr,
                 },
             ) = (left.as_ref(), right.as_ref())
-                && is_whatever(lr)
-                && is_whatever(rl)
+                && exprs_structurally_eq(lr, rl)
+                && count_whatever(lr) > 0
             {
-                let shared = format!("__wc_{}", counter);
-                *counter += 1;
+                // Chained comparison expanded to `(ll OP m) && (m OP rr)`: assign
+                // params left-to-right (ll, then the shared middle once, then rr)
+                // and reuse the same replaced middle in both comparisons so each
+                // distinct operand maps to its own positional argument.
+                let new_ll = replace_whatever_numbered(ll, counter);
+                let new_mid = replace_whatever_numbered(lr, counter);
+                let new_rr = replace_whatever_numbered(rr, counter);
                 return Expr::Binary {
                     left: Box::new(Expr::Binary {
-                        left: Box::new(replace_whatever_numbered(ll, counter)),
+                        left: Box::new(new_ll),
                         op: lop.clone(),
-                        right: Box::new(Expr::Var(shared.clone())),
+                        right: Box::new(new_mid.clone()),
                     }),
                     op: TokenKind::AndAnd,
                     right: Box::new(Expr::Binary {
-                        left: Box::new(Expr::Var(shared)),
+                        left: Box::new(new_mid),
                         op: rop.clone(),
-                        right: Box::new(replace_whatever_numbered(rr, counter)),
+                        right: Box::new(new_rr),
                     }),
                 };
             }

--- a/t/whatever-chained-comparison.t
+++ b/t/whatever-chained-comparison.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Whatever-currying of chained comparisons: `a OP m OP b` curries over its
+# distinct operands. The chain expands internally to `(a OP m) && (m OP b)` with
+# the middle `m` duplicated; the WhateverCode arity must count `m`'s placeholders
+# once (so a single-`*` middle gives a 1-arg WhateverCode, not 2-arg).
+
+plan 12;
+
+# --- single placeholder in the middle term ---
+{
+    my $f = (1 < *+1 < 5);
+    isa-ok $f, Code, '1 < *+1 < 5 curries (1 arg)';
+    is-deeply $f(3), True,  '... (3) -> True';
+    is-deeply $f(5), False, '... (5) -> False';
+    is-deeply $f(0), False, '... (0) -> False';
+}
+
+# --- method call in the middle term ---
+{
+    my $f = (11 < *.flip < 50);
+    isa-ok $f, Code, '11 < *.flip < 50 curries';
+    is-deeply $f(52),   True,  '... (52) -> True';
+    is-deeply $f(25),   False, '... (25) -> False';
+    is-deeply $f("01"), False, '... ("01") -> False';
+}
+
+# --- multiple operands, each contributing its own placeholders ---
+{
+    # operands: `22 + *.flip` (1), `*² + *.flip²` (2), `*` (1) => arity 4
+    my $f = (22 + *.flip < *² + *.flip² < *);
+    isa-ok $f, Code, '3-way chain with compound operands curries (4 args)';
+    is-deeply $f(23, 45, 67, 100000), True,  '... True case';
+    is-deeply $f(23, 45, 67, 10),     False, '... False case';
+}
+
+# --- plain (non-chained) curry still 2-arg ---
+is (* + *)(40, 2), 42, 'non-chained `* + *` stays 2-arg';


### PR DESCRIPTION
## Summary

Whatever-currying of **chained comparisons** — `(1 < *+1 < 5)`, `(11 < *.flip < 50)`,
`(22 + *.flip < *² + *.flip² < *)` — now produces a `WhateverCode` of the correct
arity. Previously `(1 < *+1 < 5)(3)` died with *"expected 2 arguments but got 1"*.

## Root cause

mutsu expands a chained comparison `a OP m OP b` into `(a OP m) && (m OP b)`,
duplicating the middle term `m`. When the chain is Whatever-curried,
`count_whatever`/`replace_whatever_numbered` counted `m`'s placeholders **twice**,
so a single-`*` middle yielded a 2-arg WhateverCode.

The existing code special-cased only a *bare* `*` middle. This generalizes it to
any structurally-equal middle term (`*+1`, `*.flip`, `*² + *.flip²`): the shared
middle is counted/replaced **once**, so arity = number of distinct operands and
the middle reuses the same positional parameter(s) on both sides of the `&&`.

`Expr` can't derive `PartialEq` (it embeds `Value`), and this path only runs while
wrapping a WhateverCode, so a `Debug`-string structural comparison is used.

## Tests

- `roast/S02-types/whatever.t` subtest 125 (*chained ops with whatever curry in them*,
  6 asserts) now passes; the file's pass count rises accordingly.
- New `t/whatever-chained-comparison.t` (12 asserts).
- `make test` passes; normal non-Whatever chained comparisons and plain `* + *`
  currying are unaffected.

## Not in scope (documented in TODO_roast/S02.md)

Other remaining whatever.t failures are separate features: call-argument Whatever
(`$sub(*)`, tests 75-76/126) — a blanket fix regresses many CallOn-represented
forms; parenthesized `(*)` smartmatch (test 121); compile-time `where`/`BEGIN`
WhateverCode eval (122-124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)