### PR TITLE
fix(lazy): grep/map over an exclusive-end infinite range; honor last/next in the pipe

### DIFF
--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -56,6 +56,12 @@ impl Interpreter {
             | Value::RangeExcl(_, end)
             | Value::RangeExclStart(_, end)
             | Value::RangeExclBoth(_, end) => *end == i64::MAX,
+            // An exclusive/whatever infinite range (`^Inf`, `0..^Inf`) is stored
+            // as a GenericRange with an infinite end — also a lazy pipe source.
+            Value::GenericRange { end, .. } => {
+                let end_f = end.to_f64();
+                end_f.is_infinite() && end_f.is_sign_positive()
+            }
             Value::LazyList(ll) => ll.lazy_pipe.is_some(),
             _ => false,
         }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -877,12 +877,21 @@ impl Interpreter {
     }
 
     pub(super) fn force_lazy_list(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {
-        // A lazy map/grep pipeline is rooted at an infinite source; a strict
-        // force cannot terminate. Match raku (and the VM path) and throw
-        // X::Cannot::Lazy. Bounded pulls go through the VM's `force_lazy_pipe`.
-        // (Its cache is seeded empty, so the early cache return below would
-        // otherwise yield a wrong partial/empty result.)
+        // A lazy map/grep pipeline is rooted at an infinite source. It can still
+        // terminate when the callback runs `last`; attempt a bounded force and
+        // return the result if the pipe became `done`, otherwise throw
+        // X::Cannot::Lazy (genuinely infinite). Mirrors `force_lazy_list_vm`.
         if list.lazy_pipe.is_some() {
+            const EAGER_FORCE_CAP: usize = 1_000_000;
+            let forced = self.force_lazy_pipe(list, EAGER_FORCE_CAP)?;
+            let done = list
+                .lazy_pipe
+                .as_ref()
+                .map(|p| p.lock().unwrap().done)
+                .unwrap_or(true);
+            if done {
+                return Ok(forced);
+            }
             return Err(RuntimeError::typed_msg(
                 "X::Cannot::Lazy",
                 "Cannot coerce an infinite lazy list to a strict list",

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -375,12 +375,25 @@ impl Interpreter {
             return self.force_scan_lazy_list(list, 200_000);
         }
 
-        // A lazy map/grep pipeline is rooted at an infinite source, so a full
-        // (strict) force can never terminate. Match raku and throw
-        // X::Cannot::Lazy rather than spinning forever. Methods that know their
-        // own name (e.g. `.elems`/`.sort`) raise a more specific message at the
-        // dispatch site before reaching here.
+        // A lazy map/grep pipeline is rooted at an infinite source. It can still
+        // be forced when the callback runs `last` (which ends the sequence) —
+        // e.g. `(^Inf).grep({ last if $_ > 5; True }).eager`. So attempt a
+        // bounded force: if the pipe terminates within the cap (via `last` or a
+        // finite source), return it; otherwise it is genuinely infinite and we
+        // throw X::Cannot::Lazy, matching raku. Methods that know their own name
+        // (e.g. `.elems`/`.sort`) raise a more specific message at the dispatch
+        // site before reaching here.
         if list.lazy_pipe.is_some() {
+            const EAGER_FORCE_CAP: usize = 1_000_000;
+            let forced = self.force_lazy_pipe(list, EAGER_FORCE_CAP)?;
+            let done = list
+                .lazy_pipe
+                .as_ref()
+                .map(|p| p.lock().unwrap().done)
+                .unwrap_or(true);
+            if done {
+                return Ok(forced);
+            }
             return Err(RuntimeError::typed_msg(
                 "X::Cannot::Lazy",
                 "Cannot coerce an infinite lazy list to a strict list",
@@ -812,7 +825,7 @@ impl Interpreter {
     /// list's cache. A `grep` stage filters (0 or 1 output per source element);
     /// a `map` stage transforms (a `Slip` result contributes multiple). The
     /// source itself may be another lazy pipeline, so chains nest.
-    pub(super) fn force_lazy_pipe(
+    pub(crate) fn force_lazy_pipe(
         &mut self,
         list: &LazyList,
         needed: usize,
@@ -863,17 +876,39 @@ impl Interpreter {
                     // side effects reach the enclosing scope). A `grep` keeps the
                     // element when the matcher is truthy; a `map` transforms it (a
                     // `Slip` result contributes multiple elements).
-                    let produced: Vec<Value> = if is_grep {
-                        if self.vm_grep_item_matches(&func, &elem)? {
-                            vec![elem]
-                        } else {
-                            Vec::new()
+                    //
+                    // Loop control inside the callback is honored: `last` ends the
+                    // sequence (excluding the current element), `next` skips the
+                    // current element. This makes `(^Inf).grep({last if …})`
+                    // terminate instead of running forever.
+                    let applied: Result<Vec<Value>, RuntimeError> = if is_grep {
+                        match self.vm_grep_item_matches(&func, &elem) {
+                            Ok(true) => Ok(vec![elem]),
+                            Ok(false) => Ok(Vec::new()),
+                            Err(e) => Err(e),
                         }
                     } else {
-                        match self.vm_call_on_value(func, vec![elem], None)? {
-                            Value::Slip(items) => items.as_ref().clone(),
-                            v => vec![v],
+                        self.vm_call_on_value(func, vec![elem], None)
+                            .map(|v| match v {
+                                Value::Slip(items) => items.as_ref().clone(),
+                                v => vec![v],
+                            })
+                    };
+                    let produced: Vec<Value> = match applied {
+                        Ok(p) => p,
+                        Err(e) if e.is_last => {
+                            // `last`: terminate the sequence, current element excluded.
+                            let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
+                            spec.done = true;
+                            drop(spec);
+                            let cache = list.cache.lock().unwrap();
+                            let c = cache.as_ref().cloned().unwrap_or_default();
+                            let n = needed.min(c.len());
+                            return Ok(c[..n].to_vec());
                         }
+                        // `next`: skip the current element and continue.
+                        Err(e) if e.is_next => Vec::new(),
+                        Err(e) => return Err(e),
                     };
                     {
                         let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
@@ -916,14 +951,45 @@ impl Interpreter {
                     Ok(None)
                 }
             }
+            // Integer-start GenericRange (e.g. `^Inf`, `0..^Inf`): pull the
+            // idx-th element directly so an infinite range stays lazy instead of
+            // being materialized.
+            Value::GenericRange {
+                start,
+                end,
+                excl_start,
+                excl_end,
+            } if matches!(start.as_ref(), Value::Int(_)) => {
+                let s = match start.as_ref() {
+                    Value::Int(i) => *i,
+                    _ => unreachable!(),
+                };
+                let base = if *excl_start { s.saturating_add(1) } else { s };
+                let cur = match base.checked_add(idx as i64) {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                let end_f = end.to_f64();
+                let in_bounds = if end_f.is_infinite() && end_f.is_sign_positive() {
+                    true
+                } else {
+                    let cur_f = cur as f64;
+                    if *excl_end {
+                        cur_f < end_f
+                    } else {
+                        cur_f <= end_f
+                    }
+                };
+                Ok(in_bounds.then_some(Value::Int(cur)))
+            }
             Value::Seq(items) | Value::Slip(items) => Ok(items.get(idx).cloned()),
             Value::Array(items, _) => Ok(items.get(idx).cloned()),
             Value::LazyList(ll) => {
                 let items = self.force_lazy_list_vm_n(ll, idx + 1)?;
                 Ok(items.get(idx).cloned())
             }
-            // Other sources (GenericRange, etc.) are not gated into the lazy
-            // pipeline; materialize once and index.
+            // Other sources (non-integer GenericRange, etc.) are not gated into
+            // the lazy pipeline; materialize once and index.
             other => {
                 let items = crate::runtime::value_to_list(other);
                 Ok(items.get(idx).cloned())

--- a/t/lazy-grep-infinite-exclusive-range.t
+++ b/t/lazy-grep-infinite-exclusive-range.t
@@ -1,0 +1,39 @@
+use Test;
+
+# grep/map over an *exclusive-end* infinite range (`^Inf`, `0..^Inf`) must be
+# truly lazy (apply the matcher), like `0..Inf` / `1..Inf`. And a `last`/`next`
+# inside the callback must be honored, so an `.eager` that the callback
+# terminates with `last` returns a finite result instead of failing.
+
+plan 14;
+
+# --- ^Inf grep applies the matcher lazily ---
+is (^Inf).grep(* %% 5)[^3].join(','), '0,5,10', '^Inf grep filters lazily';
+is (0..^Inf).grep(* %% 5)[^3].join(','), '0,5,10', '0..^Inf grep filters lazily';
+is (^Inf).grep(* > 3)[^3].join(','), '4,5,6', '^Inf grep with a threshold';
+is (^Inf).grep(* %% 5).head(4).join(','), '0,5,10,15', '.head over a ^Inf grep';
+is (^Inf).grep(* %% 5)[2], 10, 'index into a ^Inf grep';
+ok (^Inf).grep(*.is-prime).is-lazy, '^Inf grep is lazy';
+is (^Inf).grep(*.is-prime).head(5).join(','), '2,3,5,7,11', 'primes from ^Inf';
+
+# --- map over ^Inf stays lazy ---
+is (^Inf).map(* * 2)[^3].join(','), '0,2,4', '^Inf map is lazy';
+
+# --- last inside the callback terminates an otherwise-infinite grep ---
+is (^Inf).grep({ last if $_ > 5; True }).eager.join, '012345',
+    'last in grep over ^Inf terminates .eager';
+is (1..Inf).grep({ last if $_ > 5; True }).eager.join, '12345',
+    'last in grep over 1..Inf terminates .eager';
+is (0..Inf).grep({ last if $_ > 5; True }).eager.join, '012345',
+    'last in grep over 0..Inf terminates .eager';
+
+# --- next inside the callback skips elements ---
+is (^Inf).grep({ next if $_ %% 2; $_ > 0 }).head(3).join(','), '1,3,5',
+    'next in grep over ^Inf skips elements';
+
+# --- last in a map over ^Inf terminates too ---
+is (^Inf).map({ last if $_ > 3; $_ * 10 }).eager.join(','), '0,10,20,30',
+    'last in map over ^Inf terminates .eager';
+
+# --- finite ranges are unaffected ---
+is (^10).grep(* %% 5).join(','), '0,5', 'finite range grep unchanged';


### PR DESCRIPTION
## Problem

`grep`/`map` over an **exclusive-end** infinite range (`^Inf`, `0..^Inf`) was a no-op:

```
(^Inf).grep(* %% 5)[^3]   # mutsu: (0 1 2)   rakudo: (0 5 10)
```

`0..Inf` / `1..Inf` already worked — only the exclusive/whatever-end form (`^Inf`, stored as a `GenericRange` with an infinite end) was missed.

## Fix

- `is_lazy_pipe_source` now recognizes a `GenericRange` with an infinite positive end (mirroring `is_lazy_for_set_ops`), so `^Inf` enters the lazy pipeline.
- `pull_source_element` gained an integer-start `GenericRange` arm so it pulls the i-th element directly instead of materializing the (infinite) range.

Routing `^Inf` through the pipe exposed that the lazy pipe **ignored loop control** — a `last`/`next` inside the callback was not honored, so `(^Inf).grep({ last if $_ > 5; True }).eager` ran forever (and the previously-eager `^Inf` path, which *did* honor `last`, regressed — caught by the whitelisted `S32-list/grep.t`). Fixes:

- `force_lazy_pipe` catches a `last` signal (ends the sequence, current element excluded) and a `next` signal (skips the element).
- `force_lazy_list` / `force_lazy_list_vm` no longer reject a pipe unconditionally: they attempt a bounded force and return the result if the pipe became `done` (terminated by `last` or a finite source), else throw `X::Cannot::Lazy`.

**Bonus:** `(1..Inf).grep({ last … }).eager` previously failed with "Cannot coerce an infinite lazy list to a strict list"; it now works too.

## Tests

- New `t/lazy-grep-infinite-exclusive-range.t` (14 assertions): lazy filtering/indexing/`.head` over `^Inf`/`0..^Inf`, `is-lazy`, `last`/`next` in grep and map callbacks terminating `.eager`, finite-range guard.
- Whitelisted roast `S32-list/grep.t` (was regressing → now PASS), `S32-list/{map,grep-k,grep-v}.t`, `S02-types/{lazy-lists,infinity}.t`, `S04-statements/lazy.t`, `S07-iterators/range-iterator.t` pass.
- `make test` PASS (8517 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)