### PR TITLE
fix(range): .join with no separator joins Range elements, not its gist

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -274,6 +274,22 @@ pub(super) fn dispatch(
                     .collect::<Vec<_>>()
                     .join("");
                 Some(Some(Ok(Value::str(joined))))
+            } else if target.is_range() {
+                // A Range has no materialized backing slice, so `as_list_items`
+                // returns None. Expand it to its elements and join with the
+                // empty default separator — NOT `target.to_string_value()`,
+                // which renders the Range with space-separated gist semantics
+                // (`(1..5).join` must be "12345", not "1 2 3 4 5").
+                let items = crate::runtime::utils::value_to_list(target);
+                if items.iter().any(|v| matches!(v, Value::Instance { .. })) {
+                    return Some(None);
+                }
+                let joined = items
+                    .iter()
+                    .map(|v| v.to_str_context())
+                    .collect::<Vec<_>>()
+                    .join("");
+                Some(Some(Ok(Value::str(joined))))
             } else {
                 Some(Some(Ok(Value::str(target.to_string_value()))))
             }

--- a/t/range-join-default.t
+++ b/t/range-join-default.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `.join` with no argument uses the empty string as the separator. A Range has
+# no materialized backing list, so the 0-arg fast path previously fell back to
+# the Range's space-separated gist ("1 2 3 4 5") instead of joining its
+# elements ("12345"). Regression test for that.
+
+plan 12;
+
+is (1..5).join, "12345", "Int Range .join with no separator";
+is ("a".."e").join, "abcde", "Str Range .join with no separator";
+is (1..5).join("-"), "1-2-3-4-5", "Range .join with explicit separator";
+is (1..5).join(""), "12345", "Range .join with empty separator";
+is (1..5).join(", "), "1, 2, 3, 4, 5", "Range .join with comma separator";
+is (1^..^5).join, "234", "exclusive Range .join";
+is (1..1).join, "1", "single-element Range .join";
+is (1..0).join, "", "empty Range .join";
+is (1..3).reverse.join, "321", "reversed Range .join";
+is (1.5..4.5).join, "1.52.53.54.5", "Rat-endpoint Range .join";
+is (1..5).list.join, "12345", "Range.list .join still works";
+is (1, 2, 3).join, "123", "plain List .join unaffected";


### PR DESCRIPTION
## Problem

`.join` with no argument joins with the empty string. A `Range` has no materialized backing slice, so the 0-arg `.join` fast path's `as_list_items()` returned `None` and fell through to `target.to_string_value()`, which renders a Range with **space-separated gist** semantics:

```raku
say (1..5).join;       # was "1 2 3 4 5"  — WRONG, raku: "12345"
say ("a".."e").join;   # was "a b c d e"  — WRONG, raku: "abcde"
```

The n-arg form (`(1..5).join("-")`) and `(1..5).list.join` were already correct — only the no-separator Range path was wrong.

## Fix

In the 0-arg `.join` path, expand a Range to its elements and join with `""`, matching List/Array behavior.

## Tests

`t/range-join-default.t` (12 assertions): Int/Str ranges, explicit/empty/comma separators, exclusive/single/empty ranges, reversed, Rat-endpoint, `.list.join`, and plain List. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)