### PR TITLE
feat(set-ops): support negated set membership/relational operators

### DIFF
--- a/src/parser/expr/precedence_meta_ops.rs
+++ b/src/parser/expr/precedence_meta_ops.rs
@@ -444,6 +444,51 @@ fn parse_set_op(input: &str) -> Option<(TokenKind, usize)> {
     }
 }
 
+/// Parse a negated set-membership / set-relational operator that returns a Bool
+/// and can therefore be negated with the `!` meta-prefix or written with a
+/// precomposed Unicode "negated" glyph. Returns the *positive* `TokenKind`,
+/// which the caller wraps in a `Bang` unary.
+///
+/// Handles the ASCII forms `!(elem)`, `!(cont)`, `!(<=)`, `!(>=)`, `!(>)`,
+/// `!(==)` and the Unicode glyphs `\u{2209}` (\u{2209}), `\u{220C}` (\u{220C}),
+/// `\u{2288}` (\u{2288}), `\u{2289}` (\u{2289}). `!(<)` and `\u{2284}`/`\u{2285}`/`\u{2262}`
+/// already have dedicated handling in `parse_set_op`, so they are intentionally
+/// left out here.
+fn parse_negated_set_op(input: &str) -> Option<(TokenKind, usize)> {
+    if let Some(rest) = input.strip_prefix('!') {
+        // Check the 4-char forms before the 3-char ones so that e.g. `(<=)`
+        // is not mis-parsed as `(<)` followed by stray `=`.
+        let positive = if rest.starts_with("(elem)") {
+            Some((TokenKind::SetElem, 6))
+        } else if rest.starts_with("(cont)") {
+            Some((TokenKind::SetCont, 6))
+        } else if rest.starts_with("(<=)") {
+            Some((TokenKind::SetSubset, 4))
+        } else if rest.starts_with("(>=)") {
+            Some((TokenKind::SetSuperset, 4))
+        } else if rest.starts_with("(>)") {
+            Some((TokenKind::SetStrictSuperset, 3))
+        } else if rest.starts_with("(==)") {
+            Some((TokenKind::Ident("(==)".to_string()), 4))
+        } else {
+            None
+        };
+        return positive.map(|(tok, len)| (tok, 1 + len));
+    }
+    // Precomposed Unicode negated glyphs missing from `parse_set_op`.
+    if input.starts_with('\u{2209}') {
+        Some((TokenKind::SetElem, '\u{2209}'.len_utf8()))
+    } else if input.starts_with('\u{220C}') {
+        Some((TokenKind::SetCont, '\u{220C}'.len_utf8()))
+    } else if input.starts_with('\u{2288}') {
+        Some((TokenKind::SetSubset, '\u{2288}'.len_utf8()))
+    } else if input.starts_with('\u{2289}') {
+        Some((TokenKind::SetSuperset, '\u{2289}'.len_utf8()))
+    } else {
+        None
+    }
+}
+
 /// Structural infix: but, does, set operators
 pub(super) fn structural_expr(input: &str) -> PResult<'_, Expr> {
     let (mut rest, mut left) = concat_expr(input)?;
@@ -491,6 +536,30 @@ pub(super) fn structural_expr(input: &str) -> PResult<'_, Expr> {
                 left: Box::new(left),
                 op: TokenKind::Ident("S&".to_string()),
                 right: Box::new(right),
+            };
+            rest = r;
+            continue;
+        }
+        // Negated set membership / relational operators: !(elem), !(cont),
+        // !(<=), !(>=), !(>), !(==), and Unicode glyphs (in/cont/subset/superset).
+        // Lower to `!(left <positive set op> right)` — a negated Bool.
+        if let Some((tok, len)) = parse_negated_set_op(r) {
+            let r = &r[len..];
+            let (r, _) = ws(r)?;
+            let (r, right) = concat_expr(r).map_err(|err| {
+                enrich_expected_error(
+                    err,
+                    "expected expression after negated set operator",
+                    r.len(),
+                )
+            })?;
+            left = Expr::Unary {
+                op: TokenKind::Bang,
+                expr: Box::new(Expr::Binary {
+                    left: Box::new(left),
+                    op: tok,
+                    right: Box::new(right),
+                }),
             };
             rest = r;
             continue;

--- a/t/negated-set-op.t
+++ b/t/negated-set-op.t
@@ -1,0 +1,49 @@
+use Test;
+
+plan 26;
+
+my $a = (1, 2);
+my $b = (1, 2, 3);
+
+# Negated set membership: !(elem) / ∉
+ok !(9 (elem) $b),       '9 not (elem) b is true via inner';
+ok 9 !(elem) $b,         '9 !(elem) b';
+nok 2 !(elem) $b,        '2 !(elem) b is false';
+ok 9 ∉ $b,               '9 ∉ b';
+nok 2 ∉ $b,              '2 ∉ b is false';
+
+# Negated containment: !(cont) / ∌
+ok $b !(cont) 9,         'b !(cont) 9';
+nok $b !(cont) 2,        'b !(cont) 2 is false';
+ok $b ∌ 9,               'b ∌ 9';
+nok $b ∌ 2,              'b ∌ 2 is false';
+
+# Negated subset: !(<=) / ⊈
+nok $a !(<=) $b,         'a !(<=) b is false (a is subset)';
+ok $b !(<=) $a,          'b !(<=) a is true';
+ok $b ⊈ $a,              'b ⊈ a';
+nok $a ⊈ $b,             'a ⊈ b is false';
+
+# Negated superset: !(>=) / ⊉
+ok $a !(>=) $b,          'a !(>=) b is true';
+nok $b !(>=) $a,         'b !(>=) a is false (b is superset)';
+ok $a ⊉ $b,              'a ⊉ b';
+nok $b ⊉ $a,             'b ⊉ a is false';
+
+# Negated strict subset: !(<) / ⊄
+nok $a !(<) $b,          'a !(<) b is false';
+ok $a !(>) $b,           'a !(>) b is true';
+
+# Negated set equality: !(==) / ≢
+ok $a !(==) $b,          'a !(==) b is true';
+nok $a !(==) $a,         'a !(==) a is false';
+ok $a ≢ $b,              'a ≢ b';
+nok $a ≢ $a,             'a ≢ a is false';
+
+# Works with Set objects too
+my $s = set(1, 2, 3);
+ok 9 !(elem) $s,         '9 !(elem) set';
+nok 1 !(elem) $s,        '1 !(elem) set is false';
+
+# Chained / combined with boolean
+ok (9 !(elem) $b) && (8 !(elem) $b), 'two negated memberships combined';


### PR DESCRIPTION
## Summary

The negated set-membership / set-relational operators were not parsed:

- `3 !(elem) (1,2,3)` was split into **three separate statements** (`3`, `!(elem)`, `(1,2,3)`) instead of one negated-membership expression.
- `9 ∉ $b`, `$b ∌ 9`, `$b ⊈ $a`, `$a ⊉ $b` failed to parse entirely (these glyphs were missing from `parse_set_op`).
- `$a !(<=) $b` / `!(>=)` / `!(>)` / `!(==)` were parse errors.

`!(<)` and the Unicode `⊄` / `⊅` / `≢` already worked via dedicated handling in `parse_set_op`, and are left untouched.

## Fix

Add `parse_negated_set_op` to the `structural_expr` infix loop. It recognizes the ASCII `!(op)` forms and the precomposed Unicode glyphs `∉ ∌ ⊈ ⊉`, and lowers them to `!(left <positive set op> right)` — the same standard `Bang` negation of a `Bool`-returning set comparison that already executes correctly in both the VM and the interpreter (verified that e.g. `!(2 (elem) $b)` already worked end-to-end). No new opcode or runtime path is needed.

Prefix `!(...)` boolean negation is unaffected because the new recognizer only fires in the infix position (after a left operand).

## Verification

- All 20 negated-set-op cases now match `raku` exactly.
- New pin test `t/negated-set-op.t` (26 subtests).
- Whitelisted roast `set_elem.t`, `set_subset.t`, `set_proper_subset.t`, `set_equality.t`, `set_intersection.t`, `S03-metaops/not.t`, `infix.t`, `misc.t` all PASS.
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)