### PR TITLE
fix(range): .Int/.Numeric/.Real/.Num numerify a Range to its element count

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -12,6 +12,14 @@ pub(super) fn dispatch(
     target: &Value,
     method: &str,
 ) -> Option<Option<Result<Value, RuntimeError>>> {
+    // A Range numerifies to its element count (`.elems`): `.Int`/`.Numeric`/
+    // `.Real` yield that count as an `Int`, `.Num` as a `Num`. An infinite
+    // range yields `Inf` for the real-valued coercions and fails for `.Int`
+    // ("Cannot convert Inf to Int"). Handle this before the per-method arms,
+    // which only know how to numerify scalar types.
+    if target.is_range() && matches!(method, "Int" | "Numeric" | "Real" | "Num") {
+        return Some(Some(range_numeric_coercion(target, method)));
+    }
     match method {
         "self" => {
             // For unhandled Failures, .self throws the exception
@@ -757,4 +765,31 @@ pub(super) fn dispatch(
         }
         _ => None,
     }
+}
+
+/// Numerify a Range to its element count for `.Int`/`.Numeric`/`.Real`/`.Num`.
+/// Finite ranges yield the count (as `Num` for `.Num`, else `Int`); an infinite
+/// range yields `Inf` for the real-valued coercions and fails for `.Int`.
+/// `target` is assumed to be a Range (checked by the caller).
+fn range_numeric_coercion(target: &Value, method: &str) -> Result<Value, RuntimeError> {
+    if super::is_infinite_range(target) {
+        return if method == "Int" {
+            Err(RuntimeError::new("Cannot convert Inf to Int".to_string()))
+        } else {
+            Ok(Value::Num(f64::INFINITY))
+        };
+    }
+    let count = match target {
+        Value::Range(s, e) => (*e - *s + 1).max(0),
+        Value::RangeExcl(s, e) | Value::RangeExclStart(s, e) => (*e - *s).max(0),
+        Value::RangeExclBoth(s, e) => (*e - *s - 1).max(0),
+        // GenericRange (e.g. Rat endpoints `1.5..5.5`) has no closed-form count;
+        // materialize it the same way `.elems` does.
+        _ => crate::runtime::utils::value_to_list(target).len() as i64,
+    };
+    Ok(if method == "Num" {
+        Value::Num(count as f64)
+    } else {
+        Value::Int(count)
+    })
 }

--- a/t/range-numeric-coercion.t
+++ b/t/range-numeric-coercion.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A Range numerifies to its element count (.elems): .Int/.Numeric/.Real yield
+# that count as an Int, .Num as a Num. An infinite range yields Inf for the
+# real-valued coercions and fails for .Int. Previously these all errored with
+# "No such method ... for invocant of type 'Range'".
+
+plan 22;
+
+# --- finite integer ranges ---
+is (1..10).Numeric, 10, "Range.Numeric is the element count";
+is (1..10).Int, 10, "Range.Int is the element count";
+is (1..10).Real, 10, "Range.Real is the element count";
+is (1..10).Num, 10, "Range.Num is the element count";
+is (1..10).Numeric.^name, "Int", "Range.Numeric returns an Int";
+is (1..10).Int.^name, "Int", "Range.Int returns an Int";
+is (1..10).Real.^name, "Int", "Range.Real returns an Int";
+is (1..10).Num.^name, "Num", "Range.Num returns a Num";
+
+# --- exclusive ranges ---
+is (0..^10).Int, 10, "exclusive-end Range.Int";
+is (0^..10).Int, 10, "exclusive-start Range.Int";
+is (0^..^10).Int, 9, "exclusive-both Range.Int";
+
+# --- non-integer-endpoint ranges ---
+is (1.5..5.5).Int, 5, "Rat-endpoint Range.Int";
+is (1.5..5.5).Numeric, 5, "Rat-endpoint Range.Numeric";
+is ("a".."e").Numeric, 5, "Str Range.Numeric";
+
+# --- consistency with .elems and numeric context ---
+is (1..10).Int, (1..10).elems, "Range.Int equals .elems";
+is +(1..10), 10, "Range in numeric context is its element count";
+
+# --- infinite ranges ---
+is (1..Inf).Numeric, Inf, "infinite Range.Numeric is Inf";
+is (1..Inf).Real, Inf, "infinite Range.Real is Inf";
+is (1..Inf).Num, Inf, "infinite Range.Num is Inf";
+is (-Inf..0).Numeric, Inf, "left-infinite Range.Numeric is Inf";
+dies-ok { (1..Inf).Int }, "infinite Range.Int dies (cannot convert Inf to Int)";
+
+# --- regression: non-Range coercions still work ---
+is (1, 2, 3).Numeric, 3, "List.Numeric unaffected";


### PR DESCRIPTION
## Problem

In Raku a `Range` numerifies to its number of elements (`.elems`):

```raku
say (1..10).Numeric;   # 10  (Int)
say (1..10).Int;       # 10  (Int)
say (1..10).Real;      # 10  (Int)
say (1..10).Num;       # 10  (Num)
say +(1..10);          # 10
```

An infinite range yields `Inf` for the real-valued coercions and fails for `.Int`. mutsu errored on all of these with `No such method '...' for invocant of type 'Range'`.

`Int`/`Numeric` were intercepted by the coercion dispatcher (which only knew how to numerify scalar/Array/Hash/Seq and fell through for Range), so they never reached any Range-aware handler.

## Fix

Add a Range pre-check in `dispatch_core_coerce` that returns the element count in the requested numeric type:
- closed-form count for int-endpoint ranges (inclusive/exclusive ends),
- materialized count for Rat/Str-endpoint `GenericRange`s,
- `Inf` for infinite ranges (`.Numeric`/`.Real`/`.Num`), and a "Cannot convert Inf to Int" failure for `.Int`.

`.Num` returns a `Num`; the others return an `Int`.

## Tests

`t/range-numeric-coercion.t` (22 assertions): finite int/exclusive/Rat/Str ranges, return-type checks, `.elems`/numeric-context consistency, infinite ranges (`Inf` and dying `.Int`), and a List-coercion regression guard. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)