### PR TITLE
chore: gitignore and remove stray IO test temp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tempfile*
 wip.txt
 handle-between-threads-*
 proc-async-*
+_tmp-io-colon-invocant-*
 
 target-local/
 .claude/worktrees/

--- a/_tmp-io-colon-invocant-2918632-28638.txt
+++ b/_tmp-io-colon-invocant-2918632-28638.txt
@@ -1,2 +1,0 @@
-alpha
-betagamma


### PR DESCRIPTION
## Summary
- `_tmp-io-colon-invocant-2918632-28638.txt` was accidentally committed — it's a transient artifact from an IO test run.
- Remove the file and add `_tmp-io-colon-invocant-*` to `.gitignore` so it cannot be re-committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)