### PR TITLE
fix(metaops): X and Z are list-associative (chained cross/zip build flat n-tuples)

### DIFF
--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -495,11 +495,59 @@ impl Compiler {
                 return;
             }
         }
+        // List-associative chaining for X/Z: `a X b X c` is a single n-ary
+        // cross/zip producing flat n-tuples, not left-nested pairs. Collect a
+        // chain of identical (meta, op) MetaOps into one flat operand list and
+        // emit a single n-ary op. Only the plain general op reaches here; the
+        // special short-circuit ops above return early, so they never chain.
+        if meta == "X" || meta == "Z" {
+            let mut operands: Vec<&Expr> = Vec::new();
+            Self::collect_meta_chain(meta, op, left, right, &mut operands);
+            if operands.len() > 2 {
+                for operand in &operands {
+                    self.compile_expr(operand);
+                }
+                let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
+                let op_idx = self.code.add_constant(Value::str(op.to_string()));
+                self.code.emit(OpCode::MetaOpNary {
+                    meta_idx,
+                    op_idx,
+                    count: operands.len() as u32,
+                });
+                return;
+            }
+        }
         self.compile_expr(left);
         self.compile_expr(right);
         let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
         let op_idx = self.code.add_constant(Value::str(op.to_string()));
         self.code.emit(OpCode::MetaOp { meta_idx, op_idx });
+    }
+
+    /// Flatten a left-nested chain of identical (meta, op) MetaOps into a flat
+    /// operand list. `a X b X c` parses as `MetaOp(X, MetaOp(X, a, b), c)`; this
+    /// collects `[a, b, c]`.
+    fn collect_meta_chain<'a>(
+        meta: &str,
+        op: &str,
+        left: &'a Expr,
+        right: &'a Expr,
+        operands: &mut Vec<&'a Expr>,
+    ) {
+        if let Expr::MetaOp {
+            meta: lm,
+            op: lo,
+            left: ll,
+            right: lr,
+        } = left
+            && lm == meta
+            && lo == op
+        {
+            Self::collect_meta_chain(meta, op, ll, lr, operands);
+        } else {
+            operands.push(left);
+        }
+        operands.push(right);
     }
 
     /// Compile InfixFunc (atan2, sprintf, flip-flop, etc.).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -971,6 +971,16 @@ pub(crate) enum OpCode {
         op_idx: u32,
     },
 
+    // -- List-associative n-ary MetaOp (X/Z chained: `a X b X c`) --
+    // Pops `count` operands off the stack and combines them in a single
+    // n-ary cross (X) or zip (Z) so the result is flat n-tuples rather than
+    // left-nested pairs.
+    MetaOpNary {
+        meta_idx: u32,
+        op_idx: u32,
+        count: u32,
+    },
+
     // -- InfixFunc (atan2, sprintf) --
     InfixFunc {
         name_idx: u32,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -4010,6 +4010,15 @@ impl Interpreter {
                 *ip += 1;
             }
 
+            OpCode::MetaOpNary {
+                meta_idx,
+                op_idx,
+                count,
+            } => {
+                self.exec_meta_op_nary(code, *meta_idx, *op_idx, *count)?;
+                *ip += 1;
+            }
+
             // -- InfixFunc --
             OpCode::InfixFunc {
                 name_idx,

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -2185,6 +2185,145 @@ impl Interpreter {
         Ok(())
     }
 
+    /// List-associative n-ary cross (`X`) / zip (`Z`). `a X b X c` combines all
+    /// operands at once so each result is a flat n-tuple (or an n-way reduction
+    /// when an operator is attached), matching Raku's list associativity.
+    pub(super) fn exec_meta_op_nary(
+        &mut self,
+        code: &CompiledCode,
+        meta_idx: u32,
+        op_idx: u32,
+        count: u32,
+    ) -> Result<(), RuntimeError> {
+        let n = count as usize;
+        let mut operands: Vec<Value> = Vec::with_capacity(n);
+        for _ in 0..n {
+            operands.push(self.stack.pop().unwrap_or(Value::Nil));
+        }
+        operands.reverse();
+        let meta = Self::const_str(code, meta_idx).to_string();
+        let op = Self::const_str(code, op_idx).to_string();
+        let make_tuple = op.is_empty() || op == ",";
+
+        let result = match meta.as_str() {
+            "X" => {
+                let value_is_lazy = |v: &Value| match v {
+                    Value::LazyList(_) => true,
+                    Value::Range(_, end)
+                    | Value::RangeExcl(_, end)
+                    | Value::RangeExclStart(_, end)
+                    | Value::RangeExclBoth(_, end) => *end == i64::MAX,
+                    Value::GenericRange { end, .. } => {
+                        let end_f = end.to_f64();
+                        end_f.is_infinite() && end_f.is_sign_positive()
+                    }
+                    _ => false,
+                };
+                let lazy_inputs = operands.iter().any(value_is_lazy);
+                let lazy_limit = 256usize;
+                let lists: Vec<Vec<Value>> = operands
+                    .iter()
+                    .map(|v| {
+                        if value_is_lazy(v) {
+                            let iter = ZipIter::from_value(v);
+                            let len = iter.len().min(lazy_limit);
+                            (0..len).map(|i| iter.nth(i)).collect()
+                        } else {
+                            runtime::value_to_list(v)
+                        }
+                    })
+                    .collect();
+                // Cartesian product: iterate combinations in row-major order,
+                // varying the last operand fastest (matches Raku's X ordering).
+                let mut results: Vec<Value> = Vec::new();
+                let mut indices = vec![0usize; n];
+                let any_empty = lists.iter().any(|l| l.is_empty());
+                if !any_empty {
+                    'outer: loop {
+                        let combo: Vec<Value> =
+                            (0..n).map(|k| lists[k][indices[k]].clone()).collect();
+                        results.push(self.combine_meta_tuple(&op, make_tuple, combo)?);
+                        // Increment the mixed-radix index from the right.
+                        let mut k = n;
+                        loop {
+                            if k == 0 {
+                                break 'outer;
+                            }
+                            k -= 1;
+                            indices[k] += 1;
+                            if indices[k] < lists[k].len() {
+                                break;
+                            }
+                            indices[k] = 0;
+                        }
+                    }
+                }
+                if lazy_inputs {
+                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                        results,
+                    )))
+                } else if results.is_empty() {
+                    Value::Seq(std::sync::Arc::new(Vec::new()))
+                } else {
+                    Value::array(results)
+                }
+            }
+            "Z" => {
+                let iters: Vec<ZipIter> = operands.iter().map(ZipIter::from_value).collect();
+                let all_lazy = iters.iter().all(|it| it.is_lazy());
+                let len = iters
+                    .iter()
+                    .map(|it| it.len())
+                    .min()
+                    .unwrap_or(0)
+                    .min(MAX_ZIP_EXPAND);
+                let mut results: Vec<Value> = Vec::with_capacity(len);
+                for i in 0..len {
+                    let combo: Vec<Value> = iters.iter().map(|it| it.nth(i)).collect();
+                    results.push(self.combine_meta_tuple(&op, make_tuple, combo)?);
+                }
+                if all_lazy {
+                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                        results,
+                    )))
+                } else {
+                    Value::array(results)
+                }
+            }
+            _ => {
+                return Err(RuntimeError::new(format!(
+                    "Unknown n-ary meta operator: {}",
+                    meta
+                )));
+            }
+        };
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// Combine one tuple of operands for an n-ary X/Z: either build a flat
+    /// tuple (no operator) or left-fold the operator across all elements.
+    fn combine_meta_tuple(
+        &mut self,
+        op: &str,
+        make_tuple: bool,
+        combo: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        if make_tuple {
+            return Ok(Value::array(combo));
+        }
+        let mut iter = combo.into_iter();
+        let mut acc = iter.next().unwrap_or(Value::Nil);
+        for elem in iter {
+            acc = if op == "~~" {
+                Value::Bool(self.vm_smart_match(&acc, &elem))
+            } else {
+                self.eval_reduction_operator_values(op, &acc, &elem)?
+            };
+        }
+        Ok(acc)
+    }
+
     pub(super) fn exec_infix_func_op(
         &mut self,
         code: &CompiledCode,

--- a/t/chained-cross-zip.t
+++ b/t/chained-cross-zip.t
@@ -1,0 +1,46 @@
+use Test;
+
+# X and Z are list-associative: `a X b X c` is a single n-ary cross/zip
+# producing flat n-tuples, not left-nested pairs.
+
+plan 22;
+
+# --- Cross (X) chained: flat tuples ---
+is (1 X 2 X 3).raku, '((1, 2, 3),)', 'scalar X chain builds one 3-tuple';
+is (1 X 2 X 3 X 4).raku, '((1, 2, 3, 4),)', 'scalar X chain builds one 4-tuple';
+is ((1,2) X (3,4) X (5,6)).elems, 8, 'X of three 2-lists has 8 combos';
+is ((1,2) X (3,4) X (5,6))[0].raku, '(1, 3, 5)', 'first X combo is a flat triple';
+is ((1,2) X (3,4) X (5,6))[7].raku, '(2, 4, 6)', 'last X combo is a flat triple';
+
+# --- Cross with operator: n-ary reduction ---
+is ((1,2) X+ (10,20) X+ (100,200)).List, (111, 211, 121, 221, 112, 212, 122, 222), 'X+ chain sums across all operands';
+is (<a b> X~ <c d> X~ <e f>).List, <ace acf ade adf bce bcf bde bdf>, 'X~ chain concatenates across all operands';
+is ((1..2) X* (1..2) X* (1..2)).List, (1, 2, 2, 4, 2, 4, 4, 8), 'X* chain multiplies across all operands';
+
+# --- Zip (Z) chained: flat tuples ---
+is (1 Z 2 Z 3).raku, '((1, 2, 3),)', 'scalar Z chain builds one 3-tuple';
+is ((1,2) Z (3,4) Z (5,6)).elems, 2, 'Z of three 2-lists has 2 tuples';
+is ((1,2) Z (3,4) Z (5,6))[0].raku, '(1, 3, 5)', 'first Z tuple is a flat triple';
+is ((1,2) Z (3,4) Z (5,6))[1].raku, '(2, 4, 6)', 'second Z tuple is a flat triple';
+
+# --- Zip with operator: n-ary reduction ---
+is ((1,2) Z+ (10,20) Z+ (100,200)).List, (111, 222), 'Z+ chain sums positionally across all operands';
+is ((1,2,3) Z~ <a b c> Z~ <x y z>).List, <1ax 2by 3cz>, 'Z~ chain concatenates positionally';
+is ((1,2,3) Z* (4,5,6) Z* (7,8,9)).List, (28, 80, 162), 'Z* chain multiplies positionally';
+
+# --- Zip stops at the shortest operand ---
+is ((1,2,3) Z (4,5) Z (6,7,8,9)).elems, 2, 'Z chain stops at the shortest operand';
+
+# --- Ranges as operands ---
+is (1..3 Z 4..6 Z 7..9).List, ((1,4,7), (2,5,8), (3,6,9)), 'Z chain over ranges';
+is ((1..2) X (1..2) X (1..2)).elems, 8, 'X chain over ranges has 8 combos';
+
+# --- 2-operand cases unchanged ---
+is (1 X 2).raku, '((1, 2),)', '2-operand X still builds a pair';
+is (1 Z 2).raku, '((1, 2),)', '2-operand Z still builds a pair';
+
+# --- Empty operand short-circuits the whole cross ---
+is ((1,2) X () X (3,4)).elems, 0, 'X chain with an empty operand is empty';
+
+# --- Z=> still pairs up ---
+is ((1,2,3) Z=> <a b c>).map(*.value).List, <a b c>, 'Z=> pairs each key with its value';


### PR DESCRIPTION
## Problem

`X` and `Z` are **list-associative** in Raku: `a X b X c` is a single n-ary cross / zip, producing flat n-tuples, not left-nested pairs. mutsu evaluated the chain pairwise, giving wrong structure (and wrong values when an operator was attached).

```
# Before (mutsu)              # After (rakudo-correct)
1 X 2 X 3   => (((1 2) 3))    1 X 2 X 3   => ((1 2 3))
(1,2) X+ (10,20) X+ (100,200) => (111 211 121 221 112 212 122 222)
(1,2) Z+ (10,20) Z+ (100,200) => (111 222)
<a b> X~ <c d> X~ <e f>       => (ace acf ade adf bce bcf bde bdf)
```

## Fix

- The compiler flattens a left-nested chain of identical `(meta, op)` MetaOps into a flat operand list and emits a new `MetaOpNary` opcode.
- The VM combines all operands at once: cartesian product for `X`, positional zip for `Z`; each combination becomes a flat tuple (no operator) or a left-fold of the operator across all elements.
- The 2-operand path is untouched, so all special short-circuit forms (`X&&`, `Zandthen`, `Xxx`, `Z=>`, …) keep their existing behavior.

## Tests

- New `t/chained-cross-zip.t` (22 assertions) covering chained X/Z with and without operators, ranges, shortest-operand truncation, empty-operand short-circuit, and the unchanged 2-operand cases.
- Whitelisted roast `S03-metaops/{cross,zip,reduce}.t`, `S32-list/{cross,reduce}.t`, `S32-container/zip.t`, `S03-operators/reduce-le1arg.t` all pass.
- `make test` PASS (8428 tests).

## Out of scope (pre-existing, deferred)

Bare-comma precedence: `1,2 X 3,4` should treat the comma operator as tighter than `X` (`(1,2) X (3,4)`); mutsu currently mis-splits it. This reproduces on the 2-operand path and is unrelated to list associativity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)