### PR TITLE
fix(hash): flatten bare %h in list/hash context; keep $-sourced hashes itemized

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -654,6 +654,21 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
             Value::Pair(key, boxed_val) => {
                 map.insert(key, *boxed_val);
             }
+            // A bare hash in list context flattens into its key=>value pairs
+            // (`%m = (%h,)` / `%(%h,)`). A hash sourced from a `$` scalar is
+            // itemized as `Value::Scalar(Hash)` (see `Interpreter::itemize_value`)
+            // and does NOT match here, so it stays an opaque single element —
+            // matching Raku, where `%m = ($hashitem,)` dies "Odd number".
+            // Object-hash keys are preserved via `typed_key`.
+            Value::Hash(h) => {
+                for (k, v) in h.iter() {
+                    let key_obj = h.typed_key(k);
+                    if !matches!(&key_obj, Value::Str(_)) {
+                        original_keys.insert(k.clone(), key_obj);
+                    }
+                    map.insert(k.clone(), v.clone());
+                }
+            }
             Value::ValuePair(key, boxed_val) => {
                 let str_key = Value::hash_key_encode(&key);
                 if !matches!(key.as_ref(), Value::Str(_)) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1036,6 +1036,21 @@ impl Interpreter {
     }
 
     /// Execute one opcode at *ip, advancing ip for the next instruction.
+    /// Itemize a value read from a `$` scalar container so it behaves as a
+    /// single element in list context. Arrays/Lists flip to their itemized
+    /// `ArrayKind`; Seq and Hash are wrapped in a `Value::Scalar` container so a
+    /// `$`-sourced hash stays opaque (it must not flatten into pairs on
+    /// hash-assignment the way a bare `%h` does). Already-itemized values and
+    /// non-container scalars pass through unchanged.
+    fn itemize_value(val: Value) -> Value {
+        match val {
+            Value::Array(items, kind) if !kind.is_itemized() => Value::Array(items, kind.itemize()),
+            Value::Seq(items) => Value::Scalar(Box::new(Value::Seq(items))),
+            Value::Hash(_) => Value::Scalar(Box::new(val)),
+            other => other,
+        }
+    }
+
     fn exec_one(
         &mut self,
         code: &CompiledCode,
@@ -2083,18 +2098,11 @@ impl Interpreter {
             OpCode::Itemize => {
                 // Wrap Array/List values in their itemized (Scalar-container)
                 // variant so they are treated as single items in list context.
-                // Hash is already an item (not flattened in list context), so
-                // it is left unchanged.
+                // A Hash from a `$` scalar container is itemized by wrapping it in
+                // a Scalar so it stays opaque in list context (`%m = ($h,)` must
+                // NOT flatten it into pairs, unlike a bare `%h` which does).
                 let val = self.stack.pop().unwrap_or(Value::Nil);
-                let itemized = match val {
-                    Value::Array(items, kind) if !kind.is_itemized() => {
-                        Value::Array(items, kind.itemize())
-                    }
-                    // Itemize a Seq by wrapping it in a scalar container
-                    Value::Seq(items) => Value::Scalar(Box::new(Value::Seq(items))),
-                    other => other,
-                };
-                self.stack.push(itemized);
+                self.stack.push(Self::itemize_value(val));
                 *ip += 1;
             }
             OpCode::ItemizeVar(name_idx) => {
@@ -2115,13 +2123,7 @@ impl Interpreter {
                 let result = if is_bound_decont {
                     val
                 } else {
-                    match val {
-                        Value::Array(items, kind) if !kind.is_itemized() => {
-                            Value::Array(items, kind.itemize())
-                        }
-                        Value::Seq(items) => Value::Scalar(Box::new(Value::Seq(items))),
-                        other => other,
-                    }
+                    Self::itemize_value(val)
                 };
                 self.stack.push(result);
                 *ip += 1;

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -137,6 +137,11 @@ impl Interpreter {
     }
 
     fn set_contains(&mut self, container: &Value, needle: &Value) -> bool {
+        // A `$`-scalar holding a hash/array is itemized as `Value::Scalar`
+        // (see `Interpreter::itemize_value`); the container is transparent to
+        // membership, so decontainerize before matching on the inner type.
+        let container = container.descalarize();
+        let needle = needle.descalarize();
         let key = needle.to_string_value();
         match container {
             Value::Set(s, _) => s.contains(&key),

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -630,30 +630,12 @@ impl Interpreter {
         // scalar containers (`$h`) are NOT pre-flattened, so they appear as
         // opaque items (triggering the odd-number check when expected).
         let hash_val = match value {
-            Value::Array(ref items, kind) => {
-                // When a hash variable (%h) appears in a list being assigned to
-                // another hash (%m = %h, a => 42), the hash should be flattened
-                // into its pairs. However, a hash in a scalar ($hashitem) should
-                // stay opaque. We can distinguish: if the array has >1 element
-                // and contains Hash values alongside Pair values, flatten them.
-                let needs_flatten = !kind.is_itemized()
-                    && items.len() > 1
-                    && items.iter().any(|v| matches!(v, Value::Hash(_)));
-                if needs_flatten {
-                    let mut flattened = Vec::new();
-                    for item in items.iter() {
-                        if let Value::Hash(h) = item {
-                            for (k, v) in h.as_ref().iter() {
-                                flattened.push(Value::Pair(k.clone(), Box::new(v.clone())));
-                            }
-                        } else {
-                            flattened.push(item.clone());
-                        }
-                    }
-                    runtime::utils::build_hash_from_items(flattened)?
-                } else {
-                    runtime::utils::build_hash_from_items(items.iter().cloned().collect())?
-                }
+            Value::Array(ref items, _) => {
+                // `build_hash_from_items` flattens a bare `%h` element into its
+                // pairs while leaving an itemized `Value::Scalar(Hash)` (from a
+                // `$` scalar) opaque, so `%m = (%h,)` flattens and `%m =
+                // ($hashitem,)` raises "Odd number" — matching Raku.
+                runtime::utils::build_hash_from_items(items.iter().cloned().collect())?
             }
             Value::Seq(ref items) | Value::Slip(ref items) => {
                 runtime::utils::build_hash_from_items(items.iter().cloned().collect())?

--- a/t/hash-from-list-itemization.t
+++ b/t/hash-from-list-itemization.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 14;
+
+# A bare `%h` in a list flattens into its pairs on hash-assignment / hash-context,
+# but a hash sourced from a `$` scalar container is itemized and stays opaque.
+# (Container itemization: distinguishes `(%h,)` from `($hashitem,)`.)
+
+my %h = a => 1, b => 2;
+
+# Single-element list with a bare hash -> flattens.
+{
+    my %c = (%h,);
+    is %c.elems, 2, '(%h,) flattens into pairs (elems)';
+    is %c<a>, 1, '(%h,) flatten keeps value a';
+    is %c<b>, 2, '(%h,) flatten keeps value b';
+}
+
+# Hash-context coercion `%(...)` of a bare hash -> flattens.
+{
+    my $r = %(%h,);
+    is $r<a>, 1, '%(%h,) flattens (a)';
+    is $r<b>, 2, '%(%h,) flattens (b)';
+}
+
+# Multi-element list with a bare hash -> flattens alongside other pairs.
+{
+    my %m = %h, c => 3;
+    is %m.elems, 3, '%h, c => 3 flattens %h and adds c';
+    is %m<c>, 3, 'extra pair present';
+    is %m<a>, 1, 'flattened pair present';
+}
+
+# A `$`-sourced (itemized) hash in a single-element list must NOT flatten:
+# Raku raises X::Hash::Store::OddNumber.
+{
+    my $hi = %h;
+    dies-ok { my %c = ($hi,) }, '($hashitem,) does not flatten (odd number)';
+}
+
+# Array assignment keeps a hash as a single element either way.
+{
+    my $hi = %h;
+    is (my @a = (%h,)).elems, 1, '@a = (%h,) is one element';
+    is (my @b = ($hi,)).elems, 1, '@a = ($hi,) is one element';
+    is @b[0]<a>, 1, 'itemized hash element is intact';
+}
+
+# Explicit itemization `$(...)` also stays opaque.
+{
+    my $hi = %h;
+    is $hi.VAR.^name, 'Scalar', '$-sourced hash reflects as Scalar container';
+    is %h.VAR.^name, 'Hash', '%-sourced hash reflects as Hash';
+}


### PR DESCRIPTION
## Summary

`my %c = (%h,)` and `%(%h,)` raised *"Odd number of elements found where hash
initializer expected"* and **aborted**, because mutsu couldn't distinguish a bare
`%h` (which flattens into pairs in hash context) from a `$`-sourced itemized hash
`$hashitem` (which stays opaque — Raku raises `X::Hash::Store::OddNumber`).

Both decontainerized to a bare `Value::Hash`, so the old heuristic — flatten only
when the list had **>1 element** — was wrong in *both* directions: it missed
`(%h,)` and wrongly flattened `($hashitem, :c(42))`.

## Fix (container itemization)

- `Interpreter::itemize_value` (the `Itemize`/`ItemizeVar` opcodes) now wraps a
  `$`-sourced Hash in `Value::Scalar`, mirroring `Seq`, making an itemized hash
  representationally distinct from a bare `%h`.
- `build_hash_from_items` — the single chokepoint for `%m = (...)` **and** `.hash`
  / `%(...)` — flattens a bare `Value::Hash` element into its pairs (preserving
  object-hash keys via `typed_key`), while leaving `Value::Scalar(Hash)` opaque.
- Dropped the redundant element-count heuristic in the hash-assignment path.

This is the itemization discriminator the previous attempt (#2958, reverted)
lacked — that PR added an unconditional flatten arm and regressed
`assigning-refs.t`. With producer-side itemization, the flatten is now correctly
gated.

## Impact

Unblocks `S09-hashes/objecthash.t` — was aborting at test 37 (ran 36/62), now
runs the full plan with only object-hash *type-enforcement* subtests remaining
(follow-up PRs). Resolves the long-standing `list-to-hash-flatten-itemization`
blocker.

## Tests
- New `t/hash-from-list-itemization.t` (14).
- `assigning-refs.t` / `hash.t` / `S09-typed-arrays/hashes.t` green; full `t/`
  suite 7850 pass; `cargo test` 462 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)