### PR TITLE
fix(subst): propagate replacement-block writes to closed-over lexicals

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,7 +196,7 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 180/191 pass. **NOT whitelistable as written**: reference rakudo itself
+  - 182/191 pass. **NOT whitelistable as written**: reference rakudo itself
     fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
     file cannot reach a clean pass. Remaining mutsu failures span several distinct
     (mostly regex-internal) features:
@@ -220,14 +220,17 @@
     expects marks to be preserved in rakudo. This is a Rakudo samespace/ignoremark
     interaction artifact (plain `s:i:m///` drops marks; only adding `:ss` revives
     them); not replicated to avoid a special-case hack.
-  - 146-152: `.subst` `:samecase`/`:samemark` adverbs are parsed but not applied
-    in `dispatch_subst` (`_samecase` etc. are unused); `:samecase` with block
-    replacement also unimplemented.
+  - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
+    and block replacement (152 fixed via the closure-writeback fix below).
   - 156: `s:i($i)/.../` must throw `X::Value::Dynamic` (non-constant adverb).
   - 159: `s///` on a read-only `$_` (method `$_` param) must die.
   - 161, 169: empty pattern `s[] = ...` must throw `X::Syntax::Regex::NullRegex`.
-  - 162: `.subst(/(\w)/, { $m = $/[0] })` — closure mutation of an outer var is
-    discarded (subst closure env is cloned and restored, losing writeback).
+  - 152, 162 (FIXED): `.subst`/`s///` replacement block mutations to closed-over
+    lexicals (`{ $m = $/[0] }`, `{ $str++ }`) now write back. `eval_subst_replacement_cased`
+    no longer clobbers the caller env: it seeds only captured names the live env lacks
+    (so a `:g` counter advances across matches instead of resetting from the snapshot)
+    and propagates the captured lexicals' post-block values back, skipping the injected
+    match-context names (`$/`, `$_`, `$0`.., `<name>`).
   - 181 (FIXED): invalid `:x` argument now throws `X::Str::Match::x`. `dispatch_subst`
     validates `x_count` with the existing `is_valid_match_x_arg`/`str_match_x_error`
     helpers (shared with `.match`) before running the substitution.

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -939,10 +939,23 @@ impl Interpreter {
                 .ok_or_else(|| RuntimeError::new("subst closure has been garbage collected"))?,
             _ => return Ok(replacement_str.to_string()),
         };
-        let saved = self.env.clone();
-        // Set up closure environment
+        let mut saved = self.env.clone();
+        // The replacement block may mutate variables it closes over
+        // (`s/.../{ $n++ }/`, `{ $m = $/[0] }`). Remember its captured lexical
+        // names so those writes can be propagated back to the caller after the
+        // block runs; the blanket env restore below would otherwise discard
+        // them. The match-context names injected just below (`$/`, `$_`, `$0`..,
+        // `<name>`) are NOT captured lexicals and must not leak back.
+        let captured_keys: Vec<crate::symbol::Symbol> = sub_data.env.keys().copied().collect();
+        // Set up closure environment. Only supply captured names the live env
+        // doesn't already hold: for a `:g` substitution this routine runs once
+        // per match, and re-seeding from the (fixed) capture snapshot would reset
+        // a closed-over counter (`{ $n++ }`) on every match. The live env carries
+        // the previous match's writeback forward.
         for (k, v) in &sub_data.env {
-            self.env.insert_sym(*k, v.clone());
+            if self.env.get_sym(*k).is_none() {
+                self.env.insert_sym(*k, v.clone());
+            }
         }
         if let Some(captures) = captures {
             let match_obj = Value::make_match_object_full(
@@ -990,6 +1003,23 @@ impl Interpreter {
             self.env.insert("_".to_string(), match_val);
         }
         let result = self.eval_block_value(&sub_data.body).unwrap_or(Value::Nil);
+        // Propagate the block's writes to its closed-over lexicals back to the
+        // caller before restoring the outer env, skipping the injected
+        // match-context names (`$/`, `$_`, positional `$0`.., `<name>`).
+        for k in captured_keys {
+            let name = k.resolve();
+            let is_match_context = name == "/"
+                || name == "_"
+                || name == "$_"
+                || (!name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()))
+                || name.starts_with('<');
+            if is_match_context {
+                continue;
+            }
+            if let Some(v) = self.env.get_sym(k) {
+                saved.insert_sym(k, v.clone());
+            }
+        }
         self.env = saved;
         Ok(cased(result.to_string_value()))
     }

--- a/t/subst-closure-writeback.t
+++ b/t/subst-closure-writeback.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A `.subst` / `s///` replacement block may mutate variables it closes over.
+# Those writes must propagate back to the caller (the substitution machinery
+# previously cloned and restored the whole env around the block, discarding
+# them), and across matches under `:g` the counter must keep advancing.
+
+plan 6;
+
+# single mutation visible outside
+{
+    my $n = 0;
+    "abc".subst(/(\w)/, { $n++; "x" });
+    is $n, 1, 'closure mutation in .subst writes back (single match)';
+}
+
+# :g runs the block once per match and carries the mutation forward
+{
+    my $n = 0;
+    "abc".subst(/\w/, { $n++; "x" }, :g);
+    is $n, 3, 'closure counter advances across :g matches';
+}
+
+# assigning an outer variable from the match inside the block
+{
+    my $m;
+    "abc".subst(/(\w)/, { $m = ~$/[0]; "x" });
+    is $m, 'a', 'block can assign an outer var from $/';
+}
+
+# post-increment string replacement + :samecase across :g (roast subst.t 152)
+{
+    my $str = "that";
+    is 'The foo and the bar'.subst(/:i the/, { ++$str }, :samecase),
+        'Thau foo and the bar', 'pre-incr block replacement with :samecase';
+    is 'The foo and the bar'.subst(/:i the/, { $str++ }, :g, :samecase),
+        'Thau foo and thav bar', ':g block replacement advances shared $str';
+}
+
+# the outer topic is untouched by the block's injected match topic
+{
+    $_ = "OUTER";
+    "abc".subst(/\w/, { "x" }, :g);
+    is $_, "OUTER", 'outer $_ restored after subst block';
+}


### PR DESCRIPTION
## Summary

A `.subst` / `s///` replacement **block** may mutate variables it closes over
(`{ $n++ }`, `{ $m = $/[0] }`). `eval_subst_replacement_cased` cloned the whole
env and restored it verbatim around the block, **discarding those writes** —
unlike every other closure-call path (a stored closure, an inline `&blk`
argument, and `.map` blocks all write back correctly; only the subst path didn't).

## Fix

Two coupled changes in `eval_subst_replacement_cased`:

1. **Seed only the captured names the live env lacks.** For a `:g` substitution
   this routine runs once per match; re-seeding from the fixed capture snapshot
   reset a closed-over counter on every match, so `{ $n++ }` stayed at `1`. The
   live env now carries the previous match's value forward.
2. **Propagate the captured lexicals' post-block values back** into the saved env
   before restoring it, skipping the injected match-context names (`$/`, `$_`,
   positional `$0`.., `<name>`) so the outer topic and match vars don't leak.

## Tests

- `roast/S05-substitution/subst.t` tests **152** (`:g` + `:samecase` + block
  replacement) and **162** (outer-var assignment from `$/`) now pass (182/191).
- New `t/subst-closure-writeback.t` (6 asserts).
- `make test` passes; the substitution/transliteration roast suites show no new
  failures (only the unrelated pre-existing subst.t items remain).

§A isolated-subsystem fix (subst-local; the general closure-writeback paths were
already correct), zero main-track conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)