### PR TITLE
fix(bind): scalar bind to an inline `my` shares a cell

### DIFF
--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -194,6 +194,18 @@ impl Compiler {
             // Anonymous scalar assignment (`$ = value`) produces a writable
             // container, so wrap it with VarRef so `is rw` dispatch can match.
             Expr::AssignExpr { name, .. } => Some(name.clone()),
+            // An inline declaration used as an argument (`$y := my $x`,
+            // `f(my $z)`) parses to `DoStmt(VarDecl { .. })`. Compiling it
+            // declares the variable in the enclosing scope and leaves its value
+            // on the stack; wrap that with a VarRef to the freshly-declared
+            // variable so a `:=` bind (or an `is rw` parameter) can alias the
+            // new container rather than snapshotting its value. The `VarDecl`
+            // `name` already carries the sigil convention WrapVarRef expects
+            // ("x" for `$x`, "@x" for `@x`, "%y" for `%y`).
+            Expr::DoStmt(stmt) => match stmt.as_ref() {
+                Stmt::VarDecl { name, .. } => Some(name.clone()),
+                _ => None,
+            },
             _ => None,
         };
         // For Index expressions, create temp variables for `is rw` writeback

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -761,16 +761,22 @@ impl Compiler {
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
                     self.bind_terminal = false;
-                } else if scalar_bind_decont && matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
+                } else if scalar_bind_decont
+                    && (matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
+                        || matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. })))
                 {
                     // A scalar `:=` bind to a *whole* container variable
                     // (`my $ref := @a` / `my $ref := %h`) must alias the same
                     // container, not snapshot it (so `$ref.push` mutates `@a`).
+                    // Likewise a bind to an inline declaration (`my $a := my $b`,
+                    // which the parser leaves as a bare `VarDecl` with the
+                    // `__scalar_bind` trait rather than wrapping it in the
+                    // MarkBind SyntheticBlock that `my $a := $b` gets) must alias
+                    // the freshly-declared variable's container.
                     // Route through compile_call_arg so WrapVarRef is emitted and
-                    // SetLocal's whole-container bind path shares one cell, just
-                    // like `my @b := @a`. (Scalar binds normally take the
-                    // assignment path below, which only Arc-shares — a COW push
-                    // would then detach the alias.)
+                    // SetLocal's bind path shares one cell. (Scalar binds normally
+                    // take the assignment path below, which only Arc-shares — a
+                    // COW push would then detach the alias.)
                     self.scalar_bind_autovivify = true;
                     self.bind_terminal = true;
                     self.compile_call_arg(expr);

--- a/t/scalar-bind-inline-my.t
+++ b/t/scalar-bind-inline-my.t
@@ -1,0 +1,63 @@
+use Test;
+
+# Binding a scalar to an inline-declared scalar (`$y := my $x`,
+# `my $a := my $b`) must alias the same container, so writes through either
+# name are visible on the other -- matching Rakudo. Previously the inline `my`
+# declaration's name was lost, so the bind snapshotted Nil and shared no cell.
+
+plan 11;
+
+# Rebind an existing scalar to an inline my
+{
+    my $y = 5;
+    $y := my $x;
+    $x = 9;
+    is $y, 9, 'write through $x reaches $y';
+    $y = 7;
+    is $x, 7, 'write through $y reaches $x (bidirectional)';
+}
+
+# The inline-declared variable starts undefined and is a normal lexical
+{
+    my $y = 5;
+    $y := my $x;
+    ok $x.defined.not, 'inline $x starts undefined';
+    ok $y.defined.not, 'rebound $y is also undefined';
+}
+
+# Declaration-and-bind to an inline my (`my $a := my $b`)
+{
+    my $a := my $b;
+    $b = 5;
+    is $a, 5, 'write through $b reaches $a';
+    $a = 9;
+    is $b, 9, 'write through $a reaches $b';
+}
+
+# Independent decl+inline binds do not interfere
+{
+    my $a := my $b;
+    my $c := my $d;
+    $b = 1;
+    $d = 2;
+    is $a, 1, 'first pair independent';
+    is $c, 2, 'second pair independent';
+}
+
+# Three-way aliasing chain
+{
+    my $y;
+    $y := my $x;
+    my $z := $x;
+    $x = 5;
+    is $y, 5, 'chain reaches $y';
+    is $z, 5, 'chain reaches $z';
+}
+
+# Regression: pre-declared scalar bind still aliases
+{
+    my $b;
+    my $a := $b;
+    $b = 1;
+    is $a, 1, 'pre-declared scalar bind still shares a cell';
+}


### PR DESCRIPTION
## Problem

`$y := my $x` (scalar rebind) and `my $a := my $b` (declaration-and-bind) must alias the same container (Rakudo):

```raku
my $y = 5;
$y := my $x;
$x = 9;
say $y;        # raku: 9   mutsu (before): Nil
```

mutsu snapshotted `Nil` — the inline `my $x` declared a variable but no cell sharing was established.

## Root cause

The pre-declared forms (`$y := $x`, `my $a := $b`) already work because the compiler routes the RHS through `compile_call_arg`, which emits `WrapVarRef` so the bind aliases the source variable's container. An inline `my $x` on the RHS parses to `DoStmt(VarDecl { name, .. })`, which `compile_call_arg`'s `source_name` match did not recognize — so no `WrapVarRef`, and the bind only snapshotted the value.

## Fix

- `compile_call_arg` now maps `DoStmt(VarDecl { name })` to that name. The declaration runs in the enclosing scope and leaves its value on the stack; the `VarRef` then aliases the freshly-declared container. This covers the scalar rebind path (`$y := my $x`) and also makes `is rw` parameters bind through an inline-`my` argument, matching Raku.
- The VarDecl-bind path (`my $a := my $b`) does not get the `MarkBind` SyntheticBlock wrapper that `my $a := $b` gets, so it took the plain-assignment branch. Extend the scalar `__scalar_bind` branch to also route a `DoStmt(VarDecl)` RHS through `compile_call_arg`.

Completes the inline-`my` bind family started in #3146 (`@a[1] := my $x`).

## Verification

- New `t/scalar-bind-inline-my.t` (11 subtests) passes on both `raku` and `mutsu` — rebind, decl+bind, bidirectional write-through, independence, aliasing chains, and a pre-declared regression guard.
- All existing `t/*bind*` / `t/*rebind*` tests pass.
- `is rw` through an inline-`my` arg, whole-container `$r := @x`, and pre-declared binds verified unchanged.
- `make test`: Result PASS (Files=839, Tests=7890, Failed: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)