### PR TITLE
fix(list): scalar-held hash stays a single element on @-assignment

### DIFF
--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -811,14 +811,20 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             )
         }
         Value::LazyList(_) => value,
-        Value::Hash(ref map) => {
-            // Hash assigned to @-var: flatten into pairs
+        // A bare Hash assigned to an @-var flattens into its pairs
+        // (`my @a = %h`). An *itemized* hash (`my $h = %(...); my @a = $h`)
+        // stays a single element — `ItemizeVar` now tags it with
+        // `HashData.itemized` rather than the old `Scalar(Hash)` wrapper, so it
+        // must be handled here too (the `Scalar(inner)` arm below covers the
+        // Set/Bag/Mix itemized forms, which still use the wrapper).
+        Value::Hash(ref map) if !map.itemized => {
             let pairs: Vec<Value> = map
                 .iter()
                 .map(|(k, v)| map.typed_pair(k, v.clone()))
                 .collect();
             Value::real_array(pairs)
         }
+        Value::Hash(map) => Value::real_array(vec![Value::Hash(map)]),
         // A scalar holding a Hash/Set/Bag/Mix (itemized by `ItemizeVar` as
         // `Scalar(container)`) stays a single element, but unwrap the Scalar so
         // `@a[0]` is the bare container (preserving its `.gist`/`.raku`/type),


### PR DESCRIPTION
## Summary
A regression introduced by #3151: `my $h = %(...); my @a = $h` now flattens the hash into its pairs (`@a.elems` 1 → 2) instead of keeping it as a single element.

```raku
my $h = %(a => 1, b => 2);
my @a = $h;
say @a.elems;     # was 2, should be 1
say @a[0].^name;  # was Pair, should be Hash
```

## Root cause
#3151 changed `ItemizeVar` to tag an itemized hash with `HashData.itemized` instead of wrapping it in `Scalar(Hash)`. It updated `value_to_list` for the new flag but **missed `coerce_to_array`** (the `@a = ...` assignment path), which still flattened *every* `Value::Hash` into its pairs and only kept the old `Scalar(Hash)` wrapper whole.

CI's `prove t/` is non-fatal (`|| echo ...; roast is authoritative`), so the resulting `t/array-assign-setbagmix-flatten.t` failure slipped into `main`.

## Fix
Guard the flattening arm with `!map.itemized` and add an itemized arm that keeps the hash as one element — mirroring `value_to_list` and the existing `Scalar(inner)` arm for Set/Bag/Mix.

## Tests
- `t/array-assign-setbagmix-flatten.t` and `t/hash-itemization-flag.t` both pass.
- Verified against `raku`: bare `%h` still flattens (`my @a = %h` → 2), `(%h,)` still flattens in hash context (the #3151 feature), while `$h`/`item %h`/`$(%h)` stay single.
- `make test` PASS; `roast/S02-types/hash.t`, `roast/S03-binding/hashes.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)