### PR TITLE
fix(map): an immutable Map reports type Map and renders as Map.new((...))

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -572,7 +572,10 @@ fn dispatch_capture(
             for (k, v) in named {
                 map.insert(k.clone(), v.clone());
             }
-            Some(Ok(Value::hash(map)))
+            // Capture.hash returns an immutable Map, not a mutable Hash.
+            let mut data = crate::value::HashData::new(map);
+            data.declared_type = Some("Map".to_string());
+            Some(Ok(Value::Hash(std::sync::Arc::new(data))))
         }
         "list" => Some(Ok(Value::array(positional.to_vec()))),
         "elems" => Some(Ok(Value::Int(positional.len() as i64))),

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -132,7 +132,7 @@ fn is_self_array_ref_marker(v: &Value) -> bool {
 /// immediately followed by another word char. A digit-leading key (`"1"`), a
 /// dotted key (`"1.5"`), or a key with a trailing/doubled `-`/`'` (`"x-"`,
 /// `"a--b"`) is NOT an identifier and renders as `"key" => value`.
-fn is_adverbial_pair_key(s: &str) -> bool {
+pub(crate) fn is_adverbial_pair_key(s: &str) -> bool {
     let mut chars = s.chars().peekable();
     match chars.next() {
         Some(c) if c.is_alphabetic() || c == '_' => {}
@@ -511,6 +511,30 @@ pub fn raku_value(v: &Value) -> String {
             format!("{} => {}", key_repr, raku_value(value))
         }
         Value::Hash(map) => {
+            // An immutable Map renders as `Map.new((:k(v), ...))`.
+            if map.declared_type.as_deref() == Some("Map") {
+                let mut sorted_keys: Vec<&String> = map.keys().collect();
+                sorted_keys.sort();
+                let parts: Vec<String> = sorted_keys
+                    .iter()
+                    .map(|k| {
+                        let v = &map[*k];
+                        let repr = if matches!(v, Value::Nil) {
+                            "Any".to_string()
+                        } else {
+                            raku_hash_value(v)
+                        };
+                        let typed = map.typed_key(k);
+                        match &typed {
+                            Value::Str(s) if is_adverbial_pair_key(s) => {
+                                format!(":{}({})", s, repr)
+                            }
+                            _ => format!("{} => {}", raku_value(&typed), repr),
+                        }
+                    })
+                    .collect();
+                return format!("Map.new(({}))", parts.join(","));
+            }
             // Cycle detection for recursive hash structures.
             // When a self-referencing hash is found, produce Raku-style output:
             //   ((my %Hash_<ptr>) = {:a(42), :b(%Hash_<ptr>)})

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -565,6 +565,11 @@ impl Interpreter {
             other => {
                 // Check container type metadata for typed Hash/Array
                 if let Some(info) = self.container_type_metadata(other) {
+                    // A declared type (e.g. an immutable `Map`) names the value
+                    // directly, mirroring `.WHAT`.
+                    if let Some(ref declared) = info.declared_type {
+                        return Ok(Value::str(declared.clone()));
+                    }
                     match other {
                         Value::Hash(_) => {
                             if let Some(ref key_type) = info.key_type {

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -214,6 +214,38 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let mut sorted_keys: Vec<&String> = map.keys().collect();
         sorted_keys.sort();
+        // An immutable Map renders as `Map.new((:k(v), ...))`, not the
+        // `(my % = ...)` typed-hash form.
+        if info.declared_type.as_deref() == Some("Map") {
+            let parts: Vec<String> =
+                sorted_keys
+                    .iter()
+                    .map(|k| {
+                        let v = &map[*k];
+                        let repr = if matches!(v, Value::Nil) {
+                            "Any".to_string()
+                        } else {
+                            self.call_method_with_values(v.clone(), "raku", vec![])
+                                .map(|r| r.to_string_value())
+                                .unwrap_or_else(|_| format!("{:?}", v))
+                        };
+                        let typed = map.typed_key(k);
+                        match &typed {
+                        Value::Str(s)
+                            if crate::builtins::methods_0arg::raku_repr::is_adverbial_pair_key(s) =>
+                        {
+                            format!(":{}({})", s, repr)
+                        }
+                        _ => format!(
+                            "{} => {}",
+                            crate::builtins::methods_0arg::raku_value(&typed),
+                            repr
+                        ),
+                    }
+                    })
+                    .collect();
+            return Ok(Value::str(format!("Map.new(({}))", parts.join(","))));
+        }
         // When key type is non-string (e.g. Int), use `key => value` format
         // instead of colonpair `:key(value)` format.
         let use_arrow = info.key_type.is_some()

--- a/t/map-type-repr.t
+++ b/t/map-type-repr.t
@@ -1,0 +1,40 @@
+use Test;
+
+# An immutable Map (Capture.hash, .Map coercion, Map.new) must report its type
+# as `Map` and render as `Map.new((...))`, not as a mutable `Hash` / typed-hash.
+
+plan 16;
+
+# --- Capture.hash returns a Map ---
+is \(a => 1).hash.^name, 'Map', 'Capture.hash is a Map';
+is \(a => 1, b => 2).hash.^name, 'Map', 'multi-key Capture.hash is a Map';
+is \(a => 1).hash<a>, 1, 'Capture.hash is still indexable';
+is (1, 2, 3).Capture.hash.^name, 'Map', '.Capture.hash is a Map';
+
+# --- .Map coercion ---
+is %(a => 1).Map.^name, 'Map', '%h.Map is a Map';
+is (a => 1, b => 2).Map.^name, 'Map', 'list.Map is a Map';
+
+# --- Map.new ---
+is Map.new('a', 1).^name, 'Map', 'Map.new is a Map';
+
+# --- .WHAT agrees with .^name ---
+is %(a => 1).Map.WHAT.^name, 'Map', '.WHAT.^name agrees';
+
+# --- .raku renders as Map.new((...)) ---
+is %(a => 1).Map.raku, 'Map.new((:a(1)))', 'Map.raku is Map.new form';
+is %(a => 1, b => 2).Map.raku, 'Map.new((:a(1),:b(2)))', 'multi-key Map.raku';
+is \(a => 1).hash.raku, 'Map.new((:a(1)))', 'Capture.hash.raku is Map.new form';
+
+# --- non-identifier keys use arrow form ---
+is Map.new('1', 'x').raku, 'Map.new(("1" => "x"))', 'numeric-key Map.raku uses arrow form';
+
+# --- .raku round-trips through EVAL ---
+is %(a => 1).Map.raku.EVAL.^name, 'Map', 'Map.raku round-trips to a Map';
+is %(a => 1, b => 2).Map.raku.EVAL<b>, 2, 'round-tripped Map is indexable';
+
+# --- gist is unchanged ---
+is %(a => 1).Map.gist, 'Map.new((a => 1))', 'Map.gist form';
+
+# --- a plain Hash still reports Hash (no over-tagging) ---
+is %(a => 1).^name, 'Hash', 'a plain hash is still a Hash';


### PR DESCRIPTION
## Problem

`Capture.hash`, `.Map` coercion, and `Map.new` all produce an **immutable Map**, but mutsu mislabeled them as a mutable `Hash`. `.WHAT` already read the `declared_type` Map marker on the backing `HashData`, but `.^name` and `.raku`/`dd` did not — so the introspection paths disagreed.

```
                       before              after (rakudo-correct)
\(a => 1).hash.^name   Hash                Map
%(a => 1).Map.^name    Hash[]              Map
%(a => 1).Map.raku     (my  % = :a(1))     Map.new((:a(1)))
```

## Fix

- `Capture.hash` tags its result `HashData` with `declared_type = "Map"` (it previously returned a plain `Value::hash`).
- `dispatch_caret_name` (`.^name`) returns `declared_type` directly when present, matching `.WHAT`, instead of synthesizing `Hash[<value_type>]`.
- Both the interpreter (`dispatch_constrained_hash_raku`) and builtins (`raku_value`) `.raku` paths render a Map-declared hash as `Map.new((:k(v), ...))` — arrow form (`"1" => v`) for non-identifier keys. This fixes the `.raku` method and `dd`.

## Tests

- New `t/map-type-repr.t` (16 assertions): `.^name`/`.WHAT`/`.raku`/`.gist` for `Capture.hash`, `.Map`, `Map.new`; `.raku` EVAL round-trip; and a guard that a plain hash still reports `Hash`.
- Whitelisted roast `S05-capture/{named,dot,caps}.t`, `S32-hash/map.t`, `S06-signature/type-capture.t` pass.
- `make test` PASS (8422 tests).

## Out of scope (pre-existing, deferred)

`dd` on a `$`-held container drops the `Type $x = $(...)` prefix (e.g. `dd $h` for a scalar-held Hash). This reproduces for a plain `Hash` too and is unrelated to the Map type tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)