### PR TITLE
feat(lazy): generate closure-based infinite sequences on demand

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -27,8 +27,12 @@ The blockers, in rough order of how many files they gate:
   binding/`:=`-alias, `is rw`/take-rw, `.VAR`, typed-hash default survival,
   closure capture-by-container, object-hash `%{Mu}` keys, Arc-pointer typed-array
   flaky. This is PLAN.md's "🟣 第2優先" and the single largest lever.
-- **Real lazy infinite sequences** — `@a[0..*]`, `fib[100]`, `X::Cannot::Lazy`
-  on same-type lazy iterables; mutsu materializes `1…∞` to a finite list.
+- **Real lazy infinite sequences** — `@a[0..*]`, `X::Cannot::Lazy` on same-type
+  lazy iterables. Closure-based infinite sequences (`1, 1, *+* ... *`) now
+  generate on demand for scalar/`constant`/`.lazy` forms (`$s[100]`, `fib[100]`);
+  the remaining gap is **lazy arrays** — `my @a = 1..*` still materializes to a
+  finite prefix because Array mutation ops (clone/unshift/shift/:delete/elem-assign)
+  have no reify-on-demand path yet.
 - **Threading / concurrency primitives** — Semaphore, nonblocking await, lock
   contention, remaining Supply combinators (all of S17).
 - **RakuAST** — `Formatter.AST`, anything needing a reflectable AST.
@@ -289,9 +293,11 @@ Interpreter-removal / first-class-container tracks advance.
   set-operator mutability tracking. (12/17/36/37 also fail in rakudo.)
 - **S09-subscript/slice.t** — **Hard**, 9/39 then aborts at line 310: slices with
   infinite sequences (`@a[0..*]`).
-- **S04-declarations/constant.t** — **Medium**, 65/72. Remaining: lazy-seq `fib[100]`
-  (46), `G::c` qualified name via constant alias (44), multi-candidate sharing.
-  NOT whitelistable until the lazy-seq lands.
+- **S04-declarations/constant.t** — **Medium**. Lazy-seq `fib[100]` (46) now PASSES:
+  closure-based infinite sequences (`0, 1, *+* ... *`) generate elements on demand
+  via `LazyList.closure_seq` (re-invokes the generator over the growing history).
+  Remaining blocker: `G::c` qualified name via constant-aliased enum (44) — a
+  dispatch issue, NOT laziness. NOT whitelistable until that lands.
 
 **Dispatch / MOP / EVAL-in-class:**
 

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -384,6 +384,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                             sequence_spec: None,
                             coroutine: None,
                             lazy_pipe: None,
+                            closure_seq: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
@@ -408,6 +409,7 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                     sequence_spec: None,
                     coroutine: None,
                     lazy_pipe: None,
+                    closure_seq: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1099,6 +1099,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     sequence_spec: None,
                     coroutine: None,
                     lazy_pipe: None,
+                    closure_seq: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -126,6 +126,10 @@ pub(super) fn dispatch(
                                 .lazy_pipe
                                 .as_ref()
                                 .map(|p| std::sync::Mutex::new(p.lock().unwrap().clone())),
+                            closure_seq: list
+                                .closure_seq
+                                .as_ref()
+                                .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
                         },
                     )))));
                 }
@@ -170,6 +174,7 @@ pub(super) fn dispatch(
                     sequence_spec: None,
                     coroutine: None,
                     lazy_pipe: None,
+                    closure_seq: None,
                 },
             )))))
         }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -532,6 +532,7 @@ impl Interpreter {
             sequence_spec: None,
             coroutine: None,
             lazy_pipe: None,
+            closure_seq: None,
         };
         Value::LazyList(std::sync::Arc::new(list))
     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1626,6 +1626,10 @@ impl Interpreter {
                             .lazy_pipe
                             .as_ref()
                             .map(|p| std::sync::Mutex::new(p.lock().unwrap().clone())),
+                        closure_seq: list
+                            .closure_seq
+                            .as_ref()
+                            .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
                     }))
                 } else {
                     v

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -133,6 +133,190 @@ impl Interpreter {
         })
     }
 
+    /// Produce the next element of a closure-based sequence given the current
+    /// element `history`. Returns `Ok(Some(v))` for the next value, or
+    /// `Ok(None)` when the generator signalled termination (`last`, or a
+    /// suppressed error). Side effects in a fast-path generator are reflected
+    /// back into `closure_env` so subsequent calls observe them.
+    ///
+    /// This is the single per-element step shared by the initial generation
+    /// loop in `eval_sequence` and the on-demand extension of an infinite
+    /// closure sequence (`Interpreter::extend_closure_sequence`).
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn sequence_closure_step(
+        &mut self,
+        generator: &Value,
+        history: &[Value],
+        precompiled: Option<(
+            &crate::opcode::CompiledCode,
+            &std::collections::HashMap<String, crate::opcode::CompiledFunction>,
+        )>,
+        closure_env: &mut Option<crate::env::Env>,
+        suppress_generator_error: bool,
+    ) -> Result<Option<Value>, RuntimeError> {
+        let genfn = generator;
+        let val = if let Value::Sub(data) = genfn {
+            if self.sequence_has_registered_routine(&data.package.resolve(), &data.name.resolve()) {
+                let args = match self
+                    .sequence_routine_param_mode(&data.package.resolve(), &data.name.resolve())
+                {
+                    SequenceRoutineParamMode::Fixed(arity) => {
+                        Self::collect_sequence_args_fixed(history, arity)?
+                    }
+                    SequenceRoutineParamMode::Slurpy { min_arity } => {
+                        Self::collect_sequence_args_slurpy(history, min_arity)
+                    }
+                };
+                let name_str = data.name.resolve();
+                let call_name = name_str.strip_prefix('&').unwrap_or(&name_str);
+                match self.call_function(call_name, args) {
+                    Ok(v) => v,
+                    Err(_e) if suppress_generator_error => return Ok(None),
+                    Err(e) => return Err(e),
+                }
+            } else {
+                let slurpy_index = data
+                    .params
+                    .iter()
+                    .position(|param| param.starts_with('@') || param.starts_with('%'));
+                let args: Vec<Value> = if data.params.is_empty() {
+                    // No declared params: sequence generators still receive history in @_.
+                    history.to_vec()
+                } else if let Some(min_arity) = slurpy_index {
+                    Self::collect_sequence_args_slurpy(history, min_arity)
+                } else {
+                    let arity = data.params.len();
+                    Self::collect_sequence_args_fixed(history, arity)?
+                };
+                let needs_full_binding = data.param_defs.iter().any(|pd| {
+                    pd.type_constraint.is_some()
+                        || pd.literal_value.is_some()
+                        || pd.shape_constraints.is_some()
+                        || pd.named
+                        || pd.slurpy
+                        || pd.double_slurpy
+                });
+                if needs_full_binding {
+                    match self.call_sub_value(Value::Sub(data.clone()), args, false) {
+                        Ok(v) => v,
+                        Err(_e) if suppress_generator_error => return Ok(None),
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    let saved = self.env.clone();
+                    // Pre-run snapshot of the generator's captured vars. After the
+                    // body runs we propagate back only the captures it GENUINELY
+                    // mutated (e.g. `++$i`, `++$sunk`); a capture that merely
+                    // shadows a caller variable without being written — notably
+                    // the very `$s` this sequence is bound to — is left untouched,
+                    // so the generator cannot clobber unrelated outer variables.
+                    let pre: Vec<(crate::symbol::Symbol, Value)> = closure_env
+                        .as_ref()
+                        .map(|e| e.iter().map(|(k, v)| (*k, v.clone())).collect())
+                        .unwrap_or_default();
+                    // Use the mutable closure env so side-effects persist across
+                    // iterations (e.g. `my $i = 0; { ++$i } ... *`).
+                    if let Some(env) = closure_env.as_ref() {
+                        for (k, v) in env.iter() {
+                            self.env.insert_sym(*k, v.clone());
+                        }
+                    }
+
+                    // Bind parameters
+                    for (i, param) in data.params.iter().enumerate() {
+                        if param.starts_with('@') {
+                            let rest = if i < args.len() {
+                                args[i..].to_vec()
+                            } else {
+                                Vec::new()
+                            };
+                            self.env.insert(param.clone(), Value::array(rest));
+                            break;
+                        }
+                        if param.starts_with('%') {
+                            let mut map = std::collections::HashMap::new();
+                            for item in args.iter().skip(i) {
+                                if let Value::Pair(k, v) = item {
+                                    map.insert(k.clone(), (**v).clone());
+                                }
+                            }
+                            self.env
+                                .insert(param.clone(), Value::Hash(Value::hash_arc(map)));
+                            break;
+                        }
+                        if let Some(arg) = args.get(i) {
+                            self.env.insert(param.clone(), arg.clone());
+                        }
+                    }
+
+                    // Bind $_ to last arg
+                    if let Some(last_arg) = args.last() {
+                        self.env.insert("_".to_string(), last_arg.clone());
+                    }
+                    // Bind @_ to the argument history window.
+                    self.env
+                        .insert("@_".to_string(), Value::array(args.clone()));
+
+                    let exec_result = if let Some((code, fns)) = precompiled {
+                        self.eval_precompiled_block_fast(code, fns)
+                    } else {
+                        self.eval_block_value(&data.body)
+                    };
+                    // Propagate genuinely-mutated captures into both the
+                    // persistent closure env (so the next pull sees them) and the
+                    // caller (so outer side effects like `++$sunk` are visible),
+                    // then restore the caller env. This runs on every exit path —
+                    // including `last` — so `{ ++$sunk; last }` still records its
+                    // side effect even though the body signals termination.
+                    let mut restored = saved;
+                    for (k, before) in &pre {
+                        if let Some(after) = self.env.get_sym(*k)
+                            && after != before
+                        {
+                            let after = after.clone();
+                            if let Some(gen_env) = closure_env.as_mut() {
+                                gen_env.insert_sym(*k, after.clone());
+                            }
+                            if restored.contains_key_sym(*k) {
+                                restored.insert_sym(*k, after);
+                            }
+                        }
+                    }
+                    self.env = restored;
+                    match exec_result {
+                        Ok(v) => v,
+                        Err(e) if e.return_value.is_some() => e.return_value.unwrap(),
+                        Err(e) if e.is_last => return Ok(None),
+                        Err(_e) if suppress_generator_error => return Ok(None),
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        } else if let Value::Routine { name: rname, .. } = genfn {
+            let package = match genfn {
+                Value::Routine { package, .. } => package,
+                _ => unreachable!(),
+            };
+            let args = match self.sequence_routine_param_mode(&package.resolve(), &rname.resolve())
+            {
+                SequenceRoutineParamMode::Fixed(arity) => {
+                    Self::collect_sequence_args_fixed(history, arity)?
+                }
+                SequenceRoutineParamMode::Slurpy { min_arity } => {
+                    Self::collect_sequence_args_slurpy(history, min_arity)
+                }
+            };
+            match self.call_sub_value(genfn.clone(), args, false) {
+                Ok(v) => v,
+                Err(_e) if suppress_generator_error => return Ok(None),
+                Err(e) => return Err(e),
+            }
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(val))
+    }
+
     pub(super) fn eval_sequence(
         &mut self,
         left: Value,
@@ -811,178 +995,28 @@ impl Interpreter {
                 None
             };
 
+        // Tracks whether a closure generator signalled termination (`last`)
+        // during initial generation. When it did, the sequence is finite and
+        // must NOT be left as a resumable infinite closure sequence.
+        let mut closure_generation_finished = false;
         'seq_gen: for _ in 0..max_gen {
             let next = match &mode {
                 SeqMode::Closure => {
                     let suppress_generator_error =
                         matches!(endpoint_kind, Some(EndpointKind::Value(_)));
                     let genfn = generator.as_ref().unwrap();
-                    if let Value::Sub(data) = genfn {
-                        if self.sequence_has_registered_routine(
-                            &data.package.resolve(),
-                            &data.name.resolve(),
-                        ) {
-                            let args = match self.sequence_routine_param_mode(
-                                &data.package.resolve(),
-                                &data.name.resolve(),
-                            ) {
-                                SequenceRoutineParamMode::Fixed(arity) => {
-                                    Self::collect_sequence_args_fixed(&result, arity)?
-                                }
-                                SequenceRoutineParamMode::Slurpy { min_arity } => {
-                                    Self::collect_sequence_args_slurpy(&result, min_arity)
-                                }
-                            };
-                            let name_str = data.name.resolve();
-                            let call_name = name_str.strip_prefix('&').unwrap_or(&name_str);
-                            match self.call_function(call_name, args) {
-                                Ok(v) => v,
-                                Err(_e) if suppress_generator_error => break 'seq_gen,
-                                Err(e) => return Err(e),
-                            }
-                        } else {
-                            let restore_env_with_side_effects =
-                                |saved: crate::env::Env,
-                                 current: &crate::env::Env|
-                                 -> crate::env::Env {
-                                    let mut merged = saved;
-                                    for (k, v) in current.iter() {
-                                        if merged.contains_key_sym(*k) {
-                                            merged.insert_sym(*k, v.clone());
-                                        }
-                                    }
-                                    merged
-                                };
-                            let slurpy_index = data
-                                .params
-                                .iter()
-                                .position(|param| param.starts_with('@') || param.starts_with('%'));
-                            let args: Vec<Value> = if data.params.is_empty() {
-                                // No declared params: sequence generators still receive history in @_.
-                                result.clone()
-                            } else if let Some(min_arity) = slurpy_index {
-                                Self::collect_sequence_args_slurpy(&result, min_arity)
-                            } else {
-                                let arity = data.params.len();
-                                Self::collect_sequence_args_fixed(&result, arity)?
-                            };
-                            let needs_full_binding = data.param_defs.iter().any(|pd| {
-                                pd.type_constraint.is_some()
-                                    || pd.literal_value.is_some()
-                                    || pd.shape_constraints.is_some()
-                                    || pd.named
-                                    || pd.slurpy
-                                    || pd.double_slurpy
-                            });
-                            if needs_full_binding {
-                                match self.call_sub_value(Value::Sub(data.clone()), args, false) {
-                                    Ok(v) => v,
-                                    Err(_e) if suppress_generator_error => break 'seq_gen,
-                                    Err(e) => return Err(e),
-                                }
-                            } else {
-                                let saved = self.env.clone();
-                                // Use the mutable closure env so side-effects persist
-                                // across iterations (e.g. `my $i = 0; { ++$i } ... *`).
-                                let closure_env = generator_closure_env.as_ref().unwrap();
-                                for (k, v) in closure_env.iter() {
-                                    self.env.insert_sym(*k, v.clone());
-                                }
-
-                                // Bind parameters
-                                for (i, param) in data.params.iter().enumerate() {
-                                    if param.starts_with('@') {
-                                        let rest = if i < args.len() {
-                                            args[i..].to_vec()
-                                        } else {
-                                            Vec::new()
-                                        };
-                                        self.env.insert(param.clone(), Value::array(rest));
-                                        break;
-                                    }
-                                    if param.starts_with('%') {
-                                        let mut map = std::collections::HashMap::new();
-                                        for item in args.iter().skip(i) {
-                                            if let Value::Pair(k, v) = item {
-                                                map.insert(k.clone(), (**v).clone());
-                                            }
-                                        }
-                                        self.env.insert(
-                                            param.clone(),
-                                            Value::Hash(Value::hash_arc(map)),
-                                        );
-                                        break;
-                                    }
-                                    if let Some(arg) = args.get(i) {
-                                        self.env.insert(param.clone(), arg.clone());
-                                    }
-                                }
-
-                                // Bind $_ to last arg
-                                if let Some(last_arg) = args.last() {
-                                    self.env.insert("_".to_string(), last_arg.clone());
-                                }
-                                // Bind @_ to the argument history window.
-                                self.env
-                                    .insert("@_".to_string(), Value::array(args.clone()));
-
-                                let exec_result =
-                                    if let Some((ref code, ref fns)) = precompiled_closure {
-                                        self.eval_precompiled_block_fast(code, fns)
-                                    } else {
-                                        self.eval_block_value(&data.body)
-                                    };
-                                let val = match exec_result {
-                                    Ok(v) => v,
-                                    Err(e) if e.return_value.is_some() => e.return_value.unwrap(),
-                                    Err(e) if e.is_last => {
-                                        self.env = restore_env_with_side_effects(saved, &self.env);
-                                        break;
-                                    }
-                                    Err(_e) if suppress_generator_error => {
-                                        self.env = restore_env_with_side_effects(saved, &self.env);
-                                        break 'seq_gen;
-                                    }
-                                    Err(e) => {
-                                        self.env = restore_env_with_side_effects(saved, &self.env);
-                                        return Err(e);
-                                    }
-                                };
-                                // Propagate side-effects back to the mutable closure env
-                                // so the next iteration sees updated values.
-                                if let Some(ref mut gen_env) = generator_closure_env {
-                                    for (k, v) in self.env.iter() {
-                                        if gen_env.contains_key_sym(*k) {
-                                            gen_env.insert_sym(*k, v.clone());
-                                        }
-                                    }
-                                }
-                                self.env = restore_env_with_side_effects(saved, &self.env);
-                                val
-                            }
+                    match self.sequence_closure_step(
+                        genfn,
+                        &result,
+                        precompiled_closure.as_ref().map(|t| (&t.0, &t.1)),
+                        &mut generator_closure_env,
+                        suppress_generator_error,
+                    )? {
+                        Some(v) => v,
+                        None => {
+                            closure_generation_finished = true;
+                            break 'seq_gen;
                         }
-                    } else if let Value::Routine { name: rname, .. } = genfn {
-                        let package = match genfn {
-                            Value::Routine { package, .. } => package,
-                            _ => unreachable!(),
-                        };
-                        let args = match self
-                            .sequence_routine_param_mode(&package.resolve(), &rname.resolve())
-                        {
-                            SequenceRoutineParamMode::Fixed(arity) => {
-                                Self::collect_sequence_args_fixed(&result, arity)?
-                            }
-                            SequenceRoutineParamMode::Slurpy { min_arity } => {
-                                Self::collect_sequence_args_slurpy(&result, min_arity)
-                            }
-                        };
-                        match self.call_sub_value(genfn.clone(), args, false) {
-                            Ok(v) => v,
-                            Err(_e) if suppress_generator_error => break 'seq_gen,
-                            Err(e) => return Err(e),
-                        }
-                    } else {
-                        break;
                     }
                 }
                 SeqMode::Arithmetic(step) => {
@@ -1358,6 +1392,23 @@ impl Interpreter {
             if let Some(spec) = seq_spec {
                 Ok(Value::LazyList(std::sync::Arc::new(
                     crate::value::LazyList::new_sequence(result, spec),
+                )))
+            } else if matches!(mode, SeqMode::Closure)
+                && !closure_generation_finished
+                && let Some(gen_fn) = generator
+            {
+                // Infinite closure-based sequence (`1, 1, * + * ... *`): keep the
+                // generator so elements past the eager prefix are produced on
+                // demand instead of truncating to the initial cache.
+                let state = crate::value::ClosureSeqState {
+                    generator: gen_fn,
+                    closure_env: generator_closure_env,
+                    precompiled: precompiled_closure
+                        .map(|(c, f)| (std::sync::Arc::new(c), std::sync::Arc::new(f))),
+                    finished: false,
+                };
+                Ok(Value::LazyList(std::sync::Arc::new(
+                    crate::value::LazyList::new_closure_sequence(result, state),
                 )))
             } else {
                 Ok(Value::LazyList(std::sync::Arc::new(

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1813,6 +1813,28 @@ pub(crate) enum ForLoopResumeState {
     CStyleLoop,
 }
 
+/// Pre-compiled fast-path body for a closure sequence generator: the compiled
+/// code plus its associated compiled functions.
+pub(crate) type CompiledClosureBody = (Arc<CompiledCode>, Arc<HashMap<String, CompiledFunction>>);
+
+/// State for an infinite closure-based sequence (`1, 1, * + * ... *`).
+///
+/// Unlike `SequenceSpec` (arithmetic/geometric, computed without VM context),
+/// a closure generator must re-invoke user code to produce each next element,
+/// so its state is kept here and extended on demand via the VM.
+#[derive(Clone)]
+pub(crate) struct ClosureSeqState {
+    /// The generator closure (`Value::Sub` or `Value::Routine`).
+    pub(crate) generator: Value,
+    /// Mutable captured env for side-effecting generators (e.g. `my $i = 0; { $i++ } ... *`).
+    /// Persisted across pulls so side effects accumulate.
+    pub(crate) closure_env: Option<Env>,
+    /// Pre-compiled fast-path body for the generator (when the fast path applies).
+    pub(crate) precompiled: Option<CompiledClosureBody>,
+    /// Set once the generator signals termination (`last`/error) so we stop pulling.
+    pub(crate) finished: bool,
+}
+
 /// Saved VM state for a suspended gather coroutine.
 /// When `take` is encountered during gather body execution, the VM state
 /// is captured here so execution can resume later for more elements.
@@ -1851,6 +1873,10 @@ pub(crate) struct LazyList {
     /// demand, so `(1..Inf).map(...)`/`.grep(...)` stay truly lazy instead of
     /// materializing the (possibly infinite) source.
     pub(crate) lazy_pipe: Option<Mutex<MapGrepSpec>>,
+    /// Infinite closure-based sequence generator (`1, 1, * + * ... *`).
+    /// When present, more elements are produced on demand by re-invoking the
+    /// generator closure over the growing element history.
+    pub(crate) closure_seq: Option<Mutex<ClosureSeqState>>,
 }
 
 impl std::fmt::Debug for LazyList {
@@ -1886,6 +1912,10 @@ impl Clone for LazyList {
                 .lazy_pipe
                 .as_ref()
                 .map(|p| Mutex::new(p.lock().unwrap().clone())),
+            closure_seq: self
+                .closure_seq
+                .as_ref()
+                .map(|c| Mutex::new(c.lock().unwrap().clone())),
         }
     }
 }
@@ -1904,6 +1934,7 @@ impl LazyList {
             sequence_spec: None,
             coroutine: None,
             lazy_pipe: None,
+            closure_seq: None,
         }
     }
 
@@ -1920,6 +1951,7 @@ impl LazyList {
             sequence_spec: Some(spec),
             coroutine: None,
             lazy_pipe: None,
+            closure_seq: None,
         }
     }
 
@@ -1936,6 +1968,7 @@ impl LazyList {
             sequence_spec: None,
             coroutine: None,
             lazy_pipe: None,
+            closure_seq: None,
         }
     }
 
@@ -1968,6 +2001,28 @@ impl LazyList {
                 source_idx: 0,
                 done: false,
             })),
+            closure_seq: None,
+        }
+    }
+
+    /// Create an infinite closure-based sequence (`1, 1, * + * ... *`).
+    ///
+    /// `seeds` is the initial element history (already includes any eagerly
+    /// generated prefix); `state` carries the generator closure so more
+    /// elements can be produced on demand via the VM.
+    pub(crate) fn new_closure_sequence(seeds: Vec<Value>, state: ClosureSeqState) -> Self {
+        Self {
+            body: Vec::new(),
+            env: crate::env::Env::new(),
+            cache: Mutex::new(Some(seeds)),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: None,
+            sequence_spec: None,
+            coroutine: None,
+            lazy_pipe: None,
+            closure_seq: Some(Mutex::new(state)),
         }
     }
 

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -567,6 +567,14 @@ impl Interpreter {
             return Self::extend_sequence_cache(list, spec, needed);
         }
 
+        // For infinite closure-based sequences (`1, 1, * + * ... *`), re-invoke
+        // the generator closure over the growing history to produce elements on
+        // demand, so an unbounded sequence stays lazy instead of truncating to
+        // its eager prefix.
+        if list.closure_seq.is_some() {
+            return self.extend_closure_sequence(list, needed);
+        }
+
         // Lazy map/grep pipeline: pull from the source and apply the stage on
         // demand (one source element at a time), so an infinite source stays
         // lazy instead of materializing.
@@ -1353,6 +1361,63 @@ impl Interpreter {
         } else {
             val
         }
+    }
+
+    /// Extend an infinite closure-based sequence to at least `needed` elements
+    /// by re-invoking its generator closure over the growing element history.
+    /// Returns whatever is available (possibly fewer than `needed`) once the
+    /// generator signals termination.
+    fn extend_closure_sequence(
+        &mut self,
+        list: &LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        // Fast path: already cached enough.
+        {
+            let cache = list.cache.lock().unwrap();
+            if let Some(cached) = cache.as_ref()
+                && cached.len() >= needed
+            {
+                return Ok(cached[..needed].to_vec());
+            }
+        }
+
+        // Snapshot the current history without holding the cache lock across
+        // user-code execution.
+        let mut history = {
+            let cache = list.cache.lock().unwrap();
+            cache.as_ref().cloned().unwrap_or_default()
+        };
+
+        let state_mutex = list.closure_seq.as_ref().unwrap();
+        let mut guard = state_mutex.lock().unwrap();
+        let state = &mut *guard;
+        let generator = state.generator.clone();
+
+        while history.len() < needed && !state.finished {
+            let precompiled = state
+                .precompiled
+                .as_ref()
+                .map(|(c, f)| (c.as_ref(), f.as_ref()));
+            match self.sequence_closure_step(
+                &generator,
+                &history,
+                precompiled,
+                &mut state.closure_env,
+                false,
+            )? {
+                Some(v) => history.push(v),
+                None => {
+                    state.finished = true;
+                    break;
+                }
+            }
+        }
+
+        // Publish the extended history back to the cache.
+        *list.cache.lock().unwrap() = Some(history.clone());
+        let take = needed.min(history.len());
+        Ok(history[..take].to_vec())
     }
 
     /// Extend a sequence-spec lazy list's cache to at least `needed` elements.

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -52,6 +52,7 @@ impl Interpreter {
                     for_loop_resume: None,
                 })),
                 lazy_pipe: None,
+                closure_seq: None,
             };
             let val = Value::LazyList(std::sync::Arc::new(list));
             self.stack.push(val);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -384,9 +384,14 @@ impl Interpreter {
                     Some(n) => self.force_scan_lazy_list(ll, n)?,
                     None => self.force_lazy_list_vm(ll)?,
                 }
-            } else if ll.coroutine.is_some() || ll.lazy_pipe.is_some() {
-                // Gather-based lazy list / lazy map-grep pipeline: force only as
-                // many elements as needed via bounded incremental pull.
+            } else if ll.coroutine.is_some()
+                || ll.lazy_pipe.is_some()
+                || ll.sequence_spec.is_some()
+                || ll.closure_seq.is_some()
+            {
+                // Gather-based lazy list / lazy map-grep pipeline / infinite
+                // arithmetic-or-closure sequence: force only as many elements as
+                // needed via bounded incremental pull.
                 match &index {
                     Value::Int(i) if *i >= 0 => {
                         self.force_lazy_list_vm_n(ll, (*i as usize).saturating_add(1))?

--- a/t/lazy-closure-seq.t
+++ b/t/lazy-closure-seq.t
@@ -1,0 +1,67 @@
+use Test;
+
+# Real lazy infinite closure-based sequences (`1, 1, * + * ... *`).
+# Elements past the eager prefix are produced on demand by re-invoking the
+# generator closure, so indexing far into an infinite sequence works (and
+# promotes to BigInt) instead of returning Nil.
+
+plan 16;
+
+# --- scalar-bound Seq, single index ---
+{
+    my $s = (1, 1, * + * ... *);
+    is $s[10], 89, 'fib seq index 10';
+    is $s[20], 10946, 'fib seq index 20';
+    is $s[40], 165580141, 'fib seq index 40 (past eager prefix)';
+    # fib(100) overflows i64: the closure `+` promotes to BigInt automatically.
+    is $s[100], 573147844013817084101, 'fib seq index 100 is a BigInt';
+}
+
+# --- .lazy-marked array, single index and slice ---
+{
+    my @a = (1, 1, * + * ... *).lazy;
+    is @a[15], 987, '.lazy fib array index 15';
+    is @a[^8].join(','), '1,1,2,3,5,8,13,21', '.lazy fib array slice';
+}
+
+# --- constant binding indexed deep ---
+{
+    constant fib := 0, 1, *+* ... *;
+    is fib[10], 55, 'constant fib index 10';
+    is fib[100], 354224848179261915075, 'constant fib index 100';
+}
+
+# --- side-effecting generator keeps state across on-demand pulls ---
+{
+    my $i = 0;
+    my @s = ({ $i++ } ... *).lazy;
+    is @s[0..4].join(','), '0,1,2,3,4', 'side-effecting closure generator';
+    is @s[10], 10, 'side-effecting closure generator continues on demand';
+}
+
+# --- named sub as generator ---
+{
+    sub add2($a, $b) { $a + $b }
+    my $s = (1, 1, &add2 ... *);
+    is $s[10], 89, 'named-sub generator index 10';
+    is $s[30], 1346269, 'named-sub generator index 30';
+}
+
+# --- single-arg closure generator ---
+{
+    my $s = (1, { $_ + 2 } ... *);
+    is $s[100], 201, 'single-arg closure generator deep index';
+}
+
+# --- a closure generator that terminates (`last`) stays finite ---
+{
+    my @s = (1, 2, 3, { last } ... *);
+    is @s.elems, 3, 'closure generator that calls last yields a finite list';
+    is @s[10]:exists, False, 'no elements past the finite end';
+}
+
+# --- the eager prefix is unaffected ---
+{
+    my $s = (2, 4, * * * ... *);  # multiplicative-ish closure
+    is $s[0], 2, 'eager prefix element 0 intact';
+}


### PR DESCRIPTION
## Summary

Closure-generated infinite sequences (`1, 1, * + * ... *`, `0, 1, *+* ... *`) were eagerly materialized to a ~32-element prefix and frozen as a plain cached list, so indexing past the prefix returned `Nil` (e.g. `fib[100]` → `Nil`). This makes them **truly lazy**: elements past the eager prefix are produced on demand by re-invoking the generator closure.

```raku
my $s = (1, 1, * + * ... *);
say $s[100];          # before: Nil   after: 573147844013817084101

constant fib := 0, 1, *+* ... *;
say fib[100];         # before: Nil   after: 354224848179261915075

my @a = (2, 4, 6 ... *).lazy;
say @a[100];          # before: Nil   after: 202
```

## How

- New `LazyList.closure_seq` (`ClosureSeqState`) keeps the generator closure, its captured env, and the pre-compiled fast-path body. `Interpreter::extend_closure_sequence` extends the cache on demand over the growing element history (promoting to BigInt naturally, since the closure's `+` does).
- Extracted the per-element generator invocation into a shared `sequence_closure_step`, used by both the initial generation loop and the on-demand extension.
- Routed `sequence_spec` / `closure_seq` lazy lists through the bounded incremental-pull index path (previously only gather/lazy-pipe did) — this also fixes `(2,4,6 ... *)[100]`.
- Fixed a latent env-corruption bug: the generator's captured env could leak a stale shadow of an outer variable (notably the very `$s` the sequence is bound to) back through the env overlay, clobbering it on the second pull. Now only captures the body **genuinely mutated** (e.g. `++$i`, `++$sunk`) propagate back to the caller.

## Scope

Unblocks `S04-declarations/constant.t` test 46 (`fib[100]`); the file's only remaining failure is the unrelated `G::c` constant-aliased-enum dispatch (test 44).

Lazy **arrays** (`my @a = 1..*`) remain eager: Array mutation ops (clone / unshift / shift / `:delete` / element-assign) have no reify-on-demand path yet, and preserving laziness there regresses `S32-array/{create,delete-adverb}.t`. Left as a follow-up.

## Tests

- New `t/lazy-closure-seq.t` (16 subtests: scalar/`.lazy`/`constant` indexing, side-effecting & named-sub generators, `last`-terminated finite sequences, BigInt promotion).
- `make test` green; targeted roast sample (134 sequence/lazy/range/list/array tests) all pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)