### PR TITLE
fix(hash): Hash.push/.append flatten a Seq or Slip of Pairs

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1247,6 +1247,7 @@ roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
 roast/integration/advent2011-day16.t
+roast/integration/advent2011-day20.t
 roast/integration/advent2011-day22.t
 roast/integration/advent2011-day24.t
 roast/integration/advent2012-day02.t

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -3952,6 +3952,12 @@ impl Interpreter {
                     let inner_pairs = Self::hash_push_collect_pairs(items.to_vec());
                     pairs.extend(inner_pairs);
                 }
+                Value::Seq(items) | Value::Slip(items) => {
+                    // A Seq/Slip of pairs (e.g. from `%h.push: %x.invert`) is
+                    // flattened like an array, not stringified as one key.
+                    let inner_pairs = Self::hash_push_collect_pairs(items.to_vec());
+                    pairs.extend(inner_pairs);
+                }
                 Value::Hash(h, ..) => {
                     for (k, v) in h.iter() {
                         pairs.push((k.clone(), v.clone()));
@@ -3984,6 +3990,9 @@ impl Interpreter {
                     pairs.push((*k, *v));
                 }
                 Value::Array(items, ..) => {
+                    pairs.extend(Self::hash_push_collect_pairs_kv(items.to_vec()));
+                }
+                Value::Seq(items) | Value::Slip(items) => {
                     pairs.extend(Self::hash_push_collect_pairs_kv(items.to_vec()));
                 }
                 Value::Hash(h, ..) => {

--- a/t/hash-push-seq-of-pairs.t
+++ b/t/hash-push-seq-of-pairs.t
@@ -1,0 +1,37 @@
+# Hash.push / Hash.append must flatten a Seq (or Slip) of Pairs the same way it
+# flattens an Array of Pairs. A Seq operand (e.g. from `%h.push: %x.invert`) used
+# to fall through to the alternating key/value arm, stringifying the whole Seq
+# into a single mangled key.
+use Test;
+
+plan 5;
+
+# Seq of pairs (literal .Seq).
+{
+    my %h = a => 1;
+    %h.push: (b => 2, c => 3).Seq;
+    is-deeply %h, {a => 1, b => 2, c => 3}, 'push of a Seq of pairs flattens';
+}
+
+# .invert returns a Seq of pairs.
+{
+    my %h    = a => 1;
+    my %x    = x => 'a', y => 'b';
+    %h.push: %x.invert;
+    is-deeply %h, {a => [1, 'x'], b => 'y'}, 'push of %h.invert (a Seq) flattens';
+}
+
+# Existing key stacks into an array (push semantics) via a Seq operand.
+{
+    my %h = a => 1;
+    %h.push: (a => 2, a => 3).Seq;
+    is-deeply %h<a>, [1, 2, 3], 'push of a Seq stacks repeated keys';
+}
+
+# append from a Seq.
+{
+    my %h = a => [1];
+    %h.append: (a => 2, b => 3).Seq;
+    is-deeply %h<a>, [1, 2], 'append of a Seq flattens into existing array';
+    is-deeply %h<b>, 3,      'append of a Seq stores a fresh key as a scalar';
+}


### PR DESCRIPTION
## Problem

`Hash.push` / `Hash.append` recursively flatten an **Array** of Pairs, but not a **Seq** or **Slip**. A Seq operand fell through to the alternating key/value arm, stringifying the entire Seq into one mangled key:

```raku
my %song = Panacea => 'found a lover', Photek => 'ni ten ichi ryu';
my %artist = 'modus operandi' => 'Photek', 'dying civilization' => 'Panacea';
%song.push: %artist.invert;   # .invert returns a Seq of Pairs
```

Expected `{Panacea => [...], Photek => [...]}`; mutsu produced a key like `"Photek\tmodus operandi Panacea\tdying civilization" => Any`.

## Fix

Add `Seq`/`Slip` arms to both `hash_push_collect_pairs` and `hash_push_collect_pairs_kv`, recursing exactly like the existing `Array` arm.

## Result

- Whitelists `roast/integration/advent2011-day20.t` (16/16).
- New regression test `t/hash-push-seq-of-pairs.t`.
- `make test`: cargo 462/462; only intermittent `t/io-socket-async-listen.t` (async, unrelated — passes on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)