### PR TITLE
fix(quanthash): Bag/BagHash element --/++ clamps the returned value at 0

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2041,6 +2041,25 @@ impl Interpreter {
         } else {
             self.decrement_value_smart(&effective)?
         };
+        // A Bag/BagHash holds non-negative integer counts: decrementing a weight
+        // below 0 clamps the *returned* (and stored) value to 0 (the element is
+        // then removed), so `--$bh<k>` on an absent key returns 0, not -1. Mix
+        // weights are unbounded and keep their negative value.
+        let target_is_bag = matches!(container.as_ref(), Some(Value::Bag(..)))
+            || matches!(
+                container.as_ref(),
+                Some(Value::Package(sym)) if sym.resolve() == "BagHash"
+            )
+            || declared_type_incdec.as_deref() == Some("BagHash")
+            || declared_constraint_incdec.as_deref() == Some("BagHash");
+        let new_val = if target_is_bag {
+            match &new_val {
+                Value::Int(n) if *n < 0 => Value::Int(0),
+                _ => new_val,
+            }
+        } else {
+            new_val
+        };
         // Type-check the incremented value against the element constraint of a
         // typed array/hash, e.g. `subset Y of Int where 1..10; my Y @x; @x[0]=10;
         // @x[0]++` must throw when the new value (11) falls outside the subset.

--- a/t/for-pairs-value-quanthash-writeback.t
+++ b/t/for-pairs-value-quanthash-writeback.t
@@ -5,7 +5,7 @@ use Test;
 # Weight 0 (or False for Set) removes the key; a non-numeric Str raises
 # X::Str::Numeric. Immutable Bag/Mix/Set remain read-only.
 
-plan 18;
+plan 23;
 
 # --- Parser: `.value--` is `.value` then postfix `--`, not a method `value--` ---
 {
@@ -95,4 +95,21 @@ plan 18;
     throws-like { .value = 0 for $s.pairs },
       X::Assignment::RO,
       'immutable Set .pairs .value is read-only';
+}
+
+# --- Typed BagHash element autovivification clamps at 0 ---
+{
+    my BagHash $bh;
+    is $bh<poinc>++, 0, 'BagHash $bh<k>++ returns 0 on autoviv';
+    is $bh<poinc>, 1, 'BagHash $bh<k>++ leaves 1';
+}
+{
+    my BagHash $bh;
+    is $bh<podec>--, 0, 'BagHash $bh<k>-- returns 0 on autoviv';
+    is $bh<podec>, 0, 'BagHash $bh<k>-- stays at 0 (no negative counts)';
+}
+{
+    my BagHash $bh;
+    # Prefix -- on an absent key returns the clamped new value (0), not -1.
+    is --$bh<prdec>, 0, 'BagHash --$bh<k> returns 0 (clamped), not -1';
 }


### PR DESCRIPTION
## Summary

`--$bh<k>` (prefix decrement) on an absent or zero `BagHash` key returned `-1` instead of `0`. The container write already clamped correctly (a non-positive count removes the element), but the value pushed for the `return_new` (prefix) case was the raw `Int(-1)`.

Now `exec_inc_dec_index_op` clamps the returned (and stored) value to `0` whenever the target is a `Bag`/`BagHash`, while a `Mix` keeps its negative weights (Mix weights are unbounded).

## Impact

Fixes the *"BagHash autovivification of non-existent keys"* subtest in `S02-types/baghash.t` (test 287). Combined with the just-merged `.pairs`/`.values` writeback work (#3126), `baghash.t` is now **340/344**.

Remaining `baghash.t` failures are separate features: >64-bit Bag weights (322), parameterized `BagHash` element type-check (331), hyper `>>--` on a BagHash (337-338).

## Tests

- `t/for-pairs-value-quanthash-writeback.t` extended (18 → 23): typed `BagHash` element `++`/`--`/prefix-`--` autovivification clamps at 0.
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)