### PR TITLE
fix(exception): X::AdHoc .Str and .throw surface the payload, not the type repr

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1182,6 +1182,18 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     if cn == "Exception" {
                         return Some(Ok(Value::str(format!("Something went wrong in ({})", cn))));
                     }
+                    // X::AdHoc carries its text in `payload`, not `message`
+                    // (`die "..."` builds one). `.Str` returns that payload,
+                    // mirroring `.gist`/`.message`.
+                    if cn == "X::AdHoc" {
+                        if let Some(payload) = attributes.as_map().get("payload") {
+                            let payload_str = payload.to_string_value();
+                            if !payload_str.is_empty() {
+                                return Some(Ok(Value::str(payload_str)));
+                            }
+                        }
+                        return Some(Ok(Value::str("Unexplained error".to_string())));
+                    }
                     // Construct message from typed exception attributes
                     if let Some(formatted) =
                         crate::builtins::exception_message::format_exception_message(
@@ -1357,10 +1369,33 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         // composed roles (e.g. X::Control) to decide whether the throw
         // should raise a control exception.
         if cn == "Exception" || cn.starts_with("X::") || cn == "Failure" {
+            // Derive the human message the same way `.message`/`.gist`/`.Str`
+            // do — an X::AdHoc carries its text in `payload` (not `message`),
+            // and a typed exception's message is built from its attributes —
+            // rather than the type repr (`X::AdHoc()`) that
+            // `target.to_string_value()` would yield.
             let msg = attributes
                 .as_map()
                 .get("message")
                 .map(|v| v.to_string_value())
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    if cn == "X::AdHoc" {
+                        attributes
+                            .as_map()
+                            .get("payload")
+                            .map(|v| v.to_string_value())
+                            .filter(|s| !s.is_empty())
+                    } else {
+                        None
+                    }
+                })
+                .or_else(|| {
+                    crate::builtins::exception_message::format_exception_message(
+                        &cn,
+                        &attributes.as_map(),
+                    )
+                })
                 .unwrap_or_else(|| target.to_string_value());
             let mut err = RuntimeError::new(&msg);
             err.exception = Some(Box::new(target.clone()));

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1910,11 +1910,26 @@ impl Interpreter {
                     .iter()
                     .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
             if is_exception {
-                let msg = attributes
+                // Derive the human message via `.message` (X::AdHoc → `payload`,
+                // a typed exception → its formatted message) rather than the
+                // type repr (`X::AdHoc()`), which `target.to_string_value()`
+                // would yield for an exception built without a `message` attr.
+                let has_message = attributes
                     .as_map()
                     .get("message")
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_else(|| target.to_string_value());
+                    .map(|v| !v.to_string_value().is_empty())
+                    .unwrap_or(false);
+                let msg = if has_message {
+                    attributes
+                        .as_map()
+                        .get("message")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_default()
+                } else {
+                    self.call_method_with_values(target.clone(), "message", vec![])
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|_| target.to_string_value())
+                };
                 let mut err = RuntimeError::new(&msg);
                 err.exception = Some(Box::new(target.clone()));
                 return Err(err);

--- a/t/exception-adhoc-message.t
+++ b/t/exception-adhoc-message.t
@@ -1,0 +1,66 @@
+use Test;
+
+# X::AdHoc carries its text in `payload`, not `message` (it is what
+# `die "..."` builds). `.message`, `.gist`, AND `.Str` must all surface that
+# payload, and `.throw`ing such an exception must propagate the payload text
+# (not the type repr `X::AdHoc()`) as the caught message. Previously `.Str`
+# returned "X::AdHoc with no message" and a thrown X::AdHoc surfaced
+# "X::AdHoc()".
+
+plan 11;
+
+my $e = X::AdHoc.new(payload => "boom");
+is $e.message, 'boom', 'X::AdHoc.message is the payload';
+is $e.payload, 'boom', 'X::AdHoc.payload';
+is $e.Str,     'boom', 'X::AdHoc.Str is the payload (was "with no message")';
+is $e.gist,    'boom', 'X::AdHoc.gist is the payload';
+
+# Throwing surfaces the payload as the caught message / stringification.
+{
+    my $msg;
+    try {
+        X::AdHoc.new(payload => "kaboom").throw;
+        CATCH { default { $msg = .message } }
+    }
+    is $msg, 'kaboom', 'thrown X::AdHoc caught .message is the payload';
+}
+{
+    my $s;
+    try {
+        X::AdHoc.new(payload => "kaboom").throw;
+        CATCH { default { $s = .Str } }
+    }
+    is $s, 'kaboom', 'thrown X::AdHoc caught .Str is the payload';
+}
+
+# $! after a try holds the payload message.
+try { X::AdHoc.new(payload => "splat").throw };
+is $!.message, 'splat', '$!.message after thrown X::AdHoc';
+
+# A typed exception thrown surfaces its formatted message.
+{
+    my $msg;
+    try {
+        X::NYI.new(feature => "widgets").throw;
+        CATCH { default { $msg = .message } }
+    }
+    is $msg, 'widgets not yet implemented. Sorry.', 'thrown typed exception message';
+}
+
+# A user-defined Exception subclass with a custom .message is honored on throw.
+my class MyErr is Exception { method message { "custom boom" } }
+{
+    my $msg;
+    try {
+        MyErr.new.throw;
+        CATCH { default { $msg = .message } }
+    }
+    is $msg, 'custom boom', 'user Exception custom .message on throw';
+}
+
+# `die` with an X::AdHoc instance also surfaces the payload.
+try { die X::AdHoc.new(payload => "died-with") };
+is $!.message, 'died-with', '$!.message after die X::AdHoc';
+
+# An empty-payload X::AdHoc stringifies to the placeholder.
+is X::AdHoc.new.Str, 'Unexplained error', 'empty X::AdHoc.Str placeholder';


### PR DESCRIPTION
## Problem
```raku
say X::AdHoc.new(payload => "hello").Str;     # raku: hello — mutsu: "X::AdHoc with no message"
X::AdHoc.new(payload => "p").throw;           # caught .message → raku: p — mutsu: "X::AdHoc()"
X::NYI.new(feature => "foo").throw;           # caught .message → raku: foo not yet implemented...
```
`.message`/`.gist`/`.payload` on an `X::AdHoc` were already correct, but
`.Str` and the value thrown by `.throw` were not.

## Cause
X::AdHoc carries its text in `payload`, not `message` (it is what
`die "..."` builds). Three paths failed to fall back to `payload`:
- the `.Str` arm in `native_method_0arg` (checked only `message`),
- the native fast-path `.throw` handler (fell back to
  `target.to_string_value()` → the type repr `X::AdHoc()`),
- the slow-path `.throw` handler (same fallback).

## Fix
Derive the message the way `.message`/`.gist` already do: non-empty
`message` → `payload` (X::AdHoc) → `format_exception_message` (typed
exceptions, so `X::NYI.throw` gives "… not yet implemented. Sorry.") →
type repr as last resort. The slow path derives it via `.message`
dispatch, so a user `Exception` subclass with a custom `method message`
is honored on throw.

## Test
`t/exception-adhoc-message.t` (11 assertions) — verified against `raku`.
Covers `.Str`/`.gist`/`.message`/`.payload`, caught `.message`/`.Str`
after `.throw`, `$!` after `try`, typed-exception throw, user-subclass
custom `.message`, `die X::AdHoc`, and the empty-payload placeholder.
Whitelisted exception roast (`S04-exception-handlers/*`, `S04-exceptions/*`)
all pass.

Found via differential probing (raku vs mutsu).

### Out of scope
The top-level *uncaught* display still prints `Runtime error: <msg>`
(mutsu's prefix) rather than raku's bare `<msg>` + backtrace — a separate,
pervasive display concern (only `OpCode::Die` attaches a backtrace; the
prefix affects all uncaught errors). The message *content* is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)