### PR TITLE
fix(repr): itemize aggregate hash values in .raku / .perl

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -157,6 +157,25 @@ fn raku_array_wrap(inner: &str, kind: ArrayKind) -> String {
 /// Render a value for `.raku` but strip itemization (Scalar container).
 /// In Raku, `@a.raku` renders itemized elements without the `$` prefix:
 ///   my @a = $[1,2,3]; @a.raku  # [[1, 2, 3],]  (not $[1, 2, 3])
+/// Render a value that is stored as a *hash value* for `.raku`/`.perl`.
+///
+/// In Raku, every hash value lives in a `Scalar` container, so an aggregate
+/// (Array/List/Hash/Seq) value is itemized: `{:a($[1, 2])}`, `{:a(${:b(1)})}`,
+/// `{:a($(1, 2, 3))}`, `{:a($((1, 2).Seq))}`. Scalars (Int/Str/Range/Pair/Set…)
+/// are rendered as-is. Values whose own repr already carries the `$` sigil
+/// (e.g. an explicitly itemized `$[1, 2]`) are not double-itemized.
+fn raku_hash_value(v: &Value) -> String {
+    let base = raku_value(v);
+    if base.starts_with('$') {
+        return base;
+    }
+    match v {
+        Value::Array(..) | Value::Hash(_) => format!("${base}"),
+        Value::Seq(_) => format!("$({base})"),
+        _ => base,
+    }
+}
+
 fn raku_value_as_element(v: &Value) -> String {
     match v {
         Value::Array(items, kind) => {
@@ -521,7 +540,7 @@ pub fn raku_value(v: &Value) -> String {
                             let repr = if matches!(v, Value::Nil) {
                                 "Any".to_string()
                             } else {
-                                raku_value(v)
+                                raku_hash_value(v)
                             };
                             format!(":{}({})", k, repr)
                         }
@@ -530,7 +549,7 @@ pub fn raku_value(v: &Value) -> String {
                         let repr = if matches!(v, Value::Nil) {
                             "Any".to_string()
                         } else {
-                            raku_value(v)
+                            raku_hash_value(v)
                         };
                         format!("{} => {}", raku_value(&typed), repr)
                     }

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -166,7 +166,10 @@ fn raku_array_wrap(inner: &str, kind: ArrayKind) -> String {
 /// (e.g. an explicitly itemized `$[1, 2]`) are not double-itemized.
 fn raku_hash_value(v: &Value) -> String {
     let base = raku_value(v);
-    if base.starts_with('$') {
+    // Don't double-itemize a value whose repr already carries a sigil: an
+    // explicitly itemized `$[...]`, or a cycle-reference placeholder for a
+    // recursive structure (`%hash_<ptr>` / `@Array_<ptr>`).
+    if base.starts_with(['$', '@', '%']) {
         return base;
     }
     match v {

--- a/t/hash-raku-itemization.t
+++ b/t/hash-raku-itemization.t
@@ -1,0 +1,82 @@
+use Test;
+
+# In Raku every hash value lives in a Scalar container, so an aggregate
+# (Array / List / Hash / Seq) value is itemized in `.raku` / `.perl`:
+#   {:a($[1, 2])}, {:a(${:b(1)})}, {:a($(1, 2, 3))}
+# Scalars (Int / Str / Range / Pair / Set ...) are rendered as-is.
+
+plan 16;
+
+# Hash value that is itself a Hash
+{
+    my %h; %h<a><b> = 1;
+    is %h.raku, '{:a(${:b(1)})}', 'nested autoviv hash value is itemized';
+}
+{
+    my %h; %h<a><b><c> = 1;
+    is %h.raku, '{:a(${:b(${:c(1)})})}', 'deep nested autoviv hash values';
+}
+{
+    my %h; %h{1}{2} = 3;
+    is %h.raku, '{"1" => ${"2" => 3}}', 'non-ident key nested hash value';
+}
+{
+    my %h = a => {b => 1};
+    is %h.raku, '{:a(${:b(1)})}', 'hash literal value';
+}
+
+# Hash value that is an Array / List / Seq
+{
+    my %h = a => [1, 2, 3];
+    is %h.raku, '{:a($[1, 2, 3])}', 'array value is itemized';
+}
+{
+    my %h = a => (1, 2, 3);
+    is %h.raku, '{:a($(1, 2, 3))}', 'list value is itemized';
+}
+{
+    my %h = a => (1,);
+    is %h.raku, '{:a($(1,))}', 'one-element list value';
+}
+{
+    my %h = a => [1, 2].Seq;
+    is %h.raku, '{:a($((1, 2).Seq))}', 'Seq value is itemized';
+}
+{
+    my @a = 1, 2;
+    my %h = x => @a;
+    is %h.raku, '{:x($[1, 2])}', '@-array value is itemized';
+}
+
+# Already-itemized values are not double-itemized
+{
+    my %h = a => $[1, 2];
+    is %h.raku, '{:a($[1, 2])}', 'explicit $[...] value not doubled';
+}
+
+# Scalar / non-aggregate values are NOT itemized
+{
+    my %h = a => 1, b => 2;
+    is %h.raku, '{:a(1), :b(2)}', 'Int values unchanged';
+}
+{
+    my %h = a => "x";
+    is %h.raku, '{:a("x")}', 'Str value unchanged';
+}
+{
+    my %h = a => (1..3);
+    is %h.raku, '{:a(1..3)}', 'Range value unchanged';
+}
+{
+    my %h = a => (1 => 2);
+    is %h.raku, '{:a(1 => 2)}', 'Pair value unchanged';
+}
+
+# .perl matches .raku
+{
+    my %h = a => [1, 2];
+    is %h.perl, '{:a($[1, 2])}', '.perl matches .raku';
+}
+
+# Array elements are NOT itemized (only hash values are)
+is [[1, 2], [3, 4]].raku, '[[1, 2], [3, 4]]', 'arrays inside an array are not itemized';


### PR DESCRIPTION
## Summary

In Raku every hash value lives in a `Scalar` container, so an aggregate (Array / List / Hash / Seq) value is itemized when rendered by `.raku` / `.perl`:

```
my %h; %h<a><b> = 1;  say %h.raku   # {:a(${:b(1)})}
my %h = a => [1,2,3]; say %h.raku   # {:a($[1, 2, 3])}
my %h = a => (1,2,3); say %h.raku   # {:a($(1, 2, 3))}
```

mutsu rendered these without the leading `$` (`{:a({:b(1)})}`, `{:a([1, 2, 3])}`, …).

## Fix

Add a `raku_hash_value` helper used for hash-value rendering that prefixes `$` for `Array` / `List` / `Hash` / `Seq` values (wrapping a `Seq` in `$(...)`), while leaving scalars (`Int`/`Str`/`Range`/`Pair`/`Set`/…) and already-itemized `$[...]` values untouched. Array *elements* are unaffected — only hash values are itemized, matching Raku.

Verified against `raku` for nested autoviv, array/list/Seq/hash values, already-itemized values, and all the non-aggregate scalar value types.

## Tests

- New `t/hash-raku-itemization.t` (16 cases).
- Whitelisted repr tests still pass: `S02-types/array_ref.t`, `assigning-refs.t`, `baghash.t`, `mix.t`, `S32-hash/keys_values.t`, `S02-literals/autoref.t`, `S02-types/hash.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)