### PR TITLE
fix(methods): method parameters are read-only by default

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -226,10 +226,15 @@
     duplicated `else if` blocks in `apply_substitutions` /
     `apply_substitutions_with_captures` / `apply_substitutions_dynamic` by routing
     them all through the single chokepoint.
-  - 102: `ss:i:m` (samespace + ignorecase + *ignoremark*, **not** samemark) still
-    expects marks to be preserved in rakudo. This is a Rakudo samespace/ignoremark
-    interaction artifact (plain `s:i:m///` drops marks; only adding `:ss` revives
-    them); not replicated to avoid a special-case hack.
+  - 102 (WON'T FIX — Rakudo quirk): `ss:i:m` (samespace + ignorecase +
+    *ignoremark*, **not** samemark) expects combining marks to *transfer* from the
+    matched text to the replacement (`ḇ`→`x̱`, `Ć`→`ý`). Re-verified 2026-06-16:
+    plain `s:i:m/ÅbCd/wxyz/` on "aḇĆd" gives `"wxyz"` (marks dropped) in rakudo,
+    but **adding `:ss` revives them** (`"w\nx̱\tý z"`). `:samespace` logically
+    governs only whitespace, so its effect on mark transfer is a Rakudo-specific
+    interaction artifact. Replicating it would require special-case logic keyed on
+    the `:ss`+`:m` combination — a hack, which the project rules forbid. Effectively
+    blocks a clean subst.t whitelist (the only other gap, 187, is real but rare).
   - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
     and block replacement (152 fixed via the closure-writeback fix below).
   - 156 (FIXED): `s:i($i)/.../` now throws `X::Value::Dynamic` (non-constant

--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -196,11 +196,11 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 188/191 pass. **Whitelistable in principle**: although reference rakudo on
+  - 189/191 pass. **Whitelistable in principle**: although reference rakudo on
     this box fails tests 157 (`:i(1) is OK`) and 170 (`s[]="" when $_ is not set`),
     **mutsu passes both** (157 outright; 170 is `#?rakudo todo`, so a mutsu failure
     there would not fail the file anyway). So fixing the remaining mutsu failures
-    (102, 159, 187) does reach a clean mutsu pass and the file can be
+    (102, 187) does reach a clean mutsu pass and the file can be
     whitelisted. Remaining mutsu failures span several distinct (mostly
     regex-internal) features:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
@@ -237,14 +237,16 @@
     was only flagging `*`-twigil dynamic vars (`$*foo`); broadened to flag any
     variable reference (any sigil followed by a name char/twigil), since the
     adverb value must be a literal constant. `:i(1)`/`:i(True)` still pass.
-  - 159: `s///` on a read-only `$_` (method `$_` param) must die. PARTIAL: the
-    `s///` writeback now honors a read-only topic (`exec_subst_op` routes through
-    `write_subst_topic_checked`, throwing X::Assignment::RO on an actual match), so
-    `sub ($_) { s/c// }` / `sub ($x is readonly) { ... }` die correctly. The roast
-    test uses a *method* `$_` param, and mutsu does not yet mark method params
-    read-only at all (even `method ($x) { $x = 5 }` lives) — a separate binding fix
-    (method params bind with empty `param_defs`, so the readonly-marking loop in
-    `bind_function_args_values` is skipped).
+  - 159 (FIXED): `s///` on a read-only *method* `$_` param now dies. Method params
+    are now marked read-only by default (matching subs). The fast method path
+    (`call_compiled_method_fast`) binds params directly without
+    `bind_function_args_values`, so it never marked them read-only — even
+    `method ($x) { $x = 5 }` lived. Added `mark_fast_method_params_readonly`
+    (mirrors the slow path: `$` scalar params that are not `is rw`/`copy`/`raw`,
+    not `@`/`%`, not attribute/sigilless/invocant). The light call frame skips the
+    slow path's full `readonly_vars` snapshot for perf, so each newly-marked name
+    is recorded on the frame (`readonly_added`) and dropped in `pop_call_frame`
+    (O(params), no whole-set clone). Local: t/readonly-method-params.t.
   - 161, 169: empty pattern `s[] = ...` must throw `X::Syntax::Regex::NullRegex`.
   - 152, 162 (FIXED): `.subst`/`s///` replacement block mutations to closed-over
     lexicals (`{ $m = $/[0] }`, `{ $str++ }`) now write back. `eval_subst_replacement_cased`

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -176,6 +176,11 @@ pub(crate) struct VmCallFrame {
     pub saved_stack_depth: usize,
     /// None when using light call frame (simple methods that don't use `:=` binding).
     pub saved_readonly: Option<HashSet<String>>,
+    /// Read-only var names this frame *newly* added to `readonly_vars` (used by
+    /// the light-frame method path, which marks `$` scalar params read-only
+    /// without cloning the whole set). Removed on `pop_call_frame`. Empty for the
+    /// slow path, which restores the full set via `saved_readonly` instead.
+    pub readonly_added: Vec<String>,
     pub saved_env_dirty: bool,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -37,6 +37,7 @@ impl Interpreter {
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
             saved_readonly: Some(self.save_readonly_vars()),
+            readonly_added: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
@@ -53,6 +54,7 @@ impl Interpreter {
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
             saved_readonly: None,
+            readonly_added: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
             saved_env_dirty: self.env_dirty,
@@ -72,7 +74,13 @@ impl Interpreter {
         self.locals = std::mem::take(&mut frame.saved_locals);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
+            // Slow path: restore the whole snapshot (covers any `:=` marking).
             self.restore_readonly_vars(readonly);
+        } else if !frame.readonly_added.is_empty() {
+            // Light-frame method path: drop only the param names this frame added.
+            for name in &frame.readonly_added {
+                self.unmark_readonly(name);
+            }
         }
         self.env_dirty = frame.saved_env_dirty;
         frame

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -858,6 +858,40 @@ impl Interpreter {
         }
     }
 
+    /// Mark a compiled method's `$` scalar parameters read-only, mirroring
+    /// `bind_function_args_values`. Routine params are read-only by default
+    /// unless `is rw`/`is copy`/`is raw`; `@`/`%` params and attribute-binding
+    /// params (`$!x`/`$.x`) stay writable. Sigilless (`\x`) params are raw
+    /// aliases. The light-frame fast path skips the slow path's readonly
+    /// snapshot, so each newly-marked name is recorded on the current call frame
+    /// and dropped in `pop_call_frame`.
+    fn mark_fast_method_params_readonly(&mut self, method_def: &crate::runtime::MethodDef) {
+        for pd in &method_def.param_defs {
+            if pd.name.is_empty()
+                || pd.name == "__type_only__"
+                || pd.name == "__subsig__"
+                || pd.sigilless
+                || pd.is_invocant
+                || pd.name.starts_with('!')
+                || pd.name.starts_with('.')
+                || pd.name.starts_with('@')
+                || pd.name.starts_with('%')
+            {
+                continue;
+            }
+            if pd.traits.iter().any(|t| t == "rw" || t == "copy" || t == "raw") {
+                continue;
+            }
+            if self.readonly_vars().contains(pd.name.as_str()) {
+                continue; // already read-only (e.g. caller-owned same name)
+            }
+            self.mark_readonly(&pd.name);
+            if let Some(frame) = self.call_frames.last_mut() {
+                frame.readonly_added.push(pd.name.clone());
+            }
+        }
+    }
+
     /// Fast path for read-only compiled methods. Bypasses all env_mut() calls
     /// to avoid the ~12μs Arc::make_mut deep clone. Populates locals directly
     /// from source data (attributes, args, special variables).
@@ -1012,6 +1046,11 @@ impl Interpreter {
                 env.insert(param_name.to_string(), param_val.clone());
             }
         }
+
+        // Raku: routine parameters are read-only by default (`method m($x) { $x = 5 }`
+        // dies). The slow path does this in `bind_function_args_values`; the fast
+        // path binds params directly, so mark `$` scalar params read-only here.
+        self.mark_fast_method_params_readonly(method_def);
 
         // Populate locals directly
         self.locals = vec![Value::Nil; cc.locals.len()];

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -879,7 +879,11 @@ impl Interpreter {
             {
                 continue;
             }
-            if pd.traits.iter().any(|t| t == "rw" || t == "copy" || t == "raw") {
+            if pd
+                .traits
+                .iter()
+                .any(|t| t == "rw" || t == "copy" || t == "raw")
+            {
                 continue;
             }
             if self.readonly_vars().contains(pd.name.as_str()) {

--- a/t/readonly-method-params.t
+++ b/t/readonly-method-params.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 10;
+
+# Routine parameters are read-only by default in Raku. This must hold for
+# *method* parameters too (not just subs) — assigning to or mutating a plain
+# `$` method parameter dies with X::Assignment::RO.
+
+class C {
+    method assign($x)      { $x = 5 }
+    method subst($_)       { s/c// }
+    method incr($x)        { $x++ }
+    method rw($x is rw)    { $x = 5; $x }
+    method copy($x is copy) { $x = 5; $x }
+    method arr(@a)         { @a.push(9); @a }
+    method hsh(%h)         { %h<k> = 1; %h }
+    method read($x)        { $x * 2 }
+}
+
+dies-ok { C.new.assign(3) },  'method $x = 5 dies (X::Assignment::RO)';
+dies-ok { C.new.subst('ccc') }, 's/// on method $_ param dies';
+dies-ok { C.new.incr(3) },    'method $x++ dies';
+
+throws-like { C.new.assign(3) }, X::Assignment::RO,
+    'method param assignment throws X::Assignment::RO';
+
+is C.new.rw(my $a = 1), 5,   'is rw method param is writable';
+is C.new.copy(7), 5,         'is copy method param is writable';
+is-deeply C.new.arr([1, 2]), [1, 2, 9], '@ method param container is mutable';
+is-deeply C.new.hsh(%(a => 1)).sort, (a => 1, k => 1), '% method param is mutable';
+is C.new.read(21), 42,       'reading a method param works';
+
+# The read-only marking must not leak past the method: a caller variable of the
+# same name stays writable afterwards.
+{
+    my $x = 1;
+    try C.new.assign(99);  # swallow the X::Assignment::RO
+    $x = 2;
+    is $x, 2, 'caller $x stays writable after a method with a $x param';
+}


### PR DESCRIPTION
Routine parameters are read-only in Raku unless declared `is rw`/`is copy`/`is raw`. Subs enforced this (via `bind_function_args_values`), but **methods did not**: the fast method-dispatch path (`call_compiled_method_fast`) binds parameters directly into env/locals without `bind_function_args_values`, so it never marked them read-only. As a result `method m($x) { $x = 5 }` and `method ro($_) { s/c// }` ran silently instead of dying with `X::Assignment::RO` (roast `S05-substitution/subst.t` test 159).

## Fix

- `mark_fast_method_params_readonly` mirrors the slow path: mark `$` scalar params read-only unless `is rw`/`is copy`/`is raw`; leave `@`/`%` container params, attribute-binding params (`$!x`/`$.x`), sigilless (`\x`), and the invocant writable.
- The light call frame deliberately skips the slow path's full `readonly_vars` snapshot (clone) for speed. Instead of reintroducing that per-call cost, record just the names this frame *newly* marked on `VmCallFrame::readonly_added` and drop them in `pop_call_frame` — O(params), no whole-set clone, and it cannot leak a caller's same-named writable variable.

## Impact

General correctness fix for **all** method parameter mutation, not just subst. `subst.t` advances 188/191 → **189/191** (only 102 samemark transfer and 187 `S{}=` placeholder hoist remain — documented in `TODO_roast/S05.md`).

## Testing

New `t/readonly-method-params.t` (10 subtests: assign/`s///`/`++` die; `is rw`/`is copy`/`@`/`%` stay mutable; no caller leak); full local `make test` passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)