### PR TITLE
fix(try): set $! to an unthrown Failure's exception

### DIFF
--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -3033,18 +3033,26 @@ impl Interpreter {
         }
         match body_result {
             Ok(()) => {
-                // Successful try resets $! to Nil
-                self.env_mut().insert("!".to_string(), Value::Nil);
                 self.discard_let_saves(let_mark);
                 // A `try` that completes normally but yields a soft Failure value
                 // (e.g. the result of an expression that returned a Failure rather
                 // than throwing) handles that Failure: its value is now "caught",
-                // so subsequent uses must not re-throw the stored exception.
+                // so subsequent uses must not re-throw the stored exception. Per
+                // Raku semantics `$!` is then set to that Failure's exception
+                // (a successful try with a non-Failure result resets `$!` to Nil).
+                let mut failure_exception = None;
                 if let Some(top) = self.stack.last()
                     && matches!(top, Value::Instance { class_name, .. } if class_name == "Failure")
                 {
                     top.mark_failure_handled();
+                    if let Value::Instance { attributes, .. } = top
+                        && let Some(exc) = attributes.as_map().get("exception")
+                    {
+                        failure_exception = Some(exc.clone());
+                    }
                 }
+                self.env_mut()
+                    .insert("!".to_string(), failure_exception.unwrap_or(Value::Nil));
                 *ip = end;
                 Ok(())
             }

--- a/t/try-failure-bang.t
+++ b/t/try-failure-bang.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 10;
+
+# A `try` block whose result is an *unthrown* Failure sets $! to that
+# Failure's exception (Raku semantics), not Nil.
+{
+    my $r = try { "42abc".Int };
+    nok $r.defined, 'try over failing .Int yields an undefined (Failure) result';
+    is $!.^name, 'X::Str::Numeric', '$! is set to the Failure exception after try';
+}
+
+# An explicit Failure returned from a try block also populates $!.
+{
+    my $r = try { Failure.new("custom") };
+    nok $r.defined, 'explicit Failure from try is undefined';
+    is $!.^name, 'X::AdHoc', '$! is the explicit Failure exception';
+}
+
+# A successful try with a normal value resets $! to Nil/Any.
+{
+    my $r = try { 41 + 1 };
+    is $r, 42, 'successful try returns its value';
+    nok $!.defined, '$! is undefined after a successful try';
+}
+
+# A thrown exception inside try still sets $! (unchanged behaviour).
+{
+    my $r = try { die "boom" };
+    nok $r.defined, 'try over die yields undefined';
+    is $!.^name, 'X::AdHoc', '$! is X::AdHoc after a caught die';
+}
+
+# $! reflects the *most recent* try.
+{
+    try { "xx".Int };
+    my $first = $!.^name;
+    try { 1 + 1 };
+    is $first, 'X::Str::Numeric', 'first try set $! to the numeric failure';
+    nok $!.defined, 'second (successful) try cleared $!';
+}


### PR DESCRIPTION
## Summary

A `try` block whose result value is an **unthrown Failure** did not populate `$!`:

```raku
my $r = try { "42abc".Int };   # returns a Failure (not thrown)
say $!.^name;                  # mutsu: Any   raku: X::Str::Numeric
```

Raku sets `$!` to the Failure's exception in this case. mutsu unconditionally reset `$!` to `Nil` on a normally-completing `try`, only setting it when an exception was actually *thrown* (`die`/CATCH).

## Fix

In `exec_try_catch_op_inner` (`src/vm/vm_control_ops.rs`), the `Ok` branch now, when the try result on the stack is a `Failure`, reads its `exception` attribute and assigns that to `$!` (still marking the Failure handled so it does not re-throw later). A successful `try` with a non-Failure result still resets `$!` to `Nil`.

## Verification

Matches `raku` across all four cases:

| block | `$!.^name` |
|-------|-----------|
| `try { 1 }` | `Any` |
| `try { "42abc".Int }` | `X::Str::Numeric` |
| `try { die "boom" }` | `X::AdHoc` |
| `try { Failure.new("x") }` | `X::AdHoc` |

- New pin test `t/try-failure-bang.t` (10 subtests).
- All whitelisted `S04-exception*` / `S04-statements/try.t` roast tests PASS.
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)