### PR TITLE
fix(subst): support :x(Range) in the operator s///|S/// forms

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,11 +196,11 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 187/191 pass. **Whitelistable in principle**: although reference rakudo on
+  - 188/191 pass. **Whitelistable in principle**: although reference rakudo on
     this box fails tests 157 (`:i(1) is OK`) and 170 (`s[]="" when $_ is not set`),
     **mutsu passes both** (157 outright; 170 is `#?rakudo todo`, so a mutsu failure
     there would not fail the file anyway). So fixing the remaining mutsu failures
-    (102, 159, 184, 187) does reach a clean mutsu pass and the file can be
+    (102, 159, 187) does reach a clean mutsu pass and the file can be
     whitelisted. Remaining mutsu failures span several distinct (mostly
     regex-internal) features:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
@@ -263,11 +263,14 @@
     method call via `|(:g)` / `|($name => v)` now flattens to a *named* argument
     (`append_slip_item` ValuePair→Pair), so `.subst(|(:nth(1..3)), ...)` is seen
     as the `:nth` adverb (was silently kept as a positional `ValuePair`).
-  - 184: `:x(1..3)` range argument to `:x` in the *operator* form `S:x(1..3)/`/
-    `s:x(1..3)/` (opcode `x_count` is a single `u32`, cannot carry a range; the
-    parser drops `:x(1..3)` because "1..3" fails to `parse::<usize>`). `.subst`
-    method form already handles `:x(Range)` via `dispatch_subst`. Needs the
-    operator opcode to carry a range spec (mirror `nth_idx`'s raw-string approach).
+  - 184 (FIXED): `:x(1..3)` range argument to `:x` in the *operator* form
+    `S:x(1..3)/`/`s:x(1..3)/`. The `:x` spec is now carried as a raw string
+    (`MatchAdverbs.repeat: Option<String>`, AST `x: Option<String>`, opcode
+    `x_idx` const-pool index) mirroring `nth_idx`, and parsed at substitution
+    time (`parse_subst_x_spec` → `(lo, hi)`: exact `N`→`(N,N)`, `lo..hi` range,
+    `*`/`Inf` unbounded). `select_substitution_ranges` requires >= `lo` matches
+    and keeps up to `hi`. The `m//` match form keeps `:x` as an exact count.
+    Local: t/subst-x-range.t.
   - 188-190 (FIXED): placeholder params (`$^a`) inside `S/5/$^a/` (string
     replacement) and `S/$^a/X/` / `S{$^a}='X'` (placeholder in the pattern). Two
     fixes: (a) the placeholder collector now scans the raw subst pattern/replacement

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -160,7 +160,9 @@ pub(crate) enum Expr {
         samespace: bool,
         global: bool,
         nth: Option<String>,
-        x: Option<usize>,
+        /// Raw `:x` adverb argument spec: a count (`"3"`) or a range
+        /// (`"1..3"`), parsed at substitution time. `None` when `:x` is absent.
+        x: Option<String>,
         perl5: bool,
     },
     NonDestructiveSubst {
@@ -172,7 +174,9 @@ pub(crate) enum Expr {
         samespace: bool,
         global: bool,
         nth: Option<String>,
-        x: Option<usize>,
+        /// Raw `:x` adverb argument spec: a count (`"3"`) or a range
+        /// (`"1..3"`), parsed at substitution time. `None` when `:x` is absent.
+        x: Option<String>,
         perl5: bool,
     },
     Transliterate {

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -122,12 +122,15 @@ impl Compiler {
         samespace: bool,
         global: bool,
         nth: &Option<String>,
-        x: &Option<usize>,
+        x: &Option<String>,
         perl5: bool,
     ) {
         let pattern_idx = self.code.add_constant(Value::str(pattern.to_string()));
         let replacement_idx = self.code.add_constant(Value::str(replacement.to_string()));
         let nth_idx = nth
+            .as_ref()
+            .map(|raw| self.code.add_constant(Value::str(raw.clone())));
+        let x_idx = x
             .as_ref()
             .map(|raw| self.code.add_constant(Value::str(raw.clone())));
         self.code.emit(OpCode::Subst {
@@ -139,7 +142,7 @@ impl Compiler {
             samespace,
             global,
             nth_idx,
-            x_count: x.map(|n| n as u32),
+            x_idx,
             perl5,
         });
     }
@@ -156,12 +159,15 @@ impl Compiler {
         samespace: bool,
         global: bool,
         nth: &Option<String>,
-        x: &Option<usize>,
+        x: &Option<String>,
         perl5: bool,
     ) {
         let pattern_idx = self.code.add_constant(Value::str(pattern.to_string()));
         let replacement_idx = self.code.add_constant(Value::str(replacement.to_string()));
         let nth_idx = nth
+            .as_ref()
+            .map(|raw| self.code.add_constant(Value::str(raw.clone())));
+        let x_idx = x
             .as_ref()
             .map(|raw| self.code.add_constant(Value::str(raw.clone())));
         self.code.emit(OpCode::NonDestructiveSubst {
@@ -173,7 +179,7 @@ impl Compiler {
             samespace,
             global,
             nth_idx,
-            x_count: x.map(|n| n as u32),
+            x_idx,
             perl5,
         });
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -853,7 +853,9 @@ pub(crate) enum OpCode {
         samespace: bool,
         global: bool,
         nth_idx: Option<u32>,
-        x_count: Option<u32>,
+        /// Constant-pool index of the raw `:x` spec string (`"3"` / `"1..3"`),
+        /// or `None` when `:x` is absent.
+        x_idx: Option<u32>,
         perl5: bool,
     },
 
@@ -867,7 +869,9 @@ pub(crate) enum OpCode {
         samespace: bool,
         global: bool,
         nth_idx: Option<u32>,
-        x_count: Option<u32>,
+        /// Constant-pool index of the raw `:x` spec string (`"3"` / `"1..3"`),
+        /// or `None` when `:x` is absent.
+        x_idx: Option<u32>,
         perl5: bool,
     },
 

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -142,7 +142,9 @@ struct MatchAdverbs {
     global: bool,
     exhaustive: bool,
     overlap: bool,
-    repeat: Option<usize>,
+    /// Raw `:x` adverb argument spec: a count (`"3"`) or a range (`"1..3"`),
+    /// kept as a string so the substitution can support range arguments.
+    repeat: Option<String>,
     ignore_case: bool,
     ignore_mark: bool,
     samemark: bool,
@@ -338,23 +340,19 @@ fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
                 adverbs.nth = Some(raw.trim().to_string());
             }
         } else if name == "x" {
+            // `:x(N)` (exact count) or `:x(1..3)` (range): keep the raw argument
+            // string for the substitution to parse. `:Nx` carries the count in
+            // `leading_digits`.
             if let Some(raw) = arg {
                 let trimmed = raw.trim();
-                if !trimmed.is_empty()
-                    && let Ok(count) = trimmed.parse::<usize>()
-                {
-                    adverbs.repeat = Some(count);
+                if !trimmed.is_empty() {
+                    adverbs.repeat = Some(trimmed.to_string());
                 }
-            } else if !leading_digits.is_empty()
-                && let Ok(count) = leading_digits.parse::<usize>()
-            {
-                adverbs.repeat = Some(count);
+            } else if !leading_digits.is_empty() {
+                adverbs.repeat = Some(leading_digits.clone());
             }
-        } else if !leading_digits.is_empty()
-            && name == "x"
-            && let Ok(count) = leading_digits.parse::<usize>()
-        {
-            adverbs.repeat = Some(count);
+        } else if !leading_digits.is_empty() && name == "x" {
+            adverbs.repeat = Some(leading_digits.clone());
         } else {
             return Err(regex_adverb_error(
                 &name,
@@ -751,7 +749,12 @@ fn build_regex_with_adverbs(pattern: String, adverbs: &MatchAdverbs) -> Value {
         global: adverbs.global,
         exhaustive: adverbs.exhaustive,
         overlap: adverbs.overlap,
-        repeat: adverbs.repeat,
+        // The `m//` match form keeps `:x` as an exact count; range `:x(1..3)`
+        // support lives in the substitution path (parsed from the AST string).
+        repeat: adverbs
+            .repeat
+            .as_ref()
+            .and_then(|s| s.parse::<usize>().ok()),
         nth: adverbs.nth.as_ref().map(|s| Arc::new(s.clone())),
         perl5: adverbs.perl5,
         pos: adverbs.pos,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3798,7 +3798,7 @@ impl Interpreter {
                 samespace,
                 global,
                 nth_idx,
-                x_count,
+                x_idx,
                 perl5,
             } => {
                 self.exec_subst_op(
@@ -3811,7 +3811,7 @@ impl Interpreter {
                     *samespace,
                     *global,
                     *nth_idx,
-                    *x_count,
+                    *x_idx,
                     *perl5,
                 )?;
                 *ip += 1;
@@ -3825,7 +3825,7 @@ impl Interpreter {
                 samespace,
                 global,
                 nth_idx,
-                x_count,
+                x_idx,
                 perl5,
             } => {
                 self.exec_non_destructive_subst_op(
@@ -3838,7 +3838,7 @@ impl Interpreter {
                     *samespace,
                     *global,
                     *nth_idx,
-                    *x_count,
+                    *x_idx,
                     *perl5,
                 )?;
                 *ip += 1;

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -456,7 +456,7 @@ impl Interpreter {
         samespace: bool,
         global: bool,
         nth_idx: Option<u32>,
-        x_count: Option<u32>,
+        x_idx: Option<u32>,
         perl5: bool,
     ) -> Result<(), RuntimeError> {
         let pattern = Self::const_str(code, pattern_idx).to_string();
@@ -472,11 +472,11 @@ impl Interpreter {
         };
 
         let nth_spec = nth_idx.map(|idx| Self::const_str(code, idx).to_string());
-        let x_count = x_count.map(|n| n as usize);
+        let x_spec = x_idx.map(|idx| Self::const_str(code, idx).to_string());
         let target = self.env().get("_").cloned().unwrap_or(Value::Nil);
         let text = target.to_string_value();
 
-        if nth_spec.is_none() && x_count.is_none() && !global {
+        if nth_spec.is_none() && x_spec.is_none() && !global {
             if perl5 {
                 let found = self.regex_find_first_p5(&pattern, &text);
                 if let Some((start, end)) = found {
@@ -551,10 +551,14 @@ impl Interpreter {
         // so each match can expand $0, $1 etc. independently.
         let (ranges, per_match_captures) = if perl5 {
             let all_matches = loan_env!(self, regex_find_all_p5(&pattern, &text));
-            let selected = if global && nth_spec.is_none() && x_count.is_none() {
+            let selected = if global && nth_spec.is_none() && x_spec.is_none() {
                 all_matches
             } else {
-                Self::select_substitution_ranges(&all_matches, nth_spec.as_deref(), x_count)?
+                Self::select_substitution_ranges(
+                    &all_matches,
+                    nth_spec.as_deref(),
+                    x_spec.as_deref(),
+                )?
             };
             (selected, Vec::new())
         } else {
@@ -570,10 +574,14 @@ impl Interpreter {
             }
             let all_ranges: Vec<(usize, usize)> =
                 matches_with_caps.iter().map(|(s, e, _)| (*s, *e)).collect();
-            let selected = if global && nth_spec.is_none() && x_count.is_none() {
+            let selected = if global && nth_spec.is_none() && x_spec.is_none() {
                 all_ranges
             } else {
-                Self::select_substitution_ranges(&all_ranges, nth_spec.as_deref(), x_count)?
+                Self::select_substitution_ranges(
+                    &all_ranges,
+                    nth_spec.as_deref(),
+                    x_spec.as_deref(),
+                )?
             };
             // Extract captures for selected ranges
             let captures: Vec<Vec<String>> = selected
@@ -593,7 +601,7 @@ impl Interpreter {
         // Match even when combined with :g (e.g. `s:2nd:g/./Z/` yields a Match).
         let single_nth = nth_spec.as_deref().is_some_and(|s| !s.contains(','));
         let nth_is_multi = nth_spec.as_deref().is_some_and(|s| s.contains(','));
-        let result_is_list = !single_nth && (global || x_count.is_some() || nth_is_multi);
+        let result_is_list = !single_nth && (global || x_spec.is_some() || nth_is_multi);
         if ranges.is_empty() {
             if result_is_list {
                 // :g / :x with no match: result is an empty List (falsy).
@@ -702,7 +710,7 @@ impl Interpreter {
         samespace: bool,
         global: bool,
         nth_idx: Option<u32>,
-        x_count: Option<u32>,
+        x_idx: Option<u32>,
         perl5: bool,
     ) -> Result<(), RuntimeError> {
         let pattern = Self::const_str(code, pattern_idx).to_string();
@@ -718,11 +726,11 @@ impl Interpreter {
         };
 
         let nth_spec = nth_idx.map(|idx| Self::const_str(code, idx).to_string());
-        let x_count = x_count.map(|n| n as usize);
+        let x_spec = x_idx.map(|idx| Self::const_str(code, idx).to_string());
         let target = self.env().get("_").cloned().unwrap_or(Value::Nil);
         let text = target.to_string_value();
 
-        if nth_spec.is_none() && x_count.is_none() && !global {
+        if nth_spec.is_none() && x_spec.is_none() && !global {
             if perl5 {
                 let found = self.regex_find_first_p5(&pattern, &text);
                 if let Some((start, end)) = found {
@@ -785,10 +793,14 @@ impl Interpreter {
 
         let (ranges, per_match_captures) = if perl5 {
             let all_matches = loan_env!(self, regex_find_all_p5(&pattern, &text));
-            let selected = if global && nth_spec.is_none() && x_count.is_none() {
+            let selected = if global && nth_spec.is_none() && x_spec.is_none() {
                 all_matches
             } else {
-                Self::select_substitution_ranges(&all_matches, nth_spec.as_deref(), x_count)?
+                Self::select_substitution_ranges(
+                    &all_matches,
+                    nth_spec.as_deref(),
+                    x_spec.as_deref(),
+                )?
             };
             (selected, Vec::new())
         } else {
@@ -803,10 +815,14 @@ impl Interpreter {
             }
             let all_ranges: Vec<(usize, usize)> =
                 matches_with_caps.iter().map(|(s, e, _)| (*s, *e)).collect();
-            let selected = if global && nth_spec.is_none() && x_count.is_none() {
+            let selected = if global && nth_spec.is_none() && x_spec.is_none() {
                 all_ranges
             } else {
-                Self::select_substitution_ranges(&all_ranges, nth_spec.as_deref(), x_count)?
+                Self::select_substitution_ranges(
+                    &all_ranges,
+                    nth_spec.as_deref(),
+                    x_spec.as_deref(),
+                )?
             };
             let captures: Vec<Vec<String>> = selected
                 .iter()
@@ -823,7 +839,7 @@ impl Interpreter {
         // or a multi-value :nth yields a List of Matches in $/.
         let single_nth = nth_spec.as_deref().is_some_and(|s| !s.contains(','));
         let nth_is_multi = nth_spec.as_deref().is_some_and(|s| s.contains(','));
-        let result_is_list = !single_nth && (global || x_count.is_some() || nth_is_multi);
+        let result_is_list = !single_nth && (global || x_spec.is_some() || nth_is_multi);
         if ranges.is_empty() {
             let slash = if result_is_list {
                 Value::array(Vec::new())
@@ -887,8 +903,11 @@ impl Interpreter {
     fn select_substitution_ranges(
         all_matches: &[(usize, usize)],
         nth_spec: Option<&str>,
-        x_count: Option<usize>,
+        x_spec: Option<&str>,
     ) -> Result<Vec<(usize, usize)>, RuntimeError> {
+        // `:x(N)` requires exactly N matches; `:x(lo..hi)` requires at least
+        // `lo` and keeps at most `hi`. Returns `(lo, hi)`.
+        let x_bounds = x_spec.map(Self::parse_subst_x_spec);
         if let Some(raw) = nth_spec {
             // :nth may carry a comma-separated list of 1-based indices, e.g.
             // `:nth(1,3)`. Indices must be >= 1 and monotonically increasing.
@@ -902,25 +921,59 @@ impl Interpreter {
                     }
                 }
             }
-            // When combined with :x(N), keep only the first N selected matches.
-            if let Some(n) = x_count {
-                if selected.len() < n {
+            // When combined with :x(lo..hi), require at least `lo` and keep up
+            // to `hi` of the selected matches.
+            if let Some((lo, hi)) = x_bounds {
+                if selected.len() < lo {
                     return Ok(Vec::new());
                 }
-                selected.truncate(n);
+                selected.truncate(hi);
             }
             return Ok(selected);
         }
-        if let Some(n) = x_count {
-            if n == 0 {
+        if let Some((lo, hi)) = x_bounds {
+            if hi == 0 || all_matches.len() < lo {
                 return Ok(Vec::new());
             }
-            if all_matches.len() < n {
-                return Ok(Vec::new());
-            }
-            return Ok(all_matches.iter().copied().take(n).collect());
+            return Ok(all_matches.iter().copied().take(hi).collect());
         }
         Ok(all_matches.first().copied().into_iter().collect())
+    }
+
+    /// Parse a `:x` adverb spec into `(lo, hi)` match-count bounds. A bare count
+    /// `"3"` is `(3, 3)`; a range `"1..3"` / `"1..^3"` maps to its endpoints;
+    /// `"*"`/`"Inf"` is unbounded `(0, usize::MAX)`.
+    fn parse_subst_x_spec(raw: &str) -> (usize, usize) {
+        let token = raw.trim();
+        if token == "*" || token.eq_ignore_ascii_case("Inf") {
+            return (0, usize::MAX);
+        }
+        let parse_bound = |s: &str| s.trim().parse::<i64>().ok();
+        if let Some(idx) = token.find("..") {
+            let lo_s = &token[..idx];
+            let mut rest = &token[idx + 2..];
+            let excl = rest.starts_with('^');
+            if excl {
+                rest = &rest[1..];
+            }
+            let lo = parse_bound(lo_s).unwrap_or(0).max(0) as usize;
+            let hi = if rest.trim() == "*" || rest.trim().eq_ignore_ascii_case("Inf") {
+                usize::MAX
+            } else {
+                match parse_bound(rest) {
+                    Some(h) if h >= 0 => {
+                        let h = h as usize;
+                        if excl { h.saturating_sub(1) } else { h }
+                    }
+                    _ => usize::MAX,
+                }
+            };
+            return (lo, hi);
+        }
+        match parse_bound(token) {
+            Some(n) if n >= 0 => (n as usize, n as usize),
+            _ => (0, usize::MAX),
+        }
     }
 
     /// Parse an `:nth` spec into a list of 1-based indices. Accepts a single

--- a/t/subst-x-range.t
+++ b/t/subst-x-range.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 9;
+
+# `:x(Range)` in the operator substitution forms (S/// and s///): replace at
+# least `lo` and at most `hi` matches, and set `$/` to a List of Match objects.
+
+# Non-destructive S///
+is-deeply (S:x(1..3)/./Z/ with 'abcd'), 'ZZZd', 'S:x(1..3) replaces up to 3';
+is-deeply $/».Str, ('a', 'b', 'c'), 'S:x(1..3) $/ is the matched List';
+isa-ok $/, List, 'S:x(range) sets $/ to a List';
+
+# Destructive s///
+{
+    my $v = 'abcd';
+    $v ~~ s:x(1..3)/./Z/;
+    is $v, 'ZZZd', 's:x(1..3) replaces up to 3 in place';
+    is-deeply $/».Str, ('a', 'b', 'c'), 's:x(1..3) $/ matched List';
+}
+
+# Range upper bound caps the replacements even with more matches available.
+{
+    my $v = 'aaaaa';
+    $v ~~ s:x(1..2)/a/X/;
+    is $v, 'XXaaa', 's:x(1..2) caps at 2';
+}
+
+# Too few matches for the lower bound: no substitution.
+{
+    my $v = 'ab';
+    $v ~~ s:x(3..5)/./Z/;
+    is $v, 'ab', 's:x(3..5) with too few matches is a no-op';
+}
+
+# Exact count still works (regression).
+{
+    my $v = 'aaaa';
+    $v ~~ s:x(2)/a/b/;
+    is $v, 'bbaa', 's:x(2) exact count still works';
+}
+
+# `:Nx` shorthand still works (regression).
+{
+    my $v = 'aaaa';
+    $v ~~ s:2x/a/b/;
+    is $v, 'bbaa', 's:2x shorthand still works';
+}


### PR DESCRIPTION
The operator substitution `s:x(1..3)/`/`S:x(1..3)/` silently dropped a range `:x` argument: the parser only accepted an integer (`"1..3".parse::<usize>()` failed), and the AST/opcode carried `:x` as a single count (`Option<usize>` / `Option<u32>`), which cannot represent a range. So `S:x(1..3)/./Z/` replaced only the first match instead of up to three.

## Fix

Carry the `:x` spec as a raw string end-to-end, mirroring `:nth` (`nth_idx`):

- `MatchAdverbs.repeat` and AST `Subst.x`/`NonDestructiveSubst.x` are now `Option<String>`; the parser stores the raw argument (`"3"`, `"1..3"`, `"*"`).
- The opcode field becomes `x_idx: Option<u32>` (constant-pool index) instead of `x_count: Option<u32>`.
- `select_substitution_ranges` parses the spec via `parse_subst_x_spec` into `(lo, hi)` bounds: exact `N` → `(N, N)`, `lo..hi`/`lo..^hi` → the range, `*`/`Inf` → unbounded. Requires at least `lo` matches, keeps up to `hi`.

The `m//` match form keeps `:x` as an exact count (out of scope for ranges). `:x(N)` / `:Nx` exact-count behavior is unchanged.

## Impact

`subst.t` advances 187/191 → **188/191** (only 102 samemark transfer, 159 read-only method params, 187 `S{}=` placeholder hoist remain — documented in `TODO_roast/S05.md`).

## Testing

New `t/subst-x-range.t` (9 subtests); full local `make test` passes; `:x(N)`/`:Nx`/`m:x(N)` regression-checked against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)