### PR TITLE
fix(complex): integer-exponent ** is exact (no floating-point noise)

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -1226,6 +1226,35 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 Value::Complex(0.0, 0.0)
             };
         }
+        // Integer real exponent: compute by repeated multiplication
+        // (exponentiation by squaring) so the result stays exact, matching
+        // raku. The polar `exp(b*ln a)` form below introduces floating-point
+        // noise (e.g. `(0+1i)**2` would be `-1+1.2e-16i` instead of `-1+0i`).
+        if bi == 0.0 && br.fract() == 0.0 && br.abs() <= 1024.0 {
+            let cmul = |xr: f64, xi: f64, yr: f64, yi: f64| -> (f64, f64) {
+                (xr * yr - xi * yi, xr * yi + xi * yr)
+            };
+            let mut e = br.abs() as u64;
+            let (mut rr, mut ri) = (1.0_f64, 0.0_f64);
+            let (mut pr, mut pi) = (ar, ai);
+            while e > 0 {
+                if e & 1 == 1 {
+                    let (nr, ni) = cmul(rr, ri, pr, pi);
+                    rr = nr;
+                    ri = ni;
+                }
+                let (sr, si) = cmul(pr, pi, pr, pi);
+                pr = sr;
+                pi = si;
+                e >>= 1;
+            }
+            if br < 0.0 {
+                // Reciprocal: 1 / (rr + ri·i) = (rr - ri·i) / (rr² + ri²).
+                let denom = rr * rr + ri * ri;
+                return Value::Complex(rr / denom, -ri / denom);
+            }
+            return Value::Complex(rr, ri);
+        }
         let ln_r = (ar * ar + ai * ai).sqrt().ln();
         let ln_i = ai.atan2(ar);
         let wr = br * ln_r - bi * ln_i;

--- a/t/complex-integer-power.t
+++ b/t/complex-integer-power.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Complex exponentiation with an integer exponent must be computed by repeated
+# multiplication so the result stays exact, like raku. The polar `exp(b*ln a)`
+# form introduced floating-point noise: `(0+1i)**2` was
+# `-1+0.00000000000000012246467991473532i` instead of `-1+0i`.
+
+plan 12;
+
+is (0+1i) ** 2, -1+0i,  'i**2 == -1';
+# i**3 is -i; its gist keeps the signed-zero real part (`-0-1i`), which a
+# `-0-1i` literal would not round-trip, so compare the rendered gist.
+is ((0+1i) ** 3).gist, '-0-1i', 'i**3 == -i (exact, no float noise)';
+is (0+1i) ** 4,  1+0i,  'i**4 == 1';
+is (1+1i) ** 2,  0+2i,  '(1+i)**2 == 2i';
+is (2+3i) ** 2, -5+12i, '(2+3i)**2';
+is (1+2i) ** 3, -11-2i, '(1+2i)**3';
+is (3+0i) ** 2,  9+0i,  'real-valued complex squares exactly';
+is (1+1i) ** 10, 0+32i, '(1+i)**10';
+is (0+1i) ** 0,  1+0i,  'anything**0 == 1';
+
+# Negative integer exponent (reciprocal of the integer power).
+is (0+1i) ** -1, 0-1i,  'i**-1 == -i';
+is (1+1i) ** -2, 0-0.5i, '(1+i)**-2';
+
+# A non-integer exponent still uses the polar form (unchanged).
+is-approx ((2+3i) ** 0.5).abs, sqrt(sqrt(13)), 'fractional exponent via polar';


### PR DESCRIPTION
## Problem
```raku
say (0+1i) ** 2;   # raku: -1+0i — mutsu: -1+0.00000000000000012246467991473532i
say (1+1i) ** 2;   # raku: 0+2i  — mutsu: 0.00000000000000012246467991473532+2i
say (3+0i) ** 2;   # raku: 9+0i  — mutsu: 9.000000000000002+0i
```
Complex exponentiation always used the polar `exp(b·ln a)` form, which
introduces rounding error even for integer exponents.

## Fix
For a real integer exponent (imaginary part 0, whole, `|exp| <= 1024`),
compute the power by exponentiation-by-squaring over complex
multiplication, matching raku (which uses repeated multiplication). A
negative exponent takes the reciprocal of the positive power.
Non-integer / complex exponents keep the polar form unchanged, as does
real `**`.

## Test
`t/complex-integer-power.t` (12 assertions) — verified against `raku`.
Whitelisted roast `S32-num/{power,complex,complex-logarithms,exp}.t`
all pass.

Found via differential probing (raku vs mutsu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)