### PR TITLE
refactor(value): concentrate aliased Arc-mut casts into one audited choke point (Track C)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2313,16 +2313,13 @@ impl Interpreter {
                         match self.deepmap_leaf_call(block, item) {
                             Ok((v, new_src)) => {
                                 if new_src != *item {
-                                    // Write the mutated leaf back into the
-                                    // source array in place so all holders of
-                                    // the Arc see it (Raku container
-                                    // semantics). SAFETY: mutsu is
-                                    // single-threaded; same pattern as the
-                                    // other interior-mutation sites.
-                                    let ptr = std::sync::Arc::as_ptr(items)
-                                        as *mut crate::value::ArrayData;
+                                    // Write the mutated leaf back into the source
+                                    // array in place so all holders of the Arc see
+                                    // it (Raku container semantics).
+                                    // SAFETY: aliased in-place mutation of a shared
+                                    // container; see `arc_contents_mut`.
                                     unsafe {
-                                        (&mut *ptr).items[idx] = new_src;
+                                        crate::value::arc_contents_mut(items).items[idx] = new_src;
                                     }
                                 }
                                 result.push(v);
@@ -2394,13 +2391,14 @@ impl Interpreter {
                             Ok((Value::Slip(items), _)) if items.is_empty() => continue,
                             Ok((val, new_src)) => {
                                 if new_src != *v {
-                                    // Write the mutated leaf back into the
-                                    // source hash in place (see the Array arm).
-                                    // SAFETY: mutsu is single-threaded.
-                                    let ptr =
-                                        std::sync::Arc::as_ptr(map) as *mut crate::value::HashData;
+                                    // Write the mutated leaf back into the source
+                                    // hash in place (see the Array arm).
+                                    // SAFETY: aliased in-place mutation of a shared
+                                    // container; see `arc_contents_mut`.
                                     unsafe {
-                                        (&mut *ptr).map.insert(k.clone(), new_src);
+                                        crate::value::arc_contents_mut(map)
+                                            .map
+                                            .insert(k.clone(), new_src);
                                     }
                                 }
                                 result.insert(k.clone(), val);

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1069,45 +1069,47 @@ impl Interpreter {
             };
             // Check if we can mutate in-place (shared reference)
             if Arc::strong_count(arc) > 1 {
-                let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                unsafe {
-                    for arg in args {
-                        match arg {
-                            Value::Pair(k, v) => {
-                                let key = k.as_str().to_string();
-                                let map = &mut (*ptr).map;
-                                if let Some(existing) = map.get(&key) {
-                                    // Key exists: create itemized array
-                                    let arr = Value::Array(
-                                        Arc::new(crate::value::ArrayData::new(vec![
-                                            existing.clone(),
-                                            *v,
-                                        ])),
-                                        crate::value::ArrayKind::ItemArray,
-                                    );
-                                    map.insert(key, arr);
-                                } else {
-                                    map.insert(key, *v);
-                                }
+                // SAFETY: aliased in-place mutation of a shared hash (guarded by
+                // strong_count > 1, the exact case that needs the shared write);
+                // see `arc_contents_mut`. No borrow into the map is live across
+                // each insert.
+                let data = unsafe { crate::value::arc_contents_mut(arc) };
+                for arg in args {
+                    match arg {
+                        Value::Pair(k, v) => {
+                            let key = k.as_str().to_string();
+                            let map = &mut data.map;
+                            if let Some(existing) = map.get(&key) {
+                                // Key exists: create itemized array
+                                let arr = Value::Array(
+                                    Arc::new(crate::value::ArrayData::new(vec![
+                                        existing.clone(),
+                                        *v,
+                                    ])),
+                                    crate::value::ArrayKind::ItemArray,
+                                );
+                                map.insert(key, arr);
+                            } else {
+                                map.insert(key, *v);
                             }
-                            Value::ValuePair(k, v) => {
-                                let key = k.to_string_value();
-                                let map = &mut (*ptr).map;
-                                if let Some(existing) = map.get(&key) {
-                                    let arr = Value::Array(
-                                        Arc::new(crate::value::ArrayData::new(vec![
-                                            existing.clone(),
-                                            *v,
-                                        ])),
-                                        crate::value::ArrayKind::ItemArray,
-                                    );
-                                    map.insert(key, arr);
-                                } else {
-                                    map.insert(key, *v);
-                                }
-                            }
-                            _ => {}
                         }
+                        Value::ValuePair(k, v) => {
+                            let key = k.to_string_value();
+                            let map = &mut data.map;
+                            if let Some(existing) = map.get(&key) {
+                                let arr = Value::Array(
+                                    Arc::new(crate::value::ArrayData::new(vec![
+                                        existing.clone(),
+                                        *v,
+                                    ])),
+                                    crate::value::ArrayKind::ItemArray,
+                                );
+                                map.insert(key, arr);
+                            } else {
+                                map.insert(key, *v);
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 return Ok(target);

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -228,16 +228,16 @@ impl Interpreter {
                 "prepend" => flatten_append_args(args),
                 _ => unreachable!(),
             };
-            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
-            unsafe {
-                let data = &mut *ptr;
-                if matches!(method, "unshift" | "prepend") {
-                    let mut combined = vals;
-                    combined.append(&mut data.items);
-                    data.items = combined;
-                } else {
-                    data.items.extend(vals);
-                }
+            // SAFETY: aliased in-place mutation of a shared array (guarded by
+            // strong_count > 1, the exact case that needs the shared write); see
+            // `arc_contents_mut`. No borrow into the items is live across this.
+            let data = unsafe { crate::value::arc_contents_mut(arc) };
+            if matches!(method, "unshift" | "prepend") {
+                let mut combined = vals;
+                combined.append(&mut data.items);
+                data.items = combined;
+            } else {
+                data.items.extend(vals);
             }
             return Ok(target);
         }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -212,14 +212,15 @@ pub(crate) fn mark_shaped_array_items(
     if items.shape.as_deref() == Some(shape) {
         return;
     }
-    // SAFETY: mutsu is single-threaded. The shape is metadata about this one
-    // logical array, shared by every holder of the `Arc` — matching the prior
-    // pointer-keyed side-table semantics (any holder of the same pointer saw
-    // the shape). Interior mutation preserves "mark after the array Value is
-    // already placed" without requiring a write-back through the caller.
-    let ptr = Arc::as_ptr(items) as *mut crate::value::ArrayData;
+    // The shape is metadata about this one logical array, shared by every holder
+    // of the `Arc` — matching the prior pointer-keyed side-table semantics (any
+    // holder of the same pointer saw the shape). Interior mutation preserves
+    // "mark after the array Value is already placed" without a write-back through
+    // the caller.
+    // SAFETY: aliased in-place mutation of a shared container; see
+    // `arc_contents_mut`. No borrow into the array is live across this write.
     unsafe {
-        (*ptr).shape = Some(shape.to_vec());
+        crate::value::arc_contents_mut(items).shape = Some(shape.to_vec());
     }
 }
 

--- a/src/value/aliased_mut.rs
+++ b/src/value/aliased_mut.rs
@@ -1,0 +1,68 @@
+//! The single audited choke point for *aliased, in-place* mutation of a
+//! shared `Arc<ArrayData>` / `Arc<HashData>` container.
+//!
+//! # Why this exists
+//!
+//! mutsu represents `Value::Array`/`Value::Hash` as `Arc<ArrayData>` /
+//! `Arc<HashData>` copy-on-write containers that nonetheless carry a *shared
+//! identity*: when a container is bound (`:=`), pushed to through an alias, or
+//! grown through a `ContainerRef`, the mutation must be visible through **every**
+//! holder of the same `Arc` (Raku container semantics). `Arc::get_mut` /
+//! `Arc::make_mut` cannot express that — `get_mut` returns `None` the moment the
+//! `Arc` is aliased (which is exactly when we need the shared write), and
+//! `make_mut` clones, severing the alias. So the in-place write through the
+//! shared `Arc`'s contents is fundamental, not an optimization.
+//!
+//! Before this module those writes were ~35 scattered, hand-rolled
+//! `unsafe { &mut *(Arc::as_ptr(arc) as *mut _) }` blocks, several carrying the
+//! *incorrect* `// SAFETY: mutsu is single-threaded` justification (ANALYSIS
+//! §2.3: `clone_for_thread` + `thread::spawn` can move a clone of the same `Arc`
+//! onto another OS thread, so "single-threaded" is false). Concentrating them
+//! here gives one audited primitive, one accurate safety contract, and — most
+//! importantly — **one site to change** when arrays/hashes gain interior
+//! mutability (first-class container cells / PLAN.md Track B), which is what
+//! actually removes the underlying unsoundness.
+//!
+//! # ⚠️ Known unsoundness (tracked, not removed here)
+//!
+//! Writing through a pointer derived from `Arc::as_ptr` (a `*const T`) is a
+//! provenance violation under Stacked/Tree Borrows even single-threaded, and a
+//! genuine data race when the same `Arc` is shared across threads. This module
+//! **concentrates and honestly documents** that pre-existing unsoundness; it does
+//! not fix it. The real fix is wrapping the mutated collections in interior
+//! mutability (`UnsafeCell` / a lock) once arrays/hashes become first-class
+//! `ContainerRef` cells. Until then, this is the deliberate, single, auditable
+//! choke point — do not reintroduce ad-hoc `Arc::as_ptr as *mut` casts elsewhere.
+
+use std::sync::Arc;
+
+/// Returns a `&mut T` aliasing the contents of a shared `Arc<T>`, for a
+/// deliberate aliased in-place mutation of an `ArrayData`/`HashData` container.
+///
+/// The returned borrow is tied to the lifetime of the `&Arc<T>` argument, so the
+/// `&mut` cannot outlive the handle it came from (a small improvement over the
+/// raw `Arc::as_ptr as *mut` casts this replaces, which produced an unbounded
+/// pointer).
+///
+/// # Safety
+///
+/// The caller must guarantee that for the entire lifetime of the returned `&mut`:
+///
+/// * **No aliasing borrow is live.** No other reference (`&T` or `&mut T`) into
+///   the same `Arc`'s contents may exist while this `&mut` is held. In practice
+///   this means: read what you need out first, then take this borrow, then write,
+///   and do not re-enter the VM (which could observe the container) while the
+///   borrow is held.
+/// * **No concurrent access from another thread.** See the module-level "Known
+///   unsoundness" note — this obligation is *currently violable* for containers
+///   captured into a spawned thread, and that gap is intentionally left for the
+///   first-class-container (Track B) work to close.
+///
+/// This function does not, and cannot, check these obligations; it is the
+/// single place where the project's container-aliasing invariant is trusted.
+#[allow(clippy::mut_from_ref)]
+pub(crate) unsafe fn arc_contents_mut<T>(arc: &Arc<T>) -> &mut T {
+    // SAFETY: delegated to the caller per the contract above. This is the only
+    // `Arc::as_ptr as *mut` cast in the codebase.
+    unsafe { &mut *(Arc::as_ptr(arc) as *mut T) }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -456,11 +456,13 @@ impl PartialEq for MixData {
     }
 }
 
+mod aliased_mut;
 mod display;
 mod error;
 mod serde_support;
 pub(crate) mod signature;
 pub(crate) mod types;
+pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use types::what_type_name;
 
 /// Get current time as seconds since UNIX epoch (returns 0.0 on WASM).
@@ -2948,14 +2950,12 @@ impl Value {
     /// Returns `None` if `self` is not a `Value::Hash`.
     pub fn hash_autovivify(&self, key: &str) -> Option<Value> {
         if let Value::Hash(arc) = self {
-            // SAFETY: mutsu is single-threaded.  We ensure no immutable
-            // references into the HashMap are alive when we mutate.
-            let ptr = Arc::as_ptr(arc) as *mut HashData;
-            unsafe {
-                if !(*ptr).map.contains_key(key) {
-                    let new_hash = Value::hash(HashMap::new());
-                    (*ptr).map.insert(key.to_string(), new_hash);
-                }
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let data = unsafe { arc_contents_mut(arc) };
+            if !data.map.contains_key(key) {
+                let new_hash = Value::hash(HashMap::new());
+                data.map.insert(key.to_string(), new_hash);
             }
             Some(Value::HashSlotRef {
                 hash: arc.clone(),
@@ -2979,23 +2979,21 @@ impl Value {
     ///   behavior) and returned by value (shared Arc).
     pub fn hash_autovivify_cell(&self, key: &str) -> Option<Value> {
         if let Value::Hash(arc) = self {
-            // SAFETY: mutsu is single-threaded; no immutable borrow into the map
-            // is alive across this mutation.
-            let ptr = Arc::as_ptr(arc) as *mut HashData;
-            unsafe {
-                match (*ptr).map.get_mut(key) {
-                    Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
-                    Some(elem @ (Value::Array(..) | Value::Hash(..))) => Some(elem.clone()),
-                    Some(elem) => {
-                        let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
-                        *elem = Value::ContainerRef(cell.clone());
-                        Some(Value::ContainerRef(cell))
-                    }
-                    None => {
-                        let new_hash = Value::hash(HashMap::new());
-                        (*ptr).map.insert(key.to_string(), new_hash.clone());
-                        Some(new_hash)
-                    }
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let data = unsafe { arc_contents_mut(arc) };
+            match data.map.get_mut(key) {
+                Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
+                Some(elem @ (Value::Array(..) | Value::Hash(..))) => Some(elem.clone()),
+                Some(elem) => {
+                    let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+                    *elem = Value::ContainerRef(cell.clone());
+                    Some(Value::ContainerRef(cell))
+                }
+                None => {
+                    let new_hash = Value::hash(HashMap::new());
+                    data.map.insert(key.to_string(), new_hash.clone());
+                    Some(new_hash)
                 }
             }
         } else {
@@ -3037,30 +3035,28 @@ impl Value {
     /// writes go through `hash_insert_through` (Stage 0).
     pub fn hash_slot_ref(&self, key: &str, terminal: bool) -> Option<Value> {
         if let Value::Hash(arc) = self {
-            // SAFETY: mutsu is single-threaded; no immutable borrow into the
-            // map is alive across this mutation.
-            let ptr = Arc::as_ptr(arc) as *mut HashData;
-            unsafe {
-                match (*ptr).map.get_mut(key) {
-                    Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
-                    Some(elem @ (Value::Array(..) | Value::Hash(..))) if !terminal => {
-                        // Intermediate container: return the element value
-                        // itself — it shares the inner Arc, so the eventual
-                        // leaf promotion by the next index op lands in the
-                        // physical map the entry points to (Stage 2: no
-                        // `HashSlotRef` back-reference needed).
-                        Some(elem.clone())
-                    }
-                    Some(elem) => {
-                        let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
-                        *elem = Value::ContainerRef(cell.clone());
-                        Some(Value::ContainerRef(cell))
-                    }
-                    None => Some(Value::HashSlotRef {
-                        hash: arc.clone(),
-                        key: key.to_string(),
-                    }),
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let data = unsafe { arc_contents_mut(arc) };
+            match data.map.get_mut(key) {
+                Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
+                Some(elem @ (Value::Array(..) | Value::Hash(..))) if !terminal => {
+                    // Intermediate container: return the element value
+                    // itself — it shares the inner Arc, so the eventual
+                    // leaf promotion by the next index op lands in the
+                    // physical map the entry points to (Stage 2: no
+                    // `HashSlotRef` back-reference needed).
+                    Some(elem.clone())
                 }
+                Some(elem) => {
+                    let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+                    *elem = Value::ContainerRef(cell.clone());
+                    Some(Value::ContainerRef(cell))
+                }
+                None => Some(Value::HashSlotRef {
+                    hash: arc.clone(),
+                    key: key.to_string(),
+                }),
             }
         } else {
             None
@@ -3073,10 +3069,10 @@ impl Value {
     /// Uses the same interior-mutation approach as `hash_autovivify`.
     pub fn hash_assign_at(&self, key: &str, val: Value) -> Option<Value> {
         if let Value::Hash(arc) = self {
-            let ptr = Arc::as_ptr(arc) as *mut HashData;
-            unsafe {
-                Value::hash_insert_through(&mut (*ptr).map, key.to_string(), val.clone());
-            }
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let data = unsafe { arc_contents_mut(arc) };
+            Value::hash_insert_through(&mut data.map, key.to_string(), val.clone());
             Some(val)
         } else {
             None
@@ -3103,10 +3099,10 @@ impl Value {
     /// Uses interior mutation (same as hash_autovivify).
     pub fn hash_slot_write(&self, val: Value) {
         if let Value::HashSlotRef { hash, key } = self {
-            let ptr = Arc::as_ptr(hash) as *mut HashData;
-            unsafe {
-                Value::hash_insert_through(&mut (*ptr).map, key.clone(), val);
-            }
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let data = unsafe { arc_contents_mut(hash) };
+            Value::hash_insert_through(&mut data.map, key.clone(), val);
         }
     }
 
@@ -3117,10 +3113,10 @@ impl Value {
     /// concurrent reads/writes to the same Arc.
     pub fn array_push_in_place(&self, val: Value) -> bool {
         if let Value::Array(arc, _) = self {
-            let ptr = Arc::as_ptr(arc) as *mut ArrayData;
-            unsafe {
-                (&mut *ptr).items.push(val);
-            }
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the items is live across the push.
+            let data = unsafe { arc_contents_mut(arc) };
+            data.items.push(val);
             true
         } else {
             false
@@ -3159,30 +3155,30 @@ impl Value {
     /// element at the single read chokepoint (`resolve_array_entry`).
     pub fn array_slot_ref(&self, idx: usize, terminal: bool) -> Option<Value> {
         if let Value::Array(arc, _kind) = self {
-            // SAFETY: mutsu is single-threaded.
-            let ptr = Arc::as_ptr(arc) as *mut ArrayData;
-            unsafe {
-                while (&(*ptr)).len() <= idx {
-                    (&mut (*ptr)).push(Value::Nil);
-                }
-                let elem = &mut (&mut (*ptr))[idx];
-                if let Value::ContainerRef(cell) = elem {
-                    return Some(Value::ContainerRef(cell.clone()));
-                }
-                // Only promote a *scalar* leaf to a cell. A container element
-                // (Array/Hash) is an intermediate level of a deeper path
-                // (`$s[1][1]`, `$s[1]<k>`); return the element value itself —
-                // it shares the inner Arc, so the eventual leaf promotion by
-                // the next index op lands in the same physical Vec/HashMap the
-                // stored element points to (Stage 2: no `ArraySlotRef`
-                // back-reference needed).
-                if !terminal && matches!(elem, Value::Array(..) | Value::Hash(..)) {
-                    return Some(elem.clone());
-                }
-                let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
-                *elem = Value::ContainerRef(cell.clone());
-                Some(Value::ContainerRef(cell))
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the items is live across the
+            // growth/promotion below.
+            let data = unsafe { arc_contents_mut(arc) };
+            while data.len() <= idx {
+                data.push(Value::Nil);
             }
+            let elem = &mut data[idx];
+            if let Value::ContainerRef(cell) = elem {
+                return Some(Value::ContainerRef(cell.clone()));
+            }
+            // Only promote a *scalar* leaf to a cell. A container element
+            // (Array/Hash) is an intermediate level of a deeper path
+            // (`$s[1][1]`, `$s[1]<k>`); return the element value itself —
+            // it shares the inner Arc, so the eventual leaf promotion by
+            // the next index op lands in the same physical Vec/HashMap the
+            // stored element points to (Stage 2: no `ArraySlotRef`
+            // back-reference needed).
+            if !terminal && matches!(elem, Value::Array(..) | Value::Hash(..)) {
+                return Some(elem.clone());
+            }
+            let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+            *elem = Value::ContainerRef(cell.clone());
+            Some(Value::ContainerRef(cell))
         } else {
             None
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3296,12 +3296,13 @@ impl Interpreter {
                 if let Some(val) = self.get_env_with_main_alias(name) {
                     match &val {
                         Value::Array(arc, _) => {
-                            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
-                            unsafe { (&mut *ptr).items.clear() };
+                            // SAFETY: aliased in-place clear of a shared container;
+                            // see `arc_contents_mut`.
+                            unsafe { crate::value::arc_contents_mut(arc).items.clear() };
                         }
                         Value::Hash(arc) => {
-                            let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                            unsafe { (*ptr).map.clear() };
+                            // SAFETY: aliased in-place clear; see `arc_contents_mut`.
+                            unsafe { crate::value::arc_contents_mut(arc).map.clear() };
                         }
                         _ => {}
                     }
@@ -3310,12 +3311,12 @@ impl Interpreter {
                 if let Some(slot) = self.find_local_slot(code, name) {
                     match &self.locals[slot] {
                         Value::Array(arc, _) => {
-                            let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
-                            unsafe { (&mut *ptr).items.clear() };
+                            // SAFETY: aliased in-place clear; see `arc_contents_mut`.
+                            unsafe { crate::value::arc_contents_mut(arc).items.clear() };
                         }
                         Value::Hash(arc) => {
-                            let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                            unsafe { (*ptr).map.clear() };
+                            // SAFETY: aliased in-place clear; see `arc_contents_mut`.
+                            unsafe { crate::value::arc_contents_mut(arc).map.clear() };
                         }
                         _ => {
                             self.locals[slot] = Value::Nil;

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -403,13 +403,11 @@ impl Interpreter {
                 // mutation on a *nested* element reaches it (the read shares the
                 // inner Arc with the slot holding it), plus the by-identity scan
                 // for any top-level binding that COW-detached.
-                // SAFETY: mutsu is single-threaded; no immutable borrow into
-                // this ArrayData is alive across the write.
-                {
-                    let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
-                    unsafe {
-                        (*ptr).items = items.clone();
-                    }
+                // SAFETY: aliased in-place mutation of a shared container; see
+                // `arc_contents_mut`. No borrow into this ArrayData is live
+                // across the write.
+                unsafe {
+                    crate::value::arc_contents_mut(existing).items = items.clone();
                 }
                 loan_env!(
                     self,
@@ -778,12 +776,11 @@ impl Interpreter {
         if let Value::Array(existing, kind) = &target {
             // In-place write back through the target's `Arc<ArrayData>` so a
             // nested-element hyper mutation reaches the element (see the twin
-            // site in `exec_hyper_method_call_op`). SAFETY: single-threaded.
-            {
-                let ptr = std::sync::Arc::as_ptr(existing) as *mut crate::value::ArrayData;
-                unsafe {
-                    (*ptr).items = items.clone();
-                }
+            // site in `exec_hyper_method_call_op`).
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`.
+            unsafe {
+                crate::value::arc_contents_mut(existing).items = items.clone();
             }
             loan_env!(
                 self,

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -319,15 +319,14 @@ impl Interpreter {
             let result_arc = Value::hash_arc(new_map);
             // Now fix up the circular references: set the placeholder values
             // to point to the result_arc itself.
-            let map = Arc::as_ptr(&result_arc) as *mut crate::value::HashData;
+            // SAFETY: result_arc was just created here; building a
+            // self-referential cycle requires the in-place write (a freshly
+            // created Arc cannot be made cyclic via `get_mut`). See
+            // `arc_contents_mut`; no borrow into the map is live across the write.
+            let data = unsafe { crate::value::arc_contents_mut(&result_arc) };
             for key in &circular_keys {
-                // SAFETY: We just created result_arc and hold the only reference,
-                // so no other thread can access it.
-                unsafe {
-                    (*map)
-                        .map
-                        .insert(key.clone(), Value::Hash(result_arc.clone()));
-                }
+                data.map
+                    .insert(key.clone(), Value::Hash(result_arc.clone()));
             }
             *new_arc = result_arc;
         }
@@ -402,23 +401,22 @@ impl Interpreter {
                     // Mark the new hash as seen so recursive calls don't
                     // re-enter it via self-referencing values.
                     seen_hashes.push(new_hash_ptr);
-                    // SAFETY: We just created new_hash_arc and hold the only ref.
-                    let map_ptr = Arc::as_ptr(&new_hash_arc) as *mut crate::value::HashData;
-                    unsafe {
-                        for key in &self_ref_keys {
-                            (*map_ptr)
-                                .map
-                                .insert(key.clone(), Value::Hash(new_hash_arc.clone()));
-                        }
-                        for hv in (*map_ptr).map.values_mut() {
-                            Self::replace_array_refs_in_value(
-                                hv,
-                                old_ptr,
-                                new_array,
-                                kind,
-                                seen_hashes,
-                            );
-                        }
+                    // SAFETY: new_hash_arc was just created here; the
+                    // self-reference insert and the in-place recursive fixup must
+                    // alias it. See `arc_contents_mut`.
+                    let data = unsafe { crate::value::arc_contents_mut(&new_hash_arc) };
+                    for key in &self_ref_keys {
+                        data.map
+                            .insert(key.clone(), Value::Hash(new_hash_arc.clone()));
+                    }
+                    for hv in data.map.values_mut() {
+                        Self::replace_array_refs_in_value(
+                            hv,
+                            old_ptr,
+                            new_array,
+                            kind,
+                            seen_hashes,
+                        );
                     }
                     seen_hashes.pop();
                     *map = new_hash_arc;
@@ -464,24 +462,22 @@ impl Interpreter {
                 }
             }
             let result_arc = crate::value::Value::array_arc(new_items);
-            let items_ptr = Arc::as_ptr(&result_arc) as *mut crate::value::ArrayData;
-            // SAFETY: We just created result_arc and hold the only reference,
-            // so no other thread can access it.
-            unsafe {
-                let data = &mut *items_ptr;
-                for idx in &circular_indices {
-                    data.items[*idx] = Value::Array(result_arc.clone(), *kind);
-                }
-                for idx in &hash_fixup_indices {
-                    let mut seen = Vec::new();
-                    Self::replace_array_refs_in_value(
-                        &mut data.items[*idx],
-                        *old_ptr,
-                        &result_arc,
-                        *kind,
-                        &mut seen,
-                    );
-                }
+            // SAFETY: result_arc was just created here; building a
+            // self-referential cycle and the in-place recursive fixup must alias
+            // it. See `arc_contents_mut`.
+            let data = unsafe { crate::value::arc_contents_mut(&result_arc) };
+            for idx in &circular_indices {
+                data.items[*idx] = Value::Array(result_arc.clone(), *kind);
+            }
+            for idx in &hash_fixup_indices {
+                let mut seen = Vec::new();
+                Self::replace_array_refs_in_value(
+                    &mut data.items[*idx],
+                    *old_ptr,
+                    &result_arc,
+                    *kind,
+                    &mut seen,
+                );
             }
             *new_arc = result_arc;
         }
@@ -2095,10 +2091,12 @@ impl Interpreter {
                         // Use in-place mutation when the array is shared
                         // (strong_count > 1) to preserve identity semantics,
                         // matching the behavior of index assignment.
-                        // SAFETY: mutsu is single-threaded.
                         let use_inplace = Arc::strong_count(arr) > 1 && !name.starts_with('@');
                         let a: &mut crate::value::ArrayData = if use_inplace {
-                            unsafe { &mut *(Arc::as_ptr(arr) as *mut crate::value::ArrayData) }
+                            // SAFETY: aliased in-place mutation of a shared array
+                            // (strong_count > 1, the case that needs the shared
+                            // write); see `arc_contents_mut`.
+                            unsafe { crate::value::arc_contents_mut(arr) }
                         } else {
                             Arc::make_mut(arr)
                         };
@@ -2905,11 +2903,13 @@ impl Interpreter {
                 };
                 if let Some((items, i)) = list_scalar_hit {
                     // Update the Scalar element in-place.
-                    // SAFETY: mutsu is single-threaded; we have exclusive
-                    // access to self, so no other thread can read this Arc.
-                    let arr: &mut Vec<Value> =
-                        unsafe { &mut *(std::sync::Arc::as_ptr(&items) as *mut _) };
-                    arr[i] = Value::Scalar(Box::new(val.clone()));
+                    // SAFETY: aliased in-place mutation of a shared list backing;
+                    // see `arc_contents_mut`. No borrow into the items is live
+                    // across the write. (The old code cast the `ArrayData` pointer
+                    // straight to `*mut Vec<Value>`, assuming `items` sits at
+                    // offset 0; this types it properly as `&mut ArrayData`.)
+                    let data = unsafe { crate::value::arc_contents_mut(&items) };
+                    data.items[i] = Value::Scalar(Box::new(val.clone()));
                     self.stack.push(val);
                     return Ok(());
                 }
@@ -3515,7 +3515,9 @@ impl Interpreter {
                             // object-hash original keys) so the original-key map
                             // travels with the hash through copy-on-write.
                             let hd: &mut crate::value::HashData = if use_inplace {
-                                unsafe { &mut *(Arc::as_ptr(hash) as *mut crate::value::HashData) }
+                                // SAFETY: aliased in-place mutation of a shared
+                                // hash; see `arc_contents_mut`.
+                                unsafe { crate::value::arc_contents_mut(hash) }
                             } else {
                                 Arc::make_mut(hash)
                             };
@@ -3586,14 +3588,12 @@ impl Interpreter {
                                     // Use in-place mutation when the array is shared
                                     // (strong_count > 1) to preserve identity semantics
                                     // and support shared `ContainerRef` cell binding.
-                                    // SAFETY: mutsu is single-threaded.
                                     let use_inplace =
                                         Arc::strong_count(items) > 1 && !var_name.starts_with('@');
                                     let arr: &mut crate::value::ArrayData = if use_inplace {
-                                        unsafe {
-                                            &mut *(Arc::as_ptr(items)
-                                                as *mut crate::value::ArrayData)
-                                        }
+                                        // SAFETY: aliased in-place mutation of a
+                                        // shared array; see `arc_contents_mut`.
+                                        unsafe { crate::value::arc_contents_mut(items) }
                                     } else {
                                         Arc::make_mut(items)
                                     };
@@ -4099,14 +4099,13 @@ impl Interpreter {
                         // Use interior mutation when the inner array is shared
                         // (e.g., by a `ContainerRef` cell from := binding).
                         if Arc::strong_count(inner_arr) > 1 {
-                            let ptr = Arc::as_ptr(inner_arr) as *mut crate::value::ArrayData;
-                            unsafe {
-                                let v = &mut (*ptr).items;
-                                while v.len() <= j {
-                                    v.push(Value::Nil);
-                                }
-                                Value::assign_element_slot(&mut v[j], val.clone());
+                            // SAFETY: aliased in-place mutation of a shared array
+                            // (strong_count > 1); see `arc_contents_mut`.
+                            let v = &mut unsafe { crate::value::arc_contents_mut(inner_arr) }.items;
+                            while v.len() <= j {
+                                v.push(Value::Nil);
                             }
+                            Value::assign_element_slot(&mut v[j], val.clone());
                         } else {
                             let inner = Arc::make_mut(inner_arr);
                             if j >= inner.len() {
@@ -4119,14 +4118,10 @@ impl Interpreter {
                 }
                 Value::Hash(inner_hash) => {
                     if Arc::strong_count(inner_hash) > 1 {
-                        let ptr = Arc::as_ptr(inner_hash) as *mut crate::value::HashData;
-                        unsafe {
-                            Value::hash_insert_through(
-                                &mut (*ptr).map,
-                                outer_key.clone(),
-                                val.clone(),
-                            );
-                        }
+                        // SAFETY: aliased in-place mutation of a shared hash
+                        // (strong_count > 1); see `arc_contents_mut`.
+                        let hd = unsafe { crate::value::arc_contents_mut(inner_hash) };
+                        Value::hash_insert_through(&mut hd.map, outer_key.clone(), val.clone());
                     } else {
                         let h = Arc::make_mut(inner_hash);
                         Value::hash_insert_through(h, outer_key.clone(), val.clone());
@@ -4156,9 +4151,11 @@ impl Interpreter {
             // `.WHICH` pointer identity. When shared, keep the make_mut COW
             // detach. The cast MUST target `HashData` (not its inner map) —
             // see docs/hashdata-migration-plan.md "Latent UB found & fixed".
-            // SAFETY: single strong holder and mutsu is single-threaded.
             let oh: &mut crate::value::HashData = if Arc::strong_count(outer_hash) == 1 {
-                unsafe { &mut *(Arc::as_ptr(outer_hash) as *mut crate::value::HashData) }
+                // SAFETY: single strong holder; in-place avoids the make_mut
+                // relocation that would break `.WHICH` identity. See
+                // `arc_contents_mut`.
+                unsafe { crate::value::arc_contents_mut(outer_hash) }
             } else {
                 Arc::make_mut(outer_hash)
             };
@@ -4194,15 +4191,13 @@ impl Interpreter {
             Value::Array(arr, _) => {
                 if let Ok(i) = outer_key.parse::<usize>() {
                     if Arc::strong_count(arr) > 1 {
-                        // SAFETY: mutsu is single-threaded.
-                        let ptr = Arc::as_ptr(arr) as *mut crate::value::ArrayData;
-                        unsafe {
-                            let v = &mut (*ptr).items;
-                            while v.len() <= i {
-                                v.push(Value::Nil);
-                            }
-                            Value::assign_element_slot(&mut v[i], val);
+                        // SAFETY: aliased in-place mutation of a shared array
+                        // (strong_count > 1); see `arc_contents_mut`.
+                        let v = &mut unsafe { crate::value::arc_contents_mut(arr) }.items;
+                        while v.len() <= i {
+                            v.push(Value::Nil);
                         }
+                        Value::assign_element_slot(&mut v[i], val);
                     } else {
                         let a = Arc::make_mut(arr);
                         if i >= a.len() {
@@ -4657,10 +4652,10 @@ impl Interpreter {
                     Some((_, cell)) => Value::ContainerRef(cell.clone()),
                     None => val.clone(),
                 };
-                let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                unsafe {
-                    Value::hash_insert_through(&mut (*ptr).map, key.clone(), stored);
-                }
+                // SAFETY: aliased in-place mutation of a shared hash so the change
+                // is visible to all holders of the same Arc; see `arc_contents_mut`.
+                let hd = unsafe { crate::value::arc_contents_mut(arc) };
+                Value::hash_insert_through(&mut hd.map, key.clone(), stored);
                 // For a fresh-cell bind, write the cell back to the source var
                 // so both sides alias the same container.
                 if let Some((Some(src), cell)) = &bind_cell {
@@ -4675,28 +4670,28 @@ impl Interpreter {
                 // Interior mutation: write into the array via raw pointer
                 // so the change is visible to all holders of the same Arc.
                 if let Ok(i) = key.parse::<usize>() {
-                    let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
-                    unsafe {
-                        let v = &mut (*ptr).items;
-                        while v.len() <= i {
-                            v.push(Value::Nil);
-                        }
-                        match &bind_cell {
-                            // Bind mode installs the shared cell at the element;
-                            // the same cell is written back to the source var
-                            // below so both sides alias.
-                            Some((_, cell)) => v[i] = Value::ContainerRef(cell.clone()),
-                            // An element source (`:= @b[j]`) not promoted to a
-                            // cell installs the payload directly (rare; left to a
-                            // later slice).
-                            None if bind_source.is_some() => v[i] = val.clone(),
-                            None => {
-                                // Write THROUGH an existing `:=`-bound cell so an
-                                // assignment reached via a stack target (e.g.
-                                // `get()<subkey>[1] = …`) updates the shared cell
-                                // instead of clobbering it (nested.t 11-12).
-                                Value::assign_element_slot(&mut v[i], val.clone());
-                            }
+                    // SAFETY: aliased in-place mutation of a shared array so the
+                    // change is visible to all holders of the same Arc; see
+                    // `arc_contents_mut`.
+                    let v = &mut unsafe { crate::value::arc_contents_mut(arc) }.items;
+                    while v.len() <= i {
+                        v.push(Value::Nil);
+                    }
+                    match &bind_cell {
+                        // Bind mode installs the shared cell at the element;
+                        // the same cell is written back to the source var
+                        // below so both sides alias.
+                        Some((_, cell)) => v[i] = Value::ContainerRef(cell.clone()),
+                        // An element source (`:= @b[j]`) not promoted to a
+                        // cell installs the payload directly (rare; left to a
+                        // later slice).
+                        None if bind_source.is_some() => v[i] = val.clone(),
+                        None => {
+                            // Write THROUGH an existing `:=`-bound cell so an
+                            // assignment reached via a stack target (e.g.
+                            // `get()<subkey>[1] = …`) updates the shared cell
+                            // instead of clobbering it (nested.t 11-12).
+                            Value::assign_element_slot(&mut v[i], val.clone());
                         }
                     }
                     // For a fresh-cell bind, write the cell back to the source var.
@@ -4763,23 +4758,20 @@ impl Interpreter {
         match target {
             Value::Hash(arc) => {
                 let k = Value::hash_key_encode(key);
-                // SAFETY: mutsu is single-threaded; no live borrow into the map.
-                let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                unsafe {
-                    Value::hash_insert_through(&mut (*ptr).map, k, val);
-                }
+                // SAFETY: aliased in-place mutation of a shared hash; see
+                // `arc_contents_mut`. No live borrow into the map.
+                let hd = unsafe { crate::value::arc_contents_mut(arc) };
+                Value::hash_insert_through(&mut hd.map, k, val);
             }
             Value::Array(arc, _) => {
                 if let Some(i) = Self::index_to_usize(key) {
-                    // SAFETY: mutsu is single-threaded.
-                    let ptr = Arc::as_ptr(arc) as *mut crate::value::ArrayData;
-                    unsafe {
-                        let v = &mut (*ptr).items;
-                        while v.len() <= i {
-                            v.push(Value::Nil);
-                        }
-                        Value::assign_element_slot(&mut v[i], val);
+                    // SAFETY: aliased in-place mutation of a shared array; see
+                    // `arc_contents_mut`.
+                    let v = &mut unsafe { crate::value::arc_contents_mut(arc) }.items;
+                    while v.len() <= i {
+                        v.push(Value::Nil);
                     }
+                    Value::assign_element_slot(&mut v[i], val);
                 }
             }
             _ => {}
@@ -4806,15 +4798,14 @@ impl Interpreter {
         let cell = match &self.locals[idx] {
             Value::HashSlotRef { hash, key } => {
                 let cell = Arc::new(std::sync::Mutex::new(val));
-                // SAFETY: mutsu is single-threaded; no live borrow into the map.
-                let ptr = Arc::as_ptr(hash) as *mut crate::value::HashData;
-                unsafe {
-                    Value::hash_insert_through(
-                        &mut (*ptr).map,
-                        key.clone(),
-                        Value::ContainerRef(cell.clone()),
-                    );
-                }
+                // SAFETY: aliased in-place mutation of a shared hash; see
+                // `arc_contents_mut`. No live borrow into the map.
+                let hd = unsafe { crate::value::arc_contents_mut(hash) };
+                Value::hash_insert_through(
+                    &mut hd.map,
+                    key.clone(),
+                    Value::ContainerRef(cell.clone()),
+                );
                 cell
             }
             Value::DeferredHashAccess { parent_slot, key } => {
@@ -4831,15 +4822,10 @@ impl Interpreter {
                 };
                 let cell = Arc::new(std::sync::Mutex::new(val));
                 if let Value::Hash(arc) = &inner_hash {
-                    // SAFETY: mutsu is single-threaded; no live borrow into the map.
-                    let ptr = Arc::as_ptr(arc) as *mut crate::value::HashData;
-                    unsafe {
-                        Value::hash_insert_through(
-                            &mut (*ptr).map,
-                            key,
-                            Value::ContainerRef(cell.clone()),
-                        );
-                    }
+                    // SAFETY: aliased in-place mutation of a shared hash; see
+                    // `arc_contents_mut`. No live borrow into the map.
+                    let hd = unsafe { crate::value::arc_contents_mut(arc) };
+                    Value::hash_insert_through(&mut hd.map, key, Value::ContainerRef(cell.clone()));
                 }
                 cell
             }

--- a/t/aliased-container-mutation.t
+++ b/t/aliased-container-mutation.t
@@ -1,0 +1,66 @@
+# Pins the aliased in-place container mutations that go through the single
+# `crate::value::arc_contents_mut` choke point (Track C: concentrating the
+# scattered `Arc::as_ptr as *mut` casts). These exercise the cyclic-builder
+# sites (fixup_circular_*_refs), UndefineAggregate, shared `.push`, and
+# `:=`-alias element writes.
+use Test;
+
+plan 12;
+
+# --- circular array self-reference (fixup_circular_array_refs) ---
+{
+    my @a = 1, 2;
+    @a = 42, @a;
+    is @a[0], 42, 'circular array: head element';
+    is @a[1][0], 42, 'circular array: one level of cycle';
+    is @a[1][1][0], 42, 'circular array: deeper cycle resolves';
+}
+
+# --- circular hash self-reference (fixup_circular_hash_refs) ---
+{
+    my %h = a => 1;
+    %h = b => 2, c => %h;
+    is %h<b>, 2, 'circular hash: plain entry';
+    is %h<c><b>, 2, 'circular hash: self-reference resolves';
+}
+
+# --- UndefineAggregate clears the shared container in place ---
+{
+    my @b = 1, 2, 3;
+    undefine @b;
+    is @b.elems, 0, 'undefine empties an array';
+    my %m = x => 1, y => 2;
+    undefine %m;
+    is %m.elems, 0, 'undefine empties a hash';
+}
+
+# --- shared `.push` (hash push on an aliased Hash) ---
+{
+    my %p = a => 1;
+    %p.push: (a => 2);
+    is %p<a>.sort.join(','), '1,2', 'hash push combines values';
+}
+
+# --- `:=` alias: push/index through an alias is visible at the source ---
+{
+    my @c = 1, 2;
+    my @d := @c;
+    @d.push(3);
+    is @c.join(','), '1,2,3', 'push through := alias reaches source array';
+    @d[0] = 99;
+    is @c[0], 99, 'index assign through := alias reaches source array';
+}
+
+{
+    my %src = a => 1;
+    my %al := %src;
+    %al<b> = 2;
+    is %src<b>, 2, 'key assign through := alias reaches source hash';
+}
+
+# --- deepmap leaf writeback into a shared array (deepmap_iterate_inner) ---
+{
+    my @e = [1, 2], [3, 4];
+    @e.deepmap: * + 10;
+    is @e[0][0], 1, 'deepmap does not mutate a non-rw source leaf';
+}


### PR DESCRIPTION
## What

The 35 scattered `unsafe { &mut *(Arc::as_ptr(arc) as *mut ArrayData/HashData) }` sites that perform **aliased, in-place** mutation of a shared container were hand-rolled, and several carried the **incorrect** `// SAFETY: mutsu is single-threaded` justification (ANALYSIS §2.3: `clone_for_thread` + `thread::spawn` can move a clone of the same `Arc` onto another OS thread, so "single-threaded" is false).

This is the **interim hardening** named in ANALYSIS §2.3 ("当面の安全策"). It does **not** remove the underlying provenance/data-race unsoundness — investigation confirmed all 30 genuine sites are *intentional* aliased mutations (0 are simple `get_mut` wins), so true removal requires giving `ArrayData`/`HashData` interior mutability when arrays/hashes become first-class `ContainerRef` cells (PLAN.md Track B). Instead it concentrates + honestly documents the unsoundness behind one swappable choke point.

## How

- Add `crate::value::arc_contents_mut(&Arc<T>) -> &mut T` — the single audited `unsafe` primitive with one accurate safety contract (no live aliasing borrow, no concurrent thread), documenting the known unsoundness and the Track B fix.
- Route all 35 sites (`value/mod.rs`, `vm.rs`, `vm_var_assign_ops.rs`, `vm_hyper_method_ops.rs`, `runtime/{methods,methods_call_helpers,utils,builtins_collection}.rs`) through it, deleting the false SAFETY comments.
- Tie the returned `&mut` to the `&Arc` lifetime (the raw casts produced an unbounded pointer).
- Fix a latent double-cast (`*const ArrayData as *mut Vec<Value>`, assuming `items` sits at offset 0) in the List-scalar element write — now properly typed `&mut ArrayData`.

A grep guarantees there is now **exactly one** `Arc::as_ptr as *mut` cast in the codebase (inside the helper). The eventual Track B cell-ification is now a single-site change.

## Verification

- `make test` PASS (810 files / 7549 tests); clippy + fmt clean.
- Whitelisted `S03-binding/*` and binding/hyper/nested/deepmap `t/` tests PASS.
- New `t/aliased-container-mutation.t` (circular self-refs, undefine, shared push, `:=`-alias writes, deepmap) matches `raku` exactly.
- Confirmed the two non-whitelisted roast partial-fails seen during testing (`S02-types/array.t`) reproduce identically on `main` — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)