### PR TITLE
fix(gist): Set/Bag/Mix render Pair elements via the element gist, not the raw key

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -863,9 +863,12 @@ pub(crate) fn setbagmix_gist(value: &Value) -> Option<String> {
             let type_name = if *mutable { "SetHash" } else { "Set" };
             let mut keys: Vec<&String> = s.iter().collect();
             keys.sort();
+            // Render each element via its original type's gist (so a Pair element
+            // is `a => 1`, not the internal `a\t1` string key); a plain Str/Int
+            // element gists bare, identical to the raw key.
             let inner = keys
                 .iter()
-                .map(|k| k.as_str())
+                .map(|k| gist_value(&s.typed_key(k)))
                 .collect::<Vec<_>>()
                 .join(" ");
             Some(format!("{}({})", type_name, inner))
@@ -877,10 +880,11 @@ pub(crate) fn setbagmix_gist(value: &Value) -> Option<String> {
             let inner = keys
                 .iter()
                 .map(|(k, v)| {
+                    let key = gist_value(&b.typed_key(k));
                     if **v == BigInt::from(1) {
-                        (*k).clone()
+                        key
                     } else {
-                        format!("{}({})", k, v)
+                        format!("{}({})", key, v)
                     }
                 })
                 .collect::<Vec<_>>()
@@ -894,12 +898,13 @@ pub(crate) fn setbagmix_gist(value: &Value) -> Option<String> {
             let inner = keys
                 .iter()
                 .map(|(k, v)| {
+                    let key = gist_value(&m.typed_key(k));
                     if (**v - 1.0).abs() < f64::EPSILON {
-                        (*k).clone()
+                        key
                     } else if v.fract() == 0.0 {
-                        format!("{}({})", k, **v as i64)
+                        format!("{}({})", key, **v as i64)
                     } else {
-                        format!("{}({})", k, v)
+                        format!("{}({})", key, v)
                     }
                 })
                 .collect::<Vec<_>>()

--- a/t/setbagmix-gist-pair-elements.t
+++ b/t/setbagmix-gist-pair-elements.t
@@ -1,0 +1,31 @@
+use Test;
+
+# A Set/Bag/Mix whose elements are Pairs (or other non-string typed values)
+# renders each element via its original type's gist in `.gist` -- `a => 1`, not
+# the internal `a\t1` string key. Plain Str/Int elements are unaffected.
+
+plan 11;
+
+# Pair elements keep their `key => value` gist
+is set("a" => 1, "b" => 2).gist, 'Set(a => 1 b => 2)', 'Set of Pairs';
+is bag("x" => 3).gist, 'Bag(x => 3)', 'Bag with a Pair element';
+is mix("a" => 1.5).gist, 'Mix(a => 1.5)', 'Mix with a Pair element (fractional)';
+
+# Plain elements are unchanged
+is set("a", "b").gist, 'Set(a b)', 'Set of Str';
+is set(1, 2, 3).gist, 'Set(1 2 3)', 'Set of Int';
+is bag(1, 1, 2).gist, 'Bag(1(2) 2)', 'Bag of Int with weights';
+is bag("x", "x", "x").gist, 'Bag(x(3))', 'single-key Bag';
+
+# `(pair, ...).Mix` treats pairs as key=>weight (not Pair elements)
+is (a => 1, b => 3).Mix.gist, 'Mix(a b(3))', 'pair-list .Mix uses key=>weight';
+
+# The say/gist fast path and the explicit .gist method agree
+is set("a" => 1).gist, set("a" => 1).gist, '.gist is deterministic';
+{
+    my $m = mix("k" => 2.5);
+    is $m.gist, 'Mix(k => 2.5)', 'Mix Pair element via say-path helper';
+}
+
+# Empty containers unaffected
+is set().gist, 'Set()', 'empty Set.gist';


### PR DESCRIPTION
## Problem

`setbagmix_gist` rendered each element with its internal string key, so a Set/Bag/Mix whose elements are Pairs showed the tab-joined `.Str` form of the Pair instead of the element's gist:

```raku
set("a"=>1,"b"=>2).gist   # raku: Set(a => 1 b => 2)   mutsu (before): Set(a\t1 b\t2)
bag("x"=>3).gist          # raku: Bag(x => 3)          mutsu (before): Bag(x\t3)
mix("a"=>1.5).gist        # raku: Mix(a => 1.5)        mutsu (before): Mix(a\t1.5)
```

## Fix

Render each element via `gist_value(typed_key(k))` instead of the raw string key. A plain Str/Int element gists identically to its key, so the common cases are unchanged; only Pair (and other non-string typed) elements are fixed. The helper is shared by the say/gist fast path and the `.gist` method dispatch, so both render identically.

## Verification

- New `t/setbagmix-gist-pair-elements.t` (11 subtests) passes on `raku` and `mutsu`: Pair elements, plain Str/Int elements (unchanged), pair-list `.Mix`, and empty containers.
- Existing `t/setbagmix-say-gist.t` still passes.
- `make test`: Result PASS (Files=842, Tests=7927, Failed: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)