### PR TITLE
fix(given): scalar-decl topic (`given my $x = ...`) aliases $x rw

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -200,11 +200,18 @@
     fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
     file cannot reach a clean pass. Remaining mutsu failures span several distinct
     (mostly regex-internal) features:
-  - ABORT FIXED: the file previously aborted mid-run at the `s[...] OP= ...`
+  - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
     block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`). `given LITERAL -> $_ is
     copy` marked `$_` read-only (the `$_ = $_` copy-head desugar then died on the
     RO topic). Now a `-> $_ is copy` pointy head sets `topic_readonly = false` and
-    suppresses the source-writeback tag (a detached copy). All 191 tests now run.
+    suppresses the source-writeback tag (a detached copy).
+  - ABORT FIXED (2): `given my $x = 'abc' { s[b] = 'de' }` (line ~290) aborted with
+    "Cannot modify an immutable Str" — a scalar *declaration* used as the topic
+    (`DoStmt(VarDecl)`) was marked read-only, so the in-block `s///` died on the RO
+    `$_`. Now a scalar-decl topic aliases the declared `$x` rw (like `given $x`):
+    `topic_readonly = false` + `TagContainerRef`. All 191 tests now run again.
+    (Known orthogonal gap: an in-place `s///` on `$_` does not write back through
+    the `given $x` container alias — only direct `$_ = ...` does.)
   - 85, 86 (FIXED): `s///` / `ss///` against a *matching* string literal
     (`'abc' ~~ s/b/g/`) now throws X::Assignment::RO; a non-matching attempt stays
     a no-op. (SmartMatchExpr carries an `lhs_is_literal` flag.)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1712,6 +1712,24 @@ impl Compiler {
                     topic_readonly = false;
                 } else {
                     self.compile_expr(topic);
+                    // `given my $x = EXPR` (a scalar declaration used as the topic)
+                    // aliases the freshly-declared `$x` rw, exactly like `given $x`,
+                    // so `$_ = ...` / `s///` inside the block write back to `$x`.
+                    // The declaration is wrapped in a `DoStmt`; the VarDecl name has
+                    // no sigil for scalars (arrays/hashes carry `@`/`%`).
+                    let topic_decl_scalar = match topic {
+                        Expr::DoStmt(inner) => match inner.as_ref() {
+                            Stmt::VarDecl { name, .. }
+                                if !name.starts_with('@')
+                                    && !name.starts_with('%')
+                                    && !name.starts_with('&') =>
+                            {
+                                Some(name.clone())
+                            }
+                            _ => None,
+                        },
+                        _ => None,
+                    };
                     // `is copy` makes a detached copy, so suppress the
                     // source-writeback tag even for a bare-variable topic.
                     let source_name = if is_copy_topic {
@@ -1721,7 +1739,7 @@ impl Compiler {
                             Expr::Var(name) => Some(name.clone()),
                             Expr::ArrayVar(name) => Some(format!("@{}", name)),
                             Expr::HashVar(name) => Some(format!("%{}", name)),
-                            _ => None,
+                            _ => topic_decl_scalar.clone(),
                         }
                     };
                     if let Some(source_name) = source_name {
@@ -1729,10 +1747,13 @@ impl Compiler {
                         self.code.emit(OpCode::TagContainerRef(name_idx));
                     }
                     // The topic is read-only unless it is a bare scalar variable
-                    // (`given $x` aliases `$x` rw) or an `is copy` writable copy.
+                    // (`given $x` aliases `$x` rw), a scalar declaration topic
+                    // (`given my $x = ...`), or an `is copy` writable copy.
                     // `given @a` / `given 42` / `given expr()` are read-only (Raku
                     // errors on `$_ = ...`).
-                    topic_readonly = !is_copy_topic && !matches!(topic, Expr::Var(_));
+                    topic_readonly = !is_copy_topic
+                        && !matches!(topic, Expr::Var(_))
+                        && topic_decl_scalar.is_none();
                 }
                 // A pointy block (`given @a -> @p { ... }`) is desugared by the
                 // parser into `@p := $_` at the body head. Record that bound


### PR DESCRIPTION
## Summary

`given my \$x = "abc" { ... }` marked the topic `\$_` **read-only** because the declaration is wrapped in a `DoStmt(VarDecl)` — neither a bare `Expr::Var` nor an `is copy` head. Any in-block topic mutation (`\$_ = ...`, `s///`) then died with *"Cannot modify an immutable value"*, aborting the rest of the program.

## Fix

Treat a scalar declaration used as the topic exactly like `given \$x`: alias the freshly-declared `\$x` rw (`topic_readonly = false` + `TagContainerRef`) so `\$_ = ...` writes back to `\$x`. Arrays/hashes (`given my @a = ...`) and non-variable topics stay read-only, matching Raku.

## Impact

Unblocks the entire tail of `S05-substitution/subst.t`: it previously aborted at the `given my \$x = 'abc' { s[b] = 'de' }` block (~test 110); now **all 191 tests run** (it still has individual failures + 2 rakudo-also-fails, so not yet whitelistable).

`make test` passes (7549 tests, 0 failures). Whitelisted `given`/`when` roast tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)