### PR TITLE
fix(numeric): sign() on a Complex requires a Real

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -6,6 +6,7 @@ roast/6.d/S02-literals/version.t
 roast/6.d/S05-capture/match-object.t
 roast/6.d/S32-num/atanh.t
 roast/6.d/S32-num/log.t
+roast/6.d/S32-num/sign.t
 roast/6.d/S32-num/sqrt.t
 roast/6.d/S32-str/sprintf-b.t
 roast/6.d/S32-str/sprintf-c.t

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -378,13 +378,39 @@ pub(super) fn dispatch(
                     })
                 }
                 Value::Complex(re, im) => {
-                    // sign of a Complex number is the number divided by its absolute value
-                    let abs = (re * re + im * im).sqrt();
-                    if abs == 0.0 {
-                        Value::Complex(0.0, 0.0)
-                    } else {
-                        Value::Complex(re / abs, im / abs)
+                    // `sign` requires a Real. A Complex with a non-zero imaginary
+                    // part cannot be coerced to Real, so it throws X::Numeric::Real
+                    // (matching `.Int`/`.Real` coercion). A purely real Complex
+                    // yields the Int sign of its real part.
+                    if *im != 0.0 {
+                        let mut attrs = std::collections::HashMap::new();
+                        let rendered = if *im >= 0.0 {
+                            format!("{re}+{im}i")
+                        } else {
+                            format!("{re}{im}i")
+                        };
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!(
+                                "Cannot convert {rendered} to Real: imaginary part not zero"
+                            )),
+                        );
+                        attrs.insert("target".to_string(), Value::Package(Symbol::intern("Real")));
+                        attrs.insert("source".to_string(), target.clone());
+                        let ex = Value::make_instance(Symbol::intern("X::Numeric::Real"), attrs);
+                        let mut err = RuntimeError::new(
+                            "Cannot convert Complex to Real: imaginary part not zero",
+                        );
+                        err.exception = Some(Box::new(ex));
+                        return Some(Some(Err(err)));
                     }
+                    Value::Int(if *re > 0.0 {
+                        1
+                    } else if *re < 0.0 {
+                        -1
+                    } else {
+                        0
+                    })
                 }
                 Value::Enum { value, .. } => Value::Int(value.as_i64().signum()),
                 _ => return Some(None),

--- a/t/sign-complex.t
+++ b/t/sign-complex.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 7;
+
+# `sign` requires a Real. A Complex with a non-zero imaginary part cannot be
+# coerced to Real, so it throws X::Numeric::Real; a purely real Complex yields
+# the Int sign of its real part.
+
+throws-like { sign(3+4i) }, X::Numeric::Real, 'sign() on Complex with imaginary part throws';
+throws-like { (3+4i).sign }, X::Numeric::Real, '.sign on Complex with imaginary part throws';
+
+is sign(3+0i),   1, 'sign() of a positive real Complex is 1';
+is sign(-2+0i), -1, 'sign() of a negative real Complex is -1';
+is sign(0+0i),   0, 'sign() of zero Complex is 0';
+is (5+0i).sign,  1, '.sign of a positive real Complex is 1';
+
+# Make sure ordinary numeric sign is unaffected.
+is (-7).sign, -1, '.sign on a plain Int still works';


### PR DESCRIPTION
## Summary

`sign` is a Real operation. A `Complex` with a non-zero imaginary part cannot be coerced to Real, so it must throw `X::Numeric::Real` (the same exception `.Int`/`.Real` coercion already throws). mutsu instead returned a complex "unit" value (`number / abs`). A purely real `Complex` (imaginary part `0`) now yields the `Int` sign of its real part.

Verified vs `raku`:
```
sign(3+4i)   # throws X::Numeric::Real: "Cannot convert 3+4i to Real: imaginary part not zero"
sign(3+0i)   # 1
sign(-2+0i)  # -1
sign(0+0i)   # 0
```

## Impact

Whitelists `roast/6.d/S32-num/sign.t` (1/1). All other `S32-num` tests still pass.

## Tests

New `t/sign-complex.t` (7 cases). `make test` passes; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)