### PR TITLE
test(roast): whitelist 3 newly-passing integration tests

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1229,6 +1229,8 @@ roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t
 roast/integration/advent2009-day04.t
+roast/integration/advent2009-day05.t
+roast/integration/advent2009-day06.t
 roast/integration/advent2009-day07.t
 roast/integration/advent2009-day08.t
 roast/integration/advent2009-day13.t
@@ -1239,6 +1241,7 @@ roast/integration/advent2009-day19.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day08.t
+roast/integration/advent2010-day10.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t


### PR DESCRIPTION
## Summary

A sweep of all non-whitelisted roast files found three that now pass cleanly:

- `integration/advent2009-day05.t`
- `integration/advent2009-day06.t`
- `integration/advent2010-day10.t`

Each was verified with the debug binary and the CI `run-roast-test.sh` harness over multiple runs. They are deterministic algorithm/integration tests (no concurrency or timing sensitivity), so they are safe to whitelist.

`S02-names-vars/perl.t` also newly passes in the sweep, but it is the documented typed-container alloc / hash-order flaky (intermittent `exit 255` with `Failed: 0`), so it is intentionally **not** added.

Whitelist remains sorted (`LC_ALL=C sort -c` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)