### PR TITLE
fix(for): `$_ = X for %h.values` aliases the hash value and writes back

### DIFF
--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -284,6 +284,7 @@ impl Compiler {
             explicit_zero_params: false,
             multi_param_names: Vec::new(),
             loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
+            hash_values_mode: Self::for_iterable_is_hash_values(iterable),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -657,6 +657,23 @@ impl Compiler {
         )
     }
 
+    /// Detect `%h.values` on a hash variable: the loop variable aliases a hash
+    /// value, so a plain (`$_` / named) topic writeback must update the hash by
+    /// key order (`$_ = X for %h.values` mutates `%h`). Bare `for %h` iterates
+    /// Pairs (no value writeback) and `.keys` yields read-only keys, so this is
+    /// intentionally narrow: only the `.values` transform on a `%`-source.
+    fn for_iterable_is_hash_values(iterable: &Expr) -> bool {
+        if let Expr::MethodCall {
+            target, name, args, ..
+        } = iterable
+            && args.is_empty()
+            && *name == "values"
+        {
+            return Self::for_iterable_source_name(target).is_some_and(|s| s.starts_with('%'));
+        }
+        false
+    }
+
     fn normalize_for_iterable(&self, iterable: &Expr) -> Expr {
         match iterable {
             // Scalar variables are item containers in `for` and should not be flattened.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1397,6 +1397,7 @@ impl Compiler {
                         .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
                         .collect(),
                     loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
+                    hash_values_mode: Self::for_iterable_is_hash_values(iterable),
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -752,6 +752,12 @@ pub(crate) enum OpCode {
         /// source tag is still kept so the Pair's rw `.value` alias can detect
         /// immutability and propagate.
         loop_var_wraps_element: bool,
+        /// When true, the iterable is `%h.values` on a hash variable: the loop
+        /// variable (`$_` / a plain named param) aliases the hash *value*, so a
+        /// `$_ = ...` topic assignment must write back to the hash by key order
+        /// (`$_ = X for %h.values` mutates `%h`). Distinguished from bare `for
+        /// %h` (iterates Pairs, no value writeback) and `.keys` (read-only).
+        hash_values_mode: bool,
     },
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3485,6 +3485,7 @@ impl Interpreter {
                 explicit_zero_params,
                 multi_param_names,
                 loop_var_wraps_element,
+                hash_values_mode,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -3504,6 +3505,7 @@ impl Interpreter {
                     explicit_zero_params: *explicit_zero_params,
                     multi_param_names: multi_param_names.clone(),
                     loop_var_wraps_element: *loop_var_wraps_element,
+                    hash_values_mode: *hash_values_mode,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -24,6 +24,9 @@ pub(super) struct ForLoopSpec {
     /// When true (`.pairs`/`.antipairs`), the loop variable is a `Pair` wrapping
     /// the element, so the plain per-element source writeback is suppressed.
     pub(super) loop_var_wraps_element: bool,
+    /// When true (`%h.values`), the loop variable aliases a hash value, so a
+    /// `$_ = ...` topic writeback must update the hash by key order.
+    pub(super) hash_values_mode: bool,
 }
 
 pub(super) struct WhileLoopSpec {
@@ -660,7 +663,11 @@ impl Interpreter {
         self.container_ref_reversed = false;
         // Capture hash key order before the loop so writeback uses the
         // original key order even after the hash is mutated during iteration.
-        let hash_keys_for_writeback: Option<Vec<String>> = if rw_writeback {
+        // Needed for the rw-param `%h.values -> $v is rw` writeback and for the
+        // plain topic `$_ = X for %h.values` writeback (hash_values_mode).
+        let hash_keys_for_writeback: Option<Vec<String>> = if rw_writeback
+            || (writes_back_loop_var && spec.hash_values_mode)
+        {
             container_binding
                 .as_ref()
                 .filter(|s| s.starts_with('%'))
@@ -813,6 +820,8 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
+                                spec.hash_values_mode,
+                                &hash_keys_for_writeback,
                             );
                         }
                         if rw_writeback {
@@ -872,6 +881,8 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
+                                spec.hash_values_mode,
+                                &hash_keys_for_writeback,
                             );
                         }
                         if rw_writeback {
@@ -932,6 +943,8 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
+                                spec.hash_values_mode,
+                                &hash_keys_for_writeback,
                             );
                         }
                         if rw_writeback {
@@ -973,6 +986,8 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
+                                spec.hash_values_mode,
+                                &hash_keys_for_writeback,
                             );
                         }
                         if rw_writeback {
@@ -1004,6 +1019,8 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
+                                spec.hash_values_mode,
+                                &hash_keys_for_writeback,
                             );
                         }
                         if rw_writeback {
@@ -1946,6 +1963,7 @@ impl Interpreter {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn write_back_for_topic_item(
         &mut self,
         code: &CompiledCode,
@@ -1954,10 +1972,22 @@ impl Interpreter {
         idx: usize,
         reversed: bool,
         total_items: usize,
+        hash_values_mode: bool,
+        hash_keys: &Option<Vec<String>>,
     ) {
         let Some(source) = source_var else {
             return;
         };
+        // `$_ = X for %h.values` / `for %h.values -> $v { $v = X }`: the loop
+        // variable aliases a hash *value*, so write it back to the source hash
+        // by the pre-captured key order. Bare `for %h` (Pairs) and `.keys` do
+        // not reach here (no hash_values_mode tag).
+        if source.starts_with('%') {
+            if hash_values_mode {
+                self.write_back_hash_value_item(code, source, param_name, idx, hash_keys);
+            }
+            return;
+        }
         if !source.starts_with('@') {
             return;
         }
@@ -1995,6 +2025,45 @@ impl Interpreter {
             std::sync::Arc::new(crate::value::ArrayData::new(updated)),
             kind,
         );
+        self.set_env_with_main_alias(source, updated_value.clone());
+        self.update_local_if_exists(code, source, &updated_value);
+    }
+
+    /// Write the loop variable back to a hash value during `for %h.values`
+    /// (`$_ = X for %h.values` / `for %h.values -> $v { $v = X }`). The hash key
+    /// at iteration position `idx` comes from the pre-captured key order, so the
+    /// value lands on the same key the `.values` list yielded. Skips the rebuild
+    /// when the value is provably unchanged (read-only loops stay O(n)).
+    fn write_back_hash_value_item(
+        &mut self,
+        code: &CompiledCode,
+        source: &str,
+        param_name: &Option<String>,
+        idx: usize,
+        hash_keys: &Option<Vec<String>>,
+    ) {
+        let loop_var = param_name.as_deref().unwrap_or("_");
+        let Some(current) = self.env().get(loop_var).cloned() else {
+            return;
+        };
+        let Some(keys) = hash_keys else {
+            return;
+        };
+        let Some(key) = keys.get(idx) else {
+            return;
+        };
+        let Some(Value::Hash(hash_items)) = self.get_env_with_main_alias(source) else {
+            return;
+        };
+        if hash_items
+            .get(key)
+            .is_some_and(|existing| Self::loop_var_unchanged(&current, existing))
+        {
+            return;
+        }
+        let mut updated = hash_items.as_ref().clone();
+        updated.insert(key.clone(), current);
+        let updated_value = Value::Hash(Value::hash_arc(updated));
         self.set_env_with_main_alias(source, updated_value.clone());
         self.update_local_if_exists(code, source, &updated_value);
     }

--- a/t/for-hash-values-topic-writeback.t
+++ b/t/for-hash-values-topic-writeback.t
@@ -1,0 +1,58 @@
+use Test;
+
+# `$_ = X for %h.values` aliases the hash value and writes back by key order.
+plan 9;
+
+{
+    my %h = a => 1, b => 2, c => 3;
+    $_ = $_ * 10 for %h.values;
+    is %h.sort».kv.flat.join(","), "a,10,b,20,c,30", 'topic assign writes back';
+}
+
+{
+    my %h = a => 1, b => 2;
+    $_++ for %h.values;
+    is %h.sort».kv.flat.join(","), "a,2,b,3", 'topic ++ writes back';
+}
+
+{
+    my %h = a => 1, b => 2;
+    for %h.values { $_ = $_ + 100 }
+    is %h.sort».kv.flat.join(","), "a,101,b,102", 'block form topic assign writes back';
+}
+
+{
+    # read-only iteration must not corrupt the hash
+    my %h = a => 5, b => 6;
+    my $sum = 0;
+    $sum += $_ for %h.values;
+    is $sum, 11, 'read-only sum over values';
+    is %h.sort».kv.flat.join(","), "a,5,b,6", 'read-only values leaves hash unchanged';
+}
+
+{
+    # bare `for %h` iterates Pairs and must NOT value-writeback
+    my %h = a => 1, b => 2;
+    for %h { }
+    is %h.sort».kv.flat.join(","), "a,1,b,2", 'bare for over hash leaves it unchanged';
+}
+
+{
+    # rw named param over .values still writes back
+    my %h = a => 1, b => 2, c => 3;
+    for %h.values -> $v is rw { $v *= 2 }
+    is %h.sort».kv.flat.join(","), "a,2,b,4,c,6", 'rw named param over values writes back';
+}
+
+{
+    # .kv rw still works
+    my %h = a => 1, b => 2;
+    for %h.kv -> $k, $v is rw { $v += 10 }
+    is %h.sort».kv.flat.join(","), "a,11,b,12", '.kv rw writeback';
+}
+
+{
+    # plain named param over .values is read-only (raku throws)
+    my %h = a => 1, b => 2;
+    dies-ok { for %h.values -> $v { $v = 9 } }, 'plain named param over values is read-only';
+}


### PR DESCRIPTION
## Summary

`$_ = X for %h.values` (and the block form `for %h.values { $_ = X }`) is a **value alias** in Raku: it mutates `%h` by key order. mutsu's topic writeback (`write_back_for_topic_item`) only handled `@`-sources and bailed on `%`, so the write silently no-oped.

```raku
my %h = a => 1, b => 2, c => 3;
$_ = $_ * 10 for %h.values;
say %h.sort».kv;   # before: ((a 1)(b 2)(c 3))  →  now: ((a 10)(b 20)(c 30))
```

## Approach

Thread a `hash_values_mode` flag (compiler `for_iterable_is_hash_values`: outermost `.values` on a `%`-variable) through `ForLoop`/`ForLoopSpec` so the VM distinguishes:
- `%h.values` → value alias, write back by key order
- bare `for %h` → iterates Pairs, **no** value writeback
- `.keys` → read-only (raku throws)

When set, the topic/named loop variable is written back via the new `write_back_hash_value_item`, reusing the same pre-captured `hash_keys` ordering the rw-param `%h.values -> $v is rw` path already relies on. The unchanged-value guard keeps read-only `.values` loops O(n).

## Out of scope (next work)

- QuantHash (Mix/Bag/MixHash/BagHash) element rw writeback through a scalar `$b.values` (the `baghash.t`/`mixhash.t` abort point) — touches the mutable weight model; separate effort.
- `$_ = X if cond for ...` conditional-body writeback no-ops for `@` too (pre-existing env-scoping limitation), so hashes are now at parity with arrays.

## Test

`t/for-hash-values-topic-writeback.t` (9 subtests). `make test` PASS (7611 tests), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)