### PR TITLE
fix(junction): slurpy params do not auto-thread a Junction argument

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -141,11 +141,10 @@
     Slips flatten among multiple args. Sigilless `+foo` now binds a read-only List
     under the bare name (was undeclared, aborting the file). File progresses
     43 -> 51 of 86 run. Local coverage: t/onearg-slurpy-rule.t.
+  - tests 34-35 FIXED: a Junction passed to a slurpy param (`*@a` / `+@a`) is now
+    captured as one element instead of auto-threading (vm_call_autothread.rs skips
+    slurpy positional params). Local coverage: t/slurpy-junction-no-autothread.t.
   - Remaining blockers (each its own feature, no single-PR whitelist):
-    - tests 34-35: Mu slurpy `*@a` must NOT autothread a Junction argument
-      (`slurp_obj_thread(3|4|5)` should call once); needs junction-autothread
-      suppression for slurpy params. The `multi` variant additionally aborts the
-      file with "Test failures".
     - test 52+ (`oneargraw(1..*)[^5]`): lazy infinite slurpy — the single-arg
       rule must keep an infinite range lazy (HARD, real-lazy-sequence blocker).
     - Seq/List identity: `+foo` must preserve a single Seq as Seq (`.WHAT === Seq`)

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -138,6 +138,12 @@ impl Interpreter {
                 let positional_pds: Vec<&crate::ast::ParamDef> =
                     pds.iter().filter(|pd| !pd.named).collect();
                 if let Some(pd) = positional_pds.get(idx) {
+                    // A slurpy param (`*@a`, `+@a`, `**@a`) collects its elements
+                    // as raw Mu values, so a Junction argument is captured as-is
+                    // rather than auto-threaded.
+                    if pd.slurpy || pd.onearg || pd.double_slurpy {
+                        return false;
+                    }
                     // Don't auto-thread if param accepts Mu or Junction
                     if let Some(tc) = &pd.type_constraint {
                         if matches!(tc.as_str(), "Mu" | "Junction") {

--- a/t/slurpy-junction-no-autothread.t
+++ b/t/slurpy-junction-no-autothread.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 8;
+
+# A Junction passed to a *slurpy* parameter is captured as-is (one element),
+# NOT auto-threaded — the slurpy binds its elements as raw Mu values.
+
+{
+    my $count = 0;
+    sub f(*@a) { $count++ }
+    f(3|4|5);
+    is $count, 1, '*@a slurpy does not autothread a Junction arg';
+}
+
+{
+    my $count = 0;
+    multi sub g(*@a) { $count++ }
+    g(3|4|5);
+    is $count, 1, 'multi *@a slurpy does not autothread a Junction arg';
+}
+
+{
+    my $count = 0;
+    sub h(+@a) { $count++ }
+    h(3|4|5);
+    is $count, 1, '+@a single-argument-rule slurpy does not autothread';
+}
+
+{
+    my $count = 0;
+    sub i($x, *@a) { $count++ }
+    i(6, 3|4|5);
+    is $count, 1, 'Junction landing in a trailing slurpy does not autothread';
+}
+
+# But a Junction bound to an ordinary (Any-typed) positional param DOES autothread.
+{
+    my $count = 0;
+    sub j($x) { $count++ }
+    j(3|4|5);
+    is $count, 3, 'Junction in an untyped scalar param autothreads';
+}
+
+{
+    my $count = 0;
+    sub k($x, *@a) { $count++ }
+    k(3|4|5, 6);
+    is $count, 3, 'Junction in a leading scalar param autothreads even with a slurpy';
+}
+
+# The slurpy actually holds the Junction value.
+{
+    sub l(*@a) { @a[0] }
+    my $j = l(3|4|5);
+    ok $j ~~ Junction, 'the slurpy element is the Junction itself';
+    is l(3|4|5).elems, 1, 'one element captured';
+}


### PR DESCRIPTION
## Summary

A Junction passed to a **slurpy** parameter (`*@a`, `+@a`, `**@a`) must be captured as a single element, not auto-threaded. A slurpy binds its elements as raw `Mu` values, and Junction auto-threading is suppressed for `Mu`-typed bindings (verified: `Mu $x` does not autothread, `Any $x`/`Int $x`/untyped do).

The autothread filter in `vm_call_autothread.rs` built `positional_pds` from all non-named params — **including the slurpy** — and then treated the slurpy's absent type constraint as "default Any", so it auto-threaded:

```
sub f(*@a) { ... }; f(3|4|5)   # ran the body 3 times instead of once
```

Fix: skip slurpy positional params (`slurpy`/`onearg`/`double_slurpy`) when deciding whether to auto-thread.

Verified against `raku`:
```
sub f(*@a){...};    f(3|4|5)     # once  — junction captured as @a[0]
multi sub g(*@a){}; g(3|4|5)     # once
sub h(+@a){...};    h(3|4|5)     # once
sub i($x,*@a){};    i(6, 3|4|5)  # once  — junction in trailing slurpy
sub j($x){...};     j(3|4|5)     # 3×    — untyped scalar still autothreads
sub k($x,*@a){};    k(3|4|5, 6)  # 3×    — junction in leading scalar autothreads
```

## Impact

Fixes roast `S06-signature/slurpy-params.t` tests 34-35 (`Mu slurpy param doesnt autothread`, both the plain and `multi` forms).

## Tests

New `t/slurpy-junction-no-autothread.t` (8 cases). `make test` passes; clippy/fmt clean; S03-junctions roast tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)