### PR TITLE
docs(roast): record baghash.t/mixhash.t progress

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -194,15 +194,18 @@
     `$_ = X for $b.values`, `for $b.kv -> \k,\v { v = X }` mutate the weight by key, weight 0
     removes the key, a non-numeric Str throws X::Str::Numeric, immutable Bag/Mix/Set still RO.
     See t/for-quanthash-values-rw-writeback.t.
-  - REMAINING BLOCKER (abort ~290): two distinct, pre-existing mechanisms, NOT QuantHash-specific:
-    1. **sigilless `\v++`/`\v--` postfix** on an rw for-param (`for $b.kv -> \k,\v { v-- }`,
-       line 688) — fails "Cannot resolve caller postfix:<-->; requires mutable arguments" for
-       arrays too (`for @a -> \v { v-- }`). `$v is rw` (sigil) works; only sigilless `\v` lacks
-       a mutable-lvalue binding for postfix inc/dec. Compiler emits a call form, not in-place.
-    2. **`.pairs .value = X` / `.value--`** (line 600/701) — the Pair `.value=` lvalue handler
-       (runtime/methods_mut.rs) scans env for a backing Hash/Array; add a Mix/Bag/Set backing
-       branch (use `topic_source_var` to find the source QuantHash). Plain-Hash `.pairs .value=`
-       already works.
+  - PROGRESS: now 340/344 (no longer aborts; runs the full plan). The two abort
+    blockers are FIXED:
+    1. sigilless `\v++`/`\v--` postfix on an rw for-param — FIXED #3124 (BareWord arm in
+       compile_expr_postfix_inc/dec + register for-loop sigilless params into sigilless_locals).
+    2. `.pairs .value = X` / `.value--` writeback into QuantHash weights — FIXED #3126 (QuantHash
+       branch in assign_method_lvalue_with_values keyed on topic_source_var; reuses
+       quanthash_set_weight; `.value--` topic-method parse fix; negative Bag weight removal).
+       Also #3128: Bag/BagHash element `--`/prefix-`--` clamps the returned value at 0.
+  - REMAINING (4 failing, all distinct separate features):
+    - 322: >64-bit Bag weights (`%h<foo> = 10000000000000000000`) — Bag counts are i64; needs BigInt.
+    - 331: parameterized `BagHash[T]` element type-check on `%bh<foo> = 42` (dies-ok).
+    - 337-338: hyper `$b>>--` on a BagHash (currently mangles to `("-1"=>0).BagHash`).
   - DONE: 206/207 (`BagHash[Str]` element-bind wrong-type croak + init croak) — parameterized
     `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]`.new now embeds the keyof type metadata so
     `$b{42}=1` throws X::TypeCheck::Binding. Also fixed `MixHash[T].new` returning an
@@ -274,9 +277,9 @@
     and `.kv` for a mutable MixHash landed (`$_ = X for $m.values`, `for $m.kv -> \k,\v { v=X }`
     mutate the weight; weight 0 removes; non-numeric Str → X::Str::Numeric). See
     t/for-quanthash-values-rw-writeback.t.
-  - REMAINING BLOCKER (abort ~237): same two pre-existing mechanisms as baghash.t —
-    (1) sigilless `\v++`/`\v--` postfix on an rw for-param (fails for arrays too), and
-    (2) `.pairs .value = X` Pair-lvalue writeback into the QuantHash weights. See S02 baghash.t note.
+  - PROGRESS: now 290/295 (no longer aborts). The two abort blockers FIXED via the same
+    work as baghash.t (#3124 sigilless `\v++/\v--`, #3126 `.pairs .value=`/`.value--` writeback).
+  - REMAINING (5 failing): 244, 246, 282, 288-289 — not yet triaged (separate features).
 - [ ] roast/S02-types/mix-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t


### PR DESCRIPTION
Updates `TODO_roast/S02.md` to reflect that `S02-types/baghash.t` (340/344) and `mixhash.t` (290/295) no longer abort mid-plan after the QuantHash `.pairs`/`.values` writeback fixes (#3124, #3126, #3128). Records the remaining distinct failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)