### PR TITLE
fix(attributes): mirror whole-container assign to array/hash attribute into the cell (Phase 3)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1947,6 +1947,16 @@ impl Interpreter {
                         self.update_local_if_exists(code, &target_var, &val);
                     }
                 }
+                // Phase 3 Stage 2b: mirror a whole-container assign to an
+                // array/hash attribute (`@!a = (...)`, `%!h = (...)`, and the
+                // public `@.a`/`%.h` twigils) into self's shared cell. A scalar
+                // attribute is parsed sigil-stripped to the local `!x` and mirrors
+                // via the SetLocal path; an array/hash attribute keeps its `@`/`%`
+                // sigil and is stored here through SetGlobal, which otherwise never
+                // reaches the cell — so the write was silently lost (a same-method
+                // `@!a` read goes cell-direct and saw the unchanged default). This
+                // is a cheap prefix-check no-op for every non-attribute name.
+                self.mirror_array_hash_attr_to_cell(code, *name_idx, None);
                 *ip += 1;
             }
             OpCode::SetVarType { name_idx, tc_idx } => {

--- a/t/attr-array-hash-whole-assign.t
+++ b/t/attr-array-hash-whole-assign.t
@@ -1,0 +1,84 @@
+# Whole-container assignment to an array/hash private/public attribute twigil
+# (`@!a = (...)`, `%!h = (...)`, `@.a = (...)`, `%.h = (...)`) inside a method.
+#
+# A scalar attribute is parsed sigil-stripped to the local `!x` and mirrors to
+# self's shared cell via the SetLocal path; an array/hash attribute keeps its
+# `@`/`%` sigil and is stored through SetGlobal, which previously never mirrored
+# the new container into the cell — so the write was silently lost (a same-method
+# `@!a` read goes cell-direct and saw the unchanged default).
+use Test;
+
+plan 12;
+
+# --- whole-array assign to a private attribute ---
+{
+    class A {
+        has @.list;
+        method seed { @!list = (1, 2, 3) }
+        method seed-from(@src) { @!list = @src }
+        method inside { @!list = (7, 8); @!list.elems }
+    }
+    my $a = A.new;
+    $a.seed;
+    is $a.list.join(','), '1,2,3', 'whole-array assign via @!list = (...)';
+
+    my $b = A.new;
+    $b.seed-from([4, 5, 6]);
+    is $b.list.join(','), '4,5,6', 'whole-array assign from a param';
+
+    my $c = A.new;
+    is $c.inside, 2, 'same-method read after @!list assign sees the new value';
+    is $c.list.join(','), '7,8', 'value persists after the method returns';
+}
+
+# --- whole-hash assign to a private attribute ---
+{
+    class H {
+        has %.map;
+        method seed { %!map = (a => 1, b => 2) }
+        method inside { %!map = (x => 9); %!map.elems }
+    }
+    my $h = H.new;
+    $h.seed;
+    is $h.map<a>, 1, 'whole-hash assign via %!map = (...): key a';
+    is $h.map<b>, 2, 'whole-hash assign via %!map = (...): key b';
+    is $h.map.elems, 2, 'whole-hash assign element count';
+
+    my $h2 = H.new;
+    is $h2.inside, 1, 'same-method read after %!map assign sees the new value';
+}
+
+# --- public twigil (@.a / %.h) still works ---
+{
+    class P {
+        has @.nums;
+        has %.dict;
+        method f { @.nums = (10, 20); %.dict = (k => 1) }
+    }
+    my $p = P.new;
+    $p.f;
+    is $p.nums.join(','), '10,20', 'whole-array assign via @.nums = (...)';
+    is $p.dict<k>, 1, 'whole-hash assign via %.dict = (...)';
+}
+
+# --- assign then mutate (push) keeps working together ---
+{
+    class M {
+        has @.items;
+        method build { @!items = (1, 2); @!items.push(3) }
+    }
+    my $m = M.new;
+    $m.build;
+    is $m.items.join(','), '1,2,3', 'assign followed by push on the same attribute';
+}
+
+# --- reassigning replaces (not appends) ---
+{
+    class R {
+        has @.v;
+        method twice { @!v = (1, 2, 3); @!v = (9) }
+    }
+    my $r = R.new;
+    $r.twice;
+    is $r.v.join(','), '9', 'a second whole-array assign replaces the first';
+}


### PR DESCRIPTION
## What

A whole-container assignment to an **array/hash attribute** inside a method — `@!a = (...)`, `%!h = (...)`, and the public `@.a`/`%.h` twigils — was **silently lost**. The value never reached `self`'s shared attribute cell, so even a same-method `@!a` read (which goes cell-direct under Phase 3 Stage 2) saw the unchanged default, and the attribute stayed empty after the method returned.

```raku
class A { has @.list; method f { @!list = (1, 2, 3) } }
A.new.f.list;   # was [] — now [1, 2, 3]
```

## Root cause

A scalar attribute `$!x` is parsed **sigil-stripped** to the local `!x` and mirrors to the cell via the `SetLocal` path. But an array/hash attribute **keeps its `@`/`%` sigil** (AST name `@!list`) and is stored through `SetGlobal`, which — unlike the `AssignExpr` op (`exec_assign_expr_op`) — never called `mirror_array_hash_attr_to_cell`. So in-place mutation (`@!a.push`) worked (it mutates the cell's container directly) but whole-container *replacement* did not.

## Fix

After the `SetGlobal` store, call `mirror_array_hash_attr_to_cell(code, name_idx, None)` — the same mirror the `AssignExpr` path already uses (`None` forces the mirror, since a whole assign always replaces). It is gated on the `@!`/`@.`/`%!`/`%.` twigil + the attribute existing in the cell, so it is a **cheap prefix-check no-op** for every non-attribute name. (+10 lines, one call.)

## Not covered (separate, deeper slice)

Live `:=` aliasing of an array/hash attribute to an external container (`@!a := @src` so a later `@src.push` is visible). The bind now copies the values correctly at bind time but does not yet establish an ongoing shared-Arc alias.

## Verification

- `make test` PASS (811 files / 7561 tests); clippy + fmt clean.
- Whitelisted `S12-attributes/*` (instance/native/clone/defaults/delegation/recursive/mutators) and `S03-binding/attributes.t` PASS — no regression.
- New `t/attr-array-hash-whole-assign.t` (12 subtests) matches `raku` exactly.
- Confirmed the unrelated `S12-attributes/class.t` 14/21 failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)