### PR TITLE
fix(supply): stop (1..Inf).Supply from capacity-overflow panicking

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -533,8 +533,15 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
                     items.to_vec()
                 }
-                Value::Range(a, b) => (*a..=*b).map(Value::Int).collect(),
-                Value::RangeExcl(a, b) => (*a..*b).map(Value::Int).collect(),
+                // Route Range-family sources through `value_to_list`, which caps at
+                // `MAX_RANGE_EXPAND` instead of expanding `(a..=i64::MAX)` directly.
+                // The raw `.collect()` here used to `capacity overflow`-panic on an
+                // infinite range, e.g. `(1..Inf).Supply` (ANALYSIS §8.7 / §8.2).
+                Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::GenericRange { .. } => crate::runtime::utils::value_to_list(target),
                 _ => vec![target.clone()],
             };
             let mut attrs = std::collections::HashMap::new();

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -485,7 +485,15 @@ impl Interpreter {
                         }
                     }
                     if Self::supply_has_active_callback(&tap_cb) {
-                        self.call_sub_value(tap_cb.clone(), vec![v.clone()], true)?;
+                        // A `done`/`last` inside the tap callback completes the tap
+                        // cleanly: stop emitting and fall through to the done
+                        // callback. It must not surface as a runtime error (this is
+                        // how `(1..Inf).Supply.tap({ ...; done if ... })` terminates).
+                        match self.call_sub_value(tap_cb.clone(), vec![v.clone()], true) {
+                            Ok(_) => {}
+                            Err(err) if err.is_react_done || err.is_last => break,
+                            Err(err) => return Err(err),
+                        }
                     }
                 }
 

--- a/t/supply-infinite-range.t
+++ b/t/supply-infinite-range.t
@@ -1,0 +1,32 @@
+use Test;
+
+# Regression: `(1..Inf).Supply` used to `capacity overflow`-panic because the
+# Supply coercion expanded the infinite Range to a Vec eagerly (ANALYSIS §8.7).
+# It must now coerce without crashing (capped at MAX_RANGE_EXPAND), and a `done`
+# inside the tap callback must terminate the tap cleanly rather than surfacing as
+# a runtime error.
+
+plan 4;
+
+{
+    my $s = (1..Inf).Supply;
+    isa-ok $s, Supply, "(1..Inf).Supply coerces without crashing";
+}
+
+{
+    my @seen;
+    (1..Inf).Supply.tap({ @seen.push($_); done if $_ >= 3 });
+    is-deeply @seen, [1, 2, 3], "done inside tap stops an infinite-range Supply";
+}
+
+{
+    my @seen;
+    (1..5).Supply.tap({ @seen.push($_) });
+    is-deeply @seen, [1, 2, 3, 4, 5], "finite-range Supply still replays all values";
+}
+
+{
+    my @seen;
+    (1..Inf).Supply.tap({ @seen.push($_); last if @seen == 2 });
+    is-deeply @seen, [1, 2], "last inside tap also stops the Supply cleanly";
+}


### PR DESCRIPTION
## Summary

Fixes the one deterministic residual crash found in the ANALYSIS.md rev2 re-audit (§8.7).

`.Supply` coercion expanded a Range source with a raw `(a..=b).map(Value::Int).collect()`, which `capacity overflow`-panics (process abort) when the range is unbounded:

```raku
my $s = (1..Inf).Supply;                              # was: capacity overflow abort
$s.tap({ say $_; done if $_ >= 3 });                  # raku => 1 2 3
```

This was the last unguarded infinite-Range expansion site after the §8.2 sweep, and it ran in the top-level worker thread, so the §5 (#3045) panic→`X::` boundary did not even convert it — the process aborted (with `exit 0`).

## Changes

- **`coercion.rs`**: route Range-family Supply sources through `value_to_list`, which caps at `MAX_RANGE_EXPAND` instead of expanding to `i64::MAX` (the same guard the rest of the file already uses). Also covers `RangeExclStart` / `RangeExclBoth` / `GenericRange`, which were previously unhandled.
- **`native_supply_mut_methods.rs`**: the static-values tap loop now treats a `done`/`last` raised inside the tap callback as clean termination (`break`) instead of propagating it as a bare `Runtime error:`. This makes `(1..Inf).Supply.tap({ ...; done if ... })` emit-then-stop, matching rakudo.

## Tests

- New `t/supply-infinite-range.t` — coerce without crash, `done`/`last` stop the tap, finite ranges still replay fully. Passes on both rakudo and mutsu.
- All 34 `t/supply-*.t` pass; whitelisted `S17-supply/*` roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)