### PR TITLE
fix(regex): quantified built-in named char-class subrule yields capture list

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -4574,23 +4574,29 @@ impl Interpreter {
                 };
             // When both a user alias ($<name>=) and a builtin class name are pending,
             // the alias becomes the primary capture and the builtin name becomes secondary.
-            let primary_named = pending_named_capture.take();
-            let secondary_named = if primary_named.is_some() {
+            let user_alias = pending_named_capture.take();
+            let primary_is_user_alias = user_alias.is_some();
+            let secondary_named = if primary_is_user_alias {
                 // Alias takes precedence; builtin name (if any) becomes secondary capture.
                 pending_builtin_named_capture.take()
             } else {
                 None
             };
-            let primary_named = primary_named.or_else(|| pending_builtin_named_capture.take());
+            let primary_named = user_alias.or_else(|| pending_builtin_named_capture.take());
             let hash_capture = pending_hash_capture.take();
-            // A named capture on a *quantified* atom (`$<x>=<[a..z]>*`, `$<x>=\w+`)
+            // A USER alias on a *quantified* atom (`$<x>=<[a..z]>*`, `$<x>=\w+`)
             // captures the WHOLE quantified span as a single Match (e.g. "abc"),
             // and a zero-width match still produces an (empty) capture — matching
             // Raku. mutsu's quantifier loop otherwise applies the named capture
             // per-iteration (yielding `[a, b, c]`) and drops the zero-match case.
             // Wrap the quantified atom in a non-capturing group so the named
             // capture sits on a `quant: One` token spanning the entire run.
-            let wrap_named_quant = primary_named.is_some()
+            //
+            // A *builtin subrule* (`<alpha>+`, `<digit>**3`) is the opposite: Raku
+            // quantifies the subrule itself, producing a LIST with one Match per
+            // repetition. So only wrap when the primary name is a user alias; a
+            // bare builtin keeps its per-iteration captures via the quantifier loop.
+            let wrap_named_quant = primary_is_user_alias
                 && hash_capture.is_none()
                 && token_separator.is_none()
                 && matches!(

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -659,7 +659,7 @@ impl Interpreter {
                             named_with_hash.insert(hash_name.clone(), Vec::new());
                         }
                     }
-                    let mut match_obj = Value::make_match_object_full(
+                    let mut match_obj = Value::make_match_object_full_q(
                         captures.matched.clone(),
                         captures.from as i64,
                         captures.to as i64,
@@ -669,6 +669,7 @@ impl Interpreter {
                         &captures.positional_subcaps,
                         &captures.positional_quantified,
                         Some(&text),
+                        &captures.named_quantified,
                     );
                     // Apply hash captures: set named entries to Hash values
                     if !captures.hash_captures.is_empty()

--- a/t/regex-quantified-named-subrule.t
+++ b/t/regex-quantified-named-subrule.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A quantified built-in named char-class subrule (`<alpha>+`, `<digit>**N`)
+# produces a LIST of Match objects -- one per repetition -- accessible via the
+# named capture, matching Rakudo. (A user alias `$<x>=\w+` still captures the
+# whole span as a single Match; that is exercised elsewhere.)
+
+plan 18;
+
+# <alpha>+ : one Match per matched char
+ok "abc" ~~ /<alpha>+/, 'matched <alpha>+';
+is $/.Str, 'abc', 'whole match spans the run';
+isa-ok $<alpha>, Array, '$<alpha> is an Array for <alpha>+';
+is $<alpha>.elems, 3, '<alpha>+ captured 3 entries';
+is $<alpha>[0].Str, 'a', 'entry 0';
+is $<alpha>[1].Str, 'b', 'entry 1';
+is $<alpha>[2].Str, 'c', 'entry 2';
+
+# <digit>+
+ok "123" ~~ /<digit>+/, 'matched <digit>+';
+is $<digit>.elems, 3, '<digit>+ captured 3 entries';
+is $<digit>.map(*.Str).join('|'), '1|2|3', '<digit>+ entries in order';
+
+# <alpha> ** 2 : counted quantifier also lists
+ok "abcd" ~~ /<alpha> ** 2/, 'matched <alpha> ** 2';
+is $<alpha>.elems, 2, '<alpha> ** 2 captured 2 entries';
+
+# <alpha>* matching zero times -> empty Array, not Nil/Any
+ok "" ~~ /<alpha>*/, '<alpha>* matches empty string';
+isa-ok $<alpha>, Array, 'zero-match <alpha>* still yields an Array';
+is $<alpha>.elems, 0, 'zero-match <alpha>* is an empty list';
+
+# A single (unquantified) <alpha> remains a plain Match
+ok "a" ~~ /<alpha>/, 'matched single <alpha>';
+isa-ok $<alpha>, Match, 'single <alpha> is a Match';
+is $<alpha>.Str, 'a', 'single <alpha> value';


### PR DESCRIPTION
## Problem

A quantified built-in named char-class subrule must produce a **list** of `Match` objects (one per repetition) under the named capture, matching Rakudo:

```raku
"abc" ~~ /<alpha>+/;
say $<alpha>.^name;   # raku: Array     mutsu (before): Match
say $<alpha>.elems;   # raku: 3         mutsu (before): 0
```

mutsu instead captured the whole quantified span as a single `Match` (`"abc"`).

## Root cause

The `wrap_named_quant` parser path wrapped *every* named capture on a quantified atom into a non-capturing `quant: One` group spanning the whole run. That is correct for a **user alias** (`$<x>=\w+` → single `Match "abc"`), but wrong for a **built-in subrule**, where Raku quantifies the subrule itself and yields a per-repetition list.

Fix: restrict the wrap to user aliases (`pending_named_capture`). A bare built-in name (`pending_builtin_named_capture`) keeps its per-iteration captures via the quantifier matching loop, which already records each repetition and marks the name in `named_quantified`.

## Zero-match fix

`<alpha>*` over `""` should yield an **empty Array** for `$<alpha>`. The `~~` smart-match path built the `Match` via `make_match_object_full` (which drops `named_quantified`), so a quantified named capture that matched zero times produced `Any`. Switched it to `make_match_object_full_q` passing `captures.named_quantified`, aligning the `~~` path with the grammar parse path.

## Verification

- New `t/regex-quantified-named-subrule.t` (18 subtests) passes on both `raku` and `mutsu`.
- User-alias semantics preserved (`$<x>=\w+` → single `Match`).
- All local `t/regex*.t`, `t/grammar*.t`, `t/match*.t`, `t/subst*.t` pass.
- All whitelisted `S05-*` roast tests pass.
- `make test`: Result PASS (Files=835, Tests=7847, Failed: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)