### PR TITLE
fix(quanthash): hyper >>++ / >>-- applies to weights and writes back

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -377,6 +377,11 @@ impl Compiler {
         let target_name_idx = match target {
             Expr::ArrayVar(n) => Some(self.code.add_constant(Value::str(format!("@{}", n)))),
             Expr::HashVar(n) => Some(self.code.add_constant(Value::str(format!("%{}", n)))),
+            // A scalar holding a QuantHash (`$b>>--`, `$b := <...>.BagHash`) also
+            // needs its name for precise weight writeback. The `@`/`%` writeback
+            // paths below are sigil-guarded so a bare scalar name only drives the
+            // QuantHash postfix path, leaving Array/Hash behavior unchanged.
+            Expr::Var(n) => Some(self.code.add_constant(Value::str(n.clone()))),
             _ => None,
         };
         self.code.emit(OpCode::HyperMethodCall {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -25,6 +25,77 @@ impl Interpreter {
         self.env_dirty = true;
     }
 
+    /// `$b>>++` / `$b>>--` on a Bag/Mix/Set: apply the postfix op to each weight,
+    /// return the *original* QuantHash, and write the in/decremented weights back
+    /// to the source variable. A Bag count that reaches <= 0 (a Mix weight that
+    /// reaches 0.0) removes the element; an immutable Bag/Mix/Set has read-only
+    /// weights and errors like Raku ("postfix:<--> requires mutable arguments").
+    fn exec_hyper_quant_postfix(
+        &mut self,
+        code: &CompiledCode,
+        target: &Value,
+        target_var: Option<&str>,
+        increment: bool,
+    ) -> Result<(), RuntimeError> {
+        let is_mutable = matches!(
+            target,
+            Value::Bag(_, true) | Value::Mix(_, true) | Value::Set(_, true)
+        );
+        if !is_mutable {
+            let opname = if increment {
+                "postfix:<++>"
+            } else {
+                "postfix:<-->"
+            };
+            return Err(RuntimeError::new(format!(
+                "Cannot resolve caller {}(Int:D); the parameter requires mutable arguments",
+                opname
+            )));
+        }
+        let delta: i64 = if increment { 1 } else { -1 };
+        let new_value = match target {
+            Value::Bag(bag, _) => {
+                let mut counts = std::collections::HashMap::new();
+                for (k, c) in bag.counts.iter() {
+                    let n = c + delta;
+                    if n > 0 {
+                        counts.insert(k.clone(), n);
+                    }
+                }
+                Value::bag_hash(counts)
+            }
+            Value::Mix(mix, _) => {
+                let mut weights = std::collections::HashMap::new();
+                for (k, w) in mix.iter() {
+                    let n = w + delta as f64;
+                    if n != 0.0 {
+                        weights.insert(k.clone(), n);
+                    }
+                }
+                Value::mix_hash(weights)
+            }
+            Value::Set(set, _) => {
+                // Set membership is weight 1: `++` keeps the element (weight 2 is
+                // still "present"), `--` drops it (weight 0).
+                let mut elems = std::collections::HashSet::new();
+                if increment {
+                    for k in set.elements.iter() {
+                        elems.insert(k.clone());
+                    }
+                }
+                Value::set_hash(elems)
+            }
+            _ => unreachable!(),
+        };
+        if let Some(var) = target_var {
+            self.write_back_hyper_target_var(code, var, new_value);
+        }
+        // Postfix returns the original QuantHash unchanged (the source var now
+        // holds the mutated copy; `target` still points at the original backing).
+        self.stack.push(target.clone());
+        Ok(())
+    }
+
     pub(super) fn exec_hyper_method_call_op(
         &mut self,
         code: &CompiledCode,
@@ -57,6 +128,21 @@ impl Interpreter {
         // Mark Seq as consumed (single-use semantics).
         if let Value::Seq(ref arc) = target {
             crate::value::seq_consume(arc)?;
+        }
+        // `$b>>++` / `$b>>--` on a Bag/Mix/Set applies the postfix op to each
+        // *weight* (treating the QuantHash like a Hash of weights): it returns
+        // the *original* QuantHash and writes the in/decremented weights back to
+        // the source variable. Handled here because the generic value_to_list path
+        // below expands a QuantHash to its elements, not its keyed weights.
+        if matches!(method_raw, "postfix:<++>" | "postfix:<-->")
+            && matches!(&target, Value::Bag(..) | Value::Mix(..) | Value::Set(..))
+        {
+            return self.exec_hyper_quant_postfix(
+                code,
+                &target,
+                target_var.as_deref(),
+                method_raw == "postfix:<++>",
+            );
         }
         // Hyper method/postfix on a Hash applies to each *value*, preserving the
         // keys: `%h>>.uc` and `%h>>!` yield a Hash, not a list of pairs.
@@ -385,7 +471,10 @@ impl Interpreter {
             }
         }
         if let Value::Array(existing, kind) = &target {
-            if let Some(var) = &target_var {
+            if let Some(var) = target_var
+                .as_ref()
+                .filter(|v| v.starts_with('@') || v.starts_with('%'))
+            {
                 // Precise writeback to the *named* `@`-variable's binding only.
                 // A bound variable holds a shared `ContainerRef` cell (e.g.
                 // `$b := @a`): write the new array through the cell so aliases
@@ -444,7 +533,10 @@ impl Interpreter {
                 map.insert(key.clone(), item.clone());
             }
             let new_hash = Value::Hash(Value::hash_arc(map));
-            if let Some(var) = &target_var {
+            if let Some(var) = target_var
+                .as_ref()
+                .filter(|v| v.starts_with('@') || v.starts_with('%'))
+            {
                 // Precise writeback to the named `%`-variable (see the Array
                 // arm); avoids corrupting a COW copy `my %g = %h`.
                 self.write_back_hyper_target_var(code, var, new_hash);

--- a/t/hyper-postfix-quanthash.t
+++ b/t/hyper-postfix-quanthash.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `$b>>++` / `$b>>--` on a mutable QuantHash applies the postfix op to each
+# weight: it returns the *original* QuantHash and writes the in/decremented
+# weights back to the source variable. Bag counts reaching <= 0 (Mix weights
+# reaching 0.0) are removed. Immutable Bag/Mix/Set have read-only weights.
+
+plan 10;
+
+# BagHash >>-- (the rakudo #5057 case).
+{
+    my $b := <a b c d e a b>.BagHash;
+    is-deeply $b>>--, <a b c d e a b>.BagHash, 'BagHash >>-- returns the original';
+    is-deeply $b, <a b>.BagHash, 'BagHash >>-- decrements the source (0-weights removed)';
+}
+
+# MixHash >>-- (the rakudo #5057 case).
+{
+    my $m := <a b c d e a b>.MixHash;
+    is-deeply $m>>--, <a b c d e a b>.MixHash, 'MixHash >>-- returns the original';
+    is-deeply $m, <a b>.MixHash, 'MixHash >>-- decrements the source';
+}
+
+# BagHash >>++ increments each weight.
+{
+    my $b := <a b>.BagHash;
+    is-deeply $b>>++, <a b>.BagHash, 'BagHash >>++ returns the original';
+    is-deeply $b, <a a b b>.BagHash, 'BagHash >>++ increments the source';
+}
+
+# A plain `my` (non-bound) BagHash also writes back.
+{
+    my $b = <a a b>.BagHash;
+    $b>>--;
+    is-deeply $b, <a>.BagHash, 'my-bound BagHash >>-- writes back';
+}
+
+# SetHash >>-- drops every element (weight 1 -> 0).
+{
+    my $s := <a b c>.SetHash;
+    $s>>--;
+    is-deeply $s, ().SetHash, 'SetHash >>-- empties the set';
+}
+
+# Immutable Bag/Mix weights are read-only.
+{
+    my $b = <a a b>.Bag;
+    dies-ok { $b>>-- }, 'immutable Bag >>-- dies (read-only weights)';
+}
+{
+    my $m = (a => 1.5).Mix;
+    dies-ok { $m>>-- }, 'immutable Mix >>-- dies (read-only weights)';
+}


### PR DESCRIPTION
## Summary

`$b>>--` on a BagHash/MixHash/SetHash mangled to garbage (`("-1"=>0).BagHash`) — the generic hyper path expands a QuantHash to its *elements* via `value_to_list` and applied `postfix:<-->` to the wrong things.

A dedicated path in `exec_hyper_method_call_op` now handles postfix `++`/`--` on a Bag/Mix/Set: it applies the op to each **weight** (like a Hash of weights), returns the **original** QuantHash, and writes the in/decremented weights back to the source variable. Bag counts reaching `<= 0` (Mix weights reaching `0.0`) remove the element; an immutable Bag/Mix/Set errors (`requires mutable arguments`), matching Raku.

To write back through a scalar holding a QuantHash (`$b := <...>.BagHash`), the compiler now records the bare scalar name for `Expr::Var` hyper targets. The existing `@`/`%` Array/Hash writeback paths are sigil-guarded, so a bare scalar name only drives the new QuantHash postfix path — Array/Hash behavior for scalar targets keeps its overwrite-by-identity path unchanged (verified: `$x := @a; $x>>.succ` still works).

## Impact

- `S02-types/baghash.t` 337-338, `mixhash.t` 288-289 now pass.
- **baghash.t: 343/344** (only >64-bit Bag weights remain), **mixhash.t: 293/295** (only `X::Cannot::Lazy` remains).

## Tests

- `t/hyper-postfix-quanthash.t` (10 cases): Bag/Mix/Set `>>--`/`>>++`, bound & `my` vars, removal, immutability.
- `make test` passes (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)