### PR TITLE
fix(subst): $/ List results, slipped-pair named args, compile-time :i check

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,10 +196,13 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 182/191 pass. **NOT whitelistable as written**: reference rakudo itself
-    fails 2 (tests 157 `:i(1) is OK`, 170 `s[]="" when $_ is not set`), so the
-    file cannot reach a clean pass. Remaining mutsu failures span several distinct
-    (mostly regex-internal) features:
+  - 184/191 pass. **Whitelistable in principle**: although reference rakudo on
+    this box fails tests 157 (`:i(1) is OK`) and 170 (`s[]="" when $_ is not set`),
+    **mutsu passes both** (157 outright; 170 is `#?rakudo todo`, so a mutsu failure
+    there would not fail the file anyway). So fixing the remaining mutsu failures
+    (102, 159, 184, 187-190) does reach a clean mutsu pass and the file can be
+    whitelisted. Remaining mutsu failures span several distinct (mostly
+    regex-internal) features:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
     block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`). `given LITERAL -> $_ is
     copy` marked `$_` read-only (the `$_ = $_` copy-head desugar then died on the
@@ -229,7 +232,11 @@
     them); not replicated to avoid a special-case hack.
   - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
     and block replacement (152 fixed via the closure-writeback fix below).
-  - 156: `s:i($i)/.../` must throw `X::Value::Dynamic` (non-constant adverb).
+  - 156 (FIXED): `s:i($i)/.../` now throws `X::Value::Dynamic` (non-constant
+    adverb). The compile-time boolean-flag-adverb check (`contains_dynamic_var`)
+    was only flagging `*`-twigil dynamic vars (`$*foo`); broadened to flag any
+    variable reference (any sigil followed by a name char/twigil), since the
+    adverb value must be a literal constant. `:i(1)`/`:i(True)` still pass.
   - 159: `s///` on a read-only `$_` (method `$_` param) must die. PARTIAL: the
     `s///` writeback now honors a read-only topic (`exec_subst_op` routes through
     `write_subst_topic_checked`, throwing X::Assignment::RO on an actual match), so
@@ -248,9 +255,19 @@
   - 181 (FIXED): invalid `:x` argument now throws `X::Str::Match::x`. `dispatch_subst`
     validates `x_count` with the existing `is_valid_match_x_arg`/`str_match_x_error`
     helpers (shared with `.match`) before running the substitution.
-  - 184, 186: `:x(1..3)` range argument to `:x` in operator/method form (opcode
-    `x_count` is a single `u32`, cannot carry a range); `.subst` does not set
-    `$/` to a List of matches for multi-match adverbs.
+  - 186 (FIXED): `.subst` now sets `$/` to a List of Match objects for multi-match
+    adverbs (`:g`/`:x`/multi-`:nth`), a single Match for single-`:nth`, and an
+    empty List for `:g` with no match — in both the native `.subst(:g)` path and
+    `dispatch_subst`. Also added the ordinal adverbs `:st`/`:nd`/`:rd`/`:th` and
+    `:nth(Range)` to `dispatch_subst`. Separately, a positional pair slipped into a
+    method call via `|(:g)` / `|($name => v)` now flattens to a *named* argument
+    (`append_slip_item` ValuePair→Pair), so `.subst(|(:nth(1..3)), ...)` is seen
+    as the `:nth` adverb (was silently kept as a positional `ValuePair`).
+  - 184: `:x(1..3)` range argument to `:x` in the *operator* form `S:x(1..3)/`/
+    `s:x(1..3)/` (opcode `x_count` is a single `u32`, cannot carry a range; the
+    parser drops `:x(1..3)` because "1..3" fails to `parse::<usize>`). `.subst`
+    method form already handles `:x(Range)` via `dispatch_subst`. Needs the
+    operator opcode to carry a range spec (mirror `nth_idx`'s raw-string approach).
   - 187-190: placeholder params (`$^a`) inside `[3,4].map:{ S{...}=$^a }`. Root
     cause: a block with explicit placeholders should leave `$_` bound to the
     *outer* lexical topic, but mutsu leaves `$_` undefined inside the placeholder

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -205,13 +205,19 @@ fn is_boolean_flag_adverb(name: &str) -> bool {
     )
 }
 
-/// True when an adverb argument source references a dynamic variable
-/// (a `*` twigil: `$*foo`, `@*ARGS`, `%*ENV`, `&*bar`).
+/// True when a boolean-flag adverb argument is not a compile-time constant.
+/// These adverbs (`:i`, `:m`, `:s`, ...) are compile-time switches, so their
+/// value must be a literal (`:i(1)`, `:i(True)`) — any variable reference
+/// (`:i($i)`, `:i(@*ARGS[0])`, `:i($obj.attr)`) is X::Value::Dynamic. We detect
+/// non-constness by the presence of a sigil that begins a variable name (a
+/// regular or twigil'd lexical/dynamic/attribute variable).
 fn contains_dynamic_var(src: &str) -> bool {
     let bytes = src.as_bytes();
-    bytes
-        .windows(2)
-        .any(|w| matches!(w[0], b'$' | b'@' | b'%' | b'&') && w[1] == b'*')
+    bytes.windows(2).any(|w| {
+        matches!(w[0], b'$' | b'@' | b'%' | b'&')
+            && (w[1].is_ascii_alphabetic()
+                || matches!(w[1], b'_' | b'*' | b'!' | b'.' | b'^' | b':' | b'<'))
+    })
 }
 
 fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -563,6 +563,48 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Expand a `:nth`/`:st`/`:nd`/`:rd`/`:th` adverb argument into a list of
+    /// 1-based match indices. Accepts an Int, an Array of Ints, or any Range
+    /// variant (`:nth(1..3)`).
+    fn subst_nth_indices(value: &Value) -> Vec<i64> {
+        match value {
+            Value::Int(n) => vec![*n],
+            Value::Array(items, _) => items.iter().map(|v: &Value| v.to_f64() as i64).collect(),
+            Value::Range(lo, hi) => (*lo..=*hi).collect(),
+            Value::RangeExcl(lo, hi) => (*lo..*hi).collect(),
+            Value::RangeExclStart(lo, hi) => ((*lo + 1)..=*hi).collect(),
+            Value::RangeExclBoth(lo, hi) => ((*lo + 1)..*hi).collect(),
+            _ => vec![value.to_f64() as i64],
+        }
+    }
+
+    /// Build the `$/` value after a multi-match substitution. With a List-result
+    /// adverb (`:g`/`:x`/multi-`:nth`) `$/` is a (possibly empty) List of Match
+    /// objects; otherwise it is the single first Match, or Nil when nothing
+    /// matched.
+    fn subst_match_var(selected: &[RegexCaptures], text: &str, result_is_list: bool) -> Value {
+        let to_match = |c: &RegexCaptures| {
+            Value::make_match_object_full(
+                c.matched.clone(),
+                c.from as i64,
+                c.to as i64,
+                &c.positional,
+                &c.named,
+                &c.named_subcaps,
+                &c.positional_subcaps,
+                &c.positional_quantified,
+                Some(text),
+            )
+        };
+        if result_is_list {
+            Value::array(selected.iter().map(to_match).collect())
+        } else if let Some(c) = selected.first() {
+            to_match(c)
+        } else {
+            Value::Nil
+        }
+    }
+
     pub(super) fn dispatch_subst(
         &mut self,
         target: Value,
@@ -581,13 +623,13 @@ impl Interpreter {
                 match key.as_str() {
                     "g" | "global" => global = value.truthy(),
                     "x" => x_count = Some(*value.clone()),
-                    "nth" => match value.as_ref() {
-                        Value::Int(n) => nth = Some(vec![*n]),
-                        Value::Array(items, _) => {
-                            nth = Some(items.iter().map(|v: &Value| v.to_f64() as i64).collect());
-                        }
-                        _ => nth = Some(vec![value.to_f64() as i64]),
-                    },
+                    // `:nth`, plus the ordinal aliases `:st`/`:nd`/`:rd`/`:th`, all
+                    // select 1-based match indices. The argument may be an Int, a
+                    // list of Ints, or a Range (`:nth(1..3)`).
+                    "nth" | "st" | "nd" | "rd" | "th" => {
+                        let idxs = Self::subst_nth_indices(value);
+                        nth.get_or_insert_with(Vec::new).extend(idxs);
+                    }
                     "1st" | "first" if value.truthy() => nth = Some(vec![1]),
                     "2nd" | "second" if value.truthy() => nth = Some(vec![2]),
                     "3rd" | "third" if value.truthy() => nth = Some(vec![3]),
@@ -684,8 +726,25 @@ impl Interpreter {
                 } else {
                     self.regex_match_all_with_captures(&pat, &text)
                 };
+                // After a multi-match substitution `$/` is a List of Match objects
+                // for `:g`/`:x`/multi-`:nth`, but a single Match for a single-index
+                // `:nth` (even when combined with `:g`, e.g. `s:2nd:g/./Z/`).
+                let nth_len = nth.as_ref().map(|v| v.len());
+                let single_nth = nth_len == Some(1);
+                let nth_is_multi = nth_len.is_some_and(|n| n > 1);
+                let result_is_list =
+                    !single_nth && (pat_global || x_count.is_some() || nth_is_multi);
+                let empty_match_var = |me: &mut Self| {
+                    let v = if result_is_list {
+                        Value::array(Vec::new())
+                    } else {
+                        Value::Nil
+                    };
+                    me.env.insert("/".to_string(), v);
+                };
+
                 if all_captures.is_empty() {
-                    self.env.insert("/".to_string(), Value::Nil);
+                    empty_match_var(self);
                     return Ok(Value::str(text));
                 }
                 let chars: Vec<char> = text.chars().collect();
@@ -710,7 +769,7 @@ impl Interpreter {
                         selected.retain(|cap| cap.from >= p);
                         // The first remaining match must be exactly at p
                         if selected.is_empty() || selected[0].from != p {
-                            self.env.insert("/".to_string(), Value::Nil);
+                            empty_match_var(self);
                             return Ok(Value::str(text));
                         }
                     }
@@ -741,7 +800,7 @@ impl Interpreter {
                     if let Some((lo, hi)) = resolve_x_count(&x_count) {
                         let count = selected.len();
                         if count < lo {
-                            self.env.insert("/".to_string(), Value::Nil);
+                            empty_match_var(self);
                             return Ok(Value::str(text));
                         }
                         if count > hi {
@@ -750,7 +809,7 @@ impl Interpreter {
                     }
 
                     if selected.is_empty() {
-                        self.env.insert("/".to_string(), Value::Nil);
+                        empty_match_var(self);
                         return Ok(Value::str(text));
                     }
 
@@ -773,6 +832,8 @@ impl Interpreter {
                     }
                     let suffix: String = chars[last_end..].iter().collect();
                     result.push_str(&suffix);
+                    let match_var = Self::subst_match_var(&selected, &text, result_is_list);
+                    self.env.insert("/".to_string(), match_var);
                     Ok(Value::str(result))
                 } else if let Some(captures) = {
                     if is_p5 {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -15,6 +15,17 @@ impl Interpreter {
             // a bare Hash into pairs before wrapping in a Slip. A Hash that is already
             // inside a Slip (e.g. from a Capture's positional list) should stay as-is.
             Value::Hash(_) => args.push(item.clone()),
+            // A `(:key(val))` positional-pair slipped via `|(...)` flattens back
+            // to a *named* argument in Raku (e.g. `.subst(|(:g), ...)` passes `:g`
+            // as the named `:g` adverb). Mirror `append_slip_value`'s ValuePair
+            // arm so the slipped pair is recognized as a named argument.
+            Value::ValuePair(key, val) => {
+                if let Value::Str(name) = key.as_ref() {
+                    args.push(Value::Pair(name.to_string(), val.clone()));
+                } else {
+                    args.push(item.clone());
+                }
+            }
             Value::Range(..)
             | Value::RangeExcl(..)
             | Value::RangeExclStart(..)

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -119,8 +119,15 @@ impl Interpreter {
         }
 
         if matches.is_empty() {
-            // No match: `$/` becomes Nil and the original string is returned.
-            self.env_mut().insert("/".to_string(), Value::Nil);
+            // No match: the original string is returned. `$/` becomes an empty
+            // List for a global subst (Rakudo: `$/` is always a List under `:g`),
+            // or Nil for a non-global subst.
+            let empty = if global {
+                Value::array(Vec::new())
+            } else {
+                Value::Nil
+            };
+            self.env_mut().insert("/".to_string(), empty);
             return Ok(Value::str(text.to_string()));
         }
 
@@ -150,21 +157,34 @@ impl Interpreter {
         }
         result.extend(chars[last_end..].iter());
 
-        if !global {
-            let (start, end, caps) = &matches[0];
-            let matched: String = chars[*start..*end].iter().collect();
-            let match_obj = Value::make_match_object_full(
+        // `$/` policy: a non-global `.subst` sets it to the single (first) Match;
+        // a global `.subst` sets it to a List of every Match object (matching
+        // `s:g///` and Rakudo's `.subst(:g)` — `$/` is always a List, even for a
+        // single match).
+        let make_match = |start: usize, end: usize, caps: &[String]| {
+            let matched: String = chars[start..end].iter().collect();
+            Value::make_match_object_full(
                 matched,
-                *start as i64,
-                *end as i64,
+                start as i64,
+                end as i64,
                 caps,
                 &HashMap::new(),
                 &HashMap::new(),
                 &[],
                 &[],
                 Some(text),
-            );
-            self.env_mut().insert("/".to_string(), match_obj);
+            )
+        };
+        if global {
+            let list: Vec<Value> = matches
+                .iter()
+                .map(|(start, end, caps)| make_match(*start, *end, caps))
+                .collect();
+            self.env_mut().insert("/".to_string(), Value::array(list));
+        } else {
+            let (start, end, caps) = &matches[0];
+            self.env_mut()
+                .insert("/".to_string(), make_match(*start, *end, caps));
         }
 
         Ok(Value::str(result))


### PR DESCRIPTION
Three independent correctness fixes advancing `roast/S05-substitution/subst.t` from 182/191 to **184/191**, with general improvements to method-call arg binding and regex-adverb handling beyond subst.

## Fixes

1. **`.subst` sets `$/` after multi-match substitution** (test 186). The native `.subst(:g)` path and `dispatch_subst` now set `$/` to a List of Match objects for List-result adverbs (`:g`/`:x`/multi-`:nth`), a single Match for single-index `:nth` (even with `:g`), and an empty List for `:g` with no match — matching Rakudo and the existing `s:g///` operator behavior. Also adds ordinal adverbs `:st`/`:nd`/`:rd`/`:th` and `:nth(Range)` to `dispatch_subst`.

2. **Slipped positional pair → named argument** (general). `|(:g)` / `|($name => v)` now flattens to a *named* argument (`append_slip_item`: `ValuePair` → `Pair`), mirroring `append_slip_value`. Previously the slipped pair stayed a positional `ValuePair`, so `.subst(|(:nth(1..3)), ...)` never saw the adverb. Matches Rakudo (`|(:g)` is a named arg) and is not subst-specific.

3. **Non-constant boolean-flag regex adverb → compile-time `X::Value::Dynamic`** (test 156). `s:i($i)/.../` now dies at compile time. The check previously only flagged `*`-twigil dynamic vars (`$*foo`); broadened to flag any variable reference, since `:i`/`:m`/`:s`/... values must be compile-time literals. `:i(1)`/`:i(True)` still pass.

## Remaining subst.t blockers (documented in `TODO_roast/S05.md`)

subst.t is whitelistable in principle — mutsu passes tests 157/170 that reference rakudo fails. Remaining mutsu failures: 102 (samemark combining-mark transfer), 159 (read-only method params), 184 (operator `:x(Range)`), 187-190 (placeholder-block topic scoping).

## Testing

Full local `make test` passes; targeted `make roast` files (match.t, 67222.t, substr.t) pass; added slip-pair semantics verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)