### PR TITLE
docs(roast): baghash.t/mixhash.t status after key type-check fix

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -202,10 +202,20 @@
        branch in assign_method_lvalue_with_values keyed on topic_source_var; reuses
        quanthash_set_weight; `.value--` topic-method parse fix; negative Bag weight removal).
        Also #3128: Bag/BagHash element `--`/prefix-`--` clamps the returned value at 0.
-  - REMAINING (4 failing, all distinct separate features):
-    - 322: >64-bit Bag weights (`%h<foo> = 10000000000000000000`) — Bag counts are i64; needs BigInt.
-    - 331: parameterized `BagHash[T]` element type-check on `%bh<foo> = 42` (dies-ok).
-    - 337-338: hyper `$b>>--` on a BagHash (currently mangles to `("-1"=>0).BagHash`).
+  - 331 parameterized `BagHash[T]` element key type-check (`%bh<foo> = 42` dies-ok) — FIXED #3131
+    (exec_index_assign_expr_named_op_inner reads the bracket key type from the container metadata's
+    value_type; numeric-string keys `<7>` are IntStr allomorphs and pass). baghash.t now 341/344.
+  - REMAINING (3 failing, distinct separate features — NOT this campaign):
+    - 322: >64-bit Bag weights (`%h<foo> = 10000000000000000000`) — Bag counts are i64; needs BigInt
+      counts in BagData (data-model change).
+    - 337-338: hyper `$b>>--` on a BagHash (currently mangles to `("-1"=>0).BagHash`). NEEDS a
+      QuantHash-specific path in exec_hyper_method_call_op (vm_hyper_method_ops.rs): currently
+      `items = value_to_list(target)` expands a Bag to its *elements*, so `postfix:<-->` is applied to
+      the wrong things. Correct semantics (verified w/ raku): treat like a Hash — apply the op to each
+      *weight by key*; postfix returns the ORIGINAL bag, and the source var (`target_var`) is mutated
+      in place to the decremented weights (0/neg removed for Bag, kept for Mix). The hyper machinery
+      applies methods to detached values so it can't capture an in-place postfix's new state — must
+      special-case postfix:<++>/<--> to compute new weights + write back via target_var.
   - DONE: 206/207 (`BagHash[Str]` element-bind wrong-type croak + init croak) — parameterized
     `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]`.new now embeds the keyof type metadata so
     `$b{42}=1` throws X::TypeCheck::Binding. Also fixed `MixHash[T].new` returning an
@@ -277,9 +287,11 @@
     and `.kv` for a mutable MixHash landed (`$_ = X for $m.values`, `for $m.kv -> \k,\v { v=X }`
     mutate the weight; weight 0 removes; non-numeric Str → X::Str::Numeric). See
     t/for-quanthash-values-rw-writeback.t.
-  - PROGRESS: now 290/295 (no longer aborts). The two abort blockers FIXED via the same
-    work as baghash.t (#3124 sigilless `\v++/\v--`, #3126 `.pairs .value=`/`.value--` writeback).
-  - REMAINING (5 failing): 244, 246, 282, 288-289 — not yet triaged (separate features).
+  - PROGRESS: now 291/295 (no longer aborts). Abort blockers FIXED via the same work as
+    baghash.t (#3124 sigilless `\v++/\v--`, #3126 `.pairs .value=`/`.value--`); 282 parameterized
+    `MixHash[T]` key type-check FIXED #3131.
+  - REMAINING (4 failing): 244, 246 (X::Cannot::Lazy — lazy-list op on a MixHash), 288-289
+    (hyper `$m>>--` — same QuantHash hyper-postfix gap as baghash.t 337-338, see that note).
 - [ ] roast/S02-types/mix-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t


### PR DESCRIPTION
Updates `TODO_roast/S02.md`: `baghash.t` is now 341/344 and `mixhash.t` 291/295 after #3131 (parameterized QuantHash key type-check). Records a detailed analysis of the remaining failures (>64-bit Bag weights, hyper `>>--` on a QuantHash, `X::Cannot::Lazy`) with implementation notes for a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)