### PR TITLE
fix(signatures): destructure list/array/hash variables in sub-signatures

### DIFF
--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -1,8 +1,20 @@
 use super::*;
 
 pub(in crate::runtime) fn positional_values_from_unpack_target(value: &Value) -> Vec<Value> {
+    // A variable passed by reference (e.g. `f(@a)` / `f($items)`) arrives as a
+    // varref Capture wrapping the real value; unwrap before destructuring.
+    if let Some((_, inner)) = varref_from_value(value) {
+        return positional_values_from_unpack_target(&inner);
+    }
     match value {
         Value::Capture { positional, .. } => (**positional).clone(),
+        // For sub-signature destructuring, a list is always taken apart
+        // element-wise even when itemized — e.g. `$(3, 4)` or an array variable
+        // bound to a single destructuring positional via the single-argument
+        // rule. `value_to_list` would otherwise return an itemized list as a
+        // single opaque element, which fails the destructuring arity check.
+        Value::Array(data, _) => data.items.clone(),
+        Value::Seq(items) | Value::Slip(items) => (**items).clone(),
         other => crate::runtime::value_to_list(other),
     }
 }
@@ -170,9 +182,32 @@ pub(in crate::runtime) fn sigilless_readonly_key(name: &str) -> String {
     format!("__mutsu_sigilless_readonly::{}", name)
 }
 
+/// Collect the `Pair`/`ValuePair` elements of a list into a named map. Used
+/// when a list of pairs is destructured by named sub-signature params.
+fn pairs_in_list_to_named(items: &[Value]) -> std::collections::HashMap<String, Value> {
+    let mut out = std::collections::HashMap::new();
+    for item in items {
+        match item {
+            Value::Pair(key, val) => {
+                out.insert(key.clone(), val.as_ref().clone());
+            }
+            Value::ValuePair(key, val) => {
+                out.insert(key.to_string_value(), val.as_ref().clone());
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
 pub(in crate::runtime) fn named_values_from_unpack_target(
     value: &Value,
 ) -> std::collections::HashMap<String, Value> {
+    // Unwrap a varref Capture (a by-reference variable argument) to the real
+    // value before extracting named entries.
+    if let Some((_, inner)) = varref_from_value(value) {
+        return named_values_from_unpack_target(&inner);
+    }
     match value {
         Value::Capture { named, .. } => (**named).clone(),
         Value::Hash(map) => map.map.clone(),
@@ -183,6 +218,10 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
             out.insert("value".to_string(), *val.clone());
             out
         }
+        // A list of Pairs (e.g. `(a => 1, b => 2)`) destructured by named
+        // params `(:$a, :$b)` binds each pair's key to its value.
+        Value::Array(data, _) => pairs_in_list_to_named(&data.items),
+        Value::Seq(items) | Value::Slip(items) => pairs_in_list_to_named(items),
         Value::Instance { attributes, .. } => attributes.to_map(),
         _ => std::collections::HashMap::new(),
     }

--- a/t/subsig-destructure-varref.t
+++ b/t/subsig-destructure-varref.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 12;
+
+# Positional destructuring of a list bound by reference (single-argument rule).
+sub pos2(($x, $y)) { $x + $y }
+{
+    my @a = (3, 4);
+    is pos2(@a), 7, 'positional destructure of @array variable';
+}
+{
+    my $items = (3, 4);
+    is pos2($items), 7, 'positional destructure of itemized list variable';
+}
+is pos2([3, 4]), 7, 'positional destructure of array literal';
+
+# Three-element list var.
+sub pos3(($a, $b, $c)) { "$a-$b-$c" }
+{
+    my @t = (1, 2, 3);
+    is pos3(@t), '1-2-3', 'three-element positional destructure of @array';
+}
+
+# Named destructuring of a list of pairs.
+sub named2((:$foo, :$bar)) { $foo + $bar }
+is named2((foo => 10, bar => 20)), 30, 'named destructure of pair-list literal';
+{
+    my @list = (foo => 10, bar => 20);
+    is named2(@list), 30, 'named destructure of @array of pairs';
+}
+
+# Named destructuring of a Hash variable.
+sub named-h((:$a, :$b)) { $a * $b }
+{
+    my %h = a => 3, b => 4;
+    is named-h(%h), 12, 'named destructure of %hash variable';
+}
+is named-h({ a => 3, b => 4 }), 12, 'named destructure of hash literal';
+
+# Named destructure with a default.
+sub named-def((:$x, :$y = 99)) { "$x/$y" }
+{
+    my @l = (x => 5,);
+    is named-def(@l), '5/99', 'named destructure applies default for missing key';
+}
+
+# Subsignature on a named array parameter (single-argument rule).
+sub typed-pos(@p ($x, $y)) { $x * $y }
+{
+    my @pt = (6, 7);
+    is typed-pos(@pt), 42, 'subsignature on @-sigil param with array variable';
+}
+
+# Named destructure picks up keys regardless of order.
+sub conn((:$host, :$port)) { "$host:$port" }
+{
+    my %config = port => 8080, host => "example";
+    is conn(%config), 'example:8080', 'named destructure of hash var, key order independent';
+}
+
+# A pair-list with non-Str keys.
+sub vpairs((:$one, :$two)) { ($one // 0) + ($two // 0) }
+{
+    my @pl = (one => 100, two => 200);
+    is vpairs(@pl), 300, 'named destructure picks both keys from pair-list var';
+}


### PR DESCRIPTION
## Summary

A sub-signature parameter failed to bind when the destructured argument was a **variable** rather than a literal:

| Call | Before | raku |
|------|--------|------|
| `sub f(($x,$y)){…}; my @a=(3,4); f(@a)` | `Too few positional arguments in sub-signature binding` | binds `$x=3, $y=4` |
| `my $items=(3,4); f($items)` | same error | binds |
| `sub h((:$foo,:$bar)){…}; h((foo=>1, bar=>2))` | `0` (unbound) | binds |
| `my @list=(foo=>1, bar=>2); h(@list)` | `0` (unbound) | binds |

Root cause: a variable passed to a destructuring param arrives as a **varref `Capture`** (the by-reference wrapper), and `positional_values_from_unpack_target` matched its empty `positional` slot; for itemized lists, `value_to_list` returned the whole list as a single opaque element. A *list of pairs* was likewise not recognized as a source of named values.

## Fix

In `src/runtime/types/signature.rs`:
- `positional_values_from_unpack_target` and `named_values_from_unpack_target` first **unwrap a varref `Capture`** to the underlying value.
- For positional destructuring, itemized `Array`/`Seq`/`Slip` lists are taken apart element-wise (itemization does not hide the elements from a destructure).
- For named destructuring, a list's `Pair`/`ValuePair` elements are collected into the named map (new `pairs_in_list_to_named` helper).

This also fixes the multi-dispatch *matching* path (`sub_signature_matches_value`) for file-scope subjects, since it shares these helpers.

## Out of scope

The multi-dispatch + **block-scope lexical** + destructuring + array-variable combination resolves via a separate VM-native dispatch path that never reaches the runtime matcher; that is a pre-existing issue (fails identically on `main`) and is not addressed here.

## Verification

- New pin test `t/subsig-destructure-varref.t` (12 subtests), all pass.
- Whitelisted roast `S06-signature/{unpack-array,unpack-object,passing-arrays,passing-hashes,named-parameters,positional,optional,defaults,arity,multidimensional}.t` and `S06-multi/unpackability.t` all PASS.
- `make test` PASS.
- (`S06-signature/slurpy-params.t` fails identically with and without this change — a pre-existing `+@`-onearg / lazy-range issue on `main`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)