### PR TITLE
fix(seq): .sum/.min/.max/.Int compute over a Seq's elements

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -341,6 +341,10 @@ pub(super) fn dispatch(
             }
             Value::Hash(_) => None,
             Value::Package(_) | Value::Instance { .. } => None,
+            // A Seq/Slip is a materialized list; defer to the interpreter,
+            // which re-dispatches its elements as an Array so min/max compute
+            // over them. (The `_` arm below would return the Seq itself.)
+            Value::Seq(..) | Value::Slip(..) => None,
             _ => Some(Ok(target.clone())),
         }),
         "max" => Some(match target {
@@ -380,6 +384,10 @@ pub(super) fn dispatch(
             }
             Value::Hash(_) => None,
             Value::Package(_) | Value::Instance { .. } => None,
+            // A Seq/Slip is a materialized list; defer to the interpreter,
+            // which re-dispatches its elements as an Array so min/max compute
+            // over them. (The `_` arm below would return the Seq itself.)
+            Value::Seq(..) | Value::Slip(..) => None,
             _ => Some(Ok(target.clone())),
         }),
         "excludes-min" => Some(match target {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -415,6 +415,21 @@ impl Interpreter {
                 return Err(crate::value::seq_consumed_error());
             }
         }
+        // A non-lazy Seq is a materialized list; numeric aggregation/coercion
+        // methods (`.sum`/`.min`/`.max`/`.Int`) are only wired up for `Array`
+        // (and `.min`/`.max` route through `builtin_min`/`builtin_max`, which
+        // treat a bare Seq as a single element), so a `.map(...).sum` chain
+        // either threw "No such method" or returned the Seq itself. Re-dispatch
+        // these on the Seq's elements as a List so they behave like an Array.
+        if let Value::Seq(items) = &target
+            && matches!(method, "sum" | "min" | "max" | "Int")
+        {
+            let arr = Value::Array(
+                std::sync::Arc::new(crate::value::ArrayData::new(items.to_vec())),
+                crate::value::ArrayKind::List,
+            );
+            return self.call_method_with_values(arr, method, args);
+        }
         // User-defined ^method (metamethod) dispatch.
         // `method ^foo(Mu) { ... }` in a class body defines a metamethod.
         // The caller (VM) already prepends the type object to args.

--- a/t/seq-numeric-aggregation.t
+++ b/t/seq-numeric-aggregation.t
@@ -1,0 +1,29 @@
+use Test;
+
+# Numeric aggregation/coercion methods on a Seq (the result of `.map`/`.grep`,
+# etc.) must compute over its elements, like an Array. Previously `.sum`/`.Int`
+# threw "No such method ... for invocant of type 'Seq'" and `.min`/`.max`
+# returned the Seq itself instead of the extremum.
+
+plan 12;
+
+is (1, 2, 3).map(* ** 2).sum, 14, '.map(...).sum';
+is (1 .. 5).grep(* > 2).sum, 12, '.grep(...).sum';
+is (1, 2, 3).map(* + 0).min, 1, '.map(...).min';
+is (1, 2, 3).map(* + 0).max, 3, '.map(...).max';
+is (1, 2, 3).map(* + 0).Int, 3, '.map(...).Int is the element count';
+
+# Explicit Seq.
+is (5, 3, 8, 1).Seq.min, 1, 'Seq.min';
+is (5, 3, 8, 1).Seq.max, 8, 'Seq.max';
+is (5, 3, 8, 1).Seq.sum, 17, 'Seq.sum';
+is <c a b>.Seq.min, 'a', 'Seq.min on strings';
+
+# Empty Seq.
+is ().Seq.sum, 0, 'empty Seq.sum is 0';
+
+# A chained reduction still works.
+is (1 .. 10).grep(* %% 2).map(* * 10).sum, 300, 'grep+map+sum chain';
+
+# Array behavior is unchanged (regression guard).
+is (3, 1, 2).min, 1, 'Array.min still works';


### PR DESCRIPTION
## Problem
```raku
(1, 2, 3).map(* ** 2).sum;   # raku: 14 — mutsu: No such method 'sum' for type 'Seq'
(1, 2, 3).map(* + 0).min;    # raku: 1  — mutsu: (1 2 3)
(1, 2, 3).map(* + 0).Int;    # raku: 3  — mutsu: No such method 'Int' for type 'Seq'
```
Since `.map`/`.grep` return a `Seq`, these very common reduction chains
were broken.

## Cause
- `.sum`/`.Int` were only wired up for `Array` in the native list
  dispatch, so a `Seq` reached no handler.
- `.min`/`.max` matched in the native range/list dispatch but its `_`
  arm returned `target.clone()` for a `Seq` (and `builtin_min`/`max`
  treat a bare Seq as a single element).

## Fix
Re-dispatch a non-lazy `Seq` for these methods on its elements as a
List: a guard in `call_method_with_values` (right after the consumed-Seq
guard) handles `sum`/`min`/`max`/`Int`, and the native `min`/`max` arms
return `None` for `Seq`/`Slip` so they fall through to it. Array and
scalar behavior is unchanged; `.minmax`/`.Numeric`/`.Rat` already worked.

## Test
`t/seq-numeric-aggregation.t` (12 assertions) — verified against `raku`.
Whitelisted list/sequence roast (`S32-list/{reduce,minmax,categorize}.t`,
`S03-sequence/*`) all pass.

Found via differential probing (raku vs mutsu); same class as #3125
(`Seq.reverse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)