### PR TITLE
fix(objecthash): type enforcement for object hashes (objecthash.t 62/62)

### DIFF
--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -2,7 +2,12 @@
 
 - [ ] roast/S09-autovivification/autoincrement.t
 - [ ] roast/S09-autovivification/autovivification.t
-- [ ] roast/S09-hashes/objecthash.t
+- [x] roast/S09-hashes/objecthash.t
+  - 62/62 pass (whitelisted). Object-hash type enforcement: Any-keyed hash rejects
+    Mu keys (instance type identity no longer falls back to "Any"), Hash.push key/
+    value/array-conflict type checks, `Int(Str)` coercion keys (X::Str::Numeric on
+    non-numeric), and plain-built-vs-WHICH-keyed element-assign consistency for
+    clone+update.
 - [ ] roast/S09-multidim/assign.t
 - [ ] roast/S09-multidim/decl.t
 - [ ] roast/S09-multidim/indexing.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -539,6 +539,7 @@ roast/S07-iterators/range-iterator.t
 roast/S07-slip/slip.t
 roast/S09-autovivification/autoincrement.t
 roast/S09-autovivification/autovivification.t
+roast/S09-hashes/objecthash.t
 roast/S09-multidim/XX-POS-on-dimensioned.t
 roast/S09-multidim/XX-POS-on-undimensioned.t
 roast/S09-multidim/assign.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2695,6 +2695,141 @@ impl Interpreter {
                 "push" | "append" => {
                     let is_push = method == "push";
 
+                    // Typed / object hashes (`my Int %h{Rat}`) must type-check both
+                    // the pushed key (against the object-hash key type) and value
+                    // (against the element type), and reject a push that would turn a
+                    // scalar-typed value into an array (duplicate key). Read the
+                    // constraints off the hash's own metadata (authoritative,
+                    // travels with COW) falling back to the variable's declared
+                    // constraints.
+                    let (key_constraint, value_constraint, is_object_hash) =
+                        match self.env.get(&key) {
+                            Some(Value::Hash(h)) => (
+                                h.key_type
+                                    .clone()
+                                    .or_else(|| self.var_hash_key_constraint(&key)),
+                                h.value_type
+                                    .clone()
+                                    .or_else(|| self.var_type_constraint(&key)),
+                                h.key_type.is_some()
+                                    || self.var_hash_key_constraint(&key).is_some(),
+                            ),
+                            _ => (
+                                self.var_hash_key_constraint(&key),
+                                self.var_type_constraint(&key),
+                                self.var_hash_key_constraint(&key).is_some(),
+                            ),
+                        };
+                    let needs_typed_push = is_object_hash
+                        || value_constraint
+                            .as_deref()
+                            .is_some_and(|c| !matches!(c, "" | "Any" | "Mu"));
+                    if needs_typed_push {
+                        let kv_pairs = Self::hash_push_collect_pairs_kv(args);
+                        // Snapshot the existing stored value for each pushed key so
+                        // the duplicate-key array-conflict check can run before the
+                        // mutable borrow (type_matches_value needs `&mut self`).
+                        let existing: Vec<Option<Value>> = {
+                            let h = match self.env.get(&key) {
+                                Some(Value::Hash(h)) => Some(h),
+                                _ => None,
+                            };
+                            kv_pairs
+                                .iter()
+                                .map(|(k, _)| {
+                                    let wk = if is_object_hash {
+                                        crate::runtime::utils::value_which_key(k)
+                                    } else {
+                                        k.to_string_value()
+                                    };
+                                    h.and_then(|h| h.map.get(&wk).cloned())
+                                })
+                                .collect()
+                        };
+                        for (i, (k, v)) in kv_pairs.iter().enumerate() {
+                            if let Some(kc) = &key_constraint
+                                && !matches!(kc.as_str(), "" | "Any" | "Mu")
+                                && !self.type_matches_value(kc, k)
+                            {
+                                return Err(crate::runtime::utils::type_check_element_typed_error(
+                                    &key, kc, k,
+                                ));
+                            }
+                            if let Some(vc) = &value_constraint
+                                && !matches!(vc.as_str(), "" | "Any" | "Mu")
+                            {
+                                if !matches!(v, Value::Nil) && !self.type_matches_value(vc, v) {
+                                    return Err(
+                                        crate::runtime::utils::type_check_element_typed_error(
+                                            &key, vc, v,
+                                        ),
+                                    );
+                                }
+                                // A duplicate key turns the scalar value into an
+                                // array; reject it when the element type does not
+                                // accept that array.
+                                if let Some(ex) = &existing[i] {
+                                    let resulting = match ex {
+                                        Value::Array(arr, ..) => {
+                                            let mut items = arr.to_vec();
+                                            items.push(v.clone());
+                                            Value::real_array(items)
+                                        }
+                                        other => Value::real_array(vec![other.clone(), v.clone()]),
+                                    };
+                                    if !self.type_matches_value(vc, &resulting) {
+                                        return Err(
+                                            crate::runtime::utils::type_check_element_typed_error(
+                                                &key, vc, &resulting,
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(Value::Hash(arc_hash)) = self.env.get_mut(&key) {
+                            let hash = Arc::make_mut(arc_hash);
+                            for (k, v) in kv_pairs {
+                                let wk = if is_object_hash {
+                                    crate::runtime::utils::value_which_key(&k)
+                                } else {
+                                    k.to_string_value()
+                                };
+                                if is_object_hash {
+                                    hash.original_keys
+                                        .get_or_insert_with(std::collections::HashMap::new)
+                                        .insert(wk.clone(), k);
+                                }
+                                Self::hash_push_insert(hash, wk, v, is_push);
+                            }
+                            return Ok(Value::Hash(Arc::clone(arc_hash)));
+                        }
+                        // No existing hash in the variable: build a fresh typed
+                        // hash from the pushed pairs (preserving the constraints).
+                        let mut map = std::collections::HashMap::new();
+                        let mut orig = std::collections::HashMap::new();
+                        for (k, v) in kv_pairs {
+                            let wk = if is_object_hash {
+                                crate::runtime::utils::value_which_key(&k)
+                            } else {
+                                k.to_string_value()
+                            };
+                            if is_object_hash {
+                                orig.insert(wk.clone(), k);
+                            }
+                            Self::hash_push_insert(&mut map, wk, v, is_push);
+                        }
+                        let mut hd = crate::value::HashData::new(map);
+                        if is_object_hash {
+                            hd.original_keys = Some(orig);
+                            hd.key_type = key_constraint;
+                        }
+                        hd.value_type = value_constraint;
+                        let result = Value::Hash(Arc::new(hd));
+                        self.env.insert(key, result.clone());
+                        return Ok(result);
+                    }
+
                     // Fast path: COW via Arc::make_mut (O(1) when refcount=1)
                     if let Some(Value::Hash(arc_hash)) = self.env.get_mut(&key) {
                         let hash = Arc::make_mut(arc_hash);
@@ -3827,6 +3962,43 @@ impl Interpreter {
                     let key = arg.to_string_value();
                     let val = iter.next().unwrap_or(Value::Nil);
                     pairs.push((key, val));
+                }
+            }
+        }
+        pairs
+    }
+
+    /// Like [`hash_push_collect_pairs`] but preserves the original key *value*
+    /// (not its stringification), so typed object hashes can type-check the key
+    /// and store it under its `.WHICH` key. The first element of each tuple is
+    /// the key value, the second the value.
+    fn hash_push_collect_pairs_kv(args: Vec<Value>) -> Vec<(Value, Value)> {
+        let mut pairs = Vec::new();
+        let mut iter = args.into_iter().peekable();
+        while let Some(arg) = iter.next() {
+            match arg {
+                Value::Pair(k, v) => {
+                    pairs.push((Value::str(k), *v));
+                }
+                Value::ValuePair(k, v) => {
+                    pairs.push((*k, *v));
+                }
+                Value::Array(items, ..) => {
+                    pairs.extend(Self::hash_push_collect_pairs_kv(items.to_vec()));
+                }
+                Value::Hash(h, ..) => {
+                    for (k, v) in h.map.iter() {
+                        let key = h
+                            .original_keys
+                            .as_ref()
+                            .and_then(|o| o.get(k).cloned())
+                            .unwrap_or_else(|| Value::str(k.clone()));
+                        pairs.push((key, v.clone()));
+                    }
+                }
+                other => {
+                    let val = iter.next().unwrap_or(Value::Nil);
+                    pairs.push((other, val));
                 }
             }
         }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -937,6 +937,14 @@ impl Interpreter {
                     }
                 }
             }
+            // An instance's type identity is fully determined by its class name,
+            // parents, MRO, and composed roles (all checked above). Do NOT fall
+            // through to the generic `value_type_name` fallback, which reports
+            // every instance as "Any" — that wrongly accepts a `Mu.new` instance
+            // for an `Any` constraint (`Mu` is a direct subtype of `Mu`, not
+            // `Any`). The checks above already match `Any`/`Mu`/`Cool`/... via
+            // the MRO for ordinary classes.
+            return false;
         }
         // Mixin allomorphic types: check both inner type and mixin type keys
         if let Value::Mixin(inner, mixins) = value {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3210,9 +3210,52 @@ impl Interpreter {
             }
             _ => {
                 // For object hashes, use .WHICH as the internal key.
-                let is_object_hash = var_name.starts_with('%')
-                    && loan_env!(self, var_hash_key_constraint(&var_name)).is_some();
-                let key = if is_object_hash {
+                let key_constraint = if var_name.starts_with('%') {
+                    loan_env!(self, var_hash_key_constraint(&var_name))
+                } else {
+                    None
+                };
+                let is_object_hash = key_constraint.is_some();
+                // A coercion key type (`my %h{Int(Str)}`) coerces the key to the
+                // target type before it is stored / `.WHICH`-keyed. A failed
+                // coercion (e.g. a non-numeric string into Int) throws, matching
+                // raku (`X::Str::Numeric`).
+                let idx = if let Some(kc) = &key_constraint
+                    && let Some(open) = kc.find('(')
+                    && kc.ends_with(')')
+                    && open > 0
+                    && !self.type_matches_value(&kc[..open], &idx)
+                {
+                    // A numeric coercion target rejects a non-numeric string the
+                    // raku way (`X::Str::Numeric`) rather than silently coercing
+                    // it to 0, since the lenient `coerce_value` fast path does not
+                    // throw.
+                    if matches!(
+                        &kc[..open],
+                        "Int" | "UInt" | "Num" | "Rat" | "FatRat" | "Real" | "Numeric" | "Complex"
+                    ) {
+                        runtime::utils::check_str_numeric(&idx)?;
+                    }
+                    loan_env!(self, try_coerce_value_for_constraint(kc, idx.clone()))?
+                } else {
+                    idx
+                };
+                // Determine the keying mode for an object hash. A freshly created
+                // or already-`.WHICH`-keyed hash (one carrying `original_keys`) is
+                // keyed by `.WHICH`. A *plain-built* object hash — e.g. one bulk
+                // assigned from a pair list (`my %h{Mu} = :42a, ...`), whose keys
+                // were stringified during hash construction and which carries no
+                // `original_keys` — must keep using plain string keys here so that
+                // a follow-up element assignment (`%h<c> = ...`) overwrites the
+                // existing entry instead of inserting a duplicate under a `.WHICH`
+                // key. (Fully unifying object-hash keying across construction,
+                // flatten, gist and comparison is a larger change.)
+                let use_which = is_object_hash
+                    && match &index_target {
+                        Some(Value::Hash(h)) => h.original_keys.is_some() || h.map.is_empty(),
+                        _ => true,
+                    };
+                let key = if use_which {
                     runtime::utils::value_which_key(&idx)
                 } else {
                     idx.to_string_value()
@@ -3596,8 +3639,10 @@ impl Interpreter {
                                 Value::hash_insert_through(&mut hd.map, key.clone(), val.clone());
                             }
                             // For object hashes, store the original key object in
-                            // the embedded `original_keys` map (COW-stable).
-                            if is_object_hash {
+                            // the embedded `original_keys` map (COW-stable). Skip
+                            // for a plain-keyed object hash (see `use_which`) so it
+                            // is not flipped into `.WHICH` keying mid-stream.
+                            if use_which {
                                 hd.original_keys
                                     .get_or_insert_with(std::collections::HashMap::new)
                                     .insert(key.clone(), idx.clone());
@@ -3803,7 +3848,7 @@ impl Interpreter {
                                 let mut hash = std::collections::HashMap::new();
                                 hash.insert(key.clone(), val.clone());
                                 let mut hash_val = Value::hash(hash);
-                                if is_object_hash {
+                                if use_which {
                                     let mut orig = HashMap::new();
                                     orig.insert(key.clone(), idx.clone());
                                     hash_val =
@@ -3826,7 +3871,7 @@ impl Interpreter {
                         let mut hash = std::collections::HashMap::new();
                         hash.insert(key.clone(), val.clone());
                         let mut hash_val = Value::hash(hash);
-                        if is_object_hash {
+                        if use_which {
                             let mut orig = HashMap::new();
                             orig.insert(key.clone(), idx.clone());
                             hash_val = runtime::utils::set_hash_original_keys(hash_val, orig);


### PR DESCRIPTION
Whitelist `roast/S09-hashes/objecthash.t` (62/62) by fixing five object-hash type enforcement gaps.

## Changes

1. **`Any`-keyed hash rejects `Mu` keys** (`type_matching.rs`). An `Instance` value no longer falls through to the generic `value_type_name` fallback, which reports every instance as `"Any"`. Instance type identity is fully determined by class name / parents / MRO / composed roles (all already checked), so a `Mu.new` instance is correctly **not** an `Any`. This also makes `Mu.new ~~ Any` return `False`, matching rakudo.

2. **`Hash.push` type checks** (`methods_mut.rs`). `%h.push` on a typed object hash (`my Int %h{Rat}`) now type-checks both the pushed key (against the object-hash key type) and value (against the element type), and rejects a push that would turn a scalar-typed value into an array via a duplicate key.

3. **Coercion key types** (`vm_var_assign_ops.rs`). `my %h{Int(Str)}; %h<a> = 42` now coerces the key to the target type and throws `X::Str::Numeric` for a non-numeric string, instead of silently coercing it to `0`.

4. **Plain-built vs `.WHICH`-keyed consistency** (`vm_var_assign_ops.rs`). Element assignment to a plain-built object hash (bulk assigned from a pair list, `my %h{Mu} = :42a, ...`) keeps using plain string keys so a follow-up `%h<c> = ...` (and `.clone` + update) overwrites the existing entry rather than inserting a duplicate under a `.WHICH` key. (Fully unifying object-hash keying across construction, flatten, gist and comparison is a larger change tracked separately.)

## Testing

- `roast/S09-hashes/objecthash.t`: 62/62, whitelisted.
- Verified no regressions in affected whitelisted tests (`S02-types/mu`, `hash`, `baghash`, `mixhash`, `pair`, `S03-binding/hashes`, `S12-class/basic`) — remaining `not ok` there are `# TODO` tests.
- `make test`: the only non-TODO `t/` failure (`array-assign-setbagmix-flatten.t` 12-13, scalar-held hash itemization) reproduces on `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)