### PR TITLE
fix(hash): a plain hash always reports Str keys, not the bare numeric value

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -478,8 +478,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(items) => {
-                    let has_orig = crate::runtime::utils::hash_original_keys_snapshot(target)
-                        .is_some_and(|m| !m.is_empty());
+                    let has_orig = crate::runtime::utils::hash_uses_typed_keys(target);
                     let mut kv = Vec::new();
                     for (k, v) in items.iter() {
                         if has_orig {
@@ -563,8 +562,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(items) => {
-                    let has_orig = crate::runtime::utils::hash_original_keys_snapshot(target)
-                        .is_some_and(|m| !m.is_empty());
+                    let has_orig = crate::runtime::utils::hash_uses_typed_keys(target);
                     let pairs: Vec<Value> = if has_orig {
                         items
                             .iter()

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -126,6 +126,33 @@ fn is_self_array_ref_marker(v: &Value) -> bool {
     matches!(v, Value::Pair(name, _) if name == "__mutsu_self_array_ref")
 }
 
+/// Whether a string key may be rendered in the adverbial pair form
+/// `:key(value)`. Mirrors Raku's `<.ident>`: the key must start with a letter
+/// or `_`, continue with word chars, and may contain `-`/`'` only when each is
+/// immediately followed by another word char. A digit-leading key (`"1"`), a
+/// dotted key (`"1.5"`), or a key with a trailing/doubled `-`/`'` (`"x-"`,
+/// `"a--b"`) is NOT an identifier and renders as `"key" => value`.
+fn is_adverbial_pair_key(s: &str) -> bool {
+    let mut chars = s.chars().peekable();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    while let Some(c) = chars.next() {
+        if c.is_alphanumeric() || c == '_' {
+            continue;
+        }
+        if c == '-' || c == '\'' {
+            match chars.peek() {
+                Some(&n) if n.is_alphanumeric() || n == '_' => continue,
+                _ => return false,
+            }
+        }
+        return false;
+    }
+    true
+}
+
 fn raku_array_wrap_counted(inner: &str, kind: ArrayKind, count: usize) -> String {
     match kind {
         ArrayKind::Array | ArrayKind::Shaped | ArrayKind::Lazy => format!("[{}]", inner),
@@ -446,10 +473,7 @@ pub fn raku_value(v: &Value) -> String {
         }
         Value::Complex(r, i) => format!("<{}>", crate::value::format_complex(*r, *i)),
         Value::Pair(key, value) => {
-            let ident_like = !key.is_empty()
-                && key
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+            let ident_like = is_adverbial_pair_key(key);
             if ident_like {
                 match value.as_ref() {
                     Value::Bool(true) => format!(":{}", key),
@@ -466,10 +490,7 @@ pub fn raku_value(v: &Value) -> String {
         }
         Value::ValuePair(key, value) => {
             if let Value::Str(key_str) = key.as_ref() {
-                let ident_like = !key_str.is_empty()
-                    && key_str
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+                let ident_like = is_adverbial_pair_key(key_str);
                 if ident_like {
                     return match value.as_ref() {
                         Value::Bool(true) => format!(":{}", key_str),
@@ -529,12 +550,7 @@ pub fn raku_value(v: &Value) -> String {
                         Value::Str(s) => Some((**s).clone()),
                         _ => None,
                     };
-                    let is_ident = key_str.as_deref().is_some_and(|k| {
-                        !k.is_empty()
-                            && k.starts_with(|c: char| c.is_alphabetic() || c == '_')
-                            && k.chars()
-                                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-                    });
+                    let is_ident = key_str.as_deref().is_some_and(is_adverbial_pair_key);
                     if is_ident {
                         // Raku's `.raku` renders every value in the colon-pair
                         // form `:key(value.raku)` — including Bool, which shows

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -139,14 +139,19 @@ pub(crate) fn hash_original_keys_snapshot(hash: &Value) -> Option<HashMap<String
     None
 }
 
+/// Whether reading this hash's entries should yield typed (original) keys
+/// rather than `Str` keys. See [`crate::value::HashData::has_typed_keys`].
+pub(crate) fn hash_uses_typed_keys(hash: &Value) -> bool {
+    matches!(hash, Value::Hash(arc) if arc.has_typed_keys())
+}
+
 /// Retrieve the original (typed) key value for a hash entry, if available.
-/// Falls back to the string key if no original key is embedded.
+/// Falls back to the string key if no original key is embedded. Honors the
+/// object-hash gate (see [`HashData::typed_key`]): a plain hash always yields a
+/// `Str` key.
 pub(crate) fn hash_typed_key(hash: &Value, str_key: &str) -> Value {
-    if let Value::Hash(arc) = hash
-        && let Some(orig_keys) = arc.original_keys.as_ref()
-        && let Some(orig) = orig_keys.get(str_key)
-    {
-        return orig.clone();
+    if let Value::Hash(arc) = hash {
+        return arc.typed_key(str_key);
     }
     Value::str(str_key.to_string())
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1323,13 +1323,28 @@ impl HashData {
         self.declared_type = None;
     }
 
+    /// Whether reading this hash's entries should yield typed (original) keys
+    /// rather than plain `Str` keys. Only object hashes (`my %h{KeyType}`,
+    /// marked by `key_type`) and hashes coerced from a Set/Bag/Mix (tagged with
+    /// the `__mutsu_setty_origin` marker) preserve typed keys. A *plain* hash
+    /// always reports `Str` keys even if construction speculatively recorded a
+    /// typed key (e.g. the `Int` 1 from `my %h = 1..6`), because Raku hash keys
+    /// are always stringified.
+    pub fn has_typed_keys(&self) -> bool {
+        self.original_keys.as_ref().is_some_and(|orig| {
+            !orig.is_empty()
+                && (self.key_type.is_some() || orig.contains_key("__mutsu_setty_origin"))
+        })
+    }
+
     /// Get the original (typed) key Value for a stored string key. For object
     /// hashes (`my %h{Int}`) the stored key is a `.WHICH` string (e.g.
     /// `"Int|1"`); this returns the real key object (`Int(1)`). Plain hashes
-    /// have no `original_keys`, so this returns a `Str`. Mirrors
-    /// `BagData::typed_key`.
+    /// report a `Str`. Mirrors `BagData::typed_key`. Honors [`Self::has_typed_keys`]:
+    /// a plain hash's speculative `original_keys` is ignored.
     pub fn typed_key(&self, str_key: &str) -> Value {
-        if let Some(ref orig) = self.original_keys
+        if self.has_typed_keys()
+            && let Some(ref orig) = self.original_keys
             && let Some(v) = orig.get(str_key)
         {
             return v.clone();

--- a/t/hash-numeric-key-str.t
+++ b/t/hash-numeric-key-str.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A plain Hash always stringifies its keys (Raku hash keys are always Str),
+# even when built from bare numeric values (`my %h = 1..6`). They must report
+# as Str in .keys/.pairs/.kv/.raku/.antipairs, and a numeric-looking Str pair
+# key renders with quotes in .raku (`"1" => 2`), not the adverbial `:1(2)`.
+
+plan 24;
+
+# --- plain hash from a flat numeric list: keys are Str ---
+{
+    my %h = 1..6;
+    is %h.keys.sort.map(*.^name).join(" "), "Str Str Str", "keys are Str";
+    is %h.pairs.sort.map(*.key.^name).join(" "), "Str Str Str", "pairs keys are Str";
+    is %h.kv.sort.map(*.^name).join(" "), "Str Int Str Int Str Int",
+        "kv keys are Str, values Int";
+    is %h.antipairs.sort.map(*.value.^name).join(" "), "Str Str Str",
+        "antipairs values are Str";
+    is %h.raku, '{"1" => 2, "3" => 4, "5" => 6}', "hash .raku quotes numeric keys";
+    is %h.pairs.sort.map(*.raku).join(", "),
+        '"1" => 2, "3" => 4, "5" => 6', "pair .raku quotes numeric keys";
+}
+
+# --- plain hash from bare values ---
+{
+    my %h = (1, "a", 2, "b");
+    is %h.pairs.sort.map(*.key.^name).join(" "), "Str Str", "bare-value keys are Str";
+    is %h{"1"}, "a", "string subscript works";
+    is %h{1}, "a", "numeric subscript coerces to string key";
+}
+
+# --- Pair .raku key quoting rules (Raku <.ident>) ---
+{
+    is ("1" => 2).raku, '"1" => 2', "digit-leading key is quoted";
+    is ("1a" => 2).raku, '"1a" => 2', "digit-leading alnum key is quoted";
+    is ("1.5" => 2).raku, '"1.5" => 2', "dotted key is quoted";
+    is ("a b" => 2).raku, '"a b" => 2', "space key is quoted";
+    is ("-x" => 2).raku, '"-x" => 2', "leading-hyphen key is quoted";
+    is ("x-" => 2).raku, '"x-" => 2', "trailing-hyphen key is quoted";
+    is ("a--b" => 2).raku, '"a--b" => 2', "doubled-hyphen key is quoted";
+    is ("a'" => 2).raku, '"a\'" => 2', "trailing-apostrophe key is quoted";
+    is ("a1" => 2).raku, ':a1(2)', "alnum identifier uses adverbial form";
+    is ("_x" => 2).raku, ':_x(2)', "underscore-leading identifier is adverbial";
+    is ("a-b" => 2).raku, ':a-b(2)', "internal-hyphen identifier is adverbial";
+    is ("a'b" => 2).raku, ':a\'b(2)', "internal-apostrophe identifier is adverbial";
+}
+
+# --- object hash still preserves typed keys ---
+{
+    my %h{Any} = (1, "a", 2, "b");
+    is %h.pairs.sort.map(*.key.^name).join(" "), "Int Int",
+        "object hash preserves Int keys";
+    is %h{1}, "a", "object hash numeric lookup works";
+}
+
+# --- Set/Bag/Mix .hash keeps typed keys (object hash semantics) ---
+{
+    is set(1, 2, 3).hash.keys.sort.map(*.^name).join(" "), "Int Int Int",
+        "Set.hash preserves Int keys";
+}


### PR DESCRIPTION
## Problem

A plain `Hash` stringifies its keys — Raku hash keys are always `Str` — even when built from bare numeric values such as `my %h = 1..6`. mutsu spoke with two voices:

```raku
my %h = 1..6;
say %h.keys.sort.map(*.^name);   # (Str Str Str)   — correct
say %h.pairs.sort.map(*.key.^name);  # was (Int Int Int)  — WRONG
say %h.raku;                     # was {1 => 2, ...}  — WRONG, raku: {"1" => 2, ...}
say %h.pairs.sort.raku;          # was (1 => 2, ...)  — WRONG, raku: ("1" => 2, ...)
```

Two root causes:

1. **Speculative typed keys leaked into plain hashes.** `build_hash_from_items` records a bare non-`Str` key (the `Int` 1) in `HashData.original_keys`, and the read paths (`.pairs`/`.kv`/`.raku`/`.antipairs`) honored it unconditionally. `original_keys` is meant only for **object hashes** (`my %h{KeyType}`).

2. **Pair `.raku` mis-quoted numeric-looking keys.** A `Str` key that is not a valid Raku identifier (`<.ident>`) must render as `"key" => value`, but the old check treated any alphanumeric/`_`/`-` run as an identifier, so `"1"` produced the invalid `:1(2)` instead of `"1" => 2`.

## Fix

- Add `HashData::has_typed_keys`: typed keys are honored only for an object hash (`key_type` set) or a hash coerced from a Set/Bag/Mix (`__mutsu_setty_origin` marker). A plain hash always reports `Str`.
- Route `HashData::typed_key`, the runtime `hash_typed_key`, and the new `hash_uses_typed_keys` through it; update the `.kv`/`.pairs` fast paths.
- Add `is_adverbial_pair_key` implementing the real `<.ident>` rule (leading letter/`_`, word chars, `-`/`'` only when followed by a word char) and use it in the three Pair/ValuePair/Hash `.raku` rendering sites.

Object hashes (`my %h{Any} = (1, "a")` → `Int` keys) and `Set/Bag/Mix.hash` are unaffected.

## Tests

New `t/hash-numeric-key-str.t` (24 assertions) covering plain numeric-key hashes, the `<.ident>` quoting edge cases (`"1"`, `"1.5"`, `"-x"`, `"x-"`, `"a--b"`, `"a'"` vs `:a1`, `:_x`, `:a-b`, `:a'b`), object-hash preservation, and Set.hash. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)