### PR TITLE
fix(list): .head/.tail/.rotate/.unique/.repeated return a Seq

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -978,30 +978,37 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
                 let leaves = crate::runtime::utils::shaped_array_leaves(arg);
                 let len = leaves.len();
                 if len == 0 {
-                    return Some(Ok(Value::array(Vec::new())));
+                    return Some(Ok(Value::Seq(std::sync::Arc::new(Vec::new()))));
                 }
                 let n = 1usize % len;
                 let mut rotated = Vec::with_capacity(len);
                 rotated.extend_from_slice(&leaves[n..]);
                 rotated.extend_from_slice(&leaves[..n]);
-                return Some(Ok(Value::array(rotated)));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(rotated))));
             }
-            Some(Ok(match arg {
-                Value::Array(items, ..) => {
-                    // rotate with no count defaults to 1
-                    let n = 1usize;
-                    let len = items.len();
-                    if len == 0 {
-                        Value::array(Vec::new())
-                    } else {
-                        let n = n % len;
-                        let mut rotated = Vec::with_capacity(len);
-                        rotated.extend_from_slice(&items[n..]);
-                        rotated.extend_from_slice(&items[..n]);
-                        Value::array(rotated)
-                    }
+            // rotate with no count defaults to 1; returns a Seq (raku semantics).
+            let items: Option<Vec<Value>> = match arg {
+                Value::Array(items, ..) => Some(items.iter().cloned().collect()),
+                Value::Seq(items) | Value::Slip(items) => Some((**items).clone()),
+                Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::GenericRange { .. } => {
+                    Some(crate::runtime::Interpreter::value_to_list(arg))
                 }
-                _ => Value::Nil,
+                _ => None,
+            };
+            Some(Ok(match items {
+                Some(items) if !items.is_empty() => {
+                    let n = 1usize % items.len();
+                    let mut rotated = Vec::with_capacity(items.len());
+                    rotated.extend_from_slice(&items[n..]);
+                    rotated.extend_from_slice(&items[..n]);
+                    Value::Seq(std::sync::Arc::new(rotated))
+                }
+                Some(_) => Value::Seq(std::sync::Arc::new(Vec::new())),
+                None => Value::Nil,
             }))
         }
         "flat" => {

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -164,7 +164,7 @@ pub(super) fn dispatch(
                         result.push(item.clone());
                     }
                 }
-                Some(Ok(Value::array(result)))
+                Some(Ok(Value::Seq(Arc::new(result))))
             }
             Value::Seq(items) | Value::Slip(items) => {
                 let mut seen: Vec<Value> = Vec::new();
@@ -178,7 +178,7 @@ pub(super) fn dispatch(
                         result.push(item.clone());
                     }
                 }
-                Some(Ok(Value::array(result)))
+                Some(Ok(Value::Seq(Arc::new(result))))
             }
             Value::LazyList(_) => None,
             // Supply.unique is handled by native_supply
@@ -199,7 +199,7 @@ pub(super) fn dispatch(
                         seen.push(item.clone());
                     }
                 }
-                Some(Ok(Value::array(result)))
+                Some(Ok(Value::Seq(Arc::new(result))))
             }
             Value::Seq(items) | Value::Slip(items) => {
                 let mut seen: Vec<Value> = Vec::new();
@@ -214,10 +214,10 @@ pub(super) fn dispatch(
                         seen.push(item.clone());
                     }
                 }
-                Some(Ok(Value::array(result)))
+                Some(Ok(Value::Seq(Arc::new(result))))
             }
             Value::LazyList(_) => None,
-            _ => Some(Ok(Value::array(Vec::new()))),
+            _ => Some(Ok(Value::Seq(Arc::new(Vec::new())))),
         }),
         "floor" => Some(match target {
             Value::Num(f) if f.is_nan() || f.is_infinite() => Some(Ok(Value::Num(*f))),

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1276,20 +1276,22 @@ pub(crate) fn native_method_1arg(
                 _ => return None,
             };
             if n <= 0 {
-                return Some(Ok(Value::array(vec![])));
+                return Some(Ok(Value::Seq(std::sync::Arc::new(vec![]))));
             }
             let n = n as usize;
             match target {
-                Value::Array(items, ..) => {
-                    Some(Ok(Value::array(items[..n.min(items.len())].to_vec())))
-                }
+                Value::Array(items, ..) => Some(Ok(Value::Seq(std::sync::Arc::new(
+                    items[..n.min(items.len())].to_vec(),
+                )))),
                 Value::Range(a, b) => {
                     let items: Vec<Value> = (*a..=*b).take(n).map(Value::Int).collect();
-                    Some(Ok(Value::array(items)))
+                    Some(Ok(Value::Seq(std::sync::Arc::new(items))))
                 }
                 _ => {
                     let items = runtime::value_to_list(target);
-                    Some(Ok(Value::array(items[..n.min(items.len())].to_vec())))
+                    Some(Ok(Value::Seq(std::sync::Arc::new(
+                        items[..n.min(items.len())].to_vec(),
+                    ))))
                 }
             }
         }
@@ -1300,7 +1302,7 @@ pub(crate) fn native_method_1arg(
                     _ => return None,
                 };
                 let start = items.len().saturating_sub(n);
-                Some(Ok(Value::array(items[start..].to_vec())))
+                Some(Ok(Value::Seq(std::sync::Arc::new(items[start..].to_vec()))))
             }
             Value::Instance { class_name, .. } if class_name == "Supply" => None,
             _ => {
@@ -1310,7 +1312,7 @@ pub(crate) fn native_method_1arg(
                 };
                 let items = runtime::value_to_list(target);
                 let start = items.len().saturating_sub(n);
-                Some(Ok(Value::array(items[start..].to_vec())))
+                Some(Ok(Value::Seq(std::sync::Arc::new(items[start..].to_vec()))))
             }
         },
         "combinations" => {

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -140,7 +140,7 @@ impl Interpreter {
                 if args.is_empty() {
                     return Ok(pulled.pop().unwrap_or(Value::Nil));
                 }
-                return Ok(Value::array(pulled));
+                return Ok(Value::Seq(std::sync::Arc::new(pulled)));
             }
         }
 
@@ -151,7 +151,7 @@ impl Interpreter {
 
         let tail_count = self.resolve_supply_tail_count(args.first(), items.len())?;
         let start = items.len().saturating_sub(tail_count);
-        Ok(Value::array(items[start..].to_vec()))
+        Ok(Value::Seq(std::sync::Arc::new(items[start..].to_vec())))
     }
 
     /// Handle `.head(&callable)` / `.head(*)` where the argument is a
@@ -183,7 +183,7 @@ impl Interpreter {
             _ => len,
         };
         let count = count.clamp(0, len) as usize;
-        Ok(Value::array(items[..count].to_vec()))
+        Ok(Value::Seq(std::sync::Arc::new(items[..count].to_vec())))
     }
 
     pub(in crate::runtime) fn callback_uses_supply_list(callback: &Value) -> bool {
@@ -245,7 +245,7 @@ impl Interpreter {
             }
         };
         if items.is_empty() {
-            return Ok(Value::array(Vec::new()));
+            return Ok(Value::Seq(std::sync::Arc::new(Vec::new())));
         }
         let len = items.len() as i64;
         let by = match args.first() {
@@ -265,6 +265,6 @@ impl Interpreter {
             let dst = ((i as i64 + len - shift) % len) as usize;
             out[dst] = item;
         }
-        Ok(Value::array(out))
+        Ok(Value::Seq(std::sync::Arc::new(out)))
     }
 }

--- a/src/runtime/methods_collection_ops/unique_squish.rs
+++ b/src/runtime/methods_collection_ops/unique_squish.rs
@@ -88,7 +88,7 @@ impl Interpreter {
             }
         }
 
-        Ok(Value::array(unique_items))
+        Ok(Value::Seq(std::sync::Arc::new(unique_items)))
     }
 
     pub(in crate::runtime) fn dispatch_repeated(
@@ -177,7 +177,7 @@ impl Interpreter {
             }
         }
 
-        Ok(Value::array(repeated_items))
+        Ok(Value::Seq(std::sync::Arc::new(repeated_items)))
     }
 
     pub(crate) fn dispatch_squish(


### PR DESCRIPTION
## Summary

These list methods return a **`Seq`** in Raku, but mutsu returned a `List`/`Array`:

```
(1,2,3).head(2).^name      # raku: Seq   mutsu(before): List
(1,2,3).tail(2).^name      # raku: Seq   mutsu(before): List
(1,2,3).rotate.^name       # raku: Seq   mutsu(before): List
(1,2,2,3).unique.^name     # raku: Seq   mutsu(before): List
(1,2,2,3).repeated.^name   # raku: Seq   mutsu(before): List
```

Switch the result sites to `Value::Seq` across the fast-path (`dispatch_core_list.rs` unique/repeated, `methods_narg.rs` `head(N)`/`tail(N)`) and slow-path (`tail_rotate.rs` rotate and WhateverCode head·tail, `unique_squish.rs` with-args unique/repeated). The no-arg `.head`/`.tail` (single element) keep returning the bare element, matching Raku.

Also make the single-arg `rotate($x)` native function return a `Seq` and accept `Seq`/`Slip`/`Range` arguments (it previously returned `Nil` for non-Array) — the same latent fix applied to `sort` in #3197.

Continues the `Seq` theme of #3196 (sort/reverse) and #3197 (keys/values/kv/pairs/antipairs).

## Test

- `make test` PASS
- roast `S32-list/{unique,repeated,head,tail,squish}.t`, `S32-array/rotate.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)