### PR TITLE
fix(signature): correct +@ / +foo single-argument-rule flattening

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -133,16 +133,23 @@
   - Slurpy *scalar* params (`*$f`, `*$s`) now bind: each captures the next single
     positional arg (skipping named/Pair args), leaving the rest for a trailing
     `*@`. Implemented in `runtime/types/binding.rs` (new branch in the
-    `pd.slurpy` chain, guarded by `!name.starts_with('@')`). Tests 30-33 now pass;
-    the file progresses 29 -> 43 of 86 run. Local coverage: t/slurpy-params.t.
+    `pd.slurpy` chain, guarded by `!name.starts_with('@')`). Tests 30-33 now pass.
+    Local coverage: t/slurpy-params.t.
+  - Single-argument-rule slurpy (`+@foo` / sigilless `+foo`) flattening FIXED
+    (binding.rs `pd.onearg` branch): a single Iterable arg flattens (incl. Range /
+    Seq); multiple top-level args are NOT flattened (each is one element); only
+    Slips flatten among multiple args. Sigilless `+foo` now binds a read-only List
+    under the bare name (was undeclared, aborting the file). File progresses
+    43 -> 51 of 86 run. Local coverage: t/onearg-slurpy-rule.t.
   - Remaining blockers (each its own feature, no single-PR whitelist):
     - tests 34-35: Mu slurpy `*@a` must NOT autothread a Junction argument
       (`slurp_obj_thread(3|4|5)` should call once); needs junction-autothread
       suppression for slurpy params. The `multi` variant additionally aborts the
       file with "Test failures".
-    - tests 39, 41-43 (and the `+foo`/`+@foo` blocks after): single-argument-rule
-      slurpy (`+@foo`, `+foo`) flattening of Range / nested list+arg / lazy Seq is
-      incomplete (`.elems` off).
+    - test 52+ (`oneargraw(1..*)[^5]`): lazy infinite slurpy — the single-arg
+      rule must keep an infinite range lazy (HARD, real-lazy-sequence blocker).
+    - Seq/List identity: `+foo` must preserve a single Seq as Seq (`.WHAT === Seq`)
+      while `+@foo` converts it to List; mutsu materializes both to Array.
 - [ ] roast/S06-signature/slurpy-placeholders.t
 - [ ] roast/S06-signature/sub-ref.t
 - [ ] roast/S06-signature/tree-node-parameters.t

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -336,30 +336,31 @@ impl Interpreter {
                         Value::Array(arr, kind) if !kind.is_itemized() => arr.to_vec(),
                         Value::Slip(arr) => arr.to_vec(),
                         Value::Seq(arr) => arr.to_vec(),
+                        single @ (Value::Range(..)
+                        | Value::RangeExcl(..)
+                        | Value::RangeExclStart(..)
+                        | Value::RangeExclBoth(..)
+                        | Value::GenericRange { .. }) => {
+                            // A single iterable argument is used as the argument
+                            // list: a finite range flattens to its elements.
+                            let mut items = Vec::new();
+                            flatten_into_slurpy(&[single], &mut items);
+                            items
+                        }
                         other => vec![other],
                     }
                 } else {
-                    // Multiple args: collect like *@ (flattening slurpy)
+                    // Multiple top-level args: the single-argument rule does NOT
+                    // flatten them — each top-level argument becomes one element
+                    // (e.g. `f(1..3, 4)` is a 2-element list, the range is not
+                    // expanded). Only Slips flatten, since slips always flatten.
                     let mut items = Vec::new();
                     for val in remaining_positional {
                         let val = unwrap_varref_value(val);
                         match val {
                             Value::Pair(..) => {} // skip named args
-                            Value::Array(arr, kind) => {
-                                if kind.is_itemized() {
-                                    items.push(Value::Array(arr, kind));
-                                } else {
-                                    flatten_into_slurpy(&arr, &mut items);
-                                }
-                            }
-                            val @ (Value::Range(..)
-                            | Value::RangeExcl(..)
-                            | Value::RangeExclStart(..)
-                            | Value::RangeExclBoth(..)
-                            | Value::GenericRange { .. }
-                            | Value::Seq(..)
-                            | Value::Slip(..)) => {
-                                flatten_into_slurpy(&[val], &mut items);
+                            Value::Slip(arr) => {
+                                flatten_into_slurpy(&arr, &mut items);
                             }
                             other => {
                                 items.push(other);
@@ -370,7 +371,16 @@ impl Interpreter {
                 };
                 positional_idx = args.len(); // consume all remaining args
                 let slurpy_value = Value::real_array(items);
-                if !pd.name.is_empty() {
+                if pd.sigilless {
+                    // Sigilless single-argument rule slurpy (`+foo`): bind a
+                    // read-only List under the bare name, with no `@` sigil.
+                    if !pd.name.is_empty() {
+                        self.env
+                            .insert(sigilless_readonly_key(&pd.name), Value::Bool(true));
+                        self.env.remove(&sigilless_alias_key(&pd.name));
+                        self.bind_param_value(&pd.name, slurpy_value.clone());
+                    }
+                } else if !pd.name.is_empty() {
                     let key = if pd.name.starts_with('@') {
                         pd.name.clone()
                     } else {

--- a/t/onearg-slurpy-rule.t
+++ b/t/onearg-slurpy-rule.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 18;
+
+# The single-argument rule slurpy `+@a` / `+foo`:
+#   - a single Iterable argument is used as the argument list (flattened),
+#   - multiple top-level arguments are NOT flattened (each becomes one element).
+
+# --- +@foo (array sigil) ---
+sub a(+@foo) { @foo }
+
+is a(1,2,3).elems,        3, '+@: comma separates top-level args';
+is a((1,2,3)).elems,      3, '+@: single list arg flattens';
+is a([1,2,3]).elems,      3, '+@: single array arg flattens';
+is a(1..3).elems,         3, '+@: single range arg flattens';
+is a(1...3).elems,        3, '+@: single seq arg flattens';
+is a((1,2,3),4).elems,    2, '+@: list + extra arg is NOT flattened';
+is a([1,2,3],4).elems,    2, '+@: array + extra arg is NOT flattened';
+is a(1..3,4).elems,       2, '+@: range + extra arg is NOT flattened';
+
+# --- +foo (sigilless) ---
+sub s(+foo) { foo }
+
+is s(1,2,3).elems,        3, '+foo: comma separates top-level args';
+is s((1,2,3)).elems,      3, '+foo: single list arg flattens';
+is s(1..3).elems,         3, '+foo: single range arg flattens';
+is s(1..3,4).elems,       2, '+foo: range + extra arg is NOT flattened';
+is s([1,2,3],4).elems,    2, '+foo: array + extra arg is NOT flattened';
+
+# --- with a leading positional / named ---
+sub f($x, :$y, +@foo) { @foo }
+
+is f(0,:y,1,2,3).elems,   3, '+@ after positional: comma separates';
+is f(0,:y,1..3).elems,    3, '+@ after positional: single range flattens';
+is f(0,:y,1..3,4).elems,  2, '+@ after positional: range + extra not flattened';
+
+# slips always flatten, even among multiple args
+is a(|(1,2),3).elems,     3, '+@: a slip flattens among multiple args';
+is a(slip(1,2),3,4).elems, 4, '+@: slip + extras';


### PR DESCRIPTION
## Summary

Fixes the single-argument-rule slurpy (`+@foo`, sigilless `+foo`) flattening to match Raku semantics. Per the single argument rule, a **single** Iterable argument is used as the argument list (flattened), while **multiple** top-level arguments are NOT flattened — each becomes one element.

Three bugs fixed in `runtime/types/binding.rs` (`pd.onearg` branch):

1. **Multiple args over-flattened.** `f(1..3, 4)` returned 4 elements (it flattened the range like `*@`) instead of 2. Now only Slips flatten among multiple args; every other top-level arg (Range, Seq, Array, …) stays one element.
2. **Single Range not flattened.** `f(1..3)` returned 1 instead of 3. A single iterable Range now flattens to its elements.
3. **Sigilless `+foo` undeclared.** It bound the value under `@foo`, so a body reference to bare `foo` was "not declared" and aborted the file. It now binds a read-only List under the bare name.

Verified against `raku`:
```
sub f(+@foo){@foo.elems}
f(1..3,4)      # 2   (was 4)
f((1,2),(3,4)) # 2
f(1..3)        # 3   (was 1)
f(|(1,2),3)    # 3   (slip flattens)
```

## Impact

roast `S06-signature/slurpy-params.t` progresses **43 → 51 of 86** run. Remaining blockers are separate features (Junction-no-autothread, lazy infinite slurpy, Seq/List identity) documented in `TODO_roast/S06.md`.

## Tests

New `t/onearg-slurpy-rule.t` (18 cases). `make test` passes; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)