### PR TITLE
fix(io): flatten Slip args in say/put/print/note; put concatenates multiple args

### DIFF
--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -318,10 +318,27 @@ impl Interpreter {
         self.stack.push(Value::capture(positional, named));
     }
 
+    /// Flatten top-level `Slip` arguments into the surrounding argument list.
+    /// A `|(...)` slip passed to a list operator (say/put/print/note) spreads its
+    /// elements as individual arguments, exactly like the parenthesized-call path.
+    fn flatten_slip_args(values: Vec<Value>) -> Vec<Value> {
+        if !values.iter().any(|v| matches!(v, Value::Slip(_))) {
+            return values;
+        }
+        let mut out = Vec::with_capacity(values.len());
+        for v in values {
+            match v {
+                Value::Slip(items) => out.extend(items.iter().cloned()),
+                other => out.push(other),
+            }
+        }
+        out
+    }
+
     pub(super) fn exec_say_op(&mut self, n: u32) -> Result<(), RuntimeError> {
         let n = n as usize;
         let start = self.stack.len() - n;
-        let values: Vec<Value> = self.stack.drain(start..).collect();
+        let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
         let mut parts = Vec::new();
         for v in &values {
             let v = loan_env!(self, auto_fetch_proxy(v))?;
@@ -345,7 +362,7 @@ impl Interpreter {
             "Noted".to_string()
         } else {
             let start = self.stack.len() - n;
-            let values: Vec<Value> = self.stack.drain(start..).collect();
+            let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
             let mut parts = Vec::new();
             for v in &values {
                 if needs_method_dispatch(v) {
@@ -363,24 +380,39 @@ impl Interpreter {
     pub(super) fn exec_put_op(&mut self, n: u32) -> Result<(), RuntimeError> {
         let n = n as usize;
         let start = self.stack.len() - n;
-        let values: Vec<Value> = self.stack.drain(start..).collect();
-        // put threads through Junctions: each eigenstate gets put individually
-        let mut lines = Vec::new();
+        let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+        // A lone Junction argument autothreads: each eigenstate is put on its
+        // own line (`put 1|2` => "1\n2\n").
+        if values.len() == 1 && matches!(&values[0], Value::Junction { .. }) {
+            let v = loan_env!(self, auto_fetch_proxy(&values[0]))?;
+            check_rat_divide_by_zero(&v)?;
+            let mut lines = Vec::new();
+            self.collect_put_lines(&v, &mut lines)?;
+            for line in &lines {
+                loan_env!(self, write_to_named_handle("$*OUT", line, true))?;
+            }
+            return Ok(());
+        }
+        // Otherwise concatenate every argument's `.Str` into a single line plus a
+        // trailing newline (`put 1, 2, 3` => "123\n"), like `print` with a newline.
+        let mut content = String::new();
         for v in &values {
             let v = loan_env!(self, auto_fetch_proxy(v))?;
             check_rat_divide_by_zero(&v)?;
-            self.collect_put_lines(&v, &mut lines)?;
+            if needs_method_dispatch(&v) {
+                content.push_str(&loan_env!(self, render_str_value(&v)));
+            } else {
+                content.push_str(&v.to_str_context());
+            }
         }
-        for line in &lines {
-            loan_env!(self, write_to_named_handle("$*OUT", line, true))?;
-        }
+        loan_env!(self, write_to_named_handle("$*OUT", &content, true))?;
         Ok(())
     }
 
     pub(super) fn exec_print_op(&mut self, n: u32) -> Result<(), RuntimeError> {
         let n = n as usize;
         let start = self.stack.len() - n;
-        let values: Vec<Value> = self.stack.drain(start..).collect();
+        let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
         let mut content = String::new();
         for v in &values {
             check_rat_divide_by_zero(v)?;

--- a/t/slip-listop-args.t
+++ b/t/slip-listop-args.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A `|(...)` Slip passed to a list operator (say/put/print/note) spreads its
+# elements as individual arguments, like the parenthesized-call form.
+# `put` with multiple arguments concatenates their .Str and adds one newline.
+
+plan 17;
+
+# --- Slip flattening into say/print/put ---
+is run-say('say |(1,2,3)'), "123\n", 'say flattens a leading Slip arg';
+is run-say('say 1, |(2,3), 4'), "1234\n", 'say flattens a mid-list Slip arg';
+is run-say('say |(1,2,3), |(4,5)'), "12345\n", 'say flattens multiple Slip args';
+is run-say('my @a = <a b c>; say |@a'), "abc\n", 'say flattens a Slip from an array';
+is run-say('print |(1,2,3)'), "123", 'print flattens a Slip arg';
+
+# --- A parenthesized list is NOT a Slip: stays one list argument ---
+is run-say('say (1,2,3)'), "(1 2 3)\n", 'a bare list arg is a single gisted value';
+
+# --- put: multiple args concatenate into one line ---
+is run-say('put 1,2,3'), "123\n", 'put concatenates multiple args on one line';
+is run-say('put "a","b"'), "ab\n", 'put concatenates string args';
+is run-say('put |(1,2,3)'), "123\n", 'put flattens a Slip then concatenates';
+is run-say('my @a=1,2,3; put |@a'), "123\n", 'put flattens an array Slip';
+is run-say('put 42'), "42\n", 'put of a single value';
+is run-say('my @a=1,2,3; put @a'), "1 2 3\n", 'put of an array stringifies with spaces';
+
+# --- put threads a lone Junction onto separate lines ---
+is run-say('put 1|2'), "1\n2\n", 'put autothreads a lone Junction arg';
+
+# --- say does NOT thread a Junction; it gists it ---
+is run-say('say 1|2'), "any(1, 2)\n", 'say gists a Junction without threading';
+
+# --- note flattens Slips to STDERR ---
+is run-note('note |(1,2,3)'), "123\n", 'note flattens a Slip arg';
+
+# --- empty Slip contributes nothing ---
+is run-say('say 1, |(), 2'), "12\n", 'an empty Slip arg contributes nothing';
+is run-say('put |()'), "\n", 'put of only an empty Slip is just a newline';
+
+sub run-say($code) {
+    my $proc = run($*EXECUTABLE, '-e', $code, :out);
+    $proc.out.slurp(:close);
+}
+sub run-note($code) {
+    my $proc = run($*EXECUTABLE, '-e', $code, :err);
+    $proc.err.slurp(:close);
+}


### PR DESCRIPTION
## Problems

Two related bugs in the no-paren list-operator statement forms:

**1. `|(...)` Slips were not flattened into the argument list.**

```
            before (mutsu)   after (rakudo-correct)
say |(1,2,3)   (1 2 3)          123
print |(1,2,3) 1 2 3            123
put |@a        1\n2\n3          123
```

The parenthesized-call form `say(|(1,2,3))` already flattened the Slip; the statement forms (`Stmt::Say/Print/Put/Note`) did not — they compiled their exprs directly and rendered the Slip as a single list-gist.

**2. `put` with multiple arguments emitted one line per argument.**

```
            before (mutsu)   after (rakudo-correct)
put 1,2,3      1\n2\n3\n        123\n
put "a","b"    a\nb\n           ab\n
```

Raku's `put` concatenates the `.Str` of all arguments onto a single line plus one trailing newline (like `print` + newline). This was exposed once Slips flattened, but reproduces independently (`put 1,2,3`).

## Fix

- New `flatten_slip_args` helper expands top-level `Value::Slip` arguments into individual arguments; applied in `exec_say/note/put/print_op`.
- `exec_put_op` now concatenates all args into one line + newline. A **lone** `Junction` argument still autothreads onto separate lines (`put 1|2` => "1\n2\n"); `say` continues to gist a Junction without threading (`say 1|2` => "any(1, 2)").

## Tests

- New `t/slip-listop-args.t` (17 assertions): Slip flattening in say/print/put/note, multi-arg `put` concatenation, lone-Junction threading, `say` Junction gisting, and empty-Slip edge cases.
- Whitelisted roast `S07-slip/slip.t`, `S02-types/list.t`, `S02-types/lists.t`, `S06-currying/slurpy.t`, `S16-io/say.t` pass.
- `make test` PASS (8423 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)