### PR TITLE
fix(test): do not hijack core list skip() as Test::skip in VM fast-path

### DIFF
--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -53,6 +53,19 @@ impl Interpreter {
         // synthetic `__test_callsite_line` argument and stash it so TAP
         // diagnostics report the right source line.
         let (clean_args, callsite_line) = self.sanitize_call_args(args);
+        // `skip` collides with the core list routine `skip(Int $n, *@list)`.
+        // Test's `skip($reason?, $count = 1)` always takes a Str (or no) first
+        // arg, so a numeric first arg followed by a list operand means the core
+        // routine was intended (a file may selectively import Test without
+        // `&skip`). Decline here and let the normal `call_function` path apply
+        // the same disambiguation (builtins.rs `"skip"` arm) and dispatch the
+        // list-skip builtin.
+        if name == "skip"
+            && clean_args.len() >= 2
+            && matches!(clean_args[0], Value::Int(..) | Value::Num(..))
+        {
+            return None;
+        }
         loan_env!(self, set_pending_callsite_line(callsite_line));
         match loan_env!(self, call_test_function(name, &clean_args)) {
             // Matched and handled by the typed Test dispatcher.

--- a/t/skip-list-vs-test.t
+++ b/t/skip-list-vs-test.t
@@ -1,0 +1,22 @@
+# `skip` collides with two routines: the core list routine
+# `skip(Int $n, *@list)` and Test's `skip($reason?, $count = 1)`. With Test
+# loaded, a numeric first arg + a list operand must dispatch to the core list
+# routine (not be hijacked as a test-skip), while a Str first arg stays Test's
+# skip. Regression for the VM fast-path that hijacked `skip` unconditionally.
+use Test;
+
+plan 6;
+
+# Core list skip (numeric first arg) — must NOT emit SKIP TAP lines.
+is-deeply skip(2, <a b c d e>), <c d e>, 'skip(Int, List) is the core list routine';
+is-deeply skip(0, <a b c>),     <a b c>, 'skip(0, List) skips nothing';
+is-deeply skip(5, <a b c>),     (),      'skip(N, List) past the end is empty';
+
+my @array = <x y z w>;
+is-deeply skip(2, @array), <z w>, 'skip(Int, @array) flattens the array operand';
+
+# Method form is unaffected.
+is-deeply <a b c d>.skip(1), <b c d>, 'List.skip(N) method form works';
+
+# Test's skip (Str first arg) still skips tests.
+skip "deliberately skipped", 1;


### PR DESCRIPTION
## Problem

The VM fast-path `try_native_test_function` dispatched any call named `skip` to Test's `skip($reason?, $count = 1)` whenever the Test module was loaded, even when the program meant the core list routine `skip(Int $n, *@list)`.

A file that selectively imports Test without `&skip` — the idiom used by `roast/S32-list/skip.t`:

```raku
BEGIN my (&plan, &subtest, &is, &is-deeply, &throws-like) = do {
    use Test;
    (&plan, &subtest, &is, &is-deeply, &throws-like)
}
```

…would then have every `skip(N, $list)` emit `# SKIP N` TAP lines instead of skipping list elements, inflating the test count: **skip.t ran 206 tests of a planned 55**.

## Fix

`call_function` already disambiguates this case (builtins.rs `"skip"` arm: a numeric first arg with a list operand is the core routine), but the VM fast-path short-circuited before reaching it. This mirrors the same check in `try_native_test_function`: decline `skip` when the first arg is numeric and there are ≥ 2 args, letting the normal path dispatch the list-skip builtin. `skip("reason", $count)` and single-arg `skip 1` stay Test::skip.

## Result

- `S32-list/skip.t`: **29 failures → 2** (remaining 2 are Seq-laziness, out of scope; file still not whitelistable).
- Whitelisted skip-using tests (`S24-testing/1-basic`, `3-output`, `S17-supply/skip`, `S32-list/toggle`) all still pass.
- New regression test `t/skip-list-vs-test.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)