### PR TITLE
feat(for): element-source `.values` writeback (`for %h<k>.values { $_ *= 2 }`)

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -294,6 +294,95 @@ impl Compiler {
         }
     }
 
+    /// Does `expr` ultimately root at a variable, so an `Index` over it is an
+    /// assignable lvalue (e.g. `%h<k>`, `@a[i]`, `%h<a><b>`)? Function-call and
+    /// other non-lvalue roots are excluded so we never synthesize a writeback
+    /// assignment into a temporary (which would error where Raku is silent).
+    fn for_element_container_is_lvalue(expr: &Expr) -> bool {
+        match expr {
+            Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_) | Expr::BareWord(_) => true,
+            Expr::Index { target, .. } => Self::for_element_container_is_lvalue(target),
+            _ => false,
+        }
+    }
+
+    /// Rewrite `for <ELEM>.values { ... }`, where `<ELEM>` is a var-rooted
+    /// `Index` lvalue (`%h<k>` / `@a[i]` / `%h<a><b>`), into:
+    ///
+    ///   my @tmp = <ELEM>;          # copy the element array into a temp
+    ///   for @tmp.values { ... };   # reuse the array-source per-element writeback
+    ///   <ELEM> = @tmp;             # write the temp back into the element
+    ///
+    /// Returns `None` for anything but this exact shape (plain `@a`/`%h` sources
+    /// are already handled by `for_iterable_source_name`).
+    fn desugar_for_element_source(&mut self, stmt: &Stmt) -> Option<Vec<Stmt>> {
+        let Stmt::For { iterable, .. } = stmt else {
+            return None;
+        };
+        let Expr::MethodCall {
+            target, name, args, ..
+        } = iterable
+        else {
+            return None;
+        };
+        if !args.is_empty() || name.resolve() != "values" {
+            return None;
+        }
+        let Expr::Index {
+            target: container,
+            index,
+            is_positional,
+        } = target.as_ref()
+        else {
+            return None;
+        };
+        if !Self::for_element_container_is_lvalue(container) {
+            return None;
+        }
+
+        let tmp = format!("__for_elem_src_{}", self.code.constants.len());
+        let element = target.as_ref().clone();
+
+        let decl = Stmt::VarDecl {
+            name: format!("@{}", tmp),
+            expr: element,
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: vec![("__has_initializer".to_string(), None)],
+            where_constraint: None,
+        };
+
+        // The rewritten for-loop iterates `@tmp.values`; cloning the original
+        // For and swapping only its iterable preserves params/body/label/mode.
+        let mut for_stmt = stmt.clone();
+        if let Stmt::For {
+            iterable: new_iterable,
+            ..
+        } = &mut for_stmt
+        {
+            *new_iterable = Expr::MethodCall {
+                target: Box::new(Expr::ArrayVar(tmp.clone())),
+                name: crate::symbol::Symbol::intern("values"),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            };
+        }
+
+        let writeback = Stmt::Expr(Expr::IndexAssign {
+            target: container.clone(),
+            index: index.clone(),
+            value: Box::new(Expr::ArrayVar(tmp)),
+            is_positional: *is_positional,
+        });
+
+        Some(vec![decl, for_stmt, writeback])
+    }
+
     pub(super) fn compile_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::Expr(expr) => {
@@ -1293,6 +1382,18 @@ impl Compiler {
                 rw_block,
                 explicit_zero_params,
             } => {
+                // Element-source writeback: `for %h<k>.values { $_ *= 2 }` /
+                // `for @a[i].values { ... }`. The plain @/%-source writeback only
+                // handles named container variables, so an element source (an
+                // Index expression) is rewritten to copy the element into a temp
+                // array, iterate that (reusing the array-source writeback), then
+                // write the temp back into the element after the loop.
+                if let Some(desugared) = self.desugar_for_element_source(stmt) {
+                    for s in &desugared {
+                        self.compile_stmt(s);
+                    }
+                    return;
+                }
                 let (pre_stmts, mut loop_body, post_stmts) =
                     self.expand_loop_phasers(body, label.as_deref());
                 let non_setline_count = body

--- a/t/for-element-source-writeback.t
+++ b/t/for-element-source-writeback.t
@@ -1,0 +1,59 @@
+use Test;
+
+plan 10;
+
+# `for %h<k>.values { $_ *= 2 }` aliases the array element's values and writes
+# the mutations back into %h<k>.
+{
+    my %h = a => [1, 2, 3];
+    for %h<a>.values { $_ *= 2 }
+    is-deeply %h<a>, [2, 4, 6], 'hash element .values writeback';
+}
+
+# Array element source.
+{
+    my @a = [10, 20], [30, 40];
+    for @a[0].values { $_ += 1 }
+    is-deeply @a[0], [11, 21], 'array element .values writeback';
+    is-deeply @a[1], [30, 40], 'sibling element untouched';
+}
+
+# Nested element source.
+{
+    my %h = a => { b => [1, 2, 3] };
+    for %h<a><b>.values { $_ *= 10 }
+    is-deeply %h<a><b>, [10, 20, 30], 'nested element .values writeback';
+}
+
+# `last` mid-loop writes back the partial mutations.
+{
+    my %h = a => [1, 2, 3, 4];
+    for %h<a>.values { last if $_ == 3; $_ = 0 }
+    is-deeply %h<a>, [0, 0, 3, 4], 'partial writeback on last';
+}
+
+# Pointy `is rw` named param.
+{
+    my %h = a => [1, 2, 3];
+    for %h<a>.values -> $v is rw { $v += 100 }
+    is-deeply %h<a>, [101, 102, 103], 'pointy is rw element writeback';
+}
+
+# Read-only loop does not mutate the element.
+{
+    my %h = a => [1, 2, 3];
+    my $sum = 0;
+    for %h<a>.values { $sum += $_ }
+    is $sum, 6, 'read-only loop sums elements';
+    is-deeply %h<a>, [1, 2, 3], 'read-only loop leaves element unchanged';
+}
+
+# Element source nested inside an outer loop.
+{
+    my %m = a => [1, 2, 3], b => [4, 5, 6];
+    for <a b> -> $k {
+        for %m{$k}.values { $_ *= 2 }
+    }
+    is-deeply %m<a>, [2, 4, 6], 'outer-loop element writeback (a)';
+    is-deeply %m<b>, [8, 10, 12], 'outer-loop element writeback (b)';
+}


### PR DESCRIPTION
## Summary
`for %h<k>.values { \$_ *= 2 }` and `for @a[i].values { ... }` aliased the array element's values but never wrote the mutations back. The per-element source writeback only handles **named** container variables (`@a`/`%h`), so an element source (an `Index` expression) was silently dropped.

```raku
my %h = a => [1,2,3];
for %h<a>.values { \$_ *= 2 }
say %h<a>;   # was [1 2 3], now [2 4 6]  (matches raku)
```

## Approach
Rewrite the loop in the compiler when the iterable is `<ELEM>.values` and `<ELEM>` is a var-rooted `Index` lvalue (`%h<k>` / `@a[i]` / `%h<a><b>`):

```raku
my @tmp = <ELEM>;          # copy the element array into a temp
for @tmp.values { ... };   # reuse the existing array-source writeback
<ELEM> = @tmp;             # write the temp back into the element
```

This reuses the well-tested, `loop_var_unchanged`-guarded array-source per-element writeback and only adds **one** nested writeback after the loop (no per-iteration O(n) nested write). Non-lvalue roots (e.g. `foo()[i].values`) are excluded so we never synthesize an assignment into a temporary (where Raku is silent).

## Tests
- `t/for-element-source-writeback.t` (10 subtests) — hash/array/nested element, pointy `is rw`, partial writeback on `last`, read-only loop (no spurious mutation), and element source nested in an outer loop. All match `raku`.
- `make test` PASS (no regressions); whitelisted `roast/S32-array/pairs.t`, `roast/S02-types/mix.t`, `roast/S03-binding/arrays.t` pass.

Note: bare `for %h<k> { ... }` (no `.values`) is intentionally out of scope — there `%h<k>` is a single itemized topic, a separate pre-existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)