### PR TITLE
fix(parser): allow a set/baggy infix operator after a method call

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1872,7 +1872,16 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 // Detect illegal space between method name and parens
                 if (r.starts_with(' ') || r.starts_with('\t')) && !r.starts_with('\\') {
                     let after_ws = r.trim_start_matches([' ', '\t']);
-                    if after_ws.starts_with('(') {
+                    // A `(...)`-delimited set/baggy infix operator after a method
+                    // call (`@a.Set (|) @b.Set`, `$x.Bag (+) $y.Bag`) is an
+                    // *operator*, not a space-separated call-arg list. Leave it
+                    // for the infix parser instead of erroring on the space.
+                    const SET_INFIX_OPS: &[&str] = &[
+                        "(elem)", "(cont)", "(<=)", "(>=)", "(==)", "(&)", "(+)", "(-)", "(.)",
+                        "(<)", "(>)", "(^)", "(|)",
+                    ];
+                    let is_set_infix_op = SET_INFIX_OPS.iter().any(|op| after_ws.starts_with(op));
+                    if after_ws.starts_with('(') && !is_set_infix_op {
                         return Err(PError::expected_at(
                             "Confused. no space allowed between method name and the left parenthesis",
                             r,

--- a/t/set-op-after-method.t
+++ b/t/set-op-after-method.t
@@ -1,0 +1,21 @@
+# A `(...)`-delimited set/baggy infix operator immediately after a method call,
+# with a space before it (`@a.Set (|) @b.Set`), is an operator — not a
+# space-separated call-arg list. mutsu erroneously rejected the space with
+# "no space allowed between method name and the left parenthesis".
+use Test;
+
+plan 10;
+
+is ((1,2,3).Set (|) (3,4).Set).keys.sort.join(","), '1,2,3,4', 'union (|) after .Set';
+is ((1,2,3).Set (&) (2,3,4).Set).keys.sort.join(","), '2,3', 'intersection (&) after .Set';
+is ((1,2,3).Set (-) (2).Set).keys.sort.join(","), '1,3', 'difference (-) after .Set';
+is ((1,2).Set (^) (2,3).Set).keys.sort.join(","), '1,3', 'symmetric diff (^) after .Set';
+ok ((1,2).Set (<=) (1,2,3).Set), 'subset (<=) after .Set';
+ok ((1,2,3).Set (>) (1,2).Set), 'strict superset (>) after .Set';
+ok (2 (elem) (1,2,3).Set), '(elem) before .Set';
+ok ((1,2,3).Set (cont) 2), '(cont) after .Set';
+is ((1,2).Bag (+) (2,3).Bag).total, 4, 'baggy union (+) after .Bag';
+
+# A genuine space-before-call-paren is still an error.
+ok (try { EVAL 'my @a = 1, 2; @a.map (1)' } === Nil and $!.defined),
+    'real "space before call paren" still rejected';


### PR DESCRIPTION
## What

A `(...)`-delimited set/baggy **infix operator** immediately after a method call, with a space before it, is an operator — not a space-separated call-arg list:

```raku
say ((1,2,3).Set (|) (3,4).Set).keys.sort;   # was: "no space allowed between
                                              #  method name and the left
                                              #  parenthesis" — now: (1 2 3 4)
say ((1,2).Bag (+) (2,3).Bag).total;          # 4
```

Found by probe-driven differential testing against `raku`.

## Root cause

The postfix parser, after reading a method name (`.Set`), rejected a following ` (` as an illegal space-before-call-paren. But `(|)`, `(+)`, `(-)`, `(&)`, `(^)`, `(.)`, `(<)`, `(<=)`, `(>)`, `(>=)`, `(==)`, `(elem)`, `(cont)` are infix operators (set/baggy ops); only a genuine call-arg list (`@a.map (1)`) is the error. The operands worked when bound to a variable first (`$a (+) $b`), so this only bit the `TERM.method (op) ...` form.

## Fix

Skip the space-paren error when the `(...)` token is one of the set/baggy infix operators, leaving it for the infix parser. A genuine `@a.map (1)` is still rejected.

## Verification

- `make test` PASS (817 files / 7620 tests); clippy + fmt clean.
- Whitelisted `S03-operators/set_*` (union/addition/intersection/difference/elem/subset — 4044 tests) still PASS — no regression.
- New `t/set-op-after-method.t` (10: `(|)`/`(&)`/`(-)`/`(^)`/`(<=)`/`(>)`/`(elem)`/`(cont)`/`(+)` after `.Set`/`.Bag`, plus the real space-before-call-paren still rejected) matches `raku`.

## Out of scope (separate pre-existing bug, noted)

A `{...}`/`{key}` postcircumfix subscript on a parenthesized term (`(...){key}`) is not applied — a distinct block-vs-subscript ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)