### PR TITLE
fix(quanthash): .pairs .value=/.value-- writeback (+ .value-- parse, negative Bag weight)

### DIFF
--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -2249,7 +2249,10 @@ pub(super) fn topic_method_call(input: &str) -> PResult<'_, Expr> {
     } else {
         (r, None)
     };
-    let (rest, name) = take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
+    // Parse the method name with the proper Raku hyphen rule: a `-` is part of
+    // the identifier only when followed by another identifier char, so `.value--`
+    // is `.value` followed by postfix `--`, not a method named `value--`.
+    let (rest, name) = crate::parser::primary::var::parse_ident_with_hyphens(r)?;
     let name = Symbol::intern(name);
     // Detect illegal space between method name and parens: .method (args) is Confused
     // Raku requires no space between method name and opening paren.

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -909,6 +909,27 @@ impl Interpreter {
                     *cell.lock().unwrap() = value.clone();
                     return Ok(value);
                 }
+                // `.value = X` / `.value--` on a Pair yielded by a mutable
+                // QuantHash's `.pairs` (`for $b.pairs { .value = 42 }`,
+                // `$b` a BagHash/MixHash/SetHash) writes the new weight back to
+                // the source container. `topic_source_var` names that container
+                // (set by the for-loop). Weight 0 removes the key; a non-numeric
+                // Str coercion raises X::Str::Numeric. Immutable Bag/Mix/Set fall
+                // through to the read-only Bool guard below.
+                if let Some(source) = self.topic_source_var.clone()
+                    && matches!(
+                        self.env.get(&source),
+                        Some(Value::Bag(_, true) | Value::Mix(_, true) | Value::Set(_, true))
+                    )
+                {
+                    // The current bytecode isn't threaded into this builtin path,
+                    // so pass an empty code: `quanthash_set_weight` then updates
+                    // env (and main-alias) only, which is what the post-loop read
+                    // of `$b` resolves through here.
+                    let code = crate::opcode::CompiledCode::new();
+                    self.quanthash_set_weight(&code, &source, key, &value)?;
+                    return Ok(value);
+                }
                 let mut selected_hash: Option<std::sync::Arc<crate::value::HashData>> = None;
                 let mut selected_array: Option<std::sync::Arc<crate::value::ArrayData>> = None;
 

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -2110,7 +2110,7 @@ impl Interpreter {
     /// does: Int for Bag, Real for Mix, truthiness for Set. A non-numeric `Str`
     /// raises X::Str::Numeric, and a zero weight removes the key (Raku semantics).
     /// No-op (and Ok) if `source` does not hold a mutable QuantHash.
-    fn quanthash_set_weight(
+    pub(crate) fn quanthash_set_weight(
         &mut self,
         code: &CompiledCode,
         source: &str,
@@ -2121,7 +2121,10 @@ impl Interpreter {
             Some(Value::Bag(bag, true)) => {
                 let count = Self::bag_assignment_count(value)?;
                 let mut b = (*bag).clone();
-                if count == 0 {
+                // A Bag holds positive integer counts: a weight of 0 *or below*
+                // removes the element (negative counts are not representable),
+                // unlike a Mix where a negative weight is retained.
+                if count <= 0 {
                     b.counts.remove(&key);
                 } else {
                     b.counts.insert(key, count);

--- a/t/for-pairs-value-quanthash-writeback.t
+++ b/t/for-pairs-value-quanthash-writeback.t
@@ -1,0 +1,98 @@
+use Test;
+
+# `.value = X` / `.value--` on a Pair yielded by a mutable QuantHash's `.pairs`
+# writes the new weight back to the source container (BagHash/MixHash/SetHash).
+# Weight 0 (or False for Set) removes the key; a non-numeric Str raises
+# X::Str::Numeric. Immutable Bag/Mix/Set remain read-only.
+
+plan 18;
+
+# --- Parser: `.value--` is `.value` then postfix `--`, not a method `value--` ---
+{
+    my $p = a => 5;
+    $p.value--;
+    is $p.value, 4, '$pair.value-- decrements the pair value';
+}
+{
+    my @seen;
+    for (a => 1, b => 2) { @seen.push(.value) };
+    is-deeply @seen, [1, 2], '.value as a topic method still reads the pair value';
+}
+
+# --- BagHash .pairs .value writeback ---
+{
+    my $b = (a => 5).BagHash;
+    .value = 999 for $b.pairs;
+    is $b<a>, 999, 'BagHash .value = N from a .pairs alias';
+}
+{
+    my $bh = <a a b b b c>.BagHash;
+    for $bh.pairs { .value-- }
+    is $bh<a>, 1, 'BagHash .value-- (a: 2 -> 1)';
+    is $bh<b>, 2, 'BagHash .value-- (b: 3 -> 2)';
+    is $bh<c>, 0, 'BagHash .value-- removing last occurrence (c: 1 -> 0)';
+}
+{
+    my $bh = <a a b>.BagHash;
+    for $bh.pairs { .value = 42 }
+    is $bh<a>, 42, 'BagHash .value = 42 sets the weight';
+    is $bh<b>, 42, 'BagHash .value = 42 sets the weight (b)';
+}
+{
+    my $bh = <a a b>.BagHash;
+    for $bh.pairs { .value = 0 }
+    is $bh.elems, 0, 'BagHash .value = 0 removes all elements';
+}
+# A Bag weight that goes negative removes the element (unlike a Mix).
+{
+    my $bh = <a b b c d e f>.BagHash;
+    .value = -1 for $bh.pairs;
+    is-deeply $bh, ().BagHash, 'BagHash .value = -1 removes elements (negative weight)';
+}
+{
+    my $bh = <a b b c>.BagHash;
+    .value-- for $bh.pairs;
+    .value-- for $bh.pairs;
+    is-deeply $bh, ().BagHash, 'BagHash repeated .value-- past zero removes elements';
+}
+# A Mix keeps negative weights.
+{
+    my $m = (a => 1.0, b => 2.0).MixHash;
+    .value = -2.5 for $m.pairs;
+    is $m<a>, -2.5, 'MixHash retains a negative weight';
+}
+
+# --- MixHash .pairs .value writeback ---
+{
+    my $m = (a => 1.5, b => 2.0).MixHash;
+    .value = 9.5 for $m.pairs;
+    is $m<a>, 9.5, 'MixHash .value = 9.5 from a .pairs alias';
+}
+
+# --- SetHash .pairs .value writeback ---
+{
+    my $sh = <a b c>.SetHash;
+    for $sh.pairs { .value = False if .key eq 'b' }
+    is $sh<b>, False, 'SetHash .value = False removes the element';
+    is $sh<a>, True, 'SetHash other elements unaffected';
+}
+
+# --- Coercion / immutability ---
+{
+    my $bh = (a => 3).BagHash;
+    throws-like { .value = "foo" for $bh.pairs },
+      X::Str::Numeric,
+      'non-numeric Str on a mutable BagHash .pairs alias raises X::Str::Numeric';
+}
+{
+    my $b = (a => 5).Bag;
+    throws-like { .value = 9 for $b.pairs },
+      X::Assignment::RO,
+      'immutable Bag .pairs .value is read-only';
+}
+{
+    my $s = <a b>.Set;
+    throws-like { .value = 0 for $s.pairs },
+      X::Assignment::RO,
+      'immutable Set .pairs .value is read-only';
+}


### PR DESCRIPTION
## Summary

Three cohesive fixes that complete for-loop writeback through a **mutable QuantHash's `.pairs`** (`for $b.pairs { .value = 42 }`, `.value--`, …):

### 1. Parser — `.value--` on the topic
`for $b.pairs { .value-- }` was parsed as a method call named `value--`, because the topic-method-name scanner consumed any trailing `-`. Now uses `parse_ident_with_hyphens`, so a `-` joins the identifier only when followed by another identifier char — matching the already-correct `$x.value--` path. Fixes `.value--` / `.value-foo` topic calls for **every** type.

### 2. Writeback — QuantHash weights
`.value = X` / `.value--` on a Pair yielded by a mutable BagHash/MixHash/SetHash `.pairs` now writes the new weight back to the source container. `assign_method_lvalue_with_values` gains a QuantHash branch keyed on `topic_source_var` (the for-loop's source container), reusing the VM's `quanthash_set_weight` (now `pub(crate)`). Weight 0 (or `False` for Set) removes the key; a non-numeric `Str` raises `X::Str::Numeric`; immutable Bag/Mix/Set stay read-only.

### 3. Negative Bag weight removes
A `Bag` weight of 0 *or below* removes the element (negative integer counts aren't representable), while a `Mix` retains a negative weight. Fixes both the `.values` and `.pairs` negative-weight paths.

## Impact

Combined with #3124 (now merged):
- `S02-types/baghash.t`: runs all **344** tests, 5 failing (was aborting at ~290).
- `S02-types/mixhash.t`: runs all **295** tests, 5 failing (was aborting at ~237).

Remaining failures are separate features (autovivification of a `BagHash` typed-container, >64-bit weights, element type-check on assignment).

## Tests

- `t/for-pairs-value-quanthash-writeback.t` (18 cases): parser, Bag/Mix/Set writeback, weight-0/negative removal, Str coercion, immutability.
- `make test` passes (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)