### PR TITLE
fix(set): preserve QuantHash mutability through set operators and eqv

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -288,9 +288,12 @@ Interpreter-removal / first-class-container tracks advance.
 
 **Real lazy infinite sequences:**
 
-- **S03-operators/eqv.t** — 62/64. "Throws/lives in lazy cases" needs X::Cannot::Lazy
-  for same-type lazy iterables (mutsu materializes `1…∞`); "Setty eqv Setty" needs
-  set-operator mutability tracking. (12/17/36/37 also fail in rakudo.)
+- **S03-operators/eqv.t** — 63/64. "Setty eqv Setty" FIXED (eqv now distinguishes
+  Set/SetHash, Bag/BagHash, Mix/MixHash; set operators preserve first-operand
+  mutability — PR set-op-mutability). Remaining: "Throws/lives in lazy cases" needs
+  X::Cannot::Lazy for same-type lazy iterables (blocked: mutsu materializes `1…∞`,
+  `.List`/`.Array` of an infinite Seq lose laziness — same root as lazy-arrays).
+  (12/17/36/37 also fail in rakudo.)
 - **S09-subscript/slice.t** — **Hard**, 9/39 then aborts at line 310: slices with
   infinite sequences (`@a[0..*]`).
 - **S04-declarations/constant.t** — **Medium**. Lazy-seq `fib[100]` (46) now PASSES:

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -93,7 +93,8 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
         }
     }
     match target {
-        Value::Set(_, _) => return Ok(target),
+        // Always return the immutable variant; the caller flips it for `.SetHash`.
+        Value::Set(s, _) => return Ok(Value::Set(s, false)),
         // A List `(...)` invocant flattens its elements in list context; an
         // Array `[...]` (or itemized) invocant takes each element whole.
         Value::Array(items, crate::value::ArrayKind::List) => {
@@ -330,7 +331,8 @@ pub(crate) fn to_bag(target: Value, what: &str) -> Result<Value, RuntimeError> {
     }
 
     match target {
-        Value::Bag(_, _) => return Ok(target),
+        // Always return the immutable variant; the caller flips it for `.BagHash`.
+        Value::Bag(b, _) => return Ok(Value::Bag(b, false)),
         Value::Pair(_, _) | Value::ValuePair(_, _) => {
             add_item(
                 &mut counts,
@@ -642,7 +644,8 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
     let mut weights: HashMap<String, f64> = HashMap::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
     match target {
-        Value::Mix(_, _) => return Ok(target),
+        // Always return the immutable variant; the caller flips it for `.MixHash`.
+        Value::Mix(m, _) => return Ok(Value::Mix(m, false)),
         // A List `(...)` invocant flattens its elements in list context; an
         // Array `[...]` (or itemized) invocant takes each element whole.
         Value::Array(items, crate::value::ArrayKind::List) => {

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -957,12 +957,27 @@ impl Interpreter {
                 {
                     arg0 = Value::Array(items.clone(), crate::value::ArrayKind::List);
                 }
-                if matches!(arg0, Value::Mix(_, _)) {
-                    return self.dispatch_to_mix(arg0);
-                }
-                return self.dispatch_to_bag_with_what(arg0, "Bag");
+                // Single-arg multiply preserves the operand's mutability
+                // (`[(.)] SetHash` -> BagHash); single-arg addition does not
+                // (`[(+)] SetHash` -> Bag).
+                let mutable = matches!(op, "(.)" | "⊍") && set_result_mutability(&arg0);
+                let coerced = if matches!(arg0, Value::Mix(_, _)) {
+                    self.dispatch_to_mix(arg0)?
+                } else {
+                    self.dispatch_to_bag_with_what(arg0, "Bag")?
+                };
+                return Ok(with_set_mutability(coerced, mutable));
             }
-            if matches!(op, "(-)" | "∖" | "(|)" | "∪" | "(&)" | "∩" | "(^)" | "⊖") {
+            if matches!(op, "(-)" | "∖") {
+                // Single-arg difference always yields the immutable variant
+                // (`[(-)] SetHash` -> Set), unlike union/intersection which
+                // preserve the operand's mutability.
+                return Ok(with_set_mutability(
+                    coerce_value_to_quanthash(&args[0]),
+                    false,
+                ));
+            }
+            if matches!(op, "(|)" | "∪" | "(&)" | "∩" | "(^)" | "⊖") {
                 return Ok(coerce_value_to_quanthash(&args[0]));
             }
             return Ok(args[0].clone());
@@ -1120,6 +1135,9 @@ impl Interpreter {
                 }
             }
         }
+        // A 3+-arg set reduction takes its result mutability from the first
+        // operand (captured before promotion below may strip it).
+        let multi_set_mutable = is_set_op && args.len() > 2 && set_result_mutability(&args[0]);
         // For set operators with 3+ args, promote all to the highest set type first.
         // In Raku, infix:<(-)>(Set, Set, Mix) promotes all to Mix before reducing.
         let args = if is_set_op && args.len() > 2 {
@@ -1159,7 +1177,10 @@ impl Interpreter {
         // Multi-arg symmetric difference is NOT a left-fold.
         // For each key, the result weight = max_weight - second_max_weight.
         if matches!(op, "(^)" | "⊖") && args.len() > 2 {
-            return Ok(crate::runtime::utils::set_sym_diff_multi(&args));
+            return Ok(with_set_mutability(
+                crate::runtime::utils::set_sym_diff_multi(&args),
+                multi_set_mutable,
+            ));
         }
         let mut acc = args[0].clone();
         for rhs in &args[1..] {

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -52,10 +52,17 @@ impl Interpreter {
                 } else {
                     "categorize"
                 };
+                // A mutable QuantHash invocant (BagHash/MixHash/SetHash) yields a
+                // result of the same mutable type; builtin_classify builds an
+                // immutable Bag/Mix, so re-overlay the invocant's mutability.
+                let result_mutable = set_result_mutability(&target);
                 let mut call_args = Vec::with_capacity(args.len() + 1);
                 call_args.extend(args.iter().cloned());
                 call_args.push(Value::Pair("into".to_string(), Box::new(target)));
-                Some(self.builtin_classify(classify_name, &call_args))
+                Some(
+                    self.builtin_classify(classify_name, &call_args)
+                        .map(|r| with_set_mutability(r, result_mutable)),
+                )
             }
             "from-loop" | "from_loop" if matches!(&target, Value::Package(name) if name == "Seq") => {
                 Some(self.dispatch_seq_from_loop(args))

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1518,12 +1518,27 @@ impl Interpreter {
                 }
                 Ok(Value::array(items))
             }
-            "(|)" | "∪" => Self::apply_set_union(left, right),
-            "(+)" | "⊎" => Self::apply_set_addition(left, right),
-            "(.)" | "⊍" => Self::apply_set_multiply(left, right),
-            "(-)" | "∖" => Ok(set_diff_values(left, right)),
-            "(&)" | "∩" => Ok(set_intersect_values(left, right)),
-            "(^)" | "⊖" => Ok(set_sym_diff_values(left, right)),
+            // Set operators take their result mutability from the first operand.
+            "(|)" | "∪" => Self::apply_set_union(left, right)
+                .map(|r| with_set_mutability(r, set_result_mutability(left))),
+            "(+)" | "⊎" => Self::apply_set_addition(left, right)
+                .map(|r| with_set_mutability(r, set_result_mutability(left))),
+            "(.)" | "⊍" => Self::apply_set_multiply(left, right)
+                .map(|r| with_set_mutability(r, set_result_mutability(left))),
+            "(-)" | "∖" => Ok(with_set_mutability(
+                set_diff_values(left, right),
+                set_result_mutability(left),
+            )),
+            "(&)" | "∩" => Ok(with_set_mutability(
+                set_intersect_values(left, right),
+                set_result_mutability(left),
+            )),
+            // Symmetric difference demotes to an immutable Set when the right
+            // operand is not a QuantHash, but only at the Set level.
+            "(^)" | "⊖" => Ok(with_set_mutability(
+                set_sym_diff_values(left, right),
+                set_sym_diff_mutability(left, right),
+            )),
             "(==)" | "≡" => Ok(Value::Bool(Self::apply_set_equality(left, right)?)),
             "≢" => Ok(Value::Bool(!Self::apply_set_equality(left, right)?)),
             _ if op.ends_with('=') && op.len() > 1 => {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -2756,6 +2756,46 @@ fn to_bag_map(v: &Value) -> HashMap<String, i64> {
     }
 }
 
+/// Whether a set operator's left operand makes the result a mutable QuantHash.
+/// Raku's set operators (`(|)`/`(&)`/`(-)`/`(^)`/`(.)`/`(+)`) take their
+/// result's mutability from the FIRST operand only: an immutable operand
+/// (Set/Bag/Mix, a list, or a type object used as an element) yields an
+/// immutable result even when a later operand is a SetHash/BagHash/MixHash.
+pub(crate) fn set_result_mutability(v: &Value) -> bool {
+    matches!(
+        v,
+        Value::Set(_, true) | Value::Bag(_, true) | Value::Mix(_, true)
+    )
+}
+
+/// Whether a value is an actual QuantHash instance (Set/Bag/Mix, mutable or
+/// not) as opposed to a list, hash, or bare type object. Used by symmetric
+/// difference, whose result stays mutable only when BOTH operands are
+/// QuantHashes (`SetHash (^) Set` -> SetHash, but `SetHash (^) <a b>` -> Set).
+pub(crate) fn is_quanthash_instance(v: &Value) -> bool {
+    matches!(v, Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _))
+}
+
+/// Result mutability for symmetric difference (`(^)`). Like the other set
+/// operators it follows the first operand, but at the Set level it additionally
+/// demotes to an immutable Set when the right operand is not a QuantHash
+/// (`SetHash (^) <a b>` -> Set). The demotion does NOT apply once the result is
+/// promoted to Bag/Mix level (`BagHash (^) <a b>` -> BagHash).
+pub(crate) fn set_sym_diff_mutability(left: &Value, right: &Value) -> bool {
+    set_result_mutability(left)
+        && (is_quanthash_instance(right) || matches!(left, Value::Bag(_, _) | Value::Mix(_, _)))
+}
+
+/// Overlay the given mutability onto a freshly-built set-operator result.
+pub(crate) fn with_set_mutability(result: Value, mutable: bool) -> Value {
+    match result {
+        Value::Set(d, _) => Value::Set(d, mutable),
+        Value::Bag(d, _) => Value::Bag(d, mutable),
+        Value::Mix(d, _) => Value::Mix(d, mutable),
+        other => other,
+    }
+}
+
 /// Standalone set difference: left (-) right
 /// Implements Raku type promotion: Mix > Bag > Set
 ///

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -134,31 +134,34 @@ impl Value {
             // full type-strict eqv, because mutsu does not always retain a Set
             // element's exact numeric type (a Rat element can fall back to its
             // Str key), and a full eqv would wrongly split two equal Rat sets.
-            // NOTE: mutability (Set vs SetHash) is intentionally NOT compared
-            // here — mutsu's set operators do not yet reliably preserve SetHash
-            // mutability through `(|)`/`(&)` etc., and comparing it would
-            // spuriously split results that only differ in that flag. The
-            // remaining Set-vs-SetHash eqv distinction (eqv.t test 165) is
-            // tracked in BLOCKERS.md.
-            (Value::Set(a, _), Value::Set(b, _)) => {
+            // Mutability (Set vs SetHash) is part of the type, so eqv must
+            // distinguish them (`Set.new(42) eqv SetHash.new(42)` is False).
+            // Raku's set operators (`(|)`/`(&)` etc.) always yield an immutable
+            // Set regardless of operand mutability, so comparing the flag here
+            // matches values produced by those operators too.
+            (Value::Set(a, a_mut), Value::Set(b, b_mut)) => {
                 fn allomorph_kind(v: &Value) -> Option<String> {
                     match v {
                         Value::Mixin(inner, mixins) => allomorph_type_name(inner, mixins),
                         _ => None,
                     }
                 }
-                a.elements.len() == b.elements.len()
+                a_mut == b_mut
+                    && a.elements.len() == b.elements.len()
                     && a.elements.iter().all(|k| {
                         b.elements.contains(k)
                             && allomorph_kind(&a.typed_key(k)) == allomorph_kind(&b.typed_key(k))
                     })
             }
+            // Bag/Mix: like Set, eqv distinguishes the immutable variant from
+            // its mutable QuantHash (Bag vs BagHash, Mix vs MixHash). The data
+            // comparison is delegated to PartialEq, which ignores the flag.
+            (Value::Bag(a, a_mut), Value::Bag(b, b_mut)) => a_mut == b_mut && a == b,
+            (Value::Mix(a, a_mut), Value::Mix(b, b_mut)) => a_mut == b_mut && a == b,
             (Value::Int(_), Value::Int(_))
             | (Value::Str(_), Value::Str(_))
             | (Value::Bool(_), Value::Bool(_))
             | (Value::BigRat(_, _), Value::BigRat(_, _))
-            | (Value::Bag(_, _), Value::Bag(_, _))
-            | (Value::Mix(_, _), Value::Mix(_, _))
             | (Value::Enum { .. }, Value::Enum { .. })
             | (Value::Regex(_), Value::Regex(_))
             | (Value::RegexWithAdverbs { .. }, Value::RegexWithAdverbs { .. })

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -391,6 +391,7 @@ impl Interpreter {
         if Self::is_failure_value(&left) || Self::is_failure_value(&right) {
             return Err(RuntimeError::new("Exception"));
         }
+        let result_mutable = runtime::set_result_mutability(&left);
 
         let result = match (left, right) {
             (Value::Mix(a, _), Value::Mix(b, _)) => {
@@ -452,7 +453,8 @@ impl Interpreter {
                 Value::set(left_set)
             }
         };
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
         Ok(())
     }
 
@@ -489,6 +491,7 @@ impl Interpreter {
         let left_level = Self::set_type_level_full(&left);
         let right_level = Self::set_type_level_full(&right);
         let result_level = left_level.max(right_level).max(1); // minimum Bag
+        let result_mutable = runtime::set_result_mutability(&left);
 
         let result = match result_level {
             2 => {
@@ -512,7 +515,8 @@ impl Interpreter {
                 Value::bag(a)
             }
         };
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
         Ok(())
     }
 
@@ -694,6 +698,7 @@ impl Interpreter {
         let left_level = Self::set_type_level(&left);
         let right_level = Self::set_type_level(&right);
         let result_level = left_level.max(right_level);
+        let result_mutable = runtime::set_result_mutability(&left);
 
         let result = match result_level {
             2 => {
@@ -727,7 +732,8 @@ impl Interpreter {
                 Value::set(a.intersection(&b).cloned().collect())
             }
         };
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
         Ok(())
     }
 
@@ -750,23 +756,29 @@ impl Interpreter {
             return Err(err);
         }
 
+        let result_mutable = runtime::set_result_mutability(&left);
         let result = runtime::Interpreter::apply_reduction_op("(.)", &left, &right)?;
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
         Ok(())
     }
 
     pub(super) fn exec_set_diff_op(&mut self) {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let result_mutable = runtime::set_result_mutability(&left);
         let result = runtime::set_diff_values(&left, &right);
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
     }
 
     pub(super) fn exec_set_sym_diff_op(&mut self) {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let result_mutable = runtime::set_sym_diff_mutability(&left, &right);
         let result = runtime::set_sym_diff_values(&left, &right);
-        self.stack.push(result);
+        self.stack
+            .push(runtime::with_set_mutability(result, result_mutable));
     }
 
     pub(super) fn exec_set_subset_op(&mut self) {

--- a/t/set-op-mutability.t
+++ b/t/set-op-mutability.t
@@ -1,0 +1,50 @@
+use Test;
+
+# Set operators take their result mutability from the FIRST operand, and
+# `eqv` distinguishes Set from SetHash (and Bag from BagHash, Mix from MixHash).
+
+plan 25;
+
+# eqv distinguishes mutability
+nok Set.new(42) eqv SetHash.new(42), 'Set does not eqv SetHash';
+ok  Set.new(42) eqv Set.new(42), 'Set eqv Set';
+ok  SetHash.new(42) eqv SetHash.new(42), 'SetHash eqv SetHash';
+nok Bag.new(<a a>) eqv BagHash.new(<a a>), 'Bag does not eqv BagHash';
+nok Mix.new(<a a>) eqv MixHash.new(<a a>), 'Mix does not eqv MixHash';
+
+# union/intersection/difference: result follows the left operand
+is (SetHash.new(<a b>) (|) Set.new(<c>)).^name, 'SetHash', '(|) SetHash left -> SetHash';
+is (Set.new(<a b>) (|) SetHash.new(<c>)).^name, 'Set', '(|) Set left -> Set';
+is (SetHash.new(<a b>) (&) SetHash.new(<a>)).^name, 'SetHash', '(&) SetHash -> SetHash';
+is (Set.new(<a b>) (&) SetHash.new(<a>)).^name, 'Set', '(&) Set left -> Set';
+is (SetHash.new(<a b>) (-) Set.new(<a>)).^name, 'SetHash', '(-) SetHash left -> SetHash';
+is (Set.new(<a b>) (-) SetHash.new(<a>)).^name, 'Set', '(-) Set left -> Set';
+
+# addition/multiply promote to Bag level, keeping left mutability
+is (SetHash.new(<a b>) (+) Set.new(<a>)).^name, 'BagHash', '(+) SetHash left -> BagHash';
+is (Set.new(<a b>) (+) SetHash.new(<a>)).^name, 'Bag', '(+) Set left -> Bag';
+is (BagHash.new(<a b>) (.) Bag.new(<a>)).^name, 'BagHash', '(.) BagHash left -> BagHash';
+is (Bag.new(<a b>) (.) BagHash.new(<a>)).^name, 'Bag', '(.) Bag left -> Bag';
+
+# symmetric difference: binary form stays mutable only when BOTH are QuantHashes
+is (SetHash.new(<a b>) (^) Set.new(<b c>)).^name, 'SetHash', '(^) SetHash (^) Set -> SetHash';
+is (SetHash.new(<a b>) (^) <b c>).^name, 'Set', '(^) SetHash (^) List -> Set';
+is (Set.new(<a b>) (^) SetHash.new(<b c>)).^name, 'Set', '(^) Set left -> Set';
+
+# 3+-arg symmetric difference follows the first operand
+is (&infix:<(^)>(SetHash.new(<a>), SetHash.new(<b>), <c>)).^name, 'SetHash',
+    '3-arg (^) SetHash first -> SetHash';
+is (&infix:<(^)>(Set.new(<a>), SetHash.new(<b>), SetHash.new(<c>))).^name, 'Set',
+    '3-arg (^) Set first -> Set';
+
+# single-arg reductions
+is (&infix:<(|)>(SetHash.new(<a b>))).^name, 'SetHash', 'single (|) preserves SetHash';
+is (&infix:<(-)>(SetHash.new(<a b>))).^name, 'Set', 'single (-) demotes to Set';
+
+# eqv on the results of operators
+ok (SetHash.new(<a b>) (|) SetHash.new(<c>)) eqv SetHash.new(<a b c>),
+    'SetHash union eqv SetHash';
+nok (Set.new(<a b>) (|) Set.new(<c>)) eqv SetHash.new(<a b c>),
+    'Set union does not eqv SetHash';
+ok (Set.new(<a b>) (|) SetHash.new(<c>)) eqv Set.new(<a b c>),
+    'mixed union (Set left) eqv Set';

--- a/t/set-op-mutability.t
+++ b/t/set-op-mutability.t
@@ -3,7 +3,7 @@ use Test;
 # Set operators take their result mutability from the FIRST operand, and
 # `eqv` distinguishes Set from SetHash (and Bag from BagHash, Mix from MixHash).
 
-plan 25;
+plan 28;
 
 # eqv distinguishes mutability
 nok Set.new(42) eqv SetHash.new(42), 'Set does not eqv SetHash';
@@ -48,3 +48,12 @@ nok (Set.new(<a b>) (|) Set.new(<c>)) eqv SetHash.new(<a b c>),
     'Set union does not eqv SetHash';
 ok (Set.new(<a b>) (|) SetHash.new(<c>)) eqv Set.new(<a b c>),
     'mixed union (Set left) eqv Set';
+
+# classify-list / categorize-list keep the invocant's mutable QuantHash type
+my &m = { "cat" ~ ($_ %% 2 ?? 2 !! 1) };
+is BagHash.new.classify-list(&m, [1, 2, 3]).^name, 'BagHash',
+    'classify-list on BagHash -> BagHash';
+is MixHash.new.classify-list(&m, [1, 2, 3]).^name, 'MixHash',
+    'classify-list on MixHash -> MixHash';
+is %().classify-list(&m, [1, 2, 3]).^name, 'Hash',
+    'classify-list on Hash -> Hash';


### PR DESCRIPTION
## Summary

Raku's set operators take their result mutability from the **first operand** (`SetHash (|) Set` → SetHash, `Set (|) SetHash` → Set), and `eqv` distinguishes a `Set` from a `SetHash` (likewise `Bag`/`BagHash`, `Mix`/`MixHash`). mutsu previously produced an immutable result for every operator and an `eqv` that ignored the mutable flag, so e.g. `Set.new(42) eqv SetHash.new(42)` wrongly returned `True`.

## Changes

- **`eqv`** now compares the mutable flag for Set/Bag/Mix.
- **Union/intersection/difference/addition/multiply** overlay the left operand's mutability onto their result, in both the VM opcode and the `&infix:<…>(…)` function-call paths.
- **Symmetric difference `(^)`** follows the first operand but additionally demotes to an immutable Set when the right operand is not a QuantHash — only at the Set level (`SetHash (^) <a b>` → Set, but `BagHash (^) <a b>` → BagHash). 3+-arg `(^)` follows the first operand.
- **Single-arg reductions**: `[(-)]` demotes to immutable, `[(.)]` preserves mutability, matching rakudo.
- **`.Set`/`.Bag`/`.Mix` coercion** of an already-QuantHash value now returns the immutable variant (the caller flips it for `.SetHash` etc.).

Shared helpers (`set_result_mutability`, `with_set_mutability`, `is_quanthash_instance`, `set_sym_diff_mutability`) live in `runtime::utils` so the VM and the function-call dispatch use one implementation (no duplicated logic).

## Tests

- Fixes `roast/S03-operators/eqv.t` "Setty eqv Setty" (test 55); eqv.t now 63/64 (remaining is the lazy `X::Cannot::Lazy` case, blocked on lazy-list materialization).
- All `set_*` operator roast tests (`set_union`, `set_intersection`, `set_difference`, `set_symmetric_difference`, `set_addition`, `set_multiply`, `set_equality`) still pass.
- `baghash.t` / `mixhash.t` / `baggy.t` still pass.
- New `t/set-op-mutability.t` (25 subtests).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)