### PR TITLE
fix(list): .keys/.values/.kv/.pairs/.antipairs return a Seq

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -954,13 +954,27 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
             if crate::runtime::utils::is_shaped_array(arg) {
                 let mut leaves = crate::runtime::utils::shaped_array_leaves(arg);
                 leaves.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                return Some(Ok(Value::array(leaves)));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(leaves))));
             }
             Some(Ok(match arg {
                 Value::Array(items, ..) => {
                     let mut sorted = (**items).clone();
                     sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                    Value::array(sorted.items)
+                    Value::Seq(std::sync::Arc::new(sorted.items))
+                }
+                Value::Seq(items) | Value::Slip(items) => {
+                    let mut sorted = (**items).clone();
+                    sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
+                    Value::Seq(std::sync::Arc::new(sorted))
+                }
+                Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::GenericRange { .. } => {
+                    let mut sorted = crate::runtime::Interpreter::value_to_list(arg);
+                    sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
+                    Value::Seq(std::sync::Arc::new(sorted))
                 }
                 _ => Value::Nil,
             }))

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -378,7 +378,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         }
                     })
                     .collect();
-                return Some(Ok(Value::array(keys)));
+                return Some(Ok(Value::Seq(Arc::new(keys))));
             }
             match target {
                 Value::Hash(map) => {
@@ -399,35 +399,35 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     } else {
                         map.keys().map(|k| Value::hash_key_decode(k)).collect()
                     };
-                    Some(Ok(Value::array(keys)))
+                    Some(Ok(Value::Seq(Arc::new(keys))))
                 }
                 Value::Pair(key, _) => {
                     Some(Ok(Value::Seq(Arc::new(vec![Value::str(key.clone())]))))
                 }
                 Value::ValuePair(key, _) => Some(Ok(Value::Seq(Arc::new(vec![*key.clone()])))),
-                Value::Nil => Some(Ok(Value::array(Vec::new()))),
-                Value::Set(s, _) => {
-                    Some(Ok(Value::array(s.iter().map(|k| s.typed_key(k)).collect())))
-                }
-                Value::Bag(b, _) => {
-                    Some(Ok(Value::array(b.keys().map(|k| b.typed_key(k)).collect())))
-                }
-                Value::Mix(m, _) => {
-                    Some(Ok(Value::array(m.keys().map(|k| m.typed_key(k)).collect())))
-                }
+                Value::Nil => Some(Ok(Value::Seq(Arc::new(Vec::new())))),
+                Value::Set(s, _) => Some(Ok(Value::Seq(Arc::new(
+                    s.iter().map(|k| s.typed_key(k)).collect(),
+                )))),
+                Value::Bag(b, _) => Some(Ok(Value::Seq(Arc::new(
+                    b.keys().map(|k| b.typed_key(k)).collect(),
+                )))),
+                Value::Mix(m, _) => Some(Ok(Value::Seq(Arc::new(
+                    m.keys().map(|k| m.typed_key(k)).collect(),
+                )))),
                 Value::Package(_) => None, // let runtime handle (may be enum type)
-                v if v.is_range() => Some(Ok(Value::array(positional_keys(
+                v if v.is_range() => Some(Ok(Value::Seq(Arc::new(positional_keys(
                     &crate::runtime::utils::value_to_list(v),
-                )))),
-                other => Some(Ok(Value::array(positional_keys(
+                ))))),
+                other => Some(Ok(Value::Seq(Arc::new(positional_keys(
                     &crate::runtime::utils::value_to_list(other),
-                )))),
+                ))))),
             }
         }
         "values" => {
             if crate::runtime::utils::is_shaped_array(target) {
                 let leaves = crate::runtime::utils::shaped_array_leaves(target);
-                return Some(Ok(Value::array(leaves)));
+                return Some(Ok(Value::Seq(Arc::new(leaves))));
             }
             match target {
                 Value::Hash(map) => {
@@ -435,30 +435,30 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     // hash element is a `ContainerRef`, and `.values` must yield
                     // the inner value, not the cell (else sort/compare leak).
                     let values: Vec<Value> = map.values().map(|v| v.deref_container()).collect();
-                    Some(Ok(Value::array(values)))
+                    Some(Ok(Value::Seq(Arc::new(values))))
                 }
                 Value::Pair(_, value) | Value::ValuePair(_, value) => {
                     Some(Ok(Value::Seq(Arc::new(vec![*value.clone()]))))
                 }
-                Value::Nil => Some(Ok(Value::array(Vec::new()))),
-                Value::Set(s, _) => Some(Ok(Value::array(
+                Value::Nil => Some(Ok(Value::Seq(Arc::new(Vec::new())))),
+                Value::Set(s, _) => Some(Ok(Value::Seq(Arc::new(
                     s.iter().map(|_| Value::Bool(true)).collect(),
-                ))),
-                Value::Bag(b, _) => Some(Ok(Value::array(
+                )))),
+                Value::Bag(b, _) => Some(Ok(Value::Seq(Arc::new(
                     b.values().map(|v| Value::from_bigint(v.clone())).collect(),
-                ))),
-                Value::Mix(m, _) => Some(Ok(Value::array(
+                )))),
+                Value::Mix(m, _) => Some(Ok(Value::Seq(Arc::new(
                     m.values()
                         .map(|v| crate::value::mix_weight_to_value(*v))
                         .collect(),
-                ))),
+                )))),
                 Value::Package(_) => None, // let runtime handle (may be enum type)
-                v if v.is_range() => {
-                    Some(Ok(Value::array(crate::runtime::utils::value_to_list(v))))
-                }
+                v if v.is_range() => Some(Ok(Value::Seq(Arc::new(
+                    crate::runtime::utils::value_to_list(v),
+                )))),
                 Value::LazyList(_) => None, // fall through to runtime to force
-                other => Some(Ok(Value::array(crate::runtime::utils::value_to_list(
-                    other,
+                other => Some(Ok(Value::Seq(Arc::new(
+                    crate::runtime::utils::value_to_list(other),
                 )))),
             }
         }
@@ -474,7 +474,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     }
                     kv.push(val);
                 }
-                return Some(Ok(Value::array(kv)));
+                return Some(Ok(Value::Seq(Arc::new(kv))));
             }
             match target {
                 Value::Hash(items) => {
@@ -489,7 +489,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         }
                         kv.push(v.clone());
                     }
-                    Some(Ok(Value::array(kv)))
+                    Some(Ok(Value::Seq(Arc::new(kv))))
                 }
                 Value::Pair(key, value) => Some(Ok(Value::Seq(Arc::new(vec![
                     Value::str(key.clone()),
@@ -498,14 +498,14 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Value::ValuePair(key, value) => {
                     Some(Ok(Value::Seq(Arc::new(vec![*key.clone(), *value.clone()]))))
                 }
-                Value::Nil => Some(Ok(Value::array(Vec::new()))),
+                Value::Nil => Some(Ok(Value::Seq(Arc::new(Vec::new())))),
                 Value::Set(s, _) => {
                     let mut kv = Vec::new();
                     for k in s.iter() {
                         kv.push(Value::str(k.clone()));
                         kv.push(Value::Bool(true));
                     }
-                    Some(Ok(Value::array(kv)))
+                    Some(Ok(Value::Seq(Arc::new(kv))))
                 }
                 Value::Bag(b, _) => {
                     let mut kv = Vec::new();
@@ -513,7 +513,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         kv.push(Value::str(k.clone()));
                         kv.push(Value::from_bigint(v.clone()));
                     }
-                    Some(Ok(Value::array(kv)))
+                    Some(Ok(Value::Seq(Arc::new(kv))))
                 }
                 Value::Mix(m, _) => {
                     let mut kv = Vec::new();
@@ -521,7 +521,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         kv.push(Value::str(k.clone()));
                         kv.push(crate::value::mix_weight_to_value(*v));
                     }
-                    Some(Ok(Value::array(kv)))
+                    Some(Ok(Value::Seq(Arc::new(kv))))
                 }
                 Value::Enum { key, value, .. } => Some(Ok(Value::Seq(Arc::new(vec![
                     Value::str(key.resolve()),
@@ -537,12 +537,12 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         words: *words,
                     }))
                 }
-                v if v.is_range() => Some(Ok(Value::array(positional_kv(
+                v if v.is_range() => Some(Ok(Value::Seq(Arc::new(positional_kv(
                     &crate::runtime::utils::value_to_list(v),
-                )))),
-                other => Some(Ok(Value::array(positional_kv(
+                ))))),
+                other => Some(Ok(Value::Seq(Arc::new(positional_kv(
                     &crate::runtime::utils::value_to_list(other),
-                )))),
+                ))))),
             }
         }
         "pairs" => {
@@ -559,7 +559,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         Value::ValuePair(Box::new(key), Box::new(val))
                     })
                     .collect();
-                return Some(Ok(Value::array(pairs)));
+                return Some(Ok(Value::Seq(Arc::new(pairs))));
             }
             match target {
                 Value::Hash(items) => {
@@ -579,37 +579,37 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
                             .collect()
                     };
-                    Some(Ok(Value::array(pairs)))
+                    Some(Ok(Value::Seq(Arc::new(pairs))))
                 }
-                Value::Set(s, _) => Some(Ok(Value::array(
+                Value::Set(s, _) => Some(Ok(Value::Seq(Arc::new(
                     s.iter()
                         .map(|k| Value::Pair(k.clone(), Box::new(Value::Bool(true))))
                         .collect(),
-                ))),
-                Value::Bag(b, _) => Some(Ok(Value::array(
+                )))),
+                Value::Bag(b, _) => Some(Ok(Value::Seq(Arc::new(
                     b.iter()
                         .map(|(k, v)| {
                             Value::Pair(k.clone(), Box::new(Value::from_bigint(v.clone())))
                         })
                         .collect(),
-                ))),
-                Value::Mix(m, _) => Some(Ok(Value::array(
+                )))),
+                Value::Mix(m, _) => Some(Ok(Value::Seq(Arc::new(
                     m.iter()
                         .map(|(k, v)| {
                             Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v)))
                         })
                         .collect(),
-                ))),
+                )))),
                 Value::Pair(_, _) | Value::ValuePair(_, _) => {
-                    Some(Ok(Value::array(vec![target.clone()])))
+                    Some(Ok(Value::Seq(Arc::new(vec![target.clone()]))))
                 }
                 Value::Package(_) => None, // let runtime handle (may be enum type)
-                v if v.is_range() => Some(Ok(Value::array(positional_pairs(
+                v if v.is_range() => Some(Ok(Value::Seq(Arc::new(positional_pairs(
                     &crate::runtime::utils::value_to_list(v),
-                )))),
-                other => Some(Ok(Value::array(positional_pairs(
+                ))))),
+                other => Some(Ok(Value::Seq(Arc::new(positional_pairs(
                     &crate::runtime::utils::value_to_list(other),
-                )))),
+                ))))),
             }
         }
         "pairup" => match target {
@@ -657,7 +657,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         make_inverted_pair(val, key)
                     })
                     .collect();
-                return Some(Ok(Value::array(pairs)));
+                return Some(Ok(Value::Seq(Arc::new(pairs))));
             }
             match target {
                 Value::Hash(items) => {
@@ -671,9 +671,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             }
                         })
                         .collect();
-                    Some(Ok(Value::array(pairs)))
+                    Some(Ok(Value::Seq(Arc::new(pairs))))
                 }
-                Value::Bag(items, _) => Some(Ok(Value::array(
+                Value::Bag(items, _) => Some(Ok(Value::Seq(Arc::new(
                     items
                         .iter()
                         .map(|(k, v)| {
@@ -683,8 +683,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             )
                         })
                         .collect(),
-                ))),
-                Value::Set(items, _) => Some(Ok(Value::array(
+                )))),
+                Value::Set(items, _) => Some(Ok(Value::Seq(Arc::new(
                     items
                         .iter()
                         .map(|k| {
@@ -694,8 +694,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             )
                         })
                         .collect(),
-                ))),
-                Value::Mix(items, _) => Some(Ok(Value::array(
+                )))),
+                Value::Mix(items, _) => Some(Ok(Value::Seq(Arc::new(
                     items
                         .iter()
                         .map(|(k, v)| {
@@ -705,7 +705,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             )
                         })
                         .collect(),
-                ))),
+                )))),
                 Value::Capture { positional, named } => {
                     let mut pairs: Vec<Value> = positional
                         .iter()
@@ -723,16 +723,16 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                             Box::new(Value::str(k.clone())),
                         ));
                     }
-                    Some(Ok(Value::array(pairs)))
+                    Some(Ok(Value::Seq(Arc::new(pairs))))
                 }
                 Value::Package(_) => None, // let runtime handle (may be enum type)
                 v if v.is_range() => {
                     let values = crate::runtime::utils::value_to_list(v);
-                    Some(Ok(Value::array(positional_antipairs(&values))))
+                    Some(Ok(Value::Seq(Arc::new(positional_antipairs(&values)))))
                 }
                 other => {
                     let values = crate::runtime::utils::value_to_list(other);
-                    Some(Ok(Value::array(positional_antipairs(&values))))
+                    Some(Ok(Value::Seq(Arc::new(positional_antipairs(&values)))))
                 }
             }
         }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -627,7 +627,7 @@ impl Interpreter {
                     }
                     _ => Vec::new(),
                 };
-                Some(Ok(Value::array(keys)))
+                Some(Ok(Value::Seq(Arc::new(keys))))
             }
             Value::Hash(ref map) => {
                 if let Some(info) = self.container_type_metadata(&target)
@@ -642,7 +642,7 @@ impl Interpreter {
                             .keys()
                             .map(|k| utils::hash_typed_key(&target, k))
                             .collect();
-                        return Some(Ok(Value::array(keys)));
+                        return Some(Ok(Value::Seq(Arc::new(keys))));
                     }
                     // Fallback: try coercion from string key
                     let key_constraint = info.key_type.unwrap();
@@ -654,10 +654,10 @@ impl Interpreter {
                             .unwrap_or_else(|_| Value::str(key.clone()));
                         keys.push(coerced);
                     }
-                    return Some(Ok(Value::array(keys)));
+                    return Some(Ok(Value::Seq(Arc::new(keys))));
                 }
                 let keys = map.keys().cloned().map(Value::str).collect::<Vec<Value>>();
-                Some(Ok(Value::array(keys)))
+                Some(Ok(Value::Seq(Arc::new(keys))))
             }
             Value::Mixin(inner, _) if matches!(inner.as_ref(), Value::Hash(_)) => {
                 Some(self.call_method_with_values(inner.as_ref().clone(), "keys", vec![]))
@@ -672,13 +672,13 @@ impl Interpreter {
             Value::Capture { positional, named } => {
                 let mut vals = *positional;
                 vals.extend(named.values().cloned());
-                Ok(Value::array(vals))
+                Ok(Value::Seq(Arc::new(vals)))
             }
-            Value::Array(items, ..) => Ok(Value::array(items.to_vec())),
-            Value::Hash(map) => Ok(Value::array(map.values().cloned().collect())),
-            Value::Pair(_, value) => Ok(Value::array(vec![*value.clone()])),
-            Value::ValuePair(_, value) => Ok(Value::array(vec![*value.clone()])),
-            _ => Ok(Value::array(Vec::new())),
+            Value::Array(items, ..) => Ok(Value::Seq(Arc::new(items.to_vec()))),
+            Value::Hash(map) => Ok(Value::Seq(Arc::new(map.values().cloned().collect()))),
+            Value::Pair(_, value) => Ok(Value::Seq(Arc::new(vec![*value.clone()]))),
+            Value::ValuePair(_, value) => Ok(Value::Seq(Arc::new(vec![*value.clone()]))),
+            _ => Ok(Value::Seq(Arc::new(Vec::new()))),
         }
     }
 

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -163,7 +163,8 @@ impl Interpreter {
         // e.g. .trans: (/\@/ => "-",), :c  passes (pair,) as an Array arg.
         let mut flat_args: Vec<Value> = Vec::new();
         for arg in args {
-            if let Value::Array(items, ..) = arg {
+            // `.pairs`/`.list` now yield a Seq, so accept Array/Seq/Slip alike.
+            if let Some(items) = arg.as_list_items() {
                 let all_pairs = items
                     .iter()
                     .all(|v| matches!(v, Value::Pair(..) | Value::ValuePair(..)));

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3773,6 +3773,9 @@ impl Interpreter {
                                         self.env.get(&env_key).cloned().unwrap_or(Value::Nil);
                                     let elements = match &value {
                                         Value::Array(arr, _) => arr.as_ref().clone(),
+                                        Value::Seq(items) | Value::Slip(items) => {
+                                            crate::value::ArrayData::new((**items).clone())
+                                        }
                                         _ => crate::value::ArrayData::new(vec![value]),
                                     };
                                     let mut alt_patterns = Vec::new();
@@ -5060,6 +5063,9 @@ impl Interpreter {
                             .unwrap_or(Value::Nil);
                         let elements = match &value {
                             Value::Array(arr, _) => arr.as_ref().clone(),
+                            Value::Seq(items) | Value::Slip(items) => {
+                                crate::value::ArrayData::new((**items).clone())
+                            }
                             _ => crate::value::ArrayData::new(vec![value]),
                         };
                         let mut alts = Vec::new();
@@ -5094,6 +5100,9 @@ impl Interpreter {
                         .unwrap_or(Value::Nil);
                     let elements = match &value {
                         Value::Array(arr, _) => arr.as_ref().clone(),
+                        Value::Seq(items) | Value::Slip(items) => {
+                            crate::value::ArrayData::new((**items).clone())
+                        }
                         _ => crate::value::ArrayData::new(vec![value]),
                     };
                     let mut alts = Vec::new();
@@ -5127,6 +5136,9 @@ impl Interpreter {
                     let val = self.eval_string_as_source(&expr_str);
                     let elements = match &val {
                         Value::Array(arr, _) => arr.as_ref().clone(),
+                        Value::Seq(items) | Value::Slip(items) => {
+                            crate::value::ArrayData::new((**items).clone())
+                        }
                         _ => crate::value::ArrayData::new(vec![val]),
                     };
                     let mut alts = Vec::new();


### PR DESCRIPTION
## Summary

In Raku, the positional/associative accessors `.keys`, `.values`, `.kv`, `.pairs`, `.antipairs` all return a **`Seq`**, but mutsu returned a `List`/`Array`. Visible via `.^name` and `.raku`:

```
(1,2,3).keys.^name   # raku: Seq             mutsu(before): List
(1,2,3).keys.raku    # raku: (0, 1, 2).Seq   mutsu(before): (0, 1, 2)
%h.keys.^name        # raku: Seq             mutsu(before): List
```

Switch the result sites for these five methods — the fast-path list dispatch (`collection.rs`) and the Hash/Stash/Capture slow-path (`methods_dispatch_match3.rs`) — from `Value::array` to `Value::Seq`, for all of List / Array / Range / Hash / Set / Bag / Mix receivers. mutsu's `Seq` is an eager `Arc<Vec<Value>>`, so only the result type tag changes; `is-deeply` already normalizes a `Seq` via `.cache`, so existing comparisons are unaffected.

This follows the same theme as #3196 (`.sort`/`.reverse` → `Seq`).

## Latent bug fixed (exposed by this change)

The single-arg `sort($x)` native function only handled `Value::Array` and returned **`Nil`** for a `Seq`/`Slip`/`Range` argument. Once `keys` started returning a `Seq`, `sort(keys(%h))` silently produced nothing. `sort` now coerces `Seq`/`Slip`/`Range` to a sorted `Seq`, matching its documented return type. This restored `S32-hash/keys_values.t` (`~sort(keys(%hash))`).

## Test

- `make test` PASS
- roast `S32-hash/{keys_values,kv,pairs,antipairs,invert}.t`, `S09-hashes/objecthash.t`, `S02-types/hash.t`, all whitelisted `S32-hash`/`S32-list`/`S32-array`/`S09` tests PASS
- `S02-types/{set,bag,capture}.t` failures verified pre-existing (identical on a clean build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)