### PR TITLE
fix(bind): standalone `$x := @a[i]` shares a cell with the element

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1114,6 +1114,7 @@ impl Compiler {
                     self.code.emit(OpCode::CheckReadOnly(name_idx));
                 }
                 if matches!(op, AssignOp::Bind) {
+                    let mut scalar_elem_bind = false;
                     if effective_name.starts_with('@') {
                         self.code.emit(OpCode::MarkBindContext);
                     } else if !effective_name.starts_with('%') && !effective_name.starts_with('&') {
@@ -1124,10 +1125,24 @@ impl Compiler {
                         // assignment and clears the marker, so `$r.VAR.^name`
                         // would wrongly report Scalar and `@a = $r` would itemize.
                         self.code.emit(OpCode::MarkScalarBindContext);
+                        // A bound array/hash element (`$x := @a[1]`) must share a
+                        // cell with the source slot so a later `$x = v` writes
+                        // through to `@a[1]`, exactly like the `my $x := @a[1]`
+                        // VarDecl path. Without cell promotion the rebind just
+                        // snapshots the element value.
+                        scalar_elem_bind = matches!(expr, Expr::Index { .. });
                     }
                     // Signal rebind context for cleanup of old bind pairs.
                     self.code.emit(OpCode::MarkRebindContext);
-                    self.compile_call_arg(expr);
+                    if scalar_elem_bind {
+                        self.scalar_bind_autovivify = true;
+                        self.bind_terminal = true;
+                        self.compile_call_arg(expr);
+                        self.scalar_bind_autovivify = false;
+                        self.bind_terminal = false;
+                    } else {
+                        self.compile_call_arg(expr);
+                    }
                 } else {
                     // Fuse `$x OP= rhs` (parsed as `$x = $x OP rhs`) into an
                     // atomic RMW for plain env-named scalars (Track C). The fused

--- a/t/scalar-rebind-element-cell.t
+++ b/t/scalar-rebind-element-cell.t
@@ -1,0 +1,71 @@
+use Test;
+
+# Binding an already-declared scalar to an array/hash element in a *separate*
+# statement (`my $x; $x := @a[1]`) must share a cell with the element, so a
+# later `$x = v` writes through to `@a[1]` — exactly like the single-statement
+# `my $x := @a[1]` form. Previously the standalone rebind only snapshotted the
+# element value, so the write never reached the container.
+
+plan 9;
+
+{
+    my @a = 1, 2, 3;
+    my $x;
+    $x := @a[1];
+    $x = 5;
+    is-deeply @a, [1, 5, 3], 'rebind $x := @a[1] writes through to the array';
+    is $x, 5, 'and $x reads the shared value';
+}
+
+{
+    my %h = a => 1, b => 2;
+    my $x;
+    $x := %h<a>;
+    $x = 9;
+    is %h<a>, 9, 'rebind $x := %h<a> writes through to the hash';
+}
+
+{
+    my @a = [1, 2], [3, 4];
+    my $x;
+    $x := @a[0][1];
+    $x = 99;
+    is-deeply @a, [[1, 99], [3, 4]], 'rebind to a nested element writes through';
+}
+
+# Single-statement form is unchanged.
+{
+    my @a = 1, 2, 3;
+    my $r := @a[1];
+    $r = 99;
+    is-deeply @a, [1, 99, 3], 'my $r := @a[1] still works';
+}
+
+# Re-rebinding to a different element follows the new target.
+{
+    my @a = 1, 2, 3;
+    my $x := @a[0];
+    $x := @a[2];
+    $x = 99;
+    is-deeply @a, [1, 2, 99], 're-rebind retargets the cell';
+}
+
+# Var-to-var rebind is unaffected (no element/cell promotion needed, but must
+# still alias).
+{
+    my $y = 10;
+    my $x;
+    $x := $y;
+    $x = 5;
+    is $y, 5, 'scalar-to-scalar rebind still aliases';
+}
+
+# Element bound through a rebind reads the current element value.
+{
+    my @a = 7, 8, 9;
+    my $x;
+    $x := @a[2];
+    is $x, 9, 'rebound element reads its current value';
+    @a[2] = 100;
+    is $x, 100, 'and reflects a later write to the element';
+}


### PR DESCRIPTION
## Problem
```raku
my @a = 1, 2, 3;
my $x;
$x := @a[1];
$x = 5;
say @a;        # raku: [1 5 3] — mutsu: [1 2 3]
```
Binding a scalar to an array/hash element in a *separate* statement only
snapshotted the element value; a later write to the scalar never reached
the container. The single-statement `my $x := @a[1]` form already worked.

## Cause
The VarDecl bind path (`my $x := @a[1]`) sets `scalar_bind_autovivify` +
`bind_terminal`, which promotes the indexed element to a shared
`ContainerRef` cell so the binding aliases it. The standalone
`Stmt::Assign { op: Bind }` path (`$x := @a[1]`) compiled the RHS as a
plain value read, so no cell was shared.

## Fix
Set the same flags for a standalone scalar rebind whose RHS is an
`Expr::Index`, promoting the element to a cell. Non-element scalar
rebinds (`$x := $y`) and `@`/`%` rebinds are unchanged.

## Test
`t/scalar-rebind-element-cell.t` (9 assertions) — verified against
`raku`. Covers array/hash/nested elements, single-statement form,
re-rebind, scalar-to-scalar rebind, and later element writes reflecting
through. All whitelisted `S03-binding` roast pass.

Found via differential probing (raku vs mutsu); first-class containers
(Track B) follow-up.

### Out of scope (separate, narrower path)
`@a[1] := my $x` (element as bind *target* with an inline `my` source)
still snapshots — a different element-as-target code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)