### PR TITLE
fix(placeholder): bare placeholder blocks keep the outer $_ topic

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,11 +196,11 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 184/191 pass. **Whitelistable in principle**: although reference rakudo on
+  - 187/191 pass. **Whitelistable in principle**: although reference rakudo on
     this box fails tests 157 (`:i(1) is OK`) and 170 (`s[]="" when $_ is not set`),
     **mutsu passes both** (157 outright; 170 is `#?rakudo todo`, so a mutsu failure
     there would not fail the file anyway). So fixing the remaining mutsu failures
-    (102, 159, 184, 187-190) does reach a clean mutsu pass and the file can be
+    (102, 159, 184, 187) does reach a clean mutsu pass and the file can be
     whitelisted. Remaining mutsu failures span several distinct (mostly
     regex-internal) features:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
@@ -268,11 +268,22 @@
     parser drops `:x(1..3)` because "1..3" fails to `parse::<usize>`). `.subst`
     method form already handles `:x(Range)` via `dispatch_subst`. Needs the
     operator opcode to carry a range spec (mirror `nth_idx`'s raw-string approach).
-  - 187-190: placeholder params (`$^a`) inside `[3,4].map:{ S{...}=$^a }`. Root
-    cause: a block with explicit placeholders should leave `$_` bound to the
-    *outer* lexical topic, but mutsu leaves `$_` undefined inside the placeholder
-    block (raku keeps the enclosing `$_`). The substitution then operates on the
-    wrong/empty topic. Broader fix in block topicalization, not subst-local.
+  - 188-190 (FIXED): placeholder params (`$^a`) inside `S/5/$^a/` (string
+    replacement) and `S/$^a/X/` / `S{$^a}='X'` (placeholder in the pattern). Two
+    fixes: (a) the placeholder collector now scans the raw subst pattern/replacement
+    *strings* for `$^x`/`@^x`/… (`collect_placeholders_in_str`), so the block gains
+    `$^a` as a param and the element binds there instead of `$_`; (b) a *block* with
+    placeholder params keeps the enclosing lexical `$_` instead of resetting it to
+    Any (the `$_`-reset in `call_compiled_closure_with_topic` is skipped when the
+    `param_defs` carry placeholder names — a bare placeholder block is a block, not
+    a routine). Local: t/placeholder-block-topic.t.
+  - 187: `S{5}=$^a` (the `S{...}=EXPR` assignment form) desugars to
+    `.subst(/5/, { $^a })` — the replacement EXPR is wrapped in an auto-generated
+    closure, so the user's `$^a` lands *inside* that closure and is not hoisted to
+    the enclosing block. Indistinguishable at the AST level from an explicit
+    `.subst(/5/, { $^a })` closure replacement (where `$^a` genuinely belongs to
+    the replacement closure). Fixing requires the parser to mark the `S{}=`-desugared
+    replacement closure so its placeholders bubble up to the surrounding block.
   - Fixed in this pass: `:g`/`:x`/multi-`:nth` now return a List of Match in `$/`
     (single `:nth(N)` stays a Match even with `:g`); `s:g[...] = expr` with
     captures/`$/`/`$0` on the RHS evaluated per match; multi-value `:nth(a,b)`

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1303,8 +1303,57 @@ fn collect_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
     }
 }
 
+/// Scan a raw `s///`/`S///` pattern or replacement *string* for placeholder
+/// variables (`$^a`, `@^a`, `%^a`, `&^a`). The substitution stores its pattern
+/// and replacement as un-parsed strings, so the normal expression walk never
+/// sees the placeholders inside `S/5/$^a/`; this recovers them in the same name
+/// format the `Expr::Var`/`ArrayVar`/… arms produce (`$`→`^a`, `@`→`@^a`, …).
+fn collect_placeholders_in_str(src: &str, out: &mut Vec<String>) {
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        let sigil = bytes[i];
+        if matches!(sigil, b'$' | b'@' | b'%' | b'&')
+            && bytes[i + 1] == b'^'
+            && bytes[i + 2].is_ascii_alphabetic()
+        {
+            let start = i + 2;
+            let mut j = start;
+            while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+                j += 1;
+            }
+            let name = &src[start..j];
+            let entry = match sigil {
+                b'$' => format!("^{}", name),
+                b'@' => format!("@^{}", name),
+                b'%' => format!("%^{}", name),
+                _ => format!("&^{}", name),
+            };
+            if !out.contains(&entry) {
+                out.push(entry);
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+}
+
 fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
     match expr {
+        Expr::Subst {
+            pattern,
+            replacement,
+            ..
+        }
+        | Expr::NonDestructiveSubst {
+            pattern,
+            replacement,
+            ..
+        } => {
+            collect_placeholders_in_str(pattern, out);
+            collect_placeholders_in_str(replacement, out);
+        }
         Expr::Var(name) if name.starts_with('^') || name.starts_with(':') => {
             if !out.contains(name) {
                 out.push(name.clone());
@@ -1596,6 +1645,19 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
 /// own placeholder scope.
 fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
     match expr {
+        Expr::Subst {
+            pattern,
+            replacement,
+            ..
+        }
+        | Expr::NonDestructiveSubst {
+            pattern,
+            replacement,
+            ..
+        } => {
+            collect_placeholders_in_str(pattern, out);
+            collect_placeholders_in_str(replacement, out);
+        }
         Expr::Var(name) if name.starts_with('^') || name.starts_with(':') => {
             if !out.contains(name) {
                 out.push(name.clone());

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -383,8 +383,19 @@ impl Interpreter {
             }
         }
 
-        // Raku: routines get their own $_ initialized to (Any).
-        if cc.is_routine && !data.param_defs.iter().any(|pd| pd.name == "_") {
+        // Raku: routines get their own $_ initialized to (Any). A *block* with
+        // placeholder params (`{ $^a }`) is still a block, not a routine, so it
+        // keeps the enclosing lexical `$_` (mutsu compiles such a bare block as a
+        // routine for `return`/`&?ROUTINE` purposes, but its topic must still be
+        // the outer `$_`). Skip the reset when an explicit `$_` param is present
+        // or when the signature is made of placeholder params (`$^x`).
+        let has_placeholder_param = data.param_defs.iter().any(|pd| {
+            pd.name.starts_with('^') || pd.name.starts_with("@^") || pd.name.starts_with("%^")
+        });
+        if cc.is_routine
+            && !has_placeholder_param
+            && !data.param_defs.iter().any(|pd| pd.name == "_")
+        {
             self.env_mut().insert(
                 "_".to_string(),
                 Value::Package(crate::symbol::Symbol::intern("Any")),

--- a/t/placeholder-block-topic.t
+++ b/t/placeholder-block-topic.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 7;
+
+# A bare block with placeholder params is still a *block*: it keeps the
+# enclosing lexical `$_` (it does not reset the topic to Any the way a routine
+# does), while the element binds to the placeholder parameter.
+{
+    $_ = "12345";
+    is-deeply [3, 4].map({ "t=$_ a=$^a" }), ("t=12345 a=3", "t=12345 a=4"),
+        'placeholder block inherits outer $_; element binds to $^a';
+}
+
+# Placeholder inside an immutable substitution replacement string (S/p/$^a/):
+# the substitution runs on the inherited outer `$_`.
+{
+    $_ = "12345";
+    is-deeply [3, 4].map({ S/5/$^a/ }), ("12343", "12344"),
+        'placeholder in S/// replacement (// quoter)';
+}
+
+# Placeholder inside the substitution pattern.
+{
+    $_ = "12345";
+    is-deeply [3, 4].map({ S/$^a/X/ }), ("12X45", "123X5"),
+        'placeholder in S/// pattern (// quoter)';
+}
+{
+    $_ = "12345";
+    is-deeply [3, 4].map({ S{$^a} = 'X' }), ("12X45", "123X5"),
+        'placeholder in S{} pattern ({} quoter)';
+}
+
+# Direct placeholder call keeps the caller's `$_`.
+{
+    $_ = "OUTER";
+    my $b = { "t=[$_] a=$^a" };
+    is $b(5), "t=[OUTER] a=5", 'direct placeholder block call keeps outer $_';
+}
+
+# A real `sub` does NOT inherit `$_` (topic is Any), even with placeholders.
+{
+    $_ = "OUTER";
+    my $s = sub { defined($_) ?? "def" !! "undef" };
+    is $s(), "undef", 'sub resets $_ to Any (not inherited)';
+}
+
+# A normal sub parameter is unaffected by the topic change.
+{
+    sub double($x) { $x * 2 }
+    is double(21), 42, 'normal sub parameter still works';
+}


### PR DESCRIPTION
A block written with placeholder parameters (`{ $^a }`) is a *block*, not a routine: it binds the element to the placeholder and keeps the enclosing lexical `$_`. mutsu got this wrong in two ways, so `[3,4].map({ S/5/$^a/ })` (roast `S05-substitution/subst.t` 188-190) produced `("3","4")` instead of `("12343","12344")`.

## Fixes

1. **Placeholders embedded in a substitution were never collected.** `s///`/`S///` store their pattern and replacement as raw strings, so the expression walk in `collect_placeholders`/`_shallow` never saw the `$^a` inside `S/5/$^a/`. The block had no params, the map element bound to `$_`, and `$^a` was unbound. Added `collect_placeholders_in_str` to scan the subst pattern/replacement strings for `$^x`/`@^x`/`%^x`/`&^x`.

2. **A bare placeholder block reset `$_` to `(Any)`.** `{ $^a }` compiles via `compile_routine_closure_body` (is_routine = true), so the routine `$_`→Any reset in `call_compiled_closure_with_topic` fired and the block lost the enclosing topic. Skip that reset when the `param_defs` carry placeholder names — a bare placeholder block is a block, not a routine. A real `sub { $^a }` is unaffected (it routes through `AnonSub` with empty `param_defs`, so it still resets `$_` to Any like Rakudo).

## Impact

`subst.t` advances 184/191 → **187/191** (188-190 now pass). Remaining: 187 (`S{5}=$^a` assignment-closure form — the desugared replacement closure doesn't hoist its placeholder to the enclosing block), 102 (samemark), 159 (read-only method params), 184 (operator `:x(Range)`) — documented in `TODO_roast/S05.md`.

## Testing

New `t/placeholder-block-topic.t` (7 subtests); full local `make test` passes. Verified `sub`/normal-param/topic semantics against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)