### PR TITLE
fix(raku): Set/Bag/Mix render proper constructor form in .raku/.perl/dd

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -336,23 +336,11 @@ pub(super) fn dispatch(
                 ))))
             }
         }
-        Value::Bag(b, mutable) => {
+        Value::Bag(_, _) => {
             if method == "raku" || method == "perl" {
-                let type_name = if *mutable { "BagHash" } else { "Bag" };
-                let mut keys: Vec<(&String, &num_bigint::BigInt)> = b.iter().collect();
-                keys.sort_by_key(|(k, _)| (*k).clone());
-                let pairs = keys
-                    .iter()
-                    .map(|(k, v)| {
-                        format!(
-                            "\"{}\"=>{}",
-                            k.replace('\\', "\\\\").replace('"', "\\\""),
-                            v
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",");
-                Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
+                Some(Ok(Value::str(
+                    super::raku_repr::setbagmix_raku(target).unwrap(),
+                )))
             } else {
                 // gist: Bag(key(count) ...) or BagHash(key(count) ...)
                 Some(Ok(Value::str(
@@ -360,22 +348,11 @@ pub(super) fn dispatch(
                 )))
             }
         }
-        Value::Set(s, mutable) => {
+        Value::Set(_, _) => {
             if method == "raku" || method == "perl" {
-                let type_name = if *mutable { "SetHash" } else { "Set" };
-                let mut keys: Vec<&String> = s.iter().collect();
-                keys.sort();
-                let pairs = keys
-                    .iter()
-                    .map(|k| {
-                        format!(
-                            "\"{}\"=>Bool::True",
-                            k.replace('\\', "\\\\").replace('"', "\\\"")
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",");
-                Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
+                Some(Ok(Value::str(
+                    super::raku_repr::setbagmix_raku(target).unwrap(),
+                )))
             } else {
                 // gist: Set(a b c) or SetHash(a b c)
                 Some(Ok(Value::str(
@@ -383,28 +360,11 @@ pub(super) fn dispatch(
                 )))
             }
         }
-        Value::Mix(m, mutable) => {
+        Value::Mix(_, _) => {
             if method == "raku" || method == "perl" {
-                let type_name = if *mutable { "MixHash" } else { "Mix" };
-                let mut keys: Vec<(&String, &f64)> = m.iter().collect();
-                keys.sort_by_key(|(k, _)| (*k).clone());
-                let pairs = keys
-                    .iter()
-                    .map(|(k, v)| {
-                        let v_str = if v.fract() == 0.0 {
-                            format!("{}", **v as i64)
-                        } else {
-                            format!("{}", v)
-                        };
-                        format!(
-                            "\"{}\"=>{}",
-                            k.replace('\\', "\\\\").replace('"', "\\\""),
-                            v_str
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",");
-                Some(Ok(Value::str(format!("({}).{}", pairs, type_name))))
+                Some(Ok(Value::str(
+                    super::raku_repr::setbagmix_raku(target).unwrap(),
+                )))
             } else {
                 // gist: Mix(key(weight) ...) or MixHash(key(weight) ...)
                 Some(Ok(Value::str(

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -640,7 +640,69 @@ pub fn raku_value(v: &Value) -> String {
             }
             format!("\\({})", parts.join(", "))
         }
+        Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+            setbagmix_raku(v).unwrap_or_else(|| v.to_string_value())
+        }
         other => other.to_string_value(),
+    }
+}
+
+/// Render the `.raku`/`.perl` form of a Set/Bag/Mix (and their mutable `*Hash`
+/// variants): `Set.new(1,2,3)`, `("a"=>2,"b"=>1).Bag`, `(:a(1.5)=>1).Mix`.
+/// Each element is rendered with its original type (via `typed_key`), not the
+/// internal string key. Returns `None` for any other value. Shared by
+/// `raku_value` (recursive element rendering) and the `.raku` method dispatch
+/// so both render identically.
+pub(crate) fn setbagmix_raku(v: &Value) -> Option<String> {
+    match v {
+        // An empty *immutable* Set/Bag/Mix renders via its lowercase coercer
+        // (`set()`/`bag()`/`mix()`) in Raku, not the non-empty form. The empty
+        // mutable variants keep their non-empty form (`SetHash.new()` /
+        // `().BagHash` / `().MixHash`), so only special-case the immutable ones.
+        Value::Set(s, false) if s.is_empty() => Some("set()".to_string()),
+        Value::Bag(b, false) if b.is_empty() => Some("bag()".to_string()),
+        Value::Mix(m, false) if m.is_empty() => Some("mix()".to_string()),
+        Value::Set(s, mutable) => {
+            let type_name = if *mutable { "SetHash" } else { "Set" };
+            let mut keys: Vec<&String> = s.iter().collect();
+            keys.sort();
+            let elems = keys
+                .iter()
+                .map(|k| raku_value(&s.typed_key(k)))
+                .collect::<Vec<_>>()
+                .join(",");
+            Some(format!("{}.new({})", type_name, elems))
+        }
+        Value::Bag(b, mutable) => {
+            let type_name = if *mutable { "BagHash" } else { "Bag" };
+            let mut keys: Vec<(&String, &num_bigint::BigInt)> = b.iter().collect();
+            keys.sort_by_key(|(k, _)| (*k).clone());
+            let pairs = keys
+                .iter()
+                .map(|(k, w)| format!("{}=>{}", raku_value(&b.typed_key(k)), w))
+                .collect::<Vec<_>>()
+                .join(",");
+            Some(format!("({}).{}", pairs, type_name))
+        }
+        Value::Mix(m, mutable) => {
+            let type_name = if *mutable { "MixHash" } else { "Mix" };
+            let mut keys: Vec<(&String, &f64)> = m.iter().collect();
+            keys.sort_by_key(|(k, _)| (*k).clone());
+            let pairs = keys
+                .iter()
+                .map(|(k, w)| {
+                    let w_str = if w.fract() == 0.0 {
+                        format!("{}", **w as i64)
+                    } else {
+                        format!("{}", w)
+                    };
+                    format!("{}=>{}", raku_value(&m.typed_key(k)), w_str)
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            Some(format!("({}).{}", pairs, type_name))
+        }
+        _ => None,
     }
 }
 

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -324,6 +324,10 @@ impl Interpreter {
                 let inner: Vec<String> = items.iter().map(Self::dd_format).collect();
                 format!("$[{}]", inner.join(", "))
             }
+            Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
+                crate::builtins::methods_0arg::raku_repr::setbagmix_raku(val)
+                    .unwrap_or_else(|| format!("{:?}", val))
+            }
             _ => format!("{:?}", val),
         }
     }

--- a/t/setbagmix-raku-repr.t
+++ b/t/setbagmix-raku-repr.t
@@ -1,0 +1,62 @@
+use Test;
+
+# `.raku`/`.perl` of a Set/Bag/Mix (and the mutable *Hash variants) renders the
+# proper constructor form -- `Set.new(1,2,3)`, `("a"=>2).Bag`, `(:x(1.5)=>1).Mix`
+# -- with each element shown in its ORIGINAL type, and round-trips through EVAL.
+# (Set/Bag/Mix iteration order is unspecified, so assert on round-trip and on
+# the constructor shape rather than an exact string.)
+
+plan 18;
+
+# Round-trips (the authoritative correctness check)
+{
+    my $s = set(1, 2, 3);
+    ok $s.raku.EVAL eqv $s, 'Set.raku round-trips';
+}
+{
+    my $s = set("a", "b", "c");
+    ok $s.raku.EVAL eqv $s, 'Set of Str round-trips';
+}
+{
+    my $b = bag("a", "a", "b");
+    ok $b.raku.EVAL eqv $b, 'Bag.raku round-trips';
+}
+{
+    my $m = mix("x" => 1.5, "y" => 2);
+    ok $m.raku.EVAL eqv $m, 'Mix.raku round-trips';
+}
+{
+    my $sh = SetHash.new(1, 2, 3);
+    ok $sh.raku.EVAL eqv $sh, 'SetHash.raku round-trips';
+}
+{
+    my $bh = BagHash.new(1, 1, 2);
+    ok $bh.raku.EVAL eqv $bh, 'BagHash.raku round-trips';
+}
+
+# Constructor shape
+ok set(1, 2, 3).raku.starts-with('Set.new('), 'Set uses Set.new(...)';
+ok set("a").raku.contains('"a"'), 'Str element is quoted in Set.raku';
+ok set(7).raku.contains('7') && !set(7).raku.contains('"7"'),
+    'Int element is unquoted in Set.raku';
+ok bag("a", "a").raku.ends-with('.Bag'), 'Bag uses (...).Bag';
+ok bag("a", "a").raku.contains('=>2'), 'Bag shows the weight';
+ok mix("x" => 1.5).raku.ends-with('.Mix'), 'Mix uses (...).Mix';
+
+# Empty immutable containers use the lowercase coercer form
+is set().raku, 'set()', 'empty Set.raku is set()';
+is bag().raku, 'bag()', 'empty Bag.raku is bag()';
+is mix().raku, 'mix()', 'empty Mix.raku is mix()';
+
+# A Set element inside an array keeps its constructor form in .raku
+{
+    my @a = [set(1, 2, 3)];
+    is @a.raku.EVAL.elems, 1, 'array-with-Set .raku round-trips to 1 element';
+    ok @a.raku.contains('Set.new('), 'Set element in array .raku keeps Set.new(...)';
+}
+
+# .raku of a Set as a Hash value (already worked) stays correct
+{
+    my %h = k => set(1, 2);
+    ok %h.raku.contains('Set.new('), 'Set as a Hash value keeps Set.new(...)';
+}

--- a/t/setbagmix-say-gist.t
+++ b/t/setbagmix-say-gist.t
@@ -26,8 +26,8 @@ is (a => 1, b => 3).Mix.gist, 'Mix(a b(3))', 'Mix weight 1 omits the suffix';
 # --- nested inside a Hash value: the element gists with its wrapper ---
 is { x => set(1, 2) }.gist, '{x => Set(1 2)}', 'Set nested in a Hash value';
 
-# --- .raku is unaffected (still the pair-list form) ---
-is set("a").raku, '("a"=>Bool::True).Set', 'Set.raku unchanged';
+# --- .raku renders the proper constructor form (see t/setbagmix-raku-repr.t) ---
+is set("a").raku, 'Set.new("a")', 'Set.raku uses Set.new(...)';
 
 # --- empty collections ---
 is set().gist, 'Set()', 'empty Set.gist';


### PR DESCRIPTION
## Problem

`.raku`/`.perl` of a Set/Bag/Mix produced a non-round-tripping form and forced every element to a quoted string:

```raku
say set(1,2,3).raku;   # raku: Set.new(1,2,3)   mutsu (before): ("1"=>Bool::True,"2"=>Bool::True,"3"=>Bool::True).Set
say [set(1,2,3)].raku; # raku: [Set.new(...)]   mutsu (before): [1 2 3]   (flattened)
dd set(1,2,3);         # raku: Set.new(...)      mutsu (before): Set(SetData { elements: ... })   (raw Rust debug)
```

## Fix

- Add a shared `setbagmix_raku` helper (`raku_repr.rs`) rendering:
  - Set/SetHash → `Set.new(e, ...)` / `SetHash.new(e, ...)`
  - Bag/BagHash → `(e=>w, ...).Bag` / `.BagHash`
  - Mix/MixHash → `(e=>w, ...).Mix` / `.MixHash`
  
  Each element is rendered via `typed_key` + `raku_value`, so an Int element is `1`, a Str `"a"`, and a Pair element `:a(1.5)` — matching Raku. Empty *immutable* containers use the lowercase coercer form (`set()`/`bag()`/`mix()`).
- `raku_value` (the recursive element renderer) now handles Set/Bag/Mix via the helper, so they keep their constructor form as a list/array/hash element.
- The `.raku` method dispatch delegates to the helper, replacing the old inline pair-list logic.
- `dd` renders Set/Bag/Mix via the helper instead of `{:?}` Rust debug.

## Verification

- New `t/setbagmix-raku-repr.t` (18 subtests) passes on `raku` and `mutsu`: round-trips through EVAL, constructor shape, original-type elements, empty-container forms, and Set-as-element in array/Hash.
- Updated `t/setbagmix-say-gist.t` which had codified the old (wrong) `.raku` string — roast is authoritative, so the local assertion is now `Set.new("a")`.
- Whitelisted `S02-types/{baggy,baghash,mix,mixhash,...}`, `S32-array/perl.t`, `S02-magicals/PERL.t` roast tests pass locally.
- `make test`: Result PASS (Files=842, Tests=7934, Failed: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)