### PR TITLE
fix(quanthash): enforce key type of a parameterized BagHash/MixHash/SetHash

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3238,6 +3238,43 @@ impl Interpreter {
                     &index_target,
                     Some(Value::Mix(..) | Value::Bag(..) | Value::Set(..))
                 );
+                // A parameterized QuantHash (`BagHash[Int]`, `MixHash[Str]`, ...)
+                // constrains its *keys*: `%bh<foo> = 42` on a `BagHash[Int]` must
+                // throw because the key "foo" is not an Int. The bracketed key type
+                // is carried in the container metadata's `value_type` (e.g.
+                // "BagHash[Int]") for Bag/Mix/Set, falling back to `declared_type`.
+                if target_is_quanthash
+                    && let Some(meta) = index_target
+                        .as_ref()
+                        .and_then(|c| self.container_type_metadata(c))
+                    && let Some(declared) = meta
+                        .declared_type
+                        .as_deref()
+                        .filter(|d| d.contains('['))
+                        .or(Some(meta.value_type.as_str()))
+                    && let Some(open) = declared.find('[')
+                    && declared.ends_with(']')
+                {
+                    let key_type = &declared[open + 1..declared.len() - 1];
+                    // A numeric-looking string key (`%bh<7>`) is an allomorph
+                    // (IntStr in Raku) that satisfies a numeric key type, so only a
+                    // string that does NOT coerce to the numeric type (`%bh<foo>`)
+                    // is rejected.
+                    let allomorph_ok = matches!(&idx, Value::Str(s)
+                        if crate::runtime::str_numeric::parse_raku_str_to_numeric(s).is_some())
+                        && matches!(
+                            key_type,
+                            "Int" | "UInt" | "Num" | "Rat" | "Real" | "Numeric" | "Cool"
+                        );
+                    if !matches!(key_type, "" | "Any" | "Mu" | "Str")
+                        && !allomorph_ok
+                        && !self.type_matches_value(key_type, &idx)
+                    {
+                        return Err(runtime::utils::type_check_binding_typed_error(
+                            key_type, &idx,
+                        ));
+                    }
+                }
                 if let Some(constraint) = array_elem_constraint
                     && !target_is_quanthash
                     && !matches!(val, Value::Nil)

--- a/t/parameterized-quanthash-key-typecheck.t
+++ b/t/parameterized-quanthash-key-typecheck.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A parameterized QuantHash (`BagHash[Int]`, `MixHash[Int]`, `SetHash[Str]`, ...)
+# constrains its *keys*. Assigning an element under a key of the wrong type must
+# throw X::TypeCheck::Binding. Numeric-string keys (`<7>`) are allomorphs and
+# satisfy a numeric key type.
+
+plan 9;
+
+# BagHash[Int]: non-numeric Str key rejected, numeric keys accepted.
+{
+    my %bh is BagHash[Int] = 1, 2, 3;
+    is %bh.keyof, Int, 'BagHash[Int] keyof is Int';
+    throws-like { %bh<foo> = 42 }, X::TypeCheck::Binding,
+      'BagHash[Int]: assigning a non-numeric Str key fails';
+    lives-ok { %bh<7> = 3 }, 'BagHash[Int]: numeric-string key <7> is allowed';
+    is %bh<7>, 3, 'BagHash[Int]: <7> weight set';
+    lives-ok { %bh{8} = 2 }, 'BagHash[Int]: Int key 8 is allowed';
+}
+
+# MixHash[Int]: same key constraint.
+{
+    my %mh is MixHash[Int] = 1, 2, 3;
+    throws-like { %mh<foo> = 42e0 }, X::TypeCheck::Binding,
+      'MixHash[Int]: assigning a non-numeric Str key fails';
+}
+
+# SetHash[Str]: string keys are fine.
+{
+    my %sh is SetHash[Str];
+    lives-ok { %sh<abc> = True }, 'SetHash[Str]: Str key is allowed';
+    is %sh<abc>, True, 'SetHash[Str]: element set';
+}
+
+# Unparameterized BagHash accepts any key type (no constraint).
+{
+    my %b is BagHash;
+    lives-ok { %b<foo> = 5 }, 'plain BagHash accepts a Str key';
+}


### PR DESCRIPTION
## Summary

`%bh<foo> = 42` on a `my %bh is BagHash[Int]` silently succeeded — Raku throws `X::TypeCheck::Binding` because the key `"foo"` is not an `Int`. The element-assign path consulted `var_hash_key_constraint` (empty for these container-typed vars) but never the container metadata's bracketed key type.

`exec_index_assign_expr_named_op_inner` now, when the target is a Bag/Mix/Set, reads the bracket parameter of the container's declared type (carried in the metadata's `value_type`, e.g. `"BagHash[Int]"`) and rejects a key of the wrong type.

A numeric-string key (`%bh<7>`) is an allomorph (`IntStr` in Raku) and satisfies a numeric key type, so only non-coercible string keys (`<foo>`) are rejected; `Str`-keyed QuantHashes and unparameterized ones are unaffected.

## Impact

- `S02-types/baghash.t` test 331, `mixhash.t` test 282 ("adding element of wrong type fails") now pass.
- baghash.t: **341/344**, mixhash.t: **291/295**.

Remaining: >64-bit Bag weights (322), hyper `>>--` on a QuantHash (337-338 / 288-289), `X::Cannot::Lazy` (mixhash 244/246).

## Tests

- `t/parameterized-quanthash-key-typecheck.t` (9 cases).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)