### PR TITLE
fix(flipflop): parse ff/fff at conditional precedence; smart-match constant operands

### DIFF
--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -532,16 +532,31 @@ pub(super) fn parse_junction_infix_op(input: &str) -> Option<(JunctionInfixOp, u
             return None;
         }
         Some((JunctionInfixOp::All, 1))
-    // ^ but not ^.. or ^^ or ^=
+    // ^ but not ^.. or ^^ or ^= or a start-excluding flip-flop (^ff / ^fff …)
     } else if input.starts_with('^')
         && !input.starts_with("^.")
         && !input.starts_with("^^")
         && !input.starts_with("^=")
+        && !starts_with_caret_flipflop(input)
     {
         Some((JunctionInfixOp::One, 1))
     } else {
         None
     }
+}
+
+/// True when `input` begins with a start-excluding flip-flop operator
+/// (`^ff`, `^ff^`, `^fff`, `^fff^`). These must not be mis-parsed as the
+/// one-junction infix `^` followed by a bare `ff`/`fff`.
+fn starts_with_caret_flipflop(input: &str) -> bool {
+    for op in ["^fff^", "^fff", "^ff^", "^ff"] {
+        if let Some(rest) = input.strip_prefix(op)
+            && !is_ident_char(rest.as_bytes().first().copied())
+        {
+            return true;
+        }
+    }
+    false
 }
 
 pub(super) fn parse_or_or_op(input: &str) -> Option<(LogicalOp, usize)> {

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -912,7 +912,42 @@ fn not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             },
         ));
     }
-    or_or_expr_mode(input, mode)
+    flipflop_expr_mode(input, mode)
+}
+
+/// Flip-flop operators (`ff`/`fff` and the endpoint-excluding forms) at
+/// Raku's *conditional* precedence (`?? !!` level): looser than tight-or
+/// (`||`), tight-and (`&&`), and the chaining comparisons (`==` etc.), but
+/// tighter than item assignment (`=`) and the comma/list-infix operators. So
+/// `$n == 3 ff $n == 6` parses as `($n == 3) ff ($n == 6)`.
+fn flipflop_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
+    let (mut rest, mut left) = or_or_expr_mode(input, mode)?;
+    let mut current_assoc_key: Option<String> = None;
+    loop {
+        let (r, _) = ws(rest)?;
+        let Some((name, len)) = parse_flipflop_infix(r) else {
+            break;
+        };
+        if let Some(prev) = current_assoc_key.as_deref()
+            && prev != name
+        {
+            return Err(non_list_associative_error(prev, &name));
+        }
+        let r = &r[len..];
+        let (r, _) = ws(r)?;
+        let (r, right) = or_or_expr_mode(r, mode).map_err(|err| {
+            enrich_expected_error(err, "expected expression after flip-flop operator", r.len())
+        })?;
+        left = Expr::InfixFunc {
+            name: name.clone(),
+            left: Box::new(left),
+            right: vec![right],
+            modifier: None,
+        };
+        current_assoc_key = Some(name);
+        rest = r;
+    }
+    Ok((rest, left))
 }
 
 /// || , ^^ , and //
@@ -1583,28 +1618,6 @@ fn parse_list_infix_loop<'a>(
             rest = r;
             continue;
         }
-        // Flip-flop operators: ff/fff and endpoint-excluding forms.
-        if let Some((name, len)) = parse_flipflop_infix(r) {
-            if let Some(prev) = current_assoc_key.as_deref()
-                && prev != name
-            {
-                return Err(non_list_associative_error(prev, &name));
-            }
-            let r = &r[len..];
-            let (r, _) = ws(r)?;
-            let (r, right) = range_expr(r).map_err(|err| {
-                enrich_expected_error(err, "expected expression after flip-flop operator", r.len())
-            })?;
-            *left = Expr::InfixFunc {
-                name: name.clone(),
-                left: Box::new(left.clone()),
-                right: vec![right],
-                modifier: None,
-            };
-            *current_assoc_key = Some(name);
-            rest = r;
-            continue;
-        }
         // User-defined infix words (typically via my &infix:<...> = ...),
         // e.g. `42 same-in-Int "42"`.
         // Do not span statement boundaries across newlines.
@@ -2051,6 +2064,8 @@ fn is_reserved_infix_word(name: &str) -> bool {
             | "le"
             | "ge"
             | "eqv"
+            | "ff"
+            | "fff"
             | "after"
             | "before"
             | "gcd"

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -2307,14 +2307,19 @@ impl Interpreter {
 
     fn flip_flop_operand_truthy(&mut self, value: &Value, is_rhs: bool) -> bool {
         match value {
+            // `*` means "always" on the LHS and "never" on the RHS.
             Value::Whatever => !is_rhs,
-            Value::Regex(_)
-            | Value::RegexWithAdverbs { .. }
-            | Value::Routine { is_regex: true, .. } => {
+            // A boolean operand is used directly (the common
+            // `$n == 3 ff $n == 5` comparison form).
+            Value::Bool(b) => *b,
+            // Every other operand (a regex, or a constant such as `2 ff 4`)
+            // is smart-matched against the topic `$_` — the sed-style line
+            // matching where `2 ff 4` means "from when `$_ ~~ 2` until
+            // `$_ ~~ 4`".
+            _ => {
                 let topic = self.env().get("_").cloned().unwrap_or(Value::Nil);
                 self.vm_smart_match(&topic, value)
             }
-            _ => value.truthy(),
         }
     }
 

--- a/t/flip-flop.t
+++ b/t/flip-flop.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 13;
 
 sub test_ff($code, @a) {
     my $ret = '';
@@ -13,6 +13,28 @@ sub test_ff($code, @a) {
 is test_ff({ /B/ ff /D/ }, <A B C D E>), 'xBCDx', 'ff keeps state until rhs matches';
 is test_ff({ /B/ ^ff /D/ }, <A B C D E>), 'xxCDx', '^ff excludes start value';
 is test_ff({ /B/ fff^ /D/ }, <A B C D E>), 'xBCxx', 'fff^ excludes end value';
+
+# Precedence: flip-flop is at conditional precedence (looser than the chaining
+# comparison `==`), so `$_ == 3 ff $_ == 5` parses as `($_ == 3) ff ($_ == 5)`.
+is test_ff({ $_ == 3 ff  $_ == 5 }, 1..7), 'xx345xx', 'ff binds looser than ==';
+is test_ff({ $_ == 3 ^ff $_ == 5 }, 1..7), 'xxx45xx', '^ff binds looser than ==';
+is test_ff({ $_ == 3 ff^ $_ == 5 }, 1..7), 'xx34xxx', 'ff^ binds looser than ==';
+is test_ff({ $_ == 3 ^ff^ $_ == 5 }, 1..7), 'xxx4xxx', '^ff^ binds looser than ==';
+is test_ff({ $_ == 3 fff $_ == 5 }, 1..7), 'xx345xx', 'fff binds looser than ==';
+
+# A constant operand is smart-matched against the topic `$_` (sed-style).
+is test_ff({ 3 ff 5 }, 1..7), 'xx345xx', 'constant operands smart-match against $_';
+is test_ff({ 3 ^ff 5 }, 1..7), 'xxx45xx', '^ff with constant operands';
+
+# Item assignment is looser than flip-flop: `$x = 3 ff 5` is `$x = (3 ff 5)`.
+{
+    my $ret = '';
+    for 1..5 {
+        my $x = $_ == 2 ff $_ == 4;
+        $ret ~= $x ?? $_ !! 'x';
+    }
+    is $ret, 'x234x', 'item assignment is looser than flip-flop';
+}
 
 {
     my $ret = '';


### PR DESCRIPTION
## Problem

The flip-flop operators `ff`/`fff` (and the endpoint-excluding `^ff`/`ff^`/`^ff^` forms) were parsed inside `parse_list_infix_loop`, i.e. **tighter** than the chaining comparison `==`. So a common form like:

```raku
for 1..10 -> $n { print "$n " if $n == 3 ff $n == 6 }
```

mis-parsed `$n == 3 ff $n == 6` as the chained comparison `$n == (3 ff $n) == 6` and produced **no output** (raku: `3 4 5 6`).

Raku places flip-flop at **conditional** precedence (the `?? !!` level): looser than `||`/`&&` and the chaining comparisons, but tighter than item assignment and the comma/list-infix operators.

## Fix

- Add a dedicated `flipflop_expr_mode` tier between `not_expr_mode` and `or_or_expr_mode`; remove flip-flop handling from `parse_list_infix_loop`.
- Reserve `ff`/`fff` as infix words so the generic custom-infix path no longer grabs them, and stop the one-junction infix `^` from swallowing the leading `^` of a start-excluding `^ff`/`^fff`/`^ff^`/`^fff^` operator.
- Smart-match a non-`Bool` flip-flop operand against the topic `$_` (sed-style): `2 ff 4` now means "from when `$_ ~~ 2` until `$_ ~~ 4`", matching Raku. Boolean operands (the common `$n == 3 ff $n == 5` comparison form) are still used directly.

All 8 variants (`ff`/`fff` × `^…`/`…^`/`^…^`) now match `raku` for both comparison and constant operands.

## Tests

- `roast/S03-operators/flip-flop.t` still passes 40/40.
- Extends `t/flip-flop.t` (5 → 13 cases) with precedence, constant-operand smart-match, and item-assignment-looser-than-ff cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)