### PR TITLE
fix(smartmatch): `$_ ~~ s///` / `tr///` must mutate the topic in place

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -108,13 +108,21 @@
   - 3/16 pass (tests 1, 3, 5). Failures: lexical array reset per iteration (2, 4), itemized array in for loop (6-7), `for @a -> $x` argument list (8). Only 8 tests reached. Difficulty: Medium
 - [ ] roast/S04-statements/for.t
   - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
-  - 99/111 (was 97/111). Multi-param pointy blocks now carry a full ParamDef per
+  - 100/111 (was 99). Multi-param pointy blocks now carry a full ParamDef per
     param (`params_def` on `Stmt::For`): a short final chunk over required params
     throws `Too few positionals passed; expected N arguments but got M` mid-loop
     (test 49), and `-> $a, $b = 7` applies defaults via an `_.elems > i ?? _[i] !!
-    default` bind (test 52). Remaining 12: throws-like string-EVAL scope isolation
-    (50), lazy/expanding-list iteration (82/83/105/107), is-rw slurpy (90-92),
-    decontainerize (100), sink final method call (102), `for @a[*]` holes (111).
+    default` bind (test 52). Test 97 (`$_ ~~ s///` backref writeback) FIXED via
+    #3170 (smartmatch topic-restore clobbered the in-place substitution). Remaining 11:
+    throws-like string-EVAL scope isolation (50, blocked on EVAL lexical scope =
+    my-6e.t), label-less `last` Nil-vs-() (65, `#TODO Rakudo`), expanding-list live
+    iteration (82/83, blocked: `Value::Array` is COW Arc, push detaches the loop's
+    held snapshot — first-class container), is-rw slurpy `*@v is raw` write-through
+    (90-92, container identity), for-loop decontainerize (100, container identity),
+    sink final method call (102, BLOCKED on container identity — implementing
+    instance `.sink` dispatch in `SinkPop` regresses sink.t 5/6/7 which guard that
+    `is rw`-container-wrapped and `.=` results are NOT sunk; mutsu deconts and sinks
+    them), lazy for-loop laziness (105/107), `for @a[*]` holes (111).
 - [ ] roast/S04-statements/for_with_only_one_item.t
 - [x] roast/S04-statements/gather.t
   - 39/39. `take-rw EXPR` now carries an `is_rw` flag (`Stmt::Take(Expr, bool)`)

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1251,6 +1251,10 @@ impl Interpreter {
             }
             return Err(RuntimeError::assignment_ro(Some("Str")));
         }
+        // When the LHS alias *is* the topic itself (`$_ ~~ s///`), the
+        // substitution-modified topic must persist — restoring `saved_topic`
+        // below would clobber it. Skip the restore in that case.
+        let lhs_is_topic = lhs_var.as_deref() == Some("_");
         if let Some(var_name) = lhs_var {
             let modified_topic = self.env().get("_").cloned().unwrap_or(Value::Nil);
             self.env_mut()
@@ -1260,10 +1264,12 @@ impl Interpreter {
             // caller sees it without an O(locals) sync_locals_from_env pull.
             self.update_local_if_exists(code, var_name, &modified_topic);
         }
-        if let Some(v) = saved_topic {
-            self.env_mut().insert("_".to_string(), v);
-        } else {
-            self.env_mut().remove("_");
+        if !lhs_is_topic {
+            if let Some(v) = saved_topic {
+                self.env_mut().insert("_".to_string(), v);
+            } else {
+                self.env_mut().remove("_");
+            }
         }
         // When RHS was a transliterate (tr///), return the result directly.
         // In Raku, $x ~~ tr/a/b/ returns a StrDistance that stringifies to the after-string.

--- a/t/smartmatch-subst-topic.t
+++ b/t/smartmatch-subst-topic.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 9;
+
+# `$_ ~~ s///` must mutate the topic itself in place.
+{
+    $_ = "11 22";
+    $_ ~~ s/\s/-/;
+    is $_, "11-22", '$_ ~~ s/// mutates the topic';
+}
+
+# bare s/// (implicit topic) still works
+{
+    $_ = "aa bb";
+    s/\s/-/;
+    is $_, "aa-bb", 'bare s/// mutates the topic';
+}
+
+# backreferences in `$_ ~~ s///`
+{
+    $_ = "11 22 33";
+    $_ ~~ s/\s(\S+)\s(\S+)/-$0-$1/;
+    is $_, "11-22-33", '$_ ~~ s/// with backreferences';
+}
+
+# inside a for loop, $_ aliases the array element and writes back
+{
+    my @a = ("11 22", "33 44");
+    for @a {
+        $_ ~~ s/\s/-/;
+    }
+    is @a.join(' '), '11-22 33-44', 'for { $_ ~~ s/// } writes back to array';
+}
+
+# for loop with backreferences (roast S04-statements/for.t test 97)
+{
+    my @strs = ("11 22 33", "44 55 66", "77 88 99");
+    for @strs {
+        $_ ~~ s/\s(\S+)\s(\S+)/-$0-$1/;
+    }
+    is @strs.join(' '), '11-22-33 44-55-66 77-88-99',
+        'substitution with backreferences in for loop';
+}
+
+# a normal variable on the LHS still writes back
+{
+    my $x = "11 22";
+    $x ~~ s/\s/-/;
+    is $x, "11-22", '$x ~~ s/// mutates a named variable';
+}
+
+# `$_ ~~ tr///` mutates the topic in place
+{
+    $_ = "abc";
+    $_ ~~ tr/a..c/A..C/;
+    is $_, "ABC", '$_ ~~ tr/// mutates the topic';
+}
+
+# `$_ ~~ /regex/` does NOT mutate the topic (non-destructive)
+{
+    $_ = "hello";
+    my $m = ($_ ~~ /ell/);
+    is $_, "hello", '$_ ~~ /regex/ leaves the topic unchanged';
+    ok $m, '$_ ~~ /regex/ still matches';
+}


### PR DESCRIPTION
## Problem

The explicit smartmatch form `$_ ~~ s/.../.../` ran the substitution against the temporarily-bound `$_` topic but then **unconditionally restored the pre-smartmatch topic value**, clobbering the in-place modification. So `$_ ~~ s///` left `$_` unchanged, while a named variable `$x ~~ s///` and the bare `s///` (implicit topic) both worked.

```raku
$_ = "11 22"; $_ ~~ s/\s/-/; say $_;   # mutsu: "11 22"  raku: "11-22"
```

This also broke `for @a { $_ ~~ s/// }` — the loop topic aliases the array element, so the lost mutation never wrote back. That includes the backreference form in **roast `S04-statements/for.t` test 97**.

## Fix

In `exec_smart_match_expr_op`, when the LHS alias *is* the topic itself (`lhs_var == "_"`), skip the topic restore so the substitution-/transliteration-modified topic persists. Named-variable and literal-LHS paths are unaffected.

## Tests

- `t/smartmatch-subst-topic.t` (new, 9 cases)
- `roast/S04-statements/for.t`: test 97 now passes (12 → 11 failures)
- `make test`: PASS (855 files, 8083 tests)
- No regressions in whitelisted S05-substitution / S05-transliteration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)