### PR TITLE
fix(subst): honor a read-only topic in destructive s///

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -223,7 +223,14 @@
   - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
     and block replacement (152 fixed via the closure-writeback fix below).
   - 156: `s:i($i)/.../` must throw `X::Value::Dynamic` (non-constant adverb).
-  - 159: `s///` on a read-only `$_` (method `$_` param) must die.
+  - 159: `s///` on a read-only `$_` (method `$_` param) must die. PARTIAL: the
+    `s///` writeback now honors a read-only topic (`exec_subst_op` routes through
+    `write_subst_topic_checked`, throwing X::Assignment::RO on an actual match), so
+    `sub ($_) { s/c// }` / `sub ($x is readonly) { ... }` die correctly. The roast
+    test uses a *method* `$_` param, and mutsu does not yet mark method params
+    read-only at all (even `method ($x) { $x = 5 }` lives) — a separate binding fix
+    (method params bind with empty `param_defs`, so the readonly-marking loop in
+    `bind_function_args_values` is skipped).
   - 161, 169: empty pattern `s[] = ...` must throw `X::Syntax::Regex::NullRegex`.
   - 152, 162 (FIXED): `.subst`/`s///` replacement block mutations to closed-over
     lexicals (`{ $m = $/[0] }`, `{ $str++ }`) now write back. `eval_subst_replacement_cased`

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -490,10 +490,7 @@ impl VM {
                         samespace,
                     );
                     let result = Value::str(out);
-                    self.env_mut().insert("_".to_string(), result.clone());
-                    self.env_mut().insert("$_".to_string(), result.clone());
-                    self.env_mut()
-                        .insert("__mutsu_rw_map_topic__".to_string(), result);
+                    self.write_subst_topic_checked(result)?;
                     // Create Match object and set $/
                     let match_obj = Self::make_subst_match(&text, start, end);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
@@ -535,10 +532,7 @@ impl VM {
                         )
                     };
                     let result = Value::str(out);
-                    self.env_mut().insert("_".to_string(), result.clone());
-                    self.env_mut().insert("$_".to_string(), result.clone());
-                    self.env_mut()
-                        .insert("__mutsu_rw_map_topic__".to_string(), result);
+                    self.write_subst_topic_checked(result)?;
                     // Create Match object and set $/
                     let match_obj = Self::make_subst_match(&text, start, end);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
@@ -651,11 +645,7 @@ impl VM {
             )
         };
         let result = Value::str(out);
-        self.env_mut().insert("_".to_string(), result.clone());
-        self.env_mut().insert("$_".to_string(), result.clone());
-        // Track topic mutation for map rw writeback
-        self.env_mut()
-            .insert("__mutsu_rw_map_topic__".to_string(), result);
+        self.write_subst_topic_checked(result)?;
         // For :g / :x, $/ and the substitution result are a List of Match
         // objects; otherwise a single Match for the first (and only) range.
         if result_is_list {
@@ -675,6 +665,28 @@ impl VM {
         self.env_mut().insert("/".to_string(), match_obj.clone());
         self.substitution_in_smartmatch = self.in_smartmatch_rhs;
         self.stack.push(match_obj);
+        Ok(())
+    }
+
+    /// Write a destructive `s///` result back to the topic, throwing
+    /// `X::Assignment::RO` when the topic is bound read-only (e.g. a
+    /// `method ro($_) {...}` / `sub ($x is readonly) {...}` parameter). Only
+    /// reached after a substitution actually occurred, so a non-matching
+    /// `s///` against a read-only topic stays a no-op.
+    fn write_subst_topic_checked(&mut self, result: Value) -> Result<(), RuntimeError> {
+        if self.interpreter.readonly_vars().contains("_") {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "message".to_string(),
+                Value::str("Cannot modify an immutable Str".to_string()),
+            );
+            attrs.insert("value".to_string(), result);
+            return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+        }
+        self.env_mut().insert("_".to_string(), result.clone());
+        self.env_mut().insert("$_".to_string(), result.clone());
+        self.env_mut()
+            .insert("__mutsu_rw_map_topic__".to_string(), result);
         Ok(())
     }
 

--- a/t/subst-readonly-topic.t
+++ b/t/subst-readonly-topic.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A destructive `s///` mutates its topic in place. When the topic is bound
+# read-only (a scalar `$_` / named parameter without `is rw`/`is copy`), an
+# actual substitution must throw X::Assignment::RO. A non-matching `s///`
+# writes nothing and stays a no-op.
+
+plan 5;
+
+# matching s/// on a read-only $_ parameter dies
+{
+    sub ro-topic($_) { s/c// }
+    dies-ok { ro-topic('ccc') }, 's/// on a read-only $_ parameter dies';
+}
+
+# non-matching s/// on a read-only $_ parameter is a no-op (lives)
+{
+    sub ro-topic-nomatch($_) { s/z// }
+    lives-ok { ro-topic-nomatch('ccc') },
+        'non-matching s/// on a read-only topic is a no-op';
+}
+
+# the thrown exception is X::Assignment::RO
+{
+    sub ro-topic2($_) { s/c/X/ }
+    my $ex = (try { ro-topic2('ccc') }) // $!;
+    isa-ok $ex, X::Assignment::RO, 's/// RO violation is X::Assignment::RO';
+}
+
+# a mutable topic still substitutes normally
+{
+    $_ = 'ccc';
+    s/c/X/;
+    is $_, 'Xcc', 's/// on a mutable topic mutates it';
+}
+
+# :g over a mutable loop topic still works
+{
+    my @a = <ccc ddd>;
+    for @a { s:g/c/X/ }
+    is @a.join(','), 'XXX,ddd', ':g s/// over a mutable loop topic';
+}


### PR DESCRIPTION
## Summary

A destructive `s///` mutated its topic via a raw `env.insert("_", ...)`,
bypassing the read-only check that plain assignment (`$x = ...`) performs. So
`sub ($_) { s/c// }` and `sub ($x is readonly) { ... }` silently mutated a
read-only parameter instead of dying with `X::Assignment::RO`.

## Fix

`exec_subst_op` now routes all three topic-writeback sites through a new
`write_subst_topic_checked`, which throws `X::Assignment::RO` when the topic is
in `readonly_vars`. The check is only reached **after** a substitution actually
occurred, so a non-matching `s///` against a read-only topic stays a no-op
(matching Rakudo, and consistent with the existing literal-target RO behavior).
Mutable topics and `:g` are unchanged — the helper performs the identical
writeback when the topic is writable.

## Tests

- New `t/subst-readonly-topic.t` (5 asserts).
- `make test` passes; no regressions in the substitution/transliteration roast
  suites.

## Scope note

roast `S05-substitution/subst.t` test 159 uses a **method** `$_` parameter, and
mutsu does not yet mark *method* params read-only at all (even
`method ($x) { $x = 5 }` lives — method params bind with empty `param_defs`, so
the readonly-marking loop in `bind_function_args_values` is skipped). That is a
separate, higher-blast-radius binding fix; this PR fixes the sub / `is readonly`
cases and is a prerequisite for 159 rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)