### PR TITLE
fix(bind): element-as-target bind to an inline `my` shares a cell

### DIFF
--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -307,6 +307,17 @@ fn bind_source_name(expr: &Expr) -> Option<String> {
             };
             Some(format!("{}\x00idx\x00{}", target_name, idx_str))
         }
+        // Inline declaration on the RHS of a bind, e.g. `@a[1] := my $x` or
+        // `$y := my $x`. The `my $x` parses to a `DoStmt(VarDecl { .. })` whose
+        // `name` already carries the sigil convention used by bind metadata
+        // ("x" for `$x`, "@x" for `@x`, "%y" for `%y`). The declaration itself
+        // runs in the enclosing scope when the bind value is evaluated; here we
+        // only need to surface the declared variable's name so the bind sets up
+        // cell sharing between the target and the freshly-declared variable.
+        Expr::DoStmt(stmt) => match stmt.as_ref() {
+            Stmt::VarDecl { name, .. } => Some(name.clone()),
+            _ => None,
+        },
         _ => None,
     }
 }

--- a/t/element-bind-inline-my.t
+++ b/t/element-bind-inline-my.t
@@ -1,0 +1,73 @@
+use Test;
+
+# Binding an array/hash element to an inline-declared scalar
+# (`@a[1] := my $x`) must share a container cell between the element and the
+# freshly-declared variable, so writes through either side are visible on the
+# other -- matching Rakudo. Previously the inline `my` declaration's name was
+# lost, so the element snapshotted Nil and never shared a cell.
+
+plan 11;
+
+# Array element <- inline my, write through the variable
+{
+    my @a = 1, 2, 3;
+    @a[1] := my $x;
+    $x = 99;
+    is @a[1], 99, 'write through $x reaches @a[1]';
+    is @a.join(','), '1,99,3', 'array reflects the bound write';
+}
+
+# Array element <- inline my, write through the element (bidirectional)
+{
+    my @a = 1, 2, 3;
+    @a[1] := my $x;
+    @a[1] = 5;
+    is $x, 5, 'write through @a[1] reaches $x';
+}
+
+# Hash element <- inline my
+{
+    my %h;
+    %h<k> := my $v;
+    $v = 42;
+    is %h<k>, 42, 'write through $v reaches %h<k>';
+    %h<k> = 7;
+    is $v, 7, 'write through %h<k> reaches $v';
+}
+
+# The inline-declared variable is visible in the enclosing scope
+{
+    my @a = 1, 2, 3;
+    @a[1] := my $x;
+    ok $x.defined.not, 'inline $x starts undefined (bound to a fresh cell)';
+    $x = 11;
+    is $x, 11, '$x is a normal lexical after the bind';
+}
+
+# Pre-declared element bind still works (regression guard)
+{
+    my @a = 1, 2, 3;
+    my $x;
+    @a[1] := $x;
+    $x = 99;
+    is @a[1], 99, 'pre-declared element bind still shares a cell';
+}
+
+# Autovivified array element via inline my
+{
+    my @a;
+    @a[2] := my $y;
+    $y = 'z';
+    is @a[2], 'z', 'autovivified element binds to inline my';
+    is @a.elems, 3, 'array grew to hold the bound element';
+}
+
+# Multi-element independent binds
+{
+    my @a = 0, 0, 0;
+    @a[0] := my $p;
+    @a[2] := my $q;
+    $p = 'a';
+    $q = 'c';
+    is @a.join(','), 'a,0,c', 'independent element binds do not interfere';
+}


### PR DESCRIPTION
## Problem

Binding an array/hash element to an inline-declared scalar must share a container cell, so writes through either side are visible on the other (Rakudo):

```raku
my @a = 1, 2, 3;
@a[1] := my $x;
$x = 99;
say @a;        # raku: [1 99 3]   mutsu (before): [1 Nil 3]
```

mutsu left the element holding `Nil` — the inline `my $x` declared a variable, but no cell sharing was established.

## Root cause

An inline `my $x` on the RHS of an element bind parses to `DoStmt(VarDecl { name: "x", .. })`. `bind_source_name` — which produces the source metadata that the `__mutsu_bind_index_value` desugar uses to set up cell sharing — did not recognize that form and returned `None`, so the metadata was `Nil` and no sharing happened.

The `VarDecl`'s `name` already follows the bind-metadata sigil convention (`"x"` / `"@x"` / `"%y"`), and the declaration itself already runs in the enclosing scope when the bind value is evaluated (a later `$x = …` in the same scope already saw it). So surfacing that name is all that's needed: the existing pre-declared bind path (`@a[1] := $x`) then establishes the shared cell **bidirectionally**.

## Fix

Extend `bind_source_name` to unwrap `Expr::DoStmt(Stmt::VarDecl { name, .. })` and return the declared name.

## Verification

- New `t/element-bind-inline-my.t` (11 subtests) passes on both `raku` and `mutsu`, covering array/hash element binds, bidirectional write-through, autovivification, multi-element independence, and a pre-declared regression guard.
- All existing `t/*bind*`, `t/*rebind*`, `t/*element*`, `t/*cell*` tests pass.
- `make test`: Result PASS (Files=837, Tests=7861, Failed: 0).

## Follow-up (out of scope)

Scalar-to-scalar inline-my bind (`$y := my $x`) is a separate desugar (scalar `Bind` op, not `__mutsu_bind_index_value`) and is still broken; left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)