### PR TITLE
fix(gist): Set/Bag/Mix keep their type wrapper as a list/array element

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -522,6 +522,13 @@ pub(super) fn dispatch(
                     } if class_name == "Match" => {
                         crate::runtime::utils::match_gist(&(attributes).as_map(), 0)
                     }
+                    Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+                        // A Set/Bag/Mix nested in a list/array gist keeps its
+                        // type-name wrapper (`Set(a b c)`), like the say/gist
+                        // fast path, rather than its bare-element `.Str` form.
+                        crate::runtime::utils::setbagmix_gist(v)
+                            .unwrap_or_else(|| v.to_string_value())
+                    }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),
                 }
@@ -580,6 +587,13 @@ pub(super) fn dispatch(
                         ..
                     } if class_name == "Match" => {
                         crate::runtime::utils::match_gist(&(attributes).as_map(), 0)
+                    }
+                    Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+                        // A Set/Bag/Mix nested in a list/array gist keeps its
+                        // type-name wrapper (`Set(a b c)`), like the say/gist
+                        // fast path, rather than its bare-element `.Str` form.
+                        crate::runtime::utils::setbagmix_gist(v)
+                            .unwrap_or_else(|| v.to_string_value())
                     }
                     other if other.is_range() => range_gist_string(other),
                     other => other.to_string_value(),

--- a/t/setbagmix-array-element-gist.t
+++ b/t/setbagmix-array-element-gist.t
@@ -1,0 +1,29 @@
+use Test;
+
+# A Set/Bag/Mix that sits *as* an element of a list/array/seq keeps its
+# type-name wrapper in `.gist` (`Set(1 2 3)`), like the say/gist fast path,
+# rather than collapsing to its bare-element `.Str` form (`1 2 3`). The
+# explicit `.gist` method previously diverged from `say`'s implicit gist here.
+
+plan 10;
+
+is [set(1, 2, 3)].gist, '[Set(1 2 3)]', 'Set element in array .gist';
+is (set(1, 2, 3),).gist, '(Set(1 2 3))', 'Set element in list .gist';
+is [bag(1, 1, 2)].gist, '[Bag(1(2) 2)]', 'Bag element in array .gist';
+is (bag("a", "a", "b"),).gist, '(Bag(a(2) b))', 'Bag element in list .gist';
+is [set(1, 2), set(3, 4)].gist, '[Set(1 2) Set(3 4)]', 'multiple Set elements';
+is (set("x"),).Seq.gist, '(Set(x))', 'Set element in a Seq .gist';
+is (set(1, 2),).Slip.gist, '(Set(1 2))', 'Set element in a Slip .gist';
+
+# Mixed with other container elements (each keeps its own gist form)
+is [set(1, 2), {a => 1}, (3, 4)].gist, '[Set(1 2) {a => 1} (3 4)]',
+    'Set, Hash and List elements each gist correctly';
+
+# Hash value (already correct) stays correct
+is { k => set(1, 2) }.gist, '{k => Set(1 2)}', 'Set as a Hash value .gist';
+
+# The implicit say-gist and the explicit .gist method agree
+{
+    my @a = (set(1, 2, 3),);
+    is @a.gist, '[Set(1 2 3)]', 'explicit .gist matches the say fast path';
+}


### PR DESCRIPTION
## Problem

The explicit `.gist` method on an Array/Seq/Slip rendered a Set/Bag/Mix *element* as its bare elements instead of the type-name-wrapped form, diverging from `say`'s implicit gist:

```raku
my @a = (set(1,2,3),);
say @a;        # [Set(1 2 3)]   (gist_value fast path — already correct)
say @a.gist;   # raku: [Set(1 2 3)]   mutsu (before): [1 2 3]
```

## Root cause

The `.gist` method's local `gist_item` helpers (one for the Array arm, one for the Seq/Slip arm in `dispatch_core_repr.rs`) handled Array/Hash/Pair/Junction/Match/Range elements but let Set/Bag/Mix fall through to `other => other.to_string_value()` — the bare-element `.Str` form.

## Fix

Add a Set/Bag/Mix arm to both `gist_item` helpers that defers to the shared `setbagmix_gist`, matching the say/gist fast path (`gist_value`).

## Verification

- New `t/setbagmix-array-element-gist.t` (10 subtests) passes on `raku` and `mutsu`: Set/Bag/Mix in array/list/Seq/Slip, multiple elements, mixed with Hash/List elements, Hash-value (already-correct) guard, and implicit-vs-explicit gist agreement.
- `make test`: Result PASS (Files=840, Tests=7900, Failed: 0).

## Follow-up (out of scope)

`.raku` of a Set/Bag/Mix (both standalone and as an element) is still wrong (`("1"=>Bool::True,...).Set` vs `Set.new(...)`) — a separate, deeper representation bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)