### PR TITLE
fix(smartmatch): `$_ ~~ s///` in `given`/`with` writes back to the source

### DIFF
--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1263,6 +1263,19 @@ impl Interpreter {
             // mirror the (possibly substitution-modified) topic into it so the
             // caller sees it without an O(locals) sync_locals_from_env pull.
             self.update_local_if_exists(code, var_name, &modified_topic);
+            // When the topic itself was modified (`$_ ~~ s///` inside a
+            // `given $x` / `with $x` block), `$_` aliases the source scalar
+            // variable, so the in-place substitution must propagate back to it —
+            // mirroring the whole-topic writeback the `$_ = ...` assign path does.
+            if lhs_is_topic
+                && let Some(ref source_var) = self.topic_source_var
+                && !source_var.starts_with('@')
+                && !source_var.starts_with('%')
+            {
+                let sv = source_var.clone();
+                self.set_env_with_main_alias(&sv, modified_topic.clone());
+                self.update_local_if_exists(code, &sv, &modified_topic);
+            }
         }
         if !lhs_is_topic {
             if let Some(v) = saved_topic {

--- a/t/given-with-subst-topic.t
+++ b/t/given-with-subst-topic.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 7;
+
+# `$_ ~~ s///` inside `given $x` must write back to the source scalar, because
+# the topic aliases the source variable's container.
+{
+    my $y = "ab";
+    given $y { $_ ~~ s/a/X/ }
+    is $y, "Xb", 'given $x { $_ ~~ s/// } writes back to the source';
+}
+
+# same for `with`
+{
+    my $z = "hello";
+    with $z { $_ ~~ s/l/L/ }
+    is $z, "heLlo", 'with $x { $_ ~~ s/// } writes back to the source';
+}
+
+# backreferences propagate too
+{
+    my $s = "11 22 33";
+    given $s { $_ ~~ s/\s(\S+)\s(\S+)/-$0-$1/ }
+    is $s, "11-22-33", 'given $x { $_ ~~ s/// } with backreferences';
+}
+
+# `$_ ~~ tr///` likewise mutates the source
+{
+    my $t = "abc";
+    given $t { $_ ~~ tr/a..c/A..C/ }
+    is $t, "ABC", 'given $x { $_ ~~ tr/// } writes back to the source';
+}
+
+# a plain assignment to the topic still works (unchanged behaviour)
+{
+    my $a = 1;
+    given $a { $_ = 5 }
+    is $a, 5, 'given $x { $_ = ... } still writes back';
+}
+
+# a non-destructive match must NOT alter the source
+{
+    my $m = "hello";
+    given $m { $_ ~~ /ell/ }
+    is $m, "hello", 'given $x { $_ ~~ /regex/ } leaves the source unchanged';
+}
+
+# nested: outer topic restored after inner given
+{
+    my $outer = "OUT";
+    my $inner = "in";
+    given $outer {
+        given $inner { $_ ~~ s/i/I/ }
+        is $_, "OUT", 'outer topic restored after inner given';
+    }
+}


### PR DESCRIPTION
## Problem

In a `given $x { ... }` / `with $x { ... }` block the topic `$_` aliases the source scalar variable's container. A plain assignment `$_ = ...` already propagated back to `$x` (via `topic_source_var`), but an in-place substitution did not:

```raku
my $y = "ab"; given $y { $_ ~~ s/a/X/ }; say $y;   # mutsu: "ab"  raku: "Xb"
```

The smartmatch handler updated `$_` and its local slot but never the topic source.

## Fix

When the smartmatch LHS *is* the topic (`lhs_var == "_"`), mirror the modified topic into `topic_source_var` (scalar sources only — array/hash topic writeback is handled by the for/given element-source path), exactly as the `$_ = ...` assign path does. Follow-up to #3170 (which fixed the for-loop / standalone-topic case).

## Tests

- `t/given-with-subst-topic.t` (new, 7 cases incl. `tr///`, backrefs, nested given, non-destructive `/regex/` no-op)
- `make test`: PASS (857 files, 8107 tests)
- No regressions: for.t, sink.t, subst.t, given.t, when.t unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)