### PR TITLE
fix(repr): Bool::True in .raku and route dd through .raku

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -428,7 +428,7 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         Value::FatRat(n, d) => format!("FatRat.new({}, {})", n, d),
-        Value::Bool(b) => if *b { "True" } else { "False" }.to_string(),
+        Value::Bool(b) => if *b { "Bool::True" } else { "Bool::False" }.to_string(),
         Value::Num(f) => {
             if f.is_nan() {
                 "NaN".to_string()
@@ -453,6 +453,7 @@ pub fn raku_value(v: &Value) -> String {
             if ident_like {
                 match value.as_ref() {
                     Value::Bool(true) => format!(":{}", key),
+                    Value::Bool(false) => format!(":!{}", key),
                     _ => format!(":{}({})", key, raku_value(value)),
                 }
             } else {
@@ -472,6 +473,7 @@ pub fn raku_value(v: &Value) -> String {
                 if ident_like {
                     return match value.as_ref() {
                         Value::Bool(true) => format!(":{}", key_str),
+                        Value::Bool(false) => format!(":!{}", key_str),
                         _ => format!(":{}({})", key_str, raku_value(value)),
                     };
                 }
@@ -534,19 +536,16 @@ pub fn raku_value(v: &Value) -> String {
                                 .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
                     });
                     if is_ident {
+                        // Raku's `.raku` renders every value in the colon-pair
+                        // form `:key(value.raku)` — including Bool, which shows
+                        // as `:a(Bool::True)`, not the adverbial `:a` / `:!a`.
                         let k = key_str.as_deref().unwrap();
-                        if let Value::Bool(true) = v {
-                            format!(":{}", k)
-                        } else if let Value::Bool(false) = v {
-                            format!(":!{}", k)
+                        let repr = if matches!(v, Value::Nil) {
+                            "Any".to_string()
                         } else {
-                            let repr = if matches!(v, Value::Nil) {
-                                "Any".to_string()
-                            } else {
-                                raku_hash_value(v)
-                            };
-                            format!(":{}({})", k, repr)
-                        }
+                            raku_hash_value(v)
+                        };
+                        format!(":{}({})", k, repr)
                     } else {
                         // Non-identifier keys: use "key" => value format
                         let repr = if matches!(v, Value::Nil) {

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -306,29 +306,44 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_dd(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let val = args.first().cloned().unwrap_or(Value::Nil);
-        let repr = Self::dd_format(&val);
-        self.emit_stderr(&format!("{}\n", repr));
-        Ok(val)
+        let arg_sources = self.pending_call_arg_sources.clone().unwrap_or_default();
+        for (i, val) in args.iter().enumerate() {
+            let source_name = arg_sources.get(i).and_then(|entry| entry.as_deref());
+            let repr = Self::dd_format(val, source_name);
+            self.emit_stderr(&format!("{}\n", repr));
+        }
+        Ok(args.first().cloned().unwrap_or(Value::Nil))
     }
 
     /// Format a value for `dd` output (Raku-style debug representation).
-    fn dd_format(val: &Value) -> String {
-        match val {
-            Value::Bool(true) => "Bool::True".to_string(),
-            Value::Bool(false) => "Bool::False".to_string(),
-            Value::Nil => "Nil".to_string(),
-            Value::Int(n) => n.to_string(),
-            Value::Str(s) => format!("\"{}\"", s),
-            Value::Array(items, _) => {
-                let inner: Vec<String> = items.iter().map(Self::dd_format).collect();
-                format!("$[{}]", inner.join(", "))
+    ///
+    /// The value part is the value's `.raku` representation. When the argument
+    /// is a plain variable (e.g. `dd %h`), Raku prefixes it with the runtime
+    /// type and the variable name: `Hash %h = {:a(1)}`. Literals and complex
+    /// expressions render as just the value.
+    fn dd_format(val: &Value, source_name: Option<&str>) -> String {
+        let value_repr = crate::builtins::methods_0arg::raku_repr::raku_value(val);
+        match source_name {
+            Some(name) if Self::dd_is_plain_var(name) => {
+                let ty = crate::runtime::utils::value_type_name(val);
+                format!("{} {} = {}", ty, name, value_repr)
             }
-            Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
-                crate::builtins::methods_0arg::raku_repr::setbagmix_raku(val)
-                    .unwrap_or_else(|| format!("{:?}", val))
-            }
-            _ => format!("{:?}", val),
+            _ => value_repr,
         }
+    }
+
+    /// A `dd` argument source counts as a named variable only when it is a bare
+    /// sigil + identifier (`$x`, `@a`, `%h`, `&c`) — not an index/expression.
+    fn dd_is_plain_var(name: &str) -> bool {
+        let mut chars = name.chars();
+        match chars.next() {
+            Some('$') | Some('@') | Some('%') | Some('&') => {}
+            _ => return false,
+        }
+        let rest = &name[1..];
+        !rest.is_empty()
+            && rest
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == ':')
     }
 }

--- a/t/bool-raku-repr.t
+++ b/t/bool-raku-repr.t
@@ -1,0 +1,55 @@
+use Test;
+
+# Bool renders as `Bool::True` / `Bool::False` in `.raku` / `.perl`,
+# both at top level and nested inside arrays and hashes. Hash values are
+# rendered in the colon-pair form `:key(Bool::True)`, not the adverbial
+# `:key` / `:!key` form.
+
+plan 16;
+
+is True.raku,  'Bool::True',  'True.raku';
+is False.raku, 'Bool::False', 'False.raku';
+is True.perl,  'Bool::True',  'True.perl';
+
+is [True, False].raku, '[Bool::True, Bool::False]', 'Bool inside array';
+is (True, False).raku, '(Bool::True, Bool::False)', 'Bool inside list';
+
+{
+    my %h = a => True;
+    is %h.raku, '{:a(Bool::True)}', 'True hash value uses :a(Bool::True)';
+}
+{
+    my %h = a => False;
+    is %h.raku, '{:a(Bool::False)}', 'False hash value uses :a(Bool::False)';
+}
+{
+    my %h = a => True, b => 2;
+    is %h.raku, '{:a(Bool::True), :b(2)}', 'mixed Bool / Int hash values';
+}
+{
+    my %h = a => True;
+    is %h.perl, '{:a(Bool::True)}', '.perl matches .raku for Bool value';
+}
+{
+    my %h = :a, :!b;
+    is %h.raku, '{:a(Bool::True), :b(Bool::False)}', 'adverbial pairs render expanded';
+}
+
+# Non-ident key with a Bool value
+{
+    my %h = "1" => True;
+    is %h.raku, '{"1" => Bool::True}', 'non-ident key Bool value';
+}
+
+# Bool inside a nested (itemized) hash value
+{
+    my %h; %h<a><b> = True;
+    is %h.raku, '{:a(${:b(Bool::True)})}', 'Bool in nested hash value';
+}
+
+# A standalone Pair with a Bool value uses the adverbial form (unlike a hash
+# value, which expands to :key(Bool::True)).
+is (:foo).raku,         ':foo',           'Pair with True is :foo';
+is (:!bar).raku,        ':!bar',          'Pair with False is :!bar';
+is (foo => True).raku,  ':foo',           'fat-arrow Pair True';
+is (bar => False).raku, ':!bar',          'fat-arrow Pair False';


### PR DESCRIPTION
Stacked on #3186 (base will retarget to `main` once #3186 merges).

## Summary

Two related debug-representation fixes.

### Bool `.raku` / `.perl`

`raku_value` rendered a `Bool` as `True` / `False`, so:

```
[True, False].raku   # was [True, False]      -> now [Bool::True, Bool::False]
{a => True}.raku     # was {:a}               -> now {:a(Bool::True)}
{a => False}.raku    # was {:!a}              -> now {:a(Bool::False)}
```

Raku's `.raku` / `.perl` always use `Bool::True` / `Bool::False`, and hash values use the colon-pair form `:a(Bool::True)`, not the adverbial `:a` / `:!a`.

### `dd`

`dd` formatted most values with raw Rust `{:?}` debug output:

```
my %h = a => 1; dd %h    # was: Hash(HashData { map: {"a": Int(1)}, ... })
                         # now: Hash %h = {:a(1)}
dd [1,2,3]               # was: $[1, 2, 3]   -> now: [1, 2, 3]
```

Route the value part through the `.raku` representation, and — when the argument is a plain `@`/`%`/`&` variable — prefix it with the runtime type and variable name (`Array @a = [1, 2, 3]`), matching Raku. Multiple arguments each print on their own line. (Scalar `$x` arguments lack a sigil in the call-site source metadata and so are not yet prefixed; they render as just the value.)

## Tests

- New `t/bool-raku-repr.t` (12 cases).
- Full local `t/` suite passes; whitelisted repr tests pass (`S32-array/perl.t`, `S02-types/{array_ref,assigning-refs,baghash,mix,bool,hash}.t`, `S02-literals/{pairs,quoting}.t`, `S03-operators/adverbial-modifiers.t`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)