### PR TITLE
fix(list): .sort and .reverse return a Seq, not a List/Array

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -924,18 +924,18 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 // 1D shaped array: reverse the leaves
                 let mut leaves = crate::runtime::utils::shaped_array_leaves(arg);
                 leaves.reverse();
-                return Some(Ok(Value::array(leaves)));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(leaves))));
             }
             Some(Ok(match arg {
                 Value::Array(items, ..) => {
                     let mut reversed = (**items).clone();
                     reversed.reverse();
-                    Value::array(reversed.items)
+                    Value::Seq(std::sync::Arc::new(reversed.items))
                 }
                 Value::Seq(items) | Value::Slip(items) => {
                     let mut reversed = (**items).clone();
                     reversed.reverse();
-                    Value::array(reversed)
+                    Value::Seq(std::sync::Arc::new(reversed))
                 }
                 Value::Range(..)
                 | Value::RangeExcl(..)
@@ -944,10 +944,10 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 | Value::GenericRange { .. } => {
                     let mut items = crate::runtime::Interpreter::value_to_list(arg);
                     items.reverse();
-                    Value::array(items)
+                    Value::Seq(std::sync::Arc::new(items))
                 }
-                // reverse() on a string returns a single-element list (not a flip)
-                other => Value::array(vec![other.clone()]),
+                // reverse() on a string returns a single-element Seq (not a flip)
+                other => Value::Seq(std::sync::Arc::new(vec![other.clone()])),
             }))
         }
         "sort" => {

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -73,7 +73,7 @@ pub(super) fn dispatch(
                     (**items).clone().items
                 };
                 sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                Some(Ok(Value::array(sorted)))
+                Some(Ok(Value::Seq(Arc::new(sorted))))
             }
             _ => None,
         }),
@@ -90,11 +90,8 @@ pub(super) fn dispatch(
                 }
                 let mut reversed = (**items).clone();
                 reversed.reverse();
-                // .reverse returns a List (Seq in Raku), not an Array
-                Some(Ok(Value::Array(
-                    std::sync::Arc::new(reversed),
-                    crate::value::ArrayKind::List,
-                )))
+                // .reverse returns a Seq in Raku, not an Array
+                Some(Ok(Value::Seq(std::sync::Arc::new(reversed.items))))
             }
             Value::Range(a, b)
             | Value::RangeExcl(a, b)
@@ -105,10 +102,7 @@ pub(super) fn dispatch(
                 } else {
                     let mut reversed = crate::runtime::utils::value_to_list(target);
                     reversed.reverse();
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(reversed)),
-                        crate::value::ArrayKind::List,
-                    )))
+                    Some(Ok(Value::Seq(std::sync::Arc::new(reversed))))
                 }
             }
             Value::GenericRange { end, .. } => {
@@ -117,10 +111,7 @@ pub(super) fn dispatch(
                 let end_is_neg_inf = matches!(end.as_ref(), Value::Num(n) if n.is_infinite() && n.is_sign_negative());
                 if end_is_neg_inf {
                     // Empty range -- reverse is empty
-                    return Some(Some(Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
-                        crate::value::ArrayKind::List,
-                    ))));
+                    return Some(Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new())))));
                 }
                 // For finite generic ranges, expand and reverse
                 let items = crate::runtime::utils::value_to_list(target);
@@ -130,10 +121,7 @@ pub(super) fn dispatch(
                 } else {
                     let mut reversed = items;
                     reversed.reverse();
-                    Some(Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(reversed)),
-                        crate::value::ArrayKind::List,
-                    )))
+                    Some(Ok(Value::Seq(std::sync::Arc::new(reversed))))
                 }
             }
             Value::Str(s) => Some(Ok(Value::str(s.chars().rev().collect()))),
@@ -143,10 +131,7 @@ pub(super) fn dispatch(
                 // here, so `items` already holds the pulled values.)
                 let mut reversed = items.to_vec();
                 reversed.reverse();
-                Some(Ok(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(reversed)),
-                    crate::value::ArrayKind::List,
-                )))
+                Some(Ok(Value::Seq(std::sync::Arc::new(reversed))))
             }
             Value::Instance {
                 class_name,

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1142,7 +1142,7 @@ impl Interpreter {
         if args.len() != 1 {
             let mut items: Vec<Value> = args.to_vec();
             items.reverse();
-            return Ok(Value::array(items));
+            return Ok(Value::Seq(Arc::new(items)));
         }
         // LazyIoLines must be materialized by the interpreter (native bails).
         if let Value::LazyIoLines { handle, .. } = &args[0] {
@@ -1151,10 +1151,7 @@ impl Interpreter {
                 lines.push(Value::str(line));
             }
             lines.reverse();
-            return Ok(Value::Array(
-                Arc::new(crate::value::ArrayData::new(lines)),
-                ArrayKind::List,
-            ));
+            return Ok(Value::Seq(Arc::new(lines)));
         }
         // Single arg: delegate to the single shared native `reverse` (Array / Seq
         // / Slip / Range / 1-D shaped / Str), instead of a drifting second copy


### PR DESCRIPTION
## Summary

In Raku, `.sort`, `.reverse` and the `sort(...)`/`reverse(...)` sub forms all return a **`Seq`**, but mutsu returned a `List`/`Array`:

```
(1,2,3).sort.^name      # raku: Seq   mutsu(before): List
(1,2,3).reverse.^name   # raku: Seq   mutsu(before): List
reverse(1,2,3).^name    # raku: Seq   mutsu(before): List
```

mutsu's `Seq` is an eager `Arc<Vec<Value>>` (the same shape as a materialized list), so only the **result type tag** was wrong — `.sort` even returned an `Array` kind. The fast-path list dispatch (`dispatch_core_list.rs`), the `reverse` native function (`functions.rs`), and the `reverse` slow-path (`builtins_collection.rs`) all now produce `Value::Seq`.

`.^name` now reports `Seq`, matching Rakudo; indexing, assignment to `@a`, and stringification are unaffected since `Seq` already round-trips as a list everywhere.

## Test

- `make test` PASS
- roast `S32-list/{sort,reverse,seq}.t`, `S03-metaops/reverse.t`, `S02-types/{list,lists}.t`, `S02-lists/indexing.t` all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)