### PR TITLE
feat(signatures): implement Signature.returns

### DIFF
--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -37,6 +37,11 @@ impl Interpreter {
                 "__mutsu_callable_type".to_string(),
                 Value::str_from(callable_type),
             );
+            // Carry the declared return type so `.signature.returns` / `.returns`
+            // reflect a `--> Type` declaration on the method.
+            if let Some(rt) = &def.return_type {
+                env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
+            }
             if has_multi {
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
@@ -83,6 +88,11 @@ impl Interpreter {
                 "__mutsu_callable_type".to_string(),
                 Value::str_from(callable_type),
             );
+            // Carry the declared return type so `.signature.returns` / `.returns`
+            // reflect a `--> Type` declaration on the role method.
+            if let Some(rt) = &def.return_type {
+                env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
+            }
             if has_multi {
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
@@ -1925,9 +1935,11 @@ impl Interpreter {
         attrs.insert("name".to_string(), Value::str(display_name));
         attrs.insert("is_dispatcher".to_string(), Value::Bool(is_dispatcher));
 
-        // Build a Signature object for this method
+        // Build a Signature object for this method, threading the return type
+        // so that `.signature.returns` reflects a `--> Type` declaration.
         let param_defs = &method_def.param_defs;
-        let sig_info = crate::value::signature::param_defs_to_sig_info(param_defs, None);
+        let sig_info =
+            crate::value::signature::param_defs_to_sig_info(param_defs, return_type.clone());
         attrs.insert(
             "signature".to_string(),
             crate::value::signature::make_signature_value(sig_info),

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -204,6 +204,13 @@ pub(crate) fn make_signature_value_with_owner(info: SigInfo, owner_key: Option<S
         "params".to_string(),
         make_params_value_with_owner(&info.params, &owner_key),
     );
+    // `.returns` yields the return-type type object, defaulting to `Mu` when
+    // the signature declares no explicit return type. (Signature has no `.of`.)
+    let return_type = info.return_type.clone().unwrap_or_else(|| "Mu".to_string());
+    attrs.insert(
+        "returns".to_string(),
+        Value::Package(Symbol::intern(&return_type)),
+    );
     let val = Value::make_instance(Symbol::intern("Signature"), attrs);
     // Register the SigInfo for later lookup (smartmatch, etc.)
     if let Value::Instance { id, .. } = &val {

--- a/t/signature-returns.t
+++ b/t/signature-returns.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 11;
+
+# Signature.returns yields the declared return-type type object.
+sub with-ret(--> Str) { "x" }
+is &with-ret.signature.returns.^name, 'Str', 'sub --> Str: returns is Str';
+ok &with-ret.signature.returns === Str, 'returns is the Str type object';
+
+sub int-ret(Int $x --> Int) { $x }
+is &int-ret.signature.returns.^name, 'Int', 'sub --> Int: returns is Int';
+
+# No explicit return type defaults to Mu.
+sub no-ret($x) { $x }
+is &no-ret.signature.returns.^name, 'Mu', 'no return type: returns is Mu';
+ok &no-ret.signature.returns === Mu, 'default returns is the Mu type object';
+
+# Pointy block with a return type.
+my &p = -> Int $x --> Str { "$x" };
+is &p.signature.returns.^name, 'Str', 'pointy block --> Str: returns is Str';
+
+# .returns is also reachable straight off a Signature literal value.
+is (-> --> Int {}).signature.returns.^name, 'Int', 'anon block --> Int';
+
+# A method signature.
+class C { method m(--> Bool) { True } }
+is C.^lookup("m").signature.returns.^name, 'Bool', 'method --> Bool: returns is Bool';
+
+# .returns type object gist.
+is &no-ret.signature.returns.gist, '(Mu)', 'Mu type object gist';
+is &with-ret.signature.returns.gist, '(Str)', 'Str type object gist';
+
+# The signature value is a Signature.
+ok (-> --> Int {}).signature.^name eq 'Signature', 'signature value is a Signature';


### PR DESCRIPTION
## Summary

`$sig.returns` threw `No such method 'returns' for invocant of type 'Signature'`. It now yields the declared return-type type object (defaulting to `Mu`), matching `raku`:

```raku
(-> Int $x --> Str {}).signature.returns      # Str   (was: No such method)
sub f($x) {}; &f.signature.returns            # Mu
sub g(--> Int) {}; &g.signature.returns       # Int
class C { method m(--> Bool) {} }
C.^lookup("m").signature.returns              # Bool  (was: Mu)
```

## Fix

- `make_signature_value` stores a `returns` attribute (the return type, or `Mu`). Signature deliberately has **no** `.of` method — `raku`'s `Signature` doesn't either.
- For **methods**, `param_defs_to_sig_info` now threads the declared return type into the signature, and `classhow_lookup` carries a `--> Type` declaration into the looked-up method's env (`__mutsu_return_type`), so both `Class.^lookup("m").returns` and `...signature.returns` reflect it.

Signature `.gist`/`.raku` rendering is unchanged (it reads `info.return_type`, not the new attribute), verified byte-identical to `raku`.

## Verification

- New pin test `t/signature-returns.t` (11 subtests).
- Whitelisted roast `S06-signature/{introspection,code,definite-return,named-parameters,positional,types}.t` PASS.
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)