### PR TITLE
fix(parser): parse a ternary inside a no-paren call argument

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -184,15 +184,16 @@ pub(super) fn ternary(input: &str) -> PResult<'_, Expr> {
 /// Also handles item assignment (`=`, `~=`, `+=`, etc.) within a single
 /// argument so that `f $a ~= $b, $c` parses as `f(($a ~= $b), $c)`.
 pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
-    let (rest, expr) = or_or_expr_mode(input, ExprMode::NoSequenceNoFeed)?;
+    let (rest, expr) = call_arg_ternary_expr(input)?;
     let (r, _) = ws(rest)?;
 
     // Handle compound assignment operators (+=, ~=, //=, etc.) in call-arg context.
     // The RHS is a single expression (no comma collection) since commas separate
-    // function arguments at this level.
+    // function arguments at this level. Item assignment is looser than the
+    // conditional `?? !!`, so the RHS parses a ternary too.
     if let Some((after_op, op)) = parse_compound_assign_op(r) {
         let (after_ws, _) = ws(after_op)?;
-        if let Ok((r2, rhs)) = or_or_expr_mode(after_ws, ExprMode::NoSequenceNoFeed)
+        if let Ok((r2, rhs)) = call_arg_ternary_expr(after_ws)
             && let Ok(result) = build_compound_assign_expr(expr.clone(), op, rhs)
         {
             return Ok((r2, result));
@@ -203,12 +204,45 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
     if r.starts_with('=') && !r.starts_with("==") && !r.starts_with("=>") {
         let r_eq = &r[1..];
         let (r_eq, _) = ws(r_eq)?;
-        if let Ok((r2, rhs)) = or_or_expr_mode(r_eq, ExprMode::NoSequenceNoFeed) {
+        if let Ok((r2, rhs)) = call_arg_ternary_expr(r_eq) {
             return Ok((r2, assign_to_target_expr(expr, rhs)));
         }
     }
 
     Ok((rest, expr))
+}
+
+/// Parse a single call argument at *conditional* (`?? !!`) precedence: an
+/// `or_or` expression optionally followed by a ternary. The comma operator
+/// separates arguments at a looser level, so `f $cond ?? $a !! $b` binds the
+/// ternary inside the argument (matching Raku) rather than wrapping the whole
+/// call as `(f $cond) ?? $a !! $b`.
+fn call_arg_ternary_expr(input: &str) -> PResult<'_, Expr> {
+    let (rest, cond) = or_or_expr_mode(input, ExprMode::NoSequenceNoFeed)?;
+    let (r, _) = ws(rest)?;
+    let Ok((r, _)) = parse_tag(r, "??") else {
+        return Ok((rest, cond));
+    };
+    let (r, _) = ws(r)?;
+    let (r, then_expr) = call_arg_ternary_expr(r).map_err(|err| {
+        enrich_expected_error(err, "expected then-expression after '??'", r.len())
+    })?;
+    let (r, _) = ws(r)?;
+    let (r, _) = parse_tag(r, "!!").map_err(|err| {
+        enrich_expected_error(err, "expected '!!' in ternary expression", r.len())
+    })?;
+    let (r, _) = ws(r)?;
+    let (r, else_expr) = call_arg_ternary_expr(r).map_err(|err| {
+        enrich_expected_error(err, "expected else-expression after '!!'", r.len())
+    })?;
+    Ok((
+        r,
+        Expr::Ternary {
+            cond: Box::new(cond),
+            then_expr: Box::new(then_expr),
+            else_expr: Box::new(else_expr),
+        },
+    ))
 }
 
 pub(super) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {

--- a/t/ternary-call-arg.t
+++ b/t/ternary-call-arg.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 9;
+
+# A ternary `?? !!` is at conditional precedence, which is tighter than the
+# comma that separates no-paren call arguments. So `f $cond ?? $a !! $b` must
+# bind the ternary *inside* the argument, not wrap the whole call as
+# `(f $cond) ?? $a !! $b`.
+
+sub one($v) { $v }
+sub two($a, $b) { "$a|$b" }
+
+is (one True ?? "yes" !! "no"), "yes", 'ternary binds inside a no-paren arg';
+is (one False ?? "yes" !! "no"), "no", 'ternary false branch inside a no-paren arg';
+
+# Comparison condition inside the argument.
+is (one 5 > 3 ?? "big" !! "small"), "big", 'comparison ternary cond in arg';
+
+# Nested ternary inside the argument.
+is (one 1 ?? (0 ?? "a" !! "b") !! "c"), "b", 'nested ternary in arg';
+
+# `&&` / `||` are tighter than the ternary, so they belong to the condition.
+is (one True && False ?? "T" !! "F"), "F", '&& binds tighter than ?? in arg';
+is (one True || False ?? "T" !! "F"), "T", '|| binds tighter than ?? in arg';
+
+# Item assignment is looser than the ternary: `$x = cond ?? a !! b`.
+my $x;
+is (one $x = 2 > 1 ?? "P" !! "Q"), "P", 'assignment RHS parses a ternary in arg';
+is $x, "P", 'the assignment took effect with the ternary value';
+
+# Multiple arguments each carrying a ternary.
+is (two 1 ?? "x" !! "y", 2 ?? "m" !! "n"), "x|m", 'two args each with a ternary';


### PR DESCRIPTION
## Problem

A ternary `?? !!` is at **conditional** precedence, which is tighter than the comma separating no-paren call arguments. mutsu's `call_arg_expr` parsed each argument only at `or_or` precedence (tighter than the ternary), so:

```raku
sub p($l, $v) { say $v }
p "x", True ?? "yes" !! "no"
```

mis-parsed as `(p "x", True) ?? "yes" !! "no"` — the ternary wrapped the whole call (printing `True`) instead of binding inside the argument. Raku binds it inside the argument, so `$v` is `"yes"`. The parenthesized call form `p("x", True ?? "yes" !! "no")` already worked; only the no-paren form was affected.

## Fix

Add `call_arg_ternary_expr`: parse the `or_or` condition, then an optional `?? then !! else` (branches recurse at the same conditional precedence). Use it for the argument itself and for the RHS of an in-argument item assignment, since assignment is looser than the conditional (`f $x = $cond ?? $a !! $b`). `&&`/`||` stay tighter than `??` (they belong to the condition).

All cases now match `raku`, including nested ternaries, comparison conditions, `&&`/`||` conditions, assignment RHS, and multiple arguments each carrying a ternary.

## Tests

- Adds `t/ternary-call-arg.t` (9 cases).
- `make test` passes (855 files, 8091 tests); `roast/S03-operators/ternary.t`, `precedence.t`, `S06-signature/passing-arrays.t` still pass; no regression in `S02-types/whatever.t` (113/… unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)