### PR TITLE
fix(regex): a `** N..M` range quantifier on a non-capturing atom adds no capture

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1770,7 +1770,11 @@ impl Interpreter {
                     let core = if alts.len() == 1 {
                         alts.into_iter().next().unwrap_or_default()
                     } else {
-                        format!("({})", alts.join("|"))
+                        // Non-capturing `[...]`: a plain `**N..M` on a
+                        // non-capturing atom must not introduce a positional
+                        // capture (`(...)` would). Capture-bearing atoms never
+                        // reach this string-expansion path.
+                        format!("[{}]", alts.join("|"))
                     };
                     if min == 0 { format!("[{core}]?") } else { core }
                 }

--- a/t/regex-range-quant-no-capture.t
+++ b/t/regex-range-quant-no-capture.t
@@ -1,0 +1,31 @@
+use Test;
+
+# A range quantifier `** N..M` on a non-capturing atom must NOT introduce a
+# spurious positional capture. Previously mutsu's LTM string-expansion wrapped
+# the length alternatives in a capturing group `(aaa|aa)`, leaking `$/[0]`.
+
+plan 14;
+
+# --- No capture from a plain range-quantified atom ---
+ok "aaa" ~~ /a ** 2..3/, 'a ** 2..3 matches';
+is $/.Str, 'aaa', 'matches greedily up to the max';
+is $/.elems, 0, 'no positional captures leak';
+is $/.list.elems, 0, '.list is empty';
+
+ok "aaaa" ~~ /a ** 2..3/, 'matches at most max repetitions';
+is $/.Str, 'aaa', 'stops at the max of the range';
+
+ok "a" ~~ /a ** 0..3/, '0..3 matches a single rep';
+is $/.elems, 0, '0..M form also has no captures';
+
+# --- A bracketed (non-capturing) atom likewise captures nothing ---
+ok "abcabc" ~~ /[abc] ** 1..2/, 'non-capturing bracket repeats';
+is $/.elems, 0, 'bracket-group range quantifier has no captures';
+
+# --- An explicit capture group still captures every repetition ---
+ok "aaaa" ~~ /(a) ** 2..3/, 'capturing group repeats';
+is $/[0].elems, 3, 'a captured atom keeps all its matches';
+
+# --- Fixed count (** N) was already correct; keep it that way ---
+ok "aaa" ~~ /a ** 2/, 'fixed count matches';
+is $/.elems, 0, 'fixed count has no captures';


### PR DESCRIPTION
## Problem

A range quantifier `** N..M` applied to a **non-capturing** atom leaked a spurious positional capture:

```
"aaa" ~~ /a ** 2..3/;
$/.elems   # mutsu: 1   rakudo: 0
$/[0]      # mutsu: ｢aaa｣   rakudo: Nil
```

`a+` and the fixed-count `a ** 2` form were already correct — only the `** N..M` *range* form was affected.

## Root cause

mutsu's LTM (longest-token-match) string-expansion of `**N..M` builds the length alternatives (`aaa`, `aa`, greedy-first) and wrapped them in a **capturing** group `(aaa|aa)`, which created `$/[0]`. Switched to a non-capturing group `[aaa|aa]`.

Capture-bearing atoms never reach this string-expansion path (an earlier guard defers them to the normal per-token parser), so:
- explicit `(a) ** 2..3` still captures every repetition (`$/[0].elems == 3`),
- the `% sep` / `%% sep` separator forms are unaffected.

## Tests

- New `t/regex-range-quant-no-capture.t` (14 assertions): no capture from plain/bracketed range quantifiers, greedy upper bound, `0..M` form, explicit capture group still captures, fixed-count unchanged.
- Whitelisted roast `S05-metasyntax/repeat.t`, `S05-match/{non-capturing,basics}.t`, `S05-capture/caps.t`, `S05-mass/stdrules.t` pass.
- `make test` PASS (8458 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)