### PR TITLE
fix(parser): apply postfix operators to a statement-leading hash literal

### DIFF
--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1891,7 +1891,13 @@ pub(super) fn block_stmt(input: &str) -> PResult<'_, Stmt> {
     if let Ok((rest, hash_expr)) = crate::parser::primary::misc::block_or_hash_expr(input)
         && matches!(hash_expr, Expr::Hash(_))
     {
-        return parse_statement_modifier(rest, Stmt::Expr(hash_expr));
+        // A statement-leading hash literal may carry postfix operators
+        // (`{a => 1}.keys`, `{a => 1}<b>`, `{a => 1}.map(...)`). Without this the
+        // hash terminated the statement and a following `.keys` was mis-parsed as
+        // a new `$_.keys` statement. `postfix_expr_continue` is a no-op when no
+        // postfix follows, so a bare `{a => 1}` statement is unchanged.
+        let (rest, expr) = super::super::expr::postfix_expr_continue(rest, hash_expr)?;
+        return parse_statement_modifier(rest, Stmt::Expr(expr));
     }
     let (rest, body) = block(input)?;
     let (r_ws, _) = ws(rest)?;

--- a/t/hash-literal-postfix-stmt.t
+++ b/t/hash-literal-postfix-stmt.t
@@ -1,0 +1,29 @@
+# A statement-leading hash literal `{...}` may carry postfix operators
+# (`{a => 1}.keys`, `{a => 1}<b>`, `{a => 1}.map(...)`). Previously the hash
+# terminated the statement and a following `.keys` was mis-parsed as a new
+# `$_.keys` statement (so the value was lost / dispatched on the topic). This is
+# the classic block-vs-hash disambiguation: a `{...}` term with a postfix is one
+# expression, not a self-terminating block statement.
+use Test;
+
+plan 9;
+
+# The block bodies below start with a hash literal carrying a postfix; the block
+# is invoked so the body's value is observable.
+is { {a => 1}.keys.join }(), 'a', 'hash literal . method (.keys.join)';
+is { {a => 1, b => 2}.elems }(), 2, 'hash literal .elems';
+is { {a => 1, b => 2}.map({ .value * 10 }).sort.join(',') }(), '10,20',
+    'hash literal .map chain';
+is { {a => 5}<a> }(), 5, 'hash literal <> subscript';
+is { {a => 1, b => 2}.values.sort.join(',') }(), '1,2', 'hash literal .values';
+is { {x => 10}.kv.join('=') }(), 'x=10', 'hash literal .kv';
+
+# A bare hash literal statement (no postfix) is still a Hash, not a block.
+is do { my $h = { {a => 1} }(); $h.^name }, 'Hash', 'bare hash literal stays a Hash';
+
+# A bare block statement (not a hash) still runs as a block.
+is do { my $n = 0; { $n = 7 }; $n }, 7, 'bare block statement still runs';
+
+# Chained postfix on a hash literal at statement start.
+is { {a => 1, b => 2, c => 3}.pairs.grep(*.value > 1).map(*.key).sort.join(',') }(),
+    'b,c', 'hash literal .pairs.grep.map chain';


### PR DESCRIPTION
## What

A `{...}` hash literal at the **start of a statement** may carry postfix operators — `{a => 1}.keys`, `{a => 1}<b>`, `{a => 1}.map(...)`. mutsu parsed the hash as a self-terminating statement and then mis-parsed the following `.keys` as a **new** `$_.keys` statement (dispatched on the topic), so the chain silently returned the wrong value:

```raku
say { {a => 1}.keys.join }();   # was: (empty) — now: a
say { {a => 1, b => 2}.map({ .value * 10 }).sort.join(',') }();  # was: error — now: 10,20
```

Found by probe-driven differential testing against `raku`.

## Fix

`block_stmt` already handled postfix operators for the **block** case, but the **hash** branch returned `Stmt::Expr(hash)` immediately without consuming a trailing postfix. Route the hash through `postfix_expr_continue` (a no-op when no postfix follows, so a bare `{a => 1}` statement is unchanged), mirroring the block path. +1 line of logic.

## Verification

- `make test` PASS (815 files / 7602 tests); clippy + fmt clean.
- Whitelisted `S04-statements/{given,gather,do,if,loop}` + `S04-blocks-and-statements/pointy` + `S02-literals/{pairs,adverbs}` PASS — no regression.
- New `t/hash-literal-postfix-stmt.t` (9: `.keys`/`.elems`/`.map` chains, `<>` subscript, `.values`/`.kv`/`.pairs.grep.map`, plus bare-hash and bare-block unchanged) matches `raku`.

## Out of scope (separate pre-existing bug)

A `{...}` **postcircumfix subscript** on a hash literal (`{a => 5}{"b"}`) is not applied even in expression context — a distinct block-vs-subscript ambiguity, unrelated to statement termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)