### PR TITLE
fix(methods): alias a method's plain array/hash positional param to the caller

### DIFF
--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -46,12 +46,37 @@ impl Interpreter {
             .param_defs
             .iter()
             .any(|pd| pd.traits.iter().any(|t| t == "rw"));
-        let can_skip_merge = !has_rw_params && !cc.has_env_writes;
+        // A plain (non-`is copy`) `@`/`%` positional param binds the caller's
+        // container by alias (Raku readonly-container semantics): `.push`,
+        // element assign, and whole-container `=` all propagate to the caller.
+        // mutsu realizes this via the same exit-time writeback as `is rw`
+        // (`bind_function_args_values` adds it to `rw_bindings`,
+        // `apply_rw_bindings_to_env`/the merge writes it back). That writeback
+        // lives only on the full path's `else` (merge) branch — so a method with
+        // such a param must NOT take the fast path, and must NOT be allowed to
+        // `can_skip_merge` (a `.push` mutation is not a static env write, so
+        // `cc.has_env_writes` can be false while the container still changed).
+        // Subs already route through their writeback; only the method fast path
+        // dropped this. Excludes slurpy/named/`is copy`/attr-twigil params.
+        let has_aliasable_container_params = method_def.param_defs.iter().any(|pd| {
+            !pd.is_invocant
+                && !pd.traits.iter().any(|t| t == "invocant")
+                && !pd.slurpy
+                && !pd.double_slurpy
+                && !pd.named
+                && !pd.traits.iter().any(|t| t == "copy")
+                && pd.sub_signature.is_none()
+                && pd.name.len() > 1
+                && (pd.name.starts_with('@') || pd.name.starts_with('%'))
+                && !pd.name[1..].starts_with(['!', '.'])
+        });
+        let can_skip_merge =
+            !has_rw_params && !has_aliasable_container_params && !cc.has_env_writes;
 
         // Fast path: bypass env entirely and populate locals directly from
         // source data. Avoids the ~12μs Arc::make_mut deep clone that the
         // first env_mut() call triggers.
-        if !has_rw_params {
+        if !has_rw_params && !has_aliasable_container_params {
             let has_invocant_constraint = method_def.param_defs.iter().any(|pd| {
                 (pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
                     && pd.type_constraint.is_some()

--- a/t/method-param-array-hash-alias.t
+++ b/t/method-param-array-hash-alias.t
@@ -1,0 +1,101 @@
+# A plain `@`/`%` positional parameter of a METHOD binds the caller's container
+# by alias (Raku readonly-container semantics): `.push`, element assignment, and
+# whole-container `=` all propagate to the caller — exactly as they already do
+# for SUB parameters. The method fast path previously bypassed the exit-time
+# writeback (only `is rw` forced the full path), so method array/hash params
+# silently failed to alias their argument.
+use Test;
+
+plan 14;
+
+# --- array param: .push propagates (instance method) ---
+{
+    class A1 { method add(@a) { @a.push(99) } }
+    my @o = 1, 2, 3;
+    A1.new.add(@o);
+    is @o.join(','), '1,2,3,99', 'method array param .push propagates to caller';
+}
+
+# --- array param: .push propagates (class/type-object method) ---
+{
+    class A2 { method add(@a) { @a.push(7) } }
+    my @o = 1, 2;
+    A2.add(@o);
+    is @o.join(','), '1,2,7', 'class-method array param .push propagates';
+}
+
+# --- array param: whole-container assign propagates ---
+{
+    class A3 { method reset(@a) { @a = (8, 8) } }
+    my @o = 1, 2, 3;
+    A3.new.reset(@o);
+    is @o.join(','), '8,8', 'method array param whole-assign propagates';
+}
+
+# --- array param: element assignment propagates ---
+{
+    class A4 { method setfirst(@a) { @a[0] = 42 } }
+    my @o = 1, 2, 3;
+    A4.new.setfirst(@o);
+    is @o.join(','), '42,2,3', 'method array param element assign propagates';
+}
+
+# --- hash param: key assignment propagates ---
+{
+    class H1 { method put(%h) { %h<x> = 9 } }
+    my %o = a => 1;
+    H1.new.put(%o);
+    is %o<x>, 9, 'method hash param key assign propagates';
+    is %o.elems, 2, 'method hash param hash grew';
+}
+
+# --- hash param: whole-container assign propagates ---
+{
+    class H2 { method reset(%h) { %h = (z => 5) } }
+    my %o = a => 1, b => 2;
+    H2.new.reset(%o);
+    is %o.keys.sort.join(','), 'z', 'method hash param whole-assign propagates';
+}
+
+# --- is copy: does NOT propagate ---
+{
+    class CP { method f(@a is copy) { @a.push(99) } }
+    my @o = 1, 2;
+    CP.new.f(@o);
+    is @o.join(','), '1,2', 'method array param is copy does not propagate';
+}
+
+# --- a literal argument has no caller variable: no crash, value seen inside ---
+{
+    class Lit { method total(@a) { @a.push(10); @a.elems } }
+    is Lit.new.total([1, 2, 3]), 4, 'method array param works with a literal arg';
+}
+
+# --- read-only use does not corrupt the caller ---
+{
+    class RO { method sum(@a) { my $s = 0; $s += $_ for @a; $s } }
+    my @o = 1, 2, 3, 4;
+    is RO.new.sum(@o), 10, 'method array param read-only use returns correctly';
+    is @o.join(','), '1,2,3,4', 'read-only use leaves the caller unchanged';
+}
+
+# --- multiple params, mixed sigils ---
+{
+    class Mix { method go($x, @a, %h) { @a.push($x); %h<k> = $x } }
+    my @o = 1;
+    my %m = a => 0;
+    Mix.new.go(5, @o, %m);
+    is @o.join(','), '1,5', 'mixed-sigil method: array param aliased';
+    is %m<k>, 5, 'mixed-sigil method: hash param aliased';
+}
+
+# --- nested: a method calling another method, both aliasing ---
+{
+    class Nest {
+        method outer(@a) { self.inner(@a); @a.push(2) }
+        method inner(@a) { @a.push(1) }
+    }
+    my @o;
+    Nest.new.outer(@o);
+    is @o.join(','), '1,2', 'nested method calls both alias the same caller array';
+}


### PR DESCRIPTION
## What

A plain (non-`is copy`) `@`/`%` positional parameter binds the caller's container **by alias** under Raku's readonly-container semantics: `.push`, element assignment, and whole-container `=` assignment all propagate to the caller. **Sub** parameters already did this — but the equivalent **method** call silently dropped it:

```raku
class C { method add(@a) { @a.push(99) } }
my @o = 1, 2; C.new.add(@o); say @o;   # was [1 2] — now [1 2 99]
```

This is the root cause uncovered while investigating attribute `:=` bind-aliasing: `@!a := @src` couldn't alias because `@src` itself didn't even alias its caller argument inside a method.

## Root cause

The method dispatch **fast path** (`call_compiled_method_fast`) is taken whenever the method has no `is rw` param, and it bypasses the exit-time rw writeback entirely. So only `is rw` forced the full (merge) path; a plain aliasable `@`/`%` param took the fast path and never wrote back. The writeback also lives only on the full path's `else`/merge branch, so the method must additionally be denied `can_skip_merge` — a `.push` is not a static env write, so `cc.has_env_writes` can be false while the container changed.

Subs route through their writeback already; only the method fast path dropped this.

## Fix

Compute `has_aliasable_container_params` (a plain, non-`copy`, non-slurpy, non-named, non-attribute-twigil `@`/`%` positional param) and treat it like `has_rw_params` for routing — exclude it from the fast path and from `can_skip_merge`, so it takes the full path that already performs the writeback (`bind_function_args_values` records the param→source mapping in `rw_bindings`; the merge writes the final container value back). +27 lines.

## Verification

- `make test` PASS (813 files / 7577 tests); clippy + fmt clean.
- Whitelisted `S06-signature/*` (incl. `passing-arrays.t`/`passing-hashes.t`) and `S12-attributes/*` PASS — no regression.
- The prior #3114 attribute whole-assign and `t/param-array-alias.t` (sub aliasing) still pass.
- New `t/method-param-array-hash-alias.t` (14 subtests: push/element/whole-assign/`is copy`/literal/read-only/mixed-sigil/nested) matches `raku` exactly.
- Debug micro-bench of a method taking an array param did not regress (the dropped fast path was not a net win for container-param methods).

## Not covered (separate, deeper slice)

Live `:=` aliasing of an array/hash **attribute** (`@!a := @src`). The param now aliases its source, but the attribute `:=` still copies into the cell rather than sharing the Arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)