### PR TITLE
fix(oop): is-rw method returning @!attr[$i] / %!attr{$k} is assignable

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -629,6 +629,114 @@ impl Interpreter {
         }
     }
 
+    /// Detect an `is rw` method whose body returns an *indexed* attribute
+    /// element — `@!attr[$param]` or `%!attr{$param}` — where the index/key is
+    /// a single positional parameter. Returns `(attr_name, param_name,
+    /// is_positional)`. Such a method exposes the element as a writable lvalue,
+    /// so `$obj.at($i) = v` assigns into the attribute container's element.
+    /// (The simpler `{ $!attr }` form is handled by
+    /// `rw_method_attribute_target`.)
+    fn rw_method_indexed_attr_target(body: &[Stmt]) -> Option<(String, String, bool)> {
+        let first = body.iter().find(|s| !matches!(s, Stmt::SetLine(_)))?;
+        let expr = match first {
+            Stmt::Expr(e) | Stmt::Return(e) => e,
+            _ => return None,
+        };
+        // Unwrap `return-rw EXPR`.
+        let expr = match expr {
+            Expr::Call { name, args } if name == "return-rw" && args.len() == 1 => &args[0],
+            other => other,
+        };
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+        } = expr
+            && let Expr::Var(param) = index.as_ref()
+        {
+            // `@!attr[...]` parses as `ArrayVar("!attr")`, `%!attr{...}` as
+            // `HashVar("!attr")`.
+            let attr = match target.as_ref() {
+                Expr::ArrayVar(a) | Expr::HashVar(a) if a.starts_with('!') && a.len() > 1 => {
+                    &a[1..]
+                }
+                _ => return None,
+            };
+            return Some((attr.to_string(), param.clone(), *is_positional));
+        }
+        None
+    }
+
+    /// Assign `value` into element `index_value` of the array/hash attribute
+    /// `attr_name` on the instance, then write the updated instance back through
+    /// `target_var`. Backs `$obj.rw-method(idx) = value` where the method
+    /// returns `@!attr[idx]` / `%!attr{key}`.
+    #[allow(clippy::too_many_arguments)]
+    fn assign_rw_indexed_attr(
+        &mut self,
+        attributes: &std::sync::Arc<crate::value::InstanceAttrs>,
+        class_name: Symbol,
+        target_id: u64,
+        target_var: Option<&str>,
+        attr_name: &str,
+        index_value: Value,
+        is_positional: bool,
+        value: Value,
+    ) -> Result<Value, RuntimeError> {
+        let mut updated = attributes.to_map();
+        let container = updated.get(attr_name).cloned().unwrap_or(Value::Nil);
+        let new_container = if is_positional {
+            let idx = crate::runtime::utils::to_int(&index_value);
+            let (mut data, kind) = match container {
+                Value::Array(items, kind) => ((*items).clone(), kind),
+                Value::Nil => (
+                    crate::value::ArrayData::new(Vec::new()),
+                    crate::value::ArrayKind::Array,
+                ),
+                other => {
+                    return Err(RuntimeError::assignment_ro_typename(
+                        &crate::value::what_type_name(&other),
+                        &value.to_string_value(),
+                    ));
+                }
+            };
+            if idx < 0 {
+                return Err(RuntimeError::new(format!(
+                    "Index {} out of range for rw element assignment",
+                    idx
+                )));
+            }
+            let idx = idx as usize;
+            if idx >= data.items.len() {
+                data.items.resize(idx + 1, Value::Nil);
+            }
+            data.items[idx] = value.clone();
+            Value::Array(std::sync::Arc::new(data), kind)
+        } else {
+            let key = index_value.to_string_value();
+            let mut data = match container {
+                Value::Hash(items) => (*items).clone(),
+                Value::Nil => crate::value::HashData::new(std::collections::HashMap::new()),
+                other => {
+                    return Err(RuntimeError::assignment_ro_typename(
+                        &crate::value::what_type_name(&other),
+                        &value.to_string_value(),
+                    ));
+                }
+            };
+            data.map.insert(key, value.clone());
+            Value::Hash(std::sync::Arc::new(data))
+        };
+        updated.insert(attr_name.to_string(), new_container);
+        if let Some(var_name) = target_var {
+            self.env.insert(
+                var_name.to_string(),
+                Value::write_back_sharing(attributes, class_name, updated, target_id),
+            );
+        }
+        Ok(value)
+    }
+
     pub(crate) fn assign_method_lvalue_with_values(
         &mut self,
         target_var: Option<&str>,
@@ -1196,6 +1304,24 @@ impl Interpreter {
                     }
                     return Ok(assigned_value);
                 }
+                // `method at($i) is rw { @!d[$i] }` — assign into the indexed
+                // attribute element.
+                if let Some((attr, param, is_pos)) =
+                    Self::rw_method_indexed_attr_target(&method_def.body)
+                    && let Some(pos) = method_def.params.iter().position(|p| p == &param)
+                    && let Some(idx_val) = method_args.get(pos).cloned()
+                {
+                    return self.assign_rw_indexed_attr(
+                        attributes,
+                        *class_name,
+                        target_id,
+                        target_var,
+                        &attr,
+                        idx_val,
+                        is_pos,
+                        value,
+                    );
+                }
             } else {
                 // No explicit method found — try auto-accessor for public `is rw` attributes
                 let class_attrs = self.collect_class_attributes(qualifier);
@@ -1610,6 +1736,23 @@ impl Interpreter {
                 );
             }
             return Ok(assigned_value);
+        }
+        // `method at($i) is rw { @!d[$i] }` — assign into the indexed attribute
+        // element.
+        if let Some((attr, param, is_pos)) = Self::rw_method_indexed_attr_target(&method_def.body)
+            && let Some(pos) = method_def.params.iter().position(|p| p == &param)
+            && let Some(idx_val) = method_args.get(pos).cloned()
+        {
+            return self.assign_rw_indexed_attr(
+                &attributes,
+                class_name,
+                target_id,
+                target_var,
+                &attr,
+                idx_val,
+                is_pos,
+                value,
+            );
         }
 
         // Check if this is a delegation method — forward assignment to delegate

--- a/t/rw-method-indexed-element.t
+++ b/t/rw-method-indexed-element.t
@@ -1,0 +1,66 @@
+use Test;
+
+# An `is rw` method that returns an *indexed* attribute element —
+# `@!attr[$i]` or `%!attr{$k}` — exposes that element as a writable lvalue, so
+# `$obj.at($i) = v` assigns into the attribute container. Previously this threw
+# X::Assignment::RO ("rw method does not expose an assignable attribute");
+# only the bare-scalar-attribute form (`{ $!x }`) worked.
+
+plan 10;
+
+# --- positional element ---
+{
+    my class C { has @.d; method at($i) is rw { @!d[$i] } }
+    my $c = C.new(d => [1, 2, 3]);
+    $c.at(1) = 99;
+    is-deeply $c.d, [1, 99, 3], 'rw method @!d[$i] assigns into the element';
+
+    $c.at(0) = 10;
+    $c.at(2) = 30;
+    is-deeply $c.d, [10, 99, 30], 'multiple rw element assignments accumulate';
+
+    is $c.at(1), 99, 'reading the rw method still returns the element value';
+}
+
+# --- associative element ---
+{
+    my class H { has %.h; method at($k) is rw { %!h{$k} } }
+    my $h = H.new(h => { a => 1 });
+    $h.at('a') = 99;
+    is $h.h<a>, 99, 'rw method %!h{$k} assigns into the value';
+    $h.at('b') = 5;
+    is $h.h<b>, 5, 'rw method autovivifies a new key';
+}
+
+# --- return-rw form ---
+{
+    my class R { has @.d; method at($i) is rw { return-rw @!d[$i] } }
+    my $r = R.new(d => [1, 2, 3]);
+    $r.at(1) = 42;
+    is-deeply $r.d, [1, 42, 3], 'return-rw @!d[$i] assigns into the element';
+}
+
+# --- the bare-scalar-attribute rw method is unaffected ---
+{
+    my class S { has $.x; method getx is rw { $!x } }
+    my $s = S.new(x => 1);
+    $s.getx = 99;
+    is $s.x, 99, 'bare scalar-attribute rw method still works';
+}
+
+# --- the `is rw` attribute accessor is unaffected ---
+{
+    my class A { has $.x is rw; }
+    my $a = A.new(x => 1);
+    $a.x = 7;
+    is $a.x, 7, 'is rw attribute accessor still works';
+}
+
+# --- assigning past the end resizes the array ---
+{
+    my class G { has @.d; method at($i) is rw { @!d[$i] } }
+    my $g = G.new(d => [1, 2]);
+    $g.at(4) = 9;
+    is $g.d.elems, 5, 'rw element assignment past the end resizes';
+    is $g.d[4], 9, 'the new slot holds the assigned value';
+}


### PR DESCRIPTION
## Problem
```raku
class C { has @.d; method at($i) is rw { @!d[$i] } }
my $c = C.new(d => [1,2,3]);
$c.at(1) = 99;   # raku: $c.d is [1 99 3] — mutsu: X::Assignment::RO
```
An `is rw` method returning an indexed attribute element (`@!d[$i]` /
`%!h{$k}`) was not assignable. Only the bare-scalar form
(`method x is rw { $!x }`) and the `is rw` attribute accessor worked.

## Cause
The rw-method assignment path recognized only a body whose leading
expression is a bare attribute (`$!attr`). An indexed return fell through
to the run-method-and-check-for-Proxy fallback, which saw the element
*value* (not a writable lvalue) and raised `X::Assignment::RO`.

## Fix
Add `rw_method_indexed_attr_target` to detect `@!attr[$param]` /
`%!attr{$param}` (index/key is a single positional parameter), and
`assign_rw_indexed_attr` to assign `value` into that element of the
attribute container — resizing the array / autovivifying the key as
needed — then write the instance back. Wired into both the qualified and
unqualified rw-method assignment paths. The bare-scalar form and the
`is rw` accessor are unchanged.

## Test
`t/rw-method-indexed-element.t` (10 assertions) — verified against
`raku`. Covers positional/associative elements, `return-rw`, multiple
assignments, read-through, autoviv/resize, and the unchanged scalar
forms. Whitelisted roast `S12-*` (incl. `mutators.t`) pass.

Found via differential probing (raku vs mutsu); a first-class containers
(Track B) follow-up — a long-deferred lvalue-return gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)