### PR TITLE
fix(str): support sprintf method form with two or more args

### DIFF
--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -65,6 +65,21 @@ impl Interpreter {
             "put" if args.is_empty() => Some(self.dispatch_put(&target)),
             "printf" if args.is_empty() => Some(self.dispatch_printf(&target)),
             "sprintf" if args.is_empty() => Some(self.dispatch_sprintf(&target)),
+            "sprintf" => {
+                // Method form `$format.sprintf(*@args)` == `sprintf($format, @args)`
+                // for two or more args (the 1-arg form is a native fast-path
+                // method; the 0-arg arm above is a no-directive passthrough).
+                let fmt = target.to_string_value();
+                Some(
+                    crate::runtime::sprintf::validate_sprintf_directives(&fmt, args.len())
+                        .and_then(|_| {
+                            crate::runtime::sprintf::validate_sprintf_arg_types(&fmt, &args)
+                        })
+                        .map(|_| {
+                            Value::str(crate::runtime::sprintf::format_sprintf_args(&fmt, &args))
+                        }),
+                )
+            }
             "shape" if args.is_empty() => self.dispatch_shape(&target),
             "default" if args.is_empty() => Self::dispatch_default(&target),
             "note" if args.is_empty() => Some(self.dispatch_note(&target)),

--- a/t/str-sprintf-method.t
+++ b/t/str-sprintf-method.t
@@ -1,0 +1,17 @@
+# `$format.sprintf(*@args)` — the method form of `sprintf`, equivalent to
+# `sprintf($format, @args)` (raku-doc Type/independent-routines: "%s's weight is
+# %.2f %s".sprintf(...)). mutsu had only the 0-arg passthrough and a 1-arg native
+# fast path; two-or-more args threw X::Method::NotFound.
+use Test;
+
+plan 9;
+
+is "%s=%s".sprintf("k", "v"), 'k=v', 'two string args';
+is "%s the %d%s".sprintf("þor", 1, "st"), 'þor the 1st', 'three mixed args';
+is "%05d".sprintf(42), '00042', 'single numeric arg still works';
+is "%d + %d = %d".sprintf(2, 3, 5), '2 + 3 = 5', 'three numeric args';
+is "%.2f".sprintf(3.14159), '3.14', 'float precision, single arg';
+is "%x-%o-%b".sprintf(255, 8, 5), 'ff-10-101', 'hex/oct/bin radix args';
+is "%-5s|".sprintf("hi"), 'hi   |', 'left-justify width';
+is "no directives".sprintf(), 'no directives', 'zero args, no directives';
+is "%2\$s %1\$s".sprintf("a", "b"), 'b a', 'positional argument indices';


### PR DESCRIPTION
## What

`\$format.sprintf(*@args)` is the method form of `sprintf` (raku-doc Type/independent-routines: `"%s's weight is %.2f %s".sprintf(...)`). mutsu only had the 0-arg passthrough and a **1-arg** native fast path, so two-or-more args threw `X::Method::NotFound`:

```raku
say "%s=%s".sprintf("k", "v");          # was: No such method 'sprintf' — now: k=v
say "%s the %d%s".sprintf("þor", 1, "st"); # þor the 1st
```

Found by probe-driven differential testing against `raku`.

## Fix

Add a multi-arg `sprintf` arm to the by-name method dispatch that mirrors the `Format` renderer (`validate_sprintf_directives` + `validate_sprintf_arg_types` + `format_sprintf_args`), so the method validates and formats exactly like the `sprintf(...)` sub. The 0-arg passthrough and 1-arg native fast path are unchanged.

## Verification

- `make test` PASS (815 files / 7600 tests); clippy + fmt clean.
- New `t/str-sprintf-method.t` (9: multi string/numeric args, hex/oct/bin radix, width, precision, positional `%2\$s` indices) matches `raku` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)