### PR TITLE
fix(seq): support .reverse on a Seq/Slip

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -130,6 +130,17 @@ pub(super) fn dispatch(
                 }
             }
             Value::Str(s) => Some(Ok(Value::str(s.chars().rev().collect()))),
+            Value::Seq(items) | Value::Slip(items) => {
+                // A non-lazy Seq/Slip reverses its materialized elements. (Lazy
+                // Seqs are deferred-materialized by the slow path before reaching
+                // here, so `items` already holds the pulled values.)
+                let mut reversed = items.to_vec();
+                reversed.reverse();
+                Some(Ok(Value::Array(
+                    std::sync::Arc::new(crate::value::ArrayData::new(reversed)),
+                    crate::value::ArrayKind::List,
+                )))
+            }
             Value::Instance {
                 class_name,
                 attributes,

--- a/t/seq-reverse.t
+++ b/t/seq-reverse.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 9;
+
+# .reverse on a Seq (the result of .comb, .map, .grep, etc.) must work,
+# not throw "No such method 'reverse' for invocant of type 'Seq'".
+is "abc".comb.reverse.join, "cba", '.comb.reverse.join';
+is-deeply "abc".comb.reverse.List, ('c', 'b', 'a'), '.comb.reverse elements';
+
+is-deeply (1..3).map(* + 1).reverse.List, (4, 3, 2), '.map(...).reverse';
+is-deeply (1..5).grep(* > 2).reverse.List, (5, 4, 3), '.grep(...).reverse';
+
+# Explicit Seq / Slip.
+my $s = (3, 1, 2).Seq;
+is-deeply $s.reverse.List, (2, 1, 3), 'Seq.reverse';
+is-deeply <a b c>.Slip.reverse.List, ('c', 'b', 'a'), 'Slip.reverse';
+
+# An empty Seq reverses to an empty list.
+is-deeply ().Seq.reverse.List, (), 'empty Seq.reverse';
+
+# Reversing a Seq twice round-trips.
+is-deeply (1, 2, 3, 4).Seq.reverse.reverse.List, (1, 2, 3, 4), 'Seq.reverse.reverse round-trips';
+
+# .reverse on a sorted Seq.
+is-deeply (3, 1, 2).Seq.sort.reverse.List, (3, 2, 1), 'Seq.sort.reverse';


### PR DESCRIPTION
## Problem
`.reverse` threw `No such method 'reverse' for invocant of type 'Seq'`:

```raku
say "abc".comb.reverse;        # raku: (c b a) — mutsu: Runtime error
say (1..5).grep(* > 2).reverse # raku: (5 4 3) — mutsu: Runtime error
```

Since `.comb` / `.map` / `.grep` all return a `Seq`, the very common
`"abc".comb.reverse` chain was broken.

## Cause
In the 0-arg native list dispatch (`dispatch_core_list.rs`), `reverse`
only matched `Value::Array`. For a `Seq`/`Slip` it returned `Some(None)`
and fell through to the slow path, which has no `reverse` arm — unlike
`sort`/`unique`/`squish`/`rotate`, which are all handled — so it ended
in "No such method".

## Fix
Add a `Value::Seq | Value::Slip` arm mirroring the existing
`unique`/`repeated` handling (lazy Seqs are deferred-materialized by the
slow path before reaching here, so the elements are already concrete).
Returns a List, consistent with the existing Array arm.

## Test
`t/seq-reverse.t` (9 assertions) — verified against `raku`.

Found via differential probing (raku vs mutsu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)