### PR TITLE
fix(array): single-element [set(...)] keeps the Set/Bag/Mix whole

### DIFF
--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -96,6 +96,13 @@ impl Interpreter {
                 }
                 // Scalar-wrapped values (.item / $()) are never flattened.
                 Value::Scalar(inner) => elems.push(Value::Scalar(inner)),
+                // Set/Bag/Mix are Iterable but NOT Positional, so they do not
+                // flatten in list context (unlike a List/Array/Seq/Range, and
+                // unlike a Hash, which does flatten to its pairs). A single
+                // `[set(1,2)]` therefore keeps the Set whole as one element.
+                // (Matches raku and `flat(set(...))`; `value_to_list` would
+                // otherwise decompose it into its key/True pairs.)
+                v @ (Value::Set(..) | Value::Bag(..) | Value::Mix(..)) => elems.push(v),
                 // In bracket-array literals (`[...]`), a single element is in
                 // list context and should flatten one level (e.g. `[2..6]`,
                 // `[@a]`, `[(1,2,3)]`), while multi-element forms keep each

--- a/t/array-literal-setbagmix-no-flatten.t
+++ b/t/array-literal-setbagmix-no-flatten.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A single-element array literal `[x]` flattens `x` one level when `x` is a
+# Positional/list-like value (List, Array, Seq, Range) or a Hash, but a
+# Set/Bag/Mix is NOT Positional and must stay whole as one element.
+# Previously `[set(1,2)]` decomposed the Set into its `key => True` pairs
+# (elems 2) because the single-element flatten path used value_to_list, which
+# expands a Set to pairs. Matches raku and `flat(set(...))`.
+
+plan 16;
+
+# --- Set/Bag/Mix stay whole (one element) ---
+is [set(1, 2)].elems, 1, '[set] keeps the Set whole';
+is [set(1, 2)][0].WHAT.^name, 'Set', '[set][0] is a Set';
+is [bag(1, 1, 2)].elems, 1, '[bag] keeps the Bag whole';
+is [bag(1, 1, 2)][0].WHAT.^name, 'Bag', '[bag][0] is a Bag';
+is [(a => 1).Mix].elems, 1, '[Mix] keeps the Mix whole';
+is [(a => 1).Mix][0].WHAT.^name, 'Mix', '[Mix][0] is a Mix';
+
+# A parenthesised single-Set list behaves the same.
+is [(set(1, 2),)].elems, 1, '[(set,)] keeps the Set whole';
+
+# --- list-like values still flatten one level ---
+is [(1, 2, 3)].elems, 3, '[(1,2,3)] flattens the List';
+is [1 .. 3].elems, 3, '[1..3] flattens the Range';
+is [<a b c>].elems, 3, '[<a b c>] flattens the word list';
+my @nums = 1, 2, 3, 4;
+is [@nums].elems, 4, '[@arr] flattens the array';
+
+# --- Hash still flattens to its pairs (Hash IS flattened, unlike Set) ---
+is [{ a => 1, b => 2 }].elems, 2, '[{...}] flattens the Hash to pairs';
+is [%(a => 1, b => 2, c => 3)].elems, 3, '[%h] flattens the Hash to pairs';
+
+# --- nested arrays / itemized values keep their own count ---
+is [[1, 2], [3, 4]].elems, 2, '[[..],[..]] keeps each nested array';
+is [$(1, 2, 3)].elems, 1, '[$(...)] keeps the itemized list whole';
+
+# --- multi-element form: each Set is one element ---
+is [set(1, 2), bag(3), 9].elems, 3, 'multi-element [set, bag, 9] keeps each whole';


### PR DESCRIPTION
## Problem
```raku
say [set(1,2)].elems;       # raku: 1 — mutsu: 2
say [set(1,2)][0].WHAT;     # raku: (Set) — mutsu: (Pair)
```
A single-element `[set(...)]` decomposed the Set into its `key => True`
pairs instead of keeping it as one element.

## Cause
The single-element bracket-array flatten path (`exec_make_array_op`,
`n == 1`) expands its element via `value_to_list`, which decomposes a
Set/Bag/Mix into pairs. But a Set/Bag/Mix is `Iterable` yet **not**
`Positional`, so — like a Scalar, and unlike a List/Array/Seq/Range or a
Hash — it does not flatten in list context:

```raku
[set(1,2)].elems      == 1   # Set stays whole
flat(set(1,2)).elems  == 1   # flat agrees
[{a=>1, b=>2}].elems  == 2   # Hash DOES flatten to pairs
[(1,2,3)].elems       == 3   # List flattens
```

## Fix
Add a `Set | Bag | Mix` arm in `exec_make_array_op` that pushes the value
whole instead of flattening it. Hash and the list-like types are
unaffected.

## Test
`t/array-literal-setbagmix-no-flatten.t` (16 assertions) — verified
against `raku`. Covers Set/Bag/Mix kept whole, List/Range/Array/Hash
still flattening, nested arrays, and multi-element forms.

Found via differential probing (raku vs mutsu).

### Out of scope (separate, opposite bug)
`my @a = set(1,2)` should flatten the Set to its pairs (raku elems 2,
mutsu 1) — array *assignment* list-context semantics, a deeper and
riskier change, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)