### PR TITLE
fix(gather): eagerly reify a gather LazyList in an array literal

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1247,6 +1247,7 @@ roast/integration/advent2010-day10.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
+roast/integration/advent2011-day05.t
 roast/integration/advent2011-day16.t
 roast/integration/advent2011-day20.t
 roast/integration/advent2011-day22.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1225,6 +1225,7 @@ roast/S32-trig/sin.t
 roast/S32-trig/sinh.t
 roast/S32-trig/tan.t
 roast/S32-trig/tanh.t
+roast/integration/99problems-01-to-10.t
 roast/integration/99problems-11-to-20.t
 roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -94,6 +94,10 @@ impl Interpreter {
                     Err(_) => continue,
                 }
             } else if let Value::LazyList(ll) = &val
+                && ll.coroutine.is_some()
+                && ll.sequence_spec.is_none()
+                && ll.scan_spec.is_none()
+                && ll.lazy_pipe.is_none()
                 && !matches!(
                     ll.env.get("__mutsu_preserve_lazy_on_array_assign"),
                     Some(Value::Bool(true))
@@ -102,8 +106,11 @@ impl Interpreter {
                 // Array literals (`[...]`) are eager: a gather/take LazyList must
                 // run now so its side effects happen (e.g. `take shift @array`
                 // mutating an outer array a surrounding `while` loops on) and its
-                // elements materialize. A `lazy`-marked list is left lazy (it may
-                // be infinite); so is one that fails a strict force.
+                // elements materialize. Only a plain gather (coroutine, no
+                // sequence/scan/pipe spec) is forced — an infinite `...` sequence
+                // or a lazy map/grep pipe must stay lazy (forcing a sequence_spec
+                // would truncate it to its finite cache). A `lazy`-marked list is
+                // likewise left lazy; so is one that fails a strict force.
                 match self.force_lazy_list_vm(ll) {
                     Ok(items) => Value::Seq(std::sync::Arc::new(items)),
                     Err(_) => val,

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -93,6 +93,21 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(_) => continue,
                 }
+            } else if let Value::LazyList(ll) = &val
+                && !matches!(
+                    ll.env.get("__mutsu_preserve_lazy_on_array_assign"),
+                    Some(Value::Bool(true))
+                )
+            {
+                // Array literals (`[...]`) are eager: a gather/take LazyList must
+                // run now so its side effects happen (e.g. `take shift @array`
+                // mutating an outer array a surrounding `while` loops on) and its
+                // elements materialize. A `lazy`-marked list is left lazy (it may
+                // be infinite); so is one that fails a strict force.
+                match self.force_lazy_list_vm(ll) {
+                    Ok(items) => Value::Seq(std::sync::Arc::new(items)),
+                    Err(_) => val,
+                }
             } else {
                 val
             };

--- a/t/array-literal-eager-gather.t
+++ b/t/array-literal-eager-gather.t
@@ -1,0 +1,53 @@
+# An array literal `[...]` is eager: a gather/take LazyList element must be run
+# at construction time so its side effects happen and its elements materialize.
+# Previously `[ gather {...} ]` stored the unrun LazyList and `value_to_list`
+# read its (empty) cache, yielding `[]` and — when the gather mutated an outer
+# array a surrounding `while` looped on — an infinite loop.
+use Test;
+
+plan 6;
+
+# Direct gather in an array literal flattens its taken values.
+is-deeply [ gather { take 1; take 2; take 3 } ], [1, 2, 3],
+    'array literal flattens a single gather element';
+
+# The gather body runs at array-build time (its side effects are visible).
+{
+    my @array = <a b c>;
+    my $x = [ gather { while @array { take shift @array } } ];
+    is-deeply $x, [<a b c>], 'gather inside [...] reifies its elements';
+    is @array.elems, 0, 'gather body ran at array-build time (array drained)';
+}
+
+# Nested gather/take with an outer gather-while that depends on the inner
+# gather draining the shared array (99problems "pack" idiom).
+{
+    sub group2 (*@array is copy) {
+        gather while @array {
+            take [
+                gather {
+                    my $h = @array[0];
+                    while @array and $h eq @array[0] {
+                        take shift @array;
+                    }
+                }
+            ];
+        }
+    }
+    is-deeply [group2(<a a a a b c c a a d e e e e>)],
+        [[<a a a a>], [<b>], [<c c>], [<a a>], [<d>], [<e e e e>]],
+        'nested gather-while + inner gather draining a shared array';
+}
+
+# Multi-element literals keep each gather itemized as its own element.
+is-deeply [[gather { take 1; take 2 }], [gather { take 3 }]],
+    [[1, 2], [3]], 'nested array-of-gathers keeps each itemized';
+
+# A `lazy`-marked infinite gather must NOT be force-materialized by the array
+# literal — that would never terminate. We only assert that construction
+# terminates here; lazily slicing such a list back out of the array literal is a
+# separate, deeper lazy-sequence feature mutsu does not yet support.
+{
+    my @a = [lazy gather { take $_ for 1..Inf }];
+    pass 'lazy infinite gather in [...] does not hang at build time';
+}


### PR DESCRIPTION
## Problem

An array literal `[...]` is eager, but `exec_make_array_op` left a gather/take `LazyList` element **unrun** and flattened it via `value_to_list`, which only reads the (empty) cache:

```raku
say [ gather { take 1; take 2; take 3 } ];   # was: []   (raku: [1 2 3])
```

Worse, a nested gather looped forever:

```raku
sub group2 (*@array is copy) {
    gather while @array {
        take [ gather { my $h = @array[0];
                        while @array and $h eq @array[0] { take shift @array } } ];
    }
}
```

The inner gather never ran, so the shared `@array` never drained and the outer `while @array` never terminated — `roast/integration/99problems-01-to-10.t` test 21 hung.

## Fix

Force a gather `LazyList` to materialize at array-build time (mirroring the `@`-assignment path in `vm_var_assign_ops`), so its side effects happen and its elements appear. A `lazy`-marked list (`__mutsu_preserve_lazy_on_array_assign`) or one that fails a strict force (infinite map/grep pipe) is left lazy — no hang, matching raku where plain `gather` is eager and `lazy gather` stays lazy.

## Result

- Whitelists `roast/integration/99problems-01-to-10.t` (22/22).
- New regression test `t/array-literal-eager-gather.t` (incl. the nested 99problems idiom and a `lazy`-marker termination check).
- `make test`: cargo 462/462, prove all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)