### PR TITLE
fix(lazy): say/put/note/print render a LazyList's contents, not "LazyList"

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3014,6 +3014,22 @@ impl Interpreter {
             }
         }
 
+        // gist/Str/raku of a *genuinely* lazy list (an infinite sequence or a
+        // lazy map/grep pipeline) cannot reify the whole sequence, so raku
+        // renders a placeholder instead of materializing: `(...)` for gist/raku,
+        // `...` for Str. (An eager gather has neither `sequence_spec` nor
+        // `lazy_pipe` and falls through to the force-and-render path below,
+        // which materializes its elements.)
+        if let Value::LazyList(ll) = &target
+            && matches!(method, "gist" | "Str" | "raku" | "perl")
+            && (ll.lazy_pipe.is_some() || ll.sequence_spec.is_some())
+        {
+            return Ok(Value::str(if method == "Str" {
+                "...".to_string()
+            } else {
+                "(...)".to_string()
+            }));
+        }
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -496,6 +496,20 @@ impl Interpreter {
         } else {
             target
         };
+        // gist/Str/raku of a *genuinely* lazy list (an infinite sequence or a
+        // lazy map/grep pipeline) renders as raku's placeholder rather than
+        // reifying the (possibly infinite) sequence: `(...)` for gist/raku,
+        // `...` for Str. An eager gather has neither `sequence_spec` nor
+        // `lazy_pipe` and is forced & rendered normally below.
+        if let Value::LazyList(ref ll) = target
+            && matches!(method, "gist" | "Str" | "raku" | "perl")
+            && (ll.lazy_pipe.is_some() || ll.sequence_spec.is_some())
+        {
+            self.stack.push(Value::str(
+                if method == "Str" { "..." } else { "(...)" }.to_string(),
+            ));
+            return Ok(());
+        }
         // Force gather-sourced LazyList before method dispatch for methods that need
         // element access. This must happen before the native method fast path, because
         // builtins don't have access to the interpreter for forcing.

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -17,6 +17,13 @@ fn needs_method_dispatch(v: &Value) -> bool {
         // dispatch; `render_gist_value`/`render_str_value` fall back to the
         // default `(TypeName)` rendering when no such method exists.
         Value::Package(..) => true,
+        // A LazyList (gather/take, infinite sequence, lazy map/grep pipeline)
+        // must be rendered via `.gist`/`.Str` method dispatch: an eager gather
+        // is forced to its elements, while a genuinely lazy/infinite one
+        // renders as raku's placeholder (`(...)` / `...`). The pure
+        // `gist_value`/`to_str_context` fast paths would print the bare type
+        // name "LazyList" instead.
+        Value::LazyList(..) => true,
         // A collection whose gist embeds an element's gist must be rendered via
         // method dispatch when any element needs it (e.g. an instance/type-object
         // with a custom `method gist`), so the per-element gist is honored.

--- a/t/lazy-list-say-display.t
+++ b/t/lazy-list-say-display.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `say`/`note`/`put`/`print` on a LazyList must render its contents, not the
+# bare type name "LazyList". An eager gather is materialized to its elements;
+# a genuinely lazy/infinite sequence or map/grep pipeline renders as raku's
+# placeholder (`(...)` for gist-style, `...` for Str-style) rather than being
+# reified.
+
+plan 12;
+
+# --- eager gather: say uses .gist => (elements) ---
+is (gather { take 1; take 2; take 3 }).gist, '(1 2 3)', 'gather.gist';
+is (gather { take 1; take 2; take 3 }).Str, '1 2 3', 'gather.Str';
+
+# say/put/note funnel through the same gist/Str rendering as above. We assert
+# the underlying methods rather than capturing stdout, but cover all forms via
+# their rendering method:
+{
+    my $g = gather { take $_ * 10 for 1 .. 3 };
+    is $g.gist, '(10 20 30)', 'gather-with-loop gist';
+}
+
+# An empty gather renders as the empty list.
+is (gather { }).gist, '()', 'empty gather.gist';
+
+# --- genuinely lazy: infinite sequence renders as a placeholder ---
+is (1, 2, 4 ... *).gist, '(...)', 'infinite sequence .gist is (...)';
+is (1, 2, 4 ... *).Str, '...', 'infinite sequence .Str is ...';
+
+# --- lazy map/grep pipeline over an infinite source ---
+is (1 .. *).map(* + 1).gist, '(...)', 'lazy map pipeline .gist is (...)';
+is (1 .. *).grep(* %% 2).Str, '...', 'lazy grep pipeline .Str is ...';
+
+# --- a FINITE sequence is already a Seq, fully rendered (not a placeholder) ---
+is (1, 2, 4 ... 64).gist, '(1 2 4 8 16 32 64)', 'finite sequence renders fully';
+
+# --- lazy pipeline can still be sliced (laziness preserved) ---
+is-deeply (1 .. *).map(* + 1).head(3).List, (2, 3, 4), 'lazy map head still works';
+is-deeply (1 .. *).grep(* %% 2).head(3).List, (2, 4, 6), 'lazy grep head still works';
+
+# --- a forced gather behaves as a normal Seq afterward ---
+is-deeply (gather { take 5; take 6 }).reverse.List, (6, 5), 'gather.reverse';


### PR DESCRIPTION
## Problem
```raku
say gather { take 1; take 2; take 3 };   # raku: (1 2 3) — mutsu: LazyList
put gather { take 1; take 2 };            # raku: 1 2     — mutsu: LazyList
say (1, 2, 4 ... *);                      # raku: (...)   — mutsu: LazyList
say (1 .. *).map(* + 1);                  # raku: (...)   — mutsu: LazyList
```
`say`/`put`/`note`/`print` of a `LazyList` printed the bare type name
`LazyList` instead of its contents.

## Cause
The four output ops choose between the pure `gist_value`/`to_str_context`
fast path and method dispatch via `needs_method_dispatch`, which had no
`LazyList` arm — so a LazyList fell to the fast path, whose `_` branch
yields the type name. (`.gist`/`.WHAT`/`my @a = …` were already correct.)

## Fix
- `needs_method_dispatch` now returns `true` for `LazyList`, so all four
  output ops route it through `.gist`/`.Str`. An **eager gather** is then
  forced to its elements and rendered (`say` → `(1 2 3)`, `put` → `1 2`).
- A **genuinely lazy** list (infinite sequence, or a lazy `map`/`grep`
  pipeline over an infinite source) can't be reified, so it renders as
  raku's placeholder — `(...)` for gist/raku, `...` for Str. Added as a
  guard in both the interpreter (`call_method_with_values`) and the VM
  (`exec_call_method_op`) paths, before the force step that previously
  threw `X::Cannot::Lazy` ("Cannot .gist a lazy list").

A finite sequence is materialized to a Seq before display, so it is
unaffected (still renders all elements).

## Test
`t/lazy-list-say-display.t` (12 assertions) — verified against `raku`.
All existing lazy/gather tests still pass (`gather-lazy`, `grep-lazy-range`,
`lazy-method-map-grep`, `eager-ops-cannot-lazy`, …), as do the whitelisted
roast `S02-types/lazy-lists.t`, `S04-statements/{gather,lazy}.t`.

Found via differential probing (raku vs mutsu).

### Out of scope (separate)
`gather { … }.is-lazy` returns True (raku: False) — the `.is-lazy` method
treats every LazyList as lazy. Fixing it has broader blast radius
(`lazy_guard`, coercion) and there is no marker distinguishing
`lazy gather` from a plain `gather`; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)