### PR TITLE
fix(for): postfix/prefix ++/-- on a sigilless rw for-param writes back

### DIFF
--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -10,6 +10,18 @@ impl Compiler {
             }
             let name_idx = self.code.add_constant(Value::str(name.clone()));
             self.code.emit(OpCode::PostIncrement(name_idx));
+        } else if let Expr::BareWord(name) = expr {
+            if self.sigilless_locals.contains(name.as_str()) {
+                // Sigilless rw binding (e.g. for-loop `-> \v { v++ }`): the bare
+                // word IS the env var, so increment it in place by name.
+                let name_idx = self.code.add_constant(Value::str(name.clone()));
+                self.code.emit(OpCode::PostIncrement(name_idx));
+            } else {
+                self.compile_expr(&Expr::Call {
+                    name: Symbol::intern("__mutsu_incdec_nomatch"),
+                    args: vec![Expr::Literal(Value::str_from("postfix:<++>"))],
+                });
+            }
         } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
             // state/my declarator in expression position: `state $x++`, `my $x.++`
             self.compile_expr(expr);
@@ -89,6 +101,17 @@ impl Compiler {
             }
             let name_idx = self.code.add_constant(Value::str(name.clone()));
             self.code.emit(OpCode::PostDecrement(name_idx));
+        } else if let Expr::BareWord(name) = expr {
+            if self.sigilless_locals.contains(name.as_str()) {
+                // Sigilless rw binding (e.g. for-loop `-> \v { v-- }`).
+                let name_idx = self.code.add_constant(Value::str(name.clone()));
+                self.code.emit(OpCode::PostDecrement(name_idx));
+            } else {
+                self.compile_expr(&Expr::Call {
+                    name: Symbol::intern("__mutsu_incdec_nomatch"),
+                    args: vec![Expr::Literal(Value::str_from("postfix:<-->"))],
+                });
+            }
         } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
             self.compile_expr(expr);
             self.code.emit(OpCode::Pop);

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -39,6 +39,16 @@ impl Compiler {
                     }
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::PreIncrement(name_idx));
+                } else if let Expr::BareWord(name) = expr {
+                    if self.sigilless_locals.contains(name.as_str()) {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        self.code.emit(OpCode::PreIncrement(name_idx));
+                    } else {
+                        self.compile_expr(&Expr::Call {
+                            name: Symbol::intern("__mutsu_incdec_nomatch"),
+                            args: vec![Expr::Literal(Value::str_from("prefix:<++>"))],
+                        });
+                    }
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
                     self.compile_expr(expr);
                     self.code.emit(OpCode::Pop);
@@ -67,6 +77,16 @@ impl Compiler {
                     }
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::PreDecrement(name_idx));
+                } else if let Expr::BareWord(name) = expr {
+                    if self.sigilless_locals.contains(name.as_str()) {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        self.code.emit(OpCode::PreDecrement(name_idx));
+                    } else {
+                        self.compile_expr(&Expr::Call {
+                            name: Symbol::intern("__mutsu_incdec_nomatch"),
+                            args: vec![Expr::Literal(Value::str_from("prefix:<-->"))],
+                        });
+                    }
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
                     self.compile_expr(expr);
                     self.code.emit(OpCode::Pop);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1407,8 +1407,7 @@ impl Compiler {
                 // (rw aliases), so we only add them to the set, not mark them.
                 let sigilless_param_names: Vec<String> = if has_sigilless {
                     let mut names = Vec::new();
-                    let single_sigilless =
-                        (**param_def).as_ref().is_some_and(|def| def.sigilless);
+                    let single_sigilless = (**param_def).as_ref().is_some_and(|def| def.sigilless);
                     if let Some(p) = param.as_ref().filter(|_| single_sigilless) {
                         names.push(p.strip_prefix('\\').unwrap_or(p).to_string());
                     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1399,7 +1399,37 @@ impl Compiler {
                     loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
                     values_mode: Self::for_iterable_is_values_alias(iterable),
                 });
+                // Register sigilless for-params (`-> \v`, `-> \k, \v`) as
+                // sigilless locals while compiling the body so postfix/prefix
+                // `++`/`--` on the bare word (`v--`, `++v`) resolve to an
+                // in-place PostDecrement/etc. on the bound env var rather than
+                // the `__mutsu_incdec_nomatch` fallback. They are NOT readonly
+                // (rw aliases), so we only add them to the set, not mark them.
+                let sigilless_param_names: Vec<String> = if has_sigilless {
+                    let mut names = Vec::new();
+                    let single_sigilless =
+                        (**param_def).as_ref().is_some_and(|def| def.sigilless);
+                    if let Some(p) = param.as_ref().filter(|_| single_sigilless) {
+                        names.push(p.strip_prefix('\\').unwrap_or(p).to_string());
+                    }
+                    for (p, def) in params.iter().zip(params_def.iter()) {
+                        if def.sigilless {
+                            names.push(p.strip_prefix('\\').unwrap_or(p).to_string());
+                        }
+                    }
+                    names
+                } else {
+                    Vec::new()
+                };
+                let newly_registered: Vec<String> = sigilless_param_names
+                    .iter()
+                    .filter(|n| self.sigilless_locals.insert((*n).clone()))
+                    .cloned()
+                    .collect();
                 self.compile_body_with_implicit_try(&loop_body);
+                for n in &newly_registered {
+                    self.sigilless_locals.remove(n);
+                }
                 self.code.patch_loop_end(loop_idx);
                 for s in &post_stmts {
                     self.compile_stmt(s);

--- a/t/for-sigilless-rw.t
+++ b/t/for-sigilless-rw.t
@@ -4,7 +4,7 @@ use Test;
 # alias the source element directly. In Raku they are writable, and
 # modifications propagate back to the source container.
 
-plan 11;
+plan 17;
 
 # Single sigilless param over an array writes back.
 {
@@ -71,4 +71,34 @@ plan 11;
     my @a = 7, 8, 9;
     for @a -> \v { my $x = v + 1 };
     is-deeply @a, [7, 8, 9], 'unmodified sigilless param does not mutate the source';
+}
+
+# Postfix/prefix ++/-- on a sigilless param writes back to the array.
+{
+    my @a = 1, 2, 3;
+    for @a -> \v { v-- };
+    is-deeply @a, [0, 1, 2], 'postfix -- on sigilless param writes back';
+}
+{
+    my @a = 1, 2, 3;
+    for @a -> \v { v++ };
+    is-deeply @a, [2, 3, 4], 'postfix ++ on sigilless param writes back';
+}
+{
+    my @a = 1, 2, 3;
+    for @a -> \v { ++v };
+    is-deeply @a, [2, 3, 4], 'prefix ++ on sigilless param writes back';
+}
+{
+    my @a = 1, 2, 3;
+    for @a -> \v { --v };
+    is-deeply @a, [0, 1, 2], 'prefix -- on sigilless param writes back';
+}
+
+# ++/-- on the value of a `%h.kv -> \k, \v` binding writes back to the hash.
+{
+    my %h = a => 1, b => 2;
+    for %h.kv -> \k, \v { v++ };
+    is %h<a>, 2, 'kv sigilless v++ updates value a';
+    is %h<b>, 3, 'kv sigilless v++ updates value b';
 }


### PR DESCRIPTION
## Summary

`for @a -> \v { v-- }` — and `++`/`--` in both prefix and postfix form, including the value of a `for %h.kv -> \k, \v { v++ }` binding — previously threw:

```
Cannot resolve caller postfix:<-->(...); the parameter requires mutable arguments
```

A sigilless for-param parses to `Expr::BareWord`, which the inc/dec compiler dropped to the `__mutsu_incdec_nomatch` fallback (only `Expr::Var` was handled). The `$v is rw` sigiled form already worked.

## Fix

- Register sigilless for-params (`-> \v`, `-> \k, \v`) into `sigilless_locals` while compiling the loop body (without marking them readonly — they are rw aliases), then deregister after.
- Add a `BareWord` arm to the prefix/postfix inc/dec compilers that emits an in-place `PreIncrement`/`PostDecrement`/etc. on the bound env var when the name is a known sigilless local. The for-loop's existing rw-writeback (#3115/#3121) then propagates the mutated value back to the source array / hash / mutable QuantHash.

A bare type name (`Int--`) is still routed to the nomatch fallback, so it errors exactly as before (verified against `raku`).

## Impact

- S02-types/baghash.t: 290 → 293
- S02-types/mixhash.t: 237 → 240

(Both still abort later on the separate `.pairs .value = X` QuantHash-writeback blocker.)

## Tests

- `t/for-sigilless-rw.t` extended (11 → 17): postfix/prefix `++`/`--` writeback over arrays and the `%h.kv` value alias.
- `make test` passes (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)