### PR TITLE
fix(list): support .head(&callable) / .head(*) WhateverCode arguments

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -2600,6 +2600,21 @@ impl Interpreter {
         {
             return self.dispatch_tail(target, &args);
         }
+        // `.head(&callable)` / `.head(*)` — WhateverCode/Whatever argument. The
+        // native fast path only handles plain numeric counts; resolve the
+        // callable here against a finite, materializable target.
+        if method == "head"
+            && args.len() == 1
+            && matches!(
+                &args[0],
+                Value::Whatever | Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
+            )
+            && !bypass_native_fastpath
+            && !matches!(&target, Value::Instance { .. })
+            && !Self::is_lazy_tail_target(&target)
+        {
+            return self.dispatch_head(target, &args[0]);
+        }
         // .raku/.perl on constrained Hash
         if matches!(method, "raku" | "perl")
             && args.is_empty()

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Interpreter {
-    fn is_lazy_tail_target(target: &Value) -> bool {
+    pub(in crate::runtime) fn is_lazy_tail_target(target: &Value) -> bool {
         match target {
             Value::LazyList(_) => true,
             Value::Range(_, end)
@@ -152,6 +152,38 @@ impl Interpreter {
         let tail_count = self.resolve_supply_tail_count(args.first(), items.len())?;
         let start = items.len().saturating_sub(tail_count);
         Ok(Value::array(items[start..].to_vec()))
+    }
+
+    /// Handle `.head(&callable)` / `.head(*)` where the argument is a
+    /// WhateverCode/Callable or a bare Whatever. Raku invokes the callable with
+    /// `0` and uses the result `n` as an offset from the end: the number of
+    /// leading elements to keep is `len + n` (clamped to `0..=len`). A bare
+    /// `*` (Whatever) keeps the whole list. Plain numeric counts are handled by
+    /// the native fast path, not here.
+    pub(in crate::runtime) fn dispatch_head(
+        &mut self,
+        target: Value,
+        arg: &Value,
+    ) -> Result<Value, RuntimeError> {
+        let items = crate::runtime::utils::value_to_list(&target);
+        let len = items.len() as i64;
+        let count = match arg {
+            Value::Whatever => len,
+            Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } => {
+                let computed = self.eval_call_on_value(arg.clone(), vec![Value::Int(0)])?;
+                let n = match &computed {
+                    Value::Whatever => len,
+                    Value::Int(i) => *i,
+                    Value::Num(f) => *f as i64,
+                    Value::Rat(num, den) if *den != 0 => *num / *den,
+                    other => other.to_string_value().parse::<i64>().unwrap_or(0),
+                };
+                (len + n).clamp(0, len)
+            }
+            _ => len,
+        };
+        let count = count.clamp(0, len) as usize;
+        Ok(Value::array(items[..count].to_vec()))
     }
 
     pub(in crate::runtime) fn callback_uses_supply_list(callback: &Value) -> bool {

--- a/t/head-whatevercode.t
+++ b/t/head-whatevercode.t
@@ -1,0 +1,43 @@
+use Test;
+
+# .head with a WhateverCode / Whatever argument keeps "all but the last N"
+# elements (the callable is invoked with 0; count = len + result).
+
+plan 18;
+
+# WhateverCode *-N on a List
+is (1,2,3,4,5).head(*-2).list, (1, 2, 3), 'List.head(*-2)';
+is (1,2,3,4,5).head(*-0).list, (1, 2, 3, 4, 5), 'List.head(*-0) keeps all';
+is (1,2,3,4,5).head(*-10).list, (), 'List.head(*-N) clamps to empty';
+
+# WhateverCode on a Range
+is (1..10).head(*-3).list, (1, 2, 3, 4, 5, 6, 7), 'Range.head(*-3)';
+is (1..5).head(*-2).list, (1, 2, 3), 'Range.head(*-2)';
+
+# WhateverCode on an Array (variable and literal)
+my @a = 1..5;
+is @a.head(*-2).list, (1, 2, 3), 'Array.head(*-2)';
+is [10,20,30,40].head(*-1).list, (10, 20, 30), 'array literal .head(*-1)';
+
+# WhateverCode on a string list
+is <a b c d e>.head(*-2).list, ('a', 'b', 'c'), 'string list .head(*-2)';
+
+# Non-subtractive WhateverCode: callable(0) result is offset from end
+is (1,2,3,4,5).head(*/2).list, (1, 2, 3, 4, 5), 'head(*/2) -> callable(0)=0 keeps all';
+is (1,2,3,4,5).head(*+1).list, (1, 2, 3, 4, 5), 'head(*+1) clamps to all';
+
+# bare Whatever keeps everything
+is (1,2,3).head(*).list, (1, 2, 3), 'head(*) keeps all';
+is (1..4).head(*).list, (1, 2, 3, 4), 'Range.head(*) keeps all';
+
+# explicit pointy block behaves like the WhateverCode
+is (1,2,3,4,5).head(-> $n { $n - 2 }).list, (1, 2, 3), 'head(pointy block)';
+
+# plain numeric counts are unaffected
+is (1,2,3,4,5).head(2).list, (1, 2), 'plain head(2) still works';
+is (1,2,3,4,5).head(2.5).list, (1, 2), 'head(2.5) truncates';
+is (1,2,3,4,5).head(0).list, (), 'head(0) is empty';
+is (1..10).head(3).list, (1, 2, 3), 'Range.head(3) still works';
+
+# head with no argument returns the first element
+is (1,2,3).head, 1, 'head with no arg';


### PR DESCRIPTION
## Summary

`.head` only accepted a plain numeric count. A WhateverCode argument such as `.head(*-2)` (keep all but the last 2) or a bare `*` fell through the native fast path and died with `No such method 'head'`, even though the symmetric `.tail(*-N)` already worked.

```
$ raku  -e 'say (1..10).head(*-3)'     # (1 2 3 4 5 6 7)
$ mutsu -e 'say (1..10).head(*-3)'     # before: Runtime error: No such method 'head' ...
```

## Fix

Add `dispatch_head`, mirroring `dispatch_tail`: invoke the callable with `0` and use the result `n` as an offset from the end, keeping `len + n` leading elements (clamped to `0..=len`); a bare `Whatever` keeps the whole list. Plain numeric counts continue through the native fast path. Lazy / infinite targets are left untouched (only finite, materializable targets are intercepted).

Verified against `raku` for `*-N`, `*/2`, `*+1`, `*-0`, bare `*`, pointy blocks, and plain/fractional numeric counts.

## Tests

- New `t/head-whatevercode.t` (18 cases).
- `roast/S32-list/head.t` (60) and `roast/S32-list/tail.t` (57) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)