### PR TITLE
docs: rev2 re-audit of ANALYSIS.md + PLAN.md (CP-3 collapse, residual Supply crash)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,116 +1,154 @@
 # mutsu コードベース分析 (Architecture & Quality Review)
 
-作成日: 2026-06-03
-対象: `main` (cfff80fc 時点)
+作成日: 2026-06-03 (初版) / **rev2: 2026-06-15 全面再監査**
+対象: 初版 `main` (cfff80fc) / rev2 `main` (b7ced0fe)
 方法: 4 つの調査エージェントによるサブシステム精読 + 主張の実機再現確認。
 すべての指摘は `file:line` の根拠付き。再現可能な不具合は実際に走らせて確認した。
+rev2 では初版の全指摘を現行コードに突き合わせ、`【✅修正済み】`/`【⚠️残存】` を更新し、
+新たに §8.7 (`.Supply` 無限 Range クラッシュ) を実機特定して追加した。
 
-> ## ✅ 進捗トラッキング (2026-06-15 更新)
-> 本分析が挙げた「確認済みバグ」の大半はその後修正された。各節の見出しに `【✅修正済み】`
-> / `【⚠️残存】` を付記した。サマリ:
-> - **✅ 修正済み**: §2.1 / §8.1 遅延リスト崩壊・`grep` eager collect、§8.2 無限 Range 即時展開クラッシュ、
->   §2.2 / §8.3 並行 scalar / state 共有（Track C: #2980/#2982 ほか）、§8.4 regex 毎マッチ再パース（#3064/#3065）、
->   §5 panic→`X::` 変換境界（#3045）、§4-1 roast fudge のユーザコード誤作動（`MUTSU_FUDGE` ゲート化）、
->   §5 `Value` enum 肥大 variant の Box 化（#3073/#3074/#3076、`size_of::<Value>()` 72→48・-33%、40B tier は
->   hot path 回避で意図的打ち切り）。
-> - **⚠️ 残存**: §2.3 unsafe aliasing の UB 余地（本格修正は Track B 依存）、§2.4 `RuntimeError` god-struct、
->   §4-2 `.^methods`/`.can` 直書きリストのドリフト、§1.x VM/Interpreter 結合・locals↔env 二重ストア
->   （CP-1 env-loan で進行中）。
+> ## ✅ 進捗トラッキング (2026-06-15 rev2: 全面再監査 @ `b7ced0fe`)
+> 初版 (2026-06-03 @ `cfff80fc`) の指摘を **4 つの調査エージェント + 実機再現** で再検証し直した。
+> 各節の見出しに `【✅修正済み】` / `【⚠️残存】` を付記。初版から最大の構造変化は
+> **§1.1 の「VM はバイトコードシム」批判が前提ごと変わった**こと: CP-3 collapse で
+> bytecode VM が `Interpreter` 構造体へ**完全に溶け込んだ** (別 struct も `self.interpreter.*`
+> 1300 箇所も消滅、残り 2 件はコメントのみ)。実行は今や単一 `Interpreter` 上のメソッド呼び出しで、
+> 「VM↔Interpreter 境界越えフォールバック」という構図自体が無くなった (`loan_env!` も no-op 化)。
+> サマリ:
+> - **✅ 修正済み (実機再現で確認)**: §1.1 VM/Interpreter 分離 → **CP-3 collapse で単一 struct 化** /
+>   §2.1・§8.1 遅延リスト崩壊・`grep` eager collect (`(1..Inf).grep(* %% 3)[^4]` → `(3 6 9 12)`) /
+>   §8.2 無限 Range 即時展開クラッシュ (coerce/grep を `materialize_capped` 経由へ) /
+>   §2.2・§8.3 並行 scalar / state 共有 (`my $c=0; await (^4).map:{start{$c++}}; say $c` → `4`、Track C
+>   #2980/#2982/#3059/#3061/#3063) / §8.4 regex 毎マッチ再パース (`REGEX_PARSE_CACHE` + #3064/#3065) /
+>   §3.1 regex validator/matcher 二重実装 → **`src/regex_validate.rs` を削除し単一パーサに統合** /
+>   §5 panic→`X::` 変換境界 (#3045、メインスレッドのみ) / §4-1 roast fudge 誤作動 (`MUTSU_FUDGE` ゲート化) /
+>   §5 `Value` enum 肥大 (`size_of::<Value>()` 72→48・guard で恒久ロック)。
+> - **⚠️ 残存 / 新規**: **【新規・実機再現】§8.7 `.Supply` coercion が無限 Range を未ガード展開し
+>   worker thread で `capacity overflow` abort** (§5 の worker-thread 未保護と複合、唯一の決定的残存クラッシュ) /
+>   §1.2 locals↔env 二重ストア + sync 機構 (CP-3 で struct は 1 つになったが二重ストアは温存) /
+>   §1.3 クロージャ env 捕捉 (upvalue 不在は不変、ただし `compute_needs_env_sync` は per-closure 精緻化済み) /
+>   §1.4 ローカルスロットのレキシカルスコープ不在 / §2.3 unsafe `Arc::as_ptr as *mut` (11→4 箇所に減・
+>   `strong_count` ガード追加だが SAFETY コメントは "single-threaded" のまま陳腐化) / §2.4 `RuntimeError`
+>   god-struct (18 制御フロー bool 不変) / §4-2 `.^methods`/`.can` 直書きリスト / §6 衛生 (root の
+>   `bom-test-*` ゴミが **254 件**に増殖)。
 
 ---
 
 ## 0. サマリ
 
-mutsu は Rust 製の minimal Raku 互換インタプリタで、規模は **約 27 万行 / 307 ファイル**。
-roast の通過状況は良好で (`roast-whitelist.txt` = 1238 件、`too_difficult.txt` = 40 件)、
+mutsu は Rust 製の minimal Raku 互換インタプリタで、規模は **約 29.3 万行 / 331 ファイル** (rev2)。
+roast の通過状況はさらに伸び (`roast-whitelist.txt` = **1270 件**、`too_difficult.txt` = 40 件)、
 言語機能のカバレッジは広い。**「roast を通すためだけのハードコード出力」のような露骨な不正は
 ほぼ無く**、プロジェクト規約 (「test-specific hack 禁止」) は概ね守られている。
 
-一方で、**アーキテクチャ上の根本的なねじれ**がいくつか存在する。最重要は次の 3 つ:
+初版が挙げた**アーキテクチャ上の根本的なねじれ 3 つは、その後の大改修でいずれも解消または
+大幅前進した** (rev2 で実機再確認):
 
-1. **「バイトコード VM」は実態として tree-walking interpreter の薄いフロントエンド**であり、
-   `Interpreter` は「除去予定のレガシー」ではなく VM が依存する実行基盤そのものである。
-2. **遅延リストが eager 実装 + 上限キャップの偽装**であり、無限リスト操作が
-   誤った有限値や **Rust パニック (プロセスクラッシュ)** を生む。
-3. **並行モデルが状態スナップショットコピー方式**のため、`start`/Promise 間で変数が共有されず
-   意味論が壊れている。加えて配列の in-place 書き換えに使う `unsafe` の「single-threaded 前提」が
-   実スレッド生成と矛盾し、**未定義動作 (データ競合) の余地**がある。
+1. ~~「バイトコード VM」は tree-walking interpreter の薄いフロントエンド~~ → **【✅解消】
+   CP-3 collapse で bytecode VM が `Interpreter` 構造体へ完全統合**。別 struct も
+   `self.interpreter.*` 1300 箇所も消滅。「VM↔Interpreter 境界越えフォールバック」という
+   構図自体が無くなった (ただし宣言実行や一部メソッドディスパッチは依然 tree-walk **ヘルパ** 経由 — §1.1)。
+2. ~~遅延リストが eager + 上限キャップの偽装でクラッシュ~~ → **【✅大半解消】**
+   `Seq`/`LazyList` に真の pull/coroutine モデルが入り、`grep`/`coerce_to_array` は
+   `materialize_capped` 経由でキャップ。初版の代表クラッシュ (B) は解消 (§2.1/§8.1/§8.2)。
+   **ただし `.Supply` coercion に未ガード展開が 1 経路残り、worker thread で abort する (§8.7 新規)**。
+3. ~~並行モデルがスナップショットコピーで変数共有が壊れている~~ → **【✅解消】** Track C で
+   捕捉スカラ・`state`・hash/array 要素がライブ共有セル化 (§2.2/§8.3)。
+   in-place `unsafe` は 11→4 箇所に減り `strong_count` ガードが付いたが、SAFETY コメントの
+   「single-threaded 前提」は陳腐化したまま (§2.3)。
 
-以下、実機で確認した代表的なバグ 2 件。
+以下、rev2 時点で実機確認したバグ。初版の (A)(B) は**もう再現しない** (修正済み):
 
 ```raku
-# (A) 並行 state 共有が壊れている
-my $counter = 0; await (^4).map: { start { $counter++ } }; say $counter;
-#   mutsu => 1      raku => 4
+# (A) 並行 state 共有 — 初版 mutsu=>1 / 現在 mutsu=>4 (✅修正済み, raku 一致)
+my $counter = 0; await (^4).map: { start { $counter++ } }; say $counter;   # => 4
+
+# (B) 無限リスト grep — 初版 panic / 現在 (3 6 9 12) (✅修正済み, raku 一致)
+say (1..Inf).grep(* %% 3)[^4];                                             # => (3 6 9 12)
 ```
 
 ```raku
-# (B) 無限リスト操作が Rust パニックでクラッシュ
-say (1..Inf).grep(* %% 3)[^4];
-#   mutsu => thread panicked: capacity overflow / exit 101
-#   raku  => (3 6 9 12)
+# (C) 【新規・唯一の決定的残存クラッシュ】無限 Range の .Supply 化が worker thread で abort
+my $s = (1..Inf).Supply; $s.tap({ say $_; done if $_ >= 3 });
+#   mutsu => thread '<unnamed>' panicked: capacity overflow （プロセス abort）
+#   raku  => 1 2 3
+# 原因: coercion.rs:536 が `Value::Range(a,b) => (a..=b).map(...).collect()` を i64::MAX 無ガードで実行。
+# §8.2 で大半の展開サイトは塞いだが Supply 化経路が漏れており、しかも .tap が別スレッドで走るため
+# §5 の panic→X:: 変換境界 (メインスレッドのみ) が捕捉できず exit が 0 になる二重の穴。
 ```
 
-(注: `(1..Inf).elems` は mutsu でも正しく `Cannot .elems a lazy list` を投げる。
-遅延の取り扱いはメソッドごとにまちまちで、ガードされている経路と崩壊する経路が混在している。)
+(注: `(1..Inf).elems` は正しく `Cannot .elems a lazy list` を投げる。遅延の取り扱いは
+初版より格段に統一されたが、**未ガード展開サイトの "最後の数件" が残る** のが現状の姿である。)
 
 ---
 
 ## 1. アーキテクチャ評価
 
-### 1.1 VM と Interpreter の結合 — 「VM はバイトコードシムである」【最重要】
+### 1.1 VM と Interpreter の関係 — 「CP-3 collapse で単一 struct に統合」【最重要・大幅更新】
 
-CLAUDE.md は「VM はすべてをネイティブに扱うべき」「Interpreter は除去予定のレガシー」と述べるが、
-コードの実態は逆である。
+> **【✅構造解消 (CP-3 collapse)】**: 初版の「VM は `Interpreter` を所有し `self.interpreter.*` を
+> 1300 箇所超で引く薄いシム」という構図は**消滅した**。bytecode VM は `Interpreter` 構造体へ
+> **完全に溶け込み** (`src/vm.rs:153-156` のコメント: "the bytecode VM has been fully dissolved
+> into the `Interpreter` struct — the `Interpreter` *is* the bytecode VM")、`src/vm/` の `impl`
+> ブロックは今や `impl Interpreter` である。`src/interpreter.rs` は
+> `pub use crate::runtime::Interpreter;` の再エクスポート 1 行。`self.interpreter.*` の参照は
+> 全 src で **2 件のみ (どちらもコメント)**。境界越え env 貸し出しの `loan_env!` マクロも
+> no-op の自己呼び出しに退化 (`src/vm.rs:86-94`)。
 
-- VM は `Interpreter` を **所有**し (`vm.rs:83`)、共有実行状態コンテナとして使う。
-  `self.interpreter.*` 参照は VM 全体で **1300 箇所超**。内訳上位は
-  `env()` / `env_mut()` (= 変数ストア本体, ~480)、`type_matches_value`、`var_type_constraint`、
-  `current_package`、`restore_let_saves`、`readonly_vars_mut` …。
-  パッケージ状態・型検査・readonly 追跡・`let`/`temp` 復元・multi 解決・state 変数は
-  すべて Interpreter 側にある。
-- **本物の tree-walking 実行フォールバックが残存**している (CLAUDE.md が禁じているもの):
-  `call_method_with_values` (`vm/vm_call_method_compiled.rs:123,134,229,354,576`,
-  `vm/vm_call_method_mut_ops.rs:1179`, `vm/vm_data_ops.rs:301,320,357` ほか)、
-  `call_function` / `call_function_fallback` (`vm/vm_call_func_ops.rs:406,671,677,704`,
-  `vm/vm_call_dispatch.rs:68`)、`run_instance_method`、`run_react_event_loop` など。
-  `try_compiled_method_or_interpret` (`vm/vm_call_method_compiled.rs:112`) は名前からして
-  「コンパイル済みが無ければインタプリタへ落とす」もので、メソッドディスパッチは構造的に
-  Interpreter なしでは完了しない。
-- **すべての宣言 (`class`/`role`/`enum`/`subset`/`token`/`sub`/`method`) は Interpreter が実行**する。
-  AST を "stmt pool" に複製して保持し、`Register*` opcode が `interpreter.register_*_decl()` を
-  呼ぶ (`compiler/stmt.rs:2143-2167`, `vm/vm_register_ops.rs:312,1085`)。
-  クラスシステム・MRO・role 合成は完全に Interpreter 側。
-- 関数本体は **初回呼び出し時にオンザフライでコンパイル**され (`vm/vm_call_dispatch.rs:74`)、
-  最終フォールバックは `interpreter.call_function` (`:68`)。
-- これら禁止フォールバックには **規約が要求する `// TODO: compile to bytecode` が付いていない**
-  (VM ツリー全体で 0 件)。負債が「可視・追跡可能」になっていない。
+統合後の構図は「単一 `Interpreter` struct のメソッド呼び出し」であり、初版が問題視した
+**「VM↔Interpreter の二構造体境界」は無くなった**。ただし**実行戦略としての tree-walk ヘルパは温存**
+されている (もはや別オブジェクトへのフォールバックではなく、同 struct 上のメソッド分岐):
 
-**評価**: コンパイラ層自体はクリーンで、リークは VM 層に押し込まれている。
-「Interpreter を除去」するには env HashMap・クラスレジストリ・型検査を VM 所有データに移す
-大手術が必要で、現状はアスピレーションであって実態ではない。ドキュメントが実態と乖離している。
+- メソッド/関数ディスパッチのブリッジ `call_method_with_values` (`runtime/methods.rs:310`)、
+  `call_function` (`runtime/builtins.rs:315`)、`call_function_fallback`、`run_instance_method`
+  (`runtime/class.rs:725`) は健在で、bytecode 実行パスから呼ばれる。
+- **宣言 (`class`/`role`/`enum`/`sub`/`method`) は依然 tree-walk の `register_*_decl` で実行**する。
+  `Register*` opcode が AST を stmt pool から取り出して `register_sub_decl`
+  (`runtime/registration_sub.rs:280`)・`register_class_decl` (`runtime/registration_class.rs:671`)
+  などを呼ぶ (`vm/vm_register_ops.rs:468,1186,1254,1443`)。クラスシステム・MRO・role 合成は未コンパイル。
+- 関数本体は依然**初回呼び出し時にオンザフライでコンパイル**される。
+- 初版で「0 件」だった `// TODO: compile to bytecode` は **13 件**に増え、負債が可視化された
+  (`vm/vm_call_method_compiled.rs:169,489,1524,1772`、`vm/vm_data_ops.rs:407,418,443`、
+  `vm/vm_call_dispatch.rs:71` ほか)。多くは shaped-array / Phase 2 container-id / threaded shared-cell
+  依存でブロックされている旨が明記。
 
-### 1.2 二重変数ストア (locals ↔ env) と dirty 追跡
+**評価**: 「Interpreter を除去」という CLAUDE.md の目標は、**"別 struct を消す" 意味では達成された**
+(VM struct も型エイリアスも無くなった)。残る課題は「tree-walk **実行**を bytecode 化する」こと —
+宣言登録・一部メソッドフォークが未コンパイルで、これらは container-identity / shaped-array といった
+下位機構に依存する。ドキュメントと実態の乖離 (初版の主因) はおおむね解消した。
 
-ローカル変数が `self.locals: Vec<Value>` (スロット番号引き) と `interpreter.env()` (名前引き) の
-**2 箇所に二重に存在**し、手動同期が必要。VM 構造体は `env_dirty` / `locals_dirty` /
-per-slot `locals_dirty_slots: Vec<bool>` (`vm.rs:108-117`) を持ち、
-`sync_locals_from_env` / `sync_env_from_locals` / `ensure_env_synced`
-(`vm/vm_env_helpers.rs:286,318,350`) を **65 箇所**で呼ぶ。`VmCallFrame` は 8 個の
-dirty/bind フィールドをスナップショットする (`vm.rs:67-78`)。
+### 1.2 二重変数ストア (locals ↔ env) と dirty 追跡 【⚠️残存】
 
-per-slot bitmap が必要になったのは、粗いフラグが未初期化ローカルを破壊していたため
-(`vm.rs:113-117` のコメント)。これは「設計された register モデル」ではなく
-「同じデータを 2 箇所に持つのを糊付けしている」症状で、単一権威ストアにすれば丸ごと消える。
+> **⚠️ 残存 (CP-3 後も温存)**: CP-3 collapse で struct は 1 つになったが、
+> 二重ストア自体は残っている。`Interpreter` 構造体が `env: Env` (`runtime/mod.rs:836`) と
+> `locals: Vec<Value>` (`:1159`)、`env_dirty` (`:1178`)、`call_frames` (`:1177`) を
+> 「merged VM execution registers」(`:1155-1216`) として同居させる。
+
+ローカル変数が `self.locals: Vec<Value>` (スロット番号引き) と `self.env()` (名前引き) の
+**2 箇所に二重に存在**し、手動同期が必要。`sync_locals_from_env` / `sync_env_from_locals` /
+`ensure_locals_synced` (`vm/vm_env_helpers.rs` 周辺) を呼んで整合させ、per-slot 書き戻しは
+`flush_local_to_env` (`vm/vm_env_helpers.rs:379-396`) が `code.needs_env_sync` フラグで間引く。
+`VmCallFrame` は env/locals/dirty/bind を 1 フレームごとにスナップショットする (`vm.rs:143-151`)。
+
+これは「設計された register モデル」ではなく「同じデータを 2 箇所に持つのを糊付けしている」症状で、
+単一権威ストアにすれば丸ごと消える。CP-3 で `Interpreter` への統合は済んだので、次の論理ステップは
+この二重ストアの一本化である。
 
 ### 1.3 クロージャが env ベース (upvalue 不在) → フレーム全体の env 同期
 
 クロージャは upvalue を持たず、自由変数は `GetGlobal`/`GetArrayVar`/`GetHashVar` として
-Interpreter の env HashMap を引く (`compiler/expr.rs:40-58`, `helpers_sub_body.rs:461`)。
-このため `compute_needs_env_sync` (`opcode.rs:1125`) は
-**クロージャが 1 つでも存在すると全ローカルを env 書き戻し対象に保守的にマーク**する
-(`opcode.rs:1134-1136`)。register VM のはずが、毎回全ローカルを HashMap にミラーするため
-register を持つ意味が削がれている (正しさの松葉杖 + 性能税)。
+env HashMap を引く。捕捉時に env をフラットコピーして `Value::Sub` に持たせる
+(`vm/vm_register_ops.rs:326-380`)。
+
+> **⚠️ 一部改善**: 初版が問題視した「クロージャが 1 つでもあれば**全ローカル**を env 書き戻し対象に
+> 保守的マーク」は緩和された。`compute_needs_env_sync` (`opcode.rs:1349-1429`) は
+> いまや**ネストクロージャの自由変数になっているローカルだけ**を選別してマークする
+> (`free_var_syms` 解析、`opcode.rs:1402-1428`)。ただし `ForLoop`/`BlockScope`/`MakeGather` を
+> 含むコードは依然全ローカルを保守的にマークするフォールバックが残る (`:1385`)。
+> upvalue 機構そのものは未導入なので、env 経由の捕捉という本質は変わっていない。
+
+捕捉して書き換えられるローカルは `box_captured_lexicals` (`vm/vm_register_ops.rs:231-310`) で
+`ContainerRef` セルに昇格し、兄弟クロージャ間・スレッド間で共有される (§2.2 のライブセル化と同じ基盤)。
 
 ### 1.4 ローカルスロットのレキシカルスコープ不在
 
@@ -181,19 +219,23 @@ CLAUDE.md の「slang 未対応・将来課題」は正確。ユーザ定義 gra
 
 ### 2.3 `unsafe` の "single-threaded 前提" が実スレッドと矛盾 (UB の余地) 【重大】【⚠️残存】
 
-> **⚠️ 残存**: in-place mutation は単なる perf ではなく binding identity を保つ意図的実装で、
-> 本格修正は配列/ハッシュの `ContainerRef` 共有セル化（= Track B コンテナ恒等性）に依存する。
-> 当面の安全策（誤った SAFETY コメント是正 / `strong_count` ガード）は未着手。
+> **⚠️ 一部改善・残存**: in-place mutation 箇所は **11→4 件に減り**、`strong_count` ガードと
+> `Arc::make_mut` フォールバックが付いて UB の実発生は塞がれた。だが SAFETY コメントは依然
+> "mutsu is single-threaded" のままで陳腐化している (Track C でスレッドは実際に Arc を共有する)。
+> 本格的な型レベルの是正は配列/ハッシュ**要素**の `ContainerRef` セル化（Phase 2 container-id）依存。
 
-`Value::Array = Arc<Vec<Value>>` (`value/mod.rs:943`、`Value: Send + Sync` をアサート) を、
-`strong_count > 1` でも `unsafe { &mut *(Arc::as_ptr(arr) as *mut _) }` で
-**エイリアスしたまま非アトミック書き込み**する箇所が 11 件
-(`vm/vm_var_assign_ops.rs:1671-1676,1975,2007,2311,2880,2987,3200`)。
-コメントは "SAFETY: mutsu is single-threaded" だが、`clone_for_thread` + `thread::spawn` で
-同じ Arc が別スレッドへ渡る経路があり前提は偽。「`&mut self` で排他」と「Arc 中身の排他」を
-混同している (`:2311` のコメント)。実機でクラッシュ再現はしなかった (該当経路が稀) が、
-定義上はデータ競合 = UB。**改善**: 配列/ハッシュも `ContainerRef` 相当の共有セルに統一し、
-ポインタ改竄による in-place mutation を撤廃。少なくとも誤った SAFETY コメントを是正。
+`Value::Array = Arc<ArrayData>` (`value/mod.rs:1533`、`Value: Send + Sync` をアサート `:3967`) に対し、
+`unsafe { &mut *(Arc::as_ptr(arr) as *mut ArrayData/HashData) }` で **Arc 中身を生ポインタ経由で
+書き換える** in-place mutation が **4 件**残る
+(`vm/vm_var_assign_ops.rs:2101,2911,3530,4173`)。コメントは依然 "SAFETY: mutsu is single-threaded"
+(`:2098,2559,2587,2908,3514` ほか) だが、Track C で `thread::spawn` 先と同じ Arc を共有するため前提は偽。
+ただし初版時と違い、各サイトには `Arc::strong_count` ガードが付き
+(`let use_inplace = Arc::strong_count(arr) > 1 && ...;` / `== 1`)、ユニーク所有でなければ
+`Arc::make_mut` の COW パスに落ちるため、データ競合の**実発生は回避**されている。
+さらに `docs/hashdata-migration-plan.md` 記載の **offset-0 UB** (型を `*mut HashMap` と誤キャストし
+フィールド追加で SEGV) は `*mut HashData`/`*mut ArrayData` への是正で解消済み。
+**残改善**: 陳腐化した SAFETY コメントを「strong_count ガード前提」に書き換え、最終的には
+配列/ハッシュ要素も `ContainerRef` 相当に統一して生ポインタ改竄を撤廃する。
 
 ### 2.4 `RuntimeError` god-struct が制御フローをエラーチャネルで運ぶ 【⚠️残存】
 
@@ -201,7 +243,8 @@ CLAUDE.md の「slang 未対応・将来課題」は正確。ユーザ定義 gra
 `is_return/is_last/is_next/is_redo/is_goto/is_proceed/is_succeed/is_fail/is_take/is_emit/...`
 **18 個の制御フロー bool** を同居させる (`:42-59`)。`return`/`last`/`next`/`take`/`emit` を
 `Result::Err` で実装しており、エラーと制御が型レベルで混線。構造体肥大のため
-`#[allow(clippy::result_large_err)]` が 17〜18 ファイルに散在。
+`#[allow(clippy::result_large_err)]` が **11 箇所 / 5 ファイル**に散在
+(`lib.rs`/`parse_dispatch.rs`/`parser/mod.rs`×3/`doc_mode.rs`×3/`value/mod.rs`×3)。
 **改善**: `enum Control { Return, Last, Next, Take(Value), Emit(Value), ... }` を分離し
 `RuntimeError` を純エラーに縮小・Box 化。
 
@@ -209,17 +252,12 @@ CLAUDE.md の「slang 未対応・将来課題」は正確。ユーザ定義 gra
 
 ## 3. 重複実装
 
-### 3.1 正規表現文法の二重パース (validator vs matcher) 【高】
+### 3.1 正規表現文法の二重パース (validator vs matcher) 【✅修正済み】
 
-- `src/regex_validate.rs` (1108 行): パース時の構文検証専用。文字単位スキャンで **AST を作らず**
-  `X::Syntax::Regex::*` を投げるだけ。
-- `src/runtime/regex_parse.rs` (4701 行) + `runtime/regex/`: 実行時に同じ Raku regex 文法を
-  `RegexToken`/`RegexAtom` へ構造パースする本物のマッチャ。
-
-両者が `\d`、`<[...]>`、`%` 分離量化子、`«»`、`~` 平衡などの規則を**独立にエンコード**し、
-相互参照/"keep in sync" コメントが 0 件。一方だけ拡張すると validator が通すのに matcher が
-落ちる (逆も) 組合せが生じる二重メンテ構造。
-**改善**: validator を廃し、`parse_regex` を構造を返す単一パーサに統合、検証はそのドライラン呼び出しに一本化。
+> **✅ 修正済み**: 初版が指摘した独立 2 パーサのうち **`src/regex_validate.rs` は削除された** (現存せず)。
+> 構造パーサ `src/runtime/regex_parse.rs` (現 6171 行) の単一系統に統合され、二重メンテ構造は解消した。
+> ホットマッチループは `REGEX_PARSE_CACHE` (`runtime/regex_parse.rs:23`) でパース結果を再利用する
+> (§8.4 の perf 改善と同根)。検証も構造パーサのドライラン経由に一本化された。
 
 ### 3.2 制御構文の文 / 式 二重コンパイル
 
@@ -309,48 +347,63 @@ CLAUDE.md の「slang 未対応・将来課題」は正確。ユーザ定義 gra
   **✅ 修正済み (#3045)**: VM の `run`/`run_inner` + try-body `run_range_guarded` の 2 境界で
   user-code Rust panic（overflow/capacity-overflow/OOB）を catchable な `X::AdHoc`(exit 1) に変換。
   残: `start{}` ワーカースレッドは未保護、stack-overflow/巨大 alloc abort は範囲外。
-- **`#[allow(lint)]` 126 箇所**: `dead_code` 64 (未配線コード放置の示唆)、
-  `result_large_err` 17 (= `RuntimeError` 肥大の表れ、4 章 2.4 と同根)、`too_many_arguments` 35。
+- **`#[allow(lint)]` 133 箇所** (微増): `dead_code` 66 (未配線コード放置の示唆)、
+  `too_many_arguments` 38、`type_complexity` 12、`result_large_err` 11 (= `RuntimeError` 肥大の表れ、
+  §2.4 と同根)。
 
 ---
 
 ## 6. リポジトリ衛生
 
-- **テストが CWD に一時ファイルを書き散らす**: ルート直下に `bom-test-*` (12)、
-  `tempfile_filehandles_io.*` (8)、`temp-file-RT-126006-test` が散乱。原因は
-  `roast/S16-io/bom.t` / `roast/S16-filehandles/io.t` / `t/bom-stripping.t` が
-  CWD に PID 付き一時ファイルを書いて削除していないこと (前日まで増殖継続)。
-  `.gitignore` 済みでコミットはされないがルートを汚し続ける。CLAUDE.md は「一時ファイルは `tmp/`」と
-  規定しており違反。**改善**: テストを `tmp/` 配下に書かせるか LEAVE phaser で確実に削除。
-- 空ディレクトリ `t spec S22-package-format/`、`perf.data` (110MB, root 所有) も放置。
-- **500 行規約の大幅違反**: `src/` に 500 行超 157 ファイル、1000 行超 76 ファイル。
-  最大は `runtime/mod.rs` 5820、`vm/vm_var_assign_ops.rs` 5778、`runtime/regex_parse.rs` 4701、
-  `vm.rs` 3846、`compiler/stmt.rs` 2354。規約 (500 行上限) は形骸化している。
+- **テストが CWD に一時ファイルを書き散らす【⚠️悪化】**: ルート直下の `bom-test-*` が
+  **254 件**まで増殖 (初版は 12)。原因は `roast/S16-io/bom.t` / `t/bom-stripping.t` が
+  CWD に PID 付き一時ファイルを書いて削除しないこと。`.gitignore` 済みでコミットはされないが
+  ルートを汚し続ける。CLAUDE.md は「一時ファイルは `tmp/`」と規定しており違反。
+  **改善**: テストを `tmp/` 配下に書かせるか LEAVE phaser で確実に削除。(注: `perf.data` /
+  `tempfile_filehandles_io.*` は現在は無い。空ディレクトリ `t spec S22-package-format/` は残存。)
+- **500 行規約の大幅違反【⚠️悪化】**: `src/` に 500 行超 **164 ファイル**、1000 行超 **80 ファイル**。
+  最大は `vm/vm_var_assign_ops.rs` **7188**、`runtime/mod.rs` **6556**、`runtime/regex_parse.rs` **6171**、
+  `runtime/methods_object.rs` 5142、`runtime/io.rs` 4494、`vm.rs` 4354。規約 (500 行上限) は形骸化。
+  二重ストア書き込みの集中点 `vm_var_assign_ops.rs` が最大肥大ファイルなのは §1.2 の負債と同根。
 
 ---
 
 ## 7. 推奨ロードマップ (優先度順)
 
-| # | 項目 | 区分 | 効果 |
-|---|------|------|------|
-| 1 | 遅延リストを本物の pull/Iterator モデルに (Seq/Range/grep/map/elems) | 正しさ + S17 hang 解消 | 高 |
-| 2 | 並行モデルを「ライブセル共有」に (clone_for_thread スナップショット廃止) | 正しさ | 高 |
-| 3 | 配列/ハッシュを共有セル化し `Arc::as_ptr as *mut` の UB を撤廃 | 健全性 (UB) | 高 |
-| 4 | `run()` に panic→`X::` 変換境界を設置 (ユーザコードのクラッシュ防止) | 堅牢性 | 中〜高 |
-| 5 | 制御フローを `RuntimeError` から `enum Control` へ分離 | 設計 | 中 |
-| 6 | 正規表現 validator/matcher を単一パーサに統合 | 重複解消 | 中 |
-| 7 | `.^methods`/`.can` の型別リストを実ディスパッチ表から導出 | ドリフト解消 | 中 |
-| 8 | locals↔env 二重ストアを単一権威ストアに統合 (dirty 機構撤廃) | 設計 + 性能 | 中 |
-| 9 | クロージャに upvalue を導入し全フレーム env 同期を撤廃 | 性能 | 中 |
-| 10 | roast fudge を核から分離 / 一時ファイルを `tmp/` へ / 巨大ファイル分割 | 衛生 | 低〜中 |
+初版ロードマップの上位項目 (遅延リスト・並行ライブセル・panic 境界・regex 統合) は**完了済み**。
+rev2 で残る課題を再優先順位付けした。
 
-### Interpreter 除去という長期目標について
+| # | 項目 | 区分 | 効果 | 状態 |
+|---|------|------|------|------|
+| 1 | **`.Supply` 等の残り未ガード Range 展開を `materialize_capped` 経由へ** (§8.7) | 正しさ (残クラッシュ) | 中〜高 | ⚠️ 未 |
+| 2 | **worker thread にも panic→`X::` 変換境界を設置** (`start{}`/`.tap` のクラッシュ防止) | 堅牢性 | 中〜高 | ⚠️ 未 |
+| 3 | locals↔env 二重ストアを単一権威ストアに統合 (dirty 機構撤廃) | 設計 + 性能 | 中 | ⚠️ 未 |
+| 4 | クロージャに upvalue を導入し env 経由捕捉を撤廃 | 性能 | 中 | ⚠️ 未 |
+| 5 | ローカルスロットにレキシカルスコープを導入 (シャドウ衝突解消) | 正しさ + 設計 | 中 | ⚠️ 未 |
+| 6 | 制御フローを `RuntimeError` から `enum Control` へ分離 | 設計 | 中 | ⚠️ 未 |
+| 7 | `.^methods`/`.can` の型別リストを実ディスパッチ表から導出 | ドリフト解消 | 中 | ⚠️ 未 |
+| 8 | 陳腐化した `unsafe` SAFETY コメント是正 / 配列・ハッシュ要素の `ContainerRef` 化 | 健全性 (UB) | 中 | ⚠️ 一部 |
+| 9 | 宣言登録・残メソッドフォークの bytecode 化 (`// TODO: compile to bytecode` 13 件) | 設計 | 中 | ⚠️ 未 |
+| 10 | 一時ファイルを `tmp/` へ (root の `bom-test-*` 254 件) / 巨大ファイル分割 (500 行規約) | 衛生 | 低〜中 | ⚠️ 悪化 |
 
-CLAUDE.md の「Interpreter は除去予定のレガシー」は**現状そのままでは達成不能**である。
-VM は env・クラスレジストリ・型検査・signature binder を Interpreter から借りており、
-これらを VM 所有データに移すまでフォールバックは消せない。
-当面は (a) ドキュメントを実態に合わせ、(b) 残存フォールバックに規約どおり
-`// TODO: compile to bytecode` を付けて負債を可視化することを推奨する。
+#### 完了済み (初版ロードマップ)
+
+- ✅ 遅延リストの pull/coroutine モデル化 (Seq/Range/grep) — 残るは §8.7 の Supply 1 経路のみ。
+- ✅ 並行モデルのライブセル共有化 (Track C)。
+- ✅ メインスレッドの panic→`X::` 変換境界 (#3045) — ただし worker thread は未保護 (上記 #2)。
+- ✅ 正規表現 validator/matcher の単一パーサ統合 (`regex_validate.rs` 削除)。
+- ✅ roast fudge の核分離 (`MUTSU_FUDGE` ゲート化)。
+- ✅ `Value` enum 縮小 (72→48B)。
+
+### Interpreter 除去という長期目標について 【大幅前進】
+
+初版の「VM は Interpreter を借りており別 struct を消せない」という診断は、**CP-3 collapse で
+"別 struct を消す" 意味では達成された** — bytecode VM は `Interpreter` 構造体へ完全統合され、
+型エイリアスも `self.interpreter.*` 1300 箇所も無くなった。残る本質課題は「tree-walk **実行**を
+bytecode 化する」こと: 宣言登録 (`register_*_decl`) と一部メソッドフォークが未コンパイルで、
+これらは container-identity / shaped-array といった下位機構に依存する。
+負債は `// TODO: compile to bytecode` 13 件で可視化されており、初版が指摘した
+「ドキュメントと実態の乖離」はおおむね解消した。
 
 ---
 
@@ -391,8 +444,11 @@ VM は env・クラスレジストリ・型検査・signature binder を Interpr
 
 ### 8.2 系統的欠陥: 無ガードの Range 即時展開が 43 箇所、ガードは 9 箇所のみ 【✅修正済み】
 
-> **✅ 修正済み (PLAN.md §アーキ修正で消化)**: 無限 Range は遅延 pull モデルへ統一され、
-> 即時 collect 由来の `capacity overflow` panic は解消。
+> **✅ 大半修正済み (PLAN.md §アーキ修正で消化)**: 無限 Range は遅延 pull モデル
+> (`materialize_capped`) へ統一され、`grep`/`coerce_to_array`/`head`/`zip` 等の即時 collect 由来の
+> `capacity overflow` panic は解消。`coercion.rs` の Range→list 展開も `i64::MAX` ガード付き。
+> **ただし展開サイトの全数掃討は未完**: `.Supply` coercion (`coercion.rs:536-537`) に
+> 未ガードの `(a..=b).map(Value::Int).collect()` が 1 経路残存し、§8.7 の決定的クラッシュを生む。
 
 `(a..=b).map(Value::Int).collect()` という **無限 Range を `Vec<Value>` に即時展開するパターンが
 src 全体で 43 箇所**存在する (`builtins/methods_0arg/coercion.rs:249,256,308,...`,
@@ -458,13 +514,53 @@ refcount bump 化し、毎マッチの deep tree clone を除去。現状 releas
 両方が効いており、**遅延イテレータ化 + ライブセル共有の 2 つを直すことが
 roast 残件の最大ボトルネックを崩す近道**である可能性が高い。
 
+> **rev2 注記**: 本表が指す根本原因のうち 8.1/8.2/8.3 (遅延崩壊・展開クラッシュ・state 共有) と
+> 8.4 (regex 再パース) は**いずれも修正済み**。`roast-whitelist.txt` は 1238→1270 件に増加した。
+> 残る introspection ドリフト (§4-2) と god-struct (§2.4) は roast への影響が限定的で、優先度は中。
+
 ### 8.6 初版からの訂正
 
 - `(1..Inf).elems` は mutsu でも正しく `Cannot .elems a lazy list` を throw する
   (初版調査の一部メモは誤り)。遅延の問題は「一様な崩壊」ではなく「**経路ごとの不統一**」
   (8.1) が正確な姿である。
 
+### 8.7 【rev2 新規・唯一の決定的残存クラッシュ】無限 Range の `.Supply` 化が worker thread で abort
+
+§8.2 で展開サイトの大半は塞がれたが、**掃討は全数に至っていない**。`.Supply` coercion の
+`coercion.rs:536-537` だけ `i64::MAX` ガードが漏れている:
+
+```rust
+// src/builtins/methods_0arg/coercion.rs:531-539  (Supply coercion)
+let values = match target {
+    Value::Array(items, ..) => items.to_vec(),
+    Value::Seq(items) | ... => items.to_vec(),
+    Value::Range(a, b) => (*a..=*b).map(Value::Int).collect(),   // ← i64::MAX 無ガード
+    Value::RangeExcl(a, b) => (*a..*b).map(Value::Int).collect(),
+    _ => vec![target.clone()],
+};
+```
+
+実機で決定的に再現 (2/2 回 abort):
+
+```raku
+my $s = (1..Inf).Supply; $s.tap({ say $_; done if $_ >= 3 });
+#   mutsu => thread '<unnamed>' panicked: capacity overflow （プロセス abort、出力なし）
+#   raku  => 1 2 3
+```
+
+これは**二重の穴**である:
+1. **未ガード展開** (§8.2 の欠陥クラスの取りこぼし): 無限 Range を `Vec<Value>` へ即時 collect する。
+2. **worker-thread 未保護** (§5 の panic 境界の穴): `.tap` のコールバックが別スレッドで走るため、
+   §5 (#3045) で設置した panic→`X::` 変換境界 (メインスレッドのみ) が捕捉できず、`X::AdHoc` に
+   変換されずプロセスごと abort する (しかも exit code は 0 になり成功に偽装される)。
+
+**改善**: (1) `coercion.rs:536-537` を `materialize_capped` 経由に揃える。
+(2) `start{}`/`.tap` のワーカースレッド本体にも panic→`X::` 変換境界を設け、worker の panic を
+親 Promise/Supply の失敗として伝播させる (ロードマップ §7 の #1/#2)。
+
 ---
 
-*この分析は静的読解 + 実機再現に基づく。再現コマンドは 0・2・8 章に記載。
-深掘りで用いた一時スクリプトは `tmp/` (gitignored) に置いた。*
+*この分析は静的読解 + 実機再現に基づく。再現コマンドは 0・2・8 章に記載。*
+*rev2 (2026-06-15 @ `b7ced0fe`): 4 調査エージェント + 実機再現で初版を全面再検証。*
+*初版の最重要 3 指摘 (VM シム / 遅延崩壊 / 並行共有) はいずれも解消し、*
+*唯一の決定的残存クラッシュは §8.7 (`.Supply` の無限 Range 未ガード展開 × worker-thread 未保護)。*

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,13 +36,14 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 
 ### A. Track C — 並行（共有セル）
 
-スライス 1〜5 landed（共有スカラ / state / compound-assign / hash-elem / array-elem index 代入 #3063）。残り:
+スライス 1〜5 landed（共有スカラ / state / compound-assign / hash-elem / array-elem index 代入 #3063）。
+スカラ `$counter`・`state $n` の `start` 間ライブ共有は **landed・実機確認済み**（mutsu 4/3＝raku 一致、ANALYSIS rev2 §2.2/§8.3）。残り:
 
-- [ ] **並行 state/lexical/global の真共有**（ANALYSIS §8.3, §2.2）— `clone_for_thread` のスナップショットコピーをやめ、
-      共有すべき値を `Arc<Mutex>` のライブセルに。`start` ブロック間で `$counter`/`state $n` が共有されない（mutsu 1/0, raku 4/3）。
-      BLOCKERS の Threading/Async 31 件に直結。`state @`/`%` 共有は Track B 要素セル基盤に依存。
-- [ ] **`unsafe` の single-thread 前提を是正**（ANALYSIS §2.3）— `Arc::as_ptr as *mut` のエイリアス書き換え 11 箇所が
-      スレッド生成と矛盾し UB の余地。配列/ハッシュを共有セル化して撤廃。
+- [ ] **`state @`/`%`・lexical aggregate の真共有** — `start` 間で配列/ハッシュ集約変数を共有。Track B 要素セル基盤に依存。
+- [ ] **`unsafe` の single-thread 前提コメント是正**（ANALYSIS rev2 §2.3）— `Arc::as_ptr as *mut` のエイリアス書き換えは
+      11→4 箇所に減り `strong_count` ガード＋`Arc::make_mut` フォールバックで UB の実発生は回避済み。だが SAFETY コメントは
+      "mutsu is single-threaded" のまま陳腐化（`vm/vm_var_assign_ops.rs:2098,2559,2587,2908,3514`）。コメントを実態（strong_count
+      ガード前提）に是正し、最終的には配列/ハッシュ要素も `ContainerRef` 化して生ポインタ改竄を撤廃（Phase 2 依存）。
 
 ### B. perf — 起動 / 実行速度（計測駆動・MUTSU_VM_STATS / timed roast）
 
@@ -54,6 +55,12 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 
 ### C. roast backlog（BLOCKERS.md 駆動・インパクト順）
 
+- [ ] **【クラッシュ】無限 Range の `.Supply` 化が worker thread で abort**（ANALYSIS rev2 §8.7）—
+      `my $s = (1..Inf).Supply; $s.tap({...})` が `capacity overflow` でプロセス abort（exit 0 に偽装）。二重の穴:
+      ① `builtins/methods_0arg/coercion.rs:536-537` の Supply coercion が無限 Range を `i64::MAX` 無ガードで
+      `(a..=b).map(Value::Int).collect()`（§8.2 の掃討漏れ）→ `materialize_capped` 経由へ。
+      ② `.tap`/`start{}` のワーカースレッド本体に panic→`X::` 変換境界が無い（#3045 はメインスレッドのみ）→
+      worker の panic を親 Promise/Supply の失敗として伝播させる。
 - [ ] **残りの型付き例外**（X::Str::Numeric / X::Method::NotFound / X::Undeclared / X::Cannot::Lazy /
       X::EXPORTHOW::InvalidDirective 等）。詳細は BLOCKERS.md "throws-like / Exception Types"。
 - [ ] **Match キャプチャ番号付け / コンテナ kind**: (1) `$<x>=(...)` が positional スロットにも重複格納され番号がずれる
@@ -128,7 +135,7 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 
 | 指標 | 現在 | 目標 |
 |------|------|------|
-| Whitelist | **1218** | 1220+ |
+| Whitelist | **1270** | 1280+ |
 | fib(25) vs raku | **1.0x** | <10x |
 | method-call vs raku | **2.7x** | <1.5x |
 | bench-class vs raku | **2.3x** | <1.5x |


### PR DESCRIPTION
## Summary

Re-verified the 2026-06-03 `ANALYSIS.md` against current `main` (`b7ced0fe`) using fresh investigation agents + live repro, and updated `PLAN.md` accordingly.

### Biggest change: CP-3 collapse resolved the top critique
The initial analysis's #1 issue — "the bytecode VM is a thin shim over a tree-walking Interpreter" — is **structurally resolved**. CP-3 collapse dissolved the bytecode VM into the `Interpreter` struct: no separate VM struct, `self.interpreter.*` (1300+ sites) gone, `loan_env!` is now a no-op.

### Verified fixed (live repro, now matches raku)
- `my $c=0; await (^4).map:{start{$c++}}; say $c` → **4** (was 1)
- `(1..Inf).grep(* %% 3)[^4]` → **(3 6 9 12)** (was panic)
- state sharing across threads, regex re-parse cache, `regex_validate.rs` deleted (validator/matcher dedup)

### New finding: §8.7 — the one deterministic residual crash
```raku
my $s = (1..Inf).Supply; $s.tap({ say $_; done if $_ >= 3 });
# mutsu => worker-thread capacity overflow abort (exit 0)
# raku  => 1 2 3
```
Double hole: (1) `coercion.rs:536-537` Supply coercion expands an infinite Range unguarded; (2) `.tap` runs in a worker thread, which the §5 (#3045) panic→`X::` boundary (main-thread only) does not cover. Added to PLAN.md backlog — fix coming next.

### Other refreshed facts
- §2.3 unsafe `Arc::as_ptr as *mut`: 11→4 sites + `strong_count` guards (UB avoided), but SAFETY comments still say "single-threaded" (stale).
- §6 hygiene: root `bom-test-*` clutter grew 12→254; largest file `vm_var_assign_ops.rs` 7188 lines.
- Whitelist 1238→1270; roadmap re-prioritized into done vs remaining.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)