### PR TITLE
fix(quanthash): X::Cannot::Lazy.what names the target type; whitelist mixhash.t

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -277,21 +277,12 @@
 - [x] roast/S02-types/list.t
 - [ ] roast/S02-types/mixed_multi_dimensional.t
   - 0/? pass. Parse error at line 43
-- [ ] roast/S02-types/mixhash.t
-  - 216/216 pass then aborts at 216 (plan 295). Fixed 161-164 (`%h is MixHash` weight=0
-    removal + Str→X::Str::Numeric on element assign; quanthash-element-assign fix).
-  - DONE: parameterized `MixHash[T]`/`Mix[T]` element-bind type-check (keyof in `key_type`,
-    weight type stays Real in `value_type`) + `MixHash[T].new` mutability bug (now uses
-    `base_class_name`).
-  - PROGRESS: now 237 (was 216). QuantHash `= X` writeback through `.values` (topic + rw)
-    and `.kv` for a mutable MixHash landed (`$_ = X for $m.values`, `for $m.kv -> \k,\v { v=X }`
-    mutate the weight; weight 0 removes; non-numeric Str → X::Str::Numeric). See
-    t/for-quanthash-values-rw-writeback.t.
-  - PROGRESS: now 291/295 (no longer aborts). Abort blockers FIXED via the same work as
-    baghash.t (#3124 sigilless `\v++/\v--`, #3126 `.pairs .value=`/`.value--`); 282 parameterized
-    `MixHash[T]` key type-check FIXED #3131.
-  - REMAINING (4 failing): 244, 246 (X::Cannot::Lazy — lazy-list op on a MixHash), 288-289
-    (hyper `$m>>--` — same QuantHash hyper-postfix gap as baghash.t 337-338, see that note).
+- [x] roast/S02-types/mixhash.t
+  - 295/295 — WHITELISTED. The full QuantHash writeback campaign (#3124 sigilless `\v++/\v--`,
+    #3126 `.pairs .value=`/`.value--`, #3131 parameterized key type-check, #3134 hyper `$m>>--`)
+    plus the `X::Cannot::Lazy` `.what` fix (`^Inf.MixHash` / `MixHash.new(^Inf)` now report
+    `:what<MixHash>`) closed the last failures. Earlier milestones: 216→237 (`.values`/`.kv`
+    writeback), parameterized `MixHash[T]` element-bind type-check + `.new` mutability.
 - [ ] roast/S02-types/mix-iterator.t
   - 0/? pass. Parse error at line 13
 - [ ] roast/S02-types/mix.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -136,6 +136,7 @@ roast/S02-types/lists.t
 roast/S02-types/mix-iterator.t
 roast/S02-types/mix.t
 roast/S02-types/mixed_multi_dimensional.t
+roast/S02-types/mixhash.t
 roast/S02-types/mu.t
 roast/S02-types/multi_dimensional_array.t
 roast/S02-types/nan.t

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -22,10 +22,10 @@ use std::collections::{HashMap, HashSet};
 
 /// Coerce `target` to a `Set` (immutable). The caller flips the mutable flag for
 /// `.SetHash`.
-pub(crate) fn to_set(target: Value) -> Result<Value, RuntimeError> {
+pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
     // Check for lazy/infinite values
     if Interpreter::is_lazy_for_coerce(&target) {
-        return Err(RuntimeError::cannot_lazy_what("Set"));
+        return Err(RuntimeError::cannot_lazy_what(what));
     }
     let mut elems = HashSet::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
@@ -152,7 +152,7 @@ pub(crate) fn to_set(target: Value) -> Result<Value, RuntimeError> {
         // Instance types composing Baggy: delegate to internal bag data
         Value::Instance { ref attributes, .. } if attributes.contains_key("__baggy_data__") => {
             let bag_data = attributes.as_map().get("__baggy_data__").unwrap().clone();
-            return to_set(bag_data);
+            return to_set(bag_data, what);
         }
         other if other.is_range() => {
             for item in value_to_list(&other) {
@@ -621,13 +621,13 @@ fn mix_add_item_with_keys(
 
 /// Coerce `target` to a `Mix` (immutable). The caller flips the mutable flag (and
 /// registers `MixHash` type metadata) for `.MixHash`.
-pub(crate) fn to_mix(target: Value) -> Result<Value, RuntimeError> {
+pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
     // Check for lazy iterables
     if Interpreter::is_lazy_for_set_ops(&target) {
-        let mut err = RuntimeError::new("Cannot .Mix a lazy list");
+        let mut err = RuntimeError::new(format!("Cannot .{} a lazy list", what));
         err.exception = Some(Box::new(Value::make_instance(
             crate::symbol::Symbol::intern("X::Cannot::Lazy"),
-            [("what".to_string(), Value::str_from("Mix"))]
+            [("what".to_string(), Value::str_from(what))]
                 .into_iter()
                 .collect(),
         )));

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -1,8 +1,12 @@
 use super::*;
 
 impl Interpreter {
-    pub(super) fn dispatch_to_set(&self, target: Value) -> Result<Value, RuntimeError> {
-        crate::builtins::quanthash_coerce::to_set(target)
+    pub(super) fn dispatch_to_set_with_what(
+        &self,
+        target: Value,
+        what: &str,
+    ) -> Result<Value, RuntimeError> {
+        crate::builtins::quanthash_coerce::to_set(target, what)
     }
 
     /// Check if a value is lazy/infinite and cannot be coerced to a QuantHash.
@@ -118,7 +122,15 @@ impl Interpreter {
     }
 
     pub(super) fn dispatch_to_mix(&self, target: Value) -> Result<Value, RuntimeError> {
-        crate::builtins::quanthash_coerce::to_mix(target)
+        crate::builtins::quanthash_coerce::to_mix(target, "Mix")
+    }
+
+    pub(super) fn dispatch_to_mix_with_what(
+        &self,
+        target: Value,
+        what: &str,
+    ) -> Result<Value, RuntimeError> {
+        crate::builtins::quanthash_coerce::to_mix(target, what)
     }
 
     pub(super) fn dispatch_to_map(&self, target: Value) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -30,7 +30,7 @@ impl Interpreter {
             }
             "List" if args.is_empty() => Some(self.dispatch_list_coercion(target)),
             "Set" | "SetHash" if args.is_empty() => {
-                let result = match self.dispatch_to_set(target) {
+                let result = match self.dispatch_to_set_with_what(target, method) {
                     Ok(r) => r,
                     Err(e) => return Some(Err(e)),
                 };
@@ -94,7 +94,7 @@ impl Interpreter {
                 None
             }
             "Mix" | "MixHash" if args.is_empty() => {
-                let result = match self.dispatch_to_mix(target) {
+                let result = match self.dispatch_to_mix_with_what(target, method) {
                     Ok(r) => r,
                     Err(e) => return Some(Err(e)),
                 };

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3200,14 +3200,7 @@ impl Interpreter {
                     // Check for lazy iterables
                     for arg in &args {
                         if Self::is_lazy_for_set_ops(arg) {
-                            let mut err = RuntimeError::new("Cannot .Mix a lazy list");
-                            err.exception = Some(Box::new(Value::make_instance(
-                                Symbol::intern("X::Cannot::Lazy"),
-                                [("what".to_string(), Value::str_from("Mix"))]
-                                    .into_iter()
-                                    .collect(),
-                            )));
-                            return Err(err);
+                            return Err(RuntimeError::cannot_lazy_what(base_class_name));
                         }
                     }
                     if args.len() == 1 {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1079,11 +1079,13 @@ impl Interpreter {
         }
         let target = target.clone();
         let result = match method {
-            "Set" => crate::builtins::quanthash_coerce::to_set(target),
-            "SetHash" => crate::builtins::quanthash_coerce::to_set(target).map(|r| match r {
-                Value::Set(items, _) => Value::Set(items, true),
-                other => other,
-            }),
+            "Set" => crate::builtins::quanthash_coerce::to_set(target, "Set"),
+            "SetHash" => {
+                crate::builtins::quanthash_coerce::to_set(target, "SetHash").map(|r| match r {
+                    Value::Set(items, _) => Value::Set(items, true),
+                    other => other,
+                })
+            }
             "Bag" => crate::builtins::quanthash_coerce::to_bag(target, "Bag"),
             "BagHash" => {
                 crate::builtins::quanthash_coerce::to_bag(target, "BagHash").map(|r| match r {
@@ -1091,7 +1093,7 @@ impl Interpreter {
                     other => other,
                 })
             }
-            "Mix" => crate::builtins::quanthash_coerce::to_mix(target),
+            "Mix" => crate::builtins::quanthash_coerce::to_mix(target, "Mix"),
             _ => unreachable!(),
         };
         Some(result)

--- a/t/quanthash-lazy-what.t
+++ b/t/quanthash-lazy-what.t
@@ -1,0 +1,24 @@
+use Test;
+
+# Building a Set/Bag/Mix (and the mutable *Hash variants) from a lazy/infinite
+# list throws X::Cannot::Lazy whose `.what` names the specific target type, both
+# via the coercion method (`.MixHash`) and the `.new` constructor.
+
+plan 8;
+
+throws-like { ^Inf .MixHash }, X::Cannot::Lazy, :what<MixHash>,
+  '^Inf.MixHash reports :what<MixHash>';
+throws-like { MixHash.new(^Inf) }, X::Cannot::Lazy, :what<MixHash>,
+  'MixHash.new(^Inf) reports :what<MixHash>';
+throws-like { ^Inf .Mix }, X::Cannot::Lazy, :what<Mix>,
+  '^Inf.Mix reports :what<Mix>';
+throws-like { Mix.new(^Inf) }, X::Cannot::Lazy, :what<Mix>,
+  'Mix.new(^Inf) reports :what<Mix>';
+throws-like { ^Inf .BagHash }, X::Cannot::Lazy, :what<BagHash>,
+  '^Inf.BagHash reports :what<BagHash>';
+throws-like { BagHash.new(^Inf) }, X::Cannot::Lazy, :what<BagHash>,
+  'BagHash.new(^Inf) reports :what<BagHash>';
+throws-like { ^Inf .SetHash }, X::Cannot::Lazy, :what<SetHash>,
+  '^Inf.SetHash reports :what<SetHash>';
+throws-like { SetHash.new(^Inf) }, X::Cannot::Lazy, :what<SetHash>,
+  'SetHash.new(^Inf) reports :what<SetHash>';


### PR DESCRIPTION
## Summary

Building a Set/Bag/Mix (and the mutable `*Hash` variants) from a lazy/infinite list threw `X::Cannot::Lazy`, but the exception's `.what` was hardcoded (`"Mix"` / `"Set"`) instead of the actual target type. Now:

- `^Inf.MixHash` and `MixHash.new(^Inf)` report `:what<MixHash>`
- `^Inf.SetHash` reports `:what<SetHash>`, etc.

`to_set`/`to_mix` take a `what` parameter (like `to_bag` already did); the coercion-method dispatch passes the method name, and the `.new` path uses `base_class_name`.

## Impact

With this plus the QuantHash hyper-postfix fix (#3134), **`S02-types/mixhash.t` passes all 295 tests** → added to `roast-whitelist.txt`.

(`baghash.t` is at 343/344 — only >64-bit Bag weights remain, which needs BigInt counts in `BagData`.)

## Tests

- `t/quanthash-lazy-what.t` (8 cases): `.MixHash`/`.SetHash`/`.BagHash` and their `.new` forms over `^Inf` report the correct `:what`.
- `make test` passes; `mixhash.t` passes under `MUTSU_FUDGE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)