### PR TITLE
fix(coerce): Int()/Num() of an invalid string fail with X::Str::Numeric

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -8,6 +8,31 @@ use std::sync::Arc;
 
 use super::parse_raku_int_from_str;
 
+/// Build a lazy `Failure` wrapping an `X::Str::Numeric` exception for a string
+/// that cannot be numified — the shape raku's `.Int`/`.Num` produce on a bad
+/// string (the exception only fires when the Failure is sunk/used).
+pub(crate) fn str_numeric_failure(s: &str) -> Value {
+    let mut ex_attrs = std::collections::HashMap::new();
+    ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
+    ex_attrs.insert(
+        "reason".to_string(),
+        Value::str("base-10 number must begin with valid digits or '.'".to_string()),
+    );
+    ex_attrs.insert("pos".to_string(), Value::Int(0));
+    ex_attrs.insert(
+        "message".to_string(),
+        Value::str(format!(
+            "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
+            s
+        )),
+    );
+    let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), ex_attrs);
+    let mut failure_attrs = std::collections::HashMap::new();
+    failure_attrs.insert("exception".to_string(), ex);
+    failure_attrs.insert("handled".to_string(), Value::Bool(false));
+    Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+}
+
 pub(super) fn dispatch(
     target: &Value,
     method: &str,
@@ -564,10 +589,9 @@ pub(super) fn dispatch(
                     if let Ok(f) = normalized.parse::<f64>() {
                         Value::Num(f)
                     } else {
-                        return Some(Some(Err(RuntimeError::new(format!(
-                            "X::Str::Numeric: Cannot convert string '{}' to a number",
-                            s
-                        )))));
+                        // An invalid string yields a lazy X::Str::Numeric Failure,
+                        // mirroring `.Int` (not an eager X::AdHoc RuntimeError).
+                        return Some(Some(Ok(str_numeric_failure(s))));
                     }
                 }
                 Value::Bool(b) => Value::Num(if *b { 1.0 } else { 0.0 }),

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -33,7 +33,10 @@ impl Interpreter {
                 }
                 Value::FatRat(n, d) => Value::Int(n / d),
                 Value::Complex(r, _) => Value::Int(r as i64),
-                Value::Str(s) => Value::Int(s.trim().parse::<i64>().unwrap_or(0)),
+                // Delegate to `Str.Int` so an invalid string yields the same
+                // X::Str::Numeric Failure as the method form (`"abc".Int`),
+                // rather than silently coercing to 0.
+                Value::Str(s) => return self.call_method_with_values(Value::Str(s), name, vec![]),
                 Value::Bool(b) => Value::Int(if b { 1 } else { 0 }),
                 _ => Value::Int(0),
             },
@@ -88,15 +91,9 @@ impl Interpreter {
                     }
                     Value::Num(r)
                 }
-                Value::Str(s) => {
-                    if let Ok(i) = s.trim().parse::<i64>() {
-                        Value::Num(i as f64)
-                    } else if let Ok(f) = s.trim().parse::<f64>() {
-                        Value::Num(f)
-                    } else {
-                        Value::Num(0.0)
-                    }
-                }
+                // Delegate to `Str.Num` so an invalid string yields the same
+                // X::Str::Numeric Failure as the method form, not a silent 0.
+                Value::Str(s) => return self.call_method_with_values(Value::Str(s), name, vec![]),
                 Value::Bool(b) => Value::Num(if b { 1.0 } else { 0.0 }),
                 _ => Value::Num(0.0),
             },

--- a/t/int-num-coerce-bad-string.t
+++ b/t/int-num-coerce-bad-string.t
@@ -1,0 +1,50 @@
+use Test;
+
+# The `Int(...)` / `Num(...)` coercion *function* forms must behave like the
+# `.Int` / `.Num` *method* forms: an invalid string yields a lazy X::Str::Numeric
+# Failure, not a silent 0.
+
+plan 18;
+
+# --- Valid strings still coerce ---
+is Int("42"), 42, 'Int("42") coerces';
+is Int("  42  "), 42, 'Int trims surrounding whitespace';
+is Int("0xff"), 255, 'Int parses a radix prefix';
+is Num("3.14"), 3.14, 'Num("3.14") coerces';
+is Num("-2.5"), -2.5, 'Num parses a signed decimal';
+is Num("1e3"), 1000e0, 'Num parses scientific notation';
+
+# --- Invalid strings produce an X::Str::Numeric Failure (function form) ---
+{
+    my $r = try Int("abc");
+    ok !$r.defined, 'Int("abc") is an undefined (failed) value';
+    is $!.WHAT.^name, 'X::Str::Numeric', 'Int("abc") sets $! to X::Str::Numeric';
+}
+{
+    my $r = try Num("xyz");
+    ok !$r.defined, 'Num("xyz") is an undefined (failed) value';
+    is $!.WHAT.^name, 'X::Str::Numeric', 'Num("xyz") sets $! to X::Str::Numeric';
+}
+{
+    my $r = try Int("12abc");
+    ok !$r.defined, 'Int("12abc") (trailing chars) fails';
+    is $!.WHAT.^name, 'X::Str::Numeric', 'trailing-char string is X::Str::Numeric';
+}
+
+# --- Function form matches method form ---
+{
+    my $r = try "abc".Int;
+    is $!.WHAT.^name, 'X::Str::Numeric', 'method form .Int agrees';
+}
+{
+    my $r = try "xyz".Num;
+    is $!.WHAT.^name, 'X::Str::Numeric', 'method form .Num agrees';
+}
+
+# --- Defaulting past the Failure works ---
+is (try Int("abc")) // 99, 99, 'a failed Int defaults via //';
+is (try Num("xyz")) // 99, 99, 'a failed Num defaults via //';
+
+# --- Non-string coercions are unchanged ---
+is Int(3.9), 3, 'Int truncates a Num';
+is Num(5), 5e0, 'Num of an Int';


### PR DESCRIPTION
## Problem

The `Int(...)` / `Num(...)` coercion **function** forms silently returned `0` for an unparseable string, while the `.Int` / `.Num` **method** forms correctly produced an `X::Str::Numeric` Failure:

```
            before (mutsu)   after (rakudo-correct)
Int("abc")     0                X::Str::Numeric Failure
Int("12abc")   0                X::Str::Numeric Failure
Num("xyz")     0                X::Str::Numeric Failure
"abc".Int      Failure ✓        (unchanged)
```

## Fix

- `builtin_coerce`'s `Int`/`Num` arms now delegate the `Str` case to the `.Int`/`.Num` method (the same pattern the `Str` arm already used), so the function and method forms agree.
- This exposed that the `.Num` **method** itself threw an eager `X::AdHoc` RuntimeError for a bad string instead of returning a lazy Failure like `.Int`. Factored the Failure construction into a shared `str_numeric_failure` helper and used it for `.Num`, so `.Num` now returns an `X::Str::Numeric` Failure too.

## Tests

- New `t/int-num-coerce-bad-string.t` (18 assertions): valid coercions still work, invalid strings set `$!` to `X::Str::Numeric` (function and method forms), `//` defaulting past the Failure, non-string coercions unchanged.
- Whitelisted roast `S02-literals/numeric.t`, `S02-types/int-uint.t`, `S32-num/{int,base}.t`, `S32-str/numeric.t`, `S03-sequence/nonnumeric.t` pass.
- `make test` PASS (8479 tests).

## Out of scope (deferred)

- `Int("12abc")` throws the generic "begin with valid digits" message; rakudo distinguishes "trailing characters after number". Both throw X::Str::Numeric.
- `Int(True)` returns `True` in rakudo (an enum-coercion quirk) vs `1` in mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)