### PR TITLE
fix(start): panic->X:: boundary for start{}/Promise worker threads (§8.7)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -55,12 +55,6 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 
 ### C. roast backlog（BLOCKERS.md 駆動・インパクト順）
 
-- [ ] **【クラッシュ】無限 Range の `.Supply` 化が worker thread で abort**（ANALYSIS rev2 §8.7）—
-      `my $s = (1..Inf).Supply; $s.tap({...})` が `capacity overflow` でプロセス abort（exit 0 に偽装）。二重の穴:
-      ① `builtins/methods_0arg/coercion.rs:536-537` の Supply coercion が無限 Range を `i64::MAX` 無ガードで
-      `(a..=b).map(Value::Int).collect()`（§8.2 の掃討漏れ）→ `materialize_capped` 経由へ。
-      ② `.tap`/`start{}` のワーカースレッド本体に panic→`X::` 変換境界が無い（#3045 はメインスレッドのみ）→
-      worker の panic を親 Promise/Supply の失敗として伝播させる。
 - [ ] **残りの型付き例外**（X::Str::Numeric / X::Method::NotFound / X::Undeclared / X::Cannot::Lazy /
       X::EXPORTHOW::InvalidDirective 等）。詳細は BLOCKERS.md "throws-like / Exception Types"。
 - [ ] **Match キャプチャ番号付け / コンテナ kind**: (1) `$<x>=(...)` が positional スロットにも重複格納され番号がずれる

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -943,3 +943,22 @@ leak なく解決済み。ハッシュに同型が無く、前回 #3147 は leak
   context.t（`[item %h]` 非 flatten）すべて green。`t/hash-itemization-flag.t`(18)。
 - **効果**: objecthash.t の test-37 abort 解消 → 全 62 走破（残り 7 = object-hash 型 enforcement、次セッション）。
   長年の `list-to-hash-flatten-itemization` ブロッカーを、全 decont 大改修なしの低リスク変更で解消。
+
+### 2026-06-16: `start{}`/Promise worker スレッドの panic→`X::` 境界（ANALYSIS rev2 §8.7 ②）
+
+`start { ... }` / `Promise` の本体はワーカースレッド上で `call_value` 経由に実行され、メインスレッドの
+`run_top` panic 境界（#3045）の外側だった。そのためワーカー内でユーザーコードが Rust panic（整数オーバーフロー /
+capacity overflow / index OOB 等）を起こすと、そのスレッドだけが静かに死に **Promise が永久に未解決のまま
+`await` がハングする**（`panic=abort` ではプロセス全体が abort）。
+
+- `vm.rs` に再利用ヘルパ `guard_worker_panic`（`run_inner_guarded`/`run_range_guarded` と同じ
+  `install_vm_panic_hook` + `IN_VM_PANIC_BOUNDARY` + `catch_unwind` + `vm_panic_error` を共有）を追加。
+  ワーカーは別スレッドなので thread-local 境界フラグは独立に立つ（panic hook がパニック側スレッドのフラグを読み、
+  バックトレース dump を抑止）。
+- `spawn_callable_promise` のワーカー本体 `thread_interp.call_value(block, vec![])` を `guard_worker_panic` で包む。
+  caught panic は catchable `X::AdHoc`（`Internal error: ...`）の `RuntimeError` になり、既存の `promise.break_with`
+  経路で broken Promise になる → `await` が通常の `X::Await::Died` として再送出（ハングしない）。
+- ANALYSIS rev2 §8.7 ①（無限 Range の `.Supply` coercion が `i64::MAX` 無ガード collect で abort）は先行 PR で既に
+  capped `value_to_list` 経由になっており解消済み（`t/supply-infinite-range.t`）。本 PR で §8.7 を完全クローズ。
+- **検証**: `t/start-panic-boundary.t`(6) 新規。concurrency 回帰スイート（vm-panic-boundary / start-await /
+  await-died-exception / thread / promise-* 等）全 PASS。

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -130,7 +130,13 @@ impl Interpreter {
             // CP-3 collapse: the thread's cloned Interpreter *is* the VM — run the
             // block on it directly instead of wrapping it in a sub-VM.
             let mut thread_interp = thread_interp;
-            let result = thread_interp.call_value(block, vec![]);
+            // Worker bodies run via `call_value` without the main thread's
+            // `run_top` panic boundary, so guard them here: a Rust panic in
+            // user code becomes a catchable broken-Promise error (X::AdHoc)
+            // instead of silently killing the thread (hanging `await`) or
+            // aborting the process.
+            let result =
+                crate::vm::guard_worker_panic(|| thread_interp.call_value(block, vec![]));
             // Transfer any handles opened by this thread back to the awaiter.
             let mut new_handles: Vec<(usize, IoHandleState)> = Vec::new();
             let new_ids: Vec<usize> = thread_interp

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -135,8 +135,7 @@ impl Interpreter {
             // user code becomes a catchable broken-Promise error (X::AdHoc)
             // instead of silently killing the thread (hanging `await`) or
             // aborting the process.
-            let result =
-                crate::vm::guard_worker_panic(|| thread_interp.call_value(block, vec![]));
+            let result = crate::vm::guard_worker_panic(|| thread_interp.call_value(block, vec![]));
             // Transfer any handles opened by this thread back to the awaiter.
             let mut new_handles: Vec<(usize, IoHandleState)> = Vec::new();
             let new_ids: Vec<usize> = thread_interp

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -59,6 +59,36 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
     }
 }
 
+/// Run a worker-thread body under the same panic->`X::AdHoc` boundary that
+/// `run_inner_guarded`/`run_range_guarded` install for the main thread.
+///
+/// `start{}`/`Promise` bodies execute on a freshly spawned thread via
+/// `call_value`, which does NOT route through `run_top` — so the main thread's
+/// outer boundary does not cover them. Without this, a Rust panic
+/// (overflow/index-OOB/capacity-overflow) raised by user code in a worker
+/// terminates only that thread, leaving its `Promise` forever unresolved and
+/// hanging the awaiter (or, under `panic=abort`, crashing the whole process).
+/// Wrapping the body here converts such a panic into a catchable
+/// `RuntimeError` (X::AdHoc) the caller can `break_with`, so `await` rethrows
+/// it as a normal `X::Await::Died` instead of hanging.
+pub(crate) fn guard_worker_panic<T>(
+    body: impl FnOnce() -> Result<T, RuntimeError>,
+) -> Result<T, RuntimeError> {
+    install_vm_panic_hook();
+    // The worker is a distinct thread, so its thread-local starts `false`;
+    // setting it suppresses the default backtrace dump for the panic we are
+    // about to convert (the panic hook reads the panicking thread's local).
+    let prev = IN_VM_PANIC_BOUNDARY.with(|f| f.replace(true));
+    let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+    IN_VM_PANIC_BOUNDARY.with(|f| f.set(prev));
+    match caught {
+        Ok(r) => r,
+        Err(payload) => Err(Interpreter::vm_panic_error(panic_payload_message(
+            payload.as_ref(),
+        ))),
+    }
+}
+
 /// Pre-computed fast dispatch entry for compiled methods.
 /// Caches all the information needed to skip intermediate dispatch steps
 /// (wrap chain check, compiled_code extraction, fast-path eligibility checks).

--- a/t/start-panic-boundary.t
+++ b/t/start-panic-boundary.t
@@ -1,0 +1,55 @@
+# A Rust-level panic (integer overflow, capacity overflow, index OOB, ...)
+# triggered by user code inside a `start{}`/Promise worker thread must NOT hang
+# the awaiter or crash the whole process. The worker installs the same
+# panic->X:: boundary the main thread uses (see vm-panic-boundary.t), converting
+# such a panic into a broken Promise whose cause is a catchable X::AdHoc, so
+# `await` rethrows it through the normal exception machinery.
+use Test;
+
+plan 6;
+
+# 1: awaiting a worker that panics rethrows (does not hang) and is catchable.
+{
+    my $survived = False;
+    my $caught;
+    try {
+        my $p = start { my @a; @a[2**64 - 1] = 1; "unreachable" };
+        await $p;
+        CATCH { default { $caught = $_ } }
+    }
+    $survived = True;
+    ok $survived, 'await of a panicking start{} survives (no hang/crash)';
+    ok $caught.defined, 'the panic surfaces as a catchable exception';
+}
+
+# 2: the converted exception is an X::AdHoc carrying the internal-error message.
+{
+    my $msg;
+    try {
+        my $p = start { my @a; @a[2**64 - 2] = 1; };  # capacity-overflow panic
+        await $p;
+        CATCH { default { $msg = .message } }
+    }
+    ok $msg.defined && $msg.contains('Internal error'),
+        'message carries the internal-error prefix';
+}
+
+# 3: the Promise itself ends up Broken, not stuck.
+{
+    my $p = start { my @a; @a[2**64 - 1] = 1; };
+    # await inside try so the broken promise does not abort the program
+    try { await $p }
+    is $p.status, Broken, 'a panicking start{} leaves the Promise Broken';
+}
+
+# 4: a normal (non-panic) start{} is unaffected by the boundary.
+{
+    my $p = start { 40 + 2 };
+    is await($p), 42, 'ordinary start{} still resolves normally';
+}
+
+# 5: dies-ok sees the awaited panic as a thrown exception.
+dies-ok {
+    my $p = start { my @a; @a[2**64 - 1] = 1; };
+    await $p;
+}, 'dies-ok sees the awaited worker panic as a throw';


### PR DESCRIPTION
## Summary

`start{}`/`Promise` bodies execute on a freshly spawned worker thread via `call_value`, which sits **outside** the main thread's `run_top` panic boundary (#3045). A Rust panic in worker user code (integer overflow / index-OOB / capacity-overflow) therefore killed only that thread, leaving its `Promise` **forever unresolved** and hanging `await` — or, under `panic=abort`, crashing the whole process.

### Before
```
my $p = start { my @a; @a[2**64 - 1] = 1; };
await $p;   # worker panics -> Promise never resolved -> await hangs forever
```

### After
```
Runtime error: Internal error: attempt to add with overflow   # exit 1, catchable
```
`await` rethrows the converted exception as a normal `X::Await::Died`; `try`/`CATCH` catches it as `X::AdHoc`; the Promise ends up `Broken`.

## Change

- Add reusable `guard_worker_panic` helper in `vm.rs`, sharing the same `install_vm_panic_hook` + `IN_VM_PANIC_BOUNDARY` + `catch_unwind` + `vm_panic_error` machinery as the main-thread boundaries (`run_inner_guarded` / `run_range_guarded`). The worker is a distinct thread, so its thread-local boundary flag is set independently — the panic hook reads the panicking thread's flag and suppresses the backtrace dump.
- Wrap the worker body `thread_interp.call_value(block, vec![])` in `spawn_callable_promise` with it. A caught panic becomes a catchable `X::AdHoc` `RuntimeError` and flows through the existing `promise.break_with` path.

This closes ANALYSIS rev2 §8.7. Item ① (unguarded infinite-Range `.Supply` collect) was already resolved earlier via capped `value_to_list` (`t/supply-infinite-range.t`); this PR closes item ②.

## Test

- New `t/start-panic-boundary.t` (6 subtests): await rethrows / catchable / internal-error message / Promise Broken / normal start{} unaffected / dies-ok.
- `make test`: 462 cargo tests + full `prove t/` suite PASS. Concurrency regression suite (vm-panic-boundary, start-await, await-died-exception, thread, promise-*) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)