### PR TITLE
fix(range): Range * Real returns a canonical integer Range

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -200,7 +200,14 @@
 - [ ] roast/S03-operators/range-int.t
   - 0/? pass. Crashes mid-run.
 - [ ] roast/S03-operators/range.t
-  - 6/181 pass.
+  - 164/181 pass (17 fail). Two distinct blockers:
+    1. **`X::Worry::Precedence::Range`** (16 subtests, lines 268-276): compile-time worry
+       when a Range endpoint is prefixed by a looser-precedence op (`|4..5`/`~4..5`); with
+       `use fatal` it throws. Must NOT warn when parenthesized (`|(4..5)`). Parser feature.
+    2. **`do $_ for <Num/BigInt range>` rvalue collection** (offset subtest g/h, lines 323-328):
+       `my @a = do $_ for (2..4) + 5e-1` yields `[Bool::True]` instead of `[2.5,3.5,4.5]` —
+       the do-statement-modifier rvalue loses the per-iteration values for Num/BigInt ranges.
+       (`(2..4)*2`/`(^4)*2`/`(^4)/2` cases FIXED by canonical-int-range PR #3205.)
 - [ ] roast/S03-operators/reduce-le1arg.t
   - 10/54 pass.
 - [ ] roast/S03-operators/relational.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -372,12 +372,31 @@ fn range_scale(range_val: &Value, factor: &Value) -> Option<Value> {
     };
     let new_start = scale_val(start);
     let new_end = scale_val(end);
-    Some(Value::GenericRange {
-        start: Arc::new(new_start),
-        end: Arc::new(new_end),
+    Some(canonical_int_range(
+        new_start, new_end, excl_start, excl_end,
+    ))
+}
+
+/// Build a Range value, collapsing to the canonical integer-range variant
+/// (`Range`/`RangeExcl`/`RangeExclStart`/`RangeExclBoth`) when both endpoints
+/// are `Int`, so the result is `eqv` to a literal range (e.g. `(2..^5) * 5`
+/// must equal `10..^25`). Falls back to `GenericRange` for non-Int endpoints.
+fn canonical_int_range(start: Value, end: Value, excl_start: bool, excl_end: bool) -> Value {
+    if let (Value::Int(a), Value::Int(b)) = (&start, &end) {
+        let (a, b) = (*a, *b);
+        return match (excl_start, excl_end) {
+            (false, false) => Value::Range(a, b),
+            (false, true) => Value::RangeExcl(a, b),
+            (true, false) => Value::RangeExclStart(a, b),
+            (true, true) => Value::RangeExclBoth(a, b),
+        };
+    }
+    Value::GenericRange {
+        start: Arc::new(start),
+        end: Arc::new(end),
         excl_start,
         excl_end,
-    })
+    }
 }
 
 /// Divide a Range by a numeric factor. Returns Some(range) if the left is a Range.

--- a/t/range-mul-canonical.t
+++ b/t/range-mul-canonical.t
@@ -1,0 +1,19 @@
+use Test;
+
+# `Range * Real` must produce a canonical integer Range so it is `eqv` to a
+# literal range, matching `+`/`-` (regression: scaling returned a GenericRange
+# that rendered identically but failed eqv/is-deeply).
+
+plan 7;
+
+is-deeply (2..5)   * 2, 4..10,    'inclusive Range * Int';
+is-deeply (2..^5)  * 5, 10..^25,  'exclusive-end Range * Int';
+is-deeply (2^..5)  * 2, 4^..10,   'exclusive-start Range * Int';
+is-deeply (2^..^5) * 2, 4^..^10,  'exclusive-both Range * Int';
+is-deeply 5 * (2..^5),  10..^25,  'Int * Range';
+
+# role mixin is preserved across the multiplication
+my role Meows {}
+my $r := (2..^5) but Meows;
+ok ($r * 5) ~~ Meows, 'role preserved through Range * Int';
+is-deeply ($r * 5), ((10..^25) but Meows), 'mixed Range * Int eqv literal';


### PR DESCRIPTION
## Summary

`range_scale` (the `Range * Real` path) always wrapped its result in a `GenericRange`, so `(2..^5) * 5` rendered as `10..^25` but was **not** `eqv` to the literal `10..^25` (which is `Value::RangeExcl`). This broke `is-deeply` comparisons.

Addition/subtraction already preserve the canonical `Range`/`RangeExcl`/`RangeExclStart`/`RangeExclBoth` variant. Multiplication now does too, via a shared `canonical_int_range` helper that collapses Int endpoints to the matching variant (falling back to `GenericRange` for non-Int endpoints).

## Tests

- Fixes the "Range * Real" subclass case in `roast/S03-operators/range.t` (18 → 17 failures; the rest is the unrelated `X::Worry::Precedence::Range` worry feature).
- New `t/range-mul-canonical.t` (7 subtests), including role-mixin preservation.
- `autoincrement-range.t`, `range-range.t`, `rotor.t`, `cargo test --lib` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)