### PR TITLE
CP-3 cleanup: remove VM type alias + dead Env poison guard

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1041,7 +1041,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     // Buf/Blob.Str throws X::Buf::AsStr
     if (method == "Str" || method == "Stringy")
         && let Value::Instance { class_name, .. } = target
-        && crate::vm::VM::is_buf_value(target)
+        && crate::runtime::Interpreter::is_buf_value(target)
     {
         let cn = class_name.resolve();
         let mut err = RuntimeError::new(format!(
@@ -1060,7 +1060,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     // Buf/Blob .values and .list return the byte values as integers
     if (method == "values" || method == "list")
         && let Value::Instance { attributes, .. } = target
-        && crate::vm::VM::is_buf_value(target)
+        && crate::runtime::Interpreter::is_buf_value(target)
     {
         if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
             return Some(Ok(Value::array(bytes.to_vec())));

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -97,7 +97,7 @@ impl Compiler {
                 // stripped share the same key in local_map but must NOT shadow type
                 // names, so they go through GetBareWord which checks the type registry.
                 if let Some(&slot) = self.local_map.get(name.as_str()) {
-                    if crate::vm::VM::is_builtin_type(name) {
+                    if crate::runtime::Interpreter::is_builtin_type(name) {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         self.code.emit(OpCode::GetBareWord(name_idx));
                     } else if self.sigilless_locals.contains(name.as_str())

--- a/src/env.rs
+++ b/src/env.rs
@@ -129,10 +129,6 @@ pub struct Env {
     /// recursion) stays O(1) while shallow nesting (methods, ~2-5 deep) pays no
     /// flatten.
     depth: u16,
-    /// env-loan guard (CP-1 1e, interim). `true` only for the sentinel left in
-    /// `Interpreter.env` while the VM owns the real env. Accessors `debug_assert!`
-    /// it is `false`. See [`Env::poisoned`].
-    poisoned: bool,
 }
 
 /// Maximum overlay chain length before [`Env::scoped_child`] flattens the parent.
@@ -147,28 +143,6 @@ impl Env {
             parent: None,
             tombstones: None,
             depth: 0,
-            poisoned: false,
-        }
-    }
-
-    #[inline(always)]
-    fn assert_not_poisoned(&self) {
-        // env-loan (CP-1 1e) diagnostic: the interpreter's env field is a poisoned
-        // sentinel while the VM owns the real env. Reading it means a VM→interpreter
-        // call reached env without a loan wrapper. By default this is *benign* (an
-        // empty env read; the loan grind has wrapped every test-covered carrier, and
-        // CI's release roast is the authoritative safety net) — so do NOT panic.
-        // Opt in with `MUTSU_POISON_DIAG=1` to print the first such site (with a
-        // backtrace) when hunting a remaining unwrapped carrier. Remove the whole
-        // poison mechanism once env-reading interpreter helpers are all VM-native.
-        if self.poisoned && std::env::var_os("MUTSU_POISON_DIAG").is_some() {
-            static SEEN: AtomicBool = AtomicBool::new(false);
-            if !SEEN.swap(true, Ordering::Relaxed) {
-                eprintln!(
-                    "POISON-DIAG: env accessed while loaned out to the VM (first hit):\n{}",
-                    std::backtrace::Backtrace::force_capture()
-                );
-            }
         }
     }
 
@@ -192,7 +166,6 @@ impl Env {
             depth: parent.depth + 1,
             parent: Some(Arc::new(parent)),
             tombstones: None,
-            poisoned: false,
         }
     }
 
@@ -238,7 +211,6 @@ impl Env {
                     parent: None,
                     tombstones: None,
                     depth: 0,
-                    poisoned: false,
                 }
             }
         }
@@ -267,7 +239,6 @@ impl Env {
 
     #[inline]
     pub fn get_sym(&self, key: Symbol) -> Option<&Value> {
-        self.assert_not_poisoned();
         if let Some(v) = self.inner.get(&key) {
             return Some(v);
         }
@@ -292,7 +263,6 @@ impl Env {
 
     #[inline]
     pub fn contains_key_sym(&self, key: Symbol) -> bool {
-        self.assert_not_poisoned();
         if self.inner.contains_key(&key) {
             return true;
         }
@@ -311,7 +281,6 @@ impl Env {
     /// cost; see docs/vm-dual-store.md and `vm_stats::record_env_deep_copy`).
     #[inline]
     fn cow_mut(&mut self) -> &mut HashMap<Symbol, Value> {
-        self.assert_not_poisoned();
         if crate::vm::vm_stats::enabled() && Arc::strong_count(&self.inner) > 1 {
             crate::vm::vm_stats::record_env_deep_copy();
         }
@@ -406,17 +375,14 @@ impl Env {
     }
 
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, Symbol, Value> {
-        self.assert_not_poisoned();
         self.inner.iter()
     }
 
     pub fn keys(&self) -> std::collections::hash_map::Keys<'_, Symbol, Value> {
-        self.assert_not_poisoned();
         self.inner.keys()
     }
 
     pub fn values(&self) -> std::collections::hash_map::Values<'_, Symbol, Value> {
-        self.assert_not_poisoned();
         self.inner.values()
     }
 
@@ -509,7 +475,6 @@ impl From<HashMap<String, Value>> for Env {
             parent: None,
             tombstones: None,
             depth: 0,
-            poisoned: false,
         }
     }
 }
@@ -521,7 +486,6 @@ impl From<HashMap<Symbol, Value>> for Env {
             parent: None,
             tombstones: None,
             depth: 0,
-            poisoned: false,
         }
     }
 }

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -234,9 +234,9 @@ impl Interpreter {
                 format!("Failed to spurt '{}': file already exists", path),
             ));
         }
-        let is_buf = crate::vm::VM::is_buf_value(content_value);
+        let is_buf = crate::runtime::Interpreter::is_buf_value(content_value);
         let write_result = if is_buf {
-            let bytes = crate::vm::VM::extract_buf_bytes(content_value);
+            let bytes = crate::runtime::Interpreter::extract_buf_bytes(content_value);
             if append {
                 use std::io::Write;
                 fs::OpenOptions::new()

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3021,7 +3021,7 @@ impl Interpreter {
             // Neither forces the (possibly infinite) pipeline.
             && !(ll.lazy_pipe.is_some()
                 && (matches!(method, "map" | "grep")
-                    || crate::vm::VM::lazy_pipe_preserving_coercion(method)))
+                    || crate::runtime::Interpreter::lazy_pipe_preserving_coercion(method)))
         {
             let saved_env = self.env.clone();
             let items = self.force_lazy_list_bridge(ll)?;

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1096,9 +1096,9 @@ impl Interpreter {
                         format!("Failed to spurt '{}': file already exists", p),
                     ));
                 }
-                let is_buf = crate::vm::VM::is_buf_value(&content_value);
+                let is_buf = crate::runtime::Interpreter::is_buf_value(&content_value);
                 let write_result = if is_buf {
-                    let bytes = crate::vm::VM::extract_buf_bytes(&content_value);
+                    let bytes = crate::runtime::Interpreter::extract_buf_bytes(&content_value);
                     if append {
                         use std::io::Write;
                         fs::OpenOptions::new()
@@ -2691,9 +2691,9 @@ impl Interpreter {
                     .first()
                     .cloned()
                     .unwrap_or(Value::Str(String::new().into()));
-                let is_buf = crate::vm::VM::is_buf_value(&content_value);
+                let is_buf = crate::runtime::Interpreter::is_buf_value(&content_value);
                 if is_buf {
-                    let bytes = crate::vm::VM::extract_buf_bytes(&content_value);
+                    let bytes = crate::runtime::Interpreter::extract_buf_bytes(&content_value);
                     self.write_bytes_to_handle_value(&target_val, &bytes)?;
                 } else {
                     let content = content_value.to_string_value();

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1014,7 +1014,10 @@ impl Interpreter {
             }
             "%" | "mod" => crate::builtins::arith_mod(left.clone(), right.clone()),
             "**" => Ok(crate::builtins::arith_pow(left.clone(), right.clone())),
-            "~" => Ok(crate::vm::VM::concat_values(left.clone(), right.clone())),
+            "~" => Ok(crate::runtime::Interpreter::concat_values(
+                left.clone(),
+                right.clone(),
+            )),
             "&&" | "and" => {
                 if !left.truthy() {
                     Ok(left.clone())

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1436,8 +1436,8 @@ impl Interpreter {
                 is_buf(&a) && is_buf(&b)
             } =>
             {
-                let lb = crate::vm::VM::extract_buf_bytes(left);
-                let rb = crate::vm::VM::extract_buf_bytes(right);
+                let lb = crate::runtime::Interpreter::extract_buf_bytes(left);
+                let rb = crate::runtime::Interpreter::extract_buf_bytes(right);
                 lb == rb
             }
             // Instance ~~ Instance: value types (Date, DateTime) use eqv,

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1055,7 +1055,7 @@ impl Interpreter {
                     || self.get_our_var(name).is_some()
                     || local_classes.contains(name.as_str())
                     || declared.contains(name.as_str())
-                    || crate::vm::VM::is_builtin_type(name)
+                    || crate::runtime::Interpreter::is_builtin_type(name)
                     || crate::runtime::Interpreter::is_implicit_zero_arg_builtin(name)
                 {
                     return None;

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -72,9 +72,11 @@ impl Interpreter {
                         | Value::RangeExclBoth(..)
                 ) {
                     crate::runtime::value_to_list(left) == crate::runtime::value_to_list(right)
-                } else if crate::vm::VM::is_buf_value(left) && crate::vm::VM::is_buf_value(right) {
-                    crate::vm::VM::extract_buf_bytes(left)
-                        == crate::vm::VM::extract_buf_bytes(right)
+                } else if crate::runtime::Interpreter::is_buf_value(left)
+                    && crate::runtime::Interpreter::is_buf_value(right)
+                {
+                    crate::runtime::Interpreter::extract_buf_bytes(left)
+                        == crate::runtime::Interpreter::extract_buf_bytes(right)
                 } else {
                     self.stringify_test_value(left)? == self.stringify_test_value(right)?
                 }

--- a/src/runtime/test_functions/util.rs
+++ b/src/runtime/test_functions/util.rs
@@ -151,8 +151,8 @@ impl Interpreter {
 
         if let Some(c) = content {
             // If content is a Buf/Blob, write raw bytes instead of string representation
-            if crate::vm::VM::is_buf_value(&c) {
-                let raw_bytes = crate::vm::VM::extract_buf_bytes(&c);
+            if crate::runtime::Interpreter::is_buf_value(&c) {
+                let raw_bytes = crate::runtime::Interpreter::extract_buf_bytes(&c);
                 std::fs::write(&path, &raw_bytes).map_err(|e| {
                     RuntimeError::new(format!("make-temp-file: cannot write: {}", e))
                 })?;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -17,7 +17,7 @@ use num_traits::{Signed, Zero};
 pub(crate) type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
 
 thread_local! {
-    /// Set while execution is inside the `VM::run` catch_unwind boundary, so the
+    /// Set while execution is inside the `Interpreter::run` catch_unwind boundary, so the
     /// custom panic hook can stay quiet for panics that we are about to convert
     /// into a catchable `X::` error (instead of dumping a Rust backtrace).
     static IN_VM_PANIC_BOUNDARY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -26,7 +26,7 @@ thread_local! {
 static VM_PANIC_HOOK_INIT: std::sync::Once = std::sync::Once::new();
 
 /// Install (once) a panic hook that suppresses the default backtrace dump for
-/// panics caught at the `VM::run` boundary, unless the user opted into details
+/// panics caught at the `Interpreter::run` boundary, unless the user opted into details
 /// via `RUST_BACKTRACE`/`MUTSU_TRACE`. Panics outside the boundary (genuine
 /// internal bugs) still print normally.
 fn install_vm_panic_hook() {
@@ -72,7 +72,7 @@ pub(crate) struct FastMethodCacheEntry {
 }
 
 /// env-loan (CP-1 1e): call an interpreter carrier/helper that reads
-/// `self.env`, lending the VM-owned env for the duration.
+/// `self.env`, lending the Interpreter-owned env for the duration.
 ///
 /// Expands to: swap the real env into the interpreter's loan slot, run
 /// `$self.<call>`, swap it back. Unlike a closure-based helper, the
@@ -85,8 +85,8 @@ pub(crate) struct FastMethodCacheEntry {
 /// (those few sites are handled individually). See docs/vm-state-ownership.md.
 macro_rules! loan_env {
     ($self:ident, $($call:tt)+) => {{
-        // CP-3 collapse: the VM dissolved into the Interpreter, so env is no
-        // longer loaned across a VM->interpreter boundary — it is just `self.env`.
+        // CP-3 collapse: the Interpreter dissolved into the Interpreter, so env is no
+        // longer loaned across a Interpreter->interpreter boundary — it is just `self.env`.
         // This macro is now a thin self-call kept so the ~350 call sites need no
         // edit; it will be removed in a later cosmetic pass.
         $self.$($call)+
@@ -150,13 +150,12 @@ pub(crate) struct VmCallFrame {
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 
-/// CP-3 collapse: the bytecode VM has been dissolved into the `Interpreter`
-/// struct (the Interpreter *is* the bytecode VM now). `VM` is kept as a crate
-/// alias so the ~40 `impl VM` blocks and internal `VM::`/`vm: VM` references
-/// compile unchanged; a later cosmetic pass can rename them to `Interpreter`.
-pub(crate) type VM = crate::interpreter::Interpreter;
+// CP-3 collapse: the bytecode Interpreter has been fully dissolved into the `Interpreter`
+// struct — the `Interpreter` *is* the bytecode Interpreter. The former `Interpreter` type alias is
+// gone; the `impl` blocks in `src/vm/` are `impl Interpreter`. (The `vm`/`src/vm`
+// module names are retained as the home of the bytecode-execution methods.)
 
-impl VM {
+impl Interpreter {
     /// Wrap a runtime error in X::Comp::BeginTime (used for errors inside CHECK phasers).
     fn wrap_in_begin_time(inner: RuntimeError) -> RuntimeError {
         use std::collections::HashMap;
@@ -290,7 +289,7 @@ impl VM {
         err
     }
 
-    /// VM-native Stdout emit (③後段 PR-C), mirroring `Interpreter::emit_output`:
+    /// Interpreter-native Stdout emit (③後段 PR-C), mirroring `Interpreter::emit_output`:
     /// bump the Stdout-target handle's `bytes_written`, then push to the sink
     /// (immediate real-stdout flush / buffer / thread-clone shared buffer per the
     /// sink's decision). `subtest_active` comes from the interpreter (TAP state
@@ -308,7 +307,7 @@ impl VM {
         self.output_sink_mut().emit(text, subtest_active);
     }
 
-    /// VM-native Stderr emit (③後段 PR-C), mirroring the `Stderr` branch of
+    /// Interpreter-native Stderr emit (③後段 PR-C), mirroring the `Stderr` branch of
     /// `write_to_handle_value_trying` (immediate real-stderr flush or the stderr
     /// buffer; no `bytes_written` scan, no `output_emitted`).
     pub(crate) fn vm_emit_stderr(&mut self, text: &str) {
@@ -323,7 +322,7 @@ impl VM {
     /// `panic!`/`unwrap`/index-OOB/capacity-overflow triggered by user code is
     /// converted into a catchable `X::AdHoc` `RuntimeError` (exit 1, flows through
     /// `try`/`CATCH`) instead of crashing the whole process (exit 101). This also
-    /// covers EVAL and sub-VMs, which run through `VM::run`. Stack overflow
+    /// covers EVAL and sub-VMs, which run through `Interpreter::run`. Stack overflow
     /// `abort`s rather than unwinding, so it is out of scope here.
     pub(crate) fn run_top(
         &mut self,
@@ -336,7 +335,7 @@ impl VM {
     /// Run `run_inner` inside the `catch_unwind` panic->`X::AdHoc` boundary so a
     /// Rust `panic!`/overflow/index-OOB triggered by user code becomes a
     /// catchable `RuntimeError` instead of crashing the process. This is the
-    /// boundary the old ping-pong `VM::run` provided; both `run_top` (outermost)
+    /// boundary the old ping-pong `Interpreter::run` provided; both `run_top` (outermost)
     /// and `run_nested` (re-entrant carriers like `run_compiled_block`,
     /// `eval_block_value`, `run_block_raw` invoked by `dies-ok`/`try`) route
     /// through it so nested user-code panics still flow through try/CATCH.
@@ -416,7 +415,7 @@ impl VM {
                 self.sync_state_locals(code);
                 self.pop_once_scope();
                 // An uncaught CX::Return signal that escapes the top-level
-                // VM loop means the lexical target routine was not on the
+                // Interpreter loop means the lexical target routine was not on the
                 // dynamic call stack when `return` executed, so it surfaces
                 // as `X::ControlFlow::Return` with out-of-dynamic-scope set.
                 // Only perform this conversion when the current dynamic call
@@ -449,23 +448,23 @@ impl VM {
         Ok(last_stack_value.or(fallback))
     }
 
-    /// CP-3 collapse PoC: run a compiled block re-entrantly on the *existing* VM,
-    /// without the `mem::take(self)` + `VM::new(self)` + `*self = interp`
+    /// CP-3 collapse PoC: run a compiled block re-entrantly on the *existing* Interpreter,
+    /// without the `mem::take(self)` + `Interpreter::new(self)` + `*self = interp`
     /// ping-pong that the interpreter-side carriers (`run_compiled_block`,
     /// `run_block_raw`, `eval_precompiled_block_fast`) use today.
     ///
     /// The ping-pong only exists because those carriers live on the `Interpreter`
-    /// (no live VM there), so each one spins up a fresh `VM` whose per-execution
+    /// (no live Interpreter there), so each one spins up a fresh `Interpreter` whose per-execution
     /// registers (stack/locals/call_frames/topic/…) start empty. This method
     /// reproduces that "fresh registers, shared interpreter + env" semantics in
     /// place: it saves the current per-execution registers, resets them to the
-    /// `VM::new` defaults, runs the block (sharing `self.interpreter`/`self.env`
+    /// `Interpreter::new` defaults, runs the block (sharing `self.interpreter`/`self.env`
     /// directly), then restores. This is the mechanism that replaces the
-    /// ping-pong once the `Interpreter` struct is dissolved into the VM.
+    /// ping-pong once the `Interpreter` struct is dissolved into the Interpreter.
     ///
     /// Shared state (interpreter fields, env, registry/io/output handles) is
     /// intentionally *not* reset — the nested block must observe and mutate the
-    /// same state, exactly as the inner ping-pong VM does (it shares the moved
+    /// same state, exactly as the inner ping-pong Interpreter does (it shares the moved
     /// interpreter and the loaned env). Caches are gen-counted, so keeping them
     /// across the nested run is correct and avoids churn.
     pub(crate) fn run_nested(
@@ -476,23 +475,23 @@ impl VM {
         // Use the guarded runner so a Rust panic in a re-entrant carrier
         // (run_compiled_block / eval_block_value / run_block_raw — e.g. a
         // `dies-ok { ... }` block) is caught and converted, exactly as the old
-        // ping-pong `VM::run` did. (The map/grep `run_reuse` loops call
+        // ping-pong `Interpreter::run` did. (The map/grep `run_reuse` loops call
         // `with_nested_registers` directly and keep their no-boundary behavior.)
         self.with_nested_registers(|me| me.run_inner_guarded(code, compiled_fns))
     }
 
     /// Run `f` with fresh per-execution registers (stack/locals/call_frames/topic/
-    /// context flags reset to their `VM::new` defaults), restoring the outer
+    /// context flags reset to their `Interpreter::new` defaults), restoring the outer
     /// registers afterwards and flagging `env_dirty` so the outer execution
     /// re-syncs its locals from env. This is the in-place replacement for the old
-    /// `mem::take(self)` + `VM::new` ping-pong: shared state (env, interpreter
+    /// `mem::take(self)` + `Interpreter::new` ping-pong: shared state (env, interpreter
     /// fields, registry/io/output handles, gen-counted caches) is *not* reset, so
     /// the nested work observes and mutates the same state. Used by `run_nested`
     /// (single compiled block) and by the map/sort `run_reuse` loops (many
     /// iterations sharing one fresh-register scope).
     pub(crate) fn with_nested_registers<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
-        // Save the per-execution registers (the fields `VM::new` initializes
-        // fresh) and reset them to their fresh-VM defaults for the nested run.
+        // Save the per-execution registers (the fields `Interpreter::new` initializes
+        // fresh) and reset them to their fresh-Interpreter defaults for the nested run.
         let saved_stack = std::mem::take(&mut self.stack);
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_call_frames = std::mem::take(&mut self.call_frames);
@@ -585,14 +584,14 @@ impl VM {
         // Those writes land in `env`, but the restored outer `locals` slots are
         // stale, so flag the dual-store dirty to force a reload from env before
         // the outer execution next reads a local. (The ping-pong achieved this
-        // implicitly: the inner VM's env flowed back through the interpreter and
+        // implicitly: the inner Interpreter's env flowed back through the interpreter and
         // the caller re-synced from it.)
         self.env_dirty = true;
 
         result
     }
 
-    /// Invoke a callable value using the VM fast paths when available and
+    /// Invoke a callable value using the Interpreter fast paths when available and
     /// return the interpreter state to the caller.
     pub(crate) fn call_value(
         &mut self,
@@ -603,7 +602,7 @@ impl VM {
     }
 
     /// Run compiled bytecode without consuming self.
-    /// Used by map/grep to avoid VM creation/destruction per iteration.
+    /// Used by map/grep to avoid Interpreter creation/destruction per iteration.
     pub(crate) fn run_reuse(
         &mut self,
         code: &CompiledCode,
@@ -721,19 +720,19 @@ impl VM {
         }
     }
 
-    // (CP-3 collapse) The VM's env / env_mut / clone_env / set_env / take_env
+    // (CP-3 collapse) The Interpreter's env / env_mut / clone_env / set_env / take_env
     // accessors are gone — they duplicated the canonical `Interpreter` methods
     // (env now lives on the merged struct), so callers reach those directly.
 
-    /// env-loan (CP-1 1e): swap the VM-owned env into the interpreter's loan
+    /// env-loan (CP-1 1e): swap the Interpreter-owned env into the interpreter's loan
     /// slot, run `f` (a carrier that reads `self.env`), then swap the
     /// env back. The interpreter sees the live env for the duration of the
     /// carrier; the nested ping-pong (`run_block_raw` → `mem::take(self)` →
-    /// `VM::new`) carries the loaned env into the inner VM and back, so the swap
+    /// `Interpreter::new`) carries the loaned env into the inner Interpreter and back, so the swap
     /// nests correctly. Returns whatever the carrier returns.
     #[inline]
     fn loan_env_for<R>(&mut self, f: impl FnOnce(&mut Interpreter) -> R) -> R {
-        // CP-3 collapse: the VM dissolved into the Interpreter, so there is no
+        // CP-3 collapse: the Interpreter dissolved into the Interpreter, so there is no
         // separate interpreter to lend the env to — env is just `self.env`. This
         // is now a thin self-call kept so the existing call sites need no edit.
         f(self)
@@ -745,8 +744,8 @@ impl VM {
     // call reaches the single implementation directly.
 
     // env-loan wrappers for the interpreter's tree-walk carriers (they read/
-    // write `self.env`, so the VM-owned env must be lent for the
-    // call). See [`VM::loan_env_for`] and docs/vm-state-ownership.md.
+    // write `self.env`, so the Interpreter-owned env must be lent for the
+    // call). See [`Interpreter::loan_env_for`] and docs/vm-state-ownership.md.
     #[inline]
     pub(crate) fn vm_call_function(
         &mut self,
@@ -806,9 +805,9 @@ impl VM {
             return Ok(());
         }
         // CP-3 collapse PoC: instead of bouncing to `Interpreter::run_block_raw`
-        // (which spins up a fresh sub-VM via `mem::take`/`VM::new` — the
+        // (which spins up a fresh sub-Interpreter via `mem::take`/`Interpreter::new` — the
         // ping-pong), compile the block (pure, no env) and run it in-place on
-        // this VM via `run_nested`, sharing the same interpreter + env directly.
+        // this Interpreter via `run_nested`, sharing the same interpreter + env directly.
         let (code, compiled_fns) = self.compile_block_raw(stmts);
         let result = self.run_nested(&code, &compiled_fns);
         // Mirror `run_block_raw`'s trailing DESTROY pass (may run user code, so
@@ -825,7 +824,7 @@ impl VM {
         // proto/operator declarations and no trailing-sub value), the registry +
         // code-env save/restore that `Interpreter::eval_block_value` performs is a
         // no-op, so run the block in-place via `run_nested` (no `mem::take`/
-        // `VM::new` ping-pong) and only replicate the cheap scope bookkeeping
+        // `Interpreter::new` ping-pong) and only replicate the cheap scope bookkeeping
         // (block-scope depth + let/temp restore + DESTROY pass). All current
         // callers pass a single `Stmt::Expr` (registration-time default / enum /
         // role-arg evaluation). Any other shape falls back to the interpreter.
@@ -875,7 +874,7 @@ impl VM {
         }
     }
 
-    /// Override the source variable used when mutating `$_` in VM execution.
+    /// Override the source variable used when mutating `$_` in Interpreter execution.
     pub(crate) fn set_topic_source_var(&mut self, name: Option<String>) {
         self.topic_source_var = name;
     }
@@ -3682,7 +3681,7 @@ impl VM {
                 if *lexically_in_routine {
                     // Closure/block lexically inside a routine: propagate a
                     // CX::Return signal up to the enclosing routine boundary.
-                    // If the signal escapes all frames up to the VM top-level,
+                    // If the signal escapes all frames up to the Interpreter top-level,
                     // the lexical target routine is no longer on the dynamic
                     // call stack, so it will surface as
                     // `X::ControlFlow::Return` with `out-of-dynamic-scope`.
@@ -4112,7 +4111,7 @@ impl VM {
                 let result = match val {
                     Value::LazyList(ref ll) => {
                         let items = self.force_lazy_list_vm(ll)?;
-                        // Sync interpreter env changes back to VM locals.
+                        // Sync interpreter env changes back to Interpreter locals.
                         // This ensures side effects from gather bodies propagate
                         // to outer-scope variables (e.g., `$was-lazy = 0`).
                         for (i, name) in code.locals.iter().enumerate() {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -3,7 +3,7 @@ use num_traits::ToPrimitive;
 use std::sync::Arc;
 use unicode_normalization::UnicodeNormalization;
 
-impl VM {
+impl Interpreter {
     fn is_xx_reeval_thunk(data: &crate::value::SubData) -> bool {
         if !data.params.is_empty()
             || !data.param_defs.is_empty()
@@ -98,7 +98,7 @@ impl VM {
         Ok(Some(result.items))
     }
 
-    /// VM-native implementation of xx-repeat for thunks.
+    /// Interpreter-native implementation of xx-repeat for thunks.
     /// Compiles the thunk body once and runs it N times via `run_reuse`,
     /// avoiding the interpreter roundtrip through `eval_xx_repeat_thunk`.
     fn vm_xx_repeat_thunk(
@@ -597,9 +597,9 @@ impl VM {
     }
 
     /// String/Buf concatenation (`~`). This is the single authoritative impl,
-    /// shared by the VM's `~` op and the interpreter's reduction-operator path
-    /// (`apply_reduction_op` delegates here). It uses no VM state, so it is a
-    /// plain associated function callable as `crate::vm::VM::concat_values(...)`.
+    /// shared by the Interpreter's `~` op and the interpreter's reduction-operator path
+    /// (`apply_reduction_op` delegates here). It uses no Interpreter state, so it is a
+    /// plain associated function callable as `crate::runtime::Interpreter::concat_values(...)`.
     pub(crate) fn concat_values(left: Value, right: Value) -> Value {
         // Buf ~ Buf → Buf (byte concatenation, preserving LHS type)
         if Self::is_buf_value(&left) && Self::is_buf_value(&right) {
@@ -1152,7 +1152,7 @@ impl VM {
         err
     }
 
-    /// VM-native `does` check. Inlines the pure `does_check` path and
+    /// Interpreter-native `does` check. Inlines the pure `does_check` path and
     /// only falls back to the interpreter for actual role composition.
     fn vm_does_values(&mut self, left: Value, right: Value) -> Result<Value, RuntimeError> {
         // `does`/`but` on a type-object invocant (undefined scalars are stored
@@ -1219,7 +1219,7 @@ impl VM {
     pub(super) fn exec_does_op(&mut self, code: &CompiledCode) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Sync VM locals to interpreter env so BUILD submethods can access
+        // Sync Interpreter locals to interpreter env so BUILD submethods can access
         // and modify closure variables from the enclosing scope.
         self.sync_env_from_locals(code);
         let result = self.vm_does_values(left, right)?;
@@ -1240,7 +1240,7 @@ impl VM {
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // Sync VM locals to interpreter env so BUILD submethods can access
+        // Sync Interpreter locals to interpreter env so BUILD submethods can access
         // and modify closure variables from the enclosing scope.
         self.sync_env_from_locals(code);
         let updated = self.vm_does_values(left, right)?;

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 use std::sync::Arc;
 
-impl VM {
+impl Interpreter {
     /// Check if any function call arguments are Junctions that need auto-threading.
     /// Returns Some(result) if auto-threading was performed, None if no auto-threading needed.
     pub(super) fn maybe_autothread_func_call(

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::runtime::types::unwrap_varref_value;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     /// Record a deprecation event for a compiled function if it has deprecation info.
     fn record_cf_deprecation(&self, cf: &CompiledFunction) {
         if let Some((ref kind, ref name, ref package, ref msg)) = cf.deprecated_info {
@@ -24,7 +24,7 @@ impl VM {
         }
     }
 
-    /// Cached version of the VM-native [`Self::has_multi_candidates`].
+    /// Cached version of the Interpreter-native [`Self::has_multi_candidates`].
     /// Uses `fn_resolve_gen` for invalidation so it's O(1) on cache hit.
     pub(super) fn has_multi_candidates_cached(&mut self, name: &str) -> bool {
         if self.multi_candidates_cache_gen != self.fn_resolve_gen {
@@ -78,7 +78,7 @@ impl VM {
         self.vm_call_function(name, args)
     }
 
-    /// Compile a FunctionDef on-the-fly to bytecode and execute via the VM.
+    /// Compile a FunctionDef on-the-fly to bytecode and execute via the Interpreter.
     /// This avoids the interpreter's tree-walking execution path.
     #[allow(dead_code)]
     pub(super) fn compile_and_call_function_def(
@@ -212,7 +212,7 @@ impl VM {
 
     /// Whether a name that reaches the interpreter does so as a *carrier* rather
     /// than as a tree-walk fallback. `EVAL`/`EVALFILE` compile their source to
-    /// bytecode and run it on a sub-VM (`eval_block_value` -> `run_compiled_block`);
+    /// bytecode and run it on a sub-Interpreter (`eval_block_value` -> `run_compiled_block`);
     /// pseudo-package reads (`CALLER::`/`OUTER::`/`SETTING::`/`DYNAMIC::`) are
     /// reflective env lookups. Neither tree-walks user code, so they are counted
     /// in a separate stats bucket (lever A). The remaining coupling — that the
@@ -1869,20 +1869,22 @@ mod tests {
 
     #[test]
     fn carrier_functions_are_not_tree_walk_fallbacks() {
-        // EVAL/EVALFILE compile to bytecode and run on a sub-VM; pseudo-package
+        // EVAL/EVALFILE compile to bytecode and run on a sub-Interpreter; pseudo-package
         // reads are reflective env lookups. Both enter the interpreter as a
         // carrier, so they are classified out of the tree-walk fallback metric.
-        assert!(VM::is_interpreter_carrier_function("EVAL"));
-        assert!(VM::is_interpreter_carrier_function("EVALFILE"));
-        assert!(VM::is_interpreter_carrier_function("Foo::CALLER::bar"));
-        assert!(VM::is_interpreter_carrier_function("OUTER::x"));
-        assert!(VM::is_interpreter_carrier_function("SETTING::y"));
-        assert!(VM::is_interpreter_carrier_function("DYNAMIC::z"));
+        assert!(Interpreter::is_interpreter_carrier_function("EVAL"));
+        assert!(Interpreter::is_interpreter_carrier_function("EVALFILE"));
+        assert!(Interpreter::is_interpreter_carrier_function(
+            "Foo::CALLER::bar"
+        ));
+        assert!(Interpreter::is_interpreter_carrier_function("OUTER::x"));
+        assert!(Interpreter::is_interpreter_carrier_function("SETTING::y"));
+        assert!(Interpreter::is_interpreter_carrier_function("DYNAMIC::z"));
 
         // Genuine user/builtin subs are real fallbacks when they reach the
         // interpreter, not carriers.
-        assert!(!VM::is_interpreter_carrier_function("say"));
-        assert!(!VM::is_interpreter_carrier_function("my-sub"));
-        assert!(!VM::is_interpreter_carrier_function("evaluate"));
+        assert!(!Interpreter::is_interpreter_carrier_function("say"));
+        assert!(!Interpreter::is_interpreter_carrier_function("my-sub"));
+        assert!(!Interpreter::is_interpreter_carrier_function("evaluate"));
     }
 }

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     pub(super) fn exec_exec_call_op(
         &mut self,
         code: &CompiledCode,
@@ -13,7 +13,7 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
         if self.stack.len() < arity {
-            return Err(RuntimeError::new("VM stack underflow in ExecCall"));
+            return Err(RuntimeError::new("Interpreter stack underflow in ExecCall"));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -100,7 +100,9 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
         if self.stack.len() < arity {
-            return Err(RuntimeError::new("VM stack underflow in ExecCallPairs"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in ExecCallPairs",
+            ));
         }
         let start = self.stack.len() - arity;
         let args: Vec<Value> = self.stack.drain(start..).collect();
@@ -142,7 +144,9 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let total = regular_arity as usize + 1; // +1 for the slip value
         if self.stack.len() < total {
-            return Err(RuntimeError::new("VM stack underflow in ExecCallSlip"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in ExecCallSlip",
+            ));
         }
         // Pop all values from the stack in source order
         let stack_start = self.stack.len() - total;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     /// Names of builtin listops/functions that a same-named user-defined
     /// subroutine may shadow. When both exist, the user sub wins.
     ///
@@ -26,7 +26,7 @@ impl VM {
     }
 
     /// Control-flow / dispatch-control names that must never be taken over by
-    /// the lexical `&`-var VM dispatch: the interpreter's call_function match
+    /// the lexical `&`-var Interpreter dispatch: the interpreter's call_function match
     /// implements their non-local semantics (loop control, gather/take,
     /// multi-dispatch redirection), and a lexical `&return`-style binding
     /// dispatched as a plain closure would lose them (or recurse infinitely).
@@ -61,7 +61,7 @@ impl VM {
         )
     }
 
-    /// Resolve a *pure* lexical `&name` callable for VM-native dispatch
+    /// Resolve a *pure* lexical `&name` callable for Interpreter-native dispatch
     /// (Track A): a `&code` parameter binding (local slot) or a `my &f = ...`
     /// env binding, for a name with NO same-named package sub / proto / multi
     /// (the shadow case is handled separately via `lexical_override` in
@@ -320,7 +320,7 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
         if self.stack.len() < arity {
-            return Err(RuntimeError::new("VM stack underflow in CallFunc"));
+            return Err(RuntimeError::new("Interpreter stack underflow in CallFunc"));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -409,7 +409,7 @@ impl VM {
 
         // Lexical `&name` binding (e.g. from `sub callit(&foo) { foo(1) }`)
         // takes precedence over package-level compiled subs. Dispatch
-        // VM-natively via `vm_call_on_value` (same as the pure-lexical case in
+        // Interpreter-natively via `vm_call_on_value` (same as the pure-lexical case in
         // `dispatch_func_call_inner`, Track A): `call_compiled_closure` roots
         // the closure frame at the live caller env (scoped_child) so dynamic
         // vars (`my $*ERR` in the caller) stay visible, and first-class
@@ -457,7 +457,9 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let total = regular_arity as usize + 1; // +1 for the slip value
         if self.stack.len() < total {
-            return Err(RuntimeError::new("VM stack underflow in CallFuncSlip"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallFuncSlip",
+            ));
         }
         // When slip_pos is known, args are in source order on the stack.
         // Pop all values, expand the slip at its position.
@@ -540,7 +542,7 @@ impl VM {
             self.stack.push(native_result?);
         } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), &name) {
             // Pure lexical `&name` callable invoked with a slip (`op(|@args)`):
-            // dispatch VM-natively via vm_call_on_value, same as the non-slip
+            // dispatch Interpreter-natively via vm_call_on_value, same as the non-slip
             // case in `dispatch_func_call_inner` (Track A). Builtin priority is
             // preserved because try_native_function already ran above, and
             // lexical_amp_var_callable excludes builtin / package-sub names.
@@ -548,7 +550,7 @@ impl VM {
             self.stack.push(result);
             self.env_dirty = true;
         } else {
-            // Sync VM locals to env before spawning threads so closures capture them
+            // Sync Interpreter locals to env before spawning threads so closures capture them
             if name == "start" {
                 self.sync_env_from_locals(code);
             }
@@ -570,7 +572,9 @@ impl VM {
         crate::vm::vm_stats::record_function_dispatch();
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
-            return Err(RuntimeError::new("VM stack underflow in CallOnValue"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallOnValue",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -586,7 +590,7 @@ impl VM {
             arg_sources
         };
         let target = self.stack.pop().ok_or_else(|| {
-            RuntimeError::new("VM stack underflow in CallOnValue target".to_string())
+            RuntimeError::new("Interpreter stack underflow in CallOnValue target".to_string())
         })?;
 
         // Resolve slot refs to their underlying values before dispatch
@@ -632,7 +636,9 @@ impl VM {
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
         if self.stack.len() < arity {
-            return Err(RuntimeError::new("VM stack underflow in CallOnCodeVar"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallOnCodeVar",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -686,7 +692,7 @@ impl VM {
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, cf_auto_fetch))?
         } else {
-            // Sync VM locals to env before spawning threads so closures capture them
+            // Sync Interpreter locals to env before spawning threads so closures capture them
             if name == "start" {
                 self.sync_env_from_locals(code);
             }
@@ -814,7 +820,7 @@ impl VM {
                 self.env_dirty = true;
                 if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
                     // User-defined multi candidates take priority over builtins.
-                    // Resolve the winning candidate VM-side via the same resolver
+                    // Resolve the winning candidate Interpreter-side via the same resolver
                     // call_function_fallback uses (③ PR-3, ledger §2). When the
                     // winner is unambiguous and OTF-compilable, run it as compiled
                     // bytecode instead of tree-walking through the interpreter.
@@ -902,7 +908,7 @@ impl VM {
                 } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), name) {
                     // Pure lexical `&name` callable (a `&code` parameter or
                     // `my &f = ...` with no same-named package sub): dispatch
-                    // VM-natively via vm_call_on_value instead of the interpreter
+                    // Interpreter-natively via vm_call_on_value instead of the interpreter
                     // terminal (Track A, ledger §2). Builtin priority is preserved
                     // because try_native_function already ran above. Dynamic vars
                     // (`my $*ERR` in the caller) stay visible because
@@ -911,11 +917,11 @@ impl VM {
                     // or_insert (parent-chain aware), so it never shadows them.
                     self.vm_call_on_value(callable, args, Some(compiled_fns))
                 } else {
-                    // Sync VM locals to env before spawning threads so closures capture them
+                    // Sync Interpreter locals to env before spawning threads so closures capture them
                     if name == "start" {
                         self.sync_env_from_locals(code);
                     }
-                    // EVAL/EVALFILE compile to bytecode and run on a sub-VM, and
+                    // EVAL/EVALFILE compile to bytecode and run on a sub-Interpreter, and
                     // pseudo-package reads are reflective env lookups: the
                     // interpreter is a carrier here, not a tree-walk fallback.
                     // CARRIER (is_interpreter_carrier_function) vs TODO: compile to
@@ -942,7 +948,7 @@ impl VM {
     }
 
     /// Whether a resolved `FunctionDef` is simple enough to compile on-the-fly to
-    /// bytecode and run via the VM (instead of tree-walking it through the
+    /// bytecode and run via the Interpreter (instead of tree-walking it through the
     /// interpreter): a plain body and no default/where/code-signature/`&`-code
     /// params. Shared by the non-shadow OTF branch and the builtin-shadow forks
     /// (③ PR-2) so the same compilability gate is applied consistently.

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     pub(super) fn append_slip_item(args: &mut Vec<Value>, item: &Value) {
         match item {
             Value::Capture { positional, named } => {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::ast::{CallArg, Expr, Stmt};
 
-impl VM {
+impl Interpreter {
     fn try_eval_simple_protect_expr(
         &self,
         outer_code: &CompiledCode,
@@ -97,7 +97,7 @@ impl VM {
     ) -> Result<Value, RuntimeError> {
         // Native default construction: `Foo.new(...)` for a simple user-defined
         // class is pure data assembly (named args + attribute defaults), so the
-        // VM builds the instance directly instead of routing through the
+        // Interpreter builds the instance directly instead of routing through the
         // interpreter's generic constructor dispatch (lever A: shrink method-call
         // interpreter fallback).
         if method == "new"
@@ -111,7 +111,7 @@ impl VM {
         }
         // Native built-in construction: `Buf`/`Blob` (byte overlay), `utf8`/
         // `utf16` (code units), `Uni` (codepoints), `Version`/`Duration`/
-        // `StrDistance`/`Stash`/empty-instance handles — pure data builds the VM
+        // `StrDistance`/`Stash`/empty-instance handles — pure data builds the Interpreter
         // performs directly instead of routing through `dispatch_new`.
         if method == "new"
             && let Value::Package(class_name) = &target
@@ -136,10 +136,10 @@ impl VM {
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
-            // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
+            // Interpreter-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
             // resolve `IO::Handle`'s state-only methods (close/tell/eof/seek/
             // opened/t and the Tier-1 setters/getters chomp/nl-out/out-buffer/
-            // encoding/native-descriptor) in the VM through its own `io_handles`
+            // encoding/native-descriptor) in the Interpreter through its own `io_handles`
             // handle, *before* the generic native-method fallback below would
             // otherwise pre-empt them. Returns `None` (falling through to that
             // fallback unchanged) for any receiver/method/args it cannot handle
@@ -147,19 +147,19 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
                 return result;
             }
-            // VM-native text output to a File+UTF8 `IO::Handle` (print/put/say/
+            // Interpreter-native text output to a File+UTF8 `IO::Handle` (print/put/say/
             // print-nl): the write touches only handle state (PR-D Tier-2a).
             // Stdout/Stderr (need emit_output) and non-UTF8 File fall through.
             if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
                 return result;
             }
-            // VM-native raw byte output to a File `IO::Handle` (write/spurt):
+            // Interpreter-native raw byte output to a File `IO::Handle` (write/spurt):
             // raw file write, no buffering/encoding (PR-D Tier-2c). Stdout/Stderr
             // and a non-UTF8 spurt of a Str fall through.
             if let Some(result) = self.try_native_io_handle_byte_output(&target, method, &args) {
                 return result;
             }
-            // VM-native line read from a File+UTF8 `IO::Handle` (get): reads via
+            // Interpreter-native line read from a File+UTF8 `IO::Handle` (get): reads via
             // the handle's record reader (PR-D read side). ArgFiles/Stdin/non-UTF8
             // (which need @*ARGS / decode) fall through.
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
@@ -440,7 +440,7 @@ impl VM {
             }
         }
         // Native `.map` / `.grep` over a concrete array with a simple block: run
-        // the iteration loop in the VM instead of the interpreter (lever A). No
+        // the iteration loop in the Interpreter instead of the interpreter (lever A). No
         // `target_name` here (the receiver is a value, not a mutable variable),
         // so `$_`-mutating blocks fall back to the interpreter.
         if let Some(result) = self.try_native_array_map(None, &target, method, &args) {
@@ -468,7 +468,7 @@ impl VM {
         }
         // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
         // over a list-like receiver (ledger §1: native receiver dispatch ->
-        // VM-native). Pure element-folding shared with the interpreter via
+        // Interpreter-native). Pure element-folding shared with the interpreter via
         // `builtins::quanthash_coerce`. `.MixHash` falls through (it registers
         // container type metadata, which is interpreter-owned state).
         if args.is_empty()
@@ -496,12 +496,12 @@ impl VM {
         self.vm_call_method_with_values(target, method, args)
     }
 
-    /// VM-native dispatch for the pure-handle methods of an `IO::Handle`
+    /// Interpreter-native dispatch for the pure-handle methods of an `IO::Handle`
     /// (`close`/`tell`/`eof`/`seek`/`opened`/`t` plus the PR-D Tier-1
     /// setters/getters `chomp`/`nl-out`/`out-buffer`/`encoding` and
     /// `native-descriptor`) — the ones that touch only the handle's own state,
     /// with no `emit_output` / env / encoding-helper dependency.
-    /// Operates on the VM's own [`io_handles`](VM::io_handles_mut) handle and the
+    /// Operates on the Interpreter's own [`io_handles`](Interpreter::io_handles_mut) handle and the
     /// shared `IoHandleState` methods (the single authoritative impl the
     /// interpreter's `*_handle_value` wrappers also use), so behavior is identical
     /// to the interpreter's native fork.
@@ -663,19 +663,19 @@ impl VM {
         Some(result)
     }
 
-    /// VM-native text output for a `File`+UTF8 `IO::Handle` receiver
+    /// Interpreter-native text output for a `File`+UTF8 `IO::Handle` receiver
     /// (`print`/`put`/`say`/`printf`/`print-nl`): build the payload exactly as
     /// the interpreter's `native_io` handlers do — `render_str_value` for
     /// print/put, `render_gist_value` for say (byte-identical; the same helpers
-    /// the VM's own `say`/`print` ops use), the pure `sprintf` helpers for
-    /// printf — and write it through the VM's `io_handles` handle via the shared
+    /// the Interpreter's own `say`/`print` ops use), the pure `sprintf` helpers for
+    /// printf — and write it through the Interpreter's `io_handles` handle via the shared
     /// `IoHandleState::native_text_write` (PLAN.md ③ native IO PR-D Tier-2a/2b).
     ///
     /// Returns `None` (fall through to the interpreter) for any non-`IO::Handle`
     /// receiver, any other method, a junction argument (autothreading), or a
     /// handle whose target/encoding is not File+UTF8 — Stdout/Stderr need
     /// `emit_output`/`stderr_output` and a non-UTF8 File needs
-    /// `encode_with_encoding`, neither VM-reachable yet (③ 後段/④). The
+    /// `encode_with_encoding`, neither Interpreter-reachable yet (③ 後段/④). The
     /// target/encoding gate is read *before* the payload is built so a
     /// fall-through never double-runs the argument stringification.
     fn try_native_io_handle_output(
@@ -719,7 +719,7 @@ impl VM {
 
         // Resolve the target *before* building the payload, so falling through
         // (Socket / non-UTF8 File / Stdin) never runs the arg stringification
-        // twice. Stdout/Stderr emit via the VM's shared output sink (③後段 PR-C);
+        // twice. Stdout/Stderr emit via the Interpreter's shared output sink (③後段 PR-C);
         // File writes its handle state (Tier-2a).
         enum Tgt {
             File,
@@ -822,7 +822,7 @@ impl VM {
         Some(Ok(Value::Bool(true)))
     }
 
-    /// VM-native raw byte output for a `File` `IO::Handle` receiver
+    /// Interpreter-native raw byte output for a `File` `IO::Handle` receiver
     /// (`write` / `spurt`): build the bytes exactly as the interpreter's
     /// `native_io` handlers do and write them straight to the file via the
     /// shared `IoHandleState::native_write_bytes_file` (raw, `:out-buffer`- and
@@ -915,7 +915,7 @@ impl VM {
         )
     }
 
-    /// VM-native reads from a `File`+UTF8 `IO::Handle` receiver (③後段 PR-D read
+    /// Interpreter-native reads from a `File`+UTF8 `IO::Handle` receiver (③後段 PR-D read
     /// side): `get` (next line → `Str`/`Nil`), `slurp` (rest of file → `Str`),
     /// `read` (up to N bytes → `Buf`). Each delegates to the shared
     /// `IoHandleState` reader and shapes the result exactly as the interpreter's
@@ -1040,7 +1040,7 @@ impl VM {
         }
     }
 
-    /// VM-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
+    /// Interpreter-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
     /// over a list-like receiver (List/Array/Seq/Slip/Hash/Set/Bag/Mix/Pair/Range).
     /// Delegates the element folding to the single authoritative pure
     /// implementation in `builtins::quanthash_coerce`, the same one the
@@ -1097,7 +1097,7 @@ impl VM {
         Some(result)
     }
 
-    /// VM-native `.iterator` construction, mirroring
+    /// Interpreter-native `.iterator` construction, mirroring
     /// `Interpreter::dispatch_iterator_method`: an already-built `Iterator`
     /// instance returns itself; a `Seq` falls through (consumed-state tracking +
     /// `squish` env mutation are interpreter-owned); any other receiver builds an
@@ -1120,7 +1120,7 @@ impl VM {
         Some(crate::builtins::iterator_construct::build_iterator_instance(target))
     }
 
-    /// VM-native Iterator protocol over a self-contained, array-backed `Iterator`
+    /// Interpreter-native Iterator protocol over a self-contained, array-backed `Iterator`
     /// instance (`items` Array + `index` Int, no `squish_source` callbacks).
     /// Handles the index-advancing protocol methods `pull-one`/`skip-one`/
     /// `skip-at-least`/`skip-at-least-pull-one`/`sink-all`, mirroring the
@@ -1494,7 +1494,7 @@ impl VM {
         }
         if let Value::Instance { class_name, .. } = &target {
             let class = class_name.resolve();
-            // VM-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D),
+            // Interpreter-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D),
             // mut path: `$fh.method` on a variable receiver routes here, so the
             // same state-only `IO::Handle` methods must be intercepted before the
             // generic native-method fallback below. These methods mutate only the
@@ -1503,18 +1503,18 @@ impl VM {
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
                 return result;
             }
-            // VM-native text output to a File+UTF8 `IO::Handle` (print/put/say/
+            // Interpreter-native text output to a File+UTF8 `IO::Handle` (print/put/say/
             // print-nl), mut path (PR-D Tier-2a). See the non-mut twin above.
             if let Some(result) = self.try_native_io_handle_output(&target, method, &args) {
                 return result;
             }
-            // VM-native raw byte output to a File `IO::Handle` (write/spurt):
+            // Interpreter-native raw byte output to a File `IO::Handle` (write/spurt):
             // raw file write, no buffering/encoding (PR-D Tier-2c). Stdout/Stderr
             // and a non-UTF8 spurt of a Str fall through.
             if let Some(result) = self.try_native_io_handle_byte_output(&target, method, &args) {
                 return result;
             }
-            // VM-native line read from a File+UTF8 `IO::Handle` (get): reads via
+            // Interpreter-native line read from a File+UTF8 `IO::Handle` (get): reads via
             // the handle's record reader (PR-D read side). ArgFiles/Stdin/non-UTF8
             // (which need @*ARGS / decode) fall through.
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
@@ -1777,8 +1777,8 @@ impl VM {
         self.vm_call_method_mut_with_values(target_name, target, method, args)
     }
 
-    /// Execute a protect block inline in the current VM, avoiding the overhead
-    /// of creating a new VM.
+    /// Execute a protect block inline in the current Interpreter, avoiding the overhead
+    /// of creating a new Interpreter.
     pub(super) fn exec_protect_block_inline(
         &mut self,
         outer_code: &CompiledCode,
@@ -1813,7 +1813,7 @@ impl VM {
                 }
                 _ => {
                     // TODO: Handle non-Sub protect blocks (e.g. WeakSub, Routine)
-                    // in the VM. Currently these are rare and delegate to interpreter.
+                    // in the Interpreter. Currently these are rare and delegate to interpreter.
                     return self.call_protect_block(code_val);
                 }
             };

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 use std::sync::Arc;
 
-impl VM {
+impl Interpreter {
     pub(super) fn exec_call_method_dynamic_op(
         &mut self,
         code: &CompiledCode,
@@ -14,7 +14,9 @@ impl VM {
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
-            return Err(RuntimeError::new("VM stack underflow in CallMethodDynamic"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallMethodDynamic",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -22,14 +24,12 @@ impl VM {
         for arg in raw_args {
             Self::append_flattened_call_arg(&mut args, arg, false);
         }
-        let name_val = self
-            .stack
-            .pop()
-            .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamic name"))?;
-        let target = self
-            .stack
-            .pop()
-            .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamic target"))?;
+        let name_val = self.stack.pop().ok_or_else(|| {
+            RuntimeError::new("Interpreter stack underflow in CallMethodDynamic name")
+        })?;
+        let target = self.stack.pop().ok_or_else(|| {
+            RuntimeError::new("Interpreter stack underflow in CallMethodDynamic target")
+        })?;
         // Force lazy IO lines for non-lazy-preserving methods
         let method_name_str = name_val.to_string_value();
         let method = Self::rewrite_method_name(&method_name_str, modifier);
@@ -257,7 +257,7 @@ impl VM {
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new(
-                "VM stack underflow in CallMethodDynamicMut",
+                "Interpreter stack underflow in CallMethodDynamicMut",
             ));
         }
         let start = self.stack.len() - arity;
@@ -266,14 +266,12 @@ impl VM {
         for arg in raw_args {
             Self::append_flattened_call_arg(&mut args, arg, false);
         }
-        let name_val = self
-            .stack
-            .pop()
-            .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamicMut"))?;
-        let target = self
-            .stack
-            .pop()
-            .ok_or_else(|| RuntimeError::new("VM stack underflow in CallMethodDynamicMut"))?;
+        let name_val = self.stack.pop().ok_or_else(|| {
+            RuntimeError::new("Interpreter stack underflow in CallMethodDynamicMut")
+        })?;
+        let target = self.stack.pop().ok_or_else(|| {
+            RuntimeError::new("Interpreter stack underflow in CallMethodDynamicMut")
+        })?;
         let method_name_str = name_val.to_string_value();
         let method = Self::rewrite_method_name(&method_name_str, modifier);
         // Handle .* and .+ modifiers
@@ -335,7 +333,9 @@ impl VM {
         let method = Self::rewrite_method_name(method_raw, modifier);
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
-            return Err(RuntimeError::new("VM stack underflow in CallMethodMut"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallMethodMut",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -350,7 +350,7 @@ impl VM {
             raw_args
         };
         let target = self.stack.pop().ok_or_else(|| {
-            RuntimeError::new("VM stack underflow in CallMethodMut target".to_string())
+            RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
         // Force lazy IO lines for non-lazy-preserving methods
         let target = if matches!(&target, Value::LazyIoLines { .. })
@@ -399,7 +399,7 @@ impl VM {
                 None => self.force_lazy_list_vm(ll)?,
             };
             // A lazy map/grep pipeline runs its callback via `vm_call_on_value`
-            // in this VM, so its side effects on enclosing variables are
+            // in this Interpreter, so its side effects on enclosing variables are
             // legitimate and must persist (unlike gather coroutine corruption,
             // which the env restore undoes).
             if !matches!(method.as_str(), "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
@@ -517,7 +517,7 @@ impl VM {
             return Ok(());
         }
 
-        // .WHO on pseudo-package Package values: build the stash in the VM
+        // .WHO on pseudo-package Package values: build the stash in the Interpreter
         // where we have access to locals (which the interpreter doesn't have).
         if method == "WHO"
             && args.is_empty()
@@ -531,7 +531,7 @@ impl VM {
             return Ok(());
         }
 
-        // Fast path for Lock::Async.protect — execute block inline in current VM
+        // Fast path for Lock::Async.protect — execute block inline in current Interpreter
         if method == "protect"
             && args.len() == 1
             && let Value::Instance {
@@ -1177,8 +1177,8 @@ impl VM {
             }
             _ => {
                 // Native fast path for mutating list methods on a plain, untyped
-                // `@`-array (ledger §1: native receiver dispatch -> VM-native).
-                // Handles the common hot-loop case directly in the VM, writing the
+                // `@`-array (ledger §1: native receiver dispatch -> Interpreter-native).
+                // Handles the common hot-loop case directly in the Interpreter, writing the
                 // mutated array back to env, instead of routing through the
                 // tree-walking interpreter bridge. Falls through (returns None) for
                 // typed/shaped/lazy/shared/constrained arrays so the interpreter
@@ -1193,7 +1193,7 @@ impl VM {
                 }
                 // Native fast path for the simple (non-erroring) forms of `splice`
                 // on a plain, untyped `@`-array (ledger §1: native receiver
-                // dispatch -> VM-native).
+                // dispatch -> Interpreter-native).
                 if modifier.is_none()
                     && let Some(result) =
                         self.try_native_array_splice(&target_name, &target, &method, &args)
@@ -1203,7 +1203,7 @@ impl VM {
                     return Ok(());
                 }
                 // Native fast path for mutating Buf write methods on a mutable Buf
-                // instance (ledger §1: native receiver dispatch -> VM-native).
+                // instance (ledger §1: native receiver dispatch -> Interpreter-native).
                 if modifier.is_none()
                     && let Some(result) =
                         self.try_native_buf_mut(&target_name, &target, &method, &args)
@@ -1214,7 +1214,7 @@ impl VM {
                 }
                 // Native fast path for the Iterator protocol on a self-contained
                 // array-backed iterator (ledger §1: native receiver dispatch ->
-                // VM-native). `$it.pull-one` etc. compile to CallMethodMut, so the
+                // Interpreter-native). `$it.pull-one` etc. compile to CallMethodMut, so the
                 // index-advancing dispatch lands here.
                 if modifier.is_none()
                     && let Some(result) = self.try_native_iterator(&target, &method, &args)
@@ -1276,7 +1276,7 @@ impl VM {
                             .get("__mutsu_array_storage")
                             .cloned()
                             .unwrap_or(Value::real_array(Vec::new()));
-                        // VM-native fast path: simple mutators on the plain
+                        // Interpreter-native fast path: simple mutators on the plain
                         // untyped backing array are performed in Rust and the
                         // updated storage written back, with no interpreter
                         // dispatch. Richer methods fall through below.
@@ -1405,7 +1405,7 @@ impl VM {
         Ok(())
     }
 
-    /// VM-native mutating list methods (`append`/`prepend`/`unshift`/`pop`/`shift`)
+    /// Interpreter-native mutating list methods (`append`/`prepend`/`unshift`/`pop`/`shift`)
     /// on a plain, untyped `@`-array stored in env. Mirrors the interpreter's
     /// primary (`env.get_mut` + `Arc::make_mut`) branch in `methods_mut.rs`
     /// exactly for this narrow case, so the result is behavior-invariant.
@@ -1516,9 +1516,9 @@ impl VM {
         Some(Ok(result))
     }
 
-    /// VM-native simple array mutators (push/pop/shift/unshift/append/prepend)
+    /// Interpreter-native simple array mutators (push/pop/shift/unshift/append/prepend)
     /// applied directly to an `is Array`-backed instance's backing storage
-    /// `Value` (ledger §1: array-backed instance dispatch -> VM-native).
+    /// `Value` (ledger §1: array-backed instance dispatch -> Interpreter-native).
     ///
     /// Mirrors the interpreter's plain, non-shared env-keyed mutator branch
     /// (`methods_mut.rs`): the `__mutsu_array_storage` value is a plain untyped
@@ -1590,7 +1590,7 @@ impl VM {
 
     /// Rebuild an `is Array`-backed instance with its `__mutsu_array_storage`
     /// attribute replaced by `storage` and write it back into `target_name`.
-    /// Shared by the VM-native mutator fast path and the interpreter fallback.
+    /// Shared by the Interpreter-native mutator fast path and the interpreter fallback.
     fn write_back_array_storage_instance(
         &mut self,
         target_name: &str,
@@ -1616,8 +1616,8 @@ impl VM {
         self.env_dirty = true;
     }
 
-    /// VM-native `splice` on a plain, untyped `@`-array bound to `target_name`
-    /// (ledger §1: native receiver dispatch -> VM-native). Mirrors the
+    /// Interpreter-native `splice` on a plain, untyped `@`-array bound to `target_name`
+    /// (ledger §1: native receiver dispatch -> Interpreter-native). Mirrors the
     /// interpreter's `splice` branch in `methods_mut.rs` exactly (`drain` +
     /// `insert`, returning the removed elements as a real array), so the result
     /// is behavior-invariant.
@@ -1716,9 +1716,9 @@ impl VM {
         Some(Ok(Value::real_array(removed)))
     }
 
-    /// VM-native mutating Buf write methods (`write-bits`/`write-ubits`/
+    /// Interpreter-native mutating Buf write methods (`write-bits`/`write-ubits`/
     /// `write-num*`/`write-int*`/`write-uint*`) on a mutable `Buf` instance bound
-    /// to `target_name` (ledger §1: native receiver dispatch -> VM-native). Mirrors
+    /// to `target_name` (ledger §1: native receiver dispatch -> Interpreter-native). Mirrors
     /// the interpreter's instance-mutate branches in `methods_mut.rs` exactly: the
     /// byte transforms are the single shared pure implementations in `builtins/`
     /// (`buf_bits`/`buf_write_num`/`buf_write_int`), and the writeback goes

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 use std::sync::Arc;
 
-impl VM {
+impl Interpreter {
     /// Build an X::Multi::NoMatch error for a `print`/`say`/`put`/`note` call
     /// made with a positional argument on an invocant whose only candidate is
     /// the default `(Mu: *%_)` one. The `capture` attribute carries the full
@@ -177,7 +177,9 @@ impl VM {
         let method = &*method_cow;
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
-            return Err(RuntimeError::new("VM stack underflow in CallMethod"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in CallMethod",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -192,7 +194,7 @@ impl VM {
             raw_args
         };
         let target = self.stack.pop().ok_or_else(|| {
-            RuntimeError::new("VM stack underflow in CallMethod target".to_string())
+            RuntimeError::new("Interpreter stack underflow in CallMethod target".to_string())
         })?;
         // Force LazyIoLines into an eager array when calling methods on it,
         // unless the method preserves laziness (e.g., .kv).
@@ -342,7 +344,7 @@ impl VM {
             return Ok(());
         }
 
-        // Fast path for Lock::Async.protect — execute block inline in current VM
+        // Fast path for Lock::Async.protect — execute block inline in current Interpreter
         if method == "protect"
             && args.len() == 1
             && let Value::Instance {
@@ -540,7 +542,7 @@ impl VM {
             };
             // Restoring the pre-force env undoes captured-variable corruption
             // from gather coroutine forcing. A lazy map/grep pipeline runs its
-            // callback via `vm_call_on_value` in this VM, so its side effects on
+            // callback via `vm_call_on_value` in this Interpreter, so its side effects on
             // enclosing variables are legitimate and must persist.
             if !matches!(method, "elems" | "hyper" | "race") && ll.lazy_pipe.is_none() {
                 *self.env_mut() = saved_env;
@@ -736,7 +738,7 @@ impl VM {
             self.env_dirty = true;
             return Ok(());
         }
-        // .WHO on pseudo-package Package values: build the stash in the VM
+        // .WHO on pseudo-package Package values: build the stash in the Interpreter
         // where we have access to locals (which the interpreter doesn't have).
         if method == "WHO"
             && args.is_empty()
@@ -872,7 +874,7 @@ impl VM {
                 }
                 // Nil method fallback: in Raku, calling most methods on Nil returns Nil.
                 // Certain mutating methods throw exceptions.
-                // This must be in the VM path (not the interpreter's call_method_with_values)
+                // This must be in the Interpreter path (not the interpreter's call_method_with_values)
                 // to avoid affecting internal dispatch (e.g. max :by comparators).
                 if matches!(&target, Value::Nil) {
                     match method {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Find the first positional argument that is a Junction and whose corresponding
     /// parameter type constraint does not accept Junction (i.e., needs auto-threading).
     /// Returns the index of that argument, or None if no auto-threading is needed.

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -161,7 +161,7 @@ fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
         return std::cmp::Ordering::Greater;
     }
 
-    VM::spaceship_ordering(left, right)
+    Interpreter::spaceship_ordering(left, right)
 }
 
 /// Get list elements from a value (Array, Seq, List, Slip, etc.)
@@ -220,7 +220,7 @@ fn value_to_i64(v: &Value) -> Option<i64> {
     }
 }
 
-impl VM {
+impl Interpreter {
     fn parse_numeric_string_for_spaceship(s: &str) -> Result<f64, RuntimeError> {
         s.trim().parse::<f64>().map_err(|_| {
             RuntimeError::new(format!(

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -42,7 +42,7 @@ pub(super) struct CStyleLoopSpec {
     pub(super) collect: bool,
 }
 
-impl VM {
+impl Interpreter {
     fn collect_loop_value(coll: &mut Vec<Value>, value: Value) {
         match value {
             Value::Slip(items) => coll.extend(items.iter().cloned()),
@@ -107,7 +107,7 @@ impl VM {
     }
 
     /// Push a fresh loop-body declaration scope so `my` declarations inside the
-    /// body register as loop-local (see `VM::loop_local_vars`). A closure created
+    /// body register as loop-local (see `Interpreter::loop_local_vars`). A closure created
     /// in the body marks such free variables as `owned_captures`, giving Raku's
     /// per-iteration binding semantics. Must be balanced by `pop_loop_local_scope`
     /// on every exit path.
@@ -2825,7 +2825,7 @@ impl VM {
                             // the call's result in place. Gate strictly on `is_warn`:
                             // other control signals (take/emit/done) also carry a
                             // `return_value` for their own machinery, which must NOT
-                            // land on the VM operand stack here.
+                            // land on the Interpreter operand stack here.
                             if pending_err.is_warn
                                 && let Some(rv) = pending_err.return_value.take()
                             {

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -73,7 +73,7 @@ fn check_rat_divide_by_zero(v: &Value) -> Result<(), RuntimeError> {
     }
 }
 
-impl VM {
+impl Interpreter {
     pub(super) fn exec_make_array_op(&mut self, n: u32, is_real_array: bool) {
         let n = n as usize;
         let start = self.stack.len() - n;
@@ -396,7 +396,7 @@ impl VM {
     }
 }
 
-impl VM {
+impl Interpreter {
     /// Fast path for @arr.push(val) — directly appends to the array Arc.
     pub(super) fn exec_array_push_op(
         &mut self,
@@ -416,7 +416,7 @@ impl VM {
             return Ok(());
         }
         // TODO: compile to bytecode — shaped-array push, blocked-by: shaped
-        // dimension metadata check in VM. See ledger §1.
+        // dimension metadata check in Interpreter. See ledger §1.
         // Check for shaped arrays — must fall back to interpreter
         // (push is illegal on fixed-dimension arrays)
         if let Some(Value::Array(_, kind)) = self.env().get(target_name)

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// A plain, eager, list-like target — `Array`/`List`, `Seq`, `Slip`, or any
     /// `Range`. These are the shapes the native `.sort` / `.min` / `.max` /
     /// `.minmax` / `.first` paths handle without falling back to the interpreter
@@ -170,7 +170,7 @@ impl VM {
     /// Coerce an Instance operand to a numeric value via its `Numeric`/`Bridge`
     /// method. Delegates to the single authoritative implementation on the
     /// interpreter (`Interpreter::coerce_infix_operand_numeric`) so the
-    /// Instance->numeric bridge logic is not duplicated between the VM and the
+    /// Instance->numeric bridge logic is not duplicated between the Interpreter and the
     /// interpreter. Non-Instance values (the hot Int/Num/Rat path) return early
     /// inside the helper without any method dispatch.
     pub(super) fn coerce_numeric_bridge_value(
@@ -288,7 +288,7 @@ impl VM {
         )
     }
 
-    /// VM-native dispatch for calling a value (Sub, Routine, Junction, etc.).
+    /// Interpreter-native dispatch for calling a value (Sub, Routine, Junction, etc.).
     ///
     /// This avoids the interpreter's `eval_call_on_value` for common cases:
     /// - Value::Sub with compiled_code -> call_compiled_closure
@@ -325,7 +325,7 @@ impl VM {
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 
-        // Sub without compiled_code: compile on-the-fly then dispatch via VM
+        // Sub without compiled_code: compile on-the-fly then dispatch via Interpreter
         if let Value::Sub(ref data) = target
             && !data.body.is_empty()
         {
@@ -341,7 +341,7 @@ impl VM {
         }
 
         // Routine value dispatch (ledger §2, ③ PR-1). Resolve to a function name
-        // and route through the VM's unified compiled-first entry
+        // and route through the Interpreter's unified compiled-first entry
         // (`call_function_compiled_first`): user-defined subs/multi/proto run as
         // compiled bytecode, native builtins fall through to `native_function`, and
         // only genuine carriers (EVAL/pseudo-package) reach the interpreter terminal.
@@ -380,7 +380,7 @@ impl VM {
             if !args.is_empty() && !pkg.is_empty() && pkg != "GLOBAL" && self.has_class(&pkg) {
                 let invocant = args[0].clone();
                 let method_args = args[1..].to_vec();
-                // Route through the VM's unified compiled-first dispatch (ledger §1):
+                // Route through the Interpreter's unified compiled-first dispatch (ledger §1):
                 // user-defined methods run as compiled bytecode, native fall back.
                 return self.try_compiled_method_or_interpret(invocant, &name_str, method_args);
             }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Sync locals from env if the dirty flag is set, then clear the flag.
     /// If locals are also dirty, flush them to env first so we don't lose
     /// values that were only written to the locals array (fast-path SetLocal).

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Build a backtrace string from the interpreter's routine stack.
     /// Each frame is formatted as "  in sub <name> at <file> line <N>".
     ///
@@ -364,7 +364,7 @@ impl VM {
         }
     }
 
-    /// Force a LazyList by running its compiled bytecode in the VM.
+    /// Force a LazyList by running its compiled bytecode in the Interpreter.
     /// Falls back to interpreter if no compiled code is available.
     pub(super) fn force_lazy_list_vm(
         &mut self,
@@ -405,7 +405,7 @@ impl VM {
             _ => return self.force_lazy_list_bridge(list),
         };
 
-        // Save current VM state. Locals are kept coherent with env by
+        // Save current Interpreter state. Locals are kept coherent with env by
         // write-through (`flush_local_to_env`), so no explicit flush is needed
         // here; we restore locals directly on return.
         crate::vm::vm_stats::record_clone_env();
@@ -476,7 +476,7 @@ impl VM {
         }
 
         // Sync locals back to env before reading the result environment.
-        // During VM execution, variable assignments go to self.locals, not
+        // During Interpreter execution, variable assignments go to self.locals, not
         // to the interpreter env. We must flush them so the merge logic below
         // can see the changes made by the gather body.
         for (i, name) in cc.locals.iter().enumerate() {
@@ -525,7 +525,7 @@ impl VM {
             })
         };
 
-        // Restore VM state
+        // Restore Interpreter state
         self.locals = saved_locals;
         self.stack = saved_stack;
         self.env_dirty = if env_actually_changed {
@@ -593,7 +593,7 @@ impl VM {
             }
         };
 
-        // Save current VM state
+        // Save current Interpreter state
         crate::vm::vm_stats::record_clone_env();
         let saved_env = self.clone_env();
         let saved_locals = std::mem::take(&mut self.locals);
@@ -774,7 +774,7 @@ impl VM {
             })
         };
 
-        // Restore VM state
+        // Restore Interpreter state
         self.locals = saved_locals;
         self.stack = saved_stack;
         self.env_dirty = if env_actually_changed {
@@ -850,8 +850,8 @@ impl VM {
                     return Ok(c[..n].to_vec());
                 }
                 Some(elem) => {
-                    // Apply the stage with VM-native dispatch so the callback
-                    // runs in *this* VM (keeping locals/env coherent and letting
+                    // Apply the stage with Interpreter-native dispatch so the callback
+                    // runs in *this* Interpreter (keeping locals/env coherent and letting
                     // side effects reach the enclosing scope). A `grep` keeps the
                     // element when the matcher is truthy; a `map` transforms it (a
                     // `Slip` result contributes multiple elements).
@@ -1077,7 +1077,7 @@ impl VM {
         &mut self,
         left: Value,
         right: Value,
-        f: fn(&mut VM, Value, Value) -> Result<Value, RuntimeError>,
+        f: fn(&mut Interpreter, Value, Value) -> Result<Value, RuntimeError>,
     ) -> Result<Value, RuntimeError> {
         // Auto-FETCH Proxy containers in binary operations
         let left = loan_env!(self, auto_fetch_proxy(&left))?;
@@ -1357,7 +1357,7 @@ impl VM {
 
     /// Extend a sequence-spec lazy list's cache to at least `needed` elements.
     /// This generates new elements using the sequence spec (arithmetic/geometric)
-    /// without needing any VM or interpreter context.
+    /// without needing any Interpreter or interpreter context.
     fn extend_sequence_cache(
         list: &LazyList,
         spec: &crate::value::SequenceSpec,

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     /// Write a mutating hyper's result back to its *named* `@`/`%` target
     /// variable precisely. If the variable is bound (holds a shared
     /// `ContainerRef` cell, e.g. `$b := @a`), write through the cell so all
@@ -40,7 +40,9 @@ impl VM {
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
-            return Err(RuntimeError::new("VM stack underflow in HyperMethodCall"));
+            return Err(RuntimeError::new(
+                "Interpreter stack underflow in HyperMethodCall",
+            ));
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
@@ -49,10 +51,9 @@ impl VM {
         for arg in raw_args {
             Self::append_flattened_call_arg(&mut args, arg, false);
         }
-        let target = self
-            .stack
-            .pop()
-            .ok_or_else(|| RuntimeError::new("VM stack underflow in HyperMethodCall target"))?;
+        let target = self.stack.pop().ok_or_else(|| {
+            RuntimeError::new("Interpreter stack underflow in HyperMethodCall target")
+        })?;
         // Mark Seq as consumed (single-use semantics).
         if let Value::Seq(ref arc) = target {
             crate::value::seq_consume(arc)?;
@@ -657,16 +658,16 @@ impl VM {
         let arity = arity as usize;
         if self.stack.len() < arity + 2 {
             return Err(RuntimeError::new(
-                "VM stack underflow in HyperMethodCallDynamic",
+                "Interpreter stack underflow in HyperMethodCallDynamic",
             ));
         }
         let start = self.stack.len() - arity;
         let args: Vec<Value> = self.stack.drain(start..).collect();
         let name_val = self.stack.pop().ok_or_else(|| {
-            RuntimeError::new("VM stack underflow in HyperMethodCallDynamic name")
+            RuntimeError::new("Interpreter stack underflow in HyperMethodCallDynamic name")
         })?;
         let target = self.stack.pop().ok_or_else(|| {
-            RuntimeError::new("VM stack underflow in HyperMethodCallDynamic target")
+            RuntimeError::new("Interpreter stack underflow in HyperMethodCallDynamic target")
         })?;
         let mut items = crate::runtime::value_to_list(&target);
         let mut results = Vec::with_capacity(items.len());

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Parallel map/grep for HyperSeq/RaceSeq.
     /// Each item is processed in its own thread to support concurrent
     /// operations like `await` inside the map/grep block.
@@ -47,7 +47,7 @@ impl VM {
             let block_clone = block.clone();
             let is_map_flag = is_map;
             handles.push(std::thread::spawn(move || {
-                // CP-3 collapse: the cloned per-thread Interpreter *is* the VM.
+                // CP-3 collapse: the cloned per-thread Interpreter *is* the Interpreter.
                 let mut vm = thread_interp;
                 let mut results = Vec::with_capacity(batch.len());
                 let mut error: Option<RuntimeError> = None;

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) const ATTR_ALIAS_META_PREFIX: &str = "__mutsu_attr_alias::";
 
-impl VM {
+impl Interpreter {
     /// Call a compiled method body (MethodDef with compiled_code).
     /// Mirrors `Interpreter::run_instance_method_resolved` but executes bytecode.
     #[allow(clippy::too_many_arguments)]

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -100,7 +100,7 @@ fn is_parameterized_core_type(name: &str) -> bool {
 /// For arrays/lists: returns (min_element, max_element), recursing into elements.
 /// For ranges: returns (start, end).
 ///
-/// Single authoritative impl shared by the VM's `minmax` reduction and the
+/// Single authoritative impl shared by the Interpreter's `minmax` reduction and the
 /// interpreter's `apply_reduction_op` `minmax` arm (which delegates here).
 pub(crate) fn minmax_bounds_of_value(v: &Value) -> (Value, Value) {
     match v {
@@ -149,7 +149,7 @@ pub(crate) fn minmax_bounds_of_value(v: &Value) -> (Value, Value) {
     }
 }
 
-impl VM {
+impl Interpreter {
     fn is_builtin_reduction_op(op: &str) -> bool {
         if let Some(inner) = op
             .strip_prefix('R')
@@ -2979,7 +2979,7 @@ impl VM {
             // Package-qualified names (e.g. Test1::ns, Foo::Bar) are package-global
             // and must propagate out of any block scope where they were declared.
             // Sigils may appear before the qualifier (e.g. &Test1::ns, $Foo::var).
-            // Skip internal VM metadata keys (which contain `::` but are not
+            // Skip internal Interpreter metadata keys (which contain `::` but are not
             // user-visible package names, e.g. `__mutsu_var_meta::x`).
             let is_package_qualified = k.with_str(|s| {
                 let stripped = s.trim_start_matches(['$', '@', '%', '&']);

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     pub(super) fn try_native_method(
         &mut self,
         target: &Value,
@@ -219,7 +219,7 @@ impl VM {
             return Some(Ok(target.clone()));
         }
 
-        // Handle .Slip/.List/.Seq on scan-based LazyList by forcing elements via VM.
+        // Handle .Slip/.List/.Seq on scan-based LazyList by forcing elements via Interpreter.
         if result.is_none()
             && let Value::LazyList(ll) = target
             && ll.scan_spec.is_some()

--- a/src/vm/vm_native_extrema.rs
+++ b/src/vm/vm_native_extrema.rs
@@ -1,8 +1,8 @@
-//! Native `.min` / `.max` / `.minmax` in the VM.
+//! Native `.min` / `.max` / `.minmax` in the Interpreter.
 //!
 //! `@a.min`, `@a.max`, `@a.minmax`, their `:by` block forms (`*.abs`,
 //! `{ $^a <=> $^b }`), and the `:k`/`:v`/`:kv`/`:p` adverbs (min/max only) over a
-//! plain eager list run entirely in the VM. The `:by` block (the genuine
+//! plain eager list run entirely in the Interpreter. The `:by` block (the genuine
 //! Category-B fork — the only part the pure-native layer cannot do) is invoked
 //! through `vm_call_on_value`, and the folds themselves are the *single* shared
 //! implementations [`crate::runtime::Interpreter::extrema_from_values_generic`]
@@ -17,9 +17,9 @@
 use super::*;
 use crate::value::Value;
 
-impl VM {
+impl Interpreter {
     /// Try to run `target.min(...)` / `target.max(...)` natively. Returns
-    /// `Some(result)` when handled in the VM, `None` to fall back unchanged.
+    /// `Some(result)` when handled in the Interpreter, `None` to fall back unchanged.
     ///
     /// `.min`/`.max` yield a fresh value (no rw-view concern).
     pub(super) fn try_native_extrema(
@@ -88,7 +88,7 @@ impl VM {
     }
 
     /// Try to run `target.minmax(...)` natively. Returns `Some(result)` when
-    /// handled in the VM, `None` to fall back unchanged.
+    /// handled in the Interpreter, `None` to fall back unchanged.
     pub(super) fn try_native_minmax(
         &mut self,
         target: &Value,

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -1,7 +1,7 @@
-//! Native `.first` in the VM (no-adverb forms).
+//! Native `.first` in the Interpreter (no-adverb forms).
 //!
 //! `@a.first`, `@a.first({ .foo })`, `@a.first(* > 3)`, `@a.first(/rx/)`,
-//! `%h.first({ .value > 1 })` run entirely in the VM. The `Sub` matcher block
+//! `%h.first({ .value > 1 })` run entirely in the Interpreter. The `Sub` matcher block
 //! (the genuine Category-B fork) is invoked through `vm_call_on_value`; non-block
 //! patterns use the interpreter's single shared `smart_match`. The scan itself
 //! (iteration, `pair_as_positional`) is the shared
@@ -17,8 +17,8 @@ use crate::runtime::resolution::{FirstMatcher, find_first_match_generic};
 use crate::runtime::utils::pair_as_positional;
 use crate::value::Value;
 
-/// [`FirstMatcher`] backed by the bytecode VM.
-struct VmFirstMatcher<'a>(&'a mut VM);
+/// [`FirstMatcher`] backed by the bytecode Interpreter.
+struct VmFirstMatcher<'a>(&'a mut Interpreter);
 
 impl FirstMatcher for VmFirstMatcher<'_> {
     fn item_matches(&mut self, pattern: &Value, item: &Value) -> Result<bool, RuntimeError> {
@@ -34,13 +34,13 @@ impl FirstMatcher for VmFirstMatcher<'_> {
     }
 }
 
-impl VM {
+impl Interpreter {
     /// Test a `grep`/`first`-style matcher against a single `item` using
-    /// VM-native dispatch (a `Sub` block via `vm_call_on_value`, any other
+    /// Interpreter-native dispatch (a `Sub` block via `vm_call_on_value`, any other
     /// pattern via the shared `smart_match`). Used by the lazy map/grep
-    /// pipeline (`force_lazy_pipe`) so the matcher runs in this VM and keeps
+    /// pipeline (`force_lazy_pipe`) so the matcher runs in this Interpreter and keeps
     /// locals/env coherent (the interpreter's `eval_grep_over_items` spins up a
-    /// nested VM via `mem::take`, which would discard the surrounding frame).
+    /// nested Interpreter via `mem::take`, which would discard the surrounding frame).
     pub(super) fn vm_grep_item_matches(
         &mut self,
         pattern: &Value,
@@ -50,7 +50,7 @@ impl VM {
     }
 
     /// Try to run `target.first(...)` natively. Returns `Some(result)` when
-    /// handled in the VM, `None` to fall back unchanged.
+    /// handled in the Interpreter, `None` to fall back unchanged.
     pub(super) fn try_native_first(
         &mut self,
         target: &Value,

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -2,9 +2,9 @@
 //!
 //! `@a.map({ ... })` previously always fell back to the interpreter's
 //! `dispatch_map_method` orchestration (see docs/vm-decoupling.md, lever A). The
-//! block *body* already runs compiled on the VM (`vm_call_on_value` ->
+//! block *body* already runs compiled on the Interpreter (`vm_call_on_value` ->
 //! `call_compiled_closure`); only the surrounding iteration loop lived in the
-//! interpreter. This runs that loop in the VM for the common, simple case
+//! interpreter. This runs that loop in the Interpreter for the common, simple case
 //! (including multi-arity blocks like `-> $a, $b { ... }`, which consume the
 //! source in `arity`-sized chunks) and falls back for anything that needs the
 //! interpreter's richer orchestration (Slip/phaser/lazy-`return` handling,
@@ -21,9 +21,9 @@ use super::*;
 use crate::ast::{Expr, Stmt};
 use crate::token_kind::TokenKind;
 
-impl VM {
+impl Interpreter {
     /// Try to run `target.map(block)` natively. Returns `Some(result)` when
-    /// handled in the VM, `None` to fall back to the interpreter unchanged.
+    /// handled in the Interpreter, `None` to fall back to the interpreter unchanged.
     ///
     /// Only `.map` is handled here, not `.grep`: `.grep` returns a subset of the
     /// *original* elements that must stay rw-view-bound to the source array

--- a/src/vm/vm_native_sort.rs
+++ b/src/vm/vm_native_sort.rs
@@ -1,8 +1,8 @@
-//! Native `.sort` in the VM.
+//! Native `.sort` in the Interpreter.
 //!
 //! `@a.sort` and every comparator/mapper form — `@a.sort({ $^a <=> $^b })`,
 //! `@a.sort(*.abs)`, `@a.sort({ $^a.foo <=> $^b.foo })`, `%h.sort`, `.sort(:k)`,
-//! a `Routine` comparator — now run entirely in the VM. User callables are
+//! a `Routine` comparator — now run entirely in the Interpreter. User callables are
 //! invoked through [`VmSortCaller`] (a [`SortCaller`] backed by
 //! `vm_call_on_value`), and the orchestration itself (arity dispatch, merge
 //! sort, Schwartzian transform, simple-comparator inlining, `:k` index mode) is
@@ -21,8 +21,8 @@ use crate::runtime::methods_collection_ops::sort::{SortCaller, sort_value_generi
 use crate::runtime::utils::pair_as_positional;
 use crate::value::{ArrayKind, Value};
 
-/// [`SortCaller`] backed by the bytecode VM.
-struct VmSortCaller<'a>(&'a mut VM);
+/// [`SortCaller`] backed by the bytecode Interpreter.
+struct VmSortCaller<'a>(&'a mut Interpreter);
 
 impl SortCaller for VmSortCaller<'_> {
     fn call_callable(&mut self, callable: &Value, args: Vec<Value>) -> Value {
@@ -46,9 +46,9 @@ impl SortCaller for VmSortCaller<'_> {
     }
 }
 
-impl VM {
+impl Interpreter {
     /// Try to run `target.sort(...)` natively. Returns `Some(result)` when
-    /// handled in the VM, `None` to fall back to the interpreter unchanged.
+    /// handled in the Interpreter, `None` to fall back to the interpreter unchanged.
     ///
     /// `.sort` has no rw-view concern (it always yields a fresh `Seq`), so a
     /// freshly-built sorted array is a faithful result.

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -5,7 +5,7 @@
 //! highest-frequency residual method fallback). The substitution *engine* —
 //! regex matching (`regex_find_first_from_with_captures`), `$0`/`$1` capture
 //! expansion (`expand_capture_refs`) and Match-object construction — already
-//! lives VM-side because the operator form `s/.../.../ ` compiles to
+//! lives Interpreter-side because the operator form `s/.../.../ ` compiles to
 //! `OpCode::Subst` and runs natively in `exec_subst_op`. This routes the common
 //! `.subst` *method* call through the same building blocks instead of the
 //! interpreter, falling back for anything that needs the interpreter's richer
@@ -22,9 +22,9 @@ use super::*;
 use crate::value::Value;
 use std::collections::HashMap;
 
-impl VM {
+impl Interpreter {
     /// Try to run `target.subst(pattern, replacement, :g?)` natively. Returns
-    /// `Some(result)` when handled in the VM, `None` to fall back to the
+    /// `Some(result)` when handled in the Interpreter, `None` to fall back to the
     /// interpreter unchanged.
     pub(super) fn try_native_subst(
         &mut self,

--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -1,4 +1,4 @@
-//! VM-side dispatch for `Test` / `Test::Util` functions.
+//! Interpreter-side dispatch for `Test` / `Test::Util` functions.
 //!
 //! `is`/`ok`/`plan`/`is-deeply`/`subtest`/… are the bulk of the residual
 //! function-dispatch fallback when running the roast suite (see
@@ -6,11 +6,11 @@
 //! (`Interpreter::call_test_function`) rather than user AST, and are routed to
 //! the interpreter on purpose (`is_interpreter_handled_function`).
 //!
-//! Until now the VM reached them only by delegating to `Interpreter::call_function`
+//! Until now the Interpreter reached them only by delegating to `Interpreter::call_function`
 //! — the generic, giant-`match` function dispatcher — which re-runs argument
 //! sanitisation and name resolution before finally landing on
-//! `call_test_function`. This routes the VM straight to the typed Test handler
-//! instead, the same "VM owns the native dispatch table" pattern already used
+//! `call_test_function`. This routes the Interpreter straight to the typed Test handler
+//! instead, the same "Interpreter owns the native dispatch table" pattern already used
 //! for `sprintf` and the pure builtins.
 //!
 //! Scope note: the *bodies* of these functions are inherently interpreter
@@ -19,7 +19,7 @@
 //! spawning. So this decouples the *dispatch layer*, not the bodies; moving the
 //! TAP state itself out of the interpreter is the separate lever-B work.
 //!
-//! Safety: both call sites that invoke this run *after* the VM's user-function /
+//! Safety: both call sites that invoke this run *after* the Interpreter's user-function /
 //! proto / multi-candidate / on-the-fly-compile resolution has already failed to
 //! match, so a user-defined `sub ok { … }` still shadows the Test routine (it is
 //! resolved earlier and never reaches here).
@@ -27,7 +27,7 @@
 use super::*;
 use crate::value::Value;
 
-impl VM {
+impl Interpreter {
     /// Dispatch a `Test` module function straight to its typed handler when the
     /// name is a known Test function and test mode is active. Returns
     /// `Some(result)` when handled, `None` to let the caller fall back to

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -1,25 +1,25 @@
-//! VM-side react/supply drive loop (Stage 2).
+//! Interpreter-side react/supply drive loop (Stage 2).
 //!
 //! These methods were moved from `impl Interpreter` (`runtime/subtest.rs`) onto
-//! `impl VM` (Stage 2 PR1) so the `whenever`-body callbacks can run **compiled
-//! bytecode** instead of the tree-walking `call_sub_value`. The VM owns the
-//! `Interpreter` by value, so a `&mut Interpreter` method cannot construct a VM
+//! `impl Interpreter` (Stage 2 PR1) so the `whenever`-body callbacks can run **compiled
+//! bytecode** instead of the tree-walking `call_sub_value`. The Interpreter owns the
+//! `Interpreter` by value, so a `&mut Interpreter` method cannot construct a Interpreter
 //! — the loop itself must live here.
 //!
 //! All `whenever`-body / `LAST` / `QUIT` / `CLOSE` callback dispatch goes through
-//! [`VM::call_react_callback`], which runs the (on-the-fly compiled) closure via
+//! [`Interpreter::call_react_callback`], which runs the (on-the-fly compiled) closure via
 //! `vm_call_map_block` with the triggering value bound as the block topic `$_`.
 //! Loop-control signals (`done` / `next` / `last`) surface as `Err` just as the
 //! old tree-walk path produced them, so the signal mapping is unchanged. Supply
-//! `QUIT` handlers now dispatch natively too, via [`VM::call_supply_quit_handler`]
+//! `QUIT` handlers now dispatch natively too, via [`Interpreter::call_supply_quit_handler`]
 //! (Stage 3 follow-up) — no drive-loop callback routes back through the
 //! Interpreter's tree-walk `call_sub_value` anymore.
 //!
 //! The `await $supply` / `$supply.Promise` path reaches this loop through a thin
 //! `Interpreter::drive_react_subscriptions` bridge (see `runtime/supply_promise.rs`)
-//! that uses the established `mem::take` / `VM::new` / `into_interpreter` dance.
+//! that uses the established `mem::take` / `Interpreter::new` / `into_interpreter` dance.
 //!
-//! See PLAN.md Track C and the react-loop row of the VM/interpreter ledger.
+//! See PLAN.md Track C and the react-loop row of the Interpreter/interpreter ledger.
 
 use super::*;
 use crate::runtime::native_methods::{
@@ -30,7 +30,7 @@ use crate::runtime::subtest::{ReactSubscription, StreamConsumer, SupplyDrivePoli
 use std::sync::mpsc;
 use std::time::Duration;
 
-impl VM {
+impl Interpreter {
     /// Dispatch a `whenever` body or one of its `LAST` / `QUIT` / `CLOSE` phaser
     /// callbacks as **compiled bytecode** (Stage 2). The first argument, when
     /// present, is the triggering value: it is bound as the block topic `$_`
@@ -45,12 +45,12 @@ impl VM {
         self.vm_call_map_block(cb, args, topic, false)
     }
 
-    /// VM-native supply `QUIT` handler dispatch. Mirrors
+    /// Interpreter-native supply `QUIT` handler dispatch. Mirrors
     /// `Interpreter::call_supply_quit_handler` but runs the `QUIT` phaser body as
     /// **compiled bytecode** via [`Self::call_react_callback`] (with `reason`
     /// bound as `$_`) instead of the tree-walking `call_sub_value`. This is the
     /// last drive-loop callback that routed back through the Interpreter; with it
-    /// gone the VM react loop dispatches every `whenever`/`LAST`/`QUIT`/`CLOSE`
+    /// gone the Interpreter react loop dispatches every `whenever`/`LAST`/`QUIT`/`CLOSE`
     /// callback natively. A `when`/`default`/`succeed` inside the body counts as
     /// handled; any other error propagates.
     pub(crate) fn call_supply_quit_handler(

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::compiler::Compiler;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     /// Get the current source line number from the interpreter env.
     pub(super) fn current_source_line(&self) -> Option<u32> {
         self.env().get("?LINE").and_then(|v| match v {
@@ -31,7 +31,7 @@ impl VM {
                 "__mutsu_lazylist_from_gather".to_string(),
                 Value::Bool(true),
             );
-            // Compile the gather body to bytecode for VM-native forcing
+            // Compile the gather body to bytecode for Interpreter-native forcing
             let compiler = Compiler::new();
             let (compiled_code, compiled_fns) = compiler.compile(body);
             let list = LazyList {
@@ -183,7 +183,7 @@ impl VM {
     }
 
     /// Free variables of a closure being created that were declared in an
-    /// enclosing loop body (see `VM::loop_local_vars`). These become the
+    /// enclosing loop body (see `Interpreter::loop_local_vars`). These become the
     /// closure's `owned_captures`: read at call time from its own frozen captured
     /// env so each loop iteration's closure sees its own value (Raku
     /// per-iteration binding), immune to the dual-store slot re-injection.
@@ -1608,7 +1608,7 @@ impl VM {
         let body_start = *ip + 1;
 
         // `whenever` callbacks run as compiled bytecode (the drive loop lives on
-        // `impl VM`, see `vm_react_loop.rs`) but still capture their lexicals from
+        // `impl Interpreter`, see `vm_react_loop.rs`) but still capture their lexicals from
         // env. First pull any pending env updates into locals (e.g. instance
         // attribute mutations written into the shared cell after bind-stdin), then
         // flush all locals to env so captured vars are visible/mutable from the
@@ -1625,9 +1625,9 @@ impl VM {
         // If `done;` was called in the react body, skip the event loop —
         // the body already signaled that no further events should be processed.
         let body_done = matches!(&run_result, Err(e) if e.is_react_done);
-        // The react/supply drive loop runs VM-side and dispatches every
+        // The react/supply drive loop runs Interpreter-side and dispatches every
         // whenever / LAST / QUIT / CLOSE callback as compiled bytecode
-        // (Stage 2 #3038/#3039; QUIT handlers VM-native in the Stage 3 follow-up).
+        // (Stage 2 #3038/#3039; QUIT handlers Interpreter-native in the Stage 3 follow-up).
         // No drive-loop callback routes back through the tree-walk interpreter.
         let event_result = if body_done {
             // Drain any queued subscriptions so they don't leak

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     fn integral_bigint(value: &Value) -> Option<num_bigint::BigInt> {
         match value {
             Value::Int(i) => Some(num_bigint::BigInt::from(*i)),

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use crate::runtime::Interpreter;
 use crate::value::Value;
-use crate::vm::VM;
 
 /// Normalize an IO::Path for ACCEPTS comparison: cleanup + absolute.
 /// Returns the cleaned-up absolute path string.
@@ -227,8 +226,8 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             is_buf(&a) && is_buf(&b)
         } =>
         {
-            let lb = VM::extract_buf_bytes(left);
-            let rb = VM::extract_buf_bytes(right);
+            let lb = Interpreter::extract_buf_bytes(left);
+            let rb = Interpreter::extract_buf_bytes(right);
             Some(lb == rb)
         }
 
@@ -574,7 +573,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
     }
 }
 
-impl VM {
+impl Interpreter {
     /// Perform a smart match, trying pure value matching first, falling back to
     /// the interpreter for complex cases (regex, callable, type checks, etc.).
     pub(super) fn vm_smart_match(&mut self, left: &Value, right: &Value) -> bool {
@@ -598,7 +597,7 @@ impl VM {
             )
         {
             let method_name = key.as_str();
-            // Route the key-method call through the VM's unified compiled-first
+            // Route the key-method call through the Interpreter's unified compiled-first
             // dispatch (ledger §1): user-defined methods run as compiled bytecode;
             // only native/reflective methods bottom out at the interpreter. `left`
             // is never an Array/Hash/Seq here (excluded above), so the native

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -1,9 +1,9 @@
-//! Lightweight VM -> Interpreter fallback instrumentation.
+//! Lightweight Interpreter -> Interpreter fallback instrumentation.
 //!
-//! The bytecode VM is intended to execute everything natively, but today it
+//! The bytecode Interpreter is intended to execute everything natively, but today it
 //! still delegates a large fraction of method dispatch to the tree-walking
 //! `Interpreter` (see `ANALYSIS.md` section 1). This module counts how often
-//! that delegation happens so progress on decoupling the VM can be measured
+//! that delegation happens so progress on decoupling the Interpreter can be measured
 //! per change instead of guessed at.
 //!
 //! Disabled by default (a single relaxed atomic load guards every counter).
@@ -20,7 +20,7 @@ static FUNCTION_TOTAL: AtomicU64 = AtomicU64::new(0);
 static FUNCTION_FALLBACK: AtomicU64 = AtomicU64::new(0);
 /// Dispatches that enter the interpreter purely as a *carrier*, not as a
 /// tree-walk fallback. `EVAL`/`EVALFILE` compile the supplied source to
-/// bytecode and run it on a sub-VM (`run_compiled_block`); pseudo-package reads
+/// bytecode and run it on a sub-Interpreter (`run_compiled_block`); pseudo-package reads
 /// (`CALLER::`/`OUTER::`/`SETTING::`/`DYNAMIC::`) are reflective env lookups.
 /// Neither tree-walks user code, so counting them as fallbacks overstates the
 /// real decoupling gap. They are tracked separately here (lever A). See
@@ -160,7 +160,7 @@ pub(crate) fn record_locals_pull() {
     }
 }
 
-/// Print a one-line summary of VM fallback statistics to stderr.
+/// Print a one-line summary of Interpreter fallback statistics to stderr.
 ///
 /// No-op unless `MUTSU_VM_STATS` is set. Counts aggregate across worker threads
 /// (Promise/Proc::Async/hyper) because the counters are process-global.

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -411,7 +411,7 @@ fn normalize_subst_replacement(template: &str) -> String {
     out
 }
 
-impl VM {
+impl Interpreter {
     fn canonical_infix_lookup_name(name: &str) -> std::borrow::Cow<'_, str> {
         if name == "(+)" {
             return std::borrow::Cow::Borrowed("+");
@@ -1569,7 +1569,7 @@ impl VM {
         };
         // Resolve a concrete code-ref value when `name` refers to a lexical
         // `&name` variable (e.g. the `&op`/`&metaop` loop variables in
-        // S03-metaops/infix.t). Such calls must go through the VM closure
+        // S03-metaops/infix.t). Such calls must go through the Interpreter closure
         // dispatch (`vm_call_on_value`) so sigilless `rw` binding and the
         // return value behave the same as a named-sub call; the interpreter
         // fallback mishandles both for mutating sigilless subs.
@@ -1906,7 +1906,7 @@ impl VM {
     }
 
     /// Dispatch a single per-element call of a hyper function-op. Lexical
-    /// code-refs (`func_value`) go through the VM closure dispatch; named subs
+    /// code-refs (`func_value`) go through the Interpreter closure dispatch; named subs
     /// go through the compiled-first path.
     fn dispatch_hyper_func_call(
         &mut self,

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::runtime::{current_mutsu_thread_id, is_initial_thread};
 use crate::symbol::Symbol;
 
-impl VM {
+impl Interpreter {
     /// Create a Thread instance with the current thread's mutsu ID.
     pub(super) fn make_thread_instance() -> Value {
         let numeric_id = current_mutsu_thread_id();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -9,7 +9,7 @@ use unicode_normalization::UnicodeNormalization;
 /// afterwards (`None` when the source is already bound to that cell).
 type BindSourceCell = (Option<String>, Arc<std::sync::Mutex<Value>>);
 
-impl VM {
+impl Interpreter {
     /// Return the default fill value for a native type constraint.
     /// For `int`/`uint` variants returns `Value::Int(0)`,
     /// for `num` variants returns `Value::Num(0.0)`,
@@ -1467,7 +1467,7 @@ impl VM {
 
     /// Increment a value, calling .succ() on Instance values with custom methods.
     pub(super) fn increment_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
-        // Route user-defined `.succ` through the VM's unified compiled-first
+        // Route user-defined `.succ` through the Interpreter's unified compiled-first
         // dispatch (same entry point `.Str` interpolation already uses) instead
         // of a raw interpreter tree-walk — one method-dispatch path, not two.
         if let Value::Instance { .. } = val
@@ -1550,7 +1550,7 @@ impl VM {
 
     /// Decrement a value, calling .pred() on Instance values with custom methods.
     pub(super) fn decrement_value_smart(&mut self, val: &Value) -> Result<Value, RuntimeError> {
-        // Route user-defined `.pred` through the VM's unified compiled-first
+        // Route user-defined `.pred` through the Interpreter's unified compiled-first
         // dispatch (see increment_value_smart) instead of a raw interpreter
         // tree-walk — one method-dispatch path, not two.
         if let Value::Instance { .. } = val
@@ -5241,7 +5241,7 @@ impl VM {
                 return Ok(());
             }
         }
-        // Shared @/% variables may be mutated by sibling threads while this VM
+        // Shared @/% variables may be mutated by sibling threads while this Interpreter
         // still holds an old local snapshot. Prefer the shared copy so reads
         // observe the latest value without forcing array COW on every push.
         if (name.starts_with('@') || name.starts_with('%'))
@@ -6491,7 +6491,7 @@ impl VM {
         // enclosing-scoped and often read after the loop. Only record names that
         // already had a binding (a genuine shadow — there is nothing to clobber
         // otherwise), and only the first time in this loop scope so the saved
-        // value is the pre-loop one. See VM::loop_local_saved_env.
+        // value is the pre-loop one. See Interpreter::loop_local_saved_env.
         //
         // Crucially, only record names the compiler scoped to the loop body — i.e.
         // names with a local slot in `code.locals`. A `my` in a *statement
@@ -6564,7 +6564,7 @@ impl VM {
             set.insert(name.to_string());
         }
         // Track loop-body declarations so a closure created in the body can mark
-        // this name as a per-iteration `owned_capture` (see VM::loop_local_vars).
+        // this name as a per-iteration `owned_capture` (see Interpreter::loop_local_vars).
         if let Some(set) = self.loop_local_vars.last_mut() {
             set.insert(name.to_string());
         }

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::sync::Arc;
 
-impl VM {
+impl Interpreter {
     /// Resolve WhateverCode indices for array deletion.
     /// Converts `*-N` style closures to concrete integer indices.
     fn resolve_delete_index_for_array(&mut self, idx: Value, container: &Value) -> Value {

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Rich :exists adverb handler supporting negation, parameterized arg,
     /// zen slice, and secondary adverbs (:kv, :!kv, :p, :!p, :!v).
     pub(super) fn exec_exists_index_adv_op(

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     pub(super) fn exec_get_bare_word_op(
         &mut self,
         code: &CompiledCode,
@@ -202,7 +202,7 @@ impl VM {
             {
                 native_result?
             } else {
-                // Route the cold 0-arg term fallback through the VM's unified
+                // Route the cold 0-arg term fallback through the Interpreter's unified
                 // compiled-first function dispatch (ledger §2): this adds OTF
                 // compilation of simple user subs; the interpreter remains only as
                 // the terminal fallback inside call_function_compiled_first.
@@ -240,7 +240,7 @@ impl VM {
             if let Some((_pkg, short)) = name.rsplit_once("::")
                 && self.has_function(&format!("GLOBAL::{}", short))
             {
-                // Route the package-qualified term fork through the VM's unified
+                // Route the package-qualified term fork through the Interpreter's unified
                 // compiled-first function dispatch (ledger §2): interpreter remains
                 // only as the terminal fallback.
                 let result = self.call_function_compiled_first(name, Vec::new(), compiled_fns)?;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::sync::Arc;
 
-impl VM {
+impl Interpreter {
     /// Wrap a value in item (scalar) context if it's a List/Array,
     /// following Raku's rule that hash slot access returns values in item context.
     /// A List stored in a hash slot becomes an ItemList when accessed.
@@ -1772,7 +1772,7 @@ fn range_params(v: &Value) -> Option<(i64, i64, bool, bool)> {
     }
 }
 
-impl VM {
+impl Interpreter {
     /// When indexing an array with a multi-index list (e.g. `@a[0..2, 0..2]`),
     /// check if an individual index element is a Range and, if so, resolve it
     /// to a sublist (slice). Returns `None` if the index is not a range.
@@ -1781,7 +1781,7 @@ impl VM {
         items: &std::sync::Arc<crate::value::ArrayData>,
         kind: crate::value::ArrayKind,
         _len: i64,
-        vm: &mut VM,
+        vm: &mut Interpreter,
     ) -> Option<Vec<Value>> {
         let (start, end, excl_end) = match idx {
             Value::Range(a, b) => (*a, *b, false),

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl VM {
+impl Interpreter {
     /// Multi-dimensional indexing: @a[$x;$y;$z]
     /// Stack: [target, dim0, dim1, ..., dimN-1] → [result]
     pub(super) fn exec_multi_dim_index_op(&mut self, ndims: u32) -> Result<(), RuntimeError> {
@@ -297,7 +297,7 @@ impl VM {
                 Self::multi_dim_assign(container, &dims, value.clone())?;
             }
         }
-        // Also sync the updated container into the VM locals slot (if any)
+        // Also sync the updated container into the Interpreter locals slot (if any)
         // so that a later locals write-through does not restore the stale
         // pre-assignment copy from locals into env. Without this, shaped
         // array element writes like `@a[i;j] = v` can be silently lost

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 const SELF_HASH_REF_SENTINEL: &str = "__mutsu_self_hash_ref";
 const SELF_ARRAY_REF_SENTINEL: &str = "__mutsu_self_array_ref";
 
-impl VM {
+impl Interpreter {
     pub(super) fn range_end_is_unbounded(end: i64) -> bool {
         end == i64::MAX
     }


### PR DESCRIPTION
Follow-up to #3102 (CP-3 collapse). Removes the two remnants left after the VM struct was dissolved into `Interpreter`, so the end state is clean (single struct = bytecode VM, no `VM` name).

- **Drop the `type VM = Interpreter` alias**: `impl VM`→`impl Interpreter`, `VM::`→`Interpreter::`, `crate::vm::VM`→`crate::runtime::Interpreter`, `&mut VM`→`&mut Interpreter`. The `vm`/`src/vm` module names stay (home of the bytecode-execution methods).
- **Remove the dead `Env::poisoned` guard**: field + `assert_not_poisoned` + 6 call sites + initializers. This was the CP-1 env-loan sentinel; with env unified there is no loan boundary, so it was permanently `false`.

Pure cleanup, no behavior change. cargo test 462/0, full `prove t/` 810 files / 7549 tests PASS, clippy + fmt clean. Full roast via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)