### PR TITLE
fix(setbagmix): say/gist shows the type-name wrapper for Set/Bag/Mix

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -355,7 +355,9 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Bag(key(count) ...) or BagHash(key(count) ...)
-                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
+                Some(Ok(Value::str(
+                    runtime::utils::setbagmix_gist(target).unwrap(),
+                )))
             }
         }
         Value::Set(s, mutable) => {
@@ -376,7 +378,9 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Set(a b c) or SetHash(a b c)
-                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
+                Some(Ok(Value::str(
+                    runtime::utils::setbagmix_gist(target).unwrap(),
+                )))
             }
         }
         Value::Mix(m, mutable) => {
@@ -403,7 +407,9 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Mix(key(weight) ...) or MixHash(key(weight) ...)
-                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
+                Some(Ok(Value::str(
+                    runtime::utils::setbagmix_gist(target).unwrap(),
+                )))
             }
         }
         Value::Package(name) => {

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -337,21 +337,10 @@ pub(super) fn dispatch(
             }
         }
         Value::Bag(b, mutable) => {
-            let type_name = if *mutable { "BagHash" } else { "Bag" };
-            let mut keys: Vec<(&String, &i64)> = b.iter().collect();
-            keys.sort_by_key(|(k, _)| (*k).clone());
-            let inner = keys
-                .iter()
-                .map(|(k, v)| {
-                    if **v == 1 {
-                        (*k).clone()
-                    } else {
-                        format!("{}({})", k, v)
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
             if method == "raku" || method == "perl" {
+                let type_name = if *mutable { "BagHash" } else { "Bag" };
+                let mut keys: Vec<(&String, &i64)> = b.iter().collect();
+                keys.sort_by_key(|(k, _)| (*k).clone());
                 let pairs = keys
                     .iter()
                     .map(|(k, v)| {
@@ -366,14 +355,14 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Bag(key(count) ...) or BagHash(key(count) ...)
-                Some(Ok(Value::str(format!("{}({})", type_name, inner))))
+                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
             }
         }
         Value::Set(s, mutable) => {
-            let type_name = if *mutable { "SetHash" } else { "Set" };
-            let mut keys: Vec<&String> = s.iter().collect();
-            keys.sort();
             if method == "raku" || method == "perl" {
+                let type_name = if *mutable { "SetHash" } else { "Set" };
+                let mut keys: Vec<&String> = s.iter().collect();
+                keys.sort();
                 let pairs = keys
                     .iter()
                     .map(|k| {
@@ -387,19 +376,14 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Set(a b c) or SetHash(a b c)
-                let inner = keys
-                    .iter()
-                    .map(|k| k.as_str())
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                Some(Ok(Value::str(format!("{}({})", type_name, inner))))
+                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
             }
         }
         Value::Mix(m, mutable) => {
-            let type_name = if *mutable { "MixHash" } else { "Mix" };
-            let mut keys: Vec<(&String, &f64)> = m.iter().collect();
-            keys.sort_by_key(|(k, _)| (*k).clone());
             if method == "raku" || method == "perl" {
+                let type_name = if *mutable { "MixHash" } else { "Mix" };
+                let mut keys: Vec<(&String, &f64)> = m.iter().collect();
+                keys.sort_by_key(|(k, _)| (*k).clone());
                 let pairs = keys
                     .iter()
                     .map(|(k, v)| {
@@ -419,20 +403,7 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
             } else {
                 // gist: Mix(key(weight) ...) or MixHash(key(weight) ...)
-                let inner = keys
-                    .iter()
-                    .map(|(k, v)| {
-                        if (**v - 1.0).abs() < f64::EPSILON {
-                            (*k).clone()
-                        } else if v.fract() == 0.0 {
-                            format!("{}({})", k, **v as i64)
-                        } else {
-                            format!("{}({})", k, v)
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                Some(Ok(Value::str(format!("{}({})", type_name, inner))))
+                Some(Ok(Value::str(runtime::utils::setbagmix_gist(target).unwrap())))
             }
         }
         Value::Package(name) => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -779,6 +779,64 @@ pub(crate) fn coerce_to_str(value: &Value) -> String {
     value.to_str_context()
 }
 
+/// Render the `.gist` form of a Set/Bag/Mix (and their mutable `*Hash`
+/// variants): `Set(a b c)`, `Bag(a b(2))`, `Mix(a(1.5) b)`. Keys are sorted
+/// for deterministic output. Returns `None` for any other value. Shared by
+/// `gist_value` (the fast say/gist path) and the `.gist` method dispatch so
+/// both render identically.
+pub(crate) fn setbagmix_gist(value: &Value) -> Option<String> {
+    match value {
+        Value::Set(s, mutable) => {
+            let type_name = if *mutable { "SetHash" } else { "Set" };
+            let mut keys: Vec<&String> = s.iter().collect();
+            keys.sort();
+            let inner = keys
+                .iter()
+                .map(|k| k.as_str())
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some(format!("{}({})", type_name, inner))
+        }
+        Value::Bag(b, mutable) => {
+            let type_name = if *mutable { "BagHash" } else { "Bag" };
+            let mut keys: Vec<(&String, &i64)> = b.iter().collect();
+            keys.sort_by_key(|(k, _)| (*k).clone());
+            let inner = keys
+                .iter()
+                .map(|(k, v)| {
+                    if **v == 1 {
+                        (*k).clone()
+                    } else {
+                        format!("{}({})", k, v)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some(format!("{}({})", type_name, inner))
+        }
+        Value::Mix(m, mutable) => {
+            let type_name = if *mutable { "MixHash" } else { "Mix" };
+            let mut keys: Vec<(&String, &f64)> = m.iter().collect();
+            keys.sort_by_key(|(k, _)| (*k).clone());
+            let inner = keys
+                .iter()
+                .map(|(k, v)| {
+                    if (**v - 1.0).abs() < f64::EPSILON {
+                        (*k).clone()
+                    } else if v.fract() == 0.0 {
+                        format!("{}({})", k, **v as i64)
+                    } else {
+                        format!("{}({})", k, v)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some(format!("{}({})", type_name, inner))
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn gist_value(value: &Value) -> String {
     // Cycle detection for recursive data structures (shared hash/array Arcs).
     thread_local! {
@@ -846,6 +904,11 @@ pub(crate) fn gist_value(value: &Value) -> String {
                 .collect();
             SEEN_PTRS.with(|seen| pop_ptr(seen, ptr));
             format!("{{{}}}", parts.join(", "))
+        }
+        Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+            // Set/Bag/Mix gist shows the type-name wrapper, e.g. `Set(a b c)`;
+            // their `.Str` (the `_` fall-through) shows only the bare elements.
+            setbagmix_gist(value).unwrap_or_else(|| value.to_string_value())
         }
         Value::Pair(k, v) => format!("{} => {}", k, gist_value(v)),
         Value::ValuePair(k, v) => format!("{} => {}", gist_value(k), gist_value(v)),

--- a/t/setbagmix-say-gist.t
+++ b/t/setbagmix-say-gist.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `say` uses .gist, which for Set/Bag/Mix (and their mutable *Hash variants)
+# shows the type-name wrapper: `Set(a b c)`, `Bag(a b(2))`, `Mix(a(1.5) b)`.
+# Previously `say set(1,2,3)` dropped the wrapper and printed `1 2 3` because
+# the fast gist path (gist_value) had no Set/Bag/Mix arm. The wrapper must
+# match the `.gist` method exactly (shared helper), and nesting must work too.
+
+plan 14;
+
+# --- .gist produces the type-name wrapper (keys sorted for determinism) ---
+is set(1, 2, 3).gist, 'Set(1 2 3)', 'Set.gist';
+is bag(1, 2, 2).gist, 'Bag(1 2(2))', 'Bag.gist with multiplicity';
+is (a => 1.5, b => 2).Mix.gist, 'Mix(a(1.5) b(2))', 'Mix.gist with weights';
+is (1, 2, 3).SetHash.gist, 'SetHash(1 2 3)', 'SetHash.gist';
+is (1, 2, 2).BagHash.gist, 'BagHash(1 2(2))', 'BagHash.gist';
+
+# --- gist_value (the fast path used by say) must agree with .gist ---
+is set(1, 2, 3).Str, '1 2 3' | '2 1 3' | '1 3 2' | '3 1 2' | '2 3 1' | '3 2 1',
+    'Set.Str shows bare elements (no wrapper)';
+isnt set(1, 2, 3).gist, set(1, 2, 3).Str, 'Set.gist differs from Set.Str';
+
+# A Mix weight of exactly 1 is shown without the (1) suffix.
+is (a => 1, b => 3).Mix.gist, 'Mix(a b(3))', 'Mix weight 1 omits the suffix';
+
+# --- nested inside a Hash value: the element gists with its wrapper ---
+is { x => set(1, 2) }.gist, '{x => Set(1 2)}', 'Set nested in a Hash value';
+
+# --- .raku is unaffected (still the pair-list form) ---
+is set("a").raku, '("a"=>Bool::True).Set', 'Set.raku unchanged';
+
+# --- empty collections ---
+is set().gist, 'Set()', 'empty Set.gist';
+is bag().gist, 'Bag()', 'empty Bag.gist';
+
+# --- single-element determinism ---
+is set("x").gist, 'Set(x)', 'single-element Set.gist';
+is bag("x", "x", "x").gist, 'Bag(x(3))', 'single-key Bag.gist';


### PR DESCRIPTION
## Problem
```raku
say set(1,2,3);   # raku: Set(1 2 3) — mutsu: 1 2 3
say bag(1,2,2);   # raku: Bag(1 2(2)) — mutsu: 1 2(2)
say (a=>1.5).Mix; # raku: Mix(a(1.5)) — mutsu: a(1.5)
```
`say` renders via `.gist`, and `set(1,2,3).gist` already returned the
correct `Set(1 2 3)`, but `say set(1,2,3)` did not.

## Cause
The fast gist path `runtime::utils::gist_value` (taken when no element
needs interpreter method dispatch) had no Set/Bag/Mix arm, so those
values fell through to `to_string_value()` — the `.Str` form, which
omits the `Set(...)`/`Bag(...)`/`Mix(...)` wrapper.

## Fix
Extract the gist-form rendering (sorted keys, multiplicity/weight
suffixes, mutable `*Hash` names) into a shared `setbagmix_gist` helper
and call it from both `gist_value` and the `.gist` method dispatch, so
they render identically. `.Str` and `.raku` are unchanged.

## Test
`t/setbagmix-say-gist.t` (14 assertions) — verified against `raku`.
Covers top-level + `*Hash` variants + Hash-nesting + empty + single.

Found via differential probing (raku vs mutsu).

### Out of scope (separate follow-up)
`[set(1,2)]` and `(set(1,2), 3)` flatten the Set into Pairs during
list/array construction — a distinct flattening bug, not gist-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)