### PR TITLE
feat(for): `= X` writeback through `.values`/`.kv` aliases into a mutable QuantHash

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -189,12 +189,20 @@
 - [ ] roast/S02-types/baghash.t
   - 270 pass then aborts at 270 (plan 344). Fixed weight=0 removal + Str→X::Str::Numeric
     on `%h is BagHash`/scalar BagHash element assign (quanthash-element-assign fix).
-  - BLOCKER (abort at 270): QuantHash element **rw writeback through `.values`/`.kv`/`.pairs`
-    aliases** in a `for` loop — `$_ = X for $b.values`, `.value = X for $b.pairs`,
-    `for $b.kv -> \k, \v { v = X }` must write back through the Bag/BagHash value container.
-    Plain-Hash `.kv`/sigilless-param writeback landed (sigilless for-params are now rw aliases),
-    but the Mix/Bag (QuantHash) value-container mutation + topic `.values` writeback remain
-    (PLAN.md §D ① "element-source rw writeback", hot-path). See t/for-sigilless-rw.t.
+  - PROGRESS: now 290 (was 270). QuantHash `= X` writeback through `.values` (topic + `-> $v
+    is rw`) and `.kv` (`-> \k,\v` / `-> $k,$v is rw`) for a *mutable* MixHash/BagHash landed:
+    `$_ = X for $b.values`, `for $b.kv -> \k,\v { v = X }` mutate the weight by key, weight 0
+    removes the key, a non-numeric Str throws X::Str::Numeric, immutable Bag/Mix/Set still RO.
+    See t/for-quanthash-values-rw-writeback.t.
+  - REMAINING BLOCKER (abort ~290): two distinct, pre-existing mechanisms, NOT QuantHash-specific:
+    1. **sigilless `\v++`/`\v--` postfix** on an rw for-param (`for $b.kv -> \k,\v { v-- }`,
+       line 688) — fails "Cannot resolve caller postfix:<-->; requires mutable arguments" for
+       arrays too (`for @a -> \v { v-- }`). `$v is rw` (sigil) works; only sigilless `\v` lacks
+       a mutable-lvalue binding for postfix inc/dec. Compiler emits a call form, not in-place.
+    2. **`.pairs .value = X` / `.value--`** (line 600/701) — the Pair `.value=` lvalue handler
+       (runtime/methods_mut.rs) scans env for a backing Hash/Array; add a Mix/Bag/Set backing
+       branch (use `topic_source_var` to find the source QuantHash). Plain-Hash `.pairs .value=`
+       already works.
   - DONE: 206/207 (`BagHash[Str]` element-bind wrong-type croak + init croak) — parameterized
     `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]`.new now embeds the keyof type metadata so
     `$b{42}=1` throws X::TypeCheck::Binding. Also fixed `MixHash[T].new` returning an
@@ -262,11 +270,13 @@
   - DONE: parameterized `MixHash[T]`/`Mix[T]` element-bind type-check (keyof in `key_type`,
     weight type stays Real in `value_type`) + `MixHash[T].new` mutability bug (now uses
     `base_class_name`).
-  - Abort blocker (test 217, `$_ = X for $m.values`): writable `.values`/`.pairs`/`.kv`
-    aliases into the mix weights need Proxy-style writeback into the QuantHash internal
-    weights (container identity). Hard. Foundational sigilless-param rw + plain-Hash `.kv`
-    writeback landed (sigilless for-params `-> \k, \v` are now rw aliases; see
-    t/for-sigilless-rw.t); the Mix/Bag weight mutation + topic `.values` writeback remain.
+  - PROGRESS: now 237 (was 216). QuantHash `= X` writeback through `.values` (topic + rw)
+    and `.kv` for a mutable MixHash landed (`$_ = X for $m.values`, `for $m.kv -> \k,\v { v=X }`
+    mutate the weight; weight 0 removes; non-numeric Str → X::Str::Numeric). See
+    t/for-quanthash-values-rw-writeback.t.
+  - REMAINING BLOCKER (abort ~237): same two pre-existing mechanisms as baghash.t —
+    (1) sigilless `\v++`/`\v--` postfix on an rw for-param (fails for arrays too), and
+    (2) `.pairs .value = X` Pair-lvalue writeback into the QuantHash weights. See S02 baghash.t note.
 - [ ] roast/S02-types/mix-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -284,7 +284,7 @@ impl Compiler {
             explicit_zero_params: false,
             multi_param_names: Vec::new(),
             loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
-            hash_values_mode: Self::for_iterable_is_hash_values(iterable),
+            values_mode: Self::for_iterable_is_values_alias(iterable),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -657,19 +657,23 @@ impl Compiler {
         )
     }
 
-    /// Detect `%h.values` on a hash variable: the loop variable aliases a hash
-    /// value, so a plain (`$_` / named) topic writeback must update the hash by
-    /// key order (`$_ = X for %h.values` mutates `%h`). Bare `for %h` iterates
-    /// Pairs (no value writeback) and `.keys` yields read-only keys, so this is
-    /// intentionally narrow: only the `.values` transform on a `%`-source.
-    fn for_iterable_is_hash_values(iterable: &Expr) -> bool {
+    /// Detect `%h.values` / `$b.values` on a variable: the loop variable aliases
+    /// the container's *value*, so a plain (`$_` / named) topic writeback must
+    /// update the source by key order. `$_ = X for %h.values` mutates `%h`;
+    /// `$_ = X for $b.values` mutates a mutable QuantHash (MixHash/BagHash). The
+    /// VM branches on the runtime container type (Hash vs Mix/Bag/Set). Bare
+    /// `for %h` iterates Pairs (no value writeback) and `.keys` yields read-only
+    /// keys, so this is intentionally narrow: only the `.values` transform.
+    /// (`@a.values` already writes back via the `@`-source path; the flag is a
+    /// harmless no-op there.)
+    fn for_iterable_is_values_alias(iterable: &Expr) -> bool {
         if let Expr::MethodCall {
             target, name, args, ..
         } = iterable
             && args.is_empty()
             && *name == "values"
         {
-            return Self::for_iterable_source_name(target).is_some_and(|s| s.starts_with('%'));
+            return Self::for_iterable_source_name(target).is_some();
         }
         false
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1397,7 +1397,7 @@ impl Compiler {
                         .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
                         .collect(),
                     loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
-                    hash_values_mode: Self::for_iterable_is_hash_values(iterable),
+                    values_mode: Self::for_iterable_is_values_alias(iterable),
                 });
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_loop_end(loop_idx);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -752,12 +752,14 @@ pub(crate) enum OpCode {
         /// source tag is still kept so the Pair's rw `.value` alias can detect
         /// immutability and propagate.
         loop_var_wraps_element: bool,
-        /// When true, the iterable is `%h.values` on a hash variable: the loop
-        /// variable (`$_` / a plain named param) aliases the hash *value*, so a
-        /// `$_ = ...` topic assignment must write back to the hash by key order
-        /// (`$_ = X for %h.values` mutates `%h`). Distinguished from bare `for
-        /// %h` (iterates Pairs, no value writeback) and `.keys` (read-only).
-        hash_values_mode: bool,
+        /// When true, the iterable is `%h.values` / `$b.values` on a variable:
+        /// the loop variable (`$_` / a plain named param) aliases the container's
+        /// *value*, so a `$_ = ...` topic assignment writes back to the source by
+        /// key order (`$_ = X for %h.values` mutates `%h`; `for $b.values` mutates
+        /// a mutable MixHash/BagHash). The VM branches on the runtime container
+        /// type. Distinguished from bare `for %h` (Pairs, no value writeback) and
+        /// `.keys` (read-only).
+        values_mode: bool,
     },
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3485,7 +3485,7 @@ impl Interpreter {
                 explicit_zero_params,
                 multi_param_names,
                 loop_var_wraps_element,
-                hash_values_mode,
+                values_mode,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -3505,7 +3505,7 @@ impl Interpreter {
                     explicit_zero_params: *explicit_zero_params,
                     multi_param_names: multi_param_names.clone(),
                     loop_var_wraps_element: *loop_var_wraps_element,
-                    hash_values_mode: *hash_values_mode,
+                    values_mode: *values_mode,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -24,9 +24,10 @@ pub(super) struct ForLoopSpec {
     /// When true (`.pairs`/`.antipairs`), the loop variable is a `Pair` wrapping
     /// the element, so the plain per-element source writeback is suppressed.
     pub(super) loop_var_wraps_element: bool,
-    /// When true (`%h.values`), the loop variable aliases a hash value, so a
-    /// `$_ = ...` topic writeback must update the hash by key order.
-    pub(super) hash_values_mode: bool,
+    /// When true (`%h.values` / `$b.values`), the loop variable aliases the
+    /// container's value, so a `$_ = ...` topic writeback updates the source
+    /// (plain Hash or mutable MixHash/BagHash) by key order.
+    pub(super) values_mode: bool,
 }
 
 pub(super) struct WhileLoopSpec {
@@ -658,29 +659,45 @@ impl Interpreter {
         if source_immutable_quant {
             rw_writeback = false;
         }
+        // A *mutable* QuantHash (MixHash/BagHash/SetHash) source iterated via
+        // `.values`/`.kv`/`.pairs` aliases its weights: `$_ = X for $b.values`,
+        // `for $b.kv -> \k,\v { v = X }` and `.value = X for $b.pairs` all mutate
+        // the QuantHash. Detect it so the topic stays writable (not readonly) and
+        // the writeback paths can update the weight by key order, coercing the
+        // assigned value (X::Str::Numeric on a bad string; weight 0 removes the key).
+        let source_mutable_quant = container_binding.as_ref().is_some_and(|name| {
+            matches!(
+                self.get_env_with_main_alias(name),
+                Some(Value::Mix(_, true)) | Some(Value::Set(_, true)) | Some(Value::Bag(_, true))
+            )
+        });
         let mut grep_view_writes: Vec<(usize, Value)> = Vec::new();
         let container_reversed = self.container_ref_reversed;
         self.container_ref_reversed = false;
         // Capture hash key order before the loop so writeback uses the
         // original key order even after the hash is mutated during iteration.
         // Needed for the rw-param `%h.values -> $v is rw` writeback and for the
-        // plain topic `$_ = X for %h.values` writeback (hash_values_mode).
-        let hash_keys_for_writeback: Option<Vec<String>> = if rw_writeback
-            || (writes_back_loop_var && spec.hash_values_mode)
-        {
-            container_binding
-                .as_ref()
-                .filter(|s| s.starts_with('%'))
-                .and_then(|source| {
-                    if let Some(Value::Hash(hash_items)) = self.get_env_with_main_alias(source) {
-                        Some(hash_items.keys().cloned().collect())
-                    } else {
-                        None
+        // plain topic `$_ = X for %h.values` writeback (values_mode).
+        let hash_keys_for_writeback: Option<Vec<String>> =
+            if rw_writeback || (writes_back_loop_var && spec.values_mode) {
+                container_binding.as_ref().and_then(|source| {
+                    match self.get_env_with_main_alias(source) {
+                        Some(Value::Hash(hash_items)) if source.starts_with('%') => {
+                            Some(hash_items.keys().cloned().collect())
+                        }
+                        // A mutable QuantHash bound to a scalar: capture the weight
+                        // map's key order so `.values`/`.kv` writeback lands on the
+                        // same key `.values()`/`.kv` yielded (same unmodified map →
+                        // identical iteration order).
+                        Some(Value::Bag(b, true)) => Some(b.keys().cloned().collect()),
+                        Some(Value::Mix(m, true)) => Some(m.keys().cloned().collect()),
+                        Some(Value::Set(s, true)) => Some(s.elements.iter().cloned().collect()),
+                        _ => None,
                     }
                 })
-        } else {
-            None
-        };
+            } else {
+                None
+            };
         // Save multi-param values and readonly state so they can be restored
         // after the loop (inner loops must not clobber outer scope bindings).
         let saved_multi_params: Vec<(String, Option<Value>, bool, Option<Value>)> = spec
@@ -707,17 +724,22 @@ impl Interpreter {
         // (owned_captures). Balanced by pop on every exit.
         self.push_loop_local_scope();
         // Determine if the implicit topic ($_) should be read-only.
-        // Only mark $_ readonly when iterating over a known immutable collection
-        // (Mix, Set, Bag). This blocks `.value = ...` mutations on pairs from
-        // immutable collections while keeping $_ writable for expression results,
-        // multi-param for loops, and Scalar containers holding plain values.
+        // Only mark $_ readonly when iterating over an *immutable* collection
+        // (Mix/Set/Bag, the `(_, false)` variants). This blocks `.value = ...`
+        // and `$_ = ...` mutations on values/pairs from immutable collections
+        // while keeping $_ writable for a *mutable* QuantHash (MixHash/BagHash —
+        // `for $b.values { $_ = X }` / `.value = X for $b.pairs` must write back),
+        // expression results, multi-param loops, and Scalar containers.
         let topic_readonly =
             !spec.is_rw && param_name.is_none() && spec.multi_param_names.is_empty() && {
                 match &container_binding {
                     None => false,
                     Some(name) => {
                         if let Some(val) = self.get_env_with_main_alias(name) {
-                            matches!(val, Value::Mix(_, _) | Value::Set(_, _) | Value::Bag(_, _))
+                            matches!(
+                                val,
+                                Value::Mix(_, false) | Value::Set(_, false) | Value::Bag(_, false)
+                            )
                         } else {
                             false
                         }
@@ -726,11 +748,19 @@ impl Interpreter {
             };
         let total_items = chunked_items.len();
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate().skip(resume_index) {
-            self.topic_source_var = if writes_back_topic {
-                container_binding.clone()
-            } else {
-                None
-            };
+            // `topic_source_var` drives the whole-topic writeback for a scalar
+            // source (`for $x { $_[1] = ... }` writes the mutated `$_` back to
+            // `$x`). For a `.values` loop over a mutable QuantHash the topic is a
+            // *weight*, not the container — wholesale-overwriting `$b` with the
+            // weight would clobber the MixHash/BagHash. The per-element
+            // `write_back_quanthash_value_item` handles that source, so suppress
+            // the whole-topic writeback here.
+            self.topic_source_var =
+                if writes_back_topic && !(spec.values_mode && source_mutable_quant) {
+                    container_binding.clone()
+                } else {
+                    None
+                };
             // Only set $_ when no named parameter is given (for @list { ... })
             // When -> $k is used, $_ should remain from the enclosing scope
             if param_name.is_none() {
@@ -804,6 +834,48 @@ impl Interpreter {
                 {
                     body_result = Err(err);
                 }
+                // `$_ = X for $b.values` / `for $b.values -> $v { $v = X }` where
+                // `$b` is a mutable QuantHash: write the aliased weight back here,
+                // before the match, so a coercion failure (X::Str::Numeric on a
+                // non-numeric string) flows through the shared Err-arm cleanup. The
+                // Ok arm's `write_back_for_topic_item` skips scalar quant sources.
+                if body_result.is_ok()
+                    && writes_back_loop_var
+                    && spec.values_mode
+                    && source_mutable_quant
+                    && let Some(ref source) = container_binding
+                    && let Err(err) = self.write_back_quanthash_value_item(
+                        code,
+                        source,
+                        &param_name,
+                        idx,
+                        &hash_keys_for_writeback,
+                    )
+                {
+                    body_result = Err(err);
+                }
+                // The rw-param sibling of the above: `for $b.kv -> \k, \v { v = X }`
+                // and `for $b.values -> $v is rw { $v = X }` over a mutable QuantHash.
+                // Handled pre-match (coercion may raise X::Str::Numeric) so the
+                // Ok-arm `write_back_for_rw_param` (which no-ops on scalar quant
+                // sources) need not change.
+                if body_result.is_ok()
+                    && rw_writeback
+                    && source_mutable_quant
+                    && (spec.kv_mode || spec.values_mode)
+                    && let Some(ref source) = container_binding
+                    && let Err(err) = self.write_back_quanthash_rw(
+                        code,
+                        source,
+                        &spec.rw_param_names,
+                        &param_name,
+                        idx,
+                        spec.kv_mode,
+                        &hash_keys_for_writeback,
+                    )
+                {
+                    body_result = Err(err);
+                }
                 match body_result {
                     Ok(()) => {
                         // Sync state variables modified in this iteration so
@@ -820,7 +892,7 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
-                                spec.hash_values_mode,
+                                spec.values_mode,
                                 &hash_keys_for_writeback,
                             );
                         }
@@ -881,7 +953,7 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
-                                spec.hash_values_mode,
+                                spec.values_mode,
                                 &hash_keys_for_writeback,
                             );
                         }
@@ -943,7 +1015,7 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
-                                spec.hash_values_mode,
+                                spec.values_mode,
                                 &hash_keys_for_writeback,
                             );
                         }
@@ -986,7 +1058,7 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
-                                spec.hash_values_mode,
+                                spec.values_mode,
                                 &hash_keys_for_writeback,
                             );
                         }
@@ -1019,7 +1091,7 @@ impl Interpreter {
                                 idx,
                                 container_reversed,
                                 total_items,
-                                spec.hash_values_mode,
+                                spec.values_mode,
                                 &hash_keys_for_writeback,
                             );
                         }
@@ -1972,7 +2044,7 @@ impl Interpreter {
         idx: usize,
         reversed: bool,
         total_items: usize,
-        hash_values_mode: bool,
+        values_mode: bool,
         hash_keys: &Option<Vec<String>>,
     ) {
         let Some(source) = source_var else {
@@ -1981,13 +2053,17 @@ impl Interpreter {
         // `$_ = X for %h.values` / `for %h.values -> $v { $v = X }`: the loop
         // variable aliases a hash *value*, so write it back to the source hash
         // by the pre-captured key order. Bare `for %h` (Pairs) and `.keys` do
-        // not reach here (no hash_values_mode tag).
+        // not reach here (no values_mode tag).
         if source.starts_with('%') {
-            if hash_values_mode {
+            if values_mode {
                 self.write_back_hash_value_item(code, source, param_name, idx, hash_keys);
             }
             return;
         }
+        // A scalar source iterated via `.values` binding a mutable QuantHash is
+        // written back by `write_back_quanthash_value_item`, called *before* the
+        // body-result match (its coercion can raise X::Str::Numeric, which must
+        // flow through the loop's shared error cleanup). So nothing to do here.
         if !source.starts_with('@') {
             return;
         }
@@ -2027,6 +2103,129 @@ impl Interpreter {
         );
         self.set_env_with_main_alias(source, updated_value.clone());
         self.update_local_if_exists(code, source, &updated_value);
+    }
+
+    /// Set a single weight on a mutable QuantHash bound to a scalar `source`,
+    /// coercing the assigned value the same way an element store (`$b<k> = v`)
+    /// does: Int for Bag, Real for Mix, truthiness for Set. A non-numeric `Str`
+    /// raises X::Str::Numeric, and a zero weight removes the key (Raku semantics).
+    /// No-op (and Ok) if `source` does not hold a mutable QuantHash.
+    fn quanthash_set_weight(
+        &mut self,
+        code: &CompiledCode,
+        source: &str,
+        key: String,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        let updated = match self.get_env_with_main_alias(source) {
+            Some(Value::Bag(bag, true)) => {
+                let count = Self::bag_assignment_count(value)?;
+                let mut b = (*bag).clone();
+                if count == 0 {
+                    b.counts.remove(&key);
+                } else {
+                    b.counts.insert(key, count);
+                }
+                Value::Bag(std::sync::Arc::new(b), true)
+            }
+            Some(Value::Mix(mix, true)) => {
+                let weight = Self::mix_assignment_weight(value)?;
+                let mut m = (*mix).clone();
+                if weight == 0.0 {
+                    m.remove(&key);
+                } else {
+                    m.insert(key, weight);
+                }
+                Value::Mix(std::sync::Arc::new(m), true)
+            }
+            Some(Value::Set(set, true)) => {
+                let mut s = (*set).clone();
+                if value.truthy() {
+                    s.elements.insert(key);
+                } else {
+                    s.elements.remove(&key);
+                }
+                Value::Set(std::sync::Arc::new(s), true)
+            }
+            _ => return Ok(()),
+        };
+        self.set_env_with_main_alias(source, updated.clone());
+        self.update_local_if_exists(code, source, &updated);
+        Ok(())
+    }
+
+    /// Write the loop variable back to a mutable QuantHash weight during
+    /// `for $b.values` (`$_ = X for $b.values` / `for $b.values -> $v { $v = X }`,
+    /// `$b` a MixHash/BagHash/SetHash). The key at iteration position `idx` comes
+    /// from the pre-captured key order (same unmodified weight map → identical
+    /// iteration order as the materialized `.values` list).
+    fn write_back_quanthash_value_item(
+        &mut self,
+        code: &CompiledCode,
+        source: &str,
+        param_name: &Option<String>,
+        idx: usize,
+        hash_keys: &Option<Vec<String>>,
+    ) -> Result<(), RuntimeError> {
+        let loop_var = param_name.as_deref().unwrap_or("_");
+        let Some(current) = self.env().get(loop_var).cloned() else {
+            return Ok(());
+        };
+        let Some(keys) = hash_keys else {
+            return Ok(());
+        };
+        let Some(key) = keys.get(idx).cloned() else {
+            return Ok(());
+        };
+        self.quanthash_set_weight(code, source, key, &current)
+    }
+
+    /// Write a mutable QuantHash weight back from an rw for-loop param: either
+    /// `for $b.kv -> \k, \v { v = X }` (key from the `\k` param, value from `\v`)
+    /// or `for $b.values -> $v is rw { $v = X }` (key from the captured order at
+    /// `idx`, value from the single rw param / `$_`). Coercion may raise
+    /// X::Str::Numeric; weight 0 removes the key.
+    #[allow(clippy::too_many_arguments)]
+    fn write_back_quanthash_rw(
+        &mut self,
+        code: &CompiledCode,
+        source: &str,
+        rw_param_names: &[String],
+        param_name: &Option<String>,
+        idx: usize,
+        kv_mode: bool,
+        hash_keys: &Option<Vec<String>>,
+    ) -> Result<(), RuntimeError> {
+        if kv_mode {
+            // `.kv -> \k, \v`: the key is the first param, the value the second.
+            if rw_param_names.len() < 2 {
+                return Ok(());
+            }
+            let Some(key) = self.env().get(&rw_param_names[0]).cloned() else {
+                return Ok(());
+            };
+            let Some(value) = self.env().get(&rw_param_names[1]).cloned() else {
+                return Ok(());
+            };
+            self.quanthash_set_weight(code, source, key.to_string_value(), &value)
+        } else {
+            // `.values -> $v is rw`: single rw param, key by captured order.
+            let var = rw_param_names
+                .first()
+                .map(String::as_str)
+                .or(param_name.as_deref())
+                .unwrap_or("_");
+            let Some(value) = self.env().get(var).cloned() else {
+                return Ok(());
+            };
+            let Some(keys) = hash_keys else {
+                return Ok(());
+            };
+            let Some(key) = keys.get(idx).cloned() else {
+                return Ok(());
+            };
+            self.quanthash_set_weight(code, source, key, &value)
+        }
     }
 
     /// Write the loop variable back to a hash value during `for %h.values`
@@ -2207,6 +2406,17 @@ impl Interpreter {
         } else if source.starts_with('%') {
             // Hash writeback: not straightforward by index; skip for now
         } else {
+            // A mutable QuantHash bound to a scalar (`for $b.values -> $v is rw`,
+            // `for $b.kv -> \k, \v`) is written back to its weights by
+            // `write_back_quanthash_rw` *before* the body-result match (its
+            // coercion can throw). Skip the generic scalar writeback here, which
+            // would otherwise clobber `$b` with the bare weight value.
+            if matches!(
+                self.get_env_with_main_alias(source),
+                Some(Value::Bag(_, true) | Value::Mix(_, true) | Value::Set(_, true))
+            ) {
+                return;
+            }
             // Scalar binding: write back directly
             // For kv_mode with arity > 1 on a Pair source (e.g. `for $pair.kv -> $key, $value is rw`),
             // read the value from the second rw param and reconstruct the Pair.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -806,7 +806,7 @@ impl Interpreter {
         }
     }
 
-    fn mix_assignment_weight(value: &Value) -> Result<f64, RuntimeError> {
+    pub(super) fn mix_assignment_weight(value: &Value) -> Result<f64, RuntimeError> {
         match value {
             Value::Int(i) => Ok(*i as f64),
             Value::Num(n) => Ok(*n),
@@ -836,7 +836,7 @@ impl Interpreter {
     /// Coerce a value assigned to a Bag/BagHash weight to an `i64` count, with
     /// the same numeric validation as Mix: a non-numeric `Str` raises
     /// X::Str::Numeric rather than being silently treated as truthy (1).
-    fn bag_assignment_count(value: &Value) -> Result<i64, RuntimeError> {
+    pub(super) fn bag_assignment_count(value: &Value) -> Result<i64, RuntimeError> {
         match value {
             Value::Int(i) => Ok(*i),
             Value::Num(n) => Ok(*n as i64),

--- a/t/for-quanthash-values-rw-writeback.t
+++ b/t/for-quanthash-values-rw-writeback.t
@@ -1,0 +1,82 @@
+use Test;
+
+# Writing back to a *mutable* QuantHash (MixHash/BagHash) weight through a
+# `.values`/`.kv` for-loop alias. `$_ = X for $b.values` and
+# `for $b.kv -> \k, \v { v = X }` mutate the QuantHash by key; a non-numeric
+# string raises X::Str::Numeric and a zero weight removes the key. An *immutable*
+# Bag/Mix/Set still throws X::Assignment::RO.
+
+plan 16;
+
+# --- topic `.values` ---
+{
+    my $b = (a => 1, b => 2, c => 3).BagHash;
+    $_ = $_ * 10 for $b.values;
+    is "$b<a> $b<b> $b<c>", "10 20 30", 'topic .values assign writes back (Bag)';
+}
+{
+    my $b = <a a a>.BagHash;
+    for $b.values { $_-- }
+    is $b<a>, 2, 'topic .values $_-- decrements weight';
+    for $b.values { $_ = 0 }
+    is $b.elems, 0, 'topic .values $_ = 0 removes the key';
+}
+{
+    my $m = (a => 2.5, b => 1.0).MixHash;
+    $_ = $_ * 2 for $m.values;
+    is "$m<a> $m<b>", "5 2", 'topic .values assign writes back (Mix, Real weights)';
+}
+
+# --- named rw `.values` ---
+{
+    my $b = (a => 1, b => 2).BagHash;
+    for $b.values -> $v is rw { $v += 100 }
+    is "$b<a> $b<b>", "101 102", '.values -> $v is rw writes back';
+}
+
+# --- `.kv` rw ---
+{
+    my $b = (p => 5, q => 6).BagHash;
+    for $b.kv -> \k, \v { v = v + 1 }
+    is "$b<p> $b<q>", "6 7", '.kv -> \\k, \\v sigilless assign writes back';
+}
+{
+    my $m = (x => 1.5, y => 2.0).MixHash;
+    for $m.kv -> $k, $v is rw { $v = $v * 4 }
+    is "$m<x> $m<y>", "6 8", '.kv -> $k, $v is rw writes back (Mix)';
+}
+{
+    my $b = (a => 3).BagHash;
+    for $b.kv -> \k, \v { v = 0 }
+    is $b.elems, 0, '.kv setting weight 0 removes the key';
+}
+
+# --- X::Str::Numeric on a non-numeric assignment ---
+{
+    my $b = (a => 1).BagHash;
+    dies-ok { $_ = "foo" for $b.values }, 'topic .values = non-numeric Str dies';
+    my $err;
+    { $_ = "foo" for $b.values; CATCH { default { $err = .^name } } }
+    is $err, 'X::Str::Numeric', 'and it is X::Str::Numeric';
+    is $b<a>, 1, 'the weight is unchanged after the throw';
+}
+{
+    my $b = (a => 1).BagHash;
+    dies-ok { for $b.kv -> \k, \v { v = "foo" } }, '.kv = non-numeric Str dies';
+}
+
+# --- immutable Bag/Mix/Set still read-only ---
+{
+    my $b = (a => 1).Bag;
+    dies-ok { $_ = 5 for $b.values }, 'immutable Bag .values assign is read-only';
+    is $b<a>, 1, 'immutable Bag weight unchanged';
+}
+
+# --- read-only iteration leaves the QuantHash intact ---
+{
+    my $b = (a => 2, b => 3).BagHash;
+    my $sum = 0;
+    $sum += $_ for $b.values;
+    is $sum, 5, 'read-only sum over .values';
+    is "$b<a> $b<b>", "2 3", 'read-only .values leaves the Bag unchanged';
+}


### PR DESCRIPTION
## Summary

Writing to a mutable **MixHash/BagHash/SetHash** weight through a `.values`/`.kv` for-loop alias now mutates the QuantHash, matching Raku:

```raku
my $b = (a => 1, b => 2).BagHash;
$_ = $_ * 10 for $b.values;          # $b<a>=10, $b<b>=20
for $b.kv -> \k, \v { v = 0 }        # weight 0 removes the key
$_ = "foo" for $b.values;            # throws X::Str::Numeric
```

Previously these threw `X::Assignment::RO` (the topic was marked read-only for *any* Mix/Set/Bag source) or silently no-oped. This is the QuantHash half of PLAN.md §D ① "element-source rw writeback"; the plain-Hash `%h.values` half landed in #3117.

## Approach

Generalizes the `%h.values` flag from #3117 (`hash_values_mode` → `values_mode`; `for_iterable_is_values_alias` now matches `.values` on any variable source) and branches in the VM on the runtime container type:

- **`topic_readonly` relaxed to *immutable* Mix/Set/Bag only** — a mutable QuantHash keeps `$_` writable; immutable still throws RO (mix.t unaffected).
- For a mutable-QuantHash scalar source, the topic-value writeback (`write_back_quanthash_value_item`) and the rw-param writeback (`write_back_quanthash_rw`, covering `-> \k,\v` and `-> $v is rw`) run **before** the body-result match — their coercion can raise `X::Str::Numeric`, which must flow through the loop's shared error cleanup. Both delegate to `quanthash_set_weight`, reusing the element-store coercion (`bag_assignment_count`/`mix_assignment_weight`): Int for Bag, Real for Mix, truthiness for Set; weight 0 removes the key.
- `topic_source_var` (whole-scalar topic writeback) is suppressed for a mutable QuantHash `.values` loop, and the generic scalar rw writeback skips mutable QuantHash sources — both would otherwise clobber `$b` with the bare weight value.

## Impact

`baghash.t` 270→290, `mixhash.t` 216→237.

## Out of scope (remaining blockers, recorded in TODO_roast/S02.md)

Two pre-existing, **non-QuantHash-specific** mechanisms still block a full pass:
1. **sigilless `\v++`/`\v--` postfix** on an rw for-param (`for $b.kv -> \k,\v { v-- }`) — fails for arrays too (`for @a -> \v { v-- }`); `$v is rw` works. Compiler emits a call form, not in-place mutation.
2. **`.pairs .value = X` / `.value--`** Pair-lvalue writeback into QuantHash weights (the Pair `.value=` handler scans env for a backing Hash/Array; needs a Mix/Bag/Set branch).

## Test

`t/for-quanthash-values-rw-writeback.t` (16 subtests). `make test` PASS (7627 tests), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)