### PR TITLE
docs(news): record hash itemization flag (#3151)

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -922,3 +922,24 @@ CP-1（env-loan flip）完了後の CP-3（tree-walking Interpreter オブジェ
   sampling（grab/pick/roll）は i128/f64 飽和。
 - baghash.t 344/344 を whitelist 追加。bag.t は 254/255（残 252 は `class Foo is Bag` の `(+)` がサブクラス型を
   保てない別件＝Bag が subclassable Instance でない）。`t/bag-bigint-weights.t`(12)。
+
+### 第一級コンテナ: ハッシュ itemization フラグ（ArrayKind をミラー、#3151）
+
+`my %c = (%h,)` / `%(%h,)` が "Odd number of elements" で abort していた根因を解消。素の `%h`（list 文脈で pair に
+flatten）と `$`-由来の itemized hash `$hashitem`（opaque＝Raku は X::Hash::Store::OddNumber）を mutsu が区別できず、
+旧ヒューリスティック（要素数 >1 のときだけ flatten）は両方向に誤っていた。
+
+mutsu は配列ではこれを **`ArrayKind::ItemList`/`ItemArray`**（値に付くフラグ。値演算は無視、list-flatten だけが見る）で
+leak なく解決済み。ハッシュに同型が無く、前回 #3147 は leak する `Scalar(Hash)` ラッパに頼って多数の consumer（集合
+メンバシップ・list 要素として持つ hash 等）で破綻し revert。今回それをハッシュにミラー:
+
+- `HashData.itemized: bool`（`PartialEq` 対象外＝`map` のみ比較）。`Value::item()` と `Itemize`/`ItemizeVar` opcode が
+  `hash_arc_itemized`（フラグが変わる時だけ COW、`.WHICH` 保持）で立てる。**値は `Value::Hash` のまま → どの consumer
+  にも wrapper が漏れない**。Set/Bag/Mix は itemized kind が無いので従来通り `Scalar` 包み、ただし `ItemizeVar`
+  （`@a=$var`）経路のみ（plain `Itemize` でも包むと set_union.t が leak で回帰、ローカル検出して修正）。
+- `build_hash_from_items`（`%m=(...)` と `.hash`/`%(...)` の単一チョークポイント）と `value_to_list`（list/array flatten の
+  チョークポイント）が素の Hash だけ flatten、itemized は単一要素として扱う。
+- **検証**: フル whitelist 1272 ファイル/207429 テスト leak ゼロ。#3147 が壊した set_elem.t/categorize.t/map.t、および
+  context.t（`[item %h]` 非 flatten）すべて green。`t/hash-itemization-flag.t`(18)。
+- **効果**: objecthash.t の test-37 abort 解消 → 全 62 走破（残り 7 = object-hash 型 enforcement、次セッション）。
+  長年の `list-to-hash-flatten-itemization` ブロッカーを、全 decont 大改修なしの低リスク変更で解消。


### PR DESCRIPTION
Records the container-identity hash itemization flag work (#3151) in news/2026-06.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)