### PR TITLE
CP-3 collapse: dissolve VM struct into Interpreter, remove ping-pong

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -151,24 +151,6 @@ impl Env {
         }
     }
 
-    /// A *poisoned* env: a sentinel left in `Interpreter.env` while the VM owns
-    /// the real env (CP-1 1e env-loan, interim scaffolding). Any access
-    /// (`get`/`insert`/…) `debug_assert!`s `!poisoned`, so a VM→interpreter call
-    /// that reads env *without* a loan wrapper (`VM::loan_env_for`) panics
-    /// deterministically in debug test runs — pinpointing the missing wrapper
-    /// (catches direct `self.env.get(..)` field access, which an interpreter-side
-    /// flag could not). Remove once env-reading interpreter helpers are all
-    /// VM-native. See docs/vm-state-ownership.md.
-    pub(crate) fn poisoned() -> Self {
-        Self {
-            inner: Arc::new(HashMap::new()),
-            parent: None,
-            tombstones: None,
-            depth: 0,
-            poisoned: true,
-        }
-    }
-
     #[inline(always)]
     fn assert_not_poisoned(&self) {
         // env-loan (CP-1 1e) diagnostic: the interpreter's env field is a poisoned

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -334,11 +334,6 @@ impl Interpreter {
         err
     }
 
-    /// Check if a value is a Failure instance
-    pub(crate) fn is_failure_value(value: &Value) -> bool {
-        matches!(value, Value::Instance { class_name, .. } if class_name == "Failure")
-    }
-
     /// Enforce a return type constraint on a return value.
     /// Handles coercion types like Str(Numeric:D), Foo:D(), and subset types.
     fn enforce_return_type_constraint(

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -127,8 +127,10 @@ impl Interpreter {
         };
 
         spawn_user_thread(move || {
-            let vm = crate::vm::VM::new(thread_interp);
-            let (mut thread_interp, result) = vm.call_value(block, vec![]);
+            // CP-3 collapse: the thread's cloned Interpreter *is* the VM — run the
+            // block on it directly instead of wrapping it in a sub-VM.
+            let mut thread_interp = thread_interp;
+            let result = thread_interp.call_value(block, vec![]);
             // Transfer any handles opened by this thread back to the awaiter.
             let mut new_handles: Vec<(usize, IoHandleState)> = Vec::new();
             let new_ids: Vec<usize> = thread_interp
@@ -173,8 +175,8 @@ impl Interpreter {
                         let handler_interp = thread_interp.clone_for_thread();
                         let ex_val = error_val;
                         spawn_user_thread(move || {
-                            let vm = crate::vm::VM::new(handler_interp);
-                            let (_interp, _result) = vm.call_value(handler, vec![ex_val]);
+                            let mut handler_interp = handler_interp;
+                            let _ = handler_interp.call_value(handler, vec![ex_val]);
                         });
                     }
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -228,12 +228,11 @@ mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) mod value_iterator;
-pub(crate) use self::io_handles::{IoHandleTable, IoHandlesWriteGuard};
 pub(crate) use self::output_sink::OutputSink;
 #[allow(unused_imports)]
 pub(crate) use self::output_sink::{OutputSinkReadGuard, OutputSinkWriteGuard};
 pub(crate) use self::registration_class::ClassDeclModifiers;
-pub(crate) use self::registry::{Registry, RegistryReadGuard, RegistryWriteGuard};
+pub(crate) use self::registry::Registry;
 pub(crate) use self::tap_state::{TapState, TestState, TodoRange};
 
 pub(crate) use utils::*;
@@ -1152,6 +1151,68 @@ pub struct Interpreter {
     precomp_enabled: bool,
     /// When true, `augment class` is allowed (set by `use MONKEY-TYPING` or `use MONKEY`).
     monkey_typing: bool,
+
+    // === Merged VM execution registers (CP-3 collapse: the bytecode VM was
+    // dissolved into the Interpreter; these were the per-execution fields of the
+    // former `VM` struct). The Interpreter IS the bytecode VM now. ===
+    pub(crate) stack: Vec<Value>,
+    pub(crate) locals: Vec<Value>,
+    pub(crate) in_smartmatch_rhs: bool,
+    pub(crate) transliterate_in_smartmatch: bool,
+    pub(crate) substitution_in_smartmatch: bool,
+    pub(crate) last_topic_value: Option<Value>,
+    pub(crate) topic_save_stack: Vec<Value>,
+    pub(crate) container_ref_var: Option<String>,
+    pub(crate) container_ref_reversed: bool,
+    pub(crate) topic_source_var: Option<String>,
+    pub(crate) element_source: Option<(String, Value, bool)>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) for_grep_view: Option<(
+        Arc<crate::value::ArrayData>,
+        Vec<usize>,
+        crate::value::ArrayKind,
+    )>,
+    pub(crate) quanthash_bind_params: Vec<String>,
+    pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
+    pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
+    pub(crate) env_dirty: bool,
+    pub(crate) method_dispatch_pure: bool,
+    pub(crate) resume_ip: Option<usize>,
+    pub(crate) bind_context: bool,
+    pub(crate) scalar_bind_context: bool,
+    pub(crate) bound_decont_active: bool,
+    pub(crate) rebind_context: bool,
+    pub(crate) constant_context: bool,
+    pub(crate) explicit_initializer_context: bool,
+    pub(crate) vardecl_context: bool,
+    pub(crate) local_bind_pairs: Vec<(usize, usize)>,
+    pub(crate) otf_compile_cache: HashMap<u64, CompiledFunction>,
+    pub(crate) state_scope_id: Option<u64>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn_resolve_cache: HashMap<(Symbol, usize, Vec<String>), (String, u64, String)>,
+    pub(crate) fn_resolve_gen: u64,
+    pub(crate) fn_resolve_cache_gen: u64,
+    pub(crate) multi_candidates_cache: HashMap<Symbol, bool>,
+    pub(crate) multi_candidates_cache_gen: u64,
+    pub(crate) light_call_cache: HashMap<Symbol, (String, u64)>,
+    pub(crate) light_call_cache_gen: u64,
+    pub(crate) pos_light_call_cache: HashMap<Symbol, (String, u64)>,
+    pub(crate) pos_light_call_cache_gen: u64,
+    pub(crate) method_resolve_cache: HashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
+    pub(crate) fast_method_cache: HashMap<(Symbol, Symbol), crate::vm::FastMethodCacheEntry>,
+    pub(crate) block_declared_vars: Vec<HashSet<String>>,
+    pub(crate) loop_local_vars: Vec<HashSet<String>>,
+    pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,
+    pub(crate) loop_cond_active: bool,
+    pub(crate) outer_scope_locals: Vec<Vec<Value>>,
+    pub(crate) pending_alias_bind_names: Vec<(String, String)>,
+    pub(crate) otf_call_cache: HashMap<Symbol, CompiledFunction>,
+    pub(crate) otf_call_cache_gen: u64,
+    pub(crate) check_phaser_depth: u32,
+    pub(crate) gather_for_loop_resume: Option<crate::value::ForLoopResumeState>,
+    pub(crate) rw_map_topic_capture: Option<Value>,
 }
 
 /// Metadata stored per custom type created by Metamodel::Primitives.
@@ -3240,6 +3301,60 @@ impl Interpreter {
             pending_regex_error: None,
             precomp_enabled: true,
             monkey_typing: false,
+
+            // Merged VM execution registers (CP-3 collapse) — same defaults the
+            // former `VM::new` installed.
+            stack: Vec::new(),
+            locals: Vec::new(),
+            in_smartmatch_rhs: false,
+            transliterate_in_smartmatch: false,
+            substitution_in_smartmatch: false,
+            last_topic_value: None,
+            topic_save_stack: Vec::new(),
+            container_ref_var: None,
+            container_ref_reversed: false,
+            topic_source_var: None,
+            element_source: None,
+            for_grep_view: None,
+            quanthash_bind_params: Vec::new(),
+            for_param_restore_stack: Vec::new(),
+            call_frames: Vec::new(),
+            env_dirty: false,
+            method_dispatch_pure: false,
+            resume_ip: None,
+            bind_context: false,
+            scalar_bind_context: false,
+            bound_decont_active: false,
+            rebind_context: false,
+            constant_context: false,
+            explicit_initializer_context: false,
+            vardecl_context: false,
+            local_bind_pairs: Vec::new(),
+            otf_compile_cache: HashMap::new(),
+            state_scope_id: None,
+            fn_resolve_cache: HashMap::new(),
+            fn_resolve_gen: 0,
+            fn_resolve_cache_gen: 0,
+            multi_candidates_cache: HashMap::new(),
+            multi_candidates_cache_gen: 0,
+            light_call_cache: HashMap::new(),
+            light_call_cache_gen: 0,
+            pos_light_call_cache: HashMap::new(),
+            pos_light_call_cache_gen: 0,
+            method_resolve_cache: HashMap::new(),
+            last_method_resolve: None,
+            fast_method_cache: HashMap::new(),
+            block_declared_vars: Vec::new(),
+            loop_local_vars: Vec::new(),
+            loop_local_saved_env: Vec::new(),
+            loop_cond_active: false,
+            outer_scope_locals: Vec::new(),
+            pending_alias_bind_names: Vec::new(),
+            otf_call_cache: HashMap::new(),
+            otf_call_cache_gen: 0,
+            check_phaser_depth: 0,
+            gather_for_loop_resume: None,
+            rw_map_topic_capture: None,
         };
         interpreter.init_io_environment();
         // Built-in enum constants (Order/Endian/ProtocolFamily/Signal) are
@@ -4442,13 +4557,6 @@ impl Interpreter {
         std::mem::take(&mut self.env)
     }
 
-    /// env-loan (CP-1 1e): take the env out for the VM to own, leaving a
-    /// *poisoned* sentinel behind so any unwrapped VM->interpreter env access
-    /// trips the guard. Mirror: `set_env` restores a real env on the way back.
-    pub(crate) fn loan_out_env(&mut self) -> Env {
-        std::mem::replace(&mut self.env, Env::poisoned())
-    }
-
     fn normalize_var_meta_name(name: &str) -> &str {
         name.trim_start_matches(['$', '@', '%', '&'])
     }
@@ -4845,18 +4953,6 @@ impl Interpreter {
 
     pub(crate) fn container_type_metadata(&self, value: &Value) -> Option<ContainerTypeInfo> {
         container_type_metadata_with(value, &self.instance_type_metadata)
-    }
-
-    /// Clone the shared instance-type-metadata handle so the VM can read
-    /// container type metadata for `Instance` values through its own peer handle
-    /// (same reasoning as [`Self::registry_handle`]) rather than bouncing through
-    /// `self.interpreter`. Container values (Array/Hash/Set/Bag/Mix) carry their
-    /// metadata embedded in the backing data struct, so this handle only covers
-    /// the `Instance` arm of [`container_type_metadata_with`].
-    pub(crate) fn instance_type_metadata_handle(
-        &self,
-    ) -> Arc<RwLock<HashMap<u64, ContainerTypeInfo>>> {
-        self.instance_type_metadata.clone()
     }
 
     // Object-hash original keys are embedded in `HashData.original_keys`
@@ -5315,18 +5411,6 @@ impl Interpreter {
         crate::runtime::registry::RegistryReadGuard::new(&self.registry, "registry")
     }
 
-    /// Clone the shared declaration [`Registry`] handle so the VM can hold it as a
-    /// peer (PLAN.md ② → A: VM owns its own handle to the same `RwLock`). Both the
-    /// Interpreter and the VM end up pointing at the *same* lock, so mutations
-    /// through either are visible and the debug re-entrancy guard (keyed by lock
-    /// address) still correctly flags a deadlocking re-acquire. Once the
-    /// Interpreter execution path is removed (④/⑤), this collapses to a plain VM
-    /// field and the handle clone disappears.
-    #[inline]
-    pub(crate) fn registry_handle(&self) -> Arc<RwLock<Registry>> {
-        self.registry.clone()
-    }
-
     /// Write access to the shared declaration [`Registry`]. Same guard discipline
     /// as [`Self::registry`].
     #[inline]
@@ -5363,32 +5447,6 @@ impl Interpreter {
     #[inline]
     pub(crate) fn io_handles_mut(&self) -> io_handles::IoHandlesWriteGuard<'_> {
         io_handles::IoHandlesWriteGuard::new(&self.io_handles, "io_handles")
-    }
-
-    /// Clone the shared [`IoHandleTable`](io_handles::IoHandleTable) handle so the
-    /// VM can hold it as a peer (PLAN.md ③ native IO PR-C: VM owns its own handle
-    /// to the same `RwLock`, mirroring [`Self::registry_handle`]). Both point at
-    /// the same lock, so mutations through either are visible and the debug
-    /// re-entrancy guard (keyed by lock address) still flags deadlocking
-    /// re-acquires. Collapses to a plain VM field once the Interpreter execution
-    /// path is removed (④/⑤).
-    #[inline]
-    pub(crate) fn io_handles_handle(&self) -> Arc<RwLock<io_handles::IoHandleTable>> {
-        self.io_handles.clone()
-    }
-
-    /// Clone the shared [`OutputSink`] handle so the VM can write Stdout/Stderr
-    /// output natively as a peer (③後段 PR-C, same reasoning as
-    /// [`Self::io_handles_handle`]).
-    pub(crate) fn output_sink_handle(&self) -> Arc<RwLock<OutputSink>> {
-        self.output_sink.clone()
-    }
-
-    /// Clone the shared `current_package` handle so the VM can read/write the
-    /// in-scope package name through its own peer handle (same reasoning as
-    /// [`Self::registry_handle`]) rather than bouncing through `self.interpreter`.
-    pub(crate) fn current_package_handle(&self) -> Arc<RwLock<String>> {
-        self.current_package.clone()
     }
 
     /// Whether a TAP subtest is currently in progress. The VM queries this (the
@@ -5699,6 +5757,61 @@ impl Interpreter {
             pending_regex_error: None,
             precomp_enabled: self.precomp_enabled,
             monkey_typing: self.monkey_typing,
+
+            // Merged VM execution registers (CP-3 collapse): a thread clone starts
+            // with fresh per-execution registers, exactly as the former
+            // `VM::new(thread_interp)` did for a spawned thread.
+            stack: Vec::new(),
+            locals: Vec::new(),
+            in_smartmatch_rhs: false,
+            transliterate_in_smartmatch: false,
+            substitution_in_smartmatch: false,
+            last_topic_value: None,
+            topic_save_stack: Vec::new(),
+            container_ref_var: None,
+            container_ref_reversed: false,
+            topic_source_var: None,
+            element_source: None,
+            for_grep_view: None,
+            quanthash_bind_params: Vec::new(),
+            for_param_restore_stack: Vec::new(),
+            call_frames: Vec::new(),
+            env_dirty: false,
+            method_dispatch_pure: false,
+            resume_ip: None,
+            bind_context: false,
+            scalar_bind_context: false,
+            bound_decont_active: false,
+            rebind_context: false,
+            constant_context: false,
+            explicit_initializer_context: false,
+            vardecl_context: false,
+            local_bind_pairs: Vec::new(),
+            otf_compile_cache: HashMap::new(),
+            state_scope_id: None,
+            fn_resolve_cache: HashMap::new(),
+            fn_resolve_gen: 0,
+            fn_resolve_cache_gen: 0,
+            multi_candidates_cache: HashMap::new(),
+            multi_candidates_cache_gen: 0,
+            light_call_cache: HashMap::new(),
+            light_call_cache_gen: 0,
+            pos_light_call_cache: HashMap::new(),
+            pos_light_call_cache_gen: 0,
+            method_resolve_cache: HashMap::new(),
+            last_method_resolve: None,
+            fast_method_cache: HashMap::new(),
+            block_declared_vars: Vec::new(),
+            loop_local_vars: Vec::new(),
+            loop_local_saved_env: Vec::new(),
+            loop_cond_active: false,
+            outer_scope_locals: Vec::new(),
+            pending_alias_bind_names: Vec::new(),
+            otf_call_cache: HashMap::new(),
+            otf_call_cache_gen: 0,
+            check_phaser_depth: 0,
+            gather_for_loop_resume: None,
+            rw_map_topic_capture: None,
         };
         // Raku gives each start block fresh $/ and $! (they are lexically scoped).
         cloned.env.insert("/".to_string(), Value::Nil);

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -132,29 +132,6 @@ impl Interpreter {
             })
     }
 
-    pub(crate) fn call_supply_quit_handler(
-        &mut self,
-        quit_cb: Value,
-        reason: Value,
-    ) -> Result<(), RuntimeError> {
-        let saved_when = self.when_matched();
-        self.set_when_matched(false);
-        let handled = match self.call_sub_value(quit_cb, vec![reason.clone()], true) {
-            Ok(_) => true,
-            Err(err) if err.is_succeed => true,
-            Err(err) => {
-                self.set_when_matched(saved_when);
-                return Err(err);
-            }
-        };
-        self.set_when_matched(saved_when);
-        if handled {
-            Ok(())
-        } else {
-            Err(Self::runtime_error_from_supply_reason(reason))
-        }
-    }
-
     /// Run a single `whenever` QUIT phaser body with `reason` bound as `$_`,
     /// reporting how it handled the exception:
     /// - `Unhandled`: nothing matched / it rethrew — the quit propagates.

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -22,62 +22,6 @@ impl Interpreter {
         }
     }
 
-    fn union_insert_set_elem(elems: &mut std::collections::HashSet<String>, value: &Value) {
-        let pair_selected = |weight: &Value| weight.truthy() || matches!(weight, Value::Nil);
-        match value {
-            Value::Set(items, _) => {
-                elems.extend(items.iter().cloned());
-            }
-            Value::Bag(items, _) => {
-                for (k, v) in items.iter() {
-                    if *v > 0 {
-                        elems.insert(k.clone());
-                    }
-                }
-            }
-            Value::Mix(items, _) => {
-                for (k, v) in items.iter() {
-                    if *v != 0.0 {
-                        elems.insert(k.clone());
-                    }
-                }
-            }
-            Value::Hash(items) => {
-                for (k, v) in items.iter() {
-                    if v.truthy() || matches!(v, Value::Nil) {
-                        elems.insert(k.clone());
-                    }
-                }
-            }
-            _ if value.as_list_items().is_some() => {
-                for item in value.as_list_items().unwrap().iter() {
-                    Self::union_insert_set_elem(elems, item);
-                }
-            }
-            range if range.is_range() => {
-                for item in Self::value_to_list(range) {
-                    Self::union_insert_set_elem(elems, &item);
-                }
-            }
-            Value::Pair(key, weight) => {
-                if pair_selected(weight) {
-                    elems.insert(key.clone());
-                }
-            }
-            Value::ValuePair(key, weight) => {
-                if pair_selected(weight) {
-                    elems.insert(key.to_string_value());
-                }
-            }
-            other => {
-                let sv = other.to_string_value();
-                if !sv.is_empty() {
-                    elems.insert(sv);
-                }
-            }
-        }
-    }
-
     fn union_set_keys(value: &Value) -> Result<std::collections::HashSet<String>, RuntimeError> {
         if Self::union_is_lazy_input(value) {
             return Err(RuntimeError::new("X::Cannot::Lazy"));
@@ -739,38 +683,6 @@ impl Interpreter {
             )),
             Value::Package(_) => Ok(Some(0)),
             _ => Ok(Some(0)),
-        }
-    }
-
-    fn is_buf_value(val: &Value) -> bool {
-        if let Value::Instance { class_name, .. } = val {
-            let cn = class_name.resolve();
-            cn == "Buf"
-                || cn == "Blob"
-                || cn == "utf8"
-                || cn == "utf16"
-                || cn.starts_with("Buf[")
-                || cn.starts_with("Blob[")
-                || cn.starts_with("buf")
-                || cn.starts_with("blob")
-        } else {
-            false
-        }
-    }
-
-    fn extract_buf_bytes(val: &Value) -> Vec<u8> {
-        if let Value::Instance { attributes, .. } = val
-            && let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
-        {
-            items
-                .iter()
-                .map(|v| match v {
-                    Value::Int(n) => *n as u8,
-                    _ => 0,
-                })
-                .collect()
-        } else {
-            Vec::new()
         }
     }
 

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1815,18 +1815,16 @@ impl Interpreter {
         compiled_fns: &std::collections::HashMap<String, crate::opcode::CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
         self.block_scope_depth += 1;
-        let interp = std::mem::take(self);
-        let vm = crate::vm::VM::new(interp);
-        let (mut interp, result) = vm.run(code, compiled_fns);
+        // CP-3 collapse: run the precompiled block re-entrantly in place.
+        let result = self.run_nested(code, compiled_fns);
         for (slot, key) in &code.state_locals {
             if let Some(name) = code.locals.get(*slot)
-                && let Some(val) = interp.env().get(name).cloned()
+                && let Some(val) = self.env().get(name).cloned()
             {
-                interp.set_state_var(key.clone(), val);
+                self.set_state_var(key.clone(), val);
             }
         }
-        let value = interp.env().get("_").cloned().unwrap_or(Value::Nil);
-        *self = interp;
+        let value = self.env().get("_").cloned().unwrap_or(Value::Nil);
         self.block_scope_depth = self.block_scope_depth.saturating_sub(1);
         result.map(|last_value| last_value.unwrap_or(value))
     }
@@ -1942,19 +1940,17 @@ impl Interpreter {
         code: &crate::opcode::CompiledCode,
         compiled_fns: &std::collections::HashMap<String, crate::opcode::CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
-        let interp = std::mem::take(self);
-        let vm = crate::vm::VM::new(interp);
-        let (mut interp, result) = vm.run(code, compiled_fns);
+        // CP-3 collapse: run the compiled block re-entrantly in place.
+        let result = self.run_nested(code, compiled_fns);
         // Persist state variables for top-level compiled blocks too.
         for (slot, key) in &code.state_locals {
             if let Some(name) = code.locals.get(*slot)
-                && let Some(val) = interp.env().get(name).cloned()
+                && let Some(val) = self.env().get(name).cloned()
             {
-                interp.set_state_var(key.clone(), val);
+                self.set_state_var(key.clone(), val);
             }
         }
-        let value = interp.env().get("_").cloned().unwrap_or(Value::Nil);
-        *self = interp;
+        let value = self.env().get("_").cloned().unwrap_or(Value::Nil);
         result.map(|last_value| last_value.unwrap_or(value))
     }
 
@@ -2102,109 +2098,92 @@ impl Interpreter {
                 }
             }
 
-            // Create VM once, reuse across iterations
-            let interp = std::mem::take(self);
-            let mut vm = crate::vm::VM::new(interp);
-
-            let mut i = 0usize;
-            while i < list_items.len() {
-                if arity > 1 && i + arity > list_items.len() {
-                    *self = vm.into_interpreter();
-                    for (k, orig) in &saved {
-                        match orig {
-                            Some(v) => {
-                                self.env.insert(k.clone(), v.clone());
-                            }
-                            None => {
-                                self.env.remove(k);
-                            }
-                        }
+            // CP-3 collapse: run the map loop with fresh execution registers
+            // (replaces the `mem::take(self)` + `VM::new` sub-VM, reusing one
+            // register scope across all iterations). The closure returns the
+            // loop's Result; `with_nested_registers` restores the outer registers
+            // and flags env_dirty. The temporary-binding env restore (`saved`) is
+            // hoisted to after the call — it ran on every old exit path.
+            let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
+                let mut i = 0usize;
+                while i < list_items.len() {
+                    if arity > 1 && i + arity > list_items.len() {
+                        return Err(RuntimeError::new("Not enough elements for map block arity"));
                     }
-                    return Err(RuntimeError::new("Not enough elements for map block arity"));
-                }
-                {
-                    let assumed_count = data.assumed_positional.len();
-                    // Bind assumed positional args first
-                    for (idx, val) in data.assumed_positional.iter().enumerate() {
-                        if let Some(p) = data.params.get(idx) {
-                            vm.env_mut().insert(p.clone(), val.clone());
-                        }
-                    }
-                    if arity == 1 {
-                        let item = list_items[i].clone();
-                        if let Some(p) = data.params.get(assumed_count) {
-                            vm.env_mut().insert(p.clone(), item.clone());
-                        }
-                        vm.env_mut().insert(underscore.clone(), item.clone());
-                        vm.env_mut().insert(dollar_topic.clone(), item);
-                    } else {
-                        for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
-                            if i + idx < list_items.len() {
-                                vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
+                    {
+                        let assumed_count = data.assumed_positional.len();
+                        // Bind assumed positional args first
+                        for (idx, val) in data.assumed_positional.iter().enumerate() {
+                            if let Some(p) = data.params.get(idx) {
+                                vm.env_mut().insert(p.clone(), val.clone());
                             }
                         }
-                        vm.env_mut()
-                            .insert(underscore.clone(), list_items[i].clone());
-                        vm.env_mut()
-                            .insert(dollar_topic.clone(), list_items[i].clone());
-                    }
-                }
-                match vm.run_reuse(&code, &compiled_fns) {
-                    Ok(()) => {
-                        let val = vm
-                            .last_stack_value()
-                            .cloned()
-                            .or_else(|| vm.env().get("_").cloned())
-                            .unwrap_or(Value::Nil);
-                        match val {
-                            Value::Slip(elems) => result.extend(elems.iter().cloned()),
-                            v => result.push(v),
-                        }
-                    }
-                    Err(e) if e.is_next => {}
-                    Err(e) if e.is_last => break,
-                    Err(mut e) => {
-                        *self = vm.into_interpreter();
-                        for (k, orig) in &saved {
-                            match orig {
-                                Some(v) => {
-                                    self.env.insert(k.clone(), v.clone());
-                                }
-                                None => {
-                                    self.env.remove(k);
+                        if arity == 1 {
+                            let item = list_items[i].clone();
+                            if let Some(p) = data.params.get(assumed_count) {
+                                vm.env_mut().insert(p.clone(), item.clone());
+                            }
+                            vm.env_mut().insert(underscore.clone(), item.clone());
+                            vm.env_mut().insert(dollar_topic.clone(), item);
+                        } else {
+                            for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
+                                if i + idx < list_items.len() {
+                                    vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
                                 }
                             }
+                            vm.env_mut()
+                                .insert(underscore.clone(), list_items[i].clone());
+                            vm.env_mut()
+                                .insert(dollar_topic.clone(), list_items[i].clone());
                         }
-                        // A `return` inside the map block targets the routine
-                        // that lexically encloses the block. Stamp the signal
-                        // with that routine's callable id (captured in the
-                        // closure env) so propagation/out-of-dynamic-scope
-                        // detection works when the map is forced lazily after
-                        // the enclosing routine has exited.
-                        if e.is_return
-                            && e.return_target_callable_id.is_none()
-                            && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
-                        {
-                            e.return_target_callable_id = Some(*id as u64);
+                    }
+                    match vm.run_reuse(&code, &compiled_fns) {
+                        Ok(()) => {
+                            let val = vm
+                                .last_stack_value()
+                                .cloned()
+                                .or_else(|| vm.env().get("_").cloned())
+                                .unwrap_or(Value::Nil);
+                            match val {
+                                Value::Slip(elems) => result.extend(elems.iter().cloned()),
+                                v => result.push(v),
+                            }
                         }
-                        return Err(e);
+                        Err(e) if e.is_next => {}
+                        Err(e) if e.is_last => break,
+                        Err(mut e) => {
+                            // A `return` inside the map block targets the routine
+                            // that lexically encloses the block. Stamp the signal
+                            // with that routine's callable id (captured in the
+                            // closure env) so propagation/out-of-dynamic-scope
+                            // detection works when the map is forced lazily after
+                            // the enclosing routine has exited.
+                            if e.is_return
+                                && e.return_target_callable_id.is_none()
+                                && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
+                            {
+                                e.return_target_callable_id = Some(*id as u64);
+                            }
+                            return Err(e);
+                        }
+                    }
+                    i += arity;
+                }
+
+                // Run LAST phasers after the map loop completes (natural end or `last`)
+                if !last_phaser_bodies.is_empty() && i > 0 {
+                    for phaser_body in &last_phaser_bodies {
+                        let phaser_compiler = crate::compiler::Compiler::new();
+                        let (phaser_code, phaser_fns) = phaser_compiler.compile(phaser_body);
+                        // Ignore errors from LAST phasers (best-effort)
+                        let _ = vm.run_reuse(&phaser_code, &phaser_fns);
                     }
                 }
-                i += arity;
-            }
 
-            // Run LAST phasers after the map loop completes (natural end or `last`)
-            if !last_phaser_bodies.is_empty() && i > 0 {
-                for phaser_body in &last_phaser_bodies {
-                    let phaser_compiler = crate::compiler::Compiler::new();
-                    let (phaser_code, phaser_fns) = phaser_compiler.compile(phaser_body);
-                    // Ignore errors from LAST phasers (best-effort)
-                    let _ = vm.run_reuse(&phaser_code, &phaser_fns);
-                }
-            }
+                Ok(Value::array(result))
+            });
 
-            *self = vm.into_interpreter();
-            // Restore original values
+            // Restore original values (was done on every exit of the old loop).
             for (k, orig) in saved {
                 match orig {
                     Some(v) => {
@@ -2215,7 +2194,7 @@ impl Interpreter {
                     }
                 }
             }
-            return Ok(Value::array(result));
+            return loop_result;
         }
         if let Some(func) = func {
             let mut result = Vec::new();
@@ -2343,97 +2322,88 @@ impl Interpreter {
                 }
             }
 
-            let interp = std::mem::take(self);
-            let mut vm = crate::vm::VM::new(interp);
-
-            let mut i = 0usize;
-            while i < list_items.len() {
-                if arity > 1 && i + arity > list_items.len() {
-                    *self = vm.into_interpreter();
-                    for (k, orig) in &saved {
-                        match orig {
-                            Some(v) => self.env.insert(k.clone(), v.clone()),
-                            None => self.env.remove(k),
-                        };
+            // CP-3 collapse: run the rw map loop with fresh execution registers
+            // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
+            // returns the loop's Result; `with_nested_registers` restores the
+            // outer registers and flags env_dirty. The `saved`/`topic_key` env
+            // restore is hoisted to after the call (ran on every old exit).
+            let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
+                let mut i = 0usize;
+                while i < list_items.len() {
+                    if arity > 1 && i + arity > list_items.len() {
+                        return Err(RuntimeError::new("Not enough elements for map block arity"));
                     }
-                    return Err(RuntimeError::new("Not enough elements for map block arity"));
-                }
-                {
-                    let assumed_count = data.assumed_positional.len();
-                    for (idx, val) in data.assumed_positional.iter().enumerate() {
-                        if let Some(p) = data.params.get(idx) {
-                            vm.env_mut().insert(p.clone(), val.clone());
-                        }
-                    }
-                    // Clear the topic tracker before each iteration
-                    vm.env_mut().remove(topic_key);
-                    if arity == 1 {
-                        let item = list_items[i].clone();
-                        if let Some(p) = data.params.get(assumed_count) {
-                            vm.env_mut().insert(p.clone(), item.clone());
-                        }
-                        vm.env_mut().insert(underscore.clone(), item.clone());
-                        vm.env_mut().insert(dollar_topic.clone(), item);
-                    } else {
-                        for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
-                            if i + idx < list_items.len() {
-                                vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
+                    {
+                        let assumed_count = data.assumed_positional.len();
+                        for (idx, val) in data.assumed_positional.iter().enumerate() {
+                            if let Some(p) = data.params.get(idx) {
+                                vm.env_mut().insert(p.clone(), val.clone());
                             }
                         }
-                        vm.env_mut()
-                            .insert(underscore.clone(), list_items[i].clone());
-                        vm.env_mut()
-                            .insert(dollar_topic.clone(), list_items[i].clone());
+                        // Clear the topic tracker before each iteration
+                        vm.env_mut().remove(topic_key);
+                        if arity == 1 {
+                            let item = list_items[i].clone();
+                            if let Some(p) = data.params.get(assumed_count) {
+                                vm.env_mut().insert(p.clone(), item.clone());
+                            }
+                            vm.env_mut().insert(underscore.clone(), item.clone());
+                            vm.env_mut().insert(dollar_topic.clone(), item);
+                        } else {
+                            for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
+                                if i + idx < list_items.len() {
+                                    vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
+                                }
+                            }
+                            vm.env_mut()
+                                .insert(underscore.clone(), list_items[i].clone());
+                            vm.env_mut()
+                                .insert(dollar_topic.clone(), list_items[i].clone());
+                        }
                     }
+                    match vm.run_reuse(&code, &compiled_fns) {
+                        Ok(()) => {
+                            let val = vm
+                                .last_stack_value()
+                                .cloned()
+                                .or_else(|| vm.env().get("_").cloned())
+                                .unwrap_or(Value::Nil);
+                            // Write back topic mutation if it happened
+                            if arity == 1
+                                && let Some(mutated) = vm.env().get(topic_key).cloned()
+                            {
+                                list_items[i] = mutated;
+                            }
+                            match val {
+                                Value::Slip(elems) => result.extend(elems.iter().cloned()),
+                                v => result.push(v),
+                            }
+                        }
+                        Err(e) if e.is_next => {
+                            if arity == 1
+                                && let Some(mutated) = vm.env().get(topic_key).cloned()
+                            {
+                                list_items[i] = mutated;
+                            }
+                        }
+                        Err(e) if e.is_last => {
+                            if arity == 1
+                                && let Some(mutated) = vm.env().get(topic_key).cloned()
+                            {
+                                list_items[i] = mutated;
+                            }
+                            break;
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                    i += arity;
                 }
-                match vm.run_reuse(&code, &compiled_fns) {
-                    Ok(()) => {
-                        let val = vm
-                            .last_stack_value()
-                            .cloned()
-                            .or_else(|| vm.env().get("_").cloned())
-                            .unwrap_or(Value::Nil);
-                        // Write back topic mutation if it happened
-                        if arity == 1
-                            && let Some(mutated) = vm.env().get(topic_key).cloned()
-                        {
-                            list_items[i] = mutated;
-                        }
-                        match val {
-                            Value::Slip(elems) => result.extend(elems.iter().cloned()),
-                            v => result.push(v),
-                        }
-                    }
-                    Err(e) if e.is_next => {
-                        if arity == 1
-                            && let Some(mutated) = vm.env().get(topic_key).cloned()
-                        {
-                            list_items[i] = mutated;
-                        }
-                    }
-                    Err(e) if e.is_last => {
-                        if arity == 1
-                            && let Some(mutated) = vm.env().get(topic_key).cloned()
-                        {
-                            list_items[i] = mutated;
-                        }
-                        break;
-                    }
-                    Err(e) => {
-                        *self = vm.into_interpreter();
-                        for (k, orig) in &saved {
-                            match orig {
-                                Some(v) => self.env.insert(k.clone(), v.clone()),
-                                None => self.env.remove(k),
-                            };
-                        }
-                        return Err(e);
-                    }
-                }
-                i += arity;
-            }
 
-            *self = vm.into_interpreter();
+                Ok(Value::array(result))
+            });
+
             for (k, orig) in saved {
                 match orig {
                     Some(v) => self.env.insert(k, v),
@@ -2441,7 +2411,7 @@ impl Interpreter {
                 };
             }
             self.env.remove(topic_key);
-            return Ok(Value::array(result));
+            return loop_result;
         }
         // Non-Sub func: delegate to regular map
         self.eval_map_over_items(func, list_items.to_vec())
@@ -2533,104 +2503,96 @@ impl Interpreter {
                 self.env.insert_sym(*k, v.clone());
             }
 
-            // Create VM once, reuse across iterations
-            let interp = std::mem::take(self);
-            let mut vm = crate::vm::VM::new(interp);
-
-            let mut i = 0usize;
-            let mut stop = false;
-            while i < list_items.len() {
-                if arity > 1 && i + arity > list_items.len() {
-                    break;
-                }
-                let chunk: Vec<Value> = if arity == 1 {
-                    vec![list_items[i].clone()]
-                } else {
-                    list_items[i..i + arity].to_vec()
-                };
-                'body_redo: loop {
-                    {
-                        let assumed_count = data.assumed_positional.len();
-                        for (idx, val) in data.assumed_positional.iter().enumerate() {
-                            if let Some(p) = data.params.get(idx) {
-                                vm.env_mut().insert(p.clone(), val.clone());
-                            }
-                        }
-                        if arity == 1 {
-                            if let Some(p) = data.params.get(assumed_count) {
-                                vm.env_mut().insert(p.clone(), chunk[0].clone());
-                            }
-                            vm.env_mut().insert(underscore.clone(), chunk[0].clone());
-                            vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
-                            vm.env_mut()
-                                .insert(topic_source_key.clone(), chunk[0].clone());
-                        } else {
-                            for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
-                                if idx < chunk.len() {
-                                    vm.env_mut().insert(p.clone(), chunk[idx].clone());
+            // CP-3 collapse: run the grep loop with fresh execution registers
+            // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
+            // returns Ok(()) / Err on the loop; `with_nested_registers` restores
+            // the outer registers and flags env_dirty. The `saved` env restore is
+            // hoisted to after the call (ran on every old exit path).
+            let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
+                let mut i = 0usize;
+                let mut stop = false;
+                while i < list_items.len() {
+                    if arity > 1 && i + arity > list_items.len() {
+                        break;
+                    }
+                    let chunk: Vec<Value> = if arity == 1 {
+                        vec![list_items[i].clone()]
+                    } else {
+                        list_items[i..i + arity].to_vec()
+                    };
+                    'body_redo: loop {
+                        {
+                            let assumed_count = data.assumed_positional.len();
+                            for (idx, val) in data.assumed_positional.iter().enumerate() {
+                                if let Some(p) = data.params.get(idx) {
+                                    vm.env_mut().insert(p.clone(), val.clone());
                                 }
                             }
-                            vm.env_mut().insert(underscore.clone(), chunk[0].clone());
-                            vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
-                        }
-                    }
-                    vm.set_topic_source_var((arity == 1).then_some(topic_source_key.clone()));
-                    match vm.run_reuse(&code, &compiled_fns) {
-                        Ok(()) => {
-                            let pred = vm
-                                .last_stack_value()
-                                .cloned()
-                                .or_else(|| vm.env().get("_").cloned())
-                                .unwrap_or(Value::Nil);
-                            let updated_item = if arity == 1 {
-                                vm.env()
-                                    .get(&topic_source_key)
-                                    .cloned()
-                                    .unwrap_or_else(|| chunk[0].clone())
-                            } else {
-                                chunk[0].clone()
-                            };
                             if arity == 1 {
-                                list_items[i] = updated_item.clone();
+                                if let Some(p) = data.params.get(assumed_count) {
+                                    vm.env_mut().insert(p.clone(), chunk[0].clone());
+                                }
+                                vm.env_mut().insert(underscore.clone(), chunk[0].clone());
+                                vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
+                                vm.env_mut()
+                                    .insert(topic_source_key.clone(), chunk[0].clone());
+                            } else {
+                                for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
+                                    if idx < chunk.len() {
+                                        vm.env_mut().insert(p.clone(), chunk[idx].clone());
+                                    }
+                                }
+                                vm.env_mut().insert(underscore.clone(), chunk[0].clone());
+                                vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
                             }
-                            if pred.truthy() {
-                                if arity == 1 {
-                                    result.push(updated_item);
+                        }
+                        vm.set_topic_source_var((arity == 1).then_some(topic_source_key.clone()));
+                        match vm.run_reuse(&code, &compiled_fns) {
+                            Ok(()) => {
+                                let pred = vm
+                                    .last_stack_value()
+                                    .cloned()
+                                    .or_else(|| vm.env().get("_").cloned())
+                                    .unwrap_or(Value::Nil);
+                                let updated_item = if arity == 1 {
+                                    vm.env()
+                                        .get(&topic_source_key)
+                                        .cloned()
+                                        .unwrap_or_else(|| chunk[0].clone())
                                 } else {
-                                    result.push(Value::array(chunk));
+                                    chunk[0].clone()
+                                };
+                                if arity == 1 {
+                                    list_items[i] = updated_item.clone();
                                 }
-                            }
-                            break 'body_redo;
-                        }
-                        Err(e) if e.is_redo => continue 'body_redo,
-                        Err(e) if e.is_next => break 'body_redo,
-                        Err(e) if e.is_last => {
-                            stop = true;
-                            break 'body_redo;
-                        }
-                        Err(e) => {
-                            *self = vm.into_interpreter();
-                            for (k, orig) in &saved {
-                                match orig {
-                                    Some(v) => {
-                                        self.env.insert(k.clone(), v.clone());
-                                    }
-                                    None => {
-                                        self.env.remove(k);
+                                if pred.truthy() {
+                                    if arity == 1 {
+                                        result.push(updated_item);
+                                    } else {
+                                        result.push(Value::array(chunk));
                                     }
                                 }
+                                break 'body_redo;
                             }
-                            return Err(e);
+                            Err(e) if e.is_redo => continue 'body_redo,
+                            Err(e) if e.is_next => break 'body_redo,
+                            Err(e) if e.is_last => {
+                                stop = true;
+                                break 'body_redo;
+                            }
+                            Err(e) => {
+                                return Err(e);
+                            }
                         }
                     }
+                    if stop {
+                        break;
+                    }
+                    i += arity;
                 }
-                if stop {
-                    break;
-                }
-                i += arity;
-            }
+                Ok(())
+            });
 
-            *self = vm.into_interpreter();
             for (k, orig) in saved {
                 match orig {
                     Some(v) => {
@@ -2641,6 +2603,7 @@ impl Interpreter {
                     }
                 }
             }
+            loop_result?;
             return Ok((Value::array(result), list_items));
         }
         if let Some(pattern) = func {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -854,10 +854,10 @@ impl Interpreter {
         compiler.set_current_package(self.current_package());
         compiler.is_mainline = true;
         let (code, compiled_fns) = compiler.compile(&body_main);
-        let interp = std::mem::take(self);
-        let vm = crate::vm::VM::new(interp);
-        let (interp, body_result) = vm.run(&code, &compiled_fns);
-        *self = interp;
+        // CP-3 collapse: the Interpreter *is* the bytecode VM now, so run the
+        // compiled mainline directly (outermost run → fresh registers) instead of
+        // the `mem::take(self)` + `VM::new` + `*self = interp` ping-pong.
+        let body_result = self.run_top(&code, &compiled_fns);
         let queue_result = if Self::should_run_success_queue_vm(&body_result, self.env.get("_")) {
             self.run_block_raw(&success_ph)
         } else {
@@ -995,10 +995,11 @@ impl Interpreter {
             return Ok(());
         }
         let (code, compiled_fns) = self.compile_block_raw(stmts);
-        let interp = std::mem::take(self);
-        let vm = crate::vm::VM::new(interp);
-        let (interp, result) = vm.run(&code, &compiled_fns);
-        *self = interp;
+        // CP-3 collapse: run the compiled block re-entrantly in place (no
+        // `mem::take(self)` + `VM::new` ping-pong), exactly like the VM-side
+        // `vm_run_block_raw`. `run_nested` saves/resets/restores the per-execution
+        // registers and flags env_dirty so the outer locals re-sync from env.
+        let result = self.run_nested(&code, &compiled_fns);
         self.run_pending_instance_destroys()?;
         result.map(|_| ())
     }
@@ -1085,24 +1086,6 @@ impl Interpreter {
             }
         }
         Ok(())
-    }
-
-    fn is_exceptional_block_exit(err: &RuntimeError) -> bool {
-        if err.is_fail {
-            return true;
-        }
-        if err.return_value.is_some() {
-            return false;
-        }
-        !(err.is_last
-            || err.is_next
-            || err.is_redo
-            || err.is_goto
-            || err.is_proceed
-            || err.is_succeed
-            || err.is_leave
-            || err.is_resume
-            || err.is_react_done)
     }
 
     fn should_run_success_queue_raw(

--- a/src/runtime/seq_helpers/seq_arithmetic.rs
+++ b/src/runtime/seq_helpers/seq_arithmetic.rs
@@ -120,11 +120,6 @@ impl Interpreter {
         }
     }
 
-    // Compute the successor of a string (increment the last character, carrying over)
-    pub(in crate::runtime) fn string_succ(s: &str) -> String {
-        crate::builtins::str_increment::string_succ(s)
-    }
-
     pub(in crate::runtime) fn digit_string_succ_radix(s: &str, radix: u32) -> String {
         if s.is_empty() || !(2..=10).contains(&radix) {
             return s.to_string();

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -224,11 +224,9 @@ impl Interpreter {
         react_subs: Vec<crate::runtime::subtest::ReactSubscription>,
         policy: crate::runtime::subtest::SupplyDrivePolicy,
     ) -> Result<(), RuntimeError> {
-        let interp = std::mem::take(self);
-        let mut vm = crate::vm::VM::new(interp);
-        let result = vm.drive_react_subscriptions(react_subs, policy);
-        *self = vm.into_interpreter();
-        result
+        // CP-3 collapse: run the react drive loop with fresh execution registers
+        // in place instead of the `mem::take(self)` + `VM::new` sub-VM.
+        self.with_nested_registers(|vm| vm.drive_react_subscriptions_nested(react_subs, policy))
     }
 
     /// On the `await`/`.Promise` path, replay a finite/static `whenever` source

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -95,19 +95,6 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
 }
 
 impl Interpreter {
-    fn resolve_sigilless_alias_source_name(&self, source_name: &str) -> String {
-        let mut resolved = source_name.to_string();
-        let mut seen = std::collections::HashSet::new();
-        while seen.insert(resolved.clone()) {
-            let key = sigilless_alias_key(&resolved);
-            let Some(Value::Str(next)) = self.env.get(&key) else {
-                break;
-            };
-            resolved = next.to_string();
-        }
-        resolved
-    }
-
     /// Save the current readonly_vars set (call before function body execution).
     pub(crate) fn save_readonly_vars(&self) -> HashSet<String> {
         self.readonly_vars.clone()

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::result_large_err)]
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::ast::Stmt;
 use crate::env::Env;
@@ -9,12 +9,12 @@ use crate::opcode::{CompiledCode, CompiledFunction, OpCode};
 use crate::runtime;
 use crate::symbol::Symbol;
 use crate::value::{
-    ArrayKind, EnumValue, ForLoopResumeState, GatherCoroutineState, JunctionKind, LazyList,
-    RuntimeError, Value, make_rat,
+    ArrayKind, EnumValue, GatherCoroutineState, JunctionKind, LazyList, RuntimeError, Value,
+    make_rat,
 };
 use num_traits::{Signed, Zero};
 
-type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
+pub(crate) type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
 
 thread_local! {
     /// Set while execution is inside the `VM::run` catch_unwind boundary, so the
@@ -62,7 +62,7 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
 /// Pre-computed fast dispatch entry for compiled methods.
 /// Caches all the information needed to skip intermediate dispatch steps
 /// (wrap chain check, compiled_code extraction, fast-path eligibility checks).
-struct FastMethodCacheEntry {
+pub(crate) struct FastMethodCacheEntry {
     owner_class: Symbol,
     method_def: Arc<crate::runtime::MethodDef>,
     compiled_code: Arc<CompiledCode>,
@@ -72,23 +72,24 @@ struct FastMethodCacheEntry {
 }
 
 /// env-loan (CP-1 1e): call an interpreter carrier/helper that reads
-/// `self.interpreter.env`, lending the VM-owned env for the duration.
+/// `self.env`, lending the VM-owned env for the duration.
 ///
 /// Expands to: swap the real env into the interpreter's loan slot, run
-/// `$self.interpreter.<call>`, swap it back. Unlike a closure-based helper, the
+/// `$self.<call>`, swap it back. Unlike a closure-based helper, the
 /// call is inlined so it keeps the *partial* `self.interpreter` borrow — args may
 /// still borrow other `self` fields (e.g. `self.locals[i]`) exactly as the
-/// original `self.interpreter.<call>` did, so no new borrow conflicts arise.
+/// original `self.<call>` did, so no new borrow conflicts arise.
 ///
 /// Only for **value/Result-returning** helpers: the post-call swap re-borrows
 /// `self.interpreter`, so a returned reference into the interpreter cannot escape
 /// (those few sites are handled individually). See docs/vm-state-ownership.md.
 macro_rules! loan_env {
     ($self:ident, $($call:tt)+) => {{
-        ::std::mem::swap(&mut $self.env, $self.interpreter.env_mut());
-        let __loan_r = $self.interpreter.$($call)+;
-        ::std::mem::swap(&mut $self.env, $self.interpreter.env_mut());
-        __loan_r
+        // CP-3 collapse: the VM dissolved into the Interpreter, so env is no
+        // longer loaned across a VM->interpreter boundary — it is just `self.env`.
+        // This macro is now a thin self-call kept so the ~350 call sites need no
+        // edit; it will be removed in a later cosmetic pass.
+        $self.$($call)+
     }};
 }
 
@@ -139,7 +140,7 @@ fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
 }
 
 /// Saved state for a compiled function/closure/method call frame.
-pub(super) struct VmCallFrame {
+pub(crate) struct VmCallFrame {
     pub saved_env: Env,
     pub saved_locals: Vec<Value>,
     pub saved_stack_depth: usize,
@@ -149,237 +150,11 @@ pub(super) struct VmCallFrame {
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 
-pub(crate) struct VM {
-    interpreter: Interpreter,
-    /// Handle to the shared declaration [`Registry`](crate::runtime::Registry),
-    /// cloned from the interpreter at construction (PLAN.md ② → A: the VM holds the
-    /// registry as a *peer* rather than reaching through `self.interpreter`). Points
-    /// at the same `RwLock` as `self.interpreter`'s handle, so mutations through
-    /// either are visible. Stable for the VM's lifetime: the interpreter's registry
-    /// Arc is only ever replaced by `clone_for_thread` (which builds a fresh
-    /// Interpreter for a child thread), never reassigned in place during a run.
-    registry: Arc<RwLock<crate::runtime::Registry>>,
-    /// Handle to the shared [`IoHandleTable`](crate::runtime::IoHandleTable),
-    /// cloned from the interpreter at construction (PLAN.md ③ native IO PR-C: the
-    /// VM holds the IO handle table as a *peer*, mirroring `registry`). Points at
-    /// the same `RwLock` as `self.interpreter`'s handle, so mutations through
-    /// either are visible. Stable for the VM's lifetime (same `clone_for_thread`
-    /// reasoning as `registry`). Used by `try_native_io_handle_method` to resolve
-    /// pure-handle IO methods natively instead of bouncing through the interpreter.
-    io_handles: Arc<RwLock<crate::runtime::IoHandleTable>>,
-    /// The VM's clone of the shared [`OutputSink`](crate::runtime::OutputSink)
-    /// handle (same `RwLock` as the interpreter's), so Stdout/Stderr output
-    /// dispatch resolves natively instead of bouncing through the interpreter
-    /// (③後段 PR-C).
-    output_sink: Arc<RwLock<crate::runtime::OutputSink>>,
-    /// The VM's clone of the shared `current_package` handle (same `RwLock` as
-    /// the interpreter's), so the VM reads/writes the in-scope package name
-    /// through its own peer handle instead of bouncing through
-    /// `self.interpreter` — a step toward removing the interpreter bridge.
-    /// Stable for the VM's lifetime (same `clone_for_thread` reasoning as
-    /// `registry`).
-    current_package: Arc<RwLock<String>>,
-    /// The VM's clone of the shared `instance_type_metadata` handle (same
-    /// `RwLock` as the interpreter's), so the VM reads container type metadata
-    /// for `Instance` values natively (`VM::container_type_metadata`) instead of
-    /// bouncing through `self.interpreter` (CP-3 Track 1). The read touches no
-    /// env, so it needs no env loan. Writes (`register_container_type_metadata`)
-    /// still go through the interpreter and are visible here via the shared lock.
-    /// Stable for the VM's lifetime (same `clone_for_thread` reasoning as
-    /// `registry`).
-    instance_type_metadata: Arc<RwLock<HashMap<u64, crate::runtime::ContainerTypeInfo>>>,
-    /// The variable store (env), owned by the VM during opcode execution
-    /// (CP-1 env-loan, step 1e). On `VM::new` the env is pulled out of the
-    /// interpreter into here; `run`/`into_interpreter` push it back so the
-    /// returned interpreter is coherent. The interpreter keeps its own `env`
-    /// field as a *loan slot*: a carrier call (EVAL / subset-`where` /
-    /// call_sub_value / …) reads `self.interpreter.env`, so the VM swaps this
-    /// env into the interpreter around each such call (`loan_env_for`) and
-    /// swaps it back afterwards. See docs/vm-state-ownership.md
-    /// "CP-1 env-loan 設計".
-    env: Env,
-    stack: Vec<Value>,
-    locals: Vec<Value>,
-    in_smartmatch_rhs: bool,
-    /// Set by transliterate op when executed inside smartmatch RHS.
-    /// The smartmatch handler uses this to return the transliterate result
-    /// as a StrDistance-like value instead of performing eq comparison.
-    transliterate_in_smartmatch: bool,
-    /// Set by substitution op when executed inside smartmatch RHS.
-    /// The smartmatch handler returns `$/` (Match) on success or False on failure.
-    substitution_in_smartmatch: bool,
-    /// Tracks the last value passed to SetTopic, used as the REPL display value.
-    last_topic_value: Option<Value>,
-    topic_save_stack: Vec<Value>,
-    /// Container name from when/default body (for Scalar container binding)
-    container_ref_var: Option<String>,
-    /// When true, the container ref is reversed (e.g. `for @a.reverse`)
-    container_ref_reversed: bool,
-    /// Source variable name for topic binding in for loops
-    topic_source_var: Option<String>,
-    /// Element source for an lvalue container-element topic (`given %h<k>` /
-    /// `given @a[i]`): (container var name, resolved index, positional). After
-    /// the `given`/`with` body runs, the final `$_` is written back to this
-    /// element so `$_ = ...` and container mutations (`.push`) propagate.
-    element_source: Option<(String, Value, bool)>,
-    /// rw aggregate view writeback for `for @a.grep(...) { $_++ }`: when the
-    /// for-loop iterable is a grep result with a registered grep-view binding,
-    /// this holds (source array Arc, per-filtered-index source indices, kind)
-    /// so the loop can write modified topics back to the original array slots.
-    for_grep_view: Option<(
-        Arc<crate::value::ArrayData>,
-        Vec<usize>,
-        crate::value::ArrayKind,
-    )>,
-    /// Names of multi-param for-loop bindings (`-> %a, %b`) whose `%`/`@` params
-    /// must preserve a QuantHash (Set/Bag/Mix) value rather than coercing it to
-    /// a plain Hash, matching Raku's parameter-binding semantics.
-    quanthash_bind_params: Vec<String>,
-    /// Stack of single named for-loop params whose prior binding must be
-    /// restored *after* the loop's LAST/post phasers run. A for-loop pushes its
-    /// saved (name, prior-value) on normal completion; the matching
-    /// `RestoreForParam` opcode (emitted after the post phasers) pops and
-    /// applies it. LIFO so nested loops with the same param name nest correctly.
-    for_param_restore_stack: Vec<(String, Option<Value>)>,
-    /// Stack of saved call frames for compiled function/closure/method calls.
-    call_frames: Vec<VmCallFrame>,
-    /// When true, locals may be stale relative to env (interpreter bridge modified env).
-    /// Cleared after sync_locals_from_env or pop_call_frame.
-    env_dirty: bool,
-    /// Set by a compiled method dispatch to report whether it left the caller's
-    /// local slots coherent (Slice 6.3). `true` means the call provably wrote
-    /// nothing the caller can observe in its slots (a read-only / no-merge method
-    /// or a merge that propagated nothing), so the CallMethod/CallMethodMut
-    /// opcode skips its env_dirty mark and the caller avoids a per-call env->locals
-    /// pull. Defaults to `false` (conservative) for every non-compiled path
-    /// (native fallback, interpreter bridge, blocks) so a missed signal can only
-    /// cost a redundant pull, never a stale read.
-    method_dispatch_pure: bool,
-    /// The instruction pointer to resume at after a .resume call in a CATCH block.
-    /// Set when Die/Fail creates an exception, used by exec_try_catch_op.
-    resume_ip: Option<usize>,
-    /// When true, the next SetLocal is a `:=` bind (preserves container type for `@` vars).
-    bind_context: bool,
-    /// When true, the next SetLocal binds a `$` scalar to a Positional via `:=` and
-    /// must record the scalar as decontainerized. Independent of `bind_context` so
-    /// scalar binds keep their existing (fast-path) store routing.
-    scalar_bind_context: bool,
-    /// True once any scalar has been bound (`:=`) to a Positional value, marking
-    /// it as decontainerized in the env (`__mutsu_bound_decont::$name`). Guards the
-    /// (otherwise hot) marker-clearing in scalar assignment so the common case
-    /// (no such binds) stays zero-cost.
-    bound_decont_active: bool,
-    /// When true, the next SetLocal is a `:=` rebind (not VarDecl).
-    /// Used to trigger cleanup of old bind pairs and reverse aliases.
-    rebind_context: bool,
-    /// When true, the next SetLocal skips @/% container coercion (for `constant @x`).
-    constant_context: bool,
-    /// When true, the next SetLocal came from an explicit initializer (`= expr`).
-    explicit_initializer_context: bool,
-    /// When true, the next SetLocal is from a `my` VarDecl (not a plain assignment).
-    /// Used to allow overwriting immutable Blob containers in loop redeclarations.
-    vardecl_context: bool,
-    /// Local-slot binding pairs created by `:=` VarDecl in the current scope.
-    /// Each entry is (source_slot, target_slot): writing to source_slot should
-    /// propagate the value to target_slot.
-    local_bind_pairs: Vec<(usize, usize)>,
-    /// Cache for on-the-fly compiled functions, keyed by fingerprint.
-    /// Prevents re-compilation which would break state variables.
-    otf_compile_cache: HashMap<u64, CompiledFunction>,
-    /// Current closure instance ID for state variable scoping.
-    /// When Some, state var keys are suffixed with `#c{id}` to give each
-    /// closure clone its own state. Pushed/popped around closure calls.
-    state_scope_id: Option<u64>,
-    /// Cache for compiled function resolution.
-    /// Maps (name, arity) → (compiled_fns key, fingerprint).
-    #[allow(clippy::type_complexity)]
-    fn_resolve_cache: HashMap<(Symbol, usize, Vec<String>), (String, u64, String)>,
-    /// Generation counter for fn_resolve_cache invalidation.
-    fn_resolve_gen: u64,
-    /// The generation at which fn_resolve_cache was last populated.
-    fn_resolve_cache_gen: u64,
-    /// Cache for has_multi_candidates results, invalidated by fn_resolve_gen.
-    multi_candidates_cache: HashMap<Symbol, bool>,
-    /// The generation at which multi_candidates_cache was last valid.
-    multi_candidates_cache_gen: u64,
-    /// Light-call cache: maps function name symbol to (compiled_fns key, fingerprint).
-    /// Used by the light call fast path in exec_call_func_op to skip expensive
-    /// function resolution on repeated calls to the same function.
-    light_call_cache: HashMap<Symbol, (String, u64)>,
-    /// The generation at which light_call_cache was last valid.
-    light_call_cache_gen: u64,
-    /// Positional light-call cache for simple positional-only functions.
-    pos_light_call_cache: HashMap<Symbol, (String, u64)>,
-    /// The generation at which pos_light_call_cache was last valid.
-    pos_light_call_cache_gen: u64,
-    /// Method resolution cache: maps (class_name, method_name) to resolved
-    /// (owner_class, MethodDef). Avoids repeated MRO walks for the same method.
-    method_resolve_cache: HashMap<(Symbol, Symbol), MethodResolveEntry>,
-    /// Monomorphic inline cache: stores the last (class, method, owner, def)
-    /// resolution result. Skips HashMap lookup for repeated same-class calls.
-    last_method_resolve: Option<(Symbol, Symbol, String, Arc<crate::runtime::MethodDef>)>,
-    /// Fast method dispatch cache: maps (class, method) to pre-computed dispatch
-    /// info including compiled code and fast-path eligibility. Skips wrap chain
-    /// checks, compiled_code extraction, and param_def eligibility scans.
-    fast_method_cache: HashMap<(Symbol, Symbol), FastMethodCacheEntry>,
-    /// Stack of sets tracking variable names declared (via SetVarDynamic) within
-    /// each active BlockScope. Used during BlockScope restoration to avoid
-    /// propagating block-local variable values to the outer scope.
-    block_declared_vars: Vec<std::collections::HashSet<String>>,
-    /// Stack of sets tracking variable names declared (via SetVarDynamic) within
-    /// each active loop body. A loop body is re-entered per iteration, so a `my`
-    /// declared in it is a *fresh binding each iteration* — a closure created in
-    /// the body must capture that iteration's value, not the shared lexical name
-    /// (Raku per-iteration binding). When a closure is created, free variables
-    /// found in this stack are recorded as its `owned_captures`, and at call time
-    /// the closure reads them from its own frozen captured env (overwriting the
-    /// caller's current value) — immune to the dual-store slot re-injection that
-    /// otherwise leaks the loop's final value into every closure. See
-    /// docs/vm-dual-store.md / PLAN.md lever C.
-    loop_local_vars: Vec<std::collections::HashSet<String>>,
-    /// Parallel stack to `loop_local_vars`: for each loop-body-local `my` name
-    /// that *shadows an existing outer binding*, the env value it shadowed at the
-    /// moment it was first declared in the loop body. On loop exit that outer
-    /// value is restored (in both env and the shared local slot), so a block-local
-    /// `my $x` inside a loop body does not clobber an enclosing same-named outer
-    /// `$x` (Raku lexical block scoping). Names with no prior binding are not
-    /// recorded. See pop_loop_local_scope / PLAN.md lever C Slice 3.
-    loop_local_saved_env: Vec<std::collections::HashMap<String, Value>>,
-    /// True while a loop's *condition* (not its body) is being evaluated. A `my`
-    /// declared in a `while`/`until`/`loop` condition — including the statement-
-    /// modifier form `... until COND` — is lexically the enclosing scope's, not
-    /// the loop body's, and is commonly read after the loop. Suppress recording
-    /// such a declaration in `loop_local_saved_env` so loop-exit restoration does
-    /// not wipe it. See pop_loop_local_scope.
-    loop_cond_active: bool,
-    /// Stack of saved locals snapshots for each active BlockScope.
-    /// Used by GetOuterVar to access variables from enclosing lexical scopes.
-    outer_scope_locals: Vec<Vec<Value>>,
-    /// Pending alias-based bind pairs created by `:=` binding inside closures
-    /// (e.g. `$a := $arg` where `$arg is rw`).  Each entry is
-    /// (target_name, source_name): after the closure returns, the caller
-    /// creates local_bind_pairs from these so writes to source propagate to target.
-    pending_alias_bind_names: Vec<(String, String)>,
-    /// On-the-fly compiled function call cache: maps function name to its
-    /// compiled form. Used to avoid going through the interpreter fallback
-    /// for user-defined functions that were compiled on-the-fly.
-    otf_call_cache: HashMap<Symbol, CompiledFunction>,
-    /// The generation at which otf_call_cache was last valid.
-    otf_call_cache_gen: u64,
-    /// Depth counter for CHECK phaser scope. When > 0, runtime errors should
-    /// be wrapped in X::Comp::BeginTime before propagating.
-    check_phaser_depth: u32,
-    /// Temporary storage for for-loop resume state when a gather take-limit
-    /// interrupts a for loop.
-    gather_for_loop_resume: Option<ForLoopResumeState>,
-    /// Scratch slot for the native rw-`.map` writeback path. When a closure call
-    /// is made with rw-topic capture armed, `call_compiled_closure_with_topic`
-    /// stashes the block's final `$_` mutation here (read from
-    /// `__mutsu_rw_map_topic__` before the call frame is popped) so the native
-    /// map loop can write it back to the source array element. `None` when the
-    /// block did not mutate `$_`. See `vm_native_map.rs`.
-    rw_map_topic_capture: Option<Value>,
-}
+/// CP-3 collapse: the bytecode VM has been dissolved into the `Interpreter`
+/// struct (the Interpreter *is* the bytecode VM now). `VM` is kept as a crate
+/// alias so the ~40 `impl VM` blocks and internal `VM::`/`vm: VM` references
+/// compile unchanged; a later cosmetic pass can rename them to `Interpreter`.
+pub(crate) type VM = crate::interpreter::Interpreter;
 
 impl VM {
     /// Wrap a runtime error in X::Comp::BeginTime (used for errors inside CHECK phasers).
@@ -487,7 +262,6 @@ impl VM {
                 || cn.starts_with("X::")
                 || cn.starts_with("CX::")
                 || self
-                    .interpreter
                     .mro_readonly(&cn)
                     .iter()
                     .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
@@ -516,174 +290,6 @@ impl VM {
         err
     }
 
-    pub(crate) fn new(mut interpreter: Interpreter) -> Self {
-        let registry = interpreter.registry_handle();
-        let io_handles = interpreter.io_handles_handle();
-        let output_sink = interpreter.output_sink_handle();
-        let current_package = interpreter.current_package_handle();
-        let instance_type_metadata = interpreter.instance_type_metadata_handle();
-        // env-loan (CP-1 step 1e): pull the env out of the interpreter so the VM
-        // owns it during opcode execution. The interpreter's env field is left
-        // *poisoned* (a loan-slot sentinel) so any VM->interpreter call that
-        // reads env without a loan wrapper trips the debug guard; restored to a
-        // real env by `run`/`into_interpreter`.
-        let env = interpreter.loan_out_env();
-        Self {
-            interpreter,
-            registry,
-            io_handles,
-            output_sink,
-            current_package,
-            instance_type_metadata,
-            env,
-            stack: Vec::new(),
-            locals: Vec::new(),
-            in_smartmatch_rhs: false,
-            transliterate_in_smartmatch: false,
-            substitution_in_smartmatch: false,
-            last_topic_value: None,
-            topic_save_stack: Vec::new(),
-            container_ref_var: None,
-            container_ref_reversed: false,
-            topic_source_var: None,
-            element_source: None,
-            for_grep_view: None,
-            quanthash_bind_params: Vec::new(),
-            for_param_restore_stack: Vec::new(),
-            call_frames: Vec::new(),
-            env_dirty: false,
-            method_dispatch_pure: false,
-            resume_ip: None,
-            bind_context: false,
-            scalar_bind_context: false,
-            bound_decont_active: false,
-            rebind_context: false,
-            constant_context: false,
-            explicit_initializer_context: false,
-            vardecl_context: false,
-            local_bind_pairs: Vec::new(),
-            otf_compile_cache: HashMap::new(),
-            state_scope_id: None,
-            fn_resolve_cache: HashMap::new(),
-            fn_resolve_gen: 0,
-            fn_resolve_cache_gen: 0,
-            multi_candidates_cache: HashMap::new(),
-            multi_candidates_cache_gen: 0,
-            light_call_cache: HashMap::new(),
-            light_call_cache_gen: 0,
-            pos_light_call_cache: HashMap::new(),
-            pos_light_call_cache_gen: 0,
-            method_resolve_cache: HashMap::new(),
-            last_method_resolve: None,
-            fast_method_cache: HashMap::new(),
-            block_declared_vars: Vec::new(),
-            loop_local_vars: Vec::new(),
-            loop_local_saved_env: Vec::new(),
-            loop_cond_active: false,
-            outer_scope_locals: Vec::new(),
-            pending_alias_bind_names: Vec::new(),
-            otf_call_cache: HashMap::new(),
-            otf_call_cache_gen: 0,
-            check_phaser_depth: 0,
-            gather_for_loop_resume: None,
-            rw_map_topic_capture: None,
-        }
-    }
-
-    /// Write access to the shared declaration [`Registry`](crate::runtime::Registry)
-    /// via the VM's own handle (no `self.interpreter` bounce). Same lock and same
-    /// guard discipline as the interpreter's `registry_mut`: never hold the guard
-    /// across user-code re-entry.
-    #[inline]
-    pub(crate) fn registry_mut(&self) -> crate::runtime::RegistryWriteGuard<'_> {
-        crate::runtime::RegistryWriteGuard::new(&self.registry, "registry")
-    }
-
-    /// Read access to the shared declaration [`Registry`] via the VM's own handle.
-    /// Used by the VM-native dispatch predicates ([`Self::has_proto`] /
-    /// [`Self::has_multi_candidates`]) so they read the registry without bouncing
-    /// through `self.interpreter`. The guard must not be held across user-code
-    /// re-entry (same discipline as `registry_mut`).
-    #[inline]
-    pub(crate) fn registry(&self) -> crate::runtime::RegistryReadGuard<'_> {
-        crate::runtime::RegistryReadGuard::new(&self.registry, "registry")
-    }
-
-    /// VM-native `proto`-declaration check, mirroring
-    /// `Interpreter::has_proto`: reads the VM's own registry + `current_package`
-    /// handles and delegates to the single [`Registry::has_proto`] implementation.
-    #[inline]
-    pub(crate) fn has_proto(&self, name: &str) -> bool {
-        let pkg = self.current_package();
-        self.registry().has_proto(&pkg, name)
-    }
-
-    /// VM-native multi-candidate check, mirroring
-    /// `Interpreter::has_multi_candidates` via the single
-    /// [`Registry::has_multi_candidates`] implementation.
-    #[inline]
-    pub(crate) fn has_multi_candidates(&self, name: &str) -> bool {
-        let pkg = self.current_package();
-        self.registry().has_multi_candidates(&pkg, name)
-    }
-
-    /// VM-native declared-(non-multi-)function check, mirroring
-    /// `Interpreter::has_declared_function` via the single
-    /// [`Registry::has_declared_function`] implementation.
-    #[inline]
-    pub(crate) fn has_declared_function(&self, name: &str) -> bool {
-        let pkg = self.current_package();
-        self.registry().has_declared_function(&pkg, name)
-    }
-
-    /// Alias of [`Self::has_declared_function`], mirroring
-    /// `Interpreter::has_function` (which delegates to `has_declared_function`).
-    #[inline]
-    pub(crate) fn has_function(&self, name: &str) -> bool {
-        self.has_declared_function(name)
-    }
-
-    /// VM-native multi-function check, mirroring
-    /// `Interpreter::has_multi_function` via the single
-    /// [`Registry::has_multi_function`] implementation.
-    #[inline]
-    pub(crate) fn has_multi_function(&self, name: &str) -> bool {
-        let pkg = self.current_package();
-        self.registry().has_multi_function(&pkg, name)
-    }
-
-    /// The in-scope package name, read out of the VM's own `current_package`
-    /// handle as an owned `String` (no `self.interpreter` bounce). The guard is
-    /// dropped before returning, so no lock is held across the caller's work.
-    #[inline]
-    pub(crate) fn current_package(&self) -> String {
-        self.current_package.read().unwrap().clone()
-    }
-
-    /// Set the in-scope package name through the VM's own handle. Visible to the
-    /// interpreter too (same `RwLock`), preserving save/restore semantics across
-    /// the VM↔interpreter ping-pong.
-    #[inline]
-    pub(crate) fn set_current_package(&self, pkg: String) {
-        *self.current_package.write().unwrap() = pkg;
-    }
-
-    /// Write access to the shared [`IoHandleTable`](crate::runtime::IoHandleTable)
-    /// via the VM's own handle (no `self.interpreter` bounce). Same lock and guard
-    /// discipline as the interpreter's `io_handles_mut`: never hold the guard
-    /// across a re-entrant handle op.
-    #[inline]
-    pub(crate) fn io_handles_mut(&self) -> crate::runtime::IoHandlesWriteGuard<'_> {
-        crate::runtime::IoHandlesWriteGuard::new(&self.io_handles, "io_handles")
-    }
-
-    /// Write access to the shared [`OutputSink`](crate::runtime::OutputSink) via
-    /// the VM's own handle. Same guard discipline as `io_handles_mut`.
-    #[inline]
-    pub(crate) fn output_sink_mut(&self) -> crate::runtime::OutputSinkWriteGuard<'_> {
-        crate::runtime::OutputSinkWriteGuard::new(&self.output_sink, "output_sink")
-    }
-
     /// VM-native Stdout emit (③後段 PR-C), mirroring `Interpreter::emit_output`:
     /// bump the Stdout-target handle's `bytes_written`, then push to the sink
     /// (immediate real-stdout flush / buffer / thread-clone shared buffer per the
@@ -698,7 +304,7 @@ impl VM {
                 h.add_bytes_written(byte_count);
             }
         }
-        let subtest_active = self.interpreter.subtest_active();
+        let subtest_active = self.subtest_active();
         self.output_sink_mut().emit(text, subtest_active);
     }
 
@@ -706,7 +312,7 @@ impl VM {
     /// `write_to_handle_value_trying` (immediate real-stderr flush or the stderr
     /// buffer; no `bytes_written` scan, no `output_emitted`).
     pub(crate) fn vm_emit_stderr(&mut self, text: &str) {
-        let subtest_active = self.interpreter.subtest_active();
+        let subtest_active = self.subtest_active();
         self.output_sink_mut().emit_stderr(text, subtest_active);
     }
 
@@ -719,37 +325,40 @@ impl VM {
     /// `try`/`CATCH`) instead of crashing the whole process (exit 101). This also
     /// covers EVAL and sub-VMs, which run through `VM::run`. Stack overflow
     /// `abort`s rather than unwinding, so it is out of scope here.
-    pub(crate) fn run(
-        mut self,
+    pub(crate) fn run_top(
+        &mut self,
         code: &CompiledCode,
         compiled_fns: &HashMap<String, CompiledFunction>,
-    ) -> (Interpreter, Result<Option<Value>, RuntimeError>) {
+    ) -> Result<Option<Value>, RuntimeError> {
+        self.run_inner_guarded(code, compiled_fns)
+    }
+
+    /// Run `run_inner` inside the `catch_unwind` panic->`X::AdHoc` boundary so a
+    /// Rust `panic!`/overflow/index-OOB triggered by user code becomes a
+    /// catchable `RuntimeError` instead of crashing the process. This is the
+    /// boundary the old ping-pong `VM::run` provided; both `run_top` (outermost)
+    /// and `run_nested` (re-entrant carriers like `run_compiled_block`,
+    /// `eval_block_value`, `run_block_raw` invoked by `dies-ok`/`try`) route
+    /// through it so nested user-code panics still flow through try/CATCH.
+    fn run_inner_guarded(
+        &mut self,
+        code: &CompiledCode,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<Option<Value>, RuntimeError> {
         install_vm_panic_hook();
-        // Save/restore the flag so nested `VM::run` calls (EVAL, sub-VMs) don't
+        // Save/restore the flag so nested boundaries (EVAL, sub-VMs) don't
         // clobber an outer boundary's state.
         let prev = IN_VM_PANIC_BOUNDARY.with(|f| f.replace(true));
         let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.run_inner(code, compiled_fns)
         }));
         IN_VM_PANIC_BOUNDARY.with(|f| f.set(prev));
-        let result = match caught {
+        match caught {
             Ok(r) => r,
             Err(payload) => Err(Self::vm_panic_error(panic_payload_message(
                 payload.as_ref(),
             ))),
-        };
-        self.restore_env_to_interp();
-        (self.interpreter, result)
-    }
-
-    /// env-loan (CP-1 1e): push the VM-owned env back into the interpreter's
-    /// loan slot so a returned interpreter is coherent for its caller (the
-    /// ping-pong `*self = interp`, carriers, or `into_interpreter`). Mirrors the
-    /// pull in `VM::new`.
-    #[inline]
-    fn restore_env_to_interp(&mut self) {
-        let env = std::mem::take(&mut self.env);
-        self.interpreter.set_env(env);
+        }
     }
 
     /// Build a catchable `X::AdHoc` error from a caught panic message.
@@ -782,8 +391,8 @@ impl VM {
             }
         }
         self.load_state_locals(code);
-        let root_once_scope = self.interpreter.next_once_scope_id();
-        self.interpreter.push_once_scope(root_once_scope);
+        let root_once_scope = self.next_once_scope_id();
+        self.push_once_scope(root_once_scope);
         let mut ip = 0;
         while ip < code.ops.len() {
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
@@ -794,9 +403,9 @@ impl VM {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn && self.interpreter.control_handler_depth == 0 {
-                    if !self.interpreter.warning_suppressed() {
-                        self.interpreter.write_warn_to_stderr(&e.message);
+                if e.is_warn && self.control_handler_depth == 0 {
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&e.message);
                     }
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -805,7 +414,7 @@ impl VM {
                     continue;
                 }
                 self.sync_state_locals(code);
-                self.interpreter.pop_once_scope();
+                self.pop_once_scope();
                 // An uncaught CX::Return signal that escapes the top-level
                 // VM loop means the lexical target routine was not on the
                 // dynamic call stack when `return` executed, so it surfaces
@@ -814,7 +423,7 @@ impl VM {
                 // stack contains no routine — otherwise the return is meant
                 // for an enclosing routine that will catch it via its own
                 // call-frame handling further up the stack.
-                if e.is_return && self.interpreter.routine_stack().is_empty() {
+                if e.is_return && self.routine_stack().is_empty() {
                     let inner_err = RuntimeError::controlflow_return(true);
                     if self.check_phaser_depth > 0 {
                         return Err(Self::wrap_in_begin_time(inner_err));
@@ -826,12 +435,12 @@ impl VM {
                 }
                 return Err(e);
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
         self.sync_state_locals(code);
-        self.interpreter.pop_once_scope();
+        self.pop_once_scope();
         // Sync local variables back to the interpreter's env so that
         // callers (e.g. eval_block_value) can observe side effects.
         self.sync_env_from_locals(code);
@@ -864,6 +473,24 @@ impl VM {
         code: &CompiledCode,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Option<Value>, RuntimeError> {
+        // Use the guarded runner so a Rust panic in a re-entrant carrier
+        // (run_compiled_block / eval_block_value / run_block_raw — e.g. a
+        // `dies-ok { ... }` block) is caught and converted, exactly as the old
+        // ping-pong `VM::run` did. (The map/grep `run_reuse` loops call
+        // `with_nested_registers` directly and keep their no-boundary behavior.)
+        self.with_nested_registers(|me| me.run_inner_guarded(code, compiled_fns))
+    }
+
+    /// Run `f` with fresh per-execution registers (stack/locals/call_frames/topic/
+    /// context flags reset to their `VM::new` defaults), restoring the outer
+    /// registers afterwards and flagging `env_dirty` so the outer execution
+    /// re-syncs its locals from env. This is the in-place replacement for the old
+    /// `mem::take(self)` + `VM::new` ping-pong: shared state (env, interpreter
+    /// fields, registry/io/output handles, gen-counted caches) is *not* reset, so
+    /// the nested work observes and mutates the same state. Used by `run_nested`
+    /// (single compiled block) and by the map/sort `run_reuse` loops (many
+    /// iterations sharing one fresh-register scope).
+    pub(crate) fn with_nested_registers<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
         // Save the per-execution registers (the fields `VM::new` initializes
         // fresh) and reset them to their fresh-VM defaults for the nested run.
         let saved_stack = std::mem::take(&mut self.stack);
@@ -915,7 +542,7 @@ impl VM {
         self.vardecl_context = false;
         self.loop_cond_active = false;
 
-        let result = self.run_inner(code, compiled_fns);
+        let result = f(self);
 
         // Restore the outer execution registers.
         self.stack = saved_stack;
@@ -968,13 +595,11 @@ impl VM {
     /// Invoke a callable value using the VM fast paths when available and
     /// return the interpreter state to the caller.
     pub(crate) fn call_value(
-        mut self,
+        &mut self,
         target: Value,
         args: Vec<Value>,
-    ) -> (Interpreter, Result<Value, RuntimeError>) {
-        let result = self.vm_call_on_value(target, args, None);
-        self.restore_env_to_interp();
-        (self.interpreter, result)
+    ) -> Result<Value, RuntimeError> {
+        self.vm_call_on_value(target, args, None)
     }
 
     /// Run compiled bytecode without consuming self.
@@ -996,8 +621,8 @@ impl VM {
             }
         }
         self.load_state_locals(code);
-        let root_once_scope = self.interpreter.next_once_scope_id();
-        self.interpreter.push_once_scope(root_once_scope);
+        let root_once_scope = self.next_once_scope_id();
+        self.push_once_scope(root_once_scope);
         let mut ip = 0;
         while ip < code.ops.len() {
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
@@ -1008,9 +633,9 @@ impl VM {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn && self.interpreter.control_handler_depth == 0 {
-                    if !self.interpreter.warning_suppressed() {
-                        self.interpreter.write_warn_to_stderr(&e.message);
+                if e.is_warn && self.control_handler_depth == 0 {
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&e.message);
                     }
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -1019,15 +644,15 @@ impl VM {
                     continue;
                 }
                 self.sync_state_locals(code);
-                self.interpreter.pop_once_scope();
+                self.pop_once_scope();
                 return Err(e);
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
         self.sync_state_locals(code);
-        self.interpreter.pop_once_scope();
+        self.pop_once_scope();
         Ok(())
     }
 
@@ -1042,7 +667,7 @@ impl VM {
 
     fn load_state_locals(&mut self, code: &CompiledCode) {
         for (slot, key) in &code.state_locals {
-            if let Some(val) = self.interpreter.get_state_var(key) {
+            if let Some(val) = self.get_state_var(key) {
                 self.locals[*slot] = val.clone();
             }
         }
@@ -1056,7 +681,7 @@ impl VM {
                 .get(local_name)
                 .cloned()
                 .unwrap_or_else(|| self.locals[*slot].clone());
-            self.interpreter.set_state_var(key.clone(), val);
+            self.set_state_var(key.clone(), val);
         }
     }
 
@@ -1092,89 +717,35 @@ impl VM {
                 .get(local_name)
                 .cloned()
                 .unwrap_or_else(|| self.locals[*slot].clone());
-            self.interpreter.set_state_var(key.clone(), val);
+            self.set_state_var(key.clone(), val);
         }
     }
 
-    /// Read access to the variable store (env) through the VM's own seam.
-    ///
-    /// CP-1 (env-loan, step 1b): the env physically still lives in
-    /// `self.interpreter` and this accessor forwards there, so the change is
-    /// behavior-invariant. The point of routing every VM env read through this
-    /// single method now is that step 1e can flip the body to `&self.env` (env
-    /// moved into the VM) in one place. See docs/vm-state-ownership.md
-    /// "CP-1 env-loan 設計".
-    #[inline]
-    pub(crate) fn env(&self) -> &Env {
-        &self.env
-    }
-
-    /// Write access to the variable store (env) — the VM-owned env (CP-1 1e).
-    /// See [`VM::env`].
-    #[inline]
-    pub(crate) fn env_mut(&mut self) -> &mut Env {
-        &mut self.env
-    }
-
-    /// Clone the env for capture across a call/block/thread boundary
-    /// (flattens a scoped overlay). See [`VM::env`].
-    #[inline]
-    pub(crate) fn clone_env(&self) -> Env {
-        self.env.flattened()
-    }
-
-    /// Replace the entire VM-owned env. See [`VM::env`].
-    #[inline]
-    pub(crate) fn set_env(&mut self, env: Env) {
-        self.env = env;
-    }
-
-    /// Take the VM-owned env out, replacing it with an empty `Env`. See [`VM::env`].
-    #[inline]
-    pub(crate) fn take_env(&mut self) -> Env {
-        std::mem::take(&mut self.env)
-    }
+    // (CP-3 collapse) The VM's env / env_mut / clone_env / set_env / take_env
+    // accessors are gone — they duplicated the canonical `Interpreter` methods
+    // (env now lives on the merged struct), so callers reach those directly.
 
     /// env-loan (CP-1 1e): swap the VM-owned env into the interpreter's loan
-    /// slot, run `f` (a carrier that reads `self.interpreter.env`), then swap the
+    /// slot, run `f` (a carrier that reads `self.env`), then swap the
     /// env back. The interpreter sees the live env for the duration of the
     /// carrier; the nested ping-pong (`run_block_raw` → `mem::take(self)` →
     /// `VM::new`) carries the loaned env into the inner VM and back, so the swap
     /// nests correctly. Returns whatever the carrier returns.
     #[inline]
     fn loan_env_for<R>(&mut self, f: impl FnOnce(&mut Interpreter) -> R) -> R {
-        // Swap the VM-owned env into the interpreter's loan slot so the carrier
-        // sees the live env; `self.interpreter.env_mut()` is the *interpreter's*
-        // env field (disjoint from `self.env`), so the two-field swap is sound.
-        std::mem::swap(&mut self.env, self.interpreter.env_mut());
-        let r = f(&mut self.interpreter);
-        std::mem::swap(&mut self.env, self.interpreter.env_mut());
-        r
+        // CP-3 collapse: the VM dissolved into the Interpreter, so there is no
+        // separate interpreter to lend the env to — env is just `self.env`. This
+        // is now a thin self-call kept so the existing call sites need no edit.
+        f(self)
     }
 
-    /// env-loan wrapper for the interpreter's `type_matches_value` carrier
-    /// (subset `where` clauses read/write `self.env`). Lends the VM-owned env
-    /// for the duration of the type check. See [`VM::loan_env_for`].
-    #[inline]
-    pub(crate) fn type_matches_value(&mut self, constraint: &str, value: &Value) -> bool {
-        self.loan_env_for(|i| i.type_matches_value(constraint, value))
-    }
-
-    /// Read a value's container type metadata natively through the VM's peer
-    /// handle, with no interpreter bounce or env loan (CP-3 Track 1). Shares the
-    /// single implementation (`container_type_metadata_with`) with
-    /// `Interpreter::container_type_metadata`; container values read embedded
-    /// metadata, `Instance` values read the shared `instance_type_metadata` map.
-    #[inline]
-    pub(crate) fn container_type_metadata(
-        &self,
-        value: &Value,
-    ) -> Option<crate::runtime::ContainerTypeInfo> {
-        crate::runtime::container_type_metadata_with(value, &self.instance_type_metadata)
-    }
+    // (CP-3 collapse) The former `type_matches_value` and `container_type_metadata`
+    // env-loan wrappers are gone: they collided with the real `Interpreter`
+    // methods of the same name, and after the merge a plain `self.<name>(...)`
+    // call reaches the single implementation directly.
 
     // env-loan wrappers for the interpreter's tree-walk carriers (they read/
-    // write `self.interpreter.env`, so the VM-owned env must be lent for the
+    // write `self.env`, so the VM-owned env must be lent for the
     // call). See [`VM::loan_env_for`] and docs/vm-state-ownership.md.
     #[inline]
     pub(crate) fn vm_call_function(
@@ -1238,7 +809,7 @@ impl VM {
         // (which spins up a fresh sub-VM via `mem::take`/`VM::new` — the
         // ping-pong), compile the block (pure, no env) and run it in-place on
         // this VM via `run_nested`, sharing the same interpreter + env directly.
-        let (code, compiled_fns) = self.interpreter.compile_block_raw(stmts);
+        let (code, compiled_fns) = self.compile_block_raw(stmts);
         let result = self.run_nested(&code, &compiled_fns);
         // Mirror `run_block_raw`'s trailing DESTROY pass (may run user code, so
         // it needs the env loaned).
@@ -1259,12 +830,12 @@ impl VM {
         // callers pass a single `Stmt::Expr` (registration-time default / enum /
         // role-arg evaluation). Any other shape falls back to the interpreter.
         if body.iter().all(|s| matches!(s, Stmt::Expr(_))) {
-            let (code, compiled_fns) = self.interpreter.compile_block_value(body);
-            let let_mark = self.interpreter.let_saves_len();
-            self.interpreter.push_block_scope_depth();
+            let (code, compiled_fns) = self.compile_block_value(body);
+            let let_mark = self.let_saves_len();
+            self.push_block_scope_depth();
             let result = self.run_nested(&code, &compiled_fns);
-            self.interpreter.pop_block_scope_depth();
-            self.interpreter.restore_let_saves(let_mark);
+            self.pop_block_scope_depth();
+            self.restore_let_saves(let_mark);
             self.loan_env_for(|i| i.run_pending_instance_destroys())?;
             return result.map(|v| v.unwrap_or(Value::Nil));
         }
@@ -1307,13 +878,6 @@ impl VM {
     /// Override the source variable used when mutating `$_` in VM execution.
     pub(crate) fn set_topic_source_var(&mut self, name: Option<String>) {
         self.topic_source_var = name;
-    }
-
-    /// Consume the VM and return the interpreter, pushing the VM-owned env back
-    /// into the interpreter's loan slot first (env-loan, CP-1 1e).
-    pub(crate) fn into_interpreter(mut self) -> Interpreter {
-        self.restore_env_to_interp();
-        self.interpreter
     }
 
     /// Execute opcodes in [start..end), used by loop compound opcodes.
@@ -1366,9 +930,9 @@ impl VM {
                     continue;
                 }
                 // Handle warn signals inline when no CONTROL handler is active.
-                if e.is_warn && self.interpreter.control_handler_depth == 0 {
-                    if !self.interpreter.warning_suppressed() {
-                        self.interpreter.write_warn_to_stderr(&e.message);
+                if e.is_warn && self.control_handler_depth == 0 {
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&e.message);
                     }
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -1386,7 +950,7 @@ impl VM {
                 }
                 return Err(e);
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1508,7 +1072,7 @@ impl VM {
             OpCode::GetGlobal(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
                 if name == "?CALLER::LINE" {
-                    let line = self.interpreter.get_caller_line(1).unwrap_or(Value::Nil);
+                    let line = self.get_caller_line(1).unwrap_or(Value::Nil);
                     self.stack.push(line);
                     *ip += 1;
                     return Ok(());
@@ -1523,14 +1087,14 @@ impl VM {
                 // storage has been registered. Skip the whole check (a `format!`
                 // plus two `var_type_constraint` lookups) on the hot read path when
                 // no atomics exist, which is the overwhelmingly common case.
-                if self.interpreter.atomic_var_seen() {
+                if self.atomic_var_seen() {
                     let atomic_name = name.strip_prefix('$').unwrap_or(name);
                     let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
                     let is_atomic_int = loan_env!(self, var_type_constraint(name)).as_deref()
                         == Some("atomicint")
                         || loan_env!(self, var_type_constraint(atomic_name)).as_deref()
                             == Some("atomicint")
-                        || self.interpreter.get_shared_var(&atomic_name_key).is_some();
+                        || self.get_shared_var(&atomic_name_key).is_some();
                     if is_atomic_int {
                         let fetched = self.vm_call_function(
                             "__mutsu_atomic_fetch_var",
@@ -1560,8 +1124,7 @@ impl VM {
                         // Bare variable names should NOT fall back to our_vars — the
                         // lexical alias for `our` variables is block-scoped.
                         if name.contains("::") {
-                            self.interpreter
-                                .get_our_var(name)
+                            self.get_our_var(name)
                                 .cloned()
                                 .or_else(|| self.our_var_pseudo_unqualified(name))
                                 .or_else(|| {
@@ -1597,9 +1160,7 @@ impl VM {
                                         if candidate == name {
                                             continue;
                                         }
-                                        if let Some(v) =
-                                            self.interpreter.get_our_var(&candidate).cloned()
-                                        {
+                                        if let Some(v) = self.get_our_var(&candidate).cloned() {
                                             return Some(v);
                                         }
                                         if let Some(v) = self.get_env_with_main_alias(&candidate) {
@@ -1676,8 +1237,7 @@ impl VM {
                         } else {
                             format!("{cur}::{name}")
                         };
-                        self.interpreter
-                            .get_our_var(&candidate)
+                        self.get_our_var(&candidate)
                             .cloned()
                             .or_else(|| self.get_env_with_main_alias(&candidate))
                     })
@@ -1714,11 +1274,9 @@ impl VM {
                 // When the value is Nil and the variable has a type constraint,
                 // return the type object (consistent with GetLocal behavior).
                 let val = if matches!(val, Value::Nil) {
-                    if let Some(def) = self.interpreter.var_default(name) {
+                    if let Some(def) = self.var_default(name) {
                         def.clone()
-                    } else if let Some(constraint) =
-                        self.interpreter.var_type_constraint_fast(name).cloned()
-                    {
+                    } else if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
                         let nominal =
                             loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                         Value::Package(Symbol::intern(&nominal))
@@ -1858,7 +1416,7 @@ impl VM {
                 }
                 // %?RESOURCES — build from the current package's distribution context
                 if name == "%?RESOURCES" {
-                    let resources = self.interpreter.build_resources_for_package();
+                    let resources = self.build_resources_for_package();
                     self.stack.push(resources);
                     *ip += 1;
                     return Ok(());
@@ -1927,7 +1485,6 @@ impl VM {
             OpCode::GetOurVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
                 let val = self
-                    .interpreter
                     .get_our_var(name)
                     .cloned()
                     .or_else(|| self.get_env_with_main_alias(name))
@@ -1959,12 +1516,9 @@ impl VM {
                 if name_str == "__ANON_STATE__"
                     && !raw_mode
                     && !is_rebind
-                    && !self.interpreter.fatal_mode
-                    && self
-                        .interpreter
-                        .var_type_constraint_fast(name_str)
-                        .is_none()
-                    && !self.interpreter.is_readonly(name_str)
+                    && !self.fatal_mode
+                    && self.var_type_constraint_fast(name_str).is_none()
+                    && !self.is_readonly(name_str)
                     && !matches!(self.stack.last(), Some(Value::Capture { .. }))
                     && !matches!(self.env().get(name_str), Some(Value::ContainerRef(_)))
                 {
@@ -2001,17 +1555,14 @@ impl VM {
                         )));
                     }
                 }
-                if self.interpreter.strict_mode
-                    && !name.contains("::")
-                    && !self.env().contains_key(&name)
-                {
+                if self.strict_mode && !name.contains("::") && !self.env().contains_key(&name) {
                     return Err(self.strict_undeclared_error(&name));
                 }
                 // Check readonly variables (e.g., $*USAGE).
                 // Skip readonly check for SetGlobalRaw which is used for constant
                 // declarations — the constant will be re-marked readonly after this.
                 if !raw_mode {
-                    self.interpreter.check_readonly_for_modify(&name)?;
+                    self.check_readonly_for_modify(&name)?;
                 } else {
                     // Clear any previous readonly marking so this constant
                     // redeclaration can proceed (e.g., `constant sym` followed
@@ -2021,7 +1572,7 @@ impl VM {
                         .next()
                         .unwrap_or(&name)
                         .trim_start_matches(['$', '@', '%', '&']);
-                    self.interpreter.unmark_readonly(bare);
+                    self.unmark_readonly(bare);
                 }
                 // Prevent re-assignment of immutable containers (Mix, Set, Bag)
                 // Only when the variable has an explicit immutable type constraint
@@ -2056,7 +1607,7 @@ impl VM {
                     && !name.starts_with('&')
                     && !name.contains("::")
                     && matches!(self.env().get(&name), Some(Value::Package(_)))
-                    && self.interpreter.has_class(&name)
+                    && self.has_class(&name)
                 {
                     return Err(RuntimeError::new(format!(
                         "Cannot modify an immutable '{}' type object",
@@ -2110,7 +1661,6 @@ impl VM {
                                     | "buf16"
                                     | "buf32"
                             ) || self
-                                .interpreter
                                 .class_composed_roles(&cn)
                                 .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
                             if does_positional {
@@ -2160,8 +1710,7 @@ impl VM {
                         if let Value::Instance { class_name, .. } = &val
                             && class_name.resolve() == "Failure"
                             && !val.is_failure_handled()
-                            && let Some(err) =
-                                self.interpreter.failure_to_runtime_error_if_unhandled(&val)
+                            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
                         {
                             return Err(err);
                         }
@@ -2177,9 +1726,9 @@ impl VM {
                     // Wrap native integer values on assignment (overflow wrapping)
                     val = Self::wrap_native_int_by_constraint(&constraint, val)?;
                 }
-                if self.interpreter.fatal_mode
+                if self.fatal_mode
                     && !name.contains("__mutsu_")
-                    && let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val)
+                    && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
                 {
                     return Err(err);
                 }
@@ -2205,11 +1754,11 @@ impl VM {
                     // Propagate readonly status from the source variable.
                     // Binding to a readonly parameter should make the target
                     // readonly as well (persisted in env for cross-scope survival).
-                    let source_readonly = self.interpreter.is_readonly(&source_name);
+                    let source_readonly = self.is_readonly(&source_name);
                     self.env_mut()
                         .insert(readonly_key.clone(), Value::Bool(source_readonly));
                     if source_readonly {
-                        self.interpreter.mark_readonly(&name);
+                        self.mark_readonly(&name);
                     }
                     // Create a shared ContainerRef for cross-scope binding persistence.
                     if !name.starts_with('@')
@@ -2272,17 +1821,15 @@ impl VM {
                         // package-qualified variants (e.g., "K::x" for bare "x")
                         // so GetGlobal fallback (which uses qualified keys) can
                         // find the binding.
-                        self.interpreter
-                            .set_our_var(name.clone(), container.clone());
+                        self.set_our_var(name.clone(), container.clone());
                         // Update the package-qualified our_var key (e.g., "K::x"
                         // for bare "x" in class K) so GetGlobal fallback can find
                         // the binding. Only match the exact class from the method
                         // class stack to avoid clobbering unrelated package vars.
-                        if let Some(method_class) = self.interpreter.method_class_stack_top() {
+                        if let Some(method_class) = self.method_class_stack_top() {
                             let qualified = format!("{}::{}", method_class, name);
-                            if self.interpreter.get_our_var(&qualified).is_some() {
-                                self.interpreter
-                                    .set_our_var(qualified.clone(), container.clone());
+                            if self.get_our_var(&qualified).is_some() {
+                                self.set_our_var(qualified.clone(), container.clone());
                                 self.env_mut().insert(qualified, container.clone());
                             }
                         }
@@ -2330,7 +1877,7 @@ impl VM {
                 // Persist `our`-scoped variables so they survive block-scope
                 // restoration (which only preserves env keys that existed
                 // before the block).  `::('name')` falls back to this store.
-                self.interpreter.set_our_var(name.clone(), val.clone());
+                self.set_our_var(name.clone(), val.clone());
                 // Track topic mutations for map rw writeback
                 if name == "_" {
                     self.env_mut()
@@ -2412,7 +1959,7 @@ impl VM {
                 // Clear stale atomic CAS state when an @-variable is
                 // (re-)declared with a type constraint like atomicint.
                 if name.starts_with('@') && constraint == "atomicint" {
-                    self.interpreter.clear_atomic_array_state(&name);
+                    self.clear_atomic_array_state(&name);
                 }
                 self.vm_set_var_type_constraint(&name, Some(constraint.clone()));
                 // For scalar variables, if the current value is Nil, set it to the type object.
@@ -2451,7 +1998,7 @@ impl VM {
                     };
                     // Hashes embed metadata in `HashData`; write the tagged value
                     // back (no-op Arc for array/instance side-table containers).
-                    let tagged = self.interpreter.tag_container_metadata(value, info);
+                    let tagged = self.tag_container_metadata(value, info);
                     self.set_env_with_main_alias(&name, tagged.clone());
                     self.update_local_if_exists(code, &name, &tagged);
                 }
@@ -2862,7 +2409,7 @@ impl VM {
                 *ip += 1;
             }
             OpCode::SetDoesContext(flag) => {
-                self.interpreter.in_does_rhs = *flag;
+                self.in_does_rhs = *flag;
                 *ip += 1;
             }
 
@@ -3091,7 +2638,7 @@ impl VM {
                 };
                 let has_user_defined = class_name
                     .as_ref()
-                    .is_some_and(|cn| self.interpreter.has_user_method(&cn.resolve(), "defined"));
+                    .is_some_and(|cn| self.has_user_method(&cn.resolve(), "defined"));
                 let defined = if has_user_defined {
                     // Call user method directly, bypassing native method dispatch
                     let cn = class_name.unwrap();
@@ -3180,7 +2727,6 @@ impl VM {
                                 | "buf16"
                                 | "buf32"
                         ) || self
-                            .interpreter
                             .class_composed_roles(&cn)
                             .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
                         if does_positional {
@@ -3276,9 +2822,7 @@ impl VM {
                         }
                         _ => {
                             // Sinking an unhandled Failure always throws (Raku behavior)
-                            if let Some(err) =
-                                self.interpreter.failure_to_runtime_error_if_unhandled(&val)
-                            {
+                            if let Some(err) = self.failure_to_runtime_error_if_unhandled(&val) {
                                 return Err(err);
                             }
                             // Sinking a Proc with non-zero exitcode throws X::Proc::Unsuccessful
@@ -4278,9 +3822,7 @@ impl VM {
                 let name = Self::const_str(code, *name_idx).to_string();
                 let pkg_val = Value::Package(Symbol::intern(&name));
                 self.env_mut().insert(name.clone(), pkg_val.clone());
-                self.interpreter
-                    .chain_declared_packages
-                    .insert(name.clone());
+                self.chain_declared_packages.insert(name.clone());
                 self.update_local_if_exists(code, &name, &pkg_val);
                 self.env_dirty = true;
                 *ip += 1;
@@ -4289,13 +3831,11 @@ impl VM {
                 let name = Self::const_str(code, *name_idx).to_string();
                 let pkg_val = Value::Package(Symbol::intern(&name));
                 self.env_mut().insert(name.clone(), pkg_val.clone());
-                self.interpreter
-                    .chain_declared_packages
-                    .insert(name.clone());
+                self.chain_declared_packages.insert(name.clone());
                 self.update_local_if_exists(code, &name, &pkg_val);
                 // Mark as my-scoped so the package is hidden from global
                 // lookups and package stash resolution outside its scope.
-                self.interpreter.mark_my_scoped_package_item(name.clone());
+                self.mark_my_scoped_package_item(name.clone());
                 // Mark as block-declared so the name is cleaned up
                 // when the enclosing block scope exits.
                 if let Some(set) = self.block_declared_vars.last_mut() {
@@ -4488,7 +4028,7 @@ impl VM {
             OpCode::StateVarInitGuard(key_idx, jump_to) => {
                 let base_key = Self::const_str(code, *key_idx);
                 let scoped_key = self.scoped_state_key(base_key);
-                if self.interpreter.get_state_var(&scoped_key).is_some() {
+                if self.get_state_var(&scoped_key).is_some() {
                     // State already initialized: push a placeholder value on the
                     // stack (StateVarInit will discard it and use the stored value)
                     // and skip the RHS initializer.
@@ -4654,11 +4194,11 @@ impl VM {
                 *ip += 1;
             }
             OpCode::PushImportScope => {
-                self.interpreter.push_import_scope();
+                self.push_import_scope();
                 *ip += 1;
             }
             OpCode::PopImportScope => {
-                self.interpreter.pop_import_scope();
+                self.pop_import_scope();
                 *ip += 1;
             }
             OpCode::RegisterEnum(idx) => {
@@ -4744,8 +4284,7 @@ impl VM {
             } => {
                 let target = Self::const_str(code, *target_idx);
                 let source = Self::const_str(code, *source_idx);
-                self.interpreter
-                    .bind_caller_var(target, source, *depth as usize)?;
+                self.bind_caller_var(target, source, *depth as usize)?;
                 *ip += 1;
             }
             OpCode::GetOuterVar { name_idx, depth } => {
@@ -4769,7 +4308,7 @@ impl VM {
             }
             OpCode::CheckReadOnly(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
-                self.interpreter.check_readonly_for_modify(name)?;
+                self.check_readonly_for_modify(name)?;
                 // Also check env-based readonly status set by cross-scope
                 // `:=` binding (e.g. binding to a readonly sub parameter
                 // in a closure).  The readonly_vars set is scope-local
@@ -4782,7 +4321,7 @@ impl VM {
             }
             OpCode::MarkVarReadonly(name_idx) => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.interpreter.mark_readonly(&name);
+                self.mark_readonly(&name);
                 *ip += 1;
             }
 

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -526,13 +526,11 @@ impl VM {
     fn eval_concat_with_junctions(&mut self, left: Value, right: Value) -> Value {
         // Auto-FETCH and decontainerize
         let left = self
-            .interpreter
             .auto_fetch_proxy(&left)
             .unwrap_or(left)
             .descalarize()
             .clone();
         let right = self
-            .interpreter
             .auto_fetch_proxy(&right)
             .unwrap_or(right)
             .descalarize()
@@ -846,9 +844,9 @@ impl VM {
         // Warn on uninitialized type object used as repeat count
         if let Value::Package(name) = &right
             && name == "Int"
-            && !self.interpreter.warning_suppressed()
+            && !self.warning_suppressed()
         {
-            self.interpreter.write_warn_to_stderr(&format!(
+            self.write_warn_to_stderr(&format!(
                 "Use of uninitialized value of type {} in numeric context",
                 name
             ));
@@ -856,7 +854,7 @@ impl VM {
 
         // Whatever on RHS produces a WhateverCode closure
         if matches!(&right, Value::Whatever) {
-            self.stack.push(self.interpreter.make_x_whatevercode(left));
+            self.stack.push(self.make_x_whatevercode(left));
             return Ok(());
         }
 
@@ -904,9 +902,9 @@ impl VM {
         // Warn on uninitialized type object used as repeat count
         if let Value::Package(name) = &right
             && name == "Int"
-            && !self.interpreter.warning_suppressed()
+            && !self.warning_suppressed()
         {
-            self.interpreter.write_warn_to_stderr(&format!(
+            self.write_warn_to_stderr(&format!(
                 "Use of uninitialized value of type {} in numeric context",
                 name
             ));
@@ -945,7 +943,7 @@ impl VM {
             }
         } else {
             for _ in 0..repeat {
-                items.push(self.interpreter.repeat_lhs_once(&left)?);
+                items.push(self.repeat_lhs_once(&left)?);
             }
         }
 
@@ -962,7 +960,7 @@ impl VM {
     pub(super) fn exec_function_compose_op(&mut self) {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let composed = self.interpreter.compose_callables(left, right);
+        let composed = self.compose_callables(left, right);
         self.stack.push(composed);
     }
 
@@ -975,19 +973,18 @@ impl VM {
         let left_type_object = self.does_invocant_type_object(&left);
         let role_composed = match &right {
             Value::Pair(name, boxed)
-                if self.interpreter.has_role(name)
-                    && matches!(boxed.as_ref(), Value::Array(..)) =>
+                if self.has_role(name) && matches!(boxed.as_ref(), Value::Array(..)) =>
             {
                 Some(loan_env!(
                     self,
                     eval_does_values(left.clone(), right.clone())
                 ))
             }
-            Value::Package(name) if self.interpreter.has_role(&name.resolve()) => Some(loan_env!(
+            Value::Package(name) if self.has_role(&name.resolve()) => Some(loan_env!(
                 self,
                 eval_does_values(left.clone(), right.clone())
             )),
-            Value::Str(name) if self.interpreter.has_role(name) => Some(loan_env!(
+            Value::Str(name) if self.has_role(name) => Some(loan_env!(
                 self,
                 eval_does_values(left.clone(), right.clone())
             )),
@@ -1104,7 +1101,7 @@ impl VM {
             Value::Nil => Some("Any".to_string()),
             Value::Package(name) => {
                 let n = name.resolve();
-                if self.interpreter.has_class(&n) {
+                if self.has_class(&n) {
                     None
                 } else {
                     Some(n.to_string())
@@ -1166,9 +1163,7 @@ impl VM {
         let left_type_object = self.does_invocant_type_object(&left);
         // Handle array of roles: `$obj does (RoleA, RoleB)`
         if let Value::Array(ref items, ..) = right {
-            let all_roles = items
-                .iter()
-                .all(|item| self.interpreter.is_role_application(item));
+            let all_roles = items.iter().all(|item| self.is_role_application(item));
             if all_roles && !items.is_empty() {
                 if let Some(tn) = &left_type_object {
                     return Err(Self::does_type_object_error("does", tn));
@@ -1178,7 +1173,7 @@ impl VM {
         }
         // Check if the RHS is a role that needs to be composed onto the value.
         // If so, delegate to the interpreter which manages role state.
-        if self.interpreter.is_role_application(&right) {
+        if self.is_role_application(&right) {
             if let Some(tn) = &left_type_object {
                 return Err(Self::does_type_object_error("does", tn));
             }
@@ -1231,9 +1226,8 @@ impl VM {
         // Sync back: BUILD submethods may have modified closure variables.
         self.sync_locals_from_env(code);
         // Capture Mixin value for trait_mod writeback (same as DoesVar path)
-        if matches!(&result, Value::Mixin(..)) && self.interpreter.trait_mod_writeback_key.is_some()
-        {
-            self.interpreter.trait_mod_writeback_value = Some(result.clone());
+        if matches!(&result, Value::Mixin(..)) && self.trait_mod_writeback_key.is_some() {
+            self.trait_mod_writeback_value = Some(result.clone());
         }
         self.stack.push(result);
         Ok(())
@@ -1258,10 +1252,8 @@ impl VM {
         // Capture Mixin value for trait_mod writeback: when `$r does Role`
         // runs inside a trait_mod:<is>, the Mixin needs to propagate back
         // to the outer scope's `&name` variable.
-        if matches!(&updated, Value::Mixin(..))
-            && self.interpreter.trait_mod_writeback_key.is_some()
-        {
-            self.interpreter.trait_mod_writeback_value = Some(updated.clone());
+        if matches!(&updated, Value::Mixin(..)) && self.trait_mod_writeback_key.is_some() {
+            self.trait_mod_writeback_value = Some(updated.clone());
         }
         self.stack.push(updated);
         Ok(())

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -126,7 +126,7 @@ impl VM {
                             if matches!(tc.as_str(), "Mu" | "Junction") {
                                 return false;
                             }
-                            let resolved_base = self.interpreter.resolve_subset_base_type(tc);
+                            let resolved_base = self.resolve_subset_base_type(tc);
                             return !matches!(resolved_base.as_str(), "Mu" | "Junction");
                         }
                         return true; // No type constraint = default Any
@@ -147,7 +147,7 @@ impl VM {
                         // whose ultimate base type is Mu or Junction — the
                         // junction should be passed as-is to the subset's
                         // where-clause check.
-                        let resolved_base = self.interpreter.resolve_subset_base_type(tc);
+                        let resolved_base = self.resolve_subset_base_type(tc);
                         if matches!(resolved_base.as_str(), "Mu" | "Junction") {
                             return false;
                         }
@@ -271,7 +271,7 @@ impl VM {
                 if let Value::Mixin(_, ref mixins) = callable {
                     let has_call_me = mixins.keys().any(|key| {
                         key.strip_prefix("__mutsu_role__")
-                            .is_some_and(|rn| self.interpreter.role_has_method(rn, "CALL-ME"))
+                            .is_some_and(|rn| self.role_has_method(rn, "CALL-ME"))
                     });
                     if has_call_me {
                         return Some(callable);

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -6,7 +6,7 @@ impl VM {
     /// Record a deprecation event for a compiled function if it has deprecation info.
     fn record_cf_deprecation(&self, cf: &CompiledFunction) {
         if let Some((ref kind, ref name, ref package, ref msg)) = cf.deprecated_info {
-            let cl = self.interpreter.pending_callsite_line();
+            let cl = self.pending_callsite_line();
             let file = self
                 .env()
                 .get("*PROGRAM-NAME")
@@ -90,7 +90,7 @@ impl VM {
         // Use the pending callsite line for deprecation tracking,
         // since ?LINE in env may not reflect the call site yet.
         let callsite_line = crate::runtime::Interpreter::peek_callsite_line(&args)
-            .or_else(|| self.interpreter.pending_callsite_line());
+            .or_else(|| self.pending_callsite_line());
         loan_env!(
             self,
             check_deprecation_for_def_with_line(def, callsite_line)
@@ -121,11 +121,10 @@ impl VM {
                 }
                 // Resolve $?DISTRIBUTION from the function's defining package
                 compiler.current_distribution = self
-                    .interpreter
                     .package_distributions
                     .get(&pkg)
                     .cloned()
-                    .or_else(|| self.interpreter.current_distribution.clone());
+                    .or_else(|| self.current_distribution.clone());
                 compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
             };
             let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
@@ -173,14 +172,14 @@ impl VM {
 
         // Set up samewith and multi-dispatch context that call_compiled_function_named
         // expects the caller to manage (mirrors exec_call_fn_op).
-        self.interpreter.push_samewith_context(&name, None);
+        self.push_samewith_context(&name, None);
         let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(&name, &args));
 
         let result = self.call_compiled_function_named(&cf, args, compiled_fns, &pkg, &name);
 
-        self.interpreter.pop_samewith_context();
+        self.pop_samewith_context();
         if pushed_dispatch {
-            self.interpreter.pop_multi_dispatch();
+            self.pop_multi_dispatch();
         }
 
         result
@@ -192,9 +191,7 @@ impl VM {
     /// and pseudo-package qualified names that need special resolution.
     pub(super) fn is_interpreter_handled_function(&self, name: &str) -> bool {
         // Test functions are implemented as Rust methods, not via AST
-        if self.interpreter.test_mode_active()
-            && crate::runtime::Interpreter::is_test_function_name(name)
-        {
+        if self.test_mode_active() && crate::runtime::Interpreter::is_test_function_name(name) {
             return true;
         }
         // Internal functions are dispatched by the interpreter's call_function match
@@ -538,12 +535,12 @@ impl VM {
         }
         // Load persisted state variable values
         for (slot, key) in &cf.code.state_locals {
-            if let Some(val) = self.interpreter.get_state_var(key) {
+            if let Some(val) = self.get_state_var(key) {
                 self.locals[*slot] = val.clone();
             }
         }
 
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -556,14 +553,13 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter
-                        .resolve_let_saves_on_success(let_mark, true);
+                    self.resolve_let_saves_on_success(let_mark, true);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
                     fail_bypass = true;
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -576,7 +572,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -898,7 +894,7 @@ impl VM {
             }
         }
 
-        let saved_readonly = self.interpreter.save_readonly_vars();
+        let saved_readonly = self.save_readonly_vars();
         // Bind params to slots. Also write the param into the overlay when a
         // name-based reader needs it (reflective access anywhere / GetGlobal /
         // closure capture via needs_env_sync), or when it is `Nil` (the GetLocal
@@ -912,7 +908,7 @@ impl VM {
                 if let Some(ref tc) = cf.param_defs[param_idx].type_constraint
                     && !Self::fast_type_check(&val, tc)
                 {
-                    self.interpreter.restore_readonly_vars(saved_readonly);
+                    self.restore_readonly_vars(saved_readonly);
                     self.set_env(caller_env);
                     self.locals = saved_locals;
                     self.env_dirty = saved_env_dirty;
@@ -938,8 +934,7 @@ impl VM {
                 if needs_env {
                     self.env_mut().insert(param_name.clone(), val);
                 }
-                self.interpreter
-                    .mark_readonly(&cf.param_defs[param_idx].name);
+                self.mark_readonly(&cf.param_defs[param_idx].name);
             }
         }
         // Bind-time param values that a name-based reader can observe were
@@ -950,7 +945,7 @@ impl VM {
         // the SetLocal path (`flush_local_to_env`).
 
         let saved_stack_depth = self.stack.len();
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
 
         let mut ip = 0;
         let mut result = Ok(());
@@ -964,14 +959,13 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter
-                        .resolve_let_saves_on_success(let_mark, true);
+                    self.resolve_let_saves_on_success(let_mark, true);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
                     fail_bypass = true;
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -984,7 +978,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1003,7 +997,7 @@ impl VM {
 
         self.locals = saved_locals;
         self.env_dirty = saved_env_dirty;
-        self.interpreter.restore_readonly_vars(saved_readonly);
+        self.restore_readonly_vars(saved_readonly);
 
         // Restore the caller env and merge the overlay (the callee's own writes)
         // back: a write to a captured outer variable (not a declared local of
@@ -1278,7 +1272,7 @@ impl VM {
 
         // Mark parameters as readonly (by default, params are immutable in Raku).
         // Save existing readonly state so we can restore it after the call.
-        let saved_readonly = self.interpreter.save_readonly_vars();
+        let saved_readonly = self.save_readonly_vars();
         for pd in &cf.param_defs {
             if !pd.name.is_empty()
                 && !pd.sigilless
@@ -1290,7 +1284,7 @@ impl VM {
                     .iter()
                     .any(|t| t == "rw" || t == "copy" || t == "raw");
                 if !has_mutable_trait {
-                    self.interpreter.mark_readonly(&pd.name);
+                    self.mark_readonly(&pd.name);
                 }
             }
         }
@@ -1346,7 +1340,7 @@ impl VM {
         }
 
         let saved_stack_depth = self.stack.len();
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
 
         // Execute the function body
         let mut ip = 0;
@@ -1361,14 +1355,13 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter
-                        .resolve_let_saves_on_success(let_mark, true);
+                    self.resolve_let_saves_on_success(let_mark, true);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
                     fail_bypass = true;
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -1381,7 +1374,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1403,7 +1396,7 @@ impl VM {
         self.env_dirty = saved_env_dirty;
 
         // Restore readonly vars
-        self.interpreter.restore_readonly_vars(saved_readonly);
+        self.restore_readonly_vars(saved_readonly);
 
         // Restore the caller env, merging the overlay (the callee's own writes)
         // back: a write to a captured outer variable (not a declared local /
@@ -1462,7 +1455,7 @@ impl VM {
         // below), so it is reset before the body and recomputed from what the
         // merge actually wrote back to the caller env.
         let saved_env_dirty = self.env_dirty;
-        let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (args, callsite_line) = self.sanitize_call_args(&args);
         if callsite_line.is_some() {
             loan_env!(self, set_pending_callsite_line(callsite_line));
         }
@@ -1490,7 +1483,7 @@ impl VM {
             // must expose the full lexical view, not a scoped overlay.
             self.clone_env(),
         );
-        self.interpreter.push_block(sub_val);
+        self.push_block(sub_val);
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller now that sub_val / push_caller_env
@@ -1509,7 +1502,7 @@ impl VM {
         } else {
             fn_name.to_string()
         };
-        self.interpreter.push_routine_with_location(
+        self.push_routine_with_location(
             fn_package.to_string(),
             routine_push_name,
             self.current_source_line(),
@@ -1542,15 +1535,12 @@ impl VM {
         } else {
             loan_env!(self, routine_is_test_assertion_by_name(fn_name, &args))
         };
-        let pushed_assertion = self
-            .interpreter
-            .push_test_assertion_context(is_test_assertion);
+        let pushed_assertion = self.push_test_assertion_context(is_test_assertion);
 
         if cf.empty_sig && !args.is_empty() {
-            self.interpreter.pop_routine();
-            self.interpreter
-                .pop_test_assertion_context(pushed_assertion);
-            self.interpreter.pop_caller_env();
+            self.pop_routine();
+            self.pop_test_assertion_context(pushed_assertion);
+            self.pop_caller_env();
             self.stack.truncate(saved_stack_depth);
             let frame = self.pop_call_frame();
             // Drop the scoped overlay, restoring the caller env.
@@ -1598,10 +1588,9 @@ impl VM {
                 Ok(bindings) => bindings,
                 Err(e) => {
                     self.set_current_package(saved_package);
-                    self.interpreter.pop_routine();
-                    self.interpreter
-                        .pop_test_assertion_context(pushed_assertion);
-                    self.interpreter.pop_caller_env();
+                    self.pop_routine();
+                    self.pop_test_assertion_context(pushed_assertion);
+                    self.pop_caller_env();
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
                     *self.env_mut() = frame.saved_env;
@@ -1614,8 +1603,7 @@ impl VM {
                 }
             }
         };
-        self.interpreter
-            .prepare_definite_return_slot(return_spec.as_deref());
+        self.prepare_definite_return_slot(return_spec.as_deref());
 
         // Raku: $! is scoped per routine — fresh Nil on entry.
         // Only insert if $! isn't already Nil, to avoid triggering
@@ -1646,12 +1634,12 @@ impl VM {
         }
         // Load persisted state variable values
         for (slot, key) in &cf.code.state_locals {
-            if let Some(val) = self.interpreter.get_state_var(key) {
+            if let Some(val) = self.get_state_var(key) {
                 self.locals[*slot] = val.clone();
             }
         }
 
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         // Body-internal env_dirty (from nested calls) concerns the callee env,
         // which the return merge reconciles; reset so the post-merge value
         // reflects only what was actually written back to the caller.
@@ -1679,8 +1667,7 @@ impl VM {
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
                         self.stack.push(ret_val);
-                        self.interpreter
-                            .resolve_let_saves_on_success(let_mark, true);
+                        self.resolve_let_saves_on_success(let_mark, true);
                         result = Ok(());
                         break;
                     }
@@ -1702,15 +1689,14 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter
-                        .resolve_let_saves_on_success(let_mark, true);
+                    self.resolve_let_saves_on_success(let_mark, true);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
                     // fail() — restore let saves and return a Failure value
                     fail_bypass = true;
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -1723,7 +1709,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1781,10 +1767,9 @@ impl VM {
         }
 
         self.set_current_package(saved_package);
-        self.interpreter.pop_routine();
-        self.interpreter
-            .pop_test_assertion_context(pushed_assertion);
-        self.interpreter.pop_block();
+        self.pop_routine();
+        self.pop_test_assertion_context(pushed_assertion);
+        self.pop_block();
         let effective_return_spec = return_spec
             .as_deref()
             .map(|spec| loan_env!(self, resolved_type_capture_name(spec)));
@@ -1801,11 +1786,10 @@ impl VM {
         // Fast path: if the env wasn't mutated during the call (Arc still shared),
         // we can skip the expensive env merge and just restore directly.
         if restored_env.ptr_eq(self.env()) {
-            self.interpreter.pop_caller_env();
+            self.pop_caller_env();
         } else {
             let mut restored_env = restored_env;
-            self.interpreter
-                .pop_caller_env_with_writeback(&mut restored_env);
+            self.pop_caller_env_with_writeback(&mut restored_env);
             loan_env!(
                 self,
                 apply_rw_bindings_to_env(&rw_bindings, &mut restored_env)

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -44,18 +44,18 @@ impl VM {
             arg_sources
         };
         let args = self.normalize_call_args_for_target(&name, args);
-        let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (args, callsite_line) = self.sanitize_call_args(&args);
         // Auto-FETCH Proxy args for statement-level calls (same as CallFunc)
-        let args = if self.interpreter.in_lvalue_assignment {
+        let args = if self.in_lvalue_assignment {
             args
         } else {
             self.auto_fetch_proxy_args(args)?
         };
         loan_env!(self, set_pending_callsite_line(callsite_line));
         // Check wrap chain for named function calls
-        if let Some(sub_id) = self.interpreter.wrap_sub_id_for_name(&name)
-            && !self.interpreter.is_wrap_dispatching(sub_id)
-            && let Some(sub_val) = self.interpreter.get_wrapped_sub(&name)
+        if let Some(sub_id) = self.wrap_sub_id_for_name(&name)
+            && !self.is_wrap_dispatching(sub_id)
+            && let Some(sub_val) = self.get_wrapped_sub(&name)
         {
             let result = self.vm_call_sub_value(sub_val, args, false)?;
             self.stack.push(result);
@@ -63,12 +63,11 @@ impl VM {
             return Ok(());
         }
         if let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args) {
-            self.interpreter
-                .set_pending_call_arg_sources(arg_sources.clone());
+            self.set_pending_call_arg_sources(arg_sources.clone());
             let pkg = self.current_package().to_string();
             let call_result =
                 self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name);
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             call_result?;
             // No blanket mark: call_compiled_function_named already signals
             // env_dirty precisely from its return merge (matches the hot
@@ -77,9 +76,9 @@ impl VM {
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             native_result?;
         } else {
-            self.interpreter.set_pending_call_arg_sources(arg_sources);
+            self.set_pending_call_arg_sources(arg_sources);
             let exec_result = loan_env!(self, exec_call_values(&name, args));
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             exec_result?;
             // Carrier may write the caller env by name (e.g. EVAL'd lexicals). Keep
             // the env_dirty flag rather than an eager sync_locals_from_env here: an
@@ -106,7 +105,7 @@ impl VM {
         let start = self.stack.len() - arity;
         let args: Vec<Value> = self.stack.drain(start..).collect();
         // Auto-FETCH Proxy args
-        let args = if self.interpreter.in_lvalue_assignment {
+        let args = if self.in_lvalue_assignment {
             args
         } else {
             self.auto_fetch_proxy_args(args)?

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -217,7 +217,7 @@ impl VM {
                             )
                         } else {
                             let pkg = self.current_package().to_string();
-                            self.interpreter.push_samewith_context(name_str, None);
+                            self.push_samewith_context(name_str, None);
                             let pushed_dispatch =
                                 loan_env!(self, push_multi_dispatch_frame(name_str, &args));
                             let r = self.call_compiled_function_named(
@@ -227,9 +227,9 @@ impl VM {
                                 &pkg,
                                 name_str,
                             );
-                            self.interpreter.pop_samewith_context();
+                            self.pop_samewith_context();
                             if pushed_dispatch {
-                                self.interpreter.pop_multi_dispatch();
+                                self.pop_multi_dispatch();
                             }
                             r
                         };
@@ -288,7 +288,7 @@ impl VM {
             let use_cache = !self.has_multi_candidates_cached(name_str);
             if use_cache
                 && self.fn_resolve_cache_gen == self.fn_resolve_gen
-                && self.interpreter.wrap_sub_id_for_name(name_str).is_none()
+                && self.wrap_sub_id_for_name(name_str).is_none()
                 && !loan_env!(self, routine_is_test_assertion_by_name(name_str, &[]))
                 && let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(&cache_key)
                 && let Some(cf) = compiled_fns.get(cached_key.as_str())
@@ -349,7 +349,7 @@ impl VM {
             arg_sources
         };
         let args = self.normalize_call_args_for_target(&name, args);
-        let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (args, callsite_line) = self.sanitize_call_args(&args);
         // Don't auto-FETCH Proxy args for control flow builtins that must preserve containers,
         // or when in lvalue assignment context (e.g. f() = 42 calls f with in_lvalue_assignment=true).
         let skip_proxy_fetch = matches!(
@@ -361,7 +361,7 @@ impl VM {
                 | "leave"
                 | "__mutsu_assign_method_lvalue"
                 | "__mutsu_index_assign_method_lvalue"
-        ) || self.interpreter.in_lvalue_assignment;
+        ) || self.in_lvalue_assignment;
         let args = if skip_proxy_fetch {
             args
         } else {
@@ -377,7 +377,7 @@ impl VM {
                     if let Value::Mixin(_, ref mixins) = callable {
                         let has_call_me = mixins.keys().any(|key| {
                             key.strip_prefix("__mutsu_role__")
-                                .is_some_and(|rn| self.interpreter.role_has_method(rn, "CALL-ME"))
+                                .is_some_and(|rn| self.role_has_method(rn, "CALL-ME"))
                         });
                         if has_call_me {
                             return Some(callable);
@@ -397,9 +397,9 @@ impl VM {
         }
 
         // Check wrap chain for named function calls
-        if let Some(sub_id) = self.interpreter.wrap_sub_id_for_name(&name)
-            && !self.interpreter.is_wrap_dispatching(sub_id)
-            && let Some(sub_val) = self.interpreter.get_wrapped_sub(&name)
+        if let Some(sub_id) = self.wrap_sub_id_for_name(&name)
+            && !self.is_wrap_dispatching(sub_id)
+            && let Some(sub_val) = self.get_wrapped_sub(&name)
         {
             let result = self.vm_call_sub_value(sub_val, args, false)?;
             self.stack.push(result);
@@ -480,7 +480,7 @@ impl VM {
             Self::append_slip_value(&mut args, slip_val);
         }
         let args = self.normalize_call_args_for_target(&name, args);
-        let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (args, callsite_line) = self.sanitize_call_args(&args);
         loan_env!(self, set_pending_callsite_line(callsite_line));
         // A lexical `&name` parameter (or `my &name`) that shadows a same-named
         // package sub wins over the package sub, even when the call slips its
@@ -508,9 +508,7 @@ impl VM {
             let cf_auto_fetch = !cf.is_raw;
             let pkg = self.current_package().to_string();
             let result = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name)?;
-            let result = self
-                .interpreter
-                .maybe_fetch_rw_proxy(result, cf_auto_fetch)?;
+            let result = self.maybe_fetch_rw_proxy(result, cf_auto_fetch)?;
             self.stack.push(result);
             // Slice 6.3 step 2: precise env_dirty from the named-call merge.
         } else if loan_env!(self, user_function_matches_call(&name, &args)) {
@@ -612,9 +610,9 @@ impl VM {
         } else {
             false
         };
-        self.interpreter.set_pending_call_arg_sources(arg_sources);
+        self.set_pending_call_arg_sources(arg_sources);
         let result = self.vm_call_on_value(target, args, Some(compiled_fns));
-        self.interpreter.set_pending_call_arg_sources(None);
+        self.set_pending_call_arg_sources(None);
         let result = result?;
         let result = loan_env!(self, maybe_fetch_rw_proxy(result, sub_is_rw))?;
         self.stack.push(result);
@@ -643,7 +641,7 @@ impl VM {
         for arg in raw_args {
             Self::append_flattened_call_arg(&mut args, arg, false);
         }
-        let (args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (args, callsite_line) = self.sanitize_call_args(&args);
         loan_env!(self, set_pending_callsite_line(callsite_line));
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         let arg_sources = if arg_sources.as_ref().is_some_and(|s| s.len() != args.len()) {
@@ -670,10 +668,9 @@ impl VM {
             } else {
                 false
             };
-            self.interpreter
-                .set_pending_call_arg_sources(arg_sources.clone());
+            self.set_pending_call_arg_sources(arg_sources.clone());
             let result = self.vm_call_on_value(target, args, Some(compiled_fns));
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, sub_is_rw))?
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
@@ -683,10 +680,9 @@ impl VM {
         {
             let cf_auto_fetch = !cf.is_raw;
             let pkg = self.current_package().to_string();
-            self.interpreter
-                .set_pending_call_arg_sources(arg_sources.clone());
+            self.set_pending_call_arg_sources(arg_sources.clone());
             let result = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name);
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, cf_auto_fetch))?
         } else {
@@ -694,9 +690,9 @@ impl VM {
             if name == "start" {
                 self.sync_env_from_locals(code);
             }
-            self.interpreter.set_pending_call_arg_sources(arg_sources);
+            self.set_pending_call_arg_sources(arg_sources);
             let result = self.call_function_compiled_first(&name, args, compiled_fns);
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             result?
         };
         let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
@@ -722,21 +718,20 @@ impl VM {
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, true))
         } else {
-            self.interpreter
-                .set_pending_call_arg_sources(arg_sources.clone());
+            self.set_pending_call_arg_sources(arg_sources.clone());
             let compiled = if !self.has_proto(name) {
                 self.find_compiled_function(compiled_fns, name, &args)
             } else {
                 None
             };
-            self.interpreter.set_pending_call_arg_sources(None);
+            self.set_pending_call_arg_sources(None);
             if let Some(cf) = compiled {
                 // Try positional light call path first (ultra-fast, no env clone).
                 // Skip for multi functions since the cache doesn't differentiate by arg types.
                 if Self::is_positional_light_call_eligible(cf, name)
                     && !self.has_multi_candidates_cached(name)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
-                    && self.interpreter.wrap_sub_id_for_name(name).is_none()
+                    && self.wrap_sub_id_for_name(name).is_none()
                 {
                     let name_sym = Symbol::intern(name);
                     if !self.pos_light_call_cache.contains_key(&name_sym) {
@@ -757,7 +752,7 @@ impl VM {
                 // This avoids the expensive env clone/restore cycle.
                 if Self::is_light_call_eligible(cf, name)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
-                    && self.interpreter.wrap_sub_id_for_name(name).is_none()
+                    && self.wrap_sub_id_for_name(name).is_none()
                 {
                     // Populate light-call cache so subsequent calls skip resolution
                     let name_sym = Symbol::intern(name);
@@ -775,10 +770,9 @@ impl VM {
                     let result = result?;
                     return loan_env!(self, maybe_fetch_rw_proxy(result, true));
                 }
-                self.interpreter
-                    .set_pending_call_arg_sources(arg_sources.clone());
+                self.set_pending_call_arg_sources(arg_sources.clone());
                 let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(name, &args));
-                self.interpreter.push_samewith_context(name, None);
+                self.push_samewith_context(name, None);
                 // Use the function's defining package so that lookups inside the
                 // function body resolve against the correct namespace.
                 let pkg = if let Some(cached_pkg) = self.cached_fn_package(name, args.len()) {
@@ -787,7 +781,7 @@ impl VM {
                     let resolved_def = loan_env!(self, resolve_function_with_types(name, &args));
                     if let Some(ref def) = resolved_def {
                         let cl = crate::runtime::Interpreter::peek_callsite_line(&args)
-                            .or_else(|| self.interpreter.pending_callsite_line());
+                            .or_else(|| self.pending_callsite_line());
                         loan_env!(self, check_deprecation_for_def_with_line(def, cl));
                     }
                     resolved_def
@@ -796,10 +790,10 @@ impl VM {
                 };
                 let cf_auto_fetch = !cf.is_raw;
                 let result = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, name);
-                self.interpreter.set_pending_call_arg_sources(None);
-                self.interpreter.pop_samewith_context();
+                self.set_pending_call_arg_sources(None);
+                self.pop_samewith_context();
                 if pushed_dispatch {
-                    self.interpreter.pop_multi_dispatch();
+                    self.pop_multi_dispatch();
                 }
                 // Slice 6.3 step 2: no blanket mark. call_compiled_function_named
                 // now signals env_dirty precisely — its return merge sets it when a
@@ -842,7 +836,7 @@ impl VM {
                     // and corrupts behaviour (regressed S16-io/words.t,
                     // S32-io/slurp.t via is-eqv). Mirrors the non-builtin OTF path's
                     // is_interpreter_handled_function gate below.
-                    let _ = self.interpreter.take_pending_dispatch_error();
+                    let _ = self.take_pending_dispatch_error();
                     if !self.is_interpreter_handled_function(name)
                         && let Some(def) = loan_env!(self, resolve_function_with_types(name, &args))
                         && Self::def_is_otf_compilable(&def)
@@ -851,9 +845,9 @@ impl VM {
                         self.compile_and_call_function_def(&def, args, compiled_fns)
                     } else {
                         crate::vm::vm_stats::record_function_fallback(name);
-                        self.interpreter.set_pending_call_arg_sources(arg_sources);
+                        self.set_pending_call_arg_sources(arg_sources);
                         let result = self.vm_call_function_fallback(name, &args);
-                        self.interpreter.set_pending_call_arg_sources(None);
+                        self.set_pending_call_arg_sources(None);
                         let result = result?;
                         loan_env!(self, maybe_fetch_rw_proxy(result, true))
                     }
@@ -884,9 +878,9 @@ impl VM {
                         self.compile_and_call_function_def(&def, args, compiled_fns)
                     } else {
                         crate::vm::vm_stats::record_function_fallback(name);
-                        self.interpreter.set_pending_call_arg_sources(arg_sources);
+                        self.set_pending_call_arg_sources(arg_sources);
                         let result = self.vm_call_function_fallback(name, &args);
-                        self.interpreter.set_pending_call_arg_sources(None);
+                        self.set_pending_call_arg_sources(None);
                         let result = result?;
                         loan_env!(self, maybe_fetch_rw_proxy(result, true))
                     }
@@ -932,9 +926,9 @@ impl VM {
                     } else {
                         crate::vm::vm_stats::record_function_fallback(name);
                     }
-                    self.interpreter.set_pending_call_arg_sources(arg_sources);
+                    self.set_pending_call_arg_sources(arg_sources);
                     let result = self.vm_call_function(name, args);
-                    self.interpreter.set_pending_call_arg_sources(None);
+                    self.set_pending_call_arg_sources(None);
                     // Interpreter function calls (e.g. `require`) may register
                     // new subs — invalidate function resolution caches.
                     self.fn_resolve_gen += 1;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -55,11 +55,8 @@ impl VM {
             return Ok(None);
         };
         let sigiled_target = format!("@{target_name}");
-        if !self.interpreter.shared_vars_active
-            || !matches!(
-                self.interpreter.get_shared_var(&sigiled_target),
-                Some(Value::Array(..))
-            )
+        if !self.shared_vars_active
+            || !matches!(self.get_shared_var(&sigiled_target), Some(Value::Array(..)))
         {
             return Ok(None);
         }
@@ -168,7 +165,7 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
                 return result;
             }
-            if self.interpreter.is_native_method(&class, method) {
+            if self.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return loan_env!(self, call_method_with_values(target, method, args));
@@ -195,9 +192,7 @@ impl VM {
             if let Some(cn) = class_name {
                 let resolved = loan_env!(self, resolve_private_method_for_vm(&cn, method, &args));
                 if let Some((owner_class, method_def)) = resolved {
-                    let caller_allowed = self
-                        .interpreter
-                        .can_fast_dispatch_private_method_vm(&owner_class);
+                    let caller_allowed = self.can_fast_dispatch_private_method_vm(&owner_class);
                     if caller_allowed && let Some(ref cc) = method_def.compiled_code {
                         let cc = cc.clone();
                         let target_id = match &target {
@@ -235,9 +230,9 @@ impl VM {
                             &empty_fns,
                         );
                         if pushed_dispatch {
-                            self.interpreter.pop_method_dispatch();
+                            self.pop_method_dispatch();
                         }
-                        self.interpreter.pop_method_samewith_context();
+                        self.pop_method_samewith_context();
                         let (result, new_attrs, attrs_adjusted) = method_result?;
                         if let Some(id) = target_id {
                             // Commit only a `:=`-adjusted snapshot: an unadjusted
@@ -246,7 +241,7 @@ impl VM {
                             if attrs_adjusted && let Some(cell) = &attrs_cell {
                                 cell.commit_attrs(new_attrs.clone());
                             }
-                            if !self.interpreter.in_lvalue_assignment
+                            if !self.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
                                 // Without a `:=` adjustment the triple's map is
@@ -282,7 +277,7 @@ impl VM {
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.interpreter.has_user_method(&cn, method)
+                && self.has_user_method(&cn, method)
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
@@ -304,7 +299,7 @@ impl VM {
 
             // Fast method dispatch cache: skip wrap chain check, compiled_code
             // extraction, and param_def eligibility scans for known-fast methods.
-            if !self.interpreter.has_any_wrap_chains()
+            if !self.has_any_wrap_chains()
                 && let Some(entry) = self.fast_method_cache.get(&cache_key)
                 && args.len() <= entry.positional_count
             {
@@ -901,7 +896,7 @@ impl VM {
             let mut out = Vec::new();
             for arg in args {
                 if Self::is_buf_value(arg) {
-                    out.extend(self.interpreter.supply_chunk_to_bytes(arg, "utf-8"));
+                    out.extend(self.supply_chunk_to_bytes(arg, "utf-8"));
                 } else {
                     out.extend(loan_env!(self, render_str_value(arg)).into_bytes());
                 }
@@ -1270,8 +1265,8 @@ impl VM {
         // respective registry, so calling both safely covers class- and
         // role-owned methods. Neither re-enters user code (pure compilation),
         // so the registry re-entrancy discipline (②) is respected.
-        self.interpreter.compile_class_methods(owner_class);
-        self.interpreter.compile_role_methods(owner_class);
+        self.compile_class_methods(owner_class);
+        self.compile_role_methods(owner_class);
         let (owner, def) = loan_env!(
             self,
             resolve_method_with_owner_invocant(cn, method, args, target)
@@ -1332,9 +1327,9 @@ impl VM {
                 csm,
             );
             if pushed_dispatch {
-                self.interpreter.pop_method_dispatch();
+                self.pop_method_dispatch();
             }
-            self.interpreter.pop_method_samewith_context();
+            self.pop_method_samewith_context();
             result
         } else {
             let invocant_for_dispatch = if attributes.is_empty() {
@@ -1359,9 +1354,9 @@ impl VM {
                 &empty_fns,
             );
             if pushed_dispatch {
-                self.interpreter.pop_method_dispatch();
+                self.pop_method_dispatch();
             }
-            self.interpreter.pop_method_samewith_context();
+            self.pop_method_samewith_context();
             result
         };
         let (result, new_attrs, attrs_adjusted) = method_result?;
@@ -1372,7 +1367,7 @@ impl VM {
             if attrs_adjusted && let Some(cell) = &attrs_cell {
                 cell.commit_attrs(new_attrs.clone());
             }
-            if !self.interpreter.in_lvalue_assignment
+            if !self.in_lvalue_assignment
                 && let Value::Proxy { ref fetcher, .. } = result
             {
                 // Without a `:=` adjustment the triple's map is the stale entry
@@ -1428,14 +1423,8 @@ impl VM {
                     .as_ref()
                     .is_some_and(|tc| tc.contains('('))
         });
-        let has_role_bindings = self
-            .interpreter
-            .class_role_param_bindings(owner_class)
-            .is_some()
-            || self
-                .interpreter
-                .class_role_param_bindings(receiver_class)
-                .is_some();
+        let has_role_bindings = self.class_role_param_bindings(owner_class).is_some()
+            || self.class_role_param_bindings(receiver_class).is_some();
         if has_invocant_constraint || has_complex_params || has_role_bindings {
             return;
         }
@@ -1531,7 +1520,7 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
                 return result;
             }
-            if self.interpreter.is_native_method(&class, method) {
+            if self.is_native_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork, mut (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self.vm_call_method_mut_with_values(target_name, target, method, args);
@@ -1560,7 +1549,7 @@ impl VM {
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.interpreter.has_user_method(&cn, method)
+                && self.has_user_method(&cn, method)
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
@@ -1578,9 +1567,7 @@ impl VM {
             if let Some(cn) = class_name {
                 let resolved = loan_env!(self, resolve_private_method_for_vm(&cn, method, &args));
                 if let Some((owner_class, method_def)) = resolved {
-                    let caller_allowed = self
-                        .interpreter
-                        .can_fast_dispatch_private_method_vm(&owner_class);
+                    let caller_allowed = self.can_fast_dispatch_private_method_vm(&owner_class);
                     if caller_allowed && let Some(ref cc) = method_def.compiled_code {
                         let cc = cc.clone();
                         let target_id = match &target {
@@ -1618,9 +1605,9 @@ impl VM {
                             &empty_fns,
                         );
                         if pushed_dispatch {
-                            self.interpreter.pop_method_dispatch();
+                            self.pop_method_dispatch();
                         }
-                        self.interpreter.pop_method_samewith_context();
+                        self.pop_method_samewith_context();
                         let (result, new_attrs, attrs_adjusted) = method_result?;
                         if let Some(id) = target_id {
                             // Commit only a `:=`-adjusted snapshot: an unadjusted
@@ -1629,7 +1616,7 @@ impl VM {
                             if attrs_adjusted && let Some(cell) = &attrs_cell {
                                 cell.commit_attrs(new_attrs.clone());
                             }
-                            if !self.interpreter.in_lvalue_assignment
+                            if !self.in_lvalue_assignment
                                 && let Value::Proxy { ref fetcher, .. } = result
                             {
                                 // Without a `:=` adjustment the triple's map is
@@ -1666,11 +1653,9 @@ impl VM {
         {
             // Ambiguous multi dispatch: two or more candidates matched equally
             // well. Raise X::Multi::Ambiguous instead of silently picking one.
-            if self.interpreter.dispatch_ambiguous {
-                self.interpreter.dispatch_ambiguous = false;
-                let sigs = self
-                    .interpreter
-                    .format_method_candidate_signatures(&cn, method);
+            if self.dispatch_ambiguous {
+                self.dispatch_ambiguous = false;
+                let sigs = self.format_method_candidate_signatures(&cn, method);
                 return Err(
                     crate::runtime::methods_signature::make_multi_ambiguous_error(
                         method, &cn, &sigs,
@@ -1731,9 +1716,9 @@ impl VM {
                     &empty_fns,
                 );
                 if pushed_dispatch {
-                    self.interpreter.pop_method_dispatch();
+                    self.pop_method_dispatch();
                 }
-                self.interpreter.pop_method_samewith_context();
+                self.pop_method_samewith_context();
                 let (result, new_attrs, attrs_adjusted) = method_result?;
                 if let Some(id) = target_id {
                     // Commit only a `:=`-adjusted snapshot (cell-CAS race
@@ -1741,7 +1726,7 @@ impl VM {
                     if attrs_adjusted && let Some(cell) = &attrs_cell {
                         cell.commit_attrs(new_attrs.clone());
                     }
-                    if !self.interpreter.in_lvalue_assignment
+                    if !self.in_lvalue_assignment
                         && let Value::Proxy { ref fetcher, .. } = result
                     {
                         // Without a `:=` adjustment the triple's map is the stale
@@ -1814,10 +1799,8 @@ impl VM {
                         captured_bindings,
                         writeback_bindings,
                         captured_names,
-                    ) = self
-                        .interpreter
-                        .get_or_compile_protect_block_with_slots(data);
-                    self.interpreter.sync_shared_vars_for_names(
+                    ) = self.get_or_compile_protect_block_with_slots(data);
+                    self.sync_shared_vars_for_names(
                         captured_names.iter().map(|name| name.as_str()),
                     );
                     (
@@ -1831,7 +1814,7 @@ impl VM {
                 _ => {
                     // TODO: Handle non-Sub protect blocks (e.g. WeakSub, Routine)
                     // in the VM. Currently these are rare and delegate to interpreter.
-                    return self.interpreter.call_protect_block(code_val);
+                    return self.call_protect_block(code_val);
                 }
             };
 
@@ -1846,7 +1829,7 @@ impl VM {
         if captured_env.is_some() {
             for (slot, name) in captured_bindings.iter() {
                 if (name.starts_with('@') || name.starts_with('%'))
-                    && self.interpreter.get_shared_var(name).is_some()
+                    && self.get_shared_var(name).is_some()
                 {
                     // Leave shared collections unmaterialized in locals.
                     // GetLocal will read the shared value on demand.
@@ -1878,7 +1861,7 @@ impl VM {
         if let Some(captured) = captured_env {
             for (slot, name) in writeback_bindings.iter() {
                 if matches!(
-                    self.interpreter.get_shared_var(name),
+                    self.get_shared_var(name),
                     Some(Value::Array(..) | Value::Hash(..))
                 ) {
                     continue;
@@ -1890,7 +1873,7 @@ impl VM {
                 }
                 if captured.contains_key(name)
                     && !matches!(
-                        self.interpreter.get_shared_var(name),
+                        self.get_shared_var(name),
                         Some(Value::Array(..) | Value::Hash(..))
                     )
                 {
@@ -1927,14 +1910,11 @@ impl VM {
         target: &Value,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if !self.interpreter.has_any_wrap_chains() || self.interpreter.is_inside_wrap_dispatch() {
+        if !self.has_any_wrap_chains() || self.is_inside_wrap_dispatch() {
             return None;
         }
-        let cand_idx =
-            self.interpreter
-                .find_method_candidate_index(owner_class, method, method_def)?;
+        let cand_idx = self.find_method_candidate_index(owner_class, method, method_def)?;
         let chain = self
-            .interpreter
             .get_method_wrap_chain(owner_class, method, cand_idx)?
             .clone();
         let invocant_for_dispatch = target.clone();
@@ -1974,13 +1954,13 @@ impl VM {
         } else {
             None
         };
-        self.interpreter.push_wrap_dispatch_frame(frame);
+        self.push_wrap_dispatch_frame(frame);
         let result = self.vm_call_sub_value(outermost, call_args, false);
-        self.interpreter.pop_wrap_dispatch_frame();
+        self.pop_wrap_dispatch_frame();
         // Propagate closure variable mutations from the wrapper back to the
         // current env so captured variables are visible to the caller.
         if let Some(wid) = wrapper_id
-            && let Some(persisted) = self.interpreter.get_closure_env_override(wid)
+            && let Some(persisted) = self.get_closure_env_override(wid)
         {
             for (k, v) in persisted.iter() {
                 if self.env().contains_key_sym(*k) {
@@ -1990,9 +1970,9 @@ impl VM {
             self.env_dirty = true;
         }
         if pushed_dispatch {
-            self.interpreter.pop_method_dispatch();
+            self.pop_method_dispatch();
         }
-        self.interpreter.pop_method_samewith_context();
+        self.pop_method_samewith_context();
         Some(result)
     }
 }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -328,8 +328,7 @@ impl VM {
         crate::vm::vm_stats::record_method_dispatch();
         // Set pending arg sources for `is rw` dispatch matching
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
-        self.interpreter
-            .set_pending_call_arg_sources(arg_sources.clone());
+        self.set_pending_call_arg_sources(arg_sources.clone());
         let method_raw = Self::const_str(code, name_idx);
         let target_name = Self::const_str(code, target_name_idx).to_string();
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
@@ -458,11 +457,11 @@ impl VM {
                 .chars()
                 .next()
                 .is_some_and(|c| c.is_ascii_uppercase())
-            && !self.interpreter.has_type(&target_name)
+            && !self.has_type(&target_name)
             && !Self::is_builtin_type(&target_name)
-            && !self.interpreter.has_class(&target_name)
+            && !self.has_class(&target_name)
         {
-            let suggestions = self.interpreter.suggest_type_names(&target_name);
+            let suggestions = self.suggest_type_names(&target_name);
             return Err(RuntimeError::undeclared_type_symbols(
                 &target_name,
                 format!("Undeclared name:\n    {} used at line 1", target_name),
@@ -574,7 +573,7 @@ impl VM {
             && !args.is_empty()
             && target_name.starts_with('@')
             && matches!(&target, Value::Array(..))
-            && self.interpreter.shared_vars_active
+            && self.shared_vars_active
         {
             let result = loan_env!(
                 self,
@@ -613,7 +612,7 @@ impl VM {
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.interpreter.has_user_method(&cn, &method)
+                && self.has_user_method(&cn, &method)
             {
                 skip_native = true;
             }
@@ -676,7 +675,7 @@ impl VM {
             skip_native = true;
         }
         if skip_native {
-            self.interpreter.skip_pseudo_method_native = Some(method.clone());
+            self.skip_pseudo_method_native = Some(method.clone());
         }
         // Handle Match.make — must mutate the Match instance's `ast` attribute
         // and write the modified Match back to the variable.
@@ -704,7 +703,7 @@ impl VM {
                 };
                 self.env_mut().insert(target_name.to_string(), updated);
                 self.env_mut().insert("made".to_string(), value.clone());
-                self.interpreter.action_made = Some(value.clone());
+                self.action_made = Some(value.clone());
             }
             self.stack.push(value);
             self.env_dirty = true;
@@ -888,7 +887,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
+                        let new_hash = self.tag_container_metadata(new_hash, meta);
                         self.env_mut().insert(target_name.to_string(), new_hash);
                         self.stack.push(value);
                         self.env_dirty = true;
@@ -983,7 +982,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
+                        let new_hash = self.tag_container_metadata(new_hash, meta);
                         self.env_mut().insert(target_name.to_string(), new_hash);
                         self.stack.push(old_value);
                         self.env_dirty = true;
@@ -1077,7 +1076,7 @@ impl VM {
                             key_type: None,
                             declared_type: None,
                         });
-                        let new_hash = self.interpreter.tag_container_metadata(new_hash, meta);
+                        let new_hash = self.tag_container_metadata(new_hash, meta);
                         self.env_mut().insert(target_name.to_string(), new_hash);
                         if let Some((source_name, cell_val)) = bind_source_install {
                             self.set_env_with_main_alias(&source_name, cell_val.clone());
@@ -1268,13 +1267,9 @@ impl VM {
                             | "BIND-POS"
                     );
                     if is_array_method
-                        && !self.interpreter.has_user_method(&cn, &method)
+                        && !self.has_user_method(&cn, &method)
                         && attributes.contains_key("__mutsu_array_storage")
-                        && self
-                            .interpreter
-                            .mro_readonly(&cn)
-                            .iter()
-                            .any(|n| n == "Array")
+                        && self.mro_readonly(&cn).iter().any(|n| n == "Array")
                     {
                         let mut storage = attributes
                             .as_map()
@@ -1453,7 +1448,7 @@ impl VM {
         // Shared arrays keep their interior-mutation (Arc>1) semantics in the
         // interpreter so bound aliases observe the change; type-constrained or
         // metadata-bearing containers need element checks / typed empty Failures.
-        if self.interpreter.shared_vars_active
+        if self.shared_vars_active
             || loan_env!(self, var_type_constraint(target_name)).is_some()
             || self.container_type_metadata(target).is_some()
         {
@@ -1657,7 +1652,7 @@ impl VM {
         // Shared / type-constrained / metadata-bearing containers need the
         // interpreter's element checks, native-array semantics, and identity
         // sharing; let it own those.
-        if self.interpreter.shared_vars_active
+        if self.shared_vars_active
             || loan_env!(self, var_type_constraint(target_name)).is_some()
             || self.container_type_metadata(target).is_some()
         {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -126,7 +126,7 @@ impl VM {
             return None;
         }
         let cn = class_name.resolve();
-        if self.interpreter.has_user_method(&cn, method) {
+        if self.has_user_method(&cn, method) {
             return None;
         }
         // Only a *public* accessor reads through the fast path. Gating on this
@@ -134,7 +134,7 @@ impl VM {
         // under the `secret!` key, so reading it by the bare name must fall
         // through to the interpreter (which denies the access) rather than
         // leaking the private value.
-        if !self.interpreter.has_public_accessor(&cn, method) {
+        if !self.has_public_accessor(&cn, method) {
             return None;
         }
         // Public accessor confirmed. Read its backing value, stored under the
@@ -149,7 +149,7 @@ impl VM {
         match val {
             Some(v) => {
                 let out = v.clone();
-                if let Some(msg) = self.interpreter.class_attribute_deprecated(&cn, method) {
+                if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                     loan_env!(self, check_deprecation_for_method(method, &cn, &msg));
                 }
                 Some(out)
@@ -170,8 +170,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
-        self.interpreter
-            .set_pending_call_arg_sources(arg_sources.clone());
+        self.set_pending_call_arg_sources(arg_sources.clone());
         let method_raw = Self::const_str(code, name_idx);
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let method_cow = Self::rewrite_method_name_cow(method_raw, modifier);
@@ -218,9 +217,7 @@ impl VM {
         // `@x[0].push('foo')` still dies), and the result is written back to the slot.
         if let Value::Package(type_name) = &target
             && matches!(method, "push" | "append" | "unshift" | "prepend")
-            && let Some(result) = self
-                .interpreter
-                .autoviv_typed_array_push(&type_name.resolve(), &args)?
+            && let Some(result) = self.autoviv_typed_array_push(&type_name.resolve(), &args)?
         {
             self.stack.push(result);
             self.env_dirty = true;
@@ -236,7 +233,7 @@ impl VM {
                 Value::Instance { class_name, .. } if class_name == "Supplier"
             )
         {
-            if let Some(buf) = self.interpreter.supply_emit_buffer.last_mut() {
+            if let Some(buf) = self.supply_emit_buffer.last_mut() {
                 buf.push(target);
                 self.stack.push(Value::Nil);
                 // Buffering into the supply emit buffer touches no env: no mark.
@@ -408,7 +405,7 @@ impl VM {
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.interpreter.has_user_method(&cn, method)
+                && self.has_user_method(&cn, method)
             {
                 skip_native = true;
             }
@@ -470,7 +467,7 @@ impl VM {
                 "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"
             )
         {
-            self.interpreter.skip_pseudo_method_native = Some(method.to_string());
+            self.skip_pseudo_method_native = Some(method.to_string());
         }
         // Auto-FETCH Proxy containers for non-meta method calls
         // Skip auto-FETCH for Proxy subclass attribute access and decontainerized proxies
@@ -492,7 +489,7 @@ impl VM {
             if has_subclass_attr {
                 target
             } else {
-                self.interpreter.auto_fetch_proxy(&target)?
+                self.auto_fetch_proxy(&target)?
             }
         } else {
             target
@@ -797,9 +794,7 @@ impl VM {
                     | "Failure"
                     | "sink"
             )
-            && let Some(err) = self
-                .interpreter
-                .failure_to_runtime_error_if_unhandled(&target)
+            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&target)
         {
             return Err(err);
         }
@@ -845,13 +840,9 @@ impl VM {
                 } = &target
                 {
                     let cn = class_name.resolve();
-                    if !self.interpreter.has_user_method(&cn, method)
+                    if !self.has_user_method(&cn, method)
                         && attributes.contains_key("__mutsu_array_storage")
-                        && self
-                            .interpreter
-                            .mro_readonly(&cn)
-                            .iter()
-                            .any(|n| n == "Array")
+                        && self.mro_readonly(&cn).iter().any(|n| n == "Array")
                     {
                         let storage = attributes
                             .as_map()
@@ -1010,12 +1001,10 @@ impl VM {
                     method,
                     "push" | "pop" | "shift" | "unshift" | "append" | "prepend"
                 ) && matches!(&target, Value::Array(..))
-                    && let Some((attrs_ref, attr_name)) =
-                        self.interpreter.pending_proxy_subclass_attr.take()
+                    && let Some((attrs_ref, attr_name)) = self.pending_proxy_subclass_attr.take()
                 {
-                    let result = self
-                        .interpreter
-                        .proxy_subclass_array_mutate(&attrs_ref, &attr_name, method, &args)?;
+                    let result =
+                        self.proxy_subclass_array_mutate(&attrs_ref, &attr_name, method, &args)?;
                     self.stack.push(result);
                     self.env_dirty = true;
                     return Ok(());
@@ -1079,7 +1068,7 @@ impl VM {
                     // .Slip on arrays with `is default(X)`: fill holes with
                     // the default value instead of leaving Package("Any").
                     if method == "Slip" && args.is_empty() && matches!(&target, Value::Array(..)) {
-                        if let Some(def) = self.interpreter.container_default(&target).cloned() {
+                        if let Some(def) = self.container_default(&target).cloned() {
                             let Value::Array(items, ..) = &target else {
                                 unreachable!()
                             };

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -51,7 +51,7 @@ impl VM {
                         // No auto-threading needed
                     } else {
                         // Check if constraint is a subset with Mu/Junction base
-                        let resolved_base = self.interpreter.resolve_subset_base_type(constraint);
+                        let resolved_base = self.resolve_subset_base_type(constraint);
                         if resolved_base != "Mu" && resolved_base != "Junction" {
                             return Some(i);
                         }
@@ -103,7 +103,7 @@ impl VM {
         capture_rw_topic: bool,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
-        let (mut args, callsite_line) = self.interpreter.sanitize_call_args(&args);
+        let (mut args, callsite_line) = self.sanitize_call_args(&args);
         if callsite_line.is_some() {
             loan_env!(self, set_pending_callsite_line(callsite_line));
         }
@@ -183,7 +183,7 @@ impl VM {
                 let is_foreign = method_pkg != class
                     && (method_pkg.is_empty()
                         || method_pkg == "GLOBAL"
-                        || !self.interpreter.has_class(&method_pkg));
+                        || !self.has_class(&method_pkg));
                 if is_foreign {
                     // Check if the compiled code has any !attr locals
                     let has_attr_locals = cc
@@ -267,8 +267,7 @@ impl VM {
                 if matches!(data.env.get_sym(*k), Some(Value::ContainerRef(_))) {
                     return None;
                 }
-                self.interpreter
-                    .get_closure_captured_state(data.id, *k)
+                self.get_closure_captured_state(data.id, *k)
                     .map(|val| (*k, val.clone()))
             })
             .collect();
@@ -304,7 +303,7 @@ impl VM {
             "&?BLOCK".to_string(),
             Value::WeakSub(std::sync::Arc::downgrade(&block_arc)),
         );
-        self.interpreter.push_block(Value::Sub(block_arc));
+        self.push_block(Value::Sub(block_arc));
 
         // Push routine info for leave/return/when targeting.
         // For pointy blocks, we push a special marker name so that
@@ -315,14 +314,14 @@ impl VM {
             // Bare blocks and pointy blocks are NOT routine boundaries.
             // Push a marker name so &?ROUTINE skips them and finds the
             // enclosing sub/method.
-            self.interpreter.push_block_routine_with_location(
+            self.push_block_routine_with_location(
                 data.package.resolve(),
                 "<pointy-block>".to_string(),
                 call_line,
                 call_file,
             );
         } else {
-            self.interpreter.push_block_routine_with_location(
+            self.push_block_routine_with_location(
                 data.package.resolve(),
                 data.name.resolve(),
                 call_line,
@@ -335,9 +334,9 @@ impl VM {
         );
 
         if data.empty_sig && !args.is_empty() {
-            self.interpreter.pop_routine();
-            self.interpreter.pop_block();
-            self.interpreter.pop_caller_env();
+            self.pop_routine();
+            self.pop_block();
+            self.pop_caller_env();
             self.stack.truncate(saved_stack_depth);
             let frame = self.pop_call_frame();
             *self.env_mut() = frame.saved_env;
@@ -351,9 +350,9 @@ impl VM {
         ) {
             Ok(bindings) => bindings,
             Err(e) => {
-                self.interpreter.pop_routine();
-                self.interpreter.pop_block();
-                self.interpreter.pop_caller_env();
+                self.pop_routine();
+                self.pop_block();
+                self.pop_caller_env();
                 self.stack.truncate(saved_stack_depth);
                 let frame = self.pop_call_frame();
                 *self.env_mut() = frame.saved_env;
@@ -442,7 +441,7 @@ impl VM {
         // will generate closure-instance-specific keys automatically).
         for (slot, key) in &cc.state_locals {
             let scoped_key = self.scoped_state_key(key);
-            if let Some(val) = self.interpreter.get_state_var(&scoped_key) {
+            if let Some(val) = self.get_state_var(&scoped_key) {
                 self.locals[*slot] = val.clone();
             }
         }
@@ -468,7 +467,7 @@ impl VM {
             .iter()
             .any(|n| !n.is_empty() && data.env.contains_key(n));
 
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -492,7 +491,7 @@ impl VM {
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
                         self.stack.push(ret_val);
-                        self.interpreter.discard_let_saves(let_mark);
+                        self.discard_let_saves(let_mark);
                         result = Ok(());
                         break;
                     }
@@ -507,7 +506,7 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter.discard_let_saves(let_mark);
+                    self.discard_let_saves(let_mark);
                     result = Ok(());
                     break;
                 }
@@ -546,13 +545,13 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter.discard_let_saves(let_mark);
+                    self.discard_let_saves(let_mark);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
                     fail_bypass = true;
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -565,7 +564,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -613,8 +612,8 @@ impl VM {
         // Restore the previous state scope
         self.state_scope_id = saved_state_scope;
 
-        self.interpreter.pop_routine();
-        self.interpreter.pop_block();
+        self.pop_routine();
+        self.pop_block();
 
         if self.env_dirty {
             self.sync_locals_from_env(cc);
@@ -643,16 +642,14 @@ impl VM {
         // the body, so only those need persisting.
         for k in &cc.free_var_syms {
             if let Some(val) = self.env().get_sym(*k).cloned() {
-                self.interpreter
-                    .set_closure_captured_state(data.id, *k, val);
+                self.set_closure_captured_state(data.id, *k, val);
             }
         }
 
         // Environment writeback: merge changes back to caller
         let frame = self.pop_call_frame();
         let mut restored_env = frame.saved_env;
-        self.interpreter
-            .pop_caller_env_with_writeback(&mut restored_env);
+        self.pop_caller_env_with_writeback(&mut restored_env);
         loan_env!(
             self,
             apply_rw_bindings_to_env(&rw_bindings, &mut restored_env)
@@ -793,8 +790,7 @@ impl VM {
                     restored_env.insert(alias_key, v);
                 }
             }
-            self.interpreter
-                .merge_sigilless_alias_writes(&mut restored_env, self.env());
+            self.merge_sigilless_alias_writes(&mut restored_env, self.env());
         }
 
         // Only run the state-variable sync and cleanup when the closure
@@ -836,15 +832,14 @@ impl VM {
         // ensures END phasers see the final values rather than stale copies.
         // Only update keys matching the closure's captured variable names to
         // avoid overwriting unrelated captured lexicals in other END phasers.
-        if self.interpreter.end_phaser_count() > 0 && !data.env.is_empty() {
+        if self.end_phaser_count() > 0 && !data.env.is_empty() {
             let captured_strs: Vec<String> = data.env.keys().map(|s| s.resolve()).collect();
             let captured_names: std::collections::HashSet<&str> =
                 captured_strs.iter().map(|s| s.as_str()).collect();
             // Flatten: END phasers run at program exit with this captured env;
             // it must hold the full lexical view, not a transient scoped overlay.
             let current = self.clone_env();
-            self.interpreter
-                .update_end_phaser_envs_for_keys(&captured_names, &current);
+            self.update_end_phaser_envs_for_keys(&captured_names, &current);
         }
 
         let return_spec = data.env.get("__mutsu_return_type").and_then(|v| match v {

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1215,7 +1215,7 @@ impl VM {
         // that, after the match, a non-empty `pending_local_updates` reliably means
         // *this* match's embedded `{ }` code blocks wrote a caller variable by name
         // (the engine records them there but nothing consumes the log otherwise).
-        self.interpreter.pending_local_updates.clear();
+        self.pending_local_updates.clear();
         let saved_topic = self.env().get("_").cloned();
         self.env_mut().insert("_".to_string(), left.clone());
         // Sync env->locals first so that any values modified by interpreter
@@ -1301,14 +1301,14 @@ impl VM {
         //     continued matching reads it back across calls).
         // A plain regex match otherwise only writes `$/`/captures, which are
         // special vars read by name, never a caller local slot, so no pull.
-        let wrote_caller_via_code = !self.interpreter.pending_local_updates.is_empty();
+        let wrote_caller_via_code = !self.pending_local_updates.is_empty();
         let match_var_is_local = code.locals.iter().any(|n| n == "/");
         let pure = rhs_pure_regex
             && !was_substitution
             && !was_transliterate
             && !wrote_caller_via_code
             && !match_var_is_local;
-        self.interpreter.pending_local_updates.clear();
+        self.pending_local_updates.clear();
         if !pure {
             self.env_dirty = true;
         }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -322,7 +322,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -663,7 +663,7 @@ impl VM {
             .iter()
             .map(|name| {
                 let val = self.env().get(name).cloned();
-                let was_readonly = self.interpreter.readonly_vars().contains(name);
+                let was_readonly = self.readonly_vars().contains(name);
                 let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
                 let sigilless_ro = self.env().get(&sigilless_key).cloned();
                 (name.clone(), val, was_readonly, sigilless_ro)
@@ -727,7 +727,7 @@ impl VM {
             // Also set a deep-readonly flag so that method-lvalue
             // assignments like .value = ... are blocked too.
             if topic_readonly {
-                self.interpreter.mark_readonly("_");
+                self.mark_readonly("_");
                 self.env_mut()
                     .insert("__mutsu_deep_readonly::_".to_string(), Value::Bool(true));
             }
@@ -740,7 +740,7 @@ impl VM {
                 && !name.starts_with('@')
                 && !name.starts_with('%')
             {
-                self.interpreter.mark_readonly(name);
+                self.mark_readonly(name);
             }
             // `%`-sigil for-loop bindings preserve a QuantHash value (and keep
             // its type across a `%a = ...pairs` reset) instead of coercing it to
@@ -757,7 +757,7 @@ impl VM {
             // re-bind variables that may be readonly from an outer scope.
             for mp_name in &spec.multi_param_names {
                 // Clear regular readonly flag
-                self.interpreter.unmark_readonly(mp_name);
+                self.unmark_readonly(mp_name);
                 // Clear sigilless readonly flag
                 let key = format!("__mutsu_sigilless_readonly::{}", mp_name);
                 self.env_mut().insert(key, Value::Bool(false));
@@ -1003,13 +1003,13 @@ impl VM {
                                 next_index: idx + 1,
                             });
                         if topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                             self.env_mut().remove("__mutsu_deep_readonly::_");
                         }
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         self.topic_source_var = saved_topic_source;
                         self.quanthash_bind_params = saved_quanthash_bind.clone();
@@ -1029,13 +1029,13 @@ impl VM {
                     Err(e) => {
                         // Unmark readonly before propagating error
                         if topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                             self.env_mut().remove("__mutsu_deep_readonly::_");
                         }
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -1052,7 +1052,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1076,14 +1076,14 @@ impl VM {
         }
         // Unmark readonly topic after loop completion
         if topic_readonly {
-            self.interpreter.unmark_readonly("_");
+            self.unmark_readonly("_");
             self.env_mut().remove("__mutsu_deep_readonly::_");
         }
         // Unmark readonly params after loop completion
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.interpreter.readonly_vars_mut().remove(name);
+            self.readonly_vars_mut().remove(name);
         }
         // Restore saved multi-param values and readonly state
         for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {
@@ -1093,9 +1093,9 @@ impl VM {
                 self.env_mut().remove(&name);
             }
             if was_readonly {
-                self.interpreter.mark_readonly(&name);
+                self.mark_readonly(&name);
             } else {
-                self.interpreter.unmark_readonly(&name);
+                self.unmark_readonly(&name);
             }
             let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
             if let Some(ro_val) = sigilless_ro {
@@ -1168,7 +1168,7 @@ impl VM {
             .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
-        let was_topic_readonly = self.interpreter.readonly_vars().contains("_");
+        let was_topic_readonly = self.readonly_vars().contains("_");
 
         // Save the single named loop param (`for ... -> $x`) prior binding so it
         // does not leak past the loop into the enclosing scope. Without this, a
@@ -1204,10 +1204,10 @@ impl VM {
         if !spec.is_rw {
             if let Some(ref name) = param_name {
                 if !name.starts_with('@') && !name.starts_with('%') {
-                    self.interpreter.mark_readonly(name);
+                    self.mark_readonly(name);
                 }
             } else {
-                self.interpreter.mark_readonly("_");
+                self.mark_readonly("_");
             }
         }
 
@@ -1298,10 +1298,10 @@ impl VM {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if !was_topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                         }
                         self.topic_source_var = saved_topic_source;
                         if spec.restore_topic {
@@ -1322,10 +1322,10 @@ impl VM {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if !was_topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -1342,7 +1342,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
             // Use checked_add to avoid overflow when i is i64::MAX
@@ -1355,10 +1355,10 @@ impl VM {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.interpreter.readonly_vars_mut().remove(name);
+            self.readonly_vars_mut().remove(name);
         }
         if !was_topic_readonly {
-            self.interpreter.unmark_readonly("_");
+            self.unmark_readonly("_");
         }
         self.topic_source_var = saved_topic_source;
         if spec.restore_topic {
@@ -1439,17 +1439,17 @@ impl VM {
             .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
-        let was_topic_readonly = self.interpreter.readonly_vars().contains("_");
+        let was_topic_readonly = self.readonly_vars().contains("_");
 
         self.env_dirty = true;
 
         if !spec.is_rw {
             if let Some(ref name) = param_name {
                 if !name.starts_with('@') && !name.starts_with('%') {
-                    self.interpreter.mark_readonly(name);
+                    self.mark_readonly(name);
                 }
             } else {
-                self.interpreter.mark_readonly("_");
+                self.mark_readonly("_");
             }
         }
 
@@ -1523,10 +1523,10 @@ impl VM {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if !was_topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                         }
                         self.topic_source_var = saved_topic_source;
                         if spec.restore_topic {
@@ -1545,10 +1545,10 @@ impl VM {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if !was_topic_readonly {
-                            self.interpreter.unmark_readonly("_");
+                            self.unmark_readonly("_");
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -1564,7 +1564,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1572,10 +1572,10 @@ impl VM {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.interpreter.readonly_vars_mut().remove(name);
+            self.readonly_vars_mut().remove(name);
         }
         if !was_topic_readonly {
-            self.interpreter.unmark_readonly("_");
+            self.unmark_readonly("_");
         }
         self.topic_source_var = saved_topic_source;
         if spec.restore_topic {
@@ -1633,7 +1633,7 @@ impl VM {
         'for_loop: loop {
             // Read the next record (word or line) from the handle
             let line = if words {
-                self.interpreter.read_word_from_handle_value(handle)?
+                self.read_word_from_handle_value(handle)?
             } else {
                 loan_env!(self, read_line_from_handle_value(handle))?
             };
@@ -1685,7 +1685,7 @@ impl VM {
             if !spec.is_rw
                 && let Some(ref name) = param_name
             {
-                self.interpreter.mark_readonly(name);
+                self.mark_readonly(name);
             }
 
             'body_redo: loop {
@@ -1729,7 +1729,7 @@ impl VM {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.interpreter.readonly_vars_mut().remove(name);
+                            self.readonly_vars_mut().remove(name);
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -1745,7 +1745,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1754,7 +1754,7 @@ impl VM {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.interpreter.readonly_vars_mut().remove(name);
+            self.readonly_vars_mut().remove(name);
         }
         self.topic_source_var = saved_topic_source;
         if spec.restore_topic {
@@ -2228,7 +2228,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
             if let Err(e) = self.run_range(code, step_begin, loop_end, compiled_fns) {
@@ -2268,7 +2268,7 @@ impl VM {
         let stack_base = self.stack.len();
 
         let saved_topic = self.env().get("_").cloned();
-        let saved_when = self.interpreter.when_matched();
+        let saved_when = self.when_matched();
         let saved_topic_source = self.topic_source_var.take();
         let saved_element_source = self.element_source.take();
         let container_binding = self.container_ref_var.take();
@@ -2292,16 +2292,15 @@ impl VM {
         // `@p[0]=v`, and `@p.push` all propagate). So when a pointy param is
         // present, don't mark `$_` read-only: that would propagate read-only to
         // `@p` through its `@p := $_` bind and block element assignment.
-        let mark_ro = topic_readonly
-            && pointy_param.is_none()
-            && !self.interpreter.readonly_vars().contains("_");
+        let mark_ro =
+            topic_readonly && pointy_param.is_none() && !self.readonly_vars().contains("_");
         if mark_ro {
-            self.interpreter.mark_readonly("_");
+            self.mark_readonly("_");
         }
 
         let restore = |this: &mut Self, write_back: bool| {
             if mark_ro {
-                this.interpreter.unmark_readonly("_");
+                this.unmark_readonly("_");
             }
             if write_back {
                 if let Some(src) = &element_source {
@@ -2310,7 +2309,7 @@ impl VM {
                     this.write_back_given_topic(code, &container_binding, &pointy_param);
                 }
             }
-            this.interpreter.set_when_matched(saved_when);
+            this.set_when_matched(saved_when);
             if let Some(v) = saved_topic.clone() {
                 this.env_mut().insert("_".to_string(), v);
             } else {
@@ -2324,16 +2323,13 @@ impl VM {
             // corrupt `$_`) starts clean. Done after the writeback above, which
             // still reads the parameter's final value.
             if let Some(p) = &pointy_param {
-                this.interpreter
-                    .env_mut()
+                this.env_mut()
                     .remove(&format!("__mutsu_sigilless_alias::{}", p));
-                this.interpreter
-                    .env_mut()
+                this.env_mut()
                     .remove(&format!("__mutsu_sigilless_readonly::{}", p));
-                this.interpreter
-                    .env_mut()
+                this.env_mut()
                     .remove(&format!("__mutsu_bound_decont::{}", p));
-                this.interpreter.unmark_readonly(p);
+                this.unmark_readonly(p);
             }
             this.topic_source_var = saved_topic_source.clone();
             // `element_source` is a one-shot signal set by `TagElementSource`
@@ -2361,7 +2357,7 @@ impl VM {
                 restore(self, false);
                 return Err(e);
             }
-            if self.interpreter.when_matched() || self.interpreter.is_halted() {
+            if self.when_matched() || self.is_halted() {
                 break;
             }
         }
@@ -2388,7 +2384,7 @@ impl VM {
         let end = body_end as usize;
 
         let saved_topic = self.env().get("_").cloned();
-        let saved_when = self.interpreter.when_matched();
+        let saved_when = self.when_matched();
         self.env_mut().insert("_".to_string(), topic);
         loan_env!(self, set_when_matched(false));
 
@@ -2451,7 +2447,7 @@ impl VM {
             let topic = self.env().get("_").cloned().unwrap_or(Value::Nil);
             match cond_val {
                 Value::Sub(_) | Value::Routine { .. } => {
-                    let (_params, param_defs) = self.interpreter.callable_signature(&cond_val);
+                    let (_params, param_defs) = self.callable_signature(&cond_val);
                     if !param_defs.is_empty() {
                         let mut positional_required = 0usize;
                         let mut positional_total = 0usize;
@@ -2615,7 +2611,7 @@ impl VM {
                     }
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -2669,27 +2665,27 @@ impl VM {
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let saved_depth = self.stack.len();
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         let body_start = *ip + 1;
         let catch_begin = catch_start as usize;
         let control_begin = control_start as usize;
         let end = body_end as usize;
         let has_control = control_begin < end;
         if has_control {
-            self.interpreter.control_handler_depth += 1;
+            self.control_handler_depth += 1;
         }
         // Guard the protected body with a panic->X:: boundary so an internal
         // Rust panic (overflow/OOB/unwrap) raised anywhere inside it becomes a
         // catchable exception routed to the CATCH handler, instead of crashing.
         let body_result = self.run_range_guarded(code, body_start, catch_begin, compiled_fns);
         if has_control {
-            self.interpreter.control_handler_depth -= 1;
+            self.control_handler_depth -= 1;
         }
         match body_result {
             Ok(()) => {
                 // Successful try resets $! to Nil
                 self.env_mut().insert("!".to_string(), Value::Nil);
-                self.interpreter.discard_let_saves(let_mark);
+                self.discard_let_saves(let_mark);
                 // A `try` that completes normally but yields a soft Failure value
                 // (e.g. the result of an expression that returned a Failure rather
                 // than throwing) handles that Failure: its value is now "caught",
@@ -2703,14 +2699,14 @@ impl VM {
                 Ok(())
             }
             Err(e) if e.is_return => {
-                self.interpreter.discard_let_saves(let_mark);
+                self.discard_let_saves(let_mark);
                 if control_begin < end {
                     self.stack.truncate(saved_depth);
                     let saved_topic = self.env().get("_").cloned();
                     if let Some(signal_topic) = Self::control_signal_topic_value(&e) {
                         self.env_mut().insert("_".to_string(), signal_topic);
                     }
-                    let saved_when = self.interpreter.when_matched();
+                    let saved_when = self.when_matched();
                     loan_env!(self, set_when_matched(false));
                     match self.run_range(code, control_begin, end, compiled_fns) {
                         Ok(()) => {
@@ -2742,7 +2738,7 @@ impl VM {
                     && !e.is_take
                     && !e.is_emit =>
             {
-                self.interpreter.discard_let_saves(let_mark);
+                self.discard_let_saves(let_mark);
                 Err(e)
             }
             // Control signals (warn, last, next, redo, etc.) without a CONTROL
@@ -2760,7 +2756,7 @@ impl VM {
                     || e.is_react_done)
                     && control_begin >= end =>
             {
-                self.interpreter.discard_let_saves(let_mark);
+                self.discard_let_saves(let_mark);
                 Err(e)
             }
             Err(e)
@@ -2776,10 +2772,10 @@ impl VM {
                     || e.is_react_done)
                     && control_begin < end =>
             {
-                self.interpreter.discard_let_saves(let_mark);
+                self.discard_let_saves(let_mark);
                 self.stack.truncate(saved_depth);
                 let saved_topic = self.env().get("_").cloned();
-                let saved_when = self.interpreter.when_matched();
+                let saved_when = self.when_matched();
                 let mut pending_err = e;
                 loop {
                     if let Some(signal_topic) = Self::control_signal_topic_value(&pending_err) {
@@ -2793,8 +2789,8 @@ impl VM {
                         // Re-throwing a CX::Warn from CONTROL acts like the
                         // default warn handler: print to stderr and resume.
                         Err(ce) if ce.is_warn => {
-                            if !self.interpreter.warning_suppressed() {
-                                self.interpreter.write_warn_to_stderr(&ce.message);
+                            if !self.warning_suppressed() {
+                                self.write_warn_to_stderr(&ce.message);
                             }
                             self.resume_ip.take()
                         }
@@ -2836,12 +2832,12 @@ impl VM {
                                 self.stack.push(rv);
                             }
                             if has_control {
-                                self.interpreter.control_handler_depth += 1;
+                                self.control_handler_depth += 1;
                             }
                             let body_result =
                                 self.run_range(code, resume_point, catch_begin, compiled_fns);
                             if has_control {
-                                self.interpreter.control_handler_depth -= 1;
+                                self.control_handler_depth -= 1;
                             }
                             match body_result {
                                 Ok(()) => {
@@ -2908,12 +2904,12 @@ impl VM {
                 let saved_topic = self.env().get("_").cloned();
                 self.env_mut().insert("!".to_string(), err_val.clone());
                 self.env_mut().insert("_".to_string(), err_val);
-                let saved_when = self.interpreter.when_matched();
+                let saved_when = self.when_matched();
                 loan_env!(self, set_when_matched(false));
                 let catch_stack_base = self.stack.len();
                 let when_handled =
                     match self.run_range(code, catch_begin, control_begin, compiled_fns) {
-                        Ok(()) => self.interpreter.when_matched(),
+                        Ok(()) => self.when_matched(),
                         // succeed from `when` inside CATCH means exception was handled
                         Err(catch_err) if catch_err.is_succeed => {
                             // Truncate values left by default body, then push Nil
@@ -2948,8 +2944,7 @@ impl VM {
                 // Propagate when_handled upward so an enclosing CATCH region
                 // can detect that this nested CATCH (e.g., a CATCH inside a
                 // CATCH) handled the exception.
-                self.interpreter
-                    .set_when_matched(saved_when || when_handled);
+                self.set_when_matched(saved_when || when_handled);
                 if let Some(v) = saved_topic {
                     self.env_mut().insert("_".to_string(), v);
                 } else {

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -407,7 +407,7 @@ impl VM {
         // TODO: compile to bytecode — shared-array push, blocked-by: lever B
         // (threaded shared-cell ownership). See ledger §1.
         // Fall back to interpreter for shared arrays (threaded context)
-        if self.interpreter.shared_vars_active {
+        if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::Nil);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::Nil);
             let result = loan_env!(self, call_method_with_values(target, "push", vec![val]))?;
@@ -472,7 +472,6 @@ impl VM {
         // Check type constraint on the array variable.
         // For Slip values, check each element individually.
         if let Some(type_name) = self
-            .interpreter
             .var_type_constraint_fast(target_name)
             .map(|s| s.to_string())
         {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -377,11 +377,7 @@ impl VM {
             }
             // Method dispatch fallback for &?ROUTINE.dispatcher()(self, ...)
             // Only use this when the package is a known class.
-            if !args.is_empty()
-                && !pkg.is_empty()
-                && pkg != "GLOBAL"
-                && self.interpreter.has_class(&pkg)
-            {
+            if !args.is_empty() && !pkg.is_empty() && pkg != "GLOBAL" && self.has_class(&pkg) {
                 let invocant = args[0].clone();
                 let method_args = args[1..].to_vec();
                 // Route through the VM's unified compiled-first dispatch (ledger §1):
@@ -409,7 +405,7 @@ impl VM {
             // Check if any mixed-in role provides CALL-ME
             for key in mixins.keys() {
                 if let Some(role_name) = key.strip_prefix("__mutsu_role__")
-                    && self.interpreter.role_has_method(role_name, "CALL-ME")
+                    && self.role_has_method(role_name, "CALL-ME")
                 {
                     // TODO: complex case -- fall back to interpreter for CALL-ME on Mixin
                     return self.try_compiled_method_or_interpret(target, "CALL-ME", args);
@@ -451,9 +447,7 @@ impl VM {
             }
         }
         // Evaluate the thunk (call the sub with no args)
-        let result = self
-            .interpreter
-            .call_sub_value(thunk_data.thunk.clone(), vec![], true)?;
+        let result = self.call_sub_value(thunk_data.thunk.clone(), vec![], true)?;
         // Cache the result
         {
             let mut cache = thunk_data.cache.lock().unwrap();

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -36,7 +36,7 @@ impl VM {
         // phasers, threads) still flatten via `clone_env` at the capture site.
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
-            saved_readonly: Some(self.interpreter.save_readonly_vars()),
+            saved_readonly: Some(self.save_readonly_vars()),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
@@ -72,7 +72,7 @@ impl VM {
         self.locals = std::mem::take(&mut frame.saved_locals);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
-            self.interpreter.restore_readonly_vars(readonly);
+            self.restore_readonly_vars(readonly);
         }
         self.env_dirty = frame.saved_env_dirty;
         frame
@@ -102,7 +102,7 @@ impl VM {
     /// after stripping pseudo-package prefixes like GLOBAL::, OUR::, etc.
     pub(super) fn our_var_pseudo_unqualified(&self, name: &str) -> Option<Value> {
         Self::pseudo_package_unqualified_name(name)
-            .and_then(|bare| self.interpreter.get_our_var(&bare).cloned())
+            .and_then(|bare| self.get_our_var(&bare).cloned())
     }
 
     /// Strip pseudo-package qualifiers (GLOBAL::, OUR::, MY::) from a
@@ -171,16 +171,16 @@ impl VM {
         // observe the latest CAS'd value.
         if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");
-            if let Some(v) = self.interpreter.get_shared_var(&atomic_key) {
+            if let Some(v) = self.get_shared_var(&atomic_key) {
                 return Some(v);
             }
         }
         // Thread-clone @/% lookups must prefer the shared copy. Child thread
         // env snapshots can lag behind sibling mutations even when Lock::Async
         // serializes the writes through shared_vars.
-        if self.interpreter.is_thread_clone()
+        if self.is_thread_clone()
             && (name.starts_with('@') || name.starts_with('%'))
-            && let Some(v) = self.interpreter.get_shared_var(name)
+            && let Some(v) = self.get_shared_var(name)
         {
             return Some(v);
         }
@@ -197,11 +197,11 @@ impl VM {
         }
         // Fall back to shared_vars for cross-thread visibility of variables
         // that were explicitly updated by other threads.
-        if let Some(v) = self.interpreter.get_shared_var(name) {
+        if let Some(v) = self.get_shared_var(name) {
             return Some(v);
         }
         // Follow binding aliases ($CALLER::target := $source)
-        if let Some(resolved) = self.interpreter.resolve_binding(name)
+        if let Some(resolved) = self.resolve_binding(name)
             && let Some(val) = self.env().get(resolved)
         {
             return Some(val.clone());
@@ -227,7 +227,7 @@ impl VM {
             if let Some(val) = self.env().get(&placeholder) {
                 return Some(val.clone());
             }
-            if let Some(val) = self.interpreter.get_shared_var(&placeholder) {
+            if let Some(val) = self.get_shared_var(&placeholder) {
                 return Some(val);
             }
         }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -14,7 +14,7 @@ impl VM {
     ///   - <unit> (outermost): use the outermost routine frame's stored
     ///     call-site (where <unit> called the first function)
     pub(super) fn build_backtrace_string(&self) -> String {
-        let stack = self.interpreter.routine_stack();
+        let stack = self.routine_stack();
         let current_line = self.current_source_line();
         let current_file = self.current_source_file();
         // Build reversed list: stack[last] is innermost, stack[0] is outermost
@@ -62,7 +62,7 @@ impl VM {
         use crate::symbol::Symbol;
         use std::collections::HashMap;
 
-        let stack = self.interpreter.routine_stack();
+        let stack = self.routine_stack();
         let current_line = self.current_source_line();
         let current_file = self.current_source_file();
         let reversed: Vec<_> = stack.iter().rev().collect();
@@ -402,7 +402,7 @@ impl VM {
         // If no compiled code, fall back to interpreter
         let (cc, fns) = match (&list.compiled_code, &list.compiled_fns) {
             (Some(cc), Some(fns)) => (cc.clone(), fns.clone()),
-            _ => return self.interpreter.force_lazy_list_bridge(list),
+            _ => return self.force_lazy_list_bridge(list),
         };
 
         // Save current VM state. Locals are kept coherent with env by
@@ -422,9 +422,9 @@ impl VM {
         *self.env_mut() = crate::env::Env::scoped_child(list.env.flattened());
 
         // Push gather items collector
-        let saved_gather_len = self.interpreter.gather_items_len();
-        self.interpreter.push_gather_items(Vec::new());
-        self.interpreter.push_gather_take_limit(None);
+        let saved_gather_len = self.gather_items_len();
+        self.push_gather_items(Vec::new());
+        self.push_gather_take_limit(None);
 
         // Initialize locals for the compiled code
         self.locals = vec![Value::Nil; cc.locals.len()];
@@ -446,8 +446,8 @@ impl VM {
             match self.exec_one(&cc, &mut ip, run_fns) {
                 Ok(()) => {}
                 Err(e) if e.is_warn => {
-                    if !self.interpreter.warning_suppressed() {
-                        self.interpreter.write_warn_to_stderr(&e.message);
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&e.message);
                     }
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -460,19 +460,19 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
 
         // Collect gather items
-        let items = self.interpreter.pop_gather_items().unwrap_or_default();
-        self.interpreter.pop_gather_take_limit();
+        let items = self.pop_gather_items().unwrap_or_default();
+        self.pop_gather_take_limit();
 
         // Clean up extra gather items if needed
-        while self.interpreter.gather_items_len() > saved_gather_len {
-            self.interpreter.pop_gather_items();
-            self.interpreter.pop_gather_take_limit();
+        while self.gather_items_len() > saved_gather_len {
+            self.pop_gather_items();
+            self.pop_gather_take_limit();
         }
 
         // Sync locals back to env before reading the result environment.
@@ -589,7 +589,7 @@ impl VM {
             (Some(cc), Some(fns)) => (cc.clone(), fns.clone()),
             _ => {
                 // Fall back to interpreter prefix bridge
-                return self.interpreter.force_lazy_list_prefix_bridge(list, needed);
+                return self.force_lazy_list_prefix_bridge(list, needed);
             }
         };
 
@@ -648,7 +648,7 @@ impl VM {
         self.env_dirty = false;
 
         // Push gather items collector with the take limit
-        let saved_gather_len = self.interpreter.gather_items_len();
+        let saved_gather_len = self.gather_items_len();
 
         // If resuming, restore already-cached items into the gather collector
         // so that the take_value limit check accounts for them.
@@ -656,13 +656,13 @@ impl VM {
             let cache = list.cache.lock().unwrap();
             let items = cache.as_ref().cloned().unwrap_or_default();
             let len = items.len();
-            self.interpreter.push_gather_items(items);
+            self.push_gather_items(items);
             len
         } else {
-            self.interpreter.push_gather_items(Vec::new());
+            self.push_gather_items(Vec::new());
             0
         };
-        self.interpreter.push_gather_take_limit(Some(needed));
+        self.push_gather_take_limit(Some(needed));
 
         // Run the compiled code
         let run_fns = fns.as_ref();
@@ -673,8 +673,8 @@ impl VM {
             match self.exec_one(&cc, &mut ip, run_fns) {
                 Ok(()) => {}
                 Err(e) if e.is_warn => {
-                    if !self.interpreter.warning_suppressed() {
-                        self.interpreter.write_warn_to_stderr(&e.message);
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&e.message);
                     }
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -699,7 +699,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -710,12 +710,12 @@ impl VM {
         }
 
         // Collect gather items
-        let items = self.interpreter.pop_gather_items().unwrap_or_default();
-        self.interpreter.pop_gather_take_limit();
+        let items = self.pop_gather_items().unwrap_or_default();
+        self.pop_gather_take_limit();
 
-        while self.interpreter.gather_items_len() > saved_gather_len {
-            self.interpreter.pop_gather_items();
-            self.interpreter.pop_gather_take_limit();
+        while self.gather_items_len() > saved_gather_len {
+            self.pop_gather_items();
+            self.pop_gather_take_limit();
         }
 
         // Sync locals back to env
@@ -1300,7 +1300,7 @@ impl VM {
             return Err(err);
         }
         // Check for pending dispatch error (e.g., from Any ~~ Pair method call)
-        if let Some(err) = self.interpreter.take_pending_dispatch_error() {
+        if let Some(err) = self.take_pending_dispatch_error() {
             return Err(err);
         }
         if is_regex {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -151,7 +151,7 @@ impl VM {
                     _ => None,
                 };
                 if let Some(cn) = class_name
-                    && self.interpreter.has_user_method(&cn, &method)
+                    && self.has_user_method(&cn, &method)
                 {
                     skip_native = true;
                 }
@@ -450,8 +450,7 @@ impl VM {
                 // arm); avoids corrupting a COW copy `my %g = %h`.
                 self.write_back_hyper_target_var(code, var, new_hash);
             } else {
-                self.interpreter
-                    .overwrite_hash_bindings_by_identity(existing, new_hash);
+                self.overwrite_hash_bindings_by_identity(existing, new_hash);
             }
             self.env_dirty = true;
         }

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -43,11 +43,12 @@ impl VM {
         let mut handles: Vec<std::thread::JoinHandle<ThreadResult>> =
             Vec::with_capacity(num_batches);
         for batch in batches {
-            let thread_interp = self.interpreter.clone_for_thread();
+            let thread_interp = self.clone_for_thread();
             let block_clone = block.clone();
             let is_map_flag = is_map;
             handles.push(std::thread::spawn(move || {
-                let mut vm = crate::vm::VM::new(thread_interp);
+                // CP-3 collapse: the cloned per-thread Interpreter *is* the VM.
+                let mut vm = thread_interp;
                 let mut results = Vec::with_capacity(batch.len());
                 let mut error: Option<RuntimeError> = None;
                 for item in &batch {
@@ -71,13 +72,13 @@ impl VM {
                         }
                     }
                 }
-                let output = vm.interpreter.take_output();
-                let stderr = vm.interpreter.take_stderr_output();
+                let output = vm.take_output();
+                let stderr = vm.take_stderr_output();
                 let final_result = match error {
                     Some(e) => Err(e),
                     None => Ok(results),
                 };
-                (vm.interpreter, final_result, output, stderr)
+                (vm, final_result, output, stderr)
             }));
         }
         let mut all_results = Vec::with_capacity(items.len());
@@ -85,7 +86,7 @@ impl VM {
         for handle in handles {
             let (thread_interp, batch_result, output, stderr) =
                 handle.join().unwrap_or_else(|_| {
-                    let interp = self.interpreter.clone_for_thread();
+                    let interp = self.clone_for_thread();
                     (
                         interp,
                         Err(RuntimeError::new("Thread panicked in hyper/race")),
@@ -93,8 +94,8 @@ impl VM {
                         String::new(),
                     )
                 });
-            self.interpreter.emit_output(&output);
-            self.interpreter.emit_stderr(&stderr);
+            self.emit_output(&output);
+            self.emit_stderr(&stderr);
             // Shared vars are synced through the shared Arc<RwLock<>>
             drop(thread_interp);
             match batch_result {
@@ -111,7 +112,7 @@ impl VM {
             }
         }
         // Sync any shared variable updates from threads back to our env
-        self.interpreter.sync_shared_vars_to_env();
+        self.sync_shared_vars_to_env();
         if let Some(e) = first_error {
             return Err(e);
         }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -59,12 +59,8 @@ impl VM {
             let has_attr_aliases = attributes
                 .keys()
                 .any(|k| k.starts_with(ATTR_ALIAS_META_PREFIX));
-            let has_role_bindings = self
-                .interpreter
-                .class_role_param_bindings(owner_class)
-                .is_some()
+            let has_role_bindings = self.class_role_param_bindings(owner_class).is_some()
                 || self
-                    .interpreter
                     .class_role_param_bindings(receiver_class_name)
                     .is_some();
             let has_complex_params = method_def.param_defs.iter().any(|pd| {
@@ -161,14 +157,14 @@ impl VM {
         // Clear var_bindings so attribute aliases from outer interpreter-level
         // method calls don't leak into compiled method locals (e.g. `x → !x`
         // from run_instance_method_resolved shadowing a local parameter `x`).
-        let saved_var_bindings = self.interpreter.take_var_bindings();
+        let saved_var_bindings = self.take_var_bindings();
 
-        self.interpreter.push_method_class(owner_class.to_string());
+        self.push_method_class(owner_class.to_string());
 
         // Detect role context: use the pre-computed role_origin stored on the
         // MethodDef (set during role composition) instead of expensive fingerprint
         // matching on every call.
-        let role_context = if self.interpreter.is_role(owner_class) {
+        let role_context = if self.is_role(owner_class) {
             Some(owner_class.to_string())
         } else {
             method_def
@@ -195,7 +191,7 @@ impl VM {
         // Set current_package so class-scoped subs are found during method execution.
         // Only change package if the class has subs declared in its body.
         let saved_package = self.current_package().to_string();
-        if self.interpreter.has_class_scoped_subs(receiver_class_name) {
+        if self.has_class_scoped_subs(receiver_class_name) {
             self.set_current_package(receiver_class_name.to_string());
         }
 
@@ -225,14 +221,11 @@ impl VM {
         );
 
         // Role param bindings
-        if let Some(role_bindings) = self.interpreter.class_role_param_bindings(owner_class) {
+        if let Some(role_bindings) = self.class_role_param_bindings(owner_class) {
             for (name, value) in &role_bindings {
                 self.env_mut().insert(name.clone(), value.clone());
             }
-        } else if let Some(role_bindings) = self
-            .interpreter
-            .class_role_param_bindings(receiver_class_name)
-        {
+        } else if let Some(role_bindings) = self.class_role_param_bindings(receiver_class_name) {
             for (name, value) in &role_bindings {
                 self.env_mut().insert(name.clone(), value.clone());
             }
@@ -293,8 +286,8 @@ impl VM {
                             self.env_mut().insert("self".to_string(), base.clone());
                         }
                         if !self.type_matches_value(expected, &base) {
-                            self.interpreter.restore_var_bindings(saved_var_bindings);
-                            self.interpreter.pop_method_class();
+                            self.restore_var_bindings(saved_var_bindings);
+                            self.pop_method_class();
                             self.set_current_package(saved_package.clone());
                             self.stack.truncate(saved_stack_depth);
                             let frame = self.pop_call_frame();
@@ -342,7 +335,7 @@ impl VM {
                 if let Value::Str(source_name) = attr_val {
                     // A sigilless attribute is in play — enable the cell-direct
                     // routing's alias-table lookup (Phase 3 Stage 2c (ii)).
-                    self.interpreter.sigilless_attrs_active = true;
+                    self.sigilless_attrs_active = true;
                     // Set up bidirectional alias: !x ↔ alias_name
                     self.env_mut().insert(
                         format!("__mutsu_sigilless_alias::!{}", actual_attr),
@@ -385,28 +378,18 @@ impl VM {
             }
             // Check both the owner class and the receiver class for defaults
             let default_val = self
-                .interpreter
                 .class_attribute_default(owner_class, attr_name)
-                .or_else(|| {
-                    self.interpreter
-                        .class_attribute_default(receiver_class_name, attr_name)
-                });
+                .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
             if let Some(def) = default_val {
                 // Register for $!attr and $.attr variable names
-                self.interpreter
-                    .set_var_default(&format!("!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!(".{}", attr_name), def.clone());
+                self.set_var_default(&format!("!{}", attr_name), def.clone());
+                self.set_var_default(&format!(".{}", attr_name), def.clone());
                 // Also register for @!attr/@.attr and %!attr/%.attr so
                 // .VAR.default works on array/hash attributes.
-                self.interpreter
-                    .set_var_default(&format!("@!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("@.{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("%!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("%.{}", attr_name), def);
+                self.set_var_default(&format!("@!{}", attr_name), def.clone());
+                self.set_var_default(&format!("@.{}", attr_name), def.clone());
+                self.set_var_default(&format!("%!{}", attr_name), def.clone());
+                self.set_var_default(&format!("%.{}", attr_name), def);
             }
         }
 
@@ -417,8 +400,8 @@ impl VM {
         ) {
             Ok(bindings) => bindings,
             Err(e) => {
-                self.interpreter.restore_var_bindings(saved_var_bindings);
-                self.interpreter.pop_method_class();
+                self.restore_var_bindings(saved_var_bindings);
+                self.pop_method_class();
                 self.set_current_package(saved_package.clone());
                 self.stack.truncate(saved_stack_depth);
                 let frame = self.pop_call_frame();
@@ -443,13 +426,13 @@ impl VM {
         self.mirror_attributive_params_to_cell(cc, method_def);
         // Load persisted state variable values
         for (slot, key) in &cc.state_locals {
-            if let Some(val) = self.interpreter.get_state_var(key) {
+            if let Some(val) = self.get_state_var(key) {
                 self.locals[*slot] = val.clone();
             }
         }
 
         // Push routine_stack so &?ROUTINE can find the current method
-        self.interpreter.push_method_routine_with_location(
+        self.push_method_routine_with_location(
             owner_class.to_string(),
             method_name.to_string(),
             self.current_source_line(),
@@ -457,7 +440,7 @@ impl VM {
         );
 
         // Execute bytecode
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -481,7 +464,7 @@ impl VM {
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
                         self.stack.push(ret_val);
-                        self.interpreter.discard_let_saves(let_mark);
+                        self.discard_let_saves(let_mark);
                         result = Ok(());
                         break;
                     }
@@ -503,12 +486,12 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter.discard_let_saves(let_mark);
+                    self.discard_let_saves(let_mark);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -521,7 +504,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -558,15 +541,15 @@ impl VM {
             // single source; the legacy attribute writeback is gone.
             attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
 
-            let method_var_bindings = self.interpreter.take_var_bindings();
+            let method_var_bindings = self.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
             for (k, v) in method_var_bindings {
                 restored_bindings.insert(k, v);
             }
-            self.interpreter.restore_var_bindings(restored_bindings);
+            self.restore_var_bindings(restored_bindings);
 
-            self.interpreter.pop_routine();
-            self.interpreter.pop_method_class();
+            self.pop_routine();
+            self.pop_method_class();
         } else {
             // Sync locals back to env
             for (i, local_name) in cc.locals.iter().enumerate() {
@@ -647,15 +630,15 @@ impl VM {
                 merged_env.insert(source_name.clone(), val.clone());
             }
 
-            let method_var_bindings = self.interpreter.take_var_bindings();
+            let method_var_bindings = self.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
             for (k, v) in method_var_bindings {
                 restored_bindings.insert(k, v);
             }
-            self.interpreter.restore_var_bindings(restored_bindings);
+            self.restore_var_bindings(restored_bindings);
 
-            self.interpreter.pop_routine();
-            self.interpreter.pop_method_class();
+            self.pop_routine();
+            self.pop_method_class();
             self.set_current_package(saved_package.clone());
             *self.env_mut() = merged_env;
         }
@@ -676,8 +659,7 @@ impl VM {
         // Apply return type spec (e.g. `--> 5` returns literal 5 from empty body)
         let final_result = if let Some(ref return_spec) = method_def.return_type {
             let effective_return_spec = loan_env!(self, resolved_type_capture_name(return_spec));
-            self.interpreter
-                .finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
+            self.finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
         } else {
             match final_result {
                 Ok(v) => Ok(v),
@@ -893,16 +875,16 @@ impl VM {
             let scoped = crate::env::Env::scoped_child(parent);
             self.set_env(scoped);
         }
-        let saved_var_bindings = self.interpreter.take_var_bindings();
-        self.interpreter.push_method_class(owner_class.to_string());
+        let saved_var_bindings = self.take_var_bindings();
+        self.push_method_class(owner_class.to_string());
 
         let saved_package = self.current_package().to_string();
-        if self.interpreter.has_class_scoped_subs(receiver_class_name) {
+        if self.has_class_scoped_subs(receiver_class_name) {
             self.set_current_package(receiver_class_name.to_string());
         }
 
         // Compute role context without touching env
-        let role_context: Option<String> = if self.interpreter.is_role(owner_class) {
+        let role_context: Option<String> = if self.is_role(owner_class) {
             Some(owner_class.to_string())
         } else {
             method_def
@@ -930,8 +912,8 @@ impl VM {
                     && !self.type_matches_value(constraint, &val)
                 {
                     // Type mismatch — fall back to slow path for proper error
-                    self.interpreter.restore_var_bindings(saved_var_bindings);
-                    self.interpreter.pop_method_class();
+                    self.restore_var_bindings(saved_var_bindings);
+                    self.pop_method_class();
                     self.set_current_package(saved_package);
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
@@ -1061,7 +1043,7 @@ impl VM {
 
         // Load persisted state variable values
         for (slot, key) in &cc.state_locals {
-            if let Some(val) = self.interpreter.get_state_var(key) {
+            if let Some(val) = self.get_state_var(key) {
                 self.locals[*slot] = val.clone();
             }
         }
@@ -1072,29 +1054,19 @@ impl VM {
                 continue;
             }
             let default_val = self
-                .interpreter
                 .class_attribute_default(owner_class, attr_name)
-                .or_else(|| {
-                    self.interpreter
-                        .class_attribute_default(receiver_class_name, attr_name)
-                });
+                .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
             if let Some(def) = default_val {
-                self.interpreter
-                    .set_var_default(&format!("!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!(".{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("@!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("@.{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("%!{}", attr_name), def.clone());
-                self.interpreter
-                    .set_var_default(&format!("%.{}", attr_name), def);
+                self.set_var_default(&format!("!{}", attr_name), def.clone());
+                self.set_var_default(&format!(".{}", attr_name), def.clone());
+                self.set_var_default(&format!("@!{}", attr_name), def.clone());
+                self.set_var_default(&format!("@.{}", attr_name), def.clone());
+                self.set_var_default(&format!("%!{}", attr_name), def.clone());
+                self.set_var_default(&format!("%.{}", attr_name), def);
             }
         }
 
-        self.interpreter.push_method_routine_with_location(
+        self.push_method_routine_with_location(
             owner_class.to_string(),
             method_name.to_string(),
             self.current_source_line(),
@@ -1102,7 +1074,7 @@ impl VM {
         );
 
         // Execute bytecode (same as slow path)
-        let let_mark = self.interpreter.let_saves_len();
+        let let_mark = self.let_saves_len();
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -1125,7 +1097,7 @@ impl VM {
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
                         self.stack.push(ret_val);
-                        self.interpreter.discard_let_saves(let_mark);
+                        self.discard_let_saves(let_mark);
                         result = Ok(());
                         break;
                     }
@@ -1145,12 +1117,12 @@ impl VM {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.interpreter.discard_let_saves(let_mark);
+                    self.discard_let_saves(let_mark);
                     result = Ok(());
                     break;
                 }
                 Err(e) if e.is_fail => {
-                    let failure = self.interpreter.fail_error_to_failure_value(&e);
+                    let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
@@ -1163,7 +1135,7 @@ impl VM {
                     break;
                 }
             }
-            if self.interpreter.is_halted() {
+            if self.is_halted() {
                 break;
             }
         }
@@ -1208,15 +1180,15 @@ impl VM {
         // local/env writes before the env is torn down.
         let attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
 
-        let method_var_bindings = self.interpreter.take_var_bindings();
+        let method_var_bindings = self.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;
         for (k, v) in method_var_bindings {
             restored_bindings.insert(k, v);
         }
-        self.interpreter.restore_var_bindings(restored_bindings);
+        self.restore_var_bindings(restored_bindings);
 
-        self.interpreter.pop_routine();
-        self.interpreter.pop_method_class();
+        self.pop_routine();
+        self.pop_method_class();
         self.set_current_package(saved_package);
 
         if can_skip_merge {
@@ -1281,8 +1253,7 @@ impl VM {
 
         let final_result = if let Some(ref return_spec) = method_def.return_type {
             let effective_return_spec = loan_env!(self, resolved_type_capture_name(return_spec));
-            self.interpreter
-                .finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
+            self.finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
         } else {
             match final_result {
                 Ok(v) => Ok(v),

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -257,7 +257,7 @@ impl VM {
 
     fn reduction_op_associativity(&self, op: &str) -> ReductionAssoc {
         let infix_name = format!("infix:<{}>", op);
-        if let Some(assoc) = self.interpreter.infix_associativity(&infix_name) {
+        if let Some(assoc) = self.infix_associativity(&infix_name) {
             return match assoc.as_str() {
                 "right" => ReductionAssoc::Right,
                 "chain" => ReductionAssoc::Chain,
@@ -333,7 +333,7 @@ impl VM {
     }
 
     fn reduction_callable_arity(&self, callable: &Value) -> usize {
-        let (params, param_defs) = self.interpreter.callable_signature(callable);
+        let (params, param_defs) = self.callable_signature(callable);
         if !param_defs.is_empty() {
             let mut total = 0usize;
             let mut required = 0usize;
@@ -833,7 +833,7 @@ impl VM {
             ));
         }
         // Stringifying an unhandled Failure throws
-        if let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val) {
+        if let Some(err) = self.failure_to_runtime_error_if_unhandled(&val) {
             return Err(err);
         }
         // Check for user-defined prefix:<~> multi sub first (operator overloading).
@@ -1148,7 +1148,7 @@ impl VM {
             let env_key = format!("&{}", name);
             let is_declared = self.env().contains_key(&env_key);
             if !is_declared {
-                let suggestions = self.interpreter.suggest_routine_names(name);
+                let suggestions = self.suggest_routine_names(name);
                 return Err(RuntimeError::undeclared_routine_symbols(
                     name,
                     format!("Undeclared routine:\n    {} used at line 1", name),
@@ -1206,7 +1206,6 @@ impl VM {
                 _ => remaining.to_string(),
             };
             let val = self
-                .interpreter
                 .get_caller_var(&bare_name, caller_depth)
                 .unwrap_or(Value::Nil);
             self.stack.push(val);
@@ -1303,10 +1302,9 @@ impl VM {
             Value::Str(s) => s.to_string(),
             _ => unreachable!("AssignExpr name must be a string constant"),
         };
-        self.interpreter.check_readonly_for_modify(&name)?;
+        self.check_readonly_for_modify(&name)?;
         if name.starts_with('%')
             && self
-                .interpreter
                 .var_type_constraint_fast(&name)
                 .and_then(|s| Self::quant_hash_trait_from_constraint(s.as_str()))
                 == Some("Mix")
@@ -1322,8 +1320,8 @@ impl VM {
             let is_routine_symbol = self.has_function(bare)
                 || self.has_multi_function(bare)
                 || self.has_proto(bare)
-                || self.interpreter.resolve_token_defs(bare).is_some()
-                || self.interpreter.has_proto_token(bare);
+                || self.resolve_token_defs(bare).is_some()
+                || self.has_proto_token(bare);
             if is_routine_symbol && !has_variable_slot {
                 return Err(RuntimeError::assignment_ro(None));
             }
@@ -1452,7 +1450,7 @@ impl VM {
                     if let Some(ref cv) = current_val
                         && let Some(info) = self.container_type_metadata(cv)
                     {
-                        assigned = self.interpreter.tag_container_metadata(assigned, info);
+                        assigned = self.tag_container_metadata(assigned, info);
                     }
                 }
             }
@@ -1485,13 +1483,13 @@ impl VM {
             Self::normalize_scalar_assignment_value(raw_val)
         };
         if matches!(val, Value::Nil)
-            && let Some(def) = self.interpreter.var_default(&name)
+            && let Some(def) = self.var_default(&name)
         {
             val = def.clone();
         }
-        if self.interpreter.fatal_mode
+        if self.fatal_mode
             && !name.contains("__mutsu_")
-            && let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val)
+            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
         {
             return Err(err);
         }
@@ -2086,7 +2084,7 @@ impl VM {
                 if base_op == "o" {
                     let mut acc = list[0].clone();
                     for item in &list[1..] {
-                        acc = self.interpreter.compose_callables(acc, item.clone());
+                        acc = self.compose_callables(acc, item.clone());
                     }
                     self.stack.push(acc);
                     return Ok(());
@@ -2353,7 +2351,7 @@ impl VM {
     pub(super) fn exec_routine_magic_op(&mut self) -> Result<(), RuntimeError> {
         // Skip pointy-block entries in the routine stack so that &?ROUTINE
         // inside a pointy block sees the enclosing routine (sub/method).
-        let routine_stack = self.interpreter.routine_stack();
+        let routine_stack = self.routine_stack();
         let entry = routine_stack
             .iter()
             .rev()
@@ -2362,7 +2360,7 @@ impl VM {
             // Anonymous subs are pushed with "<anon>" as the sentinel name.
             // Return the block_stack Sub directly so callers can invoke it.
             if frame.name.is_empty() || frame.name == "<anon>" {
-                if let Some(val) = self.interpreter.block_stack_top().cloned()
+                if let Some(val) = self.block_stack_top().cloned()
                     && matches!(val, Value::Sub(_))
                 {
                     self.stack.push(val);
@@ -2382,7 +2380,7 @@ impl VM {
     }
 
     pub(super) fn exec_block_magic_op(&mut self) -> Result<(), RuntimeError> {
-        if let Some(val) = self.interpreter.block_stack_top().cloned() {
+        if let Some(val) = self.block_stack_top().cloned() {
             if matches!(val, Value::Sub(_)) {
                 self.stack.push(val);
             } else {
@@ -2396,8 +2394,8 @@ impl VM {
 
     pub(super) fn exec_take_op(&mut self) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap_or(Value::Nil);
-        if self.interpreter.gather_items_len() > 0 {
-            self.interpreter.take_value(val)
+        if self.gather_items_len() > 0 {
+            self.take_value(val)
         } else {
             // No enclosing gather — raise a CX::Take control exception so a
             // CONTROL block can observe it. If unhandled, the runtime wraps
@@ -2443,7 +2441,7 @@ impl VM {
     pub(super) fn exec_phaser_end_op(&mut self, code: &CompiledCode, idx: u32, site_id: u64) {
         // Only register each END phaser once (by site_id), even if the
         // opcode is encountered multiple times inside a repeatedly-called closure.
-        if !self.interpreter.register_end_phaser_site(site_id) {
+        if !self.register_end_phaser_site(site_id) {
             return;
         }
         let stmt = &code.stmt_pool[idx as usize];
@@ -2533,9 +2531,7 @@ impl VM {
             declared_constraint,
             "List" | "Array" | "Positional" | "Seq" | "Cool" | "Any" | "Mu" | "Iterable"
         ) || {
-            let ultimate_base = self
-                .interpreter
-                .resolve_subset_base_type(declared_constraint);
+            let ultimate_base = self.resolve_subset_base_type(declared_constraint);
             matches!(
                 ultimate_base.as_str(),
                 "List"
@@ -2598,7 +2594,7 @@ impl VM {
             }
             // Infinite ranges and non-matching types fall through to normal check
         }
-        if matches!(value, Value::Nil) && self.interpreter.is_definite_constraint(constraint) {
+        if matches!(value, Value::Nil) && self.is_definite_constraint(constraint) {
             return Err(RuntimeError::new(format!(
                 "X::Syntax::Variable::MissingInitializer: Variable definition of type {} needs to be given an initializer",
                 constraint
@@ -2654,10 +2650,7 @@ impl VM {
                 } else {
                     // When assigning an unhandled Failure to a typed variable,
                     // explode the Failure first (Raku behavior)
-                    if let Some(err) = self
-                        .interpreter
-                        .failure_to_runtime_error_if_unhandled(&value)
-                    {
+                    if let Some(err) = self.failure_to_runtime_error_if_unhandled(&value) {
                         return Err(err);
                     }
                     if bind_mode {
@@ -2673,21 +2666,17 @@ impl VM {
                     ));
                 }
             }
-        } else if !self.interpreter.has_type(declared_constraint)
+        } else if !self.has_type(declared_constraint)
             && !is_core_raku_type(declared_constraint)
             && !loan_env!(self, has_type_capture_binding(declared_constraint))
         {
             // Check if this is a suppressed nested class name that can be resolved
-            if self
-                .interpreter
-                .resolve_suppressed_type(declared_constraint)
-                .is_none()
-            {
+            if self.resolve_suppressed_type(declared_constraint).is_none() {
                 // Unknown user-defined type — reject it.
                 // In Raku this is a compile-time failure grouped into an
                 // X::Comp::Group whose `.sorrows` holds the underlying
                 // X::Undeclared (with type "Did you mean" suggestions).
-                let suggestions = self.interpreter.suggest_type_names(constraint);
+                let suggestions = self.suggest_type_names(constraint);
                 let mut undecl_msg = format!("Type '{}' is not declared.", constraint);
                 if suggestions.len() == 1 {
                     undecl_msg.push_str(&format!(" Did you mean '{}'?", suggestions[0]));
@@ -2723,7 +2712,7 @@ impl VM {
         }
         if !matches!(value, Value::Nil)
             && !self.type_matches_value(constraint, &value)
-            && !self.interpreter.is_container_subclass(constraint)
+            && !self.is_container_subclass(constraint)
         {
             if bind_mode {
                 return Err(crate::runtime::utils::type_check_binding_typed_error(
@@ -2765,7 +2754,7 @@ impl VM {
         // the parent after `await`. `StateVarInit` is emitted only for genuine
         // `state` declarations, so `ff`/`fff`/smart-match internal state (which
         // uses `set_state_var` directly, never a cell) is unaffected.
-        let val = if self.interpreter.shared_vars_active {
+        let val = if self.shared_vars_active {
             let coerced_initial = if name.starts_with('@') {
                 runtime::coerce_to_array(init_val)
             } else if name.starts_with('%') {
@@ -2777,7 +2766,6 @@ impl VM {
             // holds (state mutated before the first thread spawned), else from
             // this declaration's initializer.
             let initial = self
-                .interpreter
                 .get_state_var(&scoped_key)
                 .cloned()
                 .unwrap_or(coerced_initial);
@@ -2792,15 +2780,12 @@ impl VM {
                 "__mutsu_shared_state::{}",
                 crate::runtime::Interpreter::normalize_state_key(&scoped_key)
             );
-            let cell = self
-                .interpreter
-                .get_or_init_shared_state_cell(&shared_key, initial);
+            let cell = self.get_or_init_shared_state_cell(&shared_key, initial);
             // Keep the local store pointing at the cell too, so the exit-time
             // writeback and any non-cell reader observe the same Arc.
-            self.interpreter
-                .set_state_var(scoped_key.clone(), cell.clone());
+            self.set_state_var(scoped_key.clone(), cell.clone());
             cell
-        } else if let Some(stored) = self.interpreter.get_state_var(&scoped_key) {
+        } else if let Some(stored) = self.get_state_var(&scoped_key) {
             stored.clone()
         } else {
             // Coerce @ variables to Array and % variables to Hash,
@@ -2812,8 +2797,7 @@ impl VM {
             } else {
                 init_val
             };
-            self.interpreter
-                .set_state_var(scoped_key.clone(), coerced.clone());
+            self.set_state_var(scoped_key.clone(), coerced.clone());
             coerced
         };
         self.locals[slot_idx] = val.clone();
@@ -2861,10 +2845,10 @@ impl VM {
         let undo_start = undo_start as usize;
         let post_start = post_start as usize;
         let end = end as usize;
-        let routine_snapshot = self.interpreter.snapshot_routine_registry();
+        let routine_snapshot = self.snapshot_routine_registry();
         let saved_env = self.env().clone();
         let saved_locals = self.locals.clone();
-        let once_scope = self.interpreter.next_once_scope_id();
+        let once_scope = self.next_once_scope_id();
         // Track variables declared within this block scope.
         self.block_declared_vars
             .push(std::collections::HashSet::new());
@@ -2875,13 +2859,13 @@ impl VM {
         self.run_range(code, pre_start, enter_start, compiled_fns)?;
 
         let enter_result = self.run_range(code, enter_start, body_start, compiled_fns);
-        self.interpreter.push_once_scope(once_scope);
-        self.interpreter.push_block_scope_depth();
-        self.interpreter.push_lexical_class_scope();
-        self.interpreter.push_enum_scope();
+        self.push_once_scope(once_scope);
+        self.push_block_scope_depth();
+        self.push_lexical_class_scope();
+        self.push_enum_scope();
         let stack_base = self.stack.len();
         let topic_before = self.last_topic_value.clone();
-        let end_phaser_count_before = self.interpreter.end_phaser_count();
+        let end_phaser_count_before = self.end_phaser_count();
         // If ENTER died, skip the body but still run LEAVE phasers
         let mut body_result = if let Err(e) = enter_result {
             Err(e)
@@ -2975,7 +2959,7 @@ impl VM {
         }
         let post_res = self.run_range(code, post_start, end, compiled_fns);
 
-        self.interpreter.restore_routine_registry(routine_snapshot);
+        self.restore_routine_registry(routine_snapshot);
 
         // Pop the block-declared variables set.
         let block_declared = self.block_declared_vars.pop().unwrap_or_default();
@@ -2985,10 +2969,9 @@ impl VM {
         // Update captured envs of END phasers registered during this block
         // so they see the final values of block-scoped variables (which will
         // be removed from env when the block scope is restored below).
-        if self.interpreter.end_phaser_count() > end_phaser_count_before {
+        if self.end_phaser_count() > end_phaser_count_before {
             let current = self.env().clone();
-            self.interpreter
-                .update_end_phaser_envs(end_phaser_count_before, &current);
+            self.update_end_phaser_envs(end_phaser_count_before, &current);
         }
         let current_env = self.env().clone();
         let mut restored_env = saved_env.clone();
@@ -3063,7 +3046,7 @@ impl VM {
             if !saved_env.contains_key(local_name) {
                 continue;
             }
-            if let Some(val) = self.interpreter.get_our_var(qualified).cloned() {
+            if let Some(val) = self.get_our_var(qualified).cloned() {
                 if *slot < self.locals.len() {
                     self.locals[*slot] = val.clone();
                 }
@@ -3093,14 +3076,14 @@ impl VM {
         // the now-gone binding (`my %h := SetHash.new(...)` inside a block
         // must not leave `%h` readonly in the outer scope).
         for name in &block_declared {
-            self.interpreter.readonly_vars_mut().remove(name);
+            self.readonly_vars_mut().remove(name);
         }
         // Note: `our`-scoped variables persist in our_vars and are accessible
         // via package-qualified names (e.g., $Pkg::var) after block exit.
-        self.interpreter.pop_enum_scope();
-        self.interpreter.pop_lexical_class_scope();
-        self.interpreter.pop_block_scope_depth();
-        self.interpreter.pop_once_scope();
+        self.pop_enum_scope();
+        self.pop_lexical_class_scope();
+        self.pop_block_scope_depth();
+        self.pop_once_scope();
 
         if let Err(e) = post_res {
             // POST failure overrides successful body and return-value body exits
@@ -3124,7 +3107,7 @@ impl VM {
         Ok(())
     }
 
-    fn is_exceptional_block_exit(err: &RuntimeError) -> bool {
+    pub(crate) fn is_exceptional_block_exit(err: &RuntimeError) -> bool {
         if err.is_fail {
             return true;
         }
@@ -3203,9 +3186,9 @@ impl VM {
         let end = body_end as usize;
         let label = label.clone();
         let stack_base = self.stack.len();
-        let once_scope = self.interpreter.next_once_scope_id();
-        self.interpreter.push_once_scope(once_scope);
-        self.interpreter.push_enum_scope();
+        let once_scope = self.next_once_scope_id();
+        self.push_once_scope(once_scope);
+        self.push_enum_scope();
         let saved_env = if scope_isolate {
             Some((self.env().clone(), self.locals.clone()))
         } else {
@@ -3251,8 +3234,8 @@ impl VM {
                 Err(e) => break Err(e),
             }
         };
-        self.interpreter.pop_enum_scope();
-        self.interpreter.pop_once_scope();
+        self.pop_enum_scope();
+        self.pop_once_scope();
         // Restore scope if scope_isolate is true
         if let Some((saved_env, saved_locals)) = saved_env {
             let block_result = self.stack.pop().unwrap_or(Value::Nil);
@@ -3314,11 +3297,11 @@ impl VM {
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
-        let scope = loan_env!(self, current_once_scope())
-            .unwrap_or_else(|| self.interpreter.next_once_scope_id());
+        let scope =
+            loan_env!(self, current_once_scope()).unwrap_or_else(|| self.next_once_scope_id());
         let site_key = Self::const_str(code, key_idx);
         let cache_key = format!("{scope}::{site_key}");
-        if let Some(value) = self.interpreter.get_once_value(&cache_key).cloned() {
+        if let Some(value) = self.get_once_value(&cache_key).cloned() {
             self.stack.push(value);
             *ip = body_end as usize;
             return Ok(());
@@ -3333,7 +3316,7 @@ impl VM {
         } else {
             Value::Nil
         };
-        self.interpreter.set_once_value(cache_key, value.clone());
+        self.set_once_value(cache_key, value.clone());
         self.stack.push(value);
         *ip = end;
         Ok(())
@@ -3366,7 +3349,7 @@ impl VM {
         } else {
             old_val
         };
-        self.interpreter.let_saves_push(name, save_val, is_temp);
+        self.let_saves_push(name, save_val, is_temp);
     }
 
     /// Recursively deep-copy a Value so that Array/Hash snapshots are
@@ -3399,7 +3382,7 @@ impl VM {
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
-        let mark = self.interpreter.let_saves_len();
+        let mark = self.let_saves_len();
         let body_start = *ip + 1;
         let end = body_end as usize;
         match self.run_range(code, body_start, end, compiled_fns) {

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -75,7 +75,7 @@ impl VM {
             return None;
         }
         // Mixin role method bypass
-        if self.interpreter.mixin_role_has_method(target, &method_name) {
+        if self.mixin_role_has_method(target, &method_name) {
             return None;
         }
         // Instance-specific bypasses (avoid for non-Instance targets)
@@ -126,17 +126,16 @@ impl VM {
                     method_name.as_str(),
                     "gist" | "Str" | "Stringy" | "raku" | "perl"
                 );
-                let render_overridden =
-                    is_pure_render && self.interpreter.has_user_method(&cn, &method_name);
+                let render_overridden = is_pure_render && self.has_user_method(&cn, &method_name);
                 if (!is_pure_render || render_overridden)
                     && (self.type_matches_value("Real", target)
                         || self.type_matches_value("Numeric", target)
-                        || self.interpreter.has_user_method(&cn, "Bridge"))
+                        || self.has_user_method(&cn, "Bridge"))
                 {
                     return None;
                 }
                 // Native method on instance class
-                if self.interpreter.is_native_method(&cn, &method_name) {
+                if self.is_native_method(&cn, &method_name) {
                     return None;
                 }
             }
@@ -247,9 +246,7 @@ impl VM {
         if method_name == "decode" {
             return result.map(|res| {
                 res.map(|value| match value {
-                    Value::Str(decoded) => {
-                        Value::str(self.interpreter.translate_newlines_for_decode(&decoded))
-                    }
+                    Value::Str(decoded) => Value::str(self.translate_newlines_for_decode(&decoded)),
                     other => other,
                 })
             });
@@ -319,7 +316,7 @@ impl VM {
         {
             // Hashes embed metadata in `HashData`; re-tag the cloned value
             // (no-op Arc for array/instance side-table containers).
-            result = Some(Ok(self.interpreter.tag_container_metadata(v, info)));
+            result = Some(Ok(self.tag_container_metadata(v, info)));
         }
 
         result

--- a/src/vm/vm_native_extrema.rs
+++ b/src/vm/vm_native_extrema.rs
@@ -65,9 +65,7 @@ impl VM {
             }
         }
 
-        let by_arity = by
-            .as_ref()
-            .map(|b| self.interpreter.extrema_callable_arity(b));
+        let by_arity = by.as_ref().map(|b| self.extrema_callable_arity(b));
 
         // The generic fold flattens a single list argument, so wrap the target.
         let positional = [target.clone()];
@@ -85,12 +83,7 @@ impl VM {
 
         match adverb {
             None => Some(Ok(result)),
-            Some(adv) => Some(self.interpreter.apply_extrema_adverb(
-                &positional,
-                result,
-                want_max,
-                Some(&adv),
-            )),
+            Some(adv) => Some(self.apply_extrema_adverb(&positional, result, want_max, Some(&adv))),
         }
     }
 
@@ -125,9 +118,7 @@ impl VM {
             }
         }
 
-        let by_arity = by
-            .as_ref()
-            .map(|b| self.interpreter.extrema_callable_arity(b));
+        let by_arity = by.as_ref().map(|b| self.extrema_callable_arity(b));
         let positional = [target.clone()];
         Some(crate::runtime::Interpreter::minmax_from_values_generic(
             &positional,

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -29,7 +29,7 @@ impl FirstMatcher for VmFirstMatcher<'_> {
                 .vm_call_on_value(pattern.clone(), vec![call_item], None)?
                 .truthy())
         } else {
-            Ok(self.0.interpreter.smart_match(item, pattern))
+            Ok(self.0.smart_match(item, pattern))
         }
     }
 }

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -206,7 +206,7 @@ impl VM {
             let meta = self.container_type_metadata(target);
             let mut new_array = Value::real_array(source_after);
             if let Some(info) = meta {
-                new_array = self.interpreter.tag_container_metadata(new_array, info);
+                new_array = self.tag_container_metadata(new_array, info);
             }
             self.set_env_with_main_alias(&name, new_array);
         }

--- a/src/vm/vm_native_sort.rs
+++ b/src/vm/vm_native_sort.rs
@@ -42,7 +42,7 @@ impl SortCaller for VmSortCaller<'_> {
     }
 
     fn callable_arity(&self, callable: Option<&Value>) -> Result<usize, RuntimeError> {
-        self.0.interpreter.sort_callable_arity(callable)
+        self.0.sort_callable_arity(callable)
     }
 }
 

--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -37,9 +37,7 @@ impl VM {
         name: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if !crate::runtime::Interpreter::is_test_function_name(name)
-            || !self.interpreter.test_module_loaded()
-        {
+        if !crate::runtime::Interpreter::is_test_function_name(name) || !self.test_module_loaded() {
             return None;
         }
         // Some Test names collide with core builtins (notably `run`, which is the
@@ -54,11 +52,11 @@ impl VM {
         // `call_function` do before reaching `call_test_function`: strip the
         // synthetic `__test_callsite_line` argument and stash it so TAP
         // diagnostics report the right source line.
-        let (clean_args, callsite_line) = self.interpreter.sanitize_call_args(args);
+        let (clean_args, callsite_line) = self.sanitize_call_args(args);
         loan_env!(self, set_pending_callsite_line(callsite_line));
         match loan_env!(self, call_test_function(name, &clean_args)) {
             // Matched and handled by the typed Test dispatcher.
-            Ok(Some(value)) => Some(self.interpreter.maybe_fetch_rw_proxy(value, true)),
+            Ok(Some(value)) => Some(self.maybe_fetch_rw_proxy(value, true)),
             // `is_test_function_name` said yes but the dispatcher declined: fall
             // back to the generic path so behaviour is never lost.
             Ok(None) => None,

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -53,12 +53,12 @@ impl VM {
     /// gone the VM react loop dispatches every `whenever`/`LAST`/`QUIT`/`CLOSE`
     /// callback natively. A `when`/`default`/`succeed` inside the body counts as
     /// handled; any other error propagates.
-    fn call_supply_quit_handler(
+    pub(crate) fn call_supply_quit_handler(
         &mut self,
         quit_cb: Value,
         reason: Value,
     ) -> Result<(), RuntimeError> {
-        let saved_when = self.interpreter.when_matched();
+        let saved_when = self.when_matched();
         loan_env!(self, set_when_matched(false));
         match self.call_react_callback(&quit_cb, vec![reason]) {
             Ok(_) => {
@@ -82,7 +82,7 @@ impl VM {
     /// Used when `done;` was called in the react body and we just need to
     /// clean up without processing events.
     pub(crate) fn run_react_event_loop_drain(&mut self) {
-        let _ = self.interpreter.supply_emit_buffer.pop();
+        let _ = self.supply_emit_buffer.pop();
     }
 
     /// Deliver one value to a `whenever` subscription's callback, mapping the
@@ -126,11 +126,7 @@ impl VM {
 
     pub(crate) fn run_react_event_loop(&mut self) -> Result<(), RuntimeError> {
         // Take the subscriptions collected during the react body
-        let subscriptions = self
-            .interpreter
-            .supply_emit_buffer
-            .pop()
-            .unwrap_or_default();
+        let subscriptions = self.supply_emit_buffer.pop().unwrap_or_default();
         if subscriptions.is_empty() {
             return Ok(());
         }
@@ -233,19 +229,16 @@ impl VM {
                             // return). Direct emits stream live; inner `whenever`
                             // registrations still flow through `supply_emit_buffer`
                             // and are set up as ReactSubscriptions below.
-                            self.interpreter
-                                .supply_stream_consumers
-                                .push(StreamConsumer {
-                                    supplier_id: emitter_supplier_id,
-                                    consumer_cb: callback.clone(),
-                                    done: false,
-                                });
+                            self.supply_stream_consumers.push(StreamConsumer {
+                                supplier_id: emitter_supplier_id,
+                                consumer_cb: callback.clone(),
+                                done: false,
+                            });
                             let (od_res, emitted, body_ran_done) = loan_env!(
                                 self,
                                 run_on_demand_body(on_demand_cb.clone(), Some(emitter_supplier_id),)
                             );
                             let streamed_done = self
-                                .interpreter
                                 .supply_stream_consumers
                                 .pop()
                                 .map(|c| c.done)
@@ -281,9 +274,7 @@ impl VM {
                                 if crate::runtime::Interpreter::is_supply_subscription_registration(
                                     &v,
                                 ) {
-                                    if let Some(mut rsub) =
-                                        self.interpreter.value_to_react_subscription(&v)
-                                    {
+                                    if let Some(mut rsub) = self.value_to_react_subscription(&v) {
                                         rsub.on_demand_done = Some(done_promise.clone());
                                         react_subs.push(rsub);
                                     }
@@ -376,7 +367,7 @@ impl VM {
             }
         }
 
-        self.drive_react_subscriptions(react_subs, SupplyDrivePolicy::React)
+        self.drive_react_subscriptions_nested(react_subs, SupplyDrivePolicy::React)
     }
 
     /// Shared subscription drive loop backing both `react { ... }` and the
@@ -384,7 +375,7 @@ impl VM {
     /// promise-built subscriptions poll through here; `policy` selects how each
     /// emitted value is dispatched and when the loop completes (see
     /// [`SupplyDrivePolicy`]).
-    pub(crate) fn drive_react_subscriptions(
+    pub(crate) fn drive_react_subscriptions_nested(
         &mut self,
         mut react_subs: Vec<ReactSubscription>,
         mut policy: SupplyDrivePolicy,
@@ -588,14 +579,10 @@ impl VM {
                         } => {
                             // Capture values the whenever block `emit`s so a
                             // later `done` resolves the promise with the last one.
-                            self.interpreter.supply_emit_buffer.push(Vec::new());
+                            self.supply_emit_buffer.push(Vec::new());
                             let cb_result =
                                 self.call_react_callback(&sub.callback.clone(), vec![value]);
-                            let emitted = self
-                                .interpreter
-                                .supply_emit_buffer
-                                .pop()
-                                .unwrap_or_default();
+                            let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
                             if let Some(last) = emitted.last() {
                                 *last_value = last.clone();
                             }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -316,7 +316,7 @@ impl VM {
                 // next await — disconnecting the parent from the shared cell.
                 // `set_shared_var` only updates entries that already exist, so this
                 // is a no-op when the name was never snapshotted.
-                if self.interpreter.shared_vars_active {
+                if self.shared_vars_active {
                     loan_env!(self, set_shared_var(s, container.clone()));
                 }
             });
@@ -484,24 +484,16 @@ impl VM {
             self.method_resolve_cache.clear();
             self.last_method_resolve = None;
             self.fast_method_cache.clear();
-            if *is_export && !self.interpreter.suppress_exports {
+            if *is_export && !self.suppress_exports {
                 let pkg = self.current_package().to_string();
-                self.interpreter.register_exported_sub(
-                    pkg.clone(),
-                    resolved_name.clone(),
-                    export_tags.clone(),
-                );
+                self.register_exported_sub(pkg.clone(), resolved_name.clone(), export_tags.clone());
                 // If a custom `is` trait mixed a role into this routine, the
                 // resulting Mixin lives in the lexical env as `&name` but would
                 // be dropped when the module scope exits. Capture it so `import`
                 // can restore the trait-modified value.
                 let code_var_key = format!("&{}", resolved_name);
                 if let Some(val @ Value::Mixin(..)) = self.env().get(&code_var_key) {
-                    self.interpreter.record_exported_sub_value(
-                        pkg,
-                        resolved_name.clone(),
-                        val.clone(),
-                    );
+                    self.record_exported_sub_value(pkg, resolved_name.clone(), val.clone());
                 }
             }
             for (alt_params, alt_param_defs) in signature_alternates {
@@ -553,13 +545,7 @@ impl VM {
                 body,
                 multi,
             } => {
-                self.interpreter.register_token_decl(
-                    &name.resolve(),
-                    params,
-                    param_defs,
-                    body,
-                    *multi,
-                );
+                self.register_token_decl(&name.resolve(), params, param_defs, body, *multi);
                 Ok(())
             }
             _ => Err(RuntimeError::new(
@@ -584,11 +570,9 @@ impl VM {
         } = stmt
         {
             let name_str = name.resolve();
-            self.interpreter
-                .register_proto_decl(&name_str, params, param_defs, body)?;
+            self.register_proto_decl(&name_str, params, param_defs, body)?;
             if *is_export {
-                self.interpreter
-                    .register_proto_decl_as_global(&name_str, params, param_defs, body)?;
+                self.register_proto_decl_as_global(&name_str, params, param_defs, body)?;
             }
             // Apply custom trait_mod:<is> for each non-builtin trait (only if defined)
             if !custom_traits.is_empty() {
@@ -640,7 +624,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::ProtoToken { name } = stmt {
-            self.interpreter.register_proto_token_decl(&name.resolve());
+            self.register_proto_token_decl(&name.resolve());
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterProtoToken expects ProtoToken"))
@@ -721,7 +705,7 @@ impl VM {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
-        self.interpreter.no_module(module)?;
+        self.no_module(module)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
@@ -742,7 +726,7 @@ impl VM {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
-        self.interpreter.need_module(module)?;
+        self.need_module(module)?;
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
@@ -779,7 +763,7 @@ impl VM {
                 Value::make_instance(Symbol::intern("CompUnit::Repository::Installation"), attrs);
             self.env_mut().insert("*REPO".to_string(), repo);
         }
-        self.interpreter.add_lib_path(path);
+        self.add_lib_path(path);
         Ok(())
     }
 
@@ -802,8 +786,7 @@ impl VM {
                 _ => None,
             })
             .unwrap_or_else(|| vec!["DEFAULT".to_string()]);
-        self.interpreter
-            .register_exported_var(self.current_package().to_string(), name, tags);
+        self.register_exported_var(self.current_package().to_string(), name, tags);
         Ok(())
     }
 
@@ -825,16 +808,13 @@ impl VM {
                 Value::Bool(true)
             };
             let name = name.to_string();
-            self.interpreter
-                .set_var_default(&name, default_value.clone());
+            self.set_var_default(&name, default_value.clone());
             // For array/hash variables, also register the container default
             // so that element access on missing indices returns the default.
             if (name.starts_with('@') || name.starts_with('%'))
                 && let Some(container) = self.locals_get_by_name(code, &name)
             {
-                let container = self
-                    .interpreter
-                    .tag_container_default(container, default_value.clone());
+                let container = self.tag_container_default(container, default_value.clone());
                 self.locals_set_by_name(code, &name, container.clone());
                 self.set_env_with_main_alias(&name, container.clone());
                 // Replace existing Nil and uninitialized (Package("Any"))
@@ -861,9 +841,7 @@ impl VM {
                             .collect();
                         let new_arr =
                             Value::Array(Arc::new(crate::value::ArrayData::new(replaced)), kind);
-                        let new_arr = self
-                            .interpreter
-                            .tag_container_default(new_arr, default_value.clone());
+                        let new_arr = self.tag_container_default(new_arr, default_value.clone());
                         self.locals_set_by_name(code, &name, new_arr.clone());
                         self.set_env_with_main_alias(&name, new_arr);
                     }
@@ -888,7 +866,7 @@ impl VM {
                 if has_arg {
                     self.stack.pop(); // discard unsupported trait argument
                 }
-                self.interpreter.mark_readonly(name);
+                self.mark_readonly(name);
                 return Ok(());
             }
             let is_buf_trait = matches!(
@@ -914,7 +892,6 @@ impl VM {
                 let buf_type = match trait_name.as_str() {
                     "buf" | "blob" => {
                         let resolved = self
-                            .interpreter
                             .call_function("EVAL", vec![Value::str(trait_name.clone())])
                             .ok()
                             .or_else(|| self.get_env_with_main_alias(&trait_name))
@@ -982,12 +959,12 @@ impl VM {
                 };
                 // Hashes embed metadata in `HashData`; store the tagged value
                 // back into both the local slot and env.
-                let tagged = self.interpreter.tag_container_metadata(container, info);
+                let tagged = self.tag_container_metadata(container, info);
                 self.locals_set_by_name(code, &name_str, tagged.clone());
                 self.set_env_with_main_alias(&name_str, tagged);
             }
             // Mark the variable read-only to prevent mutation
-            self.interpreter.mark_readonly(&name_str);
+            self.mark_readonly(&name_str);
             self.env_dirty = true;
             return Ok(());
         }
@@ -1072,7 +1049,7 @@ impl VM {
                         // Try to coerce keys to the constraint type for type checking
                         let mut typed_keys = std::collections::HashMap::new();
                         for key in &keys {
-                            let coerced = self.interpreter.try_coerce_str_to_type(key, constraint);
+                            let coerced = self.try_coerce_str_to_type(key, constraint);
                             if let Some(ref typed_val) = coerced {
                                 if !self.type_matches_value(constraint, typed_val) {
                                     let got_type = crate::value::what_type_name(typed_val);
@@ -1128,7 +1105,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some(trait_name.clone()),
                 };
-                let instance = self.interpreter.tag_container_metadata(instance, info);
+                let instance = self.tag_container_metadata(instance, info);
                 self.locals_set_by_name(code, &name_str, instance.clone());
                 self.set_env_with_main_alias(&name_str, instance.clone());
                 // Set type constraint so future assignments are coerced correctly
@@ -1210,8 +1187,7 @@ impl VM {
             )?;
             // Store language revision metadata from the version captured at parse time
             if !name.resolve().is_empty() {
-                self.interpreter
-                    .store_language_revision_from_version(&name.resolve(), language_version);
+                self.store_language_revision_from_version(&name.resolve(), language_version);
             }
             // For anonymous enums, push the Map result onto the stack
             if name.resolve().is_empty() {
@@ -1267,7 +1243,7 @@ impl VM {
             // If the name was previously suppressed (e.g. by a `my class` in an
             // earlier block), clear the suppression before running the class body
             // so that references to the class name inside the body can resolve.
-            self.interpreter.unsuppress_name(&resolved_name);
+            self.unsuppress_name(&resolved_name);
             // TODO: Detect redeclaration of package-scoped classes across
             // EVAL boundaries (X::Redeclaration). Currently deferred because
             // distinguishing EVAL re-definitions from normal re-execution
@@ -1291,19 +1267,16 @@ impl VM {
             )?;
             // Check for assignment to native read-only params before
             // compiling (X::Assignment::RO::Comp).
-            if let Some(err) = self
-                .interpreter
-                .check_class_native_readonly_param_errors(&qualified_name)
-            {
+            if let Some(err) = self.check_class_native_readonly_param_errors(&qualified_name) {
                 return Err(err);
             }
             // Compile method bodies to bytecode for the fast path
-            self.interpreter.compile_class_methods(&qualified_name);
+            self.compile_class_methods(&qualified_name);
             // Register CUnion repr if present
             if let Some(repr_name) = repr
                 && repr_name == "CUnion"
             {
-                self.interpreter.register_cunion_class(&qualified_name);
+                self.register_cunion_class(&qualified_name);
             }
             // Register the class name in the lexical env so that
             // ::("ClassName") indirect lookups can find it in the current scope.
@@ -1326,10 +1299,10 @@ impl VM {
             // within the enclosing class body and its methods.
             let parent_is_class = qualified_name
                 .rsplit_once("::")
-                .map(|(parent, _)| self.interpreter.has_class(parent))
+                .map(|(parent, _)| self.has_class(parent))
                 .unwrap_or(false);
             if qualified_name != resolved_name && !resolved_name.contains("::") && parent_is_class {
-                self.interpreter.suppress_name(&resolved_name);
+                self.suppress_name(&resolved_name);
                 // Register the short name in the lexical env so it resolves
                 // within the enclosing class scope (e.g. `Frog` inside `Forest`).
                 let env = self.env_mut();
@@ -1360,15 +1333,12 @@ impl VM {
             // When `my class` is used, register the class name as lexically scoped
             // so it gets suppressed when the enclosing block scope exits.
             if *is_lexical {
-                self.interpreter
-                    .register_lexical_class(resolved_name.clone());
+                self.register_lexical_class(resolved_name.clone());
                 // Also mark as my-scoped so it's excluded from the parent package stash
-                self.interpreter
-                    .mark_my_scoped_package_item(qualified_name.clone());
+                self.mark_my_scoped_package_item(qualified_name.clone());
             }
             // Store language revision metadata from the version captured at parse time
-            self.interpreter
-                .store_language_revision_from_version(&qualified_name, language_version);
+            self.store_language_revision_from_version(&qualified_name, language_version);
 
             // Dispatch custom `is` traits via trait_mod:<is> if defined.
             // Merge explicitly parsed custom_traits with deferred_traits
@@ -1417,18 +1387,18 @@ impl VM {
             // Check MONKEY-TYPING pragma: we check if `use MONKEY-TYPING` or `use MONKEY`
             // was issued. Since the compiler simply ignores these `use` statements,
             // we track them at the interpreter level.
-            if !self.interpreter.monkey_typing_enabled() {
+            if !self.monkey_typing_enabled() {
                 return Err(RuntimeError::typed_msg(
                     "X::Syntax::Augment::WithoutMonkeyTyping",
                     "augment not allowed without 'use MONKEY-TYPING'",
                 ));
             }
             if *is_role {
-                return Err(self.interpreter.augment_role_error(&name_str));
+                return Err(self.augment_role_error(&name_str));
             }
             loan_env!(self, augment_class(&name_str, body))?;
             // Recompile augmented class methods for the fast path
-            self.interpreter.compile_class_methods(&name_str);
+            self.compile_class_methods(&name_str);
             Ok(())
         } else {
             Err(RuntimeError::new("AugmentClass expects AugmentClass stmt"))
@@ -1467,12 +1437,12 @@ impl VM {
             };
             // If the short name was suppressed by an earlier lexical type with
             // the same name, re-enable it before registering the new role.
-            self.interpreter.unsuppress_name(&name_str);
+            self.unsuppress_name(&name_str);
             loan_env!(
                 self,
                 register_role_decl(&qualified_name, type_params, type_param_defs, body, *is_rw,)
             )?;
-            if *is_export && !self.interpreter.suppress_exports {
+            if *is_export && !self.suppress_exports {
                 // The compiler may have pre-qualified the role name
                 // (e.g. `R1` → `GH2613::R1`) when compiling under a
                 // `unit module`. Exports use the short bare name and
@@ -1483,17 +1453,12 @@ impl VM {
                     } else {
                         (current_package.clone(), name_str.clone())
                     };
-                self.interpreter.register_exported_var(
-                    export_pkg,
-                    export_short,
-                    export_tags.clone(),
-                );
+                self.register_exported_var(export_pkg, export_short, export_tags.clone());
             }
             // Store language revision metadata from the version captured at parse time
-            self.interpreter
-                .store_language_revision_from_version(&qualified_name, language_version);
+            self.store_language_revision_from_version(&qualified_name, language_version);
             // Compile role method bodies to bytecode
-            self.interpreter.compile_role_methods(&qualified_name);
+            self.compile_role_methods(&qualified_name);
             self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(Symbol::intern(&qualified_name)),
@@ -1530,7 +1495,6 @@ impl VM {
             // `role R { method foo {}; R.foo }` work.
             if type_params.is_empty() {
                 let deferred = self
-                    .interpreter
                     .get_role_def(&qualified_name)
                     .map(|r| r.deferred_body_stmts.clone())
                     .unwrap_or_default();
@@ -1541,7 +1505,6 @@ impl VM {
 
             // Gather deferred custom traits from role registration
             let role_deferred = self
-                .interpreter
                 .get_role_def(&qualified_name)
                 .map(|r| r.deferred_custom_traits.clone())
                 .unwrap_or_default();
@@ -1598,18 +1561,14 @@ impl VM {
             // The subset type itself is already registered under its bare name
             // in the global env by `register_subset_decl`, so importing only
             // needs to make `import M` succeed (and validate export tags).
-            if *is_export && !self.interpreter.suppress_exports {
+            if *is_export && !self.suppress_exports {
                 let (export_pkg, export_short) =
                     if let Some((pkg, short)) = resolved_name.rsplit_once("::") {
                         (pkg.to_string(), short.to_string())
                     } else {
                         (self.current_package().to_string(), resolved_name)
                     };
-                self.interpreter.register_exported_var(
-                    export_pkg,
-                    export_short,
-                    export_tags.clone(),
-                );
+                self.register_exported_var(export_pkg, export_short, export_tags.clone());
             }
             self.env_dirty = true;
             Ok(())
@@ -1628,11 +1587,11 @@ impl VM {
         let end = body_end as usize;
         let body_start = *ip + 1;
         let label = self.stack.pop().unwrap_or(Value::Nil).to_string_value();
-        let ctx = self.interpreter.begin_subtest();
+        let ctx = self.begin_subtest();
         let saved_depth = self.stack.len();
         let run_result = self.run_range(code, body_start, end, compiled_fns);
         self.stack.truncate(saved_depth);
-        self.interpreter.finish_subtest(ctx, &label, run_result)?;
+        self.finish_subtest(ctx, &label, run_result)?;
         self.env_dirty = true;
         *ip = end;
         Ok(())
@@ -1658,7 +1617,7 @@ impl VM {
         self.sync_env_from_locals(code);
 
         // Enter react mode: whenever blocks will register subscriptions
-        self.interpreter.enter_react();
+        self.enter_react();
         let saved_depth = self.stack.len();
         let run_result = self.run_range(code, body_start, end, compiled_fns);
         self.stack.truncate(saved_depth);
@@ -1721,7 +1680,7 @@ impl VM {
     /// Walk the MRO of `class_name` to find a parameterized Array or Hash parent.
     /// Returns the element type if found (e.g. "Str" for `Array[Str]`).
     fn find_parameterized_container_parent(&self, class_name: &str) -> Option<String> {
-        let parents = self.interpreter.class_parents_readonly(class_name);
+        let parents = self.class_parents_readonly(class_name);
         for parent in &parents {
             if let Some(inner) = parent
                 .strip_prefix("Array[")

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -19,7 +19,7 @@ impl VM {
         }
     }
 
-    fn is_failure_value(value: &Value) -> bool {
+    pub(crate) fn is_failure_value(value: &Value) -> bool {
         matches!(value, Value::Instance { class_name, .. } if class_name == "Failure")
     }
 
@@ -216,7 +216,7 @@ impl VM {
         }
     }
 
-    fn union_insert_set_elem(elems: &mut HashSet<String>, value: &Value) {
+    pub(crate) fn union_insert_set_elem(elems: &mut HashSet<String>, value: &Value) {
         let pair_selected = |weight: &Value| weight.truthy() || matches!(weight, Value::Nil);
         match value {
             Value::Set(items, _) => {

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -610,7 +610,7 @@ impl VM {
                 Err(err) => {
                     // Non-existing method or attribute dies.
                     // Set pending dispatch error so the caller can propagate it.
-                    self.interpreter.set_pending_dispatch_error(err);
+                    self.set_pending_dispatch_error(err);
                     return false;
                 }
             }

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -478,7 +478,7 @@ impl VM {
 
         if nth_spec.is_none() && x_count.is_none() && !global {
             if perl5 {
-                let found = self.interpreter.regex_find_first_p5(&pattern, &text);
+                let found = self.regex_find_first_p5(&pattern, &text);
                 if let Some((start, end)) = found {
                     let out = Self::apply_substitutions(
                         &text,
@@ -674,7 +674,7 @@ impl VM {
     /// reached after a substitution actually occurred, so a non-matching
     /// `s///` against a read-only topic stays a no-op.
     fn write_subst_topic_checked(&mut self, result: Value) -> Result<(), RuntimeError> {
-        if self.interpreter.readonly_vars().contains("_") {
+        if self.readonly_vars().contains("_") {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert(
                 "message".to_string(),
@@ -724,7 +724,7 @@ impl VM {
 
         if nth_spec.is_none() && x_count.is_none() && !global {
             if perl5 {
-                let found = self.interpreter.regex_find_first_p5(&pattern, &text);
+                let found = self.regex_find_first_p5(&pattern, &text);
                 if let Some((start, end)) = found {
                     let out = Self::apply_substitutions(
                         &text,
@@ -2184,7 +2184,6 @@ impl VM {
             let lookup_name = Self::canonical_infix_lookup_name(&name);
             let infix_name = format!("infix:<{}>", lookup_name.as_ref());
             let assoc = self
-                .interpreter
                 .infix_associativity(&infix_name)
                 .unwrap_or_else(|| "left".to_string());
             if assoc == "chain" && call_args.len() > 2 {
@@ -2247,7 +2246,7 @@ impl VM {
         if let Some(Value::Int(id)) = self.env().get("__mutsu_callable_id") {
             return format!("callable:{id}");
         }
-        if let Some(frame) = self.interpreter.routine_stack_top() {
+        if let Some(frame) = self.routine_stack_top() {
             return format!("routine:{}::{}", frame.package, frame.name);
         }
         "top".to_string()
@@ -2290,7 +2289,6 @@ impl VM {
         is_fff: bool,
     ) -> Value {
         let seq = self
-            .interpreter
             .get_state_var(key)
             .and_then(|v| match v {
                 Value::Int(i) if *i > 0 => Some(*i),
@@ -2301,30 +2299,26 @@ impl VM {
         if seq > 0 {
             let current = seq;
             if rhs {
-                self.interpreter
-                    .set_state_var(key.to_string(), Value::Int(0));
+                self.set_state_var(key.to_string(), Value::Int(0));
                 if exclude_end {
                     Value::Nil
                 } else {
                     Value::Int(current)
                 }
             } else {
-                self.interpreter
-                    .set_state_var(key.to_string(), Value::Int(current + 1));
+                self.set_state_var(key.to_string(), Value::Int(current + 1));
                 Value::Int(current)
             }
         } else if lhs {
             if !is_fff && rhs {
-                self.interpreter
-                    .set_state_var(key.to_string(), Value::Int(0));
+                self.set_state_var(key.to_string(), Value::Int(0));
                 if exclude_start || exclude_end {
                     Value::Nil
                 } else {
                     Value::Int(1)
                 }
             } else {
-                self.interpreter
-                    .set_state_var(key.to_string(), Value::Int(2));
+                self.set_state_var(key.to_string(), Value::Int(2));
                 if exclude_start {
                     Value::Nil
                 } else {
@@ -2375,7 +2369,6 @@ impl VM {
         let scope = self.flip_flop_scope_key();
         let state_key = format!("__mutsu_ff_state::{scope}::{site_id}");
         let seq = self
-            .interpreter
             .get_state_var(&state_key)
             .and_then(|v| match v {
                 Value::Int(i) if *i > 0 => Some(*i),

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -113,7 +113,7 @@ impl VM {
         )
     }
 
-    fn string_succ(s: &str) -> String {
+    pub(crate) fn string_succ(s: &str) -> String {
         crate::builtins::str_increment::string_succ(s)
     }
 

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -47,8 +47,7 @@ impl VM {
         mixins: &std::collections::HashMap<String, Value>,
         method_name: &str,
     ) -> Option<String> {
-        self.interpreter
-            .delegated_role_attr_key_from_mixins(mixins, method_name)
+        self.delegated_role_attr_key_from_mixins(mixins, method_name)
     }
 
     fn assign_mixin_container_slot(
@@ -575,7 +574,7 @@ impl VM {
         name: &str,
         value: Value,
     ) -> Result<Value, RuntimeError> {
-        if let Some(constraint) = self.interpreter.var_type_constraint_fast(name).cloned()
+        if let Some(constraint) = self.var_type_constraint_fast(name).cloned()
             && let Some(trait_name) = Self::quant_hash_trait_from_constraint(&constraint)
         {
             // Only coerce if the variable IS a QuantHash container (declared via `is`),
@@ -590,7 +589,7 @@ impl VM {
                 return self.try_compiled_method_or_interpret(value, trait_name, vec![]);
             }
         }
-        if self.interpreter.check_readonly_for_modify(name).is_err()
+        if self.check_readonly_for_modify(name).is_err()
             && matches!(
                 value,
                 Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _)
@@ -724,7 +723,6 @@ impl VM {
                         | "BagHash"
                         | "MixHash"
                 ) || self
-                    .interpreter
                     .class_composed_roles(&cn)
                     .is_some_and(|roles| roles.iter().any(|r| r == "Associative"));
                 if does_associative {
@@ -775,7 +773,7 @@ impl VM {
                         key_type: None,
                         declared_type: Some("Map".to_string()),
                     };
-                    Ok(self.interpreter.tag_container_metadata(mapped_val, info))
+                    Ok(self.tag_container_metadata(mapped_val, info))
                 }
             }
             // Non-Associative values: coerce to Map
@@ -786,7 +784,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                Ok(self.interpreter.tag_container_metadata(hash, info))
+                Ok(self.tag_container_metadata(hash, info))
             }
             Value::Seq(items) | Value::Slip(items) => {
                 let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
@@ -795,7 +793,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                Ok(self.interpreter.tag_container_metadata(hash, info))
+                Ok(self.tag_container_metadata(hash, info))
             }
             _ => {
                 // For other types (Int, Str, etc.), coerce to Map via
@@ -807,7 +805,7 @@ impl VM {
                     key_type: None,
                     declared_type: Some("Map".to_string()),
                 };
-                Ok(self.interpreter.tag_container_metadata(hash, info))
+                Ok(self.tag_container_metadata(hash, info))
             }
         }
     }
@@ -1004,7 +1002,7 @@ impl VM {
         (raw_val, None)
     }
 
-    fn resolve_sigilless_alias_source_name(&self, source_name: &str) -> String {
+    pub(crate) fn resolve_sigilless_alias_source_name(&self, source_name: &str) -> String {
         let mut resolved = source_name.to_string();
         let mut seen = std::collections::HashSet::new();
         while seen.insert(resolved.clone()) {
@@ -1133,11 +1131,9 @@ impl VM {
                 };
                 let coerced_val = if let Some(constraint) = &value_constraint {
                     if matches!(val, Value::Nil) {
-                        if let Some(default) = self.interpreter.var_default(var_name) {
+                        if let Some(default) = self.var_default(var_name) {
                             default.clone()
-                        } else if explicit_initializer
-                            && self.interpreter.is_definite_constraint(constraint)
-                        {
+                        } else if explicit_initializer && self.is_definite_constraint(constraint) {
                             return Err(runtime::utils::type_check_element_typed_error(
                                 var_name, constraint, val,
                             ));
@@ -1222,11 +1218,9 @@ impl VM {
                 continue;
             }
             if matches!(item, Value::Nil) {
-                if let Some(default) = self.interpreter.var_default(var_name) {
+                if let Some(default) = self.var_default(var_name) {
                     coerced_items.push(default.clone());
-                } else if explicit_initializer
-                    && self.interpreter.is_definite_constraint(constraint)
-                {
+                } else if explicit_initializer && self.is_definite_constraint(constraint) {
                     return Err(runtime::utils::type_check_element_typed_error(
                         var_name, constraint, item,
                     ));
@@ -1283,8 +1277,7 @@ impl VM {
                     _ => item.clone(),
                 }
             } else if matches!(target_type.as_str(), "Array" | "List" | "Hash") && is_coercion {
-                self.interpreter
-                    .try_coerce_value_for_constraint(&format!("{target_type}()"), item.clone())?
+                self.try_coerce_value_for_constraint(&format!("{target_type}()"), item.clone())?
             } else {
                 loan_env!(
                     self,
@@ -1324,10 +1317,7 @@ impl VM {
                         }
                         let saved_env = std::mem::take(vm.env_mut());
                         *vm.env_mut() = sub_env;
-                        let result = vm
-                            .interpreter
-                            .eval_block_value(&data.body)
-                            .unwrap_or(Value::Nil);
+                        let result = vm.eval_block_value(&data.body).unwrap_or(Value::Nil);
                         *vm.env_mut() = saved_env;
                         match result {
                             Value::Int(i) => i,
@@ -1712,7 +1702,7 @@ impl VM {
         let rhs = self.stack.pop().unwrap();
         self.resolve_pending_alias_binds(code);
         let name = Self::const_str(code, name_idx);
-        self.interpreter.check_readonly_for_increment(name)?;
+        self.check_readonly_for_increment(name)?;
         // Default to Nil (NOT Int(0) like `++`) so `my $w; $w ~= "z"` yields "z",
         // not "0z"; the binary op descalarizes/numifies/stringifies Nil itself.
         let raw_val = self
@@ -1785,7 +1775,7 @@ impl VM {
             self.stack.push(val);
             return Ok(());
         }
-        self.interpreter.check_readonly_for_increment(name)?;
+        self.check_readonly_for_increment(name)?;
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
@@ -1870,7 +1860,7 @@ impl VM {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
-        self.interpreter.check_readonly_for_increment(name)?;
+        self.check_readonly_for_increment(name)?;
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
@@ -2037,7 +2027,7 @@ impl VM {
             Value::Nil => {
                 // Check if the container has an `is default(...)` value;
                 // e.g. `my @a is default(42); @a[0]++` should increment 42.
-                if let Some(def) = self.interpreter.var_default(&name) {
+                if let Some(def) = self.var_default(&name) {
                     if matches!(def, Value::Nil) {
                         Value::Int(0)
                     } else {
@@ -2079,7 +2069,7 @@ impl VM {
                     | "MixHash"
                     | "Seq"
             )
-            && !self.interpreter.is_container_subclass(constraint)
+            && !self.is_container_subclass(constraint)
             && !matches!(&new_val, Value::Nil)
             && !self.type_matches_value(constraint, &new_val)
         {
@@ -2272,7 +2262,7 @@ impl VM {
         name_idx: u32,
     ) -> Option<Result<(), RuntimeError>> {
         // Cheap early-out: only meaningful while a thread shares this env.
-        if !self.interpreter.shared_vars_active {
+        if !self.shared_vars_active {
             return None;
         }
         if !self.local_bind_pairs.is_empty() {
@@ -2312,13 +2302,10 @@ impl VM {
         }
         // Reject when type/key constraints, defaults, readonly, or bound indices
         // exist — those need the full assignment path's healing.
-        if self
-            .interpreter
-            .var_type_constraint_fast(var_name)
-            .is_some()
-            || self.interpreter.var_default(var_name).is_some()
-            || self.interpreter.var_hash_key_constraint_fast(var_name)
-            || self.interpreter.readonly_vars().contains(var_name)
+        if self.var_type_constraint_fast(var_name).is_some()
+            || self.var_default(var_name).is_some()
+            || self.var_hash_key_constraint_fast(var_name)
+            || self.readonly_vars().contains(var_name)
         {
             return None;
         }
@@ -2362,7 +2349,7 @@ impl VM {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Option<Result<(), RuntimeError>> {
-        if !self.interpreter.shared_vars_active {
+        if !self.shared_vars_active {
             return None;
         }
         if !self.local_bind_pairs.is_empty() {
@@ -2390,12 +2377,9 @@ impl VM {
         }
         // Reject typed / defaulted / shaped / readonly / bound arrays — those need
         // the full path's native-fill, hole, and shape handling.
-        if self
-            .interpreter
-            .var_type_constraint_fast(var_name)
-            .is_some()
-            || self.interpreter.var_default(var_name).is_some()
-            || self.interpreter.readonly_vars().contains(var_name)
+        if self.var_type_constraint_fast(var_name).is_some()
+            || self.var_default(var_name).is_some()
+            || self.readonly_vars().contains(var_name)
         {
             return None;
         }
@@ -2493,13 +2477,10 @@ impl VM {
         }
         // Check that no type constraints, key constraints, or defaults exist
         // Use fast lookups that avoid format! allocations
-        if self
-            .interpreter
-            .var_type_constraint_fast(var_name)
-            .is_some()
-            || self.interpreter.var_default(var_name).is_some()
-            || self.interpreter.var_hash_key_constraint_fast(var_name)
-            || self.interpreter.readonly_vars().contains(var_name)
+        if self.var_type_constraint_fast(var_name).is_some()
+            || self.var_default(var_name).is_some()
+            || self.var_hash_key_constraint_fast(var_name)
+            || self.readonly_vars().contains(var_name)
         {
             return None;
         }
@@ -2582,7 +2563,7 @@ impl VM {
                     // Sync $*HOME when %*ENV<HOME> changes
                     if key == "HOME" {
                         let home_str = val.to_string_value();
-                        let home_val = self.interpreter.make_io_path_instance(&home_str);
+                        let home_val = self.make_io_path_instance(&home_str);
                         self.env_mut()
                             .insert("$*HOME".to_string(), home_val.clone());
                         self.env_mut().insert("*HOME".to_string(), home_val);
@@ -2609,7 +2590,7 @@ impl VM {
                     }
                     if key == "HOME" {
                         let home_str = val.to_string_value();
-                        let home_val = self.interpreter.make_io_path_instance(&home_str);
+                        let home_val = self.make_io_path_instance(&home_str);
                         self.env_mut()
                             .insert("$*HOME".to_string(), home_val.clone());
                         self.env_mut().insert("*HOME".to_string(), home_val);
@@ -2661,10 +2642,10 @@ impl VM {
         // Guard against stale pointer-keyed defaults (Arc reuse across
         // allocations): only trust the saved default when a name-based
         // var_default is also registered.
-        let saved_default_outer = if self.interpreter.var_default(&save_var_name).is_some() {
+        let saved_default_outer = if self.var_default(&save_var_name).is_some() {
             self.env()
                 .get(&save_var_name)
-                .and_then(|v| self.interpreter.container_default(v).cloned())
+                .and_then(|v| self.container_default(v).cloned())
         } else {
             None
         };
@@ -2687,15 +2668,15 @@ impl VM {
             // be written back into both env and the fast-path local slot
             // (`tag_container_metadata` returns the same Arc for non-hash
             // containers, whose Arc-pointer side table is updated in place).
-            let tagged = self.interpreter.tag_container_metadata(container, info);
+            let tagged = self.tag_container_metadata(container, info);
             self.env_mut().insert(save_var_name.clone(), tagged.clone());
             self.locals_set_by_name(code, &save_var_name, tagged);
         }
         if let Some(def) = saved_default_outer
             && let Some(container) = self.env().get(&save_var_name).cloned()
-            && self.interpreter.container_default(&container).is_none()
+            && self.container_default(&container).is_none()
         {
-            let tagged = self.interpreter.tag_container_default(container, def);
+            let tagged = self.tag_container_default(container, def);
             self.env_mut().insert(save_var_name.clone(), tagged.clone());
             self.locals_set_by_name(code, &save_var_name, tagged);
         }
@@ -2844,7 +2825,7 @@ impl VM {
         // For typed container elements, explicit `is default(...)` wins over
         // the nominal type-object fallback when Nil is assigned.
         let val = if matches!(val, Value::Nil) {
-            if let Some(default) = self.interpreter.var_default(&var_name) {
+            if let Some(default) = self.var_default(&var_name) {
                 default.clone()
             } else if let Some(constraint) = loan_env!(self, var_type_constraint(&var_name)) {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
@@ -3113,7 +3094,7 @@ impl VM {
                 }
                 // Check value type constraint for hash slice assignment
                 if let Some(constraint) = loan_env!(self, var_type_constraint(&var_name))
-                    && !self.interpreter.is_container_subclass(&constraint)
+                    && !self.is_container_subclass(&constraint)
                 {
                     for v in &vals {
                         if !matches!(v, Value::Nil) && !self.type_matches_value(&constraint, v) {
@@ -3254,7 +3235,7 @@ impl VM {
                             constraint.as_str(),
                             "Hash" | "Array" | "Map" | "List" | "Bag" | "Set" | "Mix"
                                 | "BagHash" | "SetHash" | "MixHash" | "Seq"
-                        ) || self.interpreter.is_container_subclass(&constraint)))
+                        ) || self.is_container_subclass(&constraint)))
                 {
                     return Err(runtime::utils::type_check_element_typed_error(
                         &var_name,
@@ -3393,8 +3374,8 @@ impl VM {
                 // Pre-compute whether this %-sigiled variable was bound via `:=`.
                 // Bound hash variables are marked readonly, so we use that as a signal
                 // to allow in-place mutation (preserving shared identity).
-                let is_bound_hash_var = var_name.starts_with('%')
-                    && self.interpreter.readonly_vars().contains(&var_name);
+                let is_bound_hash_var =
+                    var_name.starts_with('%') && self.readonly_vars().contains(&var_name);
                 // Type check for parameterized SetHash[T] element binding.
                 // Only applies when the declared type is explicitly parameterized
                 // (e.g. SetHash[Str]), not when the constraint is just `is SetHash`.
@@ -3446,12 +3427,10 @@ impl VM {
                     attributes,
                     ..
                 }) = self.env().get(&var_name)
-                    && self
-                        .interpreter
-                        .is_container_subclass(&class_name.resolve())
+                    && self.is_container_subclass(&class_name.resolve())
                 {
                     let cn = class_name.resolve();
-                    if self.interpreter.class_inherits_from_immutable_setty(&cn) {
+                    if self.class_inherits_from_immutable_setty(&cn) {
                         let display = format!("{}()", cn);
                         return Err(RuntimeError::assignment_ro_typename(&cn, &display));
                     }
@@ -3821,7 +3800,7 @@ impl VM {
                 // Sync $*HOME when %*ENV<HOME> changes
                 if var_name == "%*ENV" && key == "HOME" {
                     let home_str = val.to_string_value();
-                    let home_val = self.interpreter.make_io_path_instance(&home_str);
+                    let home_val = self.make_io_path_instance(&home_str);
                     self.env_mut()
                         .insert("$*HOME".to_string(), home_val.clone());
                     self.env_mut().insert("*HOME".to_string(), home_val);
@@ -3852,10 +3831,10 @@ impl VM {
             // Re-attach the `is default(...)` element default after mutation
             // when a rebuild dropped it (embedded in ArrayData, so plain
             // Arc::make_mut mutations carry it on their own).
-            if let Some(def) = self.interpreter.var_default(&var_name).cloned()
-                && self.interpreter.container_default(&updated).is_none()
+            if let Some(def) = self.var_default(&var_name).cloned()
+                && self.container_default(&updated).is_none()
             {
-                let tagged = self.interpreter.tag_container_default(updated.clone(), def);
+                let tagged = self.tag_container_default(updated.clone(), def);
                 self.set_env_with_main_alias(&var_name, tagged.clone());
                 self.update_local_if_exists(code, &var_name, &tagged);
             }
@@ -3938,8 +3917,8 @@ impl VM {
                 Self::normalize_scalar_assignment_value(val)
             };
 
-            self.interpreter.check_readonly_for_modify(&resolved_name)?;
-            if let Some(default) = self.interpreter.var_default(&resolved_name)
+            self.check_readonly_for_modify(&resolved_name)?;
+            if let Some(default) = self.var_default(&resolved_name)
                 && matches!(val, Value::Nil)
             {
                 val = default.clone();
@@ -4920,7 +4899,7 @@ impl VM {
     ) -> Option<String> {
         let (bare, is_private) = Self::attr_twigil_base(name)?;
         let map = attrs.as_map();
-        if is_private && let Some(owner) = self.interpreter.method_class_stack_top() {
+        if is_private && let Some(owner) = self.method_class_stack_top() {
             let qkey = format!("{}\0{}", owner, bare);
             if map.contains_key(&qkey) {
                 return Some(qkey);
@@ -4956,7 +4935,7 @@ impl VM {
         if Self::attr_twigil_base(name).is_some() {
             return Some(name.to_string());
         }
-        if !self.interpreter.sigilless_attrs_active {
+        if !self.sigilless_attrs_active {
             return None;
         }
         self.sigilless_attr_twigil(name)
@@ -5084,7 +5063,7 @@ impl VM {
         let name = name.to_string();
         let env_val = self
             .get_env_with_main_alias(&name)
-            .or_else(|| self.interpreter.get_shared_var(&name));
+            .or_else(|| self.get_shared_var(&name));
         // `:=` bindings / slot refs keep their legacy env handling.
         if env_val
             .as_ref()
@@ -5140,7 +5119,7 @@ impl VM {
         // The mutating ops write the new container into env (or shared_vars).
         let val = self
             .get_env_with_main_alias(&name)
-            .or_else(|| self.interpreter.get_shared_var(&name));
+            .or_else(|| self.get_shared_var(&name));
         let Some(val) = val else {
             return;
         };
@@ -5211,7 +5190,7 @@ impl VM {
         let idx = idx as usize;
         // Check if this variable has a binding alias (e.g. from $CALLER::foo := $other_var)
         let name = code.locals.get(idx).cloned().unwrap_or_default();
-        if let Some(bound_to) = self.interpreter.resolve_binding(&name) {
+        if let Some(bound_to) = self.resolve_binding(&name) {
             let bound_to = bound_to.to_string();
             if let Some(val) = self.env().get(&bound_to).cloned() {
                 self.stack.push(val);
@@ -5221,7 +5200,7 @@ impl VM {
         // Attribute locals (!attr) modified by CAS: env holds the authoritative
         // value since sync_locals_from_env skips !-prefixed names for performance.
         if name.starts_with('!')
-            && self.interpreter.is_shared_var_dirty(&name)
+            && self.is_shared_var_dirty(&name)
             && let Some(val) = self.env().get(&name).cloned()
         {
             self.locals[idx] = val.clone();
@@ -5231,7 +5210,7 @@ impl VM {
         // Atomic-variable read: skip entirely (a `format!` plus two
         // `var_type_constraint` lookups) when no atomic storage has ever been
         // registered — the common case on this hot local-read path.
-        if self.interpreter.atomic_var_seen() {
+        if self.atomic_var_seen() {
             let atomic_name = name.strip_prefix('$').unwrap_or(&name);
             let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
             // Only use the scalar atomic fast path for scalar ($) variables.
@@ -5241,7 +5220,7 @@ impl VM {
                 && (loan_env!(self, var_type_constraint(&name)).as_deref() == Some("atomicint")
                     || loan_env!(self, var_type_constraint(atomic_name)).as_deref()
                         == Some("atomicint")
-                    || self.interpreter.get_shared_var(&atomic_name_key).is_some());
+                    || self.get_shared_var(&atomic_name_key).is_some());
             if is_atomic_int {
                 let fetched = loan_env!(
                     self,
@@ -5256,7 +5235,7 @@ impl VM {
         // shared key.  Check it first so reads pick up the latest CAS'd value.
         if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");
-            if let Some(shared_val) = self.interpreter.get_shared_var(&atomic_key) {
+            if let Some(shared_val) = self.get_shared_var(&atomic_key) {
                 self.locals[idx] = shared_val.clone();
                 self.stack.push(shared_val);
                 return Ok(());
@@ -5266,7 +5245,7 @@ impl VM {
         // still holds an old local snapshot. Prefer the shared copy so reads
         // observe the latest value without forcing array COW on every push.
         if (name.starts_with('@') || name.starts_with('%'))
-            && let Some(shared_val) = self.interpreter.get_shared_var(&name)
+            && let Some(shared_val) = self.get_shared_var(&name)
         {
             self.stack.push(shared_val);
             return Ok(());
@@ -5322,7 +5301,7 @@ impl VM {
         }
         // Fast path: non-Nil values are always valid — skip env lookup
         if matches!(val, Value::Nil) {
-            if let Some(shared_val) = self.interpreter.get_shared_var(&name) {
+            if let Some(shared_val) = self.get_shared_var(&name) {
                 self.stack.push(shared_val);
                 return Ok(());
             }
@@ -5339,11 +5318,11 @@ impl VM {
                 )));
             }
             // `is default(...)`: return the default value instead of Nil.
-            if let Some(def) = self.interpreter.var_default(&name) {
+            if let Some(def) = self.var_default(&name) {
                 self.stack.push(def.clone());
                 return Ok(());
             }
-            if let Some(constraint) = self.interpreter.var_type_constraint_fast(&name).cloned() {
+            if let Some(constraint) = self.var_type_constraint_fast(&name).cloned() {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                 // Nil type constraint: the type object for Nil is Value::Nil itself,
                 // not Value::Package("Nil").
@@ -5426,7 +5405,7 @@ impl VM {
         // trait op will re-set it immediately after.
         if is_vardecl {
             let name = &code.locals[idx];
-            self.interpreter.clear_var_default(name);
+            self.clear_var_default(name);
             // Clear the deleted-index tracker left over from a previous
             // same-named variable in an outer scope.
             let deleted_key = format!("__mutsu_deleted_index::{}", name);
@@ -5507,13 +5486,12 @@ impl VM {
                 val = Self::normalize_scalar_assignment_value(val);
             }
             if matches!(val, Value::Nil)
-                && let Some(def) = self.interpreter.var_default(name)
+                && let Some(def) = self.var_default(name)
             {
                 val = def.clone();
             }
-            if let Some(constraint) = self.interpreter.var_type_constraint_fast(name).cloned() {
-                if matches!(val, Value::Nil) && self.interpreter.is_definite_constraint(&constraint)
-                {
+            if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
+                if matches!(val, Value::Nil) && self.is_definite_constraint(&constraint) {
                     if has_explicit_initializer {
                         return Err(runtime::utils::type_check_assignment_typed_error(
                             name,
@@ -5547,18 +5525,16 @@ impl VM {
             // Track lazy-thunk readonly: mark when storing a LazyThunk,
             // unmark when overwriting a LazyThunk with a non-LazyThunk (rebinding).
             if matches!(self.locals[idx], Value::LazyThunk(..)) {
-                self.interpreter.mark_readonly(name);
+                self.mark_readonly(name);
             }
-            if self.interpreter.fatal_mode
+            if self.fatal_mode
                 && !name.contains("__mutsu_")
-                && let Some(err) = self
-                    .interpreter
-                    .failure_to_runtime_error_if_unhandled(&self.locals[idx])
+                && let Some(err) = self.failure_to_runtime_error_if_unhandled(&self.locals[idx])
             {
                 return Err(err);
             }
             // Update env when shared_vars is active; otherwise write through to env.
-            if self.interpreter.shared_vars_active {
+            if self.shared_vars_active {
                 loan_env!(self, set_shared_var(name, self.locals[idx].clone()));
             } else {
                 self.flush_local_to_env(code, idx);
@@ -5767,7 +5743,6 @@ impl VM {
                                 | "buf16"
                                 | "buf32"
                         ) || self
-                            .interpreter
                             .class_composed_roles(&cn)
                             .is_some_and(|roles| roles.iter().any(|r| r == "Positional"));
                         if does_positional {
@@ -5879,7 +5854,6 @@ impl VM {
                                 | "buf16"
                                 | "buf32"
                         ) || self
-                            .interpreter
                             .class_composed_roles(&cn)
                             .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
                             || attributes.contains_key("__mutsu_array_storage")
@@ -5968,7 +5942,7 @@ impl VM {
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(&shape));
                 // Preserve container type metadata
                 if let Some(info) = self.container_type_metadata(&self.locals[idx]) {
-                    assigned = self.interpreter.tag_container_metadata(assigned, info);
+                    assigned = self.tag_container_metadata(assigned, info);
                 }
             }
             let class_name = match &self.locals[idx] {
@@ -6006,14 +5980,14 @@ impl VM {
         };
         if matches!(val, Value::Nil)
             && !matches!(self.locals[idx], Value::Nil)
-            && let Some(def) = self.interpreter.var_default(name)
+            && let Some(def) = self.var_default(name)
         {
             val = def.clone();
         }
         // For array variables with `is default(X)`, replace Nil elements
         // with the default value (Raku container semantics).
         if name.starts_with('@')
-            && let Some(def) = self.interpreter.var_default(name).cloned()
+            && let Some(def) = self.var_default(name).cloned()
             && let Value::Array(ref items, kind) = val
         {
             let is_hole =
@@ -6036,7 +6010,7 @@ impl VM {
             && !name.starts_with('%')
             && !name.starts_with('@')
         {
-            if matches!(val, Value::Nil) && self.interpreter.is_definite_constraint(&constraint) {
+            if matches!(val, Value::Nil) && self.is_definite_constraint(&constraint) {
                 if has_explicit_initializer {
                     return Err(runtime::utils::type_check_assignment_typed_error(
                         name,
@@ -6261,10 +6235,8 @@ impl VM {
                 // subsequent method calls (e.g., get_x) see the binding.
                 for (slot, qualified_name) in &code.our_locals {
                     if *slot == idx {
-                        self.interpreter
-                            .set_our_var(qualified_name.clone(), container.clone());
-                        self.interpreter
-                            .set_our_var(name.to_string(), container.clone());
+                        self.set_our_var(qualified_name.clone(), container.clone());
+                        self.set_our_var(name.to_string(), container.clone());
                     }
                 }
                 self.flush_local_to_env(code, idx);
@@ -6327,9 +6299,9 @@ impl VM {
         // When binding a Proxy to a variable, update FETCH/STORE closures' captured envs
         // so they can reference the Proxy by its binding variable name (simulating capture-by-ref).
         let val = Self::update_proxy_closure_envs(val, name);
-        if self.interpreter.fatal_mode
+        if self.fatal_mode
             && !name.contains("__mutsu_")
-            && let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val)
+            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
         {
             return Err(err);
         }
@@ -6415,13 +6387,13 @@ impl VM {
                 },
             };
             let stored = std::mem::replace(&mut self.locals[idx], Value::Nil);
-            self.locals[idx] = self.interpreter.tag_container_metadata(stored, info);
+            self.locals[idx] = self.tag_container_metadata(stored, info);
         }
         // Use the potentially fixed-up value for env/shared_vars.
         let val = self.locals[idx].clone();
         // Mark variable as readonly when storing a LazyThunk
         if matches!(val, Value::LazyThunk(..)) {
-            self.interpreter.mark_readonly(name);
+            self.mark_readonly(name);
         }
         if (is_bind || is_constant) && name.starts_with('@') {
             // For `:=` bind and `constant @x`, bypass set_shared_var's
@@ -6510,7 +6482,7 @@ impl VM {
         // state left over from a previous lexical with the same name
         // (e.g. when `my @arr[N]` is declared inside a loop body).
         if name.starts_with('@') {
-            self.interpreter.clear_atomic_array_state(name);
+            self.clear_atomic_array_state(name);
         }
         // Before this loop-body-local declaration overwrites the env entry for
         // `name`, record the outer value it shadows so the enclosing same-named
@@ -6663,11 +6635,11 @@ impl VM {
             }
             if matches!(val, Value::Nil)
                 && !matches!(self.locals[idx], Value::Nil)
-                && let Some(def) = self.interpreter.var_default(name)
+                && let Some(def) = self.var_default(name)
             {
                 val = def.clone();
             }
-            if let Some(constraint) = self.interpreter.var_type_constraint_fast(name).cloned() {
+            if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
                 let val = if matches!(val, Value::Nil) {
                     if constraint == "Mu" {
                         val
@@ -6693,16 +6665,14 @@ impl VM {
                 self.locals[idx] = val.clone();
                 self.stack.push(val);
             }
-            if self.interpreter.fatal_mode
+            if self.fatal_mode
                 && !name.contains("__mutsu_")
-                && let Some(err) = self
-                    .interpreter
-                    .failure_to_runtime_error_if_unhandled(&self.locals[idx])
+                && let Some(err) = self.failure_to_runtime_error_if_unhandled(&self.locals[idx])
             {
                 return Err(err);
             }
             // Update env when shared_vars is active; otherwise write through to env.
-            if self.interpreter.shared_vars_active {
+            if self.shared_vars_active {
                 loan_env!(self, set_shared_var(name, self.locals[idx].clone()));
             } else {
                 self.flush_local_to_env(code, idx);
@@ -6719,7 +6689,7 @@ impl VM {
 
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);
         let name = &code.locals[idx];
-        self.interpreter.check_readonly_for_modify(name)?;
+        self.check_readonly_for_modify(name)?;
         let mut val = if name.starts_with('%') {
             self.coerce_hash_var_value(name, raw_val)?
         } else if name.starts_with('@') {
@@ -6757,7 +6727,7 @@ impl VM {
             Self::normalize_scalar_assignment_value(raw_val)
         };
         if matches!(val, Value::Nil)
-            && let Some(def) = self.interpreter.var_default(name)
+            && let Some(def) = self.var_default(name)
         {
             val = def.clone();
         }
@@ -6796,9 +6766,9 @@ impl VM {
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
             loan_env!(self, reset_atomic_var_key(name));
         }
-        if self.interpreter.fatal_mode
+        if self.fatal_mode
             && !name.contains("__mutsu_")
-            && let Some(err) = self.interpreter.failure_to_runtime_error_if_unhandled(&val)
+            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
         {
             return Err(err);
         }
@@ -6823,7 +6793,7 @@ impl VM {
                     None
                 },
             };
-            val = self.interpreter.tag_container_metadata(val, info);
+            val = self.tag_container_metadata(val, info);
         }
         self.locals[idx] = val.clone();
         self.set_env_with_main_alias(name, val.clone());
@@ -6854,7 +6824,7 @@ impl VM {
             let mut entries: HashMap<String, Value> = HashMap::new();
             for (key, val) in self.env().iter() {
                 let key_str = key.resolve();
-                if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+                if self.should_hide_from_my_global_stash(&key_str) {
                     continue;
                 }
                 let display_key = Self::add_sigil_prefix(&key_str);
@@ -6865,7 +6835,7 @@ impl VM {
         }
         if name.strip_suffix("::") == Some("OUR") {
             let mut entries: HashMap<String, Value> = HashMap::new();
-            for (key, val) in self.interpreter.our_vars_iter() {
+            for (key, val) in self.our_vars_iter() {
                 let display_key = Self::add_sigil_prefix(key);
                 entries.insert(display_key, val.clone());
             }
@@ -6891,7 +6861,7 @@ impl VM {
         }
         for (key, val) in self.env().iter() {
             let key_str = key.resolve();
-            if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+            if self.should_hide_from_my_global_stash(&key_str) {
                 continue;
             }
             let display_key = Self::add_sigil_prefix(&key_str);
@@ -6907,7 +6877,7 @@ impl VM {
             let mut entries: HashMap<String, Value> = HashMap::new();
             for (key, val) in self.env().iter() {
                 let key_str = key.resolve();
-                if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+                if self.should_hide_from_my_global_stash(&key_str) {
                     continue;
                 }
                 let display_key = Self::add_sigil_prefix(&key_str);
@@ -6917,7 +6887,7 @@ impl VM {
         }
         if name == "OUR" {
             let mut entries: HashMap<String, Value> = HashMap::new();
-            for (key, val) in self.interpreter.our_vars_iter() {
+            for (key, val) in self.our_vars_iter() {
                 let display_key = Self::add_sigil_prefix(key);
                 entries.insert(display_key, val.clone());
             }
@@ -6936,7 +6906,7 @@ impl VM {
         }
         for (key, val) in self.env().iter() {
             let key_str = key.resolve();
-            if self.interpreter.should_hide_from_my_global_stash(&key_str) {
+            if self.should_hide_from_my_global_stash(&key_str) {
                 continue;
             }
             let display_key = Self::add_sigil_prefix(&key_str);

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -105,11 +105,8 @@ impl VM {
         ) {
             return None;
         }
-        if self
-            .interpreter
-            .var_type_constraint_fast(var_name)
-            .is_some()
-            || self.interpreter.readonly_vars().contains(var_name)
+        if self.var_type_constraint_fast(var_name).is_some()
+            || self.readonly_vars().contains(var_name)
         {
             return None;
         }
@@ -271,10 +268,10 @@ impl VM {
         // for this variable: Arc pointers can be reused across
         // allocations, so a stale pointer-keyed entry from a freed
         // same-named container must not leak into the new container.
-        let saved_default = if self.interpreter.var_default(&var_name).is_some() {
+        let saved_default = if self.var_default(&var_name).is_some() {
             self.env()
                 .get(&var_name)
-                .and_then(|v| self.interpreter.container_default(v).cloned())
+                .and_then(|v| self.container_default(v).cloned())
         } else {
             None
         };
@@ -375,7 +372,7 @@ impl VM {
             && self.container_type_metadata(&container).is_none()
         {
             let container = container.clone();
-            let tagged = self.interpreter.tag_container_metadata(container, info);
+            let tagged = self.tag_container_metadata(container, info);
             self.env_mut().insert(var_name.to_string(), tagged.clone());
             self.update_local_if_exists(code, &var_name, &tagged);
         }
@@ -385,9 +382,9 @@ impl VM {
         // outer scope.
         if let Some(def) = saved_default
             && let Some(container) = self.env().get(&var_name).cloned()
-            && self.interpreter.container_default(&container).is_none()
+            && self.container_default(&container).is_none()
         {
-            let tagged = self.interpreter.tag_container_default(container, def);
+            let tagged = self.tag_container_default(container, def);
             self.env_mut().insert(var_name.clone(), tagged);
         }
         // Sync env value to locals so reads through locals see the

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -116,7 +116,7 @@ impl VM {
                                 return Ok(());
                             }
                         }
-                        let is_obj_hash = self.interpreter.is_object_hash(&target);
+                        let is_obj_hash = self.is_object_hash(&target);
                         let pairs: Vec<(Value, bool)> = items
                             .iter()
                             .map(|k| {
@@ -316,7 +316,7 @@ impl VM {
                     }
                     _ => {
                         // For object hashes, use WHICH for lookup, fallback to hash_key_encode
-                        let lookup_key = if self.interpreter.is_object_hash(&target) {
+                        let lookup_key = if self.is_object_hash(&target) {
                             let which = crate::runtime::utils::value_which_key(&idx);
                             if map.contains_key(&which) {
                                 which

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -43,10 +43,10 @@ impl VM {
                 name: Symbol::intern(name),
                 is_regex: false,
             }
-        } else if self.interpreter.is_name_suppressed(name) {
+        } else if self.is_name_suppressed(name) {
             // If we are inside the parent class of the suppressed nested class,
             // resolve the short name to the qualified name (e.g. Frog -> Forest::Frog).
-            if let Some(qualified) = self.interpreter.resolve_suppressed_type(name) {
+            if let Some(qualified) = self.resolve_suppressed_type(name) {
                 Value::Package(Symbol::intern(&qualified))
             } else {
                 return Err(RuntimeError::new(format!(
@@ -76,7 +76,7 @@ impl VM {
             Value::Num(f64::NAN)
         } else if name == "Inf" {
             Value::Num(f64::INFINITY)
-        } else if name == "Empty" && !self.interpreter.has_type(name) {
+        } else if name == "Empty" && !self.has_type(name) {
             // A user-declared type named `Empty` shadows the empty-Slip term
             // (it is resolved to a Package by the `has_type` branch below).
             // `Inf`/`NaN` are numeric literals and are not shadowable.
@@ -95,7 +95,7 @@ impl VM {
                 // Check for poisoned enum aliases
                 if matches!(v, Value::Enum { .. })
                     && !name.contains("::")
-                    && let Some(pkg_name) = self.interpreter.is_poisoned_enum_alias(name)
+                    && let Some(pkg_name) = self.is_poisoned_enum_alias(name)
                 {
                     let pkg_name = pkg_name.to_string();
                     let mut attrs = std::collections::HashMap::new();
@@ -120,7 +120,7 @@ impl VM {
                     return Err(err);
                 }
                 v.clone()
-            } else if self.interpreter.has_type(name) || Self::is_builtin_type(name) {
+            } else if self.has_type(name) || Self::is_builtin_type(name) {
                 Value::Package(Symbol::intern(Self::resolve_type_alias(name)))
             } else if name.contains("::")
                 && !name.starts_with('$')
@@ -156,9 +156,9 @@ impl VM {
                 self.env_dirty = true;
                 result
             }
-        } else if self.interpreter.has_type(name)
+        } else if self.has_type(name)
             || Self::is_builtin_type(name)
-            || Self::is_type_with_smiley(name, &self.interpreter)
+            || Self::is_type_with_smiley(name, self)
         {
             Value::Package(Symbol::intern(Self::resolve_type_alias(name)))
         } else if let Some(callable) = self.env().get(&format!("&{name}")).cloned()
@@ -170,15 +170,15 @@ impl VM {
             let result = self.vm_call_on_value(callable, Vec::new(), Some(compiled_fns))?;
             self.env_dirty = true;
             result
-        } else if let Some(sub_id) = self.interpreter.wrap_sub_id_for_name(name)
-            && !self.interpreter.is_wrap_dispatching(sub_id)
-            && let Some(sub_val) = self.interpreter.get_wrapped_sub(name)
+        } else if let Some(sub_id) = self.wrap_sub_id_for_name(name)
+            && !self.is_wrap_dispatching(sub_id)
+            && let Some(sub_val) = self.get_wrapped_sub(name)
         {
             let result = self.vm_call_on_value(sub_val, Vec::new(), Some(compiled_fns))?;
             self.env_dirty = true;
             result
         } else if Interpreter::is_test_function_name(name)
-            && self.interpreter.test_mode_active()
+            && self.test_mode_active()
             // Only try test function dispatch for hyphenated names (e.g.
             // `make-temp-dir`, `done-testing`). Single-word names like
             // `run`, `is`, `ok` are either builtins or need args, so they
@@ -227,8 +227,8 @@ impl VM {
         } else if name.contains("::") {
             // Check if this is an access to a non-existent enum variant
             if let Some((pkg, sym)) = name.rsplit_once("::")
-                && self.interpreter.has_enum_type(pkg)
-                && !self.interpreter.has_enum_variant(pkg, sym)
+                && self.has_enum_type(pkg)
+                && !self.has_enum_variant(pkg, sym)
             {
                 return Err(RuntimeError::new(format!(
                     "Could not find symbol '&{}' in '{}'",
@@ -249,7 +249,7 @@ impl VM {
             } else if let Some((pkg_prefix, last_seg)) = name.rsplit_once("::")
                 && !last_seg.is_empty()
                 && last_seg.starts_with(|c: char| c.is_ascii_lowercase())
-                && !self.interpreter.has_type(name)
+                && !self.has_type(name)
                 && !Self::is_builtin_type(name)
                 && !self.has_function(name)
                 && !self.has_multi_function(name)
@@ -268,9 +268,9 @@ impl VM {
                 // and resolve to the bare type name if it exists.
                 let bare = Interpreter::strip_pseudo_packages(name);
                 if bare != name
-                    && (self.interpreter.has_type(bare)
+                    && (self.has_type(bare)
                         || Self::is_builtin_type(bare)
-                        || Self::is_type_with_smiley(bare, &self.interpreter))
+                        || Self::is_type_with_smiley(bare, self))
                 {
                     Value::Package(Symbol::intern(Self::resolve_type_alias(bare)))
                 } else {
@@ -284,7 +284,7 @@ impl VM {
                 Value::Rat(n, d)
             } else if let Some(val) = crate::builtins::unicode::unicode_numeric_int_value(ch) {
                 Value::Int(val)
-            } else if let Some(our_val) = self.interpreter.get_our_var(name).cloned() {
+            } else if let Some(our_val) = self.get_our_var(name).cloned() {
                 // Single-character `our`-scoped constant declared in an inner
                 // block (see the multi-char case below for rationale).
                 our_val
@@ -304,7 +304,7 @@ impl VM {
                 attrs,
             )));
             return Err(err);
-        } else if let Some(our_val) = self.interpreter.get_our_var(name).cloned() {
+        } else if let Some(our_val) = self.get_our_var(name).cloned() {
             // `our`-scoped constants (and `our` variables) declared in an inner
             // block survive block-scope restoration in the package store
             // (`our_vars`) even though the lexical env entry was discarded.

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -238,7 +238,7 @@ impl VM {
             && crate::runtime::native_types::is_native_array_element_type(&meta.value_type)
         {
             let result = Value::real_array(items);
-            let result = self.interpreter.tag_container_metadata(result, meta);
+            let result = self.tag_container_metadata(result, meta);
             return result;
         }
         match source {
@@ -355,7 +355,7 @@ impl VM {
             };
             target = match needed {
                 Some(n) => {
-                    let forced = self.interpreter.force_lazy_io_lines_n(handle, n, words)?;
+                    let forced = self.force_lazy_io_lines_n(handle, n, words)?;
                     if kv {
                         let items = crate::runtime::utils::value_to_list(&forced);
                         let mut kv_items = Vec::with_capacity(items.len() * 2);
@@ -465,7 +465,7 @@ impl VM {
         };
         if let Value::Hash(ref items) = target {
             let hash_val = Value::Hash(items.clone());
-            if let Some(key_type) = self.interpreter.hash_key_type(&hash_val)
+            if let Some(key_type) = self.hash_key_type(&hash_val)
                 && !matches!(index, Value::Whatever | Value::Nil | Value::Sub(..))
             {
                 if let Value::Array(ref keys, ..) = index {
@@ -793,7 +793,7 @@ impl VM {
             (Value::Hash(items), Value::Str(key)) => {
                 let v = self.resolve_hash_entry(&items, &key);
                 if matches!(v, Value::Nil) {
-                    if self.interpreter.hash_autovivify {
+                    if self.hash_autovivify {
                         Value::Hash(items)
                             .hash_autovivify(&key)
                             .unwrap_or(Value::Nil)
@@ -808,7 +808,7 @@ impl VM {
                 let key_str = key.to_string();
                 let v = self.resolve_hash_entry(&items, &key_str);
                 if matches!(v, Value::Nil) {
-                    if self.interpreter.hash_autovivify {
+                    if self.hash_autovivify {
                         Value::Hash(items)
                             .hash_autovivify(&key_str)
                             .unwrap_or(Value::Nil)
@@ -847,7 +847,7 @@ impl VM {
                 let key_str = key.to_string_value();
                 let v = self.resolve_hash_entry(&items, &key_str);
                 if matches!(v, Value::Nil) {
-                    if self.interpreter.hash_autovivify {
+                    if self.hash_autovivify {
                         Value::Hash(items)
                             .hash_autovivify(&key_str)
                             .unwrap_or(Value::Nil)
@@ -1577,7 +1577,7 @@ impl VM {
                 ));
             }
             // Role parameterization: e.g. R1[C1] → ParametricRole
-            (Value::Package(name), idx) if self.interpreter.is_role(&name.resolve()) => {
+            (Value::Package(name), idx) if self.is_role(&name.resolve()) => {
                 let type_args = match idx {
                     Value::Array(items, ..) => items.to_vec(),
                     other => vec![other],

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -312,7 +312,7 @@ impl VM {
         if let Some(info) = old_type_info
             && let Some(updated) = self.env().get(&var_name).cloned()
         {
-            let tagged = self.interpreter.tag_container_metadata(updated, info);
+            let tagged = self.tag_container_metadata(updated, info);
             self.env_mut().insert(var_name.clone(), tagged.clone());
             self.update_local_if_exists(code, &var_name, &tagged);
         }
@@ -487,9 +487,7 @@ impl VM {
                     Value::Array(items, ..) => Value::Int(items.len() as i64),
                     _ => Value::Int(0),
                 };
-                let result = self
-                    .interpreter
-                    .call_sub_value(idx.clone(), vec![len], false)?;
+                let result = self.call_sub_value(idx.clone(), vec![len], false)?;
                 current =
                     Self::index_array_multidim(&current, std::slice::from_ref(&result), false)
                         .unwrap_or(Value::Nil);

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -313,7 +313,7 @@ impl VM {
 
     pub(super) fn typed_container_default(&mut self, target: &Value) -> Value {
         // Check for explicit `is default(...)` on the container first.
-        if let Some(def) = self.interpreter.container_default(target) {
+        if let Some(def) = self.container_default(target) {
             return def.clone();
         }
         if let Some(info) = self.container_type_metadata(target) {
@@ -374,7 +374,7 @@ impl VM {
 
     pub(super) fn anon_state_value(&self, name: &str) -> Option<Value> {
         let key = Self::anon_state_key(name)?;
-        self.interpreter.get_state_var(&key).cloned()
+        self.get_state_var(&key).cloned()
     }
 
     pub(super) fn sync_anon_state_value(&mut self, name: &str, value: &Value) {


### PR DESCRIPTION
## CP-3 collapse — dissolve the bytecode VM into the Interpreter

[docs/vm-state-ownership.md](docs/vm-state-ownership.md) CP-3 / [PLAN.md](PLAN.md) final-collapse: the bytecode VM (`struct VM`) and the `Interpreter` were two mutually-referencing structs (`VM { interpreter: Interpreter, ... }`) that re-entered execution via the `mem::take(self)` + `VM::new(self)` + `*self = interp` **ping-pong** (with `env` loaned across the boundary, CP-1). This dissolves the VM into the Interpreter so a **single struct *is* the bytecode VM**.

### Direction
The survivor is **`Interpreter`** (not `VM`, as the doc originally framed it), because `Interpreter` is the public entry type (`Interpreter::new()`/`.run()` used by main/lib/repl/tests). Keeping it the survivor leaves **all entry points and the public API untouched**. `VM` remains as a `pub(crate) type VM = Interpreter` alias so the ~40 `impl VM` blocks and internal `VM::` references compile unchanged (cosmetic rename deferred). The end state is identical either way.

### What changed
- Former `VM` per-execution registers (stack/locals/call_frames/caches/context flags) moved into `Interpreter`; initialized in `Interpreter::new` + `clone_for_thread`. (env + the 5 shared handles were already on Interpreter.)
- `VM::run` → `Interpreter::run_top`. Panic→`X::AdHoc` boundary extracted to `run_inner_guarded`; both `run_top` (outermost) and `run_nested` (re-entrant carriers) route through it, so a Rust panic in a `dies-ok`/`try` block still flows through try/CATCH.
- Every ping-pong site replaced with in-place re-entry: `run_block_raw` / `run_compiled_block` / `eval_precompiled_block_fast` → `run_nested`; map/grep/sort `run_reuse` loops → `with_nested_registers` (register save/reset/restore extracted from `run_nested`); thread spawns run the cloned per-thread Interpreter directly.
- `loan_env!` / `loan_env_for` become thin self-calls (env is just `self.env`); deleted VM's duplicate accessors + duplicate helpers (one impl each); deleted the now-dead loan/handle scaffolding (`loan_out_env`, `*_handle`, `Env::poisoned`).

Net **−794 lines**. `env_dirty` dual-store is intentionally retained (CP-2: structural, not removable).

### Validation
- `cargo test`: 462/0
- full `prove t/`: 810 files / 7549 tests **PASS**
- clippy + fmt clean
- full `make roast` delegated to this CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)