### PR TITLE
feat(str): implement Str.subst-mutate

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Interpreter {
     /// Dispatch .match method
-    pub(super) fn dispatch_match_method(
+    pub(crate) fn dispatch_match_method(
         &mut self,
         target: Value,
         args: &[Value],

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -605,7 +605,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn dispatch_subst(
+    pub(crate) fn dispatch_subst(
         &mut self,
         target: Value,
         args: &[Value],

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -731,6 +731,46 @@ impl Interpreter {
             self.env_dirty = true;
             return Ok(());
         }
+        // `$s.subst-mutate(pattern, replacement, ...)` substitutes in place (like
+        // `s///`) and returns the value `s///` would set in `$/`: a Match for a
+        // single hit, the `Any` type object when nothing matched, or a List of
+        // Matches under `:g`. Reuses the `.subst` machinery for the new string
+        // and the `.match` machinery for the return, then writes the new string
+        // back to the variable -- mirroring the `Match.make` pattern above.
+        if method == "subst-mutate" && matches!(&target, Value::Str(_)) {
+            let new_str = self.dispatch_subst(target.clone(), &args)?;
+            // `.match` takes the pattern + adverbs but not the replacement (the
+            // 2nd positional), so drop the replacement when building its args.
+            let mut match_args: Vec<Value> = Vec::new();
+            let mut positional_seen = 0;
+            for arg in &args {
+                if matches!(arg, Value::Pair(..)) {
+                    match_args.push(arg.clone());
+                } else {
+                    positional_seen += 1;
+                    if positional_seen != 2 {
+                        match_args.push(arg.clone());
+                    }
+                }
+            }
+            let global = args.iter().any(
+                |a| matches!(a, Value::Pair(k, v) if (k == "g" || k == "global") && v.truthy()),
+            );
+            let match_result = self.dispatch_match_method(target.clone(), &match_args)?;
+            // A single failed match yields the `Any` type object (matching `$/`
+            // after a failed `s///`), where `.match` alone would yield `Nil`.
+            let ret = if !global && matches!(match_result, Value::Nil) {
+                Value::Package(crate::symbol::Symbol::intern("Any"))
+            } else {
+                match_result
+            };
+            self.env_mut()
+                .insert(target_name.to_string(), new_str.clone());
+            self.locals_set_by_name(code, &target_name, new_str);
+            self.stack.push(ret);
+            self.env_dirty = true;
+            return Ok(());
+        }
         // .hyper/.race with named arguments in mut path
         if matches!(method.as_str(), "hyper" | "race") && !args.is_empty() {
             let mut batch: Option<i64> = None;

--- a/t/subst-mutate.t
+++ b/t/subst-mutate.t
@@ -1,0 +1,75 @@
+use Test;
+
+# Str.subst-mutate substitutes in place (like s///) and returns what s/// sets
+# in $/: a Match for a single hit, the Any type object when nothing matched, or
+# a List of Matches under :g. Previously mutsu had no such method.
+
+plan 20;
+
+# --- single substitution, in place + Match return ---
+{
+    my $s = "aaa";
+    my $r = $s.subst-mutate(/a/, "b");
+    is $s, "baa", "single subst-mutate replaces the first match in place";
+    ok $r ~~ Match, "single subst-mutate returns a Match";
+    is ~$r, "a", "the returned Match is the replaced text";
+}
+
+# --- global substitution returns a List of Matches ---
+{
+    my $s = "aaa";
+    my $r = $s.subst-mutate(/a/, "b", :g);
+    is $s, "bbb", ":g subst-mutate replaces all matches";
+    ok $r ~~ List, ":g subst-mutate returns a List";
+    is $r.elems, 3, ":g returns one Match per replacement";
+    ok $r[0] ~~ Match, ":g list elements are Match objects";
+}
+
+# --- string (non-regex) matcher ---
+{
+    my $s = "hello";
+    $s.subst-mutate("l", "L");
+    is $s, "heLlo", "string matcher replaces the first occurrence";
+}
+
+# --- no match: string untouched; Any (single) / empty List (:g) ---
+{
+    my $s = "abc";
+    my $r = $s.subst-mutate(/z/, "x");
+    is $s, "abc", "no match leaves the string unchanged";
+    nok $r.defined, "single no-match returns an undefined value";
+    ok $r === Any, "single no-match returns the Any type object";
+
+    my $t = "abc";
+    my $rg = $t.subst-mutate(/z/, "x", :g);
+    is $t, "abc", ":g no match leaves the string unchanged";
+    ok $rg ~~ List, ":g no match still returns a List";
+    is $rg.elems, 0, ":g no match returns an empty List";
+}
+
+# --- adverbs: :nth, :samecase, closure replacement ---
+{
+    my $s = "abcabc";
+    $s.subst-mutate(/b/, "X", :2nd);
+    is $s, "abcaXc", ":2nd replaces only the second match";
+
+    my $t = "hello world";
+    $t.subst-mutate(/o/, "0", :samecase);
+    is $t, "hell0 world", ":samecase adverb is honored";
+
+    my $u = "Hello";
+    $u.subst-mutate(/l/, { "L" });
+    is $u, "HeLlo", "closure replacement works";
+}
+
+# --- :g over a character class; whole-list capture of :g result ---
+{
+    my $s = "a1b2";
+    $s.subst-mutate(/\d/, "X", :g);
+    is $s, "aXbX", ":g over a character class";
+
+    my $t = "xyz";
+    my @r = $t.subst-mutate(/<[xyz]>/, "_", :g);
+    is @r.elems, 3, ":g result flattens to one element per replacement";
+    is $t, "___", ":g replaced every character";
+}


### PR DESCRIPTION
## Problem

`Str.subst-mutate` substitutes in place (like `s///`) and returns the value `s///` sets in `$/`. mutsu had no such method:

```raku
my $s = "aaa";
my $r = $s.subst-mutate(/a/, "b");      # $s is now "baa"; $r is the Match ｢a｣
my $g = $s.subst-mutate(/a/, "x", :g);  # $g is a List of Matches
```

Previously: `No such method 'subst-mutate' for invocant of type 'Str'`.

## Fix

Handle `subst-mutate` in the `CallMethodMut` path (which carries the invocant variable name for write-back), mirroring the existing `Match.make` write-back pattern:
- reuse `dispatch_subst` for the new string and `dispatch_match_method` for the return value,
- drop the replacement (2nd positional) when building the match args,
- map a single failed match from `Nil` to the `Any` type object (matching `$/` after a failed `s///`),
- write the new string back to the variable.

Supports string and regex matchers, closure replacements, and the `:g`/`:nth`/`:samecase` adverbs. The return value is a `Match` (single hit), `Any` (no hit), or a `List` of `Match` (`:g`) — exactly what `s///` sets in `$/`.

## Tests

`t/subst-mutate.t` (20 assertions): single/`:g` substitution and return types, string matcher, no-match (`Any` / empty `List`), `:2nd`/`:samecase`/closure adverbs, and whole-list capture of the `:g` result. `make test` passes; `roast/S05-substitution/match.t` still passes and the pre-existing `subst.t` partial failures (102, 187 — unrelated `ss///`/placeholder) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)