### PR TITLE
fix(grammar): rule with `%%` separator quantifier (trailing sep allowed)

### DIFF
--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -700,11 +700,19 @@ fn inject_separator_ws(pattern: &str) -> String {
             i += 1;
             continue;
         }
-        // Look for `%` followed by a separator expression
+        // Look for `%` (or `%%`) followed by a separator expression
         if c == '%' {
             out.push('%');
             i += 1;
-            // Skip whitespace after %
+            // `%%` (trailing-separator-allowed) is a single operator: emit its
+            // second `%` too, otherwise the second `%` is mistaken for the
+            // separator atom and the operator is destroyed (e.g.
+            // `\d+ %% "+"` would become `\d+ % [<.ws>? % <.ws>?] "+"`).
+            if i < chars.len() && chars[i] == '%' {
+                out.push('%');
+                i += 1;
+            }
+            // Skip whitespace after % / %%
             while i < chars.len() && chars[i].is_whitespace() {
                 out.push(chars[i]);
                 i += 1;

--- a/t/grammar-rule-percent-percent-sep.t
+++ b/t/grammar-rule-percent-percent-sep.t
@@ -1,0 +1,27 @@
+use Test;
+
+# In a grammar `rule` (which is `token` + implicit `:sigspace`), the `%%`
+# modified quantifier (separator, trailing separator allowed) was destroyed by
+# the implicit-whitespace injection: the second `%` of `%%` was mistaken for
+# the separator atom, so `<n>+ %% ","` never matched. `%` (no trailing) and
+# `%%` inside a plain `token` already worked.
+
+plan 8;
+
+grammar G1 { rule TOP { <num>+ %% "+" }; token num { \d+ } }
+ok  G1.parse("1+2+3"),  'rule <subrule>+ %% sep matches';
+ok  G1.parse("1+2+3+"), 'rule %% allows a trailing separator';
+is  G1.parse("1+2+3")<num>.elems, 3, 'rule %% captures all subrule matches';
+
+grammar G2 { rule TOP { \d+ %% "+" } }
+ok  G2.parse("1+2+3"),  'rule \d+ %% sep matches';
+ok  G2.parse("1+2+3+"), 'rule \d+ %% trailing separator';
+
+# `%` (non-trailing) still works and rejects a trailing separator.
+grammar G3 { rule TOP { \d+ % "+" } }
+ok  G3.parse("1+2+3"),  'rule \d+ % sep matches';
+nok G3.parse("1+2+3+"), 'rule % rejects a trailing separator';
+
+# Separator with surrounding whitespace in the input (sigspace).
+grammar G4 { rule TOP { <n>+ %% "," }; token n { \d+ } }
+is  G4.parse("1, 2, 3")<n>.elems, 3, 'rule %% with spaced input';


### PR DESCRIPTION
## Problem
```raku
grammar G { rule TOP { <num>+ %% "+" }; token num { \d+ } }
say so G.parse("1+2+3");   # raku: True — mutsu: False
```
In a grammar `rule`, the `%%` modified quantifier (separator, trailing
separator allowed) never matched. `%` (non-trailing) and `%%` inside a
plain `token` or `m:s//` already worked.

## Cause
A `rule` is `token` + implicit `:sigspace`, applied by textually
injecting `<.ws>` into the pattern. `inject_separator_ws`, which wraps
the separator atom in optional whitespace, only recognized a single `%`.
For `%%` it emitted the first `%`, then mistook the **second** `%` for
the separator atom — turning `\d+ %% "+"` into
`\d+ % [<.ws>? % <.ws>?] "+"`, destroying the operator and leaving the
real separator dangling.

## Fix
Treat `%%` as a single operator: emit both `%`, then wrap the real
separator atom. The existing `%%` LTM expansion (which honors
`allow_trailing_sep`) then runs as it does for `token`/`m:s`.

## Test
`t/grammar-rule-percent-percent-sep.t` (8 assertions) — verified against
`raku`. Covers `<subrule>+ %%`, bare `\d+ %%`, trailing separator,
captures, spaced input, and that `%` still rejects a trailing separator.
Whitelisted grammar/metasyntax roast all pass.

Found via differential probing (raku vs mutsu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)