### PR TITLE
fix(parser): tight @a[0]=1 at statement level is an element assign, not [op]=

### DIFF
--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -495,6 +495,37 @@ fn parse_bracket_meta_assign_op(input: &str) -> Option<(&str, String, String)> {
     if !after_bracket.starts_with('=') || after_bracket.starts_with("==") {
         return None;
     }
+    // Distinguish a reduction compound assignment (`[+]=`, `[max]=`, `[,]=`,
+    // `[R,]=`) from a subscript-then-assign (`@a[0]=1`, `@a[$i]=…`, `@a[-1]=…`,
+    // `@a[1,2]=…`, `@a[*-1]=…`). A reduction operator begins with an operator
+    // symbol/word and never with a value: a leading digit, sigil, quote,
+    // negative-index `-N`, or `*`-Whatever end-index marks a subscript/slice, so
+    // bail and let the caller parse the `[...]` as a postfix subscript on the
+    // lvalue. (A value-slice like `@a[1,2]` already trips the leading-digit/sigil
+    // test, so the comma-reductions `[,]`/`[R,]` are left intact.)
+    {
+        let t = inner.trim_start();
+        let subscript_like = match t.bytes().next() {
+            None => false, // empty `[]` keeps the prior (degenerate-reduce) path
+            Some(c) if c.is_ascii_digit() => true,
+            Some(b'$' | b'@' | b'%' | b'&' | b'"' | b'\'') => true,
+            Some(b'-') => t[1..]
+                .trim_start()
+                .bytes()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit()),
+            // A `*`-Whatever end-index (`@a[*-1]`, `@a[* - 1]`, `@a[*/2]`) — but
+            // not the bare reduction ops `[*]` (multiply) / `[**]` (power).
+            Some(b'*') => matches!(
+                t[1..].trim_start().bytes().next(),
+                Some(b'-' | b'+' | b'/' | b'%')
+            ),
+            _ => false,
+        };
+        if subscript_like {
+            return None;
+        }
+    }
     let flattened = flatten_bracket_op(inner);
     let (meta, op) = if let Some(op) = flattened.strip_prefix('R') {
         ("R", op)

--- a/t/array-elem-assign-stmt.t
+++ b/t/array-elem-assign-stmt.t
@@ -1,0 +1,84 @@
+# A statement-level array element/slice assignment with no space before the `=`
+# (`@a[0]=1`) was mis-parsed as a reduction compound assignment (`@a [0]= 1`),
+# throwing "Unsupported reduction operator: 0". The `[op]=` reduction metaop must
+# not swallow a postfix `[index]` subscript on the lvalue. (It only reproduced at
+# statement level; in expression context the normal parser was unaffected.)
+use Test;
+
+plan 14;
+
+{
+    my @a = 0, 0, 0;
+    @a[0]=1;
+    is @a.join(','), '1,0,0', 'tight @a[0]=1 at statement level';
+}
+{
+    my @a = 0, 0, 0;
+    @a[2]=9; @a[0]=1;
+    is @a.join(','), '1,0,9', 'two tight element assigns';
+}
+{
+    my @a = 0, 0, 0;
+    my $i = 1;
+    @a[$i]=7;
+    is @a.join(','), '0,7,0', 'tight @a[$i]=7 (variable index)';
+}
+{
+    my @a = 1, 2, 3;
+    @a[*-1]=0;
+    is @a.join(','), '1,2,0', 'tight @a[*-1]=0 (Whatever end index)';
+}
+{
+    my @a = 1, 2, 3, 4;
+    @a[1,2]=8,9;
+    is @a.join(','), '1,8,9,4', 'tight @a[1,2]=8,9 (slice)';
+}
+{
+    my @a = 0, 0;
+    @a[0]+=5;
+    is @a.join(','), '5,0', 'tight @a[0]+=5 (compound)';
+}
+{
+    my %h;
+    %h{"k"}=3;
+    is %h<k>, 3, 'tight %h{"k"}=3 (hash subscript)';
+}
+{
+    my @a = 0, 0;
+    for 0..0 { @a[0]=1 }
+    is @a.join(','), '1,0', 'tight element assign inside a block';
+}
+{
+    my @a = 0, 0;
+    sub setit(@x) { @x[1]=9 }
+    setit(@a);
+    is @a.join(','), '0,9', 'tight element assign inside a sub';
+}
+
+# The `[op]=` reduction compound assignment still works (space before `[`).
+{
+    my $s = 5;
+    $s [+]= 3;
+    is $s, 8, 'reduction compound [+]= still works';
+}
+{
+    my @a = 1, 2, 3;
+    @a [*]= 2;
+    is @a, 6, 'reduction compound [*]= still works';
+}
+{
+    my @a = 1, 2, 3;
+    @a [**]= 2;
+    is @a, 9, 'reduction compound [**]= still works';
+}
+{
+    my @a;
+    my @b = 1, 2;
+    @a [R,]= @b;
+    is @a.elems, 2, 'reverse-comma reduction [R,]= still works';
+}
+{
+    my @a = 1, 2, 3;
+    @a [max]= 5;
+    is @a, 5, 'word reduction [max]= still works';
+}


### PR DESCRIPTION
## What

A statement-level array element/slice assignment with **no space before the `=`** — `@a[0]=1`, `@a[\$i]=…`, `@a[*-1]=…`, `@a[1,2]=…` — was mis-parsed as a `[op]=` reduction compound assignment, throwing `Unsupported reduction operator: 0` at runtime:

```raku
my @a = 0, 0, 0;
@a[0]=1;          # was: Runtime error: Unsupported reduction operator: 0
                  # now: @a is (1 0 0)
```

Found by probe-driven differential testing against `raku`. It only reproduced at **statement level** (the statement parser's compound-assign path); in expression context (`my \$x = (@a[0]=1)`) the normal parser already bound `@a[0]` as a subscript. No `t/` test used the tight statement form, so it went unnoticed.

## Fix

`parse_bracket_meta_assign_op` treated any `[...]=` after the lvalue as a `[op]=` reduction. A reduction operator begins with an operator symbol/word, never with a value — so a `[...]` whose inner begins with a digit, sigil, quote, negative literal index (`-N`), or `*`-Whatever end-index is a subscript/slice, not a reduce op. Bail in those cases so the caller parses the `[...]` as a postfix subscript.

Preserved: the comma-reductions `[,]=`/`[R,]=` (a value-slice `@a[1,2]` already trips the leading-digit test), and `[*]=`/`[**]=` reductions (only `*-`/`*+`/`*/`/`*%` Whatever-indexes bail).

## Verification

- `make test` PASS (818 files / 7629 tests); clippy + fmt clean.
- Whitelisted `S03-metaops/{reduce,infix,misc}` + `S02-literals/subscript` + `S03-operators/{subscript-adverbs,reduce-le1arg}` PASS — `misc.t` exercises `[R,]=` and caught an over-aggressive first draft (a `contains(',')` guard) which was removed.
- New `t/array-elem-assign-stmt.t` (14: tight element/slice/Whatever-index/compound assigns at statement/block/sub level, plus `[+]=`/`[*]=`/`[**]=`/`[R,]=`/`[max]=` reductions still working) matches `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)