### PR TITLE
fix(setbagmix): sort a Set/Bag/Mix into its sorted pairs

### DIFF
--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -597,6 +597,43 @@ pub(crate) fn sort_value_generic(
                 .collect();
             sort_value_generic(caller, Value::array(items), args)
         }
+        // Set/Bag/Mix sort their decomposition into `key => weight` pairs (a
+        // Set yields `key => True`), with the original key type preserved so the
+        // ordering and `.gist` match Raku. Without this they fell through to
+        // `other => Ok(other)` and `.sort` wrongly returned the container itself.
+        Value::Set(ref s, _) => {
+            let items: Vec<Value> = s
+                .iter()
+                .map(|k| setty_typed_pair(s.typed_key(k), k, Value::Bool(true)))
+                .collect();
+            sort_value_generic(caller, Value::array(items), args)
+        }
+        Value::Bag(ref b, _) => {
+            let items: Vec<Value> = b
+                .iter()
+                .map(|(k, v)| setty_typed_pair(b.typed_key(k), k, Value::from_bigint(v.clone())))
+                .collect();
+            sort_value_generic(caller, Value::array(items), args)
+        }
+        Value::Mix(ref m, _) => {
+            let items: Vec<Value> = m
+                .iter()
+                .map(|(k, v)| {
+                    setty_typed_pair(m.typed_key(k), k, crate::value::mix_weight_to_value(*v))
+                })
+                .collect();
+            sort_value_generic(caller, Value::array(items), args)
+        }
         other => Ok(other),
+    }
+}
+
+/// Build a `key => weight` pair for a Set/Bag/Mix element, preserving the
+/// original key type (`ValuePair`) when it is not a plain string key.
+fn setty_typed_pair(typed_key: Value, str_key: &str, weight: Value) -> Value {
+    if matches!(&typed_key, Value::Str(sv) if sv.as_ref() == str_key) {
+        Value::Pair(str_key.to_string(), Box::new(weight))
+    } else {
+        Value::ValuePair(Box::new(typed_key), Box::new(weight))
     }
 }

--- a/t/native-quanthash-coerce.t
+++ b/t/native-quanthash-coerce.t
@@ -10,7 +10,9 @@ plan 26;
 
 # --- .Set ---
 is (1, 2, 2, 3).Set.elems, 3, 'List.Set dedups';
-is (1, 2, 2, 3).Set.sort, (1, 2, 3), 'Set membership';
+# `.Set.sort` yields sorted `key => True` pairs (per Raku); sort the keys to
+# check membership.
+is (1, 2, 2, 3).Set.keys.sort, (1, 2, 3), 'Set membership';
 ok <a b c> (<) <a b c d>.Set, 'Set subset op after coercion';
 is (1, [2, 3]).Set.elems, 3, 'List flattens in .Set';
 is [1, [2, 3]].Set.elems, 2, 'Array takes elements whole in .Set';

--- a/t/setbagmix-sort.t
+++ b/t/setbagmix-sort.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 12;
+
+# Bag.sort yields a sorted Seq of `key => weight` pairs (not the Bag itself).
+{
+    my $b = (1, 1, 2, 3, 3, 3).Bag;
+    is $b.sort.^name, 'Seq', 'Bag.sort returns a Seq';
+    is $b.sort.map(*.gist).join(','), '1 => 2,2 => 1,3 => 3', 'Bag.sort is by key';
+    is $b.sort».gist.join(','), '1 => 2,2 => 1,3 => 3', 'Bag.sort».gist works';
+}
+
+# Numeric keys sort numerically (typed keys preserved).
+{
+    my $b = bag(1, 2, 10, 10);
+    is $b.sort.map(*.key).join(','), '1,2,10', 'numeric keys sort numerically';
+    is $b.sort.map(*.key.^name).unique.join(','), 'Int', 'keys keep Int type';
+}
+
+# Set.sort yields `key => True` pairs sorted by key.
+{
+    my $s = set(<z a m>);
+    is $s.sort.map(*.key).join(','), 'a,m,z', 'Set.sort sorts keys';
+    is $s.sort.map(*.value).unique.join(','), 'True', 'Set.sort values are True';
+}
+
+# Mix.sort yields `key => weight` pairs sorted by key.
+{
+    my $m = ("b" => 1.5, "a" => 2.5).Mix;
+    is $m.sort.map(*.key).join(','), 'a,b', 'Mix.sort sorts keys';
+    is $m.sort.map(*.value).join(','), '2.5,1.5', 'Mix.sort weights follow keys';
+}
+
+# Sort with a comparator over the pairs.
+{
+    my $cb = (1, 1, 2, 3, 3, 3).Bag;
+    is $cb.sort(*.value).map(*.key).join(','), '2,1,3', 'Bag.sort(*.value) by weight';
+    is $cb.sort(-> $x, $y { $y.value <=> $x.value }).map(*.key).join(','), '3,1,2',
+        'Bag.sort descending by weight';
+}
+
+# Sorting an empty Bag is an empty Seq.
+is bag().sort.elems, 0, 'empty Bag.sort is empty';


### PR DESCRIPTION
## Summary

`.sort` on a `Set`/`Bag`/`Mix` returned the **container itself** — it fell through to `other => Ok(other)` in `sort_value_generic`:

```raku
my $b = bag(1, 1, 2, 3, 3, 3);
say $b.sort;        # was: Bag(1(2) 2 3(3))   want: (1 => 2 2 => 1 3 => 3)
say $b.sort».gist;  # was: garbage (Bag(1(0) 2(0)))
```

Per Raku, sorting a Setty/Baggy value sorts its decomposition into `key => weight` pairs (a `Set` yields `key => True`), returning a `Seq`.

## Fix

Add `Set`/`Bag`/`Mix` arms to `sort_value_generic` that build typed `key => weight` pairs (using `typed_key`, so `bag(1, 2, 10)` orders numerically and `.gist` matches) and recurse — mirroring the existing `Hash` arm. Comparator and `:k` sorting then work for free.

`t/native-quanthash-coerce.t` encoded the old, incorrect `Set.sort == (1,2,3)` expectation (Raku itself fails that assertion — `Set.sort` is `key => True` pairs); it now sorts `.keys` to check membership.

## Verification

Matches `raku` for Set/Bag/Mix `.sort`, `.sort».gist`, numeric-key ordering, and comparator sorts.

- New pin test `t/setbagmix-sort.t` (12 subtests).
- Whitelisted roast `S02-types/set-iterator.t`, `S03-operators/set_*.t` PASS.
- `make test` PASS (the one pre-existing local assertion corrected as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)