### PR TITLE
fix(quanthash): type-check parameterized Bag/Mix/Set element binding + MixHash[T] mutability

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -187,9 +187,12 @@
 - [ ] roast/S02-types/baggy.t
   - 0/? pass. Parse error at line 60
 - [ ] roast/S02-types/baghash.t
-  - 268/270 pass then aborts at 270 (plan 344). Fixed weight=0 removal + Str→X::Str::Numeric
+  - 270 pass then aborts at 270 (plan 344). Fixed weight=0 removal + Str→X::Str::Numeric
     on `%h is BagHash`/scalar BagHash element assign (quanthash-element-assign fix).
-  - Remaining before abort: 206 (`does` add wrong-type croak).
+  - DONE: 206/207 (`BagHash[Str]` element-bind wrong-type croak + init croak) — parameterized
+    `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]`.new now embeds the keyof type metadata so
+    `$b{42}=1` throws X::TypeCheck::Binding. Also fixed `MixHash[T].new` returning an
+    immutable Mix (was `class_name.resolve()=="MixHash"`, now `base_class_name`).
   - DONE: 268 (named arg eaten by `.new`) — `Bag/Set/Mix.new` (and the Hash variants) now
     drop top-level `Value::Pair` args (bareword `a => 1` reaches `.new` un-containerized as
     `Value::Pair`, while positional pair literals are `ValuePair` and array-flattened pairs
@@ -250,6 +253,9 @@
 - [ ] roast/S02-types/mixhash.t
   - 216/216 pass then aborts at 216 (plan 295). Fixed 161-164 (`%h is MixHash` weight=0
     removal + Str→X::Str::Numeric on element assign; quanthash-element-assign fix).
+  - DONE: parameterized `MixHash[T]`/`Mix[T]` element-bind type-check (keyof in `key_type`,
+    weight type stays Real in `value_type`) + `MixHash[T].new` mutability bug (now uses
+    `base_class_name`).
   - Abort blocker: writable `.values`/`.pairs`/`.kv` aliases into the mix weights need
     Proxy-style writeback into the QuantHash internal weights (container identity). Hard.
 - [ ] roast/S02-types/mix-iterator.t

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3146,7 +3146,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    return Ok(if has_non_str_keys {
+                    let result = if has_non_str_keys {
                         if base_class_name == "BagHash" {
                             Value::bag_hash_typed(counts, original_keys)
                         } else {
@@ -3156,7 +3156,22 @@ impl Interpreter {
                         Value::bag_hash(counts)
                     } else {
                         Value::bag(counts)
-                    });
+                    };
+                    // Embed type metadata for parameterized Bag[T]/BagHash[T] so
+                    // later element binding (`$b{42} = 1`) can type-check the key.
+                    let result = if let Some(ref ta) = type_args
+                        && let Some(constraint) = ta.first()
+                    {
+                        let info = crate::runtime::ContainerTypeInfo {
+                            value_type: constraint.clone(),
+                            key_type: Some(constraint.clone()),
+                            declared_type: Some(class_name.resolve()),
+                        };
+                        self.tag_container_metadata(result, info)
+                    } else {
+                        result
+                    };
+                    return Ok(result);
                 }
                 "Mix" | "MixHash" => {
                     let args = Self::strip_named_pair_args(args);
@@ -3260,7 +3275,10 @@ impl Interpreter {
                             }
                         }
                     }
-                    let is_hash_variant = class_name.resolve() == "MixHash";
+                    // Use `base_class_name` (not `class_name.resolve()`) so a
+                    // parameterized `MixHash[T]` is still recognized as the mutable
+                    // variant — `class_name.resolve()` would be "MixHash[T]".
+                    let is_hash_variant = base_class_name == "MixHash";
                     let result = if has_non_str_keys {
                         if is_hash_variant {
                             Value::mix_hash_with_original_keys(weights, original_keys)
@@ -3272,7 +3290,25 @@ impl Interpreter {
                     } else {
                         Value::mix(weights)
                     };
-                    let result = if is_hash_variant {
+                    // For a parameterized Mix[T]/MixHash[T] embed the element type so
+                    // later element binding (`$m{42} = 1`) can type-check the key.
+                    let param_constraint = type_args
+                        .as_ref()
+                        .and_then(|ta| ta.first())
+                        .filter(|c| c.starts_with(char::is_uppercase) && *c != "Any" && *c != "Mu");
+                    let result = if let Some(constraint) = param_constraint {
+                        // keyof is the element (key) type; the weight value type is
+                        // always Real, so keep `value_type` as "Real" and carry the
+                        // parameterized element type in `key_type`.
+                        self.tag_container_metadata(
+                            result,
+                            ContainerTypeInfo {
+                                value_type: "Real".to_string(),
+                                key_type: Some(constraint.clone()),
+                                declared_type: Some(class_name.resolve()),
+                            },
+                        )
+                    } else if is_hash_variant {
                         self.tag_container_metadata(
                             result,
                             ContainerTypeInfo {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3376,30 +3376,42 @@ impl Interpreter {
                 // to allow in-place mutation (preserving shared identity).
                 let is_bound_hash_var =
                     var_name.starts_with('%') && self.readonly_vars().contains(&var_name);
-                // Type check for parameterized SetHash[T] element binding.
-                // Only applies when the declared type is explicitly parameterized
-                // (e.g. SetHash[Str]), not when the constraint is just `is SetHash`.
+                // Type check for parameterized SetHash[T]/BagHash[T]/MixHash[T]
+                // element binding. Only applies when the declared type is explicitly
+                // parameterized (e.g. SetHash[Str]), not when the constraint is just
+                // `is SetHash`. The subscript key is the element, so it must satisfy
+                // the parameterized element (keyof) type.
                 let set_val_clone = self
                     .env()
                     .get(&var_name)
-                    .filter(|v| matches!(v, Value::Set(..)))
+                    .filter(|v| matches!(v, Value::Set(..) | Value::Bag(..) | Value::Mix(..)))
                     .cloned();
-                if let Some(set_val) = set_val_clone
-                    && let Some(info) = self.container_type_metadata(&set_val)
-                    && info
-                        .declared_type
-                        .as_deref()
-                        .is_some_and(|t| t.contains('['))
-                    && !info.value_type.is_empty()
-                    && info.value_type != "Any"
-                    && info.value_type != "Mu"
-                    && !self.type_matches_value(&info.value_type, &idx)
+                // The subscript key is checked against the element (keyof) type.
+                // For Set/Bag that equals `value_type`; for Mix the keyof lives in
+                // `key_type` (while `value_type` is the weight type, Real).
+                let elem_type = set_val_clone.as_ref().and_then(|sv| {
+                    self.container_type_metadata(sv).and_then(|info| {
+                        if !info
+                            .declared_type
+                            .as_deref()
+                            .is_some_and(|t| t.contains('['))
+                        {
+                            return None;
+                        }
+                        info.key_type
+                            .filter(|t| !t.is_empty())
+                            .or(Some(info.value_type))
+                            .filter(|t| !t.is_empty() && t != "Any" && t != "Mu")
+                    })
+                });
+                if let Some(elem_type) = elem_type
+                    && !self.type_matches_value(&elem_type, &idx)
                 {
                     let got_type = crate::value::what_type_name(&idx);
                     let got_repr = idx.to_string_value();
                     let msg = format!(
                         "Type check failed in binding; expected {} but got {} (\"{}\")",
-                        info.value_type, got_type, got_repr,
+                        elem_type, got_type, got_repr,
                     );
                     let mut attrs = std::collections::HashMap::new();
                     attrs.insert("message".to_string(), Value::str(msg.clone()));
@@ -3407,7 +3419,7 @@ impl Interpreter {
                     attrs.insert("got".to_string(), idx.clone());
                     attrs.insert(
                         "expected".to_string(),
-                        Value::Package(crate::symbol::Symbol::intern(&info.value_type)),
+                        Value::Package(crate::symbol::Symbol::intern(&elem_type)),
                     );
                     let ex = Value::make_instance(
                         crate::symbol::Symbol::intern("X::TypeCheck::Binding"),


### PR DESCRIPTION
## Summary

Parameterized `BagHash[Str].new(...)` / `MixHash[Str].new(...)` did not embed the keyof type, so a later element binding like `\$b{42} = 1` silently succeeded instead of throwing `X::TypeCheck::Binding`. Only the `.new` initializer was type-checked, and only `SetHash` embedded the type metadata.

## Changes

- Embed `ContainerTypeInfo` on parameterized `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]` in `methods_object.rs` so the keyof type survives into the value. For `Mix`, the element (keyof) type goes in `key_type` while `value_type` stays `"Real"` (the weight type).
- Extend the element-binding type-check in `vm_var_assign_ops.rs` to cover `Bag`/`Mix` (not just `Set`), checking the subscript key against the keyof type (`key_type` when present, else `value_type`).
- Fix a pre-existing bug: `MixHash[T].new` returned an **immutable** `Mix` because the mutable-variant test used `class_name.resolve() == "MixHash"` (which is `"MixHash[T]"` when parameterized). Now uses `base_class_name`.

## Impact

Unblocks `baghash.t` 206/207 and the `mixhash.t` parameterized element checks. Both files still abort later on writable `.values`/`.pairs`/`.kv` aliases (container identity), so they are not yet whitelistable.

`make test` passes (7549 tests, 0 failures). Whitelisted `bag-iterator`/`baggy`/`mix-iterator`/`set-iterator` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)