### PR TITLE
fix(temporal): delegate Duration numeric methods to its value

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -20,6 +20,28 @@ impl Interpreter {
             id: target_id,
         } = &target
         {
+            // `Duration` does `Real`: delegate numeric methods (e.g.
+            // `(now - now).abs`) to its underlying numeric value. `.Str` / `.gist`
+            // / `.raku` and other identity methods keep Duration's own behaviour.
+            if class_name.resolve() == "Duration"
+                && matches!(
+                    method,
+                    "abs"
+                        | "floor"
+                        | "ceiling"
+                        | "round"
+                        | "truncate"
+                        | "sign"
+                        | "Int"
+                        | "Rat"
+                        | "FatRat"
+                        | "Real"
+                        | "sqrt"
+                )
+            {
+                let num = crate::runtime::utils::coerce_to_numeric(target.clone());
+                return self.call_method_with_values(num, method, args);
+            }
             if let Some(private_rest) = method.strip_prefix('!') {
                 let caller_class = self
                     .method_class_stack

--- a/t/duration-numeric-methods.t
+++ b/t/duration-numeric-methods.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 16;
+
+# Duration does Real: numeric methods delegate to the underlying value.
+my $d = Duration.new(3.5);
+is $d.abs, 3.5, 'Duration.abs';
+is $d.floor, 3, 'Duration.floor';
+is $d.ceiling, 4, 'Duration.ceiling';
+is $d.round, 4, 'Duration.round (nearest)';
+is $d.truncate, 3, 'Duration.truncate';
+is $d.sign, 1, 'Duration.sign (positive)';
+is $d.Int, 3, 'Duration.Int';
+is $d.Real, 3.5, 'Duration.Real';
+
+my $neg = Duration.new(-2.7);
+is $neg.abs, 2.7, 'negative Duration.abs';
+is $neg.sign, -1, 'negative Duration.sign';
+is $neg.floor, -3, 'negative Duration.floor';
+is $neg.ceiling, -2, 'negative Duration.ceiling';
+
+# A Duration is still a Duration (identity methods unaffected).
+is $d.^name, 'Duration', 'Duration is still a Duration';
+ok $d ~~ Real, 'Duration does Real';
+
+# Difference of two Instants is a Duration whose .abs works.
+my $diff = now - now;
+ok $diff ~~ Duration, 'now - now is a Duration';
+ok $diff.abs >= 0, 'Duration.abs of an Instant difference is non-negative';


### PR DESCRIPTION
## Summary

`Duration` does `Real`, so numeric methods should work on it — but only `.Num` was wired up:

```raku
my $d = now - now;     # Duration
say $d.abs;            # was: No such method 'abs' for invocant of type 'Duration'
```

## Fix

In `dispatch_instance_and_fallback`, a `Duration` instance now delegates the common `Real` numeric methods (`abs floor ceiling round truncate sign Int Rat FatRat Real sqrt`) to its underlying numeric value via `coerce_to_numeric`. Identity/representation methods (`.Str`, `.gist`, `.raku`, `.^name`) keep Duration's own behaviour, and `coerce_to_numeric` yields a plain `Num`/`Rat`, so there is no recursion.

## Verification

Matches `raku` for positive and negative Durations across all listed methods.

- New pin test `t/duration-numeric-methods.t` (16 subtests).
- Whitelisted roast `S02-types/instants-and-durations.t`, `S32-temporal/{DateTime-Instant-Duration,Date,DateTime}.t` PASS.
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)