### PR TITLE
fix(lvalue): ternary on the LHS of an assignment selects the branch as lvalue

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -43,6 +43,27 @@ impl Compiler {
             return;
         } else if name == "__mutsu_assign_callable_lvalue"
             && args.len() == 3
+            && let Expr::Ternary {
+                cond,
+                then_expr,
+                else_expr,
+            } = &args[0]
+            && let Some(then_assign) = Self::assign_expr_for_lvalue(then_expr, &args[2])
+            && let Some(else_assign) = Self::assign_expr_for_lvalue(else_expr, &args[2])
+        {
+            // `(cond ?? $a !! $b) = rhs`: the ternary yields whichever branch is
+            // the selected lvalue, then the assignment writes through to it.
+            // Desugar to `cond ?? ($a = rhs) !! ($b = rhs)` so only the taken
+            // branch is assigned (and rhs is evaluated once, in that branch).
+            let desugared = Expr::Ternary {
+                cond: cond.clone(),
+                then_expr: Box::new(then_assign),
+                else_expr: Box::new(else_assign),
+            };
+            self.compile_expr(&desugared);
+            return;
+        } else if name == "__mutsu_assign_callable_lvalue"
+            && args.len() == 3
             && let Expr::ArrayLiteral(targets) = &args[0]
             && targets.iter().all(|t| {
                 matches!(

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -68,6 +68,57 @@ impl Compiler {
         }
     }
 
+    /// Build an assignment expression that writes `value` into the lvalue
+    /// `target`. Used to desugar a ternary (or other selector) on the LHS of an
+    /// assignment, e.g. `(cond ?? $a !! $b) = v` becomes a ternary whose
+    /// branches are `$a = v` and `$b = v`. Returns `None` when `target` is not a
+    /// supported lvalue shape.
+    pub(super) fn assign_expr_for_lvalue(target: &Expr, value: &Expr) -> Option<Expr> {
+        match target {
+            Expr::Var(name) => Some(Expr::AssignExpr {
+                name: name.clone(),
+                expr: Box::new(value.clone()),
+                is_bind: false,
+            }),
+            Expr::ArrayVar(name) => Some(Expr::AssignExpr {
+                name: format!("@{}", name),
+                expr: Box::new(value.clone()),
+                is_bind: false,
+            }),
+            Expr::HashVar(name) => Some(Expr::AssignExpr {
+                name: format!("%{}", name),
+                expr: Box::new(value.clone()),
+                is_bind: false,
+            }),
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+            } => Some(Expr::IndexAssign {
+                target: target.clone(),
+                index: index.clone(),
+                value: Box::new(value.clone()),
+                is_positional: *is_positional,
+            }),
+            Expr::Grouped(inner) => Self::assign_expr_for_lvalue(inner, value),
+            // Nested selector on a branch, e.g. `cond1 ?? (cond2 ?? $a !! $b) !! $c`.
+            Expr::Ternary {
+                cond,
+                then_expr,
+                else_expr,
+            } => {
+                let then_assign = Self::assign_expr_for_lvalue(then_expr, value)?;
+                let else_assign = Self::assign_expr_for_lvalue(else_expr, value)?;
+                Some(Expr::Ternary {
+                    cond: cond.clone(),
+                    then_expr: Box::new(then_assign),
+                    else_expr: Box::new(else_assign),
+                })
+            }
+            _ => None,
+        }
+    }
+
     pub(super) fn postfix_index_name(target: &Expr) -> Option<String> {
         match target {
             Expr::HashVar(name) => Some(format!("%{}", name)),

--- a/t/ternary-lvalue.t
+++ b/t/ternary-lvalue.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 12;
+
+# Basic ternary lvalue: assign through the selected branch.
+{
+    my $x = 1;
+    my $y = 2;
+    (1 ?? $x !! $y) = 99;
+    is $x, 99, 'true branch is assigned';
+    is $y, 2, 'false branch untouched';
+}
+
+{
+    my $a = 10;
+    my $b = 20;
+    (0 ?? $a !! $b) = 77;
+    is $a, 10, 'true branch untouched when cond is false';
+    is $b, 77, 'false branch is assigned';
+}
+
+# RHS is evaluated exactly once, only in the taken branch.
+{
+    my $calls = 0;
+    my $p = 0;
+    my $q = 0;
+    (1 ?? $p !! $q) = do { $calls++; 5 };
+    is $p, 5, 'taken branch got the value';
+    is $q, 0, 'other branch untouched';
+    is $calls, 1, 'RHS evaluated once';
+}
+
+# Index expressions as branches.
+{
+    my @arr = 1, 2, 3;
+    (1 ?? @arr[0] !! @arr[1]) = 100;
+    is-deeply @arr, [100, 2, 3], 'index lvalue branch is assigned';
+}
+
+# Nested ternary on a branch.
+{
+    my $m = 0;
+    my $n = 0;
+    my $o = 0;
+    (0 ?? $m !! (1 ?? $n !! $o)) = 42;
+    is $m, 0, 'nested: outer false branch chosen';
+    is $n, 42, 'nested: inner true branch assigned';
+    is $o, 0, 'nested: inner false branch untouched';
+}
+
+# The assignment expression yields the assigned value.
+{
+    my $x = 1;
+    my $y = 2;
+    my $r = ((1 ?? $x !! $y) = 5);
+    is $r, 5, 'ternary lvalue assignment returns the assigned value';
+}


### PR DESCRIPTION
## Summary
`(cond ?? \$a !! \$b) = v` previously raised `Cannot modify an immutable value (cannot assign through non-callable value)` because the ternary was evaluated to a value and then `__mutsu_assign_callable_lvalue` tried to assign through that non-callable result.

Raku semantics: the ternary yields whichever branch is the selected **lvalue**, then the assignment writes through to it.

## Approach
Desugar `(cond ?? A !! B) = rhs` in the compiler to `cond ?? (A = rhs) !! (B = rhs)`, so:
- only the taken branch is assigned,
- rhs is evaluated exactly once (in the taken branch),
- the whole expression yields the assigned value.

A new `assign_expr_for_lvalue` helper builds the per-branch assignment for the supported lvalue shapes: scalar/array/hash vars, `Index` expressions, grouped targets, and nested ternaries on a branch.

## Tests
- `t/ternary-lvalue.t` (12 subtests) — true/false branch selection, rhs-evaluated-once, index-lvalue branch, nested ternary, and assignment-result value. All match `raku`.
- `make test` PASS; whitelisted `roast/S03-operators/{ternary,scalar-assign,assign-is-not-binding}.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)