### PR TITLE
fix(subst): validate :x adverb value, throw X::Str::Match::x

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,7 +196,7 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 179/191 pass. **NOT whitelistable as written**: reference rakudo itself
+  - 180/191 pass. **NOT whitelistable as written**: reference rakudo itself
     fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
     file cannot reach a clean pass. Remaining mutsu failures span several distinct
     (mostly regex-internal) features:
@@ -228,8 +228,9 @@
   - 161, 169: empty pattern `s[] = ...` must throw `X::Syntax::Regex::NullRegex`.
   - 162: `.subst(/(\w)/, { $m = $/[0] })` — closure mutation of an outer var is
     discarded (subst closure env is cloned and restored, losing writeback).
-  - 181: invalid `:x` argument must throw `X::Str::Match::x` (type now
-    registered, but `.subst` does not yet validate/throw).
+  - 181 (FIXED): invalid `:x` argument now throws `X::Str::Match::x`. `dispatch_subst`
+    validates `x_count` with the existing `is_valid_match_x_arg`/`str_match_x_error`
+    helpers (shared with `.match`) before running the substitution.
   - 184, 186: `:x(1..3)` range argument to `:x` in operator/method form (opcode
     `x_count` is a single `u32`, cannot carry a range); `.subst` does not set
     `$/` to a List of matches for multi-match adverbs.

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -604,6 +604,13 @@ impl Interpreter {
                 positional.push(arg.clone());
             }
         }
+        // The `:x` adverb must be an Int/Range (or Whatever); anything else
+        // (e.g. a class instance) is an X::Str::Match::x error, mirroring `.match`.
+        if let Some(x) = &x_count
+            && !Self::is_valid_match_x_arg(x)
+        {
+            return Err(Self::str_match_x_error("subst", x));
+        }
         let pattern = positional
             .first()
             .ok_or_else(|| RuntimeError::new("subst requires a pattern argument"))?;

--- a/t/subst-x-adverb.t
+++ b/t/subst-x-adverb.t
@@ -1,0 +1,23 @@
+use Test;
+
+# The `:x` adverb to `.subst` must be an Int / Range / Whatever. An invalid
+# value (e.g. a class instance) is an X::Str::Match::x error, just like `.match`.
+
+plan 7;
+
+# valid forms keep working
+is "aaaa".subst(/a/, "X", :x(2)),   "XXaa", ':x(Int) limits the substitution count';
+is "aaaa".subst(/a/, "X", :x(*)),   "XXXX", ':x(*) substitutes all';
+is "aaaa".subst(/a/, "X", :x(1..2)), "XXaa", ':x(Range) works';
+is "aaaa".subst(/a/, "X", :x(5..6)), "aaaa", ':x(Range) past available matches yields no substitution';
+
+# invalid value throws the typed exception
+throws-like { "abc".subst(/\w/, "", :x(my class SomeInvalidXParam {}.new)) },
+    X::Str::Match::x, 'invalid :x value throws X::Str::Match::x';
+
+# the exception carries the offending value and a helpful message
+{
+    my $ex = (try { "abc".subst(/\w/, "", :x([1, 2])) }) // $!;
+    isa-ok $ex, X::Str::Match::x, ':x(Array) also throws X::Str::Match::x';
+    ok $ex.message.contains('Int or Range'), 'message mentions the expected types';
+}


### PR DESCRIPTION
## Summary

`.subst` read the `:x` adverb without validating it — an invalid value (e.g. a
class instance) silently coerced through `to_f64` instead of erroring.

`.match` already rejects such values with `X::Str::Match::x` (via the
`is_valid_match_x_arg` / `str_match_x_error` helpers in `regex_captures.rs`).
`dispatch_subst` now reuses those same helpers, so

```raku
"abc".subst(/\w/, "", :x(SomeClass.new))   # now throws X::Str::Match::x
```

matches Rakudo. Valid forms (`:x(2)`, `:x(*)`, `:x(1..2)`) are unchanged.

## Tests

- `roast/S05-substitution/subst.t` test 181 (*giving .subst invalid args throws*)
  now passes (180/191). The file stays non-whitelistable — reference Rakudo itself
  fails tests 157/170, and several regex-internal features remain (tracked in
  TODO_roast/S05.md).
- New `t/subst-x-adverb.t` (7 asserts) covering valid forms + the typed exception.
- `make test` passes.

This is a §A isolated-subsystem fix (regex/match adverb validation) with zero
main-track conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)