### PR TITLE
fix(list): Set/Bag/Mix flatten to pairs on @-assignment; itemize when scalar-held

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -807,6 +807,43 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
                 .collect();
             Value::real_array(pairs)
         }
+        // A scalar holding a Hash/Set/Bag/Mix (itemized by `ItemizeVar` as
+        // `Scalar(container)`) stays a single element, but unwrap the Scalar so
+        // `@a[0]` is the bare container (preserving its `.gist`/`.raku`/type),
+        // rather than an opaque `$(...)`-wrapped value.
+        Value::Scalar(inner)
+            if matches!(
+                inner.as_ref(),
+                Value::Hash(_) | Value::Set(..) | Value::Bag(..) | Value::Mix(..)
+            ) =>
+        {
+            Value::real_array(vec![*inner])
+        }
+        // Set/Bag/Mix assigned to an @-var flatten into their `key => weight`
+        // pairs in list context, exactly like a Hash (Raku: `my @a = set(1,2,3)`
+        // yields three `* => True` pairs, so `@a.elems == 3`). This mirrors
+        // `value_to_list`. (Note: an array *literal* `[set(...)]` does NOT
+        // flatten — that path is handled separately in `exec_make_array_op`.)
+        Value::Set(ref items, _) => Value::real_array(
+            items
+                .iter()
+                .map(|s| Value::Pair(s.clone(), Box::new(Value::Bool(true))))
+                .collect(),
+        ),
+        Value::Bag(ref items, _) => Value::real_array(
+            items
+                .iter()
+                .map(|(k, v)| Value::Pair(k.clone(), Box::new(Value::from_bigint(v.clone()))))
+                .collect(),
+        ),
+        Value::Mix(ref items, _) => Value::real_array(
+            items
+                .iter()
+                .map(|(k, v)| {
+                    Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v)))
+                })
+                .collect(),
+        ),
         other => Value::real_array(vec![other]),
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2120,6 +2120,18 @@ impl Interpreter {
                             Value::Array(items, kind.itemize())
                         }
                         Value::Seq(items) => Value::Scalar(Box::new(Value::Seq(items))),
+                        // A scalar holding a Hash/Set/Bag/Mix assigned to an `@`
+                        // variable stays a single item (Raku: `my $h = %(...);
+                        // my @a = $h` -> `@a.elems == 1`). These types have no
+                        // "itemized" container kind, so wrap them in a Scalar
+                        // (like Seq) so the `@`-coercion does not flatten them
+                        // into pairs. (A *bare* Hash/Set assigned directly,
+                        // `my @a = set(...)`, has no scalar container and DOES
+                        // flatten -- it never reaches this opcode.)
+                        other @ (Value::Hash(_)
+                        | Value::Set(..)
+                        | Value::Bag(..)
+                        | Value::Mix(..)) => Value::Scalar(Box::new(other)),
                         other => other,
                     }
                 };

--- a/t/array-assign-setbagmix-flatten.t
+++ b/t/array-assign-setbagmix-flatten.t
@@ -1,0 +1,66 @@
+use Test;
+
+# Assigning a Set/Bag/Mix directly to an `@` variable flattens it into its
+# `key => weight` pairs in list context, exactly like a Hash (Rakudo). A Set/
+# Bag/Mix held in a `$` scalar stays a single item, like any scalar container.
+
+plan 16;
+
+# Direct assignment flattens into pairs
+{
+    my @a = set(1, 2, 3);
+    is @a.elems, 3, 'Set assigned to @ flattens to 3 pairs';
+    ok @a.all ~~ Pair, 'elements are Pairs';
+    is @a.map(*.value).unique.list, (True,), 'Set pair values are True';
+}
+{
+    my @a = bag(1, 1, 2);
+    is @a.elems, 2, 'Bag assigned to @ flattens to 2 pairs';
+    is @a.sort(*.key).map(*.value).join(','), '2,1', 'Bag weights preserved';
+}
+{
+    my @a = mix('a' => 1.5, 'b' => 2);
+    is @a.elems, 2, 'Mix assigned to @ flattens to 2 pairs';
+}
+{
+    my %h = a => 1, b => 2;
+    my @a = %h;
+    is @a.elems, 2, 'Hash assigned to @ still flattens (regression guard)';
+}
+
+# Coercion methods stay consistent
+{
+    is set(1, 2, 3).Array.elems, 3, '.Array on a Set flattens';
+    is set(1, 2, 3).list.elems, 3, '.list on a Set flattens';
+}
+
+# A Set/Bag/Mix in a `$` scalar stays a single item when assigned to @
+{
+    my $s = set(1, 2, 3);
+    my @a = $s;
+    is @a.elems, 1, 'scalar-held Set stays a single item';
+    isa-ok @a[0], Set, 'the single item is the Set itself';
+}
+{
+    my $h = %(a => 1, b => 2);
+    my @a = $h;
+    is @a.elems, 1, 'scalar-held Hash stays a single item';
+    isa-ok @a[0], Hash, 'the single item is the Hash itself';
+}
+{
+    my $b = bag(1, 1, 2);
+    my @a = $b;
+    is @a.elems, 1, 'scalar-held Bag stays a single item';
+}
+
+# An array literal does NOT flatten a Set (separate path)
+{
+    my @a = [set(1, 2, 3)];
+    is @a.elems, 1, 'array literal [set(...)] stays a single element';
+}
+
+# A Set nested in a list stays one element
+{
+    my @a = (set(1, 2), 3);
+    is @a.elems, 2, 'Set inside a list literal is one element';
+}


### PR DESCRIPTION
## Problem

`my @a = set(1,2,3)` must flatten the Set into its `key => weight` pairs in list context, exactly like a Hash (Rakudo: `@a.elems == 3`). mutsu kept the Set as a single element (`@a.elems == 1`).

## Two related coercion gaps

**1. Direct assignment didn't flatten.** `coerce_to_array` (the `@`-assignment value coercion) handled `Hash` by flattening into pairs but let `Set`/`Bag`/`Mix` fall through to the scalar `other =>` arm. Added `Set`/`Bag`/`Mix` arms mirroring `value_to_list`. (An array *literal* `[set(...)]` still does NOT flatten — handled separately in `exec_make_array_op`, verified unchanged.)

**2. Scalar-held set-family wasn't itemized.** `my $s = set(...); my @a = $s` must stay a single item (`@a.elems == 1`), but `ItemizeVar` only itemized `Array`/`Seq` and passed `Hash`/`Set`/`Bag`/`Mix` through unchanged — so after fix #1 they would flatten. Now wrap them in a `Scalar` (like `Seq`), and have `coerce_to_array` unwrap that `Scalar(container)` back to the bare container as the single element (keeping `@a[0]`'s type/`.gist`/`.raku`). **This also fixes the pre-existing bug** where a scalar-held Hash flattened (`my $h = %(...); my @a = $h` gave `2` instead of `1`).

## Verification

- New `t/array-assign-setbagmix-flatten.t` (16 subtests) passes on `raku` and `mutsu`: direct flatten, scalar itemization, `.Array`/`.list`, literal `[set]`, and Set-in-a-list.
- All `t/*set*` / `t/*bag*` / `t/*mix*` / `t/*array*` / `t/*hash*` tests pass.
- Whitelisted `S02-types/{array,hash,list,baggy,baghash,mix,mixhash,...}`, `S03-operators/set_*`, `S03-binding/*`, `S02-names*` roast tests pass locally.
- `make test`: Result PASS (Files=839, Tests=7895, Failed: 0).

## Follow-up (out of scope)

A Set/Bag/Mix sitting *as* an array element still loses its type in `.gist`/`.raku` (`[1 2 3]` vs `[Set(1 2 3)]`) — a separate pre-existing display bug reproducible without this change (`my @a = (set(1,2,3),)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)