### PR TITLE
fix(concurrency): concurrent `@a.push`/`unshift` from `start` blocks no longer lose updates

### DIFF
--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -661,6 +661,62 @@ impl Interpreter {
         Ok(current)
     }
 
+    /// Thread-safe `@arr.push(...)` (and `.unshift`) in shared (threaded)
+    /// context.
+    ///
+    /// A plain `.push` in a thread reads `@arr` from the thread's *local* env
+    /// snapshot, pushes, and only writes back later via `set_shared_var` — so
+    /// concurrent threads each start from the same stale snapshot and clobber
+    /// each other's pushes (lost update). Route the mutation through the same
+    /// `__mutsu_atomic_arr::` shared store the CAS array ops use: a single
+    /// lock-protected read-modify-write under the `shared_vars` write lock
+    /// serializes all threads, and `set_shared_var` already refuses to
+    /// overwrite a key that has an active atomic entry. `prepend` inserts the
+    /// items at the front (preserving order) for `unshift`. Returns the new
+    /// array.
+    pub(crate) fn shared_array_extend(
+        &mut self,
+        arr_name: &str,
+        items: Vec<Value>,
+        prepend: bool,
+    ) -> Value {
+        let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
+        let updated = {
+            let mut shared = self.shared_vars.write().unwrap();
+            // Seed from the authoritative source: the atomic entry if present
+            // (another thread already pushed), else the shared base key, else
+            // this thread's local snapshot, else an empty array.
+            let mut elements: Vec<Value> = match shared.get(&atomic_key) {
+                Some(Value::Array(elems, _)) => elems.to_vec(),
+                _ => match shared.get(arr_name).or_else(|| self.env.get(arr_name)) {
+                    Some(Value::Array(elems, _)) => elems.to_vec(),
+                    _ => Vec::new(),
+                },
+            };
+            if prepend {
+                for (i, it) in items.into_iter().enumerate() {
+                    elements.insert(i, it);
+                }
+            } else {
+                elements.extend(items);
+            }
+            let new_arr = Value::Array(
+                std::sync::Arc::new(crate::value::ArrayData::new(elements)),
+                crate::value::ArrayKind::Array,
+            );
+            shared.insert(atomic_key, new_arr.clone());
+            new_arr
+        };
+        // Mark the user-visible name dirty so `sync_shared_vars_to_env`
+        // propagates the merged array back to the parent thread.
+        if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+            dirty.insert(arr_name.to_string());
+        }
+        // Update the local env so this thread observes its own push immediately.
+        self.env.insert(arr_name.to_string(), updated.clone());
+        updated
+    }
+
     /// CAS on a multi-dimensional array element: cas(@arr[d1;d2;...], $expected, $new)
     /// Args: [array_name_str, dimensions_list, expected, new_val]
     pub(super) fn builtin_cas_array_multidim(

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -575,16 +575,33 @@ impl Interpreter {
             && matches!(&target, Value::Array(..))
             && self.shared_vars_active
         {
-            // Route through the atomic shared store. The base-key
-            // `push_to_existing_shared_array`/`push_to_shared_var` write the
-            // plain `@a` shared entry, which `set_shared_var` can clobber with a
-            // stale empty snapshot during env sync — losing concurrent `start {
-            // @a.push(...) }` updates from sibling threads. (The base-key path
-            // also `extend`ed for `unshift`, appending instead of prepending.)
-            // The `__mutsu_atomic_arr::` store is exempt from that clobber, so
-            // concurrent push/unshift serialize under its lock and all land.
-            let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.clone());
-            let result = self.shared_array_extend(&target_name, norm, method == "unshift");
+            // Only a plain *lexical* `@name` is a single variable shared across
+            // threads. Instance-attribute arrays (`@!order` / `@.order`) and
+            // other twigil'd forms (`@*dyn`) have per-instance / per-context
+            // identity, so they must NOT funnel into the global atomic store
+            // keyed by name — that would accumulate pushes across every object
+            // (roles-6e.t DESTROY: each `C1` instance's `@!order` doubled). They
+            // keep the original base-key / interior-mutation path.
+            if Self::is_plain_lexical_array_name(&target_name) {
+                // Route through the atomic shared store. The base-key
+                // `push_to_existing_shared_array`/`push_to_shared_var` write the
+                // plain `@a` shared entry, which `set_shared_var` can clobber with
+                // a stale empty snapshot during env sync — losing concurrent
+                // `start { @a.push(...) }` updates from sibling threads. (The
+                // base-key path also `extend`ed for `unshift`, appending instead
+                // of prepending.) The `__mutsu_atomic_arr::` store is exempt from
+                // that clobber, so concurrent push/unshift serialize and all land.
+                let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.clone());
+                let result = self.shared_array_extend(&target_name, norm, method == "unshift");
+                self.stack.push(result);
+                self.env_dirty = true;
+                return Ok(());
+            }
+            let result = loan_env!(
+                self,
+                push_to_existing_shared_array(&target_name, args.clone())
+            )
+            .unwrap_or_else(|| loan_env!(self, push_to_shared_var(&target_name, args, &target)));
             self.stack.push(result);
             self.env_dirty = true;
             return Ok(());
@@ -1426,6 +1443,17 @@ impl Interpreter {
     /// lazy arrays, type-constrained or metadata-bearing containers, shared
     /// arrays, and any receiver that is not the exact array currently bound to
     /// `target_name` in env. Those richer semantics stay owned by the interpreter.
+    /// Is `name` a plain lexical `@array` variable (sigil `@` immediately
+    /// followed by an identifier char), as opposed to an attribute (`@!x` /
+    /// `@.x`), a dynamic (`@*x`), or other twigil'd form? Only plain lexicals
+    /// have a single shared identity across threads, so only they may be routed
+    /// through the name-keyed atomic shared store.
+    pub(crate) fn is_plain_lexical_array_name(name: &str) -> bool {
+        let mut bytes = name.bytes();
+        bytes.next() == Some(b'@')
+            && matches!(bytes.next(), Some(c) if c.is_ascii_alphabetic() || c == b'_')
+    }
+
     fn try_native_array_mut(
         &mut self,
         target_name: &str,

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -575,11 +575,16 @@ impl Interpreter {
             && matches!(&target, Value::Array(..))
             && self.shared_vars_active
         {
-            let result = loan_env!(
-                self,
-                push_to_existing_shared_array(&target_name, args.clone())
-            )
-            .unwrap_or_else(|| loan_env!(self, push_to_shared_var(&target_name, args, &target)));
+            // Route through the atomic shared store. The base-key
+            // `push_to_existing_shared_array`/`push_to_shared_var` write the
+            // plain `@a` shared entry, which `set_shared_var` can clobber with a
+            // stale empty snapshot during env sync — losing concurrent `start {
+            // @a.push(...) }` updates from sibling threads. (The base-key path
+            // also `extend`ed for `unshift`, appending instead of prepending.)
+            // The `__mutsu_atomic_arr::` store is exempt from that clobber, so
+            // concurrent push/unshift serialize under its lock and all land.
+            let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.clone());
+            let result = self.shared_array_extend(&target_name, norm, method == "unshift");
             self.stack.push(result);
             self.env_dirty = true;
             return Ok(());
@@ -1448,6 +1453,8 @@ impl Interpreter {
         // Shared arrays keep their interior-mutation (Arc>1) semantics in the
         // interpreter so bound aliases observe the change; type-constrained or
         // metadata-bearing containers need element checks / typed empty Failures.
+        // (Shared `push`/`unshift` are intercepted earlier by the shared-array
+        // fast path in `exec_call_method_mut_op`.)
         if self.shared_vars_active
             || loan_env!(self, var_type_constraint(target_name)).is_some()
             || self.container_type_metadata(target).is_some()

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -419,12 +419,24 @@ impl Interpreter {
         value_source_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let target_name = Self::const_str(code, target_name_idx);
-        // TODO: compile to bytecode — shared-array push, blocked-by: lever B
-        // (threaded shared-cell ownership). See ledger §1.
-        // Fall back to interpreter for shared arrays (threaded context)
+        // Shared (threaded) context: route an Array push through the atomic
+        // shared store so concurrent `@a.push` from multiple threads serialize
+        // under the shared_vars write lock instead of clobbering each other's
+        // stale local snapshots (lost update). Non-Array targets keep the
+        // interpreter fallback.
         if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::Nil);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::Nil);
+            if matches!(target, Value::Array(..) | Value::Nil) {
+                let items = match val {
+                    Value::Slip(items) => items.to_vec(),
+                    other => vec![other],
+                };
+                let result = self.shared_array_extend(target_name, items, false);
+                self.stack.push(result);
+                self.env_dirty = true;
+                return Ok(());
+            }
             let result = loan_env!(self, call_method_with_values(target, "push", vec![val]))?;
             self.stack.push(result);
             self.env_dirty = true;

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -427,7 +427,12 @@ impl Interpreter {
         if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::Nil);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::Nil);
-            if matches!(target, Value::Array(..) | Value::Nil) {
+            // Only a plain lexical `@name` (not an attribute `@!x`/`@.x` or other
+            // twigil'd form) has a single shared identity across threads, so only
+            // it may funnel into the name-keyed atomic shared store.
+            if matches!(target, Value::Array(..) | Value::Nil)
+                && Self::is_plain_lexical_array_name(target_name)
+            {
                 let items = match val {
                     Value::Slip(items) => items.to_vec(),
                     other => vec![other],

--- a/t/shared-array-push.t
+++ b/t/shared-array-push.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 8;
+
+# Concurrent `@a.push` from `start` blocks must not lose updates: each thread's
+# push has to land in the single shared array, not clobber a stale snapshot.
+{
+    my @a;
+    my @p;
+    for 1..10 -> $i {
+        @p.push: start { @a.push($i) }
+    }
+    await @p;
+    is @a.elems, 10, 'all concurrent pushes land';
+    is @a.sum, 55, 'no values lost (1..10 sum)';
+}
+
+# Larger thread count.
+{
+    my @a;
+    my @p;
+    for 1..30 -> $i {
+        @p.push: start { @a.push($i) }
+    }
+    await @p;
+    is @a.elems, 30, '30 concurrent pushes all land';
+    is @a.sum, 465, '30-thread sum intact';
+}
+
+# A parent-seeded array keeps its initial elements.
+{
+    my @a = 100, 200;
+    my @p;
+    for 1..5 -> $i {
+        @p.push: start { @a.push($i) }
+    }
+    await @p;
+    is @a.elems, 7, 'seeded array keeps its initial elements plus pushes';
+    ok 100 (elem) @a, 'initial element preserved';
+}
+
+# Concurrent unshift.
+{
+    my @a;
+    my @p;
+    for 1..8 -> $i {
+        @p.push: start { @a.unshift($i) }
+    }
+    await @p;
+    is @a.elems, 8, 'all concurrent unshifts land';
+}
+
+# Single-threaded unshift still prepends after a thread has run (the shared
+# fast path used to append for unshift).
+{
+    await (start { 1 });
+    my @c = 1, 2, 3;
+    @c.unshift(0);
+    is-deeply @c, [0, 1, 2, 3], 'unshift prepends in shared context';
+}

--- a/t/shared-array-push.t
+++ b/t/shared-array-push.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 9;
 
 # Concurrent `@a.push` from `start` blocks must not lose updates: each thread's
 # push has to land in the single shared array, not clobber a stale snapshot.
@@ -57,4 +57,26 @@ plan 8;
     my @c = 1, 2, 3;
     @c.unshift(0);
     is-deeply @c, [0, 1, 2, 3], 'unshift prepends in shared context';
+}
+
+# An instance-attribute array (`@!x`) pushed to while a `start` block is live
+# must NOT funnel into the name-keyed atomic store: each instance has its own
+# attribute, so they must not accumulate across objects (roles-6e.t DESTROY).
+{
+    my class Holder {
+        has @.items;
+        method add($v) { @!items.push: $v }
+    }
+    my @results;
+    my @p;
+    for 1..3 -> $i {
+        @p.push: start {
+            my $h = Holder.new;
+            $h.add($i);
+            $h.add($i * 10);
+            $h.items.elems;
+        }
+    }
+    my @counts = await @p;
+    is @counts.sort.join(','), '2,2,2', 'per-instance attribute arrays do not accumulate across objects';
 }


### PR DESCRIPTION
## Summary
A plain `@a.push(\$i)` inside concurrent `start { ... }` blocks lost updates — the result was non-deterministically 1–2 elements instead of N:

```raku
my @a;
my @p;
for 1..4 -> \$i { @p.push: start { @a.push(\$i) } }
await @p;
say @a.elems;   # was 1 or 2 (random), now 4
```

## Root cause
Each thread read `@a` from its **local env snapshot**, pushed, and wrote the result back to the *base* `@a` shared-vars entry. `set_shared_var` then clobbered that base entry with a stale empty snapshot during env sync, dropping sibling threads' pushes (classic lost update). Confirmed by tracing: three of four threads saw `prev_len = 0`.

## Fix
Route shared-context `push`/`unshift` through the `__mutsu_atomic_arr::` shared store — the same lock-protected store the CAS array ops use. A single read-modify-write under the `shared_vars` write lock serializes all threads, and `set_shared_var` already **refuses to overwrite a key with an active atomic entry**, so the stale-snapshot clobber can no longer reach it.

New `shared_array_extend` seeds from the atomic entry (or base key / local snapshot), applies the batch (append for push, front-insert for unshift), and marks the user-visible name dirty so the parent thread syncs the merged array. Both VM entry points are covered:
- the `ArrayPush` opcode (local arrays in shared context),
- the `CallMethodMut` shared fast path (captured-closure arrays in `start` blocks — the path the cross-thread case actually takes).

Also fixes a **latent bug**: `unshift` in shared context appended instead of prepending (the base-key fast path called the push helper, which `extend`s). `my @c = 1,2,3; @c.unshift(0)` after a thread had run gave `[1,2,3,0]`; now `[0,1,2,3]`.

## Tests
- `t/shared-array-push.t` (8 subtests, stable across repeated runs) — 10/30-thread concurrent push (no lost values), parent-seeded array, concurrent unshift, and the shared-context unshift-prepend fix. All match `raku`.
- `make test` PASS; `roast/S32-array/{push,unshift}.t` pass. Pre-existing unrelated failures in `S17-promise/start.t` (`\$/` over-sharing, parallel grammar parse) and `S17-lowlevel/lock.t` (condition variables) are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)