### PR TITLE
docs(roast): baghash.t 343/344, mixhash.t whitelisted

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -202,20 +202,15 @@
        branch in assign_method_lvalue_with_values keyed on topic_source_var; reuses
        quanthash_set_weight; `.value--` topic-method parse fix; negative Bag weight removal).
        Also #3128: Bag/BagHash element `--`/prefix-`--` clamps the returned value at 0.
-  - 331 parameterized `BagHash[T]` element key type-check (`%bh<foo> = 42` dies-ok) — FIXED #3131
-    (exec_index_assign_expr_named_op_inner reads the bracket key type from the container metadata's
-    value_type; numeric-string keys `<7>` are IntStr allomorphs and pass). baghash.t now 341/344.
-  - REMAINING (3 failing, distinct separate features — NOT this campaign):
-    - 322: >64-bit Bag weights (`%h<foo> = 10000000000000000000`) — Bag counts are i64; needs BigInt
-      counts in BagData (data-model change).
-    - 337-338: hyper `$b>>--` on a BagHash (currently mangles to `("-1"=>0).BagHash`). NEEDS a
-      QuantHash-specific path in exec_hyper_method_call_op (vm_hyper_method_ops.rs): currently
-      `items = value_to_list(target)` expands a Bag to its *elements*, so `postfix:<-->` is applied to
-      the wrong things. Correct semantics (verified w/ raku): treat like a Hash — apply the op to each
-      *weight by key*; postfix returns the ORIGINAL bag, and the source var (`target_var`) is mutated
-      in place to the decremented weights (0/neg removed for Bag, kept for Mix). The hyper machinery
-      applies methods to detached values so it can't capture an in-place postfix's new state — must
-      special-case postfix:<++>/<--> to compute new weights + write back via target_var.
+  - 331 parameterized `BagHash[T]` element key type-check (`%bh<foo> = 42` dies-ok) — FIXED #3131.
+  - 337-338 hyper `$b>>--` on a BagHash — FIXED #3134 (dedicated QuantHash path in
+    exec_hyper_method_call_op: op per weight, returns the original, writes decremented weights back;
+    0/neg removed; immutable errors).
+  - REMAINING (1 failing): **322** >64-bit Bag weights (`my %h is BagHash; %h<foo> = 10**19`).
+    mutsu represents 10^19 as `Value::BigInt`, but `BagData.counts` is `HashMap<String, i64>`:
+    `bag_assignment_count` has no BigInt arm (falls to truthy->1) and i64 can't hold 10^19 anyway.
+    Fix = `BagData.counts` -> BigInt. HIGH blast radius (BagData behind Arc with unsafe casts; all
+    Bag arithmetic/compare/display/set-ops). Same root cause as bag.t test 215. baghash.t now 343/344.
   - DONE: 206/207 (`BagHash[Str]` element-bind wrong-type croak + init croak) — parameterized
     `Bag[T]`/`BagHash[T]`/`Mix[T]`/`MixHash[T]`.new now embeds the keyof type metadata so
     `$b{42}=1` throws X::TypeCheck::Binding. Also fixed `MixHash[T].new` returning an


### PR DESCRIPTION
Records #3134 (hyper `>>--`) and #3135 (mixhash.t whitelisted). baghash.t is now 343/344; the only remaining failure is test 322 (>64-bit Bag weights, needs `BagData.counts` → BigInt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)